### PR TITLE
fix(lint): allow options api in nuxt preset

### DIFF
--- a/crates/vize_patina/src/lib.rs
+++ b/crates/vize_patina/src/lib.rs
@@ -66,7 +66,7 @@
 //! - `vapor/prefer-static-class` - Prefer static class over dynamic binding
 //! - `vapor/no-inline-template` - Disallow deprecated inline-template
 //!
-//! Script rules (enabled by opinionated / nuxt presets, or opt-in manually):
+//! Script rules (enabled by opinionated presets, or opt-in manually):
 //! - `script/no-options-api` - Disallow Options API patterns (Vapor is Composition-only)
 //! - `script/no-get-current-instance` - Disallow getCurrentInstance() (returns null in Vapor)
 //! - `script/no-next-tick` - Disallow nextTick() scheduling in Vapor-oriented code

--- a/crates/vize_patina/src/linter/script_rules/registry/mod.rs
+++ b/crates/vize_patina/src/linter/script_rules/registry/mod.rs
@@ -70,6 +70,7 @@ pub struct BuiltinScriptRuleMeta {
     pub presets: &'static [&'static str],
 }
 
+const OPINIONATED_ONLY_SCRIPT_PRESETS: &[&str] = &["opinionated"];
 const OPINIONATED_SCRIPT_PRESETS: &[&str] = &["opinionated", "nuxt"];
 const ECOSYSTEM_SCRIPT_PRESETS: &[&str] = &["ecosystem"];
 const OPT_IN_SCRIPT_PRESETS: &[&str] = &[];

--- a/crates/vize_patina/src/linter/script_rules/registry/rules.rs
+++ b/crates/vize_patina/src/linter/script_rules/registry/rules.rs
@@ -29,8 +29,8 @@ use super::names::{
     RULE_VUE_TEST_UTILS_NO_HTML_SNAPSHOT,
 };
 use super::{
-    BuiltinScriptRuleEntry, ECOSYSTEM_SCRIPT_PRESETS, OPINIONATED_SCRIPT_PRESETS,
-    OPT_IN_SCRIPT_PRESETS,
+    BuiltinScriptRuleEntry, ECOSYSTEM_SCRIPT_PRESETS, OPINIONATED_ONLY_SCRIPT_PRESETS,
+    OPINIONATED_SCRIPT_PRESETS, OPT_IN_SCRIPT_PRESETS,
 };
 use crate::rules::script::{
     ComponentOptionsNameCasing, CustomEventNameCasing, DefineEmitsDeclaration, DefineMacrosOrder,
@@ -59,7 +59,7 @@ static NO_DEEP_DESTRUCTURE_IN_PROPS_RULE: NoDeepDestructureInProps =
 /// rules stay first to preserve default diagnostic ordering; the rest are opt-in.
 #[rustfmt::skip]
 pub(in crate::linter::script_rules) static BUILTIN_SCRIPT_RULES: &[BuiltinScriptRuleEntry] = &[
-    BuiltinScriptRuleEntry { rule_name: RULE_NO_OPTIONS_API, profile_name: "patina.script_rule.no_options_api", category: "Vapor", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &NoOptionsApi },
+    BuiltinScriptRuleEntry { rule_name: RULE_NO_OPTIONS_API, profile_name: "patina.script_rule.no_options_api", category: "Vapor", fixable: false, presets: OPINIONATED_ONLY_SCRIPT_PRESETS, rule: &NoOptionsApi },
     BuiltinScriptRuleEntry { rule_name: RULE_NO_GET_CURRENT_INSTANCE, profile_name: "patina.script_rule.no_get_current_instance", category: "Vapor", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &NoGetCurrentInstance },
     BuiltinScriptRuleEntry { rule_name: RULE_NO_NEXT_TICK, profile_name: "patina.script_rule.no_next_tick", category: "Vapor", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &NoNextTick },
     BuiltinScriptRuleEntry { rule_name: RULE_PINIA_PREFER_STORE_TO_REFS, profile_name: "patina.script_rule.pinia_prefer_store_to_refs", category: "Ecosystem", fixable: false, presets: ECOSYSTEM_SCRIPT_PRESETS, rule: &PiniaPreferStoreToRefs },

--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -7,5 +7,6 @@ mod directives;
 mod jsx;
 mod jsx_fallback;
 mod no_top_level_ref;
+mod nuxt;
 mod sfc;
 mod v_for_unused_vars;

--- a/crates/vize_patina/src/linter/tests/nuxt.rs
+++ b/crates/vize_patina/src/linter/tests/nuxt.rs
@@ -1,0 +1,21 @@
+use super::{LintPreset, Linter};
+
+#[test]
+fn nuxt_preset_allows_options_api_components() {
+    let linter = Linter::with_preset(LintPreset::Nuxt);
+    let sfc = r#"<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'AppLoader',
+  props: {
+    active: Boolean
+  }
+})
+</script>
+"#;
+    let result = linter.lint_sfc(sfc, "components/AppLoader.vue");
+
+    assert_eq!(result.error_count, 0);
+    assert_eq!(result.warning_count, 0);
+}

