### PR TITLE
fix(musea): fail missing gallery plugin setup

### DIFF
--- a/crates/vize/src/commands/musea.rs
+++ b/crates/vize/src/commands/musea.rs
@@ -6,6 +6,16 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use vize_carton::{String, ToCompactString, cstr};
 
+const MUSEA_VITE_PLUGIN: &str = "@vizejs/vite-plugin-musea";
+const VITE_CONFIG_FILES: &[&str] = &[
+    "vite.config.ts",
+    "vite.config.mts",
+    "vite.config.js",
+    "vite.config.mjs",
+    "vite.config.cts",
+    "vite.config.cjs",
+];
+
 #[derive(Args)]
 pub struct MuseaArgs {
     #[command(subcommand)]
@@ -161,6 +171,7 @@ fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePlan, String> 
             "vize musea: static gallery build is not supported yet.\n  The Vite-backed Musea gallery is served by dev middleware, so `vite build` can exit successfully without emitting `.art.vue` gallery content.\n  Use `vize musea serve` for the dev gallery or keep a Storybook/static fallback until Musea static export is available."
         ));
     }
+    validate_direct_vite_musea_setup(cwd)?;
     let mut vite_args = vec![
         cstr!("dev"),
         cstr!("--host"),
@@ -179,6 +190,61 @@ fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePlan, String> 
         program,
         args: vite_args,
     })
+}
+
+fn validate_direct_vite_musea_setup(cwd: &Path) -> Result<(), String> {
+    let has_dependency = cwd.ancestors().any(has_musea_vite_plugin_dependency);
+    let config_path = find_vite_config(cwd);
+    let has_config = config_path
+        .as_ref()
+        .is_some_and(|path| vite_config_mentions_musea(path));
+
+    if has_dependency && has_config {
+        return Ok(());
+    }
+
+    let config_hint = config_path
+        .as_ref()
+        .map(|path| {
+            cstr!(
+                "found {}, but it does not import or call musea()",
+                path.display()
+            )
+        })
+        .unwrap_or_else(|| cstr!("no vite.config.* file found"));
+
+    Err(cstr!(
+        "vize musea: Musea is not configured for this Vite project.\n  Install `{}` and add `musea()` from that package to your Vite plugins before running `vize musea serve`.\n  dependency: {}\n  config: {}",
+        MUSEA_VITE_PLUGIN,
+        if has_dependency { "found" } else { "missing" },
+        config_hint
+    ))
+}
+
+fn has_musea_vite_plugin_dependency(root: &Path) -> bool {
+    package_json_has_dependency(root, MUSEA_VITE_PLUGIN)
+        || root
+            .join("node_modules")
+            .join("@vizejs")
+            .join("vite-plugin-musea")
+            .join("package.json")
+            .exists()
+}
+
+fn find_vite_config(cwd: &Path) -> Option<PathBuf> {
+    cwd.ancestors().find_map(|ancestor| {
+        VITE_CONFIG_FILES
+            .iter()
+            .map(|file_name| ancestor.join(file_name))
+            .find(|path| path.is_file())
+    })
+}
+
+fn vite_config_mentions_musea(path: &Path) -> bool {
+    let Ok(content) = fs::read_to_string(path) else {
+        return false;
+    };
+    content.contains(MUSEA_VITE_PLUGIN) || content.contains("musea(")
 }
 
 fn resolve_vite_binary(cwd: &Path) -> Option<PathBuf> {

--- a/crates/vize/src/commands/musea.rs
+++ b/crates/vize/src/commands/musea.rs
@@ -208,34 +208,11 @@ fn is_nuxt_project_root(root: &Path) -> bool {
     ["nuxt.config.ts", "nuxt.config.mts", "nuxt.config.js"]
         .into_iter()
         .any(|file_name| root.join(file_name).exists())
-        || package_json_has_dependency(root, "nuxt")
-}
-
-fn package_json_has_dependency(root: &Path, dependency: &str) -> bool {
-    let Ok(content) = fs::read_to_string(root.join("package.json")) else {
-        return false;
-    };
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
-        return false;
-    };
-
-    [
-        "dependencies",
-        "devDependencies",
-        "peerDependencies",
-        "optionalDependencies",
-    ]
-    .into_iter()
-    .any(|section| {
-        value
-            .get(section)
-            .and_then(serde_json::Value::as_object)
-            .is_some_and(|dependencies| dependencies.contains_key(dependency))
-    })
+        || setup::package_json_has_dependency(root, "nuxt")
 }
 
 fn has_vize_nuxt_integration(root: &Path) -> bool {
-    package_json_has_dependency(root, "@vizejs/nuxt")
+    setup::package_json_has_dependency(root, "@vizejs/nuxt")
         || root
             .join("node_modules")
             .join("@vizejs")

--- a/crates/vize/src/commands/musea.rs
+++ b/crates/vize/src/commands/musea.rs
@@ -1,20 +1,13 @@
 //! Musea command - Component gallery server
 
+mod setup;
+
 use clap::{Args, Subcommand};
+use setup::validate_direct_vite_musea_setup;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use vize_carton::{String, ToCompactString, cstr};
-
-const MUSEA_VITE_PLUGIN: &str = "@vizejs/vite-plugin-musea";
-const VITE_CONFIG_FILES: &[&str] = &[
-    "vite.config.ts",
-    "vite.config.mts",
-    "vite.config.js",
-    "vite.config.mjs",
-    "vite.config.cts",
-    "vite.config.cjs",
-];
 
 #[derive(Args)]
 pub struct MuseaArgs {
@@ -190,61 +183,6 @@ fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePlan, String> 
         program,
         args: vite_args,
     })
