### PR TITLE
fix(compiler): keep pascal html tags as components

### DIFF
--- a/crates/vize_armature/src/parser.rs
+++ b/crates/vize_armature/src/parser.rs
@@ -24,8 +24,8 @@ use vize_relief::{
 
 use crate::tokenizer::Tokenizer;
 
-use callbacks::ParserCallbacks;
-use whitespace::condense_whitespace;
+use element::{note_html_tree_element_close, note_html_tree_element_open};
+use {callbacks::ParserCallbacks, whitespace::condense_whitespace};
 
 /// Parser context for building AST
 pub struct Parser<'a> {
@@ -339,46 +339,14 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn push_stack_entry(&mut self, entry: ParserStackEntry<'a>) {
-        self.note_stack_tag_open(entry.element.tag.as_str());
+        note_html_tree_element_open(self, &entry.element);
         self.stack.push(entry);
     }
 
     pub(super) fn pop_stack_entry(&mut self) -> Option<ParserStackEntry<'a>> {
         let entry = self.stack.pop()?;
-        self.note_stack_tag_close(entry.element.tag.as_str());
+        note_html_tree_element_close(self, &entry.element);
         Some(entry)
-    }
-
-    fn note_stack_tag_open(&mut self, tag: &str) {
-        match tag.len() {
-            1 if tag.eq_ignore_ascii_case("p") => self.open_p_count += 1,
-            1 if tag.eq_ignore_ascii_case("a") => self.open_a_count += 1,
-            4 if tag.eq_ignore_ascii_case("form") => self.open_form_count += 1,
-            5 if tag.eq_ignore_ascii_case("table") => self.open_table_count += 1,
-            6 if tag.eq_ignore_ascii_case("button") => self.open_button_count += 1,
-            _ => {}
-        }
-    }
-
-    fn note_stack_tag_close(&mut self, tag: &str) {
-        match tag.len() {
-            1 if tag.eq_ignore_ascii_case("p") => {
-                self.open_p_count = self.open_p_count.saturating_sub(1);
-            }
-            1 if tag.eq_ignore_ascii_case("a") => {
-                self.open_a_count = self.open_a_count.saturating_sub(1);
-            }
-            4 if tag.eq_ignore_ascii_case("form") => {
-                self.open_form_count = self.open_form_count.saturating_sub(1);
-            }
-            5 if tag.eq_ignore_ascii_case("table") => {
-                self.open_table_count = self.open_table_count.saturating_sub(1);
-            }
-            6 if tag.eq_ignore_ascii_case("button") => {
-                self.open_button_count = self.open_button_count.saturating_sub(1);
-            }
-            _ => {}
-        }
     }
 
     /// Handle unclosed elements at end of parsing

--- a/crates/vize_armature/src/parser/element/mod.rs
+++ b/crates/vize_armature/src/parser/element/mod.rs
@@ -13,7 +13,7 @@ mod tags;
 mod text;
 
 use vize_relief::{
-    SourceLocation,
+    ElementNode, ElementType, Namespace, SourceLocation,
     errors::{CompilerError, ErrorCode},
 };
 
@@ -32,5 +32,49 @@ impl<'a> Parser<'a> {
         candidates
             .iter()
             .any(|candidate| tag.eq_ignore_ascii_case(candidate))
+    }
+}
+
+pub(super) fn is_html_tree_element(element: &ElementNode<'_>) -> bool {
+    element.ns == Namespace::Html && element.tag_type == ElementType::Element
+}
+
+pub(super) fn note_html_tree_element_open(parser: &mut Parser<'_>, element: &ElementNode<'_>) {
+    if !is_html_tree_element(element) {
+        return;
+    }
+
+    match element.tag.len() {
+        1 if element.tag.eq_ignore_ascii_case("p") => parser.open_p_count += 1,
+        1 if element.tag.eq_ignore_ascii_case("a") => parser.open_a_count += 1,
+        4 if element.tag.eq_ignore_ascii_case("form") => parser.open_form_count += 1,
+        5 if element.tag.eq_ignore_ascii_case("table") => parser.open_table_count += 1,
+        6 if element.tag.eq_ignore_ascii_case("button") => parser.open_button_count += 1,
+        _ => {}
+    }
+}
+
+pub(super) fn note_html_tree_element_close(parser: &mut Parser<'_>, element: &ElementNode<'_>) {
+    if !is_html_tree_element(element) {
+        return;
+    }
+
+    match element.tag.len() {
+        1 if element.tag.eq_ignore_ascii_case("p") => {
+            parser.open_p_count = parser.open_p_count.saturating_sub(1);
+        }
+        1 if element.tag.eq_ignore_ascii_case("a") => {
+            parser.open_a_count = parser.open_a_count.saturating_sub(1);
+        }
+        4 if element.tag.eq_ignore_ascii_case("form") => {
+            parser.open_form_count = parser.open_form_count.saturating_sub(1);
+        }
+        5 if element.tag.eq_ignore_ascii_case("table") => {
+            parser.open_table_count = parser.open_table_count.saturating_sub(1);
+        }
+        6 if element.tag.eq_ignore_ascii_case("button") => {
+            parser.open_button_count = parser.open_button_count.saturating_sub(1);
+        }
+        _ => {}
     }
 }

