### PR TITLE
fix(check): reject root-external explicit inputs

### DIFF
--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -5,7 +5,6 @@
 //! `.d.ts` output all share the same virtual project.
 
 #![allow(clippy::disallowed_macros)]
-
 use std::{
     path::{Path, PathBuf},
     time::{Duration, Instant},
@@ -29,7 +28,6 @@ use super::{
         resolve_tsconfig_for_files,
     },
 };
-
 mod collect;
 mod diagnostics;
 mod global_components;
@@ -39,7 +37,6 @@ mod resolve;
 mod socket;
 #[cfg(test)]
 mod tests;
-
 use collect::collect_check_files;
 use diagnostics::{
     emit_json_output, is_reported, is_suppressed_false_positive, render_diagnostics,
@@ -53,7 +50,8 @@ use nuxt_tsconfig::resolve_checker_tsconfig_path;
 #[cfg(test)]
 use nuxt_tsconfig::write_nuxt_fallback_tsconfig;
 use resolve::{
-    display_path, resolve_declaration_emit_options, resolve_from_config_dir, resolve_project_root,
+    display_path, exit_if_inputs_outside_root, explicit_input_root,
+    resolve_declaration_emit_options, resolve_from_config_dir, resolve_project_root,
     resolve_tsconfig_path, validate_corsa_server_count,
 };
 #[cfg(test)]
@@ -150,6 +148,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &[]);
     let tsconfig_path =
         resolve_tsconfig_path(effective_tsconfig.as_deref(), &cwd, &project_root, &[]);
+    let explicit_input_root = explicit_input_root(&project_root, &cwd);
     // Run-scoped caches: tsconfig chains are parsed (and their include/exclude
     // globs compiled) once per run, and each unique path is canonicalized at
     // most once across reported-file bookkeeping, diagnostic filtering, and
@@ -229,7 +228,8 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         files.sort();
         files.dedup();
     }
-
+    let validate_inputs = !args.patterns.is_empty() && tsconfig_path.is_some();
+    exit_if_inputs_outside_root(&explicit_input_root, &files, validate_inputs);
     let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &files);
     let tsconfig_path =
         resolve_tsconfig_path(effective_tsconfig.as_deref(), &cwd, &project_root, &files);

--- a/crates/vize/src/commands/check/runner/resolve.rs
+++ b/crates/vize/src/commands/check/runner/resolve.rs
@@ -107,6 +107,41 @@ pub(super) fn resolve_tsconfig_path(
     None
 }
 
+pub(super) fn explicit_input_root(project_root: &Path, cwd: &Path) -> PathBuf {
+    let cwd = vize_carton::path::canonicalize_non_verbatim(cwd);
+    if project_root.starts_with(&cwd) {
+        cwd
+    } else {
+        project_root.to_path_buf()
+    }
+}
+
+pub(super) fn exit_if_inputs_outside_root(root: &Path, files: &[PathBuf], enabled: bool) {
+    if !enabled {
+        return;
+    }
+    if let Err(error) = validate_explicit_inputs_in_root(root, files) {
+        eprintln!("\x1b[31mError:\x1b[0m {error}");
+        std::process::exit(1);
+    }
+}
+
+fn validate_explicit_inputs_in_root(root: &Path, files: &[PathBuf]) -> Result<(), String> {
+    let root = vize_carton::path::canonicalize_non_verbatim(root);
+    for file in files {
+        let path = vize_carton::path::canonicalize_non_verbatim(file);
+        if !path.starts_with(&root) {
+            return Err(format!(
+                "explicit check input `{}` is outside project root `{}`.",
+                path.display(),
+                root.display()
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
 pub(super) fn find_nearest_tsconfig_dir(path: &Path) -> Option<PathBuf> {
     let mut current = if path.is_dir() {
         Some(path)

--- a/crates/vize/tests/check_absolute_paths_cli.rs
+++ b/crates/vize/tests/check_absolute_paths_cli.rs
@@ -1,0 +1,40 @@
+use std::{path::PathBuf, process::Command};
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("vize-{name}-{}", std::process::id()))
+}
+
+#[test]
+fn check_rejects_absolute_input_outside_project_root_with_tsconfig() {
+    let case_root = unique_case_dir("check-absolute-outside-root");
+    let _ = std::fs::remove_dir_all(&case_root);
+    let project_root = case_root.join("project");
+    std::fs::create_dir_all(&project_root).unwrap();
+    std::fs::write(project_root.join("tsconfig.json"), "{}").unwrap();
+
+    let outside = case_root.join("Outside.vue");
+    std::fs::write(&outside, "<template />\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["check", "--tsconfig", "tsconfig.json"])
+        .arg(&outside)
+        .output()
+        .unwrap();
+
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        !output.status.success(),
+        "check unexpectedly passed: {stderr}"
+    );
+    assert!(
+        stderr.contains("outside project root"),
+        "missing outside-root error in: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Building Corsa virtual project"),
+        "outside-root input reached Corsa setup: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&case_root);
+}


### PR DESCRIPTION
Closes #1881.

## Summary
- reject explicit check inputs outside the project root before Corsa setup when a tsconfig is active
- keep root-external checks without a tsconfig working
- add a CLI regression test for absolute Vue paths outside the project root

## Verification
- cargo test -p vize --test check_absolute_paths_cli check_rejects_absolute_input_outside_project_root_with_tsconfig
- node --test tests/tooling/source-file-lengths.test.ts
- cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->