### PR TITLE
fix(nuxt): suppress filtered dependency sfc warnings

### DIFF
--- a/npm/builder/vite/src/plugin/load-dependency-sfc.test.ts
+++ b/npm/builder/vite/src/plugin/load-dependency-sfc.test.ts
@@ -16,7 +16,12 @@ function writeFixtureFile(filePath: string, content: string): void {
   fs.writeFileSync(filePath, content);
 }
 
-function createState(root: string): VizePluginState {
+type StateOptions = {
+  filter?: VizePluginState["filter"];
+  handleNodeModulesVue?: boolean;
+};
+
+function createState(root: string, options: StateOptions = {}): VizePluginState {
   return {
     cache: new Map(),
     ssrCache: new Map(),
@@ -28,12 +33,12 @@ function createState(root: string): VizePluginState {
     clientViteBase: "/",
     serverViteBase: "/",
     server: {} as never,
-    filter: (id) => !id.includes("node_modules") && id.endsWith(".vue"),
+    filter: options.filter ?? ((id) => !id.includes("node_modules") && id.endsWith(".vue")),
     scanPatterns: [],
     precompileBatchSize: 128,
     ignorePatterns: [],
     mergedOptions: {
-      handleNodeModulesVue: false,
+      handleNodeModulesVue: options.handleNodeModulesVue ?? false,
       exclude: ["node_modules/**", "**/node_modules/**"],
     },
     initialized: true,
@@ -52,6 +57,18 @@ function createState(root: string): VizePluginState {
   };
 }
 
+function captureWarnings(callback: () => void): string[] {
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+  try {
+    callback();
+  } finally {
+    console.warn = originalWarn;
+  }
+  return warnings;
+}
+
 const projectRoot = fs.mkdtempSync(path.join(testRoot, "nuxt-runtime-"));
 const nuxtRootSfc = path.join(
   projectRoot,
@@ -66,18 +83,13 @@ writeFixtureFile(nuxtRootSfc, "<template><div /></template>");
 
 const state = createState(projectRoot);
 
-const warnings: string[] = [];
-const originalWarn = console.warn;
-console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
-try {
+const warnings = captureWarnings(() => {
   const componentLoad = loadHook(state, nuxtRootSfc, { ssr: false });
   assert.ok(
     componentLoad && typeof componentLoad === "object",
     "Plain dependency Vue SFC loads should compile before raw SFCs reach Vite define transforms",
   );
-} finally {
-  console.warn = originalWarn;
-}
+});
 
 assert.equal(
   state.cache.has(nuxtRootSfc),
@@ -88,6 +100,57 @@ assert.deepEqual(
   warnings,
   [],
   "Dependency SFC rewrite warnings should be suppressed when node_modules handling is disabled",
+);
+
+const pnpmNuxtRootSfc = path.join(
+  projectRoot,
+  "node_modules",
+  ".pnpm",
+  "nuxt@3.19.3_vue@3.5.13",
+  "node_modules",
+  "nuxt",
+  "dist",
+  "app",
+  "components",
+  "nuxt-root.vue",
+);
+writeFixtureFile(pnpmNuxtRootSfc, "<template><span /></template>");
+
+const filteredDependencyState = createState(projectRoot, { handleNodeModulesVue: true });
+const filteredDependencyWarnings = captureWarnings(() => {
+  const componentLoad = loadHook(filteredDependencyState, pnpmNuxtRootSfc, { ssr: false });
+  assert.ok(
+    componentLoad && typeof componentLoad === "object",
+    "Filtered dependency Vue SFC loads should still compile for the Vite transform pipeline",
+  );
+});
+
+assert.equal(
+  filteredDependencyState.cache.has(pnpmNuxtRootSfc),
+  true,
+  "Filtered dependency Vue SFC loads should still populate the Vize cache",
+);
+assert.deepEqual(
+  filteredDependencyWarnings,
+  [],
+  "Dependency SFC rewrite warnings should be suppressed when node_modules is excluded by filter",
+);
+
+const includedDependencyState = createState(projectRoot, {
+  filter: (id) => id.endsWith(".vue"),
+  handleNodeModulesVue: true,
+});
+const includedDependencyWarnings = captureWarnings(() => {
+  const componentLoad = loadHook(includedDependencyState, pnpmNuxtRootSfc, { ssr: false });
+  assert.ok(
+    componentLoad && typeof componentLoad === "object",
+    "Included dependency Vue SFC loads should compile normally",
+  );
+});
+
+assert.ok(
+  includedDependencyWarnings.length > 0,
+  "Dependency SFC rewrite warnings should still log when node_modules SFCs are explicitly included",
 );
 
 const componentState = createState(projectRoot);

--- a/npm/builder/vite/src/plugin/load.ts
+++ b/npm/builder/vite/src/plugin/load.ts
@@ -360,10 +360,13 @@ export function loadHook(
 }
 
 function shouldLogSfcWarnings(state: VizePluginState, realPath: string): boolean {
-  if (
-    (state.mergedOptions.handleNodeModulesVue ?? true) === false &&
-    realPath.includes("node_modules")
-  ) {
+  if (!realPath.includes("node_modules")) {
+    return true;
+  }
+  if ((state.mergedOptions.handleNodeModulesVue ?? true) === false) {
+    return false;
+  }
+  if (!state.filter(realPath)) {
     return false;
   }
   return true;

--- a/npm/builder/vite/src/plugin/load.ts
+++ b/npm/builder/vite/src/plugin/load.ts
@@ -360,16 +360,9 @@ export function loadHook(
 }
 
 function shouldLogSfcWarnings(state: VizePluginState, realPath: string): boolean {
-  if (!realPath.includes("node_modules")) {
-    return true;
-  }
-  if ((state.mergedOptions.handleNodeModulesVue ?? true) === false) {
-    return false;
-  }
-  if (!state.filter(realPath)) {
-    return false;
-  }
-  return true;
+  if (!realPath.includes("node_modules")) return true;
+  if ((state.mergedOptions.handleNodeModulesVue ?? true) === false) return false;
+  return state.filter(realPath);
 }
 
 function isJsxComponentPath(path: string): boolean {


### PR DESCRIPTION
## Summary

- suppress Vize compiler rewrite warnings for dependency SFCs when node_modules is filtered out
- keep warnings enabled when dependency SFCs are explicitly included for Vize handling
- add a pnpm-style Nuxt runtime SFC regression for the generate warning path

Closes #2158

## Verification

- pnpm --filter @vizejs/vite-plugin test -- load-dependency-sfc
- pnpm --filter @vizejs/vite-plugin check
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->