### PR TITLE
fix(check): preserve template usage with disabled checks

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/no_unused.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/no_unused.rs
@@ -1,7 +1,8 @@
 use super::{
-    create_project_case_without_node_modules, resolve_test_tsgo_binary,
-    snapshot_project_diagnostics,
+    BatchTypeChecker, TypeChecker, create_project_case_without_node_modules, relative_path,
+    resolve_test_tsgo_binary, snapshot_project_diagnostics,
 };
+use vize_carton::cstr;
 
 #[test]
 fn batch_type_checker_marks_art_bindings_as_used_with_no_unused_locals() {
@@ -60,6 +61,90 @@ function handleSubmit() {}
 }
 
 #[test]
+fn no_check_template_bindings_still_marks_template_bindings_as_used() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case_without_node_modules(
+        "no-check-template-bindings-no-unused-locals",
+        &[
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+
+const isLoading = false
+function confirmDialog() {}
+const unusedLocal = 1
+</script>
+
+<template>
+  <Child :busy="isLoading" @save="confirmDialog" />
+  {{ missingItems }}
+</template>
+"#,
+            ),
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts">
+defineProps<{ busy?: boolean }>()
+defineEmits<{ save: [] }>()
+</script>
+
+<template><button /></template>
+"#,
+            ),
+        ],
+    );
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "noUnusedLocals": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+
+    let Some(snapshot) = snapshot_project_diagnostics_without_template_checks(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !(file == "src/App.vue"
+                && *code == Some(6133)
+                && (message.contains("Child")
+                    || message.contains("isLoading")
+                    || message.contains("confirmDialog")))
+        }),
+        "template bindings should not report TS6133, got: {snapshot:#?}"
+    );
+    assert!(
+        snapshot.iter().any(|(file, code, message)| {
+            file == "src/App.vue" && *code == Some(6133) && message.contains("unusedLocal")
+        }),
+        "unreferenced script bindings should still report TS6133, got: {snapshot:#?}"
+    );
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !(file == "src/App.vue" && *code == Some(2304) && message.contains("missingItems"))
+        }),
+        "template binding diagnostics should stay disabled, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn batch_type_checker_does_not_report_default_export_alias_as_unused() {
     if resolve_test_tsgo_binary().is_none() {
         return;
@@ -111,4 +196,38 @@ export default {
     );
 
     let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn snapshot_project_diagnostics_without_template_checks(
+    project_root: &std::path::Path,
+) -> Option<Vec<(vize_carton::String, Option<u32>, vize_carton::String)>> {
+    let mut checker = BatchTypeChecker::new(project_root).ok()?;
+    checker.set_virtual_ts_checks(true, false, true);
+    checker.scan_project().ok()?;
+    let result = checker.check_project().ok()?;
+
+    let mut snapshot: Vec<_> = result
+        .diagnostics
+        .into_iter()
+        .map(|diagnostic| {
+            (
+                relative_path(project_root, &diagnostic.file),
+                diagnostic.code,
+                cstr!(
+                    "{}:{}:{} {}",
+                    diagnostic.line + 1,
+                    diagnostic.column + 1,
+                    match diagnostic.severity {
+                        1 => "error",
+                        2 => "warning",
+                        3 => "info",
+                        _ => "hint",
+                    },
+                    diagnostic.message
+                ),
+            )
+        })
+        .collect();
+    snapshot.sort();
+    Some(snapshot)
 }

--- a/crates/vize_canon/src/virtual_ts/generator/anchors.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/anchors.rs
@@ -1,0 +1,84 @@
+//! Setup binding anchor emission for template-used names.
+
+use super::imports::collect_setup_binding_anchor_names;
+use vize_carton::{FxHashSet, String, append};
+use vize_croquis::Croquis;
+
+pub(super) fn emit_setup_binding_anchors(
+    ts: &mut String,
+    summary: &Croquis,
+    script_content: Option<&str>,
+    template_referenced_names: Option<&FxHashSet<String>>,
+    comment: &str,
+) {
+    if summary.bindings.bindings.is_empty() {
+        return;
+    }
+
+    let binding_names =
+        collect_setup_binding_anchor_names(summary, script_content, template_referenced_names);
+    let mut first = true;
+    for name in binding_names {
+        if is_reserved_anchor_name(name) {
+            continue;
+        }
+        if first {
+            append!(*ts, "\n  // {comment}\n  ");
+        } else {
+            ts.push(' ');
+        }
+        append!(*ts, "void {name};");
+        first = false;
+    }
+    if !first {
+        ts.push('\n');
+    }
+}
+
+fn is_reserved_anchor_name(name: &str) -> bool {
+    matches!(
+        name,
+        "default"
+            | "class"
+            | "new"
+            | "delete"
+            | "void"
+            | "typeof"
+            | "in"
+            | "instanceof"
+            | "return"
+            | "switch"
+            | "case"
+            | "break"
+            | "continue"
+            | "throw"
+            | "try"
+            | "catch"
+            | "finally"
+            | "if"
+            | "else"
+            | "for"
+            | "while"
+            | "do"
+            | "with"
+            | "var"
+            | "let"
+            | "const"
+            | "function"
+            | "this"
+            | "super"
+            | "import"
+            | "export"
+            | "yield"
+            | "await"
+            | "async"
+            | "static"
+            | "enum"
+            | "implements"
+            | "interface"
+            | "package"
+            | "private"
+            | "protected"
+            | "public"
+    )
+}

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -1,3 +1,4 @@
+mod anchors;
 mod emits;
 mod generics;
 mod imports;
@@ -8,11 +9,12 @@ mod script_module;
 mod setup_props;
 mod spans;
 mod template_refs;
+use self::anchors::emit_setup_binding_anchors;
 use self::emits::{emit_emit_props_helper, emit_emits_type};
 use self::generics::{generic_injection_point, references_any_identifier};
 use self::imports::{
-    collect_imported_names, collect_setup_binding_anchor_names, emit_global_component_stubs,
-    emit_reference_type_directives, extract_declared_name,
+    collect_imported_names, emit_global_component_stubs, emit_reference_type_directives,
+    extract_declared_name,
 };
 pub use self::legacy_vue2::generate_virtual_ts_with_offsets_legacy_vue2;
 use self::options_api::{
@@ -820,81 +822,32 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
 
             // In projects that opt into unused-local diagnostics, this list is
             // narrowed to template-referenced names so user TS6133 can surface.
-            if !summary.bindings.bindings.is_empty() {
-                let mut first = true;
-                let binding_names = profile!(
-                    "canon.virtual_ts.collect_setup_binding_anchor_names",
-                    collect_setup_binding_anchor_names(
-                        summary,
-                        script_content,
-                        template_referenced_names.as_ref()
-                    )
-                );
-                if !binding_names.is_empty() {
-                    append!(ts, "\n  // {reference_setup_bindings_comment}\n  ");
-                }
-                for name in binding_names {
-                    // Skip bindings that are JS keywords or would cause syntax errors
-                    if matches!(
-                        name,
-                        "default"
-                            | "class"
-                            | "new"
-                            | "delete"
-                            | "void"
-                            | "typeof"
-                            | "in"
-                            | "instanceof"
-                            | "return"
-                            | "switch"
-                            | "case"
-                            | "break"
-                            | "continue"
-                            | "throw"
-                            | "try"
-                            | "catch"
-                            | "finally"
-                            | "if"
-                            | "else"
-                            | "for"
-                            | "while"
-                            | "do"
-                            | "with"
-                            | "var"
-                            | "let"
-                            | "const"
-                            | "function"
-                            | "this"
-                            | "super"
-                            | "import"
-                            | "export"
-                            | "yield"
-                            | "await"
-                            | "async"
-                            | "static"
-                            | "enum"
-                            | "implements"
-                            | "interface"
-                            | "package"
-                            | "private"
-                            | "protected"
-                            | "public"
-                    ) {
-                        continue;
-                    }
-                    if !first {
-                        ts.push(' ');
-                    }
-                    append!(ts, "void {name};");
-                    first = false;
-                }
-                if !first {
-                    ts.push('\n');
-                }
-            }
+            profile!(
+                "canon.virtual_ts.emit_setup_binding_anchors",
+                emit_setup_binding_anchors(
+                    &mut ts,
+                    summary,
+                    script_content,
+                    template_referenced_names.as_ref(),
+                    reference_setup_bindings_comment,
+                )
+            );
 
             ts.push_str("  })();\n");
         });
