### PR TITLE
fix(canon): preserve normal script exported type bodies

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator/script_module.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module.rs
@@ -26,8 +26,7 @@ pub(super) fn collect_line_module_import_spans(script: &str) -> Vec<(u32, u32)> 
         let trimmed = line.trim_start();
         if trimmed.starts_with("import ")
             || trimmed.starts_with("import\t")
-            || (trimmed.starts_with("export ")
-                && (trimmed.contains(" from ") || trimmed.starts_with("export type ")))
+            || (trimmed.starts_with("export ") && trimmed.contains(" from "))
         {
             let start = offset + (line.len() - line.trim_start().len());
             let end = offset + line.len();

--- a/crates/vize_canon/tests/plain_script_named_exports.rs
+++ b/crates/vize_canon/tests/plain_script_named_exports.rs
@@ -60,3 +60,58 @@ export const setupParseMdFileDialogCtx = () => ({ ready: true });
 
     let _ = fs::remove_dir_all(&case_dir);
 }
+
+#[test]
+fn normal_script_exported_type_body_stays_intact_with_exported_const_typeof() {
+    let case_dir = unique_case_dir("plain-script-exported-type-body");
+    let _ = fs::remove_dir_all(&case_dir);
+    let src_dir = case_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    let vue_path = src_dir.join("PreviewMoshiQuestionCard.vue");
+    let vue_content = r#"<script lang="ts">
+import { defineComponent, PropType } from "@nuxtjs/composition-api";
+
+export const DATA_TYPE = {
+  QUESTION: "question",
+  ANSWER: "answer",
+} as const;
+
+export type RenderedBody = {
+  dataType: (typeof DATA_TYPE)[keyof typeof DATA_TYPE];
+  data: string;
+};
+
+export default defineComponent({
+  props: {
+    renderedBodies: {
+      type: Array as PropType<RenderedBody[]>,
+      default: "",
+    },
+  },
+});
+</script>
+"#;
+    fs::write(&vue_path, vue_content).unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.register_vue_file(&vue_path, vue_content).unwrap();
+    let content = project
+        .find_by_original(&vue_path)
+        .unwrap()
+        .content
+        .as_str();
+
+    assert!(
+        content.contains(
+            "export type RenderedBody = {\n  dataType: (typeof DATA_TYPE)[keyof typeof DATA_TYPE];\n  data: string;\n};"
+        ),
+        "normal <script> exported type body must remain syntactically intact:\n{content}"
+    );
+    assert!(
+        content.contains("export const DATA_TYPE = __vize_plain_script_exports.DATA_TYPE;"),
+        "normal <script> exported const must remain visible to module exports:\n{content}"
+    );
+    assert_ts_parses(content);
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize_croquis/src/script_parser/process/mod.rs
+++ b/crates/vize_croquis/src/script_parser/process/mod.rs
@@ -16,6 +16,7 @@
 mod bindings;
 mod class_component;
 mod macros;
+mod module_exports;
 mod options_api;
 mod statements;
 

--- a/crates/vize_croquis/src/script_parser/process/module_exports.rs
+++ b/crates/vize_croquis/src/script_parser/process/module_exports.rs
@@ -1,0 +1,58 @@
+use oxc_ast::ast::{BindingPattern, Declaration};
+use vize_carton::CompactString;
+
+use crate::script_parser::ScriptParseResult;
+
+pub(super) fn record_module_value_exports(result: &mut ScriptParseResult, decl: &Declaration<'_>) {
+    match decl {
+        Declaration::VariableDeclaration(variable) => {
+            for declarator in &variable.declarations {
+                record_module_value_binding(result, &declarator.id);
+            }
+        }
+        Declaration::FunctionDeclaration(func) => {
+            if let Some(id) = &func.id {
+                result
+                    .module_value_bindings
+                    .insert(CompactString::new(id.name.as_str()));
+            }
+        }
+        Declaration::ClassDeclaration(class) => {
+            if let Some(id) = &class.id {
+                result
+                    .module_value_bindings
+                    .insert(CompactString::new(id.name.as_str()));
+            }
+        }
+        _ => {}
+    }
+}
+
+fn record_module_value_binding(result: &mut ScriptParseResult, pattern: &BindingPattern<'_>) {
+    match pattern {
+        BindingPattern::BindingIdentifier(id) => {
+            result
+                .module_value_bindings
+                .insert(CompactString::new(id.name.as_str()));
+        }
+        BindingPattern::ObjectPattern(object) => {
+            for property in &object.properties {
+                record_module_value_binding(result, &property.value);
+            }
+            if let Some(rest) = &object.rest {
+                record_module_value_binding(result, &rest.argument);
+            }
+        }
+        BindingPattern::ArrayPattern(array) => {
+            for element in array.elements.iter().flatten() {
+                record_module_value_binding(result, element);
+            }
+            if let Some(rest) = &array.rest {
+                record_module_value_binding(result, &rest.argument);
+            }
+        }
+        BindingPattern::AssignmentPattern(assignment) => {
+            record_module_value_binding(result, &assignment.left);
+        }
+    }
+}

--- a/crates/vize_croquis/src/script_parser/process/statements.rs
+++ b/crates/vize_croquis/src/script_parser/process/statements.rs
@@ -314,12 +314,12 @@ fn process_class_declaration(result: &mut ScriptParseResult, class: &Class<'_>) 
             .insert(CompactString::new(name), (id.span.start, id.span.end));
     }
 }
