### PR TITLE
fix(canon): keep setup-derived type aliases in scope

### DIFF
--- a/crates/vize_canon/src/virtual_ts/tests/define_props_scope.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/define_props_scope.rs
@@ -165,3 +165,106 @@ const props = defineProps<Props>();
         output.code
     );
 }
+
+#[test]
+fn test_define_props_transitive_typeof_alias_stays_with_props_interface() {
+    let script = r#"import { pickProperties } from '~/src/shared/objectOperationUtil';
+import { FormViewStateEnum as _FormViewStateEnum } from '~/src/domain/models/form';
+
+const FormViewStateEnum = pickProperties(_FormViewStateEnum, [
+  _FormViewStateEnum.TextbookSelection_OtherStudentTextbook,
+  _FormViewStateEnum.DetailForm_OtherStudentTextbook,
+]);
+
+type FormViewState = (typeof FormViewStateEnum)[keyof typeof FormViewStateEnum];
+
+interface Props {
+  formViewState: FormViewState;
+  updateStepperStateToTextbookInput: (s: FormViewState) => void;
+}
+
+const props = defineProps<Props>();
+"#;
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    let summary = analyzer.finish();
+
+    let output =
+        generate_virtual_ts_with_offsets(&summary, Some(script), None, 0, 0, &Default::default());
+    let (module_scope, setup_and_after) = output
+        .code
+        .split_once("// ========== Setup Scope ==========")
+        .expect("setup scope marker present");
+
+    assert!(
+        !module_scope.contains("interface Props")
+            && !module_scope.contains("type FormViewState =")
+            && !module_scope.contains("formViewState: FormViewState"),
+        "setup-derived type aliases must not leak into module scope:\n{}",
+        output.code
+    );
+    assert!(
+        setup_and_after.contains(
+            "type FormViewState = (typeof FormViewStateEnum)[keyof typeof FormViewStateEnum];"
+        ),
+        "setup scope must retain the local alias derived from the local const:\n{}",
+        output.code
+    );
+    assert!(
+        setup_and_after.contains("interface Props {")
+            && setup_and_after.contains("formViewState: FormViewState;")
+            && setup_and_after
+                .contains("updateStepperStateToTextbookInput: (s: FormViewState) => void;"),
+        "Props must stay in the same setup scope as the alias it references:\n{}",
+        output.code
+    );
+    assert!(
+        setup_and_after.contains("type __VizeSetupProps = Props;"),
+        "defineProps<Props>() must resolve through the setup-local Props artifact:\n{}",
+        output.code
+    );
+}
+
+#[test]
+fn test_setup_local_type_alias_is_emitted_before_ref_type_usage() {
+    let script = r#"import { ref } from 'vue';
+
+const DialogOpenStatusEnum = {
+  None: 'None',
+  Confirm: 'Confirm',
+} as const;
+
+type DialogOpenStatus = (typeof DialogOpenStatusEnum)[keyof typeof DialogOpenStatusEnum];
+
+const dialogOpenStatus = ref<DialogOpenStatus>(DialogOpenStatusEnum.None);
+"#;
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    let summary = analyzer.finish();
+
+    let output =
+        generate_virtual_ts_with_offsets(&summary, Some(script), None, 0, 0, &Default::default());
+    let (module_scope, setup_and_after) = output
+        .code
+        .split_once("// ========== Setup Scope ==========")
+        .expect("setup scope marker present");
+
+    assert!(
+        !module_scope.contains("DialogOpenStatus"),
+        "setup-local type alias must not be emitted where its const is missing:\n{}",
+        output.code
+    );
+    let alias_at = setup_and_after
+        .find("type DialogOpenStatus = (typeof DialogOpenStatusEnum)")
+        .expect("setup scope should contain DialogOpenStatus alias");
+    let usage_at = setup_and_after
+        .find("ref<DialogOpenStatus>(DialogOpenStatusEnum.None)")
+        .expect("setup scope should contain ref typed with DialogOpenStatus");
+    assert!(
+        alias_at < usage_at,
+        "local alias must be emitted before same-scope type usage:\n{}",
+        output.code
+    );
+}

--- a/crates/vize_croquis/src/script_parser/result.rs
+++ b/crates/vize_croquis/src/script_parser/result.rs
@@ -16,6 +16,7 @@ use crate::provide::ProvideInjectTracker;
 use crate::race::RaceConditionTracker;
 use crate::reactivity::ReactivityTracker;
 use crate::scope::ScopeChain;
+use crate::script_parser::typeof_refs::TypeDependencyRefs;
 use crate::setup_context::SetupContextTracker;
 use crate::types::TypeResolver;
 use vize_carton::{CompactString, FxHashMap, FxHashSet};