--- a/crates/vize_patina/src/preset.rs
+++ b/crates/vize_patina/src/preset.rs
@@ -60,16 +60,19 @@ const ECOSYSTEM_SCRIPT_RULE_NAMES: &[&str] = &[
     "ecosystem/vue-router-prefer-named-push",
     "ecosystem/vue-test-utils-no-html-snapshot",
 ];
+const OPINIONATED_SCRIPT_RULE_NAMES: &[&str] = &[
+    "script/no-options-api",
+    "script/no-get-current-instance",
+    "script/no-next-tick",
+];
+const NUXT_SCRIPT_RULE_NAMES: &[&str] = &["script/no-get-current-instance", "script/no-next-tick"];
 
 pub(crate) const fn builtin_script_rule_names(preset: LintPreset) -> &'static [&'static str] {
     match preset {
         LintPreset::HappyPath | LintPreset::Essential | LintPreset::Incremental => &[],
         LintPreset::Ecosystem => ECOSYSTEM_SCRIPT_RULE_NAMES,
-        LintPreset::Opinionated | LintPreset::Nuxt => &[
-            "script/no-options-api",
-            "script/no-get-current-instance",
-            "script/no-next-tick",
-        ],
+        LintPreset::Opinionated => OPINIONATED_SCRIPT_RULE_NAMES,
+        LintPreset::Nuxt => NUXT_SCRIPT_RULE_NAMES,
     }
 }
 
