### PR TITLE
fix(fmt): honor entry ignores during discovery

### DIFF
--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -3,8 +3,6 @@
 #![allow(clippy::disallowed_macros)]
 
 use clap::Args;
-use glob::{MatchOptions, Pattern, glob};
-use ignore::WalkBuilder;
 use oxc_span::SourceType;
 use rayon::prelude::*;
 use std::fs;
@@ -23,8 +21,11 @@ use vize_curator::profile::{
     ProfileFileRow, ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report,
 };
 
-const NODE_MODULES_DIR: &str = "node_modules";
-const VIZE_CACHE_DIR: &str = ".vize";
+mod files;
+mod ignores;
+
+use files::collect_files;
+use ignores::load_fmt_ignore_set;
 
 #[derive(Args)]
 #[allow(clippy::disallowed_types)]
@@ -104,10 +105,11 @@ pub fn run(args: FmtArgs) {
         std::process::exit(2);
     }
     let options = build_format_options(&args);
+    let ignore_set = load_fmt_ignore_set(&args);
 
     // Collect files to format
     let collect_start = Instant::now();
-    let files: Vec<PathBuf> = collect_files(&args.patterns);
+    let files: Vec<PathBuf> = collect_files(&args.patterns, ignore_set.as_ref());
     let collect_time = collect_start.elapsed();
 
     if files.is_empty() {
@@ -375,168 +377,6 @@ fn default_fmt_patterns() -> Vec<std::string::String> {
     ]
 }
 
