### PR TITLE
fix(patina): gate compat preset rules

### DIFF
--- a/crates/vize/src/commands/lint/mod.rs
+++ b/crates/vize/src/commands/lint/mod.rs
@@ -47,24 +47,20 @@ pub fn run(args: LintArgs) {
     let render_details = should_render_lint_details(format, args.quiet);
     crate::config::write_schema(None);
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let (loaded_config, linter_config) = if args.no_config {
+    let (loaded_config, linter_config, linter_features) = if args.no_config {
         (
-            crate::config::LoadedConfigWithFeatures {
-                config: crate::config::VizeConfig::default(),
-                source_path: None,
-                features: crate::config::ConfigFeatureFlags::default(),
-            },
+            crate::config::LoadedConfigWithFeatures::default(),
             crate::config::LinterConfig::default(),
+            crate::config::LinterFeatureFlags::default(),
         )
     } else {
-        crate::config::load_config_and_linter_with_features_and_source(args.config.as_deref())
+        crate::config::load_config_and_linter_with_lint_features_and_source(args.config.as_deref())
     };
     let config_dir = loaded_config
         .source_path
         .as_deref()
         .and_then(Path::parent)
         .unwrap_or(cwd.as_path());
-    let vue_version = loaded_config.features.vue_version;
     let config = loaded_config.config;
     if !linter_config.enabled {
         eprintln!("[vize] Skipping lint because linter.enabled is false in vize.config.");
@@ -105,7 +101,8 @@ pub fn run(args: LintArgs) {
         .with_disabled_rules(linter_config.disabled_rules())
         .with_help_level(help_level)
         .with_type_aware_lint(type_aware_enabled)
-        .with_vue_version(vue_version);
+        .with_vue_version(linter_features.vue_version)
+        .with_vapor_mode(linter_features.vapor);
     #[cfg(not(target_arch = "wasm32"))]
     {
         linter = linter.with_corsa_path(configured_corsa_path);

--- a/crates/vize/tests/lint_config_cli.rs
+++ b/crates/vize/tests/lint_config_cli.rs
@@ -137,3 +137,103 @@ const items = [{ id: 1, name: 'One' }]
 
     let _ = fs::remove_dir_all(project_root);
 }
+
+#[test]
+fn lint_compiler_compatibility_vue2_allows_template_v_for_key_on_child() {
+    let project_root = temp_project_dir("compat-vue2-v-for-child-key");
+    let sfc = r#"<script setup>
+const items = [{ id: 1, name: 'One' }]
+</script>
+
+<template>
+  <template v-for="item in items">
+    <div :key="item.id">{{ item.name }}</div>
+  </template>
+</template>
+"#;
+    write_project_file(&project_root, "src/App.vue", sfc);
+    write_project_file(
+        &project_root,
+        "vize.config.json",
+        r#"{ "compiler": { "compatibility": { "vueVersion": "2" } } }"#,
+    );
+
+    let compat_vue2 = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["lint", "--config", "vize.config.json", "src/App.vue"])
+        .output()
+        .unwrap();
+    assert!(
+        compat_vue2.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compat_vue2.stdout),
+        String::from_utf8_lossy(&compat_vue2.stderr)
+    );
+
+    write_project_file(
+        &project_root,
+        "vize.config.json",
+        r#"{ "typeChecker": { "legacyVue2": true } }"#,
+    );
+    let legacy_vue2 = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["lint", "--config", "vize.config.json", "src/App.vue"])
+        .output()
+        .unwrap();
+    assert!(
+        legacy_vue2.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&legacy_vue2.stdout),
+        String::from_utf8_lossy(&legacy_vue2.stderr)
+    );
+
+    let _ = fs::remove_dir_all(project_root);
+}
+
+#[test]
+fn lint_nuxt_preset_allows_next_tick_when_compiler_vapor_is_false() {
+    let project_root = temp_project_dir("nuxt-non-vapor-next-tick");
+    let sfc = r#"<script setup lang="ts">
+import { nextTick } from 'vue'
+
+await nextTick()
+</script>
+"#;
+    write_project_file(&project_root, "src/Dialog.vue", sfc);
+    write_project_file(
+        &project_root,
+        "vize.config.json",
+        r#"{
+  "compiler": { "vapor": false },
+  "linter": { "preset": "nuxt" }
+}"#,
+    );
+
+    let nuxt_default = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["lint", "--preset", "nuxt", "--no-config", "src/Dialog.vue"])
+        .output()
+        .unwrap();
+    assert!(
+        !nuxt_default.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&nuxt_default.stdout),
+        String::from_utf8_lossy(&nuxt_default.stderr)
+    );
+    let default_stdout = String::from_utf8_lossy(&nuxt_default.stdout);
+    assert!(default_stdout.contains("script/no-next-tick"));
+
+    let non_vapor = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["lint", "--config", "vize.config.json", "src/Dialog.vue"])
+        .output()
+        .unwrap();
+    assert!(
+        non_vapor.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&non_vapor.stdout),
+        String::from_utf8_lossy(&non_vapor.stderr)
+    );
+
+    let _ = fs::remove_dir_all(project_root);
+}

