### PR TITLE
fix(musea): preserve storybook fixture context

### DIFF
--- a/crates/vize_musea/src/transform/to_csf.rs
+++ b/crates/vize_musea/src/transform/to_csf.rs
@@ -5,7 +5,10 @@
 
 #![allow(clippy::disallowed_macros)]
 
+mod script_context;
+
 use crate::types::{ArtDescriptor, ArtVariant, CsfOutput};
+use script_context::{CsfScriptContext, collect_script_context};
 use vize_carton::{String, ToCompactString, append, cstr};
 
 /// Transform an Art descriptor to Storybook CSF 3.0 format.
@@ -29,10 +32,16 @@ use vize_carton::{String, ToCompactString, append, cstr};
 /// ```
 pub fn transform_to_csf(art: &ArtDescriptor<'_>) -> CsfOutput {
     let mut output = String::default();
+    let script_context = collect_script_context(art);
 
     // Generate imports
-    output.push_str(&generate_imports(art));
+    output.push_str(&generate_imports(art, &script_context));
     output.push('\n');
+
+    if !script_context.setup_code.is_empty() {
+        output.push_str(&script_context.setup_code);
+        output.push_str("\n\n");
+    }
 
     // Generate meta (default export)
     output.push_str(&generate_meta(art));
@@ -40,7 +49,7 @@ pub fn transform_to_csf(art: &ArtDescriptor<'_>) -> CsfOutput {
 
     // Generate stories (named exports)
     for variant in &art.variants {
-        output.push_str(&generate_story(variant, art));
+        output.push_str(&generate_story(variant, &script_context));
         output.push('\n');
     }
 
@@ -59,7 +68,7 @@ pub fn transform_to_csf(art: &ArtDescriptor<'_>) -> CsfOutput {
 }
 
 /// Generate import statements.
-fn generate_imports(art: &ArtDescriptor<'_>) -> String {
+fn generate_imports(art: &ArtDescriptor<'_>, script_context: &CsfScriptContext) -> String {
     let mut imports = String::default();
 
     // Import from Storybook
@@ -70,16 +79,8 @@ fn generate_imports(art: &ArtDescriptor<'_>) -> String {
 
     append!(imports, "import Component from '{component_path}';\n");
 
-    // Add script imports if present
-    if let Some(script) = &art.script_setup {
-        // Extract imports from script setup
-        for line in script.content.lines() {
-            let trimmed = line.trim();
-            if trimmed.starts_with("import ") && !trimmed.contains("Component") {
-                imports.push_str(trimmed);
-                imports.push('\n');
-            }
-        }
+    if !script_context.imports.is_empty() {
+        imports.push_str(&script_context.imports);
     }
 
     imports
@@ -133,7 +134,7 @@ fn generate_meta(art: &ArtDescriptor<'_>) -> String {
 }
 
 /// Generate a story (named export) from a variant.
-fn generate_story(variant: &ArtVariant<'_>, _art: &ArtDescriptor<'_>) -> String {
+fn generate_story(variant: &ArtVariant<'_>, script_context: &CsfScriptContext) -> String {
     let mut story = String::default();
 
     // Convert variant name to PascalCase for export name
@@ -160,7 +161,15 @@ fn generate_story(variant: &ArtVariant<'_>, _art: &ArtDescriptor<'_>) -> String 
     story.push_str("  render: (args) => ({\n");
     story.push_str("    components: { Component },\n");
     story.push_str("    setup() {\n");
-    story.push_str("      return { args };\n");
+    if script_context.setup_bindings.is_empty() {
+        story.push_str("      return { args };\n");
+    } else {
+        append!(
+            story,
+            "      return {{ args, {} }};\n",
+            script_context.setup_bindings.join(", ")
+        );
+    }
     story.push_str("    },\n");
 
     // Use the variant's template
@@ -222,85 +231,4 @@ fn escape_template(s: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{escape_string, escape_template, to_pascal_case, transform_to_csf};
-    use crate::parse::parse_art;
-    use crate::types::ArtParseOptions;
-    use vize_carton::Bump;
-
-    #[test]
-    fn test_transform_simple() {
-        let allocator = Bump::new();
-        let source = r#"
-<art title="Button" component="./Button.vue">
-  <variant name="Primary" default>
-    <Button variant="primary">Click me</Button>
-  </variant>
-</art>
-"#;
-
-        let art = parse_art(&allocator, source, ArtParseOptions::default()).unwrap();
-        let csf = transform_to_csf(&art);
-
-        insta::assert_debug_snapshot!(csf);
-    }
-
-    #[test]
-    fn test_transform_with_category() {
-        let allocator = Bump::new();
-        let source = r#"
-<art title="Button" category="atoms" component="./Button.vue">
-  <variant name="Default">
-    <Button>Click</Button>
-  </variant>
-</art>
-"#;
-
-        let art = parse_art(&allocator, source, ArtParseOptions::default()).unwrap();
-        let csf = transform_to_csf(&art);
-
-        insta::assert_debug_snapshot!(csf);
-    }
-
-    #[test]
-    fn test_transform_multiple_variants() {
-        let allocator = Bump::new();
-        let source = r#"
-<art title="Button" component="./Button.vue">
-  <variant name="Primary">
-    <Button variant="primary">Primary</Button>
-  </variant>
-  <variant name="Secondary">
-    <Button variant="secondary">Secondary</Button>
-  </variant>
-</art>
-"#;
-
-        let art = parse_art(&allocator, source, ArtParseOptions::default()).unwrap();
-        let csf = transform_to_csf(&art);
-
-        insta::assert_debug_snapshot!(csf);
-    }
-
-    #[test]
-    fn test_to_pascal_case() {
-        assert_eq!(to_pascal_case("primary"), "Primary");
-        assert_eq!(to_pascal_case("with icon"), "WithIcon");
-        assert_eq!(to_pascal_case("my-button"), "MyButton");
-        assert_eq!(to_pascal_case("my_button"), "MyButton");
-    }
-
-    #[test]
-    fn test_escape_string() {
-        assert_eq!(escape_string("hello"), "hello");
-        assert_eq!(escape_string("it's"), "it\\'s");
-        assert_eq!(escape_string("line\nbreak"), "line\\nbreak");
-    }
-
-    #[test]
-    fn test_escape_template() {
-        assert_eq!(escape_template("hello"), "hello");
-        assert_eq!(escape_template("`code`"), "\\`code\\`");
-        assert_eq!(escape_template("${var}"), "\\${var}");
-    }
-}
+mod tests;

--- a/crates/vize_musea/src/transform/to_csf/script_context.rs
+++ b/crates/vize_musea/src/transform/to_csf/script_context.rs
@@ -1,0 +1,137 @@
+use crate::types::ArtDescriptor;
+use std::collections::BTreeSet;
+use vize_carton::{String, ToCompactString};
+
+#[derive(Default)]
+pub(super) struct CsfScriptContext {
+    pub(super) imports: String,
+    pub(super) setup_code: String,
+    pub(super) setup_bindings: Vec<String>,
+}
+
+pub(super) fn collect_script_context(art: &ArtDescriptor<'_>) -> CsfScriptContext {
+    let Some(script) = &art.script_setup else {
+        return CsfScriptContext::default();
+    };
+
+    let parsed = vize_croquis::script_parser::parse_script_setup(script.content);
+    let mut ranges = Vec::<(usize, usize)>::new();
+    let mut imports = String::default();
+
+    for import in &parsed.import_statements {
+        let range = (import.start as usize, import.end as usize);
+        if let Some(source) = script.content.get(range.0..range.1) {
+            imports.push_str(source.trim());
+            imports.push('\n');
+            ranges.push(range);
+        }
+    }
+
+    if let Some(call) = parsed.macros.define_art_call() {
+        ranges.push(expand_statement_range(
+            script.content,
+            call.start as usize,
+            call.end as usize,
+        ));
+    }
+
+    let references = collect_template_identifiers(art);
+    let mut setup_bindings = parsed
+        .bindings
+        .iter()
+        .filter(|(name, _)| references.contains(*name))
+        .map(|(name, _)| name.to_compact_string())
+        .collect::<Vec<_>>();
+    setup_bindings.sort();
+
+    CsfScriptContext {
+        imports,
+        setup_code: remove_ranges(script.content, ranges),
+        setup_bindings,
+    }
+}
+
+fn expand_statement_range(source: &str, start: usize, end: usize) -> (usize, usize) {
+    let bytes = source.as_bytes();
+    let mut expanded_end = end.min(bytes.len());
+    while expanded_end < bytes.len()
+        && bytes[expanded_end].is_ascii_whitespace()
+        && bytes[expanded_end] != b'\n'
+    {
+        expanded_end += 1;
+    }
+    if expanded_end < bytes.len() && bytes[expanded_end] == b';' {
+        expanded_end += 1;
+    }
+    (start.min(bytes.len()), expanded_end)
+}
+
+fn remove_ranges(source: &str, mut ranges: Vec<(usize, usize)>) -> String {
+    ranges.sort_unstable();
+
+    let mut output = String::default();
+    let mut cursor = 0;
+    for (start, end) in ranges {
+        if start > cursor
+            && let Some(chunk) = source.get(cursor..start)
+        {
+            output.push_str(chunk);
+        }
+        cursor = cursor.max(end);
+    }
+    if cursor < source.len()
+        && let Some(chunk) = source.get(cursor..source.len())
+    {
+        output.push_str(chunk);
+    }
+
+    normalize_setup_code(&output)
+}
+
+fn normalize_setup_code(source: &str) -> String {
+    let lines = source
+        .lines()
+        .map(str::trim_end)
+        .filter(|line| !line.trim().is_empty() && line.trim() != ";")
+        .collect::<Vec<_>>();
+
+    lines.join("\n").trim().to_compact_string()
+}
+
+fn collect_template_identifiers(art: &ArtDescriptor<'_>) -> BTreeSet<String> {
+    let mut identifiers = BTreeSet::new();
+    for variant in &art.variants {
+        collect_identifiers_into(variant.template, &mut identifiers);
+    }
+    identifiers
+}
+
+fn collect_identifiers_into(source: &str, identifiers: &mut BTreeSet<String>) {
+    let bytes = source.as_bytes();
+    let mut cursor = 0;
+
+    while cursor < bytes.len() {
+        if !is_identifier_start(bytes[cursor]) {
+            cursor += 1;
+            continue;
+        }
+
+        let start = cursor;
+        cursor += 1;
+        while cursor < bytes.len() && is_identifier_continue(bytes[cursor]) {
+            cursor += 1;
+        }
+
+        if let Some(identifier) = source.get(start..cursor) {
+            identifiers.insert(identifier.to_compact_string());
+        }
+    }
+}
+
+fn is_identifier_start(byte: u8) -> bool {
+    byte == b'_' || byte == b'$' || byte.is_ascii_alphabetic()
+}
+
+fn is_identifier_continue(byte: u8) -> bool {
+    is_identifier_start(byte) || byte.is_ascii_digit()
+}

--- a/crates/vize_musea/src/transform/to_csf/tests.rs
+++ b/crates/vize_musea/src/transform/to_csf/tests.rs
@@ -1,0 +1,134 @@
+use super::{escape_string, escape_template, to_pascal_case, transform_to_csf};
+use crate::parse::parse_art;
+use crate::types::ArtParseOptions;
+use vize_carton::Bump;
+
+fn transform(source: &str) -> crate::types::CsfOutput {
+    let allocator = Bump::new();
+    let art = parse_art(&allocator, source, ArtParseOptions::default()).unwrap();
+    transform_to_csf(&art)
+}
+
+#[test]
+fn transform_simple() {
+    let source = r#"
+<art title="Button" component="./Button.vue">
+  <variant name="Primary" default>
+    <Button variant="primary">Click me</Button>
+  </variant>
+</art>
+"#;
+
+    insta::with_settings!({ snapshot_path => "../snapshots" }, {
+        insta::assert_debug_snapshot!("transform_simple", transform(source));
+    });
+}
+
+#[test]
+fn transform_with_category() {
+    let source = r#"
+<art title="Button" category="atoms" component="./Button.vue">
+  <variant name="Default">
+    <Button>Click</Button>
+  </variant>
+</art>
+"#;
+
+    insta::with_settings!({ snapshot_path => "../snapshots" }, {
+        insta::assert_debug_snapshot!("transform_with_category", transform(source));
+    });
+}
+
+#[test]
+fn transform_multiple_variants() {
+    let source = r#"
+<art title="Button" component="./Button.vue">
+  <variant name="Primary">
+    <Button variant="primary">Primary</Button>
+  </variant>
+  <variant name="Secondary">
+    <Button variant="secondary">Secondary</Button>
+  </variant>
+</art>
+"#;
+
+    insta::with_settings!({ snapshot_path => "../snapshots" }, {
+        insta::assert_debug_snapshot!("transform_multiple_variants", transform(source));
+    });
+}
+
+#[test]
+fn transform_preserves_script_context_for_storybook() {
+    let source = r#"
+<script setup lang="ts">
+import {
+  base,
+  preparing,
+  finished,
+} from "./fixtures";
+import type { FixtureShape } from "./types";
+
+const notSucceeded: FixtureShape = { id: "not-succeeded" };
+
+defineArt("./MoshiDetailCard.vue", {
+  title: "MoshiDetailCard",
+  category: "Features/MoshiDetail",
+  tags: ["moshi", "detail"],
+});
+</script>
+
+<art>
+  <variant name="Available" default>
+    <MoshiDetailCard :moshi-with-student="base" />
+  </variant>
+  <variant name="Preparing">
+    <MoshiDetailCard :moshi-with-student="preparing" />
+  </variant>
+  <variant name="Finished">
+    <MoshiDetailCard :moshi-with-student="finished" />
+  </variant>
+  <variant name="Not Succeeded">
+    <MoshiDetailCard :moshi-with-student="notSucceeded" />
+  </variant>
+</art>
+"#;
+
+    let csf = transform(source);
+
+    assert!(
+        csf.code
+            .contains("import {\n  base,\n  preparing,\n  finished,\n} from \"./fixtures\";")
+    );
+    assert!(
+        csf.code
+            .contains("import type { FixtureShape } from \"./types\";")
+    );
+    assert!(csf.code.contains("const notSucceeded: FixtureShape"));
+    assert!(!csf.code.contains("defineArt("));
+    assert!(
+        csf.code
+            .contains("return { args, base, finished, notSucceeded, preparing };")
+    );
+}
+
+#[test]
+fn test_to_pascal_case() {
+    assert_eq!(to_pascal_case("primary"), "Primary");
+    assert_eq!(to_pascal_case("with icon"), "WithIcon");
+    assert_eq!(to_pascal_case("my-button"), "MyButton");
+    assert_eq!(to_pascal_case("my_button"), "MyButton");
+}
+
+#[test]
+fn test_escape_string() {
+    assert_eq!(escape_string("hello"), "hello");
+    assert_eq!(escape_string("it's"), "it\\'s");
+    assert_eq!(escape_string("line\nbreak"), "line\\nbreak");
+}
+
+#[test]
+fn test_escape_template() {
+    assert_eq!(escape_template("hello"), "hello");
+    assert_eq!(escape_template("`code`"), "\\`code\\`");
+    assert_eq!(escape_template("${var}"), "\\${var}");
+}


### PR DESCRIPTION
## Summary

- preserve full script setup import declarations when generating Storybook CSF
- carry non-import fixture/setup code into the generated story module
- return template-referenced script setup bindings from each story setup
- split CSF tests/helpers so source-length gates stay clean

## Root Cause

The CSF generator scanned script setup imports line-by-line. Multi-line imports were emitted as unterminated `import {` declarations, and fixture bindings referenced by generated templates were not exposed from Storybook `setup()`.

Fixes #1902.

## Validation

- `cargo test -p vize_musea transform::to_csf::tests`
- `cargo fmt --check`
- `moon run -q --target native - -- --check --base-ref FETCH_HEAD --max-lines 350 --limit 5 < tools/moon/scripts/source_file_lengths.mbtx`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->