### PR TITLE
fix(nuxt): preserve dependency style handling

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -308,7 +308,7 @@ export function loadHook(
         currentBase,
       );
     }
-    return "";
+    return null;
   }
 
   if (

--- a/npm/vite-plugin-vize/src/plugin/style-load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/style-load.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+
+import type { VizePluginState } from "./state.ts";
+import { loadHook } from "./load.ts";
+
+const emptyState: VizePluginState = {
+  cache: new Map(),
+  ssrCache: new Map(),
+  collectedCss: new Map(),
+  precompileMetadata: new Map(),
+  pendingHmrUpdateTypes: new Map(),
+  isProduction: true,
+  root: "/project",
+  clientViteBase: "/",
+  serverViteBase: "/",
+  server: null,
+  filter: () => false,
+  scanPatterns: null,
+  precompileBatchSize: 128,
+  ignorePatterns: [],
+  mergedOptions: { exclude: [/node_modules/] },
+  initialized: true,
+  dynamicImportAliasRules: [],
+  cssAliasRules: [],
+  extractCss: true,
+  componentsCssFileName: "assets/vize-components.css",
+  clientViteDefine: {},
+  serverViteDefine: {},
+  logger: {
+    log() {},
+    info() {},
+    warn() {},
+    error() {},
+  } as never,
+};
+
+const dependencyStyleLoad = loadHook(
+  emptyState,
+  "/project/node_modules/pkg/ProsePre.vue?vue=&type=style&index=0&lang=css.css",
+  { ssr: false },
+);
+
+assert.equal(
+  dependencyStyleLoad,
+  null,
+  "uncached dependency SFC styles should fall through to Nuxt/Vite style handling",
+);
+
+console.log("✅ vite-plugin-vize style load tests passed!");


### PR DESCRIPTION
## Summary
- let uncached SFC style queries fall through to the normal Vite/Nuxt style pipeline
- cover dependency style requests when Vize has no compiled cache entry

Closes #1854

## Validation
- pnpm --dir npm/vite-plugin-vize test
- node --test npm/vite-plugin-vize/src/plugin/style-load.test.ts
- pnpm --dir npm/vite-plugin-vize check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check