### PR TITLE
fix(musea): inject static build input in config

### DIFF
--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -156,16 +156,10 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
     },
 
     config(userConfig) {
-      return {
-        resolve: {
-          alias: {
-            vue: resolveVueRuntimeCompiler(),
-          },
-        },
-        ...(isMuseaStaticBuild()
-          ? museaStaticBuildConfig(userConfig.build?.rollupOptions?.input as StaticBuildInput)
-          : {}),
-      };
+      const staticBuildConfig = isMuseaStaticBuild()
+        ? museaStaticBuildConfig(userConfig.build?.rollupOptions?.input as StaticBuildInput)
+        : {};
+      return { resolve: { alias: { vue: resolveVueRuntimeCompiler() } }, ...staticBuildConfig };
     },
 
     options: applyMuseaStaticBuildInput,

--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -32,7 +32,9 @@ import {
   emitStaticGallery,
   isMuseaStaticBuild,
   loadStaticRuntimeModule,
+  museaStaticBuildConfig,
   resolveStaticRuntimeId,
+  type StaticBuildInput,
 } from "../static-export.js";
 
 const require = createRequire(import.meta.url);
@@ -153,13 +155,16 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
       return shouldApplyMuseaPlugin(env);
     },
 
-    config() {
+    config(userConfig) {
       return {
         resolve: {
           alias: {
             vue: resolveVueRuntimeCompiler(),
           },
         },
+        ...(isMuseaStaticBuild()
+          ? museaStaticBuildConfig(userConfig.build?.rollupOptions?.input as StaticBuildInput)
+          : {}),
       };
     },
 

--- a/npm/builder/vite-musea/src/static-build.test.ts
+++ b/npm/builder/vite-musea/src/static-build.test.ts
@@ -8,6 +8,7 @@ import { build, type Plugin, type ResolvedConfig } from "vite";
 import { staticPreviewId } from "./static-data.js";
 import {
   emitStaticGallery,
+  museaStaticBuildConfig,
   museaStaticBuildInput,
   loadStaticRuntimeModule,
   resolveStaticRuntimeId,
@@ -30,6 +31,42 @@ void test("static build input keeps user entries and names the preview runtime",
     app: "/repo/index.html",
     "musea-static-runtime": VIRTUAL_STATIC_RUNTIME,
   });
+});
+
+void test("static build config injects a runtime input when no index html exists", async () => {
+  const tempDir = await fs.promises.mkdtemp(
+    path.join(process.cwd(), ".tmp-musea-empty-static-build-"),
+  );
+  try {
+    const artFiles = new Map<string, ArtFileInfo>();
+    let resolvedConfig: ResolvedConfig | undefined;
+    const outDir = path.join(tempDir, "dist");
+
+    await build({
+      configFile: false,
+      root: tempDir,
+      logLevel: "silent",
+      build: {
+        outDir,
+        emptyOutDir: true,
+      },
+      plugins: [
+        createStaticBuildTestPlugin(
+          artFiles,
+          () => resolvedConfig,
+          (config) => {
+            resolvedConfig = config;
+          },
+        ),
+      ],
+    });
+
+    assert.equal(await fileExists(path.join(outDir, "__musea__", "index.html")), true);
+    assert.equal(await fileExists(path.join(outDir, "__musea__", "api", "static.json")), true);
+    assert.equal(await fileExists(path.join(outDir, "index.html")), true);
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 void test("static build emits previews with a callable side-effect runtime", async () => {
@@ -149,9 +186,8 @@ function createStaticBuildTestPlugin(
 ): Plugin {
   return {
     name: "musea-static-build-test",
-    options(options) {
-      options.input = museaStaticBuildInput(options.input as StaticBuildInput);
-      return null;
+    config(userConfig) {
+      return museaStaticBuildConfig(userConfig.build?.rollupOptions?.input as StaticBuildInput);
     },
     configResolved(config) {
       setConfig(config);


### PR DESCRIPTION
## Summary
- inject the Musea static runtime input from the Vite config hook during static builds
- keep the later options hook as a fallback
- add a Vite build regression that has no root index.html and still emits the static Musea gallery

## Root Cause
The plugin only mutated Rollup options in the `options` hook. Under Vite 8/Rolldown, the build can still resolve the default `index.html` entry before that mutation is effective, so projects without an app-level index fail before Musea emits its own static gallery.

## Validation
- pnpm --filter @vizejs/vite-plugin-musea exec tsx --test src/static-build.test.ts
- pnpm --filter @vizejs/vite-plugin-musea test
- pnpm --filter @vizejs/vite-plugin-musea check
- node --test tests/tooling/source-file-lengths.test.ts

Closes #2063
Closes #2070

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->