### PR TITLE
fix(check): cover package cwd root resolution

### DIFF
--- a/crates/vize/src/commands/check/runner/tests.rs
+++ b/crates/vize/src/commands/check/runner/tests.rs
@@ -110,7 +110,7 @@ fn resolves_monorepo_root_for_files_spanning_package_tsconfigs() {
 }
 
 #[test]
-fn resolves_package_root_for_files_inside_one_package() {
+fn resolves_package_root_for_relative_tsconfig_inside_one_package() {
     let project_root = unique_case_dir("package-root");
     let _ = std::fs::remove_dir_all(&project_root);
     let app_dir = project_root.join("packages/app");
@@ -121,10 +121,9 @@ fn resolves_package_root_for_files_inside_one_package() {
     for file in &files {
         std::fs::write(file, "").unwrap();
     }
-
-    let resolved_root = resolve_project_root(None, &project_root, &files);
-    let resolved_tsconfig = resolve_tsconfig_path(None, &project_root, &resolved_root, &files);
-
+    let tsconfig = Path::new("tsconfig.json");
+    let resolved_root = resolve_project_root(Some(tsconfig), &app_dir, &files);
+    let resolved_tsconfig = resolve_tsconfig_path(Some(tsconfig), &app_dir, &resolved_root, &files);
     assert_eq!(resolved_root, app_dir);
     assert_eq!(resolved_tsconfig, Some(resolved_root.join("tsconfig.json")));
 


### PR DESCRIPTION
## Summary
- update the package-root check runner regression to cover a relative --tsconfig resolved from the package cwd
- lock in monorepo behavior where package-local inputs keep the virtual project rooted in that package even when the repository root also has tsconfig.json

Closes #1878

## Validation
- cargo test -p vize resolves_package_root_for_relative_tsconfig_inside_one_package -- --nocapture
- cargo fmt --all --check
- cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->