### PR TITLE
fix(check): avoid invalid Vue 2 prop virtual TS

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator/options_api_support.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api_support.rs
@@ -1,4 +1,4 @@
-use oxc_ast::ast::{ObjectExpression, ObjectPropertyKind};
+use oxc_ast::ast::{ArrayExpressionElement, Expression, ObjectExpression, ObjectPropertyKind};
 use vize_carton::String;
 use vize_croquis::{Croquis, OptionGroup};
 
@@ -31,14 +31,44 @@ pub(super) fn props_source_from_object(
     source: &str,
 ) -> OptionsApiPropsSource {
     let source = String::from(source);
-    if object
-        .properties
-        .iter()
-        .any(|property| matches!(property, ObjectPropertyKind::SpreadProperty(_)))
-    {
+    if object_props_must_stay_in_value_scope(object) {
         OptionsApiPropsSource::DeferredObject(source)
     } else {
         OptionsApiPropsSource::Object(source)
+    }
+}
+
+fn object_props_must_stay_in_value_scope(object: &ObjectExpression<'_>) -> bool {
+    object.properties.iter().any(|property| match property {
+        ObjectPropertyKind::SpreadProperty(_) => true,
+        ObjectPropertyKind::ObjectProperty(property) => {
+            property.method || expression_must_stay_in_value_scope(&property.value)
+        }
+    })
+}
+
+fn expression_must_stay_in_value_scope(expression: &Expression<'_>) -> bool {
+    match expression {
+        Expression::ArrowFunctionExpression(_)
+        | Expression::CallExpression(_)
+        | Expression::FunctionExpression(_)
+        | Expression::NewExpression(_)
+        | Expression::TSAsExpression(_)
+        | Expression::TSInstantiationExpression(_)
+        | Expression::TSNonNullExpression(_)
+        | Expression::TSSatisfiesExpression(_)
+        | Expression::TSTypeAssertion(_) => true,
+        Expression::ArrayExpression(array) => array.elements.iter().any(|element| {
+            matches!(element, ArrayExpressionElement::SpreadElement(_))
+                || element
+                    .as_expression()
+                    .is_some_and(expression_must_stay_in_value_scope)
+        }),
+        Expression::ObjectExpression(object) => object_props_must_stay_in_value_scope(object),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            expression_must_stay_in_value_scope(&parenthesized.expression)
+        }
+        _ => false,
     }
 }
 

--- a/crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs
@@ -127,3 +127,52 @@ export default defineComponent({
         output.code
     );
 }
+
+#[test]
+fn test_options_api_props_with_type_cast_defers_to_setup_scope() {
+    let script = r#"import { defineComponent } from 'vue'
+import type { PropType } from 'vue'
+
+type BreadcrumbsItem = { label: string }
+
+export default defineComponent({
+    props: {
+        breadcrumbs: {
+            type: Array as PropType<BreadcrumbsItem[]>,
+            required: true,
+        },
+    },
+})
+"#;
+    let summary = analyze_options_api_script(script);
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        None,
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        !output
+            .code
+            .contains("export type Props = __RuntimePropShape<{\n        breadcrumbs:"),
+        "type-cast props must not be emitted directly in type position:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("const __vize_options_props = ({\n        breadcrumbs:"),
+        "type-cast props should stay in setup scope as a value:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains(
+            "export type Props = __RuntimePropShape<Awaited<ReturnType<typeof __setup>>[\"__vize_options_props\"]>;"
+        ),
+        "Props should be derived from the setup-scoped runtime props artifact:\n{}",
+        output.code
+    );
+}


### PR DESCRIPTION
## Summary
- keep Options API prop objects with type-only casts in setup scope before deriving Props
- cover `Array as PropType<T[]>` so generated virtual TS stays parseable

Closes #1844

## Validation
- cargo test -p vize_canon options_api_props
- cargo test -p vize_canon virtual_ts
- cargo fmt --all --check
- cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->