### PR TITLE
fix(musea): allow tokens path in external scan roots

### DIFF
--- a/npm/builder/vite-musea/src/api-routes/index.test.ts
+++ b/npm/builder/vite-musea/src/api-routes/index.test.ts
@@ -204,6 +204,48 @@ void test("createApiMiddleware returns 400 for malformed art source JSON", async
   }
 });
 
+void test("createApiMiddleware resolves tokensPath inside external scan roots", async () => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-api-tokens-root-"));
+  const appRoot = path.join(tempDir, "app");
+  const designRoot = path.join(tempDir, "design");
+  const tokensDir = path.join(designRoot, "tokens");
+
+  try {
+    await fs.promises.mkdir(appRoot, { recursive: true });
+    await fs.promises.mkdir(tokensDir, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(tokensDir, "colors.tokens.json"),
+      JSON.stringify({
+        color: {
+          primitive: {
+            gray: {
+              50: { value: "#f7f7f7" },
+            },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const ctx = createContext(appRoot);
+    ctx.scanRoots = [appRoot, designRoot];
+    ctx.tokensPath = "../design/tokens";
+
+    const response = await invokeApi(ctx, {
+      method: "GET",
+      url: "/tokens",
+    });
+
+    assert.equal(response.statusCode, 200, response.body);
+    const body = JSON.parse(response.body);
+    assert.equal(body.error, undefined);
+    assert.equal(body.meta.filePath, tokensDir);
+    assert.equal(body.tokenMap["color.primitive.gray.50"].value, "#f7f7f7");
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 void test("createApiMiddleware populates inline art palette controls from host component props", async () => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-api-inline-palette-"));
   const componentPath = path.join(tempDir, "src", "InlineButton.vue");

--- a/npm/builder/vite-musea/src/api-tokens.ts
+++ b/npm/builder/vite-musea/src/api-tokens.ts
@@ -10,7 +10,7 @@
  */
 
 import type { ApiRoutesContext, SendJson, SendError, ReadBody } from "./api-routes/index.js";
-import { HttpError, parseJsonBody, resolveInside } from "./security.js";
+import { HttpError, parseJsonBody, resolveInsideAny } from "./security.js";
 import {
   parseTokens,
   buildTokenMap,
@@ -27,7 +27,7 @@ import {
 } from "./style-dictionary.js";
 
 function resolveTokensPath(ctx: ApiRoutesContext): string {
-  return resolveInside(ctx.config.root, ctx.tokensPath!, "tokensPath");
+  return resolveInsideAny([ctx.config.root, ...ctx.scanRoots], ctx.tokensPath!, "tokensPath");
 }
 
 function sendTokenMutationError(e: unknown, sendError: SendError): void {


### PR DESCRIPTION
## Summary
- resolve Musea `tokensPath` against the same allowed root set as external art files
- allow `../design/tokens` when `design/` is already part of Musea scan roots
- add API coverage for a Nuxt-style `app/` root with external design-system tokens

## Root cause
Token APIs only accepted paths inside `config.root`. Musea can already scan art files from external include roots, but token resolution did not share that boundary, so Nuxt `srcDir` layouts rejected matching external token directories.

Closes #2184

## Verification
- `pnpm --filter @vizejs/vite-plugin-musea exec tsx --test src/api-routes/index.test.ts`
- `pnpm --filter @vizejs/vite-plugin-musea check`
- `pnpm --filter @vizejs/vite-plugin-musea test`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->