### PR TITLE
fix(musea-vrt): preserve required generated props

### DIFF
--- a/npm/builder/vite-musea/src/autogen/fallback.ts
+++ b/npm/builder/vite-musea/src/autogen/fallback.ts
@@ -80,7 +80,7 @@ export function generateArtFileJs(
     variants.push({
       name: "Default",
       isDefault: true,
-      props: defaultProps,
+      props: withRequiredPlaceholders(defaultProps, props),
       description: `${componentName} with default props`,
     });
   }
@@ -96,7 +96,7 @@ export function generateArtFileJs(
         variants.push({
           name,
           isDefault: false,
-          props: { [prop.name]: val },
+          props: withRequiredPlaceholders({ [prop.name]: val }, props),
           description: `${prop.name} = ${JSON.stringify(val)}`,
         });
       }
@@ -112,38 +112,109 @@ export function generateArtFileJs(
         variants.push({
           name: nonDefault ? toPascalCase(prop.name) : `No${toPascalCase(prop.name)}`,
           isDefault: false,
-          props: { [prop.name]: nonDefault },
+          props: withRequiredPlaceholders({ [prop.name]: nonDefault }, props),
           description: `${prop.name} = ${nonDefault}`,
         });
       }
     }
   }
 
-  // Generate art file content
-  let content = `<script setup lang="ts">\ndefineArt(${JSON.stringify(relPath)}, {\n  title: ${JSON.stringify(componentName)},\n});\n</script>\n\n<art>\n`;
-  for (const variant of variants) {
-    const attrs = variant.isDefault ? `name="${variant.name}" default` : `name="${variant.name}"`;
-    content += `  <variant ${attrs}>\n`;
-
-    const propsStr = Object.entries(variant.props)
-      .map(([k, v]) => {
-        if (typeof v === "string") return `${k}="${v}"`;
-        if (typeof v === "boolean" && v) return k;
-        if (typeof v === "boolean" && !v) return `:${k}="false"`;
-        return `:${k}="${JSON.stringify(v)}"`;
-      })
-      .join(" ");
-
-    content += `    <${componentName}${propsStr ? " " + propsStr : ""} />\n`;
-    content += `  </variant>\n\n`;
-  }
-  content += `</art>\n`;
-
   return {
     variants,
-    artFileContent: content,
+    artFileContent: generateArtFileContent(componentName, relPath, variants, props),
     componentName,
   };
