### PR TITLE
fix(musea): fail static gallery builds clearly

### DIFF
--- a/crates/vize/src/commands/musea.rs
+++ b/crates/vize/src/commands/musea.rs
@@ -156,22 +156,22 @@ fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePlan, String> 
         }
         None => PathBuf::from("vite"),
     };
-    let mut vite_args = if args.build {
-        vec![cstr!("build")]
-    } else {
-        vec![
-            cstr!("dev"),
-            cstr!("--host"),
-            args.host.clone(),
-            cstr!("--port"),
-            args.port.to_compact_string(),
-        ]
-    };
-    if args.open && !args.build {
-        vite_args.push(cstr!("--open"));
-        vite_args.push(cstr!("/__musea__"));
+    if args.build {
+        return Err(cstr!(
+            "vize musea: static gallery build is not supported yet.\n  The Vite-backed Musea gallery is served by dev middleware, so `vite build` can exit successfully without emitting `.art.vue` gallery content.\n  Use `vize musea serve` for the dev gallery or keep a Storybook/static fallback until Musea static export is available."
+        ));
     }
-    if args.strict_port && !args.build {
+    let mut vite_args = vec![
+        cstr!("dev"),
+        cstr!("--host"),
+        args.host.clone(),
+        cstr!("--port"),
+        args.port.to_compact_string(),
+    ];
+    if args.open {
+        vite_args.extend([cstr!("--open"), cstr!("/__musea__")]);
+    }
+    if args.strict_port {
         vite_args.push(cstr!("--strictPort"));
     }
 

--- a/crates/vize/src/commands/musea/tests.rs
+++ b/crates/vize/src/commands/musea/tests.rs
@@ -50,11 +50,11 @@ fn serve_plan_defaults_to_vite_dev_with_gallery_route() {
 }
 
 #[test]
-fn serve_plan_supports_vite_build() {
+fn serve_plan_rejects_static_build_with_actionable_message() {
     let temp = tempfile::tempdir().unwrap();
-    let vite_bin = write_vite_bin(temp.path());
+    write_vite_bin(temp.path());
 
-    let plan = create_serve_plan(
+    let error = create_serve_plan(
         &ServeArgs {
             build: true,
             open: true,
@@ -62,10 +62,11 @@ fn serve_plan_supports_vite_build() {
         },
         temp.path(),
     )
-    .unwrap();
+    .unwrap_err();
 
-    assert_eq!(plan.program, vite_bin);
-    assert_eq!(plan.args, ["build"]);
+    assert!(error.contains("static gallery build is not supported yet"));
+    assert!(error.contains("without emitting `.art.vue` gallery content"));
+    assert!(error.contains("Storybook/static fallback"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Stop `vize musea --build` from shelling out to a Vite build that can succeed without emitting Musea gallery content.
- Return an actionable diagnostic that explains the current dev-middleware-only gallery contract and points users at the dev gallery or a static fallback.
- Update the Musea serve plan test to lock in the fail-fast behavior.

Closes #1886

## Validation
- cargo fmt --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo test -p vize commands::musea -- --nocapture
- cargo clippy -p vize --lib -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->