### PR TITLE
fix(compiler): unref setup component tags

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -3,6 +3,7 @@
 //! This module generates JavaScript render function code from the transformed AST.
 
 mod children;
+mod component_binding;
 mod context;
 mod element;
 mod emit;

--- a/crates/vize_atelier_core/src/codegen/component_binding.rs
+++ b/crates/vize_atelier_core/src/codegen/component_binding.rs
@@ -1,0 +1,99 @@
+use crate::options::BindingType;
+use crate::{CodegenContext, RuntimeHelper};
+use vize_carton::{String, ToCompactString, camelize, capitalize};
+
+struct ComponentBinding {
+    name: String,
+    binding_type: BindingType,
+    suffix: Option<String>,
+}
+
+impl CodegenContext {
+    /// Check if a component is in binding metadata (from script setup).
+    pub fn is_component_in_bindings(&self, component: &str) -> bool {
+        self.resolve_component_binding_name(component).is_some()
+    }
+
+    /// Resolve the binding name for a component tag.
+    pub fn resolve_component_binding_name(&self, component: &str) -> Option<String> {
+        self.resolve_component_binding(component).map(|binding| {
+            if let Some(suffix) = binding.suffix {
+                let mut name = String::with_capacity(binding.name.len() + suffix.len() + 1);
+                name.push_str(binding.name.as_str());
+                name.push('.');
+                name.push_str(suffix.as_str());
+                name
+            } else {
+                binding.name
+            }
+        })
+    }
+
+    /// Push a component tag that resolves to a setup binding.
+    pub fn push_component_binding_tag(&mut self, component: &str) -> bool {
+        let Some(binding) = self.resolve_component_binding(component) else {
+            return false;
+        };
+
+        let needs_unref = self.options.inline
+            && matches!(
+                binding.binding_type,
+                BindingType::SetupLet | BindingType::SetupMaybeRef | BindingType::SetupRef
+            );
+        if needs_unref {
+            self.use_helper(RuntimeHelper::Unref);
+            self.push(self.helper(RuntimeHelper::Unref));
+            self.push("(");
+        }
+        if !self.options.inline {
+            self.push("$setup.");
+        }
+        self.push(binding.name.as_str());
+        if needs_unref {
+            self.push(")");
+        }
+        if let Some(suffix) = binding.suffix {
+            self.push(".");
+            self.push(suffix.as_str());
+        }
+        true
+    }
+
+    fn resolve_component_binding(&self, component: &str) -> Option<ComponentBinding> {
+        let metadata = self.options.binding_metadata.as_ref()?;
+
+        let resolve_base = |name: &str| {
+            if let Some(binding_type) = metadata.bindings.get(name) {
+                return Some((name.to_compact_string(), *binding_type));
+            }
+
+            let camel = camelize(name);
+            if let Some(binding_type) = metadata.bindings.get(camel.as_str()) {
+                return Some((camel, *binding_type));
+            }
+
+            let pascal = capitalize(&camel);
+            if let Some(binding_type) = metadata.bindings.get(pascal.as_str()) {
+                return Some((pascal, *binding_type));
+            }
+
+            None
+        };
+
+        if let Some((base, suffix)) = component.split_once('.') {
+            let (name, binding_type) = resolve_base(base)?;
+            return Some(ComponentBinding {
+                name,
+                binding_type,
+                suffix: Some(suffix.to_compact_string()),
+            });
+        }
+
+        let (name, binding_type) = resolve_base(component)?;
+        Some(ComponentBinding {
+            name,
+            binding_type,
+            suffix: None,
+        })
+    }
+}

--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -9,8 +9,6 @@ use super::source_map::SourceMapBuilder;
 use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::ToCompactString;
