### PR TITLE
fix(nuxt): skip vite plugin in host compiler mode

### DIFF
--- a/npm/framework/nuxt/src/index.test.ts
+++ b/npm/framework/nuxt/src/index.test.ts
@@ -86,6 +86,46 @@ void test("Nuxt module entry runs in a Nuxt 2 webpack-style context", async () =
   );
 });
 
+void test("Nuxt 2 host-compiler compatibility skips Vite plugin loading", async () => {
+  const { default: nuxtModule } = await import(new URL("../dist/index.mjs", import.meta.url).href);
+  const hookNames: string[] = [];
+  const nuxt = {
+    _version: "2.17.3",
+    options: {
+      rootDir: process.cwd(),
+      builder: "webpack",
+      build: { publicPath: "/_nuxt/" },
+      router: { base: "/" },
+      modules: [],
+      buildDir: ".nuxt",
+      dev: false,
+      vite: {},
+    },
+    hook(name: string, callback: (...args: unknown[]) => unknown) {
+      assert.equal(typeof callback, "function");
+      hookNames.push(name);
+    },
+  };
+
+  await nuxtModule(
+    {
+      compiler: true,
+      musea: false,
+      bridge: true,
+      compatibility: {
+        nuxtVersion: 2,
+        vueVersion: 2,
+        hostCompiler: true,
+        webpackVersion: 4,
+      },
+    },
+    nuxt,
+  );
+
+  assert.deepEqual(hookNames, ["close", "builder:prepared", "build:templates"]);
+  assert.deepEqual(nuxt.options.vite, {});
+});
+
 void test("packed Nuxt module depends on the Nuxt 2-safe kit line", () => {
   const packageRoot = new URL("..", import.meta.url);
   const packDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-nuxt-pack-"));

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -369,7 +369,7 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
     },
   );
   const usesVizeCompiler = shouldUseVizeCompiler(compilerOptions);
-  if (compilerOptions !== false) {
+  if (compilerOptions !== false && compilerOptions.compatibility?.hostCompiler !== true) {
     const { default: vize } = await import("@vizejs/vite-plugin");
     nuxt.options.vite ||= {};
     nuxt.options.vite.plugins = nuxt.options.vite.plugins || [];


### PR DESCRIPTION
## Summary
- avoid importing `@vizejs/vite-plugin` when Nuxt host-compiler compatibility is active
- cover the Nuxt 2 webpack 4 configuration that keeps Vue compilation on the host compiler

Closes #2186

## Verification
- pnpm --dir npm/framework/nuxt test
- pnpm --dir npm/framework/nuxt check
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->