### PR TITLE
fix(compiler): preserve scoped slot prop shadowing

### DIFF
--- a/crates/vize_atelier_core/src/codegen/expression.rs
+++ b/crates/vize_atelier_core/src/codegen/expression.rs
@@ -6,12 +6,14 @@
 
 mod generate;
 pub(crate) mod helpers;
+pub(crate) mod scope_prefix;
 
 use crate::{CompoundExpressionChild, ExpressionNode, SimpleExpressionNode};
 
 use super::{context::CodegenContext, helpers::escape_js_string};
 
-use helpers::{convert_line_comments_to_block, strip_ctx_for_slot_params};
+use helpers::convert_line_comments_to_block;
+use scope_prefix::{contains_slot_param_scope_prefix, strip_scope_prefixes_for_slot_params};
 use vize_carton::String;
 use vize_carton::ToCompactString;
 
@@ -76,11 +78,11 @@ pub fn generate_simple_expression(ctx: &mut CodegenContext, exp: &SimpleExpressi
         // the `source_map` flag is on.
         ctx.record_mapping(&exp.loc.start);
 
-        // Replace _ctx.X with X when X is a known slot/v-for parameter.
+        // Replace generated scope prefixes when X is a known slot/v-for parameter.
         // This handles destructured variables that the transform phase
-        // incorrectly prefixed with _ctx. because it didn't know the scope.
-        if ctx.has_slot_params() && content.contains("_ctx.") {
-            ctx.push(&strip_ctx_for_slot_params(ctx, &content));
+        // incorrectly prefixed because it didn't know the scope.
+        if ctx.has_slot_params() && contains_slot_param_scope_prefix(&content) {
+            ctx.push(&strip_scope_prefixes_for_slot_params(ctx, &content));
         } else {
             ctx.push(&content);
         }

--- a/crates/vize_atelier_core/src/codegen/expression/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/generate.rs
@@ -8,7 +8,8 @@ use crate::{CompoundExpressionChild, ExpressionNode};
 use super::{
     super::context::CodegenContext,
     generate_simple_expression,
-    helpers::{prefix_identifiers_with_context, strip_ctx_for_slot_params},
+    helpers::prefix_identifiers_with_context,
+    scope_prefix::{contains_slot_param_scope_prefix, strip_scope_prefixes_for_slot_params},
 };
 use vize_carton::String;
 
@@ -88,8 +89,9 @@ pub fn generate_event_handler(
                     ts_stripped
                 }
             };
-            let processed = if ctx.has_slot_params() && processed.contains("_ctx.") {
-                strip_ctx_for_slot_params(ctx, &processed)
+            let processed = if ctx.has_slot_params() && contains_slot_param_scope_prefix(&processed)
+            {
+                strip_scope_prefixes_for_slot_params(ctx, &processed)
             } else {
                 processed
             };

--- a/crates/vize_atelier_core/src/codegen/expression/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/helpers.rs
@@ -543,35 +543,3 @@ pub(crate) fn convert_line_comments_to_block(content: &str) -> String {
 
     result
 }
-
-/// Strip `_ctx.` prefix for identifiers that are slot/v-for parameters.
-pub(crate) fn strip_ctx_for_slot_params(ctx: &CodegenContext, content: &str) -> String {
-    let mut result = String::with_capacity(content.len());
-    let bytes = content.as_bytes();
-    let prefix = b"_ctx.";
-    let mut i = 0;
-
-    while i < bytes.len() {
-        if i + prefix.len() <= bytes.len() && &bytes[i..i + prefix.len()] == prefix {
-            let start = i + prefix.len();
-            let mut end = start;
-            while end < bytes.len()
-                && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_' || bytes[end] == b'$')
-            {
-                end += 1;
-            }
-            let ident = &content[start..end];
-            if !ident.is_empty() && ctx.is_slot_param(ident) {
-                result.push_str(ident);
-                i = end;
-            } else {
-                result.push_str("_ctx.");
-                i = start;
-            }
-        } else {
-            result.push(bytes[i] as char);
-            i += 1;
-        }
-    }
-    result
-}

--- a/crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs
@@ -1,0 +1,62 @@
+//! Generated scope-prefix cleanup for template locals.
+
+use super::super::context::CodegenContext;
+use vize_carton::String;
+
+const SLOT_PARAM_SCOPE_PREFIXES: [&str; 6] = [
+    "_ctx.",
+    "__props.",
+    "$props.",
+    "$setup.",
+    "$data.",
+    "$options.",
+];
+
+pub(crate) fn contains_slot_param_scope_prefix(content: &str) -> bool {
+    SLOT_PARAM_SCOPE_PREFIXES
+        .iter()
+        .any(|prefix| content.contains(prefix))
+}
+
+pub(crate) fn strip_scope_prefixes_for_slot_params(ctx: &CodegenContext, content: &str) -> String {
+    let mut result = String::with_capacity(content.len());
+    let bytes = content.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let mut stripped = false;
+        for prefix in SLOT_PARAM_SCOPE_PREFIXES {
+            let prefix_bytes = prefix.as_bytes();
+            if i + prefix_bytes.len() > bytes.len()
+                || &bytes[i..i + prefix_bytes.len()] != prefix_bytes
+            {
+                continue;
+            }
+
+            let start = i + prefix_bytes.len();
+            let mut end = start;
+            while end < bytes.len()
+                && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_' || bytes[end] == b'$')
+            {
+                end += 1;
+            }
+
+            let ident = &content[start..end];
+            if !ident.is_empty() && ctx.is_slot_param(ident) {
+                result.push_str(ident);
+                i = end;
+                stripped = true;
+                break;
+            }
+        }
+
+        if stripped {
+            continue;
+        }
+
+        result.push(bytes[i] as char);
+        i += 1;
+    }
+
+    result
+}

--- a/crates/vize_atelier_core/tests/scoped_slot_shadowing.rs
+++ b/crates/vize_atelier_core/tests/scoped_slot_shadowing.rs
@@ -1,0 +1,65 @@
+use vize_atelier_core::{
+    BindingMetadata, BindingType, CodegenOptions, CodegenResult, TransformOptions, generate, parse,
+    transform,
+};
+
+fn result_output(result: &CodegenResult) -> String {
+    let mut output = String::with_capacity(result.preamble.len() + result.code.len() + 1);
+    output.push_str(&result.preamble);
+    output.push('\n');
+    output.push_str(&result.code);
+    output
+}
+
+#[test]
+fn scoped_slot_props_shadow_inline_props_in_slot_outlet_vbind() {
+    let allocator = bumpalo::Bump::new();
+    let (mut root, errors) = parse(
+        &allocator,
+        r#"<RouterLink v-slot="{ href }"><slot v-bind="{ href }" /></RouterLink>"#,
+    );
+    assert!(errors.is_empty(), "Parse errors: {:?}", errors);
+
+    let mut bindings = vize_carton::FxHashMap::default();
+    bindings.insert("href".into(), BindingType::Props);
+    let binding_metadata = BindingMetadata {
+        bindings,
+        props_aliases: vize_carton::FxHashMap::default(),
+        is_script_setup: true,
+    };
+
+    transform(
+        &allocator,
+        &mut root,
+        TransformOptions {
+            prefix_identifiers: true,
+            inline: true,
+            binding_metadata: Some(binding_metadata.clone()),
+            ..Default::default()
+        },
+        None,
+    );
+
+    let output = result_output(&generate(
+        &root,
+        CodegenOptions {
+            prefix_identifiers: true,
+            inline: true,
+            binding_metadata: Some(binding_metadata),
+            ..Default::default()
+        },
+    ));
+
+    assert!(
+        output.contains("href: href"),
+        "slot outlet should forward the scoped slot href, not component props. Got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("__props.href")
+            && !output.contains("$props.href")
+            && !output.contains("_ctx.href"),
+        "slot-scoped href must not be emitted with component scope prefixes. Got:\n{}",
+        output
+    );
+}

--- a/crates/vize_atelier_sfc/tests/scoped_slot_shadowing.rs
+++ b/crates/vize_atelier_sfc/tests/scoped_slot_shadowing.rs
@@ -1,0 +1,75 @@
+use vize_atelier_sfc::{
+    ScriptCompileOptions, SfcCompileOptions, SfcParseOptions, TemplateCompileOptions, compile_sfc,
+    parse_sfc,
+};
+
+const SOURCE: &str = r#"<script setup lang="ts">
+defineProps<{ href?: string }>()
+</script>
+
+<template>
+  <RouterLink v-slot="{ href }">
+    <slot v-bind="{ href }" />
+  </RouterLink>
+</template>"#;
+
+#[test]
+fn script_setup_prop_does_not_shadow_scoped_slot_outlet_vbind() {
+    let descriptor = parse_sfc(SOURCE, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions {
+        script: ScriptCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        template: TemplateCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains("href: href"),
+        "slot outlet should forward RouterLink's scoped href:\n{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("__props.href")
+            && !result.code.contains("$props.href")
+            && !result.code.contains("_ctx.href"),
+        "slot outlet href must not resolve to component props:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn script_setup_prop_does_not_shadow_scoped_slot_outlet_vbind_in_ssr() {
+    let descriptor = parse_sfc(SOURCE, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions {
+        script: ScriptCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        template: TemplateCompileOptions {
+            is_ts: true,
+            ssr: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains("href: href"),
+        "SSR slot outlet should forward RouterLink's scoped href:\n{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("__props.href")
+            && !result.code.contains("$props.href")
+            && !result.code.contains("_ctx.href"),
+        "SSR slot outlet href must not resolve to component props:\n{}",
+        result.code
+    );
+}

--- a/crates/vize_atelier_ssr/src/codegen.rs
+++ b/crates/vize_atelier_ssr/src/codegen.rs
@@ -5,6 +5,7 @@
 
 mod element;
 pub(crate) mod helpers;
+mod scope_prefix;
 
 use crate::options::SsrCompilerOptions;
 use vize_atelier_core::{RootNode, RuntimeHelper, TemplateChildNode};
@@ -280,51 +281,8 @@ impl<'a> SsrCodegenContext<'a> {
         self.scoped_params.pop();
     }
 
-    pub(crate) fn is_scoped_param(&self, name: &str) -> bool {
-        self.scoped_params
-            .iter()
-            .rev()
-            .any(|params| params.contains(name))
-    }
-
     pub(crate) fn strip_ctx_for_scoped_params(&self, content: &str) -> String {
-        if self.scoped_params.is_empty() || !content.contains("_ctx.") {
-            return content.to_compact_string();
-        }
-
-        let mut result = String::with_capacity(content.len());
-        let bytes = content.as_bytes();
-        let prefix = b"_ctx.";
-        let mut index = 0;
-
-        while index < bytes.len() {
-            if index + prefix.len() <= bytes.len() && &bytes[index..index + prefix.len()] == prefix
-            {
-                let start = index + prefix.len();
-                let mut end = start;
-                while end < bytes.len()
-                    && (bytes[end].is_ascii_alphanumeric()
-                        || bytes[end] == b'_'
-                        || bytes[end] == b'$')
-                {
-                    end += 1;
-                }
-
-                let ident = &content[start..end];
-                if !ident.is_empty() && self.is_scoped_param(ident) {
-                    result.push_str(ident);
-                    index = end;
-                } else {
-                    result.push_str("_ctx.");
-                    index = start;
-                }
-            } else {
-                result.push(bytes[index] as char);
-                index += 1;
-            }
-        }
-
-        result
+        scope_prefix::strip_scope_prefixes_for_scoped_params(&self.scoped_params, content)
     }
 
     /// Push raw code to the buffer

--- a/crates/vize_atelier_ssr/src/codegen/scope_prefix.rs
+++ b/crates/vize_atelier_ssr/src/codegen/scope_prefix.rs
@@ -1,0 +1,73 @@
+//! Generated scope-prefix cleanup for SSR template locals.
+
+use vize_carton::{FxHashSet, String, ToCompactString};
+
+const SCOPED_PARAM_PREFIXES: [&str; 6] = [
+    "_ctx.",
+    "__props.",
+    "$props.",
+    "$setup.",
+    "$data.",
+    "$options.",
+];
+
+pub(crate) fn strip_scope_prefixes_for_scoped_params(
+    scoped_params: &[FxHashSet<String>],
+    content: &str,
+) -> String {
+    if scoped_params.is_empty()
+        || !SCOPED_PARAM_PREFIXES
+            .iter()
+            .any(|prefix| content.contains(prefix))
+    {
+        return content.to_compact_string();
+    }
+
+    let mut result = String::with_capacity(content.len());
+    let bytes = content.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        let mut stripped = false;
+        for prefix in SCOPED_PARAM_PREFIXES {
+            let prefix_bytes = prefix.as_bytes();
+            if index + prefix_bytes.len() > bytes.len()
+                || &bytes[index..index + prefix_bytes.len()] != prefix_bytes
+            {
+                continue;
+            }
+
+            let start = index + prefix_bytes.len();
+            let mut end = start;
+            while end < bytes.len()
+                && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_' || bytes[end] == b'$')
+            {
+                end += 1;
+            }
+
+            let ident = &content[start..end];
+            if !ident.is_empty() && is_scoped_param(scoped_params, ident) {
+                result.push_str(ident);
+                index = end;
+                stripped = true;
+                break;
+            }
+        }
+
+        if stripped {
+            continue;
+        }
+
+        result.push(bytes[index] as char);
+        index += 1;
+    }
+
+    result
+}
+
+fn is_scoped_param(scoped_params: &[FxHashSet<String>], name: &str) -> bool {
+    scoped_params
+        .iter()
+        .rev()
+        .any(|params| params.contains(name))
+}


### PR DESCRIPTION
## Summary
- Preserve scoped slot params when transformed expressions already carry generated component-scope prefixes.
- Apply the same cleanup to DOM and SSR codegen paths.
- Add core and SFC regressions for Link-like scoped `href` forwarding.

Fixes #1943

## Tests
- cargo test -p vize_atelier_core -p vize_atelier_sfc scoped_slot -- --nocapture
- cargo fmt --all --check && git diff --check && SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo clippy -p vize_atelier_core -p vize_atelier_ssr -p vize_atelier_sfc -- -D warnings -D clippy::wildcard_imports

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->