### PR TITLE
fix(nuxt): prefer ssr cache for style requests

### DIFF
--- a/npm/builder/vite/src/plugin/load.ts
+++ b/npm/builder/vite/src/plugin/load.ts
@@ -239,9 +239,9 @@ export function loadHook(
       styleRequest.path;
     const lang = styleRequest.styleLang ?? null;
     const scoped = styleRequest.styleScoped ?? null;
-
-    const compiled = state.cache.get(realPath);
-    const fallbackCompiled = compiled ?? state.ssrCache.get(realPath);
+    const fallbackCompiled = loadOptions?.ssr
+      ? (state.ssrCache.get(realPath) ?? state.cache.get(realPath))
+      : (state.cache.get(realPath) ?? state.ssrCache.get(realPath));
     const blockIndex = styleRequest.styleIndex ?? -1;
 
     if (

--- a/npm/builder/vite/src/plugin/style-load.test.ts
+++ b/npm/builder/vite/src/plugin/style-load.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 
+import type { CompiledModule } from "../types.ts";
 import type { VizePluginState } from "./state.ts";
 import { loadHook } from "./load.ts";
 
@@ -46,4 +47,40 @@ assert.equal(
   "uncached dependency SFC styles should fall through to Nuxt/Vite style handling",
 );
 
+const ssrStylePath = "/src/DeferredDemo.vue";
+const ssrStyleLoad = loadHook(
+  {
+    ...emptyState,
+    cache: new Map([
+      [
+        ssrStylePath,
+        compiledStyle("clientstyle", "export default { props: { options: { type: Object } } }"),
+      ],
+    ]),
+    ssrCache: new Map([
+      [ssrStylePath, compiledStyle("ssrstyle", ".deferred-demo-loading { height: 350px; }")],
+    ]),
+  },
+  "/src/DeferredDemo.vue?vue=&type=style&index=0&lang=css.css?inline&used.css.css?inline",
+  { ssr: true },
+);
+assert.ok(
+  ssrStyleLoad && typeof ssrStyleLoad === "object",
+  "SSR style requests with CSS suffixes should load as code objects",
+);
+assert.equal(
+  ssrStyleLoad.code,
+  ".deferred-demo-loading { height: 350px; }",
+  "SSR style requests should read style blocks from the SSR cache before the client cache",
+);
+
 console.log("✅ vite-plugin-vize style load tests passed!");
+
+function compiledStyle(scopeId: string, content: string): CompiledModule {
+  return {
+    code: `export default {}`,
+    scopeId,
+    hasScoped: false,
+    styles: [{ content, lang: "css", scoped: false, module: false, index: 0 }],
+  };
+}


### PR DESCRIPTION
## Summary
- prefer the SSR compilation cache when loading Vue style requests for SSR builds
- keep client-cache fallback only as a fallback for missing SSR style metadata
- add coverage for Nuxt/Vite CSS suffix style requests such as `.css?inline&used.css.css?inline`

## Root cause
Style request loading always checked the client cache before the SSR cache. During SSR production builds, a project SFC style request could therefore read stale or mismatched client-side style metadata before the SSR compilation result, which can route non-style content into Vite's CSS pipeline.

Closes #2176

## Verification
- `pnpm --filter @vizejs/vite-plugin check`
- `pnpm --filter @vizejs/vite-plugin test`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->