### PR TITLE
fix(musea): pass camelcase autogen props to native

### DIFF
--- a/npm/vite-plugin-musea/src/autogen/index.ts
+++ b/npm/vite-plugin-musea/src/autogen/index.ts
@@ -11,6 +11,13 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { extractPropsSimple, generateMinimalArt, generateArtFileJs } from "./fallback.js";
+import {
+  fromNativeOutput,
+  toNativeAutogenConfig,
+  toNativePropDefinitions,
+  type NativeAutogenOutput,
+  type NativePropDefinition,
+} from "./native-shape.js";
 
 /**
  * Autogen configuration options.
@@ -63,35 +70,20 @@ export interface AutogenOutput {
 interface NativeAutogen {
   generateVariants?: (
     componentPath: string,
-    props: Array<{
-      name: string;
-      prop_type: string;
-      required: boolean;
-      default_value?: unknown;
-    }>,
-    config?: {
-      max_variants?: number;
-      include_default?: boolean;
-      include_boolean_toggles?: boolean;
-      include_enum_variants?: boolean;
-      include_boundary_values?: boolean;
-      include_empty_strings?: boolean;
-    },
-  ) => {
-    variants: Array<{
-      name: string;
-      is_default: boolean;
-      props: Record<string, unknown>;
-      description?: string;
-    }>;
-    art_file_content: string;
-    component_name: string;
-  };
+    props: NativePropDefinition[],
+    config?: ReturnType<typeof toNativeAutogenConfig>,
+  ) => NativeAutogenOutput;
   analyzeSfc?: (
     source: string,
     options?: { filename?: string },
   ) => {
-    props: Array<{ name: string; type: string; required: boolean; default_value?: unknown }>;
+    props: Array<{
+      name: string;
+      type: string;
+      required: boolean;
+      defaultValue?: unknown;
+      default_value?: unknown;
+    }>;
     emits: string[];
   };
 }
@@ -135,7 +127,7 @@ export async function generateArtFile(
       name: p.name,
       propType: p.type,
       required: p.required,
-      defaultValue: p.default_value,
+      defaultValue: p.defaultValue ?? p.default_value,
     }));
   } else {
     // Fallback: simple regex-based prop extraction
@@ -155,33 +147,14 @@ export async function generateArtFile(
 
   // Use native variant generation if available
   if (binding.generateVariants) {
-    const nativeProps = props.map((p) => ({
-      name: p.name,
-      prop_type: p.propType,
-      required: p.required,
-      default_value: p.defaultValue,
-    }));
-
     const relPath = `./${path.basename(componentPath)}`;
-    const result = binding.generateVariants(relPath, nativeProps, {
-      max_variants: options.maxVariants,
-      include_default: options.includeDefault,
-      include_boolean_toggles: options.includeBooleanToggles,
-      include_enum_variants: options.includeEnumVariants,
-      include_boundary_values: options.includeBoundaryValues,
-      include_empty_strings: options.includeEmptyStrings,
-    });
+    const result = binding.generateVariants(
+      relPath,
+      toNativePropDefinitions(props),
+      toNativeAutogenConfig(options),
+    );
 
-    return {
-      variants: result.variants.map((v) => ({
-        name: v.name,
-        isDefault: v.is_default,
-        props: v.props,
-        description: v.description,
-      })),
-      artFileContent: result.art_file_content,
-      componentName: result.component_name,
-    };
+    return fromNativeOutput(result);
   }
 
   // Fallback: JS-based generation

--- a/npm/vite-plugin-musea/src/autogen/native-shape.test.ts
+++ b/npm/vite-plugin-musea/src/autogen/native-shape.test.ts
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  fromNativeOutput,
+  toNativeAutogenConfig,
+  toNativePropDefinitions,
+} from "./native-shape.js";
+
+void test("native autogen mapper uses NAPI camelCase fields", () => {
+  const [prop] = toNativePropDefinitions([
+    {
+      name: "variant",
+      propType: "'primary' | 'secondary'",
+      required: true,
+      defaultValue: "primary",
+    },
+  ]);
+
+  assert.deepEqual(prop, {
+    name: "variant",
+    propType: "'primary' | 'secondary'",
+    required: true,
+    defaultValue: "primary",
+  });
+  assert.equal("prop_type" in prop, false);
+  assert.equal("default_value" in prop, false);
+
+  assert.deepEqual(
+    toNativeAutogenConfig({
+      maxVariants: 3,
+      includeDefault: false,
+      includeBooleanToggles: false,
+      includeEnumVariants: true,
+      includeBoundaryValues: true,
+      includeEmptyStrings: false,
+    }),
+    {
+      maxVariants: 3,
+      includeDefault: false,
+      includeBooleanToggles: false,
+      includeEnumVariants: true,
+      includeBoundaryValues: true,
+      includeEmptyStrings: false,
+    },
+  );
+
+  assert.deepEqual(
+    fromNativeOutput({
+      variants: [
+        {
+          name: "Secondary",
+          isDefault: false,
+          props: { variant: "secondary" },
+        },
+      ],
+      artFileContent: "<art />",
+      componentName: "Button",
+    }),
+    {
+      variants: [
+        {
+          name: "Secondary",
+          isDefault: false,
+          props: { variant: "secondary" },
+          description: undefined,
+        },
+      ],
+      artFileContent: "<art />",
+      componentName: "Button",
+    },
+  );
+});

--- a/npm/vite-plugin-musea/src/autogen/native-shape.ts
+++ b/npm/vite-plugin-musea/src/autogen/native-shape.ts
@@ -1,0 +1,63 @@
+import type { AutogenOptions, AutogenOutput, PropDefinition } from "./index.js";
+
+export interface NativePropDefinition {
+  name: string;
+  propType: string;
+  required: boolean;
+  defaultValue?: unknown;
+}
+
+export interface NativeAutogenConfig {
+  maxVariants?: number;
+  includeDefault?: boolean;
+  includeBooleanToggles?: boolean;
+  includeEnumVariants?: boolean;
+  includeBoundaryValues?: boolean;
+  includeEmptyStrings?: boolean;
+}
+
+export interface NativeGeneratedVariant {
+  name: string;
+  isDefault: boolean;
+  props: Record<string, unknown>;
+  description?: string;
+}
+
+export interface NativeAutogenOutput {
+  variants: NativeGeneratedVariant[];
+  artFileContent: string;
+  componentName: string;
+}
+
+export function toNativePropDefinitions(props: PropDefinition[]): NativePropDefinition[] {
+  return props.map((prop) => ({
+    name: prop.name,
+    propType: prop.propType,
+    required: prop.required,
+    defaultValue: prop.defaultValue,
+  }));
+}
+
+export function toNativeAutogenConfig(options: AutogenOptions): NativeAutogenConfig {
+  return {
+    maxVariants: options.maxVariants,
+    includeDefault: options.includeDefault,
+    includeBooleanToggles: options.includeBooleanToggles,
+    includeEnumVariants: options.includeEnumVariants,
+    includeBoundaryValues: options.includeBoundaryValues,
+    includeEmptyStrings: options.includeEmptyStrings,
+  };
+}
+
+export function fromNativeOutput(output: NativeAutogenOutput): AutogenOutput {
+  return {
+    variants: output.variants.map((variant) => ({
+      name: variant.name,
+      isDefault: variant.isDefault,
+      props: variant.props,
+      description: variant.description,
+    })),
+    artFileContent: output.artFileContent,
+    componentName: output.componentName,
+  };
+}


### PR DESCRIPTION
## Summary
- align Musea autogen native calls with the NAPI camelCase shape
- preserve native analyzeSfc default values from both current and older field names
- add a regression test for the native autogen mapper

Closes #1856

## Validation
- pnpm --filter @vizejs/vite-plugin-musea exec tsx --test src/autogen/native-shape.test.ts
- pnpm --filter @vizejs/vite-plugin-musea check
- pnpm --filter @vizejs/vite-plugin-musea fmt
- pnpm --filter @vizejs/vite-plugin-musea test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->