### PR TITLE
fix(check): collect parent-relative tsconfig inputs

### DIFF
--- a/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
@@ -64,6 +64,40 @@ pub(super) fn collect_supported_files_with_options(
     collected
 }
 
+pub(super) fn collect_supported_files_for_include_roots(
+    project_root: &Path,
+    includes: &[GlobSpec],
+    excludes: &[GlobSpec],
+    options: FileCollectionOptions,
+) -> Vec<PathBuf> {
+    let normalized_project_root = normalize_input_path(project_root);
+    let mut roots = vec![normalized_project_root.clone()];
+    let mut seen_roots = FxHashSet::default();
+    seen_roots.insert(normalized_project_root.clone());
+
+    for include in includes {
+        let root = normalize_input_path(&include.base_dir);
+        if root.is_dir()
+            && !root.starts_with(&normalized_project_root)
+            && seen_roots.insert(root.clone())
+        {
+            roots.push(root);
+        }
+    }
+
+    let mut files = Vec::new();
+    let mut seen_files = FxHashSet::default();
+    for root in roots {
+        for path in collect_supported_files_with_options(&root, includes, excludes, options) {
+            if seen_files.insert(path.clone()) {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
 pub(super) fn explicit_hidden_include_roots(
     project_root: &Path,
     includes: &[GlobSpec],

--- a/crates/vize/src/commands/check/tsconfig_inputs/mod.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/mod.rs
@@ -28,7 +28,10 @@ pub(crate) use loader::{TsconfigInputCache, load_tsconfig_declaration_options};
 pub(super) use loader::{read_extends_entries, resolve_extended_tsconfig};
 pub(crate) use spec::TsconfigDeclarationOptions;
 
-use collect::{collect_supported_files_with_options, explicit_hidden_include_roots};
+use collect::{
+    collect_supported_files_for_include_roots, collect_supported_files_with_options,
+    explicit_hidden_include_roots,
+};
 use glob::{default_exclude_specs, normalize_input_path};
 use loader::collect_tsconfig_project_paths;
 use matching::{
@@ -100,8 +103,7 @@ fn collect_default_check_files_for_tsconfig(
 
     for file in &spec.files {
         let resolved = normalize_input_path(&file.resolve());
-        if resolved.starts_with(project_root)
-            && resolved.is_file()
+        if resolved.is_file()
             && is_supported_check_file_with_options(&resolved, SupportedFileOptions { include_jsx })
             && !is_nuxt_import_manifest_path(&resolved)
             && seen.insert(resolved.clone())
@@ -134,7 +136,7 @@ fn collect_default_check_files_for_tsconfig(
     };
 
     if !includes.is_empty() {
-        let collected = collect_supported_files_with_options(
+        let collected = collect_supported_files_for_include_roots(
             project_root,
             includes,
             excludes,

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
@@ -933,21 +933,21 @@ fn files_entry_with_unsupported_extension_is_dropped() {
 }
 
 #[test]
-fn files_entry_outside_project_root_is_dropped() {
-    let case_dir = unique_case_dir("tsconfig-files-outside-root");
+fn parent_relative_tsconfig_entries_are_collected() {
+    let case_dir = unique_case_dir("tsconfig-parent-relative-inputs");
     let _ = fs::remove_dir_all(&case_dir);
-    let app_dir = case_dir.join("app");
-    fs::create_dir_all(&app_dir).unwrap();
-    fs::write(case_dir.join("sibling.ts"), "export const s = true").unwrap();
-    fs::write(
-        app_dir.join("tsconfig.json"),
-        r#"{ "files": ["../sibling.ts"] }"#,
-    )
-    .unwrap();
-
-    let files = collect_default_check_files(&app_dir, Some(&app_dir.join("tsconfig.json")));
-
-    assert_eq!(files, Vec::<PathBuf>::new());
+    let generated_dir = case_dir.join(".generated");
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    fs::create_dir_all(&generated_dir).unwrap();
+    fs::write(case_dir.join("src/bad.ts"), "export const bad = true").unwrap();
+    for (name, json) in [
+        ("files.json", r#"{ "files": ["../src/bad.ts"] }"#),
+        ("include.json", r#"{ "include": ["../src/**/*.ts"] }"#),
+    ] {
+        fs::write(generated_dir.join(name), json).unwrap();
+        let files = collect_default_check_files(&generated_dir, Some(&generated_dir.join(name)));
+        assert_eq!(relative_paths(&case_dir, &files), vec!["src/bad.ts"]);
+    }
 
     let _ = fs::remove_dir_all(&case_dir);
 }


### PR DESCRIPTION
## Summary
- collect tsconfig files entries even when they resolve outside the tsconfig directory
- walk parent-relative include roots before applying existing include/exclude matching
- cover parent-relative files and include entries from generated tsconfig directories

## Verification
- cargo test -p vize parent_relative_tsconfig_entries_are_collected -- --nocapture
- cargo test -p vize commands::check::tsconfig_inputs -- --nocapture
- cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all --check && git diff --check && SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

Closes #1937

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->