### PR TITLE
fix(lint): fail unsupported fix mode

### DIFF
--- a/crates/vize/src/commands/lint/mod.rs
+++ b/crates/vize/src/commands/lint/mod.rs
@@ -30,6 +30,11 @@ use vize_patina::{
 
 pub fn run(args: LintArgs) {
     let start = Instant::now();
+    if args.fix {
+        eprintln!("\x1b[31mError:\x1b[0m `vize lint --fix` is not supported yet.");
+        eprintln!("Remove `--fix` or run Vize lint without automatic fixes.");
+        std::process::exit(2);
+    }
     if let Some(path) = args.config.as_deref()
         && !args.no_config
         && let Err(error) = crate::config::validate_explicit_config_path(path)
@@ -272,11 +277,6 @@ pub fn run(args: LintArgs) {
         {
             println!("\n{tree}");
         }
-    }
-
-    // Fix mode warning
-    if args.fix {
-        eprintln!("\nNote: --fix is not yet implemented");
     }
 
     if args.profile {

--- a/crates/vize/tests/lint_fix_cli.rs
+++ b/crates/vize/tests/lint_fix_cli.rs
@@ -1,0 +1,20 @@
+use std::process::Command;
+
+#[test]
+fn lint_fix_exits_non_zero_while_unsupported() {
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .args(["lint", "--fix", "--no-config", "does-not-exist.vue"])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("`vize lint --fix` is not supported yet"));
+}


### PR DESCRIPTION
## Summary

- reject `vize lint --fix` with a non-zero CLI usage error while automatic fixes are unsupported
- remove the previous successful no-op note
- add an integration regression test for the unsupported `--fix` path

## Validation

- `cargo fmt --all`
- `cargo test -p vize --test lint_fix_cli`

Closes #1882

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->