### PR TITLE
fix(canon): hide Vue 3 helpers in legacy Vue 2 output

### DIFF
--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -101,9 +101,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         .source_path
         .as_deref()
         .and_then(|path| crate::config::load_compiler_template_syntax(Some(path)));
-    // Configured Vue dialect (`vue.version`). Defaults to Vue 3 when unset.
-    // Threaded into canon's virtual-TS generation for dialect-aware instance
-    // typing.
+    // Configured Vue dialect (`vue.version`) threads into dialect-aware virtual TS.
     let dialect = dialect_from_features(loaded_config.features.vue_version);
     // Vue 3 Options API binding resolution is officially supported and is a
     // standard-build opt-in (not the `legacy` feature).
@@ -335,11 +333,13 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     }
 
     if args.show_virtual_ts {
-        eprintln!(
-            "\n=== {} ===",
-            vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME
-        );
-        eprintln!("{}", vize_canon::virtual_ts::SHARED_PREAMBLE_DTS);
+        if let Some(shared_helpers) = checker.shared_helpers_preamble() {
+            eprintln!(
+                "\n=== {} ===",
+                vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME
+            );
+            eprintln!("{shared_helpers}");
+        }
         for file in &virtual_files {
             eprintln!("\n=== {} ===", file.original_path.display());
             eprintln!("{}", file.content);

--- a/crates/vize/tests/check_legacy_vue2_helpers_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_helpers_cli.rs
@@ -1,0 +1,174 @@
+#![cfg(feature = "legacy")]
+
+use std::{path::Path, process::Command};
+
+use vize_carton::cstr;
+
+#[test]
+fn check_legacy_vue2_show_virtual_ts_omits_shared_helpers() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", "src/App.vue", "--show-virtual-ts"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains(vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME),
+        "legacy Vue 2 should not show a shared helpers preamble:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("declare function __vizeDefineComponent<T>(options: T): T;"),
+        "expected per-file legacy defineComponent helper:\n{stderr}"
+    );
+    for vue3_only_helper in [
+        "import('vue').Ref",
+        "import('vue').ShallowRef",
+        "import('vue').ComponentPublicInstance",
+        "import('vue').defineComponent",
+    ] {
+        assert!(
+            !stderr.contains(vue3_only_helper),
+            "legacy Vue 2 virtual TS must not contain {vue3_only_helper}:\n{stderr}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn create_project() -> std::path::PathBuf {
+    let project_root = unique_case_dir("legacy-vue2-show-virtual-ts-no-shared-helpers");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    write_test_vue2_6_stub(&project_root.join("node_modules")).unwrap();
+    write_test_vite_stub(&project_root.join("node_modules")).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        r#"{
+  "typeChecker": {
+    "legacyVue2": true
+  }
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/App.vue"),
+        r#"<script lang="ts">
+export default {
+  data() {
+    return { count: 0 }
+  },
+}
+</script>
+
+<template>
+  <div>{{ count }}</div>
+</template>
+"#,
+    )
+    .unwrap();
+    project_root
+}
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn unique_case_dir(name: &str) -> std::path::PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("{name}-{}", std::process::id()).as_str())
+}
+
+fn resolve_test_corsa_path() -> Option<String> {
+    if let Ok(path) = std::env::var("CORSA_PATH") {
+        if Path::new(&path).exists() {
+            return Some(path);
+        }
+    }
+
+    let workspace_root = workspace_root();
+    [
+        workspace_root.join("node_modules/.bin/tsgo"),
+        workspace_root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+    .map(|candidate| candidate.to_string_lossy().into_owned())
+}
+
+fn write_test_vue2_6_stub(target: &Path) -> std::io::Result<()> {
+    let vue_types_dir = target.join("vue").join("types");
+    std::fs::create_dir_all(&vue_types_dir)?;
+    std::fs::write(
+        target.join("vue").join("package.json"),
+        r#"{
+  "name": "vue",
+  "types": "types/index.d.ts"
+}"#,
+    )?;
+    std::fs::write(
+        vue_types_dir.join("index.d.ts"),
+        r#"export interface Vue {
+  $attrs: Record<string, unknown>;
+  $refs: Record<string, any>;
+  $slots: Record<string, unknown>;
+  $emit: (...args: any[]) => void;
+}
+
+export type PropType<T> = { new (...args: any[]): T & {} } | { (): T } | null;
+
+declare const VueConstructor: {
+  version: string;
+};
+
+export default VueConstructor;
+"#,
+    )?;
+    Ok(())
+}
+
+fn write_test_vite_stub(target: &Path) -> std::io::Result<()> {
+    let vite_dir = target.join("vite");
+    std::fs::create_dir_all(&vite_dir)?;
+    std::fs::write(
+        vite_dir.join("package.json"),
+        r#"{
+  "name": "vite",
+  "types": "client.d.ts"
+}"#,
+    )?;
+    std::fs::write(vite_dir.join("client.d.ts"), "")?;
+    Ok(())
+}

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -261,6 +261,13 @@ impl BatchTypeChecker {
         self.project.virtual_files_sorted()
     }
 
+    /// Access the shared helpers preamble when this checker generated one.
+    pub fn shared_helpers_preamble(&self) -> Option<&'static str> {
+        self.project
+            .uses_shared_helpers()
+            .then_some(crate::virtual_ts::SHARED_PREAMBLE_DTS)
+    }
+
     /// Emit declaration files for the scanned project.
     pub fn emit_declarations(
         &self,

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -89,7 +89,7 @@ impl VirtualProject {
         self.dialect = dialect;
     }
 
-    pub(super) fn uses_shared_helpers(&self) -> bool {
+    pub(crate) fn uses_shared_helpers(&self) -> bool {
         !self.legacy_vue2
             && !matches!(
                 self.dialect,


### PR DESCRIPTION
## Summary

- Only show `__vize_helpers.d.ts` in `--show-virtual-ts` when the batch checker actually generated a shared helper preamble.
- Keep legacy Vue 2 virtual TS on the per-file helper path so inspection output does not include Vue 3-only `import('vue')` helper references.
- Add a dedicated CLI regression with Vue 2.6-style `vue` types to ensure legacy output avoids `Ref`, `ShallowRef`, `ComponentPublicInstance`, and `defineComponent` helper imports.

## Root Cause

Legacy Vue 2 mode already skipped materializing the shared helper file and used per-file Vue 2-compatible helpers. The direct CLI display path still printed the global Vue 3 shared preamble unconditionally, so `--show-virtual-ts` could still contain Vue 3-only helper types even when the checker did not generate that shared helper file.

Fixes #1893.

## Verification

- `cargo test -p vize_canon legacy_vue2_virtual_ts_avoids_vue3_only_helper_exports -- --nocapture`
- `cargo test -p vize --lib cli::tests::check_help_snapshot -- --nocapture`
- `cargo test -p vize --features legacy --test check_legacy_vue2_helpers_cli check_legacy_vue2_show_virtual_ts_omits_shared_helpers -- --nocapture`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --cached --check && git diff --check`
