### PR TITLE
fix(check): register transitive imports for default runs

### DIFF
--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -1,9 +1,9 @@
-//! Transitive resolution of source imports for explicit `vize check` subsets.
+//! Transitive resolution of source imports for `vize check` virtual projects.
 //!
-//! `vize check src/App.vue` registers only the requested files in the virtual
-//! project, so a sibling import like `./types` or `~/components/Foo.vue` cannot
-//! see the real types and can surface false `TS2307`. This module walks the
-//! reachable graph and returns on-disk source files to register.
+//! A check run may intentionally report diagnostics for only a subset of
+//! sources, but imported local sources still need to be registered so
+//! cross-file types resolve like tsc/vue-tsc. This module walks the reachable
+//! graph and returns on-disk source files to register.
 
 use std::path::{Path, PathBuf};
 

--- a/crates/vize/src/commands/check/runner/diagnostics.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics.rs
@@ -18,25 +18,20 @@ pub(super) fn emit_json_output(json_output: JsonOutput) {
     }
 }
 
-/// Whether a registered file's diagnostics should be reported. For an explicit
-/// subset (`reported` is `Some`), only the requested files are reported; ambient
-/// and transitively-registered files exist only to resolve cross-file types.
-/// Project-level diagnostics (anchored to a tsconfig or the project root, not
-/// a source file) describe the whole check and are always reported.
+/// Whether a registered file's diagnostics should be reported. Only listed
+/// source files are reported; ambient and transitively-registered files exist
+/// only to resolve cross-file types. Project-level diagnostics (anchored to a
+/// tsconfig or the project root, not a source file) describe the whole check and
+/// are always reported.
 pub(super) fn is_reported(
-    reported: &Option<FxHashSet<PathBuf>>,
+    reported: &FxHashSet<PathBuf>,
     path: &Path,
     canonical_paths: &mut CanonicalPathCache,
 ) -> bool {
-    match reported {
-        None => true,
-        Some(set) => {
-            if !is_source_path(path) {
-                return true;
-            }
-            set.contains(&canonical_paths.canonicalize(path))
-        }
+    if !is_source_path(path) {
+        return true;
     }
+    reported.contains(&canonical_paths.canonicalize(path))
 }
 
 fn is_source_path(path: &Path) -> bool {

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -62,6 +62,59 @@ pub(crate) use socket::run_with_socket;
 #[allow(clippy::disallowed_types)]
 type JsonObject = Map<std::string::String, Value>;
 
+fn collect_default_run_files(
+    project_root: &Path,
+    cwd: &Path,
+    tsconfig_path: Option<&Path>,
+    include_jsx: bool,
+    tsconfig_input_cache: &mut TsconfigInputCache,
+    canonical_paths: &mut CanonicalPathCache,
+) -> (Vec<PathBuf>, FxHashSet<PathBuf>) {
+    let mut files = collect_default_check_files(
+        project_root,
+        tsconfig_path,
+        include_jsx,
+        tsconfig_input_cache,
+    );
+    let reported_files = canonical_file_set(&files, canonical_paths);
+    register_transitive_local_imports(&mut files, cwd, tsconfig_path, include_jsx, canonical_paths);
+
+    (files, reported_files)
+}
+
+fn canonical_file_set(
+    files: &[PathBuf],
+    canonical_paths: &mut CanonicalPathCache,
+) -> FxHashSet<PathBuf> {
+    files
+        .iter()
+        .map(|path| canonical_paths.canonicalize(path))
+        .collect()
+}
+
+fn register_transitive_local_imports(
+    files: &mut Vec<PathBuf>,
+    cwd: &Path,
+    tsconfig_path: Option<&Path>,
+    include_jsx: bool,
+    canonical_paths: &mut CanonicalPathCache,
+) {
+    let aliases = super::imports_aliases::PathAliasResolver::from_tsconfig(tsconfig_path);
+    for path in super::imports::collect_transitive_local_imports(
+        files,
+        cwd,
+        canonical_paths,
+        include_jsx,
+        Some(&aliases),
+    ) {
+        if !files.contains(&path) {
+            files.push(path);
+        }
+    }
+    files.sort();
+    files.dedup();
+}
+
 /// Run type checking directly with a materialized Corsa project.
 pub(crate) fn run_direct(args: &CheckArgs) {
     use super::nuxt;
@@ -156,38 +209,34 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let mut tsconfig_input_cache = TsconfigInputCache::default();
     let mut canonical_paths = CanonicalPathCache::default();
     let collect_start = Instant::now();
-    let mut files = if args.patterns.is_empty() {
-        collect_default_check_files(
+    let (mut files, explicit_files, reported_files): (
+        Vec<PathBuf>,
+        Vec<PathBuf>,
+        FxHashSet<PathBuf>,
+    ) = if args.patterns.is_empty() {
+        let (files, reported_files) = collect_default_run_files(
             &project_root,
+            &cwd,
             tsconfig_path.as_deref(),
             jsx_typecheck,
             &mut tsconfig_input_cache,
-        )
+            &mut canonical_paths,
+        );
+        (files, Vec::new(), reported_files)
     } else {
-        collect_check_files(&args.patterns, jsx_typecheck)
-    };
-    let explicit_files = if args.patterns.is_empty() {
-        Vec::new()
-    } else {
-        files.clone()
+        let mut files = collect_check_files(&args.patterns, jsx_typecheck);
+        let explicit_files = files.clone();
+        let reported_files = canonical_file_set(&files, &mut canonical_paths);
+        register_transitive_local_imports(
+            &mut files,
+            &cwd,
+            tsconfig_path.as_deref(),
+            jsx_typecheck,
+            &mut canonical_paths,
+        );
+        (files, explicit_files, reported_files)
     };
     let collect_time = collect_start.elapsed();
-
-    // For an explicit subset, only the requested files' diagnostics are
-    // reported: ambient `.d.ts` and transitively-registered relative imports are
-    // pulled into the program solely so cross-file types resolve, not to surface
-    // diagnostics for files the user did not ask about. `None` reports every
-    // registered file (the default full-project run).
-    let reported_files: Option<FxHashSet<PathBuf>> = if args.patterns.is_empty() {
-        None
-    } else {
-        Some(
-            files
-                .iter()
-                .map(|path| canonical_paths.canonicalize(path))
-                .collect(),
-        )
-    };
 
     if files.is_empty() {
         if args.format == "json" {
@@ -207,26 +256,9 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         return;
     }
 
-    // Explicit subsets need reachable source imports registered so cross-file
-    // types resolve like tsc/vue-tsc. Run this before root resolution so
-    // cwd-external files can still choose a covering materialization root.
-    if !args.patterns.is_empty() {
-        let aliases =
-            super::imports_aliases::PathAliasResolver::from_tsconfig(tsconfig_path.as_deref());
-        for path in super::imports::collect_transitive_local_imports(
-            &files,
-            &cwd,
-            &mut canonical_paths,
-            jsx_typecheck,
-            Some(&aliases),
-        ) {
-            if !files.contains(&path) {
-                files.push(path);
-            }
-        }
-        files.sort();
-        files.dedup();
-    }
+    // Reachable source imports are registered before root resolution so
+    // cwd-external files can still choose a covering materialization root. Only
+    // original inputs are reported; transitive files exist to resolve types.
     let validate_inputs = !args.patterns.is_empty() && tsconfig_path.is_some();
     exit_if_inputs_outside_root(&explicit_input_root, &files, validate_inputs);
     let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &files);

--- a/crates/vize/src/commands/check/runner/tests.rs
+++ b/crates/vize/src/commands/check/runner/tests.rs
@@ -10,6 +10,7 @@ use std::{
     path::{Path, PathBuf},
     sync::atomic::{AtomicUsize, Ordering},
 };
+use vize_carton::path::canonicalize_non_verbatim;
 
 fn unique_case_dir(name: &str) -> PathBuf {
     static NEXT_CASE_ID: AtomicUsize = AtomicUsize::new(0);
@@ -22,6 +23,65 @@ fn unique_case_dir(name: &str) -> PathBuf {
             "check-runner-{name}-{}-{case_id}",
             std::process::id()
         ))
+}
+
+#[test]
+fn default_tsconfig_run_registers_transitive_imports_outside_include_for_type_resolution() {
+    let project_root = unique_case_dir("default-transitive-imports");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("inside")).unwrap();
+    std::fs::create_dir_all(project_root.join("outside")).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["inside/**/*.ts"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("inside/use.ts"),
+        r#"import { ITEMS } from '../outside/lib'
+
+export const r = ITEMS.map(({ code, name }) => `${code}:${name}`)
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("outside/lib.ts"),
+        "export const ITEMS = [{ code: 'en', name: 'English' }, { code: 'ru', name: 'Russian' }]\n",
+    )
+    .unwrap();
+
+    let mut tsconfig_input_cache = super::TsconfigInputCache::default();
+    let mut canonical_paths = super::CanonicalPathCache::default();
+    let (files, reported_files) = super::collect_default_run_files(
+        &project_root,
+        &project_root,
+        Some(&project_root.join("tsconfig.json")),
+        false,
+        &mut tsconfig_input_cache,
+        &mut canonical_paths,
+    );
+
+    let included_file = canonicalize_non_verbatim(&project_root.join("inside/use.ts"));
+    let transitive_file = canonicalize_non_verbatim(&project_root.join("outside/lib.ts"));
+
+    assert!(files.contains(&included_file));
+    assert!(files.contains(&transitive_file));
+    assert!(reported_files.contains(&included_file));
+    assert!(
+        !reported_files.contains(&transitive_file),
+        "outside-include imports are registered for types, not reported"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
 }
 
 #[test]

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -304,6 +304,68 @@ const count = 1
 }
 
 #[test]
+fn check_without_patterns_resolves_imports_outside_tsconfig_include_for_types() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "default-transitive-imports-outside-include",
+        &[
+            (
+                "tsconfig.json",
+                r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["inside/**/*.ts"]
+}"#,
+            ),
+            (
+                "inside/use.ts",
+                r#"import { ITEMS } from '../outside/lib'
+
+export const r = ITEMS.map(({ code, name }) => `${code}:${name}`)
+"#,
+            ),
+            (
+                "outside/lib.ts",
+                "export const ITEMS = [{ code: 'en', name: 'English' }, { code: 'ru', name: 'Russian' }]\n",
+            ),
+        ],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(json["fileCount"], 1, "stdout:\n{stdout}\nstderr:\n{stderr}");
+    assert_eq!(
+        json["errorCount"], 0,
+        "transitive import should be registered for type resolution; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn check_json_reports_empty_result_when_no_files_match() {
     let project_root = create_cli_project("json-empty-inputs", &[]);
 


### PR DESCRIPTION
## Summary
- Register reachable local source imports for default tsconfig-based `vize check` runs.
- Keep diagnostics limited to original tsconfig inputs while using transitive files for type resolution.
- Add regression coverage for outside-include imports in default runs.

Fixes #1964

## Test Plan
- [x] cargo test -p vize --tests
- [x] git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784382254&installation_id=136613492&pr_number=1977&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1977&signature=42bf70118eb8fb2945ac29ae1124fabe0b6a7a41e9acc72df0ae4ff5982c953f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->