### PR TITLE
fix(canon): expose Vue 2 instance members on refs

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/options_api_required_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/options_api_required_props.rs
@@ -175,3 +175,102 @@ export default defineComponent({
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn legacy_vue2_component_refs_include_instance_surface() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case(
+        "legacy-vue2-component-ref-instance",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts">
+defineProps<{
+  label: string
+}>()
+
+defineEmits<{
+  select: [id: number]
+}>()
+</script>
+
+<template>
+  <button ref="inner">{{ label }}</button>
+</template>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import { ref } from 'vue'
+import Child from './Child.vue'
+
+const childRef = ref<InstanceType<typeof Child> | null>(null)
+const selected = ref(0)
+
+async function focusChild() {
+  if (childRef.value) {
+    const label: string = childRef.value.$props.label
+    childRef.value.$emit('select', 1)
+    ;(childRef.value.$el as HTMLButtonElement).focus()
+    childRef.value.$refs.inner
+    void label
+  }
+}
+
+function onSelect(id: number) {
+  selected.value = id
+}
+</script>
+
+<template>
+  <Child ref="childRef" label="Save" @select="onSelect" />
+  <button @click="focusChild">{{ selected }}</button>
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let mut checker = match BatchTypeChecker::new(&project_root) {
+        Ok(checker) => checker,
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        }
+    };
+    checker.enable_legacy_vue2();
+    checker.scan_project().unwrap();
+
+    let result = match checker.check_project() {
+        Ok(result) => result,
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        }
+    };
+
+    let relevant: Vec<_> = result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            (
+                relative_path(&project_root, &diagnostic.file),
+                diagnostic.code,
+                diagnostic.line,
+                diagnostic.column,
+                diagnostic.message.clone(),
+            )
+        })
+        .collect();
+
+    assert!(
+        relevant.is_empty(),
+        "legacy Vue 2 component refs should expose generated props/emits plus instance members: {relevant:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/virtual_project/tests/ref_arity.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/ref_arity.rs
@@ -67,6 +67,8 @@ const count = ref(0)
     assert!(!v2_content.contains("Ref<infer"));
     assert!(v2_content.contains("$listeners"));
     assert!(!default_content.contains("$listeners"));
+    assert!(v2_content.contains("type __VizeVue2ComponentInstance = {\n  $el: Element;"));
+    assert!(!default_content.contains("__VizeVue2ComponentInstance"));
     assert!(!v2_content.contains("Ref<infer V, any>"));
     assert!(!v2_content.contains("import('vue').Ref"));
     assert!(!v2_content.contains("import('vue').ComponentPublicInstance"));
@@ -167,6 +169,9 @@ export default {
         .clone();
     assert!(setup_content.contains(LEGACY_REF_UNWRAP_HELPER));
     for content in [setup_content.as_str(), options_content.as_str()] {
+        assert!(content.contains("type __VizeVue2ComponentInstance = {\n  $el: Element;"));
+        assert!(content.contains("  $refs: Record<string, any>;"));
+        assert!(content.contains("} & __VizeVue2ComponentInstance;"));
         assert!(!content.contains("import('vue').Ref"));
         assert!(!content.contains("import('vue').ShallowRef"));
         assert!(!content.contains("import('vue').ComponentPublicInstance"));

--- a/crates/vize_canon/src/batch/virtual_project/tests/snapshots/vize_canon__batch__virtual_project__tests__ref_arity__dialect_v2.snap
+++ b/crates/vize_canon/src/batch/virtual_project/tests/snapshots/vize_canon__batch__virtual_project__tests__ref_arity__dialect_v2.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_canon/src/batch/virtual_project/tests/ref_arity.rs
+assertion_line: 63
 expression: snapshot_text(v2_content.as_str())
 ---
 /// <reference lib="es2022" />
@@ -135,11 +136,34 @@ export type Emits = {};
 export type Slots = {};
 
 // ========== Default Export ==========
+type __VizeVue2ComponentInstance = {
+  $el: Element;
+  $refs: Record<string, any>;
+  $attrs: Record<string, unknown>;
+  $listeners: Record<string, unknown>;
+  $children: any[];
+  $scopedSlots: Record<string, unknown>;
+  $parent: any;
+  $root: any;
+  $options: Record<string, any>;
+  $data: Record<string, any>;
+  $on: (...args: any[]) => any;
+  $off: (...args: any[]) => any;
+  $once: (...args: any[]) => any;
+  $set: (...args: any[]) => any;
+  $delete: (...args: any[]) => any;
+  $watch: (...args: any[]) => any;
+  $nextTick: (...args: any[]) => any;
+  $forceUpdate: () => void;
+  $destroy: () => void;
+  $createElement: (...args: any[]) => any;
+  _c: (...args: any[]) => any;
+};
 type __VizeComponentInstance = {
   $props: Props;
   $emit: __EmitFn<Emits>;
   $slots: Slots;
-};
+} & __VizeVue2ComponentInstance;
 type __VizeComponentConstructor = new (...args: any[]) => __VizeComponentInstance;
 type __VizeVueComponentOptions = {
   name?: string;

--- a/crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs
@@ -31,6 +31,30 @@ const MODERN_REF_UNWRAP_HELPER: &str =
     "    type __U<T> = T extends import('vue').Ref ? T['value'] : T;\n";
 const LEGACY_DEFINE_COMPONENT_HELPER: &str =
     "declare function __vizeDefineComponent<T>(options: T): T;\n";
+pub(super) const LEGACY_COMPONENT_INSTANCE_HELPER: &str = r#"type __VizeVue2ComponentInstance = {
+  $el: Element;
+  $refs: Record<string, any>;
+  $attrs: Record<string, unknown>;
+  $listeners: Record<string, unknown>;
+  $children: any[];
+  $scopedSlots: Record<string, unknown>;
+  $parent: any;
+  $root: any;
+  $options: Record<string, any>;
+  $data: Record<string, any>;
+  $on: (...args: any[]) => any;
+  $off: (...args: any[]) => any;
+  $once: (...args: any[]) => any;
+  $set: (...args: any[]) => any;
+  $delete: (...args: any[]) => any;
+  $watch: (...args: any[]) => any;
+  $nextTick: (...args: any[]) => any;
+  $forceUpdate: () => void;
+  $destroy: () => void;
+  $createElement: (...args: any[]) => any;
+  _c: (...args: any[]) => any;
+};
+"#;
 
 pub(super) fn needs_legacy_vue2_helpers(legacy_vue2: bool, dialect: VueVersion) -> bool {
     legacy_vue2 || matches!(dialect, VueVersion::V2 | VueVersion::V2_7)
@@ -57,6 +81,30 @@ pub(super) fn define_component_helper(legacy_vue2: bool, dialect: VueVersion) ->
         LEGACY_DEFINE_COMPONENT_HELPER
     } else {
         DEFINE_COMPONENT_HELPER
+    }
+}
+
+pub(super) fn instance_helper(legacy_vue2: bool, dialect: VueVersion) -> &'static str {
+    if needs_legacy_vue2_helpers(legacy_vue2, dialect) {
+        LEGACY_COMPONENT_INSTANCE_HELPER
+    } else {
+        ""
+    }
+}
+
+pub(super) fn instance_suffix(
+    legacy_vue2: bool,
+    dialect: VueVersion,
+    has_exposed_type: bool,
+) -> &'static str {
+    match (
+        needs_legacy_vue2_helpers(legacy_vue2, dialect),
+        has_exposed_type,
+    ) {
+        (true, true) => "} & __VizeVue2ComponentInstance & Exposed;\n",
+        (true, false) => "} & __VizeVue2ComponentInstance;\n",
+        (false, true) => "} & Exposed;\n",
+        (false, false) => "};\n",
     }
 }
 

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -18,6 +18,7 @@ use self::imports::{
     extract_declared_name,
 };
 pub use self::legacy_vue2::generate_virtual_ts_with_offsets_legacy_vue2;
