### PR TITLE
fix(check): preserve Vue 2 required options props

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -12,33 +12,8 @@ mod emit_object_recursion;
 mod generic_component_listener_payload;
 mod no_check_props;
 mod no_unused;
-#[test]
-fn test_batch_type_checker_scan() {
-    let project_root = unique_case_dir("scan");
-    let _ = std::fs::remove_dir_all(&project_root);
-    let src_dir = project_root.join("src");
-    std::fs::create_dir_all(&src_dir).unwrap();
-    let vue_content = r#"<template>
-  <div>{{ message }}</div>
-</template>
-
-<script setup lang="ts">
-const message = 'Hello'
-</script>
-"#;
-    std::fs::write(src_dir.join("App.vue"), vue_content).unwrap();
-    std::fs::write(src_dir.join("utils.ts"), "export const foo = 'bar';").unwrap();
-
-    let mut checker = match BatchTypeChecker::new(&project_root) {
-        Ok(checker) => checker,
-        Err(_) => return,
-    };
-
-    checker.scan_project().unwrap();
-    assert_eq!(checker.file_count(), 2);
-
-    let _ = std::fs::remove_dir_all(&project_root);
-}
+mod options_api_required_props;
+mod scan;
 
 #[test]
 fn batch_type_checker_snapshots_vue_diagnostics() {

--- a/crates/vize_canon/src/batch/type_checker/tests/options_api_required_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/options_api_required_props.rs
@@ -1,0 +1,67 @@
+use super::{BatchTypeChecker, create_project_case, resolve_test_tsgo_binary};
+use crate::batch::TypeChecker;
+
+#[test]
+fn accepts_legacy_vue2_required_options_props_in_setup() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case(
+        "legacy-vue2-required-options-props",
+        &[(
+            "src/App.vue",
+            r#"<script lang="ts">
+import { defineComponent, type PropType } from 'vue'
+
+const componentProps = {
+  items: {
+    type: Array as PropType<Array<{ id: string }>>,
+    required: true,
+  },
+}
+
+export default defineComponent({
+  props: componentProps,
+  setup(props) {
+    props.items.findIndex((item) => item.id)
+    props.items[0]
+    return {}
+  },
+})
+</script>
+"#,
+        )],
+    );
+
+    if !project_root.join("node_modules/vue/dist").exists() {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    }
+
+    let mut checker = match BatchTypeChecker::new(&project_root) {
+        Ok(checker) => checker,
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        }
+    };
+    checker.enable_legacy_vue2();
+    checker.scan_project().unwrap();
+    let result = checker.check_project().unwrap();
+    let unexpected: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.file.ends_with("App.vue")
+                && matches!(diagnostic.code, Some(18048 | 2532 | 7031))
+        })
+        .collect();
+
+    assert!(
+        unexpected.is_empty(),
+        "expected required Vue 2 Options API props to be non-optional in setup(): {unexpected:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/type_checker/tests/scan.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/scan.rs
@@ -1,0 +1,29 @@
+use super::{BatchTypeChecker, unique_case_dir};
+
+#[test]
+fn test_batch_type_checker_scan() {
+    let project_root = unique_case_dir("scan");
+    let _ = std::fs::remove_dir_all(&project_root);
+    let src_dir = project_root.join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    let vue_content = r#"<template>
+  <div>{{ message }}</div>
+</template>
+
+<script setup lang="ts">
+const message = 'Hello'
+</script>
+"#;
+    std::fs::write(src_dir.join("App.vue"), vue_content).unwrap();
+    std::fs::write(src_dir.join("utils.ts"), "export const foo = 'bar';").unwrap();
+
+    let mut checker = match BatchTypeChecker::new(&project_root) {
+        Ok(checker) => checker,
+        Err(_) => return,
+    };
+
+    checker.scan_project().unwrap();
+    assert_eq!(checker.file_count(), 2);
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/sfc_typecheck/tests.rs
+++ b/crates/vize_canon/src/sfc_typecheck/tests.rs
@@ -3,7 +3,7 @@
 #![cfg(test)]
 mod emit_props;
 #[cfg(feature = "legacy")]
-use super::type_check_sfc_with_legacy_vue2;
+mod options_api_required_props;
 use super::{
     SfcTypeCheckOptions, SfcTypeCheckResult, SfcTypeDiagnostic, SfcTypeSeverity, type_check_sfc,
     type_check_sfc_with_options_api,
@@ -691,7 +691,7 @@ export default {
     );
 
     let options = SfcTypeCheckOptions::new("Legacy.vue");
-    let legacy_result = type_check_sfc_with_legacy_vue2(source, &options);
+    let legacy_result = super::type_check_sfc_with_legacy_vue2(source, &options);
     assert!(
         !legacy_result
             .diagnostics

--- a/crates/vize_canon/src/sfc_typecheck/tests/options_api_required_props.rs
+++ b/crates/vize_canon/src/sfc_typecheck/tests/options_api_required_props.rs
@@ -1,0 +1,42 @@
+use crate::sfc_typecheck::{SfcTypeCheckOptions, type_check_sfc_with_legacy_vue2};
+
+#[test]
+fn legacy_vue2_required_options_props_in_setup_are_defined() {
+    let source = r#"<script lang="ts">
+import { defineComponent, type PropType } from 'vue'
+
+const componentProps = {
+  items: {
+    type: Array as PropType<Array<{ id: string }>>,
+    required: true,
+  },
+}
+
+export default defineComponent({
+  props: componentProps,
+  setup(props) {
+    props.items.findIndex((item) => item.id)
+    props.items[0]
+    return {}
+  },
+})
+</script>"#;
+
+    let options = SfcTypeCheckOptions::new("RequiredOptionsProps.vue");
+    let result = type_check_sfc_with_legacy_vue2(source, &options);
+    let unexpected: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            matches!(
+                diagnostic.code.as_deref(),
+                Some("18048" | "2532" | "undefined-binding")
+            )
+        })
+        .collect();
+
+    assert!(
+        unexpected.is_empty(),
+        "Vue 2 required Options API props should be defined in setup(): {unexpected:#?}"
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -4,6 +4,7 @@ mod generics;
 mod imports;
 mod legacy_vue2;
 mod options_api;
+mod options_api_props_identifiers;
 mod options_api_support;
 mod script_module;
 mod setup_props;
@@ -21,6 +22,7 @@ use self::options_api::{
     find_default_export_targets, find_options_api_props, generate_options_api_bridge,
     generate_options_api_variables,
 };
+use self::options_api_props_identifiers::PropsConstAssertions;
 use self::setup_props::SetupPropsPlan;
 use self::spans::{
     DEFINE_COMPONENT_REF, merge_overlapping_spans, preserved_template_usage,
@@ -41,11 +43,6 @@ use super::{
 use vize_carton::{FxHashMap, FxHashSet, String, append, cstr, profile};
 use vize_croquis::{Croquis, ScopeData, ScopeKind};
 /// Generate virtual TypeScript from Vue SFC analysis.
-///
-/// The generated TypeScript uses proper scope hierarchy:
-/// 1. Module scope: imports only
-/// 2. Setup scope (__setup function): compiler macros + script content
-/// 3. Template scope (nested in setup): template expressions
 ///
 /// This ensures compiler macros like defineProps are ONLY valid in setup scope.
 pub fn generate_virtual_ts(
@@ -224,7 +221,6 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     if default_export_object.is_some() {
         ts.push_str(legacy_vue2::define_component_helper(legacy_vue2, dialect));
     }
-
     // Collect all module-level statement spans from croquis analysis once and
     // keep them sorted. Later script-body emission advances an index through
     // this list, so each source line checks only the overlapping tail instead
@@ -479,6 +475,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             // causing src_byte_offset drift that incorrectly skips user code.
             let mut src_byte_offset: usize = 0; // offset within script content
             let mut module_span_index = 0usize;
+            let mut props_const_assertions = PropsConstAssertions::new(script, options_api);
             // Script-absolute offset right after the wrapped options object.
             let mut pending_wrap_close: Option<usize> = None;
             // Deferred class-component alias: `(class_end, name)`.
@@ -539,6 +536,8 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                     }
                     pending_wrap_close = None;
                 }
+
+                props_const_assertions.splice_output_line(&mut output_line, line_start);
 
                 // Strip `export` from non-import lines inside setup scope
                 let trimmed_line = output_line.trim_start();

--- a/crates/vize_canon/src/virtual_ts/generator/options_api.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api.rs
@@ -14,10 +14,7 @@ use super::options_api_support::{
     extend_options_api_descriptor_names, is_safe_value_identifier, props_source_from_object,
 };
 use crate::virtual_ts::types::VirtualTsOptions;
-use vize_carton::CompactString;
-use vize_carton::FxHashSet;
-use vize_carton::String;
-use vize_carton::append;
+use vize_carton::{CompactString, FxHashSet, String, append};
 
 // Emit declarations for Options API template bindings
 // (`data`/`computed`/`methods`/`inject`/`setup`/`props`, plus any Nuxt 2 globals
@@ -520,9 +517,9 @@ use crate::virtual_ts::props::OptionsApiPropsSource;
 ///
 /// Returns `None` when there is no resolvable component options object or no
 /// `props:` option (or it is an unrecognized expression form). Object and array
-/// literals are recognized directly; an identifier whose initializer object can
-/// be resolved is not chased here because the runtime prop ctors would not be in
-/// scope inside the emitted `__RuntimePropShape<...>` reference.
+/// literals are recognized directly. Identifier props are deferred through setup
+/// scope so local/imported runtime prop declarations stay in value position
+/// before `__RuntimePropShape<...>` reads them.
 ///
 /// The result feeds canon's real `export type Props` for Options API
 /// components: object form maps through the shared `__RuntimePropShape<...>`
@@ -561,6 +558,8 @@ fn options_api_props_from_expression(
             }
             (!names.is_empty()).then_some(OptionsApiPropsSource::Names(names))
         }
+        Expression::Identifier(identifier) => is_safe_value_identifier(identifier.name.as_str())
+            .then(|| OptionsApiPropsSource::DeferredObject(String::from(identifier.name.as_str()))),
         Expression::ParenthesizedExpression(parenthesized) => {
             options_api_props_from_expression(script, &parenthesized.expression)
         }
@@ -577,7 +576,7 @@ fn options_api_props_from_expression(
     }
 }
 
-fn option_expression_property<'a>(
+pub(super) fn option_expression_property<'a>(
     object: &'a ObjectExpression<'a>,
     key_name: &str,
 ) -> Option<&'a Expression<'a>> {
@@ -592,7 +591,7 @@ fn option_expression_property<'a>(
     })
 }
 
