### PR TITLE
fix(canon): expose setup props in template scope

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -9,6 +9,7 @@ use vize_atelier_core::TemplateSyntaxMode;
 use vize_carton::cstr;
 mod graphql_generated;
 mod ref_arity;
+mod setup_props;
 mod tsconfig_native_options;
 mod windows_paths;
 fn unique_case_dir(name: &str) -> PathBuf {
@@ -30,7 +31,6 @@ fn assert_ts_parses(source: &str) {
         parsed.errors
     );
 }
-
 fn assert_tsx_parses(source: &str) {
     let allocator = oxc_allocator::Allocator::default();
     let parsed = oxc_parser::Parser::new(&allocator, source, oxc_span::SourceType::tsx()).parse();

--- a/crates/vize_canon/src/batch/virtual_project/tests/setup_props.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/setup_props.rs
@@ -1,0 +1,113 @@
+use std::fs;
+
+use crate::virtual_ts::VirtualTsOptions;
+
+use super::unique_case_dir;
+
+#[test]
+fn document_generator_exposes_with_defaults_props_to_template_scope() {
+    let case_dir = unique_case_dir("with-defaults-template-props");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(&case_dir).unwrap();
+    let vue_path = case_dir.join("AfsSnackbar.vue");
+    let vue_content = r#"<script setup lang="ts">
+interface Props {
+  isOpened: boolean
+  title: string
+  timeout?: number
+  interaction?:
+    | { text: string; to: string; event?: never }
+    | { text: string; event: () => void; to?: never }
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  timeout: 4000
+})
+
+void props
+</script>
+
+<template>
+  <AfsButton v-if="interaction?.to" :to="interaction.to">
+    {{ title }} {{ interaction.text }}
+  </AfsButton>
+  <span v-if="isOpened">{{ title }}</span>
+</template>
+"#;
+
+    let rewriter = super::super::super::import_rewriter::ImportRewriter::new();
+    let virtual_ts = super::super::generate_vue_document_virtual_ts(
+        &vue_path,
+        vue_content,
+        &VirtualTsOptions::default(),
+        &rewriter,
+        true,
+    )
+    .unwrap()
+    .pre_rewrite_code;
+
+    for prop in ["isOpened", "title", "interaction"] {
+        assert!(
+            virtual_ts.contains(&format!(r#"const {prop} = props["{prop}"]"#)),
+            "top-level prop `{prop}` must be emitted for template scope:\n{virtual_ts}"
+        );
+    }
+    for member in ["to", "event", "text"] {
+        assert!(
+            !virtual_ts.contains(&format!(r#"const {member} = props["{member}"]"#)),
+            "union member `{member}` must not be emitted as a top-level prop:\n{virtual_ts}"
+        );
+    }
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn legacy_document_generator_exposes_inline_define_props_to_template_scope() {
+    let case_dir = unique_case_dir("legacy-inline-template-props");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(&case_dir).unwrap();
+    let vue_path = case_dir.join("DialogHost.vue");
+    let vue_content = r#"<script setup lang="ts">
+type TargetStudent = { id: number; username: string; name: string };
+
+const props = withDefaults(defineProps<{
+  targetStudent?: TargetStudent | null
+}>(), {
+  targetStudent: null,
+})
+
+void props
+</script>
+
+<template>
+  <PlainDialog :is-opened="targetStudent !== null">
+    {{ targetStudent?.username ?? '--' }}
+  </PlainDialog>
+</template>
+"#;
+
+    let rewriter = super::super::super::import_rewriter::ImportRewriter::new();
+    let virtual_ts = super::super::generate_vue_document_virtual_ts_with_options(
+        &vue_path,
+        vue_content,
+        &VirtualTsOptions::default(),
+        &rewriter,
+        true,
+        super::super::VueDocumentVirtualTsOptions {
+            legacy_vue2: true,
+            options_api: false,
+        },
+    )
+    .unwrap()
+    .pre_rewrite_code;
+
+    assert!(
+        virtual_ts.contains(
+            r#"const targetStudent = props["targetStudent"] as Exclude<__WithDefaultsResult<Props, Pick<Props, "targetStudent">>["targetStudent"], undefined>;"#
+        ),
+        "legacy Vue2 template scope must expose inline defineProps keys:\n{virtual_ts}"
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -1,5 +1,6 @@
 mod setup_scoped;
 mod template_bindings;
+mod template_names;
 use super::helpers::{is_reserved_identifier, to_safe_identifier};
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{Argument, Expression, ObjectPropertyKind, PropertyKey};
@@ -7,7 +8,8 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use setup_scoped::props_type_ref;
 pub(crate) use setup_scoped::{PropsTypeEmission, generate_setup_scoped_props_artifact};
-use template_bindings::should_skip_template_prop_binding;
+use template_bindings::{emit_macro_template_prop_bindings, should_skip_template_prop_binding};
+pub(crate) use template_names::collect_template_prop_names;
 use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::append;
@@ -60,6 +62,7 @@ fn emit_unchecked_template_prop_binding(ts: &mut String, prop_name: &str) {
     );
     append!(*ts, "  void {binding_name};\n");
 }
+
 fn can_emit_keyed_template_prop_binding(prop_name: &str) -> bool {
     let mut chars = prop_name.chars();
     let Some(first) = chars.next() else {
@@ -418,21 +421,7 @@ pub(crate) fn generate_props_variables(
         ts.push_str("  void props; // Mark as used to avoid TS6133\n");
 
         let mut emitted_names = FxHashSet::default();
-        if has_props {
-            // Runtime-declared props: generate individual variables
-            for prop in props {
-                if should_skip_template_prop_binding(summary, prop.name.as_str()) {
-                    continue;
-                }
-                emit_template_prop_binding(
-                    ts,
-                    template_props_type_ref.as_str(),
-                    prop.name.as_str(),
-                    prop.default_value.is_some() || defaulted_prop_names.contains(&prop.name),
-                );
-                emitted_names.insert(prop.name.as_str().into());
-            }
-        } else if let Some(type_args) = define_props_type_args {
+        if let Some(type_args) = define_props_type_args {
             // Type-only defineProps<TypeName>(): extract fields
             // type_args may include angle brackets (e.g., "<Props>", "<Foo<T>>"), strip outer pair
             let type_name = strip_outer_angle_brackets(type_args.trim());
@@ -445,17 +434,28 @@ pub(crate) fn generate_props_variables(
             let type_properties = summary
                 .types
                 .extract_properties(type_reference_lookup_key(type_name));
-            for prop in &type_properties {
-                if should_skip_template_prop_binding(summary, prop.name.as_str()) {
-                    continue;
-                }
-                emit_template_prop_binding(
+            if type_properties.is_empty() && has_props {
+                emit_macro_template_prop_bindings(
                     ts,
+                    summary,
                     template_props_type_ref.as_str(),
-                    prop.name.as_str(),
-                    defaulted_prop_names.contains(&prop.name),
+                    props,
+                    &defaulted_prop_names,
+                    &mut emitted_names,
                 );
-                emitted_names.insert(prop.name.as_str().into());
+            } else {
+                for prop in &type_properties {
+                    if should_skip_template_prop_binding(summary, prop.name.as_str()) {
+                        continue;
+                    }
+                    emit_template_prop_binding(
+                        ts,
+                        template_props_type_ref.as_str(),
+                        prop.name.as_str(),
+                        defaulted_prop_names.contains(&prop.name),
+                    );
+                    emitted_names.insert(prop.name.as_str().into());
+                }
             }
 
             if should_emit_keyed_template_prop_bindings(summary, type_name, &emitted_names) {
@@ -472,6 +472,16 @@ pub(crate) fn generate_props_variables(
                     }
                 }
             }
+        } else if has_props {
+            // Runtime-declared props: generate individual variables
+            emit_macro_template_prop_bindings(
+                ts,
+                summary,
+                template_props_type_ref.as_str(),
+                props,
+                &defaulted_prop_names,
+                &mut emitted_names,
+            );
         }
         for model in models {
             if emitted_names.contains(model.name.as_str())
@@ -489,55 +499,6 @@ pub(crate) fn generate_props_variables(
         }
         ts.push('\n');
     }
-}
-
-pub(crate) fn collect_template_prop_names(summary: &Croquis) -> FxHashSet<String> {
-    let mut names = FxHashSet::default();
-    let props = summary.macros.props();
-    if !props.is_empty() {
-        for prop in props {
-            if should_skip_template_prop_binding(summary, prop.name.as_str()) {
-                continue;
-            }
-            if !is_reserved_identifier(prop.name.as_str()) {
-                continue;
-            }
-            names.insert(prop.name.as_str().into());
-        }
-        return names;
-    }
-
-    for model in summary.macros.models() {
-        if should_skip_template_prop_binding(summary, model.name.as_str()) {
-            continue;
-        }
-        if !is_reserved_identifier(model.name.as_str()) {
-            continue;
-        }
-        names.insert(model.name.as_str().into());
-    }
-
-    let Some(type_args) = summary
-        .macros
-        .define_props()
-        .and_then(|m| m.type_args.as_ref())
-    else {
-        return names;
-    };
-    let type_name = strip_outer_angle_brackets(type_args.trim());
-    let type_properties = summary
-        .types
-        .extract_properties(type_reference_lookup_key(type_name));
-    for prop in &type_properties {
-        if should_skip_template_prop_binding(summary, prop.name.as_str()) {
-            continue;
-        }
-        if !is_reserved_identifier(prop.name.as_str()) {
-            continue;
-        }
-        names.insert(prop.name.as_str().into());
-    }
-    names
 }
 
 /// Lookup key for a `defineProps<...>` type argument when resolving its fields

--- a/crates/vize_canon/src/virtual_ts/props/template_bindings.rs
+++ b/crates/vize_canon/src/virtual_ts/props/template_bindings.rs
@@ -1,5 +1,9 @@
+use vize_carton::{FxHashSet, String};
+use vize_croquis::macros::PropDefinition;
 use vize_croquis::macros::PropsDestructuredBindings;
 use vize_croquis::{BindingType, Croquis};
+
+use super::emit_template_prop_binding;
 
 #[inline]
 pub(super) fn should_skip_template_prop_binding(summary: &Croquis, prop_name: &str) -> bool {
@@ -22,4 +26,26 @@ fn is_define_props_destructure_local(
                 .values()
                 .any(|binding| binding.local.as_str() == prop_name)
     })
+}
+
+pub(super) fn emit_macro_template_prop_bindings(
+    ts: &mut String,
+    summary: &Croquis,
+    props_type_ref: &str,
+    props: &[PropDefinition],
+    defaulted_prop_names: &FxHashSet<String>,
+    emitted_names: &mut FxHashSet<String>,
+) {
+    for prop in props {
+        if should_skip_template_prop_binding(summary, prop.name.as_str()) {
+            continue;
+        }
+        emit_template_prop_binding(
+            ts,
+            props_type_ref,
+            prop.name.as_str(),
+            prop.default_value.is_some() || defaulted_prop_names.contains(&prop.name),
+        );
+        emitted_names.insert(prop.name.as_str().into());
+    }
 }

--- a/crates/vize_canon/src/virtual_ts/props/template_names.rs
+++ b/crates/vize_canon/src/virtual_ts/props/template_names.rs
@@ -1,0 +1,46 @@
+use vize_carton::{FxHashSet, String};
+use vize_croquis::Croquis;
+
+use super::super::helpers::is_reserved_identifier;
+use super::template_bindings::should_skip_template_prop_binding;
+use super::{strip_outer_angle_brackets, type_reference_lookup_key};
+
+pub(crate) fn collect_template_prop_names(summary: &Croquis) -> FxHashSet<String> {
+    let mut names = FxHashSet::default();
+    let props = summary.macros.props();
+    let type_properties = summary
+        .macros
+        .define_props()
+        .and_then(|m| m.type_args.as_ref())
+        .map(|type_args| {
+            let type_name = strip_outer_angle_brackets(type_args.trim());
+            summary
+                .types
+                .extract_properties(type_reference_lookup_key(type_name))
+        })
+        .unwrap_or_default();
+
+    if !type_properties.is_empty() {
+        for prop in &type_properties {
+            insert_reserved_prop_name(summary, &mut names, prop.name.as_str());
+        }
+    } else if !props.is_empty() {
+        for prop in props {
+            insert_reserved_prop_name(summary, &mut names, prop.name.as_str());
+        }
+        return names;
+    }
+
+    for model in summary.macros.models() {
+        insert_reserved_prop_name(summary, &mut names, model.name.as_str());
+    }
+
+    names
+}
+
+fn insert_reserved_prop_name(summary: &Croquis, names: &mut FxHashSet<String>, name: &str) {
+    if should_skip_template_prop_binding(summary, name) || !is_reserved_identifier(name) {
+        return;
+    }
+    names.insert(name.into());
+}


### PR DESCRIPTION
## Summary
- prefer resolved type-only defineProps fields over compiler補完 macro props when generating template-scope bindings
- keep compiler補完 macro props as a fallback for unresolved type-only props
- add batch/document generator regressions for withDefaults props and legacy inline defineProps template scope

## Root Cause
`withDefaults(defineProps<Props>())` could receive an augmented macro prop from the SFC compile context for a union member such as `to`. The virtual TS generator then treated macro props as authoritative and skipped the real top-level fields from `Props`, leaving template identifiers like `isOpened`, `title`, and `interaction` unresolved.

## Validation
- cargo test -p vize_canon document_generator_exposes -- --nocapture
- cargo test -p vize_canon optional_chain_union_prop_members_are_not_template_props -- --nocapture
- cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports
- node --test tests/tooling/source-file-lengths.test.ts

Closes #2061
Closes #2068

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->