### PR TITLE
fix(musea): emit static gallery builds

### DIFF
--- a/crates/vize/src/commands/musea.rs
+++ b/crates/vize/src/commands/musea.rs
@@ -1,5 +1,3 @@
-//! Musea command - Component gallery server
-
 mod setup;
 
 use clap::{Args, Subcommand};
@@ -38,7 +36,6 @@ pub struct ServeArgs {
     #[arg(long, default_value = "localhost")]
     pub host: String,
 
-    /// Stories directory
     #[arg(short, long, hide = true)]
     pub stories: Option<PathBuf>,
 
@@ -103,7 +100,8 @@ fn run_serve(args: ServeArgs) {
         }
     };
 
-    eprintln!("vize musea: starting Vite-backed component gallery...");
+    let action = if args.build { " build" } else { "" };
+    eprintln!("vize musea: starting Vite-backed gallery{}...", action);
     eprintln!(
         "  command: {} {}",
         plan.program.display(),
@@ -113,10 +111,19 @@ fn run_serve(args: ServeArgs) {
             .collect::<Vec<_>>()
             .join(" ")
     );
-    eprintln!("  route: configure @vizejs/vite-plugin-musea in Vite and open /__musea__");
+    if args.build {
+        eprintln!("  output: Musea static gallery entry is emitted under /__musea__/");
+    } else {
+        eprintln!("  route: configure @vizejs/vite-plugin-musea in Vite and open /__musea__");
+    }
 
     let status = Command::new(&plan.program)
         .args(plan.args.iter().map(|arg| arg.as_str()))
+        .envs(
+            plan.env
+                .iter()
+                .map(|item| (item.0.as_str(), item.1.as_str())),
+        )
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
@@ -142,6 +149,7 @@ fn run_serve(args: ServeArgs) {
 struct ServePlan {
     program: PathBuf,
     args: Vec<String>,
+    env: Vec<(String, String)>,
 }
 
 fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePlan, String> {
@@ -159,12 +167,15 @@ fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePlan, String> 
         }
         None => PathBuf::from("vite"),
     };
-    if args.build {
-        return Err(cstr!(
-            "vize musea: static gallery build is not supported yet.\n  The Vite-backed Musea gallery is served by dev middleware, so `vite build` can exit successfully without emitting `.art.vue` gallery content.\n  Use `vize musea serve` for the dev gallery or keep a Storybook/static fallback until Musea static export is available."
-        ));
-    }
     validate_direct_vite_musea_setup(cwd)?;
+    if args.build {
+        return Ok(ServePlan {
+            program,
+            args: vec![cstr!("build")],
+            env: vec![(cstr!("VIZE_MUSEA_STATIC_BUILD"), cstr!("1"))],
+        });
+    }
+
     let mut vite_args = vec![
         cstr!("dev"),
         cstr!("--host"),
@@ -182,13 +193,14 @@ fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePlan, String> 
     Ok(ServePlan {
         program,
         args: vite_args,
+        env: Vec::new(),
     })
 }
 
 fn resolve_vite_binary(cwd: &Path) -> Option<PathBuf> {
     for ancestor in cwd.ancestors() {
         let bin_dir = ancestor.join("node_modules").join(".bin");
-        for name in vite_bin_names() {
+        for name in VITE_BIN_NAMES {
             let candidate = bin_dir.join(name);
             if candidate.is_file() {
                 return Some(candidate);
@@ -239,14 +251,10 @@ fn nuxt_musea_message(root: &Path, build: bool) -> String {
 }
 
 #[cfg(windows)]
-fn vite_bin_names() -> &'static [&'static str] {
-    &["vite.cmd", "vite.ps1", "vite"]
-}
+const VITE_BIN_NAMES: &[&str] = &["vite.cmd", "vite.ps1", "vite"];
 
 #[cfg(not(windows))]
-fn vite_bin_names() -> &'static [&'static str] {
-    &["vite"]
-}
+const VITE_BIN_NAMES: &[&str] = &["vite"];
 
 fn run_new(args: NewArgs) {
     let target_dir = args.path.unwrap_or_else(|| PathBuf::from("."));
@@ -266,14 +274,12 @@ fn run_new(args: NewArgs) {
         project_name
     );
 
-    // Create art directory structure
     let stories_dir = target_dir.join("stories");
     if let Err(e) = fs::create_dir_all(&stories_dir) {
         eprintln!("vize musea new: failed to create stories directory: {}", e);
         std::process::exit(1);
     }
 
-    // Create example art file
     let example_story = stories_dir.join("Button.art.vue");
     let example_content = r#"<script setup lang="ts">
 defineArt("../src/Button.vue", {
@@ -312,7 +318,6 @@ defineArt("../src/Button.vue", {
         std::process::exit(1);
     }
 
-    // Create vize.config.ts
     let config_path = target_dir.join("vize.config.ts");
     if !config_path.exists() {
         let config_content = r#"import { defineConfig } from "vize";

--- a/crates/vize/src/commands/musea/tests.rs
+++ b/crates/vize/src/commands/musea/tests.rs
@@ -1,11 +1,11 @@
-use super::{ServeArgs, create_serve_plan, resolve_vite_binary, vite_bin_names};
+use super::{ServeArgs, VITE_BIN_NAMES, create_serve_plan, resolve_vite_binary};
 use std::fs;
 use std::path::{Path, PathBuf};
 
 fn write_vite_bin(root: &Path) -> PathBuf {
     let bin_dir = root.join("node_modules").join(".bin");
     fs::create_dir_all(&bin_dir).unwrap();
-    let vite_bin = bin_dir.join(vite_bin_names()[0]);
+    let vite_bin = bin_dir.join(VITE_BIN_NAMES[0]);
     fs::write(&vite_bin, "").unwrap();
     vite_bin
 }
@@ -91,11 +91,12 @@ fn serve_plan_rejects_missing_musea_vite_plugin_setup() {
 }
 
 #[test]
-fn serve_plan_rejects_static_build_with_actionable_message() {
+fn serve_plan_runs_static_build_with_musea_environment() {
     let temp = tempfile::tempdir().unwrap();
-    write_vite_bin(temp.path());
+    let vite_bin = write_vite_bin(temp.path());
+    write_musea_vite_setup(temp.path());
 
-    let error = create_serve_plan(
+    let plan = create_serve_plan(
         &ServeArgs {
             build: true,
             open: true,
@@ -104,11 +105,11 @@ fn serve_plan_rejects_static_build_with_actionable_message() {
         },
         temp.path(),
     )
-    .unwrap_err();
+    .unwrap();
 
-    assert!(error.contains("static gallery build is not supported yet"));
-    assert!(error.contains("without emitting `.art.vue` gallery content"));
-    assert!(error.contains("Storybook/static fallback"));
+    assert_eq!(plan.program, vite_bin);
+    assert_eq!(plan.args, ["build"]);
+    assert_eq!(plan.env, [("VIZE_MUSEA_STATIC_BUILD".into(), "1".into())]);
 }
 
 #[test]

--- a/npm/vite-plugin-musea/gallery/api.ts
+++ b/npm/vite-plugin-musea/gallery/api.ts
@@ -1,4 +1,16 @@
 import type { ArtFileInfo } from "../src/types/index.js";
+import {
+  emptyA11y,
+  emptyDocs,
+  emptyPalette,
+  emptyTokens,
+  fetchStaticDetail,
+  fetchStaticPayload,
+  getStaticPreviewUrl,
+  isStaticGallery,
+  joinBasePath,
+  staticMutationError,
+} from "./staticApi";
 
 export interface PaletteControl {
   name: string;
@@ -65,7 +77,7 @@ function mutationHeaders(): HeadersInit {
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
-  const res = await fetch(basePath + url);
+  const res = await fetch(joinBasePath(url));
   if (!res.ok) {
     throw new Error(`API error: ${res.status} ${res.statusText}`);
   }
@@ -73,39 +85,58 @@ async function fetchJson<T>(url: string): Promise<T> {
 }
 
 export async function fetchArts(): Promise<ArtFileInfo[]> {
+  if (isStaticGallery) return (await fetchStaticPayload()).arts;
   return fetchJson<ArtFileInfo[]>("/api/arts");
 }
 
 export async function fetchArt(artPath: string): Promise<ArtFileInfo> {
+  if (isStaticGallery) {
+    const art = (await fetchStaticPayload()).arts.find((item) => item.path === artPath);
+    if (!art) throw new Error(`Art not found: ${artPath}`);
+    return art;
+  }
   return fetchJson<ArtFileInfo>(`/api/arts/${encodeURIComponent(artPath)}`);
 }
 
 export async function fetchPalette(artPath: string): Promise<PaletteApiResponse> {
+  if (isStaticGallery) return (await fetchStaticDetail(artPath)).palette ?? emptyPalette();
   return fetchJson<PaletteApiResponse>(`/api/arts/${encodeURIComponent(artPath)}/palette`);
 }
 
 export async function fetchAnalysis(artPath: string): Promise<AnalysisApiResponse> {
+  if (isStaticGallery) {
+    return (await fetchStaticDetail(artPath)).analysis ?? { props: [], emits: [] };
+  }
   return fetchJson<AnalysisApiResponse>(`/api/arts/${encodeURIComponent(artPath)}/analysis`);
 }
 
 export async function fetchDocs(artPath: string): Promise<DocApiResponse> {
+  if (isStaticGallery) return (await fetchStaticDetail(artPath)).docs ?? emptyDocs();
   return fetchJson<DocApiResponse>(`/api/arts/${encodeURIComponent(artPath)}/docs`);
 }
 
 export async function fetchA11y(artPath: string, variantName: string): Promise<A11yApiResponse> {
+  if (isStaticGallery) {
+    return (await fetchStaticDetail(artPath)).a11y?.[variantName] ?? emptyA11y();
+  }
   return fetchJson<A11yApiResponse>(
     `/api/arts/${encodeURIComponent(artPath)}/variants/${encodeURIComponent(variantName)}/a11y`,
   );
 }
 
 export function getPreviewUrl(artPath: string, variantName: string): string {
-  return `${basePath}/preview?art=${encodeURIComponent(artPath)}&variant=${encodeURIComponent(variantName)}`;
+  if (isStaticGallery) {
+    const preview = getStaticPreviewUrl(artPath, variantName);
+    if (preview) return preview;
+  }
+  const art = encodeURIComponent(artPath);
+  const variant = encodeURIComponent(variantName);
+  return `${joinBasePath("/preview")}?art=${art}&variant=${variant}`;
 }
 
 export function getBasePath(): string {
   return basePath;
 }
-
 export interface VrtResult {
   artPath: string;
   variantName: string;
@@ -178,6 +209,7 @@ export interface TokenMutationResponse {
 }
 
 export async function fetchTokens(): Promise<TokensApiResponse> {
+  if (isStaticGallery) return (await fetchStaticPayload()).tokens ?? emptyTokens();
   return fetchJson<TokensApiResponse>("/api/tokens");
 }
 
@@ -185,7 +217,8 @@ export async function createToken(
   tokenPath: string,
   token: Omit<DesignToken, "$resolvedValue">,
 ): Promise<TokenMutationResponse> {
-  const res = await fetch(basePath + "/api/tokens", {
+  if (isStaticGallery) throw staticMutationError();
+  const res = await fetch(joinBasePath("/api/tokens"), {
     method: "POST",
     headers: mutationHeaders(),
     body: JSON.stringify({ path: tokenPath, token }),
@@ -201,7 +234,8 @@ export async function updateToken(
   tokenPath: string,
   token: Omit<DesignToken, "$resolvedValue">,
 ): Promise<TokenMutationResponse> {
-  const res = await fetch(basePath + "/api/tokens", {
+  if (isStaticGallery) throw staticMutationError();
+  const res = await fetch(joinBasePath("/api/tokens"), {
     method: "PUT",
     headers: mutationHeaders(),
     body: JSON.stringify({ path: tokenPath, token }),
@@ -214,7 +248,8 @@ export async function updateToken(
 }
 
 export async function deleteToken(tokenPath: string): Promise<TokenMutationResponse> {
-  const res = await fetch(basePath + "/api/tokens", {
+  if (isStaticGallery) throw staticMutationError();
+  const res = await fetch(joinBasePath("/api/tokens"), {
     method: "DELETE",
     headers: mutationHeaders(),
     body: JSON.stringify({ path: tokenPath }),
@@ -248,10 +283,14 @@ export interface ArtSourceResponse {
 }
 
 export async function fetchTokenUsage(): Promise<TokenUsageMap> {
+  if (isStaticGallery) return (await fetchStaticPayload()).tokenUsage ?? {};
   return fetchJson<TokenUsageMap>("/api/tokens/usage");
 }
 
 export async function fetchArtSource(artPath: string): Promise<ArtSourceResponse> {
+  if (isStaticGallery) {
+    return (await fetchStaticDetail(artPath)).source ?? { source: "", path: artPath };
+  }
   return fetchJson<ArtSourceResponse>(`/api/arts/${encodeURIComponent(artPath)}/source`);
 }
 
@@ -259,7 +298,8 @@ export async function updateArtSource(
   artPath: string,
   source: string,
 ): Promise<{ success: boolean }> {
-  const res = await fetch(basePath + `/api/arts/${encodeURIComponent(artPath)}/source`, {
+  if (isStaticGallery) throw staticMutationError();
+  const res = await fetch(joinBasePath(`/api/arts/${encodeURIComponent(artPath)}/source`), {
     method: "PUT",
     headers: mutationHeaders(),
     body: JSON.stringify({ source }),
@@ -272,7 +312,8 @@ export async function updateArtSource(
 }
 
 export async function runVrt(artPath?: string, updateSnapshots?: boolean): Promise<VrtApiResponse> {
-  const res = await fetch(basePath + "/api/run-vrt", {
+  if (isStaticGallery) throw staticMutationError();
+  const res = await fetch(joinBasePath("/api/run-vrt"), {
     method: "POST",
     headers: mutationHeaders(),
     body: JSON.stringify({ artPath, updateSnapshots }),

--- a/npm/vite-plugin-musea/gallery/staticApi.ts
+++ b/npm/vite-plugin-musea/gallery/staticApi.ts
@@ -1,0 +1,89 @@
+import type { ArtFileInfo } from "../src/types/index.js";
+import type {
+  A11yApiResponse,
+  AnalysisApiResponse,
+  ArtSourceResponse,
+  DocApiResponse,
+  PaletteApiResponse,
+  TokensApiResponse,
+  TokenUsageMap,
+} from "./api";
+
+const win = window as unknown as {
+  __MUSEA_BASE_PATH__?: string;
+  __MUSEA_STATIC__?: boolean;
+  __MUSEA_STATIC_PREVIEWS__?: Record<string, Record<string, string>>;
+};
+
+const basePath = win.__MUSEA_BASE_PATH__ ?? "/__musea__";
+const staticPreviews = win.__MUSEA_STATIC_PREVIEWS__ ?? {};
+
+export const isStaticGallery = Boolean(win.__MUSEA_STATIC__);
+
+export interface StaticGalleryPayload {
+  arts: ArtFileInfo[];
+  previews: Record<string, Record<string, string>>;
+  details: Record<
+    string,
+    {
+      source?: ArtSourceResponse;
+      palette?: PaletteApiResponse;
+      analysis?: AnalysisApiResponse;
+      docs?: DocApiResponse;
+      a11y?: Record<string, A11yApiResponse>;
+    }
+  >;
+  tokens?: TokensApiResponse;
+  tokenUsage?: TokenUsageMap;
+}
+
+let staticPayloadPromise: Promise<StaticGalleryPayload> | null = null;
+
+export function joinBasePath(url: string): string {
+  const normalizedBase = basePath === "/" ? "" : basePath.replace(/\/+$/, "");
+  return `${normalizedBase}${url.startsWith("/") ? url : `/${url}`}`;
+}
+
+export async function fetchStaticPayload(): Promise<StaticGalleryPayload> {
+  staticPayloadPromise ??= fetch(joinBasePath("/api/static.json")).then((res) => {
+    if (!res.ok) throw new Error(`API error: ${res.status} ${res.statusText}`);
+    return res.json() as Promise<StaticGalleryPayload>;
+  });
+  return staticPayloadPromise;
+}
+
+export async function fetchStaticDetail(
+  artPath: string,
+): Promise<StaticGalleryPayload["details"][string]> {
+  const detail = (await fetchStaticPayload()).details[artPath];
+  if (!detail) throw new Error(`Art not found: ${artPath}`);
+  return detail;
+}
+
+export function getStaticPreviewUrl(artPath: string, variantName: string): string | undefined {
+  return staticPreviews[artPath]?.[variantName];
+}
+
+export function staticMutationError(): Error {
+  return new Error("This action is not available in a static Musea gallery.");
+}
+
+export function emptyPalette(): PaletteApiResponse {
+  return { title: "", controls: [], groups: [], json: "{}", typescript: "" };
+}
+
+export function emptyDocs(): DocApiResponse {
+  return { markdown: "", title: "", variant_count: 0 };
+}
+
+export function emptyA11y(): A11yApiResponse {
+  return { violations: [], passes: 0, incomplete: 0 };
+}
+
+export function emptyTokens(): TokensApiResponse {
+  return {
+    categories: [],
+    tokenMap: {},
+    meta: { filePath: "", tokenCount: 0, primitiveCount: 0, semanticCount: 0 },
+  };
+}

--- a/npm/vite-plugin-musea/src/plugin/index.ts
+++ b/npm/vite-plugin-musea/src/plugin/index.ts
@@ -1,20 +1,7 @@
-/**
- * Main Musea Vite plugin implementation.
- *
- * Contains the `musea()` factory function that creates the Vite plugin,
- * including dev server middleware, config resolution, and build-start scanning.
- *
- * Virtual module hooks (resolveId / load / handleHotUpdate) are extracted into
- * `virtual.ts`.
- *
- * Middleware and API route logic is extracted into:
- * - `server-middleware.ts` -- gallery SPA, preview, art module serving
- * - `api-routes.ts` -- REST API endpoints for gallery UI
- */
-
 import type { Plugin, ViteDevServer, ResolvedConfig } from "vite";
 import { transformWithEsbuild } from "vite";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { vizeConfigStore } from "@vizejs/vite-plugin";
 
@@ -40,6 +27,23 @@ import {
 } from "./virtual.js";
 import { shouldApplyMuseaPlugin } from "./apply.js";
 import { watchMuseaArtFiles } from "./watch.js";
+import {
+  emitStaticGallery,
+  isMuseaStaticBuild,
+  loadStaticRuntimeModule,
+  museaStaticBuildConfig,
+  resolveStaticRuntimeId,
+} from "../static-export.js";
+
+const require = createRequire(import.meta.url);
+
+function resolveVueRuntimeCompiler(): string {
+  try {
+    return require.resolve("vue/dist/vue.esm-bundler.js");
+  } catch {
+    return "vue/dist/vue.esm-bundler.js";
+  }
+}
 
 function extractArtTagAttributes(source: string): Record<string, string | true> {
   const artTagMatch = source.match(/<art\b([\s\S]*?)>/i);
@@ -104,9 +108,6 @@ function extractStyleBlocks(source: string): string[] {
   return styles;
 }
 
-/**
- * Create Musea Vite plugin.
- */
 export function musea(options: MuseaOptions = {}): Plugin[] {
   let include = options.include ?? ["**/*.art.vue"];
   let exclude = options.exclude ?? ["node_modules/**", "dist/**"];
@@ -127,7 +128,6 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
   let resolvedPreviewSetup: string | null = null;
   let scanRoots: string[] = [];
 
-  // Shared state for virtual module hooks
   const virtualState: VirtualModuleState = {
     basePath,
     get inlineArt() {
@@ -142,12 +142,10 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
     processArtFile,
   };
 
-  // Create virtual module hooks
-  const resolveId = createResolveId(virtualState);
-  const load = createLoad(virtualState);
+  const virtualResolveId = createResolveId(virtualState);
+  const virtualLoad = createLoad(virtualState);
   const handleHotUpdate = createHandleHotUpdate(virtualState);
 
-  // Main plugin
   const mainPlugin: Plugin = {
     name: "vite-plugin-musea",
     enforce: "pre",
@@ -156,25 +154,22 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
     },
 
     config() {
-      // Add Vue alias for runtime template compilation
-      // This is needed because variant templates are compiled at runtime
       return {
         resolve: {
           alias: {
-            vue: "vue/dist/vue.esm-bundler.js",
+            vue: resolveVueRuntimeCompiler(),
           },
         },
+        ...(isMuseaStaticBuild() ? museaStaticBuildConfig() : {}),
       };
     },
 
     configResolved(resolvedConfig) {
       config = resolvedConfig;
 
-      // Merge musea config from vize.config.ts (plugin args > config file > defaults)
       const vizeConfig = vizeConfigStore.get(resolvedConfig.root);
       if (vizeConfig?.musea) {
         const mc = vizeConfig.musea;
-        // Only apply config file values when plugin options were not explicitly set
         if (!options.include && mc.include) include = mc.include;
         if (!options.exclude && mc.exclude) exclude = mc.exclude;
         if (!options.basePath && mc.basePath) basePath = mc.basePath;
@@ -183,22 +178,18 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
         if (options.inlineArt === undefined && mc.inlineArt !== undefined) inlineArt = mc.inlineArt;
       }
 
-      // Update virtualState.basePath in case it changed from config resolution
       virtualState.basePath = basePath;
 
-      // Resolve previewCss paths to absolute paths
       resolvedPreviewCss = previewCss.map((cssPath) =>
         path.isAbsolute(cssPath) ? cssPath : path.resolve(resolvedConfig.root, cssPath),
       );
 
-      // Resolve previewSetup path
       if (previewSetup) {
         resolvedPreviewSetup = path.isAbsolute(previewSetup)
           ? previewSetup
           : path.resolve(resolvedConfig.root, previewSetup);
       }
 
-      // Update shared state references after resolution
       virtualState.resolvedPreviewCss = resolvedPreviewCss;
       virtualState.resolvedPreviewSetup = resolvedPreviewSetup;
       scanRoots = resolveScanRoots(resolvedConfig.root, include);
@@ -207,7 +198,6 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
     configureServer(devServer) {
       server = devServer;
 
-      // Register gallery SPA, preview, and art module middleware
       registerMiddleware(devServer, {
         basePath,
         devSessionToken,
@@ -218,7 +208,6 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
         resolvedPreviewSetup,
       });
 
-      // Register API endpoints
       devServer.middlewares.use(
         `${basePath}/api`,
         createApiMiddleware({
@@ -235,13 +224,11 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
         }),
       );
 
-      // Watch for Art file changes
       devServer.watcher.on("change", async (file) => {
         if (file.endsWith(".art.vue") && shouldProcess(file, include, exclude, config.root)) {
           await processArtFile(file);
           console.log(`[musea] Reloaded: ${path.relative(config.root, file)}`);
         }
-        // Inline art: re-check .vue files on change
         if (inlineArt && file.endsWith(".vue") && !file.endsWith(".art.vue")) {
           const hadArt = artFiles.has(file);
           const source = await fs.promises.readFile(file, "utf-8");
@@ -260,7 +247,6 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
           await processArtFile(file);
           console.log(`[musea] Added: ${path.relative(config.root, file)}`);
         }
-        // Inline art: check new .vue files
         if (inlineArt && file.endsWith(".vue") && !file.endsWith(".art.vue")) {
           const source = await fs.promises.readFile(file, "utf-8");
           if (source.includes("<art")) {
@@ -277,14 +263,12 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
         }
       });
 
-      // Print Musea gallery URL after server starts
       return () => {
         devServer.httpServer?.once("listening", () => {
           const address = devServer.httpServer?.address();
           if (address && typeof address === "object") {
             const protocol = devServer.config.server.https ? "https" : "http";
             const rawHost = address.address;
-            // Normalize IPv6/IPv4 localhost addresses to "localhost"
             const host =
               rawHost === "::" ||
               rawHost === "::1" ||
@@ -303,7 +287,6 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
     },
 
     async buildStart() {
-      // Scan for Art files
       console.log(`[musea] config.root: ${config.root}, include: ${JSON.stringify(include)}`);
       const files = await scanArtFiles(config.root, include, exclude, inlineArt);
 
@@ -317,14 +300,31 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
         await processArtFile(file);
       }
 
-      // Generate Storybook CSF if enabled
       if (storybookCompat) {
         await generateStorybookFiles(artFiles, config.root, storybookOutDir);
       }
     },
 
-    resolveId,
-    load,
+    resolveId(id) {
+      return resolveStaticRuntimeId(id) ?? virtualResolveId(id);
+    },
+    load(id) {
+      return loadStaticRuntimeModule(id, artFiles) ?? virtualLoad(id);
+    },
+    async generateBundle(_options, bundle) {
+      if (!isMuseaStaticBuild()) return;
+      await emitStaticGallery((asset) => void this.emitFile(asset), bundle, {
+        config,
+        artFiles,
+        scanRoots,
+        tokensPath,
+        basePath,
+        resolvedPreviewCss,
+        resolvedPreviewSetup,
+        devSessionToken,
+        themeConfig,
+      });
+    },
     async transform(code, id) {
       if (!id.includes("?musea-virtual")) {
         return null;
@@ -350,8 +350,6 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
     handleHotUpdate,
   };
 
-  // Helper functions scoped to this plugin instance
-
   async function processArtFile(filePath: string): Promise<void> {
     try {
       const source = await fs.promises.readFile(filePath, "utf-8");
@@ -359,7 +357,6 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
       const parsed = binding.parseArt(source, { filename: filePath });
       const customMetadata = extractCustomArtMetadata(source);
 
-      // Skip files with no variants (e.g. .vue files without <art> block)
       if (!parsed.variants || parsed.variants.length === 0) return;
 
       const isInline = !filePath.endsWith(".art.vue");

--- a/npm/vite-plugin-musea/src/preview/addons.ts
+++ b/npm/vite-plugin-musea/src/preview/addons.ts
@@ -254,7 +254,8 @@ function __museaInitAddons(container, variantName, extraCaptureEvents = []) {
             // Dynamically load axe-core from local vendor route if not already loaded
             if (!window.axe) {
               const script = document.createElement('script');
-              const _basePath = location.pathname.replace(/\\/preview$/, '');
+              const _basePath = window.__MUSEA_BASE_PATH__
+                || location.pathname.replace(/\\/preview(?:\\/[^/]+\\.html)?$/, '');
               script.src = _basePath + '/vendor/axe-core.min.js';
               await new Promise((resolve, reject) => {
                 script.onload = resolve;

--- a/npm/vite-plugin-musea/src/static-data.ts
+++ b/npm/vite-plugin-musea/src/static-data.ts
@@ -1,0 +1,186 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import type { ResolvedConfig } from "vite";
+
+import { handleTokensGet, handleTokensUsage } from "./api-tokens.js";
+import {
+  handleArtAnalysis,
+  handleArtA11y,
+  handleArtDocs,
+  handleArtPalette,
+  handleArtSource,
+} from "./api-routes/handlers.js";
+import type { ApiRoutesContext, SendError, SendJson } from "./api-routes/index.js";
+import type { ArtFileInfo } from "./types/index.js";
+
+export interface StaticGalleryPayload {
+  arts: ArtFileInfo[];
+  previews: Record<string, Record<string, string>>;
+  details: Record<string, StaticArtDetails>;
+  tokens: unknown;
+  tokenUsage: unknown;
+}
+
+export interface StaticArtDetails {
+  source: unknown;
+  palette: unknown;
+  analysis: unknown;
+  docs: unknown;
+  a11y: Record<string, unknown>;
+}
+
+export interface StaticGalleryDataContext {
+  config: ResolvedConfig;
+  artFiles: Map<string, ArtFileInfo>;
+  scanRoots: string[];
+  tokensPath: string | undefined;
+  basePath: string;
+  resolvedPreviewCss: string[];
+  resolvedPreviewSetup: string | null;
+  devSessionToken: string;
+}
+
+export function staticPreviewId(artPath: string, variantName: string): string {
+  return crypto
+    .createHash("sha256")
+    .update(artPath)
+    .update("\0")
+    .update(variantName)
+    .digest("hex")
+    .slice(0, 20);
+}
+
+export function joinUrlPath(basePath: string, ...segments: string[]): string {
+  const normalizedBase = basePath === "/" ? "" : basePath.replace(/\/+$/, "");
+  const suffix = segments
+    .map((segment) => segment.replace(/^\/+|\/+$/g, ""))
+    .filter(Boolean)
+    .join("/");
+  return `${normalizedBase}/${suffix}`;
+}
+
+export async function createStaticGalleryPayload(
+  ctx: StaticGalleryDataContext,
+): Promise<StaticGalleryPayload> {
+  const apiCtx = createApiContext(ctx);
+  const arts = Array.from(ctx.artFiles.values());
+  const previews: StaticGalleryPayload["previews"] = {};
+  const details: StaticGalleryPayload["details"] = {};
+
+  for (const art of arts) {
+    previews[art.path] = {};
+    const a11y: Record<string, unknown> = {};
+
+    for (const variant of art.variants) {
+      const id = staticPreviewId(art.path, variant.name);
+      previews[art.path][variant.name] = joinUrlPath(ctx.basePath, "preview", `${id}.html`);
+      a11y[variant.name] = await captureJson((sendJson, sendError) => {
+        handleArtA11y(apiCtx, artVariantMatch(art.path, variant.name), sendJson, sendError);
+      }, emptyA11y());
+    }
+
+    details[art.path] = {
+      source: await captureJson(
+        (sendJson, sendError) => {
+          return handleArtSource(apiCtx, artMatch(art.path), sendJson, sendError);
+        },
+        { source: "", path: art.path },
+      ),
+      palette: await captureJson((sendJson, sendError) => {
+        return handleArtPalette(apiCtx, artMatch(art.path), sendJson, sendError);
+      }, emptyPalette(art)),
+      analysis: await captureJson(
+        (sendJson, sendError) => {
+          return handleArtAnalysis(apiCtx, artMatch(art.path), sendJson, sendError);
+        },
+        { props: [], emits: [] },
+      ),
+      docs: await captureJson((sendJson, sendError) => {
+        return handleArtDocs(apiCtx, artMatch(art.path), sendJson, sendError);
+      }, emptyDocs(art)),
+      a11y,
+    };
+  }
+
+  return {
+    arts,
+    previews,
+    details,
+    tokens: await captureJson((sendJson) => handleTokensGet(apiCtx, sendJson), emptyTokens()),
+    tokenUsage: await captureJson((sendJson) => handleTokensUsage(apiCtx, sendJson), {}),
+  };
+}
+
+function createApiContext(ctx: StaticGalleryDataContext): ApiRoutesContext {
+  return {
+    config: ctx.config,
+    artFiles: ctx.artFiles,
+    scanRoots: ctx.scanRoots,
+    tokensPath: ctx.tokensPath,
+    basePath: ctx.basePath,
+    resolvedPreviewCss: ctx.resolvedPreviewCss,
+    resolvedPreviewSetup: ctx.resolvedPreviewSetup,
+    devSessionToken: ctx.devSessionToken,
+    processArtFile: async (filePath: string) => {
+      await fs.promises.access(filePath);
+    },
+    getDevServerPort: () => 5173,
+  };
+}
+
+async function captureJson<T>(
+  run: (sendJson: SendJson, sendError: SendError) => void | Promise<void>,
+  fallback: T,
+): Promise<unknown> {
+  let captured: unknown = fallback;
+  const sendJson: SendJson = (data: unknown) => {
+    captured = data;
+  };
+  const sendError: SendError = (message: string, status = 500) => {
+    captured = { error: message, status };
+  };
+  await run(sendJson, sendError);
+  return captured;
+}
+
+function artMatch(artPath: string): RegExpMatchArray {
+  return ["", encodeURIComponent(artPath)] as unknown as RegExpMatchArray;
+}
+
+function artVariantMatch(artPath: string, variantName: string): RegExpMatchArray {
+  return [
+    "",
+    encodeURIComponent(artPath),
+    encodeURIComponent(variantName),
+  ] as unknown as RegExpMatchArray;
+}
+
+function emptyPalette(art: ArtFileInfo): unknown {
+  return {
+    title: art.metadata.title,
+    controls: [],
+    groups: [],
+    json: "{}",
+    typescript: "",
+  };
+}
+
+function emptyDocs(art: ArtFileInfo): unknown {
+  return {
+    markdown: "",
+    title: art.metadata.title,
+    variant_count: art.variants.length,
+  };
+}
+
+function emptyA11y(): unknown {
+  return { violations: [], passes: 0, incomplete: 0 };
+}
+
+function emptyTokens(): unknown {
+  return {
+    categories: [],
+    tokenMap: {},
+    meta: { filePath: "", tokenCount: 0, primitiveCount: 0, semanticCount: 0 },
+  };
+}

--- a/npm/vite-plugin-musea/src/static-export.test.ts
+++ b/npm/vite-plugin-musea/src/static-export.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { joinUrlPath, staticPreviewId } from "./static-data.js";
+import { loadStaticRuntimeModule, VIRTUAL_STATIC_RUNTIME } from "./static-export.js";
+import type { ArtFileInfo } from "./types/index.js";
+
+function createArt(pathname: string): ArtFileInfo {
+  return {
+    path: pathname,
+    metadata: { title: "Button", tags: [], status: "ready" },
+    variants: [{ name: "Default", template: "<Button />", isDefault: true }],
+    hasScriptSetup: false,
+    hasScript: false,
+    styleCount: 0,
+    isInline: false,
+  };
+}
+
+void test("static gallery paths stay under the configured Musea base path", () => {
+  const previewId = staticPreviewId("/repo/src/Button.art.vue", "Default");
+
+  assert.equal(previewId.length, 20);
+  assert.equal(
+    joinUrlPath("/__musea__", "preview", `${previewId}.html`),
+    `/__musea__/preview/${previewId}.html`,
+  );
+});
+
+void test("static runtime keeps discovered preview modules reachable", () => {
+  const art = createArt("/repo/src/Button.art.vue");
+  const code = loadStaticRuntimeModule("\0musea-static-runtime", new Map([[art.path, art]]));
+
+  assert.ok(code);
+  assert.match(code, /loadMuseaPreview/);
+  assert.match(code, /virtual:musea-preview:\/repo\/src\/Button\.art\.vue:Default/);
+  assert.equal(loadStaticRuntimeModule(VIRTUAL_STATIC_RUNTIME, new Map()), null);
+});

--- a/npm/vite-plugin-musea/src/static-export.ts
+++ b/npm/vite-plugin-musea/src/static-export.ts
@@ -1,0 +1,287 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { serializeScriptValue } from "./security.js";
+import {
+  createStaticGalleryPayload,
+  joinUrlPath,
+  staticPreviewId,
+  type StaticGalleryDataContext,
+  type StaticGalleryPayload,
+} from "./static-data.js";
+import type { ArtFileInfo } from "./types/index.js";
+import { escapeHtml } from "./utils.js";
+
+export const MUSEA_STATIC_BUILD_ENV = "VIZE_MUSEA_STATIC_BUILD";
+export const VIRTUAL_STATIC_RUNTIME = "virtual:musea-static-runtime";
+
+const RESOLVED_STATIC_RUNTIME = "\0musea-static-runtime";
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+type OutputBundle = Record<string, OutputChunk | { type: string; fileName: string }>;
+type OutputChunk = {
+  type: "chunk";
+  name: string;
+  fileName: string;
+  facadeModuleId: string | null;
+};
+
+export interface StaticEmitContext extends StaticGalleryDataContext {
+  themeConfig: { default: string; custom?: Record<string, unknown> } | undefined;
+}
+
+export function isMuseaStaticBuild(): boolean {
+  return process.env[MUSEA_STATIC_BUILD_ENV] === "1";
+}
+
+export function museaStaticBuildConfig(): { build: { rollupOptions: { input: object } } } {
+  return {
+    build: {
+      rollupOptions: {
+        input: { "musea-static-runtime": VIRTUAL_STATIC_RUNTIME },
+      },
+    },
+  };
+}
+
+export function resolveStaticRuntimeId(id: string): string | null {
+  return id === VIRTUAL_STATIC_RUNTIME ? RESOLVED_STATIC_RUNTIME : null;
+}
+
+export function loadStaticRuntimeModule(
+  id: string,
+  artFiles: Map<string, ArtFileInfo>,
+): string | null {
+  if (id !== RESOLVED_STATIC_RUNTIME) return null;
+
+  const entries = Array.from(artFiles.values()).flatMap((art) =>
+    art.variants.map((variant) => {
+      const key = staticPreviewId(art.path, variant.name);
+      const moduleId = `virtual:musea-preview:${art.path}:${variant.name}`;
+      return `${JSON.stringify(key)}: () => import(${JSON.stringify(moduleId)})`;
+    }),
+  );
+
+  return `
+const loaders = { ${entries.join(",\n")} };
+
+export async function loadMuseaPreview(id) {
+  const load = loaders[id];
+  if (!load) throw new Error("Musea preview not found: " + id);
+  await load();
+}
+
+if (typeof window !== "undefined") {
+  window.__MUSEA_LOAD_PREVIEW__ = loadMuseaPreview;
+}
+`;
+}
+
+export async function emitStaticGallery(
+  emitFile: (asset: { type: "asset"; fileName: string; source: string | Uint8Array }) => void,
+  bundle: OutputBundle,
+  ctx: StaticEmitContext,
+): Promise<void> {
+  const runtimeFileName = findRuntimeFileName(bundle);
+  if (!runtimeFileName) {
+    throw new Error("musea static build could not find its generated runtime entry");
+  }
+
+  const payload = await createStaticGalleryPayload(ctx);
+  const staticRoot = staticRootFromBasePath(ctx.basePath);
+  await emitGalleryShell(emitFile, staticRoot, ctx, payload);
+  emitFile({
+    type: "asset",
+    fileName: joinFileName(staticRoot, "api", "static.json"),
+    source: JSON.stringify(payload, null, 2),
+  });
+  emitFile({
+    type: "asset",
+    fileName: joinFileName(staticRoot, "api", "arts"),
+    source: JSON.stringify(payload.arts, null, 2),
+  });
+  await emitAxeVendor(emitFile, staticRoot);
+  emitPreviewHtml(emitFile, staticRoot, runtimeFileName, ctx.basePath, payload, ctx.artFiles);
+  emitRootRedirect(emitFile, staticRoot, ctx.basePath);
+}
+
+function findRuntimeFileName(bundle: OutputBundle): string | null {
+  for (const item of Object.values(bundle)) {
+    if (item.type === "chunk" && item.name === "musea-static-runtime") {
+      return item.fileName;
+    }
+  }
+  return null;
+}
+
+async function emitGalleryShell(
+  emitFile: (asset: { type: "asset"; fileName: string; source: string | Uint8Array }) => void,
+  staticRoot: string,
+  ctx: StaticEmitContext,
+  payload: StaticGalleryPayload,
+): Promise<void> {
+  const galleryDir = resolveGalleryDistDir();
+  if (!galleryDir) {
+    const { generateGalleryHtml } = await import("./gallery/index.js");
+    const html = injectStaticGlobals(
+      generateGalleryHtml(ctx.basePath, "", ctx.themeConfig),
+      ctx,
+      payload,
+    );
+    emitFile({ type: "asset", fileName: joinFileName(staticRoot, "index.html"), source: html });
+    return;
+  }
+
+  for (const filePath of await collectFiles(galleryDir)) {
+    const relative = path.relative(galleryDir, filePath).split(path.sep).join("/");
+    const target = joinFileName(staticRoot, relative);
+    const content = await fs.promises.readFile(filePath);
+    if (relative === "index.html") {
+      const html = injectStaticGlobals(content.toString("utf-8"), ctx, payload);
+      emitFile({ type: "asset", fileName: target, source: rewriteGalleryBase(html, ctx.basePath) });
+    } else {
+      emitFile({ type: "asset", fileName: target, source: content });
+    }
+  }
+
+  if (payload.arts.length === 0) {
+    return;
+  }
+}
+
+function emitPreviewHtml(
+  emitFile: (asset: { type: "asset"; fileName: string; source: string }) => void,
+  staticRoot: string,
+  runtimeFileName: string,
+  basePath: string,
+  payload: StaticGalleryPayload,
+  artFiles: Map<string, ArtFileInfo>,
+): void {
+  const previewDir = joinFileName(staticRoot, "preview");
+  const runtimeUrl = relativeUrl(previewDir, runtimeFileName);
+
+  for (const art of artFiles.values()) {
+    for (const variant of art.variants) {
+      const id = staticPreviewId(art.path, variant.name);
+      const html = generateStaticPreviewHtml(art, variant.name, id, basePath, runtimeUrl);
+      emitFile({ type: "asset", fileName: joinFileName(previewDir, `${id}.html`), source: html });
+    }
+  }
+
+  void payload;
+}
+
+function generateStaticPreviewHtml(
+  art: ArtFileInfo,
+  variantName: string,
+  previewId: string,
+  basePath: string,
+  runtimeUrl: string,
+): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(art.metadata.title)} - ${escapeHtml(variantName)}</title>
+  <script>window.__MUSEA_BASE_PATH__=${serializeScriptValue(basePath)};</script>
+  <style>html,body{width:100%;height:100%;margin:0}body{font-family:system-ui,sans-serif;background:#fff;padding:1rem;overflow:auto;box-sizing:border-box}.musea-variant{min-height:calc(100vh - 2rem)}.musea-error{color:#dc2626;background:#fef2f2;border:1px solid #fecaca;border-radius:8px;padding:1rem;font-size:.875rem}.musea-loading{color:#6b7280;font-size:.875rem}.musea-bg-checkerboard{background-image:linear-gradient(45deg,#ccc 25%,transparent 25%),linear-gradient(-45deg,#ccc 25%,transparent 25%),linear-gradient(45deg,transparent 75%,#ccc 75%),linear-gradient(-45deg,transparent 75%,#ccc 75%)!important;background-size:20px 20px!important;background-position:0 0,0 10px,10px -10px,-10px 0!important}</style>
+</head>
+<body>
+  <div id="app" class="musea-variant" data-art="${escapeHtml(art.path)}" data-variant="${escapeHtml(variantName)}">
+    <div class="musea-loading">Loading component...</div>
+  </div>
+  <script type="module">
+    import { loadMuseaPreview } from ${JSON.stringify(runtimeUrl)};
+    loadMuseaPreview(${JSON.stringify(previewId)}).catch((error) => {
+      const el = document.getElementById("app");
+      if (el) el.textContent = error instanceof Error ? error.message : String(error);
+    });
+  </script>
+</body>
+</html>`;
+}
+
+function injectStaticGlobals(
+  html: string,
+  ctx: StaticEmitContext,
+  payload: StaticGalleryPayload,
+): string {
+  const themeScript = ctx.themeConfig
+    ? `window.__MUSEA_THEME_CONFIG__=${serializeScriptValue(ctx.themeConfig)};`
+    : "";
+  const script = `<script>window.__MUSEA_BASE_PATH__=${serializeScriptValue(ctx.basePath)};window.__MUSEA_STATIC__=true;window.__MUSEA_STATIC_PREVIEWS__=${serializeScriptValue(payload.previews)};${themeScript}</script>`;
+  return html.includes("</head>")
+    ? html.replace("</head>", `${script}</head>`)
+    : `${script}${html}`;
+}
+
+function rewriteGalleryBase(html: string, basePath: string): string {
+  return html.replaceAll("/__musea__/", `${basePath.replace(/\/?$/, "/")}`);
+}
+
+function emitRootRedirect(
+  emitFile: (asset: { type: "asset"; fileName: string; source: string }) => void,
+  staticRoot: string,
+  basePath: string,
+): void {
+  if (!staticRoot) return;
+  const target = joinUrlPath(basePath, "");
+  emitFile({
+    type: "asset",
+    fileName: "index.html",
+    source: `<!doctype html><meta charset="utf-8"><meta http-equiv="refresh" content="0; url=${target}"><script>location.replace(${JSON.stringify(target)}+location.search+location.hash)</script>`,
+  });
+}
+
+async function emitAxeVendor(
+  emitFile: (asset: { type: "asset"; fileName: string; source: string | Uint8Array }) => void,
+  staticRoot: string,
+): Promise<void> {
+  try {
+    const require = createRequire(import.meta.url);
+    const axePath = require.resolve("axe-core/axe.min.js");
+    const source = await fs.promises.readFile(axePath);
+    emitFile({
+      type: "asset",
+      fileName: joinFileName(staticRoot, "vendor/axe-core.min.js"),
+      source,
+    });
+  } catch {
+    // axe-core is an optional peer; static a11y keeps the same best-effort behavior as dev.
+  }
+}
+
+function resolveGalleryDistDir(): string | null {
+  const candidates = [path.join(moduleDir, "gallery"), path.resolve(moduleDir, "../dist/gallery")];
+  return candidates.find((candidate) => fs.existsSync(path.join(candidate, "index.html"))) ?? null;
+}
+
+async function collectFiles(dir: string): Promise<string[]> {
+  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const filePath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(filePath)));
+    } else {
+      files.push(filePath);
+    }
+  }
+  return files;
+}
+
+function staticRootFromBasePath(basePath: string): string {
+  return basePath.replace(/^\/+|\/+$/g, "");
+}
+
+function joinFileName(...parts: string[]): string {
+  return parts.filter(Boolean).join("/");
+}
+
+function relativeUrl(fromDir: string, toFile: string): string {
+  const relative = path.posix.relative(fromDir || ".", toFile);
+  return relative.startsWith(".") ? relative : `./${relative}`;
+}


### PR DESCRIPTION
## Summary
- run `vize musea --build` through a Musea-specific Vite static build mode
- emit the packaged gallery shell, static API payload, preview pages, and preview runtime assets under `/__musea__/`
- make the gallery client read static payloads and disable mutation-only actions in static output

Closes #1846

## Verification
- pnpm -C npm/vite-plugin-musea check
- pnpm -C npm/vite-plugin-musea test
- pnpm -C npm/vite-plugin-musea build
- cargo test -p vize commands::musea -- --nocapture
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- VIZE_MUSEA_STATIC_BUILD=1 pnpm exec vp build --config <temp>/vite.config.mjs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->