### PR TITLE
fix(npm): align integration config handling

### DIFF
--- a/crates/vize/src/commands/musea.rs
+++ b/crates/vize/src/commands/musea.rs
@@ -1,9 +1,10 @@
+mod serve_plan;
 mod setup;
 
 use clap::{Args, Subcommand};
-use setup::validate_direct_vite_musea_setup;
+use serve_plan::create_serve_plan;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use vize_carton::{String, ToCompactString, cstr};
 
@@ -149,126 +150,6 @@ fn run_serve(args: ServeArgs) {
         }
     }
 }
-
-#[derive(Debug, PartialEq, Eq)]
-struct ServePlan {
-    program: PathBuf,
-    args: Vec<String>,
-    env: Vec<(String, String)>,
-}
-
-fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePlan, String> {
-    if let Some(stories) = &args.stories {
-        return Err(cstr!(
-            "vize musea: --stories is not supported by the Vite-backed serve entrypoint yet (got {}). Configure Musea include patterns in vize.config.ts instead.",
-            stories.display()
-        ));
-    }
-
-    let program = match resolve_vite_binary(cwd) {
-        Some(program) => program,
-        None if let Some(nuxt_root) = find_nuxt_project_root(cwd) => {
-            return Err(nuxt_musea_message(&nuxt_root, args.build));
-        }
-        None => PathBuf::from("vite"),
-    };
-    validate_direct_vite_musea_setup(cwd)?;
-    let mut env = Vec::new();
-    if let Some(config_path) = &args.config {
-        env.push((
-            cstr!("VIZE_CONFIG_FILE"),
-            config_path.to_string_lossy().as_ref().to_compact_string(),
-        ));
-    }
-
-    if args.build {
-        env.push((cstr!("VIZE_MUSEA_STATIC_BUILD"), cstr!("1")));
-        return Ok(ServePlan {
-            program,
-            args: vec![cstr!("build")],
-            env,
-        });
-    }
-
-    let mut vite_args = vec![
-        cstr!("dev"),
-        cstr!("--host"),
-        args.host.clone(),
-        cstr!("--port"),
-        args.port.to_compact_string(),
-    ];
-    if args.open {
-        vite_args.extend([cstr!("--open"), cstr!("/__musea__")]);
-    }
-    if args.strict_port {
-        vite_args.push(cstr!("--strictPort"));
-    }
-
-    Ok(ServePlan {
-        program,
-        args: vite_args,
-        env,
-    })
-}
-
-fn resolve_vite_binary(cwd: &Path) -> Option<PathBuf> {
-    for ancestor in cwd.ancestors() {
-        let bin_dir = ancestor.join("node_modules").join(".bin");
-        for name in VITE_BIN_NAMES {
-            let candidate = bin_dir.join(name);
-            if candidate.is_file() {
-                return Some(candidate);
-            }
-        }
-    }
-    None
-}
-
-fn find_nuxt_project_root(cwd: &Path) -> Option<PathBuf> {
-    cwd.ancestors()
-        .find(|ancestor| is_nuxt_project_root(ancestor))
-        .map(Path::to_path_buf)
-}
-
-fn is_nuxt_project_root(root: &Path) -> bool {
-    ["nuxt.config.ts", "nuxt.config.mts", "nuxt.config.js"]
-        .into_iter()
-        .any(|file_name| root.join(file_name).exists())
-        || setup::package_json_has_dependency(root, "nuxt")
-}
-
-fn has_vize_nuxt_integration(root: &Path) -> bool {
-    setup::package_json_has_dependency(root, "@vizejs/nuxt")
-        || root
-            .join("node_modules")
-            .join("@vizejs")
-            .join("nuxt")
-            .join("package.json")
-            .exists()
-}
-
-fn nuxt_musea_message(root: &Path, build: bool) -> String {
-    let command = if build { "nuxi build" } else { "nuxi dev" };
-    if has_vize_nuxt_integration(root) {
-        return cstr!(
-            "vize musea: detected a Nuxt project using `@vizejs/nuxt` at {}.\n  The standalone `vize musea` command only runs direct Vite projects with `vite` and `@vizejs/vite-plugin-musea` configured in Vite.\n  In this Nuxt setup, Musea is provided by the Nuxt module at `/__musea__/`; run `{}` and open that route instead.",
-            root.display(),
-            command
-        );
-    }
-
-    cstr!(
-        "vize musea: detected a Nuxt project at {}.\n  The standalone `vize musea` command only runs direct Vite projects with `vite` and `@vizejs/vite-plugin-musea` configured in Vite.\n  For Nuxt, enable `@vizejs/nuxt`, run `{}`, and open `/__musea__/` instead.",
-        root.display(),
-        command
-    )
-}
-
-#[cfg(windows)]
-const VITE_BIN_NAMES: &[&str] = &["vite.cmd", "vite.ps1", "vite"];
-
-#[cfg(not(windows))]
-const VITE_BIN_NAMES: &[&str] = &["vite"];
 
 fn run_new(args: NewArgs) {
     let target_dir = args.path.unwrap_or_else(|| PathBuf::from("."));

--- a/crates/vize/src/commands/musea.rs
+++ b/crates/vize/src/commands/musea.rs
@@ -1,12 +1,13 @@
+mod new;
 mod serve_plan;
 mod setup;
 
 use clap::{Args, Subcommand};
+use new::NewArgs;
 use serve_plan::create_serve_plan;
-use std::fs;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use vize_carton::{String, ToCompactString, cstr};
+use vize_carton::{String, cstr};
 
 #[derive(Args)]
 pub struct MuseaArgs {
@@ -71,21 +72,10 @@ impl Default for ServeArgs {
     }
 }
 
-#[derive(Args)]
-#[allow(clippy::disallowed_types)]
-pub struct NewArgs {
-    /// Name of the Musea project (defaults to current directory name)
-    pub name: Option<String>,
-
-    /// Directory to create the project in (defaults to current directory)
-    #[arg(short, long)]
-    pub path: Option<PathBuf>,
-}
-
 pub fn run(args: MuseaArgs) {
     match args.command {
         Some(MuseaCommand::Serve(serve_args)) => run_serve(serve_args),
-        Some(MuseaCommand::New(new_args)) => run_new(new_args),
+        Some(MuseaCommand::New(new_args)) => new::run(new_args),
         None => run_serve(args.serve),
     }
 }
@@ -149,94 +139,6 @@ fn run_serve(args: ServeArgs) {
             std::process::exit(1);
         }
     }
