### PR TITLE
fix(vscode): sync Vize Art release version

### DIFF
--- a/npm/editor/vscode-art/package.json
+++ b/npm/editor/vscode-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vize-art",
   "displayName": "Vize Art",
-  "version": "0.250.0",
+  "version": "0.251.0",
   "description": "Syntax highlighting for Vize Art files (*.art.vue)",
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
## Summary

- Align the Vize Art VS Code extension manifest version with the v0.251.0 release.
- Restore the editor integration version assertion used by Check / test-scripts.

## Root cause

The v0.251.0 release commit updated the main VS Code extension version but left `npm/editor/vscode-art/package.json` at `0.250.0`, so `tests/tooling/editor-integrations.test.ts` failed on main.

## Validation

- `node --test tests/tooling/editor-integrations.test.ts`
- `vp run --workspace-root test:scripts` reached and passed the editor manifest/version tests locally, then hit unrelated local PATH stale-CLI failures where `vize --version` resolved to `0.250.0`; CI is the source of truth for this lane.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->