### PR TITLE
fix(check): honor config entry ignores

### DIFF
--- a/crates/vize/src/commands/check/runner/collect.rs
+++ b/crates/vize/src/commands/check/runner/collect.rs
@@ -9,14 +9,26 @@ use glob::{MatchOptions, Pattern};
 use ignore::WalkBuilder;
 use vize_carton::{FxHashSet, String};
 
+use super::ignores::CheckIgnoreSet;
+
 const TARGET_DIR: &str = "target";
 const NODE_MODULES_DIR: &str = "node_modules";
 const VIZE_CACHE_DIR: &str = ".vize";
 
+#[cfg(test)]
 #[allow(clippy::disallowed_types)]
 pub(super) fn collect_check_files(
     patterns: &[std::string::String],
     include_jsx: bool,
+) -> Vec<PathBuf> {
+    collect_check_files_with_ignores(patterns, include_jsx, None)
+}
+
+#[allow(clippy::disallowed_types)]
+pub(super) fn collect_check_files_with_ignores(
+    patterns: &[std::string::String],
+    include_jsx: bool,
+    ignore_set: Option<&CheckIgnoreSet>,
 ) -> Vec<PathBuf> {
     let mut files = Vec::new();
     let mut seen = FxHashSet::default();
@@ -27,6 +39,7 @@ pub(super) fn collect_check_files(
             if candidate.is_file() {
                 let candidate = normalize_input_path(&candidate);
                 if is_supported_check_file(&candidate, include_jsx)
+                    && !is_ignored(&candidate, ignore_set)
                     && seen.insert(candidate.clone())
                 {
                     files.push(candidate);
@@ -34,7 +47,7 @@ pub(super) fn collect_check_files(
                 continue;
             }
             if candidate.is_dir() {
-                collect_from_dir(&candidate, &mut files, &mut seen, include_jsx);
+                collect_from_dir(&candidate, &mut files, &mut seen, include_jsx, ignore_set);
                 continue;
             }
         }
@@ -47,6 +60,7 @@ pub(super) fn collect_check_files(
             &mut seen,
             include_jsx,
             matcher.as_ref(),
+            ignore_set,
         );
     }
 
@@ -75,7 +89,9 @@ pub(super) fn collect_vue_files(patterns: &[std::string::String]) -> Vec<PathBuf
                 continue;
             }
             if candidate.is_dir() {
-                collect_from_dir_filtered(&candidate, &mut files, &mut seen, true, false, None);
+                collect_from_dir_filtered(
+                    &candidate, &mut files, &mut seen, true, false, None, None,
+                );
                 continue;
             }
         }
@@ -89,6 +105,7 @@ pub(super) fn collect_vue_files(patterns: &[std::string::String]) -> Vec<PathBuf
             true,
             false,
             matcher.as_ref(),
+            None,
         );
     }
 