-fn component_options_from_program<'a>(
+pub(super) fn component_options_from_program<'a>(
     program: &'a Program<'a>,
 ) -> Option<&'a ObjectExpression<'a>> {
     program.body.iter().find_map(|statement| {

--- a/crates/vize_canon/src/virtual_ts/generator/options_api_props_identifiers.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api_props_identifiers.rs
@@ -1,0 +1,165 @@
+//! Options API identifier `props:` support for virtual TypeScript emission.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{BindingPattern, Expression, Statement, VariableDeclarationKind};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
+use vize_carton::{FxHashSet, String};
+
+use super::options_api::{component_options_from_program, option_expression_property};
+use super::options_api_support::is_safe_value_identifier;
+
+pub(super) struct PropsConstAssertions {
+    offsets: Vec<usize>,
+    index: usize,
+}
+
+impl PropsConstAssertions {
+    pub(super) fn new(script: &str, options_api: bool) -> Self {
+        let offsets = if options_api {
+            find_const_assertion_offsets(script)
+        } else {
+            Vec::new()
+        };
+        Self { offsets, index: 0 }
+    }
+
+    pub(super) fn splice_line(&mut self, line: &str, line_start: usize) -> Option<String> {
+        while self.index < self.offsets.len() && self.offsets[self.index] <= line_start {
+            self.index += 1;
+        }
+
+        let line_end = line_start + line.len();
+        if self.index >= self.offsets.len() || self.offsets[self.index] > line_end {
+            return None;
+        }
+
+        let mut output = String::default();
+        let mut copied_until = 0usize;
+        let mut spliced = false;
+
+        while self.index < self.offsets.len() {
+            let offset = self.offsets[self.index];
+            if offset > line_end {
+                break;
+            }
+            self.index += 1;
+
+            if offset < line_start {
+                continue;
+            }
+            let column = offset - line_start;
+            if !line.is_char_boundary(column) {
+                continue;
+            }
+            output.push_str(&line[copied_until..column]);
+            output.push_str(" as const");
+            copied_until = column;
+            spliced = true;
+        }
+
+        if !spliced {
+            return None;
+        }
+
+        output.push_str(&line[copied_until..]);
+        Some(output)
+    }
+
+    pub(super) fn splice_output_line<'a>(
+        &mut self,
+        output_line: &mut std::borrow::Cow<'a, str>,
+        line_start: usize,
+    ) {
+        if let Some(spliced) = self.splice_line(output_line.as_ref(), line_start) {
+            *output_line = std::borrow::Cow::Owned(spliced.into());
+        }
+    }
+}
+
+fn find_const_assertion_offsets(script: &str) -> Vec<usize> {
+    if !script.contains("export default") {
+        return Vec::new();
+    }
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
+    if parsed.panicked {
+        return Vec::new();
+    }
+
+    let Some(options) = component_options_from_program(&parsed.program) else {
+        return Vec::new();
+    };
+    let Some(props) = option_expression_property(options, "props") else {
+        return Vec::new();
+    };
+
+    let mut prop_bindings = FxHashSet::default();
+    collect_props_identifier_names(props, &mut prop_bindings);
+    if prop_bindings.is_empty() {
+        return Vec::new();
+    }
+
+    let mut offsets = Vec::new();
+    for statement in parsed.program.body.iter() {
+        let Statement::VariableDeclaration(declaration) = statement else {
+            continue;
+        };
+        if declaration.kind != VariableDeclarationKind::Const {
+            continue;
+        }
+        for declarator in declaration.declarations.iter() {
+            let BindingPattern::BindingIdentifier(id) = &declarator.id else {
+                continue;
+            };
+            if !prop_bindings.contains(id.name.as_str()) {
+                continue;
+            }
+            let Some(init) = declarator.init.as_ref() else {
+                continue;
+            };
+            if let Some(offset) = const_assertion_offset_for_props_initializer(init) {
+                offsets.push(offset);
+            }
+        }
+    }
+    offsets.sort_unstable();
+    offsets.dedup();
+    offsets
+}
+
+fn collect_props_identifier_names<'a>(
+    expression: &'a Expression<'a>,
+    names: &mut FxHashSet<&'a str>,
+) {
+    match expression {
+        Expression::Identifier(identifier)
+            if is_safe_value_identifier(identifier.name.as_str()) =>
+        {
+            names.insert(identifier.name.as_str());
+        }
+        Expression::ParenthesizedExpression(parenthesized) => {
+            collect_props_identifier_names(&parenthesized.expression, names);
+        }
+        Expression::TSAsExpression(ts_as) => {
+            collect_props_identifier_names(&ts_as.expression, names)
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            collect_props_identifier_names(&ts_satisfies.expression, names);
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            collect_props_identifier_names(&ts_non_null.expression, names);
+        }
+        _ => {}
+    }
+}
+
+fn const_assertion_offset_for_props_initializer(expression: &Expression<'_>) -> Option<usize> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object.span().end as usize),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            const_assertion_offset_for_props_initializer(&parenthesized.expression)
+        }
+        _ => None,
+    }
+}

