### PR TITLE
fix(glyph): resolve configured entry file paths

### DIFF
--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -21,13 +21,14 @@ use vize_curator::profile::{
     ProfileFileRow, ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report,
 };
 
+mod entries;
 mod files;
 mod ignores;
 mod patterns;
 
 use files::collect_files;
 use ignores::load_fmt_ignore_set;
-use patterns::{default_fmt_patterns, has_explicit_patterns};
+use patterns::default_fmt_patterns;
 
 #[derive(Args)]
 #[allow(clippy::disallowed_types)]
@@ -107,16 +108,15 @@ pub fn run(args: FmtArgs) {
         std::process::exit(2);
     }
     let options = build_format_options(&args);
-    let ignore_set = load_fmt_ignore_set(&args);
+    let (ignore_set, patterns) = (load_fmt_ignore_set(&args), entries::resolve_patterns(&args));
 
-    // Collect files to format
     let collect_start = Instant::now();
-    let files: Vec<PathBuf> = collect_files(&args.patterns, ignore_set.as_ref());
+    let files: Vec<PathBuf> = collect_files(&patterns.values, ignore_set.as_ref());
     let collect_time = collect_start.elapsed();
 
     if files.is_empty() {
         eprintln!("No .vue, .js, .ts, .jsx, or .tsx files found matching the patterns");
-        if has_explicit_patterns(&args.patterns) {
+        if patterns.explicit {
             std::process::exit(1);
         }
         return;

--- a/crates/vize/src/commands/fmt/entries.rs
+++ b/crates/vize/src/commands/fmt/entries.rs
@@ -1,0 +1,267 @@
+use glob::glob;
+use std::path::{Path, PathBuf};
+use vize_carton::String;
+
+use super::patterns::has_explicit_patterns;
+use super::{FmtArgs, files::FmtPattern};
+use crate::config;
+
+#[allow(clippy::disallowed_types)]
+pub(super) struct ResolvedFmtPatterns {
+    pub(super) values: Vec<String>,
+    pub(super) explicit: bool,
+}
+
+pub(super) struct FmtEntryFileSet {
+    entries: Vec<FmtEntryFileScope>,
+}
+
+#[allow(clippy::disallowed_types)]
+pub(super) fn resolve_patterns(args: &FmtArgs) -> ResolvedFmtPatterns {
+    let explicit = has_explicit_patterns(&args.patterns);
+    let values = if explicit {
+        load_fmt_entry_file_set(args)
+            .as_ref()
+            .map(|entry_file_set| entry_file_set.expand_patterns(&args.patterns))
+            .unwrap_or_else(|| compact_patterns(&args.patterns))
+    } else {
+        compact_patterns(&args.patterns)
+    };
+    ResolvedFmtPatterns { values, explicit }
+}
+
+impl FmtEntryFileSet {
+    #[allow(clippy::disallowed_types)]
+    pub(super) fn expand_patterns(&self, patterns: &[std::string::String]) -> Vec<String> {
+        let mut expanded = Vec::new();
+        for pattern in patterns {
+            push_unique(&mut expanded, pattern.as_str().into());
+            if local_pattern_has_match(pattern) {
+                continue;
+            }
+            for entry in &self.entries {
+                entry.expand_missing_pattern(pattern, &mut expanded);
+            }
+        }
+        expanded
+    }
+}
+
+pub(super) fn load_fmt_entry_file_set(args: &FmtArgs) -> Option<FmtEntryFileSet> {
+    if args.no_config {
+        return None;
+    }
+    let loaded = config::load_config_entry_files_with_source(args.config.as_deref());
+    if loaded.entries.is_empty() {
+        return None;
+    }
+    let config_dir = loaded
+        .source_path
+        .as_deref()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    let entries = loaded
+        .entries
+        .into_iter()
+        .filter_map(|entry| FmtEntryFileScope::new(entry, &config_dir))
+        .collect::<Vec<_>>();
+    (!entries.is_empty()).then_some(FmtEntryFileSet { entries })
+}
+
+struct FmtEntryFileScope {
+    base_dir: PathBuf,
+    base_prefix: Option<String>,
+    files: Vec<EntryFilePattern>,
+}
+
+impl FmtEntryFileScope {
+    fn new(entry: config::ConfigEntryFiles, config_dir: &Path) -> Option<Self> {
+        let files = entry
+            .files
+            .into_iter()
+            .filter_map(|pattern| EntryFilePattern::new(pattern.as_str()))
+            .collect::<Vec<_>>();
+        if files.is_empty() {
+            return None;
+        }
+        let base_path = entry.base_path.as_deref();
+        Some(Self {
+            base_dir: resolve_base_dir(base_path, config_dir),
+            base_prefix: normalize_base_prefix(base_path),
+            files,
+        })
+    }
+
+    fn expand_missing_pattern(&self, pattern: &str, expanded: &mut Vec<String>) {
+        let normalized = normalize_pattern_text(pattern);
+        let pattern_path = Path::new(pattern);
+        if pattern_path.is_absolute() {
+            if let Some(relative) = strip_prefix_text(pattern_path, &self.base_dir)
+                && self.accepts_entry_relative_pattern(relative.as_str())
+            {
+                push_unique(expanded, normalize_path_text(pattern_path));
+            }
+            return;
+        }
+
+        if let Some(relative) = self.entry_relative_from_root_pattern(normalized.as_str())
+            && self.accepts_entry_relative_pattern(relative)
+        {
+            push_unique(expanded, join_pattern(&self.base_dir, relative));
+        }
+        if self.accepts_entry_relative_pattern(normalized.as_str()) {
+            push_unique(expanded, join_pattern(&self.base_dir, normalized.as_str()));
+        }
+    }
+
+    fn entry_relative_from_root_pattern<'a>(&self, pattern: &'a str) -> Option<&'a str> {
+        let base_prefix = self.base_prefix.as_ref()?;
+        if pattern == base_prefix {
+            return Some(".");
+        }
+        pattern
+            .strip_prefix(base_prefix.as_str())
+            .and_then(|relative| relative.strip_prefix('/'))
+    }
+
+    fn accepts_entry_relative_pattern(&self, pattern: &str) -> bool {
+        let normalized = normalize_pattern_text(pattern);
+        if normalized.is_empty() || normalized == "." {
+            return true;
+        }
+        if contains_glob_char(normalized.as_str()) {
+            return self
+                .files
+                .iter()
+                .any(|file| glob_patterns_may_overlap(file.raw.as_str(), normalized.as_str()));
+        }
+        let path = Path::new(normalized.as_str());
+        if is_format_target(path) {
+            return self.files.iter().any(|file| file.matcher.matches(path));
+        }
+        let directory_prefix = format!("{}/", normalized.trim_end_matches('/'));
+        self.files
+            .iter()
+            .any(|file| file.raw == normalized || file.raw.starts_with(directory_prefix.as_str()))
+    }
+}
+
+struct EntryFilePattern {
+    raw: String,
+    matcher: FmtPattern,
+}
+
+impl EntryFilePattern {
+    fn new(pattern: &str) -> Option<Self> {
+        let raw = normalize_pattern_text(pattern);
+        FmtPattern::new(raw.as_str(), Path::new(".")).map(|matcher| Self { raw, matcher })
+    }
+}
+
+fn resolve_base_dir(base_path: Option<&str>, config_dir: &Path) -> PathBuf {
+    let Some(base_path) = base_path.filter(|base_path| !base_path.is_empty()) else {
+        return config_dir.to_path_buf();
+    };
+    let path = Path::new(base_path);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        config_dir.join(path)
+    }
+}
+
+fn normalize_base_prefix(base_path: Option<&str>) -> Option<String> {
+    let mut base = normalize_pattern_text(base_path?);
+    while let Some(stripped) = base.strip_prefix("./") {
+        base = stripped.into();
+    }
+    base = base.trim_end_matches('/').into();
+    if base.is_empty() || base == "." || Path::new(base.as_str()).is_absolute() {
+        None
+    } else {
+        Some(base)
+    }
+}
+
+fn local_pattern_has_match(pattern: &str) -> bool {
+    let normalized = normalize_pattern_text(pattern);
+    if contains_glob_char(normalized.as_str()) {
+        return glob(normalized.as_str())
+            .map(|paths| paths.filter_map(Result::ok).next().is_some())
+            .unwrap_or(false);
+    }
+    Path::new(normalized.as_str()).exists()
+}
+
+fn glob_patterns_may_overlap(configured: &str, requested: &str) -> bool {
+    configured == requested || {
+        let configured_prefix = static_prefix_before_glob(configured);
+        let requested_prefix = static_prefix_before_glob(requested);
+        configured_prefix.is_empty()
+            || requested_prefix.is_empty()
+            || configured_prefix.starts_with(requested_prefix)
+            || requested_prefix.starts_with(configured_prefix)
+    }
+}
+
+fn static_prefix_before_glob(pattern: &str) -> &str {
+    let glob_index = pattern.find(['*', '?', '[']).unwrap_or(pattern.len());
+    let prefix = &pattern[..glob_index];
+    prefix
+        .rfind('/')
+        .map(|index| &prefix[..=index])
+        .unwrap_or("")
+}
+
+fn strip_prefix_text(path: &Path, base: &Path) -> Option<String> {
+    path.strip_prefix(base).ok().map(normalize_path_text)
+}
+
+fn join_pattern(base: &Path, pattern: &str) -> String {
+    if pattern == "." {
+        return normalize_path_text(base);
+    }
+    normalize_path_text(&base.join(pattern))
+}
+
+fn normalize_pattern_text(pattern: &str) -> String {
+    let mut normalized: String = pattern.replace('\\', "/").into();
+    while let Some(stripped) = normalized.strip_prefix("./") {
+        normalized = stripped.into();
+    }
+    normalized
+}
+
+fn normalize_path_text(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/").into()
+}
+
+fn push_unique(patterns: &mut Vec<String>, pattern: String) {
+    if !patterns.contains(&pattern) {
+        patterns.push(pattern);
+    }
+}
+
+#[allow(clippy::disallowed_types)]
+fn compact_patterns(patterns: &[std::string::String]) -> Vec<String> {
+    patterns
+        .iter()
+        .map(|pattern| pattern.as_str().into())
+        .collect()
+}
+
+fn contains_glob_char(pattern: &str) -> bool {
+    pattern.contains(['*', '?', '['])
+}
+
+fn is_format_target(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            matches!(
+                extension,
+                "vue" | "jsx" | "tsx" | "js" | "mjs" | "cjs" | "ts" | "mts" | "cts"
+            )
+        })
+}

