### PR TITLE
fix(check): resolve nuxt2 composition and context types

### DIFF
--- a/crates/vize/src/commands/check/nuxt/virtual_modules.rs
+++ b/crates/vize/src/commands/check/nuxt/virtual_modules.rs
@@ -47,13 +47,12 @@ pub(super) fn collect_fallback_path_aliases(
     // into the generated `tsconfig.json`. When present, consume those aliases
     // verbatim instead of guessing, so user-configured aliases (e.g. custom
     // `srcDir`, extra `alias` entries) are honoured.
-    if let Some(aliases) = collect_generated_path_aliases(cwd, generated_dir)
-        && !aliases.is_empty()
-    {
-        return aliases;
-    }
-
-    collect_guessed_path_aliases(cwd)
+    let mut aliases = match collect_generated_path_aliases(cwd, generated_dir) {
+        Some(aliases) if !aliases.is_empty() => aliases,
+        _ => collect_guessed_path_aliases(cwd),
+    };
+    push_nuxt_composition_api_alias(cwd, &mut aliases);
+    aliases
 }
 
 /// Parse generated `tsconfig.json` (JSON-with-comments) and lift its
@@ -141,6 +140,14 @@ fn collect_guessed_path_aliases(cwd: &Path) -> Vec<NuxtPathAlias> {
         push_path_alias(&mut aliases, "#shared/*", vec!["shared/*"]);
     }
     aliases
+}
+
+fn push_nuxt_composition_api_alias(cwd: &Path, aliases: &mut Vec<NuxtPathAlias>) {
+    let runtime_types = "node_modules/@nuxtjs/composition-api/dist/runtime/index.d.ts";
+    if !cwd.join(runtime_types).is_file() {
+        return;
+    }
+    push_path_alias(aliases, "@nuxtjs/composition-api", vec![runtime_types]);
 }
 
 fn push_path_alias(aliases: &mut Vec<NuxtPathAlias>, pattern: &str, targets: Vec<&str>) {

--- a/crates/vize/tests/check_nuxt2_plugin_injections_cli.rs
+++ b/crates/vize/tests/check_nuxt2_plugin_injections_cli.rs
@@ -30,8 +30,14 @@ fn check_nuxt2_use_context_sees_plugin_injections() {
         &project_root,
         "types/nuxt.d.ts",
         r##"declare module "@nuxt/types" {
-  export interface Context {}
-  export interface NuxtAppOptions {}
+  export interface Context {
+    app: NuxtAppOptions;
+  }
+  export interface NuxtAppOptions {
+    i18n: {
+      t(key: string): string;
+    };
+  }
 }
 
 declare module "@nuxtjs/composition-api" {
@@ -67,6 +73,7 @@ import { useContext } from "@nuxtjs/composition-api";
 
 const context = useContext();
 context.$logger.info("ready");
+context.app.$logger.info(context.app.i18n.t("ready"));
 </script>
 "#,
     );

--- a/crates/vize/tests/check_nuxt_composition_api_cli.rs
+++ b/crates/vize/tests/check_nuxt_composition_api_cli.rs
@@ -1,0 +1,156 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("check-nuxt-composition-api-{name}-{}", std::process::id()).as_str())
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn write(root: &Path, rel: &str, content: &str) {
+    let path = root.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, content).unwrap();
+}
+
+#[test]
+fn check_resolves_nuxt2_composition_api_named_exports() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("exports");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    write(&project_root, "nuxt.config.ts", "export default {};\n");
+    write(
+        &project_root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write(
+        &project_root,
+        "node_modules/@nuxtjs/composition-api/package.json",
+        r#"{
+  "name": "@nuxtjs/composition-api",
+  "version": "0.26.0",
+  "main": "./dist/runtime/index.js",
+  "module": "./dist/runtime/index.mjs",
+  "types": "./dist/runtime/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/runtime/index.mjs",
+      "require": "./dist/runtime/index.js"
+    },
+    "./package.json": "./package.json"
+  }
+}"#,
+    );
+    write(
+        &project_root,
+        "node_modules/@nuxtjs/composition-api/dist/runtime/index.d.ts",
+        r#"export declare function defineComponent<T>(options: T): T;
+export declare function ref<T>(value: T): { value: T };
+export declare function computed<T>(getter: () => T): { value: T };
+export type PropType<T> = { new (...args: never[]): T } | { (): T };
+export declare function useContext(): { app: unknown };
+export declare function useFetch<T>(callback: () => T): { fetch: () => Promise<T> };
+export declare function useStore(): { state: unknown };
+export declare function useRoute(): { value: { path: string } };
+"#,
+    );
+    write(
+        &project_root,
+        "src/App.ts",
+        r#"import {
+  computed,
+  defineComponent,
+  PropType,
+  ref,
+  useContext,
+  useFetch,
+  useRoute,
+  useStore,
+} from "@nuxtjs/composition-api";
+
+const component = defineComponent({
+  props: { label: String as PropType<string> },
+});
+const count = ref(1);
+const doubled = computed(() => count.value * 2);
+const context = useContext();
+const fetchState = useFetch(() => doubled.value);
+const store = useStore();
+const route = useRoute();
+
+void component;
+void context;
+void fetchState;
+void store;
+void route;
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "src/App.ts",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    assert!(
+        !stdout.contains("TS2307") && !stdout.contains("@nuxtjs/composition-api"),
+        "composition-api exports should resolve through Nuxt fallback paths:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/editors/vscode-art/package.json
+++ b/editors/vscode-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vize-art",
   "displayName": "Vize Art",
-  "version": "0.251.0",
+  "version": "0.252.0",
   "description": "Syntax highlighting for Vize Art files (*.art.vue)",
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
## Summary
- add a Nuxt fallback path alias for `@nuxtjs/composition-api` when its runtime declaration file is installed
- cover the package shape where `exports["."]` omits a `types` condition but package `types` points at `dist/runtime/index.d.ts`
- extend the Nuxt 2 context regression to cover app-level injected properties and `app.i18n.t(...)`
- align the VS Code art extension manifest version with the release version expected by repository checks

## Verification
- cargo fmt --all
- cargo test -p vize --test check_nuxt_composition_api_cli check_resolves_nuxt2_composition_api_named_exports -- --nocapture
- cargo test -p vize commands::check::nuxt -- --nocapture
- cargo test -p vize --test check_nuxt2_plugin_injections_cli check_nuxt2_use_context_sees_plugin_injections -- --nocapture
- GITHUB_BASE_REF=main node --test tests/tooling/source-file-lengths.test.ts
- node --test tests/tooling/editor-integrations.test.ts tests/tooling/package-manifests.test.ts
- git diff --check

Closes #2140
Closes #2145
Closes #2155
