### PR TITLE
fix(canon): normalize overlay file URIs

### DIFF
--- a/crates/vize_canon/src/corsa_bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge.rs
@@ -19,8 +19,10 @@ pub use types::{
 mod tests {
     use super::{
         CorsaBridgeConfig, LspDiagnostic, LspPosition, LspRange, TypeCheckResult,
-        VIRTUAL_URI_SCHEME,
+        VIRTUAL_URI_SCHEME, bridge,
     };
+    use crate::file_uri::path_to_file_uri;
+    use std::path::Path;
     use vize_carton::cstr;
 
     #[test]
@@ -66,5 +68,15 @@ mod tests {
         assert!(config.working_dir.is_none());
         assert_eq!(config.timeout_ms, 30000);
         assert!(!config.enable_profiling);
+    }
+
+    #[test]
+    fn normalizes_absolute_paths_with_file_uri_encoding() {
+        let path = Path::new("/workspace/app=demo/src/App.vue.ts");
+
+        assert_eq!(
+            bridge::normalize_document_uri(path.to_str().unwrap()),
+            path_to_file_uri(path)
+        );
     }
 }

--- a/crates/vize_canon/src/corsa_bridge/bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge.rs
@@ -1,7 +1,6 @@
 //! Core Corsa bridge implementation backed by `corsa-bind`.
 
 use serde_json::Value;
-use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 #[allow(clippy::disallowed_types)]
 use std::sync::{Arc, Mutex};
@@ -14,7 +13,6 @@ use super::types::{
     VIRTUAL_URI_SCHEME,
 };
 use crate::corsa_client::CorsaProjectClient;
-use crate::file_uri::path_to_file_uri;
 
 /// Bridge to Corsa for type checking and editor queries via project sessions.
 #[allow(clippy::disallowed_types)]
@@ -531,11 +529,11 @@ impl BatchTypeChecker {
     }
 }
 
