### PR TITLE
fix(check): cover setup local prop aliases

### DIFF
--- a/crates/vize_canon/src/virtual_ts/tests/define_props_scope.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/define_props_scope.rs
@@ -126,3 +126,42 @@ defineProps<WidgetProps>();
         output.code
     );
 }
+
+#[test]
+fn test_define_props_local_type_alias_is_visible_to_hoisted_props() {
+    let script = r#"type FormViewState = 'input' | 'confirm' | 'complete';
+
+interface Props {
+  formViewState: FormViewState;
+}
+
+const props = defineProps<Props>();
+"#;
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    let summary = analyzer.finish();
+
+    let output =
+        generate_virtual_ts_with_offsets(&summary, Some(script), None, 0, 0, &Default::default());
+    let (module_scope, setup_and_after) = output
+        .code
+        .split_once("// ========== Setup Scope ==========")
+        .expect("setup scope marker present");
+
+    assert!(
+        module_scope.contains("type FormViewState = 'input' | 'confirm' | 'complete';"),
+        "local type alias should be emitted before hoisted Props:\n{}",
+        output.code
+    );
+    assert!(
+        module_scope.contains("interface Props {\n  formViewState: FormViewState;\n}"),
+        "hoisted Props should retain the local alias reference:\n{}",
+        output.code
+    );
+    assert!(
+        !setup_and_after.contains("type __VizeSetupProps"),
+        "plain local type aliases should not force setup-scoped Props:\n{}",
+        output.code
+    );
+}


### PR DESCRIPTION
## Summary
- add a regression test for script-setup local type aliases referenced by generated Props
- ensure plain local aliases remain visible to hoisted Props without forcing setup-scoped props

Closes #1868

## Validation
- cargo test -p vize_canon define_props_scope -- --nocapture
- cargo fmt --all --check
- cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->