### PR TITLE
fix(check): serialize virtual project cache access

### DIFF
--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -9,6 +9,7 @@ mod error;
 mod executor;
 mod import_rewriter;
 mod materialize_fs;
+mod materialize_lock;
 mod runtime_deps;
 mod source_map;
 mod type_checker;

--- a/crates/vize_canon/src/batch/executor.rs
+++ b/crates/vize_canon/src/batch/executor.rs
@@ -9,6 +9,7 @@ use std::process::Command;
 
 use super::error::{CorsaError, CorsaNotFoundError, CorsaResult};
 use super::import_rewriter::ImportRewriter;
+use super::materialize_lock::MaterializeLock;
 use super::type_checker::{
     DeclarationEmitOptions, DeclarationEmitResult, DeclarationOutput, TypeCheckResult,
 };
@@ -41,9 +42,8 @@ pub struct CorsaExecutor {
 }
 
 impl CorsaExecutor {
-    /// Create a new executor by finding a local or global Corsa executable.
-    pub fn new(project_root: &Path) -> Result<Self, CorsaNotFoundError> {
-        Self::with_corsa_path(project_root, None)
+    pub fn new(root: &Path) -> Result<Self, CorsaNotFoundError> {
+        Self::with_corsa_path(root, None)
     }
 
     /// Create a new executor with an optional explicit Corsa executable path.
@@ -65,13 +65,10 @@ impl CorsaExecutor {
         }
     }
 
-    /// Get the resolved executable path.
     pub fn corsa_path(&self) -> &Path {
         &self.corsa_path
     }
 
-    /// Run type checking on the virtual project with an auto-tuned number of
-    /// parallel Corsa CLI processes.
     pub fn check(&self, project: &VirtualProject) -> CorsaResult<TypeCheckResult> {
         self.check_with_servers(project, None)
     }
@@ -84,6 +81,7 @@ impl CorsaExecutor {
         project: &VirtualProject,
         servers: Option<usize>,
     ) -> CorsaResult<TypeCheckResult> {
+        let _materialize_lock = MaterializeLock::acquire(project.virtual_root())?;
         profile!("canon.executor.materialize", project.materialize())?;
 
         let servers = servers.unwrap_or_else(|| auto_server_count(project));
@@ -167,6 +165,7 @@ impl CorsaExecutor {
         project: &VirtualProject,
         options: &DeclarationEmitOptions,
     ) -> CorsaResult<DeclarationEmitResult> {
+        let _materialize_lock = MaterializeLock::acquire(project.virtual_root())?;
         profile!("canon.executor.materialize_dts", project.materialize())?;
         let config_path = profile!(
             "canon.project.dts_tsconfig",

--- a/crates/vize_canon/src/batch/materialize_lock.rs
+++ b/crates/vize_canon/src/batch/materialize_lock.rs
@@ -1,0 +1,134 @@
+use std::ffi::OsString;
+use std::fs;
+use std::io::{self, ErrorKind};
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(not(unix))]
+use std::thread;
+#[cfg(not(unix))]
+use std::time::Duration;
+
+use super::error::CorsaResult;
+
+#[cfg(not(unix))]
+const LOCK_RETRY_DELAY: Duration = Duration::from_millis(25);
+
+#[cfg(unix)]
+pub(super) struct MaterializeLock {
+    file: fs::File,
+}
+
+#[cfg(not(unix))]
+pub(super) struct MaterializeLock {
+    path: PathBuf,
+}
+
+#[cfg(unix)]
+impl MaterializeLock {
+    pub(super) fn acquire(virtual_root: &Path) -> CorsaResult<Self> {
+        let path = lock_path_for(virtual_root);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let file = fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(&path)?;
+        lock_file(&file)?;
+        Ok(Self { file })
+    }
+}
+
+#[cfg(not(unix))]
+impl MaterializeLock {
+    pub(super) fn acquire(virtual_root: &Path) -> CorsaResult<Self> {
+        let path = lock_path_for(virtual_root);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        loop {
+            match fs::create_dir(&path) {
+                Ok(()) => return Ok(Self { path }),
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                    thread::sleep(LOCK_RETRY_DELAY);
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for MaterializeLock {
+    fn drop(&mut self) {
+        let _ = unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+    }
+}
+
+#[cfg(not(unix))]
+impl Drop for MaterializeLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir(&self.path);
+    }
+}
+
+fn lock_path_for(virtual_root: &Path) -> PathBuf {
+    let Some(file_name) = virtual_root.file_name() else {
+        return virtual_root.with_extension("lock");
+    };
+
+    let mut lock_name = OsString::from(file_name);
+    lock_name.push(".lock");
+    virtual_root.with_file_name(lock_name)
+}
+
+#[cfg(unix)]
+fn lock_file(file: &fs::File) -> io::Result<()> {
+    loop {
+        let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+        if result == 0 {
+            return Ok(());
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn lock_waits_until_existing_holder_drops() {
+        let root = std::env::temp_dir()
+            .join("vize-canon-lock-tests")
+            .join(std::process::id().to_string())
+            .join("node_modules/.vize/canon");
+        let _ = fs::remove_dir_all(root.parent().unwrap());
+
+        let first = MaterializeLock::acquire(&root).unwrap();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let root_for_thread = root.clone();
+        let handle = thread::spawn(move || {
+            let _second = MaterializeLock::acquire(&root_for_thread).unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+
+        assert!(acquired_rx.recv_timeout(Duration::from_millis(75)).is_err());
+        drop(first);
+        acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        handle.join().unwrap();
+
+        let _ = fs::remove_dir_all(root.parent().unwrap());
+    }
+}

--- a/crates/vize_canon/src/batch/materialize_lock.rs
+++ b/crates/vize_canon/src/batch/materialize_lock.rs
@@ -36,6 +36,7 @@ impl MaterializeLock {
         let file = fs::OpenOptions::new()
             .create(true)
             .read(true)
+            .truncate(false)
             .write(true)
             .open(&path)?;
         lock_file(&file)?;


### PR DESCRIPTION
## Summary
- add a process-wide lock around virtual project cache materialization for `vize check`
- hold the lock while Corsa reads the materialized project so parallel checks cannot prune each other
- use OS file locking on Unix and a directory lock fallback elsewhere

## Root cause
Concurrent check processes share `node_modules/.vize/canon`; one process could prune or rewrite cache entries while another process was materializing or reading them.

## Validation
- `cargo fmt --all`
- `cargo test -p vize_canon lock_waits_until_existing_holder_drops`
- `cargo test -p vize_canon materialize`

Closes #1861

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->