-#[allow(clippy::disallowed_types)]
-fn collect_files(patterns: &[std::string::String]) -> Vec<PathBuf> {
-    let mut files = Vec::new();
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-
-    for pattern in patterns {
-        let normalized = normalize_fmt_pattern(pattern);
-        if should_walk_with_gitignore(&normalized) {
-            if let Some(pattern) = FmtPattern::new(&normalized, &cwd) {
-                collect_walked_files(&pattern, &mut files);
-            }
-        } else if contains_glob_char(&normalized) {
-            if let Ok(paths) = glob(&normalized) {
-                for path in paths.flatten() {
-                    if is_format_target(&path) && !is_generated_path(&path) {
-                        files.push(path);
-                    }
-                }
-            }
-        } else {
-            let path = PathBuf::from(&normalized);
-            if is_format_target(&path) && path.is_file() && !is_generated_path(&path) {
-                files.push(path);
-            }
-        }
-    }
-
-    // Remove duplicates
-    files.sort();
-    files.dedup();
-
-    files
-}
-
-fn collect_walked_files(pattern: &FmtPattern, files: &mut Vec<PathBuf>) {
-    // Use ignore crate to walk directories respecting .gitignore
-    let walker = WalkBuilder::new(".")
-        .hidden(false)
-        .git_ignore(true)
-        .git_global(true)
-        .git_exclude(true)
-        .build();
-
-    for entry in walker.filter_map(Result::ok) {
-        let path = entry.path();
-        if is_format_target(path) && pattern.matches(path) && !is_generated_path(path) {
-            files.push(path.to_path_buf());
-        }
-    }
-}
-
-#[inline]
-fn should_walk_with_gitignore(pattern: &str) -> bool {
-    matches!(
-        pattern,
-        "**/*"
-            | "./**/*"
-            | "**/*.vue"
-            | "./**/*.vue"
-            | "**/*.jsx"
-            | "./**/*.jsx"
-            | "**/*.tsx"
-            | "./**/*.tsx"
-    )
-}
-
-struct FmtPattern {
-    pattern: Pattern,
-    cwd: PathBuf,
-    absolute: bool,
-}
-
-impl FmtPattern {
-    fn new(pattern: &str, cwd: &Path) -> Option<Self> {
-        let normalized = normalize_fmt_pattern(pattern);
-        let absolute = Path::new(&normalized).is_absolute();
-        Pattern::new(&normalized).ok().map(|pattern| Self {
-            pattern,
-            cwd: cwd.to_path_buf(),
-            absolute,
-        })
-    }
-
-    fn matches(&self, path: &Path) -> bool {
-        let candidate = if self.absolute {
-            let relative = path.strip_prefix(".").unwrap_or(path);
-            let absolute = if relative.is_absolute() {
-                relative.to_path_buf()
-            } else {
-                self.cwd.join(relative)
-            };
-            normalize_path(&absolute)
-        } else {
-            normalize_path(path.strip_prefix(".").unwrap_or(path))
-        };
-
-        self.pattern
-            .matches_with(candidate.as_str(), fmt_glob_match_options())
-    }
-}
-
-fn normalize_fmt_pattern(pattern: &str) -> vize_carton::String {
-    let mut normalized: vize_carton::String = pattern.replace('\\', "/").into();
-    while let Some(stripped) = normalized.strip_prefix("./") {
-        normalized = stripped.into();
-    }
-
-    if normalized.is_empty() || normalized == "." {
-        return "**/*".into();
-    }
-
-    if !contains_glob_char(&normalized) && Path::new(&normalized).is_dir() {
-        if !normalized.ends_with('/') {
-            normalized.push('/');
-        }
-        normalized.push_str("**/*");
-    }
-
-    normalized
-}
-
-#[inline]
-fn is_format_target(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "vue" | "jsx" | "tsx"))
-}
-
-#[inline]
-fn normalize_path(path: &Path) -> vize_carton::String {
-    path.to_string_lossy().replace('\\', "/").into()
-}
-
-#[inline]
-fn contains_glob_char(pattern: &str) -> bool {
-    pattern.contains(['*', '?', '['])
-}
-
-fn is_generated_path(path: &Path) -> bool {
-    let mut previous = None;
-    for component in path.components() {
-        let Some(name) = component.as_os_str().to_str() else {
-            previous = None;
-            continue;
-        };
-        if previous == Some(NODE_MODULES_DIR) && name == VIZE_CACHE_DIR {
-            return true;
-        }
-        previous = Some(name);
-    }
-    false
-}
-
-#[inline]
-fn fmt_glob_match_options() -> MatchOptions {
-    MatchOptions {
-        case_sensitive: !cfg!(windows),
-        require_literal_separator: true,
-        require_literal_leading_dot: false,
-    }
-}
-
 #[inline]
 #[allow(clippy::disallowed_types)]
 fn process_file(
@@ -736,74 +576,13 @@ struct FormatFileProfile {
 
 #[cfg(test)]
 mod tests {
-    use super::{FmtPattern, atomic_write, collect_files, format_file_source};
+    use super::{atomic_write, format_file_source};
     use std::{
         fs,
         path::{Path, PathBuf},
         time::{SystemTime, UNIX_EPOCH},
     };
     use vize_carton::{String, ToCompactString};
-
-    #[test]
-    fn absolute_glob_only_matches_requested_directory() {
-        let root = unique_case_dir("absolute-glob");
-        let input_dir = root.join("bench-input");
-        let other_dir = root.join("other");
-        let _ = fs::remove_dir_all(&root);
-        fs::create_dir_all(&input_dir).unwrap();
-        fs::create_dir_all(&other_dir).unwrap();
-        fs::write(input_dir.join("A.vue"), "<template><div/></template>").unwrap();
-        fs::write(other_dir.join("B.vue"), "<template><div/></template>").unwrap();
-
-        let pattern = input_dir.join("*.vue").to_string_lossy().into_owned();
-        let files = collect_files(&[pattern]);
-        let _ = fs::remove_dir_all(&root);
-
-        assert_eq!(files, vec![input_dir.join("A.vue")]);
-    }
-
-    #[test]
-    fn collect_files_skips_generated_vize_workspace() {
-        let root = unique_case_dir("generated-vize");
-        let src = root.join("src");
-        let generated = root.join("node_modules/.vize/corsa-overlay/src");
-        let _ = fs::remove_dir_all(&root);
-        fs::create_dir_all(&src).unwrap();
-        fs::create_dir_all(&generated).unwrap();
-        fs::write(src.join("App.vue"), "<template><div/></template>").unwrap();
-        fs::write(generated.join("App.vue"), "<template><div/></template>").unwrap();
-
-        let pattern = root.join("**/*.vue").to_string_lossy().into_owned();
-        let files = collect_files(&[pattern]);
-        let _ = fs::remove_dir_all(&root);
-
-        assert_eq!(files, vec![src.join("App.vue")]);
-    }
-
-    #[test]
-    fn collect_files_matches_vue_jsx_and_tsx() {
-        let root = unique_case_dir("format-targets");
-        let src = root.join("src");
-        let _ = fs::remove_dir_all(&root);
-        fs::create_dir_all(&src).unwrap();
-        fs::write(src.join("App.vue"), "<template><div/></template>").unwrap();
-        fs::write(src.join("Panel.jsx"), "const Panel=()=> <div />").unwrap();
-        fs::write(src.join("Widget.tsx"), "const Widget=()=> <div />").unwrap();
-        fs::write(src.join("types.ts"), "export type Widget = {}").unwrap();
-
-        let pattern = root.to_string_lossy().into_owned();
-        let files = collect_files(&[pattern]);
-        let _ = fs::remove_dir_all(&root);
-
-        assert_eq!(
-            files,
-            vec![
-                src.join("App.vue"),
-                src.join("Panel.jsx"),
-                src.join("Widget.tsx")
-            ]
-        );
-    }
 
     #[test]
     fn format_file_source_formats_standalone_tsx() {
@@ -818,15 +597,6 @@ mod tests {
         .unwrap();
 
         insta::assert_snapshot!(result.code.as_str());
-    }
-
-    #[test]
-    fn relative_glob_does_not_match_every_vue_file() {
-        let cwd = std::env::current_dir().unwrap();
-        let pattern = FmtPattern::new("bench/__in__/*.vue", &cwd).unwrap();
-
-        assert!(pattern.matches(Path::new("./bench/__in__/Component0000.vue")));
-        assert!(!pattern.matches(Path::new("./examples/cli/src/App.vue")));
     }
 
     #[test]

--- a/crates/vize/src/commands/fmt/files.rs
+++ b/crates/vize/src/commands/fmt/files.rs
@@ -1,0 +1,311 @@
+use glob::{MatchOptions, Pattern, glob};
+use ignore::WalkBuilder;
+use std::path::{Path, PathBuf};
+
+use super::ignores::FmtIgnoreSet;
+
+const NODE_MODULES_DIR: &str = "node_modules";
+const VIZE_CACHE_DIR: &str = ".vize";
+
+#[allow(clippy::disallowed_types)]
+pub(super) fn collect_files(
+    patterns: &[std::string::String],
+    ignore_set: Option<&FmtIgnoreSet>,
+) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+    for pattern in patterns {
+        let normalized = normalize_fmt_pattern(pattern);
+        if should_walk_with_gitignore(&normalized) {
+            if let Some(pattern) = FmtPattern::new(&normalized, &cwd) {
+                collect_walked_files(&pattern, ignore_set, &mut files);
+            }
+        } else if contains_glob_char(&normalized) {
+            if let Ok(paths) = glob(&normalized) {
+                for path in paths.flatten() {
+                    if should_include_format_file(&path, ignore_set) {
+                        files.push(path);
+                    }
+                }
+            }
+        } else {
+            let path = PathBuf::from(&normalized);
+            if path.is_file() && should_include_format_file(&path, ignore_set) {
+                files.push(path);
+            }
+        }
+    }
+
+    files.sort();
+    files.dedup();
+
+    files
+}
+
+fn collect_walked_files(
+    pattern: &FmtPattern,
+    ignore_set: Option<&FmtIgnoreSet>,
+    files: &mut Vec<PathBuf>,
+) {
+    let walker = WalkBuilder::new(".")
+        .hidden(false)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .build();
+
+    for entry in walker.filter_map(Result::ok) {
+        let path = entry.path();
+        if pattern.matches(path) && should_include_format_file(path, ignore_set) {
+            files.push(path.to_path_buf());
+        }
+    }
+}
+
+fn should_include_format_file(path: &Path, ignore_set: Option<&FmtIgnoreSet>) -> bool {
+    is_format_target(path)
+        && !is_generated_path(path)
+        && !ignore_set.is_some_and(|ignore_set| ignore_set.is_ignored(path))
+}
+
+#[inline]
+fn should_walk_with_gitignore(pattern: &str) -> bool {
+    matches!(
+        pattern,
+        "**/*"
+            | "./**/*"
+            | "**/*.vue"
+            | "./**/*.vue"
+            | "**/*.jsx"
+            | "./**/*.jsx"
+            | "**/*.tsx"
+            | "./**/*.tsx"
+    )
+}
+
+pub(super) struct FmtPattern {
+    pattern: Pattern,
+    cwd: PathBuf,
+    absolute: bool,
+}
+
+impl FmtPattern {
+    pub(super) fn new(pattern: &str, cwd: &Path) -> Option<Self> {
+        let normalized = normalize_fmt_pattern(pattern);
+        let absolute = Path::new(&normalized).is_absolute();
+        Pattern::new(&normalized).ok().map(|pattern| Self {
+            pattern,
+            cwd: cwd.to_path_buf(),
+            absolute,
+        })
+    }
+
+    pub(super) fn matches(&self, path: &Path) -> bool {
+        let candidate = if self.absolute {
+            let relative = path.strip_prefix(".").unwrap_or(path);
+            let absolute = if relative.is_absolute() {
+                relative.to_path_buf()
+            } else {
+                self.cwd.join(relative)
+            };
+            normalize_path(&absolute)
+        } else {
+            normalize_path(path.strip_prefix(".").unwrap_or(path))
+        };
+
+        self.pattern
+            .matches_with(candidate.as_str(), fmt_glob_match_options())
+    }
+}
+
+fn normalize_fmt_pattern(pattern: &str) -> vize_carton::String {
+    let mut normalized: vize_carton::String = pattern.replace('\\', "/").into();
+    while let Some(stripped) = normalized.strip_prefix("./") {
+        normalized = stripped.into();
+    }
+
+    if normalized.is_empty() || normalized == "." {
+        return "**/*".into();
+    }
+
+    if !contains_glob_char(&normalized) && Path::new(&normalized).is_dir() {
+        if !normalized.ends_with('/') {
+            normalized.push('/');
+        }
+        normalized.push_str("**/*");
+    }
+
+    normalized
+}
+
+#[inline]
+fn is_format_target(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| matches!(extension, "vue" | "jsx" | "tsx"))
+}
+
+#[inline]
+fn normalize_path(path: &Path) -> vize_carton::String {
+    path.to_string_lossy().replace('\\', "/").into()
+}
+
+#[inline]
+fn contains_glob_char(pattern: &str) -> bool {
+    pattern.contains(['*', '?', '['])
+}
+
+fn is_generated_path(path: &Path) -> bool {
+    let mut previous = None;
+    for component in path.components() {
+        let Some(name) = component.as_os_str().to_str() else {
+            previous = None;
+            continue;
+        };
+        if previous == Some(NODE_MODULES_DIR) && name == VIZE_CACHE_DIR {
+            return true;
+        }
+        previous = Some(name);
+    }
+    false
+}
+
+#[inline]
+fn fmt_glob_match_options() -> MatchOptions {
+    MatchOptions {
+        case_sensitive: !cfg!(windows),
+        require_literal_separator: true,
+        require_literal_leading_dot: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FmtPattern, collect_files};
+    use crate::commands::fmt::ignores::FmtIgnoreSet;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+    use vize_carton::{String, ToCompactString};
+
+    #[test]
+    fn absolute_glob_only_matches_requested_directory() {
+        let root = unique_case_dir("absolute-glob");
+        let input_dir = root.join("bench-input");
+        let other_dir = root.join("other");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&input_dir).unwrap();
+        fs::create_dir_all(&other_dir).unwrap();
+        fs::write(input_dir.join("A.vue"), "<template><div/></template>").unwrap();
+        fs::write(other_dir.join("B.vue"), "<template><div/></template>").unwrap();
+
+        let pattern = input_dir.join("*.vue").to_string_lossy().into_owned();
+        let files = collect_files(&[pattern], None);
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(files, vec![input_dir.join("A.vue")]);
+    }
+
+    #[test]
+    fn collect_files_skips_generated_vize_workspace() {
+        let root = unique_case_dir("generated-vize");
+        let src = root.join("src");
+        let generated = root.join("node_modules/.vize/corsa-overlay/src");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&src).unwrap();
+        fs::create_dir_all(&generated).unwrap();
+        fs::write(src.join("App.vue"), "<template><div/></template>").unwrap();
+        fs::write(generated.join("App.vue"), "<template><div/></template>").unwrap();
+
+        let pattern = root.join("**/*.vue").to_string_lossy().into_owned();
+        let files = collect_files(&[pattern], None);
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(files, vec![src.join("App.vue")]);
+    }
+
+    #[test]
+    fn collect_files_matches_vue_jsx_and_tsx() {
+        let root = unique_case_dir("format-targets");
+        let src = root.join("src");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("App.vue"), "<template><div/></template>").unwrap();
+        fs::write(src.join("Panel.jsx"), "const Panel=()=> <div />").unwrap();
+        fs::write(src.join("Widget.tsx"), "const Widget=()=> <div />").unwrap();
+        fs::write(src.join("types.ts"), "export type Widget = {}").unwrap();
+
+        let pattern = root.to_string_lossy().into_owned();
+        let files = collect_files(&[pattern], None);
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(
+            files,
+            vec![
+                src.join("App.vue"),
+                src.join("Panel.jsx"),
+                src.join("Widget.tsx")
+            ]
+        );
+    }
+
+    #[test]
+    fn collect_files_applies_entry_ignores() {
+        let root = unique_case_dir("entry-ignores");
+        let src = root.join("src");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("App.vue"), "<template><div /></template>").unwrap();
+        fs::write(src.join("Ignored.vue"), "<template><div /></template>").unwrap();
+
+        let ignore_set = FmtIgnoreSet::new(
+            &[crate::config::ConfigEntryIgnore {
+                base_path: None,
+                pattern: "src/Ignored.vue".into(),
+            }],
+            &root,
+        );
+        let pattern = root.to_string_lossy().into_owned();
+        let files = collect_files(&[pattern], ignore_set.as_ref());
+        let explicit = collect_files(
+            &[src.join("Ignored.vue").to_string_lossy().into_owned()],
+            ignore_set.as_ref(),
+        );
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(files, vec![src.join("App.vue")]);
+        assert!(explicit.is_empty());
+    }
+
+    #[test]
+    fn relative_glob_does_not_match_every_vue_file() {
+        let cwd = std::env::current_dir().unwrap();
+        let pattern = FmtPattern::new("bench/__in__/*.vue", &cwd).unwrap();
+
+        assert!(pattern.matches(Path::new("./bench/__in__/Component0000.vue")));
+        assert!(!pattern.matches(Path::new("./examples/cli/src/App.vue")));
+    }
+
+    fn unique_case_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let mut dir_name = String::from(name);
+        dir_name.push('-');
+        let pid = std::process::id().to_compact_string();
+        dir_name.push_str(pid.as_str());
+        dir_name.push('-');
+        let nanos = nanos.to_compact_string();
+        dir_name.push_str(nanos.as_str());
+        std::env::current_dir()
+            .unwrap()
+            .join("target")
+            .join("vize-tests")
+            .join("fmt")
+            .join(dir_name.as_str())
+    }
+}