-
 fn process_exported_value_declaration(
     result: &mut ScriptParseResult,
     decl: &Declaration<'_>,
     source: &str,
 ) {
+    super::module_exports::record_module_value_exports(result, decl);
     match decl {
         Declaration::VariableDeclaration(variable) => {
             process_variable_declaration(result, variable, source)

--- a/crates/vize_croquis/src/script_parser/result.rs
+++ b/crates/vize_croquis/src/script_parser/result.rs
@@ -104,6 +104,10 @@ pub struct ScriptParseResult {
     pub binding_spans: FxHashMap<CompactString, (u32, u32)>,
     /// Value import source by local binding name.
     pub import_sources: FxHashMap<CompactString, CompactString>,
+    /// Normal `<script>` value exports that canon re-emits at module scope.
+    /// Type exports may reference these through `typeof` without being
+    /// demoted into `__setup()`.
+    pub(crate) module_value_bindings: FxHashSet<CompactString>,
     /// Names referenced via `typeof X` in the body of each `type_exports`
     /// entry, indexed in parallel with `type_exports`. Used by
     /// `resolve_type_export_hoisting` to keep types adjacent to the
@@ -174,23 +178,24 @@ impl ScriptParseResult {
     /// stay inside the synthetic `__setup` function alongside the values
     /// they depend on — which is the only place TS can resolve them.
     ///
-    /// Imports add value bindings at module scope, so a `typeof importedName`
-    /// reference is left as hoisted: the import is visible from the module
-    /// scope where the type lands.
+    /// Imports and normal `<script>` named exports add value bindings at
+    /// module scope, so `typeof moduleValue` references are left hoisted: those
+    /// values are visible from the module scope where the type lands.
     pub(crate) fn resolve_type_export_hoisting(&mut self) {
         if self.type_export_typeof_refs.is_empty() {
             return;
         }
 
-        // A `typeof name` ref keeps a type hoisted only when `name` is a
-        // module-scoped import. Rather than materialize the full set of
-        // imported binding names up front (O(imports × bindings)), test each
-        // referenced name's declaration span against the import ranges on
-        // demand — `refs` is tiny, so this is O(refs × imports).
+        // A `typeof name` ref keeps a type hoisted only when `name` is visible
+        // at module scope. Rather than materialize all imported binding names
+        // up front (O(imports × bindings)), test each referenced name's
+        // declaration span against the import ranges on demand — `refs` is
+        // tiny, so this is O(refs × imports).
         for idx in 0..self.type_export_typeof_refs.len() {
             let touches_setup_value = self.type_export_typeof_refs[idx].iter().any(|name| {
                 let key = name.as_str();
                 self.bindings.bindings.contains_key(key)
+                    && !self.module_value_bindings.contains(key)
                     && !self.binding_spans.get(key).is_some_and(|(start, end)| {
                         // Bindings whose declaration site falls inside an import
                         // statement are module-scoped imports, not setup values.

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/vize_croquis/src/script_parser/tests.rs
-assertion_line: 342
 expression: result
 ---
 ScriptParseResult {
@@ -1327,6 +1326,7 @@ ScriptParseResult {
         "ref": "vue",
         "MyComponent": "./MyComponent.vue",
     },
+    module_value_bindings: {},
     type_export_typeof_refs: [],
     runtime_object_literals: {},
     options_descriptor: None,

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/vize_croquis/src/script_parser/tests.rs
-assertion_line: 330
 expression: result
 ---
 ScriptParseResult {
@@ -1311,6 +1310,7 @@ ScriptParseResult {
         ),
     },
     import_sources: {},
+    module_value_bindings: {},
     type_export_typeof_refs: [],
     runtime_object_literals: {},
     options_descriptor: None,


### PR DESCRIPTION
## Summary
- Keep normal `<script>` exported value bindings visible as module-scoped values when resolving `typeof` references in exported type bodies.
- Stop treating every line that starts with `export type` as a line-level module import span, so full AST type export spans stay intact.
- Add a regression covering the Nuxt 2 Composition API shape from #2016 and parse-check the generated virtual TS.

## Root cause
Normal `<script>` named exports were also recorded as setup bindings. When an exported type referenced one with `typeof`, the hoisting resolver demoted the type into `__setup()`, while the line-level module span collector still copied only the first `export type` line. Multi-line type bodies were split apart and generated invalid TypeScript.

## Tests
- `cargo test -p vize_canon --test plain_script_named_exports`
- `cargo test -p vize_croquis`
- `cargo test -p vize_canon`
- `cargo fmt --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`

Fixes #2016

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->