### PR TITLE
test(check): resolve Vue fixture package links

### DIFF
--- a/crates/vize/tests/check_canon_graphql_cli.rs
+++ b/crates/vize/tests/check_canon_graphql_cli.rs
@@ -32,21 +32,40 @@ fn resolve_test_corsa_path() -> Option<PathBuf> {
 }
 
 fn link_workspace_vue(project_root: &Path) -> std::io::Result<()> {
-    let workspace_node_modules = workspace_root().join("node_modules");
-    if !workspace_node_modules.exists() {
+    let Some(vue_package) = workspace_vue_package() else {
         return Err(std::io::Error::new(
             std::io::ErrorKind::NotFound,
-            "workspace node_modules missing",
+            "workspace Vue package missing",
         ));
-    }
+    };
+    let workspace_node_modules = vue_package.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace Vue package has no node_modules parent",
+        )
+    })?;
     let target = project_root.join("node_modules");
     std::fs::create_dir_all(&target)?;
-    symlink_path(&workspace_node_modules.join("vue"), &target.join("vue"))?;
+    symlink_path(&vue_package, &target.join("vue"))?;
     let vue_namespace = workspace_node_modules.join("@vue");
     if vue_namespace.exists() {
         symlink_path(&vue_namespace, &target.join("@vue"))?;
     }
     Ok(())
+}
+
+fn workspace_vue_package() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.join("node_modules/vue"),
+        root.join("tests/node_modules/vue"),
+        root.join("playground/node_modules/vue"),
+        root.join("examples/vite-musea/node_modules/vue"),
+        root.join("examples/jsx-tsx/node_modules/vue"),
+        root.join("npm/framework/nuxt/node_modules/vue"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
 }
 
 fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {

--- a/crates/vize/tests/check_reference_types_cli.rs
+++ b/crates/vize/tests/check_reference_types_cli.rs
@@ -33,21 +33,40 @@ fn resolve_test_corsa_path() -> Option<PathBuf> {
 }
 
 fn link_workspace_vue(project_root: &Path) -> std::io::Result<()> {
-    let workspace_node_modules = workspace_root().join("node_modules");
-    if !workspace_node_modules.exists() {
+    let Some(vue_package) = workspace_vue_package() else {
         return Err(std::io::Error::new(
             std::io::ErrorKind::NotFound,
-            "workspace node_modules missing",
+            "workspace Vue package missing",
         ));
-    }
+    };
+    let workspace_node_modules = vue_package.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace Vue package has no node_modules parent",
+        )
+    })?;
     let target = project_root.join("node_modules");
     std::fs::create_dir_all(&target)?;
-    symlink_path(&workspace_node_modules.join("vue"), &target.join("vue"))?;
+    symlink_path(&vue_package, &target.join("vue"))?;
     let vue_namespace = workspace_node_modules.join("@vue");
     if vue_namespace.exists() {
         symlink_path(&vue_namespace, &target.join("@vue"))?;
     }
     Ok(())
+}
+
+fn workspace_vue_package() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.join("node_modules/vue"),
+        root.join("tests/node_modules/vue"),
+        root.join("playground/node_modules/vue"),
+        root.join("examples/vite-musea/node_modules/vue"),
+        root.join("examples/jsx-tsx/node_modules/vue"),
+        root.join("npm/framework/nuxt/node_modules/vue"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
 }
 
 fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {

--- a/crates/vize/tests/check_tsx_sfc_attrs_cli.rs
+++ b/crates/vize/tests/check_tsx_sfc_attrs_cli.rs
@@ -33,21 +33,40 @@ fn resolve_test_corsa_path() -> Option<PathBuf> {
 }
 
 fn link_workspace_vue(project_root: &Path) -> std::io::Result<()> {
-    let workspace_node_modules = workspace_root().join("node_modules");
-    if !workspace_node_modules.exists() {
+    let Some(vue_package) = workspace_vue_package() else {
         return Err(std::io::Error::new(
             std::io::ErrorKind::NotFound,
-            "workspace node_modules missing",
+            "workspace Vue package missing",
         ));
-    }
+    };
+    let workspace_node_modules = vue_package.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace Vue package has no node_modules parent",
+        )
+    })?;
     let target = project_root.join("node_modules");
     std::fs::create_dir_all(&target)?;
-    symlink_path(&workspace_node_modules.join("vue"), &target.join("vue"))?;
+    symlink_path(&vue_package, &target.join("vue"))?;
     let vue_namespace = workspace_node_modules.join("@vue");
     if vue_namespace.exists() {
         symlink_path(&vue_namespace, &target.join("@vue"))?;
     }
     Ok(())
+}
+
+fn workspace_vue_package() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.join("node_modules/vue"),
+        root.join("tests/node_modules/vue"),
+        root.join("playground/node_modules/vue"),
+        root.join("examples/vite-musea/node_modules/vue"),
+        root.join("examples/jsx-tsx/node_modules/vue"),
+        root.join("npm/framework/nuxt/node_modules/vue"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
 }
 
 fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {


### PR DESCRIPTION
## Summary
- resolve Vue test fixture links from package-level node_modules when root hoisting is absent
- update TSX, reference-types, and GraphQL integration fixtures to avoid broken Vue symlinks

## Verification
- cargo test -p vize --test check_tsx_sfc_attrs_cli --test check_reference_types_cli --test check_canon_graphql_cli
- cargo llvm-cov --no-report -p vize --test check_tsx_sfc_attrs_cli -- check_tsx_story_allows_sfc_class_and_style_attrs --nocapture

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->