### PR TITLE
fix(check): honor nuxt tsconfig path shims

### DIFF
--- a/crates/vize/src/commands/check/nuxt/mod.rs
+++ b/crates/vize/src/commands/check/nuxt/mod.rs
@@ -14,6 +14,7 @@ mod parsing;
 mod plugins;
 mod source_scan;
 mod stubs;
+mod tsconfig_aliases;
 mod virtual_modules;
 
 #[cfg(test)]
@@ -25,6 +26,7 @@ use generated_dir::resolve_nuxt_generated_dir;
 use plugins::collect_plugin_injection_stubs;
 use source_scan::{collect_source_auto_import_stubs, collect_source_type_auto_import_stubs};
 use stubs::{declared_name, is_template_component_binding};
+use tsconfig_aliases::collect_explicit_virtual_module_aliases;
 use virtual_modules::{collect_fallback_module_stubs, collect_fallback_path_aliases};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -33,9 +35,18 @@ pub(in crate::commands::check) struct NuxtPathAlias {
     pub(in crate::commands::check) targets: Vec<String>,
 }
 
+#[cfg(test)]
 pub(in crate::commands::check) fn detect_nuxt_auto_imports(
     options: &mut VirtualTsOptions,
     cwd: &Path,
+) -> Vec<NuxtPathAlias> {
+    detect(options, cwd, None)
+}
+
+pub(in crate::commands::check) fn detect(
+    options: &mut VirtualTsOptions,
+    cwd: &Path,
+    tsconfig_path: Option<&Path>,
 ) -> Vec<NuxtPathAlias> {
     if !is_nuxt_project(cwd) {
         return Vec::new();
@@ -78,7 +89,8 @@ pub(in crate::commands::check) fn detect_nuxt_auto_imports(
         collect_source_auto_import_stubs(cwd, &mut collected, &mut seen_names);
         collect_source_type_auto_import_stubs(cwd, &mut collected);
     }
-    collect_fallback_module_stubs(cwd, &mut collected);
+    let explicit_aliases = collect_explicit_virtual_module_aliases(tsconfig_path);
+    collect_fallback_module_stubs(cwd, &mut collected, &explicit_aliases);
     let path_aliases = collect_fallback_path_aliases(cwd, &generated_dir);
     collect_generated_template_globals(&generated_dir, options, &seen_names);
 

--- a/crates/vize/src/commands/check/nuxt/tsconfig_aliases.rs
+++ b/crates/vize/src/commands/check/nuxt/tsconfig_aliases.rs
@@ -1,0 +1,113 @@
+//! Helpers for detecting Nuxt virtual modules already handled by `tsconfig` paths.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde_json::Value;
+use vize_carton::{FxHashSet, String};
+
+use crate::commands::check::tsconfig_inputs::{
+    parse_jsonc_value, read_extends_entries, resolve_extended_tsconfig,
+};
+
+pub(super) fn collect_explicit_virtual_module_aliases(
+    tsconfig_path: Option<&Path>,
+) -> FxHashSet<String> {
+    let mut aliases = FxHashSet::default();
+    let mut seen = FxHashSet::default();
+    if let Some(tsconfig_path) = tsconfig_path {
+        collect_explicit_virtual_module_aliases_inner(tsconfig_path, &mut aliases, &mut seen);
+    }
+    aliases
+}
+
+fn collect_explicit_virtual_module_aliases_inner(
+    tsconfig_path: &Path,
+    aliases: &mut FxHashSet<String>,
+    seen: &mut FxHashSet<PathBuf>,
+) {
+    let resolved = vize_carton::path::canonicalize_non_verbatim(tsconfig_path);
+    if !seen.insert(resolved.clone()) {
+        return;
+    }
+
+    let Ok(content) = fs::read_to_string(&resolved) else {
+        return;
+    };
+    let Ok(value) = parse_jsonc_value(&content) else {
+        return;
+    };
+
+    for extends in read_extends_entries(&value) {
+        if let Some(extended_path) = resolve_extended_tsconfig(&resolved, &extends) {
+            collect_explicit_virtual_module_aliases_inner(&extended_path, aliases, seen);
+        }
+    }
+
+    let Some(paths) = value
+        .get("compilerOptions")
+        .and_then(Value::as_object)
+        .and_then(|compiler_options| compiler_options.get("paths"))
+        .and_then(Value::as_object)
+    else {
+        return;
+    };
+
+    for alias in paths.keys().filter(|alias| is_nuxt_virtual_module(alias)) {
+        aliases.insert(alias.as_str().into());
+    }
+}
+
+fn is_nuxt_virtual_module(alias: &str) -> bool {
+    matches!(alias, "#imports" | "#components" | "#app" | "@typed-router")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_explicit_virtual_module_aliases;
+
+    #[test]
+    fn collects_virtual_module_aliases_from_tsconfig_extends_chain() {
+        let root =
+            std::env::temp_dir().join(format!("vize-nuxt-tsconfig-aliases-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+
+        std::fs::write(
+            root.join("base.json"),
+            r##"{
+  "compilerOptions": {
+    "paths": {
+      "#imports": ["types/imports.ts"],
+      "~/*": ["app/*"]
+    }
+  }
+}"##,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("tsconfig.json"),
+            r##"{
+  "extends": "./base.json",
+  "compilerOptions": {
+    "paths": {
+      "@typed-router": ["types/router.ts"],
+      "#components": ["types/components.ts"]
+    }
+  }
+}"##,
+        )
+        .unwrap();
+
+        let aliases = collect_explicit_virtual_module_aliases(Some(&root.join("tsconfig.json")));
+
+        assert!(aliases.contains("#imports"));
+        assert!(aliases.contains("#components"));
+        assert!(aliases.contains("@typed-router"));
+        assert!(!aliases.contains("~/*"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/crates/vize/src/commands/check/nuxt/virtual_modules.rs
+++ b/crates/vize/src/commands/check/nuxt/virtual_modules.rs
@@ -17,7 +17,11 @@ use super::parsing::{is_ts_identifier, source_type_for_path, source_type_for_scr
 use super::stubs::tracked_read_to_string;
 use crate::commands::check::tsconfig_inputs::parse_jsonc_value;
 
-pub(super) fn collect_fallback_module_stubs(cwd: &Path, stubs: &mut Vec<String>) {
+pub(super) fn collect_fallback_module_stubs(
+    cwd: &Path,
+    stubs: &mut Vec<String>,
+    explicit_aliases: &FxHashSet<String>,
+) {
     let imports = collect_nuxt_virtual_module_imports(cwd);
     if imports.is_empty() {
         return;
@@ -26,6 +30,9 @@ pub(super) fn collect_fallback_module_stubs(cwd: &Path, stubs: &mut Vec<String>)
     let mut modules: Vec<_> = imports.into_iter().collect();
     modules.sort_by(|left, right| left.0.cmp(&right.0));
     for (module, imports) in modules {
+        if explicit_aliases.contains(module.as_str()) {
+            continue;
+        }
         if let Some(stub) = render_module_stub(module.as_str(), &imports) {
             stubs.push(stub);
         }

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -261,9 +261,9 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         files.sort();
         files.dedup();
     }
-
     let mut virtual_ts_options = build_virtual_ts_options(&config, config_dir);
-    let nuxt_path_aliases = nuxt::detect_nuxt_auto_imports(&mut virtual_ts_options, &project_root);
+    let tsconfig = program_tsconfig_path.as_deref();
+    let nuxt_path_aliases = nuxt::detect(&mut virtual_ts_options, &project_root, tsconfig);
     collect_project_global_component_stubs(
         &mut virtual_ts_options,
         &files,

--- a/crates/vize/tests/check_nuxt_tsconfig_paths_cli.rs
+++ b/crates/vize/tests/check_nuxt_tsconfig_paths_cli.rs
@@ -1,0 +1,221 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[test]
+fn check_nuxt_sfc_virtual_ts_prefers_explicit_tsconfig_paths_over_fallback_modules() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project("nuxt-explicit-alias-shims");
+
+    write_file(&project_root, "nuxt.config.ts", "export default {}\n");
+    write_file(
+        &project_root,
+        "tsconfig.vize.json",
+        r##"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "noEmit": true,
+    "paths": {
+      "#imports": ["types/vize/imports.ts"],
+      "#components": ["types/vize/components.ts"],
+      "@typed-router": ["types/vize/typed-router.ts"]
+    }
+  },
+  "include": ["app/**/*.vue", "design/**/*.vue", "types/vize/**/*.ts"]
+}"##,
+    );
+    write_file(
+        &project_root,
+        "app/pages/index.vue",
+        r##"<script setup lang="ts">
+import { ref } from "#imports";
+import { NuxtPage } from "#components";
+import { useRouter } from "@typed-router";
+
+const count = ref(0);
+const router = useRouter();
+void [count, router, NuxtPage];
+</script>
+"##,
+    );
+    write_file(
+        &project_root,
+        "design/components/AliasConsumer.vue",
+        r##"<script setup lang="ts">
+import { NuxtLink } from "#components";
+import {
+  useAttrs,
+  useId,
+  readonly,
+  provide,
+  type InjectionKey,
+  type Ref,
+} from "#imports";
+import { useRoute, type TypedRouteLocationRawFromName } from "@typed-router";
+
+const key = Symbol("value") as InjectionKey<Ref<string>>;
+const value: Ref<string> = { value: useId() };
+provide(key, readonly(value));
+const attrs = useAttrs();
+const route = useRoute();
+const target: TypedRouteLocationRawFromName<"home"> = { name: "home" };
+
+void [attrs, route, target, NuxtLink];
+</script>
+
+<template>
+  <NuxtLink to="/">Home</NuxtLink>
+</template>
+"##,
+    );
+    write_file(
+        &project_root,
+        "types/vize/imports.ts",
+        r#"export interface Ref<T = unknown> {
+  value: T;
+}
+
+export interface InjectionKey<T> extends Symbol {}
+
+export function ref<T>(value: T): Ref<T> {
+  return { value };
+}
+
+export function useAttrs(): { id?: string } {
+  return {};
+}
+
+export function useId(): string {
+  return "id";
+}
+
+export function readonly<T>(value: T): Readonly<T> {
+  return value;
+}
+
+export function provide<T>(_key: InjectionKey<T>, _value: T): void {}
+"#,
+    );
+    write_file(
+        &project_root,
+        "types/vize/components.ts",
+        r#"export const NuxtPage = {};
+export const NuxtLink = {};
+"#,
+    );
+    write_file(
+        &project_root,
+        "types/vize/typed-router.ts",
+        r#"export type TypedRouteLocationRawFromName<Name extends string = string> = {
+  name: Name;
+};
+
+export function useRoute(): { name: string } {
+  return { name: "home" };
+}
+
+export function useRouter(): {
+  push(to: TypedRouteLocationRawFromName): void;
+} {
+  return { push() {} };
+}
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.vize.json",
+            "--no-check-props",
+            "--no-check-emits",
+            "--no-check-template-bindings",
+            "--format",
+            "json",
+            "app",
+            "design",
+            "types",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "check should use explicit tsconfig paths for Nuxt aliases\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], 0, "{stdout}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn create_project(name: &str) -> PathBuf {
+    let project_root = workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join(format!("{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    link_workspace_node_modules(&project_root);
+    project_root
+}
+
+fn write_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(file_path, content).unwrap();
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn link_workspace_node_modules(project_root: &Path) {
+    let source = workspace_root().join("node_modules");
+    if source.exists() {
+        symlink_path(&source, &project_root.join("node_modules")).unwrap();
+    }
+}
+
+fn resolve_test_corsa_path() -> Option<String> {
+    if let Some(path) = std::env::var_os("CORSA_PATH") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path.display().to_string());
+        }
+    }
+    let workspace_root = workspace_root();
+    [workspace_root.join("node_modules/.bin/tsgo")]
+        .into_iter()
+        .find(|candidate| candidate.exists())
+        .map(|candidate| candidate.display().to_string())
+}
+
+fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(source, target)
+    }
+}


### PR DESCRIPTION
## Summary
- Pass the effective check tsconfig into Nuxt auto-import detection.
- Skip permissive Nuxt fallback module stubs when the supplied tsconfig already maps that virtual module to a local shim.
- Add regression coverage for Nuxt SFC virtual TS resolving #imports, #components, and @typed-router through local path shims.

Closes #1887

## Validation
- cargo fmt --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo test -p vize nuxt::tsconfig_aliases::tests::collects_virtual_module_aliases_from_tsconfig_extends_chain -- --nocapture
- cargo test -p vize --test check_nuxt_tsconfig_paths_cli -- --nocapture
- cargo test -p vize commands::check::nuxt -- --nocapture
- cargo test -p vize --test check_cli check_nuxt -- --nocapture
- cargo clippy -p vize --lib -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->