### PR TITLE
fix(musea): parse Vue TSX slot object stories

### DIFF
--- a/crates/vize/tests/check_tsx_sfc_attrs_cli.rs
+++ b/crates/vize/tests/check_tsx_sfc_attrs_cli.rs
@@ -175,3 +175,110 @@ export const Example = () => (
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn check_tsx_story_allows_slot_object_with_kebab_update_handler() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("slot-object-events");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    link_workspace_vue(&project_root).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "types": ["vue/jsx"],
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/AfsStepperDialog.stories.tsx"),
+        r#"type TabItem = { label: string; value: string };
+
+const AfsStepperDialog = (_props: any) => <div />;
+const AfsButton = (_props: any) => <button />;
+const AfsTabs = (_props: any) => <div />;
+
+const isOpen = { value: true };
+const items = { value: [{ label: 'One', value: 'one' }] satisfies TabItem[] };
+const currentStepIndex = { value: 0 };
+const updateStepIndex = (value: number) => {
+  currentStepIndex.value = value;
+};
+const next = () => updateStepIndex(currentStepIndex.value + 1);
+const activeTab = { value: 'one' };
+const args = { items: items.value };
+
+export const Stepper = () => (
+  <AfsStepperDialog
+    value={isOpen.value}
+    items={items.value}
+    currentStepIndex={currentStepIndex.value}
+    onUpdate:current-step-index={updateStepIndex}
+  >
+    {{
+      content1: () => (
+        <div>
+          {Array.from({ length: 3 }, (_, i) => (
+            <p key={i}>sample {i + 1}</p>
+          ))}
+        </div>
+      ),
+      actions: () => <AfsButton onClick={next}>Next</AfsButton>,
+    }}
+  </AfsStepperDialog>
+);
+
+export const Tabs = () => (
+  <AfsTabs value={activeTab.value} items={args.items}>
+    {{
+      label: ({ item }: { item: TabItem }) => (
+        <span>
+          {item.label}
+          {<span class="mdi mdi-help-circle-outline" />}
+        </span>
+      ),
+    }}
+  </AfsTabs>
+);
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "src/AfsStepperDialog.stories.tsx",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        std::str::from_utf8(&output.stderr).unwrap_or("<non-utf8 stderr>")
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -140,7 +140,8 @@ impl<'a> LowerOutput<'a> {
 /// borrows `bump`.
 pub fn lower_source<'a>(bump: &'a Bump, source: &str, lang: JsxLang) -> LowerOutput<'a> {
     let allocator = oxc_allocator::Allocator::default();
-    let parsed = parse::parse_module(&allocator, source, lang);
+    let parse_source = parse::prepare_source_for_parse(source, lang);
+    let parsed = parse::parse_module(&allocator, parse_source.as_ref(), lang);
     let mapper = SpanMapper::new(source);
     let mut lowerer = Lowerer::new(bump, &mapper);
     for diagnostic in parsed.diagnostics {

--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -56,7 +56,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             return directive;
         }
 
-        let name = attr_full_name(&attr.name);
+        let name = String::from(self.mapper().slice(attr.name.span()));
         let name_loc = self.mapper().location(attr.name.span());
         match attr.value.as_ref() {
             None => self.boolean_attr(name, name_loc, loc),
@@ -164,14 +164,15 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     ) -> Option<PropNode<'a>> {
         let (raw_name, arg) = match &attr.name {
             JSXAttributeName::NamespacedName(named) => {
-                let raw_name = named.namespace.name.as_str().strip_prefix("v-")?;
-                (
-                    raw_name,
-                    Some((named.name.name.as_str(), named.name.span())),
-                )
+                let raw_name = self
+                    .mapper()
+                    .slice(named.namespace.span())
+                    .strip_prefix("v-")?;
+                let arg_name = self.mapper().slice(named.name.span());
+                (raw_name, Some((arg_name, named.name.span())))
             }
             JSXAttributeName::Identifier(id) => {
-                let raw_name = id.name.as_str().strip_prefix("v-")?;
+                let raw_name = self.mapper().slice(id.span()).strip_prefix("v-")?;
                 (raw_name, None)
             }
         };
@@ -380,16 +381,4 @@ fn split_underscore_model_modifiers(name: &str) -> Option<(&'static str, std::ve
         return None;
     }
     Some(("model", mods))
-}
-
-fn attr_full_name(name: &JSXAttributeName<'_>) -> String {
-    match name {
-        JSXAttributeName::Identifier(id) => String::from(id.name.as_str()),
-        JSXAttributeName::NamespacedName(named) => {
-            let mut full = String::from(named.namespace.name.as_str());
-            full.push(':');
-            full.push_str(named.name.name.as_str());
-            full
-        }
-    }
 }

