### PR TITLE
fix(builder): skip TSX during SFC precompile

### DIFF
--- a/npm/builder/vite/src/plugin/precompile.test.ts
+++ b/npm/builder/vite/src/plugin/precompile.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { compileAll, DEFAULT_PRECOMPILE_BATCH_SIZE, type VizePluginState } from "./state.ts";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const workspaceRoot = path.resolve(__dirname, "../../../..");
+const testRoot = path.join(
+  workspaceRoot,
+  "target",
+  "vize-tests",
+  "tests",
+  "vite-plugin-vize",
+  "precompile",
+);
+fs.mkdirSync(testRoot, { recursive: true });
+
+const root = fs.mkdtempSync(path.join(testRoot, "tsx-scan-"));
+const sourceRoot = path.join(root, "src");
+fs.mkdirSync(sourceRoot, { recursive: true });
+
+const appPath = path.join(sourceRoot, "App.vue");
+const storyPath = path.join(sourceRoot, "Button.stories.tsx");
+
+fs.writeFileSync(appPath, `<template><div>ok</div></template>`);
+fs.writeFileSync(
+  storyPath,
+  `type Meta = typeof Button;
+const Button = {};
+export const Basic = () => <Button />;
+`,
+);
+
+const state: VizePluginState = {
+  cache: new Map(),
+  ssrCache: new Map(),
+  collectedCss: new Map(),
+  precompileMetadata: new Map(),
+  pendingHmrUpdateTypes: new Map(),
+  isProduction: false,
+  root,
+  clientViteBase: "/",
+  serverViteBase: "/",
+  server: null,
+  filter: () => true,
+  scanPatterns: ["src/**/*.vue", "src/**/*.tsx"],
+  precompileBatchSize: DEFAULT_PRECOMPILE_BATCH_SIZE,
+  ignorePatterns: [],
+  mergedOptions: {},
+  initialized: true,
+  dynamicImportAliasRules: [],
+  cssAliasRules: [],
+  extractCss: false,
+  componentsCssFileName: "assets/vize-components.css",
+  clientViteDefine: {},
+  serverViteDefine: {},
+  logger: {
+    log() {},
+    info() {},
+    warn() {},
+    error() {},
+  } as never,
+};
+
+await compileAll(state);
+
+assert.ok(state.cache.has(appPath), "Vue scan matches should still be pre-compiled");
+assert.equal(
+  state.cache.has(storyPath),
+  false,
+  "TSX scan matches should stay out of the SFC precompile cache",
+);
+assert.equal(
+  state.precompileMetadata.has(storyPath),
+  false,
+  "TSX scan matches should not get SFC precompile metadata",
+);
+
+console.log("✅ vite-plugin-vize precompile tests passed!");

--- a/npm/builder/vite/src/plugin/precompile.ts
+++ b/npm/builder/vite/src/plugin/precompile.ts
@@ -34,6 +34,10 @@ export interface PrecompileChunkOptions {
   metadata?: ReadonlyMap<string, PrecompileFileMetadata>;
 }
 
+export function isPrecompileSfcPath(path: string): boolean {
+  return path.endsWith(".vue");
+}
+
 export function hasFileMetadataChanged(
   previous: PrecompileFileMetadata | undefined,
   next: PrecompileFileMetadata,

--- a/npm/builder/vite/src/plugin/state.ts
+++ b/npm/builder/vite/src/plugin/state.ts
@@ -17,6 +17,7 @@ import {
   chunkPrecompileFiles,
   diffPrecompileFiles,
   type PrecompileFileMetadata,
+  isPrecompileSfcPath,
 } from "./precompile.ts";
 
 export {
@@ -26,6 +27,7 @@ export {
   chunkPrecompileFiles,
   diffPrecompileFiles,
   hasFileMetadataChanged,
+  isPrecompileSfcPath,
   normalizePrecompileBatchSize,
   type PrecompileChunkOptions,
   type PrecompileDiff,
@@ -167,9 +169,10 @@ export async function compileAll(state: VizePluginState): Promise<void> {
     ignore: state.ignorePatterns,
     absolute: true,
   });
+  const sfcFiles = files.filter(isPrecompileSfcPath);
 
   const currentMetadata = new Map<string, PrecompileFileMetadata>();
-  for (const file of files) {
+  for (const file of sfcFiles) {
     try {
       const stat = fs.statSync(file);
       currentMetadata.set(file, {
@@ -182,11 +185,11 @@ export async function compileAll(state: VizePluginState): Promise<void> {
   }
 
   const { changedFiles, deletedFiles } = diffPrecompileFiles(
-    files,
+    sfcFiles,
     currentMetadata,
     state.precompileMetadata,
   );
-  const cachedFileCount = files.length - changedFiles.length;
+  const cachedFileCount = sfcFiles.length - changedFiles.length;
 
   for (const file of deletedFiles) {
     state.cache.delete(file);
@@ -199,7 +202,7 @@ export async function compileAll(state: VizePluginState): Promise<void> {
   }
 
   state.logger.info(
-    `Pre-compiling ${files.length} Vue files... (${changedFiles.length} changed, ${cachedFileCount} cached, ${deletedFiles.length} removed)`,
+    `Pre-compiling ${sfcFiles.length} Vue files... (${changedFiles.length} changed, ${cachedFileCount} cached, ${deletedFiles.length} removed)`,
   );
 
   if (changedFiles.length === 0) {

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -12,6 +12,7 @@ import "./plugin/resolve-peer-runtime.test.ts";
 import "./plugin/resolve-vue-runtime.test.ts";
 import "./plugin/resolve-dependency-style.test.ts";
 import "./plugin/resolve.test.ts";
+import "./plugin/precompile.test.ts";
 import "./plugin/state.test.ts";
 import "./plugin/unocss.test.ts";
 import "./plugin/vite-transform.test.ts";


### PR DESCRIPTION
## Summary
- limit build-start SFC precompilation to `.vue` files after scan pattern expansion
- keep `.tsx` scan matches on the existing transform path instead of passing them to the SFC compiler
- add a regression test covering mixed `.vue` and `.tsx` scan patterns

## Tests
- node npm/builder/vite/src/plugin/precompile.test.ts
- pnpm --filter @vizejs/vite-plugin check
- pnpm --filter @vizejs/vite-plugin test
- node --test tests/tooling/source-file-lengths.test.ts

Closes #2069

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->