### PR TITLE
fix(check): detect Nuxt2 src plugin injections

### DIFF
--- a/crates/vize/src/commands/check/nuxt/plugins.rs
+++ b/crates/vize/src/commands/check/nuxt/plugins.rs
@@ -3,24 +3,27 @@
 use std::path::Path;
 
 use ignore::WalkBuilder;
-use oxc_allocator::Allocator;
-use oxc_ast::ast::{Argument, BindingPattern, Expression, ObjectExpression, Statement};
-use oxc_parser::Parser;
-use oxc_span::SourceType;
 use vize_carton::{FxHashSet, String, cstr};
 
-use super::parsing::{
-    collect_object_keys, extract_call_expression_from_export, extract_expression,
-    extract_object_expression, find_object_property,
-};
 use super::stubs::{push_stub, tracked_read_to_string};
+
+mod extract;
+#[cfg(test)]
+mod tests;
+
+pub(super) use extract::extract_plugin_provide_keys_from_source;
 
 pub(super) fn collect_plugin_injection_stubs(
     cwd: &Path,
     stubs: &mut Vec<String>,
     seen_names: &mut FxHashSet<String>,
 ) {
-    let plugin_dirs = [cwd.join("app/plugins"), cwd.join("plugins")];
+    let plugin_dirs = [
+        cwd.join("app/plugins"),
+        cwd.join("plugins"),
+        cwd.join("src/app/plugins"),
+        cwd.join("src/plugins"),
+    ];
     let mut plugin_keys = Vec::new();
 
     for dir in plugin_dirs {
@@ -102,208 +105,4 @@ fn render_nuxt_injection_context_stub(plugin_keys: &[String]) -> String {
     stub.push_str("  interface UseContextReturn extends __VizeNuxtInjectedProperties {}\n");
     stub.push_str("}\n");
     stub
-}
-
-pub(super) fn extract_plugin_provide_keys_from_source(source: &str) -> Vec<String> {
-    let allocator = Allocator::default();
-    let source_type = SourceType::default()
-        .with_module(true)
-        .with_typescript(true);
-    let ret = Parser::new(&allocator, source, source_type).parse();
-    let mut keys = Vec::new();
-
-    for statement in &ret.program.body {
-        let Statement::ExportDefaultDeclaration(export) = statement else {
-            continue;
-        };
-        let Some(call) = extract_call_expression_from_export(&export.declaration) else {
-            continue;
-        };
-        let Expression::Identifier(callee) = &call.callee else {
-            continue;
-        };
-        if callee.name.as_str() != "defineNuxtPlugin" {
-            continue;
-        }
-        let Some(first_arg) = call.arguments.first() else {
-            continue;
-        };
-        collect_plugin_keys_from_argument(first_arg, &mut keys);
-    }
-
-    keys
-}
-
-fn collect_plugin_keys_from_argument(arg: &Argument<'_>, keys: &mut Vec<String>) {
-    match arg {
-        Argument::ObjectExpression(object) => collect_plugin_keys_from_object(object, keys),
-        Argument::ArrowFunctionExpression(arrow) => {
-            if let Some(inject_name) = nuxt2_inject_param_name(&arrow.params) {
-                collect_plugin_keys_from_nuxt2_inject_calls(
-                    &arrow.body.statements,
-                    inject_name,
-                    keys,
-                );
-            }
-            collect_plugin_keys_from_function_body(&arrow.body.statements, keys)
-        }
-        Argument::FunctionExpression(function) => {
-            if let Some(inject_name) = nuxt2_inject_param_name(&function.params)
-                && let Some(body) = &function.body
-            {
-                collect_plugin_keys_from_nuxt2_inject_calls(&body.statements, inject_name, keys);
-            }
-            if let Some(body) = &function.body {
-                collect_plugin_keys_from_function_body(&body.statements, keys);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn nuxt2_inject_param_name<'a>(params: &'a oxc_ast::ast::FormalParameters<'a>) -> Option<&'a str> {
-    let param = params.items.get(1)?;
-    binding_identifier_name(&param.pattern)
-}
-
-fn binding_identifier_name<'a>(pattern: &'a BindingPattern<'a>) -> Option<&'a str> {
-    match pattern {
-        BindingPattern::BindingIdentifier(identifier) => Some(identifier.name.as_str()),
-        _ => None,
-    }
-}
-
-fn collect_plugin_keys_from_nuxt2_inject_calls<'a>(
-    statements: &'a oxc_allocator::Vec<'a, Statement<'a>>,
-    inject_name: &str,
-    keys: &mut Vec<String>,
-) {
-    for statement in statements {
-        let Statement::ExpressionStatement(expr) = statement else {
-            continue;
-        };
-        collect_plugin_key_from_nuxt2_inject_expression(&expr.expression, inject_name, keys);
-    }
-}
-
-fn collect_plugin_key_from_nuxt2_inject_expression(
-    expression: &Expression<'_>,
-    inject_name: &str,
-    keys: &mut Vec<String>,
-) {
-    match expression {
-        Expression::CallExpression(call) => {
-            let Expression::Identifier(callee) = &call.callee else {
-                return;
-            };
-            if callee.name.as_str() != inject_name {
-                return;
-            }
-            if let Some(key) = call.arguments.first().and_then(inject_key_from_argument) {
-                keys.push(key);
-            }
-        }
-        Expression::ParenthesizedExpression(parenthesized) => {
-            collect_plugin_key_from_nuxt2_inject_expression(
-                &parenthesized.expression,
-                inject_name,
-                keys,
-            );
-        }
-        Expression::TSAsExpression(ts_as) => {
-            collect_plugin_key_from_nuxt2_inject_expression(&ts_as.expression, inject_name, keys);
-        }
-        Expression::TSSatisfiesExpression(ts_satisfies) => {
-            collect_plugin_key_from_nuxt2_inject_expression(
-                &ts_satisfies.expression,
-                inject_name,
-                keys,
-            );
-        }
-        Expression::TSNonNullExpression(ts_non_null) => {
-            collect_plugin_key_from_nuxt2_inject_expression(
-                &ts_non_null.expression,
-                inject_name,
-                keys,
-            );
-        }
-        _ => {}
-    }
-}
-
-fn inject_key_from_argument(argument: &Argument<'_>) -> Option<String> {
-    match argument {
-        Argument::StringLiteral(literal) => Some(literal.value.as_str().into()),
-        Argument::TemplateLiteral(template) => {
-            template.single_quasi().map(|value| value.as_str().into())
-        }
-        _ => None,
-    }
-}
-
-fn collect_plugin_keys_from_function_body<'a>(
-    statements: &oxc_allocator::Vec<'a, Statement<'a>>,
-    keys: &mut Vec<String>,
-) {
-    for statement in statements {
-        let Statement::ReturnStatement(ret) = statement else {
-            continue;
-        };
-        let Some(argument) = &ret.argument else {
-            continue;
-        };
-        let Some(object) = extract_object_expression(argument) else {
-            continue;
-        };
-        collect_plugin_keys_from_object(object, keys);
-    }
-}
-
-fn collect_plugin_keys_from_object(object: &ObjectExpression<'_>, keys: &mut Vec<String>) {
-    if let Some(provide_object) =
-        find_object_property(object, "provide").and_then(extract_object_expression)
-    {
-        collect_object_keys(provide_object, keys);
-    }
-
-    if let Some(setup_expression) = find_object_property(object, "setup") {
-        match extract_expression(setup_expression) {
-            Some(Expression::ArrowFunctionExpression(arrow)) => {
-                collect_plugin_keys_from_function_body(&arrow.body.statements, keys);
-            }
-            Some(Expression::FunctionExpression(function)) => {
-                if let Some(body) = &function.body {
-                    collect_plugin_keys_from_function_body(&body.statements, keys);
-                }
-            }
-            _ => {}
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{extract_plugin_provide_keys_from_source, render_nuxt_injection_context_stub};
-
-    #[test]
-    fn extracts_nuxt2_inject_keys_from_callback_plugin() {
-        let source = r#"
-export default defineNuxtPlugin((_context, register) => {
-  register('logger', { info(message) { return message.length } })
-  register(`auth`, {})
-})
-"#;
-
-        let keys = extract_plugin_provide_keys_from_source(source);
-        assert_eq!(keys, vec!["logger", "auth"]);
-    }
-
-    #[test]
-    fn renders_use_context_injection_augmentations() {
-        let stub = render_nuxt_injection_context_stub(&["logger".into()]);
-
-        assert!(stub.contains("$logger: __VizeNuxtInjection<'$logger'>;"));
-        assert!(stub.contains("interface Context extends __VizeNuxtInjectedProperties"));
-        assert!(stub.contains("interface UseContextReturn extends __VizeNuxtInjectedProperties"));
-    }
 }

--- a/crates/vize/src/commands/check/nuxt/plugins/extract.rs
+++ b/crates/vize/src/commands/check/nuxt/plugins/extract.rs
@@ -1,0 +1,284 @@
+//! AST extraction for Nuxt plugin provide/inject keys.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    Argument, BindingPattern, ExportDefaultDeclarationKind, Expression, Function, ObjectExpression,
+    Statement,
+};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::String;
+
+use super::super::parsing::{
+    collect_object_keys, extract_call_expression_from_export, extract_expression,
+    extract_object_expression, find_object_property,
+};
+
+pub(in crate::commands::check::nuxt) fn extract_plugin_provide_keys_from_source(
+    source: &str,
+) -> Vec<String> {
+    let allocator = Allocator::default();
+    let source_type = SourceType::default()
+        .with_module(true)
+        .with_typescript(true);
+    let ret = Parser::new(&allocator, source, source_type).parse();
+    let mut keys = Vec::new();
+
+    for statement in &ret.program.body {
+        let Statement::ExportDefaultDeclaration(export) = statement else {
+            continue;
+        };
+        collect_plugin_keys_from_default_export(&export.declaration, &mut keys);
+    }
+
+    keys
+}
+
+fn collect_plugin_keys_from_default_export(
+    declaration: &ExportDefaultDeclarationKind<'_>,
+    keys: &mut Vec<String>,
+) {
+    if let Some(call) = extract_call_expression_from_export(declaration) {
+        let Expression::Identifier(callee) = &call.callee else {
+            return;
+        };
+        if callee.name.as_str() != "defineNuxtPlugin" {
+            return;
+        }
+        if let Some(first_arg) = call.arguments.first() {
+            collect_plugin_keys_from_argument(first_arg, keys);
+        }
+        return;
+    }
+
+    match declaration {
+        ExportDefaultDeclarationKind::ArrowFunctionExpression(arrow) => {
+            collect_plugin_keys_from_arrow_function(arrow, keys);
+        }
+        ExportDefaultDeclarationKind::FunctionDeclaration(function)
+        | ExportDefaultDeclarationKind::FunctionExpression(function) => {
+            collect_plugin_keys_from_function(function, keys);
+        }
+        ExportDefaultDeclarationKind::ParenthesizedExpression(parenthesized) => {
+            collect_plugin_keys_from_expression(&parenthesized.expression, keys);
+        }
+        ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
+            collect_plugin_keys_from_expression(&ts_as.expression, keys);
+        }
+        ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
+            collect_plugin_keys_from_expression(&ts_satisfies.expression, keys);
+        }
+        ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
+            collect_plugin_keys_from_expression(&ts_non_null.expression, keys);
+        }
+        _ => {}
+    }
+}
+
+fn collect_plugin_keys_from_expression(expression: &Expression<'_>, keys: &mut Vec<String>) {
+    match expression {
+        Expression::ArrowFunctionExpression(arrow) => {
+            collect_plugin_keys_from_arrow_function(arrow, keys);
+        }
+        Expression::FunctionExpression(function) => {
+            collect_plugin_keys_from_function(function, keys)
+        }
+        Expression::ParenthesizedExpression(parenthesized) => {
+            collect_plugin_keys_from_expression(&parenthesized.expression, keys);
+        }
+        Expression::TSAsExpression(ts_as) => {
+            collect_plugin_keys_from_expression(&ts_as.expression, keys);
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            collect_plugin_keys_from_expression(&ts_satisfies.expression, keys);
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            collect_plugin_keys_from_expression(&ts_non_null.expression, keys);
+        }
+        _ => {}
+    }
+}
+
+fn collect_plugin_keys_from_argument(arg: &Argument<'_>, keys: &mut Vec<String>) {
+    match arg {
+        Argument::ObjectExpression(object) => collect_plugin_keys_from_object(object, keys),
+        Argument::ArrowFunctionExpression(arrow) => {
+            collect_plugin_keys_from_arrow_function(arrow, keys);
+        }
+        Argument::FunctionExpression(function) => {
+            collect_plugin_keys_from_function(function, keys);
+        }
+        _ => {}
+    }
+}
+
+fn collect_plugin_keys_from_arrow_function(
+    arrow: &oxc_ast::ast::ArrowFunctionExpression<'_>,
+    keys: &mut Vec<String>,
+) {
+    if let Some(inject_name) = nuxt2_inject_param_name(&arrow.params) {
+        collect_plugin_keys_from_nuxt2_inject_calls(&arrow.body.statements, inject_name, keys);
+    }
+    collect_plugin_keys_from_function_body(&arrow.body.statements, keys);
+}
+
+fn collect_plugin_keys_from_function(function: &Function<'_>, keys: &mut Vec<String>) {
+    let Some(body) = &function.body else {
+        return;
+    };
+    if let Some(inject_name) = nuxt2_inject_param_name(&function.params) {
+        collect_plugin_keys_from_nuxt2_inject_calls(&body.statements, inject_name, keys);
+    }
+    collect_plugin_keys_from_function_body(&body.statements, keys);
+}
+
+fn nuxt2_inject_param_name<'a>(params: &'a oxc_ast::ast::FormalParameters<'a>) -> Option<&'a str> {
+    let param = params.items.get(1)?;
+    binding_identifier_name(&param.pattern)
+}
+
+fn binding_identifier_name<'a>(pattern: &'a BindingPattern<'a>) -> Option<&'a str> {
+    match pattern {
+        BindingPattern::BindingIdentifier(identifier) => Some(identifier.name.as_str()),
+        _ => None,
+    }
+}
+
+fn collect_plugin_keys_from_nuxt2_inject_calls<'a>(
+    statements: &'a oxc_allocator::Vec<'a, Statement<'a>>,
+    inject_name: &str,
+    keys: &mut Vec<String>,
+) {
+    for statement in statements {
+        let Statement::ExpressionStatement(expr) = statement else {
+            continue;
+        };
+        collect_plugin_key_from_nuxt2_inject_expression(&expr.expression, inject_name, keys);
+    }
+}
+
+fn collect_plugin_key_from_nuxt2_inject_expression(
+    expression: &Expression<'_>,
+    inject_name: &str,
+    keys: &mut Vec<String>,
+) {
+    match expression {
+        Expression::CallExpression(call) => {
+            let Expression::Identifier(callee) = &call.callee else {
+                return;
+            };
+            if callee.name.as_str() != inject_name {
+                return;
+            }
+            if let Some(key) = call.arguments.first().and_then(inject_key_from_argument) {
+                keys.push(key);
+            }
+        }
+        Expression::ParenthesizedExpression(parenthesized) => {
+            collect_plugin_key_from_nuxt2_inject_expression(
+                &parenthesized.expression,
+                inject_name,
+                keys,
+            );
+        }
+        Expression::TSAsExpression(ts_as) => {
+            collect_plugin_key_from_nuxt2_inject_expression(&ts_as.expression, inject_name, keys);
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            collect_plugin_key_from_nuxt2_inject_expression(
+                &ts_satisfies.expression,
+                inject_name,
+                keys,
+            );
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            collect_plugin_key_from_nuxt2_inject_expression(
+                &ts_non_null.expression,
+                inject_name,
+                keys,
+            );
+        }
+        _ => {}
+    }
+}
+
+fn inject_key_from_argument(argument: &Argument<'_>) -> Option<String> {
+    match argument {
+        Argument::StringLiteral(literal) => Some(literal.value.as_str().into()),
+        Argument::TemplateLiteral(template) => {
+            template.single_quasi().map(|value| value.as_str().into())
+        }
+        _ => None,
+    }
+}
+
+fn collect_plugin_keys_from_function_body<'a>(
+    statements: &oxc_allocator::Vec<'a, Statement<'a>>,
+    keys: &mut Vec<String>,
+) {
+    for statement in statements {
+        let Statement::ReturnStatement(ret) = statement else {
+            continue;
+        };
+        let Some(argument) = &ret.argument else {
+            continue;
+        };
+        let Some(object) = extract_object_expression(argument) else {
+            continue;
+        };
+        collect_plugin_keys_from_object(object, keys);
+    }
+}
+
+fn collect_plugin_keys_from_object(object: &ObjectExpression<'_>, keys: &mut Vec<String>) {
+    if let Some(provide_object) =
+        find_object_property(object, "provide").and_then(extract_object_expression)
+    {
+        collect_object_keys(provide_object, keys);
+    }
+
+    if let Some(setup_expression) = find_object_property(object, "setup") {
+        match extract_expression(setup_expression) {
+            Some(Expression::ArrowFunctionExpression(arrow)) => {
+                collect_plugin_keys_from_function_body(&arrow.body.statements, keys);
+            }
+            Some(Expression::FunctionExpression(function)) => {
+                if let Some(body) = &function.body {
+                    collect_plugin_keys_from_function_body(&body.statements, keys);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_plugin_provide_keys_from_source;
+
+    #[test]
+    fn extracts_nuxt2_inject_keys_from_callback_plugin() {
+        let source = r#"
+export default defineNuxtPlugin((_context, register) => {
+  register('logger', { info(message) { return message.length } })
+  register(`auth`, {})
+})
+"#;
+
+        let keys = extract_plugin_provide_keys_from_source(source);
+        assert_eq!(keys, vec!["logger", "auth"]);
+    }
+
+    #[test]
+    fn extracts_nuxt2_inject_keys_from_raw_export_plugin() {
+        let source = r#"
+export default (_context, inject) => {
+  inject('logger', { info(message) { return message.length } })
+  inject(`auth`, {})
+}
+"#;
+
+        let keys = extract_plugin_provide_keys_from_source(source);
+        assert_eq!(keys, vec!["logger", "auth"]);
+    }
+}

--- a/crates/vize/src/commands/check/nuxt/plugins/tests.rs
+++ b/crates/vize/src/commands/check/nuxt/plugins/tests.rs
@@ -1,0 +1,51 @@
+use super::{collect_plugin_injection_stubs, render_nuxt_injection_context_stub};
+use vize_carton::FxHashSet;
+
+#[test]
+fn scans_src_app_plugins_for_nuxt2_injections() {
+    let project_root =
+        std::env::temp_dir().join(format!("vize-nuxt-src-app-plugins-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&project_root);
+    let plugin_dir = project_root.join("src/app/plugins");
+    std::fs::create_dir_all(&plugin_dir).unwrap();
+    std::fs::write(
+        plugin_dir.join("logger.ts"),
+        r#"export default (_context, inject) => {
+  inject("logger", {
+    info(message) {
+      return message.length;
+    },
+  });
+};
+"#,
+    )
+    .unwrap();
+
+    let mut stubs = Vec::new();
+    let mut seen_names = FxHashSet::default();
+    collect_plugin_injection_stubs(&project_root, &mut stubs, &mut seen_names);
+
+    assert!(
+        stubs
+            .iter()
+            .any(|stub| stub.contains("$logger: __VizeNuxtInjection<'$logger'>;")),
+        "expected UseContextReturn injection augmentation from src/app/plugins:\n{stubs:#?}"
+    );
+    assert!(
+        stubs
+            .iter()
+            .any(|stub| stub.contains("declare const $logger")),
+        "expected global injection stub from src/app/plugins:\n{stubs:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn renders_use_context_injection_augmentations() {
+    let stub = render_nuxt_injection_context_stub(&["logger".into()]);
+
+    assert!(stub.contains("$logger: __VizeNuxtInjection<'$logger'>;"));
+    assert!(stub.contains("interface Context extends __VizeNuxtInjectedProperties"));
+    assert!(stub.contains("interface UseContextReturn extends __VizeNuxtInjectedProperties"));
+}


### PR DESCRIPTION
## Summary
- scan common Nuxt2 source plugin roots, including src/app/plugins and src/plugins
- collect inject() keys from raw Nuxt2 export default plugin callbacks
- add regression coverage for raw plugin extraction and src/app plugin stub generation

## Tests
- cargo fmt --all --check
- cargo test -p vize plugins -- --nocapture
- cargo test -p vize --test check_nuxt2_plugin_injections_cli check_nuxt2_use_context_sees_plugin_injections -- --nocapture
- cargo clippy -p vize --lib -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check HEAD~1..HEAD

Refs #1876

Co-authored-by: ubugeeei <71201308+ubugeeei@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->