### PR TITLE
fix(check): register default transitive imports

### DIFF
--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -1,9 +1,9 @@
-//! Transitive resolution of source imports for explicit `vize check` subsets.
+//! Transitive resolution of source imports for `vize check` virtual projects.
 //!
-//! `vize check src/App.vue` registers only the requested files in the virtual
-//! project, so a sibling import like `./types` or `~/components/Foo.vue` cannot
-//! see the real types and can surface false `TS2307`. This module walks the
-//! reachable graph and returns on-disk source files to register.
+//! A check run may intentionally report diagnostics for only a subset of
+//! sources, but imported local sources still need to be registered so
+//! cross-file types resolve like tsc/vue-tsc. This module walks the reachable
+//! graph and returns on-disk source files to register.
 
 use std::path::{Path, PathBuf};
 

--- a/crates/vize/src/commands/check/runner/default_imports.rs
+++ b/crates/vize/src/commands/check/runner/default_imports.rs
@@ -1,0 +1,157 @@
+use std::path::{Path, PathBuf};
+
+use vize_carton::FxHashSet;
+
+use super::{
+    collect::path_is_inside_root,
+    ignores::{CheckIgnoreSet, retain_unignored},
+};
+use crate::commands::check::{
+    imports::collect_transitive_local_imports,
+    imports_aliases::PathAliasResolver,
+    path_cache::CanonicalPathCache,
+    tsconfig_inputs::{TsconfigInputCache, collect_default_check_files},
+};
+
+pub(super) fn collect_default_run_files(
+    project_root: &Path,
+    cwd: &Path,
+    tsconfig_path: Option<&Path>,
+    include_jsx: bool,
+    tsconfig_input_cache: &mut TsconfigInputCache,
+    canonical_paths: &mut CanonicalPathCache,
+    check_ignore_set: Option<&CheckIgnoreSet>,
+) -> (Vec<PathBuf>, FxHashSet<PathBuf>) {
+    let mut files = collect_default_check_files(
+        project_root,
+        tsconfig_path,
+        include_jsx,
+        tsconfig_input_cache,
+    );
+    retain_unignored(&mut files, check_ignore_set);
+    let reported_files = canonical_file_set(&files, canonical_paths);
+    register_transitive_local_imports(
+        &mut files,
+        cwd,
+        tsconfig_path,
+        include_jsx,
+        canonical_paths,
+        None,
+        false,
+    );
+
+    (files, reported_files)
+}
+
+pub(super) fn canonical_file_set(
+    files: &[PathBuf],
+    canonical_paths: &mut CanonicalPathCache,
+) -> FxHashSet<PathBuf> {
+    files
+        .iter()
+        .map(|path| canonical_paths.canonicalize(path))
+        .collect()
+}
+
+pub(super) fn register_transitive_local_imports(
+    files: &mut Vec<PathBuf>,
+    cwd: &Path,
+    tsconfig_path: Option<&Path>,
+    include_jsx: bool,
+    canonical_paths: &mut CanonicalPathCache,
+    explicit_input_root: Option<&Path>,
+    validate_inputs: bool,
+) {
+    let aliases = PathAliasResolver::from_tsconfig(tsconfig_path);
+    for path in
+        collect_transitive_local_imports(files, cwd, canonical_paths, include_jsx, Some(&aliases))
+    {
+        let inside_allowed = !validate_inputs
+            || explicit_input_root.is_none_or(|root| path_is_inside_root(root, &path));
+        if inside_allowed && !files.contains(&path) {
+            files.push(path);
+        }
+    }
+    files.sort();
+    files.dedup();
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use vize_carton::path::canonicalize_non_verbatim;
+
+    fn unique_case_dir(name: &str) -> PathBuf {
+        static NEXT_CASE_ID: std::sync::atomic::AtomicUsize =
+            std::sync::atomic::AtomicUsize::new(0);
+        let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("vize-tests")
+            .join(format!(
+                "check-runner-{name}-{}-{case_id}",
+                std::process::id()
+            ))
+    }
+
+    #[test]
+    fn default_tsconfig_run_registers_transitive_imports_outside_include_for_type_resolution() {
+        let project_root = unique_case_dir("default-transitive-imports");
+        let _ = std::fs::remove_dir_all(&project_root);
+        std::fs::create_dir_all(project_root.join("inside")).unwrap();
+        std::fs::create_dir_all(project_root.join("outside")).unwrap();
+        std::fs::write(
+            project_root.join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["inside/**/*.ts"]
+}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            project_root.join("inside/use.ts"),
+            r#"import { ITEMS } from '../outside/lib'
+
+export const r = ITEMS.map(({ code, name }) => `${code}:${name}`)
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            project_root.join("outside/lib.ts"),
+            "export const ITEMS = [{ code: 'en', name: 'English' }, { code: 'ru', name: 'Russian' }]\n",
+        )
+        .unwrap();
+
+        let mut tsconfig_input_cache = super::TsconfigInputCache::default();
+        let mut canonical_paths = super::CanonicalPathCache::default();
+        let (files, reported_files) = super::collect_default_run_files(
+            &project_root,
+            &project_root,
+            Some(&project_root.join("tsconfig.json")),
+            false,
+            &mut tsconfig_input_cache,
+            &mut canonical_paths,
+            None,
+        );
+
+        let included_file = canonicalize_non_verbatim(&project_root.join("inside/use.ts"));
+        let transitive_file = canonicalize_non_verbatim(&project_root.join("outside/lib.ts"));
+
+        assert!(files.contains(&included_file));
+        assert!(files.contains(&transitive_file));
+        assert!(reported_files.contains(&included_file));
+        assert!(
+            !reported_files.contains(&transitive_file),
+            "outside-include imports are registered for types, not reported"
+        );
+
+        let _ = std::fs::remove_dir_all(&project_root);
+    }
+}

