### PR TITLE
fix(vite-plugin): expose default export condition

### DIFF
--- a/npm/vite-plugin-vize/package.json
+++ b/npm/vite-plugin-vize/package.json
@@ -32,7 +32,8 @@
   "exports": {
     ".": {
       "types": "./index.d.mts",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
     }
   },
   "publishConfig": {

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -157,8 +157,7 @@ test("vite plugin publishes TypeScript client types for Vue imports", () => {
     import: "./dist/index.mjs",
     default: "./dist/index.mjs",
   });
-  assert.ok(packageJson.files?.includes("client.d.ts"));
-  assert.ok(packageJson.files?.includes("index.d.mts"));
+  assert.ok(packageJson.files?.includes("client.d.ts") && packageJson.files?.includes("index.d.mts"));
   assert.match(typeEntry, /import "\.\/client\.d\.ts"/);
   assert.match(typeEntry, /from "\.\/dist\/index\.mjs"/);
   assert.match(clientTypes, /declare module "\*\.vue"/);

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -150,14 +150,14 @@ test("vite plugin publishes TypeScript client types for Vue imports", () => {
   };
   const typeEntry = readRepoFile("npm/vite-plugin-vize/index.d.mts");
   const clientTypes = readRepoFile("npm/vite-plugin-vize/client.d.ts");
-
+  const files = packageJson.files ?? [];
   assert.equal(packageJson.types, "./index.d.mts");
   assert.deepEqual(packageJson.exports?.["."], {
     types: "./index.d.mts",
     import: "./dist/index.mjs",
     default: "./dist/index.mjs",
   });
-  assert.ok(packageJson.files?.includes("client.d.ts") && packageJson.files?.includes("index.d.mts"));
+  assert.ok(files.includes("client.d.ts") && files.includes("index.d.mts"));
   assert.match(typeEntry, /import "\.\/client\.d\.ts"/);
   assert.match(typeEntry, /from "\.\/dist\/index\.mjs"/);
   assert.match(clientTypes, /declare module "\*\.vue"/);

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -155,6 +155,7 @@ test("vite plugin publishes TypeScript client types for Vue imports", () => {
   assert.deepEqual(packageJson.exports?.["."], {
     types: "./index.d.mts",
     import: "./dist/index.mjs",
+    default: "./dist/index.mjs",
   });
   assert.ok(packageJson.files?.includes("client.d.ts"));
   assert.ok(packageJson.files?.includes("index.d.mts"));


### PR DESCRIPTION
## Summary
- add a default condition for the package root export
- keep the existing ESM import and type targets unchanged
- match the export-map shape used by other ESM packages in this workspace

## Root Cause
@vizejs/vite-plugin only exposed an import condition for its package root. Config loaders that still resolve packages through CJS-style conditions could not find an exported entry and failed before they could hand the module to an ESM-aware loader.

## Validation
- pnpm install --frozen-lockfile --offline
- pnpm --filter @vizejs/vite-plugin check
- pnpm --filter @vizejs/vite-plugin build
- node -e resolver check from npm/nuxt/package.json

Closes #1850

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->