### PR TITLE
fix(type-check): mark template art bindings used

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use vize_carton::{String, cstr};
 mod emit_object_recursion;
 mod generic_component_listener_payload;
-
+mod no_unused;
 #[test]
 fn test_batch_type_checker_scan() {
     let project_root = unique_case_dir("scan");

--- a/crates/vize_canon/src/batch/type_checker/tests/no_unused.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/no_unused.rs
@@ -1,0 +1,60 @@
+use super::{
+    create_project_case_without_node_modules, resolve_test_tsgo_binary,
+    snapshot_project_diagnostics,
+};
+
+#[test]
+fn batch_type_checker_marks_art_bindings_as_used_with_no_unused_locals() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case_without_node_modules(
+        "art-bindings-no-unused-locals",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const schema = { fields: [] as string[] }
+function handleSubmit() {}
+</script>
+
+<art>
+  <variant name="Default" default>
+    <AfsForm :schema="schema" @submit="handleSubmit" />
+  </variant>
+</art>
+"#,
+        )],
+    );
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "noUnusedLocals": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !(file == "src/App.vue"
+                && *code == Some(6133)
+                && (message.contains("schema") || message.contains("handleSubmit")))
+        }),
+        "art bindings should not report TS6133, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/virtual_project/art_usage.rs
+++ b/crates/vize_canon/src/batch/virtual_project/art_usage.rs
@@ -1,0 +1,83 @@
+use vize_atelier_core::{
+    ParserOptions, TemplateSyntaxMode, parser::parse_with_options_and_template_syntax,
+};
+use vize_atelier_sfc::{SfcDescriptor, script::resolve_template_used_identifiers};
+use vize_carton::{Bump, FxHashSet, String as CompactString};
+
+pub(super) fn collect_art_template_referenced_names(
+    descriptor: &SfcDescriptor<'_>,
+    template_syntax: TemplateSyntaxMode,
+) -> FxHashSet<CompactString> {
+    let mut names = FxHashSet::default();
+
+    for block in &descriptor.custom_blocks {
+        if block.block_type.as_ref() != "art" {
+            continue;
+        }
+        collect_variant_template_referenced_names(&block.content, template_syntax, &mut names);
+    }
+
+    names
+}
+
+fn collect_variant_template_referenced_names(
+    art_content: &str,
+    template_syntax: TemplateSyntaxMode,
+    names: &mut FxHashSet<CompactString>,
+) {
+    let mut cursor = 0;
+    while let Some(relative_start) = art_content[cursor..].find("<variant") {
+        let start = cursor + relative_start;
+        let after_name = start + "<variant".len();
+        if !is_variant_tag_boundary(art_content.as_bytes().get(after_name).copied()) {
+            cursor = after_name;
+            continue;
+        }
+
+        let Some(tag_end) = art_content[start..].find('>').map(|offset| start + offset) else {
+            break;
+        };
+        let tag = art_content[start..=tag_end].trim_end();
+        if tag.ends_with("/>") {
+            cursor = tag_end + 1;
+            continue;
+        }
+
+        let template_start = tag_end + 1;
+        let Some(close_start) = art_content[template_start..]
+            .find("</variant>")
+            .map(|offset| template_start + offset)
+        else {
+            break;
+        };
+        collect_template_source_referenced_names(
+            art_content[template_start..close_start].trim(),
+            template_syntax,
+            names,
+        );
+        cursor = close_start + "</variant>".len();
+    }
+}
+
+fn is_variant_tag_boundary(next: Option<u8>) -> bool {
+    matches!(next, Some(b' ' | b'\t' | b'\n' | b'\r' | b'>') | None)
+}
+
+fn collect_template_source_referenced_names(
+    template: &str,
+    template_syntax: TemplateSyntaxMode,
+    names: &mut FxHashSet<CompactString>,
+) {
+    if template.is_empty() {
+        return;
+    }
+
+    let allocator = Bump::new();
+    let (root, _) = parse_with_options_and_template_syntax(
+        &allocator,
+        template,
+        ParserOptions::default(),
+        template_syntax,
+    );
+    names.extend(resolve_template_used_identifiers(&root).used_ids);
+}

--- a/crates/vize_canon/src/batch/virtual_project/mod.rs
+++ b/crates/vize_canon/src/batch/virtual_project/mod.rs
@@ -24,6 +24,7 @@ use super::source_map::CompositeSourceMap;
 use super::{Diagnostic, SfcBlockType};
 use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 
