### PR TITLE
fix(nuxt): exclude musea art files from component scan

### DIFF
--- a/docs/content/guide/musea.md
+++ b/docs/content/guide/musea.md
@@ -189,7 +189,8 @@ src/components/Button.vue
 src/components/Button.art.vue
 ```
 
-Use a separate `stories` or `art` directory when a design system owns many cross-cutting examples:
+Use a separate `stories` or `art` directory when a design system owns many cross-cutting examples,
+or when Nuxt component auto-discovery scans the component directory:
 
 ```txt
 src/components/Button.vue

--- a/docs/content/integrations/nuxt.md
+++ b/docs/content/integrations/nuxt.md
@@ -174,6 +174,31 @@ export default defineNuxtConfig({
 
 When configured, the Musea gallery is available at `/__musea__/` during development.
 
+### Art File Placement
+
+Nuxt component auto-discovery scans `.vue` files inside configured component directories. Because
+Musea art files also end in `.vue`, keep `*.art.vue` files outside those directories in Nuxt
+projects and point Musea at that location:
+
+```txt
+app/components/Tag.vue
+stories/shared/Tag.art.vue
+```
+
+```ts
+export default defineNuxtConfig({
+  modules: ["@vizejs/nuxt"],
+  vize: {
+    musea: {
+      include: ["stories/**/*.art.vue"],
+    },
+  },
+});
+```
+
+When Musea is enabled through `@vizejs/nuxt`, the module also excludes `**/*.art.vue` from Nuxt's
+component scanner so colocated legacy files do not reach Nuxt's webpack or Vite component pipeline.
+
 ### Preview Setup for Nuxt
 
 Nuxt projects often use features that need to be mocked in the Musea preview environment (vue-i18n, NuxtLink, useNuxtApp, etc.):

--- a/npm/nuxt/src/index.ts
+++ b/npm/nuxt/src/index.ts
@@ -1,13 +1,3 @@
-/**
- * @vizejs/nuxt - Nuxt module for Vize
- *
- * Provides:
- * - Compiler: Vue SFC compilation via Vite plugin
- * - Musea: Component gallery with Nuxt mock support
- * - Linter: `vize lint` CLI command (via `vize` bin)
- * - Type Checker: `vize check` CLI command (via `vize` bin)
- */
-
 import {
   addServerPlugin,
   addVitePlugin,
@@ -20,6 +10,7 @@ import vize from "@vizejs/vite-plugin";
 import { musea } from "@vizejs/vite-plugin-musea";
 import { createNuxtComponentResolver, injectNuxtComponentImports } from "./components";
 import { injectNuxtI18nHelpers } from "./i18n";
+import { appendMuseaArtComponentIgnore } from "./musea-components";
 import type { VizeNuxtCompilerOptions, VizeNuxtOptions } from "./options";
 import {
   resolveNuxtBridgeOptions,
@@ -290,6 +281,8 @@ export default defineNuxtModule<VizeNuxtOptions>({
     const devOptions = resolveNuxtDevOptions(options.dev);
     const museaOptions = resolveNuxtMuseaOptions(options.musea);
     const unocssOptions = resolveNuxtUnoCssOptions(options.unocss);
+
+    if (museaOptions !== false) nuxt.hook("components:dirs", appendMuseaArtComponentIgnore);
 
     // Compiler
     const compilerOptions = resolveNuxtCompilerOptions(

--- a/npm/nuxt/src/musea-components.test.ts
+++ b/npm/nuxt/src/musea-components.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MUSEA_ART_COMPONENT_IGNORE,
+  appendMuseaArtComponentIgnore,
+  type MuseaNuxtComponentDir,
+} from "./musea-components.ts";
+
+void test("Musea component ignore converts string dirs to object dirs", () => {
+  const dirs: MuseaNuxtComponentDir[] = ["~/components"];
+
+  appendMuseaArtComponentIgnore(dirs);
+
+  assert.deepEqual(dirs, [
+    {
+      path: "~/components",
+      ignore: [MUSEA_ART_COMPONENT_IGNORE],
+    },
+  ]);
+});
+
+void test("Musea component ignore preserves existing dir options", () => {
+  const dirs: MuseaNuxtComponentDir[] = [
+    {
+      path: "~/components",
+      prefix: "Design",
+      ignore: ["**/*.stories.vue"],
+    },
+  ];
+
+  appendMuseaArtComponentIgnore(dirs);
+
+  assert.deepEqual(dirs, [
+    {
+      path: "~/components",
+      prefix: "Design",
+      ignore: ["**/*.stories.vue", MUSEA_ART_COMPONENT_IGNORE],
+    },
+  ]);
+});
+
+void test("Musea component ignore does not duplicate the art pattern", () => {
+  const dirs: MuseaNuxtComponentDir[] = [
+    {
+      path: "~/components",
+      ignore: [MUSEA_ART_COMPONENT_IGNORE],
+    },
+  ];
+
+  appendMuseaArtComponentIgnore(dirs);
+  appendMuseaArtComponentIgnore(dirs);
+
+  assert.deepEqual(dirs, [
+    {
+      path: "~/components",
+      ignore: [MUSEA_ART_COMPONENT_IGNORE],
+    },
+  ]);
+});

--- a/npm/nuxt/src/musea-components.ts
+++ b/npm/nuxt/src/musea-components.ts
@@ -1,0 +1,28 @@
+export const MUSEA_ART_COMPONENT_IGNORE = "**/*.art.vue";
+
+export type MuseaNuxtComponentDir =
+  | string
+  | {
+      ignore?: string[];
+      path: string;
+      [key: string]: unknown;
+    };
+
+export function appendMuseaArtComponentIgnore(dirs: MuseaNuxtComponentDir[]): void {
+  for (const [index, dir] of dirs.entries()) {
+    if (typeof dir === "string") {
+      dirs[index] = {
+        path: dir,
+        ignore: [MUSEA_ART_COMPONENT_IGNORE],
+      };
+      continue;
+    }
+
+    const ignore = Array.isArray(dir.ignore) ? dir.ignore : [];
+    if (ignore.includes(MUSEA_ART_COMPONENT_IGNORE)) {
+      continue;
+    }
+
+    dir.ignore = [...ignore, MUSEA_ART_COMPONENT_IGNORE];
+  }
+}


### PR DESCRIPTION
## Summary
- exclude `**/*.art.vue` from Nuxt component auto-discovery when Musea is enabled
- document Nuxt-safe Musea art file placement and `stories/**/*.art.vue` include patterns
- add unit coverage for preserving existing component dir ignore settings

Closes #1888

## Verification
- `pnpm --filter @vizejs/nuxt check`
- `pnpm --filter @vizejs/nuxt test`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `node --test tests/tooling/docs-stability.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->