### PR TITLE
fix(canon): preserve Vue 2 Vuetify component fallbacks

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/camel_case_component_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/camel_case_component_props.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::batch::BatchTypeCheckerOptions;
+use crate::virtual_ts::VirtualTsOptions;
 
 #[test]
 fn batch_type_checker_reports_camel_case_child_component_prop_error() {
@@ -109,6 +111,77 @@ defineProps<{
     assert!(
         snapshot.is_empty(),
         "forwarded optional component prop should type-check, got: {snapshot:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn batch_type_checker_legacy_vue2_accepts_vuetify_global_events_and_props() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "legacy-vue2-vuetify-global-events-props",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const width = 320;
+const hideDetails = true;
+function updateDate(newDate: string) {
+  void newDate;
+}
+</script>
+
+<template>
+  <v-date-picker
+    :width="width"
+    :hide-details="hideDetails"
+    chips
+    @input="updateDate"
+  />
+</template>
+"#,
+        )],
+    );
+
+    let options = BatchTypeCheckerOptions {
+        virtual_ts_options: VirtualTsOptions {
+            auto_import_stubs: vec![
+                "declare const VDatePicker: { new (): { $props: { mini?: boolean } } };".into(),
+            ],
+            external_template_bindings: vec!["VDatePicker".into()],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut checker = match BatchTypeChecker::with_options(&project_root, options) {
+        Ok(checker) => checker,
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        }
+    };
+    checker.enable_legacy_vue2();
+    checker.scan_project().unwrap();
+    let result = checker.check_project().unwrap();
+    let relevant = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| relative_path(&project_root, &diagnostic.file) == "src/App.vue")
+        .filter(|diagnostic| {
+            diagnostic.code == Some(2345)
+                || diagnostic.message.contains("InputEvent")
+                || diagnostic.message.contains("keyof Props")
+                || diagnostic.message.contains("hideDetails")
+                || diagnostic.message.contains("width")
+                || diagnostic.message.contains("chips")
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        relevant.is_empty(),
+        "legacy Vue 2 Vuetify globals should not report event/prop false positives: {relevant:#?}"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -11,6 +11,8 @@ mod expressions;
 mod generator;
 mod helpers;
 pub mod incremental;
+#[cfg(test)]
+mod legacy_vue2_vuetify_tests;
 mod props;
 mod scope;
 #[cfg(test)]

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -125,6 +125,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     // `$children`, `$on`, ... that Vue 3's `ComponentPublicInstance` lacks).
     let dialect = generation_options.dialect;
     let legacy_vue2 = generation_options.legacy_vue2;
+    let _ = generation_options.template_syntax_quirks;
     let options_api = generation_options.options_api || legacy_vue2;
     let hoist_shared_preamble = generation_options.hoist_shared_preamble;
     let mut ts = String::default();
@@ -744,13 +745,12 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             ts.push_str(&template_context);
             ts.push('\n');
 
-            // Props are available in template as variables
             profile!("canon.virtual_ts.generate_props_variables", {
                 setup_props_plan.generate_props_variables(
                     &mut ts,
                     summary,
                     generic_param,
-                    check_props,
+                    check_props && !legacy_vue2,
                 )
             });
             if options_api {
@@ -778,7 +778,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                             check_options,
                             virtual_ts_options: options,
                             check_unresolved_global_components: has_script_reference_types,
-                            template_syntax_quirks: generation_options.template_syntax_quirks,
+                            legacy_vue2,
                         },
                     )
                 );