+use self::legacy_vue2::{instance_helper, instance_suffix};
 use self::options_api::{
     find_default_export_targets, find_options_api_props, generate_options_api_bridge,
     generate_options_api_variables,
@@ -966,15 +967,12 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
 
     // Default export
     ts.push_str("// ========== Default Export ==========\n");
+    ts.push_str(instance_helper(legacy_vue2, dialect));
     ts.push_str("type __VizeComponentInstance = {\n");
     setup_props_plan.emit_component_props_field(&mut ts, emits_info.has_emits_for_props);
     ts.push_str("  $emit: __EmitFn<Emits>;\n");
     ts.push_str("  $slots: Slots;\n");
-    if has_exposed_type {
-        ts.push_str("} & Exposed;\n");
-    } else {
-        ts.push_str("};\n");
-    }
+    ts.push_str(instance_suffix(legacy_vue2, dialect, has_exposed_type));
     ts.push_str(
         "type __VizeComponentConstructor = new (...args: any[]) => __VizeComponentInstance;\n",
     );


### PR DESCRIPTION
Fixes #2030

Tests:
- cargo test -p vize_canon legacy_vue2_component_refs_include_instance_surface -- --nocapture
- cargo test -p vize_canon ref_arity -- --nocapture
- cargo test -p vize_canon
- cargo fmt --all -- --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Co-authored-by: Ubugeeei <ubuge1122@gmail.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->