### PR TITLE
fix(canon): load nuxt ambient declarations in tsconfig checks

### DIFF
--- a/crates/vize/src/commands/check/runner/default_imports.rs
+++ b/crates/vize/src/commands/check/runner/default_imports.rs
@@ -10,7 +10,9 @@ use crate::commands::check::{
     imports::collect_transitive_local_imports,
     imports_aliases::PathAliasResolver,
     path_cache::CanonicalPathCache,
-    tsconfig_inputs::{TsconfigInputCache, collect_default_check_files},
+    tsconfig_inputs::{
+        TsconfigInputCache, collect_default_check_files, collect_hidden_ambient_declaration_files,
+    },
 };
 
 pub(super) fn collect_default_run_files(
@@ -30,6 +32,12 @@ pub(super) fn collect_default_run_files(
     );
     retain_unignored(&mut files, check_ignore_set);
     let reported_files = canonical_file_set(&files, canonical_paths);
+    register_ambient_declaration_files(
+        &mut files,
+        project_root,
+        tsconfig_path,
+        tsconfig_input_cache,
+    );
     register_transitive_local_imports(
         &mut files,
         cwd,
@@ -41,6 +49,21 @@ pub(super) fn collect_default_run_files(
     );
 
     (files, reported_files)
+}
+
+fn register_ambient_declaration_files(
+    files: &mut Vec<PathBuf>,
+    project_root: &Path,
+    tsconfig_path: Option<&Path>,
+    tsconfig_input_cache: &mut TsconfigInputCache,
+) {
+    for path in
+        collect_hidden_ambient_declaration_files(project_root, tsconfig_path, tsconfig_input_cache)
+    {
+        if !files.contains(&path) {
+            files.push(path);
+        }
+    }
 }
 
 pub(super) fn canonical_file_set(
@@ -150,6 +173,69 @@ export const r = ITEMS.map(({ code, name }) => `${code}:${name}`)
         assert!(
             !reported_files.contains(&transitive_file),
             "outside-include imports are registered for types, not reported"
+        );
+
+        let _ = std::fs::remove_dir_all(&project_root);
+    }
+
+    #[test]
+    fn default_tsconfig_run_registers_hidden_ambient_declarations_for_type_resolution() {
+        let project_root = unique_case_dir("default-hidden-ambient");
+        let _ = std::fs::remove_dir_all(&project_root);
+        std::fs::create_dir_all(project_root.join(".nuxt/types")).unwrap();
+        std::fs::create_dir_all(project_root.join("app/plugins")).unwrap();
+        std::fs::write(
+            project_root.join("tsconfig.json"),
+            r#"{
+  "extends": "./.nuxt/tsconfig.json"
+}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            project_root.join(".nuxt/tsconfig.json"),
+            r#"{
+  "include": ["../app/**/*.ts", "./nuxt.d.ts"]
+}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            project_root.join(".nuxt/nuxt.d.ts"),
+            "/// <reference path=\"types/import-meta.d.ts\" />\nexport {};\n",
+        )
+        .unwrap();
+        std::fs::write(
+            project_root.join(".nuxt/types/import-meta.d.ts"),
+            "export {};\ndeclare global { interface ImportMeta { vitest: boolean; } }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            project_root.join("app/plugins/auth.ts"),
+            "export const runningUnderVitest = import.meta.vitest;\n",
+        )
+        .unwrap();
+
+        let mut tsconfig_input_cache = super::TsconfigInputCache::default();
+        let mut canonical_paths = super::CanonicalPathCache::default();
+        let (files, reported_files) = super::collect_default_run_files(
+            &project_root,
+            &project_root,
+            Some(&project_root.join("tsconfig.json")),
+            false,
+            &mut tsconfig_input_cache,
+            &mut canonical_paths,
+            None,
+        );
+
+        let app_file = canonicalize_non_verbatim(&project_root.join("app/plugins/auth.ts"));
+        let ambient_file =
+            canonicalize_non_verbatim(&project_root.join(".nuxt/types/import-meta.d.ts"));
+
+        assert!(files.contains(&app_file));
+        assert!(files.contains(&ambient_file));
+        assert!(reported_files.contains(&app_file));
+        assert!(
+            !reported_files.contains(&ambient_file),
+            "hidden ambient declarations are registered for types, not reported"
         );
 
         let _ = std::fs::remove_dir_all(&project_root);

