### PR TITLE
fix(check): honor no-check-props for prop key bindings

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use vize_carton::{String, cstr};
 mod emit_object_recursion;
 mod generic_component_listener_payload;
+mod no_check_props;
 mod no_unused;
 #[test]
 fn test_batch_type_checker_scan() {
@@ -17,7 +18,6 @@ fn test_batch_type_checker_scan() {
     let _ = std::fs::remove_dir_all(&project_root);
     let src_dir = project_root.join("src");
     std::fs::create_dir_all(&src_dir).unwrap();
-
     let vue_content = r#"<template>
   <div>{{ message }}</div>
 </template>

--- a/crates/vize_canon/src/batch/type_checker/tests/no_check_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/no_check_props.rs
@@ -1,0 +1,73 @@
+use super::{BatchTypeChecker, create_project_case, relative_path, resolve_test_tsgo_binary};
+use crate::batch::TypeChecker;
+
+#[test]
+fn disables_keyed_define_props_diagnostics() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case(
+        "no-check-props-keyed-define-props",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+type Props = { known: string } & { other?: boolean }
+defineProps<Props>()
+</script>
+
+<template>
+  <div>{{ known }} {{ isMini }}</div>
+</template>
+"#,
+        )],
+    );
+
+    let Some(snapshot) = diagnostics_with_check_props_disabled(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot
+            .iter()
+            .all(|(_, _, message)| !message.contains("keyof Props") && !message.contains("isMini")),
+        "check_props=false should suppress keyed prop diagnostics: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn diagnostics_with_check_props_disabled(
+    project_root: &std::path::Path,
+) -> Option<Vec<(vize_carton::String, Option<u32>, vize_carton::String)>> {
+    let mut checker = BatchTypeChecker::new(project_root).ok()?;
+    checker.set_virtual_ts_checks(false, true, true);
+    checker.scan_project().ok()?;
+    let result = checker.check_project().ok()?;
+
+    let mut snapshot: Vec<_> = result
+        .diagnostics
+        .into_iter()
+        .map(|diagnostic| {
+            (
+                relative_path(project_root, &diagnostic.file),
+                diagnostic.code,
+                vize_carton::cstr!(
+                    "{}:{}:{} {}",
+                    diagnostic.line + 1,
+                    diagnostic.column + 1,
+                    match diagnostic.severity {
+                        1 => "error",
+                        2 => "warning",
+                        3 => "info",
+                        _ => "hint",
+                    },
+                    diagnostic.message
+                ),
+            )
+        })
+        .collect();
+    snapshot.sort();
+    Some(snapshot)
+}

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -7,17 +7,13 @@ mod options_api_support;
 mod setup_props;
 mod spans;
 mod template_refs;
-
-use vize_croquis::{Croquis, ScopeData, ScopeKind};
-
-pub use self::legacy_vue2::generate_virtual_ts_with_offsets_legacy_vue2;
-
 use self::emits::{emit_emit_props_helper, emit_emits_type};
 use self::generics::{generic_injection_point, references_any_identifier};
 use self::imports::{
     collect_imported_names, collect_setup_binding_anchor_names, emit_global_component_stubs,
     emit_reference_type_directives, extract_declared_name,
 };
+pub use self::legacy_vue2::generate_virtual_ts_with_offsets_legacy_vue2;
 use self::options_api::{
     find_default_export_targets, find_options_api_props, generate_options_api_bridge,
     generate_options_api_variables,
@@ -40,7 +36,7 @@ use super::{
     types::{VirtualTsGenerationOptions, VirtualTsOptions, VirtualTsOutput, VizeMapping},
 };
 use vize_carton::{FxHashMap, FxHashSet, String, append, cstr, profile};
-
+use vize_croquis::{Croquis, ScopeData, ScopeKind};
 /// Generate virtual TypeScript from Vue SFC analysis.
 ///
 /// The generated TypeScript uses proper scope hierarchy:
@@ -64,7 +60,6 @@ pub fn generate_virtual_ts(
         &VirtualTsOptions::default(),
     )
 }
-
 /// Generate virtual TypeScript with explicit script and template offsets.
 ///
 /// `script_offset` is the byte offset of the script content within the SFC file.
@@ -89,7 +84,6 @@ pub fn generate_virtual_ts_with_offsets(
         VirtualTsGenerationOptions::default(),
     )
 }