--- a/crates/vize/src/commands/check/runner/diagnostics.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics.rs
@@ -18,25 +18,21 @@ pub(super) fn emit_json_output(json_output: JsonOutput) {
     }
 }
 
-/// Whether a registered file's diagnostics should be reported. For an explicit
-/// subset (`reported` is `Some`), only the requested files are reported; ambient
-/// and transitively-registered files exist only to resolve cross-file types.
-/// Project-level diagnostics (anchored to a tsconfig or the project root, not
-/// a source file) describe the whole check and are always reported.
+/// Whether a registered file's diagnostics should be reported. Only listed
+/// source files are reported; ambient and transitively-registered files exist
+/// only to resolve cross-file types. Project-level diagnostics (anchored to a
+/// tsconfig or the project root, not a source file) describe the whole check and
+/// are always reported.
 pub(super) fn is_reported(
-    reported: &Option<FxHashSet<PathBuf>>,
+    reported: &FxHashSet<PathBuf>,
     path: &Path,
     canonical_paths: &mut CanonicalPathCache,
 ) -> bool {
-    match reported {
-        None => true,
-        Some(set) => {
-            if !is_source_path(path) {
-                return true;
-            }
-            set.contains(&canonical_paths.canonicalize(path))
-        }
+    if !is_source_path(path) {
+        return true;
     }
+
+    reported.contains(&canonical_paths.canonicalize(path))
 }
 
 fn is_source_path(path: &Path) -> bool {

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -23,11 +23,11 @@ use super::{
     path_cache::CanonicalPathCache,
     reporting::{JsonFileResult, JsonOutput},
     tsconfig_inputs::{
-        TsconfigInputCache, collect_ambient_declaration_files, collect_default_check_files,
-        resolve_tsconfig_for_files,
+        TsconfigInputCache, collect_ambient_declaration_files, resolve_tsconfig_for_files,
     },
 };
 mod collect;
+mod default_imports;
 mod diagnostics;
 mod global_components;
 mod ignores;
@@ -37,7 +37,10 @@ mod resolve;
 mod socket;
 #[cfg(test)]
 mod tests;
-use collect::{collect_check_files_with_ignores, path_is_inside_root};
+use collect::collect_check_files_with_ignores;
+use default_imports::{
+    canonical_file_set, collect_default_run_files, register_transitive_local_imports,
+};
 use diagnostics::{
     emit_json_output, is_reported, is_suppressed_false_positive, render_diagnostics,
     save_virtual_ts_targets, write_profile_virtual_ts,
@@ -46,7 +49,7 @@ use global_components::{
     build_virtual_ts_options, collect_project_global_component_stubs, dialect_from_features,
     template_syntax_mode,
 };
-use ignores::{load_check_ignore_set, retain_unignored};
+use ignores::load_check_ignore_set;
 use nuxt_tsconfig::resolve_checker_tsconfig_path;
 #[cfg(test)]
 use nuxt_tsconfig::write_nuxt_fallback_tsconfig;
@@ -154,40 +157,32 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let mut canonical_paths = CanonicalPathCache::default();
     let check_ignore_set = load_check_ignore_set(args, config_dir);
     let collect_start = Instant::now();
-    let mut files = if args.patterns.is_empty() {
-        let mut files = collect_default_check_files(
+    let (mut files, explicit_files, reported_files): (
+        Vec<PathBuf>,
+        Vec<PathBuf>,
+        FxHashSet<PathBuf>,
+    ) = if args.patterns.is_empty() {
+        let (files, reported_files) = collect_default_run_files(
             &project_root,
+            &cwd,
             tsconfig_path.as_deref(),
             jsx_typecheck,
             &mut tsconfig_input_cache,
+            &mut canonical_paths,
+            check_ignore_set.as_ref(),
         );
-        retain_unignored(&mut files, check_ignore_set.as_ref());
-        files
+        (files, Vec::new(), reported_files)
     } else {
-        collect_check_files_with_ignores(&args.patterns, jsx_typecheck, check_ignore_set.as_ref())
-    };
-    let explicit_files = if args.patterns.is_empty() {
-        Vec::new()
-    } else {
-        files.clone()
+        let files = collect_check_files_with_ignores(
+            &args.patterns,
+            jsx_typecheck,
+            check_ignore_set.as_ref(),
+        );
+        let explicit_files = files.clone();
+        let reported_files = canonical_file_set(&files, &mut canonical_paths);
+        (files, explicit_files, reported_files)
     };
     let collect_time = collect_start.elapsed();
-
-    // For an explicit subset, only the requested files' diagnostics are
-    // reported: ambient `.d.ts` and transitively-registered relative imports are
-    // pulled into the program solely so cross-file types resolve, not to surface
-    // diagnostics for files the user did not ask about. `None` reports every
-    // registered file (the default full-project run).
-    let reported_files: Option<FxHashSet<PathBuf>> = if args.patterns.is_empty() {
-        None
-    } else {
-        Some(
-            files
-                .iter()
-                .map(|path| canonical_paths.canonicalize(path))
-                .collect(),
-        )
-    };
 
     if files.is_empty() {
         if args.format == "json" {
@@ -209,23 +204,15 @@ pub(crate) fn run_direct(args: &CheckArgs) {
 
     let validate_inputs = !args.patterns.is_empty() && tsconfig_path.is_some();
     if !args.patterns.is_empty() {
-        let aliases =
-            super::imports_aliases::PathAliasResolver::from_tsconfig(tsconfig_path.as_deref());
-        for path in super::imports::collect_transitive_local_imports(
-            &files,
+        register_transitive_local_imports(
+            &mut files,
             &cwd,
-            &mut canonical_paths,
+            tsconfig_path.as_deref(),
             jsx_typecheck,
-            Some(&aliases),
-        ) {
-            if (!validate_inputs || path_is_inside_root(&explicit_input_root, &path))
-                && !files.contains(&path)
-            {
-                files.push(path);
-            }
-        }
-        files.sort();
-        files.dedup();
+            &mut canonical_paths,
+            Some(&explicit_input_root),
+            validate_inputs,
+        );
     }
     exit_if_inputs_outside_root(&explicit_input_root, &files, validate_inputs);
     let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &files);

--- a/crates/vize/tests/check_default_imports_cli.rs
+++ b/crates/vize/tests/check_default_imports_cli.rs
@@ -1,0 +1,108 @@
+use std::{path::Path, process::Command};
+
+use vize_carton::cstr;
+
+#[test]
+fn check_without_patterns_resolves_imports_outside_tsconfig_include_for_types() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(json["fileCount"], 1, "stdout:\n{stdout}\nstderr:\n{stderr}");
+    assert_eq!(
+        json["errorCount"], 0,
+        "transitive import should be registered for type resolution; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(project_root);
+}
+
+fn create_project() -> std::path::PathBuf {
+    let project_root = unique_case_dir("default-transitive-imports-outside-include");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("inside")).unwrap();
+    std::fs::create_dir_all(project_root.join("outside")).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["inside/**/*.ts"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("inside/use.ts"),
+        r#"import { ITEMS } from '../outside/lib'
+
+export const r = ITEMS.map(({ code, name }) => `${code}:${name}`)
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("outside/lib.ts"),
+        "export const ITEMS = [{ code: 'en', name: 'English' }, { code: 'ru', name: 'Russian' }]\n",
+    )
+    .unwrap();
+    project_root
+}
+
+fn unique_case_dir(name: &str) -> std::path::PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("{name}-{}-{case_id}", std::process::id()).as_str())
+}
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn resolve_test_corsa_path() -> Option<String> {
+    let workspace_root = workspace_root();
+    let sibling_cache = workspace_root.parent()?.join("corsa-bind/.cache/tsgo");
+    if sibling_cache.exists() {
+        return Some(sibling_cache.display().to_string());
+    }
+
+    for candidate in [
+        workspace_root.join("node_modules/.bin/tsgo"),
+        workspace_root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ] {
+        if candidate.exists() {
+            return Some(candidate.display().to_string());
+        }
+    }
+
+    None
+}


### PR DESCRIPTION
## Summary
- register local transitive imports during default tsconfig runs
- keep diagnostics and JSON file counts scoped to originally reported files
- add unit and CLI regressions for imports outside tsconfig include

Fixes #1964

## Verification
- cargo test -p vize default_tsconfig_run_registers_transitive_imports_outside_include_for_type_resolution -- --nocapture
- cargo test -p vize --test check_cli check_without_patterns_resolves_imports_outside_tsconfig_include_for_types -- --nocapture
- cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->