--- a/crates/vize_armature/src/parser/element/scope.rs
+++ b/crates/vize_armature/src/parser/element/scope.rs
@@ -1,9 +1,10 @@
 //! "In body" start-tag handling: implicit end-tag closing and HTML scopes
 //! (`<a>`/`<button>`/`<li>`/`<dt>`/`<dd>`/`<option>`/`<optgroup>`/`<p>`).
 
-use vize_relief::{ElementNode, ElementType};
+use vize_relief::ElementNode;
 
 use super::super::Parser;
+use super::is_html_tree_element;
 
 impl<'a> Parser<'a> {
     pub(super) fn handle_in_body_start_tag(&mut self, tag: &str, offset: usize) {
@@ -80,13 +81,18 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn find_last_open_element_index(&self, tags: &[&str]) -> Option<usize> {
-        (0..self.stack.len())
-            .rev()
-            .find(|&i| Self::tag_in(self.stack[i].element.tag.as_str(), tags))
+        (0..self.stack.len()).rev().find(|&i| {
+            is_html_tree_element(&self.stack[i].element)
+                && Self::tag_in(self.stack[i].element.tag.as_str(), tags)
+        })
     }
 
     fn find_open_li_element_in_list_item_scope(&self) -> Option<usize> {
         for i in (0..self.stack.len()).rev() {
+            if !is_html_tree_element(&self.stack[i].element) {
+                return None;
+            }
+
             let tag = self.stack[i].element.tag.as_str();
             if tag.eq_ignore_ascii_case("li") {
                 return Some(i);
@@ -101,6 +107,10 @@ impl<'a> Parser<'a> {
 
     fn find_open_p_element_in_button_scope(&self) -> Option<usize> {
         for i in (0..self.stack.len()).rev() {
+            if !is_html_tree_element(&self.stack[i].element) {
+                return None;
+            }
+
             let tag = self.stack[i].element.tag.as_str();
             if tag.eq_ignore_ascii_case("p") {
                 return Some(i);
@@ -108,9 +118,7 @@ impl<'a> Parser<'a> {
             // Components and structural `<template>` blocks (the latter is also
             // a button-scope boundary in the HTML spec) confine `<p>`
             // auto-closing, so stop the search rather than reaching across them.
-            if self.stack[i].element.tag_type != ElementType::Element
-                || Self::is_button_scope_boundary(tag)
-            {
+            if Self::is_button_scope_boundary(tag) {
                 return None;
             }
         }
@@ -142,7 +150,9 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn should_ignore_start_tag(&self, element: &ElementNode<'a>) -> bool {
-        element.tag.eq_ignore_ascii_case("form") && self.open_form_count > 0
+        is_html_tree_element(element)
+            && element.tag.eq_ignore_ascii_case("form")
+            && self.open_form_count > 0
     }
 
     pub(in crate::parser) fn can_omit_end_tag(tag: &str) -> bool {

--- a/crates/vize_armature/src/parser/element/table.rs
+++ b/crates/vize_armature/src/parser/element/table.rs
@@ -4,6 +4,7 @@ use vize_carton::Vec;
 use vize_relief::ElementNode;
 
 use super::super::{Parser, ParserStackEntry, StackInsertion};
+use super::is_html_tree_element;
 
 impl<'a> Parser<'a> {
     pub(in crate::parser) fn nearest_table_index(&self) -> Option<usize> {
@@ -11,9 +12,10 @@ impl<'a> Parser<'a> {
             return None;
         }
 
-        (0..self.stack.len())
-            .rev()
-            .find(|&i| self.stack[i].element.tag.eq_ignore_ascii_case("table"))
+        (0..self.stack.len()).rev().find(|&i| {
+            is_html_tree_element(&self.stack[i].element)
+                && self.stack[i].element.tag.eq_ignore_ascii_case("table")
+        })
     }
 
     pub(super) fn should_foster_text(&self, content: &str) -> bool {
@@ -37,6 +39,10 @@ impl<'a> Parser<'a> {
         };
 
         for entry in self.stack.iter().skip(table_index + 1) {
+            if !is_html_tree_element(&entry.element) {
+                return false;
+            }
+
             if entry.insertion == StackInsertion::Fostered
                 || Self::tag_in(entry.element.tag.as_str(), &["caption", "td", "th"])
             {

--- a/crates/vize_armature/src/parser/element/tags.rs
+++ b/crates/vize_armature/src/parser/element/tags.rs
@@ -2,13 +2,13 @@
 
 use vize_carton::{Box, Vec};
 use vize_relief::{
-    AttributeNode, ElementNode, ElementType, ExpressionNode, Namespace, PropNode,
-    TemplateChildNode, TextNode,
+    AttributeNode, ElementNode, ExpressionNode, Namespace, PropNode, TemplateChildNode, TextNode,
     errors::{CompilerError, ErrorCode},
     options::TemplateSyntaxMode,
 };
 
 use super::super::{CurrentElement, Parser, ParserStackEntry, StackInsertion};
+use super::is_html_tree_element;
 
 /// Maximum element nesting depth retained by the parser.
 ///
@@ -79,8 +79,11 @@ impl<'a> Parser<'a> {
                 return;
             }
 
-            self.handle_in_body_start_tag(element.tag.as_str(), tag_start);
-            self.handle_in_table_start_tag(element.tag.as_str(), tag_start);
+            let is_html_tree_element = is_html_tree_element(&element);
+            if is_html_tree_element {
+                self.handle_in_body_start_tag(element.tag.as_str(), tag_start);
+                self.handle_in_table_start_tag(element.tag.as_str(), tag_start);
+            }
 
             // Check for pre tags
             let is_pre = (self.options.is_pre_tag)(element.tag.as_str());
@@ -178,10 +181,8 @@ impl<'a> Parser<'a> {
             }
 
             if current.is_self_closing || (self.options.is_void_tag)(element.tag.as_str()) {
-                let should_foster_direct = self.should_foster_start_tag(
-                    element.tag.as_str(),
-                    element.ns == Namespace::Html && element.tag_type == ElementType::Element,
-                );
+                let should_foster_direct =
+                    self.should_foster_start_tag(element.tag.as_str(), is_html_tree_element);
                 // Self-closing or void tag, add directly
                 let boxed = Box::new_in(element, self.allocator);
                 let child = TemplateChildNode::Element(boxed);
@@ -203,15 +204,16 @@ impl<'a> Parser<'a> {
                 let boxed = Box::new_in(element, self.allocator);
                 self.add_child(TemplateChildNode::Element(boxed));
             } else {
-                let insertion = if self.should_foster_start_tag(element.tag.as_str(), true) {
-                    self.report_tree_construction_recovery(
-                        &element.loc,
-                        "Foster parenting moved this element before the nearest open table.",
-                    );
-                    StackInsertion::Fostered
-                } else {
-                    StackInsertion::Normal
-                };
+                let insertion =
+                    if self.should_foster_start_tag(element.tag.as_str(), is_html_tree_element) {
+                        self.report_tree_construction_recovery(
+                            &element.loc,
+                            "Foster parenting moved this element before the nearest open table.",
+                        );
+                        StackInsertion::Fostered
+                    } else {
+                        StackInsertion::Normal
+                    };
                 // Push to stack
                 self.push_stack_entry(ParserStackEntry {
                     element,

--- a/crates/vize_atelier_dom/tests/dom_snapshot.rs
+++ b/crates/vize_atelier_dom/tests/dom_snapshot.rs
@@ -227,4 +227,12 @@ mod component {
     fn simple_component() {
         insta::assert_snapshot!(get_compiled("<MyComponent></MyComponent>"));
     }
+
+    #[test]
+    fn pascal_html_element_name_compiles_as_component() {
+        let code = get_compiled(r#"<Table><span class="x">hello</span></Table>"#);
+
+        assert!(code.contains(r#"_resolveComponent("Table")"#), "{code}");
+        assert!(code.contains(r#"_createElementVNode("span""#), "{code}");
+    }
 }


### PR DESCRIPTION
## Summary
- keep parser tree-construction counters scoped to real HTML elements
- skip HTML body/table insertion-mode handling for component tags
- cover PascalCase HTML-name components such as <Table> compiling through DOM output

## Verification
- cargo test -p vize_atelier_dom pascal_html_element_name_compiles_as_component -- --nocapture
- cargo test -p vize_armature table -- --nocapture
- cargo clippy -p vize_armature -p vize_atelier_dom -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all --check && git diff --check && SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

Closes #1940

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->