### PR TITLE
fix(check): infer options api emit payloads

### DIFF
--- a/crates/vize/tests/check_nuxt_tsconfig_paths_cli.rs
+++ b/crates/vize/tests/check_nuxt_tsconfig_paths_cli.rs
@@ -161,6 +161,110 @@ export function useRouter(): {
     let _ = std::fs::remove_dir_all(&project_root);
 }
 
+#[test]
+fn check_nuxt2_options_api_component_event_payloads_resolve_through_aliases() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project("nuxt2-options-api-emits-alias");
+
+    write_file(&project_root, "nuxt.config.ts", "export default {}\n");
+    write_file(
+        &project_root,
+        "tsconfig.json",
+        r##"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "paths": {
+      "~/*": ["*"],
+      "@/*": ["*"]
+    }
+  },
+  "include": ["src/**/*.vue"]
+}"##,
+    );
+    write_file(
+        &project_root,
+        "src/app/purposes/Keyboards.vue",
+        r##"<script setup lang="ts">
+import EnglishKeyboard, {
+  type ChoiceOption,
+} from "~/src/shared/components/keyboards/EnglishKeyboard.vue";
+
+const options: ChoiceOption[] = [{ value: "a" }];
+
+function selectOption(incomingValue: ChoiceOption) {
+  incomingValue.value.toUpperCase();
+}
+</script>
+
+<template>
+  <EnglishKeyboard :options="options" @input="selectOption" />
+</template>
+"##,
+    );
+    write_file(
+        &project_root,
+        "src/shared/components/keyboards/EnglishKeyboard.vue",
+        r##"<script lang="ts">
+import { defineComponent, type PropType } from "vue";
+
+export type ChoiceOption = { value: string };
+
+export default defineComponent({
+  props: {
+    options: {
+      type: Array as PropType<ChoiceOption[]>,
+      required: true,
+    },
+  },
+  emits: {
+    input(value: ChoiceOption) {
+      return value.value.length > 0;
+    },
+  },
+});
+</script>
+
+<template>
+  <button type="button">{{ options.length }}</button>
+</template>
+"##,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src/app/purposes/Keyboards.vue",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+            "--no-config",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "Nuxt2 alias component emits should type-check\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], 0, "{stdout}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
 fn create_project(name: &str) -> PathBuf {
     let project_root = workspace_root()
         .join("target")

--- a/crates/vize_croquis/src/script_parser.rs
+++ b/crates/vize_croquis/src/script_parser.rs
@@ -38,3 +38,6 @@ mod tests;
 
 #[cfg(test)]
 mod props_destructure_tests;
+
+#[cfg(test)]
+mod options_api_emits_tests;

--- a/crates/vize_croquis/src/script_parser/extract.rs
+++ b/crates/vize_croquis/src/script_parser/extract.rs
@@ -13,6 +13,7 @@ mod runtime_objects;
 mod slots;
 
 pub use common::{extract_call_expression, get_binding_type_from_kind};
+pub(in crate::script_parser) use emits::extract_runtime_emit_payload_type;
 pub use exports::{process_invalid_export, process_type_export};
 pub use macros::process_call_expression;
 pub(in crate::script_parser) use plain_values::reactive_destructure_source;

--- a/crates/vize_croquis/src/script_parser/extract/emits.rs
+++ b/crates/vize_croquis/src/script_parser/extract/emits.rs
@@ -136,7 +136,7 @@ fn extract_emits_from_object(
     }
 }
 
-pub(super) fn extract_runtime_emit_payload_type(
+pub(in crate::script_parser) fn extract_runtime_emit_payload_type(
     value: &Expression<'_>,
     source: &str,
 ) -> Option<CompactString> {

--- a/crates/vize_croquis/src/script_parser/options_api_emits_tests.rs
+++ b/crates/vize_croquis/src/script_parser/options_api_emits_tests.rs
@@ -1,0 +1,46 @@
+use super::{ScriptParserOptions, parse_script_with_options};
+
+#[test]
+fn parses_options_api_emits_runtime_object_payloads() {
+    let result = parse_script_with_options(
+        r#"
+type ChoiceOption = { value: string }
+
+const sharedEmits = {
+  close: null,
+}
+
+export default {
+  emits: {
+    ...sharedEmits,
+    input(value: ChoiceOption) {
+      return value.value.length > 0
+    },
+    cancel() {
+      return true
+    },
+  },
+}
+"#,
+        ScriptParserOptions {
+            options_api: true,
+            legacy_vue2: true,
+        },
+    );
+
+    let emits = result.macros.emits();
+    let input = emits
+        .iter()
+        .find(|emit| emit.name == "input")
+        .expect("input emit should be extracted");
+    assert_eq!(input.payload_type.as_deref(), Some("[value: ChoiceOption]"));
+    let cancel = emits
+        .iter()
+        .find(|emit| emit.name == "cancel")
+        .expect("cancel emit should be extracted");
+    assert_eq!(cancel.payload_type.as_deref(), Some("[]"));
+    assert!(
+        emits.iter().any(|emit| emit.name == "close"),
+        "spread emits should be extracted, got {emits:?}"
+    );
+}

--- a/crates/vize_croquis/src/script_parser/parse.rs
+++ b/crates/vize_croquis/src/script_parser/parse.rs
@@ -194,6 +194,7 @@ pub fn parse_script_with_options(source: &str, options: ScriptParserOptions) -> 
     process::collect_options_api_component_metadata(
         &mut result,
         &ret.program,
+        source,
         options.options_api,
         options.legacy_vue2,
     );

--- a/crates/vize_croquis/src/script_parser/process/options_api.rs
+++ b/crates/vize_croquis/src/script_parser/process/options_api.rs
@@ -1,9 +1,8 @@
-//! Options API component metadata collection.
-//!
-//! Walks `export default { ... }` / `defineComponent({ ... })` options objects
-//! to collect component registrations and template bindings (props, data,
-//! computed, methods, inject, setup, same-file mixins/extends) for the
-//! Options API and legacy Vue 2.7.
+//! Options API component metadata collection for component registrations and template bindings.
+
+mod emits;
+
+use emits::collect_options_api_emits_from_options as collect_emits;
 
 use oxc_ast::ast::{
     Argument, ArrayExpression, ArrayExpressionElement, BindingPattern, CallExpression,
@@ -29,6 +28,7 @@ struct ComponentOptionsRef<'a> {
 pub(in crate::script_parser) fn collect_options_api_component_metadata(
     result: &mut ScriptParseResult,
     program: &Program<'_>,
+    source: &str,
     options_api: bool,
     legacy_vue2: bool,
 ) {
@@ -45,8 +45,7 @@ pub(in crate::script_parser) fn collect_options_api_component_metadata(
 
         // Class components (vue-class-component / vue-property-decorator):
         // in an SFC the default export *is* the component, so a class default
-        // export is unambiguous. Auto-detected by AST shape — no flag, and
-        // this arm never executes for non-class components.
+        // export is unambiguous. Auto-detected by AST shape, no flag needed.
         if let Some(class) = super::class_component::class_from_export(&export.declaration) {
             super::class_component::collect_class_component_metadata(
                 result,
@@ -64,6 +63,7 @@ pub(in crate::script_parser) fn collect_options_api_component_metadata(
         if result.options_descriptor.is_none() {
             result.options_descriptor = Some(build_options_descriptor(options.object));
         }
+        collect_emits(result, options.object, &object_bindings, source);
         collect_component_registrations_from_options(result, options.object, &object_bindings);
         // Options API template bindings are valid in Vue 3 too; legacy Vue 2.7
         // implies them and additionally pulls in the Nuxt 2 globals below.

--- a/crates/vize_croquis/src/script_parser/process/options_api/emits.rs
+++ b/crates/vize_croquis/src/script_parser/process/options_api/emits.rs
@@ -1,0 +1,128 @@
+use oxc_ast::ast::{
+    ArrayExpression, ArrayExpressionElement, Expression, ObjectExpression, ObjectPropertyKind,
+};
+use vize_carton::{CompactString, FxHashMap, FxHashSet};
+
+use crate::macros::EmitDefinition;
+use crate::script_parser::{ScriptParseResult, extract::extract_runtime_emit_payload_type};
+
+use super::{option_expression_property, property_key_name};
+
+pub(super) fn collect_options_api_emits_from_options<'a>(
+    result: &mut ScriptParseResult,
+    options: &'a ObjectExpression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+    source: &str,
+) {
+    let Some(emits) = option_expression_property(options, "emits") else {
+        return;
+    };
+    collect_from_expression(
+        result,
+        emits,
+        object_bindings,
+        source,
+        &mut FxHashSet::default(),
+    );
+}
+
+fn collect_from_expression<'a>(
+    result: &mut ScriptParseResult,
+    expression: &'a Expression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+    source: &str,
+    seen_bindings: &mut FxHashSet<&'a str>,
+) {
+    match expression {
+        Expression::ArrayExpression(array) => collect_from_array(result, array),
+        Expression::ObjectExpression(object) => {
+            collect_from_object(result, object, object_bindings, source, seen_bindings);
+        }
+        Expression::Identifier(identifier) => {
+            let name = identifier.name.as_str();
+            if !seen_bindings.insert(name) {
+                return;
+            }
+            let Some(object) = object_bindings.get(name) else {
+                return;
+            };
+            collect_from_object(result, object, object_bindings, source, seen_bindings);
+        }
+        Expression::TSAsExpression(ts_as) => collect_from_expression(
+            result,
+            &ts_as.expression,
+            object_bindings,
+            source,
+            seen_bindings,
+        ),
+        Expression::TSSatisfiesExpression(ts_satisfies) => collect_from_expression(
+            result,
+            &ts_satisfies.expression,
+            object_bindings,
+            source,
+            seen_bindings,
+        ),
+        Expression::TSNonNullExpression(ts_non_null) => collect_from_expression(
+            result,
+            &ts_non_null.expression,
+            object_bindings,
+            source,
+            seen_bindings,
+        ),
+        Expression::ParenthesizedExpression(parenthesized) => collect_from_expression(
+            result,
+            &parenthesized.expression,
+            object_bindings,
+            source,
+            seen_bindings,
+        ),
+        _ => {}
+    }
+}
+
+fn collect_from_array(result: &mut ScriptParseResult, array: &ArrayExpression<'_>) {
+    for element in &array.elements {
+        let ArrayExpressionElement::StringLiteral(literal) = element else {
+            continue;
+        };
+        result.macros.add_emit(EmitDefinition {
+            name: CompactString::new(literal.value.as_str()),
+            payload_type: None,
+        });
+    }
+}
+
+fn collect_from_object<'a>(
+    result: &mut ScriptParseResult,
+    object: &'a ObjectExpression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+    source: &str,
+    seen_bindings: &mut FxHashSet<&'a str>,
+) {
+    for property in &object.properties {
+        match property {
+            ObjectPropertyKind::ObjectProperty(property) => {
+                let Some(name) = property_key_name(&property.key) else {
+                    continue;
+                };
+                result.macros.add_emit(EmitDefinition {
+                    name: CompactString::new(name),
+                    payload_type: extract_runtime_emit_payload_type(&property.value, source),
+                });
+            }
+            ObjectPropertyKind::SpreadProperty(spread) => {
+                let Expression::Identifier(identifier) = &spread.argument else {
+                    continue;
+                };
+                collect_from_expression(
+                    result,
+                    &spread.argument,
+                    object_bindings,
+                    source,
+                    seen_bindings,
+                );
+                seen_bindings.remove(identifier.name.as_str());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- extract Options API `emits` metadata from plain `<script>` component options
- expose extracted emit payloads through the existing virtual TS emit-props path
- add a Nuxt2 alias regression for Options API component listener payloads

Closes #1876

## Validation

- `cargo fmt --all --check && git diff --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo test -p vize_croquis parses_options_api_emits_runtime_object_payloads -- --nocapture`
- `cargo test -p vize check_nuxt2_options_api_component_event_payloads_resolve_through_aliases -- --nocapture`
- `cargo clippy -p vize_croquis -p vize -- -D warnings -D clippy::wildcard_imports`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->