### PR TITLE
fix(vite-plugin): tighten HMR invalidation

### DIFF
--- a/npm/builder/vite/src/hmr.test.ts
+++ b/npm/builder/vite/src/hmr.test.ts
@@ -45,4 +45,58 @@ assert.equal(
   "Callers must short-circuit no-op updates before generating HMR output",
 );
 
+const generatedCodeChangedModule: CompiledModule = {
+  ...baseModule,
+  code: "export default { name: 'Changed' }",
+};
+assert.equal(
+  hasHmrChanges(baseModule, generatedCodeChangedModule),
+  true,
+  "HMR must react when generated code changes even if native section hashes stay stable",
+);
+assert.equal(
+  detectHmrUpdateType(baseModule, generatedCodeChangedModule),
+  "full-reload",
+  "Generated code changes outside section hashes should conservatively reload the component",
+);
+
+const cssChangedWithoutStyleHashModule: CompiledModule = {
+  ...baseModule,
+  css: ".root { color: blue; }",
+};
+assert.equal(
+  hasHmrChanges(baseModule, cssChangedWithoutStyleHashModule),
+  true,
+  "HMR must react when compiled CSS changes even if the style hash is missing or unchanged",
+);
+assert.equal(
+  detectHmrUpdateType(baseModule, cssChangedWithoutStyleHashModule),
+  "style-only",
+  "CSS-only fallback changes should keep the style-only HMR path",
+);
+
+const styleMetadataChangedModule: CompiledModule = {
+  ...baseModule,
+  styles: [
+    {
+      content: ".root { color: red; }",
+      src: null,
+      lang: null,
+      scoped: false,
+      module: true,
+      index: 0,
+    },
+  ],
+};
+assert.equal(
+  hasHmrChanges(baseModule, styleMetadataChangedModule),
+  true,
+  "HMR must react when style metadata changes the generated module shape",
+);
+assert.equal(
+  detectHmrUpdateType(baseModule, styleMetadataChangedModule),
+  "full-reload",
+  "Style pipeline metadata changes can affect imports or CSS modules and should reload",
+);
+
 console.log("✅ vite-plugin-vize hmr tests passed!");