-
 /// Generate virtual TypeScript with Vue 3 Options API binding resolution
 /// enabled (opt-in, standard build — no `legacy` feature required).
 pub fn generate_virtual_ts_with_offsets_options_api(
@@ -124,6 +118,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     generation_options: VirtualTsGenerationOptions<'_>,
 ) -> VirtualTsOutput {
     let check_options = generation_options.check_options;
+    let check_props = check_options.check_props;
     // Configured Vue dialect, used to emit dialect-aware template instance typing
     // (e.g. a Vue 2 `this`/template shape with `$listeners`,
     // `$children`, `$on`, ... that Vue 3's `ComponentPublicInstance` lacks).
@@ -741,7 +736,12 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
 
             // Props are available in template as variables
             profile!("canon.virtual_ts.generate_props_variables", {
-                setup_props_plan.generate_props_variables(&mut ts, summary, generic_param)
+                setup_props_plan.generate_props_variables(
+                    &mut ts,
+                    summary,
+                    generic_param,
+                    check_props,
+                )
             });
             if options_api {
                 profile!(

--- a/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
@@ -144,8 +144,15 @@ impl SetupPropsPlan {
         ts: &mut String,
         summary: &Croquis,
         generic_param: Option<&str>,
+        check_props: bool,
     ) {
-        generate_props_variables(ts, summary, generic_param, self.template_props_type_ref());
+        generate_props_variables(
+            ts,
+            summary,
+            generic_param,
+            self.template_props_type_ref(),
+            check_props,
+        );
     }
 
     pub(super) fn template_props_type_ref(&self) -> Option<&'static str> {

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -1,9 +1,11 @@
 mod setup_scoped;
-
+use super::helpers::{is_reserved_identifier, to_safe_identifier};
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{Argument, Expression, ObjectPropertyKind, PropertyKey};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
+use setup_scoped::props_type_ref;
+pub(crate) use setup_scoped::{PropsTypeEmission, generate_setup_scoped_props_artifact};
 use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::append;
@@ -11,11 +13,6 @@ use vize_carton::cstr;
 use vize_croquis::BindingType;
 use vize_croquis::Croquis;
 use vize_croquis::macros::{MacroKind, ModelDefinition};
-
-use super::helpers::{is_reserved_identifier, to_safe_identifier};
-use setup_scoped::props_type_ref;
-pub(crate) use setup_scoped::{PropsTypeEmission, generate_setup_scoped_props_artifact};
-
 #[inline]
 fn should_skip_template_prop_binding(summary: &Croquis, prop_name: &str) -> bool {
     if summary
@@ -26,13 +23,11 @@ fn should_skip_template_prop_binding(summary: &Croquis, prop_name: &str) -> bool
     {
         return true;
     }
-
     summary
         .bindings
         .get(prop_name)
         .is_some_and(|binding_type| !matches!(binding_type, BindingType::Props))
 }
-
 fn emit_template_prop_binding(
     ts: &mut String,
     props_type_ref: &str,
@@ -50,7 +45,6 @@ fn emit_template_prop_binding(
     }
     append!(*ts, "  void {binding_name};\n");
 }
-
 fn emit_keyed_template_prop_binding(
     ts: &mut String,
     props_type_ref: &str,
@@ -71,7 +65,14 @@ fn emit_keyed_template_prop_binding(
     }
     append!(*ts, "  void {binding_name};\n");
 }
-
+fn emit_unchecked_template_prop_binding(ts: &mut String, prop_name: &str) {
+    let binding_name = to_safe_identifier(prop_name);
+    append!(
+        *ts,
+        "  const {binding_name} = (props as Record<string, unknown>)[\"{prop_name}\"];\n"
+    );
+    append!(*ts, "  void {binding_name};\n");
+}
 fn can_emit_keyed_template_prop_binding(prop_name: &str) -> bool {
     let mut chars = prop_name.chars();
     let Some(first) = chars.next() else {
@@ -82,7 +83,6 @@ fn can_emit_keyed_template_prop_binding(prop_name: &str) -> bool {
         && !prop_name.starts_with('$')
         && !is_reserved_identifier(prop_name)
 }
-
 fn collect_keyed_template_prop_names(
     summary: &Croquis,
     emitted_names: &FxHashSet<String>,
@@ -98,12 +98,10 @@ fn collect_keyed_template_prop_names(
         }
         names.insert(name.into());
     }
-
     let mut names: Vec<String> = names.into_iter().collect();
     names.sort_unstable();
     names
 }
-
 fn should_emit_keyed_template_prop_bindings(
     summary: &Croquis,
     type_name: &str,
@@ -115,16 +113,13 @@ fn should_emit_keyed_template_prop_bindings(
     if is_plain_inline_type_literal(type_name) {
         return false;
     }
-
     let base_name = strip_generic_params(type_name).trim();
     if let Some(body) = summary.types.definitions().resolve(base_name) {
         return has_top_level_type_operator(body.as_str())
             || (emitted_names.is_empty() && !is_plain_inline_type_literal(body.as_str()));
     }
-
     emitted_names.is_empty() && !summary.types.definitions().is_defined(base_name)
 }
-
 fn is_plain_inline_type_literal(type_name: &str) -> bool {
     let type_name = type_name.trim();
     if !type_name.starts_with('{') {
@@ -405,6 +400,7 @@ pub(crate) fn generate_props_variables(
     summary: &Croquis,
     generic_param: Option<&str>,
     props_type_ref_override: Option<&str>,
+    check_props: bool,
 ) {
     let props = summary.macros.props();
     let has_props = !props.is_empty();
@@ -477,12 +473,16 @@ pub(crate) fn generate_props_variables(
 
             if should_emit_keyed_template_prop_bindings(summary, type_name, &emitted_names) {
                 for name in collect_keyed_template_prop_names(summary, &emitted_names) {
-                    emit_keyed_template_prop_binding(
-                        ts,
-                        template_props_type_ref.as_str(),
-                        name.as_str(),
-                        defaulted_prop_names.contains(&name),
-                    );
+                    if check_props {
+                        emit_keyed_template_prop_binding(
+                            ts,
+                            template_props_type_ref.as_str(),
+                            name.as_str(),
+                            defaulted_prop_names.contains(&name),
+                        );
+                    } else {
+                        emit_unchecked_template_prop_binding(ts, name.as_str());
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- avoid keyed `satisfies keyof Props` template prop bindings when prop checks are disabled
- keep unchecked template prop bindings available through a `Record<string, unknown>` read
- add a batch type-checker regression test for `check_props=false`

Fixes #1870

## Validation
- cargo test -p vize_canon disables_keyed_define_props_diagnostics
- cargo test -p vize_canon test_check_props_option_disables_component_prop_checks
- cargo test -p vize_canon virtual_ts
- cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->