### PR TITLE
fix(vite-plugin): preserve optimized vue peer runtimes in dev

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/importer.ts
+++ b/npm/vite-plugin-vize/src/plugin/importer.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+import path from "node:path";
+import { classifyVitePluginRequest, splitViteIdQuery } from "@vizejs/native";
+
+export function isInsidePath(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return (
+    relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+function normalizeNuxtVirtualImporterPath(importer: string): string | null {
+  const { request } = splitViteIdQuery(importer);
+  for (const prefix of ["/@id/virtual:nuxt:", "virtual:nuxt:"]) {
+    if (!request.startsWith(prefix)) {
+      continue;
+    }
+
+    const encodedPath = request.slice(prefix.length);
+    try {
+      return decodeURIComponent(encodedPath);
+    } catch {
+      return encodedPath;
+    }
+  }
+
+  return null;
+}
+
+export function normalizeImporterFilePath(importer: string): string {
+  const nuxtVirtualPath = normalizeNuxtVirtualImporterPath(importer);
+  if (nuxtVirtualPath) {
+    return nuxtVirtualPath;
+  }
+
+  const request = classifyVitePluginRequest(importer);
+  return (
+    request.normalizedFsId ??
+    request.strippedVirtualPath ??
+    request.vizeVirtualPath ??
+    request.normalizedVuePath ??
+    splitViteIdQuery(importer).request
+  );
+}
+
+export function isProjectSourceImporter(root: string, importer?: string): boolean {
+  if (!importer) {
+    return false;
+  }
+
+  const importerPath = normalizeImporterFilePath(importer);
+  if (!path.isAbsolute(importerPath)) {
+    return false;
+  }
+
+  const normalizedImporterPath = importerPath.split(path.sep).join("/");
+  if (normalizedImporterPath.includes("/node_modules/")) {
+    return false;
+  }
+
+  if (isInsidePath(root, importerPath)) {
+    return true;
+  }
+
+  try {
+    return isInsidePath(fs.realpathSync(root), fs.realpathSync(importerPath));
+  } catch {
+    return false;
+  }
+}

--- a/npm/vite-plugin-vize/src/plugin/resolve-peer-runtime.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve-peer-runtime.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { VizePluginState } from "./state.ts";
+import { resolveIdHook } from "./resolve.ts";
+import { toVirtualId } from "../virtual.ts";
+
+const testRoot = fs.mkdtempSync(
+  path.join(fs.realpathSync(os.tmpdir()), "vize-vite-plugin-peer-runtime-"),
+);
+
+function writeFixtureFile(filePath: string, content = ""): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function createTempProject(prefix: string): string {
+  const root = fs.mkdtempSync(path.join(testRoot, prefix + "-"));
+  writeFixtureFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ name: "peer-runtime-fixture", private: true }, null, 2),
+  );
+  return root;
+}
+
+function createState(root: string): VizePluginState {
+  return {
+    cache: new Map(),
+    ssrCache: new Map(),
+    collectedCss: new Map(),
+    precompileMetadata: new Map(),
+    pendingHmrUpdateTypes: new Map(),
+    isProduction: false,
+    root,
+    clientViteBase: "/",
+    serverViteBase: "/",
+    server: {} as never,
+    filter: () => true,
+    scanPatterns: ["**/*.vue"],
+    precompileBatchSize: 128,
+    ignorePatterns: [],
+    mergedOptions: {},
+    initialized: true,
+    dynamicImportAliasRules: [],
+    cssAliasRules: [],
+    extractCss: false,
+    componentsCssFileName: "assets/vize-components.css",
+    clientViteDefine: {},
+    serverViteDefine: {},
+    logger: {
+      log() {},
+      info() {},
+      warn() {},
+      error() {},
+    } as never,
+  };
+}
+
+const nullResolveContext = {
+  resolve: async () => null,
+};
+
+{
+  const projectRoot = createTempProject("dev-source-vue-peer-runtime");
+  const mainImporter = path.join(projectRoot, "src", "main.ts");
+  const sfcImporter = path.join(projectRoot, "src", "PageOne.vue");
+  const routerPackage = path.join(projectRoot, "node_modules", "vue-router");
+  const routerEntry = path.join(routerPackage, "dist", "vue-router.js");
+
+  writeFixtureFile(mainImporter, "import { createRouter } from 'vue-router';");
+  writeFixtureFile(
+    sfcImporter,
+    "<script setup>import { useRouteQuery } from '@vueuse/router'</script>",
+  );
+  writeFixtureFile(
+    path.join(routerPackage, "package.json"),
+    JSON.stringify(
+      {
+        name: "vue-router",
+        exports: {
+          ".": {
+            import: "./dist/vue-router.js",
+            require: "./dist/vue-router.js",
+          },
+          "./package.json": "./package.json",
+        },
+        main: "dist/vue-router.js",
+      },
+      null,
+      2,
+    ),
+  );
+  writeFixtureFile(routerEntry, "export const createRouter = () => null;");
+
+  const state = createState(projectRoot);
+
+  assert.equal(
+    await resolveIdHook(nullResolveContext, state, "vue-router", mainImporter, undefined),
+    null,
+    "Dev source imports of Vue peer runtimes should stay bare so Vite optimizes vue-router consistently with dependent packages",
+  );
+  assert.equal(
+    await resolveIdHook(
+      nullResolveContext,
+      state,
+      "vue-router",
+      toVirtualId(sfcImporter),
+      undefined,
+    ),
+    null,
+    "Dev source SFC imports of Vue peer runtimes should not bypass Vite's dependency optimizer",
+  );
+}

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -15,6 +15,7 @@ import {
 } from "@vizejs/native";
 
 import type { VizePluginState } from "./state.ts";