--- a/npm/builder/vite/src/hmr.ts
+++ b/npm/builder/vite/src/hmr.ts
@@ -11,7 +11,15 @@ import { detectViteHmrUpdateType, generateViteHmrCode, hasViteHmrChanges } from 
 export type HmrUpdateType = "template-only" | "style-only" | "full-reload";
 
 export function hasHmrChanges(prev: CompiledModule | undefined, next: CompiledModule): boolean {
-  return hasViteHmrChanges(toHmrHashes(prev), toHmrHashes(next));
+  if (!prev) {
+    return true;
+  }
+
+  return (
+    hasViteHmrChanges(toHmrHashes(prev), toHmrHashes(next)) ||
+    runtimeFingerprint(prev) !== runtimeFingerprint(next) ||
+    styleFingerprint(prev) !== styleFingerprint(next)
+  );
 }
 
 /**
@@ -25,7 +33,31 @@ export function detectHmrUpdateType(
   prev: CompiledModule | undefined,
   next: CompiledModule,
 ): HmrUpdateType {
-  return detectViteHmrUpdateType(toHmrHashes(prev), toHmrHashes(next)) as HmrUpdateType;
+  if (!prev) {
+    return detectViteHmrUpdateType(undefined, toHmrHashes(next)) as HmrUpdateType;
+  }
+
+  if (prev.scriptHash !== next.scriptHash) {
+    return "full-reload";
+  }
+
+  if (prev.templateHash !== next.templateHash) {
+    return "template-only";
+  }
+
+  if (prev.styleHash !== next.styleHash) {
+    return "style-only";
+  }
+
+  if (runtimeFingerprint(prev) !== runtimeFingerprint(next)) {
+    return "full-reload";
+  }
+
+  if (styleFingerprint(prev) !== styleFingerprint(next)) {
+    return "style-only";
+  }
+
+  return "full-reload";
 }
 
 /**
@@ -43,4 +75,38 @@ function toHmrHashes(module: CompiledModule | undefined) {
         styleHash: module.styleHash,
       }
     : undefined;
+}
+
+function runtimeFingerprint(module: CompiledModule): string {
+  return JSON.stringify({
+    code: module.code,
+    scopeId: module.scopeId,
+    hasScoped: module.hasScoped,
+    macroArtifacts: module.macroArtifacts?.map((artifact) => ({
+      kind: artifact.kind,
+      name: artifact.name,
+      source: artifact.source,
+      content: artifact.content,
+      moduleCode: artifact.moduleCode,
+      start: artifact.start,
+      end: artifact.end,
+    })),
+    styles: module.styles?.map((style) => ({
+      lang: style.lang,
+      scoped: style.scoped,
+      module: style.module,
+      index: style.index,
+    })),
+    dependencies: [...(module.dependencies ?? [])].sort(),
+  });
+}
+
+function styleFingerprint(module: CompiledModule): string {
+  return JSON.stringify({
+    css: module.css,
+    styles: module.styles?.map((style) => ({
+      index: style.index,
+      content: style.content,
+    })),
+  });
 }

--- a/npm/builder/vite/src/plugin/hmr.test.ts
+++ b/npm/builder/vite/src/plugin/hmr.test.ts
@@ -9,7 +9,8 @@ import {
   VIZE_COMPONENTS_CSS_BASENAME,
   VIZE_COMPONENTS_CSS_FILE,
 } from "./hmr.ts";
-import { toVirtualId } from "../virtual.ts";
+import { compileFile } from "../compiler.ts";
+import { toPluginVisibleVirtualId, toVirtualId } from "../virtual.ts";
 
 function createState(): VizePluginState {
   return {
@@ -103,6 +104,129 @@ assert.equal(
     "Dependency updates should force full reload HMR for the owner SFC",
   );
   assert.equal(invalidatedModule, module, "Dependency updates should invalidate the owner module");
+}
+
+{
+  const vueFile = "/src/App.vue";
+  const dependencyFile = "/src/imported.css";
+  const nullVirtualModule = { url: toVirtualId(vueFile) };
+  const visibleVirtualModule = { url: toPluginVisibleVirtualId(vueFile) };
+  const rawVueModule = { url: vueFile };
+  const invalidatedModules: unknown[] = [];
+  const state = {
+    cache: new Map([
+      [
+        vueFile,
+        {
+          code: "export default {}",
+          scopeId: "app12345",
+          hasScoped: false,
+          dependencies: [dependencyFile],
+        },
+      ],
+    ]),
+    ssrCache: new Map(),
+    collectedCss: new Map(),
+    precompileMetadata: new Map(),
+    pendingHmrUpdateTypes: new Map(),
+    root: "/src",
+    logger: {
+      log() {},
+    },
+  } as unknown as VizePluginState;
+  const modulesByFile = new Map<string, Set<unknown>>([
+    [toVirtualId(vueFile), new Set([nullVirtualModule])],
+    [toPluginVisibleVirtualId(vueFile), new Set([visibleVirtualModule])],
+    [vueFile, new Set([rawVueModule])],
+  ]);
+  const ctx = {
+    file: dependencyFile,
+    server: {
+      moduleGraph: {
+        getModulesByFile(id: string) {
+          return modulesByFile.get(id);
+        },
+        invalidateModule(receivedModule: unknown) {
+          invalidatedModules.push(receivedModule);
+        },
+      },
+    },
+    read: async () => "",
+  } as unknown as HmrContext;
+
+  const modules = await handleHotUpdateHook(state, ctx);
+
+  assert.deepEqual(
+    new Set(modules),
+    new Set([nullVirtualModule, visibleVirtualModule, rawVueModule]),
+    "Dependency updates should return every module graph representation of the owner SFC",
+  );
+  assert.deepEqual(
+    new Set(invalidatedModules),
+    new Set([nullVirtualModule, visibleVirtualModule, rawVueModule]),
+    "Dependency updates should invalidate every module graph representation of the owner SFC",
+  );
+}
+
+{
+  const vueFile = "/src/Delegated.vue";
+  const previousSource = `<template><div :class="$style.root">red</div></template><style module>.root { color: red; }</style>`;
+  const nextSource = `<template><div :class="$style.root">red</div></template><style module>.root { color: blue; }</style>`;
+  const cache = new Map();
+  const previousCompiled = compileFile(
+    vueFile,
+    cache,
+    { sourceMap: false, ssr: false, vapor: false },
+    previousSource,
+  );
+  const styleModule = { url: `${vueFile}?vue&type=style&index=0&lang=css&module=.css` };
+  const state = {
+    cache: new Map([[vueFile, previousCompiled]]),
+    ssrCache: new Map(),
+    collectedCss: new Map(),
+    precompileMetadata: new Map(),
+    pendingHmrUpdateTypes: new Map(),
+    isProduction: false,
+    mergedOptions: {},
+    cssAliasRules: [],
+    clientViteBase: "/",
+    root: "/src",
+    filter: () => true,
+    logger: {
+      log() {},
+      error() {},
+    },
+  } as unknown as VizePluginState;
+  const params = new URLSearchParams();
+  params.set("vue", "");
+  params.set("type", "style");
+  params.set("index", "0");
+  params.set("lang", "css");
+  params.set("module", "");
+  const styleId = `${vueFile}?${params.toString()}`;
+  const ctx = {
+    file: vueFile,
+    server: {
+      moduleGraph: {
+        getModulesByFile(id: string) {
+          return id === `${styleId}.css` ? new Set([styleModule]) : undefined;
+        },
+        invalidateModule() {},
+      },
+      ws: {
+        send() {},
+      },
+    },
+    read: async () => nextSource,
+  } as unknown as HmrContext;
+
+  const modules = await handleHotUpdateHook(state, ctx);
+
+  assert.deepEqual(
+    modules,
+    [styleModule],
+    "Delegated style-only updates should match Vite's resolved .css style module id",
+  );
 }
 
 {
@@ -217,5 +341,4 @@ assert.equal(
     "SSR chunks should not reference client-only extracted CSS",
   );
 }
-
 console.log("✅ vite-plugin-vize plugin hmr tests passed!");

--- a/npm/builder/vite/src/plugin/hmr.ts
+++ b/npm/builder/vite/src/plugin/hmr.ts
@@ -1,4 +1,4 @@
-import type { HmrContext } from "vite";
+import type { HmrContext, ModuleNode, ViteDevServer } from "vite";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -7,7 +7,7 @@ import { getCompileOptionsForRequest } from "./state.ts";
 import { compileFile } from "../compiler.ts";
 import { detectHmrUpdateType, hasHmrChanges, type HmrUpdateType } from "../hmr.ts";
 import { hasDelegatedStyles } from "../utils/index.ts";
-import { toVirtualId } from "../virtual.ts";
+import { toPluginVisibleVirtualId, toVirtualId } from "../virtual.ts";
 import { resolveCssImports } from "../utils/css.ts";
 
 export const VIZE_COMPONENTS_CSS_BASENAME = "vize-components.css";
@@ -47,6 +47,40 @@ function getVueFilesDependingOn(state: VizePluginState, dependencyFile: string):
   return [...owners];
 }
 
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function getVueModuleFileCandidates(vueFile: string): string[] {
+  return unique([
+    toVirtualId(vueFile),
+    toPluginVisibleVirtualId(vueFile),
+    toVirtualId(vueFile, true),
+    toPluginVisibleVirtualId(vueFile, true),
+    vueFile,
+  ]);
+}
+
+function getStyleModuleFileCandidates(styleId: string): string[] {
+  return unique([styleId, `${styleId}.css`]);
+}
+
+function collectModulesByFile(server: ViteDevServer, fileIds: readonly string[]): Set<ModuleNode> {
+  const modules = new Set<ModuleNode>();
+
+  for (const fileId of fileIds) {
+    const matched = server.moduleGraph.getModulesByFile(fileId);
+    if (!matched) {
+      continue;
+    }
+    for (const mod of matched) {
+      modules.add(mod);
+    }
+  }
+
+  return modules;
+}
+
 export async function handleHotUpdateHook(
   state: VizePluginState,
   ctx: HmrContext,
@@ -64,16 +98,11 @@ export async function handleHotUpdateHook(
       state.precompileMetadata.delete(vueFile);
       state.pendingHmrUpdateTypes.set(vueFile, "full-reload");
 
-      const virtualId = toVirtualId(vueFile);
-      const modules =
-        server.moduleGraph.getModulesByFile(virtualId) ??
-        server.moduleGraph.getModulesByFile(vueFile);
+      const modules = collectModulesByFile(server, getVueModuleFileCandidates(vueFile));
 
-      if (modules) {
-        for (const module of modules) {
-          server.moduleGraph.invalidateModule(module);
-          affectedModules.add(module);
-        }
+      for (const module of modules) {
+        server.moduleGraph.invalidateModule(module);
+        affectedModules.add(module);
       }
 
       state.logger.log(
@@ -117,9 +146,7 @@ export async function handleHotUpdateHook(
 
       state.logger.log(`Re-compiled: ${path.relative(state.root, file)} (${updateType})`);
 
-      const virtualId = toVirtualId(file);
-      const modules =
-        server.moduleGraph.getModulesByFile(virtualId) ?? server.moduleGraph.getModulesByFile(file);
+      const modules = collectModulesByFile(server, getVueModuleFileCandidates(file));
 
       const hasDelegated = hasDelegatedStyles(newCompiled);
 
@@ -136,17 +163,15 @@ export async function handleHotUpdateHook(
             params.set("module", typeof block.module === "string" ? block.module : "");
           }
           const styleId = `${file}?${params.toString()}`;
-          const styleMods = server.moduleGraph.getModulesByFile(styleId);
-          if (styleMods) {
-            for (const mod of styleMods) {
-              affectedModules.add(mod);
-            }
+          const styleMods = collectModulesByFile(server, getStyleModuleFileCandidates(styleId));
+          for (const mod of styleMods) {
+            affectedModules.add(mod);
           }
         }
         if (affectedModules.size > 0) {
           return [...affectedModules];
         }
-        if (modules) {
+        if (modules.size > 0) {
           return [...modules];
         }
         return [];
@@ -172,7 +197,7 @@ export async function handleHotUpdateHook(
         return [];
       }
 
-      if (modules) {
+      if (modules.size > 0) {
         state.pendingHmrUpdateTypes.set(file, updateType);
         return [...modules];
       }


### PR DESCRIPTION
## Summary

- Tighten HMR no-op detection by comparing generated module output, macro artifacts, style metadata, dependencies, and CSS fallback fingerprints in addition to native section hashes.
- Collect all Vite module graph representations for SFC updates, including plugin-visible virtual ids, SSR virtual ids, raw Vue paths, and resolved .css style modules.
- Add regression coverage for strict fallback detection, SFC dependency invalidation across module ids, and delegated style HMR using Vite's resolved CSS id.

Closes #2036

## Validation

- `pnpm --dir npm/builder/vite check`
- `pnpm --dir npm/builder/vite test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->