### PR TITLE
fix(cli): support plain script lint and fmt inputs

### DIFF
--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -1,4 +1,4 @@
-//! Format command - High-performance Vue, JSX, and TSX formatting using vize_glyph
+//! Format command - High-performance Vue and script formatting using vize_glyph
 
 #![allow(clippy::disallowed_macros)]
 
@@ -30,7 +30,7 @@ use ignores::load_fmt_ignore_set;
 #[derive(Args)]
 #[allow(clippy::disallowed_types)]
 pub struct FmtArgs {
-    /// Glob pattern(s) to match .vue, .jsx, and .tsx files
+    /// Glob pattern(s) to match .vue, .js, .ts, .jsx, and .tsx files
     #[arg(default_values_t = default_fmt_patterns())]
     pub patterns: Vec<String>,
 
@@ -113,7 +113,7 @@ pub fn run(args: FmtArgs) {
     let collect_time = collect_start.elapsed();
 
     if files.is_empty() {
-        eprintln!("No .vue, .jsx, or .tsx files found matching the patterns");
+        eprintln!("No .vue, .js, .ts, .jsx, or .tsx files found matching the patterns");
         return;
     }
 
@@ -372,6 +372,12 @@ fn build_format_options(args: &FmtArgs) -> FormatOptions {
 fn default_fmt_patterns() -> Vec<std::string::String> {
     vec![
         "./**/*.vue".into(),
+        "./**/*.js".into(),
+        "./**/*.mjs".into(),
+        "./**/*.cjs".into(),
+        "./**/*.ts".into(),
+        "./**/*.mts".into(),
+        "./**/*.cts".into(),
         "./**/*.jsx".into(),
         "./**/*.tsx".into(),
     ]
@@ -477,41 +483,31 @@ fn format_file_source(
     options: &FormatOptions,
     allocator: &Allocator,
 ) -> Result<FormatResult, vize_glyph::FormatError> {
-    match path.extension().and_then(|extension| extension.to_str()) {
-        Some("jsx") => {
-            let code = profile!(
-                "cli.fmt.file.format_jsx",
-                format_script_with_source_type(
-                    source,
-                    options,
-                    allocator,
-                    SourceType::jsx().with_module(true),
-                )
-            )?;
-            Ok(FormatResult {
-                changed: code.as_str() != source,
-                code,
-            })
-        }
-        Some("tsx") => {
-            let code = profile!(
-                "cli.fmt.file.format_tsx",
-                format_script_with_source_type(
-                    source,
-                    options,
-                    allocator,
-                    SourceType::tsx().with_module(true),
-                )
-            )?;
-            Ok(FormatResult {
-                changed: code.as_str() != source,
-                code,
-            })
-        }
-        _ => profile!(
-            "cli.fmt.file.format_sfc",
-            format_sfc_with_allocator(source, options, allocator)
-        ),
+    if let Some(source_type) = script_source_type_for_path(path) {
+        let code = profile!(
+            "cli.fmt.file.format_script",
+            format_script_with_source_type(source, options, allocator, source_type)
+        )?;
+        return Ok(FormatResult {
+            changed: code.as_str() != source,
+            code,
+        });
+    }
+
+    profile!(
+        "cli.fmt.file.format_sfc",
+        format_sfc_with_allocator(source, options, allocator)
+    )
+}
+
+fn script_source_type_for_path(path: &Path) -> Option<SourceType> {
+    let extension = path.extension().and_then(|extension| extension.to_str())?;
+    match extension {
+        "js" | "mjs" | "cjs" => Some(SourceType::from_path("module.js").ok()?.with_module(true)),
+        "ts" | "mts" | "cts" => Some(SourceType::from_path("module.ts").ok()?.with_module(true)),
+        "jsx" => Some(SourceType::jsx().with_module(true)),
+        "tsx" => Some(SourceType::tsx().with_module(true)),
+        _ => None,
     }
 }
 

--- a/crates/vize/src/commands/fmt/files.rs
+++ b/crates/vize/src/commands/fmt/files.rs
@@ -81,6 +81,18 @@ fn should_walk_with_gitignore(pattern: &str) -> bool {
             | "./**/*.jsx"
             | "**/*.tsx"
             | "./**/*.tsx"
+            | "**/*.js"
+            | "./**/*.js"
+            | "**/*.mjs"
+            | "./**/*.mjs"
+            | "**/*.cjs"
+            | "./**/*.cjs"
+            | "**/*.ts"
+            | "./**/*.ts"
+            | "**/*.mts"
+            | "./**/*.mts"
+            | "**/*.cts"
+            | "./**/*.cts"
     )
 }
 
@@ -143,7 +155,12 @@ fn normalize_fmt_pattern(pattern: &str) -> vize_carton::String {
 fn is_format_target(path: &Path) -> bool {
     path.extension()
         .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "vue" | "jsx" | "tsx"))
+        .is_some_and(|extension| {
+            matches!(
+                extension,
+                "vue" | "jsx" | "tsx" | "js" | "mjs" | "cjs" | "ts" | "mts" | "cts"
+            )
+        })
 }
 
 #[inline]
@@ -228,15 +245,18 @@ mod tests {
     }
 
     #[test]
-    fn collect_files_matches_vue_jsx_and_tsx() {
+    fn collect_files_matches_vue_scripts_and_jsx() {
         let root = unique_case_dir("format-targets");
         let src = root.join("src");
         let _ = fs::remove_dir_all(&root);
         fs::create_dir_all(&src).unwrap();
         fs::write(src.join("App.vue"), "<template><div/></template>").unwrap();
+        fs::write(src.join("config.js"), "export default {}").unwrap();
         fs::write(src.join("Panel.jsx"), "const Panel=()=> <div />").unwrap();
+        fs::write(src.join("store.ts"), "export const count=0").unwrap();
         fs::write(src.join("Widget.tsx"), "const Widget=()=> <div />").unwrap();
-        fs::write(src.join("types.ts"), "export type Widget = {}").unwrap();
+        fs::write(src.join("types.d.ts"), "export type Widget = {}").unwrap();
+        fs::write(src.join("notes.md"), "# notes").unwrap();
 
         let pattern = root.to_string_lossy().into_owned();
         let files = collect_files(&[pattern], None);
@@ -247,7 +267,10 @@ mod tests {
             vec![
                 src.join("App.vue"),
                 src.join("Panel.jsx"),
-                src.join("Widget.tsx")
+                src.join("Widget.tsx"),
+                src.join("config.js"),
+                src.join("store.ts"),
+                src.join("types.d.ts")
             ]
         );
     }

--- a/crates/vize/src/commands/lint/args.rs
+++ b/crates/vize/src/commands/lint/args.rs
@@ -7,8 +7,20 @@ use vize_carton::String;
 #[derive(Args)]
 #[allow(clippy::disallowed_types)]
 pub struct LintArgs {
-    /// Glob pattern(s) to match .vue, standalone .html, .jsx, or .tsx files
-    #[arg(default_values = ["./**/*.vue", "./**/*.html", "./**/*.htm", "./**/*.jsx", "./**/*.tsx"])]
+    /// Glob pattern(s) to match .vue, standalone .html, .js, .ts, .jsx, or .tsx files
+    #[arg(default_values = [
+        "./**/*.vue",
+        "./**/*.html",
+        "./**/*.htm",
+        "./**/*.js",
+        "./**/*.mjs",
+        "./**/*.cjs",
+        "./**/*.ts",
+        "./**/*.mts",
+        "./**/*.cts",
+        "./**/*.jsx",
+        "./**/*.tsx"
+    ])]
     pub patterns: Vec<String>,
 
     /// Automatically fix problems (not yet implemented)

--- a/crates/vize/src/commands/lint/collect.rs
+++ b/crates/vize/src/commands/lint/collect.rs
@@ -65,7 +65,7 @@ fn add_lint_file(path: &Path, files: &mut Vec<PathBuf>, seen: &mut FxHashSet<Pat
 fn is_lintable_path(path: &Path) -> bool {
     matches!(
         path.extension().and_then(|extension| extension.to_str()),
-        Some("vue" | "html" | "htm" | "jsx" | "tsx")
+        Some("vue" | "html" | "htm" | "js" | "mjs" | "cjs" | "ts" | "mts" | "cts" | "jsx" | "tsx",)
     )
 }
 
@@ -73,6 +73,13 @@ pub(super) fn is_standalone_html_path(path: &Path) -> bool {
     matches!(
         path.extension().and_then(|extension| extension.to_str()),
         Some("html" | "htm")
+    )
+}
+
+pub(super) fn is_plain_script_path(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|extension| extension.to_str()),
+        Some("js" | "mjs" | "cjs" | "ts" | "mts" | "cts")
     )
 }
 
@@ -161,5 +168,39 @@ fn lint_glob_match_options() -> MatchOptions {
         case_sensitive: true,
         require_literal_separator: true,
         require_literal_leading_dot: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_lint_files;
+    use std::fs;
+
+    #[test]
+    fn collection_includes_vue_html_scripts_and_jsx() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("App.vue"), "").unwrap();
+        fs::write(src.join("index.html"), "").unwrap();
+        fs::write(src.join("config.js"), "").unwrap();
+        fs::write(src.join("store.ts"), "").unwrap();
+        fs::write(src.join("Panel.jsx"), "").unwrap();
+        fs::write(src.join("Widget.tsx"), "").unwrap();
+        fs::write(src.join("notes.md"), "").unwrap();
+
+        let files = collect_lint_files(&[src.display().to_string().into()]);
+
+        assert_eq!(
+            files,
+            vec![
+                src.join("App.vue"),
+                src.join("Panel.jsx"),
+                src.join("Widget.tsx"),
+                src.join("config.js"),
+                src.join("index.html"),
+                src.join("store.ts")
+            ]
+        );
     }
 }

