### PR TITLE
test(compiler): align setup component tag expectations

### DIFF
--- a/npm/vite-plugin-vize/src/compiler.test.ts
+++ b/npm/vite-plugin-vize/src/compiler.test.ts
@@ -625,8 +625,8 @@ const antDesignDomCompiled = compileFile(
 
 assert.match(
   antDesignDomCompiled.code,
-  /_create(?:Block|VNode)\(Form\.Item/,
-  "DOM builds should compile dotted component tags to direct setup member expressions",
+  /(?=[\s\S]*_create(?:Block|VNode)\(_unref\(Form\)\.Item)(?=[\s\S]*_create(?:Block|VNode)\(_unref\(Input\))/,
+  "DOM builds should unref setup component tags while preserving member access",
 );
 assert.doesNotMatch(
   antDesignDomCompiled.code,

--- a/tests/expected/sfc/patches.snap
+++ b/tests/expected/sfc/patches.snap
@@ -1388,7 +1388,7 @@ import { RouterView } from 'vue-router'
   </RouterView>
 </template>
 --- OUTPUT ---
-import { openBlock as _openBlock, createBlock as _createBlock, resolveDynamicComponent as _resolveDynamicComponent, withCtx as _withCtx } from "vue"
+import { openBlock as _openBlock, createBlock as _createBlock, unref as _unref, resolveDynamicComponent as _resolveDynamicComponent, withCtx as _withCtx } from "vue"
 
 import { RouterView } from 'vue-router'
 
@@ -1398,7 +1398,7 @@ export default {
 
 
 return (_ctx, _cache) => {
-  return (_openBlock(), _createBlock(RouterView, null, {
+  return (_openBlock(), _createBlock(_unref(RouterView), null, {
     default: _withCtx(({ Component }) => [
       (_openBlock(), _createBlock(_resolveDynamicComponent(Component)))
     ]),


### PR DESCRIPTION
## Summary

- update vite-plugin compiler assertions for setup component tag `_unref()` output
- update SFC coverage expected output for the RouterView slot fixture

## Context

Follow-up to #1986. Required checks passed there and auto-merge completed, but non-required `test-js-packages` and `coverage` still exposed stale expectations for the intentional setup component tag unwrapping behavior.

## Validation

- `cargo run -p vize_test_runner --bin coverage`
- `git diff --check`

Not run locally:

- `pnpm --dir npm/vite-plugin-vize test` because local `node_modules` is missing `napi`; this PR relies on the GitHub Actions package test for that lane.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->