--- a/crates/vize/src/commands/fmt/ignores.rs
+++ b/crates/vize/src/commands/fmt/ignores.rs
@@ -1,0 +1,61 @@
+use std::path::{Path, PathBuf};
+
+use super::{FmtArgs, files::FmtPattern};
+use crate::config;
+
+pub(super) struct FmtIgnoreSet {
+    patterns: Vec<FmtPattern>,
+}
+
+impl FmtIgnoreSet {
+    pub(super) fn new(ignores: &[config::ConfigEntryIgnore], config_dir: &Path) -> Option<Self> {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let patterns = ignores
+            .iter()
+            .filter_map(|ignore| {
+                let pattern = resolve_entry_ignore_pattern(ignore, config_dir);
+                FmtPattern::new(pattern.to_string_lossy().as_ref(), &cwd)
+            })
+            .collect::<Vec<_>>();
+        (!patterns.is_empty()).then_some(Self { patterns })
+    }
+
+    pub(super) fn is_ignored(&self, path: &Path) -> bool {
+        self.patterns.iter().any(|pattern| pattern.matches(path))
+    }
+}
+
+pub(super) fn load_fmt_ignore_set(args: &FmtArgs) -> Option<FmtIgnoreSet> {
+    if args.no_config {
+        return None;
+    }
+    let loaded = config::load_config_entry_ignores_with_source(args.config.as_deref());
+    if loaded.ignores.is_empty() {
+        return None;
+    }
+    let config_dir = loaded
+        .source_path
+        .as_deref()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    FmtIgnoreSet::new(&loaded.ignores, &config_dir)
+}
+
+fn resolve_entry_ignore_pattern(ignore: &config::ConfigEntryIgnore, config_dir: &Path) -> PathBuf {
+    let pattern = Path::new(ignore.pattern.as_str());
+    if pattern.is_absolute() {
+        return pattern.to_path_buf();
+    }
+
+    let base = ignore
+        .base_path
+        .as_deref()
+        .map(Path::new)
+        .filter(|base_path| !base_path.as_os_str().is_empty());
+    match base {
+        Some(base_path) if base_path.is_absolute() => base_path.join(pattern),
+        Some(base_path) => config_dir.join(base_path).join(pattern),
+        None => config_dir.join(pattern),
+    }
+}

