### PR TITLE
fix(native): ship legacy Vue support in npm builds

### DIFF
--- a/crates/vize_vitrine/Cargo.toml
+++ b/crates/vize_vitrine/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["glyph"]
 glyph = ["dep:vize_glyph"]
+legacy = ["vize/legacy", "vize_canon/legacy"]
 napi = [
   "dep:napi",
   "dep:napi-derive",

--- a/npm/native/package.json
+++ b/npm/native/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "build": "node ./scripts/build-local.mjs --release",
-    "build:ci": "napi build --platform --profile ci --manifest-path ../../crates/vize_vitrine/Cargo.toml -p vize_vitrine --features napi --output-dir .",
+    "build:ci": "napi build --platform --profile ci --manifest-path ../../crates/vize_vitrine/Cargo.toml -p vize_vitrine --features napi,legacy --output-dir .",
     "build:debug": "node ./scripts/build-local.mjs",
     "prepublishOnly": "napi pre-publish -t npm --no-gh-release --skip-optional-publish"
   },

--- a/npm/native/scripts/build-local.mjs
+++ b/npm/native/scripts/build-local.mjs
@@ -69,7 +69,7 @@ const buildArgs = [
   "-p",
   "vize_vitrine",
   "--features",
-  "napi",
+  "napi,legacy",
   "--output-dir",
   outputDir,
   "--no-js",

--- a/tests/tooling/moonbit-github-scripts.test.ts
+++ b/tests/tooling/moonbit-github-scripts.test.ts
@@ -351,7 +351,7 @@ test("github/build_napi_package builds Apple targets with cargo and writes the e
         "-p",
         "vize_vitrine",
         "--features",
-        "napi",
+        "napi,legacy",
         "--target",
         "aarch64-apple-darwin",
       ].join("\n"),

--- a/tests/tooling/native-legacy-build.test.ts
+++ b/tests/tooling/native-legacy-build.test.ts
@@ -65,12 +65,7 @@ test("github/build_napi_package keeps legacy features scoped to vize_vitrine", (
     const runForCrate = (crateName: string): string => {
       const result = runMoonScript(
         "github/build_napi_package",
-        [
-          packageDir,
-          `../../crates/${crateName}/Cargo.toml`,
-          crateName,
-          "x86_64-unknown-linux-gnu",
-        ],
+        [packageDir, `../../crates/${crateName}/Cargo.toml`, crateName, "x86_64-unknown-linux-gnu"],
         {
           cwd: tempDir,
           env: {

--- a/tests/tooling/native-legacy-build.test.ts
+++ b/tests/tooling/native-legacy-build.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import fs, { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { runMoonScript } from "./_helpers/moonbit.ts";
+import { writeFakeCommand } from "./support/fake-command.ts";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readRepoFile(filePath: string): string {
+  return fs.readFileSync(path.join(root, filePath), "utf-8");
+}
+
+function expectedNapiArgs(crateName: string, features: string): string {
+  return [
+    "exec",
+    "napi",
+    "build",
+    "--platform",
+    "--release",
+    "--manifest-path",
+    `../../crates/${crateName}/Cargo.toml`,
+    "-p",
+    crateName,
+    "--features",
+    features,
+    "--output-dir",
+    ".",
+    "--target",
+    "x86_64-unknown-linux-gnu",
+  ].join("\n");
+}
+
+test("vize native package builds with legacy Vue support", () => {
+  const packageJson = JSON.parse(readRepoFile("npm/native/package.json")) as {
+    scripts?: Record<string, string>;
+  };
+
+  assert.match(packageJson.scripts?.["build:ci"] ?? "", /--features napi,legacy(?:\s|$)/);
+  assert.match(readRepoFile("npm/native/scripts/build-local.mjs"), /"--features",\s+"napi,legacy"/);
+  assert.match(
+    readRepoFile("crates/vize_vitrine/Cargo.toml"),
+    /^legacy = \["vize\/legacy", "vize_canon\/legacy"\]$/m,
+  );
+});
+
+test("github/build_napi_package keeps legacy features scoped to vize_vitrine", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "native-legacy-build-"));
+  const binDir = path.join(tempDir, "bin");
+  const packageDir = path.join(tempDir, "npm", "native");
+  const argsPath = path.join(tempDir, "vp-args.txt");
+
+  try {
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(packageDir, { recursive: true });
+    writeFakeCommand(
+      binDir,
+      "vp",
+      `require("node:fs").writeFileSync(${JSON.stringify(argsPath)}, process.argv.slice(2).join("\\n"));`,
+    );
+
+    const runForCrate = (crateName: string): string => {
+      const result = runMoonScript(
+        "github/build_napi_package",
+        [
+          packageDir,
+          `../../crates/${crateName}/Cargo.toml`,
+          crateName,
+          "x86_64-unknown-linux-gnu",
+        ],
+        {
+          cwd: tempDir,
+          env: {
+            PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          },
+        },
+      );
+
+      assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
+      return fs.readFileSync(argsPath, "utf-8");
+    };
+
+    assert.equal(runForCrate("vize_vitrine"), expectedNapiArgs("vize_vitrine", "napi,legacy"));
+    assert.equal(runForCrate("vize_fresco"), expectedNapiArgs("vize_fresco", "napi"));
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -615,9 +615,10 @@ test("fresco-native publishes bundled binaries directly from the root package", 
     frescoNativePackage.scripts?.["build:ci"],
     "napi build --platform --profile ci --manifest-path ../../crates/vize_fresco/Cargo.toml -p vize_fresco --features napi --output-dir .",
   );
-  assert.equal(vizeNativePackage.scripts?.["build:ci"], "napi build --platform --profile ci --manifest-path ../../crates/vize_vitrine/Cargo.toml -p vize_vitrine --features napi,legacy --output-dir .");
-  assert.match(fs.readFileSync(path.join(root, "npm/native/scripts/build-local.mjs"), "utf-8"), /"--features",\s+"napi,legacy"/);
-  assert.match(fs.readFileSync(path.join(root, "crates/vize_vitrine/Cargo.toml"), "utf-8"), /legacy = \["vize\/legacy", "vize_canon\/legacy"\]/);
+  assert.equal(
+    vizeNativePackage.scripts?.["build:ci"],
+    "napi build --platform --profile ci --manifest-path ../../crates/vize_vitrine/Cargo.toml -p vize_vitrine --features napi,legacy --output-dir .",
+  );
 
   const frescoNativeLoader = fs.readFileSync(
     path.join(root, "npm/fresco-native/index.js"),

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -617,7 +617,15 @@ test("fresco-native publishes bundled binaries directly from the root package", 
   );
   assert.equal(
     vizeNativePackage.scripts?.["build:ci"],
-    "napi build --platform --profile ci --manifest-path ../../crates/vize_vitrine/Cargo.toml -p vize_vitrine --features napi --output-dir .",
+    "napi build --platform --profile ci --manifest-path ../../crates/vize_vitrine/Cargo.toml -p vize_vitrine --features napi,legacy --output-dir .",
+  );
+  assert.match(
+    fs.readFileSync(path.join(root, "npm/native/scripts/build-local.mjs"), "utf-8"),
+    /"--features",\s+"napi,legacy"/,
+  );
+  assert.match(
+    fs.readFileSync(path.join(root, "crates/vize_vitrine/Cargo.toml"), "utf-8"),
+    /legacy = \["vize\/legacy", "vize_canon\/legacy"\]/,
   );
 
   const frescoNativeLoader = fs.readFileSync(

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -615,18 +615,9 @@ test("fresco-native publishes bundled binaries directly from the root package", 
     frescoNativePackage.scripts?.["build:ci"],
     "napi build --platform --profile ci --manifest-path ../../crates/vize_fresco/Cargo.toml -p vize_fresco --features napi --output-dir .",
   );
-  assert.equal(
-    vizeNativePackage.scripts?.["build:ci"],
-    "napi build --platform --profile ci --manifest-path ../../crates/vize_vitrine/Cargo.toml -p vize_vitrine --features napi,legacy --output-dir .",
-  );
-  assert.match(
-    fs.readFileSync(path.join(root, "npm/native/scripts/build-local.mjs"), "utf-8"),
-    /"--features",\s+"napi,legacy"/,
-  );
-  assert.match(
-    fs.readFileSync(path.join(root, "crates/vize_vitrine/Cargo.toml"), "utf-8"),
-    /legacy = \["vize\/legacy", "vize_canon\/legacy"\]/,
-  );
+  assert.equal(vizeNativePackage.scripts?.["build:ci"], "napi build --platform --profile ci --manifest-path ../../crates/vize_vitrine/Cargo.toml -p vize_vitrine --features napi,legacy --output-dir .");
+  assert.match(fs.readFileSync(path.join(root, "npm/native/scripts/build-local.mjs"), "utf-8"), /"--features",\s+"napi,legacy"/);
+  assert.match(fs.readFileSync(path.join(root, "crates/vize_vitrine/Cargo.toml"), "utf-8"), /legacy = \["vize\/legacy", "vize_canon\/legacy"\]/);
 
   const frescoNativeLoader = fs.readFileSync(
     path.join(root, "npm/fresco-native/index.js"),

--- a/tools/moon/scripts/github/build_napi_package.mbtx
+++ b/tools/moon/scripts/github/build_napi_package.mbtx
@@ -31,6 +31,15 @@ fn binary_name(crate_name : String) -> String {
 }
 
 ///|
+fn napi_features(crate_name : String) -> String {
+  if crate_name == "vize_vitrine" {
+    "napi,legacy"
+  } else {
+    "napi"
+  }
+}
+
+///|
 fn is_apple_target(target : String) -> Bool {
   target.has_suffix("-apple-darwin")
 }
@@ -81,7 +90,7 @@ async fn build_apple_package(
       "-p",
       crate_name,
       "--features",
-      "napi",
+      napi_features(crate_name),
       "--target",
       target,
     ],
@@ -144,7 +153,7 @@ async fn run_app() -> Int {
     "-p",
     args[2],
     "--features",
-    "napi",
+    napi_features(args[2]),
     "--output-dir",
     ".",
     "--target",


### PR DESCRIPTION
## Summary
- expose a legacy feature on vize_vitrine that enables the CLI legacy Vue path
- build npm/native with napi,legacy for local, CI, and release native builds
- lock the native build features in package and release-helper tests

Closes #2060

## Tests
- node --test tests/tooling/package-manifests.test.ts tests/tooling/moonbit-github-scripts.test.ts
- cargo check -p vize_vitrine --features napi,legacy
- cargo check -p vize_vitrine --no-default-features --features napi,legacy
- cargo fmt --all --check
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->