### PR TITLE
fix(nuxt): preserve dependency SFC style requests

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/resolve-dependency-style.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve-dependency-style.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { VizePluginState } from "./state.ts";
+import { resolveIdHook } from "./resolve.ts";
+
+const testRoot = fs.mkdtempSync(
+  path.join(fs.realpathSync(os.tmpdir()), "vize-vite-plugin-dependency-style-"),
+);
+
+function writeFixtureFile(filePath: string, content = ""): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function createTempProject(prefix: string): string {
+  const root = fs.mkdtempSync(path.join(testRoot, prefix + "-"));
+  writeFixtureFile(path.join(root, "package.json"), JSON.stringify({ private: true }, null, 2));
+  writeFixtureFile(path.join(root, "app", "pages", "index.vue"), "<template />\n");
+  return root;
+}
+
+function createState(root: string): VizePluginState {
+  return {
+    cache: new Map(),
+    ssrCache: new Map(),
+    collectedCss: new Map(),
+    precompileMetadata: new Map(),
+    pendingHmrUpdateTypes: new Map(),
+    isProduction: false,
+    root,
+    clientViteBase: "/",
+    serverViteBase: "/",
+    server: {} as never,
+    filter: (id) => !id.includes("node_modules") && id.endsWith(".vue"),
+    scanPatterns: ["app/**/*.vue", "design/**/*.vue"],
+    precompileBatchSize: 128,
+    ignorePatterns: [],
+    mergedOptions: {
+      handleNodeModulesVue: false,
+      include: ["app/**/*.vue", "design/**/*.vue"],
+      exclude: ["node_modules/**", "**/node_modules/**"],
+    },
+    initialized: true,
+    dynamicImportAliasRules: [],
+    cssAliasRules: [],
+    extractCss: false,
+    componentsCssFileName: "assets/vize-components.css",
+    clientViteDefine: {},
+    serverViteDefine: {},
+    logger: {
+      log() {},
+      info() {},
+      warn() {},
+      error() {},
+    } as never,
+  };
+}
+
+const nullResolveContext = {
+  resolve: async () => null,
+};
+
+function createDependencyVuePath(projectRoot: string): string {
+  return path.join(
+    projectRoot,
+    "node_modules",
+    ".pnpm",
+    "@nuxtjs+mdc@0.19.2",
+    "node_modules",
+    "@nuxtjs",
+    "mdc",
+    "dist",
+    "runtime",
+    "components",
+    "prose",
+    "ProsePre.vue",
+  );
+}
+
+function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): string | null {
+  if (resolved == null) return null;
+  return typeof resolved === "string" ? resolved : resolved.id;
+}
+
+{
+  const projectRoot = createTempProject("style-query");
+  const source = createDependencyVuePath(projectRoot);
+  writeFixtureFile(
+    source,
+    "<template><pre /></template><style>pre code .line{display:block}</style>",
+  );
+
+  const resolved = await resolveIdHook(
+    nullResolveContext,
+    createState(projectRoot),
+    `${source}?vue=&type=style&index=0&lang=css`,
+    undefined,
+    undefined,
+  );
+
+  assert.equal(
+    expectResolvedId(resolved),
+    `${source}?vue=&type=style&index=0&lang=css.css`,
+    "Dependency Vue style queries should stay CSS-visible when dependency SFC compilation is disabled",
+  );
+
+  const fsResolved = await resolveIdHook(
+    nullResolveContext,
+    createState(projectRoot),
+    `/@fs${source}?vue=&type=style&index=0&lang=css`,
+    undefined,
+    undefined,
+  );
+
+  assert.equal(
+    expectResolvedId(fsResolved),
+    `${source}?vue=&type=style&index=0&lang=css.css`,
+    "Dependency Vue style queries from /@fs requests should normalize into the CSS pipeline",
+  );
+}
+
+{
+  const projectRoot = createTempProject("component-query");
+  const source = createDependencyVuePath(projectRoot);
+  writeFixtureFile(source, "<template><pre /></template>");
+
+  assert.equal(
+    await resolveIdHook(nullResolveContext, createState(projectRoot), source, undefined, undefined),
+    null,
+    "Dependency Vue component requests should stay on the host Nuxt/Vite route",
+  );
+
+  const query = "?nuxt_component=async&nuxt_component_name=ProsePre&nuxt_component_export=default";
+  assert.equal(
+    await resolveIdHook(
+      nullResolveContext,
+      createState(projectRoot),
+      `${source}${query}`,
+      undefined,
+      undefined,
+    ),
+    null,
+    "Nuxt dependency component wrapper queries should not be Vize-compiled",
+  );
+}
+
+console.log("✅ vite-plugin-vize dependency style resolve tests passed!");

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -926,11 +926,6 @@ export async function resolveIdHook(
       state.logger.log(`resolveId: skipping vitepress-plugin-llms style import ${id}`);
       return null;
     }
-    const handleNodeModules = state.mergedOptions.handleNodeModulesVue ?? true;
-    if (!handleNodeModules && request.path.includes("node_modules")) {
-      state.logger.log(`resolveId: skipping node_modules style import ${id}`);
-      return null;
-    }
     return `${request.normalizedFsId ?? id}${request.styleVirtualSuffix}`;
   }
 

--- a/npm/vite-plugin-vize/src/test.ts
+++ b/npm/vite-plugin-vize/src/test.ts
@@ -10,6 +10,7 @@ import "./plugin/native.test.ts";
 import "./plugin/quasar.test.ts";
 import "./plugin/resolve-peer-runtime.test.ts";
 import "./plugin/resolve-vue-runtime.test.ts";
+import "./plugin/resolve-dependency-style.test.ts";
 import "./plugin/resolve.test.ts";
 import "./plugin/state.test.ts";
 import "./plugin/unocss.test.ts";


### PR DESCRIPTION
## Summary
- keep dependency Vue style-block requests CSS-visible even when dependency SFC compilation is disabled
- continue skipping dependency Vue component and Nuxt component wrapper requests when handleNodeModulesVue is false
- add regression coverage for pnpm dependency style queries and /@fs requests

## Tests
- node npm/vite-plugin-vize/src/plugin/resolve-dependency-style.test.ts
- pnpm --filter @vizejs/vite-plugin test
- pnpm --filter @vizejs/vite-plugin check
- pnpm --filter @vizejs/nuxt test
- pnpm --filter @vizejs/nuxt check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Fixes #1954

Co-authored-by: Ubugeeei <ubuge1122@gmail.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->