### PR TITLE
fix(check): resolve ambient reference type packages

### DIFF
--- a/crates/vize/src/commands/check/runner/global_components.rs
+++ b/crates/vize/src/commands/check/runner/global_components.rs
@@ -17,7 +17,8 @@ use vize_carton::{FxHashSet, String, cstr};
 
 use super::resolve::resolve_from_config_dir;
 use crate::commands::check::tsconfig_inputs::{
-    parse_jsonc_value, read_extends_entries, resolve_extended_tsconfig,
+    parse_jsonc_value, read_extends_entries, reference_type_packages, resolve_extended_tsconfig,
+    resolve_type_package_declaration_files,
 };
 
 pub(super) fn build_virtual_ts_options(
@@ -200,7 +201,7 @@ fn collect_global_component_type_packages(
             continue;
         };
         for package in reference_type_packages(&content) {
-            push_unique_type_package(&mut packages, &mut seen, package);
+            push_unique_type_package(&mut packages, &mut seen, package.into());
         }
     }
 
@@ -264,185 +265,6 @@ fn load_tsconfig_type_packages(
     }
 
     (!inherited.is_empty()).then_some(inherited)
-}
-
-fn reference_type_packages(content: &str) -> Vec<String> {
-    content
-        .lines()
-        .filter_map(reference_types_attribute)
-        .map(String::from)
-        .collect()
-}
-
-fn reference_types_attribute(line: &str) -> Option<&str> {
-    let line = line.trim_start();
-    if !line.starts_with("///") || !line.contains("<reference") {
-        return None;
-    }
-    attribute_value(line, "types")
-}
-
-fn reference_path_attribute(line: &str) -> Option<&str> {
-    let line = line.trim_start();
-    if !line.starts_with("///") || !line.contains("<reference") {
-        return None;
-    }
-    attribute_value(line, "path")
-}
-
-fn attribute_value<'a>(line: &'a str, name: &str) -> Option<&'a str> {
-    let needle = cstr!("{name}=");
-    let start = line.find(needle.as_str())? + needle.len();
-    let quote = line[start..].chars().next()?;
-    if quote != '"' && quote != '\'' {
-        return None;
-    }
-    let value_start = start + quote.len_utf8();
-    let value_end = line[value_start..].find(quote)? + value_start;
-    line.get(value_start..value_end)
-}
-
-fn resolve_type_package_declaration_files(project_root: &Path, package: &str) -> Vec<PathBuf> {
-    let Some(package_root) = resolve_type_package_root(project_root, package) else {
-        return Vec::new();
-    };
-
-    for entry in package_declaration_entry_candidates(&package_root) {
-        if is_declaration_path(&entry) && entry.is_file() {
-            return collect_package_declaration_graph(&entry, &package_root);
-        }
-    }
-
-    Vec::new()
-}
-
-fn resolve_type_package_root(project_root: &Path, package: &str) -> Option<PathBuf> {
-    let mut current = Some(project_root);
-    while let Some(dir) = current {
-        let node_modules = dir.join("node_modules");
-        let direct = node_modules.join(package);
-        if direct.is_dir() {
-            return Some(direct);
-        }
-
-        if let Some(types_package) = fallback_types_package_name(package) {
-            let fallback = node_modules.join(types_package);
-            if fallback.is_dir() {
-                return Some(fallback);
-            }
-        }
-
-        current = dir.parent();
-    }
-
-    None
-}
-
-fn fallback_types_package_name(package: &str) -> Option<String> {
-    if package.starts_with("@types/") {
-        return None;
-    }
-    if let Some(scoped) = package.strip_prefix('@') {
-        let mut parts = scoped.split('/');
-        let scope = parts.next()?;
-        let name = parts.next()?;
-        return Some(cstr!("@types/{scope}__{name}"));
-    }
-    Some(cstr!("@types/{package}"))
-}
-
-fn package_declaration_entry_candidates(package_root: &Path) -> Vec<PathBuf> {
-    let mut candidates = Vec::new();
-    let package_json_path = package_root.join("package.json");
-    if let Ok(content) = fs::read_to_string(&package_json_path)
-        && let Ok(package_json) = parse_jsonc_value(&content)
-    {
-        for field in ["types", "typings"] {
-            if let Some(types) = package_json.get(field).and_then(Value::as_str) {
-                push_declaration_entry_candidate(&mut candidates, package_root.join(types));
-            }
-        }
-
-        if let Some(exports) = package_json.get("exports") {
-            let root_export = exports.get(".").unwrap_or(exports);
-            collect_export_type_entries(root_export, package_root, &mut candidates);
-        }
-    }
-
-    push_declaration_entry_candidate(&mut candidates, package_root.join("index.d.ts"));
-    candidates
-}
-
-fn collect_export_type_entries(value: &Value, package_root: &Path, candidates: &mut Vec<PathBuf>) {
-    match value {
-        Value::String(path) => {
-            push_declaration_entry_candidate(candidates, package_root.join(path))
-        }
-        Value::Array(values) => {
-            for value in values {
-                collect_export_type_entries(value, package_root, candidates);
-            }
-        }
-        Value::Object(map) => {
-            if let Some(types) = map.get("types").and_then(Value::as_str) {
-                push_declaration_entry_candidate(candidates, package_root.join(types));
-            }
-            for value in map.values() {
-                collect_export_type_entries(value, package_root, candidates);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn push_declaration_entry_candidate(candidates: &mut Vec<PathBuf>, path: PathBuf) {
-    if !candidates.contains(&path) {
-        candidates.push(path.clone());
-    }
-    if path.extension().is_none() {
-        let with_extension = path.with_extension("d.ts");
-        if !candidates.contains(&with_extension) {
-            candidates.push(with_extension);
-        }
-    }
-    let index = path.join("index.d.ts");
-    if !candidates.contains(&index) {
-        candidates.push(index);
-    }
-}
-
-fn collect_package_declaration_graph(entry: &Path, package_root: &Path) -> Vec<PathBuf> {
-    let package_root = vize_carton::path::canonicalize_non_verbatim(package_root);
-    let mut files = Vec::new();
-    let mut seen = FxHashSet::default();
-    let mut queue = vec![entry.to_path_buf()];
-
-    while let Some(path) = queue.pop() {
-        let path = vize_carton::path::canonicalize_non_verbatim(&path);
-        if !seen.insert(path.clone()) {
-            continue;
-        }
-        files.push(path.clone());
-
-        let Ok(content) = fs::read_to_string(&path) else {
-            continue;
-        };
-        let Some(base_dir) = path.parent() else {
-            continue;
-        };
-        for reference in content.lines().filter_map(reference_path_attribute) {
-            let referenced = base_dir.join(reference);
-            let referenced = vize_carton::path::canonicalize_non_verbatim(&referenced);
-            if referenced.starts_with(&package_root)
-                && is_declaration_path(&referenced)
-                && referenced.is_file()
-            {
-                queue.push(referenced);
-            }
-        }
-    }
-
-    files
 }
 
 fn declared_stub_name(stub: &str) -> Option<&str> {

--- a/crates/vize/src/commands/check/tsconfig_inputs/ambient.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/ambient.rs
@@ -12,6 +12,7 @@ use super::collect_default_check_files_inner;
 use super::glob::normalize_input_path;
 use super::loader::TsconfigInputCache;
 use super::matching::{is_nuxt_import_manifest_path, path_has_component};
+use super::type_references::{reference_type_packages, resolve_type_reference_declaration_files};
 
 mod top_level;
 
@@ -52,6 +53,11 @@ pub(crate) fn collect_ambient_declaration_files(
             continue;
         };
         for referenced in reference_path_declaration_files(&path, &content, &project_root) {
+            if seen.insert(referenced.clone()) {
+                files.push(referenced);
+            }
+        }
+        for referenced in reference_type_declaration_files(&path, &content) {
             if seen.insert(referenced.clone()) {
                 files.push(referenced);
             }
@@ -164,6 +170,18 @@ fn reference_path_declaration_files(
                 && is_declaration_file(&resolved)
                 && resolved.is_file())
             .then_some(resolved)
+        })
+        .collect()
+}
+
+fn reference_type_declaration_files(path: &Path, content: &str) -> Vec<PathBuf> {
+    let Some(base_dir) = path.parent() else {
+        return Vec::new();
+    };
+    reference_type_packages(content)
+        .into_iter()
+        .flat_map(|reference| {
+            resolve_type_reference_declaration_files(base_dir, reference.as_str())
         })
         .collect()
 }

--- a/crates/vize/src/commands/check/tsconfig_inputs/mod.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/mod.rs
@@ -17,6 +17,7 @@ mod jsonc;
 mod loader;
 mod matching;
 mod spec;
+mod type_references;
 
 #[cfg(test)]
 mod tests;
@@ -27,6 +28,7 @@ pub(super) use jsonc::parse_jsonc_value;
 pub(crate) use loader::{TsconfigInputCache, load_tsconfig_declaration_options};
 pub(super) use loader::{read_extends_entries, resolve_extended_tsconfig};
 pub(crate) use spec::TsconfigDeclarationOptions;
+pub(crate) use type_references::{reference_type_packages, resolve_type_package_declaration_files};
 
 use collect::{
     collect_supported_files_for_include_roots, collect_supported_files_with_options,

--- a/crates/vize/src/commands/check/tsconfig_inputs/type_references.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/type_references.rs
@@ -1,0 +1,306 @@
+//! `/// <reference types="..." />` package declaration resolution.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde_json::Value;
+use vize_carton::FxHashSet;
+
+use super::jsonc::parse_jsonc_value;
+
+pub(crate) fn reference_type_packages(content: &str) -> Vec<std::string::String> {
+    content
+        .lines()
+        .filter_map(reference_types_attribute)
+        .map(std::string::String::from)
+        .collect()
+}
+
+pub(crate) fn resolve_type_package_declaration_files(
+    project_root: &Path,
+    reference: &str,
+) -> Vec<PathBuf> {
+    resolve_type_reference_declaration_files(project_root, reference)
+}
+
+pub(crate) fn resolve_type_reference_declaration_files(
+    search_start: &Path,
+    reference: &str,
+) -> Vec<PathBuf> {
+    let Some(reference) = TypeReference::parse(reference) else {
+        return Vec::new();
+    };
+
+    for package_root in type_package_roots(search_start, reference.package.as_str()) {
+        if let Some(files) = package_declaration_files(&package_root, reference.subpath) {
+            return files;
+        }
+    }
+
+    Vec::new()
+}
+
+fn reference_types_attribute(line: &str) -> Option<&str> {
+    let line = line.trim_start();
+    if !line.starts_with("///") || !line.contains("<reference") {
+        return None;
+    }
+    attribute_value(line, "types")
+}
+
+fn attribute_value<'a>(line: &'a str, name: &str) -> Option<&'a str> {
+    let needle = format!("{name}=");
+    let start = line.find(&needle)? + needle.len();
+    let quote = line[start..].chars().next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+    let value_start = start + quote.len_utf8();
+    let value_end = line[value_start..].find(quote)? + value_start;
+    line.get(value_start..value_end)
+}
+
+struct TypeReference<'a> {
+    package: std::string::String,
+    subpath: Option<&'a str>,
+}
+
+impl<'a> TypeReference<'a> {
+    fn parse(reference: &'a str) -> Option<Self> {
+        let reference = reference.trim();
+        if reference.is_empty() || reference.starts_with('.') || reference.starts_with('/') {
+            return None;
+        }
+
+        let package_end = if let Some(scoped) = reference.strip_prefix('@') {
+            let scope_end = scoped.find('/')?;
+            let name_start = scope_end + 2;
+            let name = reference.get(name_start..)?;
+            name.find('/')
+                .map_or(reference.len(), |name_end| name_start + name_end)
+        } else {
+            reference.find('/').unwrap_or(reference.len())
+        };
+
+        let package = reference.get(..package_end)?;
+        if package.ends_with('/') || package.is_empty() {
+            return None;
+        }
+        let subpath = reference
+            .get(package_end + 1..)
+            .filter(|subpath| !subpath.is_empty());
+
+        Some(Self {
+            package: std::string::String::from(package),
+            subpath,
+        })
+    }
+}
+
+fn type_package_roots(search_start: &Path, package: &str) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    let mut seen = FxHashSet::default();
+    let mut current = if search_start.is_file() {
+        search_start.parent()
+    } else {
+        Some(search_start)
+    };
+
+    while let Some(dir) = current {
+        let node_modules = dir.join("node_modules");
+        push_existing_package_root(&mut roots, &mut seen, node_modules.join(package));
+        if let Some(types_package) = fallback_types_package_name(package) {
+            push_existing_package_root(&mut roots, &mut seen, node_modules.join(types_package));
+        }
+        current = dir.parent();
+    }
+
+    roots
+}
+
+fn push_existing_package_root(
+    roots: &mut Vec<PathBuf>,
+    seen: &mut FxHashSet<PathBuf>,
+    package_root: PathBuf,
+) {
+    if package_root.is_dir() {
+        let package_root = vize_carton::path::canonicalize_non_verbatim(&package_root);
+        if seen.insert(package_root.clone()) {
+            roots.push(package_root);
+        }
+    }
+}
+
+fn fallback_types_package_name(package: &str) -> Option<std::string::String> {
+    if package.starts_with("@types/") {
+        return None;
+    }
+    if let Some(scoped) = package.strip_prefix('@') {
+        let mut parts = scoped.split('/');
+        let scope = parts.next()?;
+        let name = parts.next()?;
+        return Some(format!("@types/{scope}__{name}"));
+    }
+    Some(format!("@types/{package}"))
+}
+
+fn package_declaration_files(package_root: &Path, subpath: Option<&str>) -> Option<Vec<PathBuf>> {
+    for entry in package_declaration_entry_candidates(package_root, subpath) {
+        if is_declaration_path(&entry) && entry.is_file() {
+            return Some(collect_package_declaration_graph(&entry, package_root));
+        }
+    }
+
+    None
+}
+
+fn package_declaration_entry_candidates(
+    package_root: &Path,
+    subpath: Option<&str>,
+) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    let package_json_path = package_root.join("package.json");
+    if let Ok(content) = fs::read_to_string(&package_json_path)
+        && let Ok(package_json) = parse_jsonc_value(&content)
+    {
+        if let Some(subpath) = subpath {
+            collect_subpath_export_type_entries(
+                &package_json,
+                package_root,
+                subpath,
+                &mut candidates,
+            );
+        } else {
+            collect_root_package_type_entries(&package_json, package_root, &mut candidates);
+        }
+    }
+
+    match subpath {
+        Some(subpath) => {
+            push_declaration_entry_candidate(&mut candidates, package_root.join(subpath))
+        }
+        None => push_declaration_entry_candidate(&mut candidates, package_root.join("index.d.ts")),
+    }
+    candidates
+}
+
+fn collect_root_package_type_entries(
+    package_json: &Value,
+    package_root: &Path,
+    candidates: &mut Vec<PathBuf>,
+) {
+    for field in ["types", "typings"] {
+        if let Some(types) = package_json.get(field).and_then(Value::as_str) {
+            push_declaration_entry_candidate(candidates, package_root.join(types));
+        }
+    }
+
+    if let Some(exports) = package_json.get("exports") {
+        let root_export = exports.get(".").unwrap_or(exports);
+        collect_export_type_entries(root_export, package_root, candidates);
+    }
+}
+
+fn collect_subpath_export_type_entries(
+    package_json: &Value,
+    package_root: &Path,
+    subpath: &str,
+    candidates: &mut Vec<PathBuf>,
+) {
+    let Some(exports) = package_json.get("exports") else {
+        return;
+    };
+    let key = format!("./{subpath}");
+    if let Some(export) = exports.get(&key) {
+        collect_export_type_entries(export, package_root, candidates);
+    }
+}
+
+fn collect_export_type_entries(value: &Value, package_root: &Path, candidates: &mut Vec<PathBuf>) {
+    match value {
+        Value::String(path) => {
+            push_declaration_entry_candidate(candidates, package_root.join(path))
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_export_type_entries(value, package_root, candidates);
+            }
+        }
+        Value::Object(map) => {
+            if let Some(types) = map.get("types").and_then(Value::as_str) {
+                push_declaration_entry_candidate(candidates, package_root.join(types));
+            }
+            for value in map.values() {
+                collect_export_type_entries(value, package_root, candidates);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn push_declaration_entry_candidate(candidates: &mut Vec<PathBuf>, path: PathBuf) {
+    push_unique_candidate(candidates, path.clone());
+    if path.extension().is_none() {
+        push_unique_candidate(candidates, path.with_extension("d.ts"));
+        push_unique_candidate(candidates, path.join("index.d.ts"));
+    }
+}
+
+fn push_unique_candidate(candidates: &mut Vec<PathBuf>, path: PathBuf) {
+    if !candidates.contains(&path) {
+        candidates.push(path);
+    }
+}
+
+fn collect_package_declaration_graph(entry: &Path, package_root: &Path) -> Vec<PathBuf> {
+    let package_root = vize_carton::path::canonicalize_non_verbatim(package_root);
+    let mut files = Vec::new();
+    let mut seen = FxHashSet::default();
+    let mut queue = vec![entry.to_path_buf()];
+
+    while let Some(path) = queue.pop() {
+        let path = vize_carton::path::canonicalize_non_verbatim(&path);
+        if !seen.insert(path.clone()) {
+            continue;
+        }
+        files.push(path.clone());
+
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Some(base_dir) = path.parent() else {
+            continue;
+        };
+        for reference in content.lines().filter_map(reference_path_attribute) {
+            let referenced =
+                vize_carton::path::canonicalize_non_verbatim(&base_dir.join(reference));
+            if referenced.starts_with(&package_root)
+                && is_declaration_path(&referenced)
+                && referenced.is_file()
+            {
+                queue.push(referenced);
+            }
+        }
+    }
+
+    files
+}
+
+fn reference_path_attribute(line: &str) -> Option<&str> {
+    let line = line.trim_start();
+    if !line.starts_with("///") || !line.contains("<reference") {
+        return None;
+    }
+    attribute_value(line, "path")
+}
+
+fn is_declaration_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".d.ts"))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize/src/commands/check/tsconfig_inputs/type_references/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/type_references/tests.rs
@@ -1,0 +1,89 @@
+use super::{reference_type_packages, resolve_type_reference_declaration_files};
+use std::path::{Path, PathBuf};
+
+fn write(root: &Path, rel: &str, content: &str) {
+    let path = root.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, content).unwrap();
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "vize-type-reference-{name}-{}-{case_id}",
+        std::process::id()
+    ))
+}
+
+fn relative_paths(root: &Path, files: &[PathBuf]) -> Vec<std::string::String> {
+    files
+        .iter()
+        .map(|path| {
+            path.strip_prefix(root)
+                .unwrap()
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
+        .collect()
+}
+
+#[test]
+fn reference_type_packages_collects_quoted_directives() {
+    assert_eq!(
+        reference_type_packages(
+            r#"
+/// <reference types="vitest/importMeta" />
+  /// <reference types='@vizejs/vite-plugin-musea/client' />
+/// <reference path="./local.d.ts" />
+"#,
+        ),
+        vec![
+            "vitest/importMeta".to_string(),
+            "@vizejs/vite-plugin-musea/client".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn type_reference_resolution_supports_subpaths_exports_and_graphs() {
+    let root = unique_case_dir("subpath");
+    let _ = std::fs::remove_dir_all(&root);
+    write(
+        &root,
+        "node_modules/vitest/importMeta.d.ts",
+        "/// <reference path=\"./globals.d.ts\" />\ndeclare global { interface ImportMeta { vitest: boolean; } }\n",
+    );
+    write(
+        &root,
+        "node_modules/vitest/globals.d.ts",
+        "declare const describe: (name: string) => void;\n",
+    );
+    write(
+        &root,
+        "node_modules/@vizejs/vite-plugin-musea/package.json",
+        r#"{ "exports": { "./client": { "types": "./client.d.ts" } } }"#,
+    );
+    write(
+        &root,
+        "node_modules/@vizejs/vite-plugin-musea/client.d.ts",
+        "declare function defineArt(source: string): void;\n",
+    );
+
+    let root = root.canonicalize().unwrap();
+    let vitest = resolve_type_reference_declaration_files(&root, "vitest/importMeta");
+    assert_eq!(
+        relative_paths(&root, &vitest),
+        vec![
+            "node_modules/vitest/importMeta.d.ts",
+            "node_modules/vitest/globals.d.ts",
+        ]
+    );
+    let musea = resolve_type_reference_declaration_files(&root, "@vizejs/vite-plugin-musea/client");
+    assert_eq!(
+        relative_paths(&root, &musea),
+        vec!["node_modules/@vizejs/vite-plugin-musea/client.d.ts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/vize/tests/check_reference_types_cli.rs
+++ b/crates/vize/tests/check_reference_types_cli.rs
@@ -1,0 +1,174 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("check-reference-types-{name}-{}", std::process::id()).as_str())
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn link_workspace_vue(project_root: &Path) -> std::io::Result<()> {
+    let workspace_node_modules = workspace_root().join("node_modules");
+    if !workspace_node_modules.exists() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace node_modules missing",
+        ));
+    }
+    let target = project_root.join("node_modules");
+    std::fs::create_dir_all(&target)?;
+    symlink_path(&workspace_node_modules.join("vue"), &target.join("vue"))?;
+    let vue_namespace = workspace_node_modules.join("@vue");
+    if vue_namespace.exists() {
+        symlink_path(&vue_namespace, &target.join("@vue"))?;
+    }
+    Ok(())
+}
+
+fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
+    if target.is_symlink() || target.is_file() {
+        std::fs::remove_file(target)?;
+    } else if target.exists() {
+        std::fs::remove_dir_all(target)?;
+    }
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(source, target)
+    }
+}
+
+fn write(root: &Path, rel: &str, content: &str) {
+    let path = root.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, content).unwrap();
+}
+
+#[test]
+fn check_loads_reference_types_from_tsconfig_ambient_declarations() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("subpath");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    link_workspace_vue(&project_root).unwrap();
+    write(
+        &project_root,
+        "node_modules/vitest/importMeta.d.ts",
+        "/// <reference path=\"./globals.d.ts\" />\nexport {};\n",
+    );
+    write(
+        &project_root,
+        "node_modules/vitest/globals.d.ts",
+        "export {};\ndeclare global { interface ImportMeta { vitest: boolean; } }\n",
+    );
+    write(
+        &project_root,
+        "node_modules/@vizejs/vite-plugin-musea/package.json",
+        r#"{ "exports": { "./client": { "types": "./client.d.ts" } } }"#,
+    );
+    write(
+        &project_root,
+        "node_modules/@vizejs/vite-plugin-musea/client.d.ts",
+        r#"export {};
+declare global {
+  function defineArt(source: string, options?: { title?: string }): void;
+}
+declare module "*.art.vue" {
+  const component: import("vue").DefineComponent<{}, {}, any>;
+  export default component;
+}
+"#,
+    );
+    write(
+        &project_root,
+        "vite-env.d.ts",
+        r#"/// <reference types="vitest/importMeta" />
+/// <reference types="@vizejs/vite-plugin-musea/client" />
+"#,
+    );
+    write(
+        &project_root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["vite-env.d.ts", "src/**/*"]
+}"#,
+    );
+    write(
+        &project_root,
+        "src/App.vue",
+        r#"<script setup lang="ts">
+if (import.meta.vitest) {
+  defineArt("./App.vue", { title: "App" })
+}
+</script>
+
+<template><div /></template>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "src/App.vue",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    assert!(
+        !stdout.contains("TS2304") && !stdout.contains("TS2339"),
+        "reference types should provide defineArt and import.meta.vitest:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
## Summary
- resolve ambient `/// <reference types>` package declarations from tsconfig-included `.d.ts` files
- support package subpaths, package `exports` type entries, and internal `reference path` declaration graphs
- share the resolver with global component package type scanning to keep both paths aligned

## Tests
- `cargo fmt --all --check`
- `cargo test -p vize type_references::tests -- --nocapture`
- `cargo test -p vize --test check_reference_types_cli -- --nocapture`
- `cargo test -p vize --lib -- --nocapture`
- `cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`

Closes #2072

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->