### PR TITLE
fix(musea): enable plugin during builds

### DIFF
--- a/npm/vite-plugin-musea/src/plugin/apply.ts
+++ b/npm/vite-plugin-musea/src/plugin/apply.ts
@@ -1,5 +1,5 @@
 import type { ConfigEnv } from "vite";
 
 export function shouldApplyMuseaPlugin(env: Pick<ConfigEnv, "command" | "mode">): boolean {
-  return env.command === "serve" && env.mode !== "test";
+  return (env.command === "serve" || env.command === "build") && env.mode !== "test";
 }

--- a/npm/vite-plugin-musea/src/plugin/index.test.ts
+++ b/npm/vite-plugin-musea/src/plugin/index.test.ts
@@ -10,6 +10,6 @@ void test("musea plugin remains active during Vite serve outside test mode", () 
   assert.equal(shouldApplyMuseaPlugin({ command: "serve", mode: "development" }), true);
 });
 
-void test("musea plugin is inactive during production builds", () => {
-  assert.equal(shouldApplyMuseaPlugin({ command: "build", mode: "production" }), false);
+void test("musea plugin remains active during production builds", () => {
+  assert.equal(shouldApplyMuseaPlugin({ command: "build", mode: "production" }), true);
 });


### PR DESCRIPTION
## Summary

- keep the Musea Vite plugin active during `vite build`
- continue disabling the plugin for Vite test mode
- update plugin-apply coverage for production builds

## Root Cause

The plugin `apply` predicate only allowed Vite serve mode, so `vize musea --build` / `vite build` skipped Musea scanning and Storybook compatibility generation. This made static build flows succeed without including discovered art files.

Fixes #1886.

## Validation

- `pnpm --dir npm/vite-plugin-musea exec tsx --test src/plugin/index.test.ts`
- `pnpm --dir npm/vite-plugin-musea exec vp check src/plugin/apply.ts src/plugin/index.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->