--- a/crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs
@@ -129,6 +129,61 @@ export default defineComponent({
 }
 
 #[test]
+fn test_options_api_props_identifier_preserves_required_literals_in_setup_scope() {
+    let script = r#"import { defineComponent, type PropType } from 'vue'
+
+const componentProps = {
+    items: {
+        type: Array as PropType<Array<{ id: string }>>,
+        required: true,
+    },
+}
+
+export default defineComponent({
+    props: componentProps,
+    setup(props) {
+        props.items.findIndex((item) => item.id)
+        return {}
+    },
+})
+"#;
+    let summary = analyze_options_api_script(script);
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        None,
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        output.code.contains("const componentProps = {"),
+        "local props object should remain in setup scope:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains("} as const"),
+        "local props object should preserve `required: true` as a literal:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("const __vize_options_props = (componentProps);"),
+        "identifier props should be captured as a setup-scoped runtime value:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains(
+            "export type Props = __RuntimePropShape<Awaited<ReturnType<typeof __setup>>[\"__vize_options_props\"]>;"
+        ),
+        "Props should be derived from the setup-scoped identifier props artifact:\n{}",
+        output.code
+    );
+}
+
+#[test]
 fn test_options_api_props_with_type_cast_defers_to_setup_scope() {
     let script = r#"import { defineComponent } from 'vue'
 import type { PropType } from 'vue'


### PR DESCRIPTION
## Summary
- preserve literal `required: true` flags for local Options API props identifiers in virtual TS
- defer identifier-based Options API props through the setup-scope runtime artifact
- add regression coverage for Vue 2 `setup(props)` required props

## Tests
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p vize_canon options_api_props -- --nocapture`
- `cargo test -p vize_canon options_api_props --features legacy -- --nocapture`
- `cargo test -p vize_canon test_type_check_legacy_vue2_required_options_props_in_setup_are_defined --features legacy -- --nocapture`
- `VIZE_TEST_WORKSPACE_NODE_MODULES=/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules cargo test -p vize_canon batch_type_checker_accepts_legacy_vue2_required_options_props_in_setup --features legacy -- --nocapture`

Closes #1982

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->