--- a/crates/vize_carton/src/config.rs
+++ b/crates/vize_carton/src/config.rs
@@ -7,7 +7,8 @@ mod normalize;
 pub use loader::{
     LoadedConfig, LoadedConfigEntryFiles, LoadedConfigEntryIgnores, LoadedConfigWithFeatures,
     load_compiler_jsx_mode, load_compiler_template_syntax, load_compiler_vue_version, load_config,
-    load_config_and_linter_with_features_and_source, load_config_and_linter_with_source,
+    load_config_and_linter_with_features_and_source,
+    load_config_and_linter_with_lint_features_and_source, load_config_and_linter_with_source,
     load_config_entry_files_with_source, load_config_entry_ignores_with_source,
     load_config_with_features_and_source, load_config_with_source, load_linter_config,
     validate_explicit_config_path,
@@ -15,8 +16,8 @@ pub use loader::{
 pub use model::{
     ArrowParens, AttributeSortOrder, ConfigEntryFiles, ConfigEntryIgnore, ConfigFeatureFlags,
     EndOfLine, FormatterConfig, GlobalTypeDeclaration, GlobalTypesConfig, JsxMode,
-    LanguageServerConfig, LintRuleSeverity, LinterConfig, LspConfig, ParseVueVersionError,
-    QuoteProps, TrailingComma, TypeCheckerConfig, VizeConfig, VueVersion,
+    LanguageServerConfig, LintRuleSeverity, LinterConfig, LinterFeatureFlags, LspConfig,
+    ParseVueVersionError, QuoteProps, TrailingComma, TypeCheckerConfig, VizeConfig, VueVersion,
 };
 pub use normalize::normalize_public_config_value;
 

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -7,6 +7,7 @@
 
 mod discovery;
 mod js;
+mod lint_features;
 mod parse;
 mod pkl;
 #[cfg(test)]
@@ -21,6 +22,8 @@ use super::model::{
     ConfigEntryFiles, ConfigEntryIgnore, ConfigFeatureFlags, LinterConfig, RawVizeConfig,
     VizeConfig,
 };
+
+pub use lint_features::load_config_and_linter_with_lint_features_and_source;
 
 const CONFIG_FILE_NAMES: [&str; 5] = [
     "vize.config.pkl",
@@ -40,7 +43,7 @@ pub struct LoadedConfig {
 }
 
 /// Loaded config with auxiliary feature flags.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct LoadedConfigWithFeatures {
     /// Effective configuration with defaults applied.
     pub config: VizeConfig,

--- a/crates/vize_carton/src/config/loader/lint_features.rs
+++ b/crates/vize_carton/src/config/loader/lint_features.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+
+use super::{LoadedConfigWithFeatures, load_linter_from_raw_config, load_raw_config_with_source};
+use crate::config::{LinterConfig, LinterFeatureFlags};
+
+/// Load configuration, feature flags, linter settings, and lint-only compatibility in one pass.
+pub fn load_config_and_linter_with_lint_features_and_source(
+    path: Option<&Path>,
+) -> (LoadedConfigWithFeatures, LinterConfig, LinterFeatureFlags) {
+    let loaded = load_raw_config_with_source(path);
+    let compiler_compatibility_vue_version = loaded.config.compiler.compatibility.vue_version;
+    let compiler_vapor = loaded.config.compiler.vapor;
+    let linter = load_linter_from_raw_config(&loaded.config);
+    let (config, features) = loaded.config.into_config_and_features();
+    let linter_features = LinterFeatureFlags::from_config_features(
+        features,
+        compiler_compatibility_vue_version,
+        compiler_vapor,
+    );
+
+    (
+        LoadedConfigWithFeatures {
+            config,
+            source_path: loaded.source_path,
+            features,
+        },
+        linter,
+        linter_features,
+    )
+}

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -109,6 +109,34 @@ impl Default for ConfigFeatureFlags {
     }
 }
 
+/// Lint-only feature switches derived from config compatibility keys.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LinterFeatureFlags {
+    pub vue_version: Option<VueVersion>,
+    pub vapor: Option<bool>,
+}
+
+impl LinterFeatureFlags {
+    pub(crate) fn from_config_features(
+        features: ConfigFeatureFlags,
+        compiler_compatibility_vue_version: Option<VueVersion>,
+        compiler_vapor: Option<bool>,
+    ) -> Self {
+        let vue_version = features
+            .vue_version
+            .or(compiler_compatibility_vue_version)
+            .or_else(|| {
+                (features.type_checker_legacy_vue2
+                    || features.language_server_legacy_vue2 == Some(true))
+                .then_some(VueVersion::V2_7)
+            });
+        Self {
+            vue_version,
+            vapor: compiler_vapor,
+        }
+    }
+}
+
 /// Raw config representation with legacy aliases preserved for migration.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]

--- a/crates/vize_carton/src/config/model/compiler.rs
+++ b/crates/vize_carton/src/config/model/compiler.rs
@@ -2,6 +2,8 @@
 
 use serde::Deserialize;
 
+use super::vue::VueVersion;
+
 /// Template syntax compatibility mode from `compiler.templateSyntax`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -49,9 +51,18 @@ impl JsxMode {
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
+pub(crate) struct RawCompilerCompatibilityConfig {
+    pub(crate) vue_version: Option<VueVersion>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
 pub(crate) struct RawCompilerConfig {
+    /// Explicit SFC Vapor mode switch from `compiler.vapor`.
+    pub(crate) vapor: Option<bool>,
     pub(crate) template_syntax: Option<RawTemplateSyntaxConfig>,
     /// Default JSX output mode (`compiler.jsxMode`); `None` when absent, which
     /// the JSX entry points treat as VDOM.
     pub(crate) jsx_mode: Option<JsxMode>,
+    pub(crate) compatibility: RawCompilerCompatibilityConfig,
 }

--- a/crates/vize_carton/tests/linter_features.rs
+++ b/crates/vize_carton/tests/linter_features.rs
@@ -1,0 +1,43 @@
+use vize_carton::config::{VueVersion, load_config_and_linter_with_lint_features_and_source};
+
+#[test]
+fn linter_features_read_compiler_compatibility_vue_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(
+        &config_path,
+        r#"{ "compiler": { "compatibility": { "vueVersion": "2" } } }"#,
+    )
+    .unwrap();
+
+    let (loaded, _, linter_features) =
+        load_config_and_linter_with_lint_features_and_source(Some(&config_path));
+
+    assert_eq!(loaded.features.vue_version, None);
+    assert_eq!(linter_features.vue_version, Some(VueVersion::V2));
+}
+
+#[test]
+fn linter_features_read_explicit_compiler_vapor_false() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(&config_path, r#"{ "compiler": { "vapor": false } }"#).unwrap();
+
+    let (_, _, linter_features) =
+        load_config_and_linter_with_lint_features_and_source(Some(&config_path));
+
+    assert_eq!(linter_features.vapor, Some(false));
+}
+
+#[test]
+fn linter_features_read_legacy_vue2_flags() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(&config_path, r#"{ "typeChecker": { "legacyVue2": true } }"#).unwrap();
+
+    let (loaded, _, linter_features) =
+        load_config_and_linter_with_lint_features_and_source(Some(&config_path));
+
+    assert!(loaded.features.type_checker_legacy_vue2);
+    assert_eq!(linter_features.vue_version, Some(VueVersion::V2_7));
+}

--- a/crates/vize_patina/src/linter.rs
+++ b/crates/vize_patina/src/linter.rs
@@ -5,6 +5,7 @@
 //! - [`config`]: `Linter` struct, builder methods, and `LintResult`
 //! - [`engine`]: Core linting methods and template extraction
 
+mod compatibility;
 mod config;
 #[cfg(not(target_arch = "wasm32"))]
 mod corsa_session;

--- a/crates/vize_patina/src/linter/compatibility.rs
+++ b/crates/vize_patina/src/linter/compatibility.rs
@@ -1,0 +1,26 @@
+use super::config::Linter;
+use vize_carton::{String, config::VueVersion};
+
+impl Linter {
+    /// Apply project-wide Vue dialect compatibility to lint rules.
+    #[inline]
+    pub fn with_vue_version(mut self, version: Option<VueVersion>) -> Self {
+        if version.is_some_and(VueVersion::is_legacy) {
+            self.disabled_rules
+                .insert(String::from("vue/no-v-for-template-key-on-child"));
+        }
+        self
+    }
+
+    /// Apply project-wide SFC Vapor mode to lint rules.
+    #[inline]
+    pub fn with_vapor_mode(mut self, enabled: Option<bool>) -> Self {
+        if enabled == Some(false) {
+            self.disabled_rules
+                .insert(String::from("script/no-get-current-instance"));
+            self.disabled_rules
+                .insert(String::from("script/no-next-tick"));
+        }
+        self
+    }
+}

--- a/crates/vize_patina/src/linter/config.rs
+++ b/crates/vize_patina/src/linter/config.rs
@@ -17,7 +17,7 @@ use crate::{
 use std::path::PathBuf;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::Mutex;
-use vize_carton::{FxHashSet, String, config::VueVersion, i18n::Locale};
+use vize_carton::{FxHashSet, String, i18n::Locale};
 
 /// Lint result for a single file.
 #[derive(Debug, Clone)]
@@ -241,16 +241,6 @@ impl Linter {
     #[inline]
     pub fn with_disabled_rules(mut self, rules: Vec<String>) -> Self {
         self.disabled_rules = rules.into_iter().collect();
-        self
-    }
-
-    /// Apply project-wide Vue dialect compatibility to lint rules.
-    #[inline]
-    pub fn with_vue_version(mut self, version: Option<VueVersion>) -> Self {
-        if version.is_some_and(VueVersion::is_legacy) {
-            self.disabled_rules
-                .insert(String::from("vue/no-v-for-template-key-on-child"));
-        }
         self
     }
 

--- a/crates/vize_patina/src/linter/tests/nuxt.rs
+++ b/crates/vize_patina/src/linter/tests/nuxt.rs
@@ -19,3 +19,45 @@ export default defineComponent({
     assert_eq!(result.error_count, 0);
     assert_eq!(result.warning_count, 0);
 }
+
+#[test]
+fn nuxt_preset_allows_next_tick_when_vapor_is_explicitly_disabled() {
+    let linter = Linter::with_preset(LintPreset::Nuxt).with_vapor_mode(Some(false));
+    let sfc = r#"<script setup lang="ts">
+import { nextTick } from 'vue'
+
+await nextTick()
+</script>
+"#;
+    let result = linter.lint_sfc(sfc, "components/Dialog.vue");
+
+    assert!(
+        !result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.rule_name == "script/no-next-tick"),
+        "non-Vapor Nuxt projects should not report script/no-next-tick, got {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn nuxt_preset_keeps_next_tick_diagnostic_when_vapor_is_unspecified() {
+    let linter = Linter::with_preset(LintPreset::Nuxt);
+    let sfc = r#"<script setup lang="ts">
+import { nextTick } from 'vue'
+
+await nextTick()
+</script>
+"#;
+    let result = linter.lint_sfc(sfc, "components/Dialog.vue");
+
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.rule_name == "script/no-next-tick"),
+        "default Nuxt preset should remain unchanged, got {:?}",
+        result.diagnostics
+    );
+}


### PR DESCRIPTION
## Summary
- thread compiler compatibility and explicit Vapor mode config into lint-only feature flags without changing existing public config structs
- disable Vue 3 template v-for key placement rule for legacy Vue compatibility signals
- disable Vapor-only Nuxt script rules when compiler.vapor is explicitly false

Closes #2062.
Closes #2067.

## Tests
- cargo test -p vize_carton --test linter_features -- --nocapture
- cargo test -p vize_patina nuxt_preset -- --nocapture
- cargo test -p vize --test lint_config_cli -- --nocapture
- cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
- cargo semver-checks -p vize_carton
- node --test tests/tooling/source-file-lengths.test.ts