### PR TITLE
test: expand regression coverage

### DIFF
--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -76,7 +76,7 @@ pub(super) fn collect_transitive_local_imports(
             };
             // Never register an ambient declaration file — its `declare module`
             // statements would shadow real modules as a program root.
-            if is_declaration_file(&resolved) {
+            if is_declaration_file(&resolved) || is_node_modules_path(&resolved) {
                 continue;
             }
             if visited.insert(resolved.clone()) {
@@ -246,6 +246,11 @@ fn is_declaration_file(path: &Path) -> bool {
         .is_some_and(|name| {
             name.ends_with(".d.ts") || name.ends_with(".d.mts") || name.ends_with(".d.cts")
         })
+}
+
+fn is_node_modules_path(path: &Path) -> bool {
+    path.components()
+        .any(|component| component.as_os_str() == std::ffi::OsStr::new("node_modules"))
 }
 
 fn has_source_extension(path: &Path, include_jsx: bool) -> bool {

--- a/crates/vize/src/commands/check/imports_tests.rs
+++ b/crates/vize/src/commands/check/imports_tests.rs
@@ -169,3 +169,120 @@ fn jsx_imports_are_resolved_only_when_jsx_typecheck_is_enabled() {
 
     let _ = std::fs::remove_dir_all(&root);
 }
+
+#[test]
+fn collects_project_import_graph_edges_without_package_boundaries() {
+    let root = std::env::temp_dir().join(cstr!("vize-imports-matrix-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::create_dir_all(root.join("node_modules/pkg")).unwrap();
+    std::fs::write(
+        root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["src/*"],
+      "@root/*": ["*"]
+    }
+  }
+}"#,
+    )
+    .unwrap();
+
+    let entry = write(
+        &root,
+        "src/entry.ts",
+        r#"import { fromSrcRoot } from "~/lib";
+import { fromProjectRoot } from "@root/shared/root";
+import type { PanelProps } from "~/components/Panel.vue";
+import { widget } from "~/components/Widget";
+import { cycleA } from "~/cycles/a";
+import { jsAlias } from "~/js-alias.js";
+import { ignoredPackage } from "pkg";
+import { ignoredMissing } from "@root/node_modules/pkg/index";
+
+void fromSrcRoot;
+void fromProjectRoot;
+void widget;
+void cycleA;
+void jsAlias;
+void ignoredPackage;
+void ignoredMissing;
+type _PanelProps = PanelProps;
+"#,
+    );
+    let lib = write(
+        &root,
+        "src/lib/index.ts",
+        r#"export { leaf } from "./leaf";
+export const fromSrcRoot = leaf;
+"#,
+    );
+    let root_shared = write(
+        &root,
+        "shared/root.ts",
+        "export const fromProjectRoot = 'root';\n",
+    );
+    let panel = write(
+        &root,
+        "src/components/Panel.vue",
+        r#"<script setup lang="ts">
+export interface PanelProps {
+  title: string;
+}
+</script>
+"#,
+    );
+    let widget = write(
+        &root,
+        "src/components/Widget.tsx",
+        "export const widget = () => null;\n",
+    );
+    let cycle_a = write(
+        &root,
+        "src/cycles/a.ts",
+        r#"import { cycleB } from "./b";
+export const cycleA = cycleB;
+"#,
+    );
+    let js_alias = write(&root, "src/js-alias.ts", "export const jsAlias = true;\n");
+    let leaf = write(&root, "src/lib/leaf.ts", "export const leaf = 1;\n");
+    let cycle_b = write(
+        &root,
+        "src/cycles/b.ts",
+        r#"import { cycleA } from "./a";
+export const cycleB = cycleA;
+"#,
+    );
+    write(
+        &root,
+        "node_modules/pkg/index.ts",
+        "export const ignoredPackage = 1;\n",
+    );
+
+    let aliases = PathAliasResolver::from_tsconfig(Some(&root.join("tsconfig.json")));
+    let discovered = collect_transitive_local_imports(
+        std::slice::from_ref(&entry),
+        &root,
+        &mut CanonicalPathCache::default(),
+        true,
+        Some(&aliases),
+    );
+
+    assert_eq!(
+        discovered,
+        vec![
+            canonicalize_non_verbatim(&lib),
+            canonicalize_non_verbatim(&root_shared),
+            canonicalize_non_verbatim(&panel),
+            canonicalize_non_verbatim(&widget),
+            canonicalize_non_verbatim(&cycle_a),
+            canonicalize_non_verbatim(&js_alias),
+            canonicalize_non_verbatim(&cycle_b),
+            canonicalize_non_verbatim(&leaf),
+        ]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/vize/src/commands/check/runner/collect_tests.rs
+++ b/crates/vize/src/commands/check/runner/collect_tests.rs
@@ -157,6 +157,60 @@ fn collect_check_files_applies_entry_ignores() {
 }
 
 #[test]
+fn collect_check_files_normalizes_entry_ignore_paths_and_duplicates() {
+    let case_dir = unique_case_dir("collect-check-entry-ignore-paths");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src/nested")).unwrap();
+    fs::create_dir_all(case_dir.join("packages/admin/src")).unwrap();
+    let app = write_file(&case_dir, "src/App.vue", "");
+    let nested = write_file(&case_dir, "src/nested/Panel.vue", "");
+    write_file(&case_dir, "src/Ignored.vue", "");
+    write_file(&case_dir, "src/nested/Ignored.vue", "");
+    write_file(&case_dir, "packages/admin/src/Ignored.vue", "");
+    let admin_page = write_file(&case_dir, "packages/admin/src/Page.vue", "");
+
+    let ignore_set = CheckIgnoreSet::new(
+        &[
+            crate::config::ConfigEntryIgnore {
+                base_path: None,
+                pattern: case_dir
+                    .join("src/Ignored.vue")
+                    .to_string_lossy()
+                    .into_owned()
+                    .into(),
+            },
+            crate::config::ConfigEntryIgnore {
+                base_path: None,
+                pattern: "src/nested/Ignored.vue".into(),
+            },
+            crate::config::ConfigEntryIgnore {
+                base_path: Some("packages/admin".into()),
+                pattern: "src\\Ignored.vue".into(),
+            },
+        ],
+        &case_dir,
+    );
+
+    let files = collect_check_files_with_ignores(
+        &vec![
+            case_dir.join("src").display().to_string(),
+            case_dir.join("src/./App.vue").display().to_string(),
+            case_dir.join("packages/admin/src").display().to_string(),
+            case_dir
+                .join("packages/admin/src/Ignored.vue")
+                .display()
+                .to_string(),
+        ],
+        false,
+        ignore_set.as_ref(),
+    );
+
+    assert_eq!(files, vec![admin_page, app, nested]);
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
 fn path_root_filter_drops_alias_imports_outside_package_cwd() {
     let workspace = unique_case_dir("package-transitive-alias-root");
     let _ = fs::remove_dir_all(&workspace);

--- a/crates/vize/src/commands/check/runner/ignores.rs
+++ b/crates/vize/src/commands/check/runner/ignores.rs
@@ -41,7 +41,11 @@ pub(super) fn retain_unignored(files: &mut Vec<PathBuf>, ignore_set: Option<&Che
 fn resolve_entry_ignore_pattern(ignore: &config::ConfigEntryIgnore, config_dir: &Path) -> PathBuf {
     let pattern = Path::new(ignore.pattern.as_str());
     if pattern.is_absolute() {
-        return pattern.to_path_buf();
+        return if pattern.exists() {
+            vize_carton::path::canonicalize_non_verbatim(pattern)
+        } else {
+            pattern.to_path_buf()
+        };
     }
 
     let config_dir = absolute_config_dir(config_dir);

--- a/crates/vize/tests/check_entry_ignores_cli.rs
+++ b/crates/vize/tests/check_entry_ignores_cli.rs
@@ -4,6 +4,9 @@ use vize_carton::cstr;
 
 #[test]
 fn check_config_entry_ignores_explicit_inputs() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
     let project_root = create_cli_project(
         "entry-ignore-explicit-check",
         &[
@@ -27,6 +30,7 @@ const count: string = 0;
 
     let output = Command::new(env!("CARGO_BIN_EXE_vize"))
         .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
         .args([
             "check",
             "--config",
@@ -57,6 +61,9 @@ const count: string = 0;
 
 #[test]
 fn check_config_entry_ignores_default_and_explicit_path_matrix() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
     let project_root = create_cli_project(
         "entry-ignore-path-matrix",
         &[
@@ -112,6 +119,7 @@ const count: string = 0;
 
     let all = run_check_json(
         &project_root,
+        &corsa_path,
         &["check", "--config", "vize.config.json", "--format", "json"],
     );
     assert_json_files(&all, &[("src/App.vue", 0)]);
@@ -125,6 +133,7 @@ const count: string = 0;
     for ignored_input in ignored_inputs {
         let json = run_check_json(
             &project_root,
+            &corsa_path,
             &[
                 "check",
                 "--config",
@@ -141,9 +150,10 @@ const count: string = 0;
     let _ = std::fs::remove_dir_all(&project_root);
 }
 
-fn run_check_json(project_root: &Path, args: &[&str]) -> serde_json::Value {
+fn run_check_json(project_root: &Path, corsa_path: &str, args: &[&str]) -> serde_json::Value {
     let output = Command::new(env!("CARGO_BIN_EXE_vize"))
         .current_dir(project_root)
+        .env("CORSA_PATH", corsa_path)
         .args(args)
         .output()
         .unwrap();
@@ -202,6 +212,26 @@ fn link_workspace_node_modules(project_root: &Path) {
     std::os::unix::fs::symlink(source, target).unwrap();
     #[cfg(windows)]
     std::os::windows::fs::symlink_dir(source, target).unwrap();
+}
+
+fn resolve_test_corsa_path() -> Option<String> {
+    if let Some(path) = std::env::var_os("CORSA_PATH") {
+        let path = std::path::PathBuf::from(path);
+        if path.exists() {
+            return Some(path.display().to_string());
+        }
+    }
+
+    let workspace_root = workspace_root();
+    let sibling_cache = workspace_root.parent()?.join("corsa-bind/.cache/tsgo");
+    if sibling_cache.exists() {
+        return Some(sibling_cache.display().to_string());
+    }
+
+    let workspace_bin = workspace_root.join("node_modules/.bin/tsgo");
+    workspace_bin
+        .exists()
+        .then(|| workspace_bin.display().to_string())
 }
 
 fn create_cli_project(name: &str, files: &[(&str, &str)]) -> std::path::PathBuf {

--- a/crates/vize/tests/check_entry_ignores_cli.rs
+++ b/crates/vize/tests/check_entry_ignores_cli.rs
@@ -182,12 +182,36 @@ fn assert_json_files(json: &serde_json::Value, expected: &[(&str, usize)]) {
     assert_eq!(json["fileCount"], expected.len());
 }
 
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn link_workspace_node_modules(project_root: &Path) {
+    let source = workspace_root().join("node_modules");
+    if !source.exists() {
+        return;
+    }
+    let target = project_root.join("node_modules");
+    if target.exists() {
+        return;
+    }
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, target).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(source, target).unwrap();
+}
+
 fn create_cli_project(name: &str, files: &[(&str, &str)]) -> std::path::PathBuf {
     let project_root = std::env::temp_dir()
         .join("vize-tests")
         .join("tests")
         .join(cstr!("{name}-{}", std::process::id()).as_str());
     let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    link_workspace_node_modules(&project_root);
     for (path, content) in files {
         let file_path = project_root.join(path);
         if let Some(parent) = file_path.parent() {

--- a/crates/vize/tests/check_entry_ignores_cli.rs
+++ b/crates/vize/tests/check_entry_ignores_cli.rs
@@ -55,16 +55,135 @@ const count: string = 0;
     let _ = std::fs::remove_dir_all(&project_root);
 }
 
-fn workspace_root() -> &'static Path {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .expect("workspace root should exist")
+#[test]
+fn check_config_entry_ignores_default_and_explicit_path_matrix() {
+    let project_root = create_cli_project(
+        "entry-ignore-path-matrix",
+        &[
+            ("vize.config.json", "{}"),
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+const count: number = 1;
+</script>
+"#,
+            ),
+            (
+                "src/AbsoluteIgnored.vue",
+                r#"<script setup lang="ts">
+const count: string = 0;
+</script>
+"#,
+            ),
+            (
+                "src/RelativeIgnored.vue",
+                r#"<script setup lang="ts">
+const count: string = 0;
+</script>
+"#,
+            ),
+            (
+                "src/WindowsIgnored.vue",
+                r#"<script setup lang="ts">
+const count: string = 0;
+</script>
+"#,
+            ),
+        ],
+    );
+    let absolute_ignored = project_root.join("src/AbsoluteIgnored.vue");
+    let absolute_ignored_json =
+        serde_json::to_string(absolute_ignored.to_string_lossy().as_ref()).unwrap();
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        format!(
+            r#"{{
+  "entries": [
+    {{
+      "name": "app",
+      "files": ["src/**/*.vue"],
+      "ignores": [{absolute_ignored_json}, "src/RelativeIgnored.vue", "src\\WindowsIgnored.vue"]
+    }}
+  ]
+}}"#
+        ),
+    )
+    .unwrap();
+
+    let all = run_check_json(
+        &project_root,
+        &["check", "--config", "vize.config.json", "--format", "json"],
+    );
+    assert_json_files(&all, &[("src/App.vue", 0)]);
+    assert_eq!(all["errorCount"], 0);
+
+    let ignored_inputs = [
+        absolute_ignored.to_string_lossy().into_owned(),
+        "src/RelativeIgnored.vue".to_owned(),
+        "src/WindowsIgnored.vue".to_owned(),
+    ];
+    for ignored_input in ignored_inputs {
+        let json = run_check_json(
+            &project_root,
+            &[
+                "check",
+                "--config",
+                "vize.config.json",
+                ignored_input.as_str(),
+                "--format",
+                "json",
+            ],
+        );
+        assert_json_files(&json, &[]);
+        assert_eq!(json["errorCount"], 0);
+    }
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn run_check_json(project_root: &Path, args: &[&str]) -> serde_json::Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root)
+        .args(args)
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    json
+}
+
+fn assert_json_files(json: &serde_json::Value, expected: &[(&str, usize)]) {
+    let files = json["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|file| {
+            (
+                file["file"].as_str().unwrap().to_owned(),
+                file["diagnostics"].as_array().unwrap().len(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let expected = expected
+        .iter()
+        .map(|(file, diagnostics)| ((*file).to_owned(), *diagnostics))
+        .collect::<Vec<_>>();
+
+    assert_eq!(files, expected);
+    assert_eq!(json["fileCount"], expected.len());
 }
 
 fn create_cli_project(name: &str, files: &[(&str, &str)]) -> std::path::PathBuf {
-    let project_root = workspace_root()
-        .join("target")
+    let project_root = std::env::temp_dir()
         .join("vize-tests")
         .join("tests")
         .join(cstr!("{name}-{}", std::process::id()).as_str());

--- a/crates/vize/tests/check_nuxt2_plugin_injections_cli.rs
+++ b/crates/vize/tests/check_nuxt2_plugin_injections_cli.rs
@@ -102,227 +102,7 @@ fn check_nuxt2_false_positive_fixture_matrix() {
         return;
     };
     let project_root = create_project("nuxt2-false-positive-matrix");
-
-    write_file(
-        &project_root,
-        "vize.config.json",
-        r#"{
-  "vue": { "version": "2.7" },
-  "typeChecker": { "legacyVue2": true }
-}"#,
-    );
-    write_file(&project_root, "nuxt.config.ts", "export default {}\n");
-    write_file(
-        &project_root,
-        "tsconfig.json",
-        r##"{
-  "compilerOptions": {
-    "strict": true,
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "baseUrl": ".",
-    "paths": { "~/*": ["*"] },
-    "noEmit": true
-  },
-  "include": ["components/**/*.vue", "pages/**/*.vue", "plugins/**/*.ts", "types/**/*.d.ts"]
-}"##,
-    );
-    write_file(
-        &project_root,
-        "types/nuxt.d.ts",
-        r##"declare module "@nuxt/types" {
-  export interface Context {}
-  export interface NuxtAppOptions {}
-}
-
-declare module "@nuxtjs/composition-api" {
-  export interface UseContextReturn
-    extends Omit<import("@nuxt/types").Context, "route" | "query" | "from" | "params"> {}
-  export function useContext(): UseContextReturn;
-}
-
-declare module "#app" {
-  export interface NuxtApp {}
-}
-"##,
-    );
-    write_file(
-        &project_root,
-        "plugins/logger.ts",
-        r#"export default (_context: unknown, inject: (key: string, value: unknown) => void) => {
-  inject("logger", {
-    info(message: string) {
-      return message.length;
-    },
-  });
-};
-"#,
-    );
-    write_file(
-        &project_root,
-        "plugins/auth.ts",
-        r#"export default (_context: unknown, inject: (key: string, value: unknown) => void) => {
-  inject("auth", {
-    loggedIn: true,
-    userName() {
-      return "Ada";
-    },
-  });
-};
-"#,
-    );
-    write_file(
-        &project_root,
-        "plugins/gtm.ts",
-        r#"export default (_context: unknown, inject: (key: string, value: unknown) => void) => {
-  inject("gtm", {
-    push(event: { name: string }) {
-      return event.name;
-    },
-  });
-};
-"#,
-    );
-    write_file(
-        &project_root,
-        "plugins/repository.ts",
-        r#"export default (_context: unknown, inject: (key: string, value: unknown) => void) => {
-  inject("accountRepository", {
-    find(id: string) {
-      return { id, label: id.toUpperCase() };
-    },
-  });
-};
-"#,
-    );
-    write_file(
-        &project_root,
-        "components/KeyboardPanel.vue",
-        r#"<script lang="ts">
-import { defineComponent, type PropType } from 'vue'
-
-export type Folder = { id: string; label: string }
-
-export default defineComponent({
-  props: {
-    folders: {
-      type: Array as PropType<Folder[]>,
-      required: true,
-    },
-  },
-  emits: {
-    'click-folder': (_folder: Folder) => true,
-    'input:math-key': (_key: string) => true,
-  },
-  methods: {
-    clickFirst() {
-      this.$emit('click-folder', this.folders[0])
-    },
-    inputKey() {
-      this.$emit('input:math-key', 'plus')
-    },
-  },
-})
-</script>
-
-<template>
-  <button @click="clickFirst">{{ folders[0].label }}</button>
-</template>
-"#,
-    );
-    write_file(
-        &project_root,
-        "components/OverlayPanel.vue",
-        r#"<script lang="ts">
-import { defineComponent } from 'vue'
-
-export default defineComponent({
-  emits: {
-    'update:is-opened-overlay-loading': (_value: boolean) => true,
-  },
-  methods: {
-    close() {
-      this.$emit('update:is-opened-overlay-loading', false)
-    },
-  },
-})
-</script>
-
-<template>
-  <button @click="close">Close</button>
-</template>
-"#,
-    );
-    write_file(
-        &project_root,
-        "pages/index.vue",
-        r#"<script lang="ts">
-import { defineComponent, type PropType } from 'vue'
-import { useContext } from '@nuxtjs/composition-api'
-import KeyboardPanel, { type Folder } from '~/components/KeyboardPanel.vue'
-import OverlayPanel from '~/components/OverlayPanel.vue'
-
-const componentProps = {
-  folders: {
-    type: Array as PropType<Folder[]>,
-    required: true,
-  },
-}
-
-function usePanelState() {
-  return {
-    panelTitle: 'Folders',
-    selectedId: 'root',
-  }
-}
-
-export default defineComponent({
-  components: { KeyboardPanel, OverlayPanel },
-  props: componentProps,
-  setup(props, { emit }) {
-    const context = useContext()
-    const repoItem = context.$accountRepository.find(props.folders[0].id)
-    context.$logger.info(context.$auth.userName())
-    context.$gtm.push({ name: repoItem.label })
-
-    const onClickFolder = (folder: Folder) => {
-      emit('click-folder', folder)
-      context.$logger.info(folder.label)
-    }
-    const onInputMathKey = (key: string) => {
-      emit('input:math-key', key)
-    }
-    const onUpdateIsOpenedOverlayLoading = (value: boolean) => {
-      emit('update:is-opened-overlay-loading', value)
-    }
-
-    return {
-      ...usePanelState(),
-      repoLabel: repoItem.label,
-      onClickFolder,
-      onInputMathKey,
-      onUpdateIsOpenedOverlayLoading,
-    }
-  },
-})
-</script>
-
-<template>
-  <section>
-    <h1>{{ panelTitle }} {{ selectedId }} {{ repoLabel }}</h1>
-    <KeyboardPanel
-      :folders="folders"
-      @click-folder="onClickFolder"
-      @input:math-key="onInputMathKey"
-    />
-    <OverlayPanel
-      @update:is-opened-overlay-loading="onUpdateIsOpenedOverlayLoading"
-    />
-  </section>
-</template>
-"#,
-    );
+    write_false_positive_fixture(&project_root);
 
     let output = Command::new(env!("CARGO_BIN_EXE_vize"))
         .current_dir(&project_root)
@@ -373,6 +153,61 @@ export default defineComponent({
     );
 
     let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[cfg(feature = "legacy")]
+const FALSE_POSITIVE_FIXTURES: &[(&str, &str)] = &[
+    (
+        "vize.config.json",
+        include_str!("fixtures/nuxt2_false_positive/vize.config.json"),
+    ),
+    (
+        "nuxt.config.ts",
+        include_str!("fixtures/nuxt2_false_positive/nuxt.config.ts"),
+    ),
+    (
+        "tsconfig.json",
+        include_str!("fixtures/nuxt2_false_positive/tsconfig.json"),
+    ),
+    (
+        "types/nuxt.d.ts",
+        include_str!("fixtures/nuxt2_false_positive/types/nuxt.d.ts"),
+    ),
+    (
+        "plugins/logger.ts",
+        include_str!("fixtures/nuxt2_false_positive/plugins/logger.ts"),
+    ),
+    (
+        "plugins/auth.ts",
+        include_str!("fixtures/nuxt2_false_positive/plugins/auth.ts"),
+    ),
+    (
+        "plugins/gtm.ts",
+        include_str!("fixtures/nuxt2_false_positive/plugins/gtm.ts"),
+    ),
+    (
+        "plugins/repository.ts",
+        include_str!("fixtures/nuxt2_false_positive/plugins/repository.ts"),
+    ),
+    (
+        "components/KeyboardPanel.vue",
+        include_str!("fixtures/nuxt2_false_positive/components/KeyboardPanel.vue"),
+    ),
+    (
+        "components/OverlayPanel.vue",
+        include_str!("fixtures/nuxt2_false_positive/components/OverlayPanel.vue"),
+    ),
+    (
+        "pages/index.vue",
+        include_str!("fixtures/nuxt2_false_positive/pages/index.vue"),
+    ),
+];
+
+#[cfg(feature = "legacy")]
+fn write_false_positive_fixture(project_root: &Path) {
+    for (path, contents) in FALSE_POSITIVE_FIXTURES {
+        write_file(project_root, path, contents);
+    }
 }
 
 fn create_project(name: &str) -> PathBuf {

--- a/crates/vize/tests/check_nuxt2_plugin_injections_cli.rs
+++ b/crates/vize/tests/check_nuxt2_plugin_injections_cli.rs
@@ -95,6 +95,286 @@ context.$logger.info("ready");
     let _ = std::fs::remove_dir_all(&project_root);
 }
 
+#[cfg(feature = "legacy")]
+#[test]
+fn check_nuxt2_false_positive_fixture_matrix() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project("nuxt2-false-positive-matrix");
+
+    write_file(
+        &project_root,
+        "vize.config.json",
+        r#"{
+  "vue": { "version": "2.7" },
+  "typeChecker": { "legacyVue2": true }
+}"#,
+    );
+    write_file(&project_root, "nuxt.config.ts", "export default {}\n");
+    write_file(
+        &project_root,
+        "tsconfig.json",
+        r##"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": { "~/*": ["*"] },
+    "noEmit": true
+  },
+  "include": ["components/**/*.vue", "pages/**/*.vue", "plugins/**/*.ts", "types/**/*.d.ts"]
+}"##,
+    );
+    write_file(
+        &project_root,
+        "types/nuxt.d.ts",
+        r##"declare module "@nuxt/types" {
+  export interface Context {}
+  export interface NuxtAppOptions {}
+}
+
+declare module "@nuxtjs/composition-api" {
+  export interface UseContextReturn
+    extends Omit<import("@nuxt/types").Context, "route" | "query" | "from" | "params"> {}
+  export function useContext(): UseContextReturn;
+}
+
+declare module "#app" {
+  export interface NuxtApp {}
+}
+"##,
+    );
+    write_file(
+        &project_root,
+        "plugins/logger.ts",
+        r#"export default (_context: unknown, inject: (key: string, value: unknown) => void) => {
+  inject("logger", {
+    info(message: string) {
+      return message.length;
+    },
+  });
+};
+"#,
+    );
+    write_file(
+        &project_root,
+        "plugins/auth.ts",
+        r#"export default (_context: unknown, inject: (key: string, value: unknown) => void) => {
+  inject("auth", {
+    loggedIn: true,
+    userName() {
+      return "Ada";
+    },
+  });
+};
+"#,
+    );
+    write_file(
+        &project_root,
+        "plugins/gtm.ts",
+        r#"export default (_context: unknown, inject: (key: string, value: unknown) => void) => {
+  inject("gtm", {
+    push(event: { name: string }) {
+      return event.name;
+    },
+  });
+};
+"#,
+    );
+    write_file(
+        &project_root,
+        "plugins/repository.ts",
+        r#"export default (_context: unknown, inject: (key: string, value: unknown) => void) => {
+  inject("accountRepository", {
+    find(id: string) {
+      return { id, label: id.toUpperCase() };
+    },
+  });
+};
+"#,
+    );
+    write_file(
+        &project_root,
+        "components/KeyboardPanel.vue",
+        r#"<script lang="ts">
+import { defineComponent, type PropType } from 'vue'
+
+export type Folder = { id: string; label: string }
+
+export default defineComponent({
+  props: {
+    folders: {
+      type: Array as PropType<Folder[]>,
+      required: true,
+    },
+  },
+  emits: {
+    'click-folder': (_folder: Folder) => true,
+    'input:math-key': (_key: string) => true,
+  },
+  methods: {
+    clickFirst() {
+      this.$emit('click-folder', this.folders[0])
+    },
+    inputKey() {
+      this.$emit('input:math-key', 'plus')
+    },
+  },
+})
+</script>
+
+<template>
+  <button @click="clickFirst">{{ folders[0].label }}</button>
+</template>
+"#,
+    );
+    write_file(
+        &project_root,
+        "components/OverlayPanel.vue",
+        r#"<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  emits: {
+    'update:is-opened-overlay-loading': (_value: boolean) => true,
+  },
+  methods: {
+    close() {
+      this.$emit('update:is-opened-overlay-loading', false)
+    },
+  },
+})
+</script>
+
+<template>
+  <button @click="close">Close</button>
+</template>
+"#,
+    );
+    write_file(
+        &project_root,
+        "pages/index.vue",
+        r#"<script lang="ts">
+import { defineComponent, type PropType } from 'vue'
+import { useContext } from '@nuxtjs/composition-api'
+import KeyboardPanel, { type Folder } from '~/components/KeyboardPanel.vue'
+import OverlayPanel from '~/components/OverlayPanel.vue'
+
+const componentProps = {
+  folders: {
+    type: Array as PropType<Folder[]>,
+    required: true,
+  },
+}
+
+function usePanelState() {
+  return {
+    panelTitle: 'Folders',
+    selectedId: 'root',
+  }
+}
+
+export default defineComponent({
+  components: { KeyboardPanel, OverlayPanel },
+  props: componentProps,
+  setup(props, { emit }) {
+    const context = useContext()
+    const repoItem = context.$accountRepository.find(props.folders[0].id)
+    context.$logger.info(context.$auth.userName())
+    context.$gtm.push({ name: repoItem.label })
+
+    const onClickFolder = (folder: Folder) => {
+      emit('click-folder', folder)
+      context.$logger.info(folder.label)
+    }
+    const onInputMathKey = (key: string) => {
+      emit('input:math-key', key)
+    }
+    const onUpdateIsOpenedOverlayLoading = (value: boolean) => {
+      emit('update:is-opened-overlay-loading', value)
+    }
+
+    return {
+      ...usePanelState(),
+      repoLabel: repoItem.label,
+      onClickFolder,
+      onInputMathKey,
+      onUpdateIsOpenedOverlayLoading,
+    }
+  },
+})
+</script>
+
+<template>
+  <section>
+    <h1>{{ panelTitle }} {{ selectedId }} {{ repoLabel }}</h1>
+    <KeyboardPanel
+      :folders="folders"
+      @click-folder="onClickFolder"
+      @input:math-key="onInputMathKey"
+    />
+    <OverlayPanel
+      @update:is-opened-overlay-loading="onUpdateIsOpenedOverlayLoading"
+    />
+  </section>
+</template>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "components",
+            "pages",
+            "--config",
+            "vize.config.json",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    assert!(
+        output.status.success(),
+        "Nuxt2 false-positive matrix should type-check\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(json["errorCount"], 0);
+    assert_eq!(json["fileCount"], 3);
+    let files = json["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|file| {
+            (
+                file["file"].as_str().unwrap().to_owned(),
+                file["diagnostics"].as_array().unwrap().clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        files,
+        vec![
+            ("components/KeyboardPanel.vue".to_owned(), Vec::new()),
+            ("components/OverlayPanel.vue".to_owned(), Vec::new()),
+            ("pages/index.vue".to_owned(), Vec::new()),
+        ]
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
 fn create_project(name: &str) -> PathBuf {
     let project_root = workspace_root()
         .join("target")

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/components/KeyboardPanel.vue
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/components/KeyboardPanel.vue
@@ -1,0 +1,30 @@
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue'
+
+export type Folder = { id: string; label: string }
+
+export default defineComponent({
+  props: {
+    folders: {
+      type: Array as PropType<Folder[]>,
+      required: true,
+    },
+  },
+  emits: {
+    'click-folder': (_folder: Folder) => true,
+    'input:math-key': (_key: string) => true,
+  },
+  methods: {
+    clickFirst() {
+      this.$emit('click-folder', this.folders[0])
+    },
+    inputKey() {
+      this.$emit('input:math-key', 'plus')
+    },
+  },
+})
+</script>
+
+<template>
+  <button @click="clickFirst">{{ folders[0].label }}</button>
+</template>

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/components/KeyboardPanel.vue
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/components/KeyboardPanel.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import { defineComponent, type PropType } from 'vue'
+import { defineComponent, type PropType } from "vue";
 
-export type Folder = { id: string; label: string }
+export type Folder = { id: string; label: string };
 
 export default defineComponent({
   props: {
@@ -11,18 +11,18 @@ export default defineComponent({
     },
   },
   emits: {
-    'click-folder': (_folder: Folder) => true,
-    'input:math-key': (_key: string) => true,
+    "click-folder": (_folder: Folder) => true,
+    "input:math-key": (_key: string) => true,
   },
   methods: {
     clickFirst() {
-      this.$emit('click-folder', this.folders[0])
+      this.$emit("click-folder", this.folders[0]);
     },
     inputKey() {
-      this.$emit('input:math-key', 'plus')
+      this.$emit("input:math-key", "plus");
     },
   },
-})
+});
 </script>
 
 <template>

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/components/OverlayPanel.vue
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/components/OverlayPanel.vue
@@ -1,16 +1,16 @@
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent } from "vue";
 
 export default defineComponent({
   emits: {
-    'update:is-opened-overlay-loading': (_value: boolean) => true,
+    "update:is-opened-overlay-loading": (_value: boolean) => true,
   },
   methods: {
     close() {
-      this.$emit('update:is-opened-overlay-loading', false)
+      this.$emit("update:is-opened-overlay-loading", false);
     },
   },
-})
+});
 </script>
 
 <template>

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/components/OverlayPanel.vue
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/components/OverlayPanel.vue
@@ -1,0 +1,18 @@
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  emits: {
+    'update:is-opened-overlay-loading': (_value: boolean) => true,
+  },
+  methods: {
+    close() {
+      this.$emit('update:is-opened-overlay-loading', false)
+    },
+  },
+})
+</script>
+
+<template>
+  <button @click="close">Close</button>
+</template>

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/nuxt.config.ts
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/nuxt.config.ts
@@ -1,1 +1,1 @@
-export default {}
+export default {};

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/nuxt.config.ts
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/nuxt.config.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/pages/index.vue
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/pages/index.vue
@@ -1,42 +1,42 @@
 <script lang="ts">
-import { defineComponent, type PropType } from 'vue'
-import { useContext } from '@nuxtjs/composition-api'
-import KeyboardPanel, { type Folder } from '~/components/KeyboardPanel.vue'
-import OverlayPanel from '~/components/OverlayPanel.vue'
+import { defineComponent, type PropType } from "vue";
+import { useContext } from "@nuxtjs/composition-api";
+import KeyboardPanel, { type Folder } from "~/components/KeyboardPanel.vue";
+import OverlayPanel from "~/components/OverlayPanel.vue";
 
 const componentProps = {
   folders: {
     type: Array as PropType<Folder[]>,
     required: true,
   },
-}
+};
 
 function usePanelState() {
   return {
-    panelTitle: 'Folders',
-    selectedId: 'root',
-  }
+    panelTitle: "Folders",
+    selectedId: "root",
+  };
 }
 
 export default defineComponent({
   components: { KeyboardPanel, OverlayPanel },
   props: componentProps,
   setup(props, { emit }) {
-    const context = useContext()
-    const repoItem = context.$accountRepository.find(props.folders[0].id)
-    context.$logger.info(context.$auth.userName())
-    context.$gtm.push({ name: repoItem.label })
+    const context = useContext();
+    const repoItem = context.$accountRepository.find(props.folders[0].id);
+    context.$logger.info(context.$auth.userName());
+    context.$gtm.push({ name: repoItem.label });
 
     const onClickFolder = (folder: Folder) => {
-      emit('click-folder', folder)
-      context.$logger.info(folder.label)
-    }
+      emit("click-folder", folder);
+      context.$logger.info(folder.label);
+    };
     const onInputMathKey = (key: string) => {
-      emit('input:math-key', key)
-    }
+      emit("input:math-key", key);
+    };
     const onUpdateIsOpenedOverlayLoading = (value: boolean) => {
-      emit('update:is-opened-overlay-loading', value)
-    }
+      emit("update:is-opened-overlay-loading", value);
+    };
 
     return {
       ...usePanelState(),
@@ -44,9 +44,9 @@ export default defineComponent({
       onClickFolder,
       onInputMathKey,
       onUpdateIsOpenedOverlayLoading,
-    }
+    };
   },
