### PR TITLE
fix(canon): keep nested union props out of template bindings

### DIFF
--- a/crates/vize_canon/src/sfc_typecheck/tests.rs
+++ b/crates/vize_canon/src/sfc_typecheck/tests.rs
@@ -1,7 +1,7 @@
 //! Tests for SFC type checking.
-
 #![cfg(test)]
 mod emit_props;
+mod optional_chain_props;
 #[cfg(feature = "legacy")]
 mod options_api_required_props;
 mod options_api_setup_spread;

--- a/crates/vize_canon/src/sfc_typecheck/tests/optional_chain_props.rs
+++ b/crates/vize_canon/src/sfc_typecheck/tests/optional_chain_props.rs
@@ -1,0 +1,63 @@
+use super::{SfcTypeCheckOptions, type_check_sfc};
+
+#[test]
+fn optional_chain_union_prop_members_are_not_template_props() {
+    let source = r#"<script setup lang="ts">
+interface Props {
+  isOpened: boolean
+  title: string
+  timeout?: number
+  interaction?:
+    | {
+        text: string
+        to: string
+        event?: never
+      }
+    | {
+        text: string
+        event: () => void
+        to?: never
+      }
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  timeout: 4000
+})
+
+void props
+</script>
+
+<template>
+  <AfsButton v-if="interaction?.to" :to="interaction.to">
+    {{ interaction.text }}
+  </AfsButton>
+  <AfsButton v-else-if="interaction?.event" @click="interaction.event">
+    {{ interaction.text }}
+  </AfsButton>
+</template>"#;
+    let options = SfcTypeCheckOptions::new("AfsSnackbar.vue").with_virtual_ts();
+    let result = type_check_sfc(source, &options);
+    let virtual_ts = result.virtual_ts.expect("virtual ts should be generated");
+
+    assert!(
+        virtual_ts.contains(r#"const interaction = props["interaction"];"#),
+        "top-level interaction prop must stay available:\n{virtual_ts}"
+    );
+    for member in ["to", "event", "text"] {
+        assert!(
+            !virtual_ts.contains(&format!(r#"const {member} = props["{member}"]"#)),
+            "member `{member}` must not be emitted as a top-level prop:\n{virtual_ts}"
+        );
+    }
+    assert!(
+        !result.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code.as_deref() == Some("TS7053")
+                && diagnostic.message.contains("\"to\"")
+                && diagnostic
+                    .message
+                    .contains("__WithDefaultsResult<Props, Pick<Props, \"timeout\">>")
+        }),
+        "optional-chain member must not report a top-level prop TS7053: {:#?}",
+        result.diagnostics
+    );
+}

--- a/crates/vize_croquis/src/drawer/template/tests.rs
+++ b/crates/vize_croquis/src/drawer/template/tests.rs
@@ -93,6 +93,17 @@ fn v_effect_references_resolve_against_v_scope() {
 }
 
 #[test]