-use vize_carton::camelize;
-use vize_carton::capitalize;
 
 /// Code generation context using a UTF-8 string buffer for performance.
 pub struct CodegenContext {
@@ -319,45 +317,6 @@ impl CodegenContext {
     #[inline]
     pub fn use_helper(&mut self, helper: RuntimeHelper) {
         self.used_helpers.add(helper);
-    }
-
-    /// Check if a component is in binding metadata (from script setup)
-    pub fn is_component_in_bindings(&self, component: &str) -> bool {
-        self.resolve_component_binding_name(component).is_some()
-    }
-
-    /// Resolve the binding name for a component tag.
-    pub fn resolve_component_binding_name(&self, component: &str) -> Option<String> {
-        let metadata = self.options.binding_metadata.as_ref()?;
-
-        let resolve_base = |name: &str| {
-            if metadata.bindings.contains_key(name) {
-                return Some(name.to_compact_string());
-            }
-
-            let camel = camelize(name);
-            if metadata.bindings.contains_key(camel.as_str()) {
-                return Some(camel);
-            }
-
-            let pascal = capitalize(&camel);
-            if metadata.bindings.contains_key(pascal.as_str()) {
-                return Some(pascal);
-            }
-
-            None
-        };
-
-        if let Some((base, suffix)) = component.split_once('.') {
-            let resolved_base = resolve_base(base)?;
-            let mut resolved = String::with_capacity(resolved_base.len() + suffix.len() + 1);
-            resolved.push_str(resolved_base.as_str());
-            resolved.push('.');
-            resolved.push_str(suffix);
-            return Some(resolved);
-        }
-
-        resolve_base(component)
     }
 
     /// Push string to buffer (alias for `push`, compatible with `appends!`/`append!` macros)

--- a/crates/vize_atelier_core/src/codegen/element/block.rs
+++ b/crates/vize_atelier_core/src/codegen/element/block.rs
@@ -308,13 +308,7 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 // Check for built-in components (Teleport, KeepAlive, Suspense)
                 ctx.use_helper(builtin);
                 ctx.push(ctx.helper(builtin));
-            } else if let Some(binding_name) = ctx.resolve_component_binding_name(&el.tag) {
-                // In inline mode, components are directly in scope (imported at module level)
-                // In function mode, use $setup.ComponentName to access setup bindings
-                if !ctx.options.inline {
-                    ctx.push("$setup.");
-                }
-                ctx.push(&binding_name);
+            } else if ctx.push_component_binding_tag(&el.tag) {
             } else {
                 ctx.push(&to_valid_asset_identifier("component", &el.tag));
             }

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -263,11 +263,7 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             } else if let Some(builtin) = is_builtin_component(&el.tag) {
                 ctx.use_helper(builtin);
                 ctx.push(ctx.helper(builtin));
-            } else if let Some(binding_name) = ctx.resolve_component_binding_name(&el.tag) {
-                if !ctx.options.inline {
-                    ctx.push("$setup.");
-                }
-                ctx.push(&binding_name);
+            } else if ctx.push_component_binding_tag(&el.tag) {
             } else {
                 ctx.push(&to_valid_asset_identifier("component", &el.tag));
             }

--- a/crates/vize_atelier_core/src/codegen/element/v_once.rs
+++ b/crates/vize_atelier_core/src/codegen/element/v_once.rs
@@ -42,10 +42,12 @@ pub fn generate_v_once_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
     // Generate the element content
     if el.tag_type == ElementType::Component {
         ctx.use_helper(RuntimeHelper::CreateVNode);
-        ctx.use_helper(RuntimeHelper::ResolveComponent);
         ctx.push(ctx.helper(RuntimeHelper::CreateVNode));
         ctx.push("(");
-        ctx.push(&to_valid_asset_identifier("component", &el.tag));
+        if !ctx.push_component_binding_tag(&el.tag) {
+            ctx.use_helper(RuntimeHelper::ResolveComponent);
+            ctx.push(&to_valid_asset_identifier("component", &el.tag));
+        }
         ctx.push(")");
     } else {
         ctx.use_helper(RuntimeHelper::CreateElementVNode);

--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -227,11 +227,7 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
                     } else if let Some(builtin) = is_builtin_component(&el.tag) {
                         ctx.use_helper(builtin);
                         ctx.push(ctx.helper(builtin));
-                    } else if let Some(binding_name) = ctx.resolve_component_binding_name(&el.tag) {
-                        if !ctx.options.inline {
-                            ctx.push("$setup.");
-                        }
-                        ctx.push(&binding_name);
+                    } else if ctx.push_component_binding_tag(&el.tag) {
                     } else {
                         ctx.push(&to_valid_asset_identifier("component", &el.tag));
                     }

