### PR TITLE
fix(check): skip unused Options API this bridge

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator/options_api.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api.rs
@@ -101,6 +101,9 @@ pub(super) fn generate_options_api_bridge(mut ts: &mut String, summary: &Croquis
     let Some(bridge) = collect_options_api_bridge(script) else {
         return;
     };
+    if bridge.computed.is_empty() && bridge.methods.is_empty() {
+        return;
+    }
 
     let mut names: Vec<&str> = summary
         .bindings
@@ -119,14 +122,6 @@ pub(super) fn generate_options_api_bridge(mut ts: &mut String, summary: &Croquis
     extend_options_api_descriptor_names(&mut names, summary);
     names.sort_unstable();
     names.dedup();
-
-    if names.is_empty()
-        && bridge.computed.is_empty()
-        && bridge.methods.is_empty()
-        && bridge.mapped_types.is_empty()
-    {
-        return;
-    }
 
     ts.push_str("  // Options API typed instance bridge\n");
     for (index, mapped_type) in bridge.mapped_types.iter().enumerate() {

--- a/crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs
@@ -236,3 +236,43 @@ export default defineComponent({
         output.code
     );
 }
+
+#[test]
+fn test_options_api_spread_only_helpers_do_not_emit_unused_this_bridge() {
+    let script = r#"import { defineComponent } from 'vue'
+import { mapState } from 'pinia'
+
+function useFakeStore() {
+    return {
+        items: [] as string[],
+        ready: true,
+    }
+}
+
+export default defineComponent({
+    computed: {
+        ...mapState(useFakeStore, ['items', 'ready']),
+    },
+})
+"#;
+    let summary = analyze_options_api_script(script);
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        None,
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        !output.code.contains("Options API typed instance bridge"),
+        "spread-only helpers should not emit an unused __VizeThis bridge:\n{}",
+        output.code
+    );
+    assert!(
+        !output.code.contains("__VizeThis"),
+        "spread-only helpers should not surface generated unused type aliases:\n{}",
+        output.code
+    );
+}


### PR DESCRIPTION
## Summary
- skip Options API typed this bridge generation when no computed or method wrappers use it
- keep mapState/mapActions spread-only components from emitting unused __VizeThis helpers
- add regression coverage for spread-only Options API helpers

## Tests
- cargo fmt --all --check
- cargo test -p vize_canon virtual_ts::tests::options_api_props_spread::test_options_api_spread_only_helpers_do_not_emit_unused_this_bridge -- --nocapture
- cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check -- crates/vize_canon/src/virtual_ts/generator/options_api.rs crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs

Refs #1876

Co-authored-by: ubugeeei <71201308+ubugeeei@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->