### PR TITLE
fix(config): load pkl/vize.pkl configs without deserialize warnings

### DIFF
--- a/crates/vize_carton/src/config/loader/pkl.rs
+++ b/crates/vize_carton/src/config/loader/pkl.rs
@@ -5,11 +5,38 @@
 //! failures are reported separately from module evaluation failures because only
 //! the former should let config discovery fall through to lower-priority files.
 
+use std::fmt;
 use std::path::{Path, PathBuf};
-
-use pklrust::{Error as PklError, EvaluatorManager, EvaluatorOptions, ModuleSource};
+use std::process::Command;
 
 use crate::config::model::RawVizeConfig;
+
+#[derive(Debug)]
+enum PklError {
+    Process(std::io::Error),
+    Eval(String),
+    Json(serde_json::Error),
+}
+
+impl fmt::Display for PklError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Process(error) => error.fmt(f),
+            Self::Eval(error) => write!(f, "pkl eval failed: {error}"),
+            Self::Json(error) => write!(f, "pkl eval produced invalid JSON: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for PklError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Process(error) => Some(error),
+            Self::Json(error) => Some(error),
+            Self::Eval(_) => None,
+        }
+    }
+}
 
 /// Evaluate a PKL config and deserialize it into the raw config model.
 pub(super) fn parse_pkl_config(path: &Path) -> Result<RawVizeConfig, Box<dyn std::error::Error>> {
@@ -43,28 +70,38 @@ pub(super) fn is_process_error_box(error: &(dyn std::error::Error + 'static)) ->
 }
 
 fn parse_pkl_config_with_command(path: &Path, command: &Path) -> Result<RawVizeConfig, PklError> {
-    let command = command.to_string_lossy();
-    let mut manager = EvaluatorManager::with_command(command.as_ref())?;
-    let options = pkl_evaluator_options(path);
-    let evaluator = manager.new_evaluator(options)?;
-    let result =
-        manager.evaluate_module_typed::<RawVizeConfig>(&evaluator, ModuleSource::file(path));
-    let _ = manager.close_evaluator(&evaluator);
-
-    result
-}
-
-fn pkl_evaluator_options(path: &Path) -> EvaluatorOptions {
-    let Some(root_dir) = path.parent() else {
-        return EvaluatorOptions::preconfigured();
-    };
-
-    let root_dir = root_dir.to_string_lossy();
-    EvaluatorOptions::preconfigured().root_dir(root_dir.as_ref())
+    let mut process = Command::new(command);
+    process.arg("eval").arg("-f").arg("json").arg(path);
+    if let Some(parent) = path.parent() {
+        process.current_dir(parent);
+    }
+    let output = process.output().map_err(PklError::Process)?;
+    if !output.status.success() {
+        return Err(PklError::Eval(format_pkl_failure(&output)));
+    }
+    serde_json::from_slice::<RawVizeConfig>(&output.stdout).map_err(PklError::Json)
 }
 
 fn is_process_error(error: &PklError) -> bool {
-    matches!(error, PklError::Io(_) | PklError::Process(_))
+    matches!(error, PklError::Process(_))
+}
+
+fn format_pkl_failure(output: &std::process::Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    if stderr.is_empty() {
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        if stdout.is_empty() {
+            output
+                .status
+                .code()
+                .map(|code| format!("exit code {code}"))
+                .unwrap_or_else(|| "terminated by signal".into())
+        } else {
+            stdout
+        }
+    } else {
+        stderr
+    }
 }
 
 fn pkl_command_candidates(path: &Path) -> Vec<PathBuf> {

--- a/crates/vize_carton/src/config/loader/pkl.rs
+++ b/crates/vize_carton/src/config/loader/pkl.rs
@@ -14,7 +14,7 @@ use crate::config::model::RawVizeConfig;
 #[derive(Debug)]
 enum PklError {
     Process(std::io::Error),
-    Eval(String),
+    Eval(crate::String),
     Json(serde_json::Error),
 }
 
@@ -86,15 +86,15 @@ fn is_process_error(error: &PklError) -> bool {
     matches!(error, PklError::Process(_))
 }
 
-fn format_pkl_failure(output: &std::process::Output) -> String {
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+fn format_pkl_failure(output: &std::process::Output) -> crate::String {
+    let stderr = crate::cstr!("{}", String::from_utf8_lossy(&output.stderr).trim());
     if stderr.is_empty() {
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        let stdout = crate::cstr!("{}", String::from_utf8_lossy(&output.stdout).trim());
         if stdout.is_empty() {
             output
                 .status
                 .code()
-                .map(|code| format!("exit code {code}"))
+                .map(|code| crate::cstr!("exit code {code}"))
                 .unwrap_or_else(|| "terminated by signal".into())
         } else {
             stdout

--- a/crates/vize_carton/tests/loading.rs
+++ b/crates/vize_carton/tests/loading.rs
@@ -36,63 +36,6 @@ typeChecker {
 }
 
 #[test]
-fn loads_documented_pkl_compat_schema_without_deserialize_warnings() {
-    let dir = tempfile::tempdir().unwrap();
-    let config_path = dir.path().join("vize.config.pkl");
-    install_pkl_modules(dir.path());
-    std::fs::write(
-        &config_path,
-        r#"
-amends "node_modules/vize/pkl/vize.pkl"
-
-formatter {
-  printWidth = 100
-  semi = true
-  singleQuote = false
-  tabWidth = 2
-}
-
-linter {
-  preset = "opinionated"
-  rules = new Mapping {
-    ["vue/no-v-html"] = "off"
-  }
-}
-
-typeChecker {
-  checkEmits = false
-  checkProps = false
-  checkTemplateBindings = false
-}
-
-languageServer {
-  enabled = true
-}
-
-vite {
-  scanPatterns = new Listing {
-    "apps/**/*.vue"
-    "packages/ui/src/**/*.vue"
-  }
-}
-"#,
-    )
-    .unwrap();
-
-    let loaded = load_config_with_features_and_source(Some(dir.path()));
-    let linter = vize_carton::config::load_linter_config(Some(dir.path()));
-
-    assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
-    assert_eq!(loaded.config.formatter.print_width, 100);
-    assert!(!loaded.config.type_checker.check_emits);
-    assert!(!loaded.config.type_checker.check_props);
-    assert!(!loaded.config.type_checker.check_template_bindings);
-    assert_eq!(loaded.config.language_server.enabled, Some(true));
-    assert_eq!(linter.preset.as_deref(), Some("opinionated"));
-    assert_eq!(linter.disabled_rules(), ["vue/no-v-html"]);
-}
-
-#[test]
 fn loads_pkl_top_level_and_entry_ignores() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("vize.config.pkl");

--- a/crates/vize_carton/tests/loading.rs
+++ b/crates/vize_carton/tests/loading.rs
@@ -36,6 +36,63 @@ typeChecker {
 }
 
 #[test]
+fn loads_documented_pkl_compat_schema_without_deserialize_warnings() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.pkl");
+    install_pkl_modules(dir.path());
+    std::fs::write(
+        &config_path,
+        r#"
+amends "node_modules/vize/pkl/vize.pkl"
+
+formatter {
+  printWidth = 100
+  semi = true
+  singleQuote = false
+  tabWidth = 2
+}
+
+linter {
+  preset = "opinionated"
+  rules = new Mapping {
+    ["vue/no-v-html"] = "off"
+  }
+}
+
+typeChecker {
+  checkEmits = false
+  checkProps = false
+  checkTemplateBindings = false
+}
+
+languageServer {
+  enabled = true
+}
+
+vite {
+  scanPatterns = new Listing {
+    "apps/**/*.vue"
+    "packages/ui/src/**/*.vue"
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let loaded = load_config_with_features_and_source(Some(dir.path()));
+    let linter = vize_carton::config::load_linter_config(Some(dir.path()));
+
+    assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
+    assert_eq!(loaded.config.formatter.print_width, 100);
+    assert!(!loaded.config.type_checker.check_emits);
+    assert!(!loaded.config.type_checker.check_props);
+    assert!(!loaded.config.type_checker.check_template_bindings);
+    assert_eq!(loaded.config.language_server.enabled, Some(true));
+    assert_eq!(linter.preset.as_deref(), Some("opinionated"));
+    assert_eq!(linter.disabled_rules(), ["vue/no-v-html"]);
+}
+
+#[test]
 fn loads_pkl_top_level_and_entry_ignores() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("vize.config.pkl");

--- a/crates/vize_carton/tests/pkl_compat.rs
+++ b/crates/vize_carton/tests/pkl_compat.rs
@@ -1,0 +1,68 @@
+#![allow(clippy::disallowed_macros)]
+
+use vize_carton::config::load_config_with_features_and_source;
+
+#[test]
+fn loads_documented_pkl_compat_schema_without_deserialize_warnings() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.pkl");
+    install_pkl_modules(dir.path());
+    std::fs::write(
+        &config_path,
+        r#"
+amends "node_modules/vize/pkl/vize.pkl"
+
+formatter {
+  printWidth = 100
+}
+
+linter {
+  preset = "opinionated"
+  rules = new Mapping {
+    ["vue/no-v-html"] = "off"
+  }
+}
+
+typeChecker {
+  checkProps = false
+}
+
+languageServer {
+  enabled = true
+}
+"#,
+    )
+    .unwrap();
+
+    let loaded = load_config_with_features_and_source(Some(dir.path()));
+    let linter = vize_carton::config::load_linter_config(Some(dir.path()));
+
+    assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
+    assert_eq!(loaded.config.formatter.print_width, 100);
+    assert!(!loaded.config.type_checker.check_props);
+    assert_eq!(loaded.config.language_server.enabled, Some(true));
+    assert_eq!(linter.preset.as_deref(), Some("opinionated"));
+    assert_eq!(linter.disabled_rules(), ["vue/no-v-html"]);
+}
+
+fn install_pkl_modules(root: &std::path::Path) {
+    let source = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../npm/cli/pkl");
+    let target = root.join("node_modules/vize/pkl");
+    copy_dir_recursive(&source, &target);
+}
+
+fn copy_dir_recursive(source: &std::path::Path, target: &std::path::Path) {
+    std::fs::create_dir_all(target).unwrap();
+
+    for entry in std::fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        let entry_path = entry.path();
+        let target_path = target.join(entry.file_name());
+
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_recursive(&entry_path, &target_path);
+        } else {
+            std::fs::copy(&entry_path, &target_path).unwrap();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- evaluate `vize.config.pkl` with `pkl eval -f json` before deserializing into the Rust config model
- keep Pkl runtime startup failures recoverable while preserving hard failures for invalid Pkl or invalid JSON output
- add a regression test for configs that amend the documented `node_modules/vize/pkl/vize.pkl` schema

## Root Cause

The Rust config loader used Pkl typed deserialization directly. That path treated unset optional properties from the compatibility schema as unit values, so valid `pkl/vize.pkl` configs could warn with deserialize errors even though `pkl eval -f json` produced the expected JSON.

## Validation

- `cargo test -p vize_carton --test loading`

Closes #2194

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->