### PR TITLE
test(fmt): cover complex template convergence

### DIFF
--- a/crates/vize_glyph/tests/template_directive_attributes.rs
+++ b/crates/vize_glyph/tests/template_directive_attributes.rs
@@ -138,3 +138,58 @@ fn sfc_multiline_template_literal_directive_attribute_is_idempotent() {
     assert_eq!(first.code, second.code, "fmt; fmt must be a no-op");
     assert_eq!(second.code, third.code, "fmt must stay at its fixed point");
 }
+
+#[test]
+fn sfc_complex_nuxt_template_converges_with_unsorted_attributes() {
+    let source = r#"<template>
+  <HeaderTop
+    v-if="studyInfo && currentQuestion"
+    :breadcrumbs="[
+      { label: purpose.name, to: `/purposes/${purpose.id}` },
+      { label: studyInfo.title, to: `/purposes/${purpose.id}/studies/${studyInfo.id}` },
+    ]"
+    :class="[
+      isOpen ? 'bg-paper border-rule' : 'bg-mute border-transparent',
+      currentQuestion.status === 'answered'
+        ? 'text-success'
+        : currentQuestion.status === 'skipped'
+          ? 'text-warning'
+          : 'text-ink',
+    ]"
+    :progress="{
+      current: questionIndex + 1,
+      total: questions.length,
+      label: `${questionIndex + 1}/${questions.length}`,
+    }"
+    @click:next="() => moveQuestion({
+      purposeId: purpose.id,
+      studyInfoId: studyInfo.id,
+      questionId: currentQuestion.id,
+    })"
+  >
+    <template #actions="{ disabled, submit }">
+      <button
+        :disabled="disabled || loading"
+        @click="submit({
+          answerStatus: currentQuestion.status,
+          selectedIds: selectedChoices.map((choice) => choice.id),
+        })"
+      >
+        Next
+      </button>
+    </template>
+  </HeaderTop>
+</template>
+"#;
+    let options = FormatOptions {
+        print_width: 120,
+        sort_attributes: false,
+        ..FormatOptions::default()
+    };
+    let first = format_sfc(source, &options).unwrap();
+    let second = format_sfc(&first.code, &options).unwrap();
+    let third = format_sfc(&second.code, &options).unwrap();
+
+    assert_eq!(first.code, second.code, "fmt; fmt must be a no-op");
+    assert_eq!(second.code, third.code, "fmt must stay at its fixed point");
+}

--- a/tests/tooling/cli-fmt-contract.test.ts
+++ b/tests/tooling/cli-fmt-contract.test.ts
@@ -49,6 +49,46 @@ function withWorkspace<T>(run: (dir: string) => T): T {
 }
 
 const UNFORMATTED = "<template><div   /></template>\n";
+const COMPLEX_NUXT_TEMPLATE = `<template>
+  <HeaderTop
+    v-if="studyInfo && currentQuestion"
+    :breadcrumbs="[
+      { label: purpose.name, to: \`/purposes/\${purpose.id}\` },
+      { label: studyInfo.title, to: \`/purposes/\${purpose.id}/studies/\${studyInfo.id}\` },
+    ]"
+    :class="[
+      isOpen ? 'bg-paper border-rule' : 'bg-mute border-transparent',
+      currentQuestion.status === 'answered'
+        ? 'text-success'
+        : currentQuestion.status === 'skipped'
+          ? 'text-warning'
+          : 'text-ink',
+    ]"
+    :progress="{
+      current: questionIndex + 1,
+      total: questions.length,
+      label: \`\${questionIndex + 1}/\${questions.length}\`,
+    }"
+    @click:next="() => moveQuestion({
+      purposeId: purpose.id,
+      studyInfoId: studyInfo.id,
+      questionId: currentQuestion.id,
+    })"
+  >
+    <template #actions="{ disabled, submit }">
+      <button
+        :disabled="disabled || loading"
+        @click="submit({
+          answerStatus: currentQuestion.status,
+          selectedIds: selectedChoices.map((choice) => choice.id),
+        })"
+      >
+        Next
+      </button>
+    </template>
+  </HeaderTop>
+</template>
+`;
 
 test("vize fmt --help documents the check/write contract and default pattern", () => {
   const result = spawnSync(VIZE.command, [...VIZE.prefix, "fmt", "--help"], {
@@ -85,6 +125,20 @@ test("vize fmt --write rewrites the file so a follow-up --check passes", () => {
     assert.notEqual(rewritten, UNFORMATTED);
 
     const recheck = runFmt(["--check", "Rewrite.vue"], dir);
+    assert.equal(recheck.status, 0, `${recheck.stdout}\n${recheck.stderr}`);
+  });
+});
+
+test("vize fmt --write and --check converge on complex unsorted Vue templates", () => {
+  withWorkspace((dir) => {
+    const file = path.join(dir, "HeaderTop.vue");
+    fs.writeFileSync(file, COMPLEX_NUXT_TEMPLATE, "utf8");
+
+    const options = ["--no-config", "--print-width", "120", "--sort-attributes", "false"];
+    const write = runFmt([...options, "--write", "HeaderTop.vue"], dir);
+    assert.equal(write.status, 0, `${write.stdout}\n${write.stderr}`);
+
+    const recheck = runFmt([...options, "--check", "HeaderTop.vue"], dir);
     assert.equal(recheck.status, 0, `${recheck.stdout}\n${recheck.stderr}`);
   });
 });


### PR DESCRIPTION
## Summary
- add a glyph regression test for complex Nuxt-style template formatting with `printWidth=120` and unsorted attributes
- add a CLI write/check convergence regression for the same option set

Closes #1879

## Validation
- cargo fmt --all --check
- cargo test -p vize_glyph --test template_directive_attributes sfc_complex_nuxt_template_converges_with_unsorted_attributes -- --nocapture
- node --test tests/tooling/cli-fmt-contract.test.ts
- cargo clippy -p vize_glyph --test template_directive_attributes -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->