--- a/crates/vize_atelier_core/src/codegen/v_if/branch.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch.rs
@@ -205,13 +205,7 @@ fn generate_if_branch_component(
     } else if let Some(builtin) = is_builtin_component(&el.tag) {
         ctx.use_helper(builtin);
         ctx.push(ctx.helper(builtin));
-    } else if let Some(binding_name) = ctx.resolve_component_binding_name(&el.tag) {
-        // In inline mode, components are directly in scope (imported at module level)
-        // In function mode, use $setup.ComponentName to access setup bindings
-        if !ctx.options.inline {
-            ctx.push("$setup.");
-        }
-        ctx.push(binding_name.as_str());
+    } else if ctx.push_component_binding_tag(&el.tag) {
     } else {
         ctx.push(&to_valid_asset_identifier("component", &el.tag));
     }

--- a/crates/vize_atelier_dom/tests/setup_component_unref.rs
+++ b/crates/vize_atelier_dom/tests/setup_component_unref.rs
@@ -32,16 +32,29 @@ fn inline_setup_ref_component_tag_uses_unref() {
 
     let (_, errors, result) = compile_template_with_options(
         &allocator,
-        r#"<div><Menu>hello</Menu><Menu v-if="show" /><Menu v-for="item in items" :key="item" /></div>"#,
+        r#"<div><Menu>hello</Menu><Menu v-if="show" /><Menu v-for="item in items" :key="item" /><Menu v-once /><Menu.Item /></div>"#,
         options,
     );
 
     assert!(errors.is_empty(), "Errors: {:?}", errors);
     let full = full_output(&result.preamble, &result.code);
     assert!(full.contains("unref as _unref"), "{full}");
+    assert_eq!(
+        full.matches("_unref(Menu").count(),
+        5,
+        "every setup ref component tag path should be unref'd:\n{full}"
+    );
     assert!(
         full.contains("_createBlock(_unref(Menu)") || full.contains("_createVNode(_unref(Menu)"),
         "setup ref component tags must be unref'd:\n{full}"
+    );
+    assert!(
+        full.contains("_createVNode(_unref(Menu))"),
+        "v-once component tags must be unref'd:\n{full}"
+    );
+    assert!(
+        full.contains("_unref(Menu).Item"),
+        "dotted setup ref component tags must unref the base binding:\n{full}"
     );
     assert!(
         !full.contains("_createBlock(Menu") && !full.contains("_createVNode(Menu"),

--- a/crates/vize_atelier_dom/tests/setup_component_unref.rs
+++ b/crates/vize_atelier_dom/tests/setup_component_unref.rs
@@ -1,0 +1,50 @@
+use vize_atelier_core::options::{BindingMetadata, BindingType, CodegenMode};
+use vize_atelier_dom::{DomCompilerOptions, compile_template_with_options};
+use vize_carton::{Bump, FxHashMap, String};
+
+fn full_output(preamble: &str, code: &str) -> String {
+    let mut full = String::with_capacity(preamble.len() + code.len() + 1);
+    full.push_str(preamble);
+    full.push('\n');
+    full.push_str(code);
+    full
+}
+
+#[test]
+fn inline_setup_ref_component_tag_uses_unref() {
+    let allocator = Bump::new();
+    let mut bindings = FxHashMap::default();
+    bindings.insert("Menu".into(), BindingType::SetupRef);
+    bindings.insert("show".into(), BindingType::SetupRef);
+    bindings.insert("items".into(), BindingType::SetupRef);
+
+    let options = DomCompilerOptions {
+        mode: CodegenMode::Module,
+        prefix_identifiers: true,
+        inline: true,
+        binding_metadata: Some(BindingMetadata {
+            bindings,
+            props_aliases: FxHashMap::default(),
+            is_script_setup: true,
+        }),
+        ..Default::default()
+    };
+
+    let (_, errors, result) = compile_template_with_options(
+        &allocator,
+        r#"<div><Menu>hello</Menu><Menu v-if="show" /><Menu v-for="item in items" :key="item" /></div>"#,
+        options,
+    );
+
+    assert!(errors.is_empty(), "Errors: {:?}", errors);
+    let full = full_output(&result.preamble, &result.code);
+    assert!(full.contains("unref as _unref"), "{full}");
+    assert!(
+        full.contains("_createBlock(_unref(Menu)") || full.contains("_createVNode(_unref(Menu)"),
+        "setup ref component tags must be unref'd:\n{full}"
+    );
+    assert!(
+        !full.contains("_createBlock(Menu") && !full.contains("_createVNode(Menu"),
+        "raw ref component tag must not be emitted:\n{full}"
+    );
+}

--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__script_setup_sfc_uses_setup_member_bindings_for_dotted_components.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__script_setup_sfc_uses_setup_member_bindings_for_dotted_components.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/vize_atelier_sfc/src/compile/tests.rs
+assertion_line: 2347
 expression: result.code.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
-import { createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
+import { createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock, unref as _unref, withCtx as _withCtx } from "vue"
 
 import { Form, Input } from 'ant-design-vue'
 
@@ -14,9 +15,9 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createBlock(Form.Item, { label: "Teacher" }, {
+  return (_openBlock(), _createBlock(_unref(Form).Item, { label: "Teacher" }, {
     default: _withCtx(() => [
-      _createVNode(Input)
+      _createVNode(_unref(Input))
     ]),
     _: 1 /* STABLE */
   }))

--- a/crates/vize_atelier_sfc/src/lib.rs
+++ b/crates/vize_atelier_sfc/src/lib.rs
@@ -314,7 +314,7 @@ import { Child } from "./components";
             result.code
         );
         assert!(
-            result.code.contains("_createBlock(Child"),
+            result.code.contains("_createBlock(_unref(Child)"),
             "numeric component v-for should render the imported component. Got:\n{}",
             result.code
         );

--- a/crates/vize_atelier_sfc/tests/setup_component_unref.rs
+++ b/crates/vize_atelier_sfc/tests/setup_component_unref.rs
@@ -4,11 +4,19 @@ use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sf
 fn script_setup_ref_component_tag_uses_unref() {
     let source = r#"<template>
   <Menu>hello</Menu>
+  <Menu v-if="show" />
+  <Menu v-for="item in items" :key="item" />
+  <Menu v-once />
+  <Menu.Item />
 </template>
 
 <script setup>
-import { computed, h } from 'vue'
-const Menu = computed(() => ({ render: () => h('div', 'x') }))
+import { computed, h, ref } from 'vue'
+const show = ref(true)
+const items = ref(['a'])
+const Menu = computed(() => Object.assign({ render: () => h('div', 'x') }, {
+  Item: { render: () => h('span', 'item') },
+}))
 </script>"#;
 
     let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
@@ -20,9 +28,24 @@ const Menu = computed(() => ({ render: () => h('div', 'x') }))
         result.code
     );
     assert!(
+        result.code.matches("_unref(Menu").count() >= 5,
+        "all computed component tag paths should be unref'd:\n{}",
+        result.code
+    );
+    assert!(
         result.code.contains("_createBlock(_unref(Menu)")
             || result.code.contains("_createVNode(_unref(Menu)"),
         "computed component tag must be unref'd:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("_createVNode(_unref(Menu))"),
+        "v-once computed component tags must be unref'd:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("_unref(Menu).Item"),
+        "dotted computed component tags must unref the base binding:\n{}",
         result.code
     );
     assert!(

--- a/crates/vize_atelier_sfc/tests/setup_component_unref.rs
+++ b/crates/vize_atelier_sfc/tests/setup_component_unref.rs
@@ -1,0 +1,33 @@
+use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sfc};
+
+#[test]
+fn script_setup_ref_component_tag_uses_unref() {
+    let source = r#"<template>
+  <Menu>hello</Menu>
+</template>
+
+<script setup>
+import { computed, h } from 'vue'
+const Menu = computed(() => ({ render: () => h('div', 'x') }))
+</script>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result = compile_sfc(&descriptor, SfcCompileOptions::default()).expect("compile");
+
+    assert!(
+        result.code.contains("unref as _unref"),
+        "computed component tags should import unref:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("_createBlock(_unref(Menu)")
+            || result.code.contains("_createVNode(_unref(Menu)"),
+        "computed component tag must be unref'd:\n{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("_createBlock(Menu") && !result.code.contains("_createVNode(Menu"),
+        "raw computed ref must not be emitted as the component type:\n{}",
+        result.code
+    );
+}

--- a/playground/e2e/__snapshots__/sfc-compile.test.ts.snap
+++ b/playground/e2e/__snapshots__/sfc-compile.test.ts.snap
@@ -8,14 +8,14 @@ exports[`SFC Compilation > Basic SFC > should compile template-only SFC 1`] = `
 
 exports[`SFC Compilation > SSR Mode > should keep custom renderer intrinsics as elements while preserving imported lowercase bindings 1`] = `
 {
-  "dom": "import { createCommentVNode as _createCommentVNode, createElementBlock as _createElementBlock, createVNode as _createVNode, openBlock as _openBlock } from "vue";
+  "dom": "import { createCommentVNode as _createCommentVNode, createElementBlock as _createElementBlock, createVNode as _createVNode, openBlock as _openBlock, unref as _unref } from "vue";
 import { Primitive } from "@tresjs/core";
 const visible = true;
 export default {
   __name: "anonymous",
   setup(__props) {
     return (_ctx, _cache) => {
-      return _openBlock(), _createElementBlock("mesh", null, [visible ? (_openBlock(), _createElementBlock("group", { key: 0 }, [_createVNode(Primitive)])) : _createCommentVNode("v-if", true)]);
+      return _openBlock(), _createElementBlock("mesh", null, [visible ? (_openBlock(), _createElementBlock("group", { key: 0 }, [_createVNode(_unref(Primitive))])) : _createCommentVNode("v-if", true)]);
     };
   }
 };",
@@ -53,14 +53,14 @@ export default {
 
 exports[`SFC Compilation > SSR Mode > should resolve dotted component tags through setup member bindings in both DOM and SSR output 1`] = `
 {
-  "dom": "import { createBlock as _createBlock, createVNode as _createVNode, openBlock as _openBlock, withCtx as _withCtx } from "vue";
+  "dom": "import { createBlock as _createBlock, createVNode as _createVNode, openBlock as _openBlock, unref as _unref, withCtx as _withCtx } from "vue";
 import { Form, Input } from "ant-design-vue";
 export default {
   __name: "anonymous",
   setup(__props) {
     return (_ctx, _cache) => {
-      return _openBlock(), _createBlock(Form.Item, { label: "Teacher" }, {
-        default: _withCtx(() => [_createVNode(Input)]),
+      return _openBlock(), _createBlock(_unref(Form).Item, { label: "Teacher" }, {
+        default: _withCtx(() => [_createVNode(_unref(Input))]),
         _: 1
       });
     };

--- a/tests/snapshots/sfc/js/patches__dynamic_component_with_v_slot_destructure.snap
+++ b/tests/snapshots/sfc/js/patches__dynamic_component_with_v_slot_destructure.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
-assertion_line: 221
-expression: js_output.as_str()
+assertion_line: 214
+expression: output.as_str()
 ---
-import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock, unref as _unref, withCtx as _withCtx } from "vue"
 
 import { RouterView } from 'vue-router'
 
@@ -14,7 +14,7 @@ export default {
 
 
 return (_ctx, _cache) => {
-  return (_openBlock(), _createBlock(RouterView, null, {
+  return (_openBlock(), _createBlock(_unref(RouterView), null, {
     default: _withCtx(({ Component }) => [
       (_openBlock(), _createBlock(_resolveDynamicComponent(Component)))
     ]),

--- a/tests/snapshots/sfc/ts/patches__dynamic_component_with_v_slot_destructure.snap
+++ b/tests/snapshots/sfc/ts/patches__dynamic_component_with_v_slot_destructure.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
-assertion_line: 198
-expression: ts_output.as_str()
+assertion_line: 214
+expression: output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
-import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock, unref as _unref, withCtx as _withCtx } from "vue"
 
 import { RouterView } from 'vue-router'
 
@@ -15,7 +15,7 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createBlock(RouterView, null, {
+  return (_openBlock(), _createBlock(_unref(RouterView), null, {
     default: _withCtx(({ Component }) => [
       (_openBlock(), _createBlock(_resolveDynamicComponent(Component)))
     ]),


### PR DESCRIPTION
## Summary

- unwrap setup ref/computed component tag bindings with `_unref()` in inline render output
- share component binding emission across block, inline, v-if, v-for, and v-once code paths
- add DOM and SFC regression coverage for setup refs used as component tags

## Root cause

The compiler resolved `<script setup>` bindings as component tags but emitted the raw binding in inline mode. For `ref` and `computed` bindings this passed the ref wrapper object to Vue as the vnode type instead of its current value.

## Validation

- `cargo fmt --all --check`
- `cargo test -p vize_atelier_core -p vize_atelier_dom -p vize_atelier_sfc`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

Closes #1969

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->