### PR TITLE
fix(canon): expose Nuxt 2 template globals

### DIFF
--- a/crates/vize/src/commands/check/nuxt/legacy_template_globals.rs
+++ b/crates/vize/src/commands/check/nuxt/legacy_template_globals.rs
@@ -1,0 +1,25 @@
+use vize_canon::virtual_ts::{TemplateGlobal, VirtualTsOptions};
+use vize_carton::ToCompactString;
+
+pub(super) fn collect(options: &mut VirtualTsOptions) {
+    for (name, type_annotation) in [
+        (
+            "$fetchState",
+            "{ pending: boolean; error: any; timestamp: number; [key: string]: any }",
+        ),
+        ("$route", "any"),
+    ] {
+        if options
+            .template_globals
+            .iter()
+            .any(|global| global.name == name)
+        {
+            continue;
+        }
+        options.template_globals.push(TemplateGlobal {
+            name: name.to_compact_string(),
+            type_annotation: type_annotation.to_compact_string(),
+            default_value: "undefined as any".into(),
+        });
+    }
+}

--- a/crates/vize/src/commands/check/nuxt/legacy_template_globals_tests.rs
+++ b/crates/vize/src/commands/check/nuxt/legacy_template_globals_tests.rs
@@ -1,0 +1,55 @@
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use vize_canon::virtual_ts::VirtualTsOptions;
+use vize_carton::cstr;
+
+use super::{detect_legacy_nuxt_auto_imports, detect_nuxt_auto_imports};
+
+#[test]
+fn detects_legacy_nuxt2_fetch_state_and_route_template_globals() {
+    let project_root = unique_case_dir("nuxt2-template-globals");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    std::fs::write(project_root.join("nuxt.config.ts"), "export default {}").unwrap();
+
+    let mut standard_options = VirtualTsOptions::default();
+    let _ = detect_nuxt_auto_imports(&mut standard_options, &project_root);
+    assert!(
+        !standard_options
+            .template_globals
+            .iter()
+            .any(|global| global.name == "$fetchState"),
+        "standard Nuxt detection should not add Nuxt 2-only globals: {:#?}",
+        standard_options.template_globals
+    );
+
+    let mut legacy_options = VirtualTsOptions::default();
+    let _ = detect_legacy_nuxt_auto_imports(&mut legacy_options, &project_root);
+    for expected in ["$fetchState", "$route"] {
+        assert!(
+            legacy_options
+                .template_globals
+                .iter()
+                .any(|global| global.name == expected),
+            "expected {expected} template global, got: {:#?}",
+            legacy_options.template_globals
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn unique_case_dir(name: &str) -> std::path::PathBuf {
+    static NEXT_CASE_ID: AtomicUsize = AtomicUsize::new(0);
+
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist");
+    let case_id = NEXT_CASE_ID.fetch_add(1, Ordering::Relaxed);
+    workspace_root
+        .join("target")
+        .join("vize-tests")
+        .join(cstr!("{name}-{}-{case_id}", std::process::id()).as_str())
+}

--- a/crates/vize/src/commands/check/nuxt/mod.rs
+++ b/crates/vize/src/commands/check/nuxt/mod.rs
@@ -10,6 +10,7 @@ use vize_carton::{FxHashSet, String, ToCompactString};
 mod fallback;
 mod generated;
 mod generated_dir;
+mod legacy_template_globals;
 mod parsing;
 mod plugins;
 mod source_scan;
@@ -17,6 +18,8 @@ mod stubs;
 mod tsconfig_aliases;
 mod virtual_modules;
 
+#[cfg(test)]
+mod legacy_template_globals_tests;
 #[cfg(test)]
 mod tests;
 
@@ -40,13 +43,22 @@ pub(in crate::commands::check) fn detect_nuxt_auto_imports(
     options: &mut VirtualTsOptions,
     cwd: &Path,
 ) -> Vec<NuxtPathAlias> {
-    detect(options, cwd, None)
+    detect(options, cwd, None, false)
+}
+
+#[cfg(test)]
+pub(in crate::commands::check) fn detect_legacy_nuxt_auto_imports(
+    options: &mut VirtualTsOptions,
+    cwd: &Path,
+) -> Vec<NuxtPathAlias> {
+    detect(options, cwd, None, true)
 }
 
 pub(in crate::commands::check) fn detect(
     options: &mut VirtualTsOptions,
     cwd: &Path,
     tsconfig_path: Option<&Path>,
+    legacy_vue2: bool,
 ) -> Vec<NuxtPathAlias> {
     if !is_nuxt_project(cwd) {
         return Vec::new();
@@ -92,6 +104,9 @@ pub(in crate::commands::check) fn detect(
     let explicit_aliases = collect_explicit_virtual_module_aliases(tsconfig_path);
     collect_fallback_module_stubs(cwd, &mut collected, &explicit_aliases);
     let path_aliases = collect_fallback_path_aliases(cwd, &generated_dir);
+    if legacy_vue2 {
+        legacy_template_globals::collect(options);
+    }
     collect_generated_template_globals(&generated_dir, options, &seen_names);
 
     for stub in &collected {

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -112,8 +112,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     // Legacy Vue 2.7 / Nuxt 2 Options-API type checking is opt-in and compiled out
     // of the default Vue 3 binary. Without the `legacy` feature, honor the config
     // flag by warning instead of silently ignoring it.
-    #[cfg(feature = "legacy")]
-    let legacy_vue2 = loaded_config.features.type_checker_legacy_vue2;
+    let legacy_vue2 = cfg!(feature = "legacy") && loaded_config.features.type_checker_legacy_vue2;
     #[cfg(not(feature = "legacy"))]
     if loaded_config.features.type_checker_legacy_vue2 {
         eprintln!(
@@ -255,7 +254,8 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     };
     let mut virtual_ts_options = build_virtual_ts_options(&config, config_dir);
     let tsconfig = program_tsconfig_path.as_deref();
-    let nuxt_path_aliases = nuxt::detect(&mut virtual_ts_options, &nuxt_project_root, tsconfig);
+    let nuxt_root = &nuxt_project_root;
+    let nuxt_path_aliases = nuxt::detect(&mut virtual_ts_options, nuxt_root, tsconfig, legacy_vue2);
     collect_project_global_component_stubs(
         &mut virtual_ts_options,
         &files,

--- a/crates/vize/tests/check_nuxt2_template_globals_cli.rs
+++ b/crates/vize/tests/check_nuxt2_template_globals_cli.rs
@@ -1,0 +1,115 @@
+#![cfg(feature = "legacy")]
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[test]
+fn check_legacy_nuxt2_template_fetch_state_and_route_globals() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("legacy-nuxt2-template-globals");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    std::fs::write(project_root.join("nuxt.config.ts"), "export default {}\n").unwrap();
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        r#"{ "typeChecker": { "legacyVue2": true } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/App.vue"),
+        r#"<script lang="ts">
+export default {}
+</script>
+<template>
+  <section v-if="$fetchState.pending">{{ $route.path }}</section>
+</template>
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src/App.vue",
+            "--format",
+            "json",
+            "--show-virtual-ts",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    assert!(
+        stderr.contains("const $fetchState:"),
+        "expected $fetchState declaration in virtual TS:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("const $route:"),
+        "expected $route declaration in virtual TS:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(format!("{name}-{}", std::process::id()))
+}
+
+fn resolve_test_corsa_path() -> Option<String> {
+    if let Ok(path) = std::env::var("CORSA_PATH")
+        && Path::new(&path).exists()
+    {
+        return Some(path);
+    }
+
+    let workspace_root = workspace_root();
+    [
+        workspace_root.join("node_modules/.bin/tsgo"),
+        workspace_root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+    .map(|candidate| candidate.to_string_lossy().into_owned())
+}


### PR DESCRIPTION
## Summary
- pass legacy Vue 2 mode into Nuxt auto-import detection
- add Nuxt 2 template globals for $fetchState and $route only in legacy mode
- cover the detector and a legacy CLI check that exercises the generated virtual TS

## Validation
- cargo test -p vize commands::check::nuxt::tests::detects_legacy_nuxt2_fetch_state_and_route_template_globals -- --nocapture
- cargo test -p vize --features legacy --test check_nuxt2_template_globals_cli -- --nocapture
- cargo fmt --all -- --check
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Closes #2171

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->