-})
+});
 </script>
 
 <template>
@@ -57,8 +57,6 @@ export default defineComponent({
       @click-folder="onClickFolder"
       @input:math-key="onInputMathKey"
     />
-    <OverlayPanel
-      @update:is-opened-overlay-loading="onUpdateIsOpenedOverlayLoading"
-    />
+    <OverlayPanel @update:is-opened-overlay-loading="onUpdateIsOpenedOverlayLoading" />
   </section>
 </template>

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/pages/index.vue
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/pages/index.vue
@@ -1,0 +1,64 @@
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue'
+import { useContext } from '@nuxtjs/composition-api'
+import KeyboardPanel, { type Folder } from '~/components/KeyboardPanel.vue'
+import OverlayPanel from '~/components/OverlayPanel.vue'
+
+const componentProps = {
+  folders: {
+    type: Array as PropType<Folder[]>,
+    required: true,
+  },
+}
+
+function usePanelState() {
+  return {
+    panelTitle: 'Folders',
+    selectedId: 'root',
+  }
+}
+
+export default defineComponent({
+  components: { KeyboardPanel, OverlayPanel },
+  props: componentProps,
+  setup(props, { emit }) {
+    const context = useContext()
+    const repoItem = context.$accountRepository.find(props.folders[0].id)
+    context.$logger.info(context.$auth.userName())
+    context.$gtm.push({ name: repoItem.label })
+
+    const onClickFolder = (folder: Folder) => {
+      emit('click-folder', folder)
+      context.$logger.info(folder.label)
+    }
+    const onInputMathKey = (key: string) => {
+      emit('input:math-key', key)
+    }
+    const onUpdateIsOpenedOverlayLoading = (value: boolean) => {
+      emit('update:is-opened-overlay-loading', value)
+    }
+
+    return {
+      ...usePanelState(),
+      repoLabel: repoItem.label,
+      onClickFolder,
+      onInputMathKey,
+      onUpdateIsOpenedOverlayLoading,
+    }
+  },
+})
+</script>
+
+<template>
+  <section>
+    <h1>{{ panelTitle }} {{ selectedId }} {{ repoLabel }}</h1>
+    <KeyboardPanel
+      :folders="folders"
+      @click-folder="onClickFolder"
+      @input:math-key="onInputMathKey"
+    />
+    <OverlayPanel
+      @update:is-opened-overlay-loading="onUpdateIsOpenedOverlayLoading"
+    />
+  </section>
+</template>

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/plugins/auth.ts
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/plugins/auth.ts
@@ -1,0 +1,8 @@
+export default (_context: unknown, inject: (key: string, value: unknown) => void) => {
+  inject("auth", {
+    loggedIn: true,
+    userName() {
+      return "Ada";
+    },
+  });
+};

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/plugins/gtm.ts
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/plugins/gtm.ts
@@ -1,0 +1,7 @@
+export default (_context: unknown, inject: (key: string, value: unknown) => void) => {
+  inject("gtm", {
+    push(event: { name: string }) {
+      return event.name;
+    },
+  });
+};

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/plugins/logger.ts
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/plugins/logger.ts
@@ -1,0 +1,7 @@
+export default (_context: unknown, inject: (key: string, value: unknown) => void) => {
+  inject("logger", {
+    info(message: string) {
+      return message.length;
+    },
+  });
+};

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/plugins/repository.ts
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/plugins/repository.ts
@@ -1,0 +1,7 @@
+export default (_context: unknown, inject: (key: string, value: unknown) => void) => {
+  inject("accountRepository", {
+    find(id: string) {
+      return { id, label: id.toUpperCase() };
+    },
+  });
+};

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/tsconfig.json
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": { "~/*": ["*"] },
+    "noEmit": true
+  },
+  "include": ["components/**/*.vue", "pages/**/*.vue", "plugins/**/*.ts", "types/**/*.d.ts"]
+}

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/tsconfig.json
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/tsconfig.json
@@ -4,8 +4,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "baseUrl": ".",
-    "paths": { "~/*": ["*"] },
+    "paths": { "~/*": ["./*"] },
     "noEmit": true
   },
   "include": ["components/**/*.vue", "pages/**/*.vue", "plugins/**/*.ts", "types/**/*.d.ts"]

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/types/nuxt.d.ts
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/types/nuxt.d.ts
@@ -1,0 +1,14 @@
+declare module "@nuxt/types" {
+  export interface Context {}
+  export interface NuxtAppOptions {}
+}
+
+declare module "@nuxtjs/composition-api" {
+  export interface UseContextReturn
+    extends Omit<import("@nuxt/types").Context, "route" | "query" | "from" | "params"> {}
+  export function useContext(): UseContextReturn;
+}
+
+declare module "#app" {
+  export interface NuxtApp {}
+}

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/types/nuxt.d.ts
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/types/nuxt.d.ts
@@ -4,8 +4,10 @@ declare module "@nuxt/types" {
 }
 
 declare module "@nuxtjs/composition-api" {
-  export interface UseContextReturn
-    extends Omit<import("@nuxt/types").Context, "route" | "query" | "from" | "params"> {}
+  export interface UseContextReturn extends Omit<
+    import("@nuxt/types").Context,
+    "route" | "query" | "from" | "params"
+  > {}
   export function useContext(): UseContextReturn;
 }
 

