### PR TITLE
fix(canon): resolve allowjs local imports

### DIFF
--- a/crates/vize/tests/check_allowjs_imports_cli.rs
+++ b/crates/vize/tests/check_allowjs_imports_cli.rs
@@ -1,0 +1,121 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("check-allowjs-imports-{name}-{}", std::process::id()).as_str())
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn write(root: &Path, rel: &str, content: &str) {
+    let path = root.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, content).unwrap();
+}
+
+#[test]
+fn check_allowjs_resolves_project_local_js_imports() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("local-js");
+    let _ = std::fs::remove_dir_all(&project_root);
+
+    write(
+        &project_root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["lint/**/*.ts", "lint/**/*.js", ".eslintrc.js"]
+}"#,
+    );
+    write(
+        &project_root,
+        ".eslintrc.js",
+        r#"export const parserOptions = { parser: "vue-eslint-parser" };
+"#,
+    );
+    write(
+        &project_root,
+        "lint/rules/no-access-process.js",
+        r#"export default {
+  meta: { messages: { unexpected: "Do not access process directly." } },
+};
+"#,
+    );
+    write(
+        &project_root,
+        "lint/__tests__/no-access-process.spec.ts",
+        r#"import { parserOptions } from "../../.eslintrc.js";
+import rule from "../rules/no-access-process";
+
+const parser: string = parserOptions.parser;
+const message: string = rule.meta.messages.unexpected;
+void parser;
+void message;
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "lint/__tests__/no-access-process.spec.ts",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    assert!(
+        !stdout.contains("TS2307"),
+        "project-local JS imports should resolve under allowJs:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -19,7 +19,7 @@ use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 
 use super::VirtualFile;
 use super::diagnostics::collect_sfc_block_ranges;
-use super::passthrough::collect_passthrough_json_modules;
+use super::passthrough::collect_passthrough_modules;
 use super::vue_codegen::{GeneratedVueFile, VueCodegenOptions, generate_vue_virtual_ts};
 
 /// Result of building a virtual file for a registered path, owned and
@@ -169,7 +169,7 @@ pub(super) fn build_vue_registered_file(
             virtual_path,
         },
         original_content: content.to_compact_string(),
-        passthrough_files: collect_passthrough_json_modules(
+        passthrough_files: collect_passthrough_modules(
             path,
             content,
             context.project_root,
@@ -224,7 +224,7 @@ pub(super) fn build_jsx_registered_file(
             virtual_path,
         },
         original_content: content.to_compact_string(),
-        passthrough_files: collect_passthrough_json_modules(
+        passthrough_files: collect_passthrough_modules(
             path,
             content,
             context.project_root,
@@ -281,12 +281,7 @@ pub(super) fn build_script_registered_file(
             virtual_path,
         },
         original_content: content.to_compact_string(),
-        passthrough_files: collect_passthrough_json_modules(
-            path,
-            content,
-            project_root,
-            virtual_root,
-        ),
+        passthrough_files: collect_passthrough_modules(path, content, project_root, virtual_root),
         diagnostics: Vec::new(),
     })
 }

--- a/crates/vize_canon/src/batch/virtual_project/passthrough.rs
+++ b/crates/vize_canon/src/batch/virtual_project/passthrough.rs
@@ -1,4 +1,4 @@
-//! Discovering relative JSON modules imported by a source file so they can be
+//! Discovering relative non-TS modules imported by a source file so they can be
 //! mirrored into the virtual project, keeping TypeScript's module resolution
 //! happy. Includes a lightweight byte-level scanner for `import`/`from`
 //! specifiers.
@@ -7,9 +7,18 @@ use std::path::{Path, PathBuf};
 
 use vize_carton::{FxHashSet, String as CompactString, ToCompactString, cstr};
 
-use super::build::mirrored_virtual_path;
+use super::{VirtualProject, build::mirrored_virtual_path};
 
-pub(super) fn collect_passthrough_json_modules(
+impl VirtualProject {
+    pub(super) fn javascript_passthrough_files(&self) -> impl Iterator<Item = &Path> {
+        self.passthrough_files
+            .keys()
+            .filter(|path| is_javascript_passthrough(path))
+            .map(PathBuf::as_path)
+    }
+}
+
+pub(super) fn collect_passthrough_modules(
     path: &Path,
     content: &str,
     project_root: &Path,
@@ -22,7 +31,7 @@ pub(super) fn collect_passthrough_json_modules(
     let mut seen = FxHashSet::default();
     let mut files = Vec::new();
     for specifier in extract_relative_module_specifiers(content) {
-        let Some(original_path) = resolve_relative_json_module(dir, &specifier) else {
+        let Some(original_path) = resolve_relative_passthrough_module(dir, &specifier) else {
             continue;
         };
         let Ok(virtual_path) = mirrored_virtual_path(project_root, virtual_root, &original_path)
@@ -104,33 +113,127 @@ fn is_relative_specifier(specifier: &str) -> bool {
     specifier.starts_with("./") || specifier.starts_with("../")
 }
 
-fn resolve_relative_json_module(dir: &Path, specifier: &str) -> Option<PathBuf> {
+const PASSTHROUGH_EXTENSIONS: &[&str] = &["js", "jsx", "mjs", "cjs", "json"];
+
+fn resolve_relative_passthrough_module(dir: &Path, specifier: &str) -> Option<PathBuf> {
     let base = dir.join(specifier);
 
-    if specifier.ends_with(".json") && base.is_file() {
+    if specifier_has_passthrough_extension(specifier) && base.is_file() {
         return Some(normalize_existing_path(&base));
     }
 
-    let candidate = append_json_extension(&base);
-    if candidate.is_file() {
-        return Some(normalize_existing_path(&candidate));
+    for extension in PASSTHROUGH_EXTENSIONS {
+        let candidate = append_extension(&base, extension);
+        if candidate.is_file() {
+            return Some(normalize_existing_path(&candidate));
+        }
     }
 
-    let candidate = base.join("index.json");
-    if candidate.is_file() {
-        return Some(normalize_existing_path(&candidate));
+    for extension in PASSTHROUGH_EXTENSIONS {
+        let candidate = base.join(cstr!("index.{extension}").as_str());
+        if candidate.is_file() {
+            return Some(normalize_existing_path(&candidate));
+        }
     }
 
     None
 }
 
-fn append_json_extension(base: &Path) -> PathBuf {
+fn append_extension(base: &Path, extension: &str) -> PathBuf {
     match base.file_name().and_then(|name| name.to_str()) {
-        Some(name) => base.with_file_name(cstr!("{name}.json")),
+        Some(name) => base.with_file_name(cstr!("{name}.{extension}")),
         None => base.to_path_buf(),
     }
 }
 
+fn specifier_has_passthrough_extension(specifier: &str) -> bool {
+    PASSTHROUGH_EXTENSIONS
+        .iter()
+        .any(|extension| specifier.ends_with(cstr!(".{extension}").as_str()))
+}
+
 fn normalize_existing_path(path: &Path) -> PathBuf {
     vize_carton::path::canonicalize_non_verbatim(path)
+}
+
+fn is_javascript_passthrough(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| matches!(extension, "js" | "jsx" | "mjs" | "cjs"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::collect_passthrough_modules;
+    use vize_carton::cstr;
+
+    fn unique_case_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(cstr!("vize-passthrough-{name}-{}", std::process::id()).as_str())
+    }
+
+    fn write(root: &Path, rel: &str, content: &str) -> PathBuf {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn collects_relative_js_and_json_modules() {
+        let case_dir = unique_case_dir("js-json");
+        let _ = std::fs::remove_dir_all(&case_dir);
+        std::fs::create_dir_all(&case_dir).unwrap();
+        let root = vize_carton::path::canonicalize_non_verbatim(&case_dir);
+        let entry = write(
+            &root,
+            "lint/__tests__/rule.spec.ts",
+            "import config from '../../.eslintrc.js'\nimport rule from '../rules/no-access-process'\nimport colors from '../../tokens/colors.json'\n",
+        );
+        write(&root, ".eslintrc.js", "export default {}\n");
+        write(
+            &root,
+            "lint/rules/no-access-process.js",
+            "export default {}\n",
+        );
+        write(&root, "tokens/colors.json", "{}\n");
+        let virtual_root = root.join("node_modules/.vize/canon");
+
+        let mut files = collect_passthrough_modules(
+            &entry,
+            &std::fs::read_to_string(&entry).unwrap(),
+            &root,
+            &virtual_root,
+        );
+        files.sort();
+
+        assert_eq!(
+            files
+                .into_iter()
+                .map(|(virtual_path, original_path)| {
+                    (
+                        virtual_path
+                            .strip_prefix(&virtual_root)
+                            .unwrap()
+                            .to_path_buf(),
+                        original_path.strip_prefix(&root).unwrap().to_path_buf(),
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                (PathBuf::from(".eslintrc.js"), PathBuf::from(".eslintrc.js")),
+                (
+                    PathBuf::from("lint/rules/no-access-process.js"),
+                    PathBuf::from("lint/rules/no-access-process.js"),
+                ),
+                (
+                    PathBuf::from("tokens/colors.json"),
+                    PathBuf::from("tokens/colors.json"),
+                ),
+            ]
+        );
+
+        let _ = std::fs::remove_dir_all(&case_dir);
+    }
 }

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
@@ -31,12 +31,9 @@ impl VirtualProject {
         self.preserve_unused_diagnostics
     }
 
-    /// Alias prefixes declared in the effective tsconfig `paths` map, with
-    /// wildcard suffixes stripped: `@/*` → `@/`, `@scope/*` → `@scope/`,
-    /// `#imports` → `#imports`. Used as a cost model for shard planning:
-    /// files importing through the same project alias are coupled. Aliases
-    /// whose every target lives under `node_modules` (e.g. a pinned `vue`
-    /// mapping) are dependency cost every program pays anyway and are skipped.
+    /// Alias prefixes declared in the effective tsconfig `paths` map, with wildcard
+    /// suffixes stripped. Used as a shard-planning cost model; aliases whose every
+    /// target lives under `node_modules` are dependency cost and are skipped.
     pub(crate) fn path_alias_prefixes(&self) -> Vec<CompactString> {
         let Ok(compiler_options) =
             self.load_compiler_options(self.resolved_tsconfig_path().as_deref())
@@ -194,14 +191,11 @@ impl VirtualProject {
             compiler_options.insert("declaration".into(), Value::Bool(true));
             compiler_options.insert("emitDeclarationOnly".into(), Value::Bool(true));
             compiler_options.insert("declarationMap".into(), Value::Bool(declaration_map));
-            compiler_options.insert(
-                "rootDir".into(),
-                Value::String(
-                    self.common_virtual_source_dir()
-                        .to_string_lossy()
-                        .into_owned(),
-                ),
-            );
+            let root_dir = self
+                .common_virtual_source_dir()
+                .to_string_lossy()
+                .into_owned();
+            compiler_options.insert("rootDir".into(), Value::String(root_dir));
             compiler_options.insert(
                 "outDir".into(),
                 Value::String(out_dir.to_string_lossy().into_owned()),
@@ -214,11 +208,12 @@ impl VirtualProject {
             compiler_options.insert("noEmit".into(), Value::Bool(true));
         }
 
+        let include_js = compiler_option_enabled(&compiler_options, "allowJs");
         config.insert("compilerOptions".into(), Value::Object(compiler_options));
         config.insert(
             "include".into(),
             Value::Array(
-                self.include_paths(include_virtual_paths)
+                self.include_paths(include_virtual_paths, include_js)
                     .into_iter()
                     .map(|path| Value::String(path.into()))
                     .collect(),
@@ -238,13 +233,13 @@ impl VirtualProject {
         })
     }
 
-    fn include_paths(&self, include_virtual_paths: Option<&[&Path]>) -> Vec<CompactString> {
+    fn include_paths(&self, paths: Option<&[&Path]>, include_js: bool) -> Vec<CompactString> {
         let relative = |path: &Path| {
             path.strip_prefix(&self.virtual_root)
                 .ok()
                 .map(|path| path.to_string_lossy().to_compact_string())
         };
-        let mut includes: Vec<_> = match include_virtual_paths {
+        let mut includes: Vec<_> = match paths {
             Some(paths) => paths.iter().filter_map(|path| relative(path)).collect(),
             None => self
                 .virtual_files
@@ -252,6 +247,9 @@ impl VirtualProject {
                 .filter_map(|path| relative(path))
                 .collect(),
         };
+        if include_js {
+            includes.extend(self.javascript_passthrough_files().filter_map(relative));
+        }
         if !self.virtual_ts_options.auto_import_stubs.is_empty() {
             includes.push(AUTO_IMPORT_STUBS_FILE.into());
         }


### PR DESCRIPTION
## Summary

- mirror relative project-local JS passthrough modules into the Canon virtual project
- include mirrored JS files in generated tsconfig only when allowJs is enabled
- add a CLI regression for TS files importing `.eslintrc.js` and extensionless local JS rules

Closes #2173

## Verification

- cargo test -p vize_canon collects_relative_js_and_json_modules -- --nocapture
- cargo test -p vize --test check_allowjs_imports_cli -- --nocapture
- cargo test -p vize_canon
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->