### PR TITLE
fix(maestro): honor legacy Vue 2 LSP config

### DIFF
--- a/crates/vize_maestro/src/server/state/config.rs
+++ b/crates/vize_maestro/src/server/state/config.rs
@@ -62,10 +62,13 @@ impl ServerState {
         *self.type_checker_options_api.write() = features.type_checker_options_api;
         *self.type_checker_legacy_vue2.write() = features.type_checker_legacy_vue2;
         *self.type_checker_jsx_typecheck.write() = features.type_checker_jsx_typecheck;
+
+        let mut lsp_features = self.lsp_features.write();
+        lsp_features.options_api = features.type_checker_options_api;
         if let Some(enabled) = features.language_server_legacy_vue2 {
-            let mut lsp_features = self.lsp_features.write();
             lsp_features.legacy_vue2 = enabled;
         }
+        lsp_features.apply_effective_compatibility();
     }
 
     fn apply_linter_config(&self, config: LinterConfig, source: &str) {
@@ -76,6 +79,7 @@ impl ServerState {
     fn apply_lsp_config(&self, config: LspConfigSection, source: &str) {
         let mut features = self.lsp_features.write();
         config.apply_to(&mut features);
+        features.apply_effective_compatibility();
         self.lsp_typecheck_enabled
             .store(features.typecheck, Ordering::SeqCst);
         tracing::info!("Loaded LSP config from {}: {:?}", source, *features);
@@ -95,8 +99,8 @@ impl ServerState {
             }
             self.apply_linter_config(linter_config, &source);
             self.apply_type_checker_config(config.type_checker, &source);
-            self.apply_lsp_config(config.language_server.into(), &source);
             self.apply_config_features(loaded.features);
+            self.apply_lsp_config(config.language_server.into(), &source);
             self.set_dialect_config(config.dialect);
         }
     }
@@ -109,8 +113,8 @@ impl ServerState {
             let source = source_path.display().to_string();
             self.apply_linter_config(linter_config, &source);
             self.apply_type_checker_config(loaded.config.type_checker, &source);
-            self.apply_lsp_config(loaded.config.language_server.into(), &source);
             self.apply_config_features(loaded.features);
+            self.apply_lsp_config(loaded.config.language_server.into(), &source);
             self.set_dialect_config(loaded.config.dialect);
         }
     }

--- a/crates/vize_maestro/src/server/state/config_tests.rs
+++ b/crates/vize_maestro/src/server/state/config_tests.rs
@@ -1,0 +1,75 @@
+use super::ServerState;
+
+#[test]
+fn language_server_legacy_vue2_reaches_logged_lsp_feature_payload() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("vize.config.json"),
+        r#"{
+          "languageServer": {
+            "enabled": true,
+            "lint": true,
+            "typecheck": true,
+            "editor": true,
+            "legacyVue2": true,
+            "formatting": true
+          },
+          "typeChecker": {
+            "optionsApi": true,
+            "tsconfig": "tsconfig.vize.json"
+          }
+        }"#,
+    )
+    .unwrap();
+
+    let state = ServerState::new();
+    state.load_workspace_config(dir.path());
+
+    let features = state.lsp_features();
+    assert!(
+        features.legacy_vue2,
+        "languageServer.legacyVue2 must be stored in runtime LSP features"
+    );
+    assert!(
+        features.options_api,
+        "typeChecker.optionsApi should be reflected in logged runtime LSP features"
+    );
+    assert!(state.legacy_vue2_enabled());
+    assert!(state.options_api_enabled());
+
+    let logged_payload = format!("{features:?}");
+    assert!(logged_payload.contains("legacy_vue2: true"));
+    assert!(logged_payload.contains("options_api: true"));
+}
+
+#[test]
+fn disabled_language_server_clears_logged_legacy_vue2_feature() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("vize.config.json"),
+        r#"{
+          "languageServer": {
+            "enabled": false,
+            "legacyVue2": true
+          }
+        }"#,
+    )
+    .unwrap();
+
+    let state = ServerState::new();
+    state.load_workspace_config(dir.path());
+
+    let features = state.lsp_features();
+    assert!(
+        !features.legacy_vue2,
+        "languageServer.enabled: false should disable LSP compatibility flags too"
+    );
+    assert!(
+        !features.options_api,
+        "disabled LSP feature config should not log implied Options API support"
+    );
+
+    let logged_payload = format!("{features:?}");
+    assert!(logged_payload.contains("legacy_vue2: false"));
+    assert!(logged_payload.contains("options_api: false"));
+}

--- a/crates/vize_maestro/src/server/state/features.rs
+++ b/crates/vize_maestro/src/server/state/features.rs
@@ -220,6 +220,12 @@ impl LspFeatureConfig {
         self.lint || self.typecheck || self.ecosystem
     }
 
+    pub(super) fn apply_effective_compatibility(&mut self) {
+        if self.legacy_vue2 {
+            self.options_api = true;
+        }
+    }
+
     fn apply_editor_bundle(&mut self, enabled: bool) {
         self.ecosystem = enabled;
         self.completion = enabled;

--- a/crates/vize_maestro/src/server/state/mod.rs
+++ b/crates/vize_maestro/src/server/state/mod.rs
@@ -11,6 +11,8 @@ mod batch_cache;
 mod corsa;
 
 #[cfg(test)]
+mod config_tests;
+#[cfg(test)]
 mod tests;
 
 use std::path::PathBuf;


### PR DESCRIPTION
## Summary
- Apply config-derived compatibility flags before storing and logging the runtime LSP feature config.
- Reflect `typeChecker.optionsApi` in the LSP runtime payload and make `legacyVue2` imply Options API support.
- Add regression tests for `languageServer.legacyVue2` and disabled LSP config behavior.

Fixes #2028

## Tests
- `cargo test -p vize_maestro`
- `cargo test -p vize_maestro server::state -- --nocapture`
- `cargo test -p vize_carton --test loading`
- `cargo fmt --all -- --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->