### PR TITLE
fix(canon): keep generated GraphQL types on real paths

### DIFF
--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -7,10 +7,14 @@
 
 use std::path::{Path, PathBuf};
 
-use vize_carton::{FxHashSet, String, ToCompactString, cstr};
+use vize_carton::{FxHashMap, FxHashSet, String, ToCompactString, cstr};
 
 use super::imports_aliases::PathAliasResolver;
 use super::path_cache::CanonicalPathCache;
+
+#[path = "imports_registration.rs"]
+mod registration;
+use registration::non_relative_import_needs_virtual_registration;
 
 /// Source extensions whose imports carry TypeScript types worth pulling into the
 /// virtual project, in module-resolution precedence order.
@@ -33,6 +37,7 @@ pub(super) fn collect_transitive_local_imports(
     aliases: Option<&PathAliasResolver>,
 ) -> Vec<PathBuf> {
     let mut visited: FxHashSet<PathBuf> = FxHashSet::default();
+    let mut registration_cache: FxHashMap<PathBuf, bool> = FxHashMap::default();
     let mut queue: Vec<PathBuf> = Vec::new();
 
     // Seed the visited set with the roots so they are never re-registered.
@@ -57,9 +62,11 @@ pub(super) fn collect_transitive_local_imports(
         // `import`/`from` string operands, so an SFC's `<template>`/`<style>`
         // are inert and no `.vue` parse is needed on this hot path.
         for specifier in extract_import_specifiers(&source) {
-            let resolved = if is_relative_specifier(&specifier) {
+            let relative_specifier = is_relative_specifier(&specifier);
+            let absolute_specifier = Path::new(specifier.as_str()).is_absolute();
+            let resolved = if relative_specifier {
                 resolve_relative_import(dir, &specifier, canonical_paths, include_jsx)
-            } else if Path::new(specifier.as_str()).is_absolute() {
+            } else if absolute_specifier {
                 resolve_import_base(Path::new(specifier.as_str()), canonical_paths, include_jsx)
             } else {
                 aliases.and_then(|aliases| {
@@ -77,6 +84,17 @@ pub(super) fn collect_transitive_local_imports(
             // Never register an ambient declaration file — its `declare module`
             // statements would shadow real modules as a program root.
             if is_declaration_file(&resolved) || is_node_modules_path(&resolved) {
+                continue;
+            }
+            if !relative_specifier
+                && !non_relative_import_needs_virtual_registration(
+                    &resolved,
+                    canonical_paths,
+                    include_jsx,
+                    aliases,
+                    &mut registration_cache,
+                )
+            {
                 continue;
             }
             if visited.insert(resolved.clone()) {
@@ -279,6 +297,9 @@ fn append_extension(base: &Path, ext: &str) -> PathBuf {
     }
 }
 
+#[cfg(test)]
+#[path = "imports_generated_tests.rs"]
+mod generated_tests;
 #[cfg(test)]
 #[path = "imports_tests.rs"]
 mod tests;

--- a/crates/vize/src/commands/check/imports_generated_tests.rs
+++ b/crates/vize/src/commands/check/imports_generated_tests.rs
@@ -1,0 +1,147 @@
+use super::super::imports_aliases::PathAliasResolver;
+use super::*;
+use vize_carton::path::canonicalize_non_verbatim;
+
+fn write(dir: &Path, rel: &str, contents: &str) -> PathBuf {
+    let path = dir.join(rel);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(&path, contents).unwrap();
+    path
+}
+
+#[test]
+fn skips_plain_absolute_generated_graphql_imports() {
+    let root =
+        std::env::temp_dir().join(cstr!("vize-imports-abs-generated-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    let schema = write(
+        &root,
+        "types/codegen/schema.ts",
+        "// Generated GraphQL schema types.\nexport enum AimQuestionDisplayKind { Text = 'TEXT' }\nexport type AimQuestion = { kind: AimQuestionDisplayKind }\n",
+    );
+    let schema_specifier = schema.with_extension("");
+    let entry = write(
+        &root,
+        "src/entry.ts",
+        cstr!(
+            "import type {{ AimQuestion }} from '{}'\nexport type Props = {{ question: AimQuestion }}\n",
+            schema_specifier.display()
+        )
+        .as_str(),
+    );
+
+    let discovered = collect_transitive_local_imports(
+        &[entry],
+        &root,
+        &mut CanonicalPathCache::default(),
+        false,
+        None,
+    );
+
+    assert!(
+        discovered.is_empty(),
+        "plain absolute generated type modules should resolve from their real path, not be copied into .vize/canon: {discovered:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn skips_plain_aliased_generated_graphql_imports() {
+    let root =
+        std::env::temp_dir().join(cstr!("vize-imports-alias-generated-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(
+        root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["*"]
+    }
+  }
+}"#,
+    )
+    .unwrap();
+    write(
+        &root,
+        "types/codegen/schema.ts",
+        "// Generated GraphQL schema types.\nexport enum AimQuestionDisplayKind { Text = 'TEXT' }\n",
+    );
+    let entry = write(
+        &root,
+        "src/entry.ts",
+        "import type { AimQuestionDisplayKind } from '~/types/codegen/schema'\nexport type Props = { kind: AimQuestionDisplayKind }\n",
+    );
+    let aliases = PathAliasResolver::from_tsconfig(Some(&root.join("tsconfig.json")));
+
+    let discovered = collect_transitive_local_imports(
+        &[entry],
+        &root,
+        &mut CanonicalPathCache::default(),
+        false,
+        Some(&aliases),
+    );
+
+    assert!(
+        discovered.is_empty(),
+        "plain aliased generated type modules should use the real tsconfig path fallback, not be copied into .vize/canon: {discovered:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn collects_absolute_project_imports_that_need_vue_rewrites() {
+    let root = std::env::temp_dir().join(cstr!("vize-imports-abs-vue-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    let widget = write(
+        &root,
+        "src/Widget.vue",
+        "<script setup lang=\"ts\">const label = 'ok'</script>\n<template><div /></template>\n",
+    );
+    let feature = write(
+        &root,
+        "src/feature.ts",
+        "import { Widget } from './nested'\nexport { Widget }\n",
+    );
+    let nested = write(
+        &root,
+        "src/nested.ts",
+        "import Widget from './Widget.vue'\nexport { Widget }\n",
+    );
+    let feature_specifier = feature.with_extension("");
+    let entry = write(
+        &root,
+        "src/entry.ts",
+        cstr!(
+            "import {{ Widget }} from '{}'\nexport {{ Widget }}\n",
+            feature_specifier.display()
+        )
+        .as_str(),
+    );
+
+    let discovered = collect_transitive_local_imports(
+        &[entry],
+        &root,
+        &mut CanonicalPathCache::default(),
+        false,
+        None,
+    );
+
+    assert_eq!(
+        discovered,
+        vec![
+            canonicalize_non_verbatim(&feature),
+            canonicalize_non_verbatim(&nested),
+            canonicalize_non_verbatim(&widget)
+        ]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/vize/src/commands/check/imports_registration.rs
+++ b/crates/vize/src/commands/check/imports_registration.rs
@@ -1,0 +1,94 @@
+use std::path::{Path, PathBuf};
+
+use vize_carton::{FxHashMap, FxHashSet};
+
+use super::super::imports_aliases::PathAliasResolver;
+use super::super::path_cache::CanonicalPathCache;
+use super::{
+    extract_import_specifiers, is_declaration_file, is_node_modules_path, is_relative_specifier,
+    resolve_import_base, resolve_relative_import,
+};
+
+pub(super) fn non_relative_import_needs_virtual_registration(
+    path: &Path,
+    canonical_paths: &mut CanonicalPathCache,
+    include_jsx: bool,
+    aliases: Option<&PathAliasResolver>,
+    cache: &mut FxHashMap<PathBuf, bool>,
+) -> bool {
+    if let Some(needs_registration) = cache.get(path) {
+        return *needs_registration;
+    }
+
+    let mut visited: FxHashSet<PathBuf> = FxHashSet::default();
+    let mut queue = vec![path.to_path_buf()];
+    let needs_registration = source_needs_virtual_registration(
+        &mut visited,
+        &mut queue,
+        canonical_paths,
+        include_jsx,
+        aliases,
+    );
+    cache.insert(path.to_path_buf(), needs_registration);
+    needs_registration
+}
+
+fn source_needs_virtual_registration(
+    visited: &mut FxHashSet<PathBuf>,
+    queue: &mut Vec<PathBuf>,
+    canonical_paths: &mut CanonicalPathCache,
+    include_jsx: bool,
+    aliases: Option<&PathAliasResolver>,
+) -> bool {
+    while let Some(file) = queue.pop() {
+        if !visited.insert(file.clone()) {
+            continue;
+        }
+        if file.extension().and_then(|extension| extension.to_str()) == Some("vue") {
+            return true;
+        }
+
+        let Ok(source) = std::fs::read_to_string(&file) else {
+            continue;
+        };
+        let Some(dir) = file.parent() else {
+            continue;
+        };
+
+        for specifier in extract_import_specifiers(&source) {
+            let candidate = Path::new(specifier.as_str());
+            let resolved = if is_relative_specifier(&specifier) {
+                resolve_relative_import(dir, &specifier, canonical_paths, include_jsx)
+            } else if candidate.is_absolute() {
+                resolve_import_base(candidate, canonical_paths, include_jsx)
+            } else {
+                aliases.and_then(|aliases| {
+                    aliases.resolve(
+                        &specifier,
+                        canonical_paths,
+                        include_jsx,
+                        resolve_import_base,
+                    )
+                })
+            };
+            let Some(resolved) = resolved else {
+                continue;
+            };
+            if is_declaration_file(&resolved) || is_node_modules_path(&resolved) {
+                continue;
+            }
+            if resolved
+                .extension()
+                .and_then(|extension| extension.to_str())
+                == Some("vue")
+            {
+                return true;
+            }
+            if !visited.contains(&resolved) {
+                queue.push(resolved);
+            }
+        }
+    }
+
+    false
+}

--- a/crates/vize/src/commands/check/imports_tests.rs
+++ b/crates/vize/src/commands/check/imports_tests.rs
@@ -72,39 +72,6 @@ fn ignores_bare_and_missing_specifiers() {
 }
 
 #[test]
-fn collects_absolute_project_imports_transitively() {
-    let root = std::env::temp_dir().join(cstr!("vize-imports-abs-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&root);
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    let schema = write(
-        &root,
-        "types/codegen/schema.ts",
-        "export enum DisplayKind { List = 'List' }\n",
-    );
-    let schema_specifier = schema.with_extension("");
-    let entry = write(
-        &root,
-        "src/entry.ts",
-        &format!(
-            "import type {{ DisplayKind }} from '{}'\nexport type Props = {{ kind: DisplayKind }}\n",
-            schema_specifier.display()
-        ),
-    );
-
-    let discovered = collect_transitive_local_imports(
-        &[entry],
-        &root,
-        &mut CanonicalPathCache::default(),
-        false,
-        None,
-    );
-
-    assert_eq!(discovered, vec![canonicalize_non_verbatim(&schema)]);
-
-    let _ = std::fs::remove_dir_all(&root);
-}
-
-#[test]
 fn collects_current_directory_index_imports() {
     let root = std::env::temp_dir().join(cstr!("vize-imports-dot-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&root);
@@ -171,7 +138,7 @@ fn jsx_imports_are_resolved_only_when_jsx_typecheck_is_enabled() {
 }
 
 #[test]
-fn collects_project_import_graph_edges_without_package_boundaries() {
+fn collects_only_non_relative_imports_that_need_virtual_rewrites() {
     let root = std::env::temp_dir().join(cstr!("vize-imports-matrix-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&root);
     std::fs::create_dir_all(root.join("src")).unwrap();
@@ -212,14 +179,14 @@ void ignoredMissing;
 type _PanelProps = PanelProps;
 "#,
     );
-    let lib = write(
+    let _lib = write(
         &root,
         "src/lib/index.ts",
         r#"export { leaf } from "./leaf";
 export const fromSrcRoot = leaf;
 "#,
     );
-    let root_shared = write(
+    let _root_shared = write(
         &root,
         "shared/root.ts",
         "export const fromProjectRoot = 'root';\n",
@@ -234,21 +201,21 @@ export interface PanelProps {
 </script>
 "#,
     );
-    let widget = write(
+    let _widget = write(
         &root,
         "src/components/Widget.tsx",
         "export const widget = () => null;\n",
     );
-    let cycle_a = write(
+    let _cycle_a = write(
         &root,
         "src/cycles/a.ts",
         r#"import { cycleB } from "./b";
 export const cycleA = cycleB;
 "#,
     );
-    let js_alias = write(&root, "src/js-alias.ts", "export const jsAlias = true;\n");
-    let leaf = write(&root, "src/lib/leaf.ts", "export const leaf = 1;\n");
-    let cycle_b = write(
+    let _js_alias = write(&root, "src/js-alias.ts", "export const jsAlias = true;\n");
+    let _leaf = write(&root, "src/lib/leaf.ts", "export const leaf = 1;\n");
+    let _cycle_b = write(
         &root,
         "src/cycles/b.ts",
         r#"import { cycleA } from "./a";
@@ -270,19 +237,7 @@ export const cycleB = cycleA;
         Some(&aliases),
     );
 
-    assert_eq!(
-        discovered,
-        vec![
-            canonicalize_non_verbatim(&lib),
-            canonicalize_non_verbatim(&root_shared),
-            canonicalize_non_verbatim(&panel),
-            canonicalize_non_verbatim(&widget),
-            canonicalize_non_verbatim(&cycle_a),
-            canonicalize_non_verbatim(&js_alias),
-            canonicalize_non_verbatim(&cycle_b),
-            canonicalize_non_verbatim(&leaf),
-        ]
-    );
+    assert_eq!(discovered, vec![canonicalize_non_verbatim(&panel)]);
 
     let _ = std::fs::remove_dir_all(&root);
 }

--- a/crates/vize/src/commands/check/runner/collect_tests.rs
+++ b/crates/vize/src/commands/check/runner/collect_tests.rs
@@ -1,7 +1,6 @@
 use super::super::ignores::CheckIgnoreSet;
 use super::{
-    base_dir_from_pattern, collect_check_files, collect_check_files_with_ignores,
-    collect_vue_files, path_is_inside_root,
+    base_dir_from_pattern, collect_check_files, collect_check_files_with_ignores, collect_vue_files,
 };
 use crate::commands::check::{
     imports::collect_transitive_local_imports, imports_aliases::PathAliasResolver,
@@ -226,7 +225,7 @@ fn path_root_filter_drops_alias_imports_outside_package_cwd() {
 }"#,
     )
     .unwrap();
-    let root_only = write_file(
+    let _root_only = write_file(
         &workspace,
         "src/generated/tecack/custom.ts",
         "export const rootOnly = 'root';\n",
@@ -261,10 +260,9 @@ void rootOnly;
         Some(&aliases),
     );
 
-    assert_eq!(discovered, vec![root_only.canonicalize().unwrap()]);
     assert!(
-        !path_is_inside_root(&package_root, &discovered[0]),
-        "root app import leaked into package inputs"
+        discovered.is_empty(),
+        "root app import leaked into package inputs: {discovered:#?}"
     );
 
     let _ = fs::remove_dir_all(&workspace);

--- a/crates/vize/tests/check_canon_graphql_cli.rs
+++ b/crates/vize/tests/check_canon_graphql_cli.rs
@@ -1,0 +1,176 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+use vize_carton::cstr;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("check-canon-graphql-{name}-{}", std::process::id()).as_str())
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn link_workspace_vue(project_root: &Path) -> std::io::Result<()> {
+    let workspace_node_modules = workspace_root().join("node_modules");
+    if !workspace_node_modules.exists() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace node_modules missing",
+        ));
+    }
+    let target = project_root.join("node_modules");
+    std::fs::create_dir_all(&target)?;
+    symlink_path(&workspace_node_modules.join("vue"), &target.join("vue"))?;
+    let vue_namespace = workspace_node_modules.join("@vue");
+    if vue_namespace.exists() {
+        symlink_path(&vue_namespace, &target.join("@vue"))?;
+    }
+    Ok(())
+}
+
+fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
+    if target.is_symlink() || target.is_file() {
+        std::fs::remove_file(target)?;
+    } else if target.exists() {
+        std::fs::remove_dir_all(target)?;
+    }
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(source, target)
+    }
+}
+
+#[test]
+fn check_explicit_vue_keeps_generated_graphql_schema_out_of_canon() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("dedupe");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    link_workspace_vue(&project_root).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["*"]
+    },
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+
+    let schema_path = project_root.join("types/codegen/schema.ts");
+    let schema_specifier = schema_path
+        .with_extension("")
+        .to_string_lossy()
+        .replace('\\', "/");
+    std::fs::create_dir_all(schema_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &schema_path,
+        r#"// Generated GraphQL schema types.
+export enum AimQuestionDisplayKind {
+  Text = 'TEXT',
+}
+
+export type AimQuestion = {
+  kind: AimQuestionDisplayKind
+}
+"#,
+    )
+    .unwrap();
+
+    let src_dir = project_root.join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(
+        src_dir.join("question.ts"),
+        r#"import type { AimQuestion } from '~/types/codegen/schema'
+
+export function expectQuestion(question: AimQuestion): AimQuestion {
+  return question
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        src_dir.join("App.vue"),
+        cstr!(
+            r#"<script setup lang="ts">
+import {{ expectQuestion }} from './question'
+import {{ AimQuestionDisplayKind, type AimQuestion }} from '{schema_specifier}'
+
+const question = {{
+  kind: AimQuestionDisplayKind.Text,
+}} satisfies AimQuestion
+
+expectQuestion(question)
+</script>
+
+<template><div /></template>
+"#
+        ),
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args(["check", "src/App.vue", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        std::str::from_utf8(&output.stderr).unwrap_or("<non-utf8 stderr>")
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    assert!(
+        project_root
+            .join("node_modules/.vize/canon/src/question.ts")
+            .exists()
+    );
+    assert!(
+        !project_root
+            .join("node_modules/.vize/canon/types/codegen/schema.ts")
+            .exists()
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -10,6 +10,10 @@ use vize_carton::String;
 use vize_carton::ToCompactString;
 use vize_carton::cstr;
 
+#[path = "import_rewriter_virtual.rs"]
+mod virtual_rewrite;
+use virtual_rewrite::absolute_import_needs_virtual_rewrite;
+
 #[derive(Debug, Clone)]
 pub struct OffsetAdjustment {
     pub original_offset: u32,
@@ -259,6 +263,9 @@ impl ImportRewriter {
                 vize_carton::path::canonicalize_non_verbatim(candidate).strip_prefix(roots.0)
             && is_rewritable_project_specifier(relative)
         {
+            if !path.ends_with(".vue") && !absolute_import_needs_virtual_rewrite(candidate) {
+                return None;
+            }
             let mut rewritten = cstr!("{}", roots.1.join(relative).display());
             if path.ends_with(".vue") {
                 rewritten.push_str(".ts");

--- a/crates/vize_canon/src/batch/import_rewriter_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_tests.rs
@@ -1,6 +1,29 @@
 use super::ImportRewriter;
 use oxc_span::SourceType;
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
+use vize_carton::cstr;
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    std::env::temp_dir().join(
+        cstr!(
+            "vize-import-rewriter-{name}-{}-{case_id}",
+            std::process::id()
+        )
+        .as_str(),
+    )
+}
+
+fn write(dir: &Path, rel: &str, contents: &str) -> PathBuf {
+    let path = dir.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(&path, contents).unwrap();
+    path
+}
 
 #[test]
 fn test_rewrite_default_import() {
@@ -72,37 +95,94 @@ fn rewrite_absolute_vue_specifier_through_symlinked_project_path() {
     std::fs::create_dir_all(real.path().join("src")).unwrap();
     std::fs::write(real.path().join("src/App.vue"), "<template />").unwrap();
 
-    let source = format!(r#"export * from "{}";"#, link.join("src/App.vue").display());
+    let source = cstr!(r#"export * from "{}";"#, link.join("src/App.vue").display());
     let virtual_root = real.path().join("node_modules/.vize/canon");
     let roots = (
         vize_carton::path::canonicalize_non_verbatim(&link),
         virtual_root.clone(),
     );
     let result = ImportRewriter::new().rewrite_for_virtual_project(
-        &source,
+        source.as_str(),
         SourceType::ts(),
         (roots.0.as_path(), roots.1.as_path()),
     );
 
     assert_eq!(
         result.code.as_str(),
-        format!(
+        cstr!(
             r#"export * from "{}";"#,
             virtual_root.join("src/App.vue.ts").display()
         )
+        .as_str()
     );
 }
 
 #[test]
-fn test_rewrite_absolute_ts_import_for_virtual_project() {
-    let rewriter = ImportRewriter::new();
-    let source = r#"import type { Kind } from '/p/types/codegen/schema';"#;
-    let roots = (Path::new("/p"), Path::new("/p/v"));
-    let result = rewriter.rewrite_for_virtual_project(source, SourceType::ts(), roots);
-    assert_eq!(
-        result.code,
-        r#"import type { Kind } from '/p/v/types/codegen/schema';"#
+fn test_keeps_plain_absolute_generated_graphql_import_for_virtual_project() {
+    let root = unique_case_dir("plain-generated-graphql");
+    let _ = fs::remove_dir_all(&root);
+    let schema = write(
+        &root,
+        "types/codegen/schema.ts",
+        "// Generated GraphQL schema types.\nexport enum Kind { List = 'LIST' }\n",
     );
+    let rewriter = ImportRewriter::new();
+    let source = cstr!(
+        "import type {{ Kind }} from '{}';",
+        schema.with_extension("").display()
+    );
+    let virtual_root = root.join("node_modules/.vize/canon");
+    let roots = (root.as_path(), virtual_root.as_path());
+    let result = rewriter.rewrite_for_virtual_project(source.as_str(), SourceType::ts(), roots);
+    assert_eq!(
+        result.code.as_str(),
+        cstr!(
+            "import type {{ Kind }} from '{}';",
+            schema.with_extension("").display()
+        )
+        .as_str()
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn test_rewrite_absolute_ts_import_that_needs_vue_rewrite_for_virtual_project() {
+    let root = unique_case_dir("ts-with-vue-import");
+    let _ = fs::remove_dir_all(&root);
+    let feature = write(
+        &root,
+        "src/feature.ts",
+        "import { Widget } from './nested'\nexport { Widget }\n",
+    );
+    write(
+        &root,
+        "src/nested.ts",
+        "import Widget from './Widget.vue'\nexport { Widget }\n",
+    );
+    write(
+        &root,
+        "src/Widget.vue",
+        "<script setup lang=\"ts\">const label = 'ok'</script>",
+    );
+    let rewriter = ImportRewriter::new();
+    let source = cstr!(
+        "import {{ Widget }} from '{}';",
+        feature.with_extension("").display()
+    );
+    let virtual_root = root.join("node_modules/.vize/canon");
+    let roots = (root.as_path(), virtual_root.as_path());
+    let result = rewriter.rewrite_for_virtual_project(source.as_str(), SourceType::ts(), roots);
+    assert_eq!(
+        result.code.as_str(),
+        cstr!(
+            "import {{ Widget }} from '{}';",
+            virtual_root.join("src/feature").display()
+        )
+        .as_str()
+    );
+
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]

--- a/crates/vize_canon/src/batch/import_rewriter_virtual.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_virtual.rs
@@ -1,0 +1,141 @@
+use std::path::{Path, PathBuf};
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Statement;
+use oxc_ast_visit::Visit;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{FxHashSet, String, cstr};
+
+use super::DynamicImportCollector;
+
+const SOURCE_EXTENSIONS: &[&str] = &[
+    ".ts", ".tsx", ".vue", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs",
+];
+
+pub(super) fn absolute_import_needs_virtual_rewrite(path: &Path) -> bool {
+    let Some(source_path) = resolve_source_path(path) else {
+        return false;
+    };
+    source_needs_virtual_rewrite(&source_path)
+}
+
+fn source_needs_virtual_rewrite(path: &Path) -> bool {
+    let mut visited: FxHashSet<PathBuf> = FxHashSet::default();
+    let mut queue = vec![path.to_path_buf()];
+
+    while let Some(file) = queue.pop() {
+        if !visited.insert(file.clone()) {
+            continue;
+        }
+        if file.extension().and_then(|extension| extension.to_str()) == Some("vue") {
+            return true;
+        }
+
+        let Ok(source) = std::fs::read_to_string(&file) else {
+            continue;
+        };
+        let Some(dir) = file.parent() else {
+            continue;
+        };
+
+        for specifier in collect_import_specifiers(&source) {
+            let candidate = Path::new(specifier.as_str());
+            let resolved = if is_relative_specifier(&specifier) {
+                resolve_source_path(&dir.join(specifier.as_str()))
+            } else if candidate.is_absolute() {
+                resolve_source_path(candidate)
+            } else {
+                None
+            };
+            let Some(resolved) = resolved else {
+                continue;
+            };
+            if is_node_modules_path(&resolved) {
+                continue;
+            }
+            if resolved
+                .extension()
+                .and_then(|extension| extension.to_str())
+                == Some("vue")
+            {
+                return true;
+            }
+            if !visited.contains(&resolved) {
+                queue.push(resolved);
+            }
+        }
+    }
+
+    false
+}
+
+fn resolve_source_path(path: &Path) -> Option<PathBuf> {
+    if path.is_file() {
+        return Some(path.to_path_buf());
+    }
+
+    for ext in SOURCE_EXTENSIONS {
+        let candidate = append_extension(path, ext);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    for ext in SOURCE_EXTENSIONS {
+        let candidate = path.join(cstr!("index{ext}").as_str());
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+fn append_extension(path: &Path, extension: &str) -> PathBuf {
+    match path.file_name().and_then(|name| name.to_str()) {
+        Some(name) => path.with_file_name(cstr!("{name}{extension}")),
+        None => path.to_path_buf(),
+    }
+}
+
+fn is_relative_specifier(specifier: &str) -> bool {
+    matches!(specifier, "." | "..") || specifier.starts_with("./") || specifier.starts_with("../")
+}
+
+fn is_node_modules_path(path: &Path) -> bool {
+    path.components()
+        .any(|component| component.as_os_str() == std::ffi::OsStr::new("node_modules"))
+}
+
+fn collect_import_specifiers(source: &str) -> Vec<String> {
+    let allocator = Allocator::default();
+    let parser = Parser::new(&allocator, source, SourceType::tsx());
+    let result = parser.parse();
+    let mut specifiers: Vec<String> = Vec::new();
+
+    for stmt in &result.program.body {
+        match stmt {
+            Statement::ImportDeclaration(decl) => {
+                specifiers.push(decl.source.value.as_str().into())
+            }
+            Statement::ExportNamedDeclaration(decl) => {
+                if let Some(source) = &decl.source {
+                    specifiers.push(source.value.as_str().into());
+                }
+            }
+            Statement::ExportAllDeclaration(decl) => {
+                specifiers.push(decl.source.value.as_str().into());
+            }
+            _ => {}
+        }
+    }
+
+    let mut collector = DynamicImportCollector::new();
+    collector.visit_program(&result.program);
+    for (_, _, path) in collector.imports {
+        specifiers.push(path);
+    }
+
+    specifiers
+}

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use vize_atelier_core::TemplateSyntaxMode;
 use vize_carton::cstr;
+mod graphql_generated;
 mod ref_arity;
 mod tsconfig_native_options;
 mod windows_paths;
@@ -75,7 +76,6 @@ fn snapshot_text(source: &str) -> std::string::String {
     }
     output
 }
-
 #[test]
 fn test_virtual_project_new() {
     let case_dir = unique_case_dir("new");

--- a/crates/vize_canon/src/batch/virtual_project/tests/graphql_generated.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/graphql_generated.rs
@@ -1,0 +1,115 @@
+use std::fs;
+
+use super::{VirtualProject, unique_case_dir};
+use vize_carton::cstr;
+
+#[test]
+fn materialized_project_keeps_generated_graphql_schema_on_real_path() {
+    let case_dir = unique_case_dir("graphql-generated-real-path");
+    let _ = fs::remove_dir_all(&case_dir);
+    let src_dir = case_dir.join("src");
+    let schema_path = case_dir.join("types/codegen/schema.ts");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::create_dir_all(schema_path.parent().unwrap()).unwrap();
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["*"]
+    }
+  }
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        &schema_path,
+        r#"// Generated GraphQL schema types.
+export enum AimQuestionDisplayKind {
+  Text = 'TEXT',
+}
+
+export type AimQuestion = {
+  kind: AimQuestionDisplayKind
+}
+"#,
+    )
+    .unwrap();
+    let question = src_dir.join("question.ts");
+    fs::write(
+        &question,
+        r#"import type { AimQuestion } from '~/types/codegen/schema'
+
+export function expectQuestion(question: AimQuestion): AimQuestion {
+  return question
+}
+"#,
+    )
+    .unwrap();
+    let schema_specifier = schema_path
+        .with_extension("")
+        .to_string_lossy()
+        .replace('\\', "/");
+    let app = src_dir.join("App.vue");
+    fs::write(
+        &app,
+        cstr!(
+            r#"<script setup lang="ts">
+import {{ expectQuestion }} from './question'
+import {{ AimQuestionDisplayKind, type AimQuestion }} from '{schema_specifier}'
+
+const question = {{
+  kind: AimQuestionDisplayKind.Text,
+}} satisfies AimQuestion
+
+expectQuestion(question)
+</script>
+
+<template><div /></template>
+"#
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.set_tsconfig_path(Some(case_dir.join("tsconfig.json")));
+    project
+        .register_paths(&[app.clone(), question.clone()])
+        .unwrap();
+    project.materialize().unwrap();
+
+    let virtual_root = project.virtual_root().to_path_buf();
+    assert!(
+        virtual_root.join("src/question.ts").exists(),
+        "the TS helper that participates in the type comparison is still materialized"
+    );
+    assert!(
+        !virtual_root.join("types/codegen/schema.ts").exists(),
+        "generated GraphQL schema types must not be duplicated into .vize/canon"
+    );
+    assert!(
+        project
+            .find_by_original(&app)
+            .unwrap()
+            .content
+            .contains(&schema_specifier),
+        "the SFC keeps using the real generated schema module"
+    );
+    assert_eq!(
+        fs::read_to_string(virtual_root.join("src/question.ts")).unwrap(),
+        fs::read_to_string(&question).unwrap(),
+        "the helper keeps the alias so the generated tsconfig fallback resolves the real schema"
+    );
+
+    let tsconfig_path = virtual_root.join("tsconfig.json");
+    let value: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
+    assert_eq!(
+        value["compilerOptions"]["paths"]["~/*"],
+        serde_json::json!(["./*", "../../../*"])
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}


### PR DESCRIPTION
## Summary
- avoid registering plain non-relative generated TS modules into the canon virtual project
- keep absolute non-Vue project imports on their real path unless their reachable graph needs Vue rewriting
- add regression coverage for import discovery, import rewriting, virtual materialization, and the CLI repro

Fixes #2022

## Tests
- cargo test -p vize generated_tests -- --nocapture
- cargo test -p vize_canon batch::import_rewriter_tests -- --nocapture
- cargo test -p vize_canon batch::virtual_project::tests::graphql_generated -- --nocapture
- cargo test -p vize --test check_canon_graphql_cli check_explicit_vue_keeps_generated_graphql_schema_out_of_canon -- --nocapture
- cargo fmt --all -- --check
- cargo clippy -p vize_canon --lib -- -D warnings
- cargo clippy -p vize --lib -- -D warnings
- cargo clippy -p vize --test check_canon_graphql_cli -- -D warnings
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Co-authored-by: Ubugeeei <ubuge1122@gmail.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->