### PR TITLE
fix(vite-plugin): restore SFC HMR updates

### DIFF
--- a/npm/builder/vite/src/plugin/hmr.test.ts
+++ b/npm/builder/vite/src/plugin/hmr.test.ts
@@ -111,6 +111,7 @@ assert.equal(
   const dependencyFile = "/src/imported.css";
   const nullVirtualModule = { url: toVirtualId(vueFile) };
   const visibleVirtualModule = { url: toPluginVisibleVirtualId(vueFile) };
+  const visibleVirtualFileModule = { url: `${vueFile}.ts?vue&vize` };
   const rawVueModule = { url: vueFile };
   const invalidatedModules: unknown[] = [];
   const state = {
@@ -137,6 +138,7 @@ assert.equal(
   const modulesByFile = new Map<string, Set<unknown>>([
     [toVirtualId(vueFile), new Set([nullVirtualModule])],
     [toPluginVisibleVirtualId(vueFile), new Set([visibleVirtualModule])],
+    [`${vueFile}.ts`, new Set([visibleVirtualFileModule])],
     [vueFile, new Set([rawVueModule])],
   ]);
   const ctx = {
@@ -158,13 +160,70 @@ assert.equal(
 
   assert.deepEqual(
     new Set(modules),
-    new Set([nullVirtualModule, visibleVirtualModule, rawVueModule]),
+    new Set([nullVirtualModule, visibleVirtualModule, visibleVirtualFileModule, rawVueModule]),
     "Dependency updates should return every module graph representation of the owner SFC",
   );
   assert.deepEqual(
     new Set(invalidatedModules),
-    new Set([nullVirtualModule, visibleVirtualModule, rawVueModule]),
+    new Set([nullVirtualModule, visibleVirtualModule, visibleVirtualFileModule, rawVueModule]),
     "Dependency updates should invalidate every module graph representation of the owner SFC",
+  );
+}
+
+{
+  const vueFile = "/src/App.vue";
+  const previousSource = `<template><h1>You did it!</h1></template>`;
+  const nextSource = `<template><h1>You did not do it!</h1></template>`;
+  const previousCompiled = compileFile(
+    vueFile,
+    new Map(),
+    { sourceMap: false, ssr: false, vapor: false },
+    previousSource,
+  );
+  const visibleVirtualFileModule = { url: `${vueFile}.ts?vue&vize` };
+  const state = {
+    cache: new Map([[vueFile, previousCompiled]]),
+    ssrCache: new Map(),
+    collectedCss: new Map(),
+    precompileMetadata: new Map(),
+    pendingHmrUpdateTypes: new Map(),
+    isProduction: false,
+    mergedOptions: {},
+    cssAliasRules: [],
+    clientViteBase: "/",
+    root: "/src",
+    filter: () => true,
+    logger: {
+      log() {},
+      error() {},
+    },
+  } as unknown as VizePluginState;
+  const ctx = {
+    file: vueFile,
+    server: {
+      moduleGraph: {
+        getModulesByFile(id: string) {
+          return id === `${vueFile}.ts` ? new Set([visibleVirtualFileModule]) : undefined;
+        },
+      },
+      ws: {
+        send() {},
+      },
+    },
+    read: async () => nextSource,
+  } as unknown as HmrContext;
+
+  const modules = await handleHotUpdateHook(state, ctx);
+
+  assert.deepEqual(
+    modules,
+    [visibleVirtualFileModule],
+    "Vue SFC edits should return Vite's query-stripped plugin-visible virtual module file",
+  );
+  assert.equal(
+    state.pendingHmrUpdateTypes.get(vueFile),
+    "template-only",
+    "Template edits should keep granular HMR when the virtual module is found",
   );
 }
 

--- a/npm/builder/vite/src/plugin/hmr.ts
+++ b/npm/builder/vite/src/plugin/hmr.ts
@@ -57,6 +57,7 @@ function getVueModuleFileCandidates(vueFile: string): string[] {
     toPluginVisibleVirtualId(vueFile),
     toVirtualId(vueFile, true),
     toPluginVisibleVirtualId(vueFile, true),
+    toPluginVisibleVirtualId(vueFile).split("?")[0],
     vueFile,
   ]);
 }


### PR DESCRIPTION
## Summary

- include Vite's query-stripped plugin-visible `.vue.ts` module file when resolving SFC HMR updates
- add regression coverage for normal `.vue` edits and dependency invalidation using that module graph representation

## Root Cause

In dev, Vize resolves SFCs to plugin-visible virtual modules such as `App.vue.ts?vue&vize`. Vite records those modules in the module graph by the query-stripped file key, `App.vue.ts`. `handleHotUpdate` only searched the raw `.vue`, null-prefixed virtual ID, and full query-bearing virtual ID, so `App.vue` edits could return no affected module and HMR would not update the browser.

Fixes #2090

## Validation

- `pnpm --dir npm/builder/vite test`
- `pnpm --dir npm/builder/vite check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->