### PR TITLE
fix(canon): keep generated codegen declarations real

### DIFF
--- a/crates/vize/src/commands/check/tsconfig_inputs/codegen_tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/codegen_tests.rs
@@ -1,0 +1,68 @@
+//! Generated GraphQL declaration collection regressions.
+
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::TsconfigInputCache;
+use vize_carton::cstr;
+
+fn collect_default_check_files(project_root: &Path, tsconfig_path: Option<&Path>) -> Vec<PathBuf> {
+    super::collect_default_check_files(
+        project_root,
+        tsconfig_path,
+        false,
+        &mut TsconfigInputCache::default(),
+    )
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("vize-tests")
+        .join(cstr!("{name}-{}-{case_id}", std::process::id()).as_str())
+}
+
+fn relative_paths(root: &Path, files: &[PathBuf]) -> Vec<String> {
+    files
+        .iter()
+        .map(|path| {
+            path.strip_prefix(root)
+                .unwrap()
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
+        .collect()
+}
+
+#[test]
+fn default_collection_skips_generated_codegen_declaration_modules() {
+    let case_dir = unique_case_dir("tsconfig-generated-codegen-dts");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    fs::create_dir_all(case_dir.join("types/codegen")).unwrap();
+    fs::write(case_dir.join("src/env.d.ts"), "declare const X: string;").unwrap();
+    fs::write(case_dir.join("src/App.vue"), "<template />").unwrap();
+    fs::write(
+        case_dir.join("types/codegen/schema.d.ts"),
+        "export enum AimQuestionDisplayKind { Text = 'TEXT' }\n",
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{ "include": ["src/**/*.vue", "src/**/*.d.ts", "types/codegen/schema.d.ts"] }"#,
+    )
+    .unwrap();
+
+    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+
+    assert_eq!(
+        relative_paths(&case_dir, &files),
+        vec!["src/App.vue", "src/env.d.ts"]
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
@@ -8,9 +8,9 @@ use vize_carton::FxHashSet;
 use super::glob::{default_exclude_specs, normalize_input_path, normalize_walked_path};
 use super::loader::{TsconfigInputCache, collect_tsconfig_project_paths};
 use super::matching::{
-    SupportedFileOptions, is_generated_path, is_hidden_path_segment, is_nuxt_import_manifest_path,
-    is_supported_check_file_with_options, matches_tsconfig_patterns,
-    should_skip_generated_for_root,
+    SupportedFileOptions, is_generated_codegen_declaration_path, is_generated_path,
+    is_hidden_path_segment, is_nuxt_import_manifest_path, is_supported_check_file_with_options,
+    matches_tsconfig_patterns, should_skip_generated_for_root,
 };
 use super::spec::{FileCollectionOptions, GlobSpec};
 
@@ -46,6 +46,7 @@ pub(super) fn collect_supported_files_with_options(
                     )
                     && (!skip_generated || !is_generated_path(path))
                     && !is_nuxt_import_manifest_path(path)
+                    && !is_generated_codegen_declaration_path(path)
                     && matches_tsconfig_patterns(path, includes, excludes)
                     && let Ok(mut collected) = collected.lock()
                 {

--- a/crates/vize/src/commands/check/tsconfig_inputs/matching.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/matching.rs
@@ -90,6 +90,27 @@ pub(super) fn is_nuxt_import_manifest_path(path: &Path) -> bool {
             .any(|window| window == [".nuxt", "types", "imports.d.ts"])
 }
 
+pub(super) fn is_generated_codegen_declaration_path(path: &Path) -> bool {
+    if !path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".d.ts"))
+    {
+        return false;
+    }
+
+    let mut previous = None;
+    path.components().any(|component| {
+        let Some(name) = component.as_os_str().to_str() else {
+            previous = None;
+            return false;
+        };
+        let is_codegen = previous == Some("types") && name == "codegen";
+        previous = Some(name);
+        is_codegen
+    })
+}
+
 pub(super) fn is_supported_check_file_with_options(
     path: &Path,
     options: SupportedFileOptions,

--- a/crates/vize/src/commands/check/tsconfig_inputs/mod.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/mod.rs
@@ -39,7 +39,8 @@ use collect::{
 use glob::{default_exclude_specs, normalize_input_path};
 use loader::collect_tsconfig_project_paths;
 use matching::{
-    SupportedFileOptions, is_nuxt_import_manifest_path, is_supported_check_file_with_options,
+    SupportedFileOptions, is_generated_codegen_declaration_path, is_nuxt_import_manifest_path,
+    is_supported_check_file_with_options,
 };
 use spec::{FileCollectionOptions, GlobSpec, TsconfigInputSpec};
 
@@ -110,6 +111,7 @@ fn collect_default_check_files_for_tsconfig(
         if resolved.is_file()
             && is_supported_check_file_with_options(&resolved, SupportedFileOptions { include_jsx })
             && !is_nuxt_import_manifest_path(&resolved)
+            && !is_generated_codegen_declaration_path(&resolved)
             && seen.insert(resolved.clone())
         {
             files.push(resolved);
@@ -150,7 +152,7 @@ fn collect_default_check_files_for_tsconfig(
             },
         );
         for path in collected {
-            if seen.insert(path.clone()) {
+            if !is_generated_codegen_declaration_path(&path) && seen.insert(path.clone()) {
                 files.push(path);
             }
         }
@@ -165,7 +167,7 @@ fn collect_default_check_files_for_tsconfig(
                         include_jsx,
                     },
                 ) {
-                    if seen.insert(path.clone()) {
+                    if !is_generated_codegen_declaration_path(&path) && seen.insert(path.clone()) {
                         files.push(path);
                     }
                 }

--- a/crates/vize/src/commands/check/tsconfig_inputs/mod.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/mod.rs
@@ -20,6 +20,8 @@ mod spec;
 mod type_references;
 
 #[cfg(test)]
+mod codegen_tests;
+#[cfg(test)]
 mod tests;
 
 pub(crate) use ambient::{

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
@@ -6,7 +6,7 @@ use super::{TsconfigInputCache, load_tsconfig_declaration_options, resolve_exten
 use std::fs;
 use std::path::{Path, PathBuf};
 use vize_carton::{cstr, path::canonicalize_non_verbatim};
-
+mod codegen;
 // Each call uses a fresh run-scoped cache, mirroring how an actual `vize
 // check` run constructs one `TsconfigInputCache` per invocation.
 fn collect_default_check_files(project_root: &Path, tsconfig_path: Option<&Path>) -> Vec<PathBuf> {

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
@@ -737,6 +737,35 @@ fn declaration_files_are_always_supported() {
 }
 
 #[test]
+fn default_collection_skips_generated_codegen_declaration_modules() {
+    let case_dir = unique_case_dir("tsconfig-generated-codegen-dts");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    fs::create_dir_all(case_dir.join("types/codegen")).unwrap();
+    fs::write(case_dir.join("src/env.d.ts"), "declare const X: string;").unwrap();
+    fs::write(case_dir.join("src/App.vue"), "<template />").unwrap();
+    fs::write(
+        case_dir.join("types/codegen/schema.d.ts"),
+        "export enum AimQuestionDisplayKind { Text = 'TEXT' }\n",
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{ "include": ["src/**/*.vue", "src/**/*.d.ts", "types/codegen/schema.d.ts"] }"#,
+    )
+    .unwrap();
+
+    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+
+    assert_eq!(
+        relative_paths(&case_dir, &files),
+        vec!["src/App.vue", "src/env.d.ts"]
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
 fn supported_extensions_cover_ts_family_and_reject_js_family() {
     let case_dir = unique_case_dir("tsconfig-ext-family");
     let _ = fs::remove_dir_all(&case_dir);

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
@@ -737,35 +737,6 @@ fn declaration_files_are_always_supported() {
 }
 
 #[test]
-fn default_collection_skips_generated_codegen_declaration_modules() {
-    let case_dir = unique_case_dir("tsconfig-generated-codegen-dts");
-    let _ = fs::remove_dir_all(&case_dir);
-    fs::create_dir_all(case_dir.join("src")).unwrap();
-    fs::create_dir_all(case_dir.join("types/codegen")).unwrap();
-    fs::write(case_dir.join("src/env.d.ts"), "declare const X: string;").unwrap();
-    fs::write(case_dir.join("src/App.vue"), "<template />").unwrap();
-    fs::write(
-        case_dir.join("types/codegen/schema.d.ts"),
-        "export enum AimQuestionDisplayKind { Text = 'TEXT' }\n",
-    )
-    .unwrap();
-    fs::write(
-        case_dir.join("tsconfig.json"),
-        r#"{ "include": ["src/**/*.vue", "src/**/*.d.ts", "types/codegen/schema.d.ts"] }"#,
-    )
-    .unwrap();
-
-    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
-
-    assert_eq!(
-        relative_paths(&case_dir, &files),
-        vec!["src/App.vue", "src/env.d.ts"]
-    );
-
-    let _ = fs::remove_dir_all(&case_dir);
-}
-
-#[test]
 fn supported_extensions_cover_ts_family_and_reject_js_family() {
     let case_dir = unique_case_dir("tsconfig-ext-family");
     let _ = fs::remove_dir_all(&case_dir);

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests/codegen.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests/codegen.rs
@@ -1,0 +1,30 @@
+use super::{collect_default_check_files, relative_paths, unique_case_dir};
+
+#[test]
+fn default_collection_skips_generated_codegen_declaration_modules() {
+    let case_dir = unique_case_dir("tsconfig-generated-codegen-dts");
+    let _ = std::fs::remove_dir_all(&case_dir);
+    std::fs::create_dir_all(case_dir.join("src")).unwrap();
+    std::fs::create_dir_all(case_dir.join("types/codegen")).unwrap();
+    std::fs::write(case_dir.join("src/env.d.ts"), "declare const X: string;").unwrap();
+    std::fs::write(case_dir.join("src/App.vue"), "<template />").unwrap();
+    std::fs::write(
+        case_dir.join("types/codegen/schema.d.ts"),
+        "export enum AimQuestionDisplayKind { Text = 'TEXT' }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{ "include": ["src/**/*.vue", "src/**/*.d.ts", "types/codegen/schema.d.ts"] }"#,
+    )
+    .unwrap();
+
+    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+
+    assert_eq!(
+        relative_paths(&case_dir, &files),
+        vec!["src/App.vue", "src/env.d.ts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize/tests/check_canon_graphql_cli.rs
+++ b/crates/vize/tests/check_canon_graphql_cli.rs
@@ -92,6 +92,8 @@ fn check_explicit_vue_keeps_generated_graphql_schema_out_of_canon() {
     let project_root = unique_case_dir("dedupe");
     let _ = std::fs::remove_dir_all(&project_root);
     std::fs::create_dir_all(&project_root).unwrap();
+    std::fs::create_dir_all(project_root.join("fragments")).unwrap();
+    std::fs::create_dir_all(project_root.join("pages")).unwrap();
     link_workspace_vue(&project_root).unwrap();
     std::fs::write(
         project_root.join("tsconfig.json"),
@@ -107,7 +109,7 @@ fn check_explicit_vue_keeps_generated_graphql_schema_out_of_canon() {
     },
     "noEmit": true
   },
-  "include": ["src/**/*", "types/**/*.d.ts"]
+  "include": ["fragments/**/*.vue", "pages/**/*.vue", "types/**/*.d.ts"]
 }"#,
     )
     .unwrap();
@@ -132,49 +134,34 @@ export type AimQuestion = {
     )
     .unwrap();
 
-    let src_dir = project_root.join("src");
-    std::fs::create_dir_all(&src_dir).unwrap();
     std::fs::write(
-        src_dir.join("question.ts"),
-        r#"import type { AimQuestion } from '~/types/codegen/schema'
+        project_root.join("pages/_studyInfoId.vue"),
+        r#"<script setup lang="ts">
+import type { AimQuestion } from '~/types/codegen/schema'
 
-export function expectQuestion(question: AimQuestion): AimQuestion {
-  return question
+export type AimContentsMoshi = {
+  components: AimQuestion[]
 }
+</script>
+
+<template><main /></template>
 "#,
     )
     .unwrap();
     std::fs::write(
-        src_dir.join("App.vue"),
+        project_root.join("fragments/MoshiContentsSection.vue"),
         cstr!(
             r#"<script setup lang="ts">
-import {{ expectQuestion }} from './question'
-import {{ AimQuestionDisplayKind, type AimQuestion }} from '{schema_specifier}'
+import type {{ AimContentsMoshi }} from '~/pages/_studyInfoId.vue'
+import {{ type AimQuestion }} from '{schema_specifier}'
 
-const question = {{
-  kind: AimQuestionDisplayKind.Text,
-}} satisfies AimQuestion
+type AimComponent = AimContentsMoshi['components'][number]
 
-expectQuestion(question)
-</script>
-
-<template><div /></template>
-"#
-        ),
-    )
-    .unwrap();
-    std::fs::write(
-        src_dir.join("Other.vue"),
-        cstr!(
-            r#"<script setup lang="ts">
-import {{ expectQuestion }} from './question'
-import {{ AimQuestionDisplayKind, type AimQuestion }} from '{schema_specifier}'
-
-const question = {{
-  kind: AimQuestionDisplayKind.Text,
-}} satisfies AimQuestion
-
-expectQuestion(question)
+const props = defineProps<{{
+  component: {{ childMoshiContentsComponents: AimQuestion[] }}
+}}>()
+const childComponents = props.component.childMoshiContentsComponents satisfies AimComponent[]
+void childComponents
 </script>
 
 <template><section /></template>
@@ -186,7 +173,16 @@ expectQuestion(question)
     let output = Command::new(env!("CARGO_BIN_EXE_vize"))
         .current_dir(&project_root)
         .env("CORSA_PATH", &corsa_path)
-        .args(["check", "src/App.vue", "src/Other.vue", "--format", "json"])
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "--no-check-props",
+            "--no-check-emits",
+            "--no-check-template-bindings",
+            "--format",
+            "json",
+        ])
         .output()
         .unwrap();
 
@@ -201,7 +197,7 @@ expectQuestion(question)
     assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
     assert!(
         project_root
-            .join("node_modules/.vize/canon/src/question.ts")
+            .join("node_modules/.vize/canon/pages/_studyInfoId.vue.ts")
             .exists()
     );
     assert!(


### PR DESCRIPTION
## Summary
- keep generated `types/codegen/*.d.ts` modules out of default check roots so aliases resolve them from the real project path
- extend the GraphQL CLI regression to cover Nuxt-style root checks and `.vue` type re-export paths

Closes #2180

## Verification
- cargo test -p vize --test check_canon_graphql_cli -- --nocapture
- cargo test -p vize commands::check::tsconfig_inputs -- --nocapture
- cargo fmt --all -- --check
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->