### PR TITLE
fix(check): include tsconfig alias imports

### DIFF
--- a/crates/vize/src/commands/check.rs
+++ b/crates/vize/src/commands/check.rs
@@ -5,6 +5,7 @@
 
 mod dts;
 mod imports;
+mod imports_aliases;
 mod nuxt;
 mod path_cache;
 mod reporting;

--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -1,18 +1,15 @@
-//! Transitive resolution of relative source imports for explicit `vize check`
-//! subsets.
+//! Transitive resolution of source imports for explicit `vize check` subsets.
 //!
 //! `vize check src/App.vue` registers only the requested files in the virtual
-//! project, so a relative import like `import { Foo } from './types'` cannot see
-//! the sibling's real types and degrades to `any` (or surfaces a false
-//! `TS2307`). `tsc`/`vue-tsc` load the whole reachable program instead. This
-//! module walks the relative-import graph from the requested files and returns
-//! the additional on-disk source files to register, so cross-file types resolve
-//! precisely — analogous to the ambient-`.d.ts` pull-in in the runner.
+//! project, so a sibling import like `./types` or `~/components/Foo.vue` cannot
+//! see the real types and can surface false `TS2307`. This module walks the
+//! reachable graph and returns on-disk source files to register.
 
 use std::path::{Path, PathBuf};
 
 use vize_carton::{FxHashSet, String, ToCompactString, cstr};
 
+use super::imports_aliases::PathAliasResolver;
 use super::path_cache::CanonicalPathCache;
 
 /// Source extensions whose imports carry TypeScript types worth pulling into the
