### PR TITLE
fix(vite): keep dependency vue imports optimized in dev

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/resolve-vue-runtime.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve-vue-runtime.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { VizePluginState } from "./state.ts";
+import { resolveIdHook } from "./resolve.ts";
+
+const testRoot = fs.mkdtempSync(
+  path.join(fs.realpathSync(os.tmpdir()), "vize-vue-runtime-resolve-"),
+);
+
+function writeFixtureFile(filePath: string, content = ""): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function createState(root: string): VizePluginState {
+  return {
+    cache: new Map(),
+    ssrCache: new Map(),
+    collectedCss: new Map(),
+    precompileMetadata: new Map(),
+    pendingHmrUpdateTypes: new Map(),
+    isProduction: false,
+    root,
+    clientViteBase: "/",
+    serverViteBase: "/",
+    server: {} as never,
+    filter: () => true,
+    scanPatterns: ["**/*.vue"],
+    precompileBatchSize: 128,
+    ignorePatterns: [],
+    mergedOptions: {},
+    initialized: true,
+    dynamicImportAliasRules: [],
+    cssAliasRules: [],
+    extractCss: false,
+    componentsCssFileName: "assets/vize-components.css",
+    clientViteDefine: {},
+    serverViteDefine: {},
+    logger: {
+      log() {},
+      info() {},
+      warn() {},
+      error() {},
+    } as never,
+  };
+}
+
+{
+  const projectRoot = fs.mkdtempSync(path.join(testRoot, "vuetify-runtime-"));
+  writeFixtureFile(path.join(projectRoot, "package.json"), "{}");
+
+  const importer = path.join(
+    projectRoot,
+    "node_modules",
+    ".pnpm",
+    "vuetify@3.11.0_vue@3.6.0",
+    "node_modules",
+    "vuetify",
+    "lib",
+    "components",
+    "VCard",
+    "VCard.mjs",
+  );
+  writeFixtureFile(importer, "import { withDirectives } from 'vue';");
+
+  const vuePackage = path.join(
+    projectRoot,
+    "node_modules",
+    ".pnpm",
+    "vue@3.6.0",
+    "node_modules",
+    "vue",
+  );
+  const projectVueHoist = path.join(projectRoot, "node_modules", ".pnpm", "node_modules", "vue");
+  const vueBundlerEntry = path.join(vuePackage, "dist", "vue.runtime.esm-bundler.js");
+  writeFixtureFile(
+    path.join(vuePackage, "package.json"),
+    JSON.stringify({ name: "vue", main: "index.js" }, null, 2),
+  );
+  writeFixtureFile(path.join(vuePackage, "index.js"), "module.exports = {};");
+  writeFixtureFile(vueBundlerEntry, "export const withDirectives = () => null;");
+  fs.mkdirSync(path.dirname(projectVueHoist), { recursive: true });
+  fs.symlinkSync(vuePackage, projectVueHoist, "dir");
+
+  const optimizedVueEntry = path.join(projectRoot, "node_modules", ".vite", "deps", "vue.js");
+  writeFixtureFile(optimizedVueEntry, "export const withDirectives = () => null;");
+
+  const resolved = await resolveIdHook(
+    {
+      resolve: async (id) => (id === "vue" ? { id: `${optimizedVueEntry}?v=abc123` } : null),
+    },
+    createState(projectRoot),
+    "vue",
+    importer,
+    undefined,
+  );
+
+  assert.equal(
+    resolved,
+    null,
+    "Dev Vue imports from dependencies should stay with Vite's optimized runtime to avoid duplicate Vue instances",
+  );
+}

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -658,23 +658,22 @@ async function resolveProjectVueRuntime(
     return null;
   }
 
-  const pnpmHoistedEntry = resolveVueBundlerEntryFromPnpmHoist(state, id, viteImporter);
-  if (pnpmHoistedEntry) {
-    state.logger.log(`resolveId: resolved project pnpm-hoisted Vue runtime to ${pnpmHoistedEntry}`);
-    return pnpmHoistedEntry;
-  }
-
   try {
     const resolved = await resolveWithVite(ctx, state, id, viteImporter, { skipSelf: true });
-    if (resolved && !isOptimizedVueDependency(resolved.id)) {
+    if (resolved && isOptimizedVueDependency(resolved.id)) return null;
+    if (resolved) {
       const projectLocalEntry = resolveProjectLocalPnpmVueRuntime(state, resolved.id);
       if (projectLocalEntry) {
         state.logger.log(`resolveId: resolved project-local Vue runtime to ${projectLocalEntry}`);
         return projectLocalEntry;
       }
     }
-  } catch {
-    // Fall back to Node resolution below.
+  } catch {}
+
+  const pnpmHoistedEntry = resolveVueBundlerEntryFromPnpmHoist(state, id, viteImporter);
+  if (pnpmHoistedEntry) {
+    state.logger.log(`resolveId: resolved project pnpm-hoisted Vue runtime to ${pnpmHoistedEntry}`);
+    return pnpmHoistedEntry;
   }
 
   const importerLocalEntry = resolveVueBundlerEntryWithNode(state, id, viteImporter);

--- a/npm/vite-plugin-vize/src/test.ts
+++ b/npm/vite-plugin-vize/src/test.ts
@@ -8,6 +8,7 @@ import "./plugin/index.test.ts";
 import "./plugin/load.test.ts";
 import "./plugin/native.test.ts";
 import "./plugin/quasar.test.ts";
+import "./plugin/resolve-vue-runtime.test.ts";
 import "./plugin/resolve.test.ts";
 import "./plugin/state.test.ts";
 import "./plugin/unocss.test.ts";


### PR DESCRIPTION
## Summary
- let dev dependency imports keep Vite's optimized Vue runtime instead of rewriting them to a direct pnpm-hoisted bundler entry
- add a Vuetify-shaped regression test so dependency render helpers do not split across duplicate Vue instances

Fixes #1920.

## Validation
- node npm/vite-plugin-vize/src/plugin/resolve-vue-runtime.test.ts
- pnpm -C npm/vite-plugin-vize test
- moon run -q --target native - -- --check --base-ref origin/main --max-lines 350 --limit 10 < tools/moon/scripts/source_file_lengths.mbtx

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->