-}
-
-fn validate_direct_vite_musea_setup(cwd: &Path) -> Result<(), String> {
-    let has_dependency = cwd.ancestors().any(has_musea_vite_plugin_dependency);
-    let config_path = find_vite_config(cwd);
-    let has_config = config_path
-        .as_ref()
-        .is_some_and(|path| vite_config_mentions_musea(path));
-
-    if has_dependency && has_config {
-        return Ok(());
-    }
-
-    let config_hint = config_path
-        .as_ref()
-        .map(|path| {
-            cstr!(
-                "found {}, but it does not import or call musea()",
-                path.display()
-            )
-        })
-        .unwrap_or_else(|| cstr!("no vite.config.* file found"));
-
-    Err(cstr!(
-        "vize musea: Musea is not configured for this Vite project.\n  Install `{}` and add `musea()` from that package to your Vite plugins before running `vize musea serve`.\n  dependency: {}\n  config: {}",
-        MUSEA_VITE_PLUGIN,
-        if has_dependency { "found" } else { "missing" },
-        config_hint
-    ))
-}
-
-fn has_musea_vite_plugin_dependency(root: &Path) -> bool {
-    package_json_has_dependency(root, MUSEA_VITE_PLUGIN)
-        || root
-            .join("node_modules")
-            .join("@vizejs")
-            .join("vite-plugin-musea")
-            .join("package.json")
-            .exists()
-}
-
-fn find_vite_config(cwd: &Path) -> Option<PathBuf> {
-    cwd.ancestors().find_map(|ancestor| {
-        VITE_CONFIG_FILES
-            .iter()
-            .map(|file_name| ancestor.join(file_name))
-            .find(|path| path.is_file())
-    })
-}
-
-fn vite_config_mentions_musea(path: &Path) -> bool {
-    let Ok(content) = fs::read_to_string(path) else {
-        return false;
-    };
-    content.contains(MUSEA_VITE_PLUGIN) || content.contains("musea(")
 }
 
 fn resolve_vite_binary(cwd: &Path) -> Option<PathBuf> {

--- a/crates/vize/src/commands/musea/setup.rs
+++ b/crates/vize/src/commands/musea/setup.rs
@@ -1,4 +1,3 @@
-use super::package_json_has_dependency;
 use std::fs;
 use std::path::{Path, PathBuf};
 use vize_carton::{String, cstr};
@@ -66,4 +65,27 @@ fn vite_config_mentions_musea(path: &Path) -> bool {
         return false;
     };
     content.contains(MUSEA_VITE_PLUGIN) || content.contains("musea(")
+}
+
+pub(super) fn package_json_has_dependency(root: &Path, dependency: &str) -> bool {
+    let Ok(content) = fs::read_to_string(root.join("package.json")) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+
+    [
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+    ]
+    .into_iter()
+    .any(|section| {
+        value
+            .get(section)
+            .and_then(serde_json::Value::as_object)
+            .is_some_and(|dependencies| dependencies.contains_key(dependency))
+    })
 }

