### PR TITLE
fix(canon): scan nested Nuxt 2 plugin injections

### DIFF
--- a/crates/vize/src/commands/check/nuxt/plugins/extract.rs
+++ b/crates/vize/src/commands/check/nuxt/plugins/extract.rs
@@ -150,10 +150,64 @@ fn collect_plugin_keys_from_nuxt2_inject_calls<'a>(
     keys: &mut Vec<String>,
 ) {
     for statement in statements {
-        let Statement::ExpressionStatement(expr) = statement else {
-            continue;
-        };
-        collect_plugin_key_from_nuxt2_inject_expression(&expr.expression, inject_name, keys);
+        collect_plugin_keys_from_nuxt2_inject_statement(statement, inject_name, keys);
+    }
+}
+
+fn collect_plugin_keys_from_nuxt2_inject_statement(
+    statement: &Statement<'_>,
+    inject_name: &str,
+    keys: &mut Vec<String>,
+) {
+    match statement {
+        Statement::ExpressionStatement(expr) => {
+            collect_plugin_key_from_nuxt2_inject_expression(&expr.expression, inject_name, keys);
+        }
+        Statement::BlockStatement(block) => {
+            collect_plugin_keys_from_nuxt2_inject_calls(&block.body, inject_name, keys);
+        }
+        Statement::IfStatement(if_stmt) => {
+            collect_plugin_keys_from_nuxt2_inject_statement(&if_stmt.consequent, inject_name, keys);
+            if let Some(alternate) = &if_stmt.alternate {
+                collect_plugin_keys_from_nuxt2_inject_statement(alternate, inject_name, keys);
+            }
+        }
+        Statement::DoWhileStatement(do_while) => {
+            collect_plugin_keys_from_nuxt2_inject_statement(&do_while.body, inject_name, keys);
+        }
+        Statement::ForInStatement(for_in) => {
+            collect_plugin_keys_from_nuxt2_inject_statement(&for_in.body, inject_name, keys);
+        }
+        Statement::ForOfStatement(for_of) => {
+            collect_plugin_keys_from_nuxt2_inject_statement(&for_of.body, inject_name, keys);
+        }
+        Statement::ForStatement(for_stmt) => {
+            collect_plugin_keys_from_nuxt2_inject_statement(&for_stmt.body, inject_name, keys);
+        }
+        Statement::LabeledStatement(labeled) => {
+            collect_plugin_keys_from_nuxt2_inject_statement(&labeled.body, inject_name, keys);
+        }
+        Statement::SwitchStatement(switch_stmt) => {
+            for case in &switch_stmt.cases {
+                collect_plugin_keys_from_nuxt2_inject_calls(&case.consequent, inject_name, keys);
+            }
+        }
+        Statement::TryStatement(try_stmt) => {
+            collect_plugin_keys_from_nuxt2_inject_calls(&try_stmt.block.body, inject_name, keys);
+            if let Some(handler) = &try_stmt.handler {
+                collect_plugin_keys_from_nuxt2_inject_calls(&handler.body.body, inject_name, keys);
+            }
+            if let Some(finalizer) = &try_stmt.finalizer {
+                collect_plugin_keys_from_nuxt2_inject_calls(&finalizer.body, inject_name, keys);
+            }
+        }
+        Statement::WhileStatement(while_stmt) => {
+            collect_plugin_keys_from_nuxt2_inject_statement(&while_stmt.body, inject_name, keys);
+        }
+        Statement::WithStatement(with_stmt) => {
+            collect_plugin_keys_from_nuxt2_inject_statement(&with_stmt.body, inject_name, keys);
+        }
+        _ => {}
     }
 }
 
@@ -261,7 +315,9 @@ mod tests {
         let source = r#"
 export default defineNuxtPlugin((_context, register) => {
   register('logger', { info(message) { return message.length } })
-  register(`auth`, {})
+  if (true) {
+    register(`auth`, {})
+  }
 })
 "#;
 
@@ -274,7 +330,9 @@ export default defineNuxtPlugin((_context, register) => {
         let source = r#"
 export default (_context, inject) => {
   inject('logger', { info(message) { return message.length } })
-  inject(`auth`, {})
+  if (true) {
+    inject(`auth`, {})
+  }
 }
 "#;
 

--- a/crates/vize/src/commands/check/nuxt/plugins/tests.rs
+++ b/crates/vize/src/commands/check/nuxt/plugins/tests.rs
@@ -11,11 +11,13 @@ fn scans_src_app_plugins_for_nuxt2_injections() {
     std::fs::write(
         plugin_dir.join("logger.ts"),
         r#"export default (_context, inject) => {
-  inject("logger", {
-    info(message) {
-      return message.length;
-    },
-  });
+  if (true) {
+    inject("logger", {
+      info(message) {
+        return message.length;
+      },
+    });
+  }
 };
 "#,
     )

--- a/crates/vize/tests/check_nuxt2_plugin_injections_cli.rs
+++ b/crates/vize/tests/check_nuxt2_plugin_injections_cli.rs
@@ -49,11 +49,13 @@ declare module "#app" {
         &project_root,
         "plugins/logger.ts",
         r#"export default (_context: unknown, inject: (key: string, value: unknown) => void) => {
-  inject("logger", {
-    info(message: string) {
-      return message.length;
-    },
-  });
+  if (true) {
+    inject("logger", {
+      info(message: string) {
+        return message.length;
+      },
+    });
+  }
 };
 "#,
     );


### PR DESCRIPTION
## Summary
- scan Nuxt 2 plugin bodies recursively for nested inject calls
- keep useContext augmentation in sync when plugin injection registration is inside branches, loops, or try blocks
- strengthen Nuxt 2 false-positive CLI coverage with nested injection fixtures

## Tests
- cargo fmt --all -- --check
- cargo test -p vize --features legacy commands::check::nuxt::plugins -- --nocapture
- cargo test -p vize --features legacy check_nuxt2_use_context_sees_plugin_injections -- --nocapture
- cargo test -p vize --features legacy check_nuxt2_false_positive_fixture_matrix -- --nocapture
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Fixes #1876

Co-authored-by: Ubugeeei <ubuge1122@gmail.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->