### PR TITLE
fix(nuxt): expose module root to cjs resolvers

### DIFF
--- a/npm/nuxt/package.json
+++ b/npm/nuxt/package.json
@@ -32,8 +32,9 @@
   "types": "./dist/index.d.mts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs",
-      "types": "./dist/index.d.mts"
+      "default": "./dist/index.mjs"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary
- add a `default` conditional export for `@vizejs/nuxt`
- keep the existing ESM import and type entries
- allow Nuxt 2/Jiti-style package root resolution to find the module entrypoint

## Root Cause
The package root export only exposed the `import` condition. CommonJS-style resolvers used by Nuxt 2/Jiti can fail package-root resolution with no matching conditional export even though `main` points at the built module.

Fixes #1869.

## Validation
- temp `node_modules` CJS `createRequire(...).resolve("@vizejs/nuxt")` resolves to `npm/nuxt/dist/index.mjs`
- `pnpm --dir npm/nuxt exec vp fmt --check package.json`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->