--- a/crates/vize_carton/src/config.rs
+++ b/crates/vize_carton/src/config.rs
@@ -5,16 +5,17 @@ mod model;
 mod normalize;
 
 pub use loader::{
-    LoadedConfig, LoadedConfigWithFeatures, load_compiler_jsx_mode, load_compiler_template_syntax,
-    load_compiler_vue_version, load_config, load_config_and_linter_with_features_and_source,
-    load_config_and_linter_with_source, load_config_with_features_and_source,
+    LoadedConfig, LoadedConfigEntryIgnores, LoadedConfigWithFeatures, load_compiler_jsx_mode,
+    load_compiler_template_syntax, load_compiler_vue_version, load_config,
+    load_config_and_linter_with_features_and_source, load_config_and_linter_with_source,
+    load_config_entry_ignores_with_source, load_config_with_features_and_source,
     load_config_with_source, load_linter_config, validate_explicit_config_path,
 };
 pub use model::{
-    ArrowParens, AttributeSortOrder, ConfigFeatureFlags, EndOfLine, FormatterConfig,
-    GlobalTypeDeclaration, GlobalTypesConfig, JsxMode, LanguageServerConfig, LintRuleSeverity,
-    LinterConfig, LspConfig, ParseVueVersionError, QuoteProps, TrailingComma, TypeCheckerConfig,
-    VizeConfig, VueVersion,
+    ArrowParens, AttributeSortOrder, ConfigEntryIgnore, ConfigFeatureFlags, EndOfLine,
+    FormatterConfig, GlobalTypeDeclaration, GlobalTypesConfig, JsxMode, LanguageServerConfig,
+    LintRuleSeverity, LinterConfig, LspConfig, ParseVueVersionError, QuoteProps, TrailingComma,
+    TypeCheckerConfig, VizeConfig, VueVersion,
 };
 pub use normalize::normalize_public_config_value;
 

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -17,7 +17,9 @@ use std::path::{Path, PathBuf};
 use discovery::{resolve_dir_path, resolve_file_path};
 use parse::{parse_raw_config_file, try_parse_raw_candidate};
 