@@ -110,6 +111,11 @@ pub struct ScriptParseResult {
     /// setup-scope values they depend on. Pushed to in lockstep with
     /// `type_exports` via `record_type_export`.
     pub(crate) type_export_typeof_refs: Vec<FxHashSet<CompactString>>,
+    /// Local type/interface identifiers referenced by each `type_exports`
+    /// entry, indexed in parallel with `type_exports`. Used with
+    /// `type_export_typeof_refs` to propagate setup-scope demotion through
+    /// aliases such as `Props -> FormViewState -> typeof FormViewStateEnum`.
+    pub(crate) type_export_type_refs: Vec<FxHashSet<CompactString>>,
     /// Static runtime object literal metadata available to macro spread args.
     pub(crate) runtime_object_literals: FxHashMap<CompactString, RuntimeObjectLiteral>,
     /// Authoritative Options API options-object descriptor, when resolved.
@@ -155,17 +161,14 @@ impl ScriptParseResult {
         }
     }
 
-    /// Record a `TypeExport` together with the `typeof` value-identifier
-    /// references found in its body. Must be the only call site that pushes
-    /// to `type_exports` so the two vectors stay in lockstep for
+    /// Record a `TypeExport` together with type/value dependency references
+    /// found in its body. Must be the only call site that pushes to
+    /// `type_exports` so the parallel dependency vectors stay in lockstep for
     /// `resolve_type_export_hoisting`.
-    pub(crate) fn record_type_export(
-        &mut self,
-        export: TypeExport,
-        typeof_refs: FxHashSet<CompactString>,
-    ) {
+    pub(crate) fn record_type_export(&mut self, export: TypeExport, refs: TypeDependencyRefs) {
         self.type_exports.push(export);
-        self.type_export_typeof_refs.push(typeof_refs);
+        self.type_export_typeof_refs.push(refs.typeof_value_refs);
+        self.type_export_type_refs.push(refs.type_refs);
     }
 
     /// Demote `TypeExport::hoisted` to `false` for any type whose body
@@ -178,7 +181,7 @@ impl ScriptParseResult {
     /// reference is left as hoisted: the import is visible from the module
     /// scope where the type lands.
     pub(crate) fn resolve_type_export_hoisting(&mut self) {
-        if self.type_export_typeof_refs.is_empty() {
+        if self.type_exports.is_empty() {
             return;
         }
 
@@ -201,6 +204,31 @@ impl ScriptParseResult {
             });
             if touches_setup_value && let Some(te) = self.type_exports.get_mut(idx) {
                 te.hoisted = false;
+            }
+        }
+
+        let mut non_hoisted_type_names: FxHashSet<CompactString> = self
+            .type_exports
+            .iter()
+            .filter(|te| !te.hoisted)
+            .map(|te| te.name.clone())
+            .collect();
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for idx in 0..self.type_exports.len() {
+                if !self.type_exports[idx].hoisted {
+                    continue;
+                }
+
+                let refs_non_hoisted_type = self.type_export_type_refs[idx]
+                    .iter()
+                    .any(|name| non_hoisted_type_names.contains(name));
+                if refs_non_hoisted_type {
+                    non_hoisted_type_names.insert(self.type_exports[idx].name.clone());
+                    self.type_exports[idx].hoisted = false;
+                    changed = true;
+                }
             }
         }
     }

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/vize_croquis/src/script_parser/tests.rs
-assertion_line: 342
 expression: result
 ---
 ScriptParseResult {
@@ -1328,6 +1327,7 @@ ScriptParseResult {
         "MyComponent": "./MyComponent.vue",
     },
     type_export_typeof_refs: [],
+    type_export_type_refs: [],
     runtime_object_literals: {},
     options_descriptor: None,
 }

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/vize_croquis/src/script_parser/tests.rs
-assertion_line: 330
 expression: result
 ---
 ScriptParseResult {
@@ -1312,6 +1311,7 @@ ScriptParseResult {
     },
     import_sources: {},
     type_export_typeof_refs: [],
+    type_export_type_refs: [],
     runtime_object_literals: {},
     options_descriptor: None,
 }

--- a/crates/vize_croquis/src/script_parser/typeof_refs.rs
+++ b/crates/vize_croquis/src/script_parser/typeof_refs.rs
@@ -9,39 +9,43 @@
 //! `Cannot find name 'X'`.
 
 use oxc_ast::ast::{
-    TSInterfaceDeclaration, TSType, TSTypeAliasDeclaration, TSTypeName, TSTypeQueryExprName,
+    Expression, TSInterfaceDeclaration, TSType, TSTypeAliasDeclaration, TSTypeName,
+    TSTypeQueryExprName, TSTypeReference,
 };
 use oxc_ast_visit::{Visit, walk};
 use vize_carton::{CompactString, FxHashSet};
