### PR TITLE
fix(lint): respect Vue 2 v-for template keys

### DIFF
--- a/crates/vize/src/commands/lint/mod.rs
+++ b/crates/vize/src/commands/lint/mod.rs
@@ -52,25 +52,24 @@ pub fn run(args: LintArgs) {
     let render_details = should_render_lint_details(format, args.quiet);
     crate::config::write_schema(None);
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    // Load the shared config and linter section from the same raw parse. The
-    // lint command is often used in watch/CI loops, so avoiding a second config
-    // evaluation keeps startup overhead out of the per-run profile.
     let (loaded_config, linter_config) = if args.no_config {
         (
-            crate::config::LoadedConfig {
+            crate::config::LoadedConfigWithFeatures {
                 config: crate::config::VizeConfig::default(),
                 source_path: None,
+                features: crate::config::ConfigFeatureFlags::default(),
             },
             crate::config::LinterConfig::default(),
         )
     } else {
-        crate::config::load_config_and_linter_with_source(args.config.as_deref())
+        crate::config::load_config_and_linter_with_features_and_source(args.config.as_deref())
     };
     let config_dir = loaded_config
         .source_path
         .as_deref()
         .and_then(Path::parent)
         .unwrap_or(cwd.as_path());
+    let vue_version = loaded_config.features.vue_version;
     let config = loaded_config.config;
     if !linter_config.enabled {
         eprintln!("[vize] Skipping lint because linter.enabled is false in vize.config.");
@@ -110,7 +109,8 @@ pub fn run(args: LintArgs) {
         .with_additional_rules(linter_config.enabled_rules())
         .with_disabled_rules(linter_config.disabled_rules())
         .with_help_level(help_level)
-        .with_type_aware_lint(type_aware_enabled);
+        .with_type_aware_lint(type_aware_enabled)
+        .with_vue_version(vue_version);
     #[cfg(not(target_arch = "wasm32"))]
     {
         linter = linter.with_corsa_path(configured_corsa_path);

--- a/crates/vize/tests/lint_config_cli.rs
+++ b/crates/vize/tests/lint_config_cli.rs
@@ -93,3 +93,47 @@ const noop = () => {}
 
     let _ = fs::remove_dir_all(project_root);
 }
+
+#[test]
+fn lint_vue2_config_allows_template_v_for_key_on_child() {
+    let project_root = temp_project_dir("vue2-v-for-child-key");
+    let sfc = r#"<script setup>
+const items = [{ id: 1, name: 'One' }]
+</script>
+
+<template>
+  <template v-for="item in items">
+    <div :key="item.id">{{ item.name }}</div>
+  </template>
+</template>
+"#;
+    write_project_file(&project_root, "src/App.vue", sfc);
+    write_project_file(
+        &project_root,
+        "vize.config.json",
+        r#"{ "vue": { "version": "2" } }"#,
+    );
+
+    let vue3 = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["lint", "--no-config", "src/App.vue"])
+        .output()
+        .unwrap();
+    assert!(!vue3.status.success());
+    let stdout = String::from_utf8_lossy(&vue3.stdout);
+    assert!(stdout.contains("vue/no-v-for-template-key-on-child"));
+
+    let vue2 = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["lint", "--config", "vize.config.json", "src/App.vue"])
+        .output()
+        .unwrap();
+    assert!(
+        vue2.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&vue2.stdout),
+        String::from_utf8_lossy(&vue2.stderr)
+    );
+
+    let _ = fs::remove_dir_all(project_root);
+}

--- a/crates/vize_patina/src/linter/config.rs
+++ b/crates/vize_patina/src/linter/config.rs
@@ -17,7 +17,7 @@ use crate::{
 use std::path::PathBuf;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::Mutex;
-use vize_carton::{FxHashSet, String, i18n::Locale};
+use vize_carton::{FxHashSet, String, config::VueVersion, i18n::Locale};
 
 /// Lint result for a single file.
 #[derive(Debug, Clone)]
@@ -241,6 +241,16 @@ impl Linter {
     #[inline]
     pub fn with_disabled_rules(mut self, rules: Vec<String>) -> Self {
         self.disabled_rules = rules.into_iter().collect();
+        self
+    }
+
+    /// Apply project-wide Vue dialect compatibility to lint rules.
+    #[inline]
+    pub fn with_vue_version(mut self, version: Option<VueVersion>) -> Self {
+        if version.is_some_and(VueVersion::is_legacy) {
+            self.disabled_rules
+                .insert(String::from("vue/no-v-for-template-key-on-child"));
+        }
         self
     }
 

--- a/crates/vize_patina/src/rules/vue/no_v_for_template_key_on_child.rs
+++ b/crates/vize_patina/src/rules/vue/no_v_for_template_key_on_child.rs
@@ -97,6 +97,7 @@ mod tests {
     use super::NoVForTemplateKeyOnChild;
     use crate::linter::Linter;
     use crate::rule::RuleRegistry;
+    use vize_carton::config::VueVersion;
 
     fn create_linter() -> Linter {
         let mut registry = RuleRegistry::new();
@@ -175,6 +176,16 @@ mod tests {
         // attribute is left to other rules.
         let result = linter.lint_template(
             r#"<template v-for="item in items"><div key="static">{{ item }}</div></template>"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn vue2_allows_key_on_template_v_for_child() {
+        let linter = create_linter().with_vue_version(Some(VueVersion::V2));
+        let result = linter.lint_template(
+            r#"<template v-for="item in items"><div :key="item.id">{{ item }}</div></template>"#,
             "test.vue",
         );
         assert_eq!(result.error_count, 0);


### PR DESCRIPTION
## Summary

- Thread `vue.version` from lint config into the Rust linter setup.
- Disable the Vue 3-only `vue/no-v-for-template-key-on-child` migration rule for legacy Vue versions.
- Add rule-level and CLI regression coverage for Vue 2 `template v-for` child keys.

## Tests

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p vize_patina vue2_allows_key_on_template_v_for_child -- --nocapture`
- `cargo test -p vize --test lint_config_cli lint_vue2_config_allows_template_v_for_key_on_child -- --nocapture`
- `cargo clippy -p vize_patina -p vize -- -D warnings -D clippy::wildcard_imports`

Closes #1983

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->