### PR TITLE
fix(check): allow Vue TSX fallthrough attrs

### DIFF
--- a/crates/vize/tests/check_tsx_sfc_attrs_cli.rs
+++ b/crates/vize/tests/check_tsx_sfc_attrs_cli.rs
@@ -1,0 +1,151 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("check-tsx-sfc-attrs-{name}-{}", std::process::id()).as_str())
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn link_workspace_vue(project_root: &Path) -> std::io::Result<()> {
+    let workspace_node_modules = workspace_root().join("node_modules");
+    if !workspace_node_modules.exists() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace node_modules missing",
+        ));
+    }
+    let target = project_root.join("node_modules");
+    std::fs::create_dir_all(&target)?;
+    symlink_path(&workspace_node_modules.join("vue"), &target.join("vue"))?;
+    let vue_namespace = workspace_node_modules.join("@vue");
+    if vue_namespace.exists() {
+        symlink_path(&vue_namespace, &target.join("@vue"))?;
+    }
+    Ok(())
+}
+
+fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
+    if target.is_symlink() || target.is_file() {
+        std::fs::remove_file(target)?;
+    } else if target.exists() {
+        std::fs::remove_dir_all(target)?;
+    }
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(source, target)
+    }
+}
+
+#[test]
+fn check_tsx_story_allows_sfc_class_and_style_attrs() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("fallthrough");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    link_workspace_vue(&project_root).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "types": ["vue/jsx"],
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/AfButton.vue"),
+        r#"<script setup lang="ts">
+defineProps<{ color: 'primary' | 'secondary' }>()
+defineEmits<{ click: [event: MouseEvent] }>()
+</script>
+<template><button /></template>
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/AfButton.stories.tsx"),
+        r#"import AfButton from './AfButton.vue';
+
+export const Example = () => (
+  <AfButton
+    class="af-mb-2"
+    style="width: 200px"
+    color="primary"
+    onClick={(event: MouseEvent) => event.preventDefault()}
+  />
+);
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "src/AfButton.stories.tsx",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        std::str::from_utf8(&output.stderr).unwrap_or("<non-utf8 stderr>")
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    let helpers =
+        std::fs::read_to_string(project_root.join("node_modules/.vize/canon/__vize_helpers.d.ts"))
+            .unwrap();
+    assert!(helpers.contains("interface IntrinsicAttributes"));
+    assert!(helpers.contains("class?: unknown; style?: unknown"));
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/virtual_project/snapshots/vize_canon__batch__virtual_project__tests__pruned_helpers.snap
+++ b/crates/vize_canon/src/batch/virtual_project/snapshots/vize_canon__batch__virtual_project__tests__pruned_helpers.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_canon/src/batch/virtual_project/tests.rs
+assertion_line: 827
 expression: helpers_content.as_str()
 ---
 // ============================================
@@ -19,6 +20,9 @@ interface ImportMeta {
   prod: boolean;
   ssr: boolean;
 }
+
+declare namespace JSX { interface IntrinsicAttributes { class?: unknown; style?: unknown; } }
+declare module 'vue/jsx-runtime' { export namespace JSX { interface IntrinsicAttributes { class?: unknown; style?: unknown; } } }
 
 // Shared type helpers used by generated virtual modules
 type __EmitShape<T> = T extends (...args: any[]) => any ? T : T extends Record<string, any> ? { [K in keyof T]: T[K] extends (...args: infer A) => any ? A : T[K] extends any[] ? T[K] : any[]; } : Record<string, any[]>;

--- a/crates/vize_canon/src/virtual_ts/helpers.rs
+++ b/crates/vize_canon/src/virtual_ts/helpers.rs
@@ -190,7 +190,7 @@ pub const SHARED_PREAMBLE_DTS: &str = concat!(
     "  dev: boolean;\n",
     "  prod: boolean;\n",
     "  ssr: boolean;\n",
-    "}\n",
+    "}\n\ndeclare namespace JSX { interface IntrinsicAttributes { class?: unknown; style?: unknown; } }\ndeclare module 'vue/jsx-runtime' { export namespace JSX { interface IntrinsicAttributes { class?: unknown; style?: unknown; } } }\n",
     "\n",
     "// Shared type helpers used by generated virtual modules\n",
     vue_type_helpers_text!(),


### PR DESCRIPTION
## Summary
- add JSX intrinsic attr coverage for class/style on Vue TSX component usage
- add a CLI regression covering a TSX story rendering a typed SFC with class, style, props, and emits
- update the shared helper snapshot for the ambient JSX declarations

Closes #2075

## Tests
- cargo fmt --all --check
- cargo test -p vize --test check_tsx_sfc_attrs_cli -- --nocapture
- cargo test -p vize_canon materialize_prunes_stale_virtual_project_entries -- --nocapture
- cargo clippy -p vize -p vize_canon -- -D warnings -D clippy::wildcard_imports
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->