--- a/crates/vize/src/commands/musea/setup.rs
+++ b/crates/vize/src/commands/musea/setup.rs
@@ -1,0 +1,69 @@
+use super::package_json_has_dependency;
+use std::fs;
+use std::path::{Path, PathBuf};
+use vize_carton::{String, cstr};
+
+const MUSEA_VITE_PLUGIN: &str = "@vizejs/vite-plugin-musea";
+const VITE_CONFIG_FILES: &[&str] = &[
+    "vite.config.ts",
+    "vite.config.mts",
+    "vite.config.js",
+    "vite.config.mjs",
+    "vite.config.cts",
+    "vite.config.cjs",
+];
+
+pub(super) fn validate_direct_vite_musea_setup(cwd: &Path) -> Result<(), String> {
+    let has_dependency = cwd.ancestors().any(has_musea_vite_plugin_dependency);
+    let config_path = find_vite_config(cwd);
+    let has_config = config_path
+        .as_ref()
+        .is_some_and(|path| vite_config_mentions_musea(path));
+
+    if has_dependency && has_config {
+        return Ok(());
+    }
+
+    let config_hint = config_path
+        .as_ref()
+        .map(|path| {
+            cstr!(
+                "found {}, but it does not import or call musea()",
+                path.display()
+            )
+        })
+        .unwrap_or_else(|| cstr!("no vite.config.* file found"));
+
+    Err(cstr!(
+        "vize musea: Musea is not configured for this Vite project.\n  Install `{}` and add `musea()` from that package to your Vite plugins before running `vize musea serve`.\n  dependency: {}\n  config: {}",
+        MUSEA_VITE_PLUGIN,
+        if has_dependency { "found" } else { "missing" },
+        config_hint
+    ))
+}
+
+fn has_musea_vite_plugin_dependency(root: &Path) -> bool {
+    package_json_has_dependency(root, MUSEA_VITE_PLUGIN)
+        || root
+            .join("node_modules")
+            .join("@vizejs")
+            .join("vite-plugin-musea")
+            .join("package.json")
+            .exists()
+}
+
+fn find_vite_config(cwd: &Path) -> Option<PathBuf> {
+    cwd.ancestors().find_map(|ancestor| {
+        VITE_CONFIG_FILES
+            .iter()
+            .map(|file_name| ancestor.join(file_name))
+            .find(|path| path.is_file())
+    })
+}
+
+fn vite_config_mentions_musea(path: &Path) -> bool {
+    let Ok(content) = fs::read_to_string(path) else {
+        return false;
+    };
+    content.contains(MUSEA_VITE_PLUGIN) || content.contains("musea(")
+}

--- a/crates/vize/src/commands/musea/tests.rs
+++ b/crates/vize/src/commands/musea/tests.rs
@@ -10,6 +10,28 @@ fn write_vite_bin(root: &Path) -> PathBuf {
     vite_bin
 }
 
+fn write_musea_vite_setup(root: &Path) {
+    fs::write(
+        root.join("package.json"),
+        r#"{
+  "devDependencies": {
+    "@vizejs/vite-plugin-musea": "0.236.0"
+  }
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("vite.config.ts"),
+        r#"import { musea } from "@vizejs/vite-plugin-musea";
+
+export default {
+  plugins: [musea()],
+};
+"#,
+    )
+    .unwrap();
+}
+
 #[test]
 fn resolves_vite_binary_from_project_ancestors() {
     let temp = tempfile::tempdir().unwrap();
@@ -24,6 +46,7 @@ fn resolves_vite_binary_from_project_ancestors() {
 fn serve_plan_defaults_to_vite_dev_with_gallery_route() {
     let temp = tempfile::tempdir().unwrap();
     let vite_bin = write_vite_bin(temp.path());
+    write_musea_vite_setup(temp.path());
 
     let plan = create_serve_plan(
         &ServeArgs {
@@ -47,6 +70,24 @@ fn serve_plan_defaults_to_vite_dev_with_gallery_route() {
             "/__musea__"
         ]
     );
+}
+
+#[test]
+fn serve_plan_rejects_missing_musea_vite_plugin_setup() {
+    let temp = tempfile::tempdir().unwrap();
+    write_vite_bin(temp.path());
+    fs::write(
+        temp.path().join("vite.config.ts"),
+        "export default { plugins: [] }",
+    )
+    .unwrap();
+
+    let error = create_serve_plan(&ServeArgs::default(), temp.path()).unwrap_err();
+
+    assert!(error.contains("Musea is not configured for this Vite project"));
+    assert!(error.contains("@vizejs/vite-plugin-musea"));
+    assert!(error.contains("dependency: missing"));
+    assert!(error.contains("does not import or call musea()"));
 }
 
 #[test]
@@ -74,6 +115,7 @@ fn serve_plan_rejects_static_build_with_actionable_message() {
 fn serve_plan_supports_strict_port_alias_for_vite() {
     let temp = tempfile::tempdir().unwrap();
     let vite_bin = write_vite_bin(temp.path());
+    write_musea_vite_setup(temp.path());
 
     let plan = create_serve_plan(
         &ServeArgs {


### PR DESCRIPTION
## Summary
- validate that direct Vite projects have `@vizejs/vite-plugin-musea` installed before `vize musea serve` starts Vite
- validate that a `vite.config.*` file imports or calls `musea()` so the documented `/__musea__` route can be mounted
- add Musea CLI plan tests for the missing setup error and updated happy paths

## Root cause
The CLI started `vite dev` even when the Musea Vite plugin was absent or not configured, so the printed `/__musea__` route could return 404.

## Validation
- `cargo fmt --all`
- `cargo test -p vize musea`
- `cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports`

Closes #1849

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->