### PR TITLE
test(check): cover graphql and package cwd regressions

### DIFF
--- a/crates/vize/tests/check_canon_graphql_cli.rs
+++ b/crates/vize/tests/check_canon_graphql_cli.rs
@@ -163,11 +163,30 @@ expectQuestion(question)
         ),
     )
     .unwrap();
+    std::fs::write(
+        src_dir.join("Other.vue"),
+        cstr!(
+            r#"<script setup lang="ts">
+import {{ expectQuestion }} from './question'
+import {{ AimQuestionDisplayKind, type AimQuestion }} from '{schema_specifier}'
+
+const question = {{
+  kind: AimQuestionDisplayKind.Text,
+}} satisfies AimQuestion
+
+expectQuestion(question)
+</script>
+
+<template><section /></template>
+"#
+        ),
+    )
+    .unwrap();
 
     let output = Command::new(env!("CARGO_BIN_EXE_vize"))
         .current_dir(&project_root)
         .env("CORSA_PATH", &corsa_path)
-        .args(["check", "src/App.vue", "--format", "json"])
+        .args(["check", "src/App.vue", "src/Other.vue", "--format", "json"])
         .output()
         .unwrap();
 

--- a/crates/vize/tests/check_package_cwd_cli.rs
+++ b/crates/vize/tests/check_package_cwd_cli.rs
@@ -161,3 +161,93 @@ void rootOnly;
 
     let _ = std::fs::remove_dir_all(&workspace);
 }
+
+#[test]
+fn check_from_package_cwd_resolves_package_local_dependencies() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+
+    let workspace = unique_case_dir("package-cwd-local-deps");
+    let _ = std::fs::remove_dir_all(&workspace);
+    std::fs::create_dir_all(&workspace).unwrap();
+    write_file(
+        &workspace,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": []
+}"#,
+    );
+
+    let package_root = workspace.join("test/e2e/onepass/sign-in");
+    write_file(
+        &package_root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write_file(
+        &package_root,
+        "node_modules/child-only/package.json",
+        r#"{ "name": "child-only", "version": "1.0.0", "types": "index.d.ts" }"#,
+    );
+    write_file(
+        &package_root,
+        "node_modules/child-only/index.d.ts",
+        "export declare const childOnly: string;\n",
+    );
+    write_file(
+        &package_root,
+        "src/main.ts",
+        r#"import { childOnly } from "child-only";
+
+const value: string = childOnly;
+void value;
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&package_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "package-local dependency check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], 0, "{stdout}\n{stderr}");
+    assert!(
+        !stdout.contains("Cannot find module 'child-only'"),
+        "child package dependency should resolve from the package cwd:\n{stdout}\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&workspace);
+}

--- a/editors/vscode-art/package.json
+++ b/editors/vscode-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vize-art",
   "displayName": "Vize Art",
-  "version": "0.251.0",
+  "version": "0.252.0",
   "description": "Syntax highlighting for Vize Art files (*.art.vue)",
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
## Summary
- extend the GraphQL generated schema regression to cover multiple SFC importers sharing the real generated module identity
- add a package-cwd regression for dependencies that exist only in the filtered child package `node_modules`
- align the VS Code art extension manifest version with the release version expected by repository checks

## Verification
- cargo fmt --all
- cargo test -p vize --test check_canon_graphql_cli check_explicit_vue_keeps_generated_graphql_schema_out_of_canon -- --nocapture
- cargo test -p vize --test check_package_cwd_cli check_from_package_cwd_resolves_package_local_dependencies -- --nocapture
- node --test tests/tooling/editor-integrations.test.ts tests/tooling/package-manifests.test.ts
- GITHUB_BASE_REF=main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Closes #2149
Closes #2151

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->