### PR TITLE
fix(fmt): honor top-level ignores

### DIFF
--- a/crates/vize/tests/fmt_config_cli.rs
+++ b/crates/vize/tests/fmt_config_cli.rs
@@ -86,3 +86,46 @@ fn fmt_check_fails_when_explicit_patterns_match_no_files() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("No .vue, .js, .ts, .jsx, or .tsx files found"));
 }
+
+#[test]
+fn fmt_check_honors_top_level_ignores_during_directory_discovery() {
+    let project = tempfile::tempdir().unwrap();
+    write_project_file(
+        project.path(),
+        "vize.config.json",
+        r#"{
+  "ignores": [
+    "src/generated/schema.ts",
+    "src/framework/static/sw.js"
+  ]
+}"#,
+    );
+    write_project_file(
+        project.path(),
+        "src/App.vue",
+        "<template><div>{{msg}}</div></template>\n<script setup lang=\"ts\">const msg=1</script>\n",
+    );
+    write_project_file(
+        project.path(),
+        "src/generated/schema.ts",
+        "export   const schema={value:1}\n",
+    );
+    write_project_file(
+        project.path(),
+        "src/framework/static/sw.js",
+        "self.addEventListener('install',()=>{})\n",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args(["fmt", "--config", "vize.config.json", "--check", "src"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Found 1 file(s)"), "{stderr}");
+    assert!(stderr.contains("Would reformat: src/App.vue"), "{stderr}");
+    assert!(!stderr.contains("src/generated/schema.ts"), "{stderr}");
+    assert!(!stderr.contains("src/framework/static/sw.js"), "{stderr}");
+}

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -205,7 +205,17 @@ pub fn load_linter_config(path: Option<&Path>) -> LinterConfig {
 
 pub fn load_config_entry_ignores_with_source(path: Option<&Path>) -> LoadedConfigEntryIgnores {
     let loaded = load_raw_config_with_source(path);
-    let ignores = loaded
+    let top_level_ignores =
+        loaded
+            .config
+            .ignores
+            .iter()
+            .cloned()
+            .map(|pattern| ConfigEntryIgnore {
+                base_path: None,
+                pattern,
+            });
+    let entry_ignores = loaded
         .config
         .entries
         .as_deref()
@@ -221,7 +231,8 @@ pub fn load_config_entry_ignores_with_source(path: Option<&Path>) -> LoadedConfi
                     pattern,
                 })
         })
