### PR TITLE
fix(vite): fall back when oxc transform is unavailable

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/compat.ts
+++ b/npm/vite-plugin-vize/src/plugin/compat.ts
@@ -1,5 +1,4 @@
 import type { Plugin, TransformResult } from "vite";
-import { transformWithOxc } from "vite";
 import { createRequire } from "node:module";
 import { classifyVitePluginRequest } from "@vizejs/native";
 
@@ -14,6 +13,7 @@ import { compileFile } from "../compiler.ts";
 import { generateOutput } from "../utils/index.ts";
 import { scopeCssForPipeline } from "../utils/css.ts";
 import { applyDefineReplacements } from "../transform.ts";
+import { transformVirtualTypeScript } from "./vite-transform.ts";
 
 export function createVueCompatPlugin(state: VizePluginState): Plugin {
   let compilerSfc: unknown = null;
@@ -135,7 +135,7 @@ export function createPostTransformPlugin(state: VizePluginState): Plugin {
             filePath: id,
           });
 
-          const result = await transformWithOxc(output, id, { lang: "ts", sourcemap: false });
+          const result = await transformVirtualTypeScript(output, id);
           const defines = transformOptions?.ssr ? state.serverViteDefine : state.clientViteDefine;
           let transformed = result.code;
           if (Object.keys(defines).length > 0) {

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { classifyVitePluginRequest } from "@vizejs/native";
 import type { TransformResult } from "vite";
-import { transformWithOxc } from "vite";
 
 import {
   getCompileOptionsForRequest,
@@ -31,6 +30,7 @@ import {
   rewriteImportMetaGlobBase,
   rewriteStaticAssetUrls,
 } from "../transform.ts";
+import { transformVirtualTypeScript } from "./vite-transform.ts";
 
 const SERVER_PLACEHOLDER_CODE = `import { createElementBlock, defineComponent } from "vue";
 export default defineComponent({
@@ -500,10 +500,7 @@ export async function transformHook(
       ? (request.strippedVirtualPath ?? "")
       : (request.vizeVirtualPath ?? pluginVisibleVirtualPath ?? "");
     try {
-      const result = await transformWithOxc(code, realPath, {
-        lang: "ts",
-        sourcemap: false,
-      });
+      const result = await transformVirtualTypeScript(code, realPath);
       const defines = getVirtualModuleDefines(state, options?.ssr ?? false);
       let transformed = result.code;
       transformed = applyDefineReplacements(transformed, defines);

--- a/npm/vite-plugin-vize/src/plugin/vite-transform.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/vite-transform.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+
+import { createVirtualTypeScriptTransformer } from "./vite-transform.ts";
+
+{
+  let used = "";
+  const transform = createVirtualTypeScriptTransformer({
+    transformWithOxc: async (code, id, options) => {
+      used = "oxc";
+      assert.equal(code, "const value: number = 1");
+      assert.equal(id, "/src/App.vue");
+      assert.deepEqual(options, { lang: "ts", sourcemap: false });
+      return { code: "const value = 1;" };
+    },
+    transformWithEsbuild: async () => {
+      used = "esbuild";
+      return { code: "" };
+    },
+  });
+
+  const result = await transform("const value: number = 1", "/src/App.vue");
+  assert.equal(used, "oxc", "Vite OXC should be preferred when available");
+  assert.equal(result.code, "const value = 1;");
+}
+
+{
+  let used = "";
+  const transform = createVirtualTypeScriptTransformer({
+    transformWithEsbuild: async (code, id, options) => {
+      used = "esbuild";
+      assert.equal(code, "const value: number = 1");
+      assert.equal(id, "/src/App.vue");
+      assert.deepEqual(options, { loader: "ts", sourcemap: false });
+      return { code: "const value = 1;" };
+    },
+  });
+
+  const result = await transform("const value: number = 1", "/src/App.vue");
+  assert.equal(used, "esbuild", "Vite 7 should fall back to transformWithEsbuild");
+  assert.equal(result.code, "const value = 1;");
+}

--- a/npm/vite-plugin-vize/src/plugin/vite-transform.ts
+++ b/npm/vite-plugin-vize/src/plugin/vite-transform.ts
@@ -1,0 +1,40 @@
+import * as vite from "vite";
+
+type TransformOutput = { code: string; map?: unknown };
+type OxcOptions = { lang: "ts"; sourcemap: false };
+type EsbuildOptions = { loader: "ts"; sourcemap: false };
+type TransformWithOxc = (
+  code: string,
+  id: string,
+  options: OxcOptions,
+) => TransformOutput | Promise<TransformOutput>;
+type TransformWithEsbuild = (
+  code: string,
+  id: string,
+  options: EsbuildOptions,
+) => TransformOutput | Promise<TransformOutput>;
+
+interface ViteTransformApi {
+  transformWithOxc?: TransformWithOxc;
+  transformWithEsbuild?: TransformWithEsbuild;
+}
+
+export function createVirtualTypeScriptTransformer(viteApi: ViteTransformApi) {
+  return async (code: string, id: string): Promise<TransformOutput> => {
+    if (typeof viteApi.transformWithOxc === "function") {
+      return viteApi.transformWithOxc(code, id, {
+        lang: "ts",
+        sourcemap: false,
+      });
+    }
+    if (typeof viteApi.transformWithEsbuild === "function") {
+      return viteApi.transformWithEsbuild(code, id, {
+        loader: "ts",
+        sourcemap: false,
+      });
+    }
+    throw new Error("Installed Vite does not expose transformWithOxc or transformWithEsbuild");
+  };
+}
+
+export const transformVirtualTypeScript = createVirtualTypeScriptTransformer(vite);

--- a/npm/vite-plugin-vize/src/test.ts
+++ b/npm/vite-plugin-vize/src/test.ts
@@ -12,4 +12,5 @@ import "./plugin/resolve-vue-runtime.test.ts";
 import "./plugin/resolve.test.ts";
 import "./plugin/state.test.ts";
 import "./plugin/unocss.test.ts";
+import "./plugin/vite-transform.test.ts";
 import "./virtual.test.ts";


### PR DESCRIPTION
## Summary
- route virtual module TypeScript transforms through a small Vite adapter
- prefer transformWithOxc when available and fall back to transformWithEsbuild for Vite versions that do not expose OXC
- cover both OXC and fallback branches in plugin tests

Fixes #1858.

## Validation
- node npm/vite-plugin-vize/src/plugin/vite-transform.test.ts
- pnpm -C npm/vite-plugin-vize test
- moon run -q --target native - -- --check --base-ref origin/main --max-lines 350 --limit 10 < tools/moon/scripts/source_file_lengths.mbtx

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->