--- a/crates/vize_atelier_jsx/src/parse.rs
+++ b/crates/vize_atelier_jsx/src/parse.rs
@@ -8,6 +8,8 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::Program;
 use oxc_parser::Parser;
 
+use std::borrow::Cow;
+
 use vize_carton::ToCompactString;
 
 use crate::diagnostics::JsxDiagnostic;
@@ -31,6 +33,48 @@ impl<'a> ParsedModule<'a> {
     /// Whether parsing produced any error-severity diagnostics.
     pub fn has_errors(&self) -> bool {
         self.panicked || self.diagnostics.iter().any(JsxDiagnostic::is_error)
+    }
+}
+
+/// Return parser input that keeps Vue's TSX-only attribute spellings parseable.
+///
+/// OXC follows TypeScript's JSX grammar, where `ns:local` accepts an identifier
+/// as the local part. Vue users also write update listeners such as
+/// `onUpdate:current-step-index={...}`. The hyphenated local name is valid Vue
+/// JSX, but it trips TSX parsing before Vize can lower it. Replace only those
+/// hyphens with `_` while preserving byte length; lowering still reads names
+/// from the original source spans, so the emitted IR keeps the authored name.
+pub fn prepare_source_for_parse(source: &str, _lang: JsxLang) -> Cow<'_, str> {
+    let bytes = source.as_bytes();
+    if !bytes.contains(&b':') || !bytes.contains(&b'-') {
+        return Cow::Borrowed(source);
+    }
+
+    let mut output = None;
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' | b'"' | b'`' => index = skip_quoted(bytes, index, bytes[index]),
+            b'/' if bytes.get(index + 1) == Some(&b'/') => {
+                index = skip_line_comment(bytes, index + 2);
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                index = skip_block_comment(bytes, index + 2);
+            }
+            b'<' if let Some(name_start) = jsx_tag_name_start(bytes, index) => {
+                index = sanitize_jsx_opening_tag(bytes, name_start, &mut output);
+            }
+            _ => index += 1,
+        }
+    }
+
+    match output {
+        Some(bytes) => Cow::Owned(
+            std::str::from_utf8(bytes.as_slice())
+                .expect("source stays utf-8")
+                .to_owned(),
+        ),
+        None => Cow::Borrowed(source),
     }
 }
 
@@ -79,6 +123,141 @@ fn oxc_error_to_diagnostic(
     JsxDiagnostic::error(error.message.to_compact_string(), start, end)
 }
 