+    }
+
+    if has_template_scope && !check_options.check_template_bindings && preserve_unused_diagnostics {
+        profile!(
+            "canon.virtual_ts.emit_no_check_template_binding_anchors",
+            emit_setup_binding_anchors(
+                &mut ts,
+                summary,
+                script_content,
+                template_referenced_names.as_ref(),
+                reference_setup_bindings_comment,
+            )
+        );
     }
 
     // Reference props destructure bindings at setup scope level.

--- a/crates/vize_canon/src/virtual_ts/tests/no_check_template_bindings.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/no_check_template_bindings.rs
@@ -53,3 +53,55 @@ const isLoading = ref(false)
     assert!(!output.code.contains("__vize_prop_check"));
     assert!(!output.code.contains("@save handler"));
 }
+
+#[test]
+fn preserves_template_usage_anchors_when_template_checks_are_disabled() {
+    let script = r#"import { ref } from 'vue'
+import Child from './Child.vue'
+
+const scriptOnly: string = 1
+const isLoading = ref(false)
+function confirmDialog() {}
+"#;
+    let template = r#"<div>
+  <Child v-for="item in missingItems" :key="item.id" :busy="isLoading" @save="confirmDialog" />
+</div>"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts_with_offsets_and_checks(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &VirtualTsOptions::default(),
+        VirtualTsGenerationOptions {
+            check_options: VirtualTsCheckOptions {
+                check_template_bindings: false,
+                ..Default::default()
+            },
+            preserve_unused_diagnostics: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(output.code.contains("const scriptOnly: string = 1"));
+    assert!(output.code.contains("__setup();"));
+    assert!(!output.code.contains("Template Scope"));
+    assert!(!output.code.contains("ComponentPublicInstance"));
+    assert!(!output.code.contains("type __R_isLoading"));
+    assert!(!output.code.contains("var isLoading:"));
+    assert!(!output.code.contains("__vize_prop_check"));
+    assert!(!output.code.contains("@save handler"));
+    assert!(!output.code.contains("void missingItems;"));
+    assert!(output.code.contains("void Child;"));
+    assert!(output.code.contains("void confirmDialog;"));
+    assert!(output.code.contains("void isLoading;"));
+}


### PR DESCRIPTION
## Summary

- keep template-referenced script bindings marked as used when template binding checks are disabled
- avoid generating the full template diagnostic scope in that mode
- add virtual TS and batch noUnusedLocals regression coverage

## Validation

- cargo test -p vize_canon virtual_ts::tests::no_check_template_bindings -- --nocapture
- cargo test -p vize_canon batch::type_checker::tests::no_unused::no_check_template_bindings_still_marks_template_bindings_as_used -- --nocapture
- cargo fmt --all --check
- git diff --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports

Closes #1960

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->