### PR TITLE
fix(check): skip generated declaration modules as ambient roots

### DIFF
--- a/crates/vize/src/commands/check/tsconfig_inputs/ambient.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/ambient.rs
@@ -13,6 +13,10 @@ use super::glob::normalize_input_path;
 use super::loader::TsconfigInputCache;
 use super::matching::{is_nuxt_import_manifest_path, path_has_component};
 
+mod top_level;
+
+use top_level::has_top_level_import_or_export;
+
 /// Collect ambient declaration (`.d.ts`) files that belong to the tsconfig
 /// "program" so their global types stay in scope when only a subset of files is
 /// checked explicitly (e.g. `vize check src/App.vue`).
@@ -61,6 +65,7 @@ pub(crate) fn collect_ambient_declaration_files(
             Ok(content) => {
                 !is_nuxt_import_manifest_path(path)
                     && !is_reference_manifest_declaration(&content)
+                    && contributes_ambient_declarations(&content)
                     && !declares_shadowing_ambient_module(&content)
             }
             Err(_) => false,
@@ -87,6 +92,21 @@ fn declares_shadowing_ambient_module(content: &str) -> bool {
     ambient_module_specifiers(content)
         .iter()
         .any(|specifier| is_shadowed_vue_package_specifier(specifier))
+}
+
+fn contributes_ambient_declarations(content: &str) -> bool {
+    !has_top_level_import_or_export(content)
+        || contains_declare_scope(content, "declare global")
+        || contains_declare_scope(content, "declare module")
+}
+
+fn contains_declare_scope(content: &str, needle: &str) -> bool {
+    content.match_indices(&needle).any(|(index, _)| {
+        content[..index]
+            .chars()
+            .next_back()
+            .is_none_or(|ch| !ch.is_alphanumeric() && ch != '_' && ch != '$')
+    })
 }
 
 fn ambient_module_specifiers(content: &str) -> Vec<std::string::String> {
@@ -187,19 +207,86 @@ fn is_reference_manifest_declaration(content: &str) -> bool {
     has_reference
 }
 
-fn has_top_level_import_or_export(content: &str) -> bool {
-    content.lines().any(|line| {
-        line.starts_with("import ")
-            || line.starts_with("import{")
-            || line.starts_with("export ")
-            || line.starts_with("export{")
-            || line.starts_with("export {}")
-    })
-}
-
 fn is_shadowed_vue_package_specifier(specifier: &str) -> bool {
     matches!(
         specifier,
         "vue" | "@vue/runtime-core" | "@vue/runtime-dom" | "vue-router"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_ambient_declaration_files;
+    use crate::commands::check::tsconfig_inputs::TsconfigInputCache;
+    use std::path::{Path, PathBuf};
+
+    fn write(root: &Path, rel: &str, content: &str) {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn unique_case_dir(name: &str) -> PathBuf {
+        static NEXT_CASE_ID: std::sync::atomic::AtomicUsize =
+            std::sync::atomic::AtomicUsize::new(0);
+        let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "vize-ambient-{name}-{}-{case_id}",
+            std::process::id()
+        ))
+    }
+
+    fn relative_paths(root: &Path, files: &[PathBuf]) -> Vec<String> {
+        files
+            .iter()
+            .map(|path| {
+                path.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect()
+    }
+
+    #[test]
+    fn ambient_collection_skips_export_only_generated_declaration_modules() {
+        let root = unique_case_dir("generated-dts");
+        let _ = std::fs::remove_dir_all(&root);
+        write(
+            &root,
+            "types/codegen/schema.d.ts",
+            "export enum AimQuestionDisplayKind { Text = 'TEXT' }\nexport type AimQuestion = { kind: AimQuestionDisplayKind };\n",
+        );
+        write(
+            &root,
+            "src/globals.d.ts",
+            "export {};\ndeclare global { type GlobalTabType = 'a' | 'b'; }\n",
+        );
+        write(
+            &root,
+            "src/env.d.ts",
+            "declare const APP_VERSION: string;\n",
+        );
+        write(&root, "src/shims.d.ts", "declare module '*.css';\n");
+        write(
+            &root,
+            "tsconfig.json",
+            r#"{
+  "include": ["src/**/*.d.ts", "types/codegen/schema.d.ts"]
+}"#,
+        );
+
+        let project_root = root.canonicalize().unwrap();
+        let files = collect_ambient_declaration_files(
+            &project_root,
+            Some(&project_root.join("tsconfig.json")),
+            &mut TsconfigInputCache::default(),
+        );
+
+        assert_eq!(
+            relative_paths(&project_root, &files),
+            vec!["src/env.d.ts", "src/globals.d.ts", "src/shims.d.ts"]
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
 }

--- a/crates/vize/src/commands/check/tsconfig_inputs/ambient/top_level.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/ambient/top_level.rs
@@ -1,0 +1,158 @@
+pub(super) fn has_top_level_import_or_export(content: &str) -> bool {
+    let bytes = content.as_bytes();
+    let mut index = 0;
+    let mut brace_depth = 0usize;
+    let mut at_statement_start = true;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'/' if bytes.get(index + 1) == Some(&b'/') => {
+                index = skip_line_comment(bytes, index + 2);
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                index = skip_block_comment(bytes, index + 2);
+            }
+            b'\'' | b'"' | b'`' => {
+                index = skip_quoted(bytes, index);
+            }
+            b'{' => {
+                brace_depth += 1;
+                at_statement_start = false;
+                index += 1;
+            }
+            b'}' => {
+                brace_depth = brace_depth.saturating_sub(1);
+                at_statement_start = brace_depth == 0;
+                index += 1;
+            }
+            b';' if brace_depth == 0 => {
+                at_statement_start = true;
+                index += 1;
+            }
+            ch if ch.is_ascii_whitespace() => {
+                index += 1;
+            }
+            _ if brace_depth == 0 && at_statement_start => {
+                if starts_with_statement_keyword(bytes, index, b"import")
+                    || starts_with_statement_keyword(bytes, index, b"export")
+                {
+                    return true;
+                }
+                at_statement_start = false;
+                index = skip_token(bytes, index);
+            }
+            _ => {
+                index += 1;
+            }
+        }
+    }
+
+    false
+}
+
+fn starts_with_statement_keyword(bytes: &[u8], index: usize, keyword: &[u8]) -> bool {
+    if !bytes[index..].starts_with(keyword) {
+        return false;
+    }
+    let after = index + keyword.len();
+    if bytes
+        .get(after)
+        .is_some_and(|ch| is_identifier_continue(*ch))
+    {
+        return false;
+    }
+
+    match keyword {
+        b"import" => bytes
+            .get(after)
+            .is_some_and(|ch| ch.is_ascii_whitespace() || matches!(ch, b'{' | b'*' | b'\'' | b'"')),
+        b"export" => bytes
+            .get(after)
+            .is_some_and(|ch| ch.is_ascii_whitespace() || matches!(ch, b'{' | b'*' | b'=')),
+        _ => false,
+    }
+}
+
+fn skip_line_comment(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() && bytes[index] != b'\n' {
+        index += 1;
+    }
+    index
+}
+
+fn skip_block_comment(bytes: &[u8], mut index: usize) -> usize {
+    while index + 1 < bytes.len() && !(bytes[index] == b'*' && bytes[index + 1] == b'/') {
+        index += 1;
+    }
+    (index + 2).min(bytes.len())
+}
+
+fn skip_quoted(bytes: &[u8], mut index: usize) -> usize {
+    let quote = bytes[index];
+    index += 1;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\\' => {
+                index = (index + 2).min(bytes.len());
+            }
+            ch if ch == quote => {
+                return index + 1;
+            }
+            _ => {
+                index += 1;
+            }
+        }
+    }
+    bytes.len()
+}
+
+fn skip_token(bytes: &[u8], mut index: usize) -> usize {
+    if !is_identifier_start(bytes[index]) {
+        return index + 1;
+    }
+    index += 1;
+    while index < bytes.len() && is_identifier_continue(bytes[index]) {
+        index += 1;
+    }
+    index
+}
+
+fn is_identifier_start(ch: u8) -> bool {
+    ch.is_ascii_alphabetic() || ch == b'_' || ch == b'$'
+}
+
+fn is_identifier_continue(ch: u8) -> bool {
+    is_identifier_start(ch) || ch.is_ascii_digit()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_top_level_import_or_export;
+
+    #[test]
+    fn nested_exports_do_not_make_ambient_declarations_external_modules() {
+        assert!(!has_top_level_import_or_export(
+            "declare module \"vue\" {\n  export interface GlobalComponents {}\n}\n",
+        ));
+        assert!(!has_top_level_import_or_export(
+            "declare global { export interface Window { appVersion: string } }\n",
+        ));
+        assert!(!has_top_level_import_or_export(
+            "type VueComponent = import('vue').Component;\n",
+        ));
+    }
+
+    #[test]
+    fn top_level_imports_and_exports_make_declarations_external_modules() {
+        assert!(has_top_level_import_or_export(
+            "import \"vue\";\ndeclare module \"vue\" { export interface GlobalComponents {} }\n",
+        ));
+        assert!(has_top_level_import_or_export(
+            "declare namespace Local { export interface Thing {} }\nexport type Named = string;\n",
+        ));
+        assert!(has_top_level_import_or_export("export{};\n"));
+        assert!(has_top_level_import_or_export(
+            "/* comment */\nexport enum GeneratedKind { A = 'A' }\n",
+        ));
+    }
+}

