### PR TITLE
fix(check): infer generic component listener payloads

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -8,8 +8,8 @@ use corsa::{
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use vize_carton::{String, cstr};
-
 mod emit_object_recursion;
+mod generic_component_listener_payload;
 
 #[test]
 fn test_batch_type_checker_scan() {

--- a/crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload.rs
@@ -1,0 +1,85 @@
+use super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
+
+#[test]
+fn batch_type_checker_infers_generic_component_listener_payload_from_props() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "generic-component-listener-payload",
+        &[
+            (
+                "src/Form.vue",
+                r#"<script setup lang="ts" generic="FormShape extends object">
+export interface FormSubmitEvent<FormShape extends object> {
+  data: FormShape
+}
+
+export interface FormEmits<FormShape extends object> {
+  (e: "submit", payload: FormSubmitEvent<FormShape>): void
+  (e: "reset"): void
+}
+
+defineProps<{
+  initialState: FormShape
+}>()
+
+defineEmits<FormEmits<FormShape>>()
+</script>
+
+<template>
+  <form />
+</template>
+"#,
+            ),
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+import Form, { type FormSubmitEvent } from './Form.vue'
+
+function login(payload: FormSubmitEvent<{ username: string; password: string }>) {
+  payload.data.username.toUpperCase()
+  payload.data.password.toUpperCase()
+}
+
+function wrong(payload: FormSubmitEvent<{ username: number; password: string }>) {
+  payload.data.username.toFixed()
+}
+</script>
+
+<template>
+  <Form
+    :initial-state="{ username: '', password: '' }"
+    @submit="login"
+    @reset="() => undefined"
+  />
+  <Form
+    :initial-state="{ username: '', password: '' }"
+    @submit="wrong"
+  />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot
+            .iter()
+            .all(|(file, _, message)| !(file == "src/App.vue" && message.contains("login"))),
+        "compatible generic component listener should not report diagnostics, got: {snapshot:#?}"
+    );
+    assert!(
+        snapshot.iter().any(|(file, code, message)| {
+            file == "src/App.vue" && *code == Some(2345) && message.contains("username: number")
+        }),
+        "incompatible generic component listener should still report TS2345, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_generic_component.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_generic_component.snap
@@ -132,7 +132,7 @@ function __setup<T extends string | number>() {
 // Invoke setup to verify types
 __setup();
 
-export type Emits = {
+export type Emits<T extends string | number = any> = {
   (e: 'select', item: T): void
 };
 export type Slots = {};
@@ -179,5 +179,5 @@ type __VizeVueComponentOptions = {
   __isKeepAlive?: boolean;
   __isBuiltIn?: boolean;
 };
-declare const __vize_component__: __VizeComponentConstructor & __VizeVueComponentOptions & { __vizeCheck: <T extends string | number = any>(props: Partial<Props<T>> & Record<string, unknown>) => void; __vizeEmitProps?: __VizeStaticEmitProps; };
+declare const __vize_component__: __VizeComponentConstructor & __VizeVueComponentOptions & { __vizeCheck: <T extends string | number = any>(props: Partial<Props<T>> & Record<string, unknown>) => void; __vizeEmitProps?: __VizeStaticEmitProps; __vizeResolveEmitProps?: <T extends string | number = any>(props: Partial<Props<T>> & Record<string, unknown>) => __EmitProps<Emits<T>>; };
 export default __vize_component__;

--- a/crates/vize_canon/src/virtual_ts/generator/emits.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/emits.rs
@@ -1,0 +1,155 @@
+use vize_carton::{FxHashSet, String, append, cstr};
+use vize_croquis::Croquis;
+
+use crate::virtual_ts::{
+    helpers::{EMIT_OVERLOAD_HELPERS, EMIT_PROPS_HELPER},
+    props::{add_generic_defaults, strip_const_modifiers},
+};
+
+pub(super) struct EmitsInfo {
+    pub(super) has_emits_for_props: bool,
+    has_runtime_emits: bool,
+    has_generic_emits: bool,
+}
+
+impl EmitsInfo {
+    pub(super) fn static_emit_props_field(&self) -> &'static str {
+        if self.has_emits_for_props {
+            "__vizeEmitProps?: __VizeStaticEmitProps;"
+        } else {
+            ""
+        }
+    }
+
+    pub(super) fn generic_emit_props_resolver_field(
+        &self,
+        generic_decl: &str,
+        generic_names: &str,
+    ) -> String {
+        let mut field = String::default();
+        if self.has_emits_for_props && self.has_generic_emits {
+            append!(
+                field,
+                "__vizeResolveEmitProps?: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => __EmitProps<Emits<{generic_names}>>;"
+            );
+        }
+        field
+    }
+}
+
+pub(super) fn emit_emits_type(
+    ts: &mut String,
+    summary: &Croquis,
+    generic_param: Option<&str>,
+    has_runtime_emits: bool,
+) -> EmitsInfo {
+    let emits_already_defined = summary
+        .type_exports
+        .iter()
+        .any(|te| te.name.as_str() == "Emits");
+    let define_emits_type_args = summary
+        .macros
+        .define_emits()
+        .and_then(|call| call.type_args.as_ref());
+    let models = summary.macros.models();
+    let has_model_emits = !models.is_empty();
+    let has_macro_emits = !summary.macros.emits().is_empty();
+    let has_emits_for_props = emits_already_defined
+        || define_emits_type_args.is_some()
+        || has_runtime_emits
+        || has_macro_emits
+        || has_model_emits;
+    let emits_generic_decl = generic_param
+        .filter(|_| !emits_already_defined)
+        .filter(|_| define_emits_type_args.is_some() || has_macro_emits || has_model_emits)
+        .map(|generic| strip_const_modifiers(&add_generic_defaults(generic)));
+    let emits_generic_suffix = emits_generic_decl
+        .as_ref()
+        .map(|generic| cstr!("<{generic}>"))
+        .unwrap_or_default();
+
+    if !emits_already_defined {
+        if let Some(type_args) = define_emits_type_args {
+            let inner_type = type_args
+                .strip_prefix('<')
+                .and_then(|s| s.strip_suffix('>'))
+                .unwrap_or(type_args.as_str());
+            if has_model_emits {
+                append!(
+                    *ts,
+                    "export type Emits{emits_generic_suffix} = {inner_type} & {{\n"
+                );
+                for model in models {
+                    let name = model.name.as_str();
+                    let payload = model.model_type.as_deref().unwrap_or("unknown");
+                    append!(*ts, "  \"update:{name}\": [value: {payload}];\n");
+                }
+                ts.push_str("};\n");
+            } else {
+                append!(
+                    *ts,
+                    "export type Emits{emits_generic_suffix} = {inner_type};\n"
+                );
+            }
+        } else if has_runtime_emits {
+            append!(
+                *ts,
+                "export type Emits{emits_generic_suffix} = Awaited<ReturnType<typeof __setup>>[\"__vize_emits\"]",
+            );
+            for model in models {
+                let name = model.name.as_str();
+                let payload = model.model_type.as_deref().unwrap_or("unknown");
+                append!(
+                    *ts,
+                    " & ((event: \"update:{name}\", value: {payload}) => void)"
+                );
+            }
+            ts.push_str(";\n");
+        } else if has_macro_emits || has_model_emits {
+            append!(*ts, "export type Emits{emits_generic_suffix} = {{\n");
+            let mut emitted_names: FxHashSet<String> = FxHashSet::default();
+            for emit in summary.macros.emits() {
+                let payload = emit.payload_type.as_deref().unwrap_or("any[]");
+                append!(*ts, "  \"{}\": {payload};\n", emit.name);
+                emitted_names.insert(emit.name.as_str().into());
+            }
+            for model in models {
+                let event_name = cstr!("update:{}", model.name);
+                if emitted_names.contains(event_name.as_str()) {
+                    continue;
+                }
+                let payload = model.model_type.as_deref().unwrap_or("unknown");
+                append!(*ts, "  \"{event_name}\": [value: {payload}];\n");
+            }
+            ts.push_str("};\n");
+        } else {
+            ts.push_str("export type Emits = {};\n");
+        }
+    }
+
+    EmitsInfo {
+        has_emits_for_props,
+        has_runtime_emits,
+        has_generic_emits: emits_generic_decl.is_some(),
+    }
+}
+
+pub(super) fn emit_emit_props_helper(
+    ts: &mut String,
+    info: &EmitsInfo,
+    hoist_shared_preamble: bool,
+) {
+    if !info.has_emits_for_props {
+        return;
+    }
+    if !hoist_shared_preamble {
+        ts.push_str(EMIT_OVERLOAD_HELPERS);
+    }
+    ts.push_str(EMIT_PROPS_HELPER);
+    ts.push('\n');
+    if info.has_runtime_emits {
+        ts.push_str("type __VizeStaticEmitProps = __EmitProps<Awaited<ReturnType<typeof __setup>>[\"__vize_emit_options\"]>;\n\n");
+    } else {
+        ts.push_str("type __VizeStaticEmitProps = __EmitProps<Emits>;\n\n");
+    }
+}

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -1,3 +1,4 @@
+mod emits;
 mod generics;
 mod imports;
 mod options_api;
@@ -7,6 +8,7 @@ mod spans;
 
 use vize_croquis::{BindingType, Croquis, ScopeData, ScopeKind};
 
+use self::emits::{emit_emit_props_helper, emit_emits_type};
 use self::generics::{generic_injection_point, references_any_identifier};
 use self::imports::{
     collect_imported_names, emit_global_component_stubs, emit_reference_type_directives,
@@ -23,9 +25,8 @@ use self::spans::{
 };
 use super::{
     helpers::{
-        EMIT_OVERLOAD_HELPERS, EMIT_PROPS_HELPER, IMPORT_META_AUGMENTATION,
-        SETUP_SCOPE_HELPER_NAMES, VUE_SETUP_HELPERS, VUE_SETUP_HELPERS_HOISTED, VUE_TYPE_HELPERS,
-        generate_template_context, to_safe_identifier,
+        IMPORT_META_AUGMENTATION, SETUP_SCOPE_HELPER_NAMES, VUE_SETUP_HELPERS,
+        VUE_SETUP_HELPERS_HOISTED, VUE_TYPE_HELPERS, generate_template_context, to_safe_identifier,
     },
     props::{
         OptionsApiPropsSource, add_generic_defaults, collect_template_prop_names,
@@ -1023,73 +1024,12 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
 
     setup_props_plan.emit_module_export(&mut ts, options_api_props.as_ref());
 
-    // Emits type
-    let emits_already_defined = summary
-        .type_exports
-        .iter()
-        .any(|te| te.name.as_str() == "Emits");
-    let define_emits_type_args = summary
-        .macros
-        .define_emits()
-        .and_then(|call| call.type_args.as_ref());
-    let models = summary.macros.models();
-    let has_model_emits = !models.is_empty();
-    let has_emits_for_props = emits_already_defined
-        || define_emits_type_args.is_some()
-        || define_emits_runtime_args.is_some()
-        || !summary.macros.emits().is_empty()
-        || has_model_emits;
-    if !emits_already_defined {
-        if let Some(type_args) = define_emits_type_args {
-            let inner_type = type_args
-                .strip_prefix('<')
-                .and_then(|s| s.strip_suffix('>'))
-                .unwrap_or(type_args.as_str());
-            if has_model_emits {
-                append!(ts, "export type Emits = {inner_type} & {{\n");
-                for model in models {
-                    let name = model.name.as_str();
-                    let payload = model.model_type.as_deref().unwrap_or("unknown");
-                    append!(ts, "  \"update:{name}\": [value: {payload}];\n");
-                }
-                ts.push_str("};\n");
-            } else {
-                append!(ts, "export type Emits = {inner_type};\n");
-            }
-        } else if define_emits_runtime_args.is_some() {
-            ts.push_str(
-                "export type Emits = Awaited<ReturnType<typeof __setup>>[\"__vize_emits\"]",
-            );
-            for model in models {
-                let name = model.name.as_str();
-                let payload = model.model_type.as_deref().unwrap_or("unknown");
-                append!(
-                    ts,
-                    " & ((event: \"update:{name}\", value: {payload}) => void)"
-                );
-            }
-            ts.push_str(";\n");
-        } else if !summary.macros.emits().is_empty() || has_model_emits {
-            ts.push_str("export type Emits = {\n");
-            let mut emitted_names: FxHashSet<String> = FxHashSet::default();
-            for emit in summary.macros.emits() {
-                let payload = emit.payload_type.as_deref().unwrap_or("any[]");
-                append!(ts, "  \"{}\": {payload};\n", emit.name);
-                emitted_names.insert(emit.name.as_str().into());
-            }
-            for model in models {
-                let event_name = cstr!("update:{}", model.name);
-                if emitted_names.contains(event_name.as_str()) {
-                    continue;
-                }
-                let payload = model.model_type.as_deref().unwrap_or("unknown");
-                append!(ts, "  \"{event_name}\": [value: {payload}];\n");
-            }
-            ts.push_str("};\n");
-        } else {
-            ts.push_str("export type Emits = {};\n");
-        }
-    }
+    let emits_info = emit_emits_type(
+        &mut ts,
+        summary,
+        generic_param,
+        define_emits_runtime_args.is_some(),
+    );
 
     // Slots type
     let slots_type_args = summary
@@ -1128,28 +1068,12 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     }
     ts.push('\n');
 
-    if has_emits_for_props {
-        // The overload helpers are file-independent; in hoisted mode the one
-        // copy in the ambient helpers file serves the whole program. The
-        // `__EmitProps` alias stays per-file in both modes: it dereferences
-        // `import('vue').EmitsToProps` (Vue >= 3.3 only), so it must remain
-        // scoped to components that actually declare emits.
-        if !hoist_shared_preamble {
-            ts.push_str(EMIT_OVERLOAD_HELPERS);
-        }
-        ts.push_str(EMIT_PROPS_HELPER);
-        ts.push('\n');
-        if define_emits_runtime_args.is_some() {
-            ts.push_str("type __VizeStaticEmitProps = __EmitProps<Awaited<ReturnType<typeof __setup>>[\"__vize_emit_options\"]>;\n\n");
-        } else {
-            ts.push_str("type __VizeStaticEmitProps = __EmitProps<Emits>;\n\n");
-        }
-    }
+    emit_emit_props_helper(&mut ts, &emits_info, hoist_shared_preamble);
 
     // Default export
     ts.push_str("// ========== Default Export ==========\n");
     ts.push_str("type __VizeComponentInstance = {\n");
-    setup_props_plan.emit_component_props_field(&mut ts, has_emits_for_props);
+    setup_props_plan.emit_component_props_field(&mut ts, emits_info.has_emits_for_props);
     ts.push_str("  $emit: __EmitFn<Emits>;\n");
     ts.push_str("  $slots: Slots;\n");
     if has_exposed_type {
@@ -1191,19 +1115,22 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     // the default export so the parent can invoke it with the assembled props
     // object and let TypeScript infer `T` from the call (see #775). Non-generic
     // components keep the plain construct signature unchanged.
-    let emit_props_static = if has_emits_for_props {
-        "__vizeEmitProps?: __VizeStaticEmitProps;"
-    } else {
-        ""
-    };
+    let emit_props_static = emits_info.static_emit_props_field();
     if let Some(generic) = setup_props_plan.generic_param(generic_param) {
         let generic_decl = add_generic_defaults(generic);
         let generic_names = extract_generic_names(generic);
+        let emit_props_resolver =
+            emits_info.generic_emit_props_resolver_field(&generic_decl, generic_names.as_str());
+        let emit_props_separator = if emit_props_resolver.is_empty() {
+            ""
+        } else {
+            " "
+        };
         append!(
             ts,
-            "declare const __vize_component__: __VizeComponentConstructor & __VizeVueComponentOptions & {{ __vizeCheck: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => void; {emit_props_static} }};\n",
+            "declare const __vize_component__: __VizeComponentConstructor & __VizeVueComponentOptions & {{ __vizeCheck: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => void; {emit_props_static}{emit_props_separator}{emit_props_resolver} }};\n",
         );
-    } else if has_emits_for_props {
+    } else if emits_info.has_emits_for_props {
         append!(
             ts,
             "declare const __vize_component__: __VizeComponentConstructor & __VizeVueComponentOptions & {{ {emit_props_static} }};\n",

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -8,14 +8,13 @@ use vize_carton::append;
 use vize_carton::cstr;
 use vize_carton::profile;
 
-use vize_croquis::{Croquis, Scope, ScopeData, ScopeId, ScopeKind, naming::to_pascal_case};
+use vize_croquis::{Croquis, Scope, ScopeData, ScopeId, ScopeKind};
 
 use crate::virtual_ts::expressions::generate_expressions;
-use crate::virtual_ts::helpers::{
-    get_dom_event_type, to_safe_identifier, to_safe_identifier_fragment,
-};
+use crate::virtual_ts::helpers::{get_dom_event_type, to_safe_identifier_fragment};
 use crate::virtual_ts::types::VizeMapping;
 
+use super::component_events::generate_component_event_types;
 use super::component_props::generate_component_props;
 use super::context::{
     ComponentPropsContext, EventHandlerExprContext, ScopeGenContext, ScopeGenerationOptions,
@@ -348,70 +347,20 @@ fn generate_scope_node(
         ScopeData::EventHandler(data) if ctx.check_options.check_emits => {
             append!(*ts, "\n{indent}// @{} handler\n", data.event_name);
 
-            let safe_event_name = to_safe_identifier(data.event_name.as_str());
-
-            if let Some(ref component_name) = data.target_component {
-                let component_ref = to_safe_identifier(component_name.as_str());
-                let component_type_name = to_safe_identifier_fragment(component_name.as_str());
-                let pascal_event = to_pascal_case(data.event_name.as_str());
-                let on_handler = cstr!("on{pascal_event}");
-
-                let prop_key = if on_handler.contains(':') {
-                    cstr!("\"{}\"", on_handler.as_str())
-                } else {
-                    on_handler
-                };
-
-                // Type alias (block-scoped in TypeScript)
-                // Include scope_id to deduplicate when same component+event appears multiple times
-                append!(
-                    *ts,
-                    "{indent}type __{component_type_name}_{scope_id}_{safe_event_name}_prop_args = typeof {component_ref} extends {{ new (): {{ $props: infer __P }} }}\n",
-                );
-                append!(
-                    *ts,
-                    "{indent}  ? __P extends {{ {prop_key}?: (...args: infer __A) => any }} ? __A : unknown[]\n",
-                );
-                append!(
-                    *ts,
-                    "{indent}  : typeof {component_ref} extends (props: infer __P) => any\n",
-                );
-                append!(
-                    *ts,
-                    "{indent}    ? __P extends {{ {prop_key}?: (...args: infer __A) => any }} ? __A : unknown[]\n",
-                );
-                append!(*ts, "{indent}    : unknown[];\n");
-                append!(
-                    *ts,
-                    "{indent}type __{component_type_name}_{scope_id}_{safe_event_name}_emit_args = typeof {component_ref} extends {{ __vizeEmitProps?: infer __EP }}\n",
-                );
-                append!(
-                    *ts,
-                    "{indent}  ? __EP extends {{ {prop_key}?: (...args: infer __A) => any }} ? __A : unknown[]\n",
-                );
-                append!(*ts, "{indent}  : unknown[];\n");
-                append!(
-                    *ts,
-                    "{indent}type __{component_type_name}_{scope_id}_{safe_event_name}_args = unknown[] extends __{component_type_name}_{scope_id}_{safe_event_name}_prop_args ? __{component_type_name}_{scope_id}_{safe_event_name}_emit_args : __{component_type_name}_{scope_id}_{safe_event_name}_prop_args;\n",
-                );
-                if ctx.template_syntax_quirks {
-                    let fallback_event = get_dom_event_type(data.event_name.as_str());
-                    append!(
-                        *ts,
-                        "{indent}type __{component_type_name}_{scope_id}_{safe_event_name}_event = __{component_type_name}_{scope_id}_{safe_event_name}_args extends [] ? any : unknown[] extends __{component_type_name}_{scope_id}_{safe_event_name}_args ? {fallback_event} : __{component_type_name}_{scope_id}_{safe_event_name}_args[0];\n",
-                    );
-                } else {
-                    append!(
-                        *ts,
-                        "{indent}type __{component_type_name}_{scope_id}_{safe_event_name}_event = __{component_type_name}_{scope_id}_{safe_event_name}_args extends [] ? any : __{component_type_name}_{scope_id}_{safe_event_name}_args[0];\n",
-                    );
-                }
-
-                let event_type =
-                    cstr!("__{component_type_name}_{scope_id}_{safe_event_name}_event");
-                let args_type = cstr!("__{component_type_name}_{scope_id}_{safe_event_name}_args");
-                let listener_type =
-                    cstr!("__{component_type_name}_{scope_id}_{safe_event_name}_listener");
+            if data.target_component.is_some() {
+                let event_types = generate_component_event_types(
+                    ts,
+                    ctx.summary,
+                    data,
+                    scope,
+                    ctx.template_prop_names,
+                    ctx.template_syntax_quirks,
+                    indent,
+                )
+                .expect("component event handler should have a target component");
+                let event_type = event_types.event_type;
+                let args_type = event_types.args_type;
+                let listener_type = event_types.listener_type;
                 // Type the listener against the FULL emit argument tuple so
                 // multi-arg emits keep every parameter (#1512). When the emit
                 // signature stays unresolved (`unknown[]`, e.g. a fallthrough

--- a/crates/vize_canon/src/virtual_ts/scope/component_events.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events.rs
@@ -1,0 +1,281 @@
+//! Component event listener type generation.
+
+use vize_carton::{FxHashSet, String, append, cstr, profile};
+use vize_croquis::{
+    Croquis, EventHandlerScopeData, Scope, ScopeData, analysis::ComponentUsage,
+    analyzer::strip_js_comments, naming::to_pascal_case,
+};
+
+use crate::virtual_ts::{
+    expressions::rewrite_reserved_template_prop,
+    helpers::{get_dom_event_type, to_camel_case, to_safe_identifier, to_safe_identifier_fragment},
+};
+
+pub(super) struct ComponentEventTypes {
+    pub(super) event_type: String,
+    pub(super) args_type: String,
+    pub(super) listener_type: String,
+}
+
+pub(super) fn generate_component_event_types(
+    ts: &mut String,
+    summary: &Croquis,
+    data: &EventHandlerScopeData,
+    scope: &Scope,
+    template_prop_names: &FxHashSet<String>,
+    template_syntax_quirks: bool,
+    indent: &str,
+) -> Option<ComponentEventTypes> {
+    let component_name = data.target_component.as_ref()?;
+    let scope_id = scope.id.as_u32();
+    let safe_event_name = to_safe_identifier(data.event_name.as_str());
+    let component_ref = to_safe_identifier(component_name.as_str());
+    let component_type_name = to_safe_identifier_fragment(component_name.as_str());
+    let pascal_event = to_pascal_case(data.event_name.as_str());
+    let on_handler = cstr!("on{pascal_event}");
+    let prop_key = if on_handler.contains(':') {
+        cstr!("\"{}\"", on_handler.as_str())
+    } else {
+        on_handler
+    };
+    let prop_args = cstr!("__{component_type_name}_{scope_id}_{safe_event_name}_prop_args");
+    let static_emit_args =
+        cstr!("__{component_type_name}_{scope_id}_{safe_event_name}_static_emit_args");
+    let emit_args = cstr!("__{component_type_name}_{scope_id}_{safe_event_name}_emit_args");
+    let args_type = cstr!("__{component_type_name}_{scope_id}_{safe_event_name}_args");
+    let event_type = cstr!("__{component_type_name}_{scope_id}_{safe_event_name}_event");
+    let listener_type = cstr!("__{component_type_name}_{scope_id}_{safe_event_name}_listener");
+
+    append!(
+        *ts,
+        "{indent}type {prop_args} = typeof {component_ref} extends {{ new (): {{ $props: infer __P }} }}\n",
+    );
+    append!(
+        *ts,
+        "{indent}  ? __P extends {{ {prop_key}?: (...args: infer __A) => any }} ? __A : unknown[]\n",
+    );
+    append!(
+        *ts,
+        "{indent}  : typeof {component_ref} extends (props: infer __P) => any\n",
+    );
+    append!(
+        *ts,
+        "{indent}    ? __P extends {{ {prop_key}?: (...args: infer __A) => any }} ? __A : unknown[]\n",
+    );
+    append!(*ts, "{indent}    : unknown[];\n");
+
+    let inferred_emit_args = generate_inferred_emit_args(
+        ts,
+        &EmitInferenceContext {
+            summary,
+            component_name: component_name.as_str(),
+            data,
+            scope,
+            component_ref: &component_ref,
+            component_type_name: &component_type_name,
+            safe_event_name: &safe_event_name,
+            prop_key: &prop_key,
+            template_prop_names,
+            indent,
+        },
+    );
+
+    if let Some(ref inferred) = inferred_emit_args {
+        append!(
+            *ts,
+            "{indent}type {static_emit_args} = typeof {component_ref} extends {{ __vizeEmitProps?: infer __EP }}\n",
+        );
+        append!(
+            *ts,
+            "{indent}  ? __EP extends {{ {prop_key}?: (...args: infer __A) => any }} ? __A : unknown[]\n",
+        );
+        append!(*ts, "{indent}  : unknown[];\n");
+        append!(
+            *ts,
+            "{indent}type {emit_args} = unknown[] extends {inferred} ? {static_emit_args} : {inferred};\n",
+        );
+        append!(
+            *ts,
+            "{indent}type {args_type} = unknown[] extends {inferred} ? (unknown[] extends {prop_args} ? {emit_args} : {prop_args}) : {inferred};\n",
+        );
+    } else {
+        append!(
+            *ts,
+            "{indent}type {emit_args} = typeof {component_ref} extends {{ __vizeEmitProps?: infer __EP }}\n",
+        );
+        append!(
+            *ts,
+            "{indent}  ? __EP extends {{ {prop_key}?: (...args: infer __A) => any }} ? __A : unknown[]\n",
+        );
+        append!(
+            *ts,
+            "{indent}  : unknown[];\n{indent}type {args_type} = unknown[] extends {prop_args} ? {emit_args} : {prop_args};\n",
+        );
+    }
+
+    if template_syntax_quirks {
+        let fallback_event = get_dom_event_type(data.event_name.as_str());
+        append!(
+            *ts,
+            "{indent}type {event_type} = {args_type} extends [] ? any : unknown[] extends {args_type} ? {fallback_event} : {args_type}[0];\n",
+        );
+    } else {
+        append!(
+            *ts,
+            "{indent}type {event_type} = {args_type} extends [] ? any : {args_type}[0];\n",
+        );
+    }
+    Some(ComponentEventTypes {
+        event_type,
+        args_type,
+        listener_type,
+    })
+}
+
+struct EmitInferenceContext<'a> {
+    summary: &'a Croquis,
+    component_name: &'a str,
+    data: &'a EventHandlerScopeData,
+    scope: &'a Scope,
+    component_ref: &'a str,
+    component_type_name: &'a str,
+    safe_event_name: &'a str,
+    prop_key: &'a str,
+    template_prop_names: &'a FxHashSet<String>,
+    indent: &'a str,
+}
+
+fn generate_inferred_emit_args(ts: &mut String, ctx: &EmitInferenceContext<'_>) -> Option<String> {
+    if !is_local_vue_component_binding(ctx.summary, ctx.component_name) {
+        return None;
+    }
+    let (usage_idx, usage) =
+        find_component_usage_for_event(ctx.summary, ctx.component_name, ctx.data, ctx.scope)?;
+    if !usage.props.iter().any(|prop| {
+        prop.name.as_str() != "key"
+            && prop.name.as_str() != "ref"
+            && prop.value.is_some()
+            && prop.is_dynamic
+    }) {
+        return None;
+    }
+
+    let scope_id = ctx.scope.id.as_u32();
+    let resolver_type = cstr!(
+        "__{}_{}_{}_emit_resolver",
+        ctx.component_type_name,
+        scope_id,
+        ctx.safe_event_name
+    );
+    let emit_props = cstr!(
+        "__vize_emit_props_{}_{}_{}",
+        usage_idx,
+        scope_id,
+        ctx.safe_event_name
+    );
+    let inferred_args = cstr!(
+        "__{}_{}_{}_inferred_emit_args",
+        ctx.component_type_name,
+        scope_id,
+        ctx.safe_event_name
+    );
+    append!(
+        *ts,
+        "{}type {resolver_type} = typeof {} extends {{ __vizeResolveEmitProps?: infer __F }} ? (__F extends (...args: any[]) => any ? __F : (props: any) => {{}}) : (props: any) => {{}};\n",
+        ctx.indent,
+        ctx.component_ref,
+    );
+    append!(
+        *ts,
+        "{}const {emit_props} = (undefined as unknown as {resolver_type})({{\n",
+        ctx.indent,
+    );
+    for prop in &usage.props {
+        if prop.name.as_str() == "key" || prop.name.as_str() == "ref" {
+            continue;
+        }
+        let Some(ref value) = prop.value else {
+            continue;
+        };
+        if !prop.is_dynamic {
+            continue;
+        }
+        let value = profile!(
+            "canon.virtual_ts.emit_payload.strip_comments",
+            strip_js_comments(value.as_str())
+        );
+        let trimmed_value = value.as_ref().trim();
+        let rewritten_value =
+            rewrite_reserved_template_prop(trimmed_value, ctx.template_prop_names);
+        let generated_value = rewritten_value
+            .as_ref()
+            .map_or_else(|| value.as_ref(), |s| s.as_str());
+        let camel_prop_name = to_camel_case(prop.name.as_str());
+        append!(
+            *ts,
+            "{}  \"{camel_prop_name}\": {generated_value},\n",
+            ctx.indent
+        );
+    }
+    append!(*ts, "{}}});\n", ctx.indent);
+    append!(
+        *ts,
+        "{}type {inferred_args} = typeof {emit_props} extends {{ {}?: (...args: infer __A) => any }} ? __A : unknown[];\n",
+        ctx.indent,
+        ctx.prop_key,
+    );
+    Some(inferred_args)
+}
+
+fn is_local_vue_component_binding(summary: &Croquis, component_name: &str) -> bool {
+    let Some((binding_start, binding_end)) = summary.binding_spans.get(component_name) else {
+        return false;
+    };
+
+    summary.scopes.iter().any(|scope| {
+        scope.span.start <= *binding_start
+            && *binding_end <= scope.span.end
+            && matches!(
+                scope.data(),
+                ScopeData::ExternalModule(data)
+                    if !data.is_type_only && data.source.as_str().ends_with(".vue")
+            )
+    })
+}
+
+fn find_component_usage_for_event<'a>(
+    summary: &'a Croquis,
+    component_name: &str,
+    data: &EventHandlerScopeData,
+    scope: &Scope,
+) -> Option<(usize, &'a ComponentUsage)> {
+    summary
+        .component_usages
+        .iter()
+        .enumerate()
+        .find(|(_, usage)| {
+            usage.name.as_str() == component_name
+                && usage.events.iter().any(|event| {
+                    event.name.as_str() == data.event_name.as_str()
+                        && event_matches_scope(usage, event.start, event.end, data, scope)
+                })
+        })
+}
+
+fn event_matches_scope(
+    usage: &ComponentUsage,
+    event_start: u32,
+    event_end: u32,
+    data: &EventHandlerScopeData,
+    scope: &Scope,
+) -> bool {
+    let exact = event_start == scope.span.start && event_end == scope.span.end;
+    let event_contains_scope = event_start <= scope.span.start && scope.span.end <= event_end;
+    let scope_in_usage = usage.start <= scope.span.start && scope.span.end <= usage.end;
+    let same_handler = usage.events.iter().any(|event| {
+        event.start == event_start
+            && event.end == event_end
+            && data.handler_expression.as_deref() == event.handler.as_deref()
+    });
+    exact || event_contains_scope || (scope_in_usage && same_handler)
+}

--- a/crates/vize_canon/src/virtual_ts/scope/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/mod.rs
@@ -5,6 +5,7 @@
 //! tree-based generation so nested scopes are properly contained.
 
 mod closures;
+mod component_events;
 mod component_props;
 mod context;
 mod emit;


### PR DESCRIPTION
## Summary
- infer generic component emit listener payloads from the same prop object used for generic prop checks
- make generated Emits aliases generic for generic script setup components
- add a regression test for typed defineEmits payloads in parent template listeners

Closes #1900

## Verification
- cargo test -p vize_canon batch_type_checker_infers_generic_component_listener_payload_from_props -- --nocapture
- cargo test -p vize_canon virtual_ts -- --nocapture
- cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports
- cargo fmt --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Note: local full `cargo test -p vize_canon` currently fails on the existing Options API template-binding test without Options API opt-in; the targeted and affected suites above pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->