### PR TITLE
fix: sync vscode-art release version

### DIFF
--- a/editors/vscode-art/package.json
+++ b/editors/vscode-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vize-art",
   "displayName": "Vize Art",
-  "version": "0.253.0",
+  "version": "0.254.0",
   "description": "Syntax highlighting for Vize Art files (*.art.vue)",
   "categories": [
     "Programming Languages"

--- a/tests/tooling/moonbit-release.test.ts
+++ b/tests/tooling/moonbit-release.test.ts
@@ -163,12 +163,16 @@ test("release script rewrites only the native-binaries catalog block in pnpm-loc
   assert.ok(out.includes("resolution: {integrity: sha512-AAA==}"), "integrity hash preserved");
 });
 
-test("release script includes the VS Code extension package in extra synced manifests", () => {
+test("release script includes editor extension packages in extra synced manifests", () => {
   const result = runMoonScript("release", ["--print-extra-package-json-paths"]);
 
   assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
-  assert.ok(
-    result.stdout.split("\n").includes("editors/vscode/package.json"),
-    "VS Code extension version must be bumped with release commits",
-  );
+  const paths = result.stdout.split("\n");
+
+  for (const manifestPath of ["editors/vscode/package.json", "editors/vscode-art/package.json"]) {
+    assert.ok(
+      paths.includes(manifestPath),
+      `${manifestPath} version must be bumped with release commits`,
+    );
+  }
 });

--- a/tools/moon/scripts/release.mbtx
+++ b/tools/moon/scripts/release.mbtx
@@ -353,7 +353,7 @@ fn replace_package_json_version(
 /// globs but still ship release artifacts and must stay aligned with the
 /// workspace version.
 fn extra_release_package_json_paths() -> Array[String] {
-  ["editors/vscode/package.json"]
+  ["editors/vscode/package.json", "editors/vscode-art/package.json"]
 }
 
 ///|


### PR DESCRIPTION
## Summary
- bump `editors/vscode-art/package.json` to the released workspace version
- include `editors/vscode-art/package.json` in release version sync automation
- extend the release script test to cover both editor extension manifests

## Root Cause
The `chore: release v0.254.0` commit updated the workspace and main VS Code extension versions, but `editors/vscode-art/package.json` stayed at `0.253.0`. The `test-scripts` CI job asserts that editor manifests match the workspace version, so `main` failed after the release commit.

## Validation
- `node --test --test-concurrency=1 tests/tooling/editor-integrations.test.ts tests/tooling/moonbit-release.test.ts`
- `cargo build --profile ci -p vize`
- `NODE_OPTIONS="--disable-warning=DEP0040 --disable-warning=DEP0169" vp run --workspace-root test:scripts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->