### PR TITLE
fix(check): respect Nuxt buildDir types

### DIFF
--- a/crates/vize/src/commands/check/nuxt/fallback.rs
+++ b/crates/vize/src/commands/check/nuxt/fallback.rs
@@ -10,18 +10,16 @@ mod fallback_values;
 use std::path::Path;
 
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{ArrayExpressionElement, Expression, ObjectExpression, Statement};
+use oxc_ast::ast::{ArrayExpressionElement, Expression};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_carton::{FxHashSet, String, ToCompactString};
 
 use super::parsing::{
-    extract_call_expression_from_export, extract_expression, extract_object_expression,
-    find_object_property,
+    default_export_config_object, extract_expression, find_object_property, nuxt_config_source,
 };
 use super::stubs::{
     declared_name, push_generic_function_stub, push_named_overload_stubs, push_stub,
-    tracked_read_to_string,
 };
 use fallback_values::fallback_value_stubs;
 
@@ -38,7 +36,7 @@ pub(super) fn collect_fallback_stubs(
         &mut fallback_names,
     );
     // The hardcoded `any` ladder silently weakens checking, so only inject it
-    // when the project has no generated `.nuxt` import manifest to rely on.
+    // when the project has no generated Nuxt import manifest to rely on.
     if !has_generated_imports {
         push_fallback_stub_group(
             fallback_value_stubs(),
@@ -249,47 +247,6 @@ pub(super) fn parse_nuxt_config_modules(config_source: &str) -> NuxtConfigModule
         }
     }
     resolved
-}
-
-/// Finds the config object behind the default export, looking through the
-/// `defineNuxtConfig(...)` wrapper as well as parenthesized/`as`/`satisfies`
-/// wrappers on either form. Returns `None` for anything else (identifier
-/// references, unknown wrapper calls, missing default export), which callers
-/// treat as an unresolved module list.
-fn default_export_config_object<'a>(
-    statements: &'a [Statement<'a>],
-) -> Option<&'a ObjectExpression<'a>> {
-    let export = statements.iter().find_map(|statement| match statement {
-        Statement::ExportDefaultDeclaration(export) => Some(export),
-        _ => None,
-    })?;
-
-    if let Some(call) = extract_call_expression_from_export(&export.declaration) {
-        if !matches!(&call.callee, Expression::Identifier(callee) if callee.name == "defineNuxtConfig")
-        {
-            return None;
-        }
-        return call
-            .arguments
-            .first()
-            .and_then(|argument| argument.as_expression())
-            .and_then(extract_object_expression);
-    }
-
-    export
-        .declaration
-        .as_expression()
-        .and_then(extract_object_expression)
-}
-
-pub(super) fn nuxt_config_source(cwd: &Path) -> String {
-    for file_name in ["nuxt.config.ts", "nuxt.config.js", "nuxt.config.mts"] {
-        let path = cwd.join(file_name);
-        if let Ok(source) = tracked_read_to_string(path.as_path()) {
-            return source.into();
-        }
-    }
-    String::default()
 }
 
 #[cfg(test)]

--- a/crates/vize/src/commands/check/nuxt/generated.rs
+++ b/crates/vize/src/commands/check/nuxt/generated.rs
@@ -1,6 +1,6 @@
-//! Detection driven by Nuxt's generated `.nuxt` type artifacts.
+//! Detection driven by Nuxt's generated type artifacts.
 
-use std::{fs, path::Path};
+use std::path::Path;
 
 use ignore::WalkBuilder;
 use vize_canon::virtual_ts::{TemplateGlobal, VirtualTsOptions};
@@ -10,6 +10,7 @@ use super::super::dts::{
     parse_declared_global_values, parse_interface_members_with_rewritten_imports,
     rewrite_relative_specifier,
 };
+use super::generated_dir::NuxtGeneratedDir;
 use super::parsing::{
     normalize_component_binding_name, parse_export_names, parse_module_specifier,
 };
