### PR TITLE
fix(check): expose Options API setup spread bindings

### DIFF
--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -50,6 +50,7 @@ mod diagnostic;
 #[cfg(feature = "native")]
 mod file_uri;
 pub mod intelligence;
+mod options_api_setup_spread;
 mod script_parse;
 pub mod sfc_typecheck;
 pub mod source_map;
@@ -64,7 +65,6 @@ pub mod legacy;
 // Batch type checking module (requires native feature)
 #[cfg(feature = "native")]
 pub mod batch;
-
 #[cfg(feature = "native")]
 pub mod corsa_bridge;
 

--- a/crates/vize_canon/src/options_api_setup_spread.rs
+++ b/crates/vize_canon/src/options_api_setup_spread.rs
@@ -1,0 +1,295 @@
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    Argument, CallExpression, ExportDefaultDeclarationKind, Expression, ObjectExpression,
+    ObjectPropertyKind, Program, PropertyKey, Statement,
+};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{FxHashSet, String};
+use vize_croquis::{BindingType, Croquis, OptionGroup};
+
+pub(crate) fn suppresses_template_undefined_refs(
+    options_api_enabled: bool,
+    script_content: Option<&str>,
+) -> bool {
+    options_api_enabled && script_content.is_some_and(setup_return_has_spread)
+}
+
+pub(crate) fn collect_template_setup_bindings(
+    summary: &Croquis,
+    options_api: bool,
+    template_referenced_names: Option<&FxHashSet<String>>,
+    script_content: Option<&str>,
+) -> Vec<String> {
+    let mut names = collect_descriptor_setup_bindings(summary, options_api);
+    if suppresses_template_undefined_refs(options_api, script_content) {
+        extend_spread_bindings(&mut names, summary, template_referenced_names);
+    }
+    if let Some(template_referenced_names) = template_referenced_names {
+        names.retain(|name| template_referenced_names.contains(name.as_str()));
+    }
+    names.sort_unstable();
+    names.dedup();
+    names
+}
+
+fn setup_return_has_spread(script: &str) -> bool {
+    if !script.contains("export default") {
+        return false;
+    }
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
+    if parsed.panicked {
+        return false;
+    }
+    let Some(options) = component_options_from_program(&parsed.program) else {
+        return false;
+    };
+    let Some(setup) = option_expression_property(options, "setup") else {
+        return false;
+    };
+    setup_return_object_from_expression(setup).is_some_and(object_has_spread)
+}
+
+fn collect_descriptor_setup_bindings(summary: &Croquis, options_api: bool) -> Vec<String> {
+    if !options_api || summary.bindings.is_script_setup {
+        return Vec::new();
+    }
+    let Some(descriptor) = summary.options_descriptor.as_ref() else {
+        return Vec::new();
+    };
+    descriptor
+        .members_in(OptionGroup::Setup)
+        .map(|member| member.name.as_str())
+        .filter(|name| {
+            is_safe_value_identifier(name)
+                && matches!(
+                    summary.bindings.get(name),
+                    Some(BindingType::SetupMaybeRef | BindingType::SetupRef)
+                )
+        })
+        .map(String::from)
+        .collect()
+}
+
+fn extend_spread_bindings(
+    names: &mut Vec<String>,
+    summary: &Croquis,
+    template_referenced_names: Option<&FxHashSet<String>>,
+) {
+    if let Some(template_referenced_names) = template_referenced_names {
+        names.extend(
+            template_referenced_names
+                .iter()
+                .filter(|name| is_safe_spread_binding(summary, name.as_str()))
+                .map(|name| String::from(name.as_str())),
+        );
+        return;
+    }
+    names.extend(
+        summary
+            .undefined_refs
+            .iter()
+            .filter(|reference| reference.context == "template expression")
+            .map(|reference| reference.name.as_str())
+            .filter(|name| is_safe_spread_binding(summary, name))
+            .map(String::from),
+    );
+}
+
+fn is_safe_spread_binding(summary: &Croquis, name: &str) -> bool {
+    is_safe_value_identifier(name) && summary.bindings.get(name).is_none()
+}
+
+fn setup_return_object_from_expression<'a>(
+    expression: &'a Expression<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::FunctionExpression(function) => {
+            setup_return_object_in_body(&function.body.as_ref()?.statements)
+        }
+        Expression::ArrowFunctionExpression(arrow) => {
+            if arrow.expression {
+                let Statement::ExpressionStatement(expr) = arrow.body.statements.first()? else {
+                    return None;
+                };
+                object_expression_from_expression(&expr.expression)
+            } else {
+                setup_return_object_in_body(&arrow.body.statements)
+            }
+        }
+        Expression::ParenthesizedExpression(parenthesized) => {
+            setup_return_object_from_expression(&parenthesized.expression)
+        }
+        Expression::TSAsExpression(ts_as) => setup_return_object_from_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            setup_return_object_from_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            setup_return_object_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn setup_return_object_in_body<'a>(
+    statements: &'a oxc_allocator::Vec<'a, Statement<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    for statement in statements.iter() {
+        if let Statement::ReturnStatement(ret) = statement
+            && let Some(argument) = ret.argument.as_ref()
+        {
+            return object_expression_from_expression(argument);
+        }
+    }
+    None
+}
+
+fn object_has_spread(object: &ObjectExpression<'_>) -> bool {
+    object
+        .properties
+        .iter()
+        .any(|property| matches!(property, ObjectPropertyKind::SpreadProperty(_)))
+}
+
+fn option_expression_property<'a>(
+    object: &'a ObjectExpression<'a>,
+    key_name: &str,
+) -> Option<&'a Expression<'a>> {
+    object.properties.iter().find_map(|property| {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return None;
+        };
+        if property.computed || property_key_name(&property.key) != Some(key_name) {
+            return None;
+        }
+        Some(&property.value)
+    })
+}
+
+fn component_options_from_program<'a>(
+    program: &'a Program<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    program.body.iter().find_map(|statement| {
+        let Statement::ExportDefaultDeclaration(export) = statement else {
+            return None;
+        };
+        component_options_from_declaration(&export.declaration)
+    })
+}
+
+fn component_options_from_declaration<'a>(
+    declaration: &'a ExportDefaultDeclarationKind<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match declaration {
+        ExportDefaultDeclarationKind::ObjectExpression(object) => Some(object.as_ref()),
+        ExportDefaultDeclarationKind::CallExpression(call) => component_options_from_call(call),
+        ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
+            component_options_from_expression(&ts_as.expression)
+        }
+        ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
+            component_options_from_expression(&ts_satisfies.expression)
+        }
+        ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
+            component_options_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn component_options_from_expression<'a>(
+    expression: &'a Expression<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object.as_ref()),
+        Expression::CallExpression(call) => component_options_from_call(call),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            component_options_from_expression(&parenthesized.expression)
+        }
+        Expression::TSAsExpression(ts_as) => component_options_from_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            component_options_from_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            component_options_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn component_options_from_call<'a>(
+    call: &'a CallExpression<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    if !is_define_component_callee(&call.callee) {
+        return None;
+    }
+    let first = call.arguments.first()?;
+    match first {
+        Argument::ObjectExpression(object) => Some(object.as_ref()),
+        Argument::CallExpression(call) => component_options_from_call(call),
+        Argument::ParenthesizedExpression(parenthesized) => {
+            component_options_from_expression(&parenthesized.expression)
+        }
+        Argument::TSAsExpression(ts_as) => component_options_from_expression(&ts_as.expression),
+        Argument::TSSatisfiesExpression(ts_satisfies) => {
+            component_options_from_expression(&ts_satisfies.expression)
+        }
+        Argument::TSNonNullExpression(ts_non_null) => {
+            component_options_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn is_define_component_callee(callee: &Expression<'_>) -> bool {
+    match callee {
+        Expression::Identifier(callee) => {
+            matches!(callee.name.as_str(), "defineComponent" | "_defineComponent")
+        }
+        Expression::StaticMemberExpression(member) => {
+            matches!(
+                member.property.name.as_str(),
+                "defineComponent" | "_defineComponent"
+            )
+        }
+        _ => false,
+    }
+}
+
+fn object_expression_from_expression<'a>(
+    expression: &'a Expression<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object.as_ref()),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            object_expression_from_expression(&parenthesized.expression)
+        }
+        Expression::TSAsExpression(ts_as) => object_expression_from_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            object_expression_from_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            object_expression_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
+        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
+        _ => None,
+    }
+}
+
+fn is_safe_value_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
+        return false;
+    }
+    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$')
+}

