### PR TITLE
fix(ready): forward check type options

### DIFF
--- a/crates/vize/src/cli.rs
+++ b/crates/vize/src/cli.rs
@@ -131,6 +131,12 @@ mod tests {
         insta::assert_snapshot!("cli_check_help", command_help("check"));
     }
 
+    #[cfg(feature = "glyph")]
+    #[test]
+    fn ready_help_snapshot() {
+        insta::assert_snapshot!("cli_ready_help", command_help("ready"));
+    }
+
     #[test]
     fn clean_help_snapshot() {
         insta::assert_snapshot!("cli_clean_help", command_help("clean"));

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -132,10 +132,10 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         eprintln!("[vize] Skipping check because typeChecker.enabled is false in vize.config.");
         return;
     }
-    let effective_tsconfig = args
-        .tsconfig
-        .clone()
-        .or_else(|| config.type_checker.tsconfig.as_ref().map(PathBuf::from));
+    let effective_tsconfig = args.tsconfig.clone().or_else(|| {
+        let candidate = config.type_checker.tsconfig.as_deref()?;
+        Some(resolve_from_config_dir(config_dir, candidate))
+    });
     let effective_corsa_path = args.corsa_path.as_ref().map(PathBuf::from).or_else(|| {
         config
             .type_checker

--- a/crates/vize/src/commands/ready.rs
+++ b/crates/vize/src/commands/ready.rs
@@ -17,12 +17,19 @@ use crate::commands::fmt::FmtArgs;
 #[allow(clippy::disallowed_types)]
 pub struct ReadyArgs {
     /// Files or directories to process.
-    #[arg(default_value = "./**/*.vue")]
     pub patterns: Vec<String>,
 
     /// Output directory for the build step.
     #[arg(short, long, default_value = "./dist")]
     pub output: PathBuf,
+
+    /// Config file path
+    #[arg(short, long)]
+    pub config: Option<PathBuf>,
+
+    /// Do not load a config file
+    #[arg(long)]
+    pub no_config: bool,
 
     /// Enable SSR mode for the build step.
     #[arg(long)]
@@ -31,18 +38,44 @@ pub struct ReadyArgs {
     /// Script extension handling for the build step.
     #[arg(long, value_enum, default_value = "downcompile")]
     pub script_ext: ScriptExtension,
+
+    /// tsconfig.json path for the check step
+    #[arg(long)]
+    pub tsconfig: Option<PathBuf>,
+
+    /// Disable prop type checks where supported
+    #[arg(long)]
+    pub no_check_props: bool,
+
+    /// Disable emit type checks where supported
+    #[arg(long)]
+    pub no_check_emits: bool,
+
+    /// Disable template binding checks where supported
+    #[arg(long)]
+    pub no_check_template_bindings: bool,
 }
 
 pub fn run(args: ReadyArgs) {
+    if let Some(path) = args.config.as_deref()
+        && !args.no_config
+        && let Err(error) = crate::config::validate_explicit_config_path(path)
+    {
+        eprintln!("\x1b[31mError:\x1b[0m {}", error);
+        std::process::exit(2);
+    }
+
+    let patterns = ready_patterns(&args.patterns);
+
     #[cfg(feature = "glyph")]
     {
         eprintln!("vize ready: fmt");
         crate::commands::fmt::run(FmtArgs {
-            patterns: args.patterns.clone(),
+            patterns: patterns.clone(),
             check: false,
             write: true,
-            config: None,
-            no_config: false,
+            config: args.config.clone(),
+            no_config: args.no_config,
             single_quote: None,
             print_width: None,
             tab_width: None,
@@ -59,14 +92,13 @@ pub fn run(args: ReadyArgs) {
 
     eprintln!("vize ready: lint");
     crate::commands::lint::run(LintArgs {
-        patterns: args
-            .patterns
+        patterns: patterns
             .iter()
             .map(|pattern| pattern.to_compact_string())
             .collect(),
         fix: false,
-        config: None,
-        no_config: false,
+        config: args.config.clone(),
+        no_config: args.no_config,
         format: "text".into(),
         max_warnings: None,
         quiet: false,
@@ -81,34 +113,14 @@ pub fn run(args: ReadyArgs) {
     });
 
     eprintln!("vize ready: check");
-    crate::commands::check::run(CheckArgs {
-        patterns: args.patterns.clone(),
-        config: None,
-        no_config: false,
-        #[cfg(unix)]
-        socket: None,
-        tsconfig: None,
-        format: "text".into(),
-        show_virtual_ts: false,
-        save_virtual_ts_for: Vec::new(),
-        max_warnings: None,
-        no_check_props: false,
-        no_check_emits: false,
-        no_check_template_bindings: false,
-        quiet: false,
-        profile: false,
-        corsa_path: None,
-        servers: None,
-        declaration: false,
-        declaration_dir: None,
-    });
+    crate::commands::check::run(check_args(&args));
 
     eprintln!("vize ready: build");
     crate::commands::build::run(BuildArgs {
-        patterns: args.patterns,
+        patterns,
         output: args.output,
-        config: None,
-        no_config: false,
+        config: args.config,
+        no_config: args.no_config,
         format: OutputFormat::Js,
         ssr: args.ssr,
         vapor: false,
@@ -120,4 +132,135 @@ pub fn run(args: ReadyArgs) {
         slow_threshold: 100,
         continue_on_error: false,
     });
+}
+
+#[allow(clippy::disallowed_types)]
+fn ready_patterns(patterns: &[String]) -> Vec<String> {
+    if patterns.is_empty() {
+        vec!["./**/*.vue".into()]
+    } else {
+        patterns.to_vec()
+    }
+}
+
+fn check_args(args: &ReadyArgs) -> CheckArgs {
+    CheckArgs {
+        patterns: check_patterns(args),
+        config: args.config.clone(),
+        no_config: args.no_config,
+        #[cfg(unix)]
+        socket: None,
+        tsconfig: args.tsconfig.clone(),
+        format: "text".into(),
+        show_virtual_ts: false,
+        save_virtual_ts_for: Vec::new(),
+        max_warnings: None,
+        no_check_props: args.no_check_props,
+        no_check_emits: args.no_check_emits,
+        no_check_template_bindings: args.no_check_template_bindings,
+        quiet: false,
+        profile: false,
+        corsa_path: None,
+        servers: None,
+        declaration: false,
+        declaration_dir: None,
+    }
+}
+
+#[allow(clippy::disallowed_types)]
+fn check_patterns(args: &ReadyArgs) -> Vec<String> {
+    if args.patterns.is_empty()
+        || args.tsconfig.is_some()
+        || config_declares_type_checker_tsconfig(args)
+    {
+        Vec::new()
+    } else {
+        args.patterns.clone()
+    }
+}
+
+fn config_declares_type_checker_tsconfig(args: &ReadyArgs) -> bool {
+    if args.no_config {
+        return false;
+    }
+
+    crate::config::load_config_with_features_and_source(args.config.as_deref())
+        .config
+        .type_checker
+        .tsconfig
+        .is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ready_args() -> ReadyArgs {
+        ReadyArgs {
+            patterns: vec!["src".into()],
+            output: PathBuf::from("./dist"),
+            config: None,
+            no_config: false,
+            ssr: false,
+            script_ext: ScriptExtension::Downcompile,
+            tsconfig: None,
+            no_check_props: false,
+            no_check_emits: false,
+            no_check_template_bindings: false,
+        }
+    }
+
+    #[test]
+    fn check_args_forward_check_options() {
+        let mut args = ready_args();
+        args.tsconfig = Some(PathBuf::from("tsconfig.vize.json"));
+        args.no_check_props = true;
+        args.no_check_emits = true;
+        args.no_check_template_bindings = true;
+
+        let check = check_args(&args);
+
+        assert!(check.patterns.is_empty());
+        assert_eq!(check.tsconfig, Some(PathBuf::from("tsconfig.vize.json")));
+        assert!(check.no_check_props);
+        assert!(check.no_check_emits);
+        assert!(check.no_check_template_bindings);
+    }
+
+    #[test]
+    fn check_uses_project_inputs_when_ready_patterns_are_defaulted() {
+        let mut args = ready_args();
+        args.patterns.clear();
+
+        assert_eq!(ready_patterns(&args.patterns), vec!["./**/*.vue"]);
+        assert!(check_args(&args).patterns.is_empty());
+    }
+
+    #[test]
+    fn check_keeps_explicit_patterns_without_tsconfig() {
+        let mut args = ready_args();
+        args.no_config = true;
+
+        assert_eq!(check_args(&args).patterns, vec!["src"]);
+    }
+
+    #[test]
+    fn check_uses_project_inputs_when_config_declares_tsconfig() {
+        let project = tempfile::tempdir().unwrap();
+        let config_path = project.path().join("vize.config.json");
+        std::fs::write(
+            &config_path,
+            r#"{
+  "typeChecker": {
+    "tsconfig": "tsconfig.vize.json"
+  }
+}"#,
+        )
+        .unwrap();
+
+        let mut args = ready_args();
+        args.config = Some(config_path);
+
+        assert!(check_args(&args).patterns.is_empty());
+    }
 }

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_ready_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_ready_help.snap
@@ -1,0 +1,51 @@
+---
+source: crates/vize/src/cli.rs
+assertion_line: 137
+expression: "command_help(\"ready\")"
+---
+Run fmt, lint, check, and build
+
+Usage: ready [OPTIONS] [PATTERNS]...
+
+Arguments:
+  [PATTERNS]...
+          Files or directories to process
+
+Options:
+  -o, --output <OUTPUT>
+          Output directory for the build step
+
+          [default: ./dist]
+
+  -c, --config <CONFIG>
+          Config file path
+
+      --no-config
+          Do not load a config file
+
+      --ssr
+          Enable SSR mode for the build step
+
+      --script-ext <SCRIPT_EXT>
+          Script extension handling for the build step
+
+          Possible values:
+          - preserve:    Preserve original script language extension (.ts -> .ts, .tsx -> .tsx, .jsx -> .jsx)
+          - downcompile: Downcompile all scripts to JavaScript (.ts -> .js, .tsx -> .js, .jsx -> .js)
+
+          [default: downcompile]
+
+      --tsconfig <TSCONFIG>
+          tsconfig.json path for the check step
+
+      --no-check-props
+          Disable prop type checks where supported
+
+      --no-check-emits
+          Disable emit type checks where supported
+
+      --no-check-template-bindings
+          Disable template binding checks where supported
+
+  -h, --help
+          Print help (see a summary with '-h')


### PR DESCRIPTION
## Summary
- Add `vize ready` pass-through for config, no-config, tsconfig, and no-check type options.
- Let the ready check step use project/tsconfig inputs when a check tsconfig is configured, so ready patterns do not force excluded files into type checking.
- Resolve `typeChecker.tsconfig` relative to the config file and cover ready help/forwarding behavior.

Closes #1895

## Verification
- cargo fmt --check
- cargo test -p vize ready -- --nocapture
- cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->