### PR TITLE
fix(musea): alias only bare vue imports

### DIFF
--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -1,7 +1,6 @@
 import type { Plugin, ViteDevServer, ResolvedConfig } from "vite";
 import { transformWithEsbuild } from "vite";
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
 import { vizeConfigStore } from "@vizejs/vite-plugin";
 
@@ -27,6 +26,7 @@ import {
 } from "./virtual.js";
 import { shouldApplyMuseaPlugin } from "./apply.js";
 import { watchMuseaArtFiles } from "./watch.js";
+import { createVueRuntimeCompilerAlias } from "./vue-alias.js";
 import {
   applyMuseaStaticBuildInput,
   emitStaticGallery,
@@ -36,16 +36,6 @@ import {
   resolveStaticRuntimeId,
   type StaticBuildInput,
 } from "../static-export.js";
-
-const require = createRequire(import.meta.url);
-
-function resolveVueRuntimeCompiler(): string {
-  try {
-    return require.resolve("vue/dist/vue.esm-bundler.js");
-  } catch {
-    return "vue/dist/vue.esm-bundler.js";
-  }
-}
 
 function extractArtTagAttributes(source: string): Record<string, string | true> {
   const artTagMatch = source.match(/<art\b([\s\S]*?)>/i);
@@ -159,7 +149,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
       const staticBuildConfig = isMuseaStaticBuild()
         ? museaStaticBuildConfig(userConfig.build?.rollupOptions?.input as StaticBuildInput)
         : {};
-      return { resolve: { alias: { vue: resolveVueRuntimeCompiler() } }, ...staticBuildConfig };
+      return { resolve: { alias: [createVueRuntimeCompilerAlias()] }, ...staticBuildConfig };
     },
 
     options: applyMuseaStaticBuildInput,

--- a/npm/builder/vite-musea/src/plugin/vue-alias.test.ts
+++ b/npm/builder/vite-musea/src/plugin/vue-alias.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createVueRuntimeCompilerAlias } from "./vue-alias.js";
+
+void test("Vue runtime compiler alias only matches the bare vue import", () => {
+  const alias = createVueRuntimeCompilerAlias();
+  assert.equal(alias.find.test("vue"), true);
+  assert.equal(alias.find.test("vue/server-renderer"), false);
+  assert.equal(alias.find.test("vue/dist/vue.runtime.esm-bundler.js"), false);
+  assert.match(alias.replacement, /vue[\\/]dist[\\/]vue\.esm-bundler\.js$/);
+});

--- a/npm/builder/vite-musea/src/plugin/vue-alias.ts
+++ b/npm/builder/vite-musea/src/plugin/vue-alias.ts
@@ -1,0 +1,20 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+export interface VueRuntimeCompilerAlias {
+  find: RegExp;
+  replacement: string;
+}
+
+export function createVueRuntimeCompilerAlias(): VueRuntimeCompilerAlias {
+  return { find: /^vue$/, replacement: resolveVueRuntimeCompiler() };
+}
+
+function resolveVueRuntimeCompiler(): string {
+  try {
+    return require.resolve("vue/dist/vue.esm-bundler.js");
+  } catch {
+    return "vue/dist/vue.esm-bundler.js";
+  }
+}


### PR DESCRIPTION
## Summary
- replace Musea's broad `vue` object alias with an exact bare-import alias
- keep `vue/server-renderer` and `vue/dist/...` requests out of the runtime-compiler rewrite path
- add a regression test for Vue subpath alias safety

## Tests
- pnpm --filter @vizejs/vite-plugin-musea exec tsx --test src/plugin/vue-alias.test.ts
- pnpm --filter @vizejs/vite-plugin-musea check
- pnpm --filter @vizejs/vite-plugin-musea test
- node --test tests/tooling/source-file-lengths.test.ts

Closes #2071

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->