@@ -101,8 +118,9 @@ fn collect_from_dir(
     files: &mut Vec<PathBuf>,
     seen: &mut FxHashSet<PathBuf>,
     include_jsx: bool,
+    ignore_set: Option<&CheckIgnoreSet>,
 ) {
-    collect_from_dir_with_matcher(dir, files, seen, include_jsx, None);
+    collect_from_dir_with_matcher(dir, files, seen, include_jsx, None, ignore_set);
 }
 
 fn collect_from_dir_with_matcher(
@@ -111,8 +129,9 @@ fn collect_from_dir_with_matcher(
     seen: &mut FxHashSet<PathBuf>,
     include_jsx: bool,
     matcher: Option<&InputGlob>,
+    ignore_set: Option<&CheckIgnoreSet>,
 ) {
-    collect_from_dir_filtered(dir, files, seen, false, include_jsx, matcher);
+    collect_from_dir_filtered(dir, files, seen, false, include_jsx, matcher, ignore_set);
 }
 
 fn collect_from_dir_filtered(
@@ -122,6 +141,7 @@ fn collect_from_dir_filtered(
     vue_only: bool,
     include_jsx: bool,
     matcher: Option<&InputGlob>,
+    ignore_set: Option<&CheckIgnoreSet>,
 ) {
     // Walk with the `ignore` crate so repository-level ignore rules prune whole
     // subtrees before we test patterns. The root path is canonicalized once and
@@ -145,6 +165,7 @@ fn collect_from_dir_filtered(
                     && is_supported_collect_file(path, vue_only, include_jsx)
                     && matcher.is_none_or(|matcher| matcher.matches(path))
                     && (!skip_generated || !is_generated_path(path))
+                    && !is_ignored(path, ignore_set)
                     && let Ok(mut collected) = collected.lock()
                 {
                     collected.push(normalize_walked_path(dir, &normalized_dir, path));
@@ -164,6 +185,10 @@ fn collect_from_dir_filtered(
     }
 }
 
+fn is_ignored(path: &Path, ignore_set: Option<&CheckIgnoreSet>) -> bool {
+    ignore_set.is_some_and(|ignore_set| ignore_set.is_ignored(path))
+}
+
 fn base_dir_from_pattern(pattern: &str) -> PathBuf {
     let glob_start = pattern.find(['*', '?', '[', '{']).unwrap_or(pattern.len());
     let prefix = &pattern[..glob_start];
@@ -181,14 +206,14 @@ fn base_dir_from_pattern(pattern: &str) -> PathBuf {
     }
 }
 
-struct InputGlob {
+pub(super) struct InputGlob {
     pattern: Pattern,
     cwd: PathBuf,
     absolute: bool,
 }
 
 impl InputGlob {
-    fn new(pattern: &str) -> Option<Self> {
+    pub(super) fn new(pattern: &str) -> Option<Self> {
         let normalized = normalize_glob_pattern(pattern);
         let absolute = Path::new(normalized.as_str()).is_absolute();
         Pattern::new(normalized.as_str()).ok().map(|pattern| Self {
@@ -198,7 +223,7 @@ impl InputGlob {
         })
     }
 
-    fn matches(&self, path: &Path) -> bool {
+    pub(super) fn matches(&self, path: &Path) -> bool {
         let candidate = if self.absolute {
             let absolute = if path.is_absolute() {
                 path.to_path_buf()
@@ -310,137 +335,5 @@ fn glob_match_options() -> MatchOptions {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{base_dir_from_pattern, collect_check_files, collect_vue_files};
-    use std::fs;
-    use std::path::{Path, PathBuf};
-    use vize_carton::cstr;
-
-    fn unique_case_dir(name: &str) -> PathBuf {
-        static NEXT_CASE_ID: std::sync::atomic::AtomicUsize =
-            std::sync::atomic::AtomicUsize::new(0);
-        let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("target")
-            .join("vize-tests")
-            .join(cstr!("{name}-{}-{case_id}", std::process::id()).as_str())
-    }
-
-    #[test]
-    fn base_dir_from_glob_patterns() {
-        assert_eq!(
-            base_dir_from_pattern("./src/**/*.vue"),
-            PathBuf::from("./src")
-        );
-        assert_eq!(base_dir_from_pattern("."), PathBuf::from("."));
-    }
-
-    #[test]
-    fn collect_check_files_includes_ts_and_vue_and_dts() {
-        let case_dir = unique_case_dir("collect-check");
-        let _ = fs::remove_dir_all(&case_dir);
-        fs::create_dir_all(case_dir.join("src")).unwrap();
-        fs::write(case_dir.join("src/App.vue"), "").unwrap();
-        fs::write(case_dir.join("src/Component.jsx"), "").unwrap();
-        fs::write(case_dir.join("src/main.ts"), "").unwrap();
-        fs::write(case_dir.join("src/env.d.ts"), "").unwrap();
-        fs::write(case_dir.join("src/skip.js"), "").unwrap();
-
-        let files = collect_check_files(&vec![case_dir.display().to_string()], false);
-
-        assert_eq!(
-            files,
-            vec![
-                case_dir.join("src/App.vue"),
-                case_dir.join("src/env.d.ts"),
-                case_dir.join("src/main.ts"),
-            ]
-        );
-
-        let _ = fs::remove_dir_all(&case_dir);
-    }
-
-    #[test]
-    fn collect_check_files_includes_jsx_only_when_enabled() {
-        let case_dir = unique_case_dir("collect-check-jsx");
-        let _ = fs::remove_dir_all(&case_dir);
-        fs::create_dir_all(case_dir.join("src")).unwrap();
-        fs::write(case_dir.join("src/App.jsx"), "").unwrap();
-        fs::write(case_dir.join("src/App.tsx"), "").unwrap();
-        fs::write(case_dir.join("src/skip.js"), "").unwrap();
-
-        let files = collect_check_files(&vec![case_dir.display().to_string()], true);
-
-        assert_eq!(
-            files,
-            vec![case_dir.join("src/App.jsx"), case_dir.join("src/App.tsx")]
-        );
-
-        let _ = fs::remove_dir_all(&case_dir);
-    }
-
-    #[test]
-    fn collect_check_files_filters_quoted_globs() {
-        let case_dir = unique_case_dir("collect-check-glob");
-        let _ = fs::remove_dir_all(&case_dir);
-        fs::create_dir_all(case_dir.join("src/nested")).unwrap();
-        fs::write(case_dir.join("src/App.vue"), "").unwrap();
-        fs::write(case_dir.join("src/main.ts"), "").unwrap();
-        fs::write(case_dir.join("src/nested/View.vue"), "").unwrap();
-        fs::write(case_dir.join("src/nested/model.ts"), "").unwrap();
-
-        let files = collect_check_files(
-            &vec![case_dir.join("src/**/*.vue").display().to_string()],
-            false,
-        );
-
-        assert_eq!(
-            files,
-            vec![
-                case_dir.join("src/App.vue"),
-                case_dir.join("src/nested/View.vue"),
-            ]
-        );
-
-        let _ = fs::remove_dir_all(&case_dir);
-    }
-
-    #[test]
-    fn collect_vue_files_stays_vue_only() {
-        let case_dir = unique_case_dir("collect-vue");
-        let _ = fs::remove_dir_all(&case_dir);
-        fs::create_dir_all(case_dir.join("src")).unwrap();
-        fs::write(case_dir.join("src/App.vue"), "").unwrap();
-        fs::write(case_dir.join("src/main.ts"), "").unwrap();
-
-        let files = collect_vue_files(&vec![case_dir.display().to_string()]);
-
-        assert_eq!(files, vec![case_dir.join("src/App.vue")]);
-
-        let _ = fs::remove_dir_all(&case_dir);
-    }
-
-    #[test]
-    fn collect_vue_files_filters_quoted_globs() {
-        let case_dir = unique_case_dir("collect-vue-glob");
-        let _ = fs::remove_dir_all(&case_dir);
-        fs::create_dir_all(case_dir.join("src/nested")).unwrap();
-        fs::write(case_dir.join("src/App.vue"), "").unwrap();
-        fs::write(case_dir.join("src/nested/View.vue"), "").unwrap();
-        fs::write(case_dir.join("src/nested/Skip.vue"), "").unwrap();
-
-        let files = collect_vue_files(&vec![
-            case_dir.join("src/nested/*.vue").display().to_string(),
-        ]);
-
-        assert_eq!(
-            files,
-            vec![
-                case_dir.join("src/nested/Skip.vue"),
-                case_dir.join("src/nested/View.vue"),
-            ]
-        );
-
-        let _ = fs::remove_dir_all(&case_dir);
-    }
-}
+#[path = "collect_tests.rs"]
+mod tests;

--- a/crates/vize/src/commands/check/runner/collect_tests.rs
+++ b/crates/vize/src/commands/check/runner/collect_tests.rs
@@ -1,0 +1,182 @@
+use super::super::ignores::CheckIgnoreSet;
+use super::{
+    base_dir_from_pattern, collect_check_files, collect_check_files_with_ignores, collect_vue_files,
+};
+use std::fs;
+use std::path::{Path, PathBuf};
+use vize_carton::cstr;
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("vize-tests")
+        .join(cstr!("{name}-{}-{case_id}", std::process::id()).as_str())
+}
+
+#[test]
+fn base_dir_from_glob_patterns() {
+    assert_eq!(
+        base_dir_from_pattern("./src/**/*.vue"),
+        PathBuf::from("./src")
+    );
+    assert_eq!(base_dir_from_pattern("."), PathBuf::from("."));
+}
+
+#[test]
+fn collect_check_files_includes_ts_and_vue_and_dts() {
+    let case_dir = unique_case_dir("collect-check");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    fs::write(case_dir.join("src/App.vue"), "").unwrap();
+    fs::write(case_dir.join("src/Component.jsx"), "").unwrap();
+    fs::write(case_dir.join("src/main.ts"), "").unwrap();
+    fs::write(case_dir.join("src/env.d.ts"), "").unwrap();
+    fs::write(case_dir.join("src/skip.js"), "").unwrap();
+
+    let files = collect_check_files(&vec![case_dir.display().to_string()], false);
+
+    assert_eq!(
+        files,
+        vec![
+            case_dir.join("src/App.vue"),
+            case_dir.join("src/env.d.ts"),
+            case_dir.join("src/main.ts"),
+        ]
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn collect_check_files_includes_jsx_only_when_enabled() {
+    let case_dir = unique_case_dir("collect-check-jsx");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    fs::write(case_dir.join("src/App.jsx"), "").unwrap();
+    fs::write(case_dir.join("src/App.tsx"), "").unwrap();
+    fs::write(case_dir.join("src/skip.js"), "").unwrap();
+
+    let files = collect_check_files(&vec![case_dir.display().to_string()], true);
+
+    assert_eq!(
+        files,
+        vec![case_dir.join("src/App.jsx"), case_dir.join("src/App.tsx")]
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn collect_check_files_filters_quoted_globs() {
+    let case_dir = unique_case_dir("collect-check-glob");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src/nested")).unwrap();
+    fs::write(case_dir.join("src/App.vue"), "").unwrap();
+    fs::write(case_dir.join("src/main.ts"), "").unwrap();
+    fs::write(case_dir.join("src/nested/View.vue"), "").unwrap();
+    fs::write(case_dir.join("src/nested/model.ts"), "").unwrap();
+
+    let files = collect_check_files(
+        &vec![case_dir.join("src/**/*.vue").display().to_string()],
+        false,
+    );
+
+    assert_eq!(
+        files,
+        vec![
+            case_dir.join("src/App.vue"),
+            case_dir.join("src/nested/View.vue"),
+        ]
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn collect_check_files_applies_entry_ignores() {
+    let case_dir = unique_case_dir("collect-check-entry-ignores");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    fs::create_dir_all(case_dir.join("design-system/src")).unwrap();
+    fs::write(case_dir.join("src/App.vue"), "").unwrap();
+    fs::write(case_dir.join("src/Ignored.vue"), "").unwrap();
+    fs::write(case_dir.join("design-system/src/Kept.vue"), "").unwrap();
+    fs::write(case_dir.join("design-system/src/Fixture.vue"), "").unwrap();
+
+    let ignore_set = CheckIgnoreSet::new(
+        &[
+            crate::config::ConfigEntryIgnore {
+                base_path: None,
+                pattern: "src/Ignored.vue".into(),
+            },
+            crate::config::ConfigEntryIgnore {
+                base_path: Some("design-system".into()),
+                pattern: "src/Fixture.vue".into(),
+            },
+        ],
+        &case_dir,
+    );
+
+    let files = collect_check_files_with_ignores(
+        &vec![case_dir.display().to_string()],
+        false,
+        ignore_set.as_ref(),
+    );
+    let explicit = collect_check_files_with_ignores(
+        &vec![case_dir.join("src/Ignored.vue").display().to_string()],
+        false,
+        ignore_set.as_ref(),
+    );
+
+    assert_eq!(
+        files,
+        vec![
+            case_dir.join("design-system/src/Kept.vue"),
+            case_dir.join("src/App.vue"),
+        ]
+    );
+    assert!(explicit.is_empty());
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn collect_vue_files_stays_vue_only() {
+    let case_dir = unique_case_dir("collect-vue");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    fs::write(case_dir.join("src/App.vue"), "").unwrap();
+    fs::write(case_dir.join("src/main.ts"), "").unwrap();
+
+    let files = collect_vue_files(&vec![case_dir.display().to_string()]);
+
+    assert_eq!(files, vec![case_dir.join("src/App.vue")]);
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn collect_vue_files_filters_quoted_globs() {
+    let case_dir = unique_case_dir("collect-vue-glob");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src/nested")).unwrap();
+    fs::write(case_dir.join("src/App.vue"), "").unwrap();
+    fs::write(case_dir.join("src/nested/View.vue"), "").unwrap();
+    fs::write(case_dir.join("src/nested/Skip.vue"), "").unwrap();
+
+    let files = collect_vue_files(&vec![
+        case_dir.join("src/nested/*.vue").display().to_string(),
+    ]);
+
+    assert_eq!(
+        files,
+        vec![
+            case_dir.join("src/nested/Skip.vue"),
+            case_dir.join("src/nested/View.vue"),
+        ]
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize/src/commands/check/runner/ignores.rs
+++ b/crates/vize/src/commands/check/runner/ignores.rs
@@ -1,0 +1,68 @@
+use std::path::{Path, PathBuf};
+
+use super::{super::CheckArgs, collect::InputGlob};
+use crate::config;
+
+pub(super) struct CheckIgnoreSet {
+    patterns: Vec<InputGlob>,
+}
+
+impl CheckIgnoreSet {
+    pub(super) fn new(ignores: &[config::ConfigEntryIgnore], config_dir: &Path) -> Option<Self> {
+        let patterns = ignores
+            .iter()
+            .filter_map(|ignore| {
+                let pattern = resolve_entry_ignore_pattern(ignore, config_dir);
+                InputGlob::new(pattern.to_string_lossy().as_ref())
+            })
+            .collect::<Vec<_>>();
+        (!patterns.is_empty()).then_some(Self { patterns })
+    }
+
+    pub(super) fn is_ignored(&self, path: &Path) -> bool {
+        self.patterns.iter().any(|pattern| pattern.matches(path))
+    }
+}
+
+pub(super) fn load_check_ignore_set(args: &CheckArgs, config_dir: &Path) -> Option<CheckIgnoreSet> {
+    if args.no_config {
+        return None;
+    }
+    let loaded_ignores = config::load_config_entry_ignores_with_source(args.config.as_deref());
+    CheckIgnoreSet::new(&loaded_ignores.ignores, config_dir)
+}
+
+pub(super) fn retain_unignored(files: &mut Vec<PathBuf>, ignore_set: Option<&CheckIgnoreSet>) {
+    if let Some(ignore_set) = ignore_set {
+        files.retain(|path| !ignore_set.is_ignored(path));
+    }
+}
+
+fn resolve_entry_ignore_pattern(ignore: &config::ConfigEntryIgnore, config_dir: &Path) -> PathBuf {
+    let pattern = Path::new(ignore.pattern.as_str());
+    if pattern.is_absolute() {
+        return pattern.to_path_buf();
+    }
+
+    let config_dir = absolute_config_dir(config_dir);
+    let base = ignore
+        .base_path
+        .as_deref()
+        .map(Path::new)
+        .filter(|base_path| !base_path.as_os_str().is_empty());
+    match base {
+        Some(base_path) if base_path.is_absolute() => base_path.join(pattern),
+        Some(base_path) => config_dir.join(base_path).join(pattern),
+        None => config_dir.join(pattern),
+    }
+}
+
+fn absolute_config_dir(config_dir: &Path) -> PathBuf {
+    if config_dir.is_absolute() {
+        return config_dir.to_path_buf();
+    }
+
+    std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(config_dir)
+}

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -1,8 +1,7 @@
 //! Check command execution logic.
 //!
-//! The direct runner delegates to `vize_canon`'s project-backed Corsa type
-//! checker so Vue SFCs, TypeScript sources, ambient declarations, and emitted
-//! `.d.ts` output all share the same virtual project.
+//! The direct runner delegates to `vize_canon`'s project-backed Corsa type checker so Vue SFCs,
+//! TypeScript sources, ambient declarations, and emitted declarations share one virtual project.
 
 #![allow(clippy::disallowed_macros)]
 use std::{
@@ -31,13 +30,14 @@ use super::{
 mod collect;
 mod diagnostics;
 mod global_components;
+mod ignores;
 mod nuxt_tsconfig;
 mod resolve;
 #[cfg(unix)]
 mod socket;
 #[cfg(test)]
 mod tests;
-use collect::collect_check_files;
+use collect::collect_check_files_with_ignores;
 use diagnostics::{
     emit_json_output, is_reported, is_suppressed_false_positive, render_diagnostics,
     save_virtual_ts_targets, write_profile_virtual_ts,
@@ -46,6 +46,7 @@ use global_components::{
     build_virtual_ts_options, collect_project_global_component_stubs, dialect_from_features,
     template_syntax_mode,
 };
+use ignores::{load_check_ignore_set, retain_unignored};
 use nuxt_tsconfig::resolve_checker_tsconfig_path;
 #[cfg(test)]
 use nuxt_tsconfig::write_nuxt_fallback_tsconfig;
@@ -149,22 +150,21 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let tsconfig_path =
         resolve_tsconfig_path(effective_tsconfig.as_deref(), &cwd, &project_root, &[]);
     let explicit_input_root = explicit_input_root(&project_root, &cwd);
-    // Run-scoped caches: tsconfig chains are parsed (and their include/exclude
-    // globs compiled) once per run, and each unique path is canonicalized at
-    // most once across reported-file bookkeeping, diagnostic filtering, and
-    // transitive import resolution.
     let mut tsconfig_input_cache = TsconfigInputCache::default();
     let mut canonical_paths = CanonicalPathCache::default();
+    let check_ignore_set = load_check_ignore_set(args, config_dir);
     let collect_start = Instant::now();
     let mut files = if args.patterns.is_empty() {
-        collect_default_check_files(
+        let mut files = collect_default_check_files(
             &project_root,
             tsconfig_path.as_deref(),
             jsx_typecheck,
             &mut tsconfig_input_cache,
-        )
+        );
+        retain_unignored(&mut files, check_ignore_set.as_ref());
+        files
     } else {
-        collect_check_files(&args.patterns, jsx_typecheck)
+        collect_check_files_with_ignores(&args.patterns, jsx_typecheck, check_ignore_set.as_ref())
     };
     let explicit_files = if args.patterns.is_empty() {
         Vec::new()

--- a/crates/vize/tests/check_entry_ignores_cli.rs
+++ b/crates/vize/tests/check_entry_ignores_cli.rs
@@ -1,0 +1,80 @@
+use std::{path::Path, process::Command};
+
+use vize_carton::cstr;
+
+#[test]
+fn check_config_entry_ignores_explicit_inputs() {
+    let project_root = create_cli_project(
+        "entry-ignore-explicit-check",
+        &[
+            (
+                "vize.config.json",
+                r#"{
+  "entries": [
+    { "name": "app", "files": ["src/**/*.vue"], "ignores": ["src/Ignored.vue"] }
+  ]
+}"#,
+            ),
+            (
+                "src/Ignored.vue",
+                r#"<script setup lang="ts">
+const count: string = 0;
+</script>
+"#,
+            ),
+        ],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args([
+            "check",
+            "--config",
+            "vize.config.json",
+            "src/Ignored.vue",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(json["fileCount"], 0);
+    assert_eq!(json["errorCount"], 0);
+    assert_eq!(json["files"].as_array().unwrap().len(), 0);
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn create_cli_project(name: &str, files: &[(&str, &str)]) -> std::path::PathBuf {
+    let project_root = workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("{name}-{}", std::process::id()).as_str());
+    let _ = std::fs::remove_dir_all(&project_root);
+    for (path, content) in files {
+        let file_path = project_root.join(path);
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(file_path, content).unwrap();
+    }
+    project_root
+}


### PR DESCRIPTION
## Summary
- apply vize.config entries[].ignores when collecting vize check inputs
- keep ignored files out of explicit and default check file sets
- move check collector tests into a split test module and add a CLI regression for ignored explicit inputs

Closes #1862

## Validation
- cargo test -p vize commands::check::runner::collect::tests::collect_check_files_applies_entry_ignores -- --nocapture
- cargo test -p vize --test check_entry_ignores_cli check_config_entry_ignores_explicit_inputs -- --nocapture
- cargo fmt --all --check
- cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff origin/main --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->