@@ -17,15 +18,16 @@ use super::stubs::{push_declared_const, tracked_read_to_string};
 
 pub(super) fn collect_generated_stubs(
     cwd: &Path,
+    generated_dir: &NuxtGeneratedDir,
     stubs: &mut Vec<String>,
     seen_names: &mut FxHashSet<String>,
     external_template_bindings: &mut FxHashSet<String>,
 ) -> bool {
-    let nuxt_types_dir = cwd.join(".nuxt/types");
+    let nuxt_types_dir = generated_dir.types_dir();
     let mut found_import_manifest = false;
 
     if nuxt_types_dir.exists() {
-        let walker = WalkBuilder::new(&nuxt_types_dir)
+        let walker = WalkBuilder::new(nuxt_types_dir.as_path())
             .hidden(false)
             .standard_filters(false)
             .build();
@@ -74,14 +76,20 @@ pub(super) fn collect_generated_stubs(
         }
     }
 
-    collect_root_generated_global_stubs(cwd, stubs, seen_names);
-    collect_root_generated_component_stubs(cwd, stubs, seen_names, external_template_bindings);
+    collect_root_generated_global_stubs(cwd, generated_dir, stubs, seen_names);
+    collect_root_generated_component_stubs(
+        cwd,
+        generated_dir,
+        stubs,
+        seen_names,
+        external_template_bindings,
+    );
 
     if found_import_manifest {
         return true;
     }
 
-    let imports_path = cwd.join(".nuxt/imports.d.ts");
+    let imports_path = generated_dir.imports_path();
     if !imports_path.exists() {
         return false;
     }
@@ -133,10 +141,11 @@ pub(super) fn collect_generated_stubs(
 
 fn collect_root_generated_global_stubs(
     cwd: &Path,
+    generated_dir: &NuxtGeneratedDir,
     stubs: &mut Vec<String>,
     seen_names: &mut FxHashSet<String>,
 ) {
-    for path in root_generated_dts_files(cwd) {
+    for path in generated_dir.root_dts_files() {
         if let Ok(values) = parse_declared_global_values(path.as_path()) {
             for (name, type_annotation) in values {
                 push_generated_declared_const(
@@ -274,11 +283,12 @@ fn module_path_exists(path: &Path) -> bool {
 
 fn collect_root_generated_component_stubs(
     cwd: &Path,
+    generated_dir: &NuxtGeneratedDir,
     stubs: &mut Vec<String>,
     seen_names: &mut FxHashSet<String>,
     external_template_bindings: &mut FxHashSet<String>,
 ) {
-    for path in root_generated_dts_files(cwd) {
+    for path in generated_dir.root_dts_files() {
         collect_global_component_stubs(
             cwd,
             path.as_path(),
@@ -287,25 +297,6 @@ fn collect_root_generated_component_stubs(
             external_template_bindings,
         );
     }
-}
-
-fn root_generated_dts_files(cwd: &Path) -> Vec<std::path::PathBuf> {
-    let nuxt_dir = cwd.join(".nuxt");
-    let Ok(entries) = fs::read_dir(&nuxt_dir) else {
-        return Vec::new();
-    };
-
-    entries
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| {
-            path.is_file()
-                && path
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .is_some_and(|name| name.ends_with(".d.ts"))
-        })
-        .collect()
 }
 
 fn collect_global_component_stubs(
@@ -333,7 +324,7 @@ fn collect_global_component_stubs(
 }
 
 pub(super) fn collect_generated_template_globals(
-    cwd: &Path,
+    generated_dir: &NuxtGeneratedDir,
     options: &mut VirtualTsOptions,
     seen_auto_imports: &FxHashSet<String>,
 ) {
@@ -343,7 +334,7 @@ pub(super) fn collect_generated_template_globals(
         .map(|global| global.name.clone())
         .collect::<FxHashSet<_>>();
 
-    for path in generated_dts_files(cwd) {
+    for path in generated_dir.dts_files() {
         let Ok(members) = parse_interface_members_with_rewritten_imports(
             path.as_path(),
             "interface ComponentCustomProperties",
@@ -365,29 +356,6 @@ pub(super) fn collect_generated_template_globals(
     if seen_auto_imports.contains("useI18n") || seen_auto_imports.contains("useLocalePath") {
         collect_i18n_template_globals(options, &mut seen_globals);
     }
-}
-
-fn generated_dts_files(cwd: &Path) -> Vec<std::path::PathBuf> {
-    let mut files = root_generated_dts_files(cwd);
-    let nuxt_types_dir = cwd.join(".nuxt/types");
-    if nuxt_types_dir.exists() {
-        let walker = WalkBuilder::new(&nuxt_types_dir)
-            .hidden(false)
-            .standard_filters(false)
-            .build();
-
-        for entry in walker.flatten() {
-            let path = entry.path();
-            let is_dts = path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.ends_with(".d.ts"));
-            if path.is_file() && is_dts {
-                files.push(path.to_path_buf());
-            }
-        }
-    }
-    files
 }
 
 fn collect_i18n_template_globals(

--- a/crates/vize/src/commands/check/nuxt/generated_dir.rs
+++ b/crates/vize/src/commands/check/nuxt/generated_dir.rs
@@ -1,0 +1,217 @@
+//! Nuxt generated directory resolution.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use ignore::WalkBuilder;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Expression;
+use oxc_parser::Parser;
+use serde_json::Value;
+use vize_carton::{String, ToCompactString};
+
+use super::parsing::{
+    default_export_config_object, extract_expression, find_object_property, nuxt_config_source,
+};
+use crate::commands::check::tsconfig_inputs::parse_jsonc_value;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct NuxtGeneratedDir {
+    path: PathBuf,
+    display: String,
+}
+
+impl NuxtGeneratedDir {
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(super) fn display(&self) -> &str {
+        self.display.as_str()
+    }
+
+    pub(super) fn imports_path(&self) -> PathBuf {
+        self.path.join("imports.d.ts")
+    }
+
+    pub(super) fn tsconfig_path(&self) -> PathBuf {
+        self.path.join("tsconfig.json")
+    }
+
+    pub(super) fn types_dir(&self) -> PathBuf {
+        self.path.join("types")
+    }
+
+    pub(super) fn root_dts_files(&self) -> Vec<PathBuf> {
+        let Ok(entries) = fs::read_dir(self.path()) else {
+            return Vec::new();
+        };
+
+        entries
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.is_file()
+                    && path
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .is_some_and(|name| name.ends_with(".d.ts"))
+            })
+            .collect()
+    }
+
+    pub(super) fn dts_files(&self) -> Vec<PathBuf> {
+        let mut files = self.root_dts_files();
+        let types_dir = self.types_dir();
+        if types_dir.exists() {
+            let walker = WalkBuilder::new(types_dir.as_path())
+                .hidden(false)
+                .standard_filters(false)
+                .build();
+
+            for entry in walker.flatten() {
+                let path = entry.path();
+                let is_dts = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with(".d.ts"));
+                if path.is_file() && is_dts {
+                    files.push(path.to_path_buf());
+                }
+            }
+        }
+        files
+    }
+}
+
+pub(super) fn resolve_nuxt_generated_dir(cwd: &Path) -> NuxtGeneratedDir {
+    let path = generated_dir_from_tsconfig_imports(cwd)
+        .or_else(|| generated_dir_from_nuxt_config(cwd))
+        .unwrap_or_else(|| cwd.join(".nuxt"));
+    let path = normalize_path_lexically(&path);
+    let display = display_path(cwd, &path);
+    NuxtGeneratedDir { path, display }
+}
+
+fn generated_dir_from_tsconfig_imports(cwd: &Path) -> Option<PathBuf> {
+    let content = std::fs::read_to_string(cwd.join("tsconfig.json")).ok()?;
+    let value = parse_jsonc_value(content.as_str()).ok()?;
+    let paths = value
+        .get("compilerOptions")
+        .and_then(Value::as_object)
+        .and_then(|compiler_options| compiler_options.get("paths"))
+        .and_then(Value::as_object)?;
+
+    for key in ["#imports", "#imports/*"] {
+        let Some(targets) = paths.get(key).and_then(Value::as_array) else {
+            continue;
+        };
+        for target in targets {
+            let Some(target) = target.as_str() else {
+                continue;
+            };
+            if let Some(dir) = generated_dir_from_imports_target(cwd, target) {
+                return Some(dir);
+            }
+        }
+    }
+
+    None
+}
+
+fn generated_dir_from_imports_target(cwd: &Path, target: &str) -> Option<PathBuf> {
+    let target = target.trim();
+    if target.is_empty() {
+        return None;
+    }
+
+    let mut path = PathBuf::from(target);
+    if !path.is_absolute() {
+        path = cwd.join(path);
+    }
+
+    let file_name = path.file_name().and_then(|name| name.to_str())?;
+    let mut dir = match file_name {
+        "imports" | "imports.d.ts" => path.parent()?.to_path_buf(),
+        "*" => {
+            let parent = path.parent()?;
+            if parent.file_name().and_then(|name| name.to_str()) == Some("imports") {
+                parent.parent()?.to_path_buf()
+            } else {
+                parent.to_path_buf()
+            }
+        }
+        _ => return None,
+    };
+
+    if dir.file_name().and_then(|name| name.to_str()) == Some("types")
+        && let Some(parent) = dir.parent()
+    {
+        dir = parent.to_path_buf();
+    }
+
+    Some(dir)
+}
+
+fn generated_dir_from_nuxt_config(cwd: &Path) -> Option<PathBuf> {
+    let source = nuxt_config_source(cwd);
+    if source.is_empty() {
+        return None;
+    }
+
+    let allocator = Allocator::default();
+    let source_type = super::parsing::source_type_for_path(Path::new("nuxt.config.ts"));
+    let ret = Parser::new(&allocator, source.as_str(), source_type).parse();
+    if ret.panicked {
+        return None;
+    }
+
+    let config_object = default_export_config_object(&ret.program.body)?;
+    let build_dir =
+        find_object_property(config_object, "buildDir").and_then(static_string_value)?;
+    let path = PathBuf::from(build_dir.as_str());
+    Some(if path.is_absolute() {
+        path
+    } else {
+        cwd.join(path)
+    })
+}
+
+fn static_string_value(expression: &Expression<'_>) -> Option<String> {
+    match extract_expression(expression)? {
+        Expression::StringLiteral(literal) => Some(literal.value.as_str().to_compact_string()),
+        Expression::TemplateLiteral(template) => template
+            .single_quasi()
+            .map(|value| value.as_str().to_compact_string()),
+        _ => None,
+    }
+}
+
+pub(super) fn normalize_path_lexically(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn display_path(cwd: &Path, path: &Path) -> String {
+    let cwd = normalize_path_lexically(cwd);
+    let relative = path.strip_prefix(&cwd).unwrap_or(path);
+    let rendered = if relative.as_os_str().is_empty() {
+        "."
+    } else {
+        relative.to_str().unwrap_or_default()
+    };
+    rendered.replace('\\', "/").to_compact_string()
+}

--- a/crates/vize/src/commands/check/nuxt/mod.rs
+++ b/crates/vize/src/commands/check/nuxt/mod.rs
@@ -9,6 +9,7 @@ use vize_carton::{FxHashSet, String, ToCompactString};
 
 mod fallback;
 mod generated;
+mod generated_dir;
 mod parsing;
 mod plugins;
 mod source_scan;
@@ -20,6 +21,7 @@ mod tests;
 
 use fallback::{collect_fallback_stubs, collect_module_fallback_stubs};
 use generated::{collect_generated_stubs, collect_generated_template_globals};
+use generated_dir::resolve_nuxt_generated_dir;
 use plugins::collect_plugin_injection_stubs;
 use source_scan::{collect_source_auto_import_stubs, collect_source_type_auto_import_stubs};
 use stubs::{declared_name, is_template_component_binding};
@@ -55,16 +57,18 @@ pub(in crate::commands::check) fn detect_nuxt_auto_imports(
     }
 
     let mut collected = Vec::new();
+    let generated_dir = resolve_nuxt_generated_dir(cwd);
     let has_generated_imports = collect_generated_stubs(
         cwd,
+        &generated_dir,
         &mut collected,
         &mut seen_names,
         &mut external_template_bindings,
     );
-    // Surface the degraded fallback: without generated `.nuxt` types,
+    // Surface the degraded fallback: without generated Nuxt types,
     // auto-imports resolve to permissive `any` stubs that hide real type
     // errors. detect_nuxt_auto_imports runs once per check, so this warns once.
-    if let Some(message) = missing_generated_types_warning(has_generated_imports) {
+    if let Some(message) = missing_generated_types_warning(has_generated_imports, &generated_dir) {
         eprintln!("{message}");
     }
     collect_plugin_injection_stubs(cwd, &mut collected, &mut seen_names);
@@ -75,8 +79,8 @@ pub(in crate::commands::check) fn detect_nuxt_auto_imports(
         collect_source_type_auto_import_stubs(cwd, &mut collected);
     }
     collect_fallback_module_stubs(cwd, &mut collected);
-    let path_aliases = collect_fallback_path_aliases(cwd);
-    collect_generated_template_globals(cwd, options, &seen_names);
+    let path_aliases = collect_fallback_path_aliases(cwd, &generated_dir);
+    collect_generated_template_globals(&generated_dir, options, &seen_names);
 
     for stub in &collected {
         if let Some(name) = declared_name(stub)
@@ -100,13 +104,20 @@ fn is_nuxt_project(cwd: &Path) -> bool {
 }
 
 /// Warning shown once per `vize check` run for a Nuxt project that has no
-/// generated `.nuxt` type artifacts. Without them, auto-imports fall back to
+/// generated Nuxt type artifacts. Without them, auto-imports fall back to
 /// permissive `any` stubs that hide real type errors, so the user is told how
 /// to generate them. Returns `None` when generated types are present (the
 /// checked types are accurate and no warning is warranted).
-fn missing_generated_types_warning(has_generated_imports: bool) -> Option<&'static str> {
-    (!has_generated_imports).then_some(
-        "vize check: no generated `.nuxt` types found; Nuxt auto-imports fall back to `any` \
-         stubs and some type errors will be missed. Run `nuxi prepare` to generate them.",
-    )
+fn missing_generated_types_warning(
+    has_generated_imports: bool,
+    generated_dir: &generated_dir::NuxtGeneratedDir,
+) -> Option<String> {
+    (!has_generated_imports).then(|| {
+        format!(
+            "vize check: no generated `{}` types found; Nuxt auto-imports fall back to `any` \
+             stubs and some type errors will be missed. Run `nuxi prepare` to generate them.",
+            generated_dir.display()
+        )
+        .into()
+    })
 }

--- a/crates/vize/src/commands/check/nuxt/parsing.rs
+++ b/crates/vize/src/commands/check/nuxt/parsing.rs
@@ -3,10 +3,12 @@
 use std::path::Path;
 
 use oxc_ast::ast::{
-    Expression, ModuleExportName, ObjectExpression, ObjectPropertyKind, PropertyKey,
+    Expression, ModuleExportName, ObjectExpression, ObjectPropertyKind, PropertyKey, Statement,
 };
 use oxc_span::SourceType;
 use vize_carton::{String, ToCompactString};
+
+use super::stubs::tracked_read_to_string;
 
 pub(super) fn source_type_for_script_lang(lang: Option<&str>) -> SourceType {
     match lang {
@@ -170,6 +172,45 @@ pub(super) fn find_object_property<'a>(
             None
         }
     })
+}
+
+/// Finds the config object behind the default export, looking through the
+/// `defineNuxtConfig(...)` wrapper as well as parenthesized/`as`/`satisfies`
+/// wrappers on either form.
+pub(super) fn default_export_config_object<'a>(
+    statements: &'a [Statement<'a>],
+) -> Option<&'a ObjectExpression<'a>> {
+    let export = statements.iter().find_map(|statement| match statement {
+        Statement::ExportDefaultDeclaration(export) => Some(export),
+        _ => None,
+    })?;
+
+    if let Some(call) = extract_call_expression_from_export(&export.declaration) {
+        if !matches!(&call.callee, Expression::Identifier(callee) if callee.name == "defineNuxtConfig")
+        {
+            return None;
+        }
+        return call
+            .arguments
+            .first()
+            .and_then(|argument| argument.as_expression())
+            .and_then(extract_object_expression);
+    }
+
+    export
+        .declaration
+        .as_expression()
+        .and_then(extract_object_expression)
+}
+
+pub(super) fn nuxt_config_source(cwd: &Path) -> String {
+    for file_name in ["nuxt.config.ts", "nuxt.config.js", "nuxt.config.mts"] {
+        let path = cwd.join(file_name);
+        if let Ok(source) = tracked_read_to_string(path.as_path()) {
+            return source.into();
+        }
+    }
+    String::default()
 }
 
 pub(super) fn collect_object_keys(object: &ObjectExpression<'_>, keys: &mut Vec<String>) {

--- a/crates/vize/src/commands/check/nuxt/tests.rs
+++ b/crates/vize/src/commands/check/nuxt/tests.rs
@@ -10,19 +10,11 @@ use vize_carton::cstr;
 use super::super::dts::rewrite_relative_specifier;
 use super::detect_nuxt_auto_imports;
 use super::fallback::{fallback_stub_strings, parse_nuxt_config_modules};
-use super::missing_generated_types_warning;
 use super::parsing::{parse_export_names, parse_module_specifier};
 use super::plugins::extract_plugin_provide_keys_from_source;
 use super::stubs::declared_name;
 
-#[test]
-fn warns_only_when_generated_nuxt_types_are_missing() {
-    assert!(missing_generated_types_warning(true).is_none());
-    let message =
-        missing_generated_types_warning(false).expect("missing generated types must warn");
-    assert!(message.contains("nuxi prepare"));
-    assert!(message.contains("`any`"));
-}
+mod build_dir;
 
 #[test]
 fn parses_module_export_lines() {

--- a/crates/vize/src/commands/check/nuxt/tests/build_dir.rs
+++ b/crates/vize/src/commands/check/nuxt/tests/build_dir.rs
@@ -1,0 +1,177 @@
+use std::path::Path;
+
+use vize_canon::virtual_ts::VirtualTsOptions;
+
+use super::super::detect_nuxt_auto_imports;
+use super::super::generated_dir::resolve_nuxt_generated_dir;
+use super::super::missing_generated_types_warning;
+use super::unique_case_dir;
+
+#[test]
+fn warns_only_when_generated_nuxt_types_are_missing() {
+    let generated_dir = resolve_nuxt_generated_dir(Path::new("/workspace"));
+    assert!(missing_generated_types_warning(true, &generated_dir).is_none());
+    let message = missing_generated_types_warning(false, &generated_dir)
+        .expect("missing generated types must warn");
+    assert!(message.contains("nuxi prepare"));
+    assert!(message.contains("`.nuxt`"));
+    assert!(message.contains("`any`"));
+}
+
+#[test]
+fn detects_generated_imports_from_nuxt_config_build_dir() {
+    let project_root = unique_case_dir("nuxt-config-build-dir-imports");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join(".out/.nuxt/types")).unwrap();
+    std::fs::write(
+        project_root.join("nuxt.config.ts"),
+        r#"export default defineNuxtConfig({ buildDir: ".out/.nuxt" })"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join(".out/.nuxt/types/imports.d.ts"),
+        r#"declare global {
+  const useCustomBuildDir: () => string
+}
+export {}
+"#,
+    )
+    .unwrap();
+
+    let mut options = VirtualTsOptions::default();
+    let _ = detect_nuxt_auto_imports(&mut options, &project_root);
+
+    assert!(
+        options
+            .auto_import_stubs
+            .iter()
+            .any(|stub| stub.as_str() == "declare const useCustomBuildDir: () => string;"),
+        "expected generated import from custom buildDir, got: {:#?}",
+        options.auto_import_stubs
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn detects_generated_imports_from_tsconfig_imports_path() {
+    let project_root = unique_case_dir("nuxt-tsconfig-imports-path");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join(".out/.nuxt")).unwrap();
+    std::fs::write(project_root.join("nuxt.config.ts"), "export default {}").unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r##"{
+  "compilerOptions": {
+    "paths": {
+      "#imports": [".out/.nuxt/imports"]
+    }
+  }
+}
+"##,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join(".out/.nuxt/imports.d.ts"),
+        r#"declare global {
+  const useImportsPathDir: () => number
+}
+export {}
+"#,
+    )
+    .unwrap();
+
+    let mut options = VirtualTsOptions::default();
+    let _ = detect_nuxt_auto_imports(&mut options, &project_root);
+
+    assert!(
+        options
+            .auto_import_stubs
+            .iter()
+            .any(|stub| stub.as_str() == "declare const useImportsPathDir: () => number;"),
+        "expected generated import from tsconfig #imports path, got: {:#?}",
+        options.auto_import_stubs
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn warning_mentions_resolved_generated_dir() {
+    let project_root = unique_case_dir("nuxt-warning-custom-build-dir");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    std::fs::write(
+        project_root.join("nuxt.config.ts"),
+        r#"export default { buildDir: ".out/.nuxt" }"#,
+    )
+    .unwrap();
+
+    let generated_dir = resolve_nuxt_generated_dir(&project_root);
+    let message = missing_generated_types_warning(false, &generated_dir)
+        .expect("missing generated types must warn");
+
+    assert!(message.contains("`.out/.nuxt`"), "{message}");
+    assert!(!message.contains("`.nuxt` types"), "{message}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn path_aliases_come_from_custom_generated_nuxt_tsconfig_when_present() {
+    let project_root = unique_case_dir("nuxt-custom-generated-tsconfig-aliases");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join(".out/.nuxt")).unwrap();
+    std::fs::create_dir_all(project_root.join("app")).unwrap();
+    std::fs::write(
+        project_root.join("nuxt.config.ts"),
+        r#"export default { buildDir: ".out/.nuxt" }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join(".out/.nuxt/tsconfig.json"),
+        r##"{
+  "compilerOptions": {
+    "paths": {
+      "~/*": ["../../app/*"],
+      "@features/*": ["../../app/features/*"]
+    }
+  }
+}
+"##,
+    )
+    .unwrap();
+
+    let mut options = VirtualTsOptions::default();
+    let aliases = detect_nuxt_auto_imports(&mut options, &project_root);
+
+    assert!(
+        aliases.iter().any(|alias| {
+            alias.pattern.as_str() == "~/*"
+                && alias
+                    .targets
+                    .iter()
+                    .any(|target| target.as_str() == "app/*")
+        }),
+        "expected rebased ~/* alias, got: {aliases:#?}"
+    );
+    assert!(
+        aliases.iter().any(|alias| {
+            alias.pattern.as_str() == "@features/*"
+                && alias
+                    .targets
+                    .iter()
+                    .any(|target| target.as_str() == "app/features/*")
+        }),
+        "expected custom @features/* alias from generated tsconfig, got: {aliases:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn default_generated_dir_remains_dot_nuxt() {
+    let generated_dir = resolve_nuxt_generated_dir(Path::new("/workspace"));
+
+    assert_eq!(generated_dir.display(), ".nuxt");
+}

--- a/crates/vize/src/commands/check/nuxt/virtual_modules.rs
+++ b/crates/vize/src/commands/check/nuxt/virtual_modules.rs
@@ -12,6 +12,7 @@ use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
 use vize_carton::{FxHashMap, FxHashSet, String, ToCompactString, append, cstr};
 
 use super::NuxtPathAlias;
+use super::generated_dir::{NuxtGeneratedDir, normalize_path_lexically};
 use super::parsing::{is_ts_identifier, source_type_for_path, source_type_for_script_lang};
 use super::stubs::tracked_read_to_string;
 use crate::commands::check::tsconfig_inputs::parse_jsonc_value;
@@ -31,12 +32,15 @@ pub(super) fn collect_fallback_module_stubs(cwd: &Path, stubs: &mut Vec<String>)
     }
 }
 
-pub(super) fn collect_fallback_path_aliases(cwd: &Path) -> Vec<NuxtPathAlias> {
+pub(super) fn collect_fallback_path_aliases(
+    cwd: &Path,
+    generated_dir: &NuxtGeneratedDir,
+) -> Vec<NuxtPathAlias> {
     // Nuxt's own `nuxi prepare` writes the project's REAL `compilerOptions.paths`
-    // into `.nuxt/tsconfig.json`. When present, consume those generated aliases
+    // into the generated `tsconfig.json`. When present, consume those aliases
     // verbatim instead of guessing, so user-configured aliases (e.g. custom
     // `srcDir`, extra `alias` entries) are honoured.
-    if let Some(aliases) = collect_generated_path_aliases(cwd)
+    if let Some(aliases) = collect_generated_path_aliases(cwd, generated_dir)
         && !aliases.is_empty()
     {
         return aliases;
@@ -45,14 +49,17 @@ pub(super) fn collect_fallback_path_aliases(cwd: &Path) -> Vec<NuxtPathAlias> {
     collect_guessed_path_aliases(cwd)
 }
 
-/// Parse `.nuxt/tsconfig.json` (JSON-with-comments) and lift its
+/// Parse generated `tsconfig.json` (JSON-with-comments) and lift its
 /// `compilerOptions.paths` into [`NuxtPathAlias`]es. Targets in the generated
-/// config are relative to `.nuxt/`, so they are rebased to be relative to the
-/// project root (`cwd`) to match how downstream `tsconfig` synthesis interprets
-/// alias targets. Returns `None` when the file is absent or unparseable so the
+/// config are relative to the generated dir, so they are rebased to be relative
+/// to the project root (`cwd`) to match how downstream `tsconfig` synthesis
+/// interprets alias targets. Returns `None` when the file is absent or unparseable so the
 /// caller can fall back to the hardcoded guesses.
-fn collect_generated_path_aliases(cwd: &Path) -> Option<Vec<NuxtPathAlias>> {
-    let tsconfig_path = cwd.join(".nuxt/tsconfig.json");
+fn collect_generated_path_aliases(
+    cwd: &Path,
+    generated_dir: &NuxtGeneratedDir,
+) -> Option<Vec<NuxtPathAlias>> {
+    let tsconfig_path = generated_dir.tsconfig_path();
     let content = tracked_read_to_string(&tsconfig_path).ok()?;
     let value = parse_jsonc_value(content.as_str()).ok()?;
 
@@ -62,7 +69,6 @@ fn collect_generated_path_aliases(cwd: &Path) -> Option<Vec<NuxtPathAlias>> {
         .and_then(|compiler_options| compiler_options.get("paths"))
         .and_then(Value::as_object)?;
 
-    let nuxt_dir = tsconfig_path.parent().unwrap_or(cwd);
     let mut aliases: Vec<NuxtPathAlias> = Vec::new();
     for (pattern, targets) in paths {
         let Some(targets) = targets.as_array() else {
@@ -71,7 +77,7 @@ fn collect_generated_path_aliases(cwd: &Path) -> Option<Vec<NuxtPathAlias>> {
         let targets: Vec<String> = targets
             .iter()
             .filter_map(Value::as_str)
-            .map(|target| rebase_generated_target(nuxt_dir, cwd, target))
+            .map(|target| rebase_generated_target(generated_dir.path(), cwd, target))
             .collect();
         if targets.is_empty() {
             continue;
@@ -90,7 +96,7 @@ fn collect_generated_path_aliases(cwd: &Path) -> Option<Vec<NuxtPathAlias>> {
     Some(aliases)
 }
 
-/// Rebase a `.nuxt/tsconfig.json` path target (relative to `.nuxt/`) to be
+/// Rebase a generated `tsconfig.json` path target (relative to generated dir) to be
 /// relative to the project root, lexically. Absolute targets and non-prefixed
 /// targets that escape the root are returned normalized but unchanged in shape.
 fn rebase_generated_target(nuxt_dir: &Path, project_root: &Path, target: &str) -> String {
@@ -106,22 +112,6 @@ fn rebase_generated_target(nuxt_dir: &Path, project_root: &Path, target: &str) -
         _ => absolute.to_string_lossy(),
     };
     rebased.replace('\\', "/").to_compact_string()
-}
-
-fn normalize_path_lexically(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                if !normalized.pop() {
-                    normalized.push(component.as_os_str());
-                }
-            }
-            _ => normalized.push(component.as_os_str()),
-        }
-    }
-    normalized
 }
 
 fn collect_guessed_path_aliases(cwd: &Path) -> Vec<NuxtPathAlias> {


### PR DESCRIPTION
## Summary
- resolve Nuxt generated type directories from root `tsconfig.json` `#imports` paths or static `nuxt.config` `buildDir` before falling back to `.nuxt`
- use the resolved generated dir for import stubs, template globals, generated path aliases, and missing-types warnings
- cover custom `buildDir`, `#imports` path detection, warning text, and generated tsconfig alias rebasing

Closes #1898

## Verification
- `cargo fmt --check && cargo test -p vize commands::check::nuxt::tests -- --nocapture`
- `cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->