### PR TITLE
fix(nuxt): avoid import meta in module entry

### DIFF
--- a/npm/nuxt/src/index.test.ts
+++ b/npm/nuxt/src/index.test.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+void test("Nuxt module entry avoids import.meta for Nuxt 2 loaders", () => {
+  const source = fs.readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+
+  assert.equal(source.includes("import.meta"), false);
+});

--- a/npm/nuxt/src/index.ts
+++ b/npm/nuxt/src/index.ts
@@ -1,7 +1,6 @@
 import {
   addServerPlugin,
   addVitePlugin,
-  createResolver,
   defineNuxtModule,
   getNuxtVersion,
   isNuxt2,
@@ -17,6 +16,7 @@ import {
   resolveNuxtMuseaOptions,
   resolveNuxtUnoCssOptions,
 } from "./options";
+import { createNuxtModuleResolver } from "./resolver";
 import {
   buildNuxtDevAssetBase,
   isVizeGeneratedVueModuleId,
@@ -268,7 +268,7 @@ export default defineNuxtModule<VizeNuxtOptions>({
     },
   },
   async setup(options, nuxt) {
-    const resolver = createResolver(import.meta.url);
+    const resolver = createNuxtModuleResolver();
     const detectedNuxtMajor = options.compatibility?.nuxtVersion ?? getDetectedNuxtMajor(nuxt) ?? 3;
     const vueVersion = options.compatibility?.vueVersion ?? (detectedNuxtMajor === 2 ? 2 : 3);
     const nuxtWithBuilderOptions = nuxt as NuxtWithBuilderOptions;

--- a/npm/nuxt/src/resolver.ts
+++ b/npm/nuxt/src/resolver.ts
@@ -1,0 +1,9 @@
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
+import { createResolver } from "@nuxt/kit";
+
+const nodeRequire = createRequire(`${process.cwd()}/package.json`);
+
+export function createNuxtModuleResolver() {
+  return createResolver(dirname(nodeRequire.resolve("@vizejs/nuxt")));
+}


### PR DESCRIPTION
## Summary
- remove `import.meta.url` from the Nuxt module entry used by Nuxt 2 loaders
- resolve the package runtime directory through Node `createRequire` in a small helper module
- add a regression test that keeps the Nuxt entry `import.meta`-free

## Validation
- `pnpm --filter @vizejs/nuxt test`
- `pnpm --filter @vizejs/nuxt check`
- `pnpm --filter @vizejs/nuxt build`
- `rg -n "import\.meta" npm/nuxt/dist/index.mjs npm/nuxt/dist/runtime/server/dev-stylesheet-links.mjs` returned no matches
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

Closes #1961.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->