### PR TITLE
fix(cli): expose lsp in native npm entrypoint

### DIFF
--- a/crates/vize_vitrine/Cargo.toml
+++ b/crates/vize_vitrine/Cargo.toml
@@ -46,7 +46,10 @@ vize_croquis = { workspace = true }
 vize_croquis_cf = { workspace = true }
 vize_canon = { workspace = true }
 vize_curator = { workspace = true }
-vize = { path = "../vize", default-features = false, features = ["glyph"], optional = true }
+vize = { path = "../vize", default-features = false, features = [
+  "glyph",
+  "maestro",
+], optional = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary

- enable the `maestro` feature for the native npm binding
- restore the `vize lsp` subcommand when invoking the npm-distributed CLI

## Root Cause

`@vizejs/native` linked the Rust CLI with only the `glyph` feature, so the feature-gated LSP command was omitted from the native binding used by the npm `vize` binary.

Fixes #1848.
Fixes #1857.

## Validation

- `cargo check -p vize_vitrine --features napi`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->