### PR TITLE
fix(glyph): stabilize plain script formatting

### DIFF
--- a/crates/vize/tests/plain_script_cli.rs
+++ b/crates/vize/tests/plain_script_cli.rs
@@ -40,6 +40,75 @@ fn fmt_check_supports_plain_ts_inputs() {
 }
 
 #[test]
+fn fmt_write_stabilizes_plain_ts_until_fixed_point() {
+    let project = tempfile::tempdir().unwrap();
+    write_project_file(
+        project.path(),
+        "app/features/authSignup/use.ts",
+        r#"import { z } from "zod"
+
+const schema = z.object({
+  confirmCode: z
+    .string()
+    .regex(/^\d{6}$/, {
+      message: t("form.validation.exactDigits", {
+        target: t("form.field.confirmCode.label"),
+        digits: 6,
+      }),
+    }),
+})
+"#,
+    );
+    write_project_file(
+        project.path(),
+        "app/features/layout/position.ts",
+        r#"function getSlotPosition(slotName: string): { style: { left: string, top: string, width: string, height: string }, inPortal: boolean } | null {
+  return null
+}
+"#,
+    );
+
+    let write = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args([
+            "fmt",
+            "--no-config",
+            "--write",
+            "app/features/authSignup/use.ts",
+            "app/features/layout/position.ts",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(write.status.code(), Some(0), "{}", output_details(&write));
+
+    let check = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args([
+            "fmt",
+            "--no-config",
+            "--check",
+            "app/features/authSignup/use.ts",
+            "app/features/layout/position.ts",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(check.status.code(), Some(0), "{}", output_details(&check));
+
+    let formatted =
+        fs::read_to_string(project.path().join("app/features/authSignup/use.ts")).unwrap();
+    assert!(
+        formatted.contains("confirmCode: z.string().regex(/^\\d{6}$/, {"),
+        "first write must produce the fixed point used by the second write"
+    );
+    let formatted =
+        fs::read_to_string(project.path().join("app/features/layout/position.ts")).unwrap();
+    assert!(
+        formatted.starts_with("function getSlotPosition(slotName: string): {"),
+        "plain TS files must use the same fixed point as SFC script blocks"
+    );
+}
+
+#[test]
 fn lint_supports_plain_ts_inputs() {
     let project = tempfile::tempdir().unwrap();
     write_project_file(

--- a/crates/vize_glyph/src/formatter.rs
+++ b/crates/vize_glyph/src/formatter.rs
@@ -194,7 +194,7 @@ impl<'a> GlyphFormatter<'a> {
             self.allocator,
             source_type,
         )
-        .unwrap_or_else(|| trimmed.to_compact_string());
+        .unwrap_or_else(|_| trimmed.to_compact_string());
 
         // Build the opening tag using byte operations
         output.extend_from_slice(b"<script");

--- a/crates/vize_glyph/src/lib.rs
+++ b/crates/vize_glyph/src/lib.rs
@@ -80,7 +80,7 @@ pub fn format_sfc_with_allocator(
 #[inline]
 pub fn format_script(source: &str, options: &FormatOptions) -> Result<String, FormatError> {
     let allocator = Allocator::with_capacity(source.len() * 2);
-    script::format_script_content(source, options, &allocator)
+    script::format_ts_script_content_stable(source, options, &allocator)
 }
 
 /// Format only script content with an explicit JavaScript/TypeScript source type.
@@ -91,7 +91,7 @@ pub fn format_script_with_source_type(
     allocator: &Allocator,
     source_type: oxc_span::SourceType,
 ) -> Result<String, FormatError> {
-    script::format_script_content_with_source_type(source, options, allocator, source_type)
+    script::format_script_content_stable(source, options, allocator, source_type)
 }
 
 /// Format only the template content

--- a/crates/vize_glyph/src/script.rs
+++ b/crates/vize_glyph/src/script.rs
@@ -11,10 +11,13 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_carton::{Allocator, String, ToCompactString};
 
+const MAX_SCRIPT_STABILIZATION_PASSES: usize = 6;
+
 /// Format JavaScript/TypeScript content using oxc_formatter
 ///
 /// Uses arena allocation for efficient memory management.
 #[inline]
+#[cfg(test)]
 pub fn format_script_content(
     source: &str,
     options: &FormatOptions,
@@ -77,18 +80,46 @@ pub(crate) fn format_script_content_stable(
     options: &FormatOptions,
     allocator: &Allocator,
     source_type: SourceType,
-) -> Option<String> {
-    let first =
-        format_script_content_with_source_type(source, options, allocator, source_type).ok()?;
+) -> Result<String, FormatError> {
+    let mut current =
+        format_script_content_with_source_type(source, options, allocator, source_type)?;
     // Skip the second (idempotence) pass when the caller only needs change
     // detection (`fmt --check`), or when the first pass was already a no-op:
     // the input is then a fixed point, so re-formatting cannot change it.
-    if options.skip_script_stabilization || first.trim_end() == source.trim_end() {
-        return Some(first);
+    if options.skip_script_stabilization || current.trim_end() == source.trim_end() {
+        return Ok(current);
     }
-    format_script_content_with_source_type(first.as_str(), options, allocator, source_type)
-        .ok()
-        .or(Some(first))
+
+    for _ in 1..MAX_SCRIPT_STABILIZATION_PASSES {
+        let next = match format_script_content_with_source_type(
+            current.as_str(),
+            options,
+            allocator,
+            source_type,
+        ) {
+            Ok(next) => next,
+            Err(_) => return Ok(current),
+        };
+        if next.trim_end() == current.trim_end() {
+            return Ok(next);
+        }
+        current = next;
+    }
+
+    Ok(current)
+}
+
+pub(crate) fn format_ts_script_content_stable(
+    source: &str,
+    options: &FormatOptions,
+    allocator: &Allocator,
+) -> Result<String, FormatError> {
+    format_script_content_stable(
+        source,
+        options,
+        allocator,
+        SourceType::ts().with_module(true),
+    )
 }
 
 pub(crate) fn source_type_for_script_lang(lang: Option<&str>) -> SourceType {

--- a/crates/vize_glyph/tests/script_idempotence.rs
+++ b/crates/vize_glyph/tests/script_idempotence.rs
@@ -1,0 +1,78 @@
+use vize_glyph::{FormatOptions, format_script};
+
+#[test]
+fn script_function_signature_return_type_is_idempotent() {
+    let source = r#"function getSlotPosition(slotName: string): { style: { left: string, top: string, width: string, height: string }, inPortal: boolean } | null {
+  return null
+}
+"#;
+    let options = FormatOptions::default();
+    let first = format_script(source, &options).unwrap();
+    let second = format_script(&first, &options).unwrap();
+    let third = format_script(&second, &options).unwrap();
+
+    assert_eq!(first, second, "fmt; fmt must be a no-op");
+    assert_eq!(second, third, "fmt must stay at its fixed point");
+}
+
+#[test]
+fn script_check_mode_still_detects_non_fixed_point_output() {
+    let source = r#"function getSlotPosition(slotName: string): { style: { left: string, top: string, width: string, height: string }, inPortal: boolean } | null {
+  return null
+}
+"#;
+    let check = FormatOptions {
+        skip_script_stabilization: true,
+        ..FormatOptions::default()
+    };
+    let write = FormatOptions::default();
+
+    let once = format_script(source, &check).unwrap();
+    let canonical = format_script(source, &write).unwrap();
+    assert_ne!(
+        once, canonical,
+        "fixture must actually exercise the non-idempotent script path"
+    );
+
+    assert_ne!(
+        format_script(&once, &check).unwrap(),
+        once,
+        "check-mode formatting must still detect a once-formatted intermediate"
+    );
+    assert_eq!(
+        format_script(&canonical, &check).unwrap(),
+        canonical,
+        "check-mode formatting must treat the fixed point as already formatted"
+    );
+}
+
+#[test]
+fn script_chained_zod_regex_call_is_idempotent() {
+    let source = r#"import { z } from "zod"
+
+const schema = z.object({
+  confirmCode: z
+    .string()
+    .regex(/^\d{6}$/, {
+      message: t("form.validation.exactDigits", {
+        target: t("form.field.confirmCode.label"),
+        digits: 6,
+      }),
+    }),
+})
+"#;
+    let options = FormatOptions::default();
+    let first = format_script(source, &options).unwrap();
+    let second = format_script(&first, &options).unwrap();
+    let third = format_script(&second, &options).unwrap();
+
+    assert_eq!(
+        first, second,
+        "first fmt pass must reach the script fixed point"
+    );
+    assert_eq!(second, third, "fmt must stay at its fixed point");
+    assert!(
+        first.contains("confirmCode: z.string().regex(/^\\d{6}$/, {"),
+        "fixture must exercise the chained-call layout reported in #2025"
+    );
+}

--- a/crates/vize_glyph/tests/sfc_script_idempotence.rs
+++ b/crates/vize_glyph/tests/sfc_script_idempotence.rs
@@ -16,3 +16,38 @@ function getSlotPosition(slotName: string): { style: { left: string, top: string
     assert_eq!(first.code, second.code, "fmt; fmt must be a no-op");
     assert_eq!(second.code, third.code, "fmt must stay at its fixed point");
 }
+
+#[test]
+fn sfc_script_chained_zod_regex_call_is_idempotent() {
+    let source = r#"<script setup lang="ts">
+import { z } from "zod"
+
+const schema = z.object({
+  confirmCode: z
+    .string()
+    .regex(/^\d{6}$/, {
+      message: t("form.validation.exactDigits", {
+        target: t("form.field.confirmCode.label"),
+        digits: 6,
+      }),
+    }),
+})
+</script>
+"#;
+    let options = FormatOptions::default();
+    let first = format_sfc(source, &options).unwrap();
+    let second = format_sfc(&first.code, &options).unwrap();
+    let third = format_sfc(&second.code, &options).unwrap();
+
+    assert_eq!(
+        first.code, second.code,
+        "first fmt pass must reach the script fixed point"
+    );
+    assert_eq!(second.code, third.code, "fmt must stay at its fixed point");
+    assert!(
+        first
+            .code
+            .contains("confirmCode: z.string().regex(/^\\d{6}$/, {"),
+        "fixture must exercise the chained-call layout reported in #2025"
+    );
+}


### PR DESCRIPTION
## Summary

- stabilize plain JS/TS formatter output to the same bounded fixed point used by SFC script blocks
- keep check-mode fast path semantics while ensuring intermediate output is still detected as unformatted
- add regression coverage for chained Zod regex calls and known multi-pass script formatting cases

Fixes #2025

## Tests

- cargo fmt --check
- cargo test -p vize_glyph
- cargo test -p vize --test plain_script_cli
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->