### PR TITLE
fix(compiler): preserve musea art setup metadata

### DIFF
--- a/crates/vize/tests/inspector_art_cli.rs
+++ b/crates/vize/tests/inspector_art_cli.rs
@@ -1,0 +1,62 @@
+use std::{fs, process::Command};
+
+#[test]
+fn inspector_compare_preserves_musea_define_art_script_setup() {
+    if !dev_vue_compiler_available() {
+        return;
+    }
+
+    let project = tempfile::tempdir().unwrap();
+    let src = project.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("CmsButton.art.vue"),
+        r#"<script setup lang="ts">
+defineArt("./CmsButton.vue", {
+  title: "CmsButton",
+  category: "Components",
+  status: "draft",
+  tags: ["button", "form"],
+});
+</script>
+
+<art>
+  <variant name="Primary" default>
+    <CmsButton color="primary">Primary</CmsButton>
+  </variant>
+</art>
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args(["inspector", "src/CmsButton.art.vue", "--format", "compare"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let vize_code = json["files"][0]["vize"]["code"].as_str().unwrap();
+    let official_code = json["files"][0]["official"]["code"].as_str().unwrap();
+    assert!(official_code.contains("defineArt"), "{official_code}");
+    assert!(vize_code.contains("defineArt"), "{vize_code}");
+}
+
+fn dev_vue_compiler_available() -> bool {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let Some(workspace_root) = manifest_dir.parent().and_then(|path| path.parent()) else {
+        return false;
+    };
+    Command::new("node")
+        .current_dir(workspace_root)
+        .args(["--input-type=module", "-e", "import('vue/compiler-sfc')"])
+        .status()
+        .is_ok_and(|status| status.success())
+}

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
@@ -24,6 +24,7 @@ use crate::types::{CssModuleMapping, SfcError};
 use super::super::function_mode::contains_top_level_await;
 use super::super::lazy_hydration::transform_lazy_hydration_macros;
 use super::super::props::validate_props_destructure_default_types;
+use super::super::statement_sections::extract_script_sections_from_program_with_options;
 use super::super::{ScriptCompileResult, TemplateParts};
 use body::compile_script_setup_inline_body;
 use parser::parse_script_content;
@@ -95,9 +96,18 @@ pub(crate) fn compile_script_setup_inline_with_context(
     // Extract user imports and setup lines from script content once; await detection
     // and output assembly share the same split. `setup_program` (when provided
     // by the parse-once pipeline) skips re-parsing `content` here.
+    let preserve_runtime_erased_macros = css_vars_id.ends_with(".art.vue");
     let (user_imports, setup_lines, ts_declarations) = profile!(
         "atelier.script_inline.parse_sections",
-        parse_script_content(content, is_ts, setup_program)
+        if preserve_runtime_erased_macros {
+            setup_program
+                .and_then(|program| {
+                    extract_script_sections_from_program_with_options(program, content, is_ts, true)
+                })
+                .unwrap_or_else(|| parse_script_content(content, is_ts, setup_program))
+        } else {
+            parse_script_content(content, is_ts, setup_program)
+        }
     );
     let setup_code: String = setup_lines.join("\n").into();
 

--- a/crates/vize_atelier_sfc/src/compile_script/statement_sections.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/statement_sections.rs
@@ -43,6 +43,15 @@ pub(crate) fn extract_script_sections_from_program(
     content: &str,
     is_ts: bool,
 ) -> Option<(Vec<String>, Vec<String>, Vec<String>)> {
+    extract_script_sections_from_program_with_options(program, content, is_ts, false)
+}
+
+pub(crate) fn extract_script_sections_from_program_with_options(
+    program: &Program<'_>,
+    content: &str,
+    is_ts: bool,
+    preserve_runtime_erased_macros: bool,
+) -> Option<(Vec<String>, Vec<String>, Vec<String>)> {
     let mut user_imports = Vec::new();
     let mut setup_lines = Vec::new();
     let mut ts_declarations = Vec::new();
@@ -63,7 +72,12 @@ pub(crate) fn extract_script_sections_from_program(
         pending_gap.push_str(&content[prev_end..start]);
 
         let slice = &content[start..end];
-        match classify_statement(stmt, slice, &runtime_bindings) {
+        match classify_statement(
+            stmt,
+            slice,
+            &runtime_bindings,
+            preserve_runtime_erased_macros,
+        ) {
             StatementBucket::Import => {
                 let mut segment = std::mem::take(&mut pending_gap);
                 segment.push_str(slice);
@@ -99,6 +113,7 @@ fn classify_statement(
     stmt: &Statement<'_>,
     slice: &str,
     runtime_bindings: &FxHashSet<String>,
+    preserve_runtime_erased_macros: bool,
 ) -> StatementBucket {
     let trimmed = slice.trim_start();
 
@@ -129,9 +144,9 @@ fn classify_statement(
             }
         }
         Statement::ExpressionStatement(expr_stmt) => {
-            if unwrap_call_expression(&expr_stmt.expression)
-                .is_some_and(|call| is_macro_call(call, runtime_bindings))
-            {
+            if unwrap_call_expression(&expr_stmt.expression).is_some_and(|call| {
+                is_macro_call(call, runtime_bindings, preserve_runtime_erased_macros)
+            }) {
                 StatementBucket::Macro
             } else {
                 StatementBucket::Setup
@@ -142,7 +157,9 @@ fn classify_statement(
                 decl.init
                     .as_ref()
                     .and_then(unwrap_call_expression)
-                    .is_some_and(|call| is_macro_call(call, runtime_bindings))
+                    .is_some_and(|call| {
+                        is_macro_call(call, runtime_bindings, preserve_runtime_erased_macros)
+                    })
             }) {
                 StatementBucket::Macro
             } else {
@@ -173,12 +190,15 @@ fn unwrap_call_expression<'a>(
 fn is_macro_call(
     call: &oxc_ast::ast::CallExpression<'_>,
     runtime_bindings: &FxHashSet<String>,
+    preserve_runtime_erased_macros: bool,
 ) -> bool {
     match &call.callee {
         Expression::Identifier(id) => {
             let name = id.name.as_str();
             is_builtin_macro(name)
-                || (is_runtime_erased_macro(name) && !runtime_bindings.contains(name))
+                || (!preserve_runtime_erased_macros
+                    && is_runtime_erased_macro(name)
+                    && !runtime_bindings.contains(name))
         }
         _ => false,
     }


### PR DESCRIPTION
Closes #1884

Validation:
- cargo fmt --all --check
- cargo test -p vize --test inspector_art_cli inspector_compare_preserves_musea_define_art_script_setup -- --nocapture
- cargo clippy -p vize_atelier_sfc -p vize -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->