+import { isInsidePath, isProjectSourceImporter, normalizeImporterFilePath } from "./importer.ts";
 import {
   LEGACY_VIZE_PREFIX,
   VIRTUAL_CSS_MODULE,
@@ -385,47 +386,6 @@ function isVuePackageEntry(id: string): boolean {
   );
 }
 
-function isInsidePath(parent: string, child: string): boolean {
-  const relative = path.relative(parent, child);
-  return (
-    relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
-  );
-}
-
-function normalizeNuxtVirtualImporterPath(importer: string): string | null {
-  const { request } = splitViteIdQuery(importer);
-  for (const prefix of ["/@id/virtual:nuxt:", "virtual:nuxt:"]) {
-    if (!request.startsWith(prefix)) {
-      continue;
-    }
-
-    const encodedPath = request.slice(prefix.length);
-    try {
-      return decodeURIComponent(encodedPath);
-    } catch {
-      return encodedPath;
-    }
-  }
-
-  return null;
-}
-
-function normalizeImporterFilePath(importer: string): string {
-  const nuxtVirtualPath = normalizeNuxtVirtualImporterPath(importer);
-  if (nuxtVirtualPath) {
-    return nuxtVirtualPath;
-  }
-
-  const request = classifyVitePluginRequest(importer);
-  return (
-    request.normalizedFsId ??
-    request.strippedVirtualPath ??
-    request.vizeVirtualPath ??
-    request.normalizedVuePath ??
-    splitViteIdQuery(importer).request
-  );
-}
-
 function isProjectLocalImporter(state: Pick<VizePluginState, "root">, importer?: string): boolean {
   if (!importer) {
     return false;
@@ -640,12 +600,18 @@ async function resolveProjectVueRuntime(
     return null;
   }
 
+  const isBuild = state.server === null;
   const viteImporter = normalizeViteRequireBase(importer) ?? importer;
   if (isVuePeerRuntimeRequest(id)) {
     const nuxtPeerEntry = resolveProjectNuxtVuePeerRuntimeEntryWithNode(state, id);
     if (nuxtPeerEntry) {
       state.logger.log(`resolveId: resolved Nuxt Vue peer runtime ${id} to ${nuxtPeerEntry}`);
       return nuxtPeerEntry;
+    }
+
+    if (!isBuild && isProjectSourceImporter(state.root, importer)) {
+      state.logger.log(`resolveId: deferring source Vue peer runtime ${id} to Vite optimizer`);
+      return null;
     }
 
     const projectLocalEntry = resolveVuePeerRuntimeEntryWithNode(state, id, viteImporter);
@@ -1016,6 +982,12 @@ export async function resolveIdHook(
       // packages in the correct node_modules directory.
       if (!id.startsWith("./") && !id.startsWith("../") && !id.startsWith("/")) {
         const isVueRuntime = isVueRuntimeRequest(id);
+        const isVuePeerRuntime = isVuePeerRuntimeRequest(id);
+        if (!isBuild && isVuePeerRuntime && isProjectSourceImporter(state.root, importer)) {
+          state.logger.log(`resolveId: deferring source Vue peer runtime ${id} to Vite optimizer`);
+          return null;
+        }
+
         if (isVueRuntime && isBuild) {
           const vueBundlerEntry = resolveVueBundlerEntryWithNode(state, id, cleanImporter);
           if (vueBundlerEntry) {

--- a/npm/vite-plugin-vize/src/test.ts
+++ b/npm/vite-plugin-vize/src/test.ts
@@ -8,6 +8,7 @@ import "./plugin/index.test.ts";
 import "./plugin/load.test.ts";
 import "./plugin/native.test.ts";
 import "./plugin/quasar.test.ts";
+import "./plugin/resolve-peer-runtime.test.ts";
 import "./plugin/resolve-vue-runtime.test.ts";
 import "./plugin/resolve.test.ts";
 import "./plugin/state.test.ts";


### PR DESCRIPTION
## Summary
- Defer Vue peer runtime imports from project source modules to Vite during dev so optimized dependencies share the same router instance.
- Keep Nuxt peer runtime and build-time ESM entry resolution paths intact.
- Add a resolver regression covering both `main.ts` and source SFC importers from the `useRouteQuery` repro.

## Verification
- `pnpm --dir npm/vite-plugin-vize check`
- `pnpm --dir npm/vite-plugin-vize test`
- Reproduced #2013 locally, patched the temp installed plugin with this resolver change, and verified `main.ts` imports `/node_modules/.vite/deps/vue-router.js` plus the `useRouteQuery` input updates `?search=bar` without the WeakMap console error.

Fixes #2013

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->