### PR TITLE
fix(formatter): indent musea art variants

### DIFF
--- a/crates/vize_glyph/src/formatter.rs
+++ b/crates/vize_glyph/src/formatter.rs
@@ -2,6 +2,7 @@
 //!
 //! Uses arena allocation and zero-copy techniques for maximum performance.
 
+mod custom_block;
 mod raw_mask;
 
 use crate::error::FormatError;
@@ -126,9 +127,7 @@ impl<'a> GlyphFormatter<'a> {
                 Block::Style(style) => {
                     self.format_style_block_fast(&mut output, style)?;
                 }
-                Block::Custom(block) => {
-                    self.format_custom_block_fast(&mut output, block)?;
-                }
+                Block::Custom(block) => custom_block::format(&mut output, block, self.options)?,
             }
         }
 
@@ -327,27 +326,6 @@ impl<'a> GlyphFormatter<'a> {
         }
 
         output.extend_from_slice(b"</style>");
-
-        Ok(())
-    }
-
-    /// Format a custom block using byte operations
-    #[inline]
-    fn format_custom_block_fast(
-        &self,
-        output: &mut Vec<u8>,
-        block: &vize_atelier_sfc::SfcCustomBlock<'_>,
-    ) -> Result<(), FormatError> {
-        output.push(b'<');
-        output.extend_from_slice(block.block_type.as_bytes());
-        write_remaining_attrs(output, &block.attrs, &[]);
-        output.push(b'>');
-        output.extend_from_slice(self.options.newline_bytes());
-        output.extend_from_slice(block.content.trim().as_bytes());
-        output.extend_from_slice(self.options.newline_bytes());
-        output.extend_from_slice(b"</");
-        output.extend_from_slice(block.block_type.as_bytes());
-        output.push(b'>');
 
         Ok(())
     }

--- a/crates/vize_glyph/src/formatter/custom_block.rs
+++ b/crates/vize_glyph/src/formatter/custom_block.rs
@@ -1,0 +1,67 @@
+use crate::{error::FormatError, options::FormatOptions};
+
+pub(super) fn format(
+    output: &mut Vec<u8>,
+    block: &vize_atelier_sfc::SfcCustomBlock<'_>,
+    options: &FormatOptions,
+) -> Result<(), FormatError> {
+    output.push(b'<');
+    output.extend_from_slice(block.block_type.as_bytes());
+    super::write_remaining_attrs(output, &block.attrs, &[]);
+    output.push(b'>');
+    output.extend_from_slice(options.newline_bytes());
+
+    if block.block_type.as_ref() == "art" {
+        write_art_content(output, block.content.as_ref(), options);
+    } else {
+        output.extend_from_slice(block.content.trim().as_bytes());
+        output.extend_from_slice(options.newline_bytes());
+    }
+
+    output.extend_from_slice(b"</");
+    output.extend_from_slice(block.block_type.as_bytes());
+    output.push(b'>');
+    Ok(())
+}
+
+fn write_art_content(output: &mut Vec<u8>, content: &str, options: &FormatOptions) {
+    let lines: Vec<&str> = content.lines().collect();
+    let start = lines
+        .iter()
+        .position(|line| !line.trim().is_empty())
+        .unwrap_or(lines.len());
+    let end = lines
+        .iter()
+        .rposition(|line| !line.trim().is_empty())
+        .map_or(start, |index| index + 1);
+    let indent = options.indent_bytes();
+    let mut depth = 1usize;
+
+    for line in &lines[start..end] {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            output.extend_from_slice(options.newline_bytes());
+            continue;
+        }
+        if trimmed.starts_with("</") {
+            depth = depth.saturating_sub(1);
+        }
+        for _ in 0..depth {
+            output.extend_from_slice(indent);
+        }
+        output.extend_from_slice(trimmed.as_bytes());
+        output.extend_from_slice(options.newline_bytes());
+        if opens_block(trimmed) {
+            depth += 1;
+        }
+    }
+}
+
+fn opens_block(line: &str) -> bool {
+    line.starts_with('<')
+        && !line.starts_with("</")
+        && !line.starts_with("<!--")
+        && !line.ends_with("/>")
+        && !line.contains("</")
+        && line.contains('>')
+}

--- a/crates/vize_glyph/tests/custom_blocks.rs
+++ b/crates/vize_glyph/tests/custom_blocks.rs
@@ -1,0 +1,53 @@
+use vize_glyph::{FormatOptions, format_sfc};
+
+#[test]
+fn art_block_indents_variants_consistently() {
+    let source = r#"<art>
+<variant name="Primary" default>
+    <DemoButton color="primary">Primary</DemoButton>
+  </variant>
+  <variant name="Secondary">
+    <DemoButton color="secondary">Secondary</DemoButton>
+  </variant>
+</art>
+"#;
+
+    let options = FormatOptions::default();
+    let first = format_sfc(source, &options).unwrap();
+    let second = format_sfc(&first.code, &options).unwrap();
+
+    assert_eq!(
+        first.code.as_str(),
+        r#"<art>
+  <variant name="Primary" default>
+    <DemoButton color="primary">Primary</DemoButton>
+  </variant>
+  <variant name="Secondary">
+    <DemoButton color="secondary">Secondary</DemoButton>
+  </variant>
+</art>
+"#
+    );
+    assert_eq!(first.code, second.code);
+}
+
+#[test]
+fn art_block_preserves_blank_lines_between_variants() {
+    let source = r#"<art>
+  <variant name="Primary" default>
+    <DemoButton>Primary</DemoButton>
+  </variant>
+
+  <variant name="Secondary">
+    <DemoButton color="secondary">Secondary</DemoButton>
+  </variant>
+</art>
+"#;
+
+    let options = FormatOptions::default();
+    let first = format_sfc(source, &options).unwrap();
+    let second = format_sfc(&first.code, &options).unwrap();
+
+    assert_eq!(first.code, source);
+    assert_eq!(first.code, second.code);
+}


### PR DESCRIPTION
## Summary
- Format Musea `<art>` custom block content with a template-like indentation pass.
- Preserve blank lines between variants while normalizing variant and child indentation.
- Move custom block formatting into a dedicated formatter module and add regression coverage.

## Validation
- `cargo test -p vize_glyph`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all --check`
- `cargo clippy -p vize_glyph -- -D warnings -D clippy::wildcard_imports`
- `git diff --check`

Closes #1874
Closes #1875

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->