### PR TITLE
fix(musea): forward static build art diagnostics

### DIFF
--- a/npm/builder/vite-musea/src/plugin/art-processing.test.ts
+++ b/npm/builder/vite-musea/src/plugin/art-processing.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { processMuseaArtFile } from "./art-processing.js";
+
+void test("processMuseaArtFile forwards parser diagnostics during build", async () => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-bad-art-"));
+  const artPath = path.join(tempDir, "stories", "Broken.art.vue");
+
+  try {
+    await fs.promises.mkdir(path.dirname(artPath), { recursive: true });
+    await fs.promises.writeFile(
+      artPath,
+      '<art><variant name="Default"><div /></variant></art>',
+      "utf8",
+    );
+
+    await assert.rejects(
+      processMuseaArtFile(artPath, { root: tempDir, command: "build" }),
+      (error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        assert.match(message, /\[musea\] Failed to process stories\/Broken\.art\.vue/);
+        assert.match(message, /Missing required 'title' attribute in <art> block/);
+        return true;
+      },
+    );
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+void test("processMuseaArtFile keeps dev processing non-fatal", async () => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-dev-bad-art-"));
+  const artPath = path.join(tempDir, "stories", "Broken.art.vue");
+  const messages: string[] = [];
+
+  try {
+    await fs.promises.mkdir(path.dirname(artPath), { recursive: true });
+    await fs.promises.writeFile(artPath, "<art>", "utf8");
+
+    const info = await processMuseaArtFile(artPath, {
+      root: tempDir,
+      command: "serve",
+      onError: (message) => messages.push(message),
+    });
+
+    assert.equal(info, null);
+    assert.equal(messages.length, 1);
+    assert.match(messages[0], /\[musea\] Failed to process stories\/Broken\.art\.vue/);
+    assert.match(messages[0], /No <art> block found in file/);
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/npm/builder/vite-musea/src/plugin/art-processing.ts
+++ b/npm/builder/vite-musea/src/plugin/art-processing.ts
@@ -1,0 +1,144 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { extractScriptSetupContent, extractScriptSetupIsolated } from "../art-module.js";
+import { loadNative } from "../native-loader.js";
+import type { ArtFileInfo, ArtMetadata } from "../types/index.js";
+
+export interface ArtProcessingContext {
+  root: string;
+  command: string;
+  onError?: (message: string) => void;
+}
+
+function extractArtTagAttributes(source: string): Record<string, string | true> {
+  const artTagMatch = source.match(/<art\b([\s\S]*?)>/i);
+  if (!artTagMatch) return {};
+
+  const attributes: Record<string, string | true> = {};
+  const attrPattern = /([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'))?/g;
+
+  for (const match of artTagMatch[1].matchAll(attrPattern)) {
+    const name = match[1];
+    if (!name || name === "/") continue;
+    attributes[name] = match[2] ?? match[3] ?? true;
+  }
+
+  return attributes;
+}
+
+function parseActionEvents(value: string | true | undefined): string[] | undefined {
+  if (typeof value !== "string") return undefined;
+
+  const events = value
+    .split(",")
+    .map((eventName) => eventName.trim().toLowerCase())
+    .filter(Boolean);
+
+  return events.length > 0 ? [...new Set(events)] : undefined;
+}
+
+function extractCustomArtMetadata(source: string): Pick<ArtMetadata, "actionEvents"> {
+  const attrs = extractArtTagAttributes(source);
+  const actionEvents = new Set(parseActionEvents(attrs["action-events"]) ?? []);
+  const captureMousemove = attrs["capture-mousemove"];
+
+  if (captureMousemove === true || captureMousemove === "true") {
+    actionEvents.add("mousemove");
+  }
+
+  return {
+    actionEvents: actionEvents.size > 0 ? [...actionEvents] : undefined,
+  };
+}
+
+function extractStyleBlocks(source: string): string[] {
+  const styles: string[] = [];
+
+  for (const match of source.matchAll(/<style\b([^>]*)>([\s\S]*?)<\/style>/gi)) {
+    const attrs = match[1] ?? "";
+    const content = match[2]?.trim();
+    const lang = attrs.match(/\blang\s*=\s*["']([^"']+)["']/i)?.[1]?.toLowerCase();
+
+    if (!content) continue;
+    if (lang && lang !== "css") continue;
+
+    styles.push(content);
+  }
+
+  return styles;
+}
+
+function formatArtProcessingError(root: string, filePath: string, error: unknown): string {
+  const detail =
+    error instanceof Error
+      ? error.message || error.name
+      : error == null
+        ? "unknown error"
+        : stringifyUnknown(error);
+  const relativePath = path.relative(root, filePath) || filePath;
+  return `[musea] Failed to process ${relativePath}: ${detail}`;
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return value.toString();
+  }
+  try {
+    return JSON.stringify(value) ?? "unknown error";
+  } catch {
+    return "unknown error";
+  }
+}
+
+export async function processMuseaArtFile(
+  filePath: string,
+  ctx: ArtProcessingContext,
+): Promise<ArtFileInfo | null> {
+  try {
+    const source = await fs.promises.readFile(filePath, "utf-8");
+    const binding = loadNative();
+    const parsed = binding.parseArt(source, { filename: filePath });
+    const customMetadata = extractCustomArtMetadata(source);
+
+    if (!parsed.variants || parsed.variants.length === 0) return null;
+
+    const isInline = !filePath.endsWith(".art.vue");
+
+    return {
+      path: filePath,
+      metadata: {
+        title: parsed.metadata.title || (isInline ? path.basename(filePath, ".vue") : ""),
+        description: parsed.metadata.description,
+        component: isInline ? undefined : parsed.metadata.component,
+        category: parsed.metadata.category,
+        tags: parsed.metadata.tags,
+        status: parsed.metadata.status as "draft" | "ready" | "deprecated",
+        order: parsed.metadata.order,
+        actionEvents: customMetadata.actionEvents ?? parsed.metadata.actionEvents,
+      },
+      variants: parsed.variants.map((v) => ({
+        name: v.name,
+        template: v.template,
+        isDefault: v.isDefault,
+        skipVrt: v.skipVrt,
+      })),
+      hasScriptSetup: isInline ? false : parsed.hasScriptSetup,
+      scriptSetupContent:
+        !isInline && parsed.hasScriptSetup ? extractScriptSetupContent(source) : undefined,
+      scriptSetupIsolated:
+        !isInline && parsed.hasScriptSetup ? extractScriptSetupIsolated(source) : true,
+      hasScript: parsed.hasScript,
+      styleCount: parsed.styleCount,
+      styleBlocks: isInline ? [] : extractStyleBlocks(source),
+      isInline,
+      componentPath: isInline ? filePath : undefined,
+    };
+  } catch (error) {
+    const message = formatArtProcessingError(ctx.root, filePath, error);
+    if (ctx.command === "build") throw new Error(message);
+    (ctx.onError ?? console.error)(message);
+    return null;
+  }
+}

--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -2,10 +2,8 @@ import type { Plugin, ViteDevServer, ResolvedConfig } from "vite";
 import { transformWithEsbuild } from "vite";
 import fs from "node:fs";
 import path from "node:path";
-import type { MuseaOptions, ArtFileInfo, ArtMetadata } from "../types/index.js";
+import type { MuseaOptions, ArtFileInfo } from "../types/index.js";
 
-import { loadNative } from "../native-loader.js";
-import { extractScriptSetupContent, extractScriptSetupIsolated } from "../art-module.js";
 import {
   shouldProcess,
   scanArtFiles,
@@ -36,69 +34,7 @@ import {
   type StaticBuildInput,
 } from "../static-export.js";
 import { resolveMuseaSharedConfig } from "./config.js";
-
-function extractArtTagAttributes(source: string): Record<string, string | true> {
-  const artTagMatch = source.match(/<art\b([\s\S]*?)>/i);
-  if (!artTagMatch) return {};
-
-  const attributes: Record<string, string | true> = {};
-  const attrPattern = /([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'))?/g;
-
-  for (const match of artTagMatch[1].matchAll(attrPattern)) {
-    const name = match[1];
-    if (!name || name === "/") continue;
-    attributes[name] = match[2] ?? match[3] ?? true;
-  }
-
-  return attributes;
-}
-
-function parseActionEvents(value: string | true | undefined): string[] | undefined {
-  if (typeof value !== "string") return undefined;
-
-  const events = value
-    .split(",")
-    .map((eventName) => eventName.trim().toLowerCase())
-    .filter(Boolean);
-
-  return events.length > 0 ? [...new Set(events)] : undefined;
-}
-
-function extractCustomArtMetadata(source: string): Pick<ArtMetadata, "actionEvents"> {
-  const attrs = extractArtTagAttributes(source);
-  const actionEvents = new Set(parseActionEvents(attrs["action-events"]) ?? []);
-  const captureMousemove = attrs["capture-mousemove"];
-
-  if (captureMousemove === true || captureMousemove === "true") {
-    actionEvents.add("mousemove");
-  }
-
-  return {
-    actionEvents: actionEvents.size > 0 ? [...actionEvents] : undefined,
-  };
-}
-
-function extractStyleBlocks(source: string): string[] {
-  const styles: string[] = [];
-
-  for (const match of source.matchAll(/<style\b([^>]*)>([\s\S]*?)<\/style>/gi)) {
-    const attrs = match[1] ?? "";
-    const content = match[2]?.trim();
-    const lang = attrs.match(/\blang\s*=\s*["']([^"']+)["']/i)?.[1]?.toLowerCase();
-
-    if (!content) {
-      continue;
-    }
-
-    if (lang && lang !== "css") {
-      continue;
-    }
-
-    styles.push(content);
-  }
-
-  return styles;
-}
+import { processMuseaArtFile } from "./art-processing.js";
 
 export function musea(options: MuseaOptions = {}): Plugin[] {
   let include = options.include ?? ["**/*.art.vue"];
@@ -260,13 +196,9 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
           if (address && typeof address === "object") {
             const protocol = devServer.config.server.https ? "https" : "http";
             const rawHost = address.address;
-            const host =
-              rawHost === "::" ||
-              rawHost === "::1" ||
-              rawHost === "0.0.0.0" ||
-              rawHost === "127.0.0.1"
-                ? "localhost"
-                : rawHost;
+            const host = ["::", "::1", "0.0.0.0", "127.0.0.1"].includes(rawHost)
+              ? "localhost"
+              : rawHost;
             const port = address.port;
             const url = `${protocol}://${host}:${port}${basePath}`;
 
@@ -342,50 +274,11 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
   };
 
   async function processArtFile(filePath: string): Promise<void> {
-    try {
-      const source = await fs.promises.readFile(filePath, "utf-8");
-      const binding = loadNative();
-      const parsed = binding.parseArt(source, { filename: filePath });
-      const customMetadata = extractCustomArtMetadata(source);
-
-      if (!parsed.variants || parsed.variants.length === 0) return;
-
-      const isInline = !filePath.endsWith(".art.vue");
-
-      const info: ArtFileInfo = {
-        path: filePath,
-        metadata: {
-          title: parsed.metadata.title || (isInline ? path.basename(filePath, ".vue") : ""),
-          description: parsed.metadata.description,
-          component: isInline ? undefined : parsed.metadata.component,
-          category: parsed.metadata.category,
-          tags: parsed.metadata.tags,
-          status: parsed.metadata.status as "draft" | "ready" | "deprecated",
-          order: parsed.metadata.order,
-          actionEvents: customMetadata.actionEvents ?? parsed.metadata.actionEvents,
-        },
-        variants: parsed.variants.map((v) => ({
-          name: v.name,
-          template: v.template,
-          isDefault: v.isDefault,
-          skipVrt: v.skipVrt,
-        })),
-        hasScriptSetup: isInline ? false : parsed.hasScriptSetup,
-        scriptSetupContent:
-          !isInline && parsed.hasScriptSetup ? extractScriptSetupContent(source) : undefined,
-        scriptSetupIsolated:
-          !isInline && parsed.hasScriptSetup ? extractScriptSetupIsolated(source) : true,
-        hasScript: parsed.hasScript,
-        styleCount: parsed.styleCount,
-        styleBlocks: isInline ? [] : extractStyleBlocks(source),
-        isInline,
-        componentPath: isInline ? filePath : undefined,
-      };
-
-      artFiles.set(filePath, info);
-    } catch (e) {
-      console.error(`[musea] Failed to process ${filePath}:`, e);
-    }
+    const info = await processMuseaArtFile(filePath, {
+      root: config.root,
+      command: config.command,
+    });
+    if (info) artFiles.set(filePath, info);
   }
 
   return [mainPlugin];


### PR DESCRIPTION
## Summary
- move Musea art file processing into a focused helper module
- make build-mode art parse failures throw a Vite-visible error with the art file path and parser message
- keep dev/HMR processing non-fatal while logging the same formatted diagnostic

## Root cause
Musea swallowed `parseArt` failures while scanning art files. In static builds this allowed the build to continue into later output phases, so the actionable parser diagnostic could be lost or replaced by an unhelpful wrapper error.

Closes #2192

## Verification
- `pnpm --filter @vizejs/vite-plugin-musea check`
- `pnpm --filter @vizejs/vite-plugin-musea test`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->