-}
-
-fn run_new(args: NewArgs) {
-    let target_dir = args.path.unwrap_or_else(|| PathBuf::from("."));
-    #[allow(clippy::disallowed_types, clippy::disallowed_methods)]
-    let project_name = args.name.unwrap_or_else(|| {
-        std::env::current_dir()
-            .ok()
-            .and_then(|p| {
-                p.file_name()
-                    .map(|name| name.to_string_lossy().as_ref().to_compact_string())
-            })
-            .unwrap_or_else(|| cstr!("stories"))
-    });
-
-    eprintln!(
-        "vize musea new: Creating Musea project '{}'...",
-        project_name
-    );
-
-    let stories_dir = target_dir.join("stories");
-    if let Err(e) = fs::create_dir_all(&stories_dir) {
-        eprintln!("vize musea new: failed to create stories directory: {}", e);
-        std::process::exit(1);
-    }
-
-    let example_story = stories_dir.join("Button.art.vue");
-    let example_content = r#"<script setup lang="ts">
-defineArt("../src/Button.vue", {
-  title: "Button",
-  category: "Components",
-  tags: ["button", "ui"],
-});
-</script>
-
-<art>
-  <variant name="Primary" default>
-    <Button variant="primary">Click me</Button>
-  </variant>
-
-  <variant name="Secondary">
-    <Button variant="secondary">Click me</Button>
-  </variant>
-
-  <variant name="Disabled">
-    <Button variant="primary" disabled>Disabled</Button>
-  </variant>
-</art>
-
-<style scoped>
-.art-preview {
-  padding: 0.5rem 1rem;
-  display: flex;
-  gap: 0.75rem;
-  align-items: center;
-}
-</style>
-"#;
-
-    if let Err(e) = fs::write(&example_story, example_content) {
-        eprintln!("vize musea new: failed to create example story: {}", e);
-        std::process::exit(1);
-    }
-
-    let config_path = target_dir.join("vize.config.ts");
-    if !config_path.exists() {
-        let config_content = r#"import { defineConfig } from "vize";
-
-export default defineConfig({
-  musea: {
-    include: ["./stories/**/*.art.vue"],
-  },
-});
-"#;
-        if let Err(e) = fs::write(&config_path, config_content) {
-            eprintln!("vize musea new: failed to create vize.config.ts: {}", e);
-            std::process::exit(1);
-        }
-        eprintln!("  Created vize.config.ts");
-    }
-
-    eprintln!("  Created stories/Button.art.vue");
-    eprintln!();
-    eprintln!("Musea project '{}' created successfully!", project_name);
-    eprintln!();
-    eprintln!("Next steps:");
-    eprintln!("  1. Add more art files in the 'stories' directory");
-    eprintln!("  2. Enable @vizejs/vite-plugin-musea in your Vite or Nuxt project");
 }
 
 #[cfg(test)]