--- a/crates/vize_canon/src/sfc_typecheck/checks.rs
+++ b/crates/vize_canon/src/sfc_typecheck/checks.rs
@@ -175,16 +175,17 @@ fn has_inferable_runtime_emits(runtime_args: &str) -> bool {
     let args = runtime_args.trim();
     !matches!(args, "" | "[]" | "{}")
 }
-
-/// Check template bindings for undefined references.
 pub fn check_template_bindings(
     summary: &vize_croquis::Croquis,
     template_offset: u32,
     result: &mut SfcTypeCheckResult,
     _strict: bool,
+    suppress_options_api_setup_spread_refs: bool,
 ) {
-    // Report undefined references using croquis scope analysis
     for undef_ref in &summary.undefined_refs {
+        if suppress_options_api_setup_spread_refs && undef_ref.context == "template expression" {
+            continue;
+        }
         result.add_diagnostic(SfcTypeDiagnostic {
             severity: SfcTypeSeverity::Error,
             message: cstr!(
@@ -204,7 +205,6 @@ pub fn check_template_bindings(
     }
 }
 
-/// Check for reactivity loss patterns.
 pub fn check_reactivity(
     summary: &vize_croquis::Croquis,
     script_offset: u32,

--- a/crates/vize_canon/src/sfc_typecheck/runner.rs
+++ b/crates/vize_canon/src/sfc_typecheck/runner.rs
@@ -1,8 +1,3 @@
-//! Main SFC type checking runner.
-//!
-//! Orchestrates parsing, analysis, and virtual TypeScript generation
-//! for a Vue Single File Component.
-
 use vize_carton::Bump;
 use vize_carton::cstr;
 
@@ -18,15 +13,6 @@ use super::{
     virtual_ts::generate_virtual_ts_with_scopes,
 };
 
-/// Perform type checking on a Vue SFC.
-///
-/// This performs AST-based type analysis using croquis for semantic analysis.
-/// It checks:
-/// - Props typing (defineProps)
-/// - Emits typing (defineEmits)
-/// - Template binding references
-///
-/// For full TypeScript type checking with Corsa, use `TypeCheckService`.
 pub fn type_check_sfc(source: &str, options: &SfcTypeCheckOptions) -> SfcTypeCheckResult {
     type_check_sfc_impl(source, options, false, false)
 }
@@ -57,13 +43,10 @@ fn type_check_sfc_impl(
     use vize_atelier_core::parser::parse;
     use vize_atelier_sfc::{SfcParseOptions, croquis::SfcCroquisOptions, parse_sfc};
 
-    // Use Instant for timing on native, skip on WASM
     #[cfg(not(target_arch = "wasm32"))]
     let start_time = std::time::Instant::now();
 
     let mut result = SfcTypeCheckResult::empty();
-
-    // Parse SFC
     let parse_opts = SfcParseOptions {
         filename: options.filename.clone(),
         ..Default::default()
@@ -183,7 +166,18 @@ fn type_check_sfc_impl(
 
     // Check template bindings
     if options.check_template_bindings && !has_template_parse_errors && !has_script_parse_errors {
-        check_template_bindings(&summary, template_offset, &mut result, options.strict);
+        let suppress_options_api_setup_spread_refs =
+            crate::options_api_setup_spread::suppresses_template_undefined_refs(
+                options_api || legacy_vue2,
+                script_content.as_deref(),
+            );
+        check_template_bindings(
+            &summary,
+            template_offset,
+            &mut result,
+            options.strict,
+            suppress_options_api_setup_spread_refs,
+        );
     }
 
     // Check reactivity loss

--- a/crates/vize_canon/src/sfc_typecheck/tests.rs
+++ b/crates/vize_canon/src/sfc_typecheck/tests.rs
@@ -4,11 +4,11 @@
 mod emit_props;
 #[cfg(feature = "legacy")]
 mod options_api_required_props;
+mod options_api_setup_spread;
 use super::{
     SfcTypeCheckOptions, SfcTypeCheckResult, SfcTypeDiagnostic, SfcTypeSeverity, type_check_sfc,
     type_check_sfc_with_options_api,
 };
-
 fn stable_snapshot_result(mut result: SfcTypeCheckResult) -> SfcTypeCheckResult {
     if result.analysis_time_ms.is_some() {
         result.analysis_time_ms = Some(0.0);

--- a/crates/vize_canon/src/sfc_typecheck/tests/options_api_setup_spread.rs
+++ b/crates/vize_canon/src/sfc_typecheck/tests/options_api_setup_spread.rs
@@ -1,0 +1,53 @@
+use crate::sfc_typecheck::{SfcTypeCheckOptions, type_check_sfc_with_options_api};
+
+#[test]
+fn options_api_setup_return_spread_exposes_template_bindings() {
+    let source = r#"<script lang="ts">
+function defineComponent(options: any): any { return options }
+function toRefs<T extends Record<string, any>>(value: T): { [K in keyof T]: { value: T[K] } } {
+  return value as any
+}
+
+function useAiSupportForm() {
+  return {
+    formInput: {
+      aiSupportTitle: '',
+      aiSupportType: '',
+      aiSupportTagName: '',
+    },
+  }
+}
+
+export default defineComponent({
+  setup() {
+    const { formInput } = useAiSupportForm()
+    return {
+      ...toRefs(formInput),
+    }
+  },
+})
+</script>
+<template>
+  <div>{{ aiSupportTitle }} {{ aiSupportType }} {{ aiSupportTagName }}</div>
+</template>"#;
+
+    let result = type_check_sfc_with_options_api(
+        source,
+        &SfcTypeCheckOptions::new("OptionsSetupSpread.vue"),
+    );
+    let unexpected: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            matches!(
+                diagnostic.code.as_deref(),
+                Some("2304" | "undefined-binding")
+            )
+        })
+        .collect();
+
+    assert!(
+        unexpected.is_empty(),
+        "Options API setup return spread bindings should be available in template scope: {unexpected:#?}"
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -714,7 +714,6 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     }
 
     setup_props_plan.emit_artifact(&mut ts, summary);
-
     // Template scope (nested inside setup)
     if has_template_scope && check_options.check_template_bindings {
         profile!("canon.virtual_ts.emit_template_scope", {
@@ -724,6 +723,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                 summary,
                 options_api,
                 template_referenced_names.as_ref(),
+                script_content,
             );
             template_ref_unwraps.emit_type_captures(&mut ts);
 

--- a/crates/vize_canon/src/virtual_ts/generator/template_refs.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/template_refs.rs
@@ -1,11 +1,8 @@
-//! Template ref and Options API setup-return unwrapping.
-
 use vize_carton::config::VueVersion;
 use vize_carton::{FxHashSet, String, append};
-use vize_croquis::{BindingType, Croquis, OptionGroup};
+use vize_croquis::{BindingType, Croquis};
 
 use super::legacy_vue2::ref_unwrap_helper;
-use super::options_api_support::is_safe_value_identifier;
 use super::spans::is_local_setup_binding;
 
 pub(super) struct TemplateRefUnwraps {
@@ -18,13 +15,15 @@ impl TemplateRefUnwraps {
         summary: &Croquis,
         options_api: bool,
         template_referenced_names: Option<&FxHashSet<String>>,
+        script_content: Option<&str>,
     ) -> Self {
-        let mut options_api_setup_bindings =
-            collect_options_api_setup_bindings(summary, options_api);
-        if let Some(template_referenced_names) = template_referenced_names {
-            options_api_setup_bindings
-                .retain(|name| template_referenced_names.contains(name.as_str()));
-        }
+        let options_api_setup_bindings =
+            crate::options_api_setup_spread::collect_template_setup_bindings(
+                summary,
+                options_api,
+                template_referenced_names,
+                script_content,
+            );
         let options_api_setup_binding_names: FxHashSet<&str> = options_api_setup_bindings
             .iter()
             .map(|name| name.as_str())
@@ -96,30 +95,4 @@ impl TemplateRefUnwraps {
             append!(ts, "    var {name}: __U<__R_{name}> = undefined as any;\n");
         }
     }
-}
-
-fn collect_options_api_setup_bindings(summary: &Croquis, options_api: bool) -> Vec<String> {
-    if !options_api || summary.bindings.is_script_setup {
-        return Vec::new();
-    }
-
-    let Some(descriptor) = summary.options_descriptor.as_ref() else {
-        return Vec::new();
-    };
-
-    let mut names: Vec<String> = descriptor
-        .members_in(OptionGroup::Setup)
-        .map(|member| member.name.as_str())
-        .filter(|name| {
-            is_safe_value_identifier(name)
-                && matches!(
-                    summary.bindings.get(name),
-                    Some(BindingType::SetupMaybeRef | BindingType::SetupRef)
-                )
-        })
-        .map(String::from)
-        .collect();
-    names.sort_unstable();
-    names.dedup();
-    names
 }

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -9,6 +9,7 @@ use vize_carton::config::VueVersion;
 mod define_props_scope;
 mod no_check_template_bindings;
 mod options_api_props_spread;
+mod options_api_setup_spread;
 mod unused_refs;
 mod vif_chain;
 fn assert_virtual_ts_snapshot(name: &str, value: &str) {
@@ -26,7 +27,6 @@ fn test_vue_setup_helpers_are_actual_functions() {
 
 #[test]
 fn test_vue_template_context() {
-    // Template context should contain Vue instance properties
     let ctx = generate_template_context(&VirtualTsOptions::default(), VueVersion::V3, false);
     assert_virtual_ts_snapshot("virtual_ts_vue_template_context", ctx.as_str());
 }

--- a/crates/vize_canon/src/virtual_ts/tests/options_api_setup_spread.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/options_api_setup_spread.rs
@@ -1,0 +1,61 @@
+use super::generate_virtual_ts_with_offsets_options_api;
+
+#[test]
+fn options_api_setup_return_spread_exposes_template_references() {
+    let script = r#"import { defineComponent, toRefs } from '@nuxtjs/composition-api'
+
+function useAiSupportForm() {
+    return {
+        formInput: {
+            aiSupportTitle: '',
+            aiSupportType: '',
+            aiSupportTagName: '',
+        },
+    }
+}
+
+export default defineComponent({
+    setup() {
+        const { formInput } = useAiSupportForm()
+        return {
+            ...toRefs(formInput),
+        }
+    },
+})
+"#;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(
+        &allocator,
+        "<div>{{ aiSupportTitle }} {{ aiSupportType }} {{ aiSupportTagName }}</div>",
+    );
+    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full())
+        .with_options_api();
+    analyzer.analyze_script_plain(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &Default::default(),
+    );
+
+    for name in ["aiSupportTitle", "aiSupportType", "aiSupportTagName"] {
+        assert!(
+            output.code.contains(&format!(
+                "type __R_{name} = __VizeOptionsSetupBinding<\"{name}\">;"
+            )),
+            "setup spread template reference should be captured from the default instance:\n{}",
+            output.code
+        );
+        assert!(
+            output
+                .code
+                .contains(&format!("var {name}: __U<__R_{name}> = undefined as any;")),
+            "setup spread template reference should be declared in template scope:\n{}",
+            output.code
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- detect Options API setup() return objects that contain spread properties
- expose template-referenced spread return bindings through the generated instance binding type
- suppress the AST-only undefined-binding diagnostic for that specific setup spread case

## Root cause
Options API setup() return names are normally available from the component instance, but a spread return such as `return { ...toRefs(formInput) }` does not give the analyzer concrete member names. The virtual TypeScript and template binding pre-check therefore treated template references such as `aiSupportTitle` as undefined.

## Validation
- cargo fmt --all --check
- git diff --check
- cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports
- cargo test -p vize_canon options_api_setup_return_spread_exposes_template_references -- --nocapture
- cargo test -p vize_canon options_api_setup_return_spread_exposes_template_bindings -- --nocapture
- cargo test -p vize_canon options_api_setup -- --nocapture

Closes #1980

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->