--- a/crates/vize/tests/fixtures/nuxt2_false_positive/vize.config.json
+++ b/crates/vize/tests/fixtures/nuxt2_false_positive/vize.config.json
@@ -1,0 +1,4 @@
+{
+  "vue": { "version": "2.7" },
+  "typeChecker": { "legacyVue2": true }
+}

--- a/crates/vize/tests/inspector_art_cli.rs
+++ b/crates/vize/tests/inspector_art_cli.rs
@@ -1,4 +1,4 @@
-use std::{fs, process::Command};
+use std::{collections::BTreeMap, fs, process::Command};
 
 #[test]
 fn inspector_compare_preserves_musea_define_art_script_setup() {
@@ -45,8 +45,188 @@ defineArt("./CmsButton.vue", {
     let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
     let vize_code = json["files"][0]["vize"]["code"].as_str().unwrap();
     let official_code = json["files"][0]["official"]["code"].as_str().unwrap();
-    assert!(official_code.contains("defineArt"), "{official_code}");
-    assert!(vize_code.contains("defineArt"), "{vize_code}");
+    assert_eq!(
+        define_art_first_args(official_code),
+        vec!["\"./CmsButton.vue\""]
+    );
+    assert_eq!(
+        define_art_first_args(vize_code),
+        vec!["\"./CmsButton.vue\""]
+    );
+}
+
+#[test]
+fn inspector_compare_preserves_musea_define_art_script_setup_matrix() {
+    if !dev_vue_compiler_available() {
+        return;
+    }
+
+    let project = tempfile::tempdir().unwrap();
+    let src = project.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("art-meta.ts"),
+        r#"export const buttonPath = "./AliasButton.vue";
+export const metadata = { title: "AliasButton" };
+"#,
+    )
+    .unwrap();
+    fs::write(
+        src.join("AliasButton.art.vue"),
+        r#"<script lang="ts">
+export const localKind = "mixed";
+</script>
+
+<script setup lang="ts">
+import { buttonPath as componentPath, metadata } from "./art-meta";
+
+defineArt(componentPath, {
+  title: metadata.title,
+  category: "Components",
+  tags: ["button", localKind],
+});
+
+defineArt("./AliasButton.secondary.vue", {
+  title: "AliasButtonSecondary",
+});
+</script>
+
+<art>
+  <variant name="Primary" default>
+    <AliasButton>Primary</AliasButton>
+  </variant>
+</art>
+"#,
+    )
+    .unwrap();
+    fs::write(
+        src.join("PlainBadge.art.vue"),
+        r#"<script setup>
+defineArt("./PlainBadge.vue", {
+  title: "PlainBadge",
+  category: "Components",
+});
+</script>
+
+<art>
+  <variant name="Default" default>
+    <PlainBadge />
+  </variant>
+</art>
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args(["inspector", "src", "--format", "compare"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let summaries = json["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|file| {
+            let path = file["path"].as_str().unwrap().to_owned();
+            let official = define_art_first_args(file["official"]["code"].as_str().unwrap());
+            let vize = define_art_first_args(file["vize"]["code"].as_str().unwrap());
+            (path, (official, vize))
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(
+        summaries,
+        BTreeMap::from([
+            (
+                "src/AliasButton.art.vue".to_owned(),
+                (
+                    vec![
+                        "componentPath".to_owned(),
+                        "\"./AliasButton.secondary.vue\"".to_owned()
+                    ],
+                    vec![
+                        "componentPath".to_owned(),
+                        "\"./AliasButton.secondary.vue\"".to_owned()
+                    ],
+                ),
+            ),
+            (
+                "src/PlainBadge.art.vue".to_owned(),
+                (
+                    vec!["\"./PlainBadge.vue\"".to_owned()],
+                    vec!["\"./PlainBadge.vue\"".to_owned()],
+                ),
+            ),
+        ])
+    );
+}
+
+fn define_art_first_args(code: &str) -> Vec<String> {
+    let marker = "defineArt(";
+    let mut args = Vec::new();
+    let mut offset = 0;
+    while let Some(index) = code[offset..].find(marker) {
+        let start = offset + index + marker.len();
+        if is_identifier_boundary(code, offset + index, "defineArt".len())
+            && let Some(arg) = first_call_arg(&code[start..])
+        {
+            args.push(arg);
+        }
+        offset = start;
+    }
+    args
+}
+
+fn is_identifier_boundary(code: &str, start: usize, len: usize) -> bool {
+    let before = start
+        .checked_sub(1)
+        .and_then(|index| code.as_bytes().get(index))
+        .copied();
+    let after = code.as_bytes().get(start + len).copied();
+    before.is_none_or(|byte| !is_identifier_byte(byte))
+        && after.is_none_or(|byte| !is_identifier_byte(byte))
+}
+
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+}
+
+fn first_call_arg(source: &str) -> Option<String> {
+    let mut depth = 0i32;
+    let mut quote = None;
+    let mut escaped = false;
+
+    for (index, ch) in source.char_indices() {
+        if let Some(active_quote) = quote {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == active_quote {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' | '`' => quote = Some(ch),
+            '(' | '[' | '{' => depth += 1,
+            ')' if depth == 0 => return Some(source[..index].trim().to_owned()),
+            ')' | ']' | '}' => depth -= 1,
+            ',' if depth == 0 => return Some(source[..index].trim().to_owned()),
+            _ => {}
+        }
+    }
+    None
 }
 
 fn dev_vue_compiler_available() -> bool {

--- a/crates/vize/tests/options_api_props_spread_cli.rs
+++ b/crates/vize/tests/options_api_props_spread_cli.rs
@@ -35,16 +35,81 @@ fn check_options_api_props_spread_with_instance_members_has_no_ts_parse_errors()
         .filter_map(|diagnostic| diagnostic.as_str().map(str::to_owned))
         .collect::<Vec<_>>();
 
-    assert!(
-        diagnostics.iter().all(|diagnostic| {
-            !diagnostic.contains("[TS1131]")
-                && !diagnostic.contains("[TS1128]")
-                && !diagnostic.contains("[TS1109]")
-        }),
+    let parse_error_codes = diagnostics
+        .iter()
+        .filter_map(|diagnostic| ts_diagnostic_code(diagnostic))
+        .filter(|code| matches!(code, 1109 | 1128 | 1131))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        parse_error_codes,
+        Vec::<u32>::new(),
         "Options API props spread must not generate virtual-TS syntax errors; got {diagnostics:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[cfg(feature = "legacy")]
+#[test]
+fn check_legacy_vue2_options_api_prop_type_matrix_cli() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_prop_type_matrix_project();
+    if !project_root.join("node_modules/vue/dist").exists() {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src/App.vue",
+            "--config",
+            "vize.config.json",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(json["errorCount"], 0);
+    assert_eq!(json["fileCount"], 1);
+    let files = json["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|file| {
+            (
+                file["file"].as_str().unwrap().to_owned(),
+                file["diagnostics"].as_array().unwrap().clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(files, vec![("src/App.vue".to_owned(), Vec::new())]);
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn ts_diagnostic_code(diagnostic: &str) -> Option<u32> {
+    let marker = diagnostic.find("[TS")?;
+    let start = marker + 3;
+    let end = diagnostic[start..].find(']')? + start;
+    diagnostic[start..end].parse().ok()
 }
 
 fn create_cli_project() -> PathBuf {
@@ -101,6 +166,102 @@ export default defineComponent({
   },
 })
 </script>
+"#,
+    )
+    .unwrap();
+    project_root
+}
+
+#[cfg(feature = "legacy")]
+fn create_prop_type_matrix_project() -> PathBuf {
+    let project_root = workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join(format!(
+            "options-api-prop-type-matrix-{}",
+            std::process::id()
+        ));
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    link_workspace_node_modules(&project_root);
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        r#"{
+  "vue": { "version": "2.7" },
+  "typeChecker": {
+    "legacyVue2": true
+  }
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/types.ts"),
+        r#"export type ImportedItem = { id: string; count: number }
+export type ImportedStatus = "ready" | "draft"
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/App.vue"),
+        r#"<script lang="ts">
+import { defineComponent, type PropType as VuePropType } from 'vue'
+import type { ImportedItem, ImportedStatus } from './types'
+
+type LocalItem = ImportedItem & { local: boolean }
+type LocalPropType<T> = VuePropType<T>
+type NestedShape = { nested: { id: string; status: ImportedStatus } }
+
+const nestedObjectProp = {
+  type: Object as LocalPropType<NestedShape>,
+  required: true,
+}
+
+export default defineComponent({
+  props: {
+    status: { type: String as VuePropType<ImportedStatus | "archived">, required: true },
+    selected: { type: Object as VuePropType<ImportedItem & { enabled: boolean }>, required: true },
+    items: { type: Array as LocalPropType<ReadonlyArray<LocalItem>>, required: true },
+    readonlyItems: { type: Array as VuePropType<readonly ImportedItem[]>, required: true },
+    formatter: { type: Function as VuePropType<(item: ImportedItem) => string>, required: true },
+    nestedObject: nestedObjectProp,
+  },
+  setup(props) {
+    const formatted = props.formatter(props.selected)
+    const firstId = props.items[0]?.id
+    const readonlyCount = props.readonlyItems[0]?.count ?? 0
+    const nestedId = props.nestedObject?.nested.id ?? ""
+    return { formatted, firstId, readonlyCount, nestedId }
+  },
+})
+</script>
+
+<template>
+  <div>
+    {{ status }}
+    {{ selected.id }}
+    {{ items[0]?.local }}
+    {{ readonlyItems[0]?.count }}
+    {{ nestedObject?.nested.status }}
+    {{ formatted }}
+    {{ firstId }}
+    {{ readonlyCount }}
+    {{ nestedId }}
+  </div>
+</template>
 "#,
     )
     .unwrap();

--- a/crates/vize_atelier_dom/tests/setup_component_unref.rs
+++ b/crates/vize_atelier_dom/tests/setup_component_unref.rs
@@ -61,3 +61,104 @@ fn inline_setup_ref_component_tag_uses_unref() {
         "raw ref component tag must not be emitted:\n{full}"
     );
 }
+
+fn component_call_targets(source: &str) -> Vec<String> {
+    let mut targets = Vec::new();
+    for marker in ["_createVNode(", "_createBlock("] {
+        let mut offset = 0;
+        while let Some(index) = source[offset..].find(marker) {
+            let start = offset + index + marker.len();
+            let Some(target) = first_call_arg(&source[start..]) else {
+                break;
+            };
+            if !target.starts_with('"') {
+                targets.push(target);
+            }
+            offset = start;
+        }
+    }
+    targets
+}
+
+fn first_call_arg(source: &str) -> Option<String> {
+    let mut depth = 0i32;
+    for (index, ch) in source.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' if depth == 0 => return Some(source[..index].trim().into()),
+            ')' => depth -= 1,
+            ',' if depth == 0 => return Some(source[..index].trim().into()),
+            _ => {}
+        }
+    }
+    None
+}
+
+fn binding_matrix() -> BindingMetadata {
+    let mut bindings = FxHashMap::default();
+    bindings.insert("RefMenu".into(), BindingType::SetupRef);
+    bindings.insert("MaybeMenu".into(), BindingType::SetupMaybeRef);
+    bindings.insert("LetMenu".into(), BindingType::SetupLet);
+    bindings.insert("ImportedMenu".into(), BindingType::SetupConst);
+    bindings.insert("ShallowMenu".into(), BindingType::SetupRef);
+    bindings.insert("lowercaseWidget".into(), BindingType::SetupConst);
+    BindingMetadata {
+        bindings,
+        props_aliases: FxHashMap::default(),
+        is_script_setup: true,
+    }
+}
+
+#[test]
+fn setup_component_tag_binding_matrix_matches_dom_modes() {
+    let allocator = Bump::new();
+    let source = r#"<RefMenu /><MaybeMenu /><LetMenu /><ImportedMenu /><ShallowMenu /><lowercase-widget /><RefMenu.Item />"#;
+
+    let inline_options = DomCompilerOptions {
+        mode: CodegenMode::Module,
+        prefix_identifiers: true,
+        inline: true,
+        binding_metadata: Some(binding_matrix()),
+        ..Default::default()
+    };
+    let (_, inline_errors, inline_result) =
+        compile_template_with_options(&allocator, source, inline_options);
+    assert_eq!(inline_errors.len(), 0);
+    let inline = full_output(&inline_result.preamble, &inline_result.code);
+    assert_eq!(
+        component_call_targets(&inline),
+        vec![
+            "_unref(RefMenu)",
+            "_unref(MaybeMenu)",
+            "_unref(LetMenu)",
+            "ImportedMenu",
+            "_unref(ShallowMenu)",
+            "lowercaseWidget",
+            "_unref(RefMenu).Item",
+        ]
+    );
+
+    let function_options = DomCompilerOptions {
+        mode: CodegenMode::Function,
+        prefix_identifiers: true,
+        inline: false,
+        binding_metadata: Some(binding_matrix()),
+        ..Default::default()
+    };
+    let (_, function_errors, function_result) =
+        compile_template_with_options(&allocator, source, function_options);
+    assert_eq!(function_errors.len(), 0);
+    let function = full_output(&function_result.preamble, &function_result.code);
+    assert_eq!(
+        component_call_targets(&function),
+        vec![
+            "$setup.RefMenu",
+            "$setup.MaybeMenu",
+            "$setup.LetMenu",
+            "$setup.ImportedMenu",
+            "$setup.ShallowMenu",
+            "$setup.lowercaseWidget",
+            "$setup.RefMenu.Item",
+        ]
+    );
+}

--- a/crates/vize_atelier_dom/tests/setup_component_unref.rs
+++ b/crates/vize_atelier_dom/tests/setup_component_unref.rs
@@ -38,27 +38,15 @@ fn inline_setup_ref_component_tag_uses_unref() {
 
     assert!(errors.is_empty(), "Errors: {:?}", errors);
     let full = full_output(&result.preamble, &result.code);
-    assert!(full.contains("unref as _unref"), "{full}");
     assert_eq!(
-        full.matches("_unref(Menu").count(),
-        5,
-        "every setup ref component tag path should be unref'd:\n{full}"
-    );
-    assert!(
-        full.contains("_createBlock(_unref(Menu)") || full.contains("_createVNode(_unref(Menu)"),
-        "setup ref component tags must be unref'd:\n{full}"
-    );
-    assert!(
-        full.contains("_createVNode(_unref(Menu))"),
-        "v-once component tags must be unref'd:\n{full}"
-    );
-    assert!(
-        full.contains("_unref(Menu).Item"),
-        "dotted setup ref component tags must unref the base binding:\n{full}"
-    );
-    assert!(
-        !full.contains("_createBlock(Menu") && !full.contains("_createVNode(Menu"),
-        "raw ref component tag must not be emitted:\n{full}"
+        component_call_targets(&full),
+        vec![
+            "_unref(Menu)",
+            "_unref(Menu)",
+            "_unref(Menu).Item",
+            "_unref(Menu)",
+            "_unref(Menu)",
+        ]
     );
 }
 

--- a/crates/vize_atelier_ssr/src/codegen.rs
+++ b/crates/vize_atelier_ssr/src/codegen.rs
@@ -3,12 +3,13 @@
 //! SSR code generation produces JavaScript that uses template literals and `_push()` calls
 //! to build HTML strings on the server side.
 
+mod component_binding;
 mod element;
 pub(crate) mod helpers;
 mod scope_prefix;
 
 use crate::options::SsrCompilerOptions;
-use vize_atelier_core::{BindingType, RootNode, RuntimeHelper, TemplateChildNode};
+use vize_atelier_core::{RootNode, RuntimeHelper, TemplateChildNode};
 use vize_carton::{Bump, FxHashSet, SmallVec, String, ToCompactString, camelize, capitalize};
 
 /// SSR codegen result
@@ -27,12 +28,6 @@ pub(crate) enum TemplatePart {
     Static(String),
     /// Dynamic expression
     Dynamic(String),
-}
-
-struct ComponentBinding {
-    name: String,
-    binding_type: BindingType,
-    suffix: Option<String>,
 }
 
 /// SSR codegen context
@@ -230,70 +225,6 @@ impl<'a> SsrCodegenContext<'a> {
     /// Use a core helper (from vue)
     pub(crate) fn use_core_helper(&mut self, helper: RuntimeHelper) {
         self.core_helpers.insert(helper);
-    }
-
-    pub(crate) fn resolve_component_binding_expr(&mut self, component: &str) -> Option<String> {
-        let binding = self.resolve_component_binding(component)?;
-        let needs_unref = self.options.inline
-            && matches!(
-                binding.binding_type,
-                BindingType::SetupLet | BindingType::SetupMaybeRef | BindingType::SetupRef
-            );
-        let mut resolved = String::default();
-
-        if needs_unref {
-            self.use_core_helper(RuntimeHelper::Unref);
-            resolved.push_str("_unref(");
-        } else if !self.options.inline {
-            resolved.push_str("$setup.");
-        }
-        resolved.push_str(binding.name.as_str());
-        if needs_unref {
-            resolved.push(')');
-        }
-        if let Some(suffix) = binding.suffix {
-            resolved.push('.');
-            resolved.push_str(suffix.as_str());
-        }
-
-        Some(resolved)
-    }
-
-    fn resolve_component_binding(&self, component: &str) -> Option<ComponentBinding> {
-        let metadata = self.options.binding_metadata.as_ref()?;
-        let resolve_base = |name: &str| {
-            if let Some(binding_type) = metadata.bindings.get(name) {
-                return Some((name.to_compact_string(), *binding_type));
-            }
-
-            let camel = camelize(name);
-            if let Some(binding_type) = metadata.bindings.get(camel.as_str()) {
-                return Some((camel, *binding_type));
-            }
-
-            let pascal = capitalize(camel.as_str());
-            if let Some(binding_type) = metadata.bindings.get(pascal.as_str()) {
-                return Some((pascal, *binding_type));
-            }
-
-            None
-        };
-
-        if let Some((base, suffix)) = component.split_once('.') {
-            let (name, binding_type) = resolve_base(base)?;
-            return Some(ComponentBinding {
-                name,
-                binding_type,
-                suffix: Some(suffix.to_compact_string()),
-            });
-        }
-
-        let (name, binding_type) = resolve_base(component)?;
-        Some(ComponentBinding {
-            name,
-            binding_type,
-            suffix: None,
-        })
     }
 
     pub(crate) fn is_self_component_reference(&self, component: &str) -> bool {

--- a/crates/vize_atelier_ssr/src/codegen.rs
+++ b/crates/vize_atelier_ssr/src/codegen.rs
@@ -8,7 +8,7 @@ pub(crate) mod helpers;
 mod scope_prefix;
 
 use crate::options::SsrCompilerOptions;
-use vize_atelier_core::{RootNode, RuntimeHelper, TemplateChildNode};
+use vize_atelier_core::{BindingType, RootNode, RuntimeHelper, TemplateChildNode};
 use vize_carton::{Bump, FxHashSet, SmallVec, String, ToCompactString, camelize, capitalize};
 
 /// SSR codegen result
@@ -27,6 +27,12 @@ pub(crate) enum TemplatePart {
     Static(String),
     /// Dynamic expression
     Dynamic(String),
+}
+
+struct ComponentBinding {
+    name: String,
+    binding_type: BindingType,
+    suffix: Option<String>,
 }
 
 /// SSR codegen context
@@ -226,37 +232,68 @@ impl<'a> SsrCodegenContext<'a> {
         self.core_helpers.insert(helper);
     }
 
-    pub(crate) fn resolve_component_binding_name(&self, component: &str) -> Option<String> {
-        let metadata = self.options.binding_metadata.as_ref()?;
+    pub(crate) fn resolve_component_binding_expr(&mut self, component: &str) -> Option<String> {
+        let binding = self.resolve_component_binding(component)?;
+        let needs_unref = self.options.inline
+            && matches!(
+                binding.binding_type,
+                BindingType::SetupLet | BindingType::SetupMaybeRef | BindingType::SetupRef
+            );
+        let mut resolved = String::default();
 
+        if needs_unref {
+            self.use_core_helper(RuntimeHelper::Unref);
+            resolved.push_str("_unref(");
+        } else if !self.options.inline {
+            resolved.push_str("$setup.");
+        }
+        resolved.push_str(binding.name.as_str());
+        if needs_unref {
+            resolved.push(')');
+        }
+        if let Some(suffix) = binding.suffix {
+            resolved.push('.');
+            resolved.push_str(suffix.as_str());
+        }
+
+        Some(resolved)
+    }
+
+    fn resolve_component_binding(&self, component: &str) -> Option<ComponentBinding> {
+        let metadata = self.options.binding_metadata.as_ref()?;
         let resolve_base = |name: &str| {
-            if metadata.bindings.contains_key(name) {
-                return Some(name.to_compact_string());
+            if let Some(binding_type) = metadata.bindings.get(name) {
+                return Some((name.to_compact_string(), *binding_type));
             }
 
             let camel = camelize(name);
-            if metadata.bindings.contains_key(camel.as_str()) {
-                return Some(camel);
+            if let Some(binding_type) = metadata.bindings.get(camel.as_str()) {
+                return Some((camel, *binding_type));
             }
 
             let pascal = capitalize(camel.as_str());
-            if metadata.bindings.contains_key(pascal.as_str()) {
-                return Some(pascal);
+            if let Some(binding_type) = metadata.bindings.get(pascal.as_str()) {
+                return Some((pascal, *binding_type));
             }
 
             None
         };
 
         if let Some((base, suffix)) = component.split_once('.') {
-            let resolved_base = resolve_base(base)?;
-            let mut resolved = String::with_capacity(resolved_base.len() + suffix.len() + 1);
-            resolved.push_str(resolved_base.as_str());
-            resolved.push('.');
-            resolved.push_str(suffix);
-            return Some(resolved);
+            let (name, binding_type) = resolve_base(base)?;
+            return Some(ComponentBinding {
+                name,
+                binding_type,
+                suffix: Some(suffix.to_compact_string()),
+            });
         }
 
-        resolve_base(component)
+        let (name, binding_type) = resolve_base(component)?;
+        Some(ComponentBinding {
+            name,
+            binding_type,
+            suffix: None,
+        })
     }
 
     pub(crate) fn is_self_component_reference(&self, component: &str) -> bool {

--- a/crates/vize_atelier_ssr/src/codegen/component_binding.rs
+++ b/crates/vize_atelier_ssr/src/codegen/component_binding.rs
@@ -1,0 +1,66 @@
+use super::SsrCodegenContext;
+use vize_atelier_core::{BindingType, RuntimeHelper};
+use vize_carton::{String, ToCompactString, camelize, capitalize};
+
+struct ComponentBinding {
+    name: String,
+    binding_type: BindingType,
+    suffix: Option<String>,
+}
+
+impl<'a> SsrCodegenContext<'a> {
+    pub(crate) fn resolve_component_binding_expr(&mut self, component: &str) -> Option<String> {
+        let binding = self.resolve_component_binding(component)?;
+        let needs_unref = self.options.inline
+            && matches!(
+                binding.binding_type,
+                BindingType::SetupLet | BindingType::SetupMaybeRef | BindingType::SetupRef
+            );
+        let mut resolved = String::default();
+
+        if needs_unref {
+            self.use_core_helper(RuntimeHelper::Unref);
+            resolved.push_str("_unref(");
+        } else if !self.options.inline {
+            resolved.push_str("$setup.");
+        }
+        resolved.push_str(binding.name.as_str());
+        if needs_unref {
+            resolved.push(')');
+        }
+        if let Some(suffix) = binding.suffix {
+            resolved.push('.');
+            resolved.push_str(suffix.as_str());
+        }
+
+        Some(resolved)
+    }
+
+    fn resolve_component_binding(&self, component: &str) -> Option<ComponentBinding> {
+        let metadata = self.options.binding_metadata.as_ref()?;
+        let resolve_base = |name: &str| {
+            if let Some(binding_type) = metadata.bindings.get(name) {
+                return Some((name.to_compact_string(), *binding_type));
+            }
+            let camel = camelize(name);
+            if let Some(binding_type) = metadata.bindings.get(camel.as_str()) {
+                return Some((camel, *binding_type));
+            }
+            let pascal = capitalize(camel.as_str());
+            metadata
+                .bindings
+                .get(pascal.as_str())
+                .map(|binding_type| (pascal, *binding_type))
+        };
+
+        let (base, suffix) = component
+            .split_once('.')
+            .map_or((component, None), |(base, suffix)| (base, Some(suffix)));
+        let (name, binding_type) = resolve_base(base)?;
+        Some(ComponentBinding {
+            name,
+            binding_type,
+            suffix: suffix.map(|suffix| suffix.to_compact_string()),
+        })
+    }
+}

--- a/crates/vize_atelier_ssr/src/codegen/element/component.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/component.rs
@@ -43,7 +43,7 @@ impl<'a> SsrCodegenContext<'a> {
         let setup_binding = if is_dynamic_component {
             None
         } else {
-            self.resolve_component_binding_name(tag)
+            self.resolve_component_binding_expr(tag)
         };
         let props = self.build_component_props(el, false, is_dynamic_component);
         let props = self.with_scope_id_prop(props);
@@ -56,11 +56,8 @@ impl<'a> SsrCodegenContext<'a> {
 
         self.push_indent();
         self.push("_push(_ssrRenderComponent(");
-        if let Some(binding_name) = setup_binding.as_deref() {
-            if !self.options.inline {
-                self.push("$setup.");
-            }
-            self.push(binding_name);
+        if let Some(binding_expr) = setup_binding.as_deref() {
+            self.push(binding_expr);
         } else {
             self.use_core_helper(RuntimeHelper::ResolveComponent);
             self.push("_resolveComponent(\"");

--- a/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
@@ -179,13 +179,8 @@ impl<'a> SsrCodegenContext<'a> {
             return self.dynamic_component_callee(el);
         }
 
-        if let Some(binding_name) = self.resolve_component_binding_name(&el.tag) {
-            let mut out = String::default();
-            if !self.options.inline {
-                out.push_str("$setup.");
-            }
-            out.push_str(&binding_name);
-            return out;
+        if let Some(binding_expr) = self.resolve_component_binding_expr(&el.tag) {
+            return binding_expr;
         }
 
         self.use_core_helper(RuntimeHelper::ResolveComponent);

--- a/crates/vize_atelier_ssr/tests/setup_component_parity.rs
+++ b/crates/vize_atelier_ssr/tests/setup_component_parity.rs
@@ -1,0 +1,99 @@
+use vize_atelier_core::options::{BindingMetadata, BindingType};
+use vize_atelier_ssr::{SsrCompilerOptions, compile_ssr_with_options};
+use vize_carton::{Bump, FxHashMap};
+
+fn binding_matrix() -> BindingMetadata {
+    let mut bindings = FxHashMap::default();
+    bindings.insert("RefMenu".into(), BindingType::SetupRef);
+    bindings.insert("MaybeMenu".into(), BindingType::SetupMaybeRef);
+    bindings.insert("LetMenu".into(), BindingType::SetupLet);
+    bindings.insert("ImportedMenu".into(), BindingType::SetupConst);
+    bindings.insert("ShallowMenu".into(), BindingType::SetupRef);
+    bindings.insert("lowercaseWidget".into(), BindingType::SetupConst);
+    BindingMetadata {
+        bindings,
+        props_aliases: FxHashMap::default(),
+        is_script_setup: true,
+    }
+}
+
+fn ssr_component_targets(source: &str) -> Vec<String> {
+    let marker = "_ssrRenderComponent(";
+    let mut targets = Vec::new();
+    let mut offset = 0;
+    while let Some(index) = source[offset..].find(marker) {
+        let start = offset + index + marker.len();
+        let Some(target) = first_call_arg(&source[start..]) else {
+            break;
+        };
+        targets.push(target);
+        offset = start;
+    }
+    targets
+}
+
+fn first_call_arg(source: &str) -> Option<String> {
+    let mut depth = 0i32;
+    for (index, ch) in source.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' if depth == 0 => return Some(source[..index].trim().to_owned()),
+            ')' => depth -= 1,
+            ',' if depth == 0 => return Some(source[..index].trim().to_owned()),
+            _ => {}
+        }
+    }
+    None
+}
+
+#[test]
+fn setup_component_tag_binding_matrix_matches_ssr_modes() {
+    let allocator = Bump::new();
+    let source = r#"<RefMenu /><MaybeMenu /><LetMenu /><ImportedMenu /><ShallowMenu /><lowercase-widget /><RefMenu.Item />"#;
+
+    let (_, inline_errors, inline_result) = compile_ssr_with_options(
+        &allocator,
+        source,
+        SsrCompilerOptions {
+            inline: true,
+            binding_metadata: Some(binding_matrix()),
+            ..Default::default()
+        },
+    );
+    assert_eq!(inline_errors.len(), 0);
+    assert_eq!(
+        ssr_component_targets(&inline_result.code),
+        vec![
+            "_unref(RefMenu)",
+            "_unref(MaybeMenu)",
+            "_unref(LetMenu)",
+            "ImportedMenu",
+            "_unref(ShallowMenu)",
+            "lowercaseWidget",
+            "_unref(RefMenu).Item",
+        ]
+    );
+
+    let (_, function_errors, function_result) = compile_ssr_with_options(
+        &allocator,
+        source,
+        SsrCompilerOptions {
+            inline: false,
+            binding_metadata: Some(binding_matrix()),
+            ..Default::default()
+        },
+    );
+    assert_eq!(function_errors.len(), 0);
+    assert_eq!(
+        ssr_component_targets(&function_result.code),
+        vec![
+            "$setup.RefMenu",
+            "$setup.MaybeMenu",
+            "$setup.LetMenu",
+            "$setup.ImportedMenu",
+            "$setup.ShallowMenu",
+            "$setup.lowercaseWidget",
+            "$setup.RefMenu.Item",
+        ]
+    );
+}

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -16,6 +16,8 @@ pub mod steps;
 mod tests;
 #[cfg(test)]
 mod tests_dotted_slots;
+#[cfg(test)]
+mod tests_setup_components;
 
 pub use compile::{
     VaporCompileResult, VaporCompilerOptions, compile_vapor, compile_vapor_with_diagnostics,

--- a/crates/vize_atelier_vapor/src/tests.rs
+++ b/crates/vize_atelier_vapor/src/tests.rs
@@ -5,9 +5,7 @@ use oxc_allocator::Allocator;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_atelier_core::TemplateSyntaxMode;
-use vize_atelier_core::options::{BindingMetadata, BindingType};
 use vize_carton::Bump;
-use vize_carton::FxHashMap;
 
 fn normalize_code(code: &str) -> String {
     code.lines()
@@ -34,14 +32,6 @@ fn assert_parses_as_module(code: &str) {
         parsed.errors,
         code
     );
-}
-
-fn component_resolution_lines(code: &str) -> Vec<String> {
-    code.lines()
-        .map(str::trim)
-        .filter(|line| line.starts_with("const _component_"))
-        .map(ToOwned::to_owned)
-        .collect()
 }
 
 #[test]
@@ -853,76 +843,6 @@ fn test_compile_v_cloak_uses_builtin_lowering() {
 
     let code = normalize_code(&result.code);
     insta::assert_snapshot!(code.as_str());
-}
-
-#[test]
-fn test_compile_custom_renderer_intrinsics_with_bound_lowercase_component() {
-    let allocator = Bump::new();
-    let mut bindings = FxHashMap::default();
-    bindings.insert("Primitive".into(), BindingType::SetupConst);
-    let result = compile_vapor(
-        &allocator,
-        r#"<mesh><group v-if="visible"><primitive></primitive></group></mesh>"#,
-        super::VaporCompilerOptions {
-            custom_renderer: true,
-            binding_metadata: Some(BindingMetadata {
-                bindings,
-                props_aliases: FxHashMap::default(),
-                is_script_setup: true,
-            }),
-            ..Default::default()
-        },
-    );
-
-    assert!(
-        result.error_messages.is_empty(),
-        "Expected no errors: {:?}",
-        result.error_messages
-    );
-
-    assert_eq!(
-        component_resolution_lines(&result.code),
-        vec!["const _component_primitive = _ctx.Primitive"]
-    );
-}
-
-#[test]
-fn test_setup_component_tag_binding_matrix_matches_vapor_behavior() {
-    let allocator = Bump::new();
-    let mut bindings = FxHashMap::default();
-    bindings.insert("RefMenu".into(), BindingType::SetupRef);
-    bindings.insert("MaybeMenu".into(), BindingType::SetupMaybeRef);
-    bindings.insert("LetMenu".into(), BindingType::SetupLet);
-    bindings.insert("ImportedMenu".into(), BindingType::SetupConst);
-    bindings.insert("ShallowMenu".into(), BindingType::SetupRef);
-    bindings.insert("lowercaseWidget".into(), BindingType::SetupConst);
-
-    let result = compile_vapor(
-        &allocator,
-        r#"<RefMenu /><MaybeMenu /><LetMenu /><ImportedMenu /><ShallowMenu /><lowercase-widget /><RefMenu.Item />"#,
-        super::VaporCompilerOptions {
-            binding_metadata: Some(BindingMetadata {
-                bindings,
-                props_aliases: FxHashMap::default(),
-                is_script_setup: true,
-            }),
-            ..Default::default()
-        },
-    );
-
-    assert_eq!(result.error_messages.len(), 0);
-    assert_eq!(
-        component_resolution_lines(&result.code),
-        vec![
-            "const _component_RefMenu = _ctx.RefMenu",
-            "const _component_MaybeMenu = _ctx.MaybeMenu",
-            "const _component_LetMenu = _ctx.LetMenu",
-            "const _component_ImportedMenu = _ctx.ImportedMenu",
-            "const _component_ShallowMenu = _ctx.ShallowMenu",
-            "const _component_lowercase_widget = _ctx.lowercaseWidget",
-            "const _component_RefMenu_Item = _ctx.RefMenu.Item",
-        ]
-    );
 }
 
 #[test]

--- a/crates/vize_atelier_vapor/src/tests.rs
+++ b/crates/vize_atelier_vapor/src/tests.rs
@@ -36,6 +36,14 @@ fn assert_parses_as_module(code: &str) {
     );
 }
 
+fn component_resolution_lines(code: &str) -> Vec<String> {
+    code.lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("const _component_"))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
 #[test]
 fn test_compile_simple_element() {
     let allocator = Bump::new();
@@ -872,10 +880,49 @@ fn test_compile_custom_renderer_intrinsics_with_bound_lowercase_component() {
         result.error_messages
     );
 
-    let code = normalize_code(&result.code);
-    assert!(code.contains("const _component_primitive = _ctx.Primitive"));
-    assert!(!code.contains(r#"_resolveComponent("group")"#));
-    assert!(!code.contains(r#"_resolveComponent("primitive")"#));
+    assert_eq!(
+        component_resolution_lines(&result.code),
+        vec!["const _component_primitive = _ctx.Primitive"]
+    );
+}
+
+#[test]
+fn test_setup_component_tag_binding_matrix_matches_vapor_behavior() {
+    let allocator = Bump::new();
+    let mut bindings = FxHashMap::default();
+    bindings.insert("RefMenu".into(), BindingType::SetupRef);
+    bindings.insert("MaybeMenu".into(), BindingType::SetupMaybeRef);
+    bindings.insert("LetMenu".into(), BindingType::SetupLet);
+    bindings.insert("ImportedMenu".into(), BindingType::SetupConst);
+    bindings.insert("ShallowMenu".into(), BindingType::SetupRef);
+    bindings.insert("lowercaseWidget".into(), BindingType::SetupConst);
+
+    let result = compile_vapor(
+        &allocator,
+        r#"<RefMenu /><MaybeMenu /><LetMenu /><ImportedMenu /><ShallowMenu /><lowercase-widget /><RefMenu.Item />"#,
+        super::VaporCompilerOptions {
+            binding_metadata: Some(BindingMetadata {
+                bindings,
+                props_aliases: FxHashMap::default(),
+                is_script_setup: true,
+            }),
+            ..Default::default()
+        },
+    );
+
+    assert_eq!(result.error_messages.len(), 0);
+    assert_eq!(
+        component_resolution_lines(&result.code),
+        vec![
+            "const _component_RefMenu = _ctx.RefMenu",
+            "const _component_MaybeMenu = _ctx.MaybeMenu",
+            "const _component_LetMenu = _ctx.LetMenu",
+            "const _component_ImportedMenu = _ctx.ImportedMenu",
+            "const _component_ShallowMenu = _ctx.ShallowMenu",
+            "const _component_lowercase_widget = _ctx.lowercaseWidget",
+            "const _component_RefMenu_Item = _ctx.RefMenu.Item",
+        ]
+    );
 }
 
 #[test]

--- a/crates/vize_atelier_vapor/src/tests_setup_components.rs
+++ b/crates/vize_atelier_vapor/src/tests_setup_components.rs
@@ -1,0 +1,76 @@
+use super::{VaporCompilerOptions, compile_vapor};
+use vize_atelier_core::options::{BindingMetadata, BindingType};
+use vize_carton::{Bump, FxHashMap};
+
+fn component_resolution_lines(code: &str) -> Vec<String> {
+    code.lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("const _component_"))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+#[test]
+fn test_compile_custom_renderer_intrinsics_with_bound_lowercase_component() {
+    let allocator = Bump::new();
+    let mut bindings = FxHashMap::default();
+    bindings.insert("Primitive".into(), BindingType::SetupConst);
+    let result = compile_vapor(
+        &allocator,
+        r#"<mesh><group v-if="visible"><primitive></primitive></group></mesh>"#,
+        VaporCompilerOptions {
+            custom_renderer: true,
+            binding_metadata: Some(BindingMetadata {
+                bindings,
+                props_aliases: FxHashMap::default(),
+                is_script_setup: true,
+            }),
+            ..Default::default()
+        },
+    );
+
+    assert_eq!(result.error_messages.len(), 0);
+    assert_eq!(
+        component_resolution_lines(&result.code),
+        vec!["const _component_primitive = _ctx.Primitive"]
+    );
+}
+
+#[test]
+fn test_setup_component_tag_binding_matrix_matches_vapor_behavior() {
+    let allocator = Bump::new();
+    let mut bindings = FxHashMap::default();
+    bindings.insert("RefMenu".into(), BindingType::SetupRef);
+    bindings.insert("MaybeMenu".into(), BindingType::SetupMaybeRef);
+    bindings.insert("LetMenu".into(), BindingType::SetupLet);
+    bindings.insert("ImportedMenu".into(), BindingType::SetupConst);
+    bindings.insert("ShallowMenu".into(), BindingType::SetupRef);
+    bindings.insert("lowercaseWidget".into(), BindingType::SetupConst);
+
+    let result = compile_vapor(
+        &allocator,
+        r#"<RefMenu /><MaybeMenu /><LetMenu /><ImportedMenu /><ShallowMenu /><lowercase-widget /><RefMenu.Item />"#,
+        VaporCompilerOptions {
+            binding_metadata: Some(BindingMetadata {
+                bindings,
+                props_aliases: FxHashMap::default(),
+                is_script_setup: true,
+            }),
+            ..Default::default()
+        },
+    );
+
+    assert_eq!(result.error_messages.len(), 0);
+    assert_eq!(
+        component_resolution_lines(&result.code),
+        vec![
+            "const _component_RefMenu = _ctx.RefMenu",
+            "const _component_MaybeMenu = _ctx.MaybeMenu",
+            "const _component_LetMenu = _ctx.LetMenu",
+            "const _component_ImportedMenu = _ctx.ImportedMenu",
+            "const _component_ShallowMenu = _ctx.ShallowMenu",
+            "const _component_lowercase_widget = _ctx.lowercaseWidget",
+            "const _component_RefMenu_Item = _ctx.RefMenu.Item",
+        ]
+    );
+}

--- a/crates/vize_canon/src/batch/type_checker/tests/options_api_required_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/options_api_required_props.rs
@@ -1,4 +1,4 @@
-use super::{BatchTypeChecker, create_project_case, resolve_test_tsgo_binary};
+use super::{BatchTypeChecker, create_project_case, relative_path, resolve_test_tsgo_binary};
 use crate::batch::TypeChecker;
 
 #[test]
@@ -61,6 +61,116 @@ export default defineComponent({
     assert!(
         unexpected.is_empty(),
         "expected required Vue 2 Options API props to be non-optional in setup(): {unexpected:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn accepts_legacy_vue2_options_prop_type_shape_matrix() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case(
+        "legacy-vue2-options-prop-type-shapes",
+        &[
+            (
+                "src/types.ts",
+                r#"export type ImportedItem = { id: string; count: number }
+export type ImportedStatus = "ready" | "draft"
+"#,
+            ),
+            (
+                "src/App.vue",
+                r#"<script lang="ts">
+import { defineComponent, type PropType as VuePropType } from 'vue'
+import type { ImportedItem, ImportedStatus } from './types'
+
+type LocalItem = ImportedItem & { local: boolean }
+type LocalPropType<T> = VuePropType<T>
+type NestedShape = { nested: { id: string; status: ImportedStatus } }
+
+const nestedObjectProp = {
+  type: Object as LocalPropType<NestedShape>,
+  required: true,
+}
+
+export default defineComponent({
+  props: {
+    status: { type: String as VuePropType<ImportedStatus | "archived">, required: true },
+    selected: { type: Object as VuePropType<ImportedItem & { enabled: boolean }>, required: true },
+    items: { type: Array as LocalPropType<ReadonlyArray<LocalItem>>, required: true },
+    readonlyItems: { type: Array as VuePropType<readonly ImportedItem[]>, required: true },
+    formatter: { type: Function as VuePropType<(item: ImportedItem) => string>, required: true },
+    nestedObject: nestedObjectProp,
+  },
+  setup(props) {
+    const formatted = props.formatter(props.selected)
+    const firstId = props.items[0]?.id
+    const readonlyCount = props.readonlyItems[0]?.count ?? 0
+    const nestedId = props.nestedObject?.nested.id ?? ""
+    return { formatted, firstId, readonlyCount, nestedId }
+  },
+})
+</script>
+
+<template>
+  <div>
+    {{ status }}
+    {{ selected.id }}
+    {{ items[0]?.local }}
+    {{ readonlyItems[0]?.count }}
+    {{ nestedObject?.nested.status }}
+    {{ formatted }}
+    {{ firstId }}
+    {{ readonlyCount }}
+    {{ nestedId }}
+  </div>
+</template>
+"#,
+            ),
+        ],
+    );
+
+    if !project_root.join("node_modules/vue/dist").exists() {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    }
+
+    let mut checker = match BatchTypeChecker::new(&project_root) {
+        Ok(checker) => checker,
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        }
+    };
+    checker.enable_legacy_vue2();
+    checker.scan_project().unwrap();
+    let result = checker.check_project().unwrap();
+    let unexpected = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.file.ends_with("App.vue")
+                && matches!(
+                    diagnostic.code,
+                    Some(1128 | 1131 | 18048 | 2339 | 2345 | 2532 | 7006 | 7031)
+                )
+        })
+        .map(|diagnostic| {
+            (
+                relative_path(&project_root, &diagnostic.file),
+                diagnostic.code,
+                diagnostic.line,
+                diagnostic.column,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        unexpected,
+        Vec::<(vize_carton::String, Option<u32>, u32, u32)>::new()
     );
 
     let _ = std::fs::remove_dir_all(&project_root);

--- a/crates/vize_musea/src/parse.rs
+++ b/crates/vize_musea/src/parse.rs
@@ -576,6 +576,41 @@ defineArt("./base-button.vue", {
     }
 
     #[test]
+    fn test_parse_define_art_metadata_matrix() {
+        let allocator = Bump::new();
+        let source = r#"
+<script>
+export const localKind = "mixed";
+</script>
+
+<script setup>
+import { default as AliasButton } from "./AliasButton.vue";
+
+defineArt(AliasButton, {
+  title: "Alias Button",
+  category: "Components",
+  tags: ["alias", localKind],
+  status: "ready",
+});
+</script>
+
+<art>
+  <variant name="Primary" default>
+    <AliasButton>Primary</AliasButton>
+  </variant>
+</art>
+"#;
+
+        let desc = parse_art(&allocator, source, ArtParseOptions::default()).unwrap();
+
+        assert_eq!(desc.metadata.title, "Alias Button");
+        assert_eq!(desc.metadata.component, Some("./AliasButton.vue"));
+        assert_eq!(desc.metadata.category, Some("Components"));
+        assert_eq!(desc.metadata.tags.as_slice(), ["alias"]);
+        assert_eq!(desc.metadata.status, crate::types::ArtStatus::Ready);
+    }
+
+    #[test]
     fn test_extract_attr() {
         assert_eq!(extract_attr(r#"title="Hello""#, "title"), Some("Hello"));
         assert_eq!(extract_attr(r#"title='Hello'"#, "title"), Some("Hello"));

--- a/crates/vize_musea/src/parse.rs
+++ b/crates/vize_musea/src/parse.rs
@@ -576,41 +576,6 @@ defineArt("./base-button.vue", {
     }
 
     #[test]
-    fn test_parse_define_art_metadata_matrix() {
-        let allocator = Bump::new();
-        let source = r#"
-<script>
-export const localKind = "mixed";
-</script>
-
-<script setup>
-import { default as AliasButton } from "./AliasButton.vue";
-
-defineArt(AliasButton, {
-  title: "Alias Button",
-  category: "Components",
-  tags: ["alias", localKind],
-  status: "ready",
-});
-</script>
-
-<art>
-  <variant name="Primary" default>
-    <AliasButton>Primary</AliasButton>
-  </variant>
-</art>
-"#;
-
-        let desc = parse_art(&allocator, source, ArtParseOptions::default()).unwrap();
-
-        assert_eq!(desc.metadata.title, "Alias Button");
-        assert_eq!(desc.metadata.component, Some("./AliasButton.vue"));
-        assert_eq!(desc.metadata.category, Some("Components"));
-        assert_eq!(desc.metadata.tags.as_slice(), ["alias"]);
-        assert_eq!(desc.metadata.status, crate::types::ArtStatus::Ready);
-    }
-
-    #[test]
     fn test_extract_attr() {
         assert_eq!(extract_attr(r#"title="Hello""#, "title"), Some("Hello"));
         assert_eq!(extract_attr(r#"title='Hello'"#, "title"), Some("Hello"));

--- a/crates/vize_musea/tests/define_art_metadata.rs
+++ b/crates/vize_musea/tests/define_art_metadata.rs
@@ -1,0 +1,37 @@
+use vize_carton::Bump;
+use vize_musea::{ArtParseOptions, ArtStatus, parse_art};
+
+#[test]
+fn parse_define_art_metadata_matrix() {
+    let allocator = Bump::new();
+    let source = r#"
+<script>
+export const localKind = "mixed";
+</script>
+
+<script setup>
+import { default as AliasButton } from "./AliasButton.vue";
+
+defineArt(AliasButton, {
+  title: "Alias Button",
+  category: "Components",
+  tags: ["alias", localKind],
+  status: "ready",
+});
+</script>
+
+<art>
+  <variant name="Primary" default>
+    <AliasButton>Primary</AliasButton>
+  </variant>
+</art>
+"#;
+
+    let desc = parse_art(&allocator, source, ArtParseOptions::default()).unwrap();
+
+    assert_eq!(desc.metadata.title, "Alias Button");
+    assert_eq!(desc.metadata.component, Some("./AliasButton.vue"));
+    assert_eq!(desc.metadata.category, Some("Components"));
+    assert_eq!(desc.metadata.tags.as_slice(), ["alias"]);
+    assert_eq!(desc.metadata.status, ArtStatus::Ready);
+}

--- a/npm/nuxt/package.json
+++ b/npm/nuxt/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "build": "vp pack",
     "dev": "vp pack --watch",
-    "test": "node --test src/*.test.ts src/**/*.test.ts",
+    "test": "pnpm build && node --test src/*.test.ts src/**/*.test.ts",
     "check": "vp check src vite.config.ts",
     "check:fix": "vp check --fix src vite.config.ts",
     "fmt": "vp fmt --write src vite.config.ts"

--- a/npm/nuxt/src/index.test.ts
+++ b/npm/nuxt/src/index.test.ts
@@ -2,8 +2,193 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import test from "node:test";
 
-void test("Nuxt module entry avoids import.meta for Nuxt 2 loaders", () => {
-  const source = fs.readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+void test("Nuxt module entry avoids import.meta syntax in loader-facing sources", () => {
+  const fixtures = [
+    ["src/index.ts", new URL("./index.ts", import.meta.url)],
+    ["dist/index.mjs", new URL("../dist/index.mjs", import.meta.url)],
+  ] as const;
 
-  assert.equal(source.includes("import.meta"), false);
+  const offsetsByFile = fixtures.map(([name, url]) => [
+    name,
+    importMetaOffsets(fs.readFileSync(url, "utf8")),
+  ]);
+
+  assert.deepEqual(offsetsByFile, [
+    ["src/index.ts", []],
+    ["dist/index.mjs", []],
+  ]);
 });
+
+void test("Nuxt module entry runs in a Nuxt 2 webpack-style context", async () => {
+  const { default: nuxtModule } = await import(new URL("../dist/index.mjs", import.meta.url).href);
+  const hookNames: string[] = [];
+  const nuxt: {
+    options: Record<string, unknown> & {
+      rootDir: string;
+      builder: string;
+      build: { publicPath: string };
+      router: { base: string };
+      modules: unknown[];
+      buildDir: string;
+      dev: boolean;
+    };
+    hook(name: string, callback: (...args: unknown[]) => unknown): void;
+  } = {
+    options: {
+      rootDir: process.cwd(),
+      builder: "webpack",
+      build: { publicPath: "/_nuxt/" },
+      router: { base: "/docs/" },
+      modules: [],
+      buildDir: ".nuxt",
+      dev: false,
+    },
+    hook(name: string, callback: (...args: unknown[]) => unknown) {
+      assert.equal(typeof callback, "function");
+      hookNames.push(name);
+    },
+  };
+
+  await nuxtModule(
+    {
+      compiler: false,
+      musea: false,
+      compatibility: { nuxtVersion: 2, vueVersion: 2 },
+    },
+    nuxt,
+  );
+
+  assert.deepEqual(await nuxtModule.getMeta(), {
+    name: "@vizejs/nuxt",
+    configKey: "vize",
+  });
+  assert.deepEqual(
+    {
+      hookNames,
+      requiredModules: nuxt.options._requiredModules,
+      vite: nuxt.options.vite,
+    },
+    {
+      hookNames: [],
+      requiredModules: { "@vizejs/nuxt": true },
+      vite: undefined,
+    },
+  );
+});
+
+function importMetaOffsets(source: string): string[] {
+  const offsets: string[] = [];
+  let index = 0;
+  let line = 1;
+  let column = 1;
+  let state: "code" | "line-comment" | "block-comment" | "single" | "double" | "template" = "code";
+  let escaped = false;
+
+  while (index < source.length) {
+    const char = source[index];
+    const next = source[index + 1];
+    const currentLine = line;
+    const currentColumn = column;
+
+    if (state === "code") {
+      if (char === "/" && next === "/") {
+        advance(2);
+        state = "line-comment";
+        continue;
+      }
+      if (char === "/" && next === "*") {
+        advance(2);
+        state = "block-comment";
+        continue;
+      }
+      if (char === "'") {
+        advance(1);
+        escaped = false;
+        state = "single";
+        continue;
+      }
+      if (char === '"') {
+        advance(1);
+        escaped = false;
+        state = "double";
+        continue;
+      }
+      if (char === "`") {
+        advance(1);
+        escaped = false;
+        state = "template";
+        continue;
+      }
+      if (
+        source.startsWith("import.meta", index) &&
+        isIdentifierBoundary(source[index - 1]) &&
+        isIdentifierBoundary(source[index + "import.meta".length])
+      ) {
+        offsets.push(`${currentLine}:${currentColumn}`);
+      }
+      advance(1);
+      continue;
+    }
+
+    if (state === "line-comment") {
+      advance(1);
+      if (char === "\n") {
+        state = "code";
+      }
+      continue;
+    }
+
+    if (state === "block-comment") {
+      if (char === "*" && next === "/") {
+        advance(2);
+        state = "code";
+        continue;
+      }
+      advance(1);
+      continue;
+    }
+
+    if (escaped) {
+      advance(1);
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      advance(1);
+      escaped = true;
+      continue;
+    }
+
+    if (
+      (state === "single" && char === "'") ||
+      (state === "double" && char === '"') ||
+      (state === "template" && char === "`")
+    ) {
+      advance(1);
+      state = "code";
+      continue;
+    }
+
+    advance(1);
+  }
+
+  return offsets;
+
+  function advance(count: number) {
+    for (let i = 0; i < count; i++) {
+      const consumed = source[index];
+      index++;
+      if (consumed === "\n") {
+        line++;
+        column = 1;
+      } else {
+        column++;
+      }
+    }
+  }
+}
+
+function isIdentifierBoundary(char: string | undefined): boolean {
+  return char === undefined || !/[A-Za-z0-9_$]/.test(char);
+}

--- a/npm/vite-plugin-musea/src/static-export.test.ts
+++ b/npm/vite-plugin-musea/src/static-export.test.ts
@@ -1,8 +1,17 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
+import vm from "node:vm";
+import type { ResolvedConfig } from "vite";
 
 import { joinUrlPath, staticPreviewId } from "./static-data.js";
-import { loadStaticRuntimeModule, VIRTUAL_STATIC_RUNTIME } from "./static-export.js";
+import {
+  emitStaticGallery,
+  loadStaticRuntimeModule,
+  VIRTUAL_STATIC_RUNTIME,
+} from "./static-export.js";
 import type { ArtFileInfo } from "./types/index.js";
 
 function createArt(pathname: string): ArtFileInfo {
@@ -36,3 +45,186 @@ void test("static runtime keeps discovered preview modules reachable", () => {
   assert.match(code, /virtual:musea-preview:\/repo\/src\/Button\.art\.vue:Default/);
   assert.equal(loadStaticRuntimeModule(VIRTUAL_STATIC_RUNTIME, new Map()), null);
 });
+
+void test("emitStaticGallery packages browser-facing static output", async () => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-static-output-"));
+  try {
+    const artPath = path.join(tempDir, "src", "Button.art.vue");
+    await fs.promises.mkdir(path.dirname(artPath), { recursive: true });
+    await fs.promises.writeFile(artPath, "<art></art>", "utf8");
+    const art = createArt(artPath);
+    const assets = new Map<string, string>();
+
+    await emitStaticGallery(
+      (asset) => {
+        assets.set(
+          asset.fileName,
+          typeof asset.source === "string"
+            ? asset.source
+            : Buffer.from(asset.source).toString("utf8"),
+        );
+      },
+      {
+        "assets/musea-static-runtime.js": {
+          type: "chunk",
+          name: "musea-static-runtime",
+          fileName: "assets/musea-static-runtime.js",
+          facadeModuleId: null,
+        },
+      },
+      {
+        config: { root: tempDir } as ResolvedConfig,
+        artFiles: new Map([[art.path, art]]),
+        scanRoots: [tempDir],
+        tokensPath: undefined,
+        basePath: "/__musea__",
+        resolvedPreviewCss: [],
+        resolvedPreviewSetup: null,
+        devSessionToken: "static-test",
+        themeConfig: undefined,
+      },
+    );
+
+    const previewId = staticPreviewId(art.path, "Default");
+    const staticPayload = JSON.parse(assetText(assets, "__musea__/api/static.json")) as {
+      arts: Array<{ path: string; metadata: { title: string }; variants: Array<{ name: string }> }>;
+      previews: Record<string, Record<string, string>>;
+    };
+    const artsPayload = JSON.parse(assetText(assets, "__musea__/api/arts")) as Array<{
+      path: string;
+      metadata: { title: string };
+      variants: Array<{ name: string }>;
+    }>;
+
+    assert.deepEqual(staticPayload.arts.map(compactArtPayload), [
+      { path: art.path, title: "Button", variants: ["Default"] },
+    ]);
+    assert.deepEqual(artsPayload.map(compactArtPayload), staticPayload.arts.map(compactArtPayload));
+    assert.deepEqual(staticPayload.previews, {
+      [art.path]: {
+        Default: `/__musea__/preview/${previewId}.html`,
+      },
+    });
+
+    const requiredAssets = new Set([
+      "__musea__/index.html",
+      "__musea__/api/static.json",
+      "__musea__/api/arts",
+      `__musea__/preview/${previewId}.html`,
+      "index.html",
+    ]);
+    assert.deepEqual([...assets.keys()].filter((fileName) => requiredAssets.has(fileName)).sort(), [
+      "__musea__/api/arts",
+      "__musea__/api/static.json",
+      "__musea__/index.html",
+      `__musea__/preview/${previewId}.html`,
+      "index.html",
+    ]);
+
+    const globals = executeStaticGlobals(assetText(assets, "__musea__/index.html"));
+    assert.deepEqual(globals, {
+      __MUSEA_BASE_PATH__: "/__musea__",
+      __MUSEA_STATIC__: true,
+      __MUSEA_STATIC_PREVIEWS__: {
+        [art.path]: {
+          Default: `/__musea__/preview/${previewId}.html`,
+        },
+      },
+    });
+
+    assert.equal(
+      previewRuntimeSpecifier(assetText(assets, `__musea__/preview/${previewId}.html`)),
+      "../../assets/musea-static-runtime.js",
+    );
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+void test("static gallery runtime reports static-mode mutation and missing detail errors", async () => {
+  const originalWindow = Reflect.get(globalThis, "window");
+  const originalFetch = globalThis.fetch;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      __MUSEA_BASE_PATH__: "/__musea__",
+      __MUSEA_STATIC__: true,
+      __MUSEA_STATIC_PREVIEWS__: {},
+    },
+  });
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        arts: [],
+        previews: {},
+        details: {},
+        tokens: undefined,
+        tokenUsage: undefined,
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  try {
+    const moduleUrl = new URL(`../gallery/staticApi.ts?static-mode-${Date.now()}`, import.meta.url)
+      .href;
+    const { fetchStaticDetail, staticMutationError } = (await import(moduleUrl)) as {
+      fetchStaticDetail: (artPath: string) => Promise<unknown>;
+      staticMutationError: () => Error;
+    };
+
+    assert.equal(
+      staticMutationError().message,
+      "This action is not available in a static Musea gallery.",
+    );
+    await assert.rejects(
+      () => fetchStaticDetail("/missing/Button.art.vue"),
+      new Error("Art not found: /missing/Button.art.vue"),
+    );
+  } finally {
+    if (originalWindow === undefined) {
+      Reflect.deleteProperty(globalThis, "window");
+    } else {
+      Object.defineProperty(globalThis, "window", {
+        configurable: true,
+        value: originalWindow,
+      });
+    }
+    globalThis.fetch = originalFetch;
+  }
+});
+
+function compactArtPayload(art: {
+  path: string;
+  metadata: { title: string };
+  variants: Array<{ name: string }>;
+}) {
+  return {
+    path: art.path,
+    title: art.metadata.title,
+    variants: art.variants.map((variant) => variant.name),
+  };
+}
+
+function assetText(assets: Map<string, string>, fileName: string): string {
+  const value = assets.get(fileName);
+  assert.notEqual(value, undefined);
+  return value as string;
+}
+
+function executeStaticGlobals(indexHtml: string): Record<string, unknown> {
+  const script = plainScripts(indexHtml)[0];
+  assert.notEqual(script, undefined);
+  const context = { window: {} as Record<string, unknown> };
+  vm.runInNewContext(script as string, context);
+  return JSON.parse(JSON.stringify(context.window)) as Record<string, unknown>;
+}
+
+function plainScripts(html: string): string[] {
+  return [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((match) => match[1] ?? "");
+}
+
+function previewRuntimeSpecifier(html: string): string {
+  const imports = [...html.matchAll(/import\s+\{\s*loadMuseaPreview\s*\}\s+from\s+("[^"]+")/g)];
+  assert.equal(imports.length, 1);
+  return JSON.parse(imports[0]![1]!) as string;
+}

--- a/npm/vite-plugin-musea/src/static-export.ts
+++ b/npm/vite-plugin-musea/src/static-export.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { generateGalleryBody, generateGalleryScript } from "./gallery/template.js";
 import { serializeScriptValue } from "./security.js";
 import {
   createStaticGalleryPayload,
@@ -124,12 +125,7 @@ async function emitGalleryShell(
 ): Promise<void> {
   const galleryDir = resolveGalleryDistDir();
   if (!galleryDir) {
-    const { generateGalleryHtml } = await import("./gallery/index.js");
-    const html = injectStaticGlobals(
-      generateGalleryHtml(ctx.basePath, "", ctx.themeConfig),
-      ctx,
-      payload,
-    );
+    const html = injectStaticGlobals(generateStaticFallbackGalleryHtml(ctx.basePath), ctx, payload);
     emitFile({ type: "asset", fileName: joinFileName(staticRoot, "index.html"), source: html });
     return;
   }
@@ -149,6 +145,23 @@ async function emitGalleryShell(
   if (payload.arts.length === 0) {
     return;
   }
+}
+
+function generateStaticFallbackGalleryHtml(basePath: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Musea - Component Gallery</title>
+  <style>html,body{min-height:100%;margin:0}body{font-family:system-ui,sans-serif}</style>
+</head>
+<body>${generateGalleryBody(basePath)}
+
+  <script type="module">${generateGalleryScript(basePath)}
+  </script>
+</body>
+</html>`;
 }
 
 function emitPreviewHtml(


### PR DESCRIPTION
## Summary
- Add exact regression matrices for check entry ignores, import mirroring, Nuxt 2 false positives, Vue 2 Options API PropType shapes, Musea metadata/static output, and setup component binding parity.
- Fix absolute entry ignore canonicalization, skip node_modules import graph edges, and align SSR setup component resolution with DOM behavior.
- Build @vizejs/nuxt before its package tests so the produced module entry is smoke-tested.

## Validation
- cargo fmt --all -- --check
- cargo test -p vize --test check_entry_ignores_cli
- cargo test -p vize collects_project_import_graph_edges_without_package_boundaries
- cargo test -p vize --features legacy --test check_nuxt2_plugin_injections_cli
- cargo test -p vize --features legacy --test options_api_props_spread_cli
- cargo test -p vize_canon --features legacy accepts_legacy_vue2_options_prop_type_shape_matrix
- cargo test -p vize_atelier_dom --test setup_component_unref
- cargo test -p vize_atelier_ssr --test setup_component_parity
- cargo test -p vize_atelier_vapor test_compile_custom_renderer_intrinsics_with_bound_lowercase_component
- cargo test -p vize_atelier_vapor test_setup_component_tag_binding_matrix_matches_vapor_behavior
- cargo test -p vize_musea test_parse_define_art_metadata_matrix
- pnpm --filter @vizejs/nuxt test
- pnpm --filter @vizejs/nuxt check
- pnpm --filter @vizejs/vite-plugin-musea test
- pnpm --filter @vizejs/vite-plugin-musea check

Closes #1987
Closes #1988
Closes #1989
Closes #1990
Closes #1991
Closes #1992
Closes #1993
Closes #2006

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->