### PR TITLE
fix(config): expose jsxTypecheck typings

### DIFF
--- a/npm/cli/pkl/jsonschema/generate.pkl
+++ b/npm/cli/pkl/jsonschema/generate.pkl
@@ -15,7 +15,6 @@ local stringListDef: JsonSchema = new JsonSchema {
   type = "array"
   items = new JsonSchema { type = "string" }
 }
-
 local configExtendsDef: JsonSchema = new JsonSchema {
   description = "Base config files or presets to compose"
   oneOf = new Listing {
@@ -23,7 +22,6 @@ local configExtendsDef: JsonSchema = new JsonSchema {
     stringListDef
   }
 }
-
 local compilerConfigDef: JsonSchema = new JsonSchema {
   type = "object"
   description = "Vue compiler options"
@@ -99,7 +97,6 @@ local compilerConfigDef: JsonSchema = new JsonSchema {
   }
   additionalProperties = false
 }
-
 local vitePluginConfigDef: JsonSchema = new JsonSchema {
   type = "object"
   description = "Vite plugin options"
@@ -137,7 +134,6 @@ local vitePluginConfigDef: JsonSchema = new JsonSchema {
   }
   additionalProperties = false
 }
-
 local linterConfigDef: JsonSchema = new JsonSchema {
   type = "object"
   description = "Linter options"
@@ -232,6 +228,11 @@ local typeCheckerConfigDef: JsonSchema = new JsonSchema {
       description = "Enable Vue 2.7 / Nuxt 2 Options API template binding support"
       default = false
     }
+    ["jsxTypecheck"] = new JsonSchema {
+      type = "boolean"
+      description = "Opt-in type-checking of .jsx/.tsx Vue components (#1497). Default-off so mixed Vue/React repositories do not accidentally route React .tsx through the Vue JSX checker. Set to true to route .jsx/.tsx through the Vize JSX virtual-TS path."
+      default = false
+    }
     ["tsconfig"] = new JsonSchema {
       type = "string"
       description = "Path to tsconfig.json"
@@ -255,7 +256,6 @@ local typeCheckerConfigDef: JsonSchema = new JsonSchema {
   }
   additionalProperties = false
 }
-
 local formatterConfigDef: JsonSchema = new JsonSchema {
   type = "object"
   description = "Formatter options"

--- a/npm/cli/src/types/generated.ts
+++ b/npm/cli/src/types/generated.ts
@@ -239,21 +239,21 @@ export interface TypeCheckerConfig {
    * Check fallthrough attrs on multi-root templates
    */
   checkFallthroughAttrs?: boolean;
-  /**
-   * Resolve Vue 3 Options API template bindings (data/computed/methods/inject/setup/props) during type checking. Opt-in; available in the standard build (not a legacy feature).
-   */
+  /** Resolve Vue 3 Options API template bindings during type checking. */
   optionsApi?: boolean;
   /**
    * Enable Vue 2.7 / Nuxt 2 Options API template binding support
    */
   legacyVue2?: boolean;
   /**
+   * Opt-in type-checking of .jsx/.tsx Vue components (#1497). Default-off so mixed Vue/React repositories do not accidentally route React .tsx through the Vue JSX checker. Set to true to route .jsx/.tsx through the Vize JSX virtual-TS path.
+   */
+  jsxTypecheck?: boolean;
+  /**
    * Path to tsconfig.json
    */
   tsconfig?: string;
-  /**
-   * Path to the Corsa executable. This is the canonical runtime key; tsgoPath is kept as a compatibility alias.
-   */
+  /** Path to the Corsa executable. tsgoPath is kept as a compatibility alias. */
   corsaPath?: string;
   /**
    * Deprecated alias for typeChecker.corsaPath

--- a/tests/tooling/config-json-shape.test.ts
+++ b/tests/tooling/config-json-shape.test.ts
@@ -113,3 +113,34 @@ test("type-aware lint opt-in is exposed across config artifacts", () => {
   assert.match(pklCompatConfig, /typeAware: Boolean\? = null/);
   assert.match(pklSchemaGenerator, /\["typeAware"\] = new JsonSchema/);
 });
+
+test("JSX type-check opt-in is exposed across config artifacts", () => {
+  const schema = JSON.parse(
+    fs.readFileSync(path.join("npm", "cli", "schemas", "vize.config.schema.json"), "utf8"),
+  ) as {
+    definitions: {
+      TypeCheckerConfig: {
+        properties: Record<string, { type?: string; description?: string }>;
+      };
+    };
+  };
+  const generatedTypes = fs.readFileSync(
+    path.join("npm", "cli", "src", "types", "generated.ts"),
+    "utf8",
+  );
+  const pklTypeCheckerConfig = fs.readFileSync(
+    path.join("npm", "cli", "pkl", "TypeCheckerConfig.pkl"),
+    "utf8",
+  );
+  const pklCompatConfig = fs.readFileSync(path.join("npm", "cli", "pkl", "vize.pkl"), "utf8");
+  const pklSchemaGenerator = fs.readFileSync(
+    path.join("npm", "cli", "pkl", "jsonschema", "generate.pkl"),
+    "utf8",
+  );
+
+  assert.equal(schema.definitions.TypeCheckerConfig.properties.jsxTypecheck.type, "boolean");
+  assert.match(generatedTypes, /jsxTypecheck\?: boolean;/);
+  assert.match(pklTypeCheckerConfig, /jsxTypecheck: Boolean = false/);
+  assert.match(pklCompatConfig, /jsxTypecheck: Boolean\? = null/);
+  assert.match(pklSchemaGenerator, /\["jsxTypecheck"\] = new JsonSchema/);
+});


### PR DESCRIPTION
## Summary
- expose `typeChecker.jsxTypecheck` in the generated public TypeScript config type
- keep the secondary Pkl JSON schema generator in sync for `optionsApi` and `jsxTypecheck`
- add a tooling regression test that checks schema, Pkl, generated types, and generator wiring stay aligned

## Root cause
`jsxTypecheck` existed in the public schema and Pkl config, but the generated TypeScript declaration and schema generator artifacts were stale, so `defineConfig()` rejected the documented key.

## Validation
- `node --test tests/tooling/config-json-shape.test.ts`

Closes #2064

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->