### PR TITLE
fix(lint): respect config entry presets

### DIFF
--- a/crates/vize/src/commands/lint/args.rs
+++ b/crates/vize/src/commands/lint/args.rs
@@ -39,9 +39,9 @@ pub struct LintArgs {
     #[arg(long, default_value = "full")]
     pub help_level: String,
 
-    /// Lint preset: ecosystem (default), happy-path, opinionated, essential, incremental, nuxt
-    #[arg(long, default_value = "ecosystem")]
-    pub preset: String,
+    /// Override the configured lint preset: ecosystem, happy-path, opinionated, essential, incremental, nuxt
+    #[arg(long)]
+    pub preset: Option<String>,
 
     /// Enable opt-in cross-file lint checks for provide/inject, reactivity flow, and race risks.
     #[arg(long)]

--- a/crates/vize/src/commands/lint/mod.rs
+++ b/crates/vize/src/commands/lint/mod.rs
@@ -93,10 +93,11 @@ pub fn run(args: LintArgs) {
         "short" => HelpLevel::Short,
         _ => HelpLevel::Full,
     };
-    let preset_name = linter_config
+    let preset_name = args
         .preset
         .as_deref()
-        .unwrap_or(args.preset.as_str());
+        .or(linter_config.preset.as_deref())
+        .unwrap_or("ecosystem");
     let preset = LintPreset::parse(preset_name).unwrap_or_default();
     let type_aware_enabled =
         args.type_aware || args.strict_reactivity || linter_config.type_aware_lint_enabled();
@@ -224,7 +225,6 @@ pub fn run(args: LintArgs) {
         .map(|(_, _, _, result)| result.warning_count)
         .sum();
 
-    // Format and print results
     let output_start = Instant::now();
     if render_details {
         let lint_results: Vec<_> = profile!(
@@ -366,7 +366,7 @@ pub fn run(args: LintArgs) {
             files.len(),
             total_errors,
             total_warnings,
-            args.preset
+            preset_name
         );
         let report = ProfileReport {
             title: "lint",

--- a/crates/vize/src/commands/ready.rs
+++ b/crates/vize/src/commands/ready.rs
@@ -71,7 +71,7 @@ pub fn run(args: ReadyArgs) {
         max_warnings: None,
         quiet: false,
         help_level: "full".into(),
-        preset: "ecosystem".into(),
+        preset: None,
         cross_file: false,
         cross_file_tree: false,
         type_aware: false,

--- a/crates/vize/tests/lint_config_cli.rs
+++ b/crates/vize/tests/lint_config_cli.rs
@@ -1,0 +1,95 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn temp_project_dir(test_name: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "vize-lint-config-cli-{}-{}-{}",
+        std::process::id(),
+        test_name,
+        nonce
+    ))
+}
+
+fn write_project_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(file_path, content).unwrap();
+}
+
+#[test]
+fn lint_uses_entry_preset_unless_cli_preset_overrides() {
+    let project_root = temp_project_dir("entry-preset");
+    write_project_file(
+        &project_root,
+        "vize.config.json",
+        r#"{
+  "entries": [
+    {
+      "name": "app",
+      "files": ["src/**/*.vue"],
+      "linter": { "preset": "incremental" }
+    }
+  ]
+}"#,
+    );
+    write_project_file(
+        &project_root,
+        "src/App.vue",
+        r#"<script setup>
+const noop = () => {}
+</script>
+
+<template>
+  <div @click="noop">Clickable</div>
+</template>
+"#,
+    );
+
+    let configured = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["lint", "--config", "vize.config.json", "src/App.vue"])
+        .output()
+        .unwrap();
+    assert!(
+        configured.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&configured.stdout),
+        String::from_utf8_lossy(&configured.stderr)
+    );
+    let configured_stdout = String::from_utf8_lossy(&configured.stdout);
+    assert!(!configured_stdout.contains("a11y/click-events-have-key-events"));
+
+    let overridden = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args([
+            "lint",
+            "--config",
+            "vize.config.json",
+            "--preset",
+            "ecosystem",
+            "--max-warnings",
+            "0",
+            "src/App.vue",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !overridden.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&overridden.stdout),
+        String::from_utf8_lossy(&overridden.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&overridden.stdout);
+    assert!(stdout.contains("a11y/click-events-have-key-events"));
+
+    let _ = fs::remove_dir_all(project_root);
+}

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -158,7 +158,7 @@ pub fn load_compiler_jsx_mode(path: Option<&Path>) -> Option<crate::config::JsxM
 /// parsing and normalizing the same config file twice.
 pub fn load_config_and_linter_with_source(path: Option<&Path>) -> (LoadedConfig, LinterConfig) {
     let loaded = load_raw_config_with_source(path);
-    let linter = LinterConfig::from(loaded.config.linter.clone());
+    let linter = load_linter_from_raw_config(&loaded.config);
     let (config, _) = loaded.config.into_config_and_features();
     (
         LoadedConfig {
@@ -177,7 +177,7 @@ pub fn load_config_and_linter_with_features_and_source(
     path: Option<&Path>,
 ) -> (LoadedConfigWithFeatures, LinterConfig) {
     let loaded = load_raw_config_with_source(path);
-    let linter = LinterConfig::from(loaded.config.linter.clone());
+    let linter = load_linter_from_raw_config(&loaded.config);
     let (config, features) = loaded.config.into_config_and_features();
     (
         LoadedConfigWithFeatures {
@@ -191,7 +191,34 @@ pub fn load_config_and_linter_with_features_and_source(
 
 /// Load linter-specific configuration from a directory or file path.
 pub fn load_linter_config(path: Option<&Path>) -> LinterConfig {
-    LinterConfig::from(load_raw_config_with_source(path).config.linter)
+    let loaded = load_raw_config_with_source(path);
+    load_linter_from_raw_config(&loaded.config)
+}
+
+fn load_linter_from_raw_config(config: &RawVizeConfig) -> LinterConfig {
+    let mut linter = LinterConfig::from(config.linter.clone());
+    if linter.preset.is_none() {
+        linter.preset = common_entry_linter_preset(config);
+    }
+    linter
+}
+
+fn common_entry_linter_preset(config: &RawVizeConfig) -> Option<crate::String> {
+    let mut common_preset: Option<crate::String> = None;
+    for entry in config.entries.as_deref().unwrap_or_default() {
+        let entry_linter = LinterConfig::from(entry.linter.clone());
+        let Some(entry_preset) = entry_linter.preset else {
+            continue;
+        };
+        if common_preset
+            .as_ref()
+            .is_some_and(|preset| preset.as_str() != entry_preset.as_str())
+        {
+            return None;
+        }
+        common_preset = Some(entry_preset);
+    }
+    common_preset
 }
 
 fn load_raw_config_with_source(path: Option<&Path>) -> LoadedRawConfig {

--- a/crates/vize_carton/src/config/loader/tests.rs
+++ b/crates/vize_carton/src/config/loader/tests.rs
@@ -210,6 +210,48 @@ export default {
 }
 
 #[test]
+fn load_linter_config_uses_common_entry_preset() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(
+        &config_path,
+        r#"{
+  "entries": [
+    { "name": "app", "files": ["components/**/*.vue"], "linter": { "preset": "incremental" } },
+    { "name": "design-system", "basePath": "design-system", "files": ["src/**/*.vue"], "linter": { "preset": "incremental" } }
+  ]
+}"#,
+    )
+    .unwrap();
+
+    let (_, loaded_linter) = load_config_and_linter_with_source(Some(&config_path));
+    let linter = load_linter_config(Some(&config_path));
+
+    assert_eq!(loaded_linter.preset.as_deref(), Some("incremental"));
+    assert_eq!(linter.preset.as_deref(), Some("incremental"));
+}
+
+#[test]
+fn load_linter_config_keeps_root_preset_over_entry_preset() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(
+        &config_path,
+        r#"{
+  "linter": { "preset": "nuxt" },
+  "entries": [
+    { "files": ["components/**/*.vue"], "linter": { "preset": "incremental" } }
+  ]
+}"#,
+    )
+    .unwrap();
+
+    let linter = load_linter_config(Some(&config_path));
+
+    assert_eq!(linter.preset.as_deref(), Some("nuxt"));
+}
+
+#[test]
 fn load_config_uses_relative_typescript_file_path() {
     let cwd = std::env::current_dir().unwrap();
     let case_dir = cwd

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -126,12 +126,19 @@ pub(crate) struct RawVizeConfig {
     language_server: RawLanguageServerConfig,
     #[serde(rename = "globalTypes")]
     pub global_types: RawGlobalTypesConfig,
+    pub entries: Option<Vec<RawConfigEntry>>,
     #[serde(rename = "check")]
     legacy_check: Option<LegacyCheckConfig>,
     #[serde(rename = "fmt")]
     legacy_formatter: Option<FormatterConfig>,
     #[serde(rename = "lsp")]
     legacy_lsp: Option<RawLanguageServerConfig>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub(crate) struct RawConfigEntry {
+    pub linter: RawLinterConfig,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -179,6 +186,7 @@ impl RawVizeConfig {
             type_checker: raw_type_checker,
             language_server: raw_language_server,
             global_types,
+            entries: _,
             legacy_check,
             legacy_formatter,
             legacy_lsp,


### PR DESCRIPTION
## Summary
- load a common `entries[].linter.preset` when no root linter preset is configured
- make `--preset` an explicit override instead of an always-present default
- add CLI coverage for config entry preset behavior and override precedence

Closes #1889

## Verification
- `cargo fmt --check`
- `cargo test -p vize_carton config::loader::tests::load_linter_config -- --nocapture`
- `cargo test -p vize lint -- --nocapture`
- `cargo test -p vize --test lint_config_cli -- --nocapture`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo test -p vize_carton -p vize`
- `cargo clippy -p vize_carton --lib -- -D warnings`
- `cargo clippy -p vize --lib -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->