### PR TITLE
fix(check): type Nuxt2 plugin injections

### DIFF
--- a/crates/vize/src/commands/check/nuxt/plugins.rs
+++ b/crates/vize/src/commands/check/nuxt/plugins.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use ignore::WalkBuilder;
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{Argument, Expression, ObjectExpression, Statement};
+use oxc_ast::ast::{Argument, BindingPattern, Expression, ObjectExpression, Statement};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_carton::{FxHashSet, String, cstr};
@@ -63,6 +63,8 @@ pub(super) fn collect_plugin_injection_stubs(
             .into(),
     );
 
+    stubs.push(render_nuxt_injection_context_stub(&plugin_keys));
+
     for key in plugin_keys {
         let injected_name = if key.starts_with('$') {
             key
@@ -75,6 +77,31 @@ pub(super) fn collect_plugin_injection_stubs(
             cstr!("declare const {injected_name}: __VizeNuxtInjection<'{injected_name}'>;"),
         );
     }
+}
+
+fn render_nuxt_injection_context_stub(plugin_keys: &[String]) -> String {
+    let mut stub = String::from("interface __VizeNuxtInjectedProperties {\n");
+    for key in plugin_keys {
+        let injected_name = if key.starts_with('$') {
+            key.clone()
+        } else {
+            cstr!("${key}")
+        };
+        stub.push_str("  ");
+        stub.push_str(injected_name.as_str());
+        stub.push_str(": __VizeNuxtInjection<'");
+        stub.push_str(injected_name.as_str());
+        stub.push_str("'>;\n");
+    }
+    stub.push_str("}\n");
+    stub.push_str("declare module \"@nuxt/types\" {\n");
+    stub.push_str("  interface Context extends __VizeNuxtInjectedProperties {}\n");
+    stub.push_str("  interface NuxtAppOptions extends __VizeNuxtInjectedProperties {}\n");
+    stub.push_str("}\n");
+    stub.push_str("declare module \"@nuxtjs/composition-api\" {\n");
+    stub.push_str("  interface UseContextReturn extends __VizeNuxtInjectedProperties {}\n");
+    stub.push_str("}\n");
+    stub
 }
 
 pub(super) fn extract_plugin_provide_keys_from_source(source: &str) -> Vec<String> {
@@ -111,14 +138,106 @@ fn collect_plugin_keys_from_argument(arg: &Argument<'_>, keys: &mut Vec<String>)
     match arg {
         Argument::ObjectExpression(object) => collect_plugin_keys_from_object(object, keys),
         Argument::ArrowFunctionExpression(arrow) => {
+            if let Some(inject_name) = nuxt2_inject_param_name(&arrow.params) {
+                collect_plugin_keys_from_nuxt2_inject_calls(
+                    &arrow.body.statements,
+                    inject_name,
+                    keys,
+                );
+            }
             collect_plugin_keys_from_function_body(&arrow.body.statements, keys)
         }
         Argument::FunctionExpression(function) => {
+            if let Some(inject_name) = nuxt2_inject_param_name(&function.params)
+                && let Some(body) = &function.body
+            {
+                collect_plugin_keys_from_nuxt2_inject_calls(&body.statements, inject_name, keys);
+            }
             if let Some(body) = &function.body {
                 collect_plugin_keys_from_function_body(&body.statements, keys);
             }
         }
         _ => {}
+    }
+}
+
+fn nuxt2_inject_param_name<'a>(params: &'a oxc_ast::ast::FormalParameters<'a>) -> Option<&'a str> {
+    let param = params.items.get(1)?;
+    binding_identifier_name(&param.pattern)
+}
+
+fn binding_identifier_name<'a>(pattern: &'a BindingPattern<'a>) -> Option<&'a str> {
+    match pattern {
+        BindingPattern::BindingIdentifier(identifier) => Some(identifier.name.as_str()),
+        _ => None,
+    }
+}
+
+fn collect_plugin_keys_from_nuxt2_inject_calls<'a>(
+    statements: &'a oxc_allocator::Vec<'a, Statement<'a>>,
+    inject_name: &str,
+    keys: &mut Vec<String>,
+) {
+    for statement in statements {
+        let Statement::ExpressionStatement(expr) = statement else {
+            continue;
+        };
+        collect_plugin_key_from_nuxt2_inject_expression(&expr.expression, inject_name, keys);
+    }
+}
+
+fn collect_plugin_key_from_nuxt2_inject_expression(
+    expression: &Expression<'_>,
+    inject_name: &str,
+    keys: &mut Vec<String>,
+) {
+    match expression {
+        Expression::CallExpression(call) => {
+            let Expression::Identifier(callee) = &call.callee else {
+                return;
+            };
+            if callee.name.as_str() != inject_name {
+                return;
+            }
+            if let Some(key) = call.arguments.first().and_then(inject_key_from_argument) {
+                keys.push(key);
+            }
+        }
+        Expression::ParenthesizedExpression(parenthesized) => {
+            collect_plugin_key_from_nuxt2_inject_expression(
+                &parenthesized.expression,
+                inject_name,
+                keys,
+            );
+        }
+        Expression::TSAsExpression(ts_as) => {
+            collect_plugin_key_from_nuxt2_inject_expression(&ts_as.expression, inject_name, keys);
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            collect_plugin_key_from_nuxt2_inject_expression(
+                &ts_satisfies.expression,
+                inject_name,
+                keys,
+            );
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            collect_plugin_key_from_nuxt2_inject_expression(
+                &ts_non_null.expression,
+                inject_name,
+                keys,
+            );
+        }
+        _ => {}
+    }
+}
+
+fn inject_key_from_argument(argument: &Argument<'_>) -> Option<String> {
+    match argument {
+        Argument::StringLiteral(literal) => Some(literal.value.as_str().into()),
+        Argument::TemplateLiteral(template) => {
+            template.single_quasi().map(|value| value.as_str().into())
+        }
+        _ => None,
     }
 }
 
