### PR TITLE
fix(formatter): fail empty explicit fmt inputs

### DIFF
--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -23,9 +23,11 @@ use vize_curator::profile::{
 
 mod files;
 mod ignores;
+mod patterns;
 
 use files::collect_files;
 use ignores::load_fmt_ignore_set;
+use patterns::{default_fmt_patterns, has_explicit_patterns};
 
 #[derive(Args)]
 #[allow(clippy::disallowed_types)]
@@ -114,6 +116,9 @@ pub fn run(args: FmtArgs) {
 
     if files.is_empty() {
         eprintln!("No .vue, .js, .ts, .jsx, or .tsx files found matching the patterns");
+        if has_explicit_patterns(&args.patterns) {
+            std::process::exit(1);
+        }
         return;
     }
 
@@ -366,21 +371,6 @@ fn build_format_options(args: &FmtArgs) -> FormatOptions {
     }
 
     opts
-}
-
-#[allow(clippy::disallowed_types)]
-fn default_fmt_patterns() -> Vec<std::string::String> {
-    vec![
-        "./**/*.vue".into(),
-        "./**/*.js".into(),
-        "./**/*.mjs".into(),
-        "./**/*.cjs".into(),
-        "./**/*.ts".into(),
-        "./**/*.mts".into(),
-        "./**/*.cts".into(),
-        "./**/*.jsx".into(),
-        "./**/*.tsx".into(),
-    ]
 }
 
 #[inline]

--- a/crates/vize/src/commands/fmt/patterns.rs
+++ b/crates/vize/src/commands/fmt/patterns.rs
@@ -1,0 +1,20 @@
+#[allow(clippy::disallowed_types)]
+pub(super) fn default_fmt_patterns() -> Vec<std::string::String> {
+    vec![
+        "./**/*.vue".into(),
+        "./**/*.js".into(),
+        "./**/*.mjs".into(),
+        "./**/*.cjs".into(),
+        "./**/*.ts".into(),
+        "./**/*.mts".into(),
+        "./**/*.cts".into(),
+        "./**/*.jsx".into(),
+        "./**/*.tsx".into(),
+    ]
+}
+
+#[inline]
+#[allow(clippy::disallowed_types)]
+pub(super) fn has_explicit_patterns(patterns: &[std::string::String]) -> bool {
+    patterns != default_fmt_patterns().as_slice()
+}

--- a/crates/vize/tests/fmt_config_cli.rs
+++ b/crates/vize/tests/fmt_config_cli.rs
@@ -1,0 +1,88 @@
+use std::{
+    fs,
+    path::Path,
+    process::{Command, Output},
+};
+
+fn write_project_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(file_path, content).unwrap();
+}
+
+fn output_details(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn write_entry_config(root: &Path) {
+    write_project_file(
+        root,
+        "vize.config.json",
+        r#"{
+  "entries": [
+    {
+      "name": "design-system",
+      "basePath": "design-system",
+      "files": ["src/**/*.vue", "src/**/*.art.vue"]
+    }
+  ]
+}"#,
+    );
+}
+
+#[test]
+fn fmt_check_supports_root_relative_paths_for_config_entries() {
+    let project = tempfile::tempdir().unwrap();
+    write_entry_config(project.path());
+    write_project_file(
+        project.path(),
+        "design-system/src/AfsButton.vue",
+        "<template><div>{{msg}}</div></template>\n<script setup lang=\"ts\">const msg=1</script>\n",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args([
+            "fmt",
+            "--config",
+            "vize.config.json",
+            "--check",
+            "design-system/src/AfsButton.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Found 1 file(s)"));
+    assert!(stderr.contains("Would reformat: design-system/src/AfsButton.vue"));
+    assert!(!stderr.contains("No .vue"));
+}
+
+#[test]
+fn fmt_check_fails_when_explicit_patterns_match_no_files() {
+    let project = tempfile::tempdir().unwrap();
+    write_entry_config(project.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args([
+            "fmt",
+            "--config",
+            "vize.config.json",
+            "--check",
+            "design-system/src/**/*.art.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("No .vue, .js, .ts, .jsx, or .tsx files found"));
+}


### PR DESCRIPTION
## Summary

- keep root-relative config entry formatter inputs covered by a CLI regression test
- return a non-zero exit when explicit formatter patterns match no supported files
- move formatter pattern helpers out of the main command module

## Validation

- cargo test -p vize --test fmt_config_cli -- --nocapture
- cargo fmt --all --check
- git diff --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports

Closes #1956

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->