--- a/crates/vize/src/commands/check/tsconfig_inputs/ambient.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/ambient.rs
@@ -39,8 +39,32 @@ pub(crate) fn collect_ambient_declaration_files(
     cache: &mut TsconfigInputCache,
 ) -> Vec<PathBuf> {
     let project_root = normalize_input_path(project_root);
-    let mut files =
-        collect_default_check_files_inner(&project_root, tsconfig_path, true, false, cache);
+    let files = collect_default_check_files_inner(&project_root, tsconfig_path, true, false, cache);
+    collect_ambient_declaration_files_from(project_root, files)
+}
+
+pub(crate) fn collect_hidden_ambient_declaration_files(
+    project_root: &Path,
+    tsconfig_path: Option<&Path>,
+    cache: &mut TsconfigInputCache,
+) -> Vec<PathBuf> {
+    let project_root = normalize_input_path(project_root);
+    let visible =
+        collect_default_check_files_inner(&project_root, tsconfig_path, false, false, cache)
+            .into_iter()
+            .collect::<FxHashSet<_>>();
+    let hidden =
+        collect_default_check_files_inner(&project_root, tsconfig_path, true, false, cache)
+            .into_iter()
+            .filter(|path| !visible.contains(path))
+            .collect();
+    collect_ambient_declaration_files_from(project_root, hidden)
+}
+
+fn collect_ambient_declaration_files_from(
+    project_root: PathBuf,
+    mut files: Vec<PathBuf>,
+) -> Vec<PathBuf> {
     let mut seen = files.iter().cloned().collect::<FxHashSet<_>>();
     let mut index = 0;
     while index < files.len() {

--- a/crates/vize/src/commands/check/tsconfig_inputs/mod.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/mod.rs
@@ -22,7 +22,9 @@ mod type_references;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use ambient::collect_ambient_declaration_files;
+pub(crate) use ambient::{
+    collect_ambient_declaration_files, collect_hidden_ambient_declaration_files,
+};
 pub(crate) use collect::resolve_tsconfig_for_files;
 pub(super) use jsonc::parse_jsonc_value;
 pub(crate) use loader::{TsconfigInputCache, load_tsconfig_declaration_options};

--- a/crates/vize/tests/check_nuxt_ambient_cli.rs
+++ b/crates/vize/tests/check_nuxt_ambient_cli.rs
@@ -1,0 +1,114 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("check-nuxt-ambient-{name}-{}", std::process::id()).as_str())
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn write(root: &Path, rel: &str, content: &str) {
+    let path = root.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, content).unwrap();
+}
+
+#[test]
+fn check_tsconfig_default_run_loads_nuxt_ambient_declarations() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("import-meta");
+    let _ = std::fs::remove_dir_all(&project_root);
+
+    write(
+        &project_root,
+        "tsconfig.json",
+        r#"{
+  "extends": "./.nuxt/tsconfig.json"
+}"#,
+    );
+    write(
+        &project_root,
+        ".nuxt/tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["../app/**/*.ts", "./nuxt.d.ts"]
+}"#,
+    );
+    write(
+        &project_root,
+        ".nuxt/nuxt.d.ts",
+        "/// <reference path=\"types/import-meta.d.ts\" />\nexport {};\n",
+    );
+    write(
+        &project_root,
+        ".nuxt/types/import-meta.d.ts",
+        "export {};\ndeclare global { interface ImportMeta { vitest: boolean; } }\n",
+    );
+    write(
+        &project_root,
+        "app/plugins/auth.ts",
+        "export const runningUnderVitest: boolean = import.meta.vitest;\n",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "check should load Nuxt ambient declarations in default tsconfig runs\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    assert!(
+        !stdout.contains("TS2339"),
+        "ImportMeta augmentation should be in scope:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
## Summary

- register tsconfig ambient declaration files during default `vize check --tsconfig` runs
- keep those hidden/generated ambient files out of the reported-file set
- add a Nuxt-style default-run regression for `.nuxt/nuxt.d.ts` references augmenting `ImportMeta`

Closes #2128

## Verification

- cargo test -p vize default_tsconfig_run_registers_hidden_ambient_declarations_for_type_resolution -- --nocapture
- cargo test -p vize --test check_nuxt_ambient_cli -- --nocapture
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->