@@ -33,6 +30,7 @@ pub(super) fn collect_transitive_local_imports(
     cwd: &Path,
     canonical_paths: &mut CanonicalPathCache,
     include_jsx: bool,
+    aliases: Option<&PathAliasResolver>,
 ) -> Vec<PathBuf> {
     let mut visited: FxHashSet<PathBuf> = FxHashSet::default();
     let mut queue: Vec<PathBuf> = Vec::new();
@@ -58,10 +56,20 @@ pub(super) fn collect_transitive_local_imports(
         // Scan the raw file text directly — the byte scanner only reacts to
         // `import`/`from` string operands, so an SFC's `<template>`/`<style>`
         // are inert and no `.vue` parse is needed on this hot path.
-        for specifier in extract_relative_specifiers(&source) {
-            let Some(resolved) =
+        for specifier in extract_import_specifiers(&source) {
+            let resolved = if is_relative_specifier(&specifier) {
                 resolve_relative_import(dir, &specifier, canonical_paths, include_jsx)
-            else {
+            } else {
+                aliases.and_then(|aliases| {
+                    aliases.resolve(
+                        &specifier,
+                        canonical_paths,
+                        include_jsx,
+                        resolve_import_base,
+                    )
+                })
+            };
+            let Some(resolved) = resolved else {
                 continue;
             };
             // Never register an ambient declaration file — its `declare module`
@@ -94,15 +102,14 @@ fn absolutize(
     Some(canonical_paths.canonicalize(&joined))
 }
 
-/// Collect the relative (`./`, `../`) module specifiers of `source`'s `import` /
-/// `export … from` / dynamic-`import(...)` statements.
+/// Collect module specifiers of `source`'s import/export/dynamic-imports.
 ///
 /// This is a deliberately lightweight byte scan rather than a full parse: the
 /// transitive walk runs on every checked file, so an AST per file regressed the
 /// benchmark. Over-matching (e.g. an import-like fragment inside a string) is
 /// harmless because each specifier is resolved against the filesystem and only
 /// real source files are registered.
-fn extract_relative_specifiers(source: &str) -> Vec<String> {
+fn extract_import_specifiers(source: &str) -> Vec<String> {
     let bytes = source.as_bytes();
     let len = bytes.len();
     let mut specifiers = Vec::new();
@@ -139,9 +146,7 @@ fn extract_relative_specifiers(source: &str) -> Vec<String> {
             }
             if k < len {
                 let specifier = &source[start..k];
-                if is_relative_specifier(specifier) {
-                    specifiers.push(specifier.to_compact_string());
-                }
+                specifiers.push(specifier.to_compact_string());
                 i = k + 1;
                 continue;
             }
@@ -181,21 +186,27 @@ fn resolve_relative_import(
     canonical_paths: &mut CanonicalPathCache,
     include_jsx: bool,
 ) -> Option<PathBuf> {
-    let base = dir.join(specifier);
+    resolve_import_base(&dir.join(specifier), canonical_paths, include_jsx)
+}
 
+pub(super) fn resolve_import_base(
+    base: &Path,
+    canonical_paths: &mut CanonicalPathCache,
+    include_jsx: bool,
+) -> Option<PathBuf> {
     // 1. The specifier already points at an existing source file.
-    if has_source_extension(&base, include_jsx) && base.is_file() {
-        return Some(canonical_paths.canonicalize(&base));
+    if has_source_extension(base, include_jsx) && base.is_file() {
+        return Some(canonical_paths.canonicalize(base));
     }
 
     // 2. A `.js`/`.mjs`/`.cjs` specifier resolving to its `.ts`/`.tsx` sibling.
-    if let Some(rewritten) = rewrite_js_to_ts(&base, canonical_paths) {
+    if let Some(rewritten) = rewrite_js_to_ts(base, canonical_paths) {
         return Some(rewritten);
     }
 
     // 3. Append a source extension: `./types` → `./types.ts`.
     for ext in resolve_extensions(include_jsx) {
-        let candidate = append_extension(&base, ext);
+        let candidate = append_extension(base, ext);
         if candidate.is_file() {
             return Some(canonical_paths.canonicalize(&candidate));
         }
@@ -261,107 +272,10 @@ fn append_extension(base: &Path, ext: &str) -> PathBuf {
     }
 }
 
+#[cfg(test)]
+#[path = "imports_tests.rs"]
+mod tests;
+
 fn cstr_index(ext: &str) -> String {
     cstr!("index{ext}")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use vize_carton::path::canonicalize_non_verbatim;
-    fn write(dir: &Path, rel: &str, contents: &str) -> PathBuf {
-        let path = dir.join(rel);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).unwrap();
-        }
-        std::fs::write(&path, contents).unwrap();
-        path
-    }
-
-    #[test]
-    fn collects_relative_ts_and_vue_imports_transitively() {
-        let root = std::env::temp_dir().join(cstr!("vize-imports-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
-        std::fs::create_dir_all(root.join("src")).unwrap();
-
-        let app = write(
-            &root,
-            "src/App.vue",
-            "<script setup lang=\"ts\">\nimport type { Sibling } from './types'\nimport Child from './Child.vue'\nconst x: Sibling = { a: 1 }\n</script>\n<template><Child /></template>\n",
-        );
-        let types = write(
-            &root,
-            "src/types.ts",
-            "export interface Sibling { a: number }\n",
-        );
-        let child = write(
-            &root,
-            "src/Child.vue",
-            "<script setup lang=\"ts\">\nimport { helper } from './nested/util'\n</script>\n<template><div /></template>\n",
-        );
-        let util = write(&root, "src/nested/util.ts", "export const helper = 1\n");
-
-        let discovered = collect_transitive_local_imports(
-            std::slice::from_ref(&app),
-            &root,
-            &mut CanonicalPathCache::default(),
-            false,
-        );
-
-        let canon = canonicalize_non_verbatim;
-        assert_eq!(discovered, vec![canon(&types), canon(&child), canon(&util)]);
-
-        let _ = std::fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn ignores_bare_and_missing_specifiers() {
-        let root = std::env::temp_dir().join(cstr!("vize-imports-bare-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
-        std::fs::create_dir_all(&root).unwrap();
-
-        let entry = write(
-            &root,
-            "entry.ts",
-            "import { ref } from 'vue'\nimport { gone } from './missing'\nexport const a = ref(0)\nvoid gone\n",
-        );
-
-        let discovered = collect_transitive_local_imports(
-            &[entry],
-            &root,
-            &mut CanonicalPathCache::default(),
-            false,
-        );
-        assert!(discovered.is_empty());
-
-        let _ = std::fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn jsx_imports_are_resolved_only_when_jsx_typecheck_is_enabled() {
-        let root = std::env::temp_dir().join(cstr!("vize-imports-jsx-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
-        std::fs::create_dir_all(root.join("src")).unwrap();
-
-        let entry = write(&root, "src/entry.tsx", "import './Panel.jsx'\n");
-        let panel = write(&root, "src/Panel.jsx", "const Panel = () => <div />\n");
-
-        let disabled = collect_transitive_local_imports(
-            &[entry.clone()],
-            &root,
-            &mut CanonicalPathCache::default(),
-            false,
-        );
-        let enabled = collect_transitive_local_imports(
-            &[entry],
-            &root,
-            &mut CanonicalPathCache::default(),
-            true,
-        );
-
-        assert_eq!(disabled, Vec::<PathBuf>::new());
-        assert_eq!(enabled, vec![canonicalize_non_verbatim(&panel)]);
-
-        let _ = std::fs::remove_dir_all(&root);
-    }
 }

--- a/crates/vize/src/commands/check/imports_aliases.rs
+++ b/crates/vize/src/commands/check/imports_aliases.rs
@@ -1,0 +1,262 @@
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use vize_carton::{FxHashSet, String};
+
+use super::path_cache::CanonicalPathCache;
+use super::tsconfig_inputs::{parse_jsonc_value, read_extends_entries, resolve_extended_tsconfig};
+
+#[derive(Default)]
+pub(super) struct PathAliasResolver {
+    aliases: Vec<PathAlias>,
+}
+
+struct PathAlias {
+    prefix: String,
+    suffix: String,
+    has_wildcard: bool,
+    targets: Vec<String>,
+    base_dir: PathBuf,
+}
+
+impl PathAliasResolver {
+    pub(super) fn from_tsconfig(tsconfig_path: Option<&Path>) -> Self {
+        let Some(tsconfig_path) = tsconfig_path else {
+            return Self::default();
+        };
+        let mut seen = FxHashSet::default();
+        load_aliases(tsconfig_path, &mut seen).unwrap_or_default()
+    }
+
+    pub(super) fn resolve(
+        &self,
+        specifier: &str,
+        canonical_paths: &mut CanonicalPathCache,
+        include_jsx: bool,
+        resolve_base: impl Fn(&Path, &mut CanonicalPathCache, bool) -> Option<PathBuf>,
+    ) -> Option<PathBuf> {
+        for alias in &self.aliases {
+            let Some(matched) = alias.match_specifier(specifier) else {
+                continue;
+            };
+            for target in &alias.targets {
+                let target = if target.contains('*') {
+                    alias.base_dir.join(target.replace('*', matched))
+                } else {
+                    alias.base_dir.join(target.as_str())
+                };
+                if let Some(resolved) = resolve_base(&target, canonical_paths, include_jsx) {
+                    return Some(resolved);
+                }
+            }
+        }
+        None
+    }
+}
+
+impl PathAlias {
+    fn match_specifier<'a>(&self, specifier: &'a str) -> Option<&'a str> {
+        if !self.has_wildcard {
+            return (self.prefix == specifier).then_some("");
+        }
+        specifier
+            .strip_prefix(self.prefix.as_str())?
+            .strip_suffix(self.suffix.as_str())
+    }
+}
+
+fn load_aliases(
+    tsconfig_path: &Path,
+    seen: &mut FxHashSet<PathBuf>,
+) -> std::io::Result<PathAliasResolver> {
+    let tsconfig_path = tsconfig_path
+        .canonicalize()
+        .unwrap_or_else(|_| tsconfig_path.to_path_buf());
+    if !seen.insert(tsconfig_path.clone()) {
+        return Ok(PathAliasResolver::default());
+    }
+
+    let content = std::fs::read_to_string(&tsconfig_path)?;
+    let value = parse_jsonc_value(&content).unwrap_or(Value::Null);
+    let dir = tsconfig_path.parent().unwrap_or(Path::new("."));
+
+    let mut resolver = PathAliasResolver::default();
+    for extends in read_extends_entries(&value) {
+        if let Some(extended) = resolve_extended_tsconfig(&tsconfig_path, &extends) {
+            resolver = load_aliases(&extended, seen)?;
+        }
+    }
+
+    let Some(options) = value.get("compilerOptions").and_then(Value::as_object) else {
+        return Ok(resolver);
+    };
+    let base_dir = options
+        .get("baseUrl")
+        .and_then(Value::as_str)
+        .map(|base| dir.join(base))
+        .unwrap_or_else(|| dir.to_path_buf());
+    let Some(paths) = options.get("paths").and_then(Value::as_object) else {
+        return Ok(resolver);
+    };
+
+    resolver.aliases.clear();
+    for (pattern, targets) in paths {
+        let Some(targets) = targets.as_array() else {
+            continue;
+        };
+        let (prefix, suffix, has_wildcard) = split_pattern(pattern);
+        let targets = targets
+            .iter()
+            .filter_map(Value::as_str)
+            .map(String::from)
+            .collect::<Vec<_>>();
+        if !targets.is_empty() {
+            resolver.aliases.push(PathAlias {
+                prefix,
+                suffix,
+                has_wildcard,
+                targets,
+                base_dir: base_dir.clone(),
+            });
+        }
+    }
+    resolver
+        .aliases
+        .sort_by_key(|alias| std::cmp::Reverse(alias.prefix.len()));
+    Ok(resolver)
+}
+
+fn split_pattern(pattern: &str) -> (String, String, bool) {
+    match pattern.split_once('*') {
+        Some((prefix, suffix)) => (prefix.into(), suffix.into(), true),
+        None => (pattern.into(), String::default(), false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PathAliasResolver;
+    use crate::commands::check::{
+        imports::{collect_transitive_local_imports, resolve_import_base},
+        path_cache::CanonicalPathCache,
+    };
+    use std::path::{Path, PathBuf};
+
+    fn write(root: &Path, rel: &str, contents: &str) -> PathBuf {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn resolves_wildcard_alias_to_vue_source() {
+        let root = tempfile::tempdir().unwrap();
+        let keyboard = write(
+            root.path(),
+            "src/keyboards/EnglishKeyboard.vue",
+            "<template />",
+        );
+        std::fs::write(
+            root.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["*"]
+    }
+  }
+}"#,
+        )
+        .unwrap();
+
+        let resolver =
+            PathAliasResolver::from_tsconfig(Some(root.path().join("tsconfig.json").as_path()));
+        let resolved = resolver.resolve(
+            "~/src/keyboards/EnglishKeyboard.vue",
+            &mut CanonicalPathCache::default(),
+            false,
+            resolve_import_base,
+        );
+
+        assert_eq!(resolved, Some(keyboard.canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn exact_alias_does_not_match_prefix() {
+        let root = tempfile::tempdir().unwrap();
+        let entry = write(root.path(), "src/exact.ts", "export const exact = 1;");
+        let prefix = write(root.path(), "src/prefix.ts", "export const prefix = 1;");
+        std::fs::write(
+            root.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@app": ["src/exact.ts"],
+      "@app/*": ["src/*"]
+    }
+  }
+}"#,
+        )
+        .unwrap();
+
+        let resolver =
+            PathAliasResolver::from_tsconfig(Some(root.path().join("tsconfig.json").as_path()));
+        let mut canonical_paths = CanonicalPathCache::default();
+        let resolved_exact =
+            resolver.resolve("@app", &mut canonical_paths, false, resolve_import_base);
+        let resolved_prefix = resolver.resolve(
+            "@app/prefix",
+            &mut canonical_paths,
+            false,
+            resolve_import_base,
+        );
+
+        assert_eq!(resolved_exact, Some(entry.canonicalize().unwrap()));
+        assert_eq!(resolved_prefix, Some(prefix.canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn collector_registers_tsconfig_alias_vue_dependencies() {
+        let root = tempfile::tempdir().unwrap();
+        let entry = write(
+            root.path(),
+            "src/Entry.vue",
+            r#"<script lang="ts">
+import EnglishKeyboard from "~/src/keyboards/EnglishKeyboard.vue";
+void EnglishKeyboard;
+</script>
+"#,
+        );
+        let keyboard = write(
+            root.path(),
+            "src/keyboards/EnglishKeyboard.vue",
+            "<template />",
+        );
+        std::fs::write(
+            root.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["*"]
+    }
+  }
+}"#,
+        )
+        .unwrap();
+
+        let resolver =
+            PathAliasResolver::from_tsconfig(Some(root.path().join("tsconfig.json").as_path()));
+        let discovered = collect_transitive_local_imports(
+            &[entry],
+            root.path(),
+            &mut CanonicalPathCache::default(),
+            false,
+            Some(&resolver),
+        );
+
+        assert_eq!(discovered, vec![keyboard.canonicalize().unwrap()]);
+    }
+}

--- a/crates/vize/src/commands/check/imports_tests.rs
+++ b/crates/vize/src/commands/check/imports_tests.rs
@@ -1,0 +1,102 @@
+use super::*;
+use vize_carton::path::canonicalize_non_verbatim;
+
+fn write(dir: &Path, rel: &str, contents: &str) -> PathBuf {
+    let path = dir.join(rel);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(&path, contents).unwrap();
+    path
+}
+
+#[test]
+fn collects_relative_ts_and_vue_imports_transitively() {
+    let root = std::env::temp_dir().join(cstr!("vize-imports-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+
+    let app = write(
+        &root,
+        "src/App.vue",
+        "<script setup lang=\"ts\">\nimport type { Sibling } from './types'\nimport Child from './Child.vue'\nconst x: Sibling = { a: 1 }\n</script>\n<template><Child /></template>\n",
+    );
+    let types = write(
+        &root,
+        "src/types.ts",
+        "export interface Sibling { a: number }\n",
+    );
+    let child = write(
+        &root,
+        "src/Child.vue",
+        "<script setup lang=\"ts\">\nimport { helper } from './nested/util'\n</script>\n<template><div /></template>\n",
+    );
+    let util = write(&root, "src/nested/util.ts", "export const helper = 1\n");
+
+    let discovered = collect_transitive_local_imports(
+        std::slice::from_ref(&app),
+        &root,
+        &mut CanonicalPathCache::default(),
+        false,
+        None,
+    );
+
+    let canon = canonicalize_non_verbatim;
+    assert_eq!(discovered, vec![canon(&types), canon(&child), canon(&util)]);
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn ignores_bare_and_missing_specifiers() {
+    let root = std::env::temp_dir().join(cstr!("vize-imports-bare-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+
+    let entry = write(
+        &root,
+        "entry.ts",
+        "import { ref } from 'vue'\nimport { gone } from './missing'\nexport const a = ref(0)\nvoid gone\n",
+    );
+
+    let discovered = collect_transitive_local_imports(
+        &[entry],
+        &root,
+        &mut CanonicalPathCache::default(),
+        false,
+        None,
+    );
+    assert!(discovered.is_empty());
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn jsx_imports_are_resolved_only_when_jsx_typecheck_is_enabled() {
+    let root = std::env::temp_dir().join(cstr!("vize-imports-jsx-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+
+    let entry = write(&root, "src/entry.tsx", "import './Panel.jsx'\n");
+    let panel = write(&root, "src/Panel.jsx", "const Panel = () => <div />\n");
+
+    let disabled = collect_transitive_local_imports(
+        &[entry.clone()],
+        &root,
+        &mut CanonicalPathCache::default(),
+        false,
+        None,
+    );
+    let enabled = collect_transitive_local_imports(
+        &[entry],
+        &root,
+        &mut CanonicalPathCache::default(),
+        true,
+        None,
+    );
+
+    assert_eq!(disabled, Vec::<PathBuf>::new());
+    assert_eq!(enabled, vec![canonicalize_non_verbatim(&panel)]);
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -207,19 +207,18 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         return;
     }
 
-    // An explicit subset only registers the requested files, so a relative
-    // import (`import { Foo } from './types'`) cannot see its sibling's real
-    // types and degrades to `any`. Register the transitive closure of relative
-    // source imports — analogous to the ambient pull-in below — so cross-file
-    // types resolve precisely, the way tsc/vue-tsc load the reachable program.
-    // Do this before root resolution so cwd-external files without tsconfig can
-    // still choose a materialization root covering all registered source files.
+    // Explicit subsets need reachable source imports registered so cross-file
+    // types resolve like tsc/vue-tsc. Run this before root resolution so
+    // cwd-external files can still choose a covering materialization root.
     if !args.patterns.is_empty() {
+        let aliases =
+            super::imports_aliases::PathAliasResolver::from_tsconfig(tsconfig_path.as_deref());
         for path in super::imports::collect_transitive_local_imports(
             &files,
             &cwd,
             &mut canonical_paths,
             jsx_typecheck,
+            Some(&aliases),
         ) {
             if !files.contains(&path) {
                 files.push(path);


### PR DESCRIPTION
## Summary
- resolve tsconfig paths aliases while collecting explicit-check import dependencies
- keep exact path aliases from matching longer specifier prefixes
- move existing import collector tests into a separate test module to avoid growing over-limit files

Refs #1876

## Validation
- cargo test -p vize imports_aliases -- --nocapture
- cargo test -p vize commands::check::imports -- --nocapture
- cargo fmt --all --check
- git diff --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->