### PR TITLE
fix(canon): load Vue JSX intrinsic types

### DIFF
--- a/crates/vize/tests/check_tsx_sfc_attrs_cli.rs
+++ b/crates/vize/tests/check_tsx_sfc_attrs_cli.rs
@@ -126,13 +126,16 @@ defineEmits<{ click: [event: MouseEvent] }>()
         r#"import AfButton from './AfButton.vue';
 
 export const Example = () => (
-  <AfButton
-    class="af-mb-2"
-    style="width: 200px"
-    color="primary"
-    is-opened={true}
-    onClick={(event: MouseEvent) => event.preventDefault()}
-  />
+  <div class="story-shell">
+    <span data-testid="label">Preview</span>
+    <AfButton
+      class="af-mb-2"
+      style="width: 200px"
+      color="primary"
+      is-opened={true}
+      onClick={(event: MouseEvent) => event.preventDefault()}
+    />
+  </div>
 );
 "#,
     )
@@ -164,6 +167,8 @@ export const Example = () => (
     let helpers =
         std::fs::read_to_string(project_root.join("node_modules/.vize/canon/__vize_helpers.d.ts"))
             .unwrap();
+    assert!(helpers.contains("/// <reference types=\"vue/jsx\" />"));
+    assert!(helpers.contains("interface IntrinsicElements"));
     assert!(helpers.contains("interface IntrinsicAttributes"));
     assert!(helpers.contains("class?: unknown; style?: unknown"));
     assert!(helpers.contains("__VizeKebabProps"));

--- a/crates/vize_canon/src/batch/virtual_project/materialize.rs
+++ b/crates/vize_canon/src/batch/virtual_project/materialize.rs
@@ -5,6 +5,7 @@
 use std::path::{Path, PathBuf};
 
 use rayon::prelude::*;
+use serde_json::Value;
 use vize_carton::{FxHashSet, String as CompactString, profile};
 
 use crate::batch::error::CorsaResult;
@@ -14,6 +15,12 @@ use crate::batch::materialize_fs::{
 use crate::batch::runtime_deps::materialize_runtime_dependencies;
 
 use super::{AUTO_IMPORT_STUBS_FILE, SHARED_HELPERS_FILE, VUE_MODULE_STUBS_FILE, VirtualProject};
+
+const VUE_JSX_INTRINSIC_ELEMENTS_DTS: &str = concat!(
+    "declare namespace JSX { interface IntrinsicElements { [name: string]: any; } }\n",
+    "declare module 'vue/jsx-runtime' { export namespace JSX { interface IntrinsicElements { [name: string]: any; } } }\n",
+    "declare module 'vue/jsx-dev-runtime' { export namespace JSX { interface IntrinsicElements { [name: string]: any; } } }\n",
+);
 
 impl VirtualProject {
     /// Materialize the virtual project to disk for diagnostics collection.
@@ -165,11 +172,39 @@ impl VirtualProject {
     /// hoist their common preamble (ImportMeta augmentation, type helpers,
     /// compiler-macro signatures) into this single program-wide declaration.
     fn write_shared_helpers(&self) -> CorsaResult<()> {
+        let mut content = CompactString::default();
+        if self.needs_vue_jsx_reference() {
+            content.push_str("/// <reference types=\"vue/jsx\" />\n");
+            content.push_str(VUE_JSX_INTRINSIC_ELEMENTS_DTS);
+        }
+        content.push_str(crate::virtual_ts::SHARED_PREAMBLE_DTS);
         write_if_changed(
             &self.virtual_root.join(SHARED_HELPERS_FILE),
-            crate::virtual_ts::SHARED_PREAMBLE_DTS.as_bytes(),
+            content.as_bytes(),
         )?;
         Ok(())
+    }
+
+    fn needs_vue_jsx_reference(&self) -> bool {
+        if self.needs_vue_jsx_compiler_options() {
+            return true;
+        }
+        let Ok(options) = self.load_compiler_options(self.resolved_tsconfig_path().as_deref())
+        else {
+            return false;
+        };
+        options
+            .get("jsxImportSource")
+            .and_then(Value::as_str)
+            .is_some_and(|source| source == "vue")
+            || options
+                .get("types")
+                .and_then(Value::as_array)
+                .is_some_and(|types| {
+                    types
+                        .iter()
+                        .any(|entry| entry.as_str().is_some_and(|entry| entry == "vue/jsx"))
+                })
     }
 
     fn expected_materialized_files(&self) -> FxHashSet<PathBuf> {

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
@@ -229,7 +229,7 @@ impl VirtualProject {
         Ok(Value::Object(config))
     }
 
-    fn needs_vue_jsx_compiler_options(&self) -> bool {
+    pub(super) fn needs_vue_jsx_compiler_options(&self) -> bool {
         self.virtual_files.values().any(|file| {
             file.virtual_path
                 .file_name()
@@ -263,7 +263,7 @@ impl VirtualProject {
         includes
     }
     #[allow(clippy::disallowed_types)]
-    fn load_compiler_options(
+    pub(super) fn load_compiler_options(
         &self,
         tsconfig_path: Option<&Path>,
     ) -> CorsaResult<Map<std::string::String, Value>> {


### PR DESCRIPTION
## Summary
- load Vue JSX ambient references when the effective tsconfig opts into Vue JSX
- provide the required JSX intrinsic namespace for native tsgo/corsa resolution
- extend the TSX SFC story regression to cover intrinsic tags

Closes #2193

## Verification
- cargo test -p vize --test check_tsx_sfc_attrs_cli -- --nocapture
- cargo test -p vize_canon --lib batch::virtual_project::tests -- --nocapture
- cargo clippy -p vize_canon --lib -- -D warnings
- cargo clippy -p vize --lib -- -D warnings
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check
- after rebase: cargo test -p vize --test check_tsx_sfc_attrs_cli -- --nocapture
- after rebase: node --test tests/tooling/source-file-lengths.test.ts
- after rebase: git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->