+fn jsx_tag_name_start(bytes: &[u8], lt: usize) -> Option<usize> {
+    let mut index = lt + 1;
+    if bytes.get(index) == Some(&b'/') {
+        index += 1;
+    }
+    bytes
+        .get(index)
+        .is_some_and(|byte| is_jsx_ident_start(*byte))
+        .then_some(index)
+}
+
+fn sanitize_jsx_opening_tag(
+    bytes: &[u8],
+    name_start: usize,
+    output: &mut Option<Vec<u8>>,
+) -> usize {
+    let mut index = skip_jsx_tag_name(bytes, name_start);
+    let mut braces = 0usize;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if braces > 0 {
+            index = skip_js_expression_byte(bytes, index, &mut braces);
+            continue;
+        }
+        match byte {
+            b'>' => return index + 1,
+            b'\'' | b'"' => index = skip_quoted(bytes, index, byte),
+            b'{' => {
+                braces = 1;
+                index += 1;
+            }
+            _ if is_jsx_ident_start(byte) => {
+                index = sanitize_possible_namespaced_attr(bytes, index, output);
+            }
+            _ => index += 1,
+        }
+    }
+    bytes.len()
+}
+
+fn skip_js_expression_byte(bytes: &[u8], index: usize, braces: &mut usize) -> usize {
+    match bytes[index] {
+        b'{' => {
+            *braces += 1;
+            index + 1
+        }
+        b'}' => {
+            *braces = braces.saturating_sub(1);
+            index + 1
+        }
+        b'\'' | b'"' => skip_quoted(bytes, index, bytes[index]),
+        b'`' => skip_quoted(bytes, index, b'`'),
+        b'/' if bytes.get(index + 1) == Some(&b'/') => skip_line_comment(bytes, index + 2),
+        b'/' if bytes.get(index + 1) == Some(&b'*') => skip_block_comment(bytes, index + 2),
+        _ => index + 1,
+    }
+}
+
+fn sanitize_possible_namespaced_attr(
+    bytes: &[u8],
+    start: usize,
+    output: &mut Option<Vec<u8>>,
+) -> usize {
+    let namespace_end = skip_jsx_attr_name_part(bytes, start);
+    if bytes.get(namespace_end) != Some(&b':') {
+        return namespace_end;
+    }
+
+    let local_start = namespace_end + 1;
+    let local_end = skip_jsx_attr_name_part(bytes, local_start);
+    for index in local_start..local_end {
+        if bytes[index] == b'-' {
+            output.get_or_insert_with(|| bytes.to_vec()).as_mut_slice()[index] = b'_';
+        }
+    }
+    local_end
+}
+
+fn skip_jsx_tag_name(bytes: &[u8], mut index: usize) -> usize {
+    while bytes
+        .get(index)
+        .is_some_and(|byte| is_jsx_attr_name_part(*byte) || matches!(byte, b':' | b'.'))
+    {
+        index += 1;
+    }
+    index
+}
+
+fn skip_jsx_attr_name_part(bytes: &[u8], mut index: usize) -> usize {
+    while bytes
+        .get(index)
+        .is_some_and(|byte| is_jsx_attr_name_part(*byte))
+    {
+        index += 1;
+    }
+    index
+}
+
+fn is_jsx_ident_start(byte: u8) -> bool {
+    byte == b'_' || byte == b'$' || byte.is_ascii_alphabetic()
+}
+
+fn is_jsx_attr_name_part(byte: u8) -> bool {
+    is_jsx_ident_start(byte) || byte.is_ascii_digit() || byte == b'-'
+}
+
+fn skip_quoted(bytes: &[u8], start: usize, quote: u8) -> usize {
+    let mut index = start + 1;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\\' => index += 2,
+            byte if byte == quote => return index + 1,
+            _ => index += 1,
+        }
+    }
+    bytes.len()
+}
+
+fn skip_line_comment(bytes: &[u8], mut index: usize) -> usize {
+    while bytes.get(index).is_some_and(|byte| *byte != b'\n') {
+        index += 1;
+    }
+    index
+}
+
+fn skip_block_comment(bytes: &[u8], mut index: usize) -> usize {
+    while index + 1 < bytes.len() {
+        if bytes[index] == b'*' && bytes[index + 1] == b'/' {
+            return index + 2;
+        }
+        index += 1;
+    }
+    bytes.len()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -116,5 +295,30 @@ mod tests {
         let allocator = Allocator::default();
         let parsed = parse_module(&allocator, "const a = (x: number) => x;", JsxLang::Jsx);
         assert!(parsed.has_errors());
+    }
+
+    #[test]
+    fn prepare_source_sanitizes_kebab_namespaced_attr_local_names() {
+        let src = "const a = <Comp onUpdate:current-step-index={h} />;";
+        let prepared = prepare_source_for_parse(src, JsxLang::Tsx);
+        assert_eq!(prepared.len(), src.len());
+        assert_eq!(
+            prepared.as_ref(),
+            "const a = <Comp onUpdate:current_step_index={h} />;"
+        );
+    }
+
+    #[test]
+    fn prepare_source_ignores_hyphens_inside_jsx_expressions() {
+        let src = "const a = <Comp value={current-step-index} />;";
+        let prepared = prepare_source_for_parse(src, JsxLang::Tsx);
+        assert!(matches!(prepared, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn prepare_source_ignores_jsx_like_text_inside_strings() {
+        let src = r#"const text = "<Comp onUpdate:current-step-index={h} />";"#;
+        let prepared = prepare_source_for_parse(src, JsxLang::Tsx);
+        assert!(matches!(prepared, Cow::Borrowed(_)));
     }
 }

--- a/crates/vize_atelier_jsx/tests/attributes.rs
+++ b/crates/vize_atelier_jsx/tests/attributes.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use common::{as_attribute, as_directive, lower_one, root_element, simple_content};
+use common::{as_attribute, as_directive, lower_one, lower_one_tsx, root_element, simple_content};
 use vize_carton::Bump;
 
 #[test]
@@ -90,4 +90,39 @@ fn jsx_element_as_attribute_value_is_dynamic_bind() {
     assert_eq!(directive.name, "bind");
     assert_eq!(simple_content(directive.arg.as_ref().unwrap()), "icon");
     assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "<Icon/>");
+}
+
+#[test]
+fn tsx_kebab_update_handler_preserves_authored_argument() {
+    let bump = Bump::new();
+    let root = lower_one_tsx(
+        &bump,
+        "const a = <Stepper onUpdate:current-step-index={updateStepIndex}/>;",
+    );
+    let directive = as_directive(&root_element(&root).props[0]);
+    assert_eq!(directive.name, "bind");
+    assert_eq!(
+        simple_content(directive.arg.as_ref().unwrap()),
+        "onUpdate:current-step-index"
+    );
+    assert_eq!(
+        simple_content(directive.exp.as_ref().unwrap()),
+        "updateStepIndex"
+    );
+}
+
+#[test]
+fn tsx_kebab_v_model_arg_preserves_authored_argument() {
+    let bump = Bump::new();
+    let root = lower_one_tsx(
+        &bump,
+        "const a = <Stepper v-model:current-step-index={value}/>;",
+    );
+    let directive = as_directive(&root_element(&root).props[0]);
+    assert_eq!(directive.name, "model");
+    assert_eq!(
+        simple_content(directive.arg.as_ref().unwrap()),
+        "current-step-index"
+    );
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "value");
 }

--- a/crates/vize_atelier_jsx/tests/slots.rs
+++ b/crates/vize_atelier_jsx/tests/slots.rs
@@ -134,3 +134,73 @@ fn scoped_slot_directive_carries_raw_param_pattern() {
         ExpressionNode::Compound(_) => panic!("expected simple param expression"),
     }
 }
