### PR TITLE
fix(check): keep filtered workspace checks package-local

### DIFF
--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -229,17 +229,16 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         )
     };
 
-    // An explicit file subset (`vize check src/App.vue`) omits ambient
-    // declaration files, since nothing imports them; `declare global` types
-    // would then be missing and surface as false `TS2304` errors. Pull the
-    // tsconfig program's `.d.ts` files back in so global types stay in scope.
+    // Explicit subsets omit ambient roots; pull package-local `.d.ts` files
+    // back in so global types stay in scope without widening package checks.
     if !args.patterns.is_empty() && program_tsconfig_path.is_some() {
+        let keep_package_local = resolve::project_root_has_package_boundary(&project_root);
         for path in collect_ambient_declaration_files(
             &project_root,
             program_tsconfig_path.as_deref(),
             &mut tsconfig_input_cache,
         ) {
-            if !files.contains(&path) {
+            if (!keep_package_local || path.starts_with(&project_root)) && !files.contains(&path) {
                 files.push(path);
             }
         }

--- a/crates/vize/src/commands/check/runner/resolve.rs
+++ b/crates/vize/src/commands/check/runner/resolve.rs
@@ -56,7 +56,7 @@ pub(super) fn resolve_project_root(
             .parent()
             .map(|parent| parent.to_path_buf())
             .unwrap_or_else(|| cwd.to_path_buf());
-        if files.is_empty() {
+        if files.is_empty() || project_root_has_package_boundary(&tsconfig_dir) {
             return tsconfig_dir;
         }
 
@@ -114,6 +114,10 @@ pub(super) fn explicit_input_root(project_root: &Path, cwd: &Path) -> PathBuf {
     } else {
         project_root.to_path_buf()
     }
+}
+
+pub(super) fn project_root_has_package_boundary(project_root: &Path) -> bool {
+    project_root.join("package.json").is_file()
 }
 
 pub(super) fn exit_if_inputs_outside_root(root: &Path, files: &[PathBuf], enabled: bool) {
@@ -231,4 +235,50 @@ pub(super) fn validate_corsa_server_count(servers: Option<usize>) -> Result<(), 
         .into());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_project_root;
+    use std::path::{Path, PathBuf};
+
+    fn unique_case_dir(name: &str) -> PathBuf {
+        static NEXT_CASE_ID: std::sync::atomic::AtomicUsize =
+            std::sync::atomic::AtomicUsize::new(0);
+        let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("workspace root should exist")
+            .join("target")
+            .join("vize-tests")
+            .join("resolve")
+            .join(name)
+            .join(std::process::id().to_string())
+            .join(case_id.to_string())
+    }
+
+    #[test]
+    fn explicit_tsconfig_with_package_boundary_does_not_widen_to_workspace_root() {
+        let workspace = unique_case_dir("package-boundary");
+        let _ = std::fs::remove_dir_all(&workspace);
+        let package_root = workspace.join("test/e2e/onepass/sign-in");
+        std::fs::create_dir_all(package_root.join("src")).unwrap();
+        std::fs::create_dir_all(workspace.join("types")).unwrap();
+        std::fs::write(package_root.join("package.json"), "{}").unwrap();
+        std::fs::write(package_root.join("tsconfig.json"), "{}").unwrap();
+        let app = package_root.join("src/main.ts");
+        let ambient = workspace.join("types/root.d.ts");
+        std::fs::write(&app, "").unwrap();
+        std::fs::write(&ambient, "declare const rootOnly: string;\n").unwrap();
+
+        let resolved = resolve_project_root(
+            Some(Path::new("tsconfig.json")),
+            &package_root,
+            &[app, ambient],
+        );
+
+        assert_eq!(resolved, package_root);
+        let _ = std::fs::remove_dir_all(&workspace);
+    }
 }

--- a/crates/vize/tests/check_workspace_package_boundary_cli.rs
+++ b/crates/vize/tests/check_workspace_package_boundary_cli.rs
@@ -1,0 +1,148 @@
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use std::{path::Path, process::Command};
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn unique_case_dir(name: &str) -> std::path::PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(name)
+        .join(std::process::id().to_string())
+        .join(case_id.to_string())
+}
+
+fn write_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(file_path, content).unwrap();
+}
+
+fn resolve_test_corsa_path() -> Option<String> {
+    let workspace_root = workspace_root();
+    let sibling_cache = workspace_root.parent()?.join("corsa-bind/.cache/tsgo");
+    if sibling_cache.exists() {
+        return Some(sibling_cache.display().to_string());
+    }
+
+    let workspace_bin = workspace_root.join("node_modules/.bin/tsgo");
+    workspace_bin
+        .exists()
+        .then(|| workspace_bin.display().to_string())
+}
+
+#[test]
+fn check_filtered_child_workspace_keeps_package_root_for_corsa_resolution() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+
+    let workspace = unique_case_dir("filtered-package-boundary");
+    let _ = std::fs::remove_dir_all(&workspace);
+    std::fs::create_dir_all(&workspace).unwrap();
+    write_file(&workspace, "package.json", r#"{ "private": true }"#);
+    write_file(
+        &workspace,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["types/**/*.d.ts"]
+}"#,
+    );
+    write_file(
+        &workspace,
+        "types/root.d.ts",
+        "declare const rootOnlyGlobal: string;\n",
+    );
+    write_file(
+        &workspace,
+        "node_modules/vue/package.json",
+        r#"{ "name": "vue", "version": "2.7.0", "types": "index.d.ts" }"#,
+    );
+    write_file(
+        &workspace,
+        "node_modules/vue/index.d.ts",
+        "export declare const version: string;\n",
+    );
+
+    let package_root = workspace.join("test/e2e/onepass/sign-in");
+    write_file(&package_root, "package.json", r#"{ "private": true }"#);
+    write_file(
+        &package_root,
+        "tsconfig.json",
+        r#"{
+  "extends": "../../../../tsconfig.json"
+}"#,
+    );
+    write_file(
+        &package_root,
+        "node_modules/vue/package.json",
+        r#"{ "name": "vue", "version": "3.4.21", "types": "index.d.ts" }"#,
+    );
+    write_file(
+        &package_root,
+        "node_modules/vue/index.d.ts",
+        r#"export declare function createApp(root: unknown): {
+  mount(selector: string): void;
+};
+"#,
+    );
+    write_file(
+        &package_root,
+        "src/main.ts",
+        r##"import { createApp } from "vue";
+
+createApp({}).mount("#app");
+"##,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&package_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "child package check resolved through the workspace root:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(package_root.to_string_lossy().as_ref()),
+        "Corsa project should be rooted at the child package:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], 0, "{stdout}\n{stderr}");
+
+    let _ = std::fs::remove_dir_all(&workspace);
+}


### PR DESCRIPTION
## Summary
- keep explicit package tsconfig checks rooted at the child package when that tsconfig directory has a package boundary
- avoid pulling parent workspace ambient declarations into package-local explicit checks
- add a CLI regression with root Vue 2-style types and child Vue 3-style types

## Verification
- cargo fmt --package vize
- cargo test -p vize --lib explicit_tsconfig_with_package_boundary_does_not_widen_to_workspace_root
- cargo test -p vize --test check_workspace_package_boundary_cli -- --nocapture
- cargo test -p vize --lib resolves_common_root_when_explicit_tsconfig_is_below_inputs
- cargo test -p vize --test check_package_cwd_cli -- --nocapture
- cargo clippy -p vize --lib -- -D warnings
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Closes #2191

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->