--- a/crates/vize/src/commands/lint/cross_file.rs
+++ b/crates/vize/src/commands/lint/cross_file.rs
@@ -20,10 +20,42 @@ pub(super) struct CrossFileLintOutput {
     pub(super) provide_inject_tree: Option<String>,
 }
 
+pub(super) type CliLintFileResult = (PathBuf, String, String, LintResult);
+
 #[derive(Clone, Copy, Debug, Default)]
 struct CrossFileSourceOffsets {
     script: u32,
     template: u32,
+}
+
+pub(super) fn apply_sfc_cross_file_lint(
+    results: &mut [CliLintFileResult],
+    help_level: HelpLevel,
+    include_tree: bool,
+) -> Option<String> {
+    let targets: Vec<_> = results
+        .iter()
+        .enumerate()
+        .filter(|(_, (path, _, _, _))| is_sfc_cross_file_target(path))
+        .map(|(index, _)| index)
+        .collect();
+    let inputs: Vec<_> = targets
+        .iter()
+        .map(|index| {
+            let (path, _, source, _) = &results[*index];
+            (path.clone(), source.clone())
+        })
+        .collect();
+    let output = build_cross_file_lint_output(&inputs, help_level, include_tree);
+    let tree = output.provide_inject_tree;
+
+    for (target_index, cross_result) in targets.into_iter().zip(output.results) {
+        if let Some((_, _, _, result)) = results.get_mut(target_index) {
+            merge_lint_result(result, cross_result);
+        }
+    }
+
+    tree
 }
 
 pub(super) fn build_cross_file_lint_output<S: AsRef<str>>(
@@ -157,6 +189,13 @@ fn analyze_sfc_for_cross_file(
     };
 
     Some((analysis, offsets))
+}
+
+fn is_sfc_cross_file_target(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|extension| extension.to_str()),
+        Some("vue")
+    )
 }
 
 fn cross_file_diagnostic_to_lint(

--- a/crates/vize/src/commands/lint/mod.rs
+++ b/crates/vize/src/commands/lint/mod.rs
@@ -1,4 +1,4 @@
-//! Lint command - Lint Vue SFC files
+//! Lint command - Lint Vue and script files
 
 mod args;
 mod collect;
@@ -11,8 +11,10 @@ mod tests;
 pub use args::LintArgs;
 
 use crate::profile_support;
-use collect::{collect_lint_files, is_standalone_html_path, resolve_lint_config_path};
-use cross_file::{build_cross_file_lint_output, merge_lint_result};
+use collect::{
+    collect_lint_files, is_plain_script_path, is_standalone_html_path, resolve_lint_config_path,
+};
+use cross_file::apply_sfc_cross_file_lint;
 use rayon::prelude::*;
 use std::fs;
 use std::io::Write;
@@ -78,14 +80,14 @@ pub fn run(args: LintArgs) {
         .type_checker
         .runtime_path()
         .map(|path| resolve_lint_config_path(config_dir, path));
-    // Collect .vue, standalone .html, and JSX/TSX files using glob patterns or directory walking
+    // Collect lintable files using glob patterns or directory walking.
     let collect_start = Instant::now();
     let files = collect_lint_files(&args.patterns);
     let collect_time = collect_start.elapsed();
 
     if files.is_empty() {
         eprintln!(
-            "No .vue, .html, .jsx, or .tsx files found matching patterns: {:?}",
+            "No .vue, .html, .js, .ts, .jsx, or .tsx files found matching patterns: {:?}",
             args.patterns
         );
         return;
@@ -135,10 +137,10 @@ pub fn run(args: LintArgs) {
         .filter_map(|path| {
             let file_start = args.profile.then(Instant::now);
             let read_start = args.profile.then(Instant::now);
-            let source = match profile!("cli.lint.file.read", fs::read_to_string(path)) {
-                Ok(s) => {
-                    global_profiler().record_fs_read_to_string(s.len());
-                    s
+            let source: String = match profile!("cli.lint.file.read", fs::read_to_string(path)) {
+                Ok(source) => {
+                    global_profiler().record_fs_read_to_string(source.len());
+                    source.into()
                 }
                 Err(e) => {
                     global_profiler().record_fs_read_to_string_failure();
@@ -155,6 +157,8 @@ pub fn run(args: LintArgs) {
             let result = profile!("cli.lint.file.lint", {
                 if is_standalone_html_path(path) {
                     linter.lint_standalone_html(&source, &filename)
+                } else if is_plain_script_path(path) {
+                    linter.lint_script(&source, &filename)
                 } else if let Some(lang) = jsx_lang_for_path(path) {
                     linter.lint_jsx(&source, &filename, lang)
                 } else {
@@ -197,23 +201,10 @@ pub fn run(args: LintArgs) {
     let cross_file_enabled = args.cross_file || args.cross_file_tree;
     let cross_file_start = args.profile.then(Instant::now);
     if cross_file_enabled {
-        let cross_file_inputs: Vec<_> = results
-            .iter()
-            .map(|(path, _, source, _)| (path.clone(), source.as_str()))
-            .collect();
-        let cross_file_output = profile!(
+        cross_file_tree = profile!(
             "cli.lint.cross_file.build",
-            build_cross_file_lint_output(&cross_file_inputs, help_level, args.cross_file_tree)
+            apply_sfc_cross_file_lint(&mut results, help_level, args.cross_file_tree)
         );
-        cross_file_tree = cross_file_output.provide_inject_tree;
-
-        profile!("cli.lint.cross_file.merge", {
-            for (index, cross_result) in cross_file_output.results.into_iter().enumerate() {
-                if let Some((_, _, _, result)) = results.get_mut(index) {
-                    merge_lint_result(result, cross_result);
-                }
-            }
-        });
     }
     let cross_file_time = cross_file_start
         .map(|start| start.elapsed())

--- a/crates/vize/src/commands/lint/tests.rs
+++ b/crates/vize/src/commands/lint/tests.rs
@@ -1,8 +1,6 @@
 //! Tests for the lint command.
 
-use super::{
-    build_cross_file_lint_output, collect::collect_lint_files, should_render_lint_details,
-};
+use super::{cross_file::build_cross_file_lint_output, should_render_lint_details};
 use std::{fs, path::Path};
 use vize_patina::{LintPreset, LintResult, Linter, OutputFormat};
 
@@ -52,28 +50,6 @@ fn report_formats_render_in_quiet_mode() {
     assert!(should_render_lint_details(OutputFormat::Markdown, true));
     assert!(should_render_lint_details(OutputFormat::Html, true));
     assert!(should_render_lint_details(OutputFormat::Agent, true));
-}
-
-#[test]
-fn lint_collection_includes_jsx_and_tsx() {
-    let dir = tempfile::tempdir().unwrap();
-    let src = dir.path().join("src");
-    fs::create_dir_all(&src).unwrap();
-    fs::write(src.join("App.vue"), "").unwrap();
-    fs::write(src.join("Panel.jsx"), "").unwrap();
-    fs::write(src.join("Widget.tsx"), "").unwrap();
-    fs::write(src.join("skip.ts"), "").unwrap();
-
-    let files = collect_lint_files(&[src.display().to_string().into()]);
-
-    assert_eq!(
-        files,
-        vec![
-            src.join("App.vue"),
-            src.join("Panel.jsx"),
-            src.join("Widget.tsx"),
-        ]
-    );
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_fmt_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_fmt_help.snap
@@ -8,9 +8,9 @@ Usage: fmt [OPTIONS] [PATTERNS]...
 
 Arguments:
   [PATTERNS]...
-          Glob pattern(s) to match .vue, .jsx, and .tsx files
+          Glob pattern(s) to match .vue, .js, .ts, .jsx, and .tsx files
 
-          [default: ./**/*.vue ./**/*.jsx ./**/*.tsx]
+          [default: ./**/*.vue ./**/*.js ./**/*.mjs ./**/*.cjs ./**/*.ts ./**/*.mts ./**/*.cts ./**/*.jsx ./**/*.tsx]
 
 Options:
       --check

--- a/crates/vize/tests/plain_script_cli.rs
+++ b/crates/vize/tests/plain_script_cli.rs
@@ -1,0 +1,74 @@
+use std::{
+    fs,
+    path::Path,
+    process::{Command, Output},
+};
+
+fn write_project_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(file_path, content).unwrap();
+}
+
+fn output_details(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn fmt_check_supports_plain_ts_inputs() {
+    let project = tempfile::tempdir().unwrap();
+    write_project_file(project.path(), "vite.config.ts", "export default {foo:1}\n");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args(["fmt", "--no-config", "--check", "vite.config.ts"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Found 1 file(s)"));
+    assert!(stderr.contains("Would reformat: vite.config.ts"));
+    assert!(stderr.contains("Checked 1 file(s)"));
+    assert!(!stderr.contains("No .vue"));
+}
+
+#[test]
+fn lint_supports_plain_ts_inputs() {
+    let project = tempfile::tempdir().unwrap();
+    write_project_file(
+        project.path(),
+        "vite.config.ts",
+        r#"import { getCurrentInstance } from "vue";
+
+const instance = getCurrentInstance();
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args([
+            "lint",
+            "--no-config",
+            "--preset",
+            "opinionated",
+            "--format",
+            "text",
+            "--help-level",
+            "none",
+            "vite.config.ts",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("script/no-get-current-instance"));
+    assert!(stdout.contains("Linted 1 files"));
+}

--- a/crates/vize_patina/src/lib.rs
+++ b/crates/vize_patina/src/lib.rs
@@ -139,6 +139,11 @@ pub fn lint_jsx(source: &str, filename: &str, lang: JsxLang) -> LintResult {
     Linter::new().lint_jsx(source, filename, lang)
 }
 
+/// Lint plain JavaScript/TypeScript source with default script rules.
+pub fn lint_script(source: &str, filename: &str) -> LintResult {
+    Linter::new().lint_script(source, filename)
+}
+
 #[cfg(test)]
 mod tests {
     use super::lint;

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -3,7 +3,6 @@
 //! Contains the core linting methods: single-file template linting,
 //! full SFC linting with template extraction, and batch file processing.
 //!
-//! Split into:
 //! - [`parse_diagnostics`]: parser-error to lint-diagnostic translation
 //! - [`template_extract`]: ultra-fast `<template>` block extraction
 //! - [`ecosystem_hint`]: source heuristics for ecosystem template rules
@@ -11,6 +10,7 @@
 
 mod ecosystem_hint;
 mod parse_diagnostics;
+mod script;
 mod tag_scan;
 mod template_extract;
 

--- a/crates/vize_patina/src/linter/engine/script.rs
+++ b/crates/vize_patina/src/linter/engine/script.rs
@@ -1,0 +1,26 @@
+use vize_carton::ToCompactString;
+
+use crate::linter::config::{LintResult, Linter};
+
+impl Linter {
+    /// Lint a plain JavaScript/TypeScript module with script-level rules.
+    pub fn lint_script(&self, source: &str, filename: &str) -> LintResult {
+        let mut result = LintResult {
+            filename: filename.to_compact_string(),
+            diagnostics: Vec::new(),
+            error_count: 0,
+            warning_count: 0,
+        };
+
+        super::super::script_rules::append_builtin_script_rules_for_source(
+            self,
+            source,
+            0,
+            &mut result,
+        );
+        result
+            .diagnostics
+            .sort_unstable_by_key(|diagnostic| (diagnostic.start, diagnostic.end));
+        result
+    }
+}

--- a/crates/vize_patina/src/linter/script_rules.rs
+++ b/crates/vize_patina/src/linter/script_rules.rs
@@ -221,7 +221,7 @@ fn merge_script_result(result: &mut LintResult, script_result: ScriptLintResult)
 /// byte prefilter, runs into its own [`ScriptLintResult`], and is merged in the
 /// original rule order. Active AST rules share one oxc parse; byte rules run
 /// directly against the source.
-fn append_builtin_script_rules_for_source(
+pub(crate) fn append_builtin_script_rules_for_source(
     linter: &Linter,
     source: &str,
     offset: usize,

--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -8,5 +8,6 @@ mod jsx;
 mod jsx_fallback;
 mod no_top_level_ref;
 mod nuxt;
+mod script;
 mod sfc;
 mod v_for_unused_vars;

--- a/crates/vize_patina/src/linter/tests/script.rs
+++ b/crates/vize_patina/src/linter/tests/script.rs
@@ -1,0 +1,20 @@
+use super::{LintPreset, Linter};
+
+#[test]
+fn lint_script_runs_script_rules() {
+    let result = Linter::with_preset(LintPreset::Opinionated).lint_script(
+        r#"import { getCurrentInstance } from "vue";
+
+const instance = getCurrentInstance();
+"#,
+        "vite.config.ts",
+    );
+
+    assert!(result.error_count > 0, "{:?}", result.diagnostics);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.rule_name == "script/no-get-current-instance")
+    );
+}


### PR DESCRIPTION
## Summary
- include plain JavaScript and TypeScript files in lint/fmt discovery and default patterns
- format plain script files through the script formatter instead of ignoring them
- run script-level lint rules for plain script inputs while keeping cross-file lint scoped to Vue SFCs

## Validation
- cargo test -p vize --test plain_script_cli -- --nocapture
- cargo test -p vize collection_includes_vue_html_scripts_and_jsx -- --nocapture
- cargo test -p vize collect_files_matches_vue_scripts_and_jsx -- --nocapture
- cargo test -p vize_patina lint_script_runs_script_rules -- --nocapture
- cargo fmt --all --check
- git diff --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo clippy -p vize -p vize_patina -- -D warnings -D clippy::wildcard_imports

Closes #1871

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->