+
+#[test]
+fn tsx_story_slot_object_with_kebab_update_handler_lowers() {
+    let bump = Bump::new();
+    let out = lower_source(
+        &bump,
+        r#"export const Example = () => (
+  <AfsStepperDialog
+    value={isOpen.value}
+    items={items.value}
+    currentStepIndex={currentStepIndex.value}
+    onUpdate:current-step-index={updateStepIndex}
+  >
+    {{
+      content1: () => (
+        <div>
+          {Array.from({ length: 10 }, (_, i) => (
+            <p key={i}>sample {i + 1}</p>
+          ))}
+        </div>
+      ),
+      actions: () => <AfsButton onClick={next}>Next</AfsButton>,
+    }}
+  </AfsStepperDialog>
+);"#,
+        JsxLang::Tsx,
+    );
+    assert!(!out.has_errors(), "diagnostics: {:?}", out.diagnostics);
+    let root = &out.roots[0].root;
+    let TemplateChildNode::Element(stepper) = &root.children[0] else {
+        panic!("expected component element root");
+    };
+
+    let update = stepper
+        .props
+        .iter()
+        .find_map(|prop| match prop {
+            PropNode::Directive(dir)
+                if dir.name.as_str() == "bind"
+                    && dir.arg.as_ref().is_some_and(|arg| {
+                        common::simple_content(arg) == "onUpdate:current-step-index"
+                    }) =>
+            {
+                Some(&**dir)
+            }
+            _ => None,
+        })
+        .expect("update handler is lowered as a dynamic bind");
+    assert_eq!(
+        common::simple_content(update.exp.as_ref().unwrap()),
+        "updateStepIndex"
+    );
+
+    let slot_names: std::vec::Vec<&str> = stepper
+        .children
+        .iter()
+        .filter_map(|child| {
+            let TemplateChildNode::Element(template) = child else {
+                return None;
+            };
+            template.props.iter().find_map(|prop| match prop {
+                PropNode::Directive(dir) if dir.name.as_str() == "slot" => {
+                    dir.arg.as_ref().map(common::simple_content)
+                }
+                _ => None,
+            })
+        })
+        .collect();
+    assert_eq!(slot_names, ["content1", "actions"]);
+}


### PR DESCRIPTION
## Summary
- sanitize Vue TSX namespaced attribute local names with kebab case before OXC parsing while preserving byte lengths
- recover JSX attribute and directive names from the original source spans during lowering
- add lowering and CLI regressions for slot-object stories with onUpdate:current-step-index handlers

## Validation
- cargo test -p vize_atelier_jsx --test attributes -- --nocapture
- cargo test -p vize_atelier_jsx --test slots -- --nocapture
- cargo test -p vize_atelier_jsx parse::tests::prepare_source -- --nocapture
- cargo test -p vize --test check_tsx_sfc_attrs_cli -- --nocapture
- cargo fmt --all -- --check
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Closes #2178