### PR TITLE
test(glyph): cover root-relative entry TS files

### DIFF
--- a/crates/vize/tests/fmt_config_cli.rs
+++ b/crates/vize/tests/fmt_config_cli.rs
@@ -115,6 +115,41 @@ fn fmt_check_supports_root_relative_art_vue_paths_for_config_entries() {
 }
 
 #[test]
+fn fmt_check_supports_root_relative_ts_paths_for_config_entries() {
+    let project = tempfile::tempdir().unwrap();
+    write_project_file(
+        project.path(),
+        "vize.config.ts",
+        r#"export default {
+  entries: [
+    { name: "app", basePath: ".", files: ["*.ts", "components/**/*.vue"] },
+    { name: "scripts", basePath: "scripts", files: ["**/*.ts"] },
+  ],
+}
+"#,
+    );
+    write_project_file(project.path(), "scripts/lint.ts", "export   const ok=1\n");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args([
+            "fmt",
+            "--config",
+            "vize.config.ts",
+            "--check",
+            "scripts/lint.ts",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Found 1 file(s)"), "{stderr}");
+    assert!(stderr.contains("Would reformat: scripts/lint.ts"), "{stderr}");
+    assert!(!stderr.contains("No .vue"), "{stderr}");
+}
+
+#[test]
 fn fmt_check_resolves_entry_relative_art_vue_paths_from_monorepo_root() {
     let project = tempfile::tempdir().unwrap();
     write_entry_ts_config(project.path());

--- a/crates/vize/tests/fmt_config_cli.rs
+++ b/crates/vize/tests/fmt_config_cli.rs
@@ -145,7 +145,10 @@ fn fmt_check_supports_root_relative_ts_paths_for_config_entries() {
     assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("Found 1 file(s)"), "{stderr}");
-    assert!(stderr.contains("Would reformat: scripts/lint.ts"), "{stderr}");
+    assert!(
+        stderr.contains("Would reformat: scripts/lint.ts"),
+        "{stderr}"
+    );
     assert!(!stderr.contains("No .vue"), "{stderr}");
 }
 


### PR DESCRIPTION
## Summary
- add a regression test for fmt with vize.config.ts entries, basePath: "scripts", and explicit root-relative scripts/lint.ts input
- verify the command reports the matched file instead of the empty explicit-pattern failure

Closes #2065.

## Tests
- cargo test -p vize --test fmt_config_cli fmt_check_supports_root_relative_ts_paths_for_config_entries -- --nocapture
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->