--- a/crates/vize/src/commands/musea.rs
+++ b/crates/vize/src/commands/musea.rs
@@ -28,6 +28,10 @@ pub enum MuseaCommand {
 #[derive(Args, Clone, Debug, PartialEq, Eq)]
 #[allow(clippy::disallowed_types)]
 pub struct ServeArgs {
+    /// Shared Vize config file path
+    #[arg(short, long, value_name = "FILE")]
+    pub config: Option<PathBuf>,
+
     /// Port to run the server on
     #[arg(short, long, default_value = "6006")]
     pub port: u16,
@@ -56,6 +60,7 @@ impl Default for ServeArgs {
     fn default() -> Self {
         Self {
             port: 6006,
+            config: None,
             host: cstr!("localhost"),
             stories: None,
             open: false,
@@ -168,11 +173,20 @@ fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePlan, String> 
         None => PathBuf::from("vite"),
     };
     validate_direct_vite_musea_setup(cwd)?;
+    let mut env = Vec::new();
+    if let Some(config_path) = &args.config {
+        env.push((
+            cstr!("VIZE_CONFIG_FILE"),
+            config_path.to_string_lossy().as_ref().to_compact_string(),
+        ));
+    }
+
     if args.build {
+        env.push((cstr!("VIZE_MUSEA_STATIC_BUILD"), cstr!("1")));
         return Ok(ServePlan {
             program,
             args: vec![cstr!("build")],
-            env: vec![(cstr!("VIZE_MUSEA_STATIC_BUILD"), cstr!("1"))],
+            env,
         });
     }
 
@@ -193,7 +207,7 @@ fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePlan, String> 
     Ok(ServePlan {
         program,
         args: vite_args,
-        env: Vec::new(),
+        env,
     })
 }
 

--- a/crates/vize/src/commands/musea/new.rs
+++ b/crates/vize/src/commands/musea/new.rs
@@ -1,0 +1,103 @@
+use clap::Args;
+use std::fs;
+use std::path::PathBuf;
+use vize_carton::{String, ToCompactString, cstr};
+
+#[derive(Args)]
+#[allow(clippy::disallowed_types)]
+pub struct NewArgs {
+    /// Name of the Musea project (defaults to current directory name)
+    pub name: Option<String>,
+
+    /// Directory to create the project in (defaults to current directory)
+    #[arg(short, long)]
+    pub path: Option<PathBuf>,
+}
+
+pub fn run(args: NewArgs) {
+    let target_dir = args.path.unwrap_or_else(|| PathBuf::from("."));
+    #[allow(clippy::disallowed_types, clippy::disallowed_methods)]
+    let project_name = args.name.unwrap_or_else(|| {
+        std::env::current_dir()
+            .ok()
+            .and_then(|p| {
+                p.file_name()
+                    .map(|name| name.to_string_lossy().as_ref().to_compact_string())
+            })
+            .unwrap_or_else(|| cstr!("stories"))
+    });
+
+    eprintln!(
+        "vize musea new: Creating Musea project '{}'...",
+        project_name
+    );
+
+    let stories_dir = target_dir.join("stories");
+    if let Err(e) = fs::create_dir_all(&stories_dir) {
+        eprintln!("vize musea new: failed to create stories directory: {}", e);
+        std::process::exit(1);
+    }
+
+    let example_story = stories_dir.join("Button.art.vue");
+    let example_content = r#"<script setup lang="ts">
+defineArt("../src/Button.vue", {
+  title: "Button",
+  category: "Components",
+  tags: ["button", "ui"],
+});
+</script>
+
+<art>
+  <variant name="Primary" default>
+    <Button variant="primary">Click me</Button>
+  </variant>
+
+  <variant name="Secondary">
+    <Button variant="secondary">Click me</Button>
+  </variant>
+
+  <variant name="Disabled">
+    <Button variant="primary" disabled>Disabled</Button>
+  </variant>
+</art>
+
+<style scoped>
+.art-preview {
+  padding: 0.5rem 1rem;
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+</style>
+"#;
+
+    if let Err(e) = fs::write(&example_story, example_content) {
+        eprintln!("vize musea new: failed to create example story: {}", e);
+        std::process::exit(1);
+    }
+
+    let config_path = target_dir.join("vize.config.ts");
+    if !config_path.exists() {
+        let config_content = r#"import { defineConfig } from "vize";
+
+export default defineConfig({
+  musea: {
+    include: ["./stories/**/*.art.vue"],
+  },
+});
+"#;
+        if let Err(e) = fs::write(&config_path, config_content) {
+            eprintln!("vize musea new: failed to create vize.config.ts: {}", e);
+            std::process::exit(1);
+        }
+        eprintln!("  Created vize.config.ts");
+    }
+
+    eprintln!("  Created stories/Button.art.vue");
+    eprintln!();
+    eprintln!("Musea project '{}' created successfully!", project_name);
+    eprintln!();
+    eprintln!("Next steps:");
+    eprintln!("  1. Add more art files in the 'stories' directory");
+    eprintln!("  2. Enable @vizejs/vite-plugin-musea in your Vite or Nuxt project");
+}

--- a/crates/vize/src/commands/musea/serve_plan.rs
+++ b/crates/vize/src/commands/musea/serve_plan.rs
@@ -1,0 +1,124 @@
+use super::{ServeArgs, setup};
+use setup::validate_direct_vite_musea_setup;
+use std::path::{Path, PathBuf};
+use vize_carton::{String, ToCompactString, cstr};
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct ServePlan {
+    pub(super) program: PathBuf,
+    pub(super) args: Vec<String>,
+    pub(super) env: Vec<(String, String)>,
+}
+
+pub(super) fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePlan, String> {
+    if let Some(stories) = &args.stories {
+        return Err(cstr!(
+            "vize musea: --stories is not supported by the Vite-backed serve entrypoint yet (got {}). Configure Musea include patterns in vize.config.ts instead.",
+            stories.display()
+        ));
+    }
+
+    let program = match resolve_vite_binary(cwd) {
+        Some(program) => program,
+        None if let Some(nuxt_root) = find_nuxt_project_root(cwd) => {
+            return Err(nuxt_musea_message(&nuxt_root, args.build));
+        }
+        None => PathBuf::from("vite"),
+    };
+    validate_direct_vite_musea_setup(cwd)?;
+    let mut env = Vec::new();
+    if let Some(config_path) = &args.config {
+        env.push((
+            cstr!("VIZE_CONFIG_FILE"),
+            config_path.to_string_lossy().as_ref().to_compact_string(),
+        ));
+    }
+
+    if args.build {
+        env.push((cstr!("VIZE_MUSEA_STATIC_BUILD"), cstr!("1")));
+        return Ok(ServePlan {
+            program,
+            args: vec![cstr!("build")],
+            env,
+        });
+    }
+
+    let mut vite_args = vec![
+        cstr!("dev"),
+        cstr!("--host"),
+        args.host.clone(),
+        cstr!("--port"),
+        args.port.to_compact_string(),
+    ];
+    if args.open {
+        vite_args.extend([cstr!("--open"), cstr!("/__musea__")]);
+    }
+    if args.strict_port {
+        vite_args.push(cstr!("--strictPort"));
+    }
+
+    Ok(ServePlan {
+        program,
+        args: vite_args,
+        env,
+    })
+}
+
+pub(super) fn resolve_vite_binary(cwd: &Path) -> Option<PathBuf> {
+    for ancestor in cwd.ancestors() {
+        let bin_dir = ancestor.join("node_modules").join(".bin");
+        for name in VITE_BIN_NAMES {
+            let candidate = bin_dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+fn find_nuxt_project_root(cwd: &Path) -> Option<PathBuf> {
+    cwd.ancestors()
+        .find(|ancestor| is_nuxt_project_root(ancestor))
+        .map(Path::to_path_buf)
+}
+
+fn is_nuxt_project_root(root: &Path) -> bool {
+    ["nuxt.config.ts", "nuxt.config.mts", "nuxt.config.js"]
+        .into_iter()
+        .any(|file_name| root.join(file_name).exists())
+        || setup::package_json_has_dependency(root, "nuxt")
+}
+
+fn has_vize_nuxt_integration(root: &Path) -> bool {
+    setup::package_json_has_dependency(root, "@vizejs/nuxt")
+        || root
+            .join("node_modules")
+            .join("@vizejs")
+            .join("nuxt")
+            .join("package.json")
+            .exists()
+}
+
+fn nuxt_musea_message(root: &Path, build: bool) -> String {
+    let command = if build { "nuxi build" } else { "nuxi dev" };
+    if has_vize_nuxt_integration(root) {
+        return cstr!(
+            "vize musea: detected a Nuxt project using `@vizejs/nuxt` at {}.\n  The standalone `vize musea` command only runs direct Vite projects with `vite` and `@vizejs/vite-plugin-musea` configured in Vite.\n  In this Nuxt setup, Musea is provided by the Nuxt module at `/__musea__/`; run `{}` and open that route instead.",
+            root.display(),
+            command
+        );
+    }
+
+    cstr!(
+        "vize musea: detected a Nuxt project at {}.\n  The standalone `vize musea` command only runs direct Vite projects with `vite` and `@vizejs/vite-plugin-musea` configured in Vite.\n  For Nuxt, enable `@vizejs/nuxt`, run `{}`, and open `/__musea__/` instead.",
+        root.display(),
+        command
+    )
+}
+
+#[cfg(windows)]
+pub(super) const VITE_BIN_NAMES: &[&str] = &["vite.cmd", "vite.ps1", "vite"];
+
+#[cfg(not(windows))]
+pub(super) const VITE_BIN_NAMES: &[&str] = &["vite"];

--- a/crates/vize/src/commands/musea/tests.rs
+++ b/crates/vize/src/commands/musea/tests.rs
@@ -1,4 +1,5 @@
-use super::{ServeArgs, VITE_BIN_NAMES, create_serve_plan, resolve_vite_binary};
+use super::ServeArgs;
+use super::serve_plan::{VITE_BIN_NAMES, create_serve_plan, resolve_vite_binary};
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/crates/vize/src/commands/musea/tests.rs
+++ b/crates/vize/src/commands/musea/tests.rs
@@ -113,6 +113,53 @@ fn serve_plan_runs_static_build_with_musea_environment() {
 }
 
 #[test]
+fn serve_plan_forwards_shared_vize_config_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let vite_bin = write_vite_bin(temp.path());
+    write_musea_vite_setup(temp.path());
+
+    let plan = create_serve_plan(
+        &ServeArgs {
+            config: Some(PathBuf::from("../vize.config.ts")),
+            ..ServeArgs::default()
+        },
+        temp.path(),
+    )
+    .unwrap();
+
+    assert_eq!(plan.program, vite_bin);
+    assert_eq!(
+        plan.env,
+        [("VIZE_CONFIG_FILE".into(), "../vize.config.ts".into())]
+    );
+}
+
+#[test]
+fn serve_plan_combines_shared_config_with_static_build_environment() {
+    let temp = tempfile::tempdir().unwrap();
+    write_vite_bin(temp.path());
+    write_musea_vite_setup(temp.path());
+
+    let plan = create_serve_plan(
+        &ServeArgs {
+            build: true,
+            config: Some(PathBuf::from("../vize.config.ts")),
+            ..ServeArgs::default()
+        },
+        temp.path(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        plan.env,
+        [
+            ("VIZE_CONFIG_FILE".into(), "../vize.config.ts".into()),
+            ("VIZE_MUSEA_STATIC_BUILD".into(), "1".into())
+        ]
+    );
+}
+
+#[test]
 fn serve_plan_supports_strict_port_alias_for_vite() {
     let temp = tempfile::tempdir().unwrap();
     let vite_bin = write_vite_bin(temp.path());

--- a/editors/vscode-art/package.json
+++ b/editors/vscode-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vize-art",
   "displayName": "Vize Art",
-  "version": "0.251.0",
+  "version": "0.252.0",
   "description": "Syntax highlighting for Vize Art files (*.art.vue)",
   "categories": [
     "Programming Languages"

--- a/npm/builder/unplugin/src/normalize-options.test.ts
+++ b/npm/builder/unplugin/src/normalize-options.test.ts
@@ -31,6 +31,7 @@ void test("legacy vue versions activate the host compiler", (t) => {
   t.assert.equal(normalizeOptions({ vueVersion: 0.11, isProduction: true }).hostCompiler, true);
   t.assert.equal(normalizeOptions({ vueVersion: 1, isProduction: true }).hostCompiler, true);
   t.assert.equal(normalizeOptions({ vueVersion: 2, isProduction: true }).hostCompiler, true);
+  t.assert.equal(normalizeOptions({ vueVersion: "2.7", isProduction: true }).hostCompiler, true);
   t.assert.equal(normalizeOptions({ vueVersion: "legacy", isProduction: true }).hostCompiler, true);
 });
 

--- a/npm/builder/unplugin/src/types.ts
+++ b/npm/builder/unplugin/src/types.ts
@@ -111,17 +111,17 @@ export interface VizeUnpluginOptions {
   debug?: boolean;
 }
 
-export type VizeVueVersion = 0.11 | 1 | 2 | 3 | "legacy";
+export type VizeVueVersion = 0.11 | 1 | 2 | "2.7" | 3 | "legacy";
 export type VizeTemplateSyntax = "standard" | "strict" | "quirks";
 
 export interface VizeCompatibilityOptions {
   /**
-   * Host Vue version. Vue 0.11/1/2 opt into host-compiler compatibility.
+   * Host Vue version. Vue 0.11/1/2/2.7 opt into host-compiler compatibility.
    */
   vueVersion?: VizeVueVersion;
   /**
    * Keep .vue files on the existing Vue compiler for legacy Vue runtimes.
-   * @default true when vueVersion is 0.11, 1, 2, or "legacy"
+   * @default true when vueVersion is 0.11, 1, 2, "2.7", or "legacy"
    */
   hostCompiler?: boolean;
   /**

--- a/npm/builder/unplugin/src/unplugin.ts
+++ b/npm/builder/unplugin/src/unplugin.ts
@@ -40,7 +40,9 @@ function normalizeVueVersion(version: VizeUnpluginOptions["vueVersion"]): VizeVu
 }
 
 function isLegacyVueVersion(version: VizeVueVersion): boolean {
-  return version === "legacy" || version === 0.11 || version === 1 || version === 2;
+  return (
+    version === "legacy" || version === 0.11 || version === 1 || version === 2 || version === "2.7"
+  );
 }
 
 function normalizeTemplateSyntax(

--- a/npm/builder/vite-musea/src/cli/utils.test.ts
+++ b/npm/builder/vite-musea/src/cli/utils.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { scanArtFiles } from "./utils.ts";
+
+void test("scanArtFiles skips unreadable directories", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-musea-scan-"));
+  const locked = path.join(root, "locked");
+
+  try {
+    fs.mkdirSync(locked);
+    fs.chmodSync(locked, 0);
+    fs.writeFileSync(path.join(root, "Button.art.vue"), "<art></art>");
+
+    const files = await scanArtFiles(root);
+
+    assert.deepEqual(files, [path.join(root, "Button.art.vue")]);
+  } finally {
+    fs.chmodSync(locked, 0o700);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/npm/builder/vite-musea/src/cli/utils.ts
+++ b/npm/builder/vite-musea/src/cli/utils.ts
@@ -14,7 +14,15 @@ export async function scanArtFiles(root: string): Promise<string[]> {
   const files: string[] = [];
 
   async function scan(dir: string): Promise<void> {
-    const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EACCES") {
+        return;
+      }
+      throw error;
+    }
 
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);

--- a/npm/builder/vite-musea/src/plugin/config.ts
+++ b/npm/builder/vite-musea/src/plugin/config.ts
@@ -1,0 +1,32 @@
+import type { ResolvedConfig } from "vite";
+import { VIZE_CONFIG_FILE_ENV, loadConfig, vizeConfigStore } from "@vizejs/vite-plugin";
+
+export async function resolveMuseaSharedConfig(resolvedConfig: ResolvedConfig) {
+  const sharedConfig = vizeConfigStore.get(resolvedConfig.root);
+  if (sharedConfig) {
+    return sharedConfig;
+  }
+
+  const configFile = process.env[VIZE_CONFIG_FILE_ENV];
+  if (!configFile) {
+    return null;
+  }
+
+  try {
+    return await loadConfig(resolvedConfig.root, {
+      configFile,
+      env: {
+        mode: resolvedConfig.mode,
+        command: resolvedConfig.command === "build" ? "build" : "serve",
+        isSsrBuild: !!resolvedConfig.build?.ssr,
+      },
+    });
+  } catch (error) {
+    throw new Error(
+      `[musea] Failed to load Vize config from ${configFile}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error },
+    );
+  }
+}

--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -2,7 +2,6 @@ import type { Plugin, ViteDevServer, ResolvedConfig } from "vite";
 import { transformWithEsbuild } from "vite";
 import fs from "node:fs";
 import path from "node:path";
-import { VIZE_CONFIG_FILE_ENV, loadConfig, vizeConfigStore } from "@vizejs/vite-plugin";
 
 import type { MuseaOptions, ArtFileInfo, ArtMetadata } from "../types/index.js";
 
@@ -37,6 +36,7 @@ import {
   shouldEnableMuseaStaticBuild,
   type StaticBuildInput,
 } from "../static-export.js";
+import { resolveMuseaSharedConfig } from "./config.js";
 
 function extractArtTagAttributes(source: string): Record<string, string | true> {
   const artTagMatch = source.match(/<art\b([\s\S]*?)>/i);
@@ -390,34 +390,4 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
   }
 
   return [mainPlugin];
-}
-
-async function resolveMuseaSharedConfig(resolvedConfig: ResolvedConfig) {
-  const sharedConfig = vizeConfigStore.get(resolvedConfig.root);
-  if (sharedConfig) {
-    return sharedConfig;
-  }
-
-  const configFile = process.env[VIZE_CONFIG_FILE_ENV];
-  if (!configFile) {
-    return null;
-  }
-
-  try {
-    return await loadConfig(resolvedConfig.root, {
-      configFile,
-      env: {
-        mode: resolvedConfig.mode,
-        command: resolvedConfig.command === "build" ? "build" : "serve",
-        isSsrBuild: !!resolvedConfig.build?.ssr,
-      },
-    });
-  } catch (error) {
-    throw new Error(
-      `[musea] Failed to load Vize config from ${configFile}: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-      { cause: error },
-    );
-  }
 }

--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -2,7 +2,7 @@ import type { Plugin, ViteDevServer, ResolvedConfig } from "vite";
 import { transformWithEsbuild } from "vite";
 import fs from "node:fs";
 import path from "node:path";
-import { vizeConfigStore } from "@vizejs/vite-plugin";
+import { VIZE_CONFIG_FILE_ENV, loadConfig, vizeConfigStore } from "@vizejs/vite-plugin";
 
 import type { MuseaOptions, ArtFileInfo, ArtMetadata } from "../types/index.js";
 
@@ -156,10 +156,10 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
     },
 
     options: applyMuseaStaticBuildInput,
-    configResolved(resolvedConfig) {
+    async configResolved(resolvedConfig) {
       config = resolvedConfig;
 
-      const vizeConfig = vizeConfigStore.get(resolvedConfig.root);
+      const vizeConfig = await resolveMuseaSharedConfig(resolvedConfig);
       if (vizeConfig?.musea) {
         const mc = vizeConfig.musea;
         if (!options.include && mc.include) include = mc.include;
@@ -390,4 +390,34 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
   }
 
   return [mainPlugin];
+}
+
+async function resolveMuseaSharedConfig(resolvedConfig: ResolvedConfig) {
+  const sharedConfig = vizeConfigStore.get(resolvedConfig.root);
+  if (sharedConfig) {
+    return sharedConfig;
+  }
+
+  const configFile = process.env[VIZE_CONFIG_FILE_ENV];
+  if (!configFile) {
+    return null;
+  }
+
+  try {
+    return await loadConfig(resolvedConfig.root, {
+      configFile,
+      env: {
+        mode: resolvedConfig.mode,
+        command: resolvedConfig.command === "build" ? "build" : "serve",
+        isSsrBuild: !!resolvedConfig.build?.ssr,
+      },
+    });
+  } catch (error) {
+    throw new Error(
+      `[musea] Failed to load Vize config from ${configFile}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error },
+    );
+  }
 }

--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -2,7 +2,6 @@ import type { Plugin, ViteDevServer, ResolvedConfig } from "vite";
 import { transformWithEsbuild } from "vite";
 import fs from "node:fs";
 import path from "node:path";
-
 import type { MuseaOptions, ArtFileInfo, ArtMetadata } from "../types/index.js";
 
 import { loadNative } from "../native-loader.js";

--- a/npm/builder/vite/src/config.ts
+++ b/npm/builder/vite/src/config.ts
@@ -24,6 +24,7 @@ export {
 };
 
 export const CONFIG_FILES = [...CONFIG_FILE_NAMES];
+export const VIZE_CONFIG_FILE_ENV = "VIZE_CONFIG_FILE";
 
 /**
  * Shared config store for inter-plugin communication.

--- a/npm/builder/vite/src/index.ts
+++ b/npm/builder/vite/src/index.ts
@@ -3,7 +3,13 @@
  */
 
 export { vize } from "./plugin/index.ts";
-export { defineConfig, loadConfig, resolveConfigExport, vizeConfigStore } from "./config.ts";
+export {
+  VIZE_CONFIG_FILE_ENV,
+  defineConfig,
+  loadConfig,
+  resolveConfigExport,
+  vizeConfigStore,
+} from "./config.ts";
 export { rewriteStaticAssetUrls as __internal_rewriteStaticAssetUrls } from "./transform.ts";
 export type {
   VizeOptions,

--- a/npm/builder/vite/src/plugin/index.test.ts
+++ b/npm/builder/vite/src/plugin/index.test.ts
@@ -21,6 +21,11 @@ import { createLegacyVueCompatibilityPlugin, isLegacyVueCompatibilityMode } from
     "vueVersion: 2 should enable legacy Vue compatibility mode",
   );
   assert.equal(
+    isLegacyVueCompatibilityMode({ vueVersion: "2.7" }),
+    true,
+    "vueVersion: 2.7 should enable legacy Vue compatibility mode",
+  );
+  assert.equal(
     isLegacyVueCompatibilityMode({ vueVersion: "legacy" }),
     true,
     "vueVersion: legacy should enable legacy Vue compatibility mode",

--- a/npm/builder/vite/src/plugin/index.ts
+++ b/npm/builder/vite/src/plugin/index.ts
@@ -6,7 +6,12 @@ import type { VizeOptions, ConfigEnv, ResolvedVizeConfig } from "../types.ts";
 import { createFilter } from "../utils/index.ts";
 import { toBrowserImportPrefix } from "../virtual.ts";
 import { shouldApplyDefineInVirtualModule, createLogger } from "../transform.ts";
-import { VIZE_CONFIG_FILE_ENV, loadConfig, resolveConfigExport, vizeConfigStore } from "../config.ts";
+import {
+  VIZE_CONFIG_FILE_ENV,
+  loadConfig,
+  resolveConfigExport,
+  vizeConfigStore,
+} from "../config.ts";
 import {
   DEFAULT_PRECOMPILE_BATCH_SIZE,
   DEFAULT_PRECOMPILE_IGNORE_PATTERNS,

--- a/npm/builder/vite/src/plugin/index.ts
+++ b/npm/builder/vite/src/plugin/index.ts
@@ -6,7 +6,12 @@ import type { VizeOptions, ConfigEnv, ResolvedVizeConfig } from "../types.ts";
 import { createFilter } from "../utils/index.ts";
 import { toBrowserImportPrefix } from "../virtual.ts";
 import { shouldApplyDefineInVirtualModule, createLogger } from "../transform.ts";
-import { loadConfig, resolveConfigExport, vizeConfigStore } from "../config.ts";
+import {
+  VIZE_CONFIG_FILE_ENV,
+  loadConfig,
+  resolveConfigExport,
+  vizeConfigStore,
+} from "../config.ts";
 import {
   DEFAULT_PRECOMPILE_BATCH_SIZE,
   DEFAULT_PRECOMPILE_IGNORE_PATTERNS,
@@ -229,20 +234,18 @@ export function vize(options: VizeOptions = {}): Plugin[] {
 
       let fileConfig: ResolvedVizeConfig | null = null;
       if (options.configMode !== false) {
+        const configFile = options.configFile ?? process.env[VIZE_CONFIG_FILE_ENV];
         try {
           fileConfig = await loadConfig(state.root, {
             mode: options.configMode ?? "root",
-            configFile: options.configFile,
+            configFile,
             env: configEnv,
           });
           if (fileConfig) {
             state.logger.log("Loaded config from vize.config file");
           }
         } catch (error) {
-          state.logger.warn(
-            `Failed to load vize config from ${options.configFile ?? state.root}:`,
-            error,
-          );
+          state.logger.warn(`Failed to load vize config from ${configFile ?? state.root}:`, error);
         }
       }
 

--- a/npm/builder/vite/src/plugin/index.ts
+++ b/npm/builder/vite/src/plugin/index.ts
@@ -6,12 +6,7 @@ import type { VizeOptions, ConfigEnv, ResolvedVizeConfig } from "../types.ts";
 import { createFilter } from "../utils/index.ts";
 import { toBrowserImportPrefix } from "../virtual.ts";
 import { shouldApplyDefineInVirtualModule, createLogger } from "../transform.ts";
-import {
-  VIZE_CONFIG_FILE_ENV,
-  loadConfig,
-  resolveConfigExport,
-  vizeConfigStore,
-} from "../config.ts";
+import { VIZE_CONFIG_FILE_ENV, loadConfig, resolveConfigExport, vizeConfigStore } from "../config.ts";
 import {
   DEFAULT_PRECOMPILE_BATCH_SIZE,
   DEFAULT_PRECOMPILE_IGNORE_PATTERNS,

--- a/npm/builder/vite/src/plugin/index.ts
+++ b/npm/builder/vite/src/plugin/index.ts
@@ -41,57 +41,12 @@ import {
   isLegacyVueCompatibilityMode,
   isLegacyVueVersion,
 } from "./vue-version.ts";
+import { mergeSharedConfig } from "./shared-config.ts";
 
 export type { VizePluginState } from "./state.ts";
 
 function aliasSortKey(find: string | RegExp): number {
   return typeof find === "string" ? find.length : find.source.length;
-}
-
-function mergeSharedConfig(
-  baseConfig: ResolvedVizeConfig | null,
-  overrideConfig: ResolvedVizeConfig | null,
-): ResolvedVizeConfig | null {
-  if (!baseConfig) return overrideConfig;
-  if (!overrideConfig) return baseConfig;
-
-  return {
-    ...baseConfig,
-    ...overrideConfig,
-    compiler: {
-      ...baseConfig.compiler,
-      ...overrideConfig.compiler,
-    },
-    vite: {
-      ...baseConfig.vite,
-      ...overrideConfig.vite,
-    },
-    linter: {
-      ...baseConfig.linter,
-      ...overrideConfig.linter,
-    },
-    typeChecker: {
-      ...baseConfig.typeChecker,
-      ...overrideConfig.typeChecker,
-    },
-    formatter: {
-      ...baseConfig.formatter,
-      ...overrideConfig.formatter,
-    },
-    languageServer: {
-      ...baseConfig.languageServer,
-      ...overrideConfig.languageServer,
-    },
-    musea: {
-      ...baseConfig.musea,
-      ...overrideConfig.musea,
-    },
-    globalTypes: {
-      ...baseConfig.globalTypes,
-      ...overrideConfig.globalTypes,
-    },
-    entries: [...baseConfig.entries, ...overrideConfig.entries],
-  };
 }
 
 function shouldExtractCssForBuild(

--- a/npm/builder/vite/src/plugin/shared-config.ts
+++ b/npm/builder/vite/src/plugin/shared-config.ts
@@ -1,0 +1,47 @@
+import type { ResolvedVizeConfig } from "../types.ts";
+
+export function mergeSharedConfig(
+  baseConfig: ResolvedVizeConfig | null,
+  overrideConfig: ResolvedVizeConfig | null,
+): ResolvedVizeConfig | null {
+  if (!baseConfig) return overrideConfig;
+  if (!overrideConfig) return baseConfig;
+
+  return {
+    ...baseConfig,
+    ...overrideConfig,
+    compiler: {
+      ...baseConfig.compiler,
+      ...overrideConfig.compiler,
+    },
+    vite: {
+      ...baseConfig.vite,
+      ...overrideConfig.vite,
+    },
+    linter: {
+      ...baseConfig.linter,
+      ...overrideConfig.linter,
+    },
+    typeChecker: {
+      ...baseConfig.typeChecker,
+      ...overrideConfig.typeChecker,
+    },
+    formatter: {
+      ...baseConfig.formatter,
+      ...overrideConfig.formatter,
+    },
+    languageServer: {
+      ...baseConfig.languageServer,
+      ...overrideConfig.languageServer,
+    },
+    musea: {
+      ...baseConfig.musea,
+      ...overrideConfig.musea,
+    },
+    globalTypes: {
+      ...baseConfig.globalTypes,
+      ...overrideConfig.globalTypes,
+    },
+    entries: [...baseConfig.entries, ...overrideConfig.entries],
+  };
+}

--- a/npm/builder/vite/src/plugin/vue-version.ts
+++ b/npm/builder/vite/src/plugin/vue-version.ts
@@ -4,7 +4,9 @@ import type { VizeOptions } from "../types.ts";
 import { createLogger } from "../transform.ts";
 
 export function isLegacyVueVersion(version: VizeOptions["vueVersion"] | undefined): boolean {
-  return version === "legacy" || version === 0.11 || version === 1 || version === 2;
+  return (
+    version === "legacy" || version === 0.11 || version === 1 || version === 2 || version === "2.7"
+  );
 }
 
 export function isLegacyVueCompatibilityMode(options: VizeOptions): boolean {

--- a/npm/builder/vite/src/types.ts
+++ b/npm/builder/vite/src/types.ts
@@ -105,16 +105,16 @@ export type CompileJsxFn = (
   options?: JsxCompileOptionsNapi,
 ) => JsxCompileResultNapi;
 
-export type VizeVueVersion = 0.11 | 1 | 2 | 3 | "legacy";
+export type VizeVueVersion = 0.11 | 1 | 2 | "2.7" | 3 | "legacy";
 
 export interface VizeCompatibilityOptions {
   /**
-   * Host Vue version. Vue 0.11/1/2 opt into host-compiler compatibility.
+   * Host Vue version. Vue 0.11/1/2/2.7 opt into host-compiler compatibility.
    */
   vueVersion?: VizeVueVersion;
   /**
    * Keep .vue files on the existing Vue compiler for legacy Vue runtimes.
-   * @default true when vueVersion is 0.11, 1, 2, or "legacy"
+   * @default true when vueVersion is 0.11, 1, 2, "2.7", or "legacy"
    */
   hostCompiler?: boolean;
   /**

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -37,10 +37,12 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs",
       "types": "./dist/index.d.mts"
     },
     "./config": {
       "import": "./dist/config.mjs",
+      "default": "./dist/config.mjs",
       "types": "./dist/config.d.mts"
     },
     "./schemas/vize.config.schema.json": "./schemas/vize.config.schema.json",
@@ -72,7 +74,7 @@
   },
   "peerDependencies": {
     "@pkl-community/pkl": "catalog:repo-tooling",
-    "vue": ">=2.7.0"
+    "vue": ">=2.6.0"
   },
   "peerDependenciesMeta": {
     "@pkl-community/pkl": {

--- a/npm/framework/nuxt/src/compiler-options.ts
+++ b/npm/framework/nuxt/src/compiler-options.ts
@@ -1,5 +1,5 @@
 export type VizeNuxtPattern = string | RegExp;
-export type VizeNuxtVueVersion = 0.11 | 1 | 2 | 3 | "legacy";
+export type VizeNuxtVueVersion = 0.11 | 1 | 2 | "2.7" | 3 | "legacy";
 
 export interface VizeNuxtCompilerCompatibilityOptions {
   vueVersion?: VizeNuxtVueVersion;
@@ -22,7 +22,7 @@ export interface VizeNuxtCompilerOptions {
    * Vue major version for the host project.
    *
    * Legacy Vue projects keep the host Vue compiler in charge. When set to
-   * `0.11`, `1`, `2`, or `"legacy"`, the underlying Vite plugin runs in
+   * `0.11`, `1`, `2`, `"2.7"`, or `"legacy"`, the underlying Vite plugin runs in
    * compatibility mode and does not intercept `.vue` files.
    */
   vueVersion?: VizeNuxtVueVersion;

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -22,7 +22,6 @@ import {
   stabilizeNuxtInjectedKeysForVizeVirtualModule,
 } from "./utils";
 import { appendOriginalVueSourceForUnoCss } from "./unocss";
-
 type ViteTransformResult = string | { code?: string; map?: unknown } | null | undefined;
 const VIZE_NUXT_AUTO_IMPORT_PATCHED = "__vizeNuxtAutoImportPatched";
 const VUE_RUNTIME_DEDUPE = [

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -1,6 +1,7 @@
 import { createNuxtComponentResolver, injectNuxtComponentImports } from "./components";
 import { injectNuxtI18nHelpers } from "./i18n";
 import { appendMuseaArtComponentIgnore } from "./musea-components";
+import "./schema";
 import type { VizeNuxtCompilerOptions, VizeNuxtOptions } from "./options";
 import {
   resolveNuxtBridgeOptions,
@@ -674,26 +675,6 @@ const vizeNuxtModule = Object.assign(
 );
 
 export default vizeNuxtModule;
-
-declare module "nuxt/schema" {
-  interface NuxtConfig {
-    vize?: Partial<VizeNuxtOptions>;
-  }
-
-  interface NuxtOptions {
-    vize?: Partial<VizeNuxtOptions>;
-  }
-}
-
-declare module "@nuxt/schema" {
-  interface NuxtConfig {
-    vize?: Partial<VizeNuxtOptions>;
-  }
-
-  interface NuxtOptions {
-    vize?: Partial<VizeNuxtOptions>;
-  }
-}
 
 // Re-export types for convenience
 export type { MuseaOptions } from "@vizejs/vite-plugin-musea";

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -675,6 +675,26 @@ const vizeNuxtModule = Object.assign(
 
 export default vizeNuxtModule;
 
+declare module "nuxt/schema" {
+  interface NuxtConfig {
+    vize?: Partial<VizeNuxtOptions>;
+  }
+
+  interface NuxtOptions {
+    vize?: Partial<VizeNuxtOptions>;
+  }
+}
+
+declare module "@nuxt/schema" {
+  interface NuxtConfig {
+    vize?: Partial<VizeNuxtOptions>;
+  }
+
+  interface NuxtOptions {
+    vize?: Partial<VizeNuxtOptions>;
+  }
+}
+
 // Re-export types for convenience
 export type { MuseaOptions } from "@vizejs/vite-plugin-musea";
 export type {

--- a/npm/framework/nuxt/src/options.test.ts
+++ b/npm/framework/nuxt/src/options.test.ts
@@ -38,18 +38,18 @@ assert.equal(
 assert.deepEqual(
   resolveNuxtCompilerOptions("/repo/app", "/", "/_nuxt/", true, {
     supportsViteCompiler: true,
-    vueVersion: 1,
+    vueVersion: "2.7",
   }),
   {
     compatibility: {
-      vueVersion: 1,
+      vueVersion: "2.7",
       hostCompiler: true,
     },
     devUrlBase: "/_nuxt/",
     exclude: NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
     root: "/repo/app",
     scanPatterns: [],
-    vueVersion: 1,
+    vueVersion: "2.7",
   },
   "Vite-based legacy Vue projects should pass host-compiler compatibility mode to the Vite plugin",
 );

--- a/npm/framework/nuxt/src/options.ts
+++ b/npm/framework/nuxt/src/options.ts
@@ -214,7 +214,9 @@ export const DEFAULT_NUXT_DEV_OPTIONS: Required<VizeNuxtDevOptions> = {
 };
 
 function isLegacyVueVersion(version: VizeNuxtVueVersion | undefined): boolean {
-  return version === 0.11 || version === 1 || version === 2 || version === "legacy";
+  return (
+    version === 0.11 || version === 1 || version === 2 || version === "2.7" || version === "legacy"
+  );
 }
 
 function normalizeNuxtCompilerCompatibilityOptions(

--- a/npm/framework/nuxt/src/options.ts
+++ b/npm/framework/nuxt/src/options.ts
@@ -337,12 +337,3 @@ export function resolveNuxtMuseaOptions(musea: VizeNuxtOptions["musea"]): MuseaO
   }
   return musea;
 }
-
-declare module "nuxt/schema" {
-  interface NuxtConfig { vize?: Partial<VizeNuxtOptions> }
-  interface NuxtOptions { vize?: Partial<VizeNuxtOptions> }
-}
-declare module "@nuxt/schema" {
-  interface NuxtConfig { vize?: Partial<VizeNuxtOptions> }
-  interface NuxtOptions { vize?: Partial<VizeNuxtOptions> }
-}

--- a/npm/framework/nuxt/src/options.ts
+++ b/npm/framework/nuxt/src/options.ts
@@ -337,3 +337,12 @@ export function resolveNuxtMuseaOptions(musea: VizeNuxtOptions["musea"]): MuseaO
   }
   return musea;
 }
+
+declare module "nuxt/schema" {
+  interface NuxtConfig { vize?: Partial<VizeNuxtOptions> }
+  interface NuxtOptions { vize?: Partial<VizeNuxtOptions> }
+}
+declare module "@nuxt/schema" {
+  interface NuxtConfig { vize?: Partial<VizeNuxtOptions> }
+  interface NuxtOptions { vize?: Partial<VizeNuxtOptions> }
+}

--- a/npm/framework/nuxt/src/schema.ts
+++ b/npm/framework/nuxt/src/schema.ts
@@ -1,0 +1,21 @@
+import type { VizeNuxtOptions } from "./options";
+
+declare module "nuxt/schema" {
+  interface NuxtConfig {
+    vize?: Partial<VizeNuxtOptions>;
+  }
+
+  interface NuxtOptions {
+    vize?: Partial<VizeNuxtOptions>;
+  }
+}
+
+declare module "@nuxt/schema" {
+  interface NuxtConfig {
+    vize?: Partial<VizeNuxtOptions>;
+  }
+
+  interface NuxtOptions {
+    vize?: Partial<VizeNuxtOptions>;
+  }
+}

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -334,7 +334,7 @@ test("vize package leaves Vue type versions to the consuming project", () => {
   assert.equal(packageJson.dependencies?.vue, undefined);
   assert.equal(packageJson.optionalDependencies?.vue, undefined);
   assert.equal(packageJson.devDependencies?.vue, "catalog:vue-stable");
-  assert.equal(packageJson.peerDependencies?.vue, ">=2.7.0");
+  assert.equal(packageJson.peerDependencies?.vue, ">=2.6.0");
   assert.deepEqual(packageJson.peerDependenciesMeta?.vue, {
     optional: true,
   });


### PR DESCRIPTION
## Summary

- accept string-based Vue 2.7 compatibility values across Vite, Nuxt, and unplugin option types
- add Nuxt config augmentation for the `vize` key used by `defineNuxtConfig`
- allow `vize musea --config <file>` to forward a shared Vize config into Vite/Musea builds and surface explicit config-load failures
- relax the optional `vue` peer for host-compiler Vue 2.6 installs and add package export fallbacks for Jiti-style loaders
- skip unreadable directories during Musea art scans

Closes #2141
Closes #2142
Closes #2147
Closes #2148
Closes #2150
Closes #2153
Closes #2157

## Verification

- `cargo test -p vize --lib commands::musea::tests`
- `pnpm --dir npm/builder/vite run check`
- `pnpm --dir npm/builder/vite run test`
- `pnpm --dir npm/builder/unplugin run check`
- `pnpm --dir npm/builder/unplugin run test`
- `pnpm --dir npm/builder/vite-musea run check`
- `pnpm --dir npm/builder/vite-musea run test`
- `pnpm --dir npm/framework/nuxt run check`
- `pnpm --dir npm/framework/nuxt run test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->