+fn component_v_bind_arg_is_not_an_undefined_template_ref() {
+    let undefined = undefined_refs_with_empty_script(
+        r#"<AfsButton v-if="interaction?.to" :to="interaction.to">{{ interaction.text }}</AfsButton>"#,
+    );
+    assert!(
+        !undefined.iter().any(|n| n == "to"),
+        "component prop names must not be template refs: {undefined:?}"
+    );
+}
+
+#[test]
 fn nested_v_scope_shadows_outer() {
     use vize_armature::parse;
     use vize_carton::Bump;

--- a/crates/vize_croquis/src/types.rs
+++ b/crates/vize_croquis/src/types.rs
@@ -206,6 +206,7 @@ impl TypeResolver {
         let mut properties = Vec::new();
         let mut depth = 0;
         let mut current = String::default();
+        let mut prev = '\0';
 
         for c in content.chars() {
             match c {
@@ -213,7 +214,11 @@ impl TypeResolver {
                     depth += 1;
                     current.push(c);
                 }
-                '}' | '>' | ')' | ']' => {
+                '}' | ')' | ']' => {
+                    depth -= 1;
+                    current.push(c);
+                }
+                '>' if prev != '=' => {
                     depth -= 1;
                     current.push(c);
                 }
@@ -225,6 +230,7 @@ impl TypeResolver {
                 }
                 _ => current.push(c),
             }
+            prev = c;
         }
 
         // Process last segment
@@ -357,64 +363,4 @@ fn is_valid_identifier(s: &str) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{TypeDefinitions, TypeResolver};
-
-    #[test]
-    fn test_extract_inline_props() {
-        let resolver = TypeResolver::new();
-        let props = resolver.extract_properties("{ msg: string, count?: number }");
-
-        assert_eq!(props.len(), 2);
-        assert_eq!(props[0].name.as_str(), "msg");
-        assert!(!props[0].optional);
-        assert_eq!(props[1].name.as_str(), "count");
-        assert!(props[1].optional);
-    }
-
-    #[test]
-    fn test_extract_props_from_reference() {
-        let mut resolver = TypeResolver::new();
-        resolver.add_interface("Props", "{ foo: string; bar: number }");
-
-        let props = resolver.extract_properties("Props");
-        assert_eq!(props.len(), 2);
-        assert_eq!(props[0].name.as_str(), "foo");
-        assert_eq!(props[1].name.as_str(), "bar");
-    }
-
-    #[test]
-    fn test_extract_emits_call_signature() {
-        let resolver = TypeResolver::new();
-        let emits =
-            resolver.extract_emits("{ (e: 'click'): void; (e: 'update', value: number): void }");
-
-        assert_eq!(emits.len(), 2);
-        assert_eq!(emits[0].as_str(), "click");
-        assert_eq!(emits[1].as_str(), "update");
-    }
-
-    #[test]
-    fn test_extract_emits_object_type() {
-        let resolver = TypeResolver::new();
-        let emits = resolver.extract_emits("{ click: []; update: [value: number] }");
-
-        assert_eq!(emits.len(), 2);
-        assert_eq!(emits[0].as_str(), "click");
-        assert_eq!(emits[1].as_str(), "update");
-    }
-
-    #[test]
-    fn test_type_definitions() {
-        let mut defs = TypeDefinitions::new();
-        defs.add_interface("Props", "{ msg: string }");
-        defs.add_type_alias("Count", "number");
-
-        assert!(defs.is_defined("Props"));
-        assert!(defs.is_defined("Count"));
-        assert!(!defs.is_defined("Unknown"));
-
-        assert!(defs.resolve("Props").is_some());
-        assert!(defs.resolve("Count").is_some());
-    }
-}
+mod tests;

--- a/crates/vize_croquis/src/types/tests.rs
+++ b/crates/vize_croquis/src/types/tests.rs
@@ -1,0 +1,95 @@
+use super::{TypeDefinitions, TypeResolver};
+
+#[test]
+fn test_extract_inline_props() {
+    let resolver = TypeResolver::new();
+    let props = resolver.extract_properties("{ msg: string, count?: number }");
+
+    assert_eq!(props.len(), 2);
+    assert_eq!(props[0].name.as_str(), "msg");
+    assert!(!props[0].optional);
+    assert_eq!(props[1].name.as_str(), "count");
+    assert!(props[1].optional);
+}
+
+#[test]
+fn test_extract_props_from_reference() {
+    let mut resolver = TypeResolver::new();
+    resolver.add_interface("Props", "{ foo: string; bar: number }");
+
+    let props = resolver.extract_properties("Props");
+    assert_eq!(props.len(), 2);
+    assert_eq!(props[0].name.as_str(), "foo");
+    assert_eq!(props[1].name.as_str(), "bar");
+}
+
+#[test]
+fn extract_properties_keeps_union_members_nested() {
+    let mut resolver = TypeResolver::new();
+    resolver.add_interface(
+        "Props",
+        r#"{
+  isOpened: boolean
+  title: string
+  timeout?: number
+  interaction?:
+    | {
+        text: string
+        to: string
+        event?: never
+      }
+    | {
+        text: string
+        event: () => void
+        to?: never
+      }
+}"#,
+    );
+
+    let names = resolver
+        .extract_properties("Props")
+        .into_iter()
+        .map(|prop| prop.name)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        names.iter().map(|name| name.as_str()).collect::<Vec<_>>(),
+        ["isOpened", "title", "timeout", "interaction"],
+        "nested union members must not become top-level props"
+    );
+}
+
+#[test]
+fn test_extract_emits_call_signature() {
+    let resolver = TypeResolver::new();
+    let emits =
+        resolver.extract_emits("{ (e: 'click'): void; (e: 'update', value: number): void }");
+
+    assert_eq!(emits.len(), 2);
+    assert_eq!(emits[0].as_str(), "click");
+    assert_eq!(emits[1].as_str(), "update");
+}
+
+#[test]
+fn test_extract_emits_object_type() {
+    let resolver = TypeResolver::new();
+    let emits = resolver.extract_emits("{ click: []; update: [value: number] }");
+
+    assert_eq!(emits.len(), 2);
+    assert_eq!(emits[0].as_str(), "click");
+    assert_eq!(emits[1].as_str(), "update");
+}
+
+#[test]
+fn test_type_definitions() {
+    let mut defs = TypeDefinitions::new();
+    defs.add_interface("Props", "{ msg: string }");
+    defs.add_type_alias("Count", "number");
+
+    assert!(defs.is_defined("Props"));
+    assert!(defs.is_defined("Count"));
+    assert!(!defs.is_defined("Unknown"));
+
+    assert!(defs.resolve("Props").is_some());
+    assert!(defs.resolve("Count").is_some());
+}


### PR DESCRIPTION
## Summary
- Treat the `>` in function return arrows as part of `=>` when splitting type members.
- Keep nested union object members from being exposed as top-level template props.
- Add regression coverage at both type-member extraction and SFC typecheck layers.

Fixes #2018

## Tests
- `cargo test -p vize_croquis`
- `cargo test -p vize_canon`
- `cargo fmt --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->