@@ -159,5 +278,32 @@ fn collect_plugin_keys_from_object(object: &ObjectExpression<'_>, keys: &mut Vec
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_plugin_provide_keys_from_source, render_nuxt_injection_context_stub};
+
+    #[test]
+    fn extracts_nuxt2_inject_keys_from_callback_plugin() {
+        let source = r#"
+export default defineNuxtPlugin((_context, register) => {
+  register('logger', { info(message) { return message.length } })
+  register(`auth`, {})
+})
+"#;
+
+        let keys = extract_plugin_provide_keys_from_source(source);
+        assert_eq!(keys, vec!["logger", "auth"]);
+    }
+
+    #[test]
+    fn renders_use_context_injection_augmentations() {
+        let stub = render_nuxt_injection_context_stub(&["logger".into()]);
+
+        assert!(stub.contains("$logger: __VizeNuxtInjection<'$logger'>;"));
+        assert!(stub.contains("interface Context extends __VizeNuxtInjectedProperties"));
+        assert!(stub.contains("interface UseContextReturn extends __VizeNuxtInjectedProperties"));
     }
 }

--- a/crates/vize/tests/check_nuxt2_plugin_injections_cli.rs
+++ b/crates/vize/tests/check_nuxt2_plugin_injections_cli.rs
@@ -1,0 +1,155 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[test]
+fn check_nuxt2_use_context_sees_plugin_injections() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project("nuxt2-plugin-injections");
+
+    write_file(&project_root, "nuxt.config.ts", "export default {}\n");
+    write_file(
+        &project_root,
+        "tsconfig.json",
+        r##"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "noEmit": true
+  },
+  "include": ["pages/**/*.vue", "plugins/**/*.ts", "types/**/*.d.ts"]
+}"##,
+    );
+    write_file(
+        &project_root,
+        "types/nuxt.d.ts",
+        r##"declare module "@nuxt/types" {
+  export interface Context {}
+  export interface NuxtAppOptions {}
+}
+
+declare module "@nuxtjs/composition-api" {
+  export interface UseContextReturn
+    extends Omit<import("@nuxt/types").Context, "route" | "query" | "from" | "params"> {}
+  export function useContext(): UseContextReturn;
+}
+
+declare module "#app" {
+  export interface NuxtApp {}
+}
+"##,
+    );
+    write_file(
+        &project_root,
+        "plugins/logger.ts",
+        r#"export default (_context: unknown, inject: (key: string, value: unknown) => void) => {
+  inject("logger", {
+    info(message: string) {
+      return message.length;
+    },
+  });
+};
+"#,
+    );
+    write_file(
+        &project_root,
+        "pages/index.vue",
+        r#"<script setup lang="ts">
+import { useContext } from "@nuxtjs/composition-api";
+
+const context = useContext();
+context.$logger.info("ready");
+</script>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "pages",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "Nuxt2 useContext plugin injections should type-check\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], 0, "{stdout}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn create_project(name: &str) -> PathBuf {
+    let project_root = workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join(format!("{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    link_workspace_node_modules(&project_root);
+    project_root
+}
+
+fn write_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(file_path, content).unwrap();
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn link_workspace_node_modules(project_root: &Path) {
+    let source = workspace_root().join("node_modules");
+    if source.exists() {
+        symlink_path(&source, &project_root.join("node_modules")).unwrap();
+    }
+}
+
+fn resolve_test_corsa_path() -> Option<String> {
+    if let Some(path) = std::env::var_os("CORSA_PATH") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path.display().to_string());
+        }
+    }
+    let workspace_root = workspace_root();
+    [workspace_root.join("node_modules/.bin/tsgo")]
+        .into_iter()
+        .find(|candidate| candidate.exists())
+        .map(|candidate| candidate.display().to_string())
+}
+
+fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(source, target)
+    }
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       "@unhead/vue": "2.1.15",
       "defu": "6.1.7",
       "devalue": "5.8.1",
-      "dompurify": "3.4.10",
+      "dompurify": "3.4.11",
       "esbuild": "0.28.1",
       "h3": "1.15.11",
       "hono": "4.12.25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,7 +197,7 @@ overrides:
   '@unhead/vue': 2.1.15
   defu: 6.1.7
   devalue: 5.8.1
-  dompurify: 3.4.10
+  dompurify: 3.4.11
   esbuild: 0.28.1
   h3: 1.15.11
   hono: 4.12.25
@@ -6796,8 +6796,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.10:
-    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -15037,7 +15037,7 @@ snapshots:
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       color-string: 2.1.4
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       highlight.js: 11.11.1
       html-to-image: 1.11.13
       immer: 10.2.0
@@ -15978,7 +15978,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.10:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -17206,7 +17206,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       es-toolkit: 1.46.1
       katex: 0.16.46
       khroma: 2.1.0
@@ -17283,7 +17283,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       marked: 14.0.0
 
   motion-dom@12.40.0:


### PR DESCRIPTION
## Summary
- detect Nuxt 2 `inject('key', value)` plugin callbacks in the Nuxt checker
- expose detected injections on Nuxt context types used by `useContext()`
- add a focused CLI regression for `useContext().$logger`

Refs #1876

## Verification
- `cargo test -p vize commands::check::nuxt::plugins`
- `cargo test -p vize --test check_nuxt2_plugin_injections_cli`
- `cargo test -p vize --test check_nuxt_tsconfig_paths_cli`
- `cargo fmt --all --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->