### PR TITLE
fix(musea): avoid broad dev watcher roots

### DIFF
--- a/npm/vite-plugin-musea/src/plugin/index.ts
+++ b/npm/vite-plugin-musea/src/plugin/index.ts
@@ -39,6 +39,7 @@ import {
   type VirtualModuleState,
 } from "./virtual.js";
 import { shouldApplyMuseaPlugin } from "./apply.js";
+import { watchMuseaArtFiles } from "./watch.js";
 
 function extractArtTagAttributes(source: string): Record<string, string | true> {
   const artTagMatch = source.match(/<art\b([\s\S]*?)>/i);
@@ -205,7 +206,6 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
 
     configureServer(devServer) {
       server = devServer;
-      devServer.watcher.add(scanRoots);
 
       // Register gallery SPA, preview, and art module middleware
       registerMiddleware(devServer, {
@@ -310,8 +310,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
       console.log(`[musea] Found ${files.length} art files`);
 
       if (server) {
-        server.watcher.add(scanRoots);
-        server.watcher.add(files);
+        watchMuseaArtFiles(server.watcher, files);
       }
 
       for (const file of files) {

--- a/npm/vite-plugin-musea/src/plugin/watch.test.ts
+++ b/npm/vite-plugin-musea/src/plugin/watch.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveScanRoots } from "../utils.ts";
+import { createMuseaWatchTargets, watchMuseaArtFiles } from "./watch.ts";
+
+void test("musea dev watcher targets discovered art files instead of scan roots", () => {
+  const root = "/workspace/apps/docs";
+  const externalRoot = "/workspace/apps/design";
+  const include = ["**/*.art.vue", "../design/**/*.art.vue"];
+  const scanRoots = resolveScanRoots(root, include);
+  const files = [
+    path.join(root, "components", "Button.art.vue"),
+    path.join(externalRoot, "Card.art.vue"),
+  ];
+
+  assert.deepEqual(scanRoots, [root, externalRoot]);
+  const targets = createMuseaWatchTargets(files);
+  assert.deepEqual(targets, files);
+  assert.equal(targets.includes(root), false);
+  assert.equal(targets.includes(externalRoot), false);
+});
+
+void test("musea dev watcher adds unique discovered files once", () => {
+  const calls: string[][] = [];
+  const file = "/workspace/apps/docs/components/Button.art.vue";
+
+  watchMuseaArtFiles(
+    {
+      add(paths) {
+        calls.push(Array.isArray(paths) ? paths : [paths]);
+        return this;
+      },
+    },
+    [file, file],
+  );
+
+  assert.deepEqual(calls, [[file]]);
+});
+
+void test("musea dev watcher skips empty file lists", () => {
+  const calls: string[][] = [];
+
+  watchMuseaArtFiles(
+    {
+      add(paths) {
+        calls.push(Array.isArray(paths) ? paths : [paths]);
+        return this;
+      },
+    },
+    [],
+  );
+
+  assert.deepEqual(calls, []);
+});

--- a/npm/vite-plugin-musea/src/plugin/watch.ts
+++ b/npm/vite-plugin-musea/src/plugin/watch.ts
@@ -1,0 +1,16 @@
+import type { ViteDevServer } from "vite";
+
+type DevWatcher = Pick<ViteDevServer["watcher"], "add">;
+
+export function createMuseaWatchTargets(files: readonly string[]): string[] {
+  return [...new Set(files)];
+}
+
+export function watchMuseaArtFiles(watcher: DevWatcher, files: readonly string[]): void {
+  const targets = createMuseaWatchTargets(files);
+  if (targets.length === 0) {
+    return;
+  }
+
+  watcher.add(targets);
+}


### PR DESCRIPTION
## Summary
- Stop registering resolved Musea scan roots with the Vite dev watcher
- Watch only discovered art files after the initial scan
- Add regression tests for broad include patterns resolving to root-level scan roots

## Root cause
Musea added broad resolved scan roots like the Vite root and ../design to chokidar. With native watchers this could recursively watch generated or ignored directories and hit EMFILE during Nuxt dev startup.

## Verification
- pnpm --filter @vizejs/vite-plugin-musea test
- pnpm --filter @vizejs/vite-plugin-musea check
- pnpm --filter @vizejs/vite-plugin-musea build
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Closes #1899

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->