### PR TITLE
fix(story): support Storybook TSX CSF

### DIFF
--- a/crates/vize/src/commands/lint/fix.rs
+++ b/crates/vize/src/commands/lint/fix.rs
@@ -36,6 +36,8 @@ fn lint_source(linter: &Linter, path: &Path, source: &str, filename: &str) -> Li
         linter.lint_standalone_html(source, filename)
     } else if is_plain_script_path(path) {
         linter.lint_script(source, filename)
+    } else if is_storybook_csf_path(path) {
+        empty_lint_result(filename)
     } else if let Some(lang) = jsx_lang_for_path(path) {
         linter.lint_jsx(source, filename, lang)
     } else {
@@ -90,5 +92,24 @@ fn jsx_lang_for_path(path: &Path) -> Option<JsxLang> {
         Some("jsx") => Some(JsxLang::Jsx),
         Some("tsx") => Some(JsxLang::Tsx),
         _ => None,
+    }
+}
+
+fn is_storybook_csf_path(path: &Path) -> bool {
+    let Some(file_name) = path.file_name().and_then(|file_name| file_name.to_str()) else {
+        return false;
+    };
+    file_name.ends_with(".stories.jsx")
+        || file_name.ends_with(".stories.tsx")
+        || file_name.ends_with(".story.jsx")
+        || file_name.ends_with(".story.tsx")
+}
+
+fn empty_lint_result(filename: &str) -> LintResult {
+    LintResult {
+        filename: filename.to_compact_string(),
+        diagnostics: Vec::new(),
+        error_count: 0,
+        warning_count: 0,
     }
 }

--- a/crates/vize/tests/lint_storybook_tsx_cli.rs
+++ b/crates/vize/tests/lint_storybook_tsx_cli.rs
@@ -1,0 +1,60 @@
+use std::{fs, path::Path, process::Command};
+
+fn write_project_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(file_path, content).unwrap();
+}
+
+#[test]
+fn lint_storybook_tsx_csf_bypasses_template_rules() {
+    let project = tempfile::tempdir().unwrap();
+    write_project_file(
+        project.path(),
+        "src/AfButton.stories.tsx",
+        r#"const items = [{ id: 1, label: "Open" }];
+
+export const Example = () => (
+  <div>
+    {items.map((item) => (
+      <button onClick={(event) => event.preventDefault()} isOpened>
+        {item.label}
+      </button>
+    ))}
+  </div>
+);
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args([
+            "lint",
+            "--no-config",
+            "--preset",
+            "happy-path",
+            "--format",
+            "json",
+            "src/AfButton.stories.tsx",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(!stdout.contains("vue/require-v-for-key"), "{stdout}");
+    assert!(!stdout.contains("vue/prop-name-casing"), "{stdout}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let [file] = json.as_array().unwrap().as_slice() else {
+        panic!("expected one lint result, got {stdout}");
+    };
+    assert_eq!(file["errorCount"], 0, "{stdout}");
+    assert_eq!(file["warningCount"], 0, "{stdout}");
+    assert_eq!(file["messages"], serde_json::json!([]), "{stdout}");
+}

--- a/editors/vscode-art/package.json
+++ b/editors/vscode-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vize-art",
   "displayName": "Vize Art",
-  "version": "0.251.0",
+  "version": "0.252.0",
   "description": "Syntax highlighting for Vize Art files (*.art.vue)",
   "categories": [
     "Programming Languages"

--- a/npm/builder/vite/src/plugin/load-storybook.test.ts
+++ b/npm/builder/vite/src/plugin/load-storybook.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+
+import type { VizePluginState } from "./state.ts";
+import { transformHook } from "./load.ts";
+
+const storybookTsxTransform = await transformHook(
+  {} as VizePluginState,
+  `export const Example = () => <button>Story</button>;\n`,
+  "/src/AfButton.stories.tsx",
+  { ssr: false },
+);
+
+assert.equal(
+  storybookTsxTransform,
+  null,
+  "Storybook TSX CSF files should stay on Vite's regular JSX pipeline",
+);
+
+const storybookJsxTransform = await transformHook(
+  {} as VizePluginState,
+  `export const Example = () => <button>Story</button>;\n`,
+  "/src/AfButton.story.jsx",
+  { ssr: false },
+);
+
+assert.equal(
+  storybookJsxTransform,
+  null,
+  "Storybook JSX CSF files should stay on Vite's regular JSX pipeline",
+);
+
+console.log("vite-plugin-vize Storybook CSF load tests passed!");

--- a/npm/builder/vite/src/plugin/load.ts
+++ b/npm/builder/vite/src/plugin/load.ts
@@ -384,7 +384,7 @@ export function loadHook(
 }
 
 function isJsxComponentPath(path: string): boolean {
-  return path.endsWith(".jsx") || path.endsWith(".tsx");
+  return /\.[jt]sx$/.test(path) && !/\.(?:stories|story)\.[jt]sx$/.test(path);
 }
 
 function shouldTransformJsxRequest(

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -5,6 +5,7 @@ import "./plugin/compat.test.ts";
 import "./plugin/css-modules.test.ts";
 import "./plugin/hmr.test.ts";
 import "./plugin/index.test.ts";
+import "./plugin/load-storybook.test.ts";
 import "./plugin/load.test.ts";
 import "./plugin/native.test.ts";
 import "./plugin/quasar.test.ts";


### PR DESCRIPTION
## Summary
- keep Storybook .story/.stories JSX/TSX CSF on Vite's regular JSX pipeline
- bypass template-rule linting for Storybook CSF JSX/TSX files
- add focused lint and Vite load regression coverage

## Verification
- cargo fmt --all
- cargo test -p vize --test lint_storybook_tsx_cli lint_storybook_tsx_csf_bypasses_template_rules -- --nocapture
- cargo test -p vize --test check_tsx_sfc_attrs_cli check_tsx_story_allows_sfc_class_and_style_attrs -- --nocapture
- pnpm --dir npm/builder/vite run test -- load-storybook.test.ts
- pnpm --dir npm/builder/vite run check
- node --test tests/tooling/editor-integrations.test.ts tests/tooling/package-manifests.test.ts
- GITHUB_BASE_REF=main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Closes #2154

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->