### PR TITLE
fix(sfc): unref setup ref component tags

### DIFF
--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -1,6 +1,6 @@
 //! Code generation context and result types.
 
-use crate::options::CodegenOptions;
+use crate::options::{BindingType, CodegenOptions};
 use crate::runtime_helpers::RuntimeHelpers;
 use crate::{Namespace, Position, RuntimeHelper};
 
@@ -358,6 +358,37 @@ impl CodegenContext {
         }
 
         resolve_base(component)
+    }
+
+    /// Emit a component tag that resolves to a script-setup binding.
+    pub fn push_component_binding_name(&mut self, binding_name: &str) {
+        if !self.options.inline {
+            self.push("$setup.");
+            self.push(binding_name);
+            return;
+        }
+
+        let (base, suffix) = binding_name.split_once('.').unwrap_or((binding_name, ""));
+        let needs_unref = self
+            .options
+            .binding_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.bindings.get(base))
+            .is_some_and(|binding_type| matches!(binding_type, BindingType::SetupRef));
+
+        if needs_unref {
+            self.use_helper(RuntimeHelper::Unref);
+            self.push(self.helper(RuntimeHelper::Unref));
+            self.push("(");
+            self.push(base);
+            self.push(")");
+            if !suffix.is_empty() {
+                self.push(".");
+                self.push(suffix);
+            }
+        } else {
+            self.push(binding_name);
+        }
     }
 
     /// Push string to buffer (alias for `push`, compatible with `appends!`/`append!` macros)

--- a/crates/vize_atelier_core/src/codegen/element/block.rs
+++ b/crates/vize_atelier_core/src/codegen/element/block.rs
@@ -309,12 +309,7 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.use_helper(builtin);
                 ctx.push(ctx.helper(builtin));
             } else if let Some(binding_name) = ctx.resolve_component_binding_name(&el.tag) {
-                // In inline mode, components are directly in scope (imported at module level)
-                // In function mode, use $setup.ComponentName to access setup bindings
-                if !ctx.options.inline {
-                    ctx.push("$setup.");
-                }
-                ctx.push(&binding_name);
+                ctx.push_component_binding_name(&binding_name);
             } else {
                 ctx.push(&to_valid_asset_identifier("component", &el.tag));
             }

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -264,10 +264,7 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.use_helper(builtin);
                 ctx.push(ctx.helper(builtin));
             } else if let Some(binding_name) = ctx.resolve_component_binding_name(&el.tag) {
-                if !ctx.options.inline {
-                    ctx.push("$setup.");
-                }
-                ctx.push(&binding_name);
+                ctx.push_component_binding_name(&binding_name);
             } else {
                 ctx.push(&to_valid_asset_identifier("component", &el.tag));
             }

--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -228,10 +228,7 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
                         ctx.use_helper(builtin);
                         ctx.push(ctx.helper(builtin));
                     } else if let Some(binding_name) = ctx.resolve_component_binding_name(&el.tag) {
-                        if !ctx.options.inline {
-                            ctx.push("$setup.");
-                        }
-                        ctx.push(&binding_name);
+                        ctx.push_component_binding_name(&binding_name);
                     } else {
                         ctx.push(&to_valid_asset_identifier("component", &el.tag));
                     }

--- a/crates/vize_atelier_core/src/codegen/v_if/branch.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch.rs
@@ -206,12 +206,7 @@ fn generate_if_branch_component(
         ctx.use_helper(builtin);
         ctx.push(ctx.helper(builtin));
     } else if let Some(binding_name) = ctx.resolve_component_binding_name(&el.tag) {
-        // In inline mode, components are directly in scope (imported at module level)
-        // In function mode, use $setup.ComponentName to access setup bindings
-        if !ctx.options.inline {
-            ctx.push("$setup.");
-        }
-        ctx.push(binding_name.as_str());
+        ctx.push_component_binding_name(&binding_name);
     } else {
         ctx.push(&to_valid_asset_identifier("component", &el.tag));
     }

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -1440,6 +1440,37 @@ var c = 3
 }
 
 #[test]
+fn test_script_setup_computed_component_tag_uses_unref() {
+    let input = r#"
+<script setup>
+import { computed } from 'vue'
+const Menu = computed(() => ({ render: () => null }))
+</script>
+
+<template>
+  <Menu>hello</Menu>
+</template>
+"#;
+
+    let descriptor = parse_sfc(input, SfcParseOptions::default()).unwrap();
+
+    let mut compile_opts = SfcCompileOptions::default();
+    compile_opts.script.id = Some("test.vue".to_compact_string());
+    let result = compile_sfc(&descriptor, compile_opts).unwrap();
+
+    assert!(
+        result.code.contains("_createBlock(_unref(Menu)"),
+        "{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("_createBlock(Menu"),
+        "{}",
+        result.code
+    );
+}
+
+#[test]
 fn test_extract_normal_script_content() {
     let input = r#"import type { NuxtRoute } from "@typed-router";
 import { useBreakpoint } from "./_utils";


### PR DESCRIPTION
## Summary
- Add a shared codegen path for script-setup component binding emission.
- Emit `_unref(...)` for inline `SetupRef` component tags so computed/ref component definitions render as components.
- Cover the computed component tag repro with an SFC regression test.

## Test Plan
- [x] `cargo fmt --check`
- [x] `cargo test -p vize_atelier_sfc test_script_setup_computed_component_tag_uses_unref`
- [x] `cargo test -p vize_atelier_sfc --lib -- --skip snapshot_tests`
- [x] `cargo test -p vize_atelier_core`

## Notes
- `cargo test -p vize_atelier_sfc --lib` reaches 519 passing tests, then 8 snapshot tests fail in this workspace because the Pkl server is not installed: `failed to start pkl server: No such file or directory`.

Fixes #1969

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784382464&installation_id=136613492&pr_number=1979&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1979&signature=0c380acffcb0f444ce3a787f2e2f30c6f15e43cc153edd875dc51e50580c3d27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->