### PR TITLE
fix(inspector): hide compare compiler stack traces

### DIFF
--- a/crates/vize/src/commands/inspector.rs
+++ b/crates/vize/src/commands/inspector.rs
@@ -23,6 +23,8 @@ use vize_atelier_sfc::{
 use vize_carton::{String, ToCompactString};
 use vize_curator::inspector as curator_inspector;
 
+mod compare_error;
+
 #[derive(Debug, Clone, Copy, ValueEnum, Default, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum InspectorOutputFormat {
@@ -558,9 +560,7 @@ fn run_official_compiler_for_compare(
 
     if !output.status.success() {
         let stderr = std::str::from_utf8(&output.stderr).unwrap_or("<stderr is not valid UTF-8>");
-        eprintln!(
-            "--format compare requires @vue/compiler-sfc in the current project or Vize workspace dev dependencies.\n{stderr}"
-        );
+        eprintln!("{}", compare_error::official_compiler_error_message(stderr));
         std::process::exit(output.status.code().unwrap_or(1));
     }
 

--- a/crates/vize/src/commands/inspector/compare_error.rs
+++ b/crates/vize/src/commands/inspector/compare_error.rs
@@ -1,0 +1,39 @@
+//! Error formatting for inspector compare's official compiler subprocess.
+
+use vize_carton::{String, cstr};
+
+pub(super) fn official_compiler_error_message(stderr: &str) -> String {
+    if is_missing_vue3_compiler(stderr) {
+        return cstr!(
+            "--format compare currently requires Vue 3 `@vue/compiler-sfc` / `vue/compiler-sfc`.\n  Vue 2 / Nuxt 2 projects are not supported by compare yet; use `--format json` or `--format agent` for inspector payloads without running the official compiler."
+        );
+    }
+
+    cstr!(
+        "--format compare requires @vue/compiler-sfc in the current project or Vize workspace dev dependencies.\n{stderr}"
+    )
+}
+
+fn is_missing_vue3_compiler(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("compiler-sfc")
+        && (lower.contains("err_module_not_found") || lower.contains("cannot find module"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::official_compiler_error_message;
+
+    #[test]
+    fn hides_node_stack_for_missing_vue_compiler_sfc() {
+        let message = official_compiler_error_message(
+            "node:internal/modules/esm/resolve:271\n\
+             Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/node_modules/vue/compiler-sfc'",
+        );
+
+        assert!(message.contains("currently requires Vue 3"));
+        assert!(message.contains("Vue 2 / Nuxt 2 projects are not supported"));
+        assert!(!message.contains("node:internal/modules"));
+        assert!(!message.contains("ERR_MODULE_NOT_FOUND"));
+    }
+}

--- a/crates/vize/tests/inspector_compare_cli.rs
+++ b/crates/vize/tests/inspector_compare_cli.rs
@@ -1,0 +1,46 @@
+use std::{fs, process::Command};
+
+#[cfg(unix)]
+#[test]
+fn inspector_compare_hides_missing_vue_compiler_stack_trace() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let project = tempfile::tempdir().unwrap();
+    let src = project.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("App.vue"),
+        "<template><div>legacy vue</div></template>\n",
+    )
+    .unwrap();
+
+    let fake_node = project.path().join("fake-node");
+    fs::write(
+        &fake_node,
+        "#!/bin/sh\n\
+         echo \"node:internal/modules/esm/resolve:271\" >&2\n\
+         echo \"Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/node_modules/vue/compiler-sfc'\" >&2\n\
+         exit 1\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&fake_node).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_node, permissions).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .env("VIZE_INSPECTOR_NODE", &fake_node)
+        .args(["inspector", "src/App.vue", "--format", "compare"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(!output.status.success(), "{stderr}");
+    assert!(stderr.contains("currently requires Vue 3"), "{stderr}");
+    assert!(
+        stderr.contains("Vue 2 / Nuxt 2 projects are not supported"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("node:internal/modules"), "{stderr}");
+    assert!(!stderr.contains("ERR_MODULE_NOT_FOUND"), "{stderr}");
+}


### PR DESCRIPTION
## Summary
- Detect missing `vue/compiler-sfc` / `@vue/compiler-sfc` failures from the compare subprocess.
- Replace raw Node module-resolution stack traces with an actionable Vue 2 / Nuxt 2 unsupported diagnostic.
- Add unit and CLI coverage for the missing compiler path.

Closes #1885

## Validation
- cargo fmt --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo test -p vize commands::inspector::compare_error -- --nocapture
- cargo test -p vize --test inspector_compare_cli -- --nocapture
- cargo test -p vize --test inspector_cli inspector_compare -- --nocapture
- cargo clippy -p vize --lib -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->