### PR TITLE
fix(formatter): preserve dotted component tags

### DIFF
--- a/crates/vize_glyph/src/template/helpers.rs
+++ b/crates/vize_glyph/src/template/helpers.rs
@@ -41,7 +41,7 @@ pub(crate) fn parse_closing_tag(source: &[u8], start: usize) -> Option<(String, 
 /// Check if a byte is a valid tag name character.
 #[inline(always)]
 pub(crate) fn is_tag_name_char(b: u8) -> bool {
-    matches!(b, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b':')
+    matches!(b, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b':' | b'.')
 }
 
 /// Check if a byte is whitespace.

--- a/crates/vize_glyph/tests/template_component_tags.rs
+++ b/crates/vize_glyph/tests/template_component_tags.rs
@@ -1,0 +1,28 @@
+use vize_glyph::{FormatOptions, format_template};
+
+#[test]
+fn dotted_component_tags_are_preserved() {
+    let source = r#"<routeLeaveConfirm.ModalAlert
+  :is-opened="routeLeaveConfirm.alertCtx.isOpened.value"
+  @click:cancel="routeLeaveConfirm.alertCtx.close"
+>
+  <p>Unsaved changes</p>
+</routeLeaveConfirm.ModalAlert>"#;
+
+    let options = FormatOptions::default();
+    let first = format_template(source, &options).unwrap();
+    let second = format_template(&first, &options).unwrap();
+
+    assert_eq!(
+        first.as_str(),
+        r#"<routeLeaveConfirm.ModalAlert
+  :is-opened="routeLeaveConfirm.alertCtx.isOpened.value"
+  @click:cancel="routeLeaveConfirm.alertCtx.close"
+>
+  <p>
+    Unsaved changes
+  </p>
+</routeLeaveConfirm.ModalAlert>"#
+    );
+    assert_eq!(first, second);
+}


### PR DESCRIPTION
## Summary
- Treat `.` as part of formatter tag names so Vue component member tags stay intact.
- Add regression coverage for dotted component open/close tags and idempotence.

## Validation
- `cargo test -p vize_glyph`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all --check`
- `cargo clippy -p vize_glyph -- -D warnings -D clippy::wildcard_imports`
- `git diff --check`

Closes #1852

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->