### PR TITLE
fix(musea): support strict serve ports

### DIFF
--- a/crates/vize/src/cli.rs
+++ b/crates/vize/src/cli.rs
@@ -105,8 +105,9 @@ fn run(cli: Cli) {
 
 #[cfg(test)]
 mod tests {
-    use super::Cli;
-    use clap::CommandFactory;
+    use super::{Cli, Commands};
+    use crate::commands::musea::MuseaCommand;
+    use clap::{CommandFactory, Parser};
 
     #[test]
     fn long_help_snapshot() {
@@ -144,6 +145,28 @@ mod tests {
     #[test]
     fn curator_help_snapshot() {
         insta::assert_snapshot!("cli_curator_help", command_help("curator"));
+    }
+
+    #[test]
+    fn musea_serve_accepts_strict_port_spellings() {
+        for args in [
+            &["vize", "musea", "--strict-port"][..],
+            &["vize", "musea", "--strictPort"][..],
+            &["vize", "musea", "serve", "--strict-port"][..],
+            &["vize", "musea", "serve", "--strictPort"][..],
+        ] {
+            let cli = Cli::try_parse_from(args).unwrap();
+            let Some(Commands::Musea(args)) = cli.command else {
+                panic!("expected musea command");
+            };
+
+            let serve_args = match args.command {
+                Some(MuseaCommand::Serve(serve_args)) => serve_args,
+                None => args.serve,
+                Some(MuseaCommand::New(_)) => panic!("expected musea serve args"),
+            };
+            assert!(serve_args.strict_port);
+        }
     }
 
     fn command_help(command_name: &str) -> String {

--- a/crates/vize/src/commands/musea/tests.rs
+++ b/crates/vize/src/commands/musea/tests.rs
@@ -58,6 +58,7 @@ fn serve_plan_supports_vite_build() {
         &ServeArgs {
             build: true,
             open: true,
+            strict_port: true,
             ..ServeArgs::default()
         },
         temp.path(),


### PR DESCRIPTION
## Summary
- accept both `--strict-port` and `--strictPort` on `vize musea serve`
- forward strict port mode to Vite dev as `--strictPort`
- move Musea serve unit tests into a submodule and add CLI parse coverage

Closes #1890

## Verification
- `cargo fmt --check`
- `cargo test -p vize musea -- --nocapture`
- `cargo test -p vize`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo clippy -p vize --lib -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->