### PR TITLE
fix(cli): honor config ignores during entry discovery

### DIFF
--- a/crates/vize/src/commands/check/runner/collect_tests.rs
+++ b/crates/vize/src/commands/check/runner/collect_tests.rs
@@ -161,12 +161,18 @@ fn collect_check_files_normalizes_entry_ignore_paths_and_duplicates() {
     let _ = fs::remove_dir_all(&case_dir);
     fs::create_dir_all(case_dir.join("src/nested")).unwrap();
     fs::create_dir_all(case_dir.join("packages/admin/src")).unwrap();
+    fs::create_dir_all(case_dir.join("scripts/node_modules/chalk/source")).unwrap();
     let app = write_file(&case_dir, "src/App.vue", "");
     let nested = write_file(&case_dir, "src/nested/Panel.vue", "");
     write_file(&case_dir, "src/Ignored.vue", "");
     write_file(&case_dir, "src/nested/Ignored.vue", "");
     write_file(&case_dir, "packages/admin/src/Ignored.vue", "");
     let admin_page = write_file(&case_dir, "packages/admin/src/Page.vue", "");
+    write_file(
+        &case_dir,
+        "scripts/node_modules/chalk/source/index.d.ts",
+        "",
+    );
 
     let ignore_set = CheckIgnoreSet::new(
         &[
@@ -185,6 +191,10 @@ fn collect_check_files_normalizes_entry_ignore_paths_and_duplicates() {
             crate::config::ConfigEntryIgnore {
                 base_path: Some("packages/admin".into()),
                 pattern: "src\\Ignored.vue".into(),
+            },
+            crate::config::ConfigEntryIgnore {
+                base_path: None,
+                pattern: "node_modules/**".into(),
             },
         ],
         &case_dir,

--- a/crates/vize/src/commands/check/runner/ignores.rs
+++ b/crates/vize/src/commands/check/runner/ignores.rs
@@ -11,10 +11,8 @@ impl CheckIgnoreSet {
     pub(super) fn new(ignores: &[config::ConfigEntryIgnore], config_dir: &Path) -> Option<Self> {
         let patterns = ignores
             .iter()
-            .filter_map(|ignore| {
-                let pattern = resolve_entry_ignore_pattern(ignore, config_dir);
-                InputGlob::new(pattern.to_string_lossy().as_ref())
-            })
+            .flat_map(|ignore| expand_entry_ignore_patterns(ignore, config_dir))
+            .filter_map(|pattern| InputGlob::new(pattern.to_string_lossy().as_ref()))
             .collect::<Vec<_>>();
         (!patterns.is_empty()).then_some(Self { patterns })
     }
@@ -61,6 +59,17 @@ fn resolve_entry_ignore_pattern(ignore: &config::ConfigEntryIgnore, config_dir: 
     }
 }
 
+fn expand_entry_ignore_patterns(
+    ignore: &config::ConfigEntryIgnore,
+    config_dir: &Path,
+) -> Vec<PathBuf> {
+    let resolved = resolve_entry_ignore_pattern(ignore, config_dir);
+    let Some(deep_pattern) = nested_node_modules_ignore(&resolved) else {
+        return vec![resolved];
+    };
+    vec![resolved, deep_pattern]
+}
+
 fn absolute_config_dir(config_dir: &Path) -> PathBuf {
     if config_dir.is_absolute() {
         return config_dir.to_path_buf();
@@ -69,4 +78,16 @@ fn absolute_config_dir(config_dir: &Path) -> PathBuf {
     std::env::current_dir()
         .unwrap_or_else(|_| PathBuf::from("."))
         .join(config_dir)
+}
+
+fn nested_node_modules_ignore(pattern: &Path) -> Option<PathBuf> {
+    let pattern_text = pattern.to_string_lossy().replace('\\', "/");
+    let suffix = "node_modules/**";
+    if !pattern_text.ends_with(suffix) || pattern_text.contains("**/node_modules/**") {
+        return None;
+    }
+    let prefix = pattern_text.trim_end_matches(suffix).trim_end_matches('/');
+    Some(PathBuf::from(
+        vize_carton::cstr!("{prefix}/**/{suffix}").as_str(),
+    ))
 }

--- a/crates/vize/src/commands/fmt/files.rs
+++ b/crates/vize/src/commands/fmt/files.rs
@@ -279,16 +279,29 @@ mod tests {
     fn collect_files_applies_entry_ignores() {
         let root = unique_case_dir("entry-ignores");
         let src = root.join("src");
+        let nested_node_modules = root.join("scripts/node_modules/chalk/source");
         let _ = fs::remove_dir_all(&root);
         fs::create_dir_all(&src).unwrap();
+        fs::create_dir_all(&nested_node_modules).unwrap();
         fs::write(src.join("App.vue"), "<template><div /></template>").unwrap();
         fs::write(src.join("Ignored.vue"), "<template><div /></template>").unwrap();
+        fs::write(
+            nested_node_modules.join("index.d.ts"),
+            "export declare const chalk: string",
+        )
+        .unwrap();
 
         let ignore_set = FmtIgnoreSet::new(
-            &[crate::config::ConfigEntryIgnore {
-                base_path: None,
-                pattern: "src/Ignored.vue".into(),
-            }],
+            &[
+                crate::config::ConfigEntryIgnore {
+                    base_path: None,
+                    pattern: "src/Ignored.vue".into(),
+                },
+                crate::config::ConfigEntryIgnore {
+                    base_path: None,
+                    pattern: "node_modules/**".into(),
+                },
+            ],
             &root,
         );
         let pattern = root.to_string_lossy().into_owned();

--- a/crates/vize/src/commands/fmt/ignores.rs
+++ b/crates/vize/src/commands/fmt/ignores.rs
@@ -12,10 +12,8 @@ impl FmtIgnoreSet {
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
         let patterns = ignores
             .iter()
-            .filter_map(|ignore| {
-                let pattern = resolve_entry_ignore_pattern(ignore, config_dir);
-                FmtPattern::new(pattern.to_string_lossy().as_ref(), &cwd)
-            })
+            .flat_map(|ignore| expand_entry_ignore_patterns(ignore, config_dir))
+            .filter_map(|pattern| FmtPattern::new(pattern.to_string_lossy().as_ref(), &cwd))
             .collect::<Vec<_>>();
         (!patterns.is_empty()).then_some(Self { patterns })
     }
@@ -42,6 +40,17 @@ pub(super) fn load_fmt_ignore_set(args: &FmtArgs) -> Option<FmtIgnoreSet> {
     FmtIgnoreSet::new(&loaded.ignores, &config_dir)
 }
 
+fn expand_entry_ignore_patterns(
+    ignore: &config::ConfigEntryIgnore,
+    config_dir: &Path,
+) -> Vec<PathBuf> {
+    let resolved = resolve_entry_ignore_pattern(ignore, config_dir);
+    let Some(deep_pattern) = nested_node_modules_ignore(&resolved) else {
+        return vec![resolved];
+    };
+    vec![resolved, deep_pattern]
+}
+
 fn resolve_entry_ignore_pattern(ignore: &config::ConfigEntryIgnore, config_dir: &Path) -> PathBuf {
     let pattern = Path::new(ignore.pattern.as_str());
     if pattern.is_absolute() {
@@ -58,4 +67,16 @@ fn resolve_entry_ignore_pattern(ignore: &config::ConfigEntryIgnore, config_dir: 
         Some(base_path) => config_dir.join(base_path).join(pattern),
         None => config_dir.join(pattern),
     }
+}
+
+fn nested_node_modules_ignore(pattern: &Path) -> Option<PathBuf> {
+    let pattern_text = pattern.to_string_lossy().replace('\\', "/");
+    let suffix = "node_modules/**";
+    if !pattern_text.ends_with(suffix) || pattern_text.contains("**/node_modules/**") {
+        return None;
+    }
+    let prefix = pattern_text.trim_end_matches(suffix).trim_end_matches('/');
+    Some(PathBuf::from(
+        vize_carton::cstr!("{prefix}/**/{suffix}").as_str(),
+    ))
 }

--- a/crates/vize/src/commands/lint/collect.rs
+++ b/crates/vize/src/commands/lint/collect.rs
@@ -5,7 +5,40 @@ use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
 use vize_carton::{FxHashSet, String};
 
-pub(super) fn collect_lint_files(patterns: &[String]) -> Vec<PathBuf> {
+use super::LintArgs;
+use crate::config;
+
+pub(super) struct LintIgnoreSet {
+    patterns: Vec<LintInputGlob>,
+}
+
+impl LintIgnoreSet {
+    fn new(ignores: &[config::ConfigEntryIgnore], config_dir: &Path) -> Option<Self> {
+        let patterns = ignores
+            .iter()
+            .flat_map(|ignore| expand_entry_ignore_patterns(ignore, config_dir))
+            .filter_map(|pattern| LintInputGlob::new(pattern.to_string_lossy().as_ref()))
+            .collect::<Vec<_>>();
+        (!patterns.is_empty()).then_some(Self { patterns })
+    }
+
+    fn is_ignored(&self, path: &Path) -> bool {
+        self.patterns.iter().any(|pattern| pattern.matches(path))
+    }
+}
+
+pub(super) fn load_lint_ignore_set(args: &LintArgs, config_dir: &Path) -> Option<LintIgnoreSet> {
+    if args.no_config {
+        return None;
+    }
+    let loaded_ignores = config::load_config_entry_ignores_with_source(args.config.as_deref());
+    LintIgnoreSet::new(&loaded_ignores.ignores, config_dir)
+}
+
+pub(super) fn collect_lint_files(
+    patterns: &[String],
+    ignore_set: Option<&LintIgnoreSet>,
+) -> Vec<PathBuf> {
     let mut files = Vec::new();
     let mut seen = FxHashSet::default();
 
@@ -13,18 +46,24 @@ pub(super) fn collect_lint_files(patterns: &[String]) -> Vec<PathBuf> {
         let candidate = PathBuf::from(pattern);
         if candidate.exists() {
             if candidate.is_file() {
-                add_lint_file(&candidate, &mut files, &mut seen);
+                add_lint_file(&candidate, ignore_set, &mut files, &mut seen);
                 continue;
             }
             if candidate.is_dir() {
-                collect_lint_files_from_dir(&candidate, None, &mut files, &mut seen);
+                collect_lint_files_from_dir(&candidate, None, ignore_set, &mut files, &mut seen);
                 continue;
             }
         }
 
         let base_dir = base_dir_from_lint_pattern(pattern);
         let matcher = LintInputGlob::new(pattern);
-        collect_lint_files_from_dir(&base_dir, matcher.as_ref(), &mut files, &mut seen);
+        collect_lint_files_from_dir(
+            &base_dir,
+            matcher.as_ref(),
+            ignore_set,
+            &mut files,
+            &mut seen,
+        );
     }
 
     files.sort();
@@ -34,6 +73,7 @@ pub(super) fn collect_lint_files(patterns: &[String]) -> Vec<PathBuf> {
 fn collect_lint_files_from_dir(
     dir: &Path,
     matcher: Option<&LintInputGlob>,
+    ignore_set: Option<&LintIgnoreSet>,
     files: &mut Vec<PathBuf>,
     seen: &mut FxHashSet<PathBuf>,
 ) {
@@ -47,17 +87,24 @@ fn collect_lint_files_from_dir(
         };
         let path = entry.path();
         if path.is_file() && matcher.is_none_or(|matcher| matcher.matches(path)) {
-            add_lint_file(path, files, seen);
+            add_lint_file(path, ignore_set, files, seen);
         }
     }
 }
 
-fn add_lint_file(path: &Path, files: &mut Vec<PathBuf>, seen: &mut FxHashSet<PathBuf>) {
+fn add_lint_file(
+    path: &Path,
+    ignore_set: Option<&LintIgnoreSet>,
+    files: &mut Vec<PathBuf>,
+    seen: &mut FxHashSet<PathBuf>,
+) {
     if !is_lintable_path(path) {
         return;
     }
     let normalized = normalize_lint_input_path(path);
-    if seen.insert(normalized.clone()) {
+    if !ignore_set.is_some_and(|ignore_set| ignore_set.is_ignored(&normalized))
+        && seen.insert(normalized.clone())
+    {
         files.push(normalized);
     }
 }
@@ -163,6 +210,62 @@ pub(super) fn resolve_lint_config_path(config_dir: &Path, candidate: &str) -> Pa
     config_dir.join(path)
 }
 
+fn expand_entry_ignore_patterns(
+    ignore: &config::ConfigEntryIgnore,
+    config_dir: &Path,
+) -> Vec<PathBuf> {
+    let resolved = resolve_entry_ignore_pattern(ignore, config_dir);
+    let Some(deep_pattern) = nested_node_modules_ignore(&resolved) else {
+        return vec![resolved];
+    };
+    vec![resolved, deep_pattern]
+}
+
+fn resolve_entry_ignore_pattern(ignore: &config::ConfigEntryIgnore, config_dir: &Path) -> PathBuf {
+    let pattern = Path::new(ignore.pattern.as_str());
+    if pattern.is_absolute() {
+        return if pattern.exists() {
+            vize_carton::path::canonicalize_non_verbatim(pattern)
+        } else {
+            pattern.to_path_buf()
+        };
+    }
+
+    let config_dir = absolute_config_dir(config_dir);
+    let base = ignore
+        .base_path
+        .as_deref()
+        .map(Path::new)
+        .filter(|base_path| !base_path.as_os_str().is_empty());
+    match base {
+        Some(base_path) if base_path.is_absolute() => base_path.join(pattern),
+        Some(base_path) => config_dir.join(base_path).join(pattern),
+        None => config_dir.join(pattern),
+    }
+}
+
+fn absolute_config_dir(config_dir: &Path) -> PathBuf {
+    if config_dir.is_absolute() {
+        return config_dir.to_path_buf();
+    }
+
+    std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(config_dir)
+}
+
+fn nested_node_modules_ignore(pattern: &Path) -> Option<PathBuf> {
+    let pattern_text = normalize_lint_path(pattern);
+    let suffix = "node_modules/**";
+    if !pattern_text.ends_with(suffix) || pattern_text.contains("**/node_modules/**") {
+        return None;
+    }
+    let prefix = pattern_text.trim_end_matches(suffix).trim_end_matches('/');
+    Some(PathBuf::from(
+        vize_carton::cstr!("{prefix}/**/{suffix}").as_str(),
+    ))
+}
+
 fn lint_glob_match_options() -> MatchOptions {
     MatchOptions {
         case_sensitive: true,
@@ -173,7 +276,7 @@ fn lint_glob_match_options() -> MatchOptions {
 
 #[cfg(test)]
 mod tests {
-    use super::collect_lint_files;
+    use super::{LintIgnoreSet, collect_lint_files};
     use std::fs;
 
     #[test]
@@ -189,7 +292,7 @@ mod tests {
         fs::write(src.join("Widget.tsx"), "").unwrap();
         fs::write(src.join("notes.md"), "").unwrap();
 
-        let files = collect_lint_files(&[src.display().to_string().into()]);
+        let files = collect_lint_files(&[src.display().to_string().into()], None);
 
         assert_eq!(
             files,
@@ -202,5 +305,37 @@ mod tests {
                 src.join("store.ts")
             ]
         );
+    }
+
+    #[test]
+    fn collection_applies_config_ignores_and_nested_node_modules() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        let scripts_dep = dir.path().join("scripts/node_modules/chalk/source");
+        fs::create_dir_all(&src).unwrap();
+        fs::create_dir_all(&scripts_dep).unwrap();
+        fs::write(src.join("App.vue"), "").unwrap();
+        fs::write(src.join("Generated.vue"), "").unwrap();
+        fs::write(scripts_dep.join("index.d.ts"), "").unwrap();
+
+        let ignore_set = LintIgnoreSet::new(
+            &[
+                crate::config::ConfigEntryIgnore {
+                    base_path: None,
+                    pattern: "src/Generated.vue".into(),
+                },
+                crate::config::ConfigEntryIgnore {
+                    base_path: None,
+                    pattern: "node_modules/**".into(),
+                },
+            ],
+            dir.path(),
+        );
+        let files = collect_lint_files(
+            &[dir.path().display().to_string().into()],
+            ignore_set.as_ref(),
+        );
+
+        assert_eq!(files, vec![src.join("App.vue")]);
     }
 }

--- a/crates/vize/src/commands/lint/mod.rs
+++ b/crates/vize/src/commands/lint/mod.rs
@@ -12,7 +12,7 @@ mod tests;
 pub use args::LintArgs;
 
 use crate::profile_support;
-use collect::{collect_lint_files, resolve_lint_config_path};
+use collect::{collect_lint_files, load_lint_ignore_set, resolve_lint_config_path};
 use cross_file::apply_sfc_cross_file_lint;
 use fix::lint_source_with_optional_fix;
 use rayon::prelude::*;
@@ -72,9 +72,10 @@ pub fn run(args: LintArgs) {
         .type_checker
         .runtime_path()
         .map(|path| resolve_lint_config_path(config_dir, path));
+    let ignore_set = load_lint_ignore_set(&args, config_dir);
     // Collect lintable files using glob patterns or directory walking.
     let collect_start = Instant::now();
-    let files = collect_lint_files(&args.patterns);
+    let files = collect_lint_files(&args.patterns, ignore_set.as_ref());
     let collect_time = collect_start.elapsed();
 
     if files.is_empty() {

--- a/crates/vize/src/commands/lint/mod.rs
+++ b/crates/vize/src/commands/lint/mod.rs
@@ -73,7 +73,6 @@ pub fn run(args: LintArgs) {
         .runtime_path()
         .map(|path| resolve_lint_config_path(config_dir, path));
     let ignore_set = load_lint_ignore_set(&args, config_dir);
-    // Collect lintable files using glob patterns or directory walking.
     let collect_start = Instant::now();
     let files = collect_lint_files(&args.patterns, ignore_set.as_ref());
     let collect_time = collect_start.elapsed();

--- a/crates/vize/tests/lint_config_cli.rs
+++ b/crates/vize/tests/lint_config_cli.rs
@@ -25,6 +25,64 @@ fn write_project_file(root: &Path, path: &str, content: &str) {
     fs::write(file_path, content).unwrap();
 }
 
+fn output_details(output: &std::process::Output) -> vize_carton::String {
+    vize_carton::cstr!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn lint_honors_config_ignores_for_directory_inputs() {
+    let project_root = temp_project_dir("directory-ignores");
+    write_project_file(
+        &project_root,
+        "vize.config.json",
+        r#"{
+  "ignores": [
+    "design-system/**",
+    "node_modules/**"
+  ]
+}"#,
+    );
+    write_project_file(
+        &project_root,
+        "src/App.vue",
+        r#"<script setup>
+const message = 'ok'
+</script>
+"#,
+    );
+    write_project_file(
+        &project_root,
+        "design-system/src/Ignored.vue",
+        r#"<script setup>
+const ignored = true
+</script>
+"#,
+    );
+    write_project_file(
+        &project_root,
+        "scripts/node_modules/chalk/source/index.d.ts",
+        "export declare const chalk: string\n",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["lint", "--config", "vize.config.json", "."])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_details(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Linted 1 files"), "{stdout}");
+    assert!(!stdout.contains("design-system"), "{stdout}");
+    assert!(!stdout.contains("scripts/node_modules"), "{stdout}");
+
+    let _ = fs::remove_dir_all(project_root);
+}
+
 #[test]
 fn lint_uses_entry_preset_unless_cli_preset_overrides() {
     let project_root = temp_project_dir("entry-preset");


### PR DESCRIPTION
## Summary
- apply config entry ignores while collecting lint files from explicit files, directories, and globs
- expand `node_modules/**` entry ignores so nested package-manager directories are skipped consistently by lint/fmt/check
- add focused unit and CLI regressions for explicit directory inputs and nested `node_modules`

## Root Cause
Lint discovery collected explicit inputs without loading the configured entry ignore set, while fmt/check only matched `node_modules/**` at the config root. That made explicit subdirectory and nested dependency paths behave differently across commands.

## Validation
- `cargo fmt --package vize`
- `cargo test -p vize --lib collection_applies_config_ignores_and_nested_node_modules`
- `cargo test -p vize --lib collect_files_applies_entry_ignores`
- `cargo test -p vize --lib collect_check_files_normalizes_entry_ignore_paths_and_duplicates`
- `cargo test -p vize --test lint_config_cli lint_honors_config_ignores_for_directory_inputs`
- `cargo clippy -p vize --lib -- -D warnings`
- `git diff --check`

Closes #2183
Closes #2190

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->