### PR TITLE
test(check): cover vue2 options proptype props

### DIFF
--- a/crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs
@@ -134,11 +134,16 @@ fn test_options_api_props_with_type_cast_defers_to_setup_scope() {
 import type { PropType } from 'vue'
 
 type BreadcrumbsItem = { label: string }
+type SelectedExamSubject = { id: string } | null
 
 export default defineComponent({
     props: {
         breadcrumbs: {
             type: Array as PropType<BreadcrumbsItem[]>,
+            required: true,
+        },
+        selectedExamSubject: {
+            type: Object as PropType<SelectedExamSubject>,
             required: true,
         },
     },
@@ -157,7 +162,7 @@ export default defineComponent({
     assert!(
         !output
             .code
-            .contains("export type Props = __RuntimePropShape<{\n        breadcrumbs:"),
+            .contains("export type Props = __RuntimePropShape<{"),
         "type-cast props must not be emitted directly in type position:\n{}",
         output.code
     );


### PR DESCRIPTION
## Summary
- extend Options API PropType regression coverage to include `Object as PropType<T>` alongside `Array as PropType<T[]>`
- assert PropType casts stay out of direct `__RuntimePropShape<{...}>` type literals

## Validation
- `cargo test -p vize_canon virtual_ts::tests::options_api_props_spread::test_options_api_props_with_type_cast_defers_to_setup_scope -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports`

Closes #1955.
Closes #1957.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->