-use super::model::{ConfigFeatureFlags, LinterConfig, RawVizeConfig, VizeConfig};
+use super::model::{
+    ConfigEntryIgnore, ConfigFeatureFlags, LinterConfig, RawVizeConfig, VizeConfig,
+};
 
 const CONFIG_FILE_NAMES: [&str; 5] = [
     "vize.config.pkl",
@@ -45,6 +47,12 @@ pub struct LoadedConfigWithFeatures {
     pub source_path: Option<PathBuf>,
     /// Auxiliary feature flags parsed from config keys.
     pub features: ConfigFeatureFlags,
+}
+
+#[derive(Debug, Clone)]
+pub struct LoadedConfigEntryIgnores {
+    pub ignores: Vec<ConfigEntryIgnore>,
+    pub source_path: Option<PathBuf>,
 }
 
 struct LoadedRawConfig {
@@ -193,6 +201,31 @@ pub fn load_config_and_linter_with_features_and_source(
 pub fn load_linter_config(path: Option<&Path>) -> LinterConfig {
     let loaded = load_raw_config_with_source(path);
     load_linter_from_raw_config(&loaded.config)
+}
+
+pub fn load_config_entry_ignores_with_source(path: Option<&Path>) -> LoadedConfigEntryIgnores {
+    let loaded = load_raw_config_with_source(path);
+    let ignores = loaded
+        .config
+        .entries
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .flat_map(|entry| {
+            entry
+                .ignores
+                .iter()
+                .cloned()
+                .map(|pattern| ConfigEntryIgnore {
+                    base_path: entry.base_path.clone(),
+                    pattern,
+                })
+        })
+        .collect();
+    LoadedConfigEntryIgnores {
+        ignores,
+        source_path: loaded.source_path,
+    }
 }
 
 fn load_linter_from_raw_config(config: &RawVizeConfig) -> LinterConfig {

--- a/crates/vize_carton/src/config/loader/tests.rs
+++ b/crates/vize_carton/src/config/loader/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     load_compiler_jsx_mode, load_compiler_template_syntax, load_compiler_vue_version,
-    load_config_and_linter_with_source, load_config_with_source, load_linter_config,
-    validate_explicit_config_path,
+    load_config_and_linter_with_source, load_config_entry_ignores_with_source,
+    load_config_with_source, load_linter_config, validate_explicit_config_path,
 };
 use crate::config::{JsxMode, VueVersion};
 
@@ -249,6 +249,34 @@ fn load_linter_config_keeps_root_preset_over_entry_preset() {
     let linter = load_linter_config(Some(&config_path));
 
     assert_eq!(linter.preset.as_deref(), Some("nuxt"));
+}
+
+#[test]
+fn load_config_entry_ignores_preserves_base_paths() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(
+        &config_path,
+        r#"{
+  "entries": [
+    { "name": "app", "ignores": ["components/Legacy.vue"] },
+    { "name": "design", "basePath": "design-system", "ignores": ["src/Fixture.vue"] }
+  ]
+}"#,
+    )
+    .unwrap();
+
+    let loaded = load_config_entry_ignores_with_source(Some(&config_path));
+
+    assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
+    assert_eq!(loaded.ignores.len(), 2);
+    assert_eq!(loaded.ignores[0].base_path, None);
+    assert_eq!(loaded.ignores[0].pattern.as_str(), "components/Legacy.vue");
+    assert_eq!(
+        loaded.ignores[1].base_path.as_deref(),
+        Some("design-system")
+    );
+    assert_eq!(loaded.ignores[1].pattern.as_str(), "src/Fixture.vue");
 }
 
 #[test]

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -138,7 +138,15 @@ pub(crate) struct RawVizeConfig {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub(crate) struct RawConfigEntry {
+    pub base_path: Option<String>,
+    pub ignores: Vec<String>,
     pub linter: RawLinterConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigEntryIgnore {
+    pub base_path: Option<String>,
+    pub pattern: String,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]


### PR DESCRIPTION
## Summary
- apply config entry ignores while discovering fmt targets
- preserve entry basePath when resolving ignore patterns
- move fmt file discovery into focused modules to keep source length guard stable

Closes #1872

## Validation
- cargo fmt --all
- cargo test -p vize collect_files_applies_entry_ignores
- cargo test -p vize_carton load_config_entry_ignores_preserves_base_paths

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->