--- a/crates/vize/tests/check_canon_graphql_cli.rs
+++ b/crates/vize/tests/check_canon_graphql_cli.rs
@@ -88,16 +88,16 @@ fn check_explicit_vue_keeps_generated_graphql_schema_out_of_canon() {
     },
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "types/**/*.d.ts"]
 }"#,
     )
     .unwrap();
 
-    let schema_path = project_root.join("types/codegen/schema.ts");
-    let schema_specifier = schema_path
-        .with_extension("")
-        .to_string_lossy()
-        .replace('\\', "/");
+    let schema_path = project_root.join("types/codegen/schema.d.ts");
+    let schema_path_text = schema_path.to_string_lossy().replace('\\', "/");
+    let schema_specifier = schema_path_text
+        .strip_suffix(".d.ts")
+        .expect("schema path should end with .d.ts");
     std::fs::create_dir_all(schema_path.parent().unwrap()).unwrap();
     std::fs::write(
         &schema_path,
@@ -168,7 +168,7 @@ expectQuestion(question)
     );
     assert!(
         !project_root
-            .join("node_modules/.vize/canon/types/codegen/schema.ts")
+            .join("node_modules/.vize/canon/types/codegen/schema.d.ts")
             .exists()
     );
 


### PR DESCRIPTION
## Summary
- keep export-only `.d.ts` modules out of the ambient declaration roots added for explicit check subsets
- preserve genuine globals, project shims, and module augmentations in the ambient pass
- update the GraphQL CLI regression to cover generated `schema.d.ts` files included by tsconfig

## Tests
- cargo test -p vize tsconfig_inputs::ambient::tests::ambient_collection_skips_export_only_generated_declaration_modules -- --nocapture
- cargo test -p vize --test check_canon_graphql_cli -- --nocapture
- cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all --check
- node --test tests/tooling/source-file-lengths.test.ts

Closes #2066

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->