### PR TITLE
fix(check): keep package cwd imports scoped

### DIFF
--- a/crates/vize/src/commands/check/runner/collect.rs
+++ b/crates/vize/src/commands/check/runner/collect.rs
@@ -259,6 +259,12 @@ fn normalize_input_path(path: &Path) -> PathBuf {
     vize_carton::path::canonicalize_non_verbatim(path)
 }
 
+pub(super) fn path_is_inside_root(root: &Path, path: &Path) -> bool {
+    let root = normalize_input_path(root);
+    let path = normalize_input_path(path);
+    path.starts_with(root)
+}
+
 fn normalize_walked_path(root: &Path, normalized_root: &Path, path: &Path) -> PathBuf {
     // Avoid a canonicalize syscall per walked file; normalize the root once.
     path.strip_prefix(root)

--- a/crates/vize/src/commands/check/runner/collect_tests.rs
+++ b/crates/vize/src/commands/check/runner/collect_tests.rs
@@ -1,6 +1,11 @@
 use super::super::ignores::CheckIgnoreSet;
 use super::{
-    base_dir_from_pattern, collect_check_files, collect_check_files_with_ignores, collect_vue_files,
+    base_dir_from_pattern, collect_check_files, collect_check_files_with_ignores,
+    collect_vue_files, path_is_inside_root,
+};
+use crate::commands::check::{
+    imports::collect_transitive_local_imports, imports_aliases::PathAliasResolver,
+    path_cache::CanonicalPathCache,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -13,6 +18,15 @@ fn unique_case_dir(name: &str) -> PathBuf {
         .join("target")
         .join("vize-tests")
         .join(cstr!("{name}-{}-{case_id}", std::process::id()).as_str())
+}
+
+fn write_file(root: &Path, rel: &str, contents: &str) -> PathBuf {
+    let path = root.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(&path, contents).unwrap();
+    path
 }
 
 #[test]
@@ -140,6 +154,66 @@ fn collect_check_files_applies_entry_ignores() {
     assert!(explicit.is_empty());
 
     let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn path_root_filter_drops_alias_imports_outside_package_cwd() {
+    let workspace = unique_case_dir("package-transitive-alias-root");
+    let _ = fs::remove_dir_all(&workspace);
+    fs::create_dir_all(&workspace).unwrap();
+    fs::write(
+        workspace.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": { "~/*": ["*"] }
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    let root_only = write_file(
+        &workspace,
+        "src/generated/tecack/custom.ts",
+        "export const rootOnly = 'root';\n",
+    );
+
+    let package_root = workspace.join("devtools");
+    fs::create_dir_all(&package_root).unwrap();
+    fs::write(
+        package_root.join("tsconfig.json"),
+        r#"{
+  "extends": "../tsconfig.json",
+  "include": ["src/**/*.vue", "src/**/*.ts"]
+}"#,
+    )
+    .unwrap();
+    let app = write_file(
+        &package_root,
+        "src/App.vue",
+        r#"<script setup lang="ts">
+import { rootOnly } from "~/src/generated/tecack/custom";
+void rootOnly;
+</script>
+"#,
+    );
+
+    let aliases = PathAliasResolver::from_tsconfig(Some(&package_root.join("tsconfig.json")));
+    let discovered = collect_transitive_local_imports(
+        std::slice::from_ref(&app),
+        &package_root,
+        &mut CanonicalPathCache::default(),
+        false,
+        Some(&aliases),
+    );
+
+    assert_eq!(discovered, vec![root_only.canonicalize().unwrap()]);
+    assert!(
+        !path_is_inside_root(&package_root, &discovered[0]),
+        "root app import leaked into package inputs"
+    );
+
+    let _ = fs::remove_dir_all(&workspace);
 }
 
 #[test]

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -37,7 +37,7 @@ mod resolve;
 mod socket;
 #[cfg(test)]
 mod tests;
-use collect::collect_check_files_with_ignores;
+use collect::{collect_check_files_with_ignores, path_is_inside_root};
 use diagnostics::{
     emit_json_output, is_reported, is_suppressed_false_positive, render_diagnostics,
     save_virtual_ts_targets, write_profile_virtual_ts,
@@ -207,9 +207,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         return;
     }
 
-    // Explicit subsets need reachable source imports registered so cross-file
-    // types resolve like tsc/vue-tsc. Run this before root resolution so
-    // cwd-external files can still choose a covering materialization root.
+    let validate_inputs = !args.patterns.is_empty() && tsconfig_path.is_some();
     if !args.patterns.is_empty() {
         let aliases =
             super::imports_aliases::PathAliasResolver::from_tsconfig(tsconfig_path.as_deref());
@@ -220,14 +218,15 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             jsx_typecheck,
             Some(&aliases),
         ) {
-            if !files.contains(&path) {
+            if (!validate_inputs || path_is_inside_root(&explicit_input_root, &path))
+                && !files.contains(&path)
+            {
                 files.push(path);
             }
         }
         files.sort();
         files.dedup();
     }
-    let validate_inputs = !args.patterns.is_empty() && tsconfig_path.is_some();
     exit_if_inputs_outside_root(&explicit_input_root, &files, validate_inputs);
     let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &files);
     let tsconfig_path =

--- a/crates/vize/tests/check_package_cwd_cli.rs
+++ b/crates/vize/tests/check_package_cwd_cli.rs
@@ -76,6 +76,10 @@ fn check_from_package_cwd_uses_package_local_tsconfig_inputs() {
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["*"]
+    },
     "noEmit": true
   },
   "include": ["src/**/*"]
@@ -84,7 +88,7 @@ fn check_from_package_cwd_uses_package_local_tsconfig_inputs() {
     write_file(
         &workspace,
         "src/generated/tecack/custom.ts",
-        "export const rootOnly: string = 1;\n",
+        "export const rootOnly: string = 'root';\n",
     );
 
     let package_root = workspace.join("devtools");
@@ -99,6 +103,7 @@ fn check_from_package_cwd_uses_package_local_tsconfig_inputs() {
     "moduleResolution": "bundler",
     "noEmit": true
   },
+  "extends": "../tsconfig.json",
   "include": ["src/**/*.ts", "src/**/*.vue"]
 }"#,
     );
@@ -106,7 +111,10 @@ fn check_from_package_cwd_uses_package_local_tsconfig_inputs() {
         &package_root,
         "src/App.vue",
         r#"<script setup lang="ts">
+import { rootOnly } from "~/src/generated/tecack/custom";
+
 const msg: string = "ok";
+void rootOnly;
 </script>
 
 <template>{{ msg }}</template>


### PR DESCRIPTION
## Summary
- keep explicit package-cwd checks scoped to the explicit input root when adding transitive alias imports
- prevent workspace-root path aliases from registering root app files as package check inputs
- extend the package-cwd CLI regression and add a non-Corsa unit regression for the alias/root filter

## Root cause
Explicit `vize check src --tsconfig tsconfig.json` runs added every transitive alias import before validating the input root. When a package tsconfig inherited a workspace-root alias, a root app file could be registered as a package input and fail with `outside project root`.

## Validation
- cargo test -p vize commands::check::runner -- --nocapture
- cargo test -p vize path_root_filter_drops_alias_imports_outside_package_cwd -- --nocapture
- cargo test -p vize --test check_package_cwd_cli -- --nocapture
- cargo fmt --all --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check
- cargo clippy -p vize --lib -- -D warnings -D clippy::wildcard_imports

Closes #1959

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->