### PR TITLE
fix(unplugin): add cjs webpack entry for jiti

### DIFF
--- a/editors/vscode-art/package.json
+++ b/editors/vscode-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vize-art",
   "displayName": "Vize Art",
-  "version": "0.251.0",
+  "version": "0.252.0",
   "description": "Syntax highlighting for Vize Art files (*.art.vue)",
   "categories": [
     "Programming Languages"

--- a/npm/builder/unplugin/package.json
+++ b/npm/builder/unplugin/package.json
@@ -55,6 +55,7 @@
     "./webpack": {
       "types": "./dist/webpack.d.mts",
       "import": "./dist/webpack.mjs",
+      "require": "./dist/webpack-cjs.cjs",
       "default": "./dist/webpack.mjs"
     },
     "./babel": {

--- a/npm/builder/unplugin/src/webpack-cjs.test.ts
+++ b/npm/builder/unplugin/src/webpack-cjs.test.ts
@@ -1,0 +1,26 @@
+import { test } from "node:test";
+import vizeWebpackCjs from "./webpack-cjs.ts";
+
+void test("webpack CJS entry loads as a no-op plugin for Nuxt 2 host-compiler configs", (t) => {
+  t.assert.doesNotThrow(() => {
+    vizeWebpackCjs({ compatibility: { nuxtVersion: 2 } }).apply({} as never);
+  });
+});
+
+void test("webpack CJS entry treats legacy Vue configs as host-compiler configs", (t) => {
+  for (const vueVersion of [0.11, 1, 2, "legacy"] as const) {
+    t.assert.doesNotThrow(() => {
+      vizeWebpackCjs({ vueVersion }).apply({} as never);
+    });
+  }
+});
+
+void test("webpack CJS entry rejects modern compiler configs", (t) => {
+  t.assert.throws(() => {
+    vizeWebpackCjs().apply({} as never);
+  }, /CommonJS/);
+
+  t.assert.throws(() => {
+    vizeWebpackCjs({ compatibility: { hostCompiler: false }, vueVersion: 2 }).apply({} as never);
+  }, /CommonJS/);
+});

--- a/npm/builder/unplugin/src/webpack-cjs.ts
+++ b/npm/builder/unplugin/src/webpack-cjs.ts
@@ -1,0 +1,53 @@
+import type { Compiler as WebpackCompiler } from "webpack";
+import type { VizeUnpluginOptions } from "./types.ts";
+
+type WebpackPlugin = {
+  apply(compiler: WebpackCompiler): void;
+};
+
+function isLegacyVueVersion(version: unknown): boolean {
+  return (
+    version === "legacy" ||
+    version === "2" ||
+    version === "2.6" ||
+    version === "2.7" ||
+    version === 0.11 ||
+    version === 1 ||
+    version === 2
+  );
+}
+
+function shouldUseHostCompiler(options: VizeUnpluginOptions | undefined): boolean {
+  const compatibility = options?.compatibility;
+  return (
+    compatibility?.hostCompiler ??
+    (compatibility?.nuxtVersion === 2 ||
+      isLegacyVueVersion(options?.vueVersion ?? compatibility?.vueVersion))
+  );
+}
+
+function createUnsupportedCjsPlugin(): WebpackPlugin {
+  return {
+    apply() {
+      throw new Error(
+        "[vize] @vizejs/unplugin/webpack was loaded through CommonJS, which is only supported for Nuxt 2/Vue 2 host-compiler configs. Use an ESM webpack config, or pass { vueVersion: 2 } / { compatibility: { hostCompiler: true } }.",
+      );
+    },
+  };
+}
+
+function createHostCompilerPlugin(): WebpackPlugin {
+  return {
+    apply() {
+      // Nuxt 2/Vue 2 keeps the host Vue compiler in charge. The CJS entry exists
+      // so jiti can load nuxt.config.ts without evaluating unplugin's ESM runtime.
+    },
+  };
+}
+
+function vizeWebpackCjs(options?: VizeUnpluginOptions): WebpackPlugin {
+  return shouldUseHostCompiler(options) ? createHostCompilerPlugin() : createUnsupportedCjsPlugin();
+}
+
+export { vizeWebpackCjs };
+export default vizeWebpackCjs;

--- a/npm/builder/unplugin/vite.config.ts
+++ b/npm/builder/unplugin/vite.config.ts
@@ -18,8 +18,9 @@ export default defineConfig({
       "src/rollup.ts",
       "src/rolldown.ts",
       "src/webpack.ts",
+      "src/webpack-cjs.ts",
     ],
-    format: "esm",
+    format: ["esm", "cjs"],
     dts: {
       resolver: "tsc",
     },

--- a/tests/tooling/bundler-plugin-manifests.test.ts
+++ b/tests/tooling/bundler-plugin-manifests.test.ts
@@ -9,6 +9,7 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
 interface ExportEntry {
   default?: string;
   import?: string;
+  require?: string;
   types?: string;
 }
 
@@ -69,6 +70,12 @@ test("@vizejs/unplugin exposes per-bundler subpath entries wired at mjs/d.mts", 
       conditions.types?.endsWith(".d.mts"),
       `${subpath} types should point at a .d.mts file, got ${conditions.types}`,
     );
+    if (subpath === "./webpack") {
+      assert.ok(
+        conditions.require?.endsWith(".cjs"),
+        `${subpath} require should point at a .cjs file, got ${conditions.require}`,
+      );
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- add a CommonJS-safe `@vizejs/unplugin/webpack` require target for Nuxt 2/jiti config loading
- keep that CJS path limited to host-compiler legacy configs and preserve the existing ESM webpack entry for modern configs
- cover the package export and CJS shim behavior with tooling and package tests

## Verification
- `pnpm --dir npm/builder/unplugin run check`
- `pnpm --dir npm/builder/unplugin run test`
- `node --test tests/tooling/bundler-plugin-manifests.test.ts`
- `GITHUB_BASE_REF=main node --test tests/tooling/source-file-lengths.test.ts`
- `pnpm --dir npm/builder/unplugin run build`
- `node - <<'NODE' ... require('./npm/builder/unplugin/dist/webpack-cjs.cjs') ... NODE`
- `git diff --check`

Closes #2146

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->