### PR TITLE
fix(patina): keep vapor script rules out of nuxt preset

### DIFF
--- a/crates/vize/tests/lint_config_cli.rs
+++ b/crates/vize/tests/lint_config_cli.rs
@@ -191,7 +191,7 @@ const items = [{ id: 1, name: 'One' }]
 }
 
 #[test]
-fn lint_nuxt_preset_allows_next_tick_when_compiler_vapor_is_false() {
+fn lint_nuxt_preset_allows_next_tick_by_default_and_when_compiler_vapor_is_false() {
     let project_root = temp_project_dir("nuxt-non-vapor-next-tick");
     let sfc = r#"<script setup lang="ts">
 import { nextTick } from 'vue'
@@ -215,13 +215,11 @@ await nextTick()
         .output()
         .unwrap();
     assert!(
-        !nuxt_default.status.success(),
+        nuxt_default.status.success(),
         "stdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&nuxt_default.stdout),
         String::from_utf8_lossy(&nuxt_default.stderr)
     );
-    let default_stdout = String::from_utf8_lossy(&nuxt_default.stdout);
-    assert!(default_stdout.contains("script/no-next-tick"));
 
     let non_vapor = Command::new(env!("CARGO_BIN_EXE_vize"))
         .current_dir(&project_root)

--- a/crates/vize_patina/src/linter/tests/nuxt.rs
+++ b/crates/vize_patina/src/linter/tests/nuxt.rs
@@ -21,11 +21,12 @@ export default defineComponent({
 }
 
 #[test]
-fn nuxt_preset_allows_next_tick_when_vapor_is_explicitly_disabled() {
-    let linter = Linter::with_preset(LintPreset::Nuxt).with_vapor_mode(Some(false));
+fn nuxt_preset_allows_vapor_only_script_patterns_by_default() {
+    let linter = Linter::with_preset(LintPreset::Nuxt);
     let sfc = r#"<script setup lang="ts">
-import { nextTick } from 'vue'
+import { getCurrentInstance, nextTick } from 'vue'
 
+const instance = getCurrentInstance()
 await nextTick()
 </script>
 "#;
@@ -36,14 +37,43 @@ await nextTick()
             .diagnostics
             .iter()
             .any(|diagnostic| diagnostic.rule_name == "script/no-next-tick"),
-        "non-Vapor Nuxt projects should not report script/no-next-tick, got {:?}",
+        "Nuxt projects should not report script/no-next-tick unless the rule is enabled, got {:?}",
+        result.diagnostics
+    );
+    assert!(
+        !result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.rule_name == "script/no-get-current-instance"),
+        "Nuxt projects should not report script/no-get-current-instance unless the rule is enabled, got {:?}",
         result.diagnostics
     );
 }
 
 #[test]
-fn nuxt_preset_keeps_next_tick_diagnostic_when_vapor_is_unspecified() {
-    let linter = Linter::with_preset(LintPreset::Nuxt);
+fn nuxt_preset_allows_next_tick_in_standalone_scripts_by_default() {
+    let result = Linter::with_preset(LintPreset::Nuxt).lint_script(
+        r#"import { nextTick } from "@nuxtjs/composition-api";
+
+await nextTick();
+"#,
+        "composables/useDialog.ts",
+    );
+
+    assert!(
+        !result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.rule_name == "script/no-next-tick"),
+        "Nuxt composables should not report script/no-next-tick unless the rule is enabled, got {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn nuxt_preset_reports_next_tick_when_rule_is_enabled() {
+    let linter = Linter::with_preset(LintPreset::Nuxt)
+        .with_additional_rules(vec!["script/no-next-tick".into()]);
     let sfc = r#"<script setup lang="ts">
 import { nextTick } from 'vue'
 
@@ -57,7 +87,7 @@ await nextTick()
             .diagnostics
             .iter()
             .any(|diagnostic| diagnostic.rule_name == "script/no-next-tick"),
-        "default Nuxt preset should remain unchanged, got {:?}",
+        "explicit script/no-next-tick should still report, got {:?}",
         result.diagnostics
     );
 }

--- a/crates/vize_patina/src/preset.rs
+++ b/crates/vize_patina/src/preset.rs
@@ -65,7 +65,7 @@ const OPINIONATED_SCRIPT_RULE_NAMES: &[&str] = &[
     "script/no-get-current-instance",
     "script/no-next-tick",
 ];
-const NUXT_SCRIPT_RULE_NAMES: &[&str] = &["script/no-get-current-instance", "script/no-next-tick"];
+const NUXT_SCRIPT_RULE_NAMES: &[&str] = &[];
 
 pub(crate) const fn builtin_script_rule_names(preset: LintPreset) -> &'static [&'static str] {
     match preset {
@@ -97,10 +97,9 @@ const OPINIONATED_CSS_RULE_NAMES: &[&str] = &[
 /// Built-in `css/*` rules enabled by a preset.
 ///
 /// The `css/*` rules are opt-in: only the strict `opinionated`/`nuxt` presets
-/// enable them (mirroring how those presets enable the opinionated script
-/// rules). The default `ecosystem` preset and the lighter presets enable none,
-/// so existing users are unaffected. Hosts can still enable any `css/*` rule by
-/// name via `with_enabled_rules`/`with_additional_rules`.
+/// enable them. The default `ecosystem` preset and the lighter presets enable
+/// none, so existing users are unaffected. Hosts can still enable any `css/*`
+/// rule by name via `with_enabled_rules`/`with_additional_rules`.
 pub(crate) const fn builtin_css_rule_names(preset: LintPreset) -> &'static [&'static str] {
     match preset {
         LintPreset::Opinionated | LintPreset::Nuxt => OPINIONATED_CSS_RULE_NAMES,
@@ -218,6 +217,13 @@ mod tests {
         );
         assert!(
             !super::builtin_script_rule_names(LintPreset::Nuxt).contains(&"script/no-options-api")
+        );
+        assert!(
+            !super::builtin_script_rule_names(LintPreset::Nuxt)
+                .contains(&"script/no-get-current-instance")
+        );
+        assert!(
+            !super::builtin_script_rule_names(LintPreset::Nuxt).contains(&"script/no-next-tick")
         );
         assert!(
             super::builtin_script_rule_names(LintPreset::Opinionated)

--- a/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
+++ b/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
@@ -365,8 +365,6 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
     "type/no-floating-promises",
     "type/no-reactivity-loss",
     "type/no-unsafe-template-binding",
-    "script/no-get-current-instance",
-    "script/no-next-tick",
     "css/no-important",
     "css/no-id-selectors",
     "css/prefer-logical-properties",

--- a/editors/vscode-art/package.json
+++ b/editors/vscode-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vize-art",
   "displayName": "Vize Art",
-  "version": "0.251.0",
+  "version": "0.252.0",
   "description": "Syntax highlighting for Vize Art files (*.art.vue)",
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
## Summary
- remove Vapor-only script rules from the Nuxt preset defaults
- keep explicit script/no-next-tick opt-in behavior covered by tests
- update preset membership snapshot

## Verification
- cargo fmt --all
- INSTA_UPDATE=always cargo test -p vize_patina preset::tests::preset_rule_membership_snapshot -- --nocapture
- cargo test -p vize_patina nuxt_preset -- --nocapture
- cargo test -p vize_patina preset::tests::happy_path_keeps_opinionated_rules_opt_in -- --nocapture
- GITHUB_BASE_REF=main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Closes #2139
Closes #2143

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->