--- a/crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs
@@ -1,0 +1,108 @@
+use vize_croquis::{Analyzer, AnalyzerOptions};
+
+use super::{
+    VirtualTsGenerationOptions, VirtualTsOptions, generate_virtual_ts_with_offsets,
+    generate_virtual_ts_with_offsets_and_checks,
+};
+
+fn standard_virtual_ts(script: &str, template: &str, options: &VirtualTsOptions) -> String {
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    generate_virtual_ts_with_offsets(&analyzer.finish(), Some(script), Some(&root), 0, 0, options)
+        .code
+        .to_string()
+}
+
+fn legacy_virtual_ts(script: &str, template: &str, options: &VirtualTsOptions) -> String {
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    generate_virtual_ts_with_offsets_and_checks(
+        &analyzer.finish(),
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        options,
+        VirtualTsGenerationOptions {
+            legacy_vue2: true,
+            ..Default::default()
+        },
+    )
+    .code
+    .to_string()
+}
+
+#[test]
+fn legacy_vue2_component_event_fallback_stays_permissive() {
+    let script = r#"import VDatePicker from './VDatePicker.vue'
+function updateDate(newDate: string) {
+  void newDate
+}
+"#;
+    let template = r#"<VDatePicker @input="updateDate" />"#;
+
+    let standard = standard_virtual_ts(script, template, &VirtualTsOptions::default());
+    assert!(
+        standard.contains("? InputEvent :"),
+        "standard component event fallback should stay DOM-typed:\n{standard}"
+    );
+
+    let legacy = legacy_virtual_ts(script, template, &VirtualTsOptions::default());
+    assert!(
+        legacy.contains("? any :") && !legacy.contains("? InputEvent :"),
+        "legacy Vue 2 component event fallback should not force DOM payloads:\n{legacy}"
+    );
+}
+
+#[test]
+fn legacy_vue2_skips_external_component_prop_checks() {
+    let script = "const width = 320\n";
+    let template = r#"<VDatePicker :width="width" />"#;
+    let options = VirtualTsOptions {
+        auto_import_stubs: vec![
+            "declare const VDatePicker: { new (): { $props: { mini?: boolean } } };".into(),
+        ],
+        external_template_bindings: vec!["VDatePicker".into()],
+        ..Default::default()
+    };
+
+    let standard = standard_virtual_ts(script, template, &options);
+    assert!(
+        standard.contains("type __VDatePicker_Props_0"),
+        "standard external component props should remain checkable:\n{standard}"
+    );
+
+    let legacy = legacy_virtual_ts(script, template, &options);
+    assert!(
+        !legacy.contains("type __VDatePicker_Props_0"),
+        "legacy Vue 2 external component props should avoid Vuetify false positives:\n{legacy}"
+    );
+}
+
+#[test]
+fn legacy_vue2_unresolved_keyed_props_are_unchecked() {
+    let script = r#"
+type Props = { mini?: boolean } & { dense?: boolean }
+defineProps<Props>()
+"#;
+    let template = r#"<v-select :width="width" :hide-details="hideDetails" />"#;
+
+    let standard = standard_virtual_ts(script, template, &VirtualTsOptions::default());
+    assert!(
+        standard.contains("\"width\" satisfies keyof Props"),
+        "standard keyed prop fallback should still catch unknown props:\n{standard}"
+    );
+
+    let legacy = legacy_virtual_ts(script, template, &VirtualTsOptions::default());
+    assert!(
+        legacy.contains("(props as Record<string, unknown>)[\"width\"]")
+            && !legacy.contains("satisfies keyof Props"),
+        "legacy Vue 2 keyed prop fallback should not reject Vuetify/mixin names:\n{legacy}"
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -168,7 +168,7 @@ pub(crate) fn generate_scope_closures(
             template_prop_names,
             template_offset,
             check_options,
-            template_syntax_quirks: options.template_syntax_quirks,
+            legacy_vue2: options.legacy_vue2,
         };
         profile!(
             "canon.virtual_ts.scope_node",
@@ -184,7 +184,6 @@ pub(crate) fn generate_scope_closures(
         );
     }
 
-    // Generate component props type checks (scope-aware)
     if check_options.check_props {
         profile!(
             "canon.virtual_ts.component_props",
@@ -199,6 +198,7 @@ pub(crate) fn generate_scope_closures(
                     template_offset,
                     options: virtual_ts_options,
                     check_unresolved_global_components: options.check_unresolved_global_components,
+                    legacy_vue2: options.legacy_vue2,
                 },
             )
         );
@@ -364,7 +364,7 @@ fn generate_scope_node(
                     data,
                     scope,
                     ctx.template_prop_names,
-                    ctx.template_syntax_quirks,
+                    ctx.legacy_vue2,
                     indent,
                 )
                 .expect("component event handler should have a target component");

--- a/crates/vize_canon/src/virtual_ts/scope/component_events.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events.rs
@@ -23,7 +23,7 @@ pub(super) fn generate_component_event_types(
     data: &EventHandlerScopeData,
     scope: &Scope,
     template_prop_names: &FxHashSet<String>,
-    _template_syntax_quirks: bool,
+    legacy_vue2: bool,
     indent: &str,
 ) -> Option<ComponentEventTypes> {
     let component_name = data.target_component.as_ref()?;
@@ -113,7 +113,11 @@ pub(super) fn generate_component_event_types(
         );
     }
 
-    let fallback_event = get_dom_event_type(data.event_name.as_str());
+    let fallback_event = if legacy_vue2 {
+        "any"
+    } else {
+        get_dom_event_type(data.event_name.as_str())
+    };
     append!(
         *ts,
         "{indent}type {event_type} = {args_type} extends [] ? any : unknown[] extends {args_type} ? {fallback_event} : {args_type}[0];\n",

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_expressions.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_expressions.rs
@@ -2,6 +2,7 @@ use vize_carton::FxHashSet;
 use vize_croquis::{Croquis, TemplateExpressionKind};
 
 use super::component_prop_checker::is_inline_function_prop_value;
+use super::component_props::component_usage_has_checkable_binding;
 use super::context::ScopeGenerationOptions;
 use crate::virtual_ts::types::VirtualTsOptions;
 
@@ -21,11 +22,13 @@ pub(super) fn collect_component_prop_expression_ranges(
         .collect();
     let mut ranges = FxHashSet::default();
     for usage in &summary.component_usages {
-        let name = usage.name.as_str();
-        let checkable = summary.bindings.bindings.contains_key(name)
-            || external_template_bindings.contains(name)
-            || (options.check_unresolved_global_components && !name.is_empty());
-        if !checkable {
+        if !component_usage_has_checkable_binding(
+            summary,
+            usage,
+            &external_template_bindings,
+            options.check_unresolved_global_components,
+            options.legacy_vue2,
+        ) {
             continue;
         }
         for prop in &usage.props {

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -48,6 +48,7 @@ pub(super) fn generate_component_props(
                 usage,
                 &external_template_bindings,
                 ctx.check_unresolved_global_components,
+                ctx.legacy_vue2,
             )
         })
         .collect();
@@ -55,7 +56,6 @@ pub(super) fn generate_component_props(
         return;
     }
 
-    // Group component usages by scope_id
     let mut components_by_scope: FxHashMap<u32, Vec<(usize, &ComponentUsage)>> =
         FxHashMap::default();
     for &(idx, usage) in &checkable_usages {
@@ -65,8 +65,6 @@ pub(super) fn generate_component_props(
             .push((idx, usage));
     }
 
-    // Emit type declarations only for components with dynamic props
-    // (TypeScript type aliases cannot be inside function bodies)
     ts.push_str("\n  // Component props type declarations\n");
 
     // Generic children expose `__vizeCheck<T>(props)`; fallback contextual
@@ -206,19 +204,20 @@ pub(super) fn generate_component_props(
     }
 }
 
-fn component_usage_has_checkable_binding(
+pub(super) fn component_usage_has_checkable_binding(
     summary: &Croquis,
     usage: &ComponentUsage,
     external_template_bindings: &FxHashSet<&str>,
     check_unresolved_global_components: bool,
+    legacy_vue2: bool,
 ) -> bool {
     let name = usage.name.as_str();
     summary.bindings.bindings.contains_key(name)
-        || external_template_bindings.contains(name)
-        || (check_unresolved_global_components && !name.is_empty())
+        || (!legacy_vue2
+            && (external_template_bindings.contains(name)
+                || (check_unresolved_global_components && !name.is_empty())))
 }
 
-/// Recursively generate component prop checks inside nested closure scopes (v-for and v-slot).
 fn generate_closure_component_props_recursive(
     ts: &mut String,
     mappings: &mut Vec<VizeMapping>,

--- a/crates/vize_canon/src/virtual_ts/scope/context.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/context.rs
@@ -17,14 +17,14 @@ pub(crate) struct ScopeGenContext<'a> {
     pub(crate) template_prop_names: &'a FxHashSet<String>,
     pub(crate) template_offset: u32,
     pub(crate) check_options: VirtualTsCheckOptions,
-    pub(crate) template_syntax_quirks: bool,
+    pub(crate) legacy_vue2: bool,
 }
 
 pub(crate) struct ScopeGenerationOptions<'a> {
     pub(crate) check_options: VirtualTsCheckOptions,
     pub(crate) virtual_ts_options: &'a VirtualTsOptions,
     pub(crate) check_unresolved_global_components: bool,
-    pub(crate) template_syntax_quirks: bool,
+    pub(crate) legacy_vue2: bool,
 }
 
 /// Context for recursive component prop checks inside v-for scopes.
@@ -60,4 +60,5 @@ pub(super) struct ComponentPropsContext<'a> {
     pub(super) template_offset: u32,
     pub(super) options: &'a VirtualTsOptions,
     pub(super) check_unresolved_global_components: bool,
+    pub(super) legacy_vue2: bool,
 }


### PR DESCRIPTION
## Summary
- keep unresolved component event payloads permissive in legacy Vue 2 mode
- skip external/global component prop checks in legacy mode while preserving local component checks
- cover Vuetify-style global component events and keyed props

Closes #2172

## Verification
- cargo fmt --all -- --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo test -p vize_canon virtual_ts::legacy_vue2_vuetify_tests -- --nocapture
- cargo test -p vize_canon batch_type_checker_legacy_vue2_accepts_vuetify_global_events_and_props -- --nocapture
- cargo test -p vize_canon test_component_event_fallback_uses_dom_event_type_when_args_stay_unknown -- --nocapture
- cargo test -p vize_canon batch_type_checker_reports_camel_case_child_component_prop_error -- --nocapture
- cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->