+mod art_usage;
 mod build;
 mod document;
 pub use document::{
@@ -36,6 +37,7 @@ mod mapping;
 mod materialize;
 mod passthrough;
 mod project;
+mod setup_props;
 mod tsconfig_gen;
 mod tsconfig_paths;
 mod vue_codegen;

--- a/crates/vize_canon/src/batch/virtual_project/setup_props.rs
+++ b/crates/vize_canon/src/batch/virtual_project/setup_props.rs
@@ -1,0 +1,122 @@
+use std::path::Path;
+
+use vize_atelier_sfc::{SfcDescriptor, script::ScriptCompileContext};
+use vize_carton::{FxHashSet, String as CompactString};
+
+pub(super) fn augment_type_based_props_from_script_context(
+    croquis: &mut vize_croquis::Croquis,
+    descriptor: &SfcDescriptor<'_>,
+    path: &Path,
+) {
+    let Some(script_setup) = descriptor.script_setup.as_ref() else {
+        return;
+    };
+    if croquis
+        .macros
+        .define_props()
+        .is_none_or(|call| call.type_args.is_none())
+    {
+        return;
+    }
+
+    let mut ctx = ScriptCompileContext::new(&script_setup.content);
+    let path_string = path.to_string_lossy();
+
+    if let Some(script) = descriptor.script.as_ref()
+        && !script.content.is_empty()
+    {
+        ctx.collect_types_from(&script.content);
+        ctx.collect_imported_types_from_path(
+            &script.content,
+            path_string.as_ref(),
+            matches!(script.lang.as_deref(), Some("ts" | "tsx")),
+        );
+    }
+    ctx.collect_imported_types_from_path(
+        &script_setup.content,
+        path_string.as_ref(),
+        matches!(script_setup.lang.as_deref(), Some("ts" | "tsx")),
+    );
+    ctx.analyze();
+
+    let known_props = known_type_based_prop_names(croquis);
+    let mut missing_props: Vec<CompactString> = ctx
+        .bindings
+        .bindings
+        .iter()
+        .filter_map(|(name, binding_type)| {
+            matches!(binding_type, vize_relief::BindingType::Props)
+                .then(|| name)
+                .filter(|name| !known_props.contains(*name))
+                .cloned()
+        })
+        .collect();
+    if missing_props.is_empty() {
+        return;
+    }
+    missing_props.sort();
+
+    for name in missing_props {
+        croquis
+            .bindings
+            .bindings
+            .entry(name.clone())
+            .or_insert(vize_relief::BindingType::Props);
+        croquis
+            .macros
+            .add_prop(vize_croquis::macros::PropDefinition {
+                name,
+                prop_type: None,
+                required: false,
+                default_value: None,
+            });
+    }
+}
+
+fn known_type_based_prop_names(croquis: &vize_croquis::Croquis) -> FxHashSet<CompactString> {
+    let mut names: FxHashSet<CompactString> = croquis
+        .macros
+        .props()
+        .iter()
+        .map(|prop| prop.name.clone())
+        .collect();
+
+    let Some(type_args) = croquis
+        .macros
+        .define_props()
+        .and_then(|call| call.type_args.as_ref())
+    else {
+        return names;
+    };
+
+    // Resolve the named type's fields through the croquis TypeResolver, which
+    // script analysis populates from the OXC AST, including local interfaces
+    // and type literals.
+    let type_name = strip_outer_angle_brackets(type_args.trim());
+    for prop in croquis
+        .types
+        .extract_properties(type_reference_lookup_key(type_name))
+    {
+        names.insert(prop.name);
+    }
+
+    names
+}
+
+fn strip_outer_angle_brackets(value: &str) -> &str {
+    value
+        .strip_prefix('<')
+        .and_then(|value| value.strip_suffix('>'))
+        .unwrap_or(value)
+}
+
+fn type_reference_lookup_key(type_name: &str) -> &str {
+    let trimmed = type_name.trim();
+    if trimmed.starts_with('{') {
+        return type_name;
+    }
+    match trimmed.find('<') {
+        Some(pos) => trimmed[..pos].trim_end(),
+        None => trimmed,
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 
-use vize_carton::{Bump, FxHashSet, String as CompactString, cstr, profile};
+use vize_carton::{Bump, String as CompactString, cstr, profile};
 
 use vize_atelier_core::{
     ParserOptions, TemplateSyntaxMode, parser::parse_with_options_and_template_syntax,
@@ -17,7 +17,6 @@ use vize_atelier_sfc::{
         analyze_sfc_descriptor_with_context_legacy_vue2,
         analyze_sfc_descriptor_with_context_options_api,
     },
-    script::ScriptCompileContext,
 };
 
 use crate::batch::error::CorsaResult;
@@ -30,6 +29,10 @@ use crate::virtual_ts::{
 
 use super::diagnostics::{
     collect_sfc_compile_diagnostic, diagnostic_for_offset, invalid_sfc_fallback_virtual_ts,
+};
+use super::{
+    art_usage::collect_art_template_referenced_names,
+    setup_props::augment_type_based_props_from_script_context,
 };
 
 pub(super) struct GeneratedVueFile {
@@ -182,6 +185,9 @@ pub(super) fn generate_vue_virtual_ts(
         "canon.croquis.augment_type_props",
         augment_type_based_props_from_script_context(&mut croquis, descriptor, path)
     );
+    let extra_template_referenced_names = codegen_options.preserve_unused_diagnostics.then(|| {
+        collect_art_template_referenced_names(descriptor, codegen_options.template_syntax)
+    });
 
     let output = profile!(
         "canon.virtual_ts.generate",
@@ -196,6 +202,7 @@ pub(super) fn generate_vue_virtual_ts(
                 check_options: codegen_options.check_options,
                 dialect: codegen_options.dialect,
                 preserve_unused_diagnostics: codegen_options.preserve_unused_diagnostics,
+                extra_template_referenced_names: extra_template_referenced_names.as_ref(),
                 options_api: codegen_options.options_api,
                 legacy_vue2: codegen_options.legacy_vue2,
                 template_syntax_quirks: matches!(
@@ -226,126 +233,4 @@ pub(super) fn generate_vue_virtual_ts(
         mappings: output.mappings,
         diagnostics,
     })
-}
-
-fn augment_type_based_props_from_script_context(
-    croquis: &mut vize_croquis::Croquis,
-    descriptor: &SfcDescriptor<'_>,
-    path: &Path,
-) {
-    let Some(script_setup) = descriptor.script_setup.as_ref() else {
-        return;
-    };
-    if croquis
-        .macros
-        .define_props()
-        .is_none_or(|call| call.type_args.is_none())
-    {
-        return;
-    }
-
-    let mut ctx = ScriptCompileContext::new(&script_setup.content);
-    let path_string = path.to_string_lossy();
-
-    if let Some(script) = descriptor.script.as_ref()
-        && !script.content.is_empty()
-    {
-        ctx.collect_types_from(&script.content);
-        ctx.collect_imported_types_from_path(
-            &script.content,
-            path_string.as_ref(),
-            matches!(script.lang.as_deref(), Some("ts" | "tsx")),
-        );
-    }
-    ctx.collect_imported_types_from_path(
-        &script_setup.content,
-        path_string.as_ref(),
-        matches!(script_setup.lang.as_deref(), Some("ts" | "tsx")),
-    );
-    ctx.analyze();
-
-    let known_props = known_type_based_prop_names(croquis);
-    let mut missing_props: Vec<CompactString> = ctx
-        .bindings
-        .bindings
-        .iter()
-        .filter_map(|(name, binding_type)| {
-            matches!(binding_type, vize_relief::BindingType::Props)
-                .then(|| name)
-                .filter(|name| !known_props.contains(*name))
-                .cloned()
-        })
-        .collect();
-    if missing_props.is_empty() {
-        return;
-    }
-    missing_props.sort();
-
-    for name in missing_props {
-        croquis
-            .bindings
-            .bindings
-            .entry(name.clone())
-            .or_insert(vize_relief::BindingType::Props);
-        croquis
-            .macros
-            .add_prop(vize_croquis::macros::PropDefinition {
-                name,
-                prop_type: None,
-                required: false,
-                default_value: None,
-            });
-    }
-}
-
-fn known_type_based_prop_names(croquis: &vize_croquis::Croquis) -> FxHashSet<CompactString> {
-    let mut names: FxHashSet<CompactString> = croquis
-        .macros
-        .props()
-        .iter()
-        .map(|prop| prop.name.clone())
-        .collect();
-
-    let Some(type_args) = croquis
-        .macros
-        .define_props()
-        .and_then(|call| call.type_args.as_ref())
-    else {
-        return names;
-    };
-
-    // Resolve the named type's fields through the croquis TypeResolver, which
-    // script analysis populates from the OXC AST — including local interfaces
-    // and type literals. This replaces the old raw-text interface scanner.
-    let type_name = strip_outer_angle_brackets(type_args.trim());
-    for prop in croquis
-        .types
-        .extract_properties(type_reference_lookup_key(type_name))
-    {
-        names.insert(prop.name);
-    }
-
-    names
-}
-
-fn strip_outer_angle_brackets(value: &str) -> &str {
-    value
-        .strip_prefix('<')
-        .and_then(|value| value.strip_suffix('>'))
-        .unwrap_or(value)
-}
-
-/// Lookup key for a `defineProps<...>` type argument: inline object literals
-/// (`{ ... }`) are passed through, while a type *reference* drops any generic
-/// instantiation (`Foo<T>` -> `Foo`) so the resolver can find the local
-/// declaration registered under its bare name.
-fn type_reference_lookup_key(type_name: &str) -> &str {
-    let trimmed = type_name.trim();
-    if trimmed.starts_with('{') {
-        return type_name;
-    }
-    match trimmed.find('<') {
-        Some(pos) => trimmed[..pos].trim_end(),
-        None => trimmed,
-    }
 }

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -21,8 +21,8 @@ use self::options_api::{
 };
 use self::setup_props::SetupPropsPlan;
 use self::spans::{
-    DEFINE_COMPONENT_HELPER, DEFINE_COMPONENT_REF, collect_template_referenced_names,
-    merge_overlapping_spans, rewrite_export_default_for_module_scope,
+    DEFINE_COMPONENT_HELPER, DEFINE_COMPONENT_REF, merge_overlapping_spans,
+    preserved_template_usage, rewrite_export_default_for_module_scope,
 };
 use self::template_refs::TemplateRefUnwraps;
 use super::{
@@ -142,7 +142,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     script_offset: u32,
     template_offset: u32,
     options: &VirtualTsOptions,
-    generation_options: VirtualTsGenerationOptions,
+    generation_options: VirtualTsGenerationOptions<'_>,
 ) -> VirtualTsOutput {
     let check_options = generation_options.check_options;
     // Configured Vue dialect, used to emit dialect-aware template instance typing
@@ -155,8 +155,8 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     let mut ts = String::default();
     let mut mappings: Vec<VizeMapping> = Vec::new();
     let preserve_unused_diagnostics = generation_options.preserve_unused_diagnostics;
-    let template_referenced_names =
-        preserve_unused_diagnostics.then(|| collect_template_referenced_names(summary));
+    let (template_referenced_names, has_template_scope) =
+        preserved_template_usage(summary, template_ast, generation_options);
     let reference_setup_bindings_comment = if preserve_unused_diagnostics {
         "Reference setup bindings used by template generation"
     } else {
@@ -733,7 +733,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     setup_props_plan.emit_artifact(&mut ts, summary);
 
     // Template scope (nested inside setup)
-    if template_ast.is_some() && check_options.check_template_bindings {
+    if has_template_scope && check_options.check_template_bindings {
         profile!("canon.virtual_ts.emit_template_scope", {
             ts.push_str("  // ========== Template Scope (inherits from setup) ==========\n");
 

--- a/crates/vize_canon/src/virtual_ts/generator/spans.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/spans.rs
@@ -1,13 +1,40 @@
 //! Span collection/merging, template-referenced-name discovery, and
 //! `export default` rewriting used while assembling the virtual TypeScript.
 
+use vize_atelier_sfc::script::resolve_template_used_identifiers;
+use vize_carton::{FxHashSet, String};
 use vize_croquis::{Croquis, ScopeData};
 
-use vize_carton::FxHashSet;
-use vize_carton::String;
+pub(super) fn preserved_template_usage(
+    summary: &Croquis,
+    template_ast: Option<&vize_relief::RootNode<'_>>,
+    generation_options: crate::virtual_ts::types::VirtualTsGenerationOptions<'_>,
+) -> (Option<FxHashSet<String>>, bool) {
+    let names = generation_options.preserve_unused_diagnostics.then(|| {
+        collect_template_referenced_names(
+            summary,
+            template_ast,
+            generation_options.extra_template_referenced_names,
+        )
+    });
+    let has_scope = template_ast.is_some() || names.as_ref().is_some_and(|names| !names.is_empty());
+    (names, has_scope)
+}
 
-pub(super) fn collect_template_referenced_names(summary: &Croquis) -> FxHashSet<String> {
+fn collect_template_referenced_names(
+    summary: &Croquis,
+    template_ast: Option<&vize_relief::RootNode<'_>>,
+    extra_template_referenced_names: Option<&FxHashSet<String>>,
+) -> FxHashSet<String> {
     let mut names = FxHashSet::default();
+
+    if let Some(template_ast) = template_ast {
+        names.extend(resolve_template_used_identifiers(template_ast).used_ids);
+    }
+
+    if let Some(extra_names) = extra_template_referenced_names {
+        names.extend(extra_names.iter().cloned());
+    }
 
     for expression in &summary.template_expressions {
         collect_expression_identifiers(&mut names, expression.content.as_str());

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -4,10 +4,10 @@ use super::{
     generate_virtual_ts, generate_virtual_ts_with_offsets,
     generate_virtual_ts_with_offsets_and_checks, generate_virtual_ts_with_offsets_options_api,
 };
-
 mod define_props_scope;
 mod no_check_template_bindings;
 mod options_api_props_spread;
+mod unused_refs;
 mod vif_chain;
 fn assert_virtual_ts_snapshot(name: &str, value: &str) {
     insta::with_settings!({

--- a/crates/vize_canon/src/virtual_ts/tests/unused_refs.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/unused_refs.rs
@@ -1,0 +1,37 @@
+use crate::virtual_ts::{
+    VirtualTsGenerationOptions, VirtualTsOptions, generate_virtual_ts_with_offsets_and_checks,
+};
+use vize_croquis::{Analyzer, AnalyzerOptions};
+
+#[test]
+fn test_preserve_unused_diagnostics_marks_static_template_refs_used() {
+    let script = r#"const activatorRef = null
+const menuRef = null
+const decoy = null
+"#;
+    let template = r#"<div ref="activatorRef"><div ref="menuRef" /></div>"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts_with_offsets_and_checks(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &VirtualTsOptions::default(),
+        VirtualTsGenerationOptions {
+            preserve_unused_diagnostics: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(output.code.contains("void activatorRef; void menuRef;"));
+    assert!(!output.code.contains("void decoy;"));
+}

--- a/crates/vize_canon/src/virtual_ts/types.rs
+++ b/crates/vize_canon/src/virtual_ts/types.rs
@@ -1,7 +1,7 @@
 //! Type definitions for virtual TypeScript generation.
 
 use std::ops::Range;
-use vize_carton::{String, config::VueVersion};
+use vize_carton::{FxHashSet, String, config::VueVersion};
 
 /// A mapping from generated virtual TS position to SFC source position.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -105,7 +105,7 @@ impl Default for VirtualTsCheckOptions {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct VirtualTsGenerationOptions {
+pub(crate) struct VirtualTsGenerationOptions<'a> {
     pub(crate) check_options: VirtualTsCheckOptions,
     /// Configured Vue dialect for this project (default [`VueVersion::V3`]).
     ///
@@ -123,6 +123,10 @@ pub(crate) struct VirtualTsGenerationOptions {
     /// Preserve TypeScript's user-authored unused local/import diagnostics by
     /// avoiding broad synthetic setup-binding references.
     pub(crate) preserve_unused_diagnostics: bool,
+    /// Extra names referenced by template-like custom blocks. Used only by
+    /// unused-local preservation so non-template blocks can mark setup
+    /// bindings as read without opting into full template type checks.
+    pub(crate) extra_template_referenced_names: Option<&'a FxHashSet<String>>,
     /// Hoist the shared preamble (ImportMeta augmentation, type helpers, and
     /// compiler-macro signatures) out of the generated module. Callers that
     /// enable this must make the shared ambient helpers file


### PR DESCRIPTION
## Summary
- collect template AST identifiers in the unused-preserving virtual TS path so static `ref="..."` bindings count as used
- collect identifiers from inline `<art>` variant templates and pass them into virtual TS generation for `noUnusedLocals`
- split helper modules to keep existing source-length constraints intact

Closes #1896

## Verification
- `cargo fmt --check`
- `cargo test -p vize_canon virtual_ts::tests -- --nocapture`
- `cargo test -p vize_canon batch_type_checker_marks_art_bindings_as_used_with_no_unused_locals -- --nocapture`
- `cargo test -p vize_canon batch_type_checker_reports_user_ts6133_with_no_unused_locals -- --nocapture`
- `cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->