### PR TITLE
fix(check): recognize defineArt in art files

### DIFF
--- a/crates/vize/tests/check_reference_types_cli.rs
+++ b/crates/vize/tests/check_reference_types_cli.rs
@@ -191,3 +191,81 @@ if (import.meta.vitest) {
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn check_provides_define_art_for_standalone_musea_art_files() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("standalone-art");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    link_workspace_vue(&project_root).unwrap();
+    write(
+        &project_root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write(
+        &project_root,
+        "src/MyButton.vue",
+        r#"<script setup lang="ts">
+defineProps<{ label?: string }>()
+</script>
+
+<template><button>{{ label }}</button></template>
+"#,
+    );
+    write(
+        &project_root,
+        "src/MyButton.art.vue",
+        r#"<art>
+defineArt("./MyButton.vue", {
+  title: "MyButton"
+});
+</art>
+
+<variant name="Default">
+  <MyButton label="Hello" />
+</variant>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "src/MyButton.art.vue",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    assert!(
+        !stdout.contains("TS2304") && !stdout.contains("defineArt"),
+        "standalone art file should receive defineArt ambient type:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -20,6 +20,15 @@ use super::build::{
     build_vue_registered_file, source_type_for_path,
 };
 
+const MUSEA_DEFINE_ART_STUB: &str =
+    "declare function defineArt(source: string, options?: Record<string, any>): void;";
+
+fn is_musea_art_vue_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".art.vue"))
+}
+
 impl VirtualProject {
     /// Create a new virtual project.
     pub fn new(project_root: &Path) -> CorsaResult<Self> {
@@ -255,6 +264,17 @@ impl VirtualProject {
     }
 
     fn absorb_registered_file(&mut self, registered: RegisteredFile) {
+        if is_musea_art_vue_path(&registered.file.original_path)
+            && !self
+                .virtual_ts_options
+                .auto_import_stubs
+                .iter()
+                .any(|stub| stub.contains("defineArt"))
+        {
+            self.virtual_ts_options
+                .auto_import_stubs
+                .push(MUSEA_DEFINE_ART_STUB.into());
+        }
         self.diagnostics.extend(registered.diagnostics);
         self.original_index.insert(
             registered.file.original_path.clone(),

--- a/editors/vscode-art/package.json
+++ b/editors/vscode-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vize-art",
   "displayName": "Vize Art",
-  "version": "0.251.0",
+  "version": "0.252.0",
   "description": "Syntax highlighting for Vize Art files (*.art.vue)",
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
## Summary
- add a virtual-project ambient declaration for Musea `defineArt` when standalone `.art.vue` files are checked
- cover standalone art-file checking with a CLI regression test
- align the VS Code art extension manifest version with the release version expected by repository checks

## Verification
- cargo fmt --all
- cargo test -p vize --test check_reference_types_cli check_provides_define_art_for_standalone_musea_art_files -- --nocapture
- GITHUB_BASE_REF=main node --test tests/tooling/source-file-lengths.test.ts
- node --test tests/tooling/editor-integrations.test.ts tests/tooling/package-manifests.test.ts
- git diff --check

Closes #2152