+}
+
+export function finalizeArtOutput(
+  output: AutogenOutput,
+  componentPath: string,
+  props: PropDefinition[],
+): AutogenOutput {
+  const variants = output.variants.map((variant) => ({
+    ...variant,
+    props: withRequiredPlaceholders(variant.props, props),
+  }));
+  return {
+    ...output,
+    variants,
+    artFileContent: generateArtFileContent(output.componentName, componentPath, variants, props),
+  };
+}
+
+function generateArtFileContent(
+  componentName: string,
+  componentPath: string,
+  variants: GeneratedVariant[],
+  props: PropDefinition[],
+): string {
+  const fixtures = new Map<string, string>();
+  let variantsContent = "";
+
+  for (const variant of variants) {
+    const attrs = variant.isDefault ? `name="${variant.name}" default` : `name="${variant.name}"`;
+    variantsContent += `  <variant ${attrs}>\n`;
+
+    const propsStr = Object.entries(variant.props)
+      .map(([k, v]) => renderPropAttribute(k, v, props, fixtures))
+      .join(" ");
+
+    variantsContent += `    <${componentName}${propsStr ? " " + propsStr : ""} />\n`;
+    variantsContent += `  </variant>\n\n`;
+  }
+
+  const fixtureLines = [...fixtures.entries()].map(
+    ([propName, fixture]) =>
+      `const ${fixture} = {} as never; // TODO: replace generated fixture for required prop ${JSON.stringify(propName)}`,
+  );
+  const fixtureBlock = fixtureLines.length > 0 ? `${fixtureLines.join("\n")}\n\n` : "";
+
+  return `<script setup lang="ts">
+${fixtureBlock}defineArt(${JSON.stringify(componentPath)}, {
+  title: ${JSON.stringify(componentName)},
+});
+</script>
+
+<art>
+${variantsContent}</art>
+`;
+}
+
+function withRequiredPlaceholders(
+  values: Record<string, unknown>,
+  props: PropDefinition[],
+): Record<string, unknown> {
+  const next = { ...values };
+  for (const prop of props) {
+    if (prop.required && prop.defaultValue === undefined && !(prop.name in next)) {
+      next[prop.name] = null;
+    }
+  }
+  return next;
+}
+
+function renderPropAttribute(
+  name: string,
+  value: unknown,
+  props: PropDefinition[],
+  fixtures: Map<string, string>,
+): string {
+  const attrName = toKebabCase(name);
+  const prop = props.find((candidate) => candidate.name === name);
+  if (prop?.required && prop.defaultValue === undefined && value == null) {
+    const fixture = fixtureIdentifier(name);
+    fixtures.set(name, fixture);
+    return `:${attrName}="${fixture}"`;
+  }
+  if (typeof value === "string") return `${attrName}="${value}"`;
+  if (typeof value === "boolean" && value) return attrName;
+  if (typeof value === "boolean" && !value) return `:${attrName}="false"`;
+  return `:${attrName}="${JSON.stringify(value)}"`;
+}
+
+function fixtureIdentifier(propName: string): string {
+  const base = propName.replace(/[^\w$]/g, "_");
+  return /^[A-Za-z_$]/.test(base) ? `${base}Fixture` : `prop${toPascalCase(base)}Fixture`;
 }
 
 export function parseUnionType(typeStr: string): unknown[] {
@@ -171,4 +242,8 @@ export function toPascalCase(str: string): string {
     .filter(Boolean)
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join("");
+}
+
+function toKebabCase(str: string): string {
+  return str.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`);
 }

--- a/npm/builder/vite-musea/src/autogen/generate.test.ts
+++ b/npm/builder/vite-musea/src/autogen/generate.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { generateArtFile } from "./index.js";
+
+void test("generateArtFile preserves required object props with fixture bindings", async () => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-autogen-required-"));
+  const componentPath = path.join(tempDir, "MoshiDetailCard.vue");
+
+  try {
+    await fs.promises.writeFile(
+      componentPath,
+      `<script setup lang="ts">
+type MoshiDetailCardFragment = { id: string };
+
+defineProps<{
+  moshiWithStudent: MoshiDetailCardFragment;
+}>();
+</script>
+
+<template>
+  <div />
+</template>
+`,
+      "utf-8",
+    );
+
+    const output = await generateArtFile(componentPath);
+
+    assert.deepEqual(output.variants[0]?.props, {
+      moshiWithStudent: null,
+    });
+    assert.match(output.artFileContent, /const moshiWithStudentFixture = \{\} as never;/);
+    assert.match(
+      output.artFileContent,
+      /<MoshiDetailCard :moshi-with-student="moshiWithStudentFixture" \/>/,
+    );
+    assert.doesNotMatch(output.artFileContent, /<MoshiDetailCard \/>/);
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/npm/builder/vite-musea/src/autogen/index.ts
+++ b/npm/builder/vite-musea/src/autogen/index.ts
@@ -10,7 +10,12 @@ import { createRequire } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
 
-import { extractPropsSimple, generateMinimalArt, generateArtFileJs } from "./fallback.js";
+import {
+  extractPropsSimple,
+  finalizeArtOutput,
+  generateMinimalArt,
+  generateArtFileJs,
+} from "./fallback.js";
 import {
   fromNativeOutput,
   toNativeAutogenConfig,
@@ -154,7 +159,7 @@ export async function generateArtFile(
       toNativeAutogenConfig(options),
     );
 
-    return fromNativeOutput(result);
+    return finalizeArtOutput(fromNativeOutput(result), relPath, props);
   }
 
   // Fallback: JS-based generation


### PR DESCRIPTION
## Summary
- re-render generated Musea art from variant metadata after native generation
- add fixture bindings for required props that have no safe generated value
- keep generated variants from silently emitting an empty `<Component />` when required props exist

## Root cause
The native autogen path returned required prop metadata in `variants[].props`, but the generated `.art.vue` content could still omit those props. That made generation look successful while the default variant did not pass required component inputs.

Closes #2185

## Verification
- `pnpm --filter @vizejs/vite-plugin-musea exec tsx --test 'src/autogen/*.test.ts'`
- `pnpm --filter @vizejs/vite-plugin-musea check`
- `pnpm --filter @vizejs/vite-plugin-musea test`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->