### PR TITLE
fix(unplugin): route webpack subpath to cjs

### DIFF
--- a/npm/builder/unplugin/package.json
+++ b/npm/builder/unplugin/package.json
@@ -54,9 +54,9 @@
     },
     "./webpack": {
       "types": "./dist/webpack.d.mts",
-      "import": "./dist/webpack.mjs",
-      "require": "./dist/webpack-cjs.cjs",
-      "default": "./dist/webpack.mjs"
+      "import": "./dist/webpack.cjs",
+      "require": "./dist/webpack.cjs",
+      "default": "./dist/webpack.cjs"
     },
     "./babel": {
       "types": "./dist/babel.d.mts",

--- a/tests/tooling/bundler-plugin-manifests.test.ts
+++ b/tests/tooling/bundler-plugin-manifests.test.ts
@@ -52,7 +52,7 @@ function leadingMajor(pin: string): number {
   return Number(match[1]);
 }
 
-test("@vizejs/unplugin exposes per-bundler subpath entries wired at mjs/d.mts", () => {
+test("@vizejs/unplugin exposes per-bundler subpath entries with jiti-safe webpack", () => {
   const manifest = readManifest("builder/unplugin");
   assert.equal(manifest.name, "@vizejs/unplugin");
 
@@ -62,10 +62,21 @@ test("@vizejs/unplugin exposes per-bundler subpath entries wired at mjs/d.mts", 
     assert.equal(typeof entry, "object", `export subpath ${subpath} must be a conditions object`);
 
     const conditions = entry as ExportEntry;
-    assert.ok(
-      conditions.import?.endsWith(".mjs"),
-      `${subpath} import should point at a .mjs file, got ${conditions.import}`,
-    );
+    if (subpath === "./webpack") {
+      assert.ok(
+        conditions.import?.endsWith(".cjs"),
+        `${subpath} import should point at a .cjs file for Nuxt 2 jiti, got ${conditions.import}`,
+      );
+      assert.ok(
+        conditions.default?.endsWith(".cjs"),
+        `${subpath} default should point at a .cjs file for Nuxt 2 jiti, got ${conditions.default}`,
+      );
+    } else {
+      assert.ok(
+        conditions.import?.endsWith(".mjs"),
+        `${subpath} import should point at a .mjs file, got ${conditions.import}`,
+      );
+    }
     assert.ok(
       conditions.types?.endsWith(".d.mts"),
       `${subpath} types should point at a .d.mts file, got ${conditions.types}`,


### PR DESCRIPTION
## Summary
- route @vizejs/unplugin/webpack import/default/require conditions to the generated webpack.cjs adapter
- lock the package manifest test so Nuxt 2 jiti does not regress to the import.meta-bearing webpack.mjs path

Closes #2182

## Verification
- pnpm --dir npm/builder/unplugin build
- pnpm --dir npm/builder/unplugin test
- pnpm --dir npm/builder/unplugin check
- node --test tests/tooling/bundler-plugin-manifests.test.ts
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check
- self-reference import/require of @vizejs/unplugin/webpack from npm/builder/unplugin

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->