@@ -212,6 +215,9 @@ mod tests {
         assert!(
             super::builtin_script_rule_names(LintPreset::Opinionated)
                 .contains(&"script/no-options-api")
+        );
+        assert!(
+            !super::builtin_script_rule_names(LintPreset::Nuxt).contains(&"script/no-options-api")
         );
         assert!(
             super::builtin_script_rule_names(LintPreset::Opinionated)

--- a/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
+++ b/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
@@ -365,7 +365,6 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
     "type/no-floating-promises",
     "type/no-reactivity-loss",
     "type/no-unsafe-template-binding",
-    "script/no-options-api",
     "script/no-get-current-instance",
     "script/no-next-tick",
     "css/no-important",

--- a/crates/vize_vitrine/src/napi/lint.rs
+++ b/crates/vize_vitrine/src/napi/lint.rs
@@ -554,7 +554,7 @@ mod tests {
             .find(|rule| rule.name == "script/no-options-api")
             .expect("script/no-options-api should be exposed");
 
-        assert_eq!(no_options_api.presets, vec!["opinionated", "nuxt"]);
+        assert_eq!(no_options_api.presets, vec!["opinionated"]);
         assert_eq!(no_options_api.default_severity, "error");
     }
 

--- a/npm/oxlint-plugin-vize/src/configs.ts
+++ b/npm/oxlint-plugin-vize/src/configs.ts
@@ -82,6 +82,11 @@ if (import.meta.vitest) {
       expect(configs.opinionatedWithTypeAware["vize/type/require-typed-props"]).toBe("warn");
     });
 
+    it("keeps Options API allowed in the Nuxt preset", () => {
+      expect(configs.nuxt["vize/script/no-options-api"]).toBeUndefined();
+      expect(configs.opinionated["vize/script/no-options-api"]).toBe("error");
+    });
+
     it("keeps ecosystem rules out of non-ecosystem presets until explicitly selected", () => {
       expect(configs.recommended["vize/ecosystem/router-link-require-to"]).toBeUndefined();
       expect(configs.nuxt["vize/ecosystem/nuxt-prefer-nuxt-link"]).toBeUndefined();

--- a/npm/oxlint-plugin-vize/src/nuxt-preset.test.ts
+++ b/npm/oxlint-plugin-vize/src/nuxt-preset.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const packageDir = path.dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = path.resolve(packageDir, "../../..");
+const pluginEntry = path.join(workspaceRoot, "npm/oxlint-plugin-vize/dist/index.mjs");
+const fixtureDir = path.join(workspaceRoot, "target", "vize-tests", "oxlint-plugin-vize-nuxt-test");
+const configPath = path.join(fixtureDir, ".oxlintrc.json");
+const optionsApiVuePath = path.join(fixtureDir, "OptionsApi.vue");
+const ansiEscapePattern = new RegExp(String.raw`\u001B\[[0-9;]*m`, "gu");
+const { configs } = await import(pathToFileURL(pluginEntry).href);
+
+assert.equal(configs.nuxt["vize/script/no-options-api"], undefined);
+assert.equal(configs.opinionated["vize/script/no-options-api"], "error");
+
+fs.rmSync(fixtureDir, { force: true, recursive: true });
+fs.mkdirSync(fixtureDir, { recursive: true });
+
+fs.writeFileSync(
+  configPath,
+  JSON.stringify(
+    {
+      plugins: ["vue"],
+      jsPlugins: [pluginEntry],
+      settings: {
+        vize: {
+          helpLevel: "none",
+          preset: "nuxt",
+        },
+      },
+      rules: {
+        "no-unused-vars": "off",
+        "vize/script/no-options-api": "error",
+      },
+    },
+    null,
+    2,
+  ),
+);
+
+fs.writeFileSync(
+  optionsApiVuePath,
+  `<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'AppLoader',
+  props: {
+    active: Boolean
+  }
+})
+</script>
+<template>
+  <div>{{ active }}</div>
+</template>
+`,
+);
+
+const run = runOxlint(["-c", ".oxlintrc.json", "-f", "stylish", "OptionsApi.vue"]);
+
+assert.equal(run.exitCode, 0, "nuxt preset should allow Options API components");
+assert.doesNotMatch(run.output, /vize\(script\/no-options-api\)/);
+
+console.log("oxlint-plugin-vize Nuxt preset tests passed!");
+
+function findOxlintBin() {
+  const pnpmStoreDir = path.join(workspaceRoot, "node_modules", ".pnpm");
+  const candidates = fs
+    .readdirSync(pnpmStoreDir)
+    .filter((entry) => entry.startsWith("oxlint@"))
+    .sort((left, right) => right.localeCompare(left))
+    .map((entry) => path.join(pnpmStoreDir, entry, "node_modules", "oxlint", "bin", "oxlint"))
+    .filter((entry) => fs.existsSync(entry));
+
+  const match = candidates[0];
+  if (match == null) {
+    throw new Error(`Unable to locate the oxlint binary in ${pnpmStoreDir}`);
+  }
+
+  return match;
+}
+
+function runOxlint(args: string[]) {
+  const env = { ...process.env };
+  delete env.GITHUB_ACTIONS;
+
+  try {
+    const stdout = execFileSync(findOxlintBin(), args, {
+      cwd: fixtureDir,
+      encoding: "utf8",
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { exitCode: 0, output: normalizeOutput(stdout) };
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "status" in error &&
+      "stdout" in error &&
+      "stderr" in error
+    ) {
+      const processError = error as { status: number | null; stdout: string; stderr: string };
+      return {
+        exitCode: processError.status ?? 1,
+        output: normalizeOutput(`${processError.stdout}${processError.stderr}`),
+      };
+    }
+
+    throw error;
+  }
+}
+
+function normalizeOutput(output: string): string {
+  return output
+    .replace(ansiEscapePattern, "")
+    .replace(new RegExp(escapeRegExp(workspaceRoot), "gu"), "<workspaceRoot>")
+    .replace(/^WARNING: JS plugins are experimental and not subject to semver\.\n/gmu, "")
+    .replace(
+      /^Breaking changes are possible while JS plugins support is under development\.\n/gmu,
+      "",
+    )
+    .trim();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`);
+}

--- a/npm/oxlint-plugin-vize/src/test.ts
+++ b/npm/oxlint-plugin-vize/src/test.ts
@@ -879,5 +879,5 @@ assert.equal(
   "<template>",
   "Diagnostics should map back to their containing SFC block",
 );
-
+await import("./nuxt-preset.test.ts");
 console.log("✅ oxlint-plugin-vize integration tests passed!");

--- a/playground/e2e/__snapshots__/wasm.test.ts.snap
+++ b/playground/e2e/__snapshots__/wasm.test.ts.snap
@@ -16,7 +16,6 @@ exports[`WASM Module > should expose lint rules with preset membership 1`] = `
   ],
   "noOptionsApi": [
     "opinionated",
-    "nuxt",
   ],
   "requireVForKey": [
     "essential",


### PR DESCRIPTION
## Summary
- remove `script/no-options-api` from the Nuxt lint preset while keeping it in the opinionated preset
- update Patina/NAPI rule metadata and exported Oxlint configs
- add Nuxt preset regression coverage for native linting and the Oxlint plugin bridge

## Root Cause
The Nuxt preset reused the opinionated script-rule membership for `script/no-options-api`, so Vue 2/Nuxt 2 Options API components were reported as errors even when users selected the Nuxt preset for compatibility migration work.

Fixes #1845.

## Validation
- `cargo test -p vize_patina nuxt_preset_allows_options_api_components`
- `cargo test -p vize_patina preset::tests::preset_rule_membership_snapshot`
- `cargo test -p vize_vitrine --features napi patina_rule_metadata_includes_opinionated_script_rules`
- `pnpm -C npm/oxlint-plugin-vize exec vp check package.json src/configs.ts src/test.ts src/nuxt-preset.test.ts`
- `pnpm -C npm/oxlint-plugin-vize test` with a rebuilt local workspace native binding
- `moon run -q --target native - -- --check --base-ref origin/main --max-lines 350 --limit 10 < tools/moon/scripts/source_file_lengths.mbtx`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->