--- a/crates/vize/src/commands/fmt/files.rs
+++ b/crates/vize/src/commands/fmt/files.rs
@@ -9,14 +9,14 @@ const VIZE_CACHE_DIR: &str = ".vize";
 
 #[allow(clippy::disallowed_types)]
 pub(super) fn collect_files(
-    patterns: &[std::string::String],
+    patterns: &[impl AsRef<str>],
     ignore_set: Option<&FmtIgnoreSet>,
 ) -> Vec<PathBuf> {
     let mut files = Vec::new();
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
     for pattern in patterns {
-        let normalized = normalize_fmt_pattern(pattern);
+        let normalized = normalize_fmt_pattern(pattern.as_ref());
         if should_walk_with_gitignore(&normalized) {
             if let Some(pattern) = FmtPattern::new(&normalized, &cwd) {
                 collect_walked_files(&pattern, ignore_set, &mut files);

--- a/crates/vize/tests/fmt_config_cli.rs
+++ b/crates/vize/tests/fmt_config_cli.rs
@@ -36,6 +36,23 @@ fn write_entry_config(root: &Path) {
     );
 }
 
+fn write_entry_ts_config(root: &Path) {
+    write_project_file(
+        root,
+        "vize.config.ts",
+        r#"export default {
+  entries: [
+    {
+      name: "design-system",
+      basePath: "design-system",
+      files: ["src/**/*.vue", "src/**/*.art.vue"],
+    },
+  ],
+}
+"#,
+    );
+}
+
 #[test]
 fn fmt_check_supports_root_relative_paths_for_config_entries() {
     let project = tempfile::tempdir().unwrap();
@@ -63,6 +80,70 @@ fn fmt_check_supports_root_relative_paths_for_config_entries() {
     assert!(stderr.contains("Found 1 file(s)"));
     assert!(stderr.contains("Would reformat: design-system/src/AfsButton.vue"));
     assert!(!stderr.contains("No .vue"));
+}
+
+#[test]
+fn fmt_check_supports_root_relative_art_vue_paths_for_config_entries() {
+    let project = tempfile::tempdir().unwrap();
+    write_entry_ts_config(project.path());
+    write_project_file(
+        project.path(),
+        "design-system/src/AfsButton.art.vue",
+        "<template><div>{{msg}}</div></template>\n<script setup lang=\"ts\">const msg=1</script>\n",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args([
+            "fmt",
+            "--config",
+            "vize.config.ts",
+            "--check",
+            "design-system/src/AfsButton.art.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Found 1 file(s)"), "{stderr}");
+    assert!(
+        stderr.contains("Would reformat: design-system/src/AfsButton.art.vue"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("No .vue"), "{stderr}");
+}
+
+#[test]
+fn fmt_check_resolves_entry_relative_art_vue_paths_from_monorepo_root() {
+    let project = tempfile::tempdir().unwrap();
+    write_entry_ts_config(project.path());
+    write_project_file(
+        project.path(),
+        "design-system/src/AfsButton.art.vue",
+        "<template><div>{{msg}}</div></template>\n<script setup lang=\"ts\">const msg=1</script>\n",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args([
+            "fmt",
+            "--config",
+            "vize.config.ts",
+            "--check",
+            "src/AfsButton.art.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Found 1 file(s)"), "{stderr}");
+    assert!(
+        stderr.contains("Would reformat: design-system/src/AfsButton.art.vue"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("No .vue"), "{stderr}");
 }
 
 #[test]

--- a/crates/vize_carton/src/config.rs
+++ b/crates/vize_carton/src/config.rs
@@ -5,17 +5,18 @@ mod model;
 mod normalize;
 
 pub use loader::{
-    LoadedConfig, LoadedConfigEntryIgnores, LoadedConfigWithFeatures, load_compiler_jsx_mode,
-    load_compiler_template_syntax, load_compiler_vue_version, load_config,
+    LoadedConfig, LoadedConfigEntryFiles, LoadedConfigEntryIgnores, LoadedConfigWithFeatures,
+    load_compiler_jsx_mode, load_compiler_template_syntax, load_compiler_vue_version, load_config,
     load_config_and_linter_with_features_and_source, load_config_and_linter_with_source,
-    load_config_entry_ignores_with_source, load_config_with_features_and_source,
-    load_config_with_source, load_linter_config, validate_explicit_config_path,
+    load_config_entry_files_with_source, load_config_entry_ignores_with_source,
+    load_config_with_features_and_source, load_config_with_source, load_linter_config,
+    validate_explicit_config_path,
 };
 pub use model::{
-    ArrowParens, AttributeSortOrder, ConfigEntryIgnore, ConfigFeatureFlags, EndOfLine,
-    FormatterConfig, GlobalTypeDeclaration, GlobalTypesConfig, JsxMode, LanguageServerConfig,
-    LintRuleSeverity, LinterConfig, LspConfig, ParseVueVersionError, QuoteProps, TrailingComma,
-    TypeCheckerConfig, VizeConfig, VueVersion,
+    ArrowParens, AttributeSortOrder, ConfigEntryFiles, ConfigEntryIgnore, ConfigFeatureFlags,
+    EndOfLine, FormatterConfig, GlobalTypeDeclaration, GlobalTypesConfig, JsxMode,
+    LanguageServerConfig, LintRuleSeverity, LinterConfig, LspConfig, ParseVueVersionError,
+    QuoteProps, TrailingComma, TypeCheckerConfig, VizeConfig, VueVersion,
 };
 pub use normalize::normalize_public_config_value;
 

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -18,7 +18,8 @@ use discovery::{resolve_dir_path, resolve_file_path};
 use parse::{parse_raw_config_file, try_parse_raw_candidate};
 
 use super::model::{
-    ConfigEntryIgnore, ConfigFeatureFlags, LinterConfig, RawVizeConfig, VizeConfig,
+    ConfigEntryFiles, ConfigEntryIgnore, ConfigFeatureFlags, LinterConfig, RawVizeConfig,
+    VizeConfig,
 };
 
 const CONFIG_FILE_NAMES: [&str; 5] = [
@@ -52,6 +53,12 @@ pub struct LoadedConfigWithFeatures {
 #[derive(Debug, Clone)]
 pub struct LoadedConfigEntryIgnores {
     pub ignores: Vec<ConfigEntryIgnore>,
+    pub source_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LoadedConfigEntryFiles {
+    pub entries: Vec<ConfigEntryFiles>,
     pub source_path: Option<PathBuf>,
 }
 
@@ -238,6 +245,37 @@ pub fn load_config_entry_ignores_with_source(path: Option<&Path>) -> LoadedConfi
     let ignores = top_level_ignores.chain(entry_ignores).collect();
     LoadedConfigEntryIgnores {
         ignores,
+        source_path: loaded.source_path,
+    }
+}
+
+pub fn load_config_entry_files_with_source(path: Option<&Path>) -> LoadedConfigEntryFiles {
+    let loaded = load_raw_config_with_source(path);
+    let mut entries = Vec::new();
+    if let Some(files) = loaded.config.files.filter(|files| !files.is_empty()) {
+        entries.push(ConfigEntryFiles {
+            base_path: loaded.config.base_path,
+            files,
+        });
+    }
+    entries.extend(
+        loaded
+            .config
+            .entries
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|entry| {
+                entry
+                    .files
+                    .filter(|files| !files.is_empty())
+                    .map(|files| ConfigEntryFiles {
+                        base_path: entry.base_path,
+                        files,
+                    })
+            }),
+    );
+    LoadedConfigEntryFiles {
+        entries,
         source_path: loaded.source_path,
     }
 }

--- a/crates/vize_carton/src/config/loader/tests.rs
+++ b/crates/vize_carton/src/config/loader/tests.rs
@@ -1,7 +1,8 @@
 use super::{
     load_compiler_jsx_mode, load_compiler_template_syntax, load_compiler_vue_version,
-    load_config_and_linter_with_source, load_config_entry_ignores_with_source,
-    load_config_with_source, load_linter_config, validate_explicit_config_path,
+    load_config_and_linter_with_source, load_config_entry_files_with_source,
+    load_config_entry_ignores_with_source, load_config_with_source, load_linter_config,
+    validate_explicit_config_path,
 };
 use crate::config::{JsxMode, VueVersion};
 
@@ -280,6 +281,35 @@ fn load_config_entry_ignores_preserves_base_paths() {
         Some("design-system")
     );
     assert_eq!(loaded.ignores[2].pattern.as_str(), "src/Fixture.vue");
+}
+
+#[test]
+fn load_config_entry_files_preserves_base_paths() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(
+        &config_path,
+        r#"{
+  "basePath": "app",
+  "files": ["src/**/*.vue"],
+  "entries": [
+    { "name": "design", "basePath": "design-system", "files": ["src/**/*.art.vue"] }
+  ]
+}"#,
+    )
+    .unwrap();
+
+    let loaded = load_config_entry_files_with_source(Some(&config_path));
+
+    assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
+    assert_eq!(loaded.entries.len(), 2);
+    assert_eq!(loaded.entries[0].base_path.as_deref(), Some("app"));
+    assert_eq!(loaded.entries[0].files, vec!["src/**/*.vue"]);
+    assert_eq!(
+        loaded.entries[1].base_path.as_deref(),
+        Some("design-system")
+    );
+    assert_eq!(loaded.entries[1].files, vec!["src/**/*.art.vue"]);
 }
 
 #[test]

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -115,6 +115,9 @@ impl Default for ConfigFeatureFlags {
 pub(crate) struct RawVizeConfig {
     #[serde(rename = "$schema")]
     pub schema: Option<String>,
+    #[serde(rename = "basePath")]
+    pub base_path: Option<String>,
+    pub files: Option<Vec<String>>,
     pub dialect: Option<VueDialect>,
     pub formatter: FormatterConfig,
     pub(crate) compiler: RawCompilerConfig,
@@ -140,6 +143,7 @@ pub(crate) struct RawVizeConfig {
 #[serde(default, rename_all = "camelCase")]
 pub(crate) struct RawConfigEntry {
     pub base_path: Option<String>,
+    pub files: Option<Vec<String>>,
     pub ignores: Option<Vec<String>>,
     pub linter: RawLinterConfig,
 }
@@ -148,6 +152,12 @@ pub(crate) struct RawConfigEntry {
 pub struct ConfigEntryIgnore {
     pub base_path: Option<String>,
     pub pattern: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigEntryFiles {
+    pub base_path: Option<String>,
+    pub files: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -187,6 +197,8 @@ impl RawVizeConfig {
     pub(crate) fn into_config_and_features(self) -> (VizeConfig, ConfigFeatureFlags) {
         let RawVizeConfig {
             schema,
+            base_path: _,
+            files: _,
             dialect,
             formatter,
             compiler,


### PR DESCRIPTION
Fixes #2020

Tests:
- cargo test -p vize --test fmt_config_cli --features glyph -- --nocapture
- cargo test -p vize_carton load_config_entry_files_preserves_base_paths -- --nocapture
- cargo fmt --all -- --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Co-authored-by: Ubugeeei <ubuge1122@gmail.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->