-fn normalize_document_uri(name: &str) -> String {
+pub(super) fn normalize_document_uri(name: &str) -> String {
     if name.starts_with("file://") {
         name.into()
     } else if name.starts_with('/') {
-        path_to_file_uri(Path::new(name))
+        crate::file_uri::path_to_file_uri(std::path::Path::new(name))
     } else {
         cstr!("{VIRTUAL_URI_SCHEME}://{name}")
     }
@@ -573,21 +571,4 @@ fn lock_client<'a>(
     client
         .lock()
         .map_err(|_| CorsaBridgeError::CommunicationError("Corsa client lock poisoned".into()))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::normalize_document_uri;
-    use crate::file_uri::path_to_file_uri;
-    use std::path::Path;
-
-    #[test]
-    fn normalizes_absolute_paths_with_file_uri_encoding() {
-        let path = Path::new("/workspace/app=demo/src/App.vue.ts");
-
-        assert_eq!(
-            normalize_document_uri(path.to_str().unwrap()),
-            path_to_file_uri(path)
-        );
-    }
 }

--- a/crates/vize_canon/src/corsa_bridge/bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge.rs
@@ -1,6 +1,7 @@
 //! Core Corsa bridge implementation backed by `corsa-bind`.
 
 use serde_json::Value;
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 #[allow(clippy::disallowed_types)]
 use std::sync::{Arc, Mutex};
@@ -13,6 +14,7 @@ use super::types::{
     VIRTUAL_URI_SCHEME,
 };
 use crate::corsa_client::CorsaProjectClient;
+use crate::file_uri::path_to_file_uri;
 
 /// Bridge to Corsa for type checking and editor queries via project sessions.
 #[allow(clippy::disallowed_types)]
@@ -533,7 +535,7 @@ fn normalize_document_uri(name: &str) -> String {
     if name.starts_with("file://") {
         name.into()
     } else if name.starts_with('/') {
-        cstr!("file://{name}")
+        path_to_file_uri(Path::new(name))
     } else {
         cstr!("{VIRTUAL_URI_SCHEME}://{name}")
     }
@@ -571,4 +573,21 @@ fn lock_client<'a>(
     client
         .lock()
         .map_err(|_| CorsaBridgeError::CommunicationError("Corsa client lock poisoned".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_document_uri;
+    use crate::file_uri::path_to_file_uri;
+    use std::path::Path;
+
+    #[test]
+    fn normalizes_absolute_paths_with_file_uri_encoding() {
+        let path = Path::new("/workspace/app=demo/src/App.vue.ts");
+
+        assert_eq!(
+            normalize_document_uri(path.to_str().unwrap()),
+            path_to_file_uri(path)
+        );
+    }
 }

--- a/crates/vize_canon/src/lsp_client/session.rs
+++ b/crates/vize_canon/src/lsp_client/session.rs
@@ -502,8 +502,8 @@ pub(super) fn line_character_to_utf16_offset(text: &str, line: u32, character: u
 mod tests {
     use super::{
         api_mode_for_executable, build_session_document_uri, line_character_to_utf16_offset,
-        materialize_session_document, overlay_changes_error_is_unsupported, path_to_file_uri,
-        should_retry_json_rpc, uri_document_identifier,
+        overlay_changes_error_is_unsupported, path_to_file_uri, should_retry_json_rpc,
+        uri_document_identifier,
     };
     use corsa::CorsaError;
     use corsa::api::{ApiMode, DocumentIdentifier};
@@ -538,43 +538,6 @@ mod tests {
         let outside_uri = path_to_file_uri(&outside);
         let mapped_outside = build_session_document_uri(&outside_uri, &project, true);
         assert_ne!(mapped_outside, outside_uri);
-
-        let _ = std::fs::remove_dir_all(project);
-    }
-
-    #[test]
-    fn keeps_encoded_vue_virtual_overlay_uri_at_real_path_inside_project() {
-        let nonce = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let project = std::env::temp_dir().join(format!(
-            "vize-canon-session-uri-eq={}-{}",
-            std::process::id(),
-            nonce
-        ));
-        let components = project.join("src/components");
-        std::fs::create_dir_all(&components).unwrap();
-        let real = components.join("Button.vue");
-        std::fs::write(&real, "<template><div /></template>").unwrap();
-
-        let virtual_path = components.join("Button.vue.ts");
-        let uri = path_to_file_uri(&virtual_path);
-        assert!(
-            uri.contains("%3D"),
-            "test workspace path must exercise file URI encoding: {uri}"
-        );
-
-        let mapped = build_session_document_uri(&uri, &project, true);
-        assert_eq!(
-            mapped, uri,
-            "encoded in-project overlay URI must stay stable"
-        );
-        assert!(
-            materialize_session_document(&uri, &mapped, "export {};").is_none(),
-            "stable overlay URIs must not materialize sibling files"
-        );
-        assert!(!virtual_path.exists());
 
         let _ = std::fs::remove_dir_all(project);
     }

--- a/crates/vize_canon/src/lsp_client/session.rs
+++ b/crates/vize_canon/src/lsp_client/session.rs
@@ -502,8 +502,8 @@ pub(super) fn line_character_to_utf16_offset(text: &str, line: u32, character: u
 mod tests {
     use super::{
         api_mode_for_executable, build_session_document_uri, line_character_to_utf16_offset,
-        overlay_changes_error_is_unsupported, path_to_file_uri, should_retry_json_rpc,
-        uri_document_identifier,
+        materialize_session_document, overlay_changes_error_is_unsupported, path_to_file_uri,
+        should_retry_json_rpc, uri_document_identifier,
     };
     use corsa::CorsaError;
     use corsa::api::{ApiMode, DocumentIdentifier};
@@ -538,6 +538,43 @@ mod tests {
         let outside_uri = path_to_file_uri(&outside);
         let mapped_outside = build_session_document_uri(&outside_uri, &project, true);
         assert_ne!(mapped_outside, outside_uri);
+
+        let _ = std::fs::remove_dir_all(project);
+    }
+
+    #[test]
+    fn keeps_encoded_vue_virtual_overlay_uri_at_real_path_inside_project() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let project = std::env::temp_dir().join(format!(
+            "vize-canon-session-uri-eq={}-{}",
+            std::process::id(),
+            nonce
+        ));
+        let components = project.join("src/components");
+        std::fs::create_dir_all(&components).unwrap();
+        let real = components.join("Button.vue");
+        std::fs::write(&real, "<template><div /></template>").unwrap();
+
+        let virtual_path = components.join("Button.vue.ts");
+        let uri = path_to_file_uri(&virtual_path);
+        assert!(
+            uri.contains("%3D"),
+            "test workspace path must exercise file URI encoding: {uri}"
+        );
+
+        let mapped = build_session_document_uri(&uri, &project, true);
+        assert_eq!(
+            mapped, uri,
+            "encoded in-project overlay URI must stay stable"
+        );
+        assert!(
+            materialize_session_document(&uri, &mapped, "export {};").is_none(),
+            "stable overlay URIs must not materialize sibling files"
+        );
+        assert!(!virtual_path.exists());
 
         let _ = std::fs::remove_dir_all(project);
     }

--- a/crates/vize_canon/src/lsp_client/tests.rs
+++ b/crates/vize_canon/src/lsp_client/tests.rs
@@ -1,7 +1,10 @@
 use super::{
-    bootstrap::resolve_corsa_executable, paths::resolve_temp_dir_base,
-    session::build_session_document_uri, utils::convert_diagnostics,
+    bootstrap::resolve_corsa_executable,
+    paths::resolve_temp_dir_base,
+    session::{build_session_document_uri, materialize_session_document},
+    utils::convert_diagnostics,
 };
+use crate::file_uri::path_to_file_uri;
 use lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
 use std::{
     fs,
@@ -172,4 +175,41 @@ fn normalizes_explicit_wrapper_path_to_native_binary() {
             .to_string_lossy()
             .into_owned()
     );
+}
+
+#[test]
+fn keeps_encoded_vue_virtual_overlay_uri_at_real_path_inside_project() {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let project = std::env::temp_dir().join(format!(
+        "vize-canon-session-uri-eq={}-{}",
+        std::process::id(),
+        nonce
+    ));
+    let components = project.join("src/components");
+    std::fs::create_dir_all(&components).unwrap();
+    let real = components.join("Button.vue");
+    std::fs::write(&real, "<template><div /></template>").unwrap();
+
+    let virtual_path = components.join("Button.vue.ts");
+    let uri = path_to_file_uri(&virtual_path);
+    assert!(
+        uri.contains("%3D"),
+        "test workspace path must exercise file URI encoding: {uri}"
+    );
+
+    let mapped = build_session_document_uri(&uri, &project, true);
+    assert_eq!(
+        mapped, uri,
+        "encoded in-project overlay URI must stay stable"
+    );
+    assert!(
+        materialize_session_document(&uri, &mapped, "export {};").is_none(),
+        "stable overlay URIs must not materialize sibling files"
+    );
+    assert!(!virtual_path.exists());
+
+    let _ = std::fs::remove_dir_all(project);
 }


### PR DESCRIPTION
## Summary
- normalize absolute virtual document paths with the shared file URI encoder
- keep encoded in-project Vue overlay URIs stable so Corsa does not write sibling `.vue.ts` files
- add regressions for `=` in workspace paths

Fixes #2010

## Verification
- cargo test -p vize_canon normalizes_absolute_paths_with_file_uri_encoding -- --nocapture
- cargo test -p vize_canon keeps_encoded_vue_virtual_overlay_uri_at_real_path_inside_project -- --nocapture
- cargo check -p vize_canon
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->