### PR TITLE
fix(musea): reject unsupported storybook tsx inputs

### DIFF
--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -23,6 +23,7 @@ import {
 import { shouldApplyMuseaPlugin } from "./apply.js";
 import { watchMuseaArtFiles } from "./watch.js";
 import { createVueRuntimeCompilerAlias } from "./vue-alias.js";
+import { assertNoUnsupportedStorybookTsxInputs } from "./storybook-inputs.js";
 import {
   applyMuseaStaticBuildInput,
   emitStaticGallery,
@@ -211,6 +212,10 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
 
     async buildStart() {
       console.log(`[musea] config.root: ${config.root}, include: ${JSON.stringify(include)}`);
+      if (storybookCompat && staticBuildEnabled) {
+        await assertNoUnsupportedStorybookTsxInputs(config.root, include, exclude);
+      }
+
       const files = await scanArtFiles(config.root, include, exclude, inlineArt);
 
       console.log(`[musea] Found ${files.length} art files`);

--- a/npm/builder/vite-musea/src/plugin/storybook-inputs.test.ts
+++ b/npm/builder/vite-musea/src/plugin/storybook-inputs.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  assertNoUnsupportedStorybookTsxInputs,
+  formatUnsupportedStorybookTsxInputError,
+  scanStorybookTsxInputs,
+} from "./storybook-inputs.js";
+
+void test("scanStorybookTsxInputs finds included TSX stories and honors excludes", async () => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-storybook-tsx-"));
+  try {
+    const storyPath = path.join(tempDir, "src", "Button.stories.tsx");
+    const excludedPath = path.join(tempDir, "node_modules", "pkg", "Ignored.stories.tsx");
+    const artPath = path.join(tempDir, "src", "Button.art.vue");
+
+    await fs.promises.mkdir(path.dirname(storyPath), { recursive: true });
+    await fs.promises.mkdir(path.dirname(excludedPath), { recursive: true });
+    await fs.promises.writeFile(storyPath, "export default {};\n", "utf8");
+    await fs.promises.writeFile(excludedPath, "export default {};\n", "utf8");
+    await fs.promises.writeFile(artPath, "<art />\n", "utf8");
+
+    assert.deepEqual(
+      await scanStorybookTsxInputs(
+        tempDir,
+        ["src/**/*.art.vue", "src/**/*.stories.tsx", "node_modules/**/*.stories.tsx"],
+        ["node_modules/**"],
+      ),
+      [storyPath],
+    );
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+void test("formatUnsupportedStorybookTsxInputError points to migration path", () => {
+  const message = formatUnsupportedStorybookTsxInputError("/repo", [
+    "/repo/src/Button.stories.tsx",
+  ]);
+
+  assert.match(message, /Storybook TSX files matched by include/);
+  assert.match(message, /src\/Button\.stories\.tsx/);
+  assert.match(message, /\.art\.vue/);
+});
+
+void test("assertNoUnsupportedStorybookTsxInputs rejects matched TSX stories", async () => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-storybook-tsx-error-"));
+  try {
+    const storyPath = path.join(tempDir, "src", "Button.stories.tsx");
+    await fs.promises.mkdir(path.dirname(storyPath), { recursive: true });
+    await fs.promises.writeFile(storyPath, "export default {};\n", "utf8");
+
+    await assert.rejects(
+      assertNoUnsupportedStorybookTsxInputs(tempDir, ["src/**/*.stories.tsx"], []),
+      /Storybook TSX files matched by include/,
+    );
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/npm/builder/vite-musea/src/plugin/storybook-inputs.ts
+++ b/npm/builder/vite-musea/src/plugin/storybook-inputs.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { matchGlob, resolveScanRoots, shouldProcess } from "../utils.js";
+
+export function isStorybookTsxInput(filePath: string): boolean {
+  return /\.(?:stories|story)\.tsx$/i.test(filePath);
+}
+
+export async function scanStorybookTsxInputs(
+  root: string,
+  include: string[],
+  exclude: string[],
+): Promise<string[]> {
+  const files = new Set<string>();
+  const visitedDirs = new Set<string>();
+
+  async function scan(dir: string): Promise<void> {
+    const resolvedDir = path.resolve(dir);
+    if (visitedDirs.has(resolvedDir)) return;
+    visitedDirs.add(resolvedDir);
+
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(resolvedDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(resolvedDir, entry.name);
+      if (isExcluded(fullPath, entry.name, exclude, root)) continue;
+
+      if (entry.isDirectory()) {
+        await scan(fullPath);
+      } else if (
+        entry.isFile() &&
+        isStorybookTsxInput(entry.name) &&
+        shouldProcess(fullPath, include, exclude, root)
+      ) {
+        files.add(fullPath);
+      }
+    }
+  }
+
+  for (const scanRoot of resolveScanRoots(root, include)) {
+    await scan(scanRoot);
+  }
+
+  return [...files].sort();
+}
+
+export async function assertNoUnsupportedStorybookTsxInputs(
+  root: string,
+  include: string[],
+  exclude: string[],
+): Promise<void> {
+  const files = await scanStorybookTsxInputs(root, include, exclude);
+  if (files.length > 0) {
+    throw new Error(formatUnsupportedStorybookTsxInputError(root, files));
+  }
+}
+
+export function formatUnsupportedStorybookTsxInputError(root: string, files: string[]): string {
+  const shown = files
+    .slice(0, 5)
+    .map((file) => `  - ${relativePath(root, file)}`)
+    .join("\n");
+  const remaining = files.length > 5 ? `\n  ... and ${files.length - 5} more` : "";
+
+  return [
+    "[musea] Storybook TSX files matched by include are not supported as Musea art inputs yet.",
+    "Remove *.stories.tsx from musea.include or migrate those stories to .art.vue files.",
+    "Matched files:",
+    `${shown}${remaining}`,
+  ].join("\n");
+}
+
+function isExcluded(filePath: string, name: string, exclude: string[], root: string): boolean {
+  return exclude.some(
+    (pattern) => matchesPathPattern(filePath, pattern, root) || matchGlob(name, pattern),
+  );
+}
+
+function matchesPathPattern(filePath: string, pattern: string, root: string): boolean {
+  const candidate = path.isAbsolute(pattern)
+    ? path.resolve(filePath)
+    : path.relative(root, filePath);
+  return matchGlob(candidate, pattern);
+}
+
+function relativePath(root: string, filePath: string): string {
+  return path.relative(root, filePath).split(path.sep).join("/");
+}


### PR DESCRIPTION
Closes #2179.

## Summary
- detect Storybook TSX files that are explicitly matched by Musea include patterns
- fail static Musea builds with a clear migration message instead of emitting an empty arts API
- cover scanning, excludes, and error formatting with regression tests

## Verification
- pnpm --filter @vizejs/vite-plugin-musea check
- pnpm --filter @vizejs/vite-plugin-musea test
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->