### PR TITLE
fix(lint): retry transient stdout writes

### DIFF
--- a/crates/vize/src/commands/lint/mod.rs
+++ b/crates/vize/src/commands/lint/mod.rs
@@ -3,6 +3,7 @@
 mod args;
 mod collect;
 mod cross_file;
+mod stdout;
 
 #[cfg(test)]
 mod tests;
@@ -14,19 +15,16 @@ use collect::{collect_lint_files, is_standalone_html_path, resolve_lint_config_p
 use cross_file::{build_cross_file_lint_output, merge_lint_result};
 use rayon::prelude::*;
 use std::fs;
-use std::io::{self, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Duration;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use vize_carton::{String, ToCompactString, cstr, profile, profiler::global_profiler};
 use vize_curator::profile::{
     ProfileFileRow, ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report,
 };
-use vize_patina::{
-    HelpLevel, JsxLang, LintPreset, Linter, OutputFormat, format_results, format_summary,
-};
+use vize_patina::{HelpLevel, JsxLang, LintPreset, Linter, OutputFormat, format_results};
 
 pub fn run(args: LintArgs) {
     let start = Instant::now();
@@ -249,7 +247,7 @@ pub fn run(args: LintArgs) {
             format_results(&lint_results, &sources, format)
         );
         if !output.trim().is_empty() {
-            write_stdout(output.as_bytes());
+            stdout::write(output.as_bytes());
         }
     }
     let output_time = output_start.elapsed();
@@ -267,19 +265,15 @@ pub fn run(args: LintArgs) {
     // Print summary
     let elapsed = start.elapsed();
     if format == OutputFormat::Text {
-        write_stdout(
-            cstr!(
-                "\n{}\n",
-                format_summary(total_errors, total_warnings, files.len())
-            )
-            .as_bytes(),
+        stdout::write_text_summary(
+            total_errors,
+            total_warnings,
+            files.len(),
+            elapsed,
+            args.cross_file_tree
+                .then_some(cross_file_tree.as_deref())
+                .flatten(),
         );
-        write_stdout(cstr!("Linted {} files in {:.4?}\n", files.len(), elapsed).as_bytes());
-        if args.cross_file_tree
-            && let Some(tree) = cross_file_tree.as_deref()
-        {
-            write_stdout(cstr!("\n{tree}\n").as_bytes());
-        }
     }
 
     if args.profile {
@@ -401,59 +395,6 @@ pub fn run(args: LintArgs) {
         eprintln!("\nToo many warnings ({} > max {})", total_warnings, max);
         std::process::exit(1);
     }
-}
-
-fn write_stdout(bytes: &[u8]) {
-    let mut stdout = io::stdout().lock();
-    if let Err(error) = write_all_retry(&mut stdout, bytes) {
-        handle_stdout_error(error);
-    }
-}
-
-fn write_all_retry<W: Write>(writer: &mut W, bytes: &[u8]) -> io::Result<()> {
-    const MAX_CONSECUTIVE_WOULD_BLOCK: usize = 1024;
-
-    let mut written = 0;
-    let mut would_block_count = 0;
-    while written < bytes.len() {
-        match writer.write(&bytes[written..]) {
-            Ok(0) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::WriteZero,
-                    "failed to write lint output",
-                ));
-            }
-            Ok(count) => {
-                written += count;
-                would_block_count = 0;
-            }
-            Err(error)
-                if matches!(
-                    error.kind(),
-                    io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock
-                ) =>
-            {
-                would_block_count += usize::from(error.kind() == io::ErrorKind::WouldBlock);
-                if would_block_count > MAX_CONSECUTIVE_WOULD_BLOCK {
-                    return Err(error);
-                }
-                std::thread::sleep(Duration::from_millis(1));
-            }
-            Err(error) => return Err(error),
-        }
-    }
-    Ok(())
-}
-
-fn handle_stdout_error(error: io::Error) -> ! {
-    if error.kind() == io::ErrorKind::BrokenPipe {
-        std::process::exit(0);
-    }
-    eprintln!(
-        "\x1b[31mError:\x1b[0m failed to write lint output: {}",
-        error
-    );
-    std::process::exit(1);
 }
 
 fn jsx_lang_for_path(path: &Path) -> Option<JsxLang> {

--- a/crates/vize/src/commands/lint/mod.rs
+++ b/crates/vize/src/commands/lint/mod.rs
@@ -14,7 +14,7 @@ use collect::{collect_lint_files, is_standalone_html_path, resolve_lint_config_p
 use cross_file::{build_cross_file_lint_output, merge_lint_result};
 use rayon::prelude::*;
 use std::fs;
-use std::io::Write;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -249,7 +249,7 @@ pub fn run(args: LintArgs) {
             format_results(&lint_results, &sources, format)
         );
         if !output.trim().is_empty() {
-            print!("{}", output);
+            write_stdout(output.as_bytes());
         }
     }
     let output_time = output_start.elapsed();
@@ -267,15 +267,18 @@ pub fn run(args: LintArgs) {
     // Print summary
     let elapsed = start.elapsed();
     if format == OutputFormat::Text {
-        println!(
-            "\n{}",
-            format_summary(total_errors, total_warnings, files.len())
+        write_stdout(
+            cstr!(
+                "\n{}\n",
+                format_summary(total_errors, total_warnings, files.len())
+            )
+            .as_bytes(),
         );
-        println!("Linted {} files in {:.4?}", files.len(), elapsed);
+        write_stdout(cstr!("Linted {} files in {:.4?}\n", files.len(), elapsed).as_bytes());
         if args.cross_file_tree
             && let Some(tree) = cross_file_tree.as_deref()
         {
-            println!("\n{tree}");
+            write_stdout(cstr!("\n{tree}\n").as_bytes());
         }
     }
 
@@ -398,6 +401,59 @@ pub fn run(args: LintArgs) {
         eprintln!("\nToo many warnings ({} > max {})", total_warnings, max);
         std::process::exit(1);
     }
+}
+
+fn write_stdout(bytes: &[u8]) {
+    let mut stdout = io::stdout().lock();
+    if let Err(error) = write_all_retry(&mut stdout, bytes) {
+        handle_stdout_error(error);
+    }
+}
+
+fn write_all_retry<W: Write>(writer: &mut W, bytes: &[u8]) -> io::Result<()> {
+    const MAX_CONSECUTIVE_WOULD_BLOCK: usize = 1024;
+
+    let mut written = 0;
+    let mut would_block_count = 0;
+    while written < bytes.len() {
+        match writer.write(&bytes[written..]) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write lint output",
+                ));
+            }
+            Ok(count) => {
+                written += count;
+                would_block_count = 0;
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock
+                ) =>
+            {
+                would_block_count += usize::from(error.kind() == io::ErrorKind::WouldBlock);
+                if would_block_count > MAX_CONSECUTIVE_WOULD_BLOCK {
+                    return Err(error);
+                }
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+fn handle_stdout_error(error: io::Error) -> ! {
+    if error.kind() == io::ErrorKind::BrokenPipe {
+        std::process::exit(0);
+    }
+    eprintln!(
+        "\x1b[31mError:\x1b[0m failed to write lint output: {}",
+        error
+    );
+    std::process::exit(1);
 }
 
 fn jsx_lang_for_path(path: &Path) -> Option<JsxLang> {

--- a/crates/vize/src/commands/lint/stdout.rs
+++ b/crates/vize/src/commands/lint/stdout.rs
@@ -1,0 +1,116 @@
+use std::io::{self, Write};
+use std::time::Duration;
+use vize_carton::cstr;
+use vize_patina::format_summary;
+
+pub(super) fn write(bytes: &[u8]) {
+    let mut stdout = io::stdout().lock();
+    if let Err(error) = write_all_retry(&mut stdout, bytes) {
+        handle_stdout_error(error);
+    }
+}
+
+pub(super) fn write_text_summary(
+    total_errors: usize,
+    total_warnings: usize,
+    file_count: usize,
+    elapsed: Duration,
+    cross_file_tree: Option<&str>,
+) {
+    write(
+        cstr!(
+            "\n{}\n",
+            format_summary(total_errors, total_warnings, file_count)
+        )
+        .as_bytes(),
+    );
+    write(cstr!("Linted {} files in {:.4?}\n", file_count, elapsed).as_bytes());
+    if let Some(tree) = cross_file_tree {
+        write(cstr!("\n{tree}\n").as_bytes());
+    }
+}
+
+fn write_all_retry<W: Write>(writer: &mut W, bytes: &[u8]) -> io::Result<()> {
+    const MAX_CONSECUTIVE_WOULD_BLOCK: usize = 1024;
+
+    let mut written = 0;
+    let mut would_block_count = 0;
+    while written < bytes.len() {
+        match writer.write(&bytes[written..]) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write lint output",
+                ));
+            }
+            Ok(count) => {
+                written += count;
+                would_block_count = 0;
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock
+                ) =>
+            {
+                would_block_count += usize::from(error.kind() == io::ErrorKind::WouldBlock);
+                if would_block_count > MAX_CONSECUTIVE_WOULD_BLOCK {
+                    return Err(error);
+                }
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+fn handle_stdout_error(error: io::Error) -> ! {
+    if error.kind() == io::ErrorKind::BrokenPipe {
+        std::process::exit(0);
+    }
+    eprintln!(
+        "\x1b[31mError:\x1b[0m failed to write lint output: {}",
+        error
+    );
+    std::process::exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_all_retry;
+    use std::io::{self, Write};
+
+    #[test]
+    fn stdout_writer_retries_temporary_would_block() {
+        struct WouldBlockOnce {
+            attempts: usize,
+            bytes: Vec<u8>,
+        }
+
+        impl Write for WouldBlockOnce {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.attempts += 1;
+                if self.attempts == 1 {
+                    return Err(io::Error::from(io::ErrorKind::WouldBlock));
+                }
+                self.bytes.extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut writer = WouldBlockOnce {
+            attempts: 0,
+            bytes: Vec::new(),
+        };
+
+        write_all_retry(&mut writer, b"lint output").unwrap();
+
+        assert_eq!(writer.bytes, b"lint output");
+        assert_eq!(writer.attempts, 2);
+    }
+}

--- a/crates/vize/src/commands/lint/tests.rs
+++ b/crates/vize/src/commands/lint/tests.rs
@@ -2,8 +2,9 @@
 
 use super::{
     build_cross_file_lint_output, collect::collect_lint_files, should_render_lint_details,
+    write_all_retry,
 };
-use std::{fs, path::Path};
+use std::{fs, io, io::Write, path::Path};
 use vize_patina::{LintPreset, LintResult, Linter, OutputFormat};
 
 fn result_for_file<'a>(results: &'a [LintResult], file_name: &str) -> &'a LintResult {
@@ -52,6 +53,39 @@ fn report_formats_render_in_quiet_mode() {
     assert!(should_render_lint_details(OutputFormat::Markdown, true));
     assert!(should_render_lint_details(OutputFormat::Html, true));
     assert!(should_render_lint_details(OutputFormat::Agent, true));
+}
+
+#[test]
+fn stdout_writer_retries_temporary_would_block() {
+    struct WouldBlockOnce {
+        attempts: usize,
+        bytes: Vec<u8>,
+    }
+
+    impl Write for WouldBlockOnce {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.attempts += 1;
+            if self.attempts == 1 {
+                return Err(io::Error::from(io::ErrorKind::WouldBlock));
+            }
+            self.bytes.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let mut writer = WouldBlockOnce {
+        attempts: 0,
+        bytes: Vec::new(),
+    };
+
+    write_all_retry(&mut writer, b"lint output").unwrap();
+
+    assert_eq!(writer.bytes, b"lint output");
+    assert_eq!(writer.attempts, 2);
 }
 
 #[test]

--- a/crates/vize/src/commands/lint/tests.rs
+++ b/crates/vize/src/commands/lint/tests.rs
@@ -2,9 +2,8 @@
 
 use super::{
     build_cross_file_lint_output, collect::collect_lint_files, should_render_lint_details,
-    write_all_retry,
 };
-use std::{fs, io, io::Write, path::Path};
+use std::{fs, path::Path};
 use vize_patina::{LintPreset, LintResult, Linter, OutputFormat};
 
 fn result_for_file<'a>(results: &'a [LintResult], file_name: &str) -> &'a LintResult {
@@ -53,39 +52,6 @@ fn report_formats_render_in_quiet_mode() {
     assert!(should_render_lint_details(OutputFormat::Markdown, true));
     assert!(should_render_lint_details(OutputFormat::Html, true));
     assert!(should_render_lint_details(OutputFormat::Agent, true));
-}
-
-#[test]
-fn stdout_writer_retries_temporary_would_block() {
-    struct WouldBlockOnce {
-        attempts: usize,
-        bytes: Vec<u8>,
-    }
-
-    impl Write for WouldBlockOnce {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.attempts += 1;
-            if self.attempts == 1 {
-                return Err(io::Error::from(io::ErrorKind::WouldBlock));
-            }
-            self.bytes.extend_from_slice(buf);
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
-
-    let mut writer = WouldBlockOnce {
-        attempts: 0,
-        bytes: Vec::new(),
-    };
-
-    write_all_retry(&mut writer, b"lint output").unwrap();
-
-    assert_eq!(writer.bytes, b"lint output");
-    assert_eq!(writer.attempts, 2);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- replace `print!`/`println!` in the lint output path with explicit stdout writes
- retry temporary `WouldBlock` / interrupted writes so non-blocking stdout does not panic
- exit cleanly on broken pipes and report controlled write errors otherwise
- add a unit regression test for a temporary `WouldBlock` stdout writer

## Validation

- `cargo fmt --all`
- `cargo test -p vize stdout_writer_retries_temporary_would_block`

Closes #1859

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->