### PR TITLE
fix(nuxt): lazy load vite plugins

### DIFF
--- a/npm/nuxt/src/index.ts
+++ b/npm/nuxt/src/index.ts
@@ -6,8 +6,6 @@ import {
   getNuxtVersion,
   isNuxt2,
 } from "@nuxt/kit";
-import vize from "@vizejs/vite-plugin";
-import { musea } from "@vizejs/vite-plugin-musea";
 import { createNuxtComponentResolver, injectNuxtComponentImports } from "./components";
 import { injectNuxtI18nHelpers } from "./i18n";
 import { appendMuseaArtComponentIgnore } from "./musea-components";
@@ -269,7 +267,7 @@ export default defineNuxtModule<VizeNuxtOptions>({
       route: { path: "/" },
     },
   },
-  setup(options, nuxt) {
+  async setup(options, nuxt) {
     const resolver = createResolver(import.meta.url);
     const detectedNuxtMajor = options.compatibility?.nuxtVersion ?? getDetectedNuxtMajor(nuxt) ?? 3;
     const vueVersion = options.compatibility?.vueVersion ?? (detectedNuxtMajor === 2 ? 2 : 3);
@@ -297,6 +295,7 @@ export default defineNuxtModule<VizeNuxtOptions>({
     );
     const usesVizeCompiler = shouldUseVizeCompiler(compilerOptions);
     if (compilerOptions !== false) {
+      const { default: vize } = await import("@vizejs/vite-plugin");
       nuxt.options.vite ||= {};
       nuxt.options.vite.plugins = nuxt.options.vite.plugins || [];
       nuxt.options.vite.plugins.push(vize(compilerOptions));
@@ -562,6 +561,7 @@ export default defineNuxtModule<VizeNuxtOptions>({
     // via Nuxt's own Vite plugins. Adding nuxtMusea globally would shadow
     // Nuxt's #imports resolution and break the app.
     if (museaOptions !== false && supportsViteCompiler) {
+      const { musea } = await import("@vizejs/vite-plugin-musea");
       const museaBasePath =
         "basePath" in museaOptions
           ? ((museaOptions as Record<string, unknown>).basePath as string)


### PR DESCRIPTION
## Summary
- defer loading @vizejs/vite-plugin until the Nuxt module actually registers the Vize compiler plugin
- defer loading @vizejs/vite-plugin-musea until Musea is enabled and the current Nuxt builder supports Vite
- keep Nuxt 2 host-compiler and musea:false module evaluation away from import.meta-only Vite plugin dependencies

## Root Cause
The Nuxt module statically imported Vite plugin packages at module load time. Nuxt 2 compatibility builds can evaluate the module through a CJS/Jiti path, so dependencies containing bare import.meta were loaded even when the compiler and Musea plugins were not registered.

## Validation
- pnpm install --frozen-lockfile --offline
- pnpm --filter @vizejs/nuxt fmt
- pnpm --filter @vizejs/nuxt check
- pnpm --filter @vizejs/nuxt test

Closes #1873

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->