### PR TITLE
fix(nuxt): avoid musea peer warnings

### DIFF
--- a/npm/nuxt/package.json
+++ b/npm/nuxt/package.json
@@ -50,7 +50,6 @@
   },
   "dependencies": {
     "@nuxt/kit": "catalog:integrations",
-    "@vizejs/musea-nuxt": "workspace:*",
     "@vizejs/vite-plugin": "workspace:*",
     "@vizejs/vite-plugin-musea": "workspace:*",
     "vize": "workspace:*"

--- a/npm/nuxt/src/index.ts
+++ b/npm/nuxt/src/index.ts
@@ -583,8 +583,8 @@ export default defineNuxtModule<VizeNuxtOptions>({
 
 // Re-export types for convenience
 export type { MuseaOptions } from "@vizejs/vite-plugin-musea";
-export type { NuxtMuseaOptions } from "@vizejs/musea-nuxt";
 export type {
+  NuxtMuseaOptions,
   VizeNuxtBridgeOptions,
   VizeNuxtCompilerCompatibilityOptions,
   VizeNuxtCompatibilityOptions,

--- a/npm/nuxt/src/options.ts
+++ b/npm/nuxt/src/options.ts
@@ -1,5 +1,4 @@
 import type { MuseaOptions } from "@vizejs/vite-plugin-musea";
-import type { NuxtMuseaOptions } from "@vizejs/musea-nuxt";
 import type {
   VizeNuxtCompilerCompatibilityOptions,
   VizeNuxtCompilerOptions,
@@ -121,6 +120,24 @@ export interface VizeNuxtDevOptions {
    * @default true
    */
   stylesheetLinks?: boolean;
+}
+
+export interface NuxtMuseaOptions {
+  route?: {
+    path?: string;
+    name?: string;
+    params?: Record<string, string>;
+    query?: Record<string, string>;
+    hash?: string;
+    fullPath?: string;
+    meta?: Record<string, unknown>;
+  };
+  runtimeConfig?: {
+    public?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  fetchMocks?: Record<string, unknown>;
+  stateMocks?: Record<string, unknown>;
 }
 
 export interface VizeNuxtOptions {

--- a/npm/nuxt/vite.config.ts
+++ b/npm/nuxt/vite.config.ts
@@ -19,7 +19,6 @@ export default defineConfig({
       neverBundle: [
         "@vizejs/vite-plugin",
         "@vizejs/vite-plugin-musea",
-        "@vizejs/musea-nuxt",
         "nitropack/runtime",
         "#vizejs/nuxt/dev-stylesheet-links-config",
         "vize",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,9 +467,6 @@ importers:
       '@nuxt/kit':
         specifier: catalog:integrations
         version: 4.4.8(magicast@0.5.2)
-      '@vizejs/musea-nuxt':
-        specifier: workspace:*
-        version: link:../musea-nuxt
       '@vizejs/vite-plugin':
         specifier: workspace:*
         version: link:../vite-plugin-vize


### PR DESCRIPTION
## Summary
- remove the Musea Nuxt mock package from @vizejs/nuxt runtime dependencies
- keep the public nuxtMusea option type local to @vizejs/nuxt so type resolution does not require the Vue 3-only mock package
- stop listing the mock package as an external for the Nuxt module build

## Root Cause
@vizejs/nuxt depended on @vizejs/musea-nuxt even when Musea was disabled. That package has Vue 3 / Vue Router 4 peer dependencies, so Nuxt 2 compatibility installs reported unrelated peer warnings.

## Validation
- pnpm --filter @vizejs/nuxt fmt
- pnpm --filter @vizejs/nuxt check
- pnpm --filter @vizejs/nuxt test
- pnpm install --frozen-lockfile --offline

Closes #1864

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->