### PR TITLE
fix(check): keep Nuxt detection inside package boundary

### DIFF
--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -694,7 +694,6 @@ fn resolve_nuxt_project_root(
     let Some(tsconfig) = explicit_tsconfig else {
         return fallback.to_path_buf();
     };
-
     let tsconfig_path = if tsconfig.is_absolute() {
         tsconfig.to_path_buf()
     } else {
@@ -704,8 +703,10 @@ fn resolve_nuxt_project_root(
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(|| fallback.to_path_buf());
-
     if is_nuxt_project_root(&tsconfig_dir) {
+        return tsconfig_dir;
+    }
+    if tsconfig_dir.join("package.json").exists() {
         return tsconfig_dir;
     }
     if let Some(parent) = tsconfig_dir.parent()
@@ -713,7 +714,6 @@ fn resolve_nuxt_project_root(
     {
         return parent.to_path_buf();
     }
-
     tsconfig_dir
 }
 

--- a/crates/vize/tests/check_nuxt_monorepo_cli.rs
+++ b/crates/vize/tests/check_nuxt_monorepo_cli.rs
@@ -114,6 +114,72 @@ declare global {
     let _ = std::fs::remove_dir_all(&project_root);
 }
 
+#[test]
+fn check_non_nuxt_child_package_does_not_warn_about_root_nuxt_generated_types() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project("monorepo-non-nuxt-child");
+    write_file(
+        &project_root,
+        "nuxt.config.ts",
+        "export default defineNuxtConfig({})\n",
+    );
+    write_file(&project_root, "design-system/package.json", "{}\n");
+    write_file(
+        &project_root,
+        "design-system/tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write_file(
+        &project_root,
+        "design-system/src/App.vue",
+        r#"<script setup lang="ts">
+const message: string = "ok";
+</script>
+
+<template>{{ message }}</template>
+"#,
+    );
+
+    let package_root = project_root.join("design-system");
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&package_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "src",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("no generated `.nuxt` types found"),
+        "non-Nuxt child package should not warn about root Nuxt artifacts:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
 fn create_project(name: &str) -> PathBuf {
     let project_root = workspace_root()
         .join("target")


### PR DESCRIPTION
## Summary
- stop `--tsconfig` Nuxt root resolution at a child package boundary
- keep parent lookup for generated `.nuxt/tsconfig.json` style configs without a package boundary
- add a monorepo CLI regression that runs `vize check` from a non-Nuxt child package under a Nuxt root

## Root Cause
`resolve_nuxt_project_root` walked from an explicit tsconfig directory to its parent whenever that parent had `nuxt.config.*`. In workspaces with a Nuxt root and unrelated child packages, that made the child package inherit Nuxt fallback behavior and emit the missing `.nuxt` warning.

## Validation
- `cargo fmt --package vize`
- `cargo test -p vize --test check_nuxt_monorepo_cli check_non_nuxt_child_package_does_not_warn_about_root_nuxt_generated_types`
- `cargo test -p vize --test check_nuxt_monorepo_cli check_explicit_nuxt_app_tsconfig_in_monorepo_keeps_app_root_detection`
- `cargo clippy -p vize --lib -- -D warnings`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

Closes #2189

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->