### PR TITLE
fix(check): resolve directory self imports

### DIFF
--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -174,7 +174,7 @@ fn is_identifier_byte(byte: u8) -> bool {
 }
 
 fn is_relative_specifier(specifier: &str) -> bool {
-    specifier.starts_with("./") || specifier.starts_with("../")
+    matches!(specifier, "." | "..") || specifier.starts_with("./") || specifier.starts_with("../")
 }
 
 /// Resolve a relative module specifier against `dir` to an existing on-disk

--- a/crates/vize/src/commands/check/imports_tests.rs
+++ b/crates/vize/src/commands/check/imports_tests.rs
@@ -72,6 +72,42 @@ fn ignores_bare_and_missing_specifiers() {
 }
 
 #[test]
+fn collects_current_directory_index_imports() {
+    let root = std::env::temp_dir().join(cstr!("vize-imports-dot-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("src/meter")).unwrap();
+
+    let entry = write(
+        &root,
+        "src/meter/AfMeterBar.vue",
+        r#"<script setup lang="ts">
+import { calcPercentage } from "."
+
+const percent = calcPercentage(2, 4)
+void percent
+</script>
+"#,
+    );
+    let index = write(
+        &root,
+        "src/meter/index.ts",
+        "export const calcPercentage = (num: number, max: number) => num / max\n",
+    );
+
+    let discovered = collect_transitive_local_imports(
+        &[entry],
+        &root,
+        &mut CanonicalPathCache::default(),
+        false,
+        None,
+    );
+
+    assert_eq!(discovered, vec![canonicalize_non_verbatim(&index)]);
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
 fn jsx_imports_are_resolved_only_when_jsx_typecheck_is_enabled() {
     let root = std::env::temp_dir().join(cstr!("vize-imports-jsx-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&root);

--- a/crates/vize/tests/check_directory_self_imports_cli.rs
+++ b/crates/vize/tests/check_directory_self_imports_cli.rs
@@ -1,0 +1,122 @@
+use std::{path::Path, process::Command};
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn unique_case_dir(name: &str) -> std::path::PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(format!("{name}-{}-{case_id}", std::process::id()))
+}
+
+fn link_workspace_node_modules(project_root: &Path) {
+    let source = workspace_root().join("node_modules");
+    let target = project_root.join("node_modules");
+    if target.exists() {
+        return;
+    }
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, target).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(source, target).unwrap();
+}
+
+fn write_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(file_path, content).unwrap();
+}
+
+fn resolve_test_corsa_path() -> Option<String> {
+    let workspace_root = workspace_root();
+    let sibling_cache = workspace_root.parent()?.join("corsa-bind/.cache/tsgo");
+    if sibling_cache.exists() {
+        return Some(sibling_cache.display().to_string());
+    }
+
+    let workspace_bin = workspace_root.join("node_modules/.bin/tsgo");
+    workspace_bin
+        .exists()
+        .then(|| workspace_bin.display().to_string())
+}
+
+#[test]
+fn check_resolves_current_directory_imports_from_vue_inputs() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+
+    let project_root = unique_case_dir("directory-self-import");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    link_workspace_node_modules(&project_root);
+    write_file(
+        &project_root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write_file(
+        &project_root,
+        "src/meter/AfMeterBar.vue",
+        r#"<script setup lang="ts">
+import { calcPercentage } from ".";
+
+const percent: number = calcPercentage(2, 4);
+</script>
+
+<template>{{ percent }}</template>
+"#,
+    );
+    write_file(
+        &project_root,
+        "src/meter/index.ts",
+        "export const calcPercentage = (num: number, max: number): number => num / max;\n",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src/meter/AfMeterBar.vue",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(!stdout.contains("TS2307"), "{stdout}\n{stderr}");
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], 0, "{stdout}\n{stderr}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
## Summary

- treat `.` and `..` as relative specifiers while collecting explicit check input imports
- pull current-directory `index.ts` files into the virtual project for Vue SFC inputs
- add unit and CLI regression coverage for `import { value } from "."`

## Validation

- cargo test -p vize commands::check::imports::tests::collects_current_directory_index_imports -- --nocapture
- cargo test -p vize --test check_directory_self_imports_cli -- --nocapture
- cargo fmt --all --check
- git diff --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports

Closes #1958

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->