### PR TITLE
fix(check): preserve normal script named exports

### DIFF
--- a/crates/vize/tests/check_plain_script_named_exports_cli.rs
+++ b/crates/vize/tests/check_plain_script_named_exports_cli.rs
@@ -1,0 +1,133 @@
+use std::{path::Path, process::Command};
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn unique_case_dir(name: &str) -> std::path::PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(format!("{name}-{}-{case_id}", std::process::id()))
+}
+
+fn link_workspace_node_modules(project_root: &Path) {
+    let source = workspace_root().join("node_modules");
+    let target = project_root.join("node_modules");
+    if target.exists() {
+        return;
+    }
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, target).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(source, target).unwrap();
+}
+
+fn create_cli_project(name: &str, files: &[(&str, &str)]) -> std::path::PathBuf {
+    let project_root = unique_case_dir(name);
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    link_workspace_node_modules(&project_root);
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+
+    for (path, source) in files {
+        let file_path = project_root.join(path);
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(file_path, source).unwrap();
+    }
+
+    project_root
+}
+
+fn resolve_test_corsa_path() -> Option<String> {
+    let workspace_root = workspace_root();
+    let sibling_cache = workspace_root.parent()?.join("corsa-bind/.cache/tsgo");
+    if sibling_cache.exists() {
+        return Some(sibling_cache.display().to_string());
+    }
+
+    let workspace_bin = workspace_root.join("node_modules/.bin/tsgo");
+    workspace_bin
+        .exists()
+        .then(|| workspace_bin.display().to_string())
+}
+
+#[test]
+fn check_preserves_named_exports_from_normal_script_vue() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "normal-script-named-exports",
+        &[
+            (
+                "src/components/ParseMdFileDialog.vue",
+                r#"<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "ParseMdFileDialog",
+});
+
+export const setupParseMdFileDialogCtx = () => ({ ready: true });
+</script>
+"#,
+            ),
+            (
+                "src/pages/Consumer.vue",
+                r#"<script setup lang="ts">
+import { setupParseMdFileDialogCtx } from "../components/ParseMdFileDialog.vue";
+
+const ctx = setupParseMdFileDialogCtx();
+const ready: boolean = ctx.ready;
+</script>
+
+<template>
+  <div>{{ ready }}</div>
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", ".", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], 0, "{stdout}\n{stderr}");
+    assert!(!stdout.contains("TS2614"), "{stdout}\n{stderr}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -4,6 +4,7 @@ mod imports;
 mod legacy_vue2;
 mod options_api;
 mod options_api_support;
+mod script_module;
 mod setup_props;
 mod spans;
 mod template_refs;
@@ -190,6 +191,11 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         .scopes
         .iter()
         .any(|scope| matches!(scope.kind, ScopeKind::NonScriptSetup));
+    let named_value_exports = self::script_module::collect_normal_script_named_value_exports(
+        script_content,
+        has_script_setup,
+        has_plain_script_scope,
+    );
 
     // Classify the main `<script>` default export in one parse. A plain
     // `export default { ... }` (Options API shape) gets wrapped with Vue's
@@ -227,7 +233,9 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             module_spans.push((imp.start, imp.end));
         }
         if let Some(script) = script_content {
-            module_spans.extend(collect_line_module_import_spans(script));
+            module_spans.extend(self::script_module::collect_line_module_import_spans(
+                script,
+            ));
         }
         for re in &summary.re_exports {
             module_spans.push((re.start, re.end));
@@ -924,22 +932,25 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     // Return runtime-derived type artifacts from __setup() so their types can be
     // extracted at module level while keeping each runtime expression in setup
     // scope, where script-setup bindings are defined.
-    let mut setup_return_fields = Vec::new();
-    setup_props_plan.push_return_field(&mut setup_return_fields);
+    let mut setup_return_fields: Vec<String> = Vec::new();
+    self::script_module::push_setup_return_fields(&named_value_exports, &mut setup_return_fields);
+    let mut setup_artifact_return_fields = Vec::new();
+    setup_props_plan.push_return_field(&mut setup_artifact_return_fields);
+    setup_return_fields.extend(setup_artifact_return_fields.into_iter().map(String::from));
     if let Some(expose) = summary.macros.define_expose()
         && expose.type_args.is_none()
         && let Some(runtime_args) = expose.runtime_args.as_ref()
     {
         append!(ts, "\n  const __vize_exposed = ({runtime_args});\n");
-        setup_return_fields.push("__vize_exposed");
+        setup_return_fields.push("__vize_exposed".into());
     }
     if let Some(runtime_args) = define_emits_runtime_args {
         append!(
             ts,
             "\n  const __vize_emit_options = ({runtime_args});\n  const __vize_emits = defineEmits(__vize_emit_options);\n"
         );
-        setup_return_fields.push("__vize_emit_options");
-        setup_return_fields.push("__vize_emits");
+        setup_return_fields.push("__vize_emit_options".into());
+        setup_return_fields.push("__vize_emits".into());
     }
     setup_props_plan.emit_options_api_artifact(&mut ts, options_api_props.as_ref());
     if !setup_return_fields.is_empty() {
@@ -951,7 +962,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
 
     // Invoke setup to keep diagnostics inside the generated setup body.
     ts.push_str("// Invoke setup to verify types\n");
-    ts.push_str("__setup();\n\n");
+    self::script_module::emit_setup_invocation_and_exports(&mut ts, &named_value_exports);
 
     setup_props_plan.emit_module_export(&mut ts, options_api_props.as_ref());
 
@@ -1074,25 +1085,4 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     ts.push_str("export default __vize_component__;\n");
 
     VirtualTsOutput { code: ts, mappings }
-}
-
-fn collect_line_module_import_spans(script: &str) -> Vec<(u32, u32)> {
-    let mut spans = Vec::new();
-    let mut offset = 0usize;
-    for raw_line in script.split_inclusive('\n') {
-        let line = raw_line.strip_suffix('\n').unwrap_or(raw_line);
-        let line = line.strip_suffix('\r').unwrap_or(line);
-        let trimmed = line.trim_start();
-        if trimmed.starts_with("import ")
-            || trimmed.starts_with("import\t")
-            || (trimmed.starts_with("export ")
-                && (trimmed.contains(" from ") || trimmed.starts_with("export type ")))
-        {
-            let start = offset + (line.len() - line.trim_start().len());
-            let end = offset + line.len();
-            spans.push((start as u32, end as u32));
-        }
-        offset += raw_line.len();
-    }
-    spans
 }

--- a/crates/vize_canon/src/virtual_ts/generator/script_module.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module.rs
@@ -1,0 +1,152 @@
+//! Module-scope facts collected from normal Vue `<script>` blocks.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{BindingPattern, Declaration, Statement};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{CompactString, FxHashSet, String as VizeString, append};
+
+pub(super) fn collect_normal_script_named_value_exports(
+    script: Option<&str>,
+    has_script_setup: bool,
+    has_plain_script_scope: bool,
+) -> Vec<CompactString> {
+    if has_script_setup || !has_plain_script_scope {
+        return Vec::new();
+    }
+    script.map(collect_named_value_exports).unwrap_or_default()
+}
+
+pub(super) fn collect_line_module_import_spans(script: &str) -> Vec<(u32, u32)> {
+    let mut spans = Vec::new();
+    let mut offset = 0usize;
+    for raw_line in script.split_inclusive('\n') {
+        let line = raw_line.strip_suffix('\n').unwrap_or(raw_line);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("import ")
+            || trimmed.starts_with("import\t")
+            || (trimmed.starts_with("export ")
+                && (trimmed.contains(" from ") || trimmed.starts_with("export type ")))
+        {
+            let start = offset + (line.len() - line.trim_start().len());
+            let end = offset + line.len();
+            spans.push((start as u32, end as u32));
+        }
+        offset += raw_line.len();
+    }
+    spans
+}
+
+pub(super) fn push_setup_return_fields(names: &[CompactString], fields: &mut Vec<CompactString>) {
+    fields.extend(names.iter().cloned());
+}
+
+pub(super) fn emit_setup_invocation_and_exports(ts: &mut VizeString, names: &[CompactString]) {
+    if names.is_empty() {
+        ts.push_str("__setup();\n\n");
+        return;
+    }
+
+    ts.push_str("const __vize_plain_script_exports = __setup();\n");
+    for name in names {
+        append!(
+            *ts,
+            "export const {name} = __vize_plain_script_exports.{name};\n"
+        );
+    }
+    ts.push('\n');
+}
+
+fn collect_named_value_exports(script: &str) -> Vec<CompactString> {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
+    if parsed.panicked {
+        return Vec::new();
+    }
+
+    let mut seen = FxHashSet::default();
+    let mut names = Vec::new();
+    for statement in &parsed.program.body {
+        collect_statement_exports(statement, &mut seen, &mut names);
+    }
+    names
+}
+
+fn collect_statement_exports(
+    statement: &Statement<'_>,
+    seen: &mut FxHashSet<CompactString>,
+    names: &mut Vec<CompactString>,
+) {
+    let Statement::ExportNamedDeclaration(export) = statement else {
+        return;
+    };
+    if export.source.is_some() || export.export_kind.is_type() {
+        return;
+    }
+    let Some(declaration) = export.declaration.as_ref() else {
+        return;
+    };
+    collect_declaration_exports(declaration, seen, names);
+}
+
+fn collect_declaration_exports(
+    declaration: &Declaration<'_>,
+    seen: &mut FxHashSet<CompactString>,
+    names: &mut Vec<CompactString>,
+) {
+    match declaration {
+        Declaration::VariableDeclaration(variable) => {
+            for declarator in &variable.declarations {
+                collect_binding_names(&declarator.id, seen, names);
+            }
+        }
+        Declaration::FunctionDeclaration(function) => {
+            if let Some(id) = &function.id {
+                push_name(id.name.as_str(), seen, names);
+            }
+        }
+        Declaration::ClassDeclaration(class) => {
+            if let Some(id) = &class.id {
+                push_name(id.name.as_str(), seen, names);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_binding_names(
+    pattern: &BindingPattern<'_>,
+    seen: &mut FxHashSet<CompactString>,
+    names: &mut Vec<CompactString>,
+) {
+    match pattern {
+        BindingPattern::BindingIdentifier(id) => push_name(id.name.as_str(), seen, names),
+        BindingPattern::ObjectPattern(object) => {
+            for property in &object.properties {
+                collect_binding_names(&property.value, seen, names);
+            }
+            if let Some(rest) = &object.rest {
+                collect_binding_names(&rest.argument, seen, names);
+            }
+        }
+        BindingPattern::ArrayPattern(array) => {
+            for element in array.elements.iter().flatten() {
+                collect_binding_names(element, seen, names);
+            }
+            if let Some(rest) = &array.rest {
+                collect_binding_names(&rest.argument, seen, names);
+            }
+        }
+        BindingPattern::AssignmentPattern(assignment) => {
+            collect_binding_names(&assignment.left, seen, names);
+        }
+    }
+}
+
+fn push_name(name: &str, seen: &mut FxHashSet<CompactString>, names: &mut Vec<CompactString>) {
+    let name = CompactString::new(name);
+    if seen.insert(name.clone()) {
+        names.push(name);
+    }
+}

--- a/crates/vize_canon/tests/plain_script_named_exports.rs
+++ b/crates/vize_canon/tests/plain_script_named_exports.rs
@@ -1,0 +1,62 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use vize_canon::VirtualProject;
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(format!("{name}-{}-{case_id}", std::process::id()))
+}
+
+fn assert_ts_parses(source: &str) {
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed = oxc_parser::Parser::new(&allocator, source, oxc_span::SourceType::ts()).parse();
+    assert!(
+        parsed.errors.is_empty(),
+        "virtual TS should parse without errors: {:?}",
+        parsed.errors
+    );
+}
+
+#[test]
+fn normal_script_named_value_exports_are_module_exports() {
+    let case_dir = unique_case_dir("plain-script-named-exports");
+    let _ = fs::remove_dir_all(&case_dir);
+    let src_dir = case_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    let vue_path = src_dir.join("ParseMdFileDialog.vue");
+    let vue_content = r#"<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "ParseMdFileDialog",
+});
+
+export const setupParseMdFileDialogCtx = () => ({ ready: true });
+</script>
+"#;
+    fs::write(&vue_path, vue_content).unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.register_vue_file(&vue_path, vue_content).unwrap();
+    let content = project
+        .find_by_original(&vue_path)
+        .unwrap()
+        .content
+        .as_str();
+
+    assert!(
+        content.contains(
+            "export const setupParseMdFileDialogCtx = __vize_plain_script_exports.setupParseMdFileDialogCtx;"
+        ),
+        "normal <script> named exports must stay available from the virtual module:\n{content}"
+    );
+    assert_ts_parses(content);
+
+    let _ = fs::remove_dir_all(&case_dir);
+}


### PR DESCRIPTION
## Summary
- Preserve named value exports declared in normal Vue `<script>` blocks in virtual TS output.
- Keep the existing setup-scope diagnostics path while adding module-level aliases for those exports.
- Add virtual project and CLI regressions for importing a normal-script named export from another SFC.

## Validation
- cargo test -p vize_canon --test plain_script_named_exports -- --nocapture
- cargo test -p vize --test check_plain_script_named_exports_cli -- --nocapture
- cargo test -p vize check_preserves_named_exports_from_split_script_vue -- --nocapture
- cargo fmt --all --check
- git diff --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo clippy -p vize_canon -p vize -- -D warnings -D clippy::wildcard_imports

Closes #1877

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->