+
+#[derive(Default)]
+pub(crate) struct TypeDependencyRefs {
+    pub typeof_value_refs: FxHashSet<CompactString>,
+    pub type_refs: FxHashSet<CompactString>,
+}
 
 /// Visitor that records the leftmost identifier of every `typeof X[.Y.Z]`
 /// it encounters inside a TypeScript type tree.
 #[derive(Default)]
 pub(crate) struct TypeofValueRefs {
-    pub idents: FxHashSet<CompactString>,
+    pub refs: TypeDependencyRefs,
 }
 
 impl<'a> Visit<'a> for TypeofValueRefs {
+    fn visit_ts_type_reference(&mut self, it: &TSTypeReference<'a>) {
+        record_type_name_root(&it.type_name, &mut self.refs.type_refs);
+        walk::walk_ts_type_reference(self, it);
+    }
+
     fn visit_ts_type_query_expr_name(&mut self, it: &TSTypeQueryExprName<'a>) {
         match it {
             TSTypeQueryExprName::IdentifierReference(id) => {
-                self.idents.insert(CompactString::new(id.name.as_str()));
+                self.refs
+                    .typeof_value_refs
+                    .insert(CompactString::new(id.name.as_str()));
             }
             TSTypeQueryExprName::QualifiedName(qn) => {
                 // `typeof A.B.C` — only the root identifier `A` resolves to a
                 // value binding; `.B.C` are property lookups on that value's
                 // type.
-                let mut left = &qn.left;
-                loop {
-                    match left {
-                        TSTypeName::IdentifierReference(id) => {
-                            self.idents.insert(CompactString::new(id.name.as_str()));
-                            break;
-                        }
-                        TSTypeName::QualifiedName(inner) => left = &inner.left,
-                        TSTypeName::ThisExpression(_) => break,
-                    }
-                }
+                record_type_name_root(&qn.left, &mut self.refs.typeof_value_refs);
             }
             TSTypeQueryExprName::TSImportType(_) => {
                 // `typeof import('foo')` resolves at module scope; never a
@@ -56,12 +60,30 @@ impl<'a> Visit<'a> for TypeofValueRefs {
     }
 }
 
+fn record_type_name_root(name: &TSTypeName<'_>, refs: &mut FxHashSet<CompactString>) {
+    match name {
+        TSTypeName::IdentifierReference(id) => {
+            refs.insert(CompactString::new(id.name.as_str()));
+        }
+        TSTypeName::QualifiedName(inner) => record_type_name_root(&inner.left, refs),
+        TSTypeName::ThisExpression(_) => {}
+    }
+}
+
+fn record_expression_root(expr: &Expression<'_>, refs: &mut FxHashSet<CompactString>) {
+    match expr {
+        Expression::Identifier(id) => {
+            refs.insert(CompactString::new(id.name.as_str()));
+        }
+        Expression::StaticMemberExpression(member) => record_expression_root(&member.object, refs),
+        _ => {}
+    }
+}
+
 /// Collect `typeof` value identifier refs in a type alias body
 /// (`type X = ...`), including its generic parameter constraints and
 /// default types.
-pub(crate) fn collect_from_type_alias(
-    decl: &TSTypeAliasDeclaration<'_>,
-) -> FxHashSet<CompactString> {
+pub(crate) fn collect_from_type_alias(decl: &TSTypeAliasDeclaration<'_>) -> TypeDependencyRefs {
     let mut visitor = TypeofValueRefs::default();
     visitor.visit_ts_type(&decl.type_annotation);
     if let Some(params) = &decl.type_parameters {
@@ -74,18 +96,17 @@ pub(crate) fn collect_from_type_alias(
             }
         }
     }
-    visitor.idents
+    visitor.refs
 }
 
 /// Collect `typeof` value identifier refs in an interface body
 /// (`interface X { ... }`), including its extends clauses and generic
 /// parameter constraints / defaults.
-pub(crate) fn collect_from_interface(
-    decl: &TSInterfaceDeclaration<'_>,
-) -> FxHashSet<CompactString> {
+pub(crate) fn collect_from_interface(decl: &TSInterfaceDeclaration<'_>) -> TypeDependencyRefs {
     let mut visitor = TypeofValueRefs::default();
     visitor.visit_ts_interface_body(&decl.body);
     for clause in decl.extends.iter() {
+        record_expression_root(&clause.expression, &mut visitor.refs.type_refs);
         if let Some(args) = &clause.type_arguments {
             for arg in args.params.iter() {
                 visitor.visit_ts_type(arg);
@@ -102,18 +123,16 @@ pub(crate) fn collect_from_interface(
             }
         }
     }
-    visitor.idents
+    visitor.refs
 }
 
 /// Dispatch helper: collect refs from any `Declaration` that may carry
 /// a type alias or interface (used by `export type` / `export interface`).
-pub(crate) fn collect_from_declaration(
-    decl: &oxc_ast::ast::Declaration<'_>,
-) -> FxHashSet<CompactString> {
+pub(crate) fn collect_from_declaration(decl: &oxc_ast::ast::Declaration<'_>) -> TypeDependencyRefs {
     match decl {
         oxc_ast::ast::Declaration::TSTypeAliasDeclaration(t) => collect_from_type_alias(t),
         oxc_ast::ast::Declaration::TSInterfaceDeclaration(i) => collect_from_interface(i),
-        _ => FxHashSet::default(),
+        _ => TypeDependencyRefs::default(),
     }
 }
 


### PR DESCRIPTION
## Summary

- track local type/interface references alongside `typeof` value references during script analysis
- propagate non-hoisted type decisions through local alias chains so setup-derived aliases stay with their values
- add regressions for `defineProps<Props>()` aliases and same-scope `ref<DialogOpenStatus>()` usage

Fixes #2015
Fixes #2024

## Tests

- cargo fmt --check
- cargo test -p vize_croquis
- cargo test -p vize_canon
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->