-        .collect();
+        .collect::<Vec<_>>();
+    let ignores = top_level_ignores.chain(entry_ignores).collect();
     LoadedConfigEntryIgnores {
         ignores,
         source_path: loaded.source_path,

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -205,16 +205,17 @@ pub fn load_linter_config(path: Option<&Path>) -> LinterConfig {
 
 pub fn load_config_entry_ignores_with_source(path: Option<&Path>) -> LoadedConfigEntryIgnores {
     let loaded = load_raw_config_with_source(path);
-    let top_level_ignores =
-        loaded
-            .config
-            .ignores
-            .iter()
-            .cloned()
-            .map(|pattern| ConfigEntryIgnore {
-                base_path: None,
-                pattern,
-            });
+    let top_level_ignores = loaded
+        .config
+        .ignores
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .cloned()
+        .map(|pattern| ConfigEntryIgnore {
+            base_path: None,
+            pattern,
+        });
     let entry_ignores = loaded
         .config
         .entries
@@ -224,6 +225,8 @@ pub fn load_config_entry_ignores_with_source(path: Option<&Path>) -> LoadedConfi
         .flat_map(|entry| {
             entry
                 .ignores
+                .as_deref()
+                .unwrap_or_default()
                 .iter()
                 .cloned()
                 .map(|pattern| ConfigEntryIgnore {

--- a/crates/vize_carton/src/config/loader/tests.rs
+++ b/crates/vize_carton/src/config/loader/tests.rs
@@ -258,6 +258,7 @@ fn load_config_entry_ignores_preserves_base_paths() {
     std::fs::write(
         &config_path,
         r#"{
+  "ignores": ["src/generated.ts"],
   "entries": [
     { "name": "app", "ignores": ["components/Legacy.vue"] },
     { "name": "design", "basePath": "design-system", "ignores": ["src/Fixture.vue"] }
@@ -269,14 +270,16 @@ fn load_config_entry_ignores_preserves_base_paths() {
     let loaded = load_config_entry_ignores_with_source(Some(&config_path));
 
     assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
-    assert_eq!(loaded.ignores.len(), 2);
+    assert_eq!(loaded.ignores.len(), 3);
     assert_eq!(loaded.ignores[0].base_path, None);
-    assert_eq!(loaded.ignores[0].pattern.as_str(), "components/Legacy.vue");
+    assert_eq!(loaded.ignores[0].pattern.as_str(), "src/generated.ts");
+    assert_eq!(loaded.ignores[1].base_path, None);
+    assert_eq!(loaded.ignores[1].pattern.as_str(), "components/Legacy.vue");
     assert_eq!(
-        loaded.ignores[1].base_path.as_deref(),
+        loaded.ignores[2].base_path.as_deref(),
         Some("design-system")
     );
-    assert_eq!(loaded.ignores[1].pattern.as_str(), "src/Fixture.vue");
+    assert_eq!(loaded.ignores[2].pattern.as_str(), "src/Fixture.vue");
 }
 
 #[test]

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -126,7 +126,7 @@ pub(crate) struct RawVizeConfig {
     language_server: RawLanguageServerConfig,
     #[serde(rename = "globalTypes")]
     pub global_types: RawGlobalTypesConfig,
-    pub ignores: Vec<String>,
+    pub ignores: Option<Vec<String>>,
     pub entries: Option<Vec<RawConfigEntry>>,
     #[serde(rename = "check")]
     legacy_check: Option<LegacyCheckConfig>,
@@ -140,7 +140,7 @@ pub(crate) struct RawVizeConfig {
 #[serde(default, rename_all = "camelCase")]
 pub(crate) struct RawConfigEntry {
     pub base_path: Option<String>,
-    pub ignores: Vec<String>,
+    pub ignores: Option<Vec<String>>,
     pub linter: RawLinterConfig,
 }
 

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -126,6 +126,7 @@ pub(crate) struct RawVizeConfig {
     language_server: RawLanguageServerConfig,
     #[serde(rename = "globalTypes")]
     pub global_types: RawGlobalTypesConfig,
+    pub ignores: Vec<String>,
     pub entries: Option<Vec<RawConfigEntry>>,
     #[serde(rename = "check")]
     legacy_check: Option<LegacyCheckConfig>,
@@ -194,6 +195,7 @@ impl RawVizeConfig {
             type_checker: raw_type_checker,
             language_server: raw_language_server,
             global_types,
+            ignores: _,
             entries: _,
             legacy_check,
             legacy_formatter,

--- a/crates/vize_carton/tests/loading.rs
+++ b/crates/vize_carton/tests/loading.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::disallowed_macros)]
 
 use vize_carton::config::{
-    VueVersion, load_config, load_config_with_features_and_source, load_config_with_source,
-    validate_explicit_config_path,
+    VueVersion, load_config, load_config_entry_ignores_with_source,
+    load_config_with_features_and_source, load_config_with_source, validate_explicit_config_path,
 };
 
 #[test]
@@ -33,6 +33,44 @@ typeChecker {
     let config = load_config(Some(dir.path()));
 
     insta::assert_snapshot!(serde_json::to_string_pretty(&config).unwrap());
+}
+
+#[test]
+fn loads_pkl_top_level_and_entry_ignores() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.pkl");
+    install_pkl_modules(dir.path());
+    std::fs::write(
+        &config_path,
+        r#"
+amends "node_modules/vize/pkl/VizeConfig.pkl"
+
+ignores = new Listing {
+  "src/generated.ts"
+}
+
+entries = new Listing {
+  new ConfigEntry {
+    name = "app"
+    ignores = new Listing { "components/Legacy.vue" }
+  }
+  new ConfigEntry {
+    name = "design"
+    basePath = "design-system"
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let loaded = load_config_entry_ignores_with_source(Some(&config_path));
+
+    assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
+    assert_eq!(loaded.ignores.len(), 2);
+    assert_eq!(loaded.ignores[0].base_path, None);
+    assert_eq!(loaded.ignores[0].pattern.as_str(), "src/generated.ts");
+    assert_eq!(loaded.ignores[1].base_path, None);
+    assert_eq!(loaded.ignores[1].pattern.as_str(), "components/Legacy.vue");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- honor top-level `ignores` when loading formatter/check ignore patterns
- keep entry-level ignore base paths intact while adding top-level patterns without a base path
- add formatter CLI regression coverage for directory discovery skipping top-level ignored files

Closes #1984

## Verification
- `cargo test -p vize_carton load_config_entry_ignores_preserves_base_paths -- --nocapture`
- `cargo test -p vize --test fmt_config_cli -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy -p vize_carton --lib -- -D warnings -D clippy::wildcard_imports`
- `cargo clippy -p vize --lib -- -D warnings -D clippy::wildcard_imports`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->