### PR TITLE
fix: use canonical virtual TS for Vue LSP queries

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -1,12 +1,24 @@
 //! Shared Corsa helpers for mapping virtual document responses back to Vue SFCs.
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
-use std::collections::HashMap;
+use tower_lsp::lsp_types::{Location, PrepareRenameResponse, Range, Url};
+#[cfg(feature = "native")]
+mod canonical;
+#[cfg(all(test, feature = "native"))]
+mod canonical_tests;
+#[cfg(feature = "native")]
+mod html_tag;
+mod workspace_edit;
 
-use tower_lsp::lsp_types::{
-    AnnotatedTextEdit, DocumentChangeOperation, DocumentChanges, Location, OneOf,
-    PrepareRenameResponse, Range, TextEdit, Url, WorkspaceEdit,
+#[cfg(feature = "native")]
+pub(crate) use canonical::{
+    canonical_source_offset_to_position, map_canonical_corsa_locations, map_canonical_lsp_range,
+    open_canonical_virtual_document,
 };
+#[cfg(feature = "native")]
+pub(crate) use html_tag::{html_tag_request_path, html_tag_virtual_document};
+pub(crate) use workspace_edit::map_corsa_workspace_edit;
+
 use vize_canon::LspLocation;
 use vize_carton::{String, cstr};
 
@@ -27,17 +39,14 @@ impl<'a> CurrentVirtualDocument<'a> {
     }
 }
 
-/// Build the virtual template request path used for Corsa queries.
 pub(crate) fn template_request_path(uri: &Url) -> String {
     cstr!("{}.template.ts", uri.path())
 }
 
-/// Build the virtual template request path for a specific art variant.
 pub(crate) fn art_template_request_path(uri: &Url, variant_index: usize) -> String {
     cstr!("{}.art_variant_{variant_index}.template.ts", uri.path())
 }
 
-/// Build the virtual script request path used for Corsa queries.
 pub(crate) fn script_request_path(uri: &Url, is_setup: bool) -> String {
     if is_setup {
         cstr!("{}.setup.ts", uri.path())
@@ -46,7 +55,6 @@ pub(crate) fn script_request_path(uri: &Url, is_setup: bool) -> String {
     }
 }
 
-/// Normalize a filesystem path into the `file://` form expected by Corsa.
 pub(crate) fn request_file_uri(path: &str) -> String {
     if path.starts_with("file://") {
         String::from(path)
@@ -128,150 +136,6 @@ pub(crate) fn map_corsa_prepare_rename(
     }
 }
 
-/// Rewrite a workspace edit so virtual-document edits target the Vue source.
-pub(crate) fn map_corsa_workspace_edit(
-    ctx: &IdeContext<'_>,
-    mut edit: WorkspaceEdit,
-) -> Option<WorkspaceEdit> {
-    if let Some(changes) = edit.changes.take() {
-        let mut mapped_changes = HashMap::with_capacity(changes.len());
-
-        for (uri, edits) in changes {
-            if let Some(current_doc) = match_current_virtual_document(ctx, uri.as_str()) {
-                let entry = mapped_changes
-                    .entry(ctx.uri.clone())
-                    .or_insert_with(Vec::new);
-                entry.extend(
-                    edits
-                        .into_iter()
-                        .filter_map(|edit| map_text_edit(ctx, current_doc.document(), edit)),
-                );
-            } else {
-                mapped_changes.insert(uri, edits);
-            }
-        }
-
-        if !mapped_changes.is_empty() {
-            edit.changes = Some(mapped_changes);
-        }
-    }
-
-    if let Some(document_changes) = edit.document_changes.take() {
-        let mapped_document_changes = match document_changes {
-            DocumentChanges::Edits(edits) => {
-                let edits = edits
-                    .into_iter()
-                    .filter_map(|edit| map_document_edit(ctx, edit))
-                    .collect::<Vec<_>>();
-
-                if edits.is_empty() {
-                    None
-                } else {
-                    Some(DocumentChanges::Edits(edits))
-                }
-            }
-            DocumentChanges::Operations(operations) => {
-                let operations = operations
-                    .into_iter()
-                    .filter_map(|operation| map_document_change_operation(ctx, operation))
-                    .collect::<Vec<_>>();
-
-                if operations.is_empty() {
-                    None
-                } else {
-                    Some(DocumentChanges::Operations(operations))
-                }
-            }
-        };
-
-        if let Some(document_changes) = mapped_document_changes {
-            edit.document_changes = Some(document_changes);
-        }
-    }
-
-    if workspace_edit_is_empty(&edit) {
-        None
-    } else {
-        Some(edit)
-    }
-}
-
-fn workspace_edit_is_empty(edit: &WorkspaceEdit) -> bool {
-    let changes_empty = edit
-        .changes
-        .as_ref()
-        .is_none_or(|changes| changes.values().all(Vec::is_empty));
-    let document_changes_empty =
-        edit.document_changes
-            .as_ref()
-            .is_none_or(|changes| match changes {
-                DocumentChanges::Edits(edits) => edits.is_empty(),
-                DocumentChanges::Operations(operations) => operations.is_empty(),
-            });
-
-    changes_empty && document_changes_empty
-}
-
-fn map_document_change_operation(
-    ctx: &IdeContext<'_>,
-    operation: DocumentChangeOperation,
-) -> Option<DocumentChangeOperation> {
-    match operation {
-        DocumentChangeOperation::Edit(edit) => {
-            map_document_edit(ctx, edit).map(DocumentChangeOperation::Edit)
-        }
-        DocumentChangeOperation::Op(op) => Some(DocumentChangeOperation::Op(op)),
-    }
-}
-
-fn map_document_edit(
-    ctx: &IdeContext<'_>,
-    mut edit: tower_lsp::lsp_types::TextDocumentEdit,
-) -> Option<tower_lsp::lsp_types::TextDocumentEdit> {
-    let current_doc = match_current_virtual_document(ctx, edit.text_document.uri.as_str());
-
-    if let Some(current_doc) = current_doc {
-        edit.text_document.uri = ctx.uri.clone();
-        edit.edits = edit
-            .edits
-            .into_iter()
-            .filter_map(|entry| match entry {
-                OneOf::Left(text_edit) => {
-                    map_text_edit(ctx, current_doc.document(), text_edit).map(OneOf::Left)
-                }
-                OneOf::Right(annotated) => {
-                    map_annotated_text_edit(ctx, current_doc.document(), annotated)
-                        .map(OneOf::Right)
-                }
-            })
-            .collect();
-    }
-
-    if edit.edits.is_empty() {
-        None
-    } else {
-        Some(edit)
-    }
-}
-
-fn map_annotated_text_edit(
-    ctx: &IdeContext<'_>,
-    document: &VirtualDocument,
-    mut edit: AnnotatedTextEdit,
-) -> Option<AnnotatedTextEdit> {
-    edit.text_edit = map_text_edit(ctx, document, edit.text_edit)?;
-    Some(edit)
-}
-
-fn map_text_edit(
-    ctx: &IdeContext<'_>,
-    document: &VirtualDocument,
-    mut edit: TextEdit,
-) -> Option<TextEdit> {
-    edit.range = map_virtual_range(ctx, document, &edit.range)?;
-    Some(edit)
-}
-
 fn map_virtual_range(
     ctx: &IdeContext<'_>,
     document: &VirtualDocument,
@@ -348,7 +212,7 @@ fn match_current_virtual_document<'a>(
     None
 }
 
-fn virtual_document_path(uri: &str) -> Option<String> {
+pub(super) fn virtual_document_path(uri: &str) -> Option<String> {
     if let Ok(parsed) = Url::parse(uri) {
         return Some(parsed.path().to_string().into());
     }

--- a/crates/vize_maestro/src/ide/corsa_support/canonical.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical.rs
@@ -1,0 +1,309 @@
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::{Location, Range, Url};
+use vize_canon::{CorsaBridge, LspLocation};
+use vize_carton::{String, cstr};
+
+use crate::ide::IdeContext;
+use crate::ide::diagnostics::VirtualTsResult;
+
+pub(crate) struct CanonicalVirtualDocument {
+    pub(crate) request_uri: String,
+    pub(crate) virtual_result: VirtualTsResult,
+}
+
+pub(crate) fn canonical_request_path(uri: &Url) -> String {
+    cstr!("{}.ts", uri.path())
+}
+
+pub(crate) async fn open_canonical_virtual_document(
+    ctx: &IdeContext<'_>,
+    bridge: &Arc<CorsaBridge>,
+) -> Option<CanonicalVirtualDocument> {
+    if !ctx.uri.path().ends_with(".vue") || ctx.uri.path().ends_with(".art.vue") {
+        return None;
+    }
+
+    let options_api = ctx.state.options_api_enabled();
+    let legacy_vue2 = ctx.state.legacy_vue2_enabled();
+    let virtual_result = crate::ide::DiagnosticService::generate_virtual_ts(
+        ctx.uri,
+        &ctx.content,
+        options_api,
+        legacy_vue2,
+    )?;
+
+    crate::ide::diagnostics::corsa::collect::overlay_sibling_vue_mirrors(
+        bridge,
+        ctx.uri,
+        &virtual_result.relative_vue_imports,
+        options_api,
+        legacy_vue2,
+    )
+    .await;
+    crate::ide::diagnostics::corsa::collect::overlay_relative_ts_imports(
+        bridge,
+        ctx.uri,
+        &virtual_result.relative_ts_imports,
+    )
+    .await;
+
+    let request_uri = bridge
+        .open_or_update_virtual_document(&canonical_request_path(ctx.uri), &virtual_result.code)
+        .await
+        .ok()?;
+
+    Some(CanonicalVirtualDocument {
+        request_uri,
+        virtual_result,
+    })
+}
+
+pub(crate) fn canonical_source_offset_to_position(
+    doc: &CanonicalVirtualDocument,
+    source_offset: usize,
+) -> Option<(u32, u32)> {
+    let generated_offset = source_offset_to_canonical_generated_offset(doc, source_offset)?;
+    Some(crate::ide::offset_to_position(
+        &doc.virtual_result.code,
+        generated_offset,
+    ))
+}
+
+fn source_offset_to_canonical_generated_offset(
+    doc: &CanonicalVirtualDocument,
+    source_offset: usize,
+) -> Option<usize> {
+    let mapping = mapping_for_source_offset(&doc.virtual_result.source_mappings, source_offset)?;
+    let generated_pre_rewrite = map_source_offset_to_generated(mapping, source_offset);
+    let generated_post_rewrite = doc
+        .virtual_result
+        .import_source_map
+        .get_virtual_offset(generated_pre_rewrite as u32);
+    Some(generated_post_rewrite as usize)
+}
+
+fn mapping_for_source_offset(
+    mappings: &[vize_canon::virtual_ts::VizeMapping],
+    offset: usize,
+) -> Option<&vize_canon::virtual_ts::VizeMapping> {
+    mappings
+        .iter()
+        .filter(|mapping| offset >= mapping.src_range.start && offset <= mapping.src_range.end)
+        .min_by_key(|mapping| {
+            mapping
+                .src_range
+                .end
+                .saturating_sub(mapping.src_range.start)
+        })
+}
+
+fn map_source_offset_to_generated(
+    mapping: &vize_canon::virtual_ts::VizeMapping,
+    source_offset: usize,
+) -> usize {
+    if let Some(span) = mapping
+        .sub_spans
+        .iter()
+        .find(|span| source_offset >= span.src_range.start && source_offset <= span.src_range.end)
+    {
+        let relative = source_offset.saturating_sub(span.src_range.start);
+        return span
+            .gen_range
+            .start
+            .saturating_add(relative.min(span.gen_range.end.saturating_sub(span.gen_range.start)));
+    }
+
+    let relative = source_offset.saturating_sub(mapping.src_range.start);
+    mapping.gen_range.start.saturating_add(
+        relative.min(
+            mapping
+                .gen_range
+                .end
+                .saturating_sub(mapping.gen_range.start),
+        ),
+    )
+}
+
+pub(crate) fn map_canonical_corsa_locations(
+    ctx: &IdeContext<'_>,
+    doc: &CanonicalVirtualDocument,
+    locations: Vec<LspLocation>,
+) -> Vec<Location> {
+    locations
+        .iter()
+        .filter_map(|location| map_canonical_corsa_location(ctx, doc, location))
+        .collect()
+}
+
+pub(crate) fn map_canonical_corsa_location(
+    ctx: &IdeContext<'_>,
+    doc: &CanonicalVirtualDocument,
+    location: &LspLocation,
+) -> Option<Location> {
+    if location_matches_uri(&location.uri, doc.request_uri.as_str())
+        || super::virtual_document_path(&location.uri).as_deref()
+            == Some(canonical_request_path(ctx.uri).as_str())
+    {
+        let range = map_canonical_lsp_range(ctx, doc, &location.range)?;
+        return Some(Location {
+            uri: ctx.uri.clone(),
+            range,
+        });
+    }
+
+    if let Some(location) = map_vue_virtual_mirror_location(location) {
+        return Some(location);
+    }
+
+    let uri = Url::parse(&location.uri).ok()?;
+    Some(Location {
+        uri,
+        range: Range {
+            start: tower_lsp::lsp_types::Position {
+                line: location.range.start.line,
+                character: location.range.start.character,
+            },
+            end: tower_lsp::lsp_types::Position {
+                line: location.range.end.line,
+                character: location.range.end.character,
+            },
+        },
+    })
+}
+
+pub(crate) fn map_canonical_lsp_range(
+    ctx: &IdeContext<'_>,
+    doc: &CanonicalVirtualDocument,
+    range: &vize_canon::LspRange,
+) -> Option<Range> {
+    let generated_start_post = crate::ide::position_to_offset(
+        &doc.virtual_result.code,
+        range.start.line,
+        range.start.character,
+    )?;
+    let generated_end_post = crate::ide::position_to_offset(
+        &doc.virtual_result.code,
+        range.end.line,
+        range.end.character,
+    )
+    .unwrap_or(generated_start_post);
+
+    let generated_start_pre = doc
+        .virtual_result
+        .import_source_map
+        .get_original_offset(generated_start_post as u32) as usize;
+    let generated_end_pre = doc
+        .virtual_result
+        .import_source_map
+        .get_original_offset(generated_end_post as u32) as usize;
+
+    let start_mapping =
+        mapping_for_generated_offset(&doc.virtual_result.source_mappings, generated_start_pre)?;
+    let source_start = map_generated_offset_to_source(start_mapping, generated_start_pre, false);
+    let source_end =
+        mapping_for_generated_offset(&doc.virtual_result.source_mappings, generated_end_pre)
+            .map(|mapping| map_generated_offset_to_source(mapping, generated_end_pre, true))
+            .unwrap_or_else(|| {
+                source_start
+                    .saturating_add(generated_end_pre.saturating_sub(generated_start_pre))
+                    .min(start_mapping.src_range.end)
+            })
+            .max(source_start);
+
+    let (start_line, start_character) = crate::ide::offset_to_position(&ctx.content, source_start);
+    let (end_line, end_character) = crate::ide::offset_to_position(&ctx.content, source_end);
+
+    Some(Range {
+        start: tower_lsp::lsp_types::Position {
+            line: start_line,
+            character: start_character,
+        },
+        end: tower_lsp::lsp_types::Position {
+            line: end_line,
+            character: end_character,
+        },
+    })
+}
+
+fn mapping_for_generated_offset(
+    mappings: &[vize_canon::virtual_ts::VizeMapping],
+    offset: usize,
+) -> Option<&vize_canon::virtual_ts::VizeMapping> {
+    mappings
+        .iter()
+        .filter(|mapping| offset >= mapping.gen_range.start && offset <= mapping.gen_range.end)
+        .min_by_key(|mapping| {
+            mapping
+                .gen_range
+                .end
+                .saturating_sub(mapping.gen_range.start)
+        })
+}
+
+fn map_generated_offset_to_source(
+    mapping: &vize_canon::virtual_ts::VizeMapping,
+    generated_offset: usize,
+    prefer_end: bool,
+) -> usize {
+    if let Some(span) = mapping.sub_spans.iter().find(|span| {
+        generated_offset >= span.gen_range.start && generated_offset <= span.gen_range.end
+    }) {
+        let relative = generated_offset.saturating_sub(span.gen_range.start);
+        let source_len = span.src_range.end.saturating_sub(span.src_range.start);
+        return span
+            .src_range
+            .start
+            .saturating_add(relative.min(source_len));
+    }
+
+    if prefer_end && generated_offset >= mapping.gen_range.end {
+        return mapping.src_range.end;
+    }
+
+    let relative = generated_offset.saturating_sub(mapping.gen_range.start);
+    let source_len = mapping
+        .src_range
+        .end
+        .saturating_sub(mapping.src_range.start);
+    mapping
+        .src_range
+        .start
+        .saturating_add(relative.min(source_len))
+}
+
+fn location_matches_uri(actual: &str, expected: &str) -> bool {
+    actual == expected
+        || super::virtual_document_path(actual).as_deref()
+            == super::virtual_document_path(expected).as_deref()
+}
+
+fn map_vue_virtual_mirror_location(location: &LspLocation) -> Option<Location> {
+    let parsed = Url::parse(&location.uri).ok()?;
+    let path = parsed.to_file_path().ok()?;
+    let file_name = path.file_name()?.to_str()?;
+    let vue_file_name = file_name.strip_suffix(".ts")?;
+    if !vue_file_name.ends_with(".vue") {
+        return None;
+    }
+
+    let source_path = path.with_file_name(vue_file_name);
+    if !source_path.is_file() {
+        return None;
+    }
+
+    let uri = Url::from_file_path(source_path).ok()?;
+    Some(Location {
+        uri,
+        range: Range {
+            start: tower_lsp::lsp_types::Position {
+                line: 0,
+                character: 0,
+            },
+            end: tower_lsp::lsp_types::Position {
+                line: 0,
+                character: 0,
+            },
+        },
+    })
+}

--- a/crates/vize_maestro/src/ide/corsa_support/canonical_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical_tests.rs
@@ -1,0 +1,63 @@
+use tower_lsp::lsp_types::Url;
+
+use super::canonical::{
+    CanonicalVirtualDocument, canonical_request_path, canonical_source_offset_to_position,
+};
+use super::request_file_uri;
+
+#[test]
+fn canonical_source_offset_maps_template_expression_to_generated_position() {
+    let uri = Url::parse("file:///tmp/TypedTemplate.vue").expect("uri");
+    let source = r#"<script setup lang="ts">
+const user = { name: 'Ada' as string }
+</script>
+
+<template>
+  {{ user.name }}
+</template>
+"#;
+    let virtual_result =
+        crate::ide::DiagnosticService::generate_virtual_ts(&uri, source, false, false)
+            .expect("virtual ts");
+    let doc = CanonicalVirtualDocument {
+        request_uri: request_file_uri(canonical_request_path(&uri).as_str()),
+        virtual_result,
+    };
+
+    let source_offset = source.rfind("name").unwrap() + "na".len();
+    let (line, character) =
+        canonical_source_offset_to_position(&doc, source_offset).expect("mapped position");
+    let generated_offset =
+        crate::ide::position_to_offset(&doc.virtual_result.code, line, character)
+            .expect("generated offset");
+    let expected_offset = doc.virtual_result.code.find("user.name").unwrap() + "user.na".len();
+
+    assert_eq!(generated_offset, expected_offset);
+}
+
+#[test]
+fn canonical_source_offset_accounts_for_vue_import_rewrite_before_script_body() {
+    let uri = Url::parse("file:///tmp/Parent.vue").expect("uri");
+    let source = r#"<script setup lang="ts">
+import Child from "./Child.vue";
+const selected = Child;
+</script>
+"#;
+    let virtual_result =
+        crate::ide::DiagnosticService::generate_virtual_ts(&uri, source, false, false)
+            .expect("virtual ts");
+    let doc = CanonicalVirtualDocument {
+        request_uri: request_file_uri(canonical_request_path(&uri).as_str()),
+        virtual_result,
+    };
+
+    let source_offset = source.rfind("Child").unwrap() + "Ch".len();
+    let (line, character) =
+        canonical_source_offset_to_position(&doc, source_offset).expect("mapped position");
+    let generated_offset =
+        crate::ide::position_to_offset(&doc.virtual_result.code, line, character)
+            .expect("generated offset");
+    let expected_offset = doc.virtual_result.code.rfind("Child").unwrap() + "Ch".len();
+
+    assert_eq!(generated_offset, expected_offset);
+}

--- a/crates/vize_maestro/src/ide/corsa_support/html_tag.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_tag.rs
@@ -1,0 +1,65 @@
+use tower_lsp::lsp_types::Url;
+use vize_carton::{String, cstr};
+
+pub(crate) struct HtmlTagVirtualDocument {
+    pub(crate) content: String,
+    pub(crate) hover_offset: usize,
+    pub(crate) definition_offset: usize,
+}
+
+pub(crate) fn html_tag_request_path(uri: &Url) -> String {
+    cstr!("{}.html_tag.ts", uri.path())
+}
+
+pub(crate) fn html_tag_virtual_document(tag_name: &str) -> Option<HtmlTagVirtualDocument> {
+    if !is_native_html_tag_candidate(tag_name) {
+        return None;
+    }
+
+    let content = cstr!(
+        "/// <reference lib=\"es2022\" />\n\
+         /// <reference lib=\"dom\" />\n\
+         /// <reference lib=\"dom.iterable\" />\n\
+         type __VizeHtmlElement = HTMLElementTagNameMap[\"{tag_name}\"];\n\
+         declare const __vizeHtmlElement: __VizeHtmlElement;\n\
+         __vizeHtmlElement;\n"
+    );
+    let definition_offset = content.find("HTMLElementTagNameMap")?;
+    let hover_offset = content.rfind("__vizeHtmlElement")?;
+
+    Some(HtmlTagVirtualDocument {
+        content,
+        hover_offset,
+        definition_offset,
+    })
+}
+
+fn is_native_html_tag_candidate(tag_name: &str) -> bool {
+    !tag_name.is_empty()
+        && !matches!(
+            tag_name,
+            "component" | "template" | "slot" | "teleport" | "suspense"
+        )
+        && tag_name
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn html_tag_virtual_document_queries_lib_dom_types() {
+        let doc = super::html_tag_virtual_document("button").expect("html tag doc");
+
+        assert!(doc.content.contains("HTMLElementTagNameMap[\"button\"]"));
+        assert_eq!(
+            &doc.content
+                [doc.definition_offset..doc.definition_offset + "HTMLElementTagNameMap".len()],
+            "HTMLElementTagNameMap",
+        );
+        assert_eq!(
+            &doc.content[doc.hover_offset..doc.hover_offset + "__vizeHtmlElement".len()],
+            "__vizeHtmlElement",
+        );
+    }
+}

--- a/crates/vize_maestro/src/ide/corsa_support/workspace_edit.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/workspace_edit.rs
@@ -1,0 +1,151 @@
+use std::collections::HashMap;
+
+use tower_lsp::lsp_types::{
+    AnnotatedTextEdit, DocumentChangeOperation, DocumentChanges, OneOf, TextEdit, WorkspaceEdit,
+};
+
+use crate::ide::IdeContext;
+use crate::virtual_code::VirtualDocument;
+
+pub(crate) fn map_corsa_workspace_edit(
+    ctx: &IdeContext<'_>,
+    mut edit: WorkspaceEdit,
+) -> Option<WorkspaceEdit> {
+    if let Some(changes) = edit.changes.take() {
+        let mut mapped_changes = HashMap::with_capacity(changes.len());
+
+        for (uri, edits) in changes {
+            if let Some(current_doc) = super::match_current_virtual_document(ctx, uri.as_str()) {
+                let entry = mapped_changes
+                    .entry(ctx.uri.clone())
+                    .or_insert_with(Vec::new);
+                entry.extend(
+                    edits
+                        .into_iter()
+                        .filter_map(|edit| map_text_edit(ctx, current_doc.document(), edit)),
+                );
+            } else {
+                mapped_changes.insert(uri, edits);
+            }
+        }
+
+        if !mapped_changes.is_empty() {
+            edit.changes = Some(mapped_changes);
+        }
+    }
+
+    if let Some(document_changes) = edit.document_changes.take() {
+        let mapped_document_changes = match document_changes {
+            DocumentChanges::Edits(edits) => {
+                let edits = edits
+                    .into_iter()
+                    .filter_map(|edit| map_document_edit(ctx, edit))
+                    .collect::<Vec<_>>();
+
+                if edits.is_empty() {
+                    None
+                } else {
+                    Some(DocumentChanges::Edits(edits))
+                }
+            }
+            DocumentChanges::Operations(operations) => {
+                let operations = operations
+                    .into_iter()
+                    .filter_map(|operation| map_document_change_operation(ctx, operation))
+                    .collect::<Vec<_>>();
+
+                if operations.is_empty() {
+                    None
+                } else {
+                    Some(DocumentChanges::Operations(operations))
+                }
+            }
+        };
+
+        if let Some(document_changes) = mapped_document_changes {
+            edit.document_changes = Some(document_changes);
+        }
+    }
+
+    if workspace_edit_is_empty(&edit) {
+        None
+    } else {
+        Some(edit)
+    }
+}
+
+fn workspace_edit_is_empty(edit: &WorkspaceEdit) -> bool {
+    let changes_empty = edit
+        .changes
+        .as_ref()
+        .is_none_or(|changes| changes.values().all(Vec::is_empty));
+    let document_changes_empty =
+        edit.document_changes
+            .as_ref()
+            .is_none_or(|changes| match changes {
+                DocumentChanges::Edits(edits) => edits.is_empty(),
+                DocumentChanges::Operations(operations) => operations.is_empty(),
+            });
+
+    changes_empty && document_changes_empty
+}
+
+fn map_document_change_operation(
+    ctx: &IdeContext<'_>,
+    operation: DocumentChangeOperation,
+) -> Option<DocumentChangeOperation> {
+    match operation {
+        DocumentChangeOperation::Edit(edit) => {
+            map_document_edit(ctx, edit).map(DocumentChangeOperation::Edit)
+        }
+        DocumentChangeOperation::Op(op) => Some(DocumentChangeOperation::Op(op)),
+    }
+}
+
+fn map_document_edit(
+    ctx: &IdeContext<'_>,
+    mut edit: tower_lsp::lsp_types::TextDocumentEdit,
+) -> Option<tower_lsp::lsp_types::TextDocumentEdit> {
+    let current_doc = super::match_current_virtual_document(ctx, edit.text_document.uri.as_str());
+
+    if let Some(current_doc) = current_doc {
+        edit.text_document.uri = ctx.uri.clone();
+        edit.edits = edit
+            .edits
+            .into_iter()
+            .filter_map(|entry| match entry {
+                OneOf::Left(text_edit) => {
+                    map_text_edit(ctx, current_doc.document(), text_edit).map(OneOf::Left)
+                }
+                OneOf::Right(annotated) => {
+                    map_annotated_text_edit(ctx, current_doc.document(), annotated)
+                        .map(OneOf::Right)
+                }
+            })
+            .collect();
+    }
+
+    if edit.edits.is_empty() {
+        None
+    } else {
+        Some(edit)
+    }
+}
+
+fn map_annotated_text_edit(
+    ctx: &IdeContext<'_>,
+    document: &VirtualDocument,
+    mut edit: AnnotatedTextEdit,
+) -> Option<AnnotatedTextEdit> {
+    edit.text_edit = map_text_edit(ctx, document, edit.text_edit)?;
+    Some(edit)
+}
+
+fn map_text_edit(
+    ctx: &IdeContext<'_>,
+    document: &VirtualDocument,
+    mut edit: TextEdit,
+) -> Option<TextEdit> {
+    edit.range = super::map_virtual_range(ctx, document, &edit.range)?;
+    Some(edit)
+}

--- a/crates/vize_maestro/src/ide/definition/service.rs
+++ b/crates/vize_maestro/src/ide/definition/service.rs
@@ -133,6 +133,12 @@ impl super::DefinitionService {
             return Some(def);
         }
 
+        if let Some(definition) =
+            Self::definition_for_html_tag_with_corsa(ctx, corsa_bridge.as_ref()).await
+        {
+            return Some(definition);
+        }
+
         let word = helpers::get_word_at_offset(&ctx.content, ctx.offset)?;
 
         if word.is_empty() {
@@ -161,29 +167,18 @@ impl super::DefinitionService {
             }
         }
 
-        // Try Corsa definition lookup first.
-        if let Some(bridge) = corsa_bridge
-            && let Some(ref virtual_docs) = ctx.virtual_docs
-            && let Some(ref tmpl) = virtual_docs.template
-            && let Some(vts_offset) =
-                crate::ide::hover::HoverService::sfc_to_virtual_ts_offset(ctx, ctx.offset)
+        // Try Corsa definition lookup first via the canonical Vue virtual TS.
+        if let Some(bridge) = corsa_bridge.as_ref()
+            && bridge.is_initialized()
+            && let Some(doc) = corsa_support::open_canonical_virtual_document(ctx, bridge).await
+            && let Some((line, character)) =
+                corsa_support::canonical_source_offset_to_position(&doc, ctx.offset)
+            && let Ok(locations) = bridge.definition(&doc.request_uri, line, character).await
+            && !locations.is_empty()
         {
-            let (line, character) = crate::ide::offset_to_position(&tmpl.content, vts_offset);
-
-            if bridge.is_initialized() {
-                let vdoc_uri = corsa_support::template_request_path(ctx.uri);
-                let Ok(uri) = bridge
-                    .open_or_update_virtual_document(&vdoc_uri, &tmpl.content)
-                    .await
-                else {
-                    return template::definition_in_template(ctx);
-                };
-
-                if let Ok(locations) = bridge.definition(&uri, line, character).await
-                    && !locations.is_empty()
-                {
-                    return Self::convert_lsp_locations(locations, ctx);
-                }
+            let locations = corsa_support::map_canonical_corsa_locations(ctx, &doc, locations);
+            if let Some(response) = Self::convert_locations(locations) {
+                return Some(response);
             }
         }
 
@@ -212,41 +207,18 @@ impl super::DefinitionService {
             return None;
         }
 
-        let is_setup = matches!(ctx.block_type, Some(BlockType::ScriptSetup));
-
-        // Try Corsa definition lookup first.
-        if let Some(bridge) = corsa_bridge
-            && let Some(ref virtual_docs) = ctx.virtual_docs
+        // Try Corsa definition lookup first via the canonical Vue virtual TS.
+        if let Some(bridge) = corsa_bridge.as_ref()
+            && bridge.is_initialized()
+            && let Some(doc) = corsa_support::open_canonical_virtual_document(ctx, bridge).await
+            && let Some((line, character)) =
+                corsa_support::canonical_source_offset_to_position(&doc, ctx.offset)
+            && let Ok(locations) = bridge.definition(&doc.request_uri, line, character).await
+            && !locations.is_empty()
         {
-            let script_doc = if is_setup {
-                virtual_docs.script_setup.as_ref()
-            } else {
-                virtual_docs.script.as_ref()
-            };
-
-            if let Some(s) = script_doc
-                && let Some(vts_offset) =
-                    crate::ide::hover::HoverService::sfc_to_virtual_ts_script_offset(
-                        ctx, ctx.offset,
-                    )
-            {
-                let (line, character) = crate::ide::offset_to_position(&s.content, vts_offset);
-
-                if bridge.is_initialized() {
-                    let vdoc_uri = corsa_support::script_request_path(ctx.uri, is_setup);
-                    let Ok(uri) = bridge
-                        .open_or_update_virtual_document(&vdoc_uri, &s.content)
-                        .await
-                    else {
-                        return script::definition_in_script(ctx);
-                    };
-
-                    if let Ok(locations) = bridge.definition(&uri, line, character).await
-                        && !locations.is_empty()
-                    {
-                        return Self::convert_lsp_locations(locations, ctx);
-                    }
-                }
+            let locations = corsa_support::map_canonical_corsa_locations(ctx, &doc, locations);
+            if let Some(response) = Self::convert_locations(locations) {
+                return Some(response);
             }
         }
 
@@ -260,16 +232,48 @@ impl super::DefinitionService {
         locations: Vec<vize_canon::LspLocation>,
         ctx: &IdeContext<'_>,
     ) -> Option<GotoDefinitionResponse> {
-        if locations.len() == 1 {
-            corsa_support::map_corsa_location(ctx, &locations[0])
-                .map(GotoDefinitionResponse::Scalar)
-        } else {
-            let locs = corsa_support::map_corsa_locations(ctx, locations);
-            if locs.is_empty() {
-                None
-            } else {
-                Some(GotoDefinitionResponse::Array(locs))
-            }
+        let locations = corsa_support::map_corsa_locations(ctx, locations);
+        Self::convert_locations(locations)
+    }
+
+    #[cfg(feature = "native")]
+    fn convert_locations(
+        locations: Vec<tower_lsp::lsp_types::Location>,
+    ) -> Option<GotoDefinitionResponse> {
+        match locations.as_slice() {
+            [] => None,
+            [location] => Some(GotoDefinitionResponse::Scalar(location.clone())),
+            _ => Some(GotoDefinitionResponse::Array(locations)),
         }
+    }
+
+    #[cfg(feature = "native")]
+    async fn definition_for_html_tag_with_corsa(
+        ctx: &IdeContext<'_>,
+        corsa_bridge: Option<&Arc<CorsaBridge>>,
+    ) -> Option<GotoDefinitionResponse> {
+        let tag_name = helpers::get_tag_at_offset(&ctx.content, ctx.offset)?;
+        if is_component_tag(&tag_name) {
+            return None;
+        }
+
+        let bridge = corsa_bridge?;
+        if !bridge.is_initialized() {
+            return None;
+        }
+
+        let doc = corsa_support::html_tag_virtual_document(&tag_name)?;
+        let request_path = corsa_support::html_tag_request_path(ctx.uri);
+        let request_uri = bridge
+            .open_or_update_virtual_document(&request_path, &doc.content)
+            .await
+            .ok()?;
+        let (line, character) = crate::ide::offset_to_position(&doc.content, doc.definition_offset);
+        let locations = bridge
+            .definition(&request_uri, line, character)
+            .await
+            .ok()?;
+
+        Self::convert_lsp_locations(locations, ctx)
     }
 }

--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -10,7 +10,7 @@
 mod builder;
 mod collectors;
 #[cfg(feature = "native")]
-mod corsa;
+pub(in crate::ide) mod corsa;
 #[cfg(all(test, feature = "native"))]
 mod editor_typecheck_tests;
 mod line_index;

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
@@ -18,7 +18,7 @@ use vize_carton::cstr;
 /// logged and skipped — a missing sibling falls through to the existing
 /// TS2307 surface, which is the desired behavior for genuinely missing
 /// modules.
-pub(super) async fn overlay_sibling_vue_mirrors(
+pub(in crate::ide) async fn overlay_sibling_vue_mirrors(
     bridge: &std::sync::Arc<vize_canon::CorsaBridge>,
     host_uri: &Url,
     initial_specifiers: &[std::string::String],
@@ -107,7 +107,7 @@ pub(super) async fn overlay_sibling_vue_mirrors(
     }
 }
 
-pub(super) async fn overlay_relative_ts_imports(
+pub(in crate::ide) async fn overlay_relative_ts_imports(
     bridge: &std::sync::Arc<vize_canon::CorsaBridge>,
     host_uri: &Url,
     initial_specifiers: &[std::string::String],

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/mod.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/mod.rs
@@ -4,7 +4,7 @@
 //! LSP bridge to collect type-checking diagnostics.
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
-mod collect;
+pub(in crate::ide) mod collect;
 mod collect_virtual;
 mod mapping;
 mod message;

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts.rs
@@ -91,7 +91,7 @@ pub(super) fn collect_relative_ts_specifiers(
 
 impl DiagnosticService {
     /// Generate virtual TypeScript for a Vue SFC.
-    pub(in crate::ide::diagnostics) fn generate_virtual_ts(
+    pub(in crate::ide) fn generate_virtual_ts(
         uri: &Url,
         content: &str,
         options_api: bool,

--- a/crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs
@@ -52,6 +52,35 @@ fn async_collect_preserves_imported_computed_callback_types() {
 }
 
 #[test]
+fn async_collect_resolves_relative_vue_imports_in_script_setup() {
+    let Some(corsa_path) = resolve_test_tsgo_binary() else {
+        return;
+    };
+    let project = tempfile::TempDir::new().expect("temp project");
+    write_vue_import_fixture(project.path());
+    write_corsa_config(project.path(), &corsa_path);
+
+    let parent_path = project.path().join("src/Parent.vue");
+    let source = std::fs::read_to_string(&parent_path).expect("parent source");
+    let uri = Url::from_file_path(&parent_path).expect("file uri");
+    let state = state_for_fixture(project.path(), &uri, &source);
+    state.load_workspace_config(project.path());
+
+    let diagnostics = crate::runtime::block_on(DiagnosticService::collect_async(&state, &uri));
+
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| !diagnostic.message.contains("Cannot find module")),
+        "relative .vue imports must resolve via editor virtual mirrors: {diagnostics:#?}",
+    );
+    assert!(
+        diagnostics.is_empty(),
+        "expected clean editor diagnostics, got: {diagnostics:#?}",
+    );
+}
+
+#[test]
 fn virtual_ts_generates_template_less_sfc_mirror() {
     let uri = Url::parse("file:///tmp/SpeakerFilterBar.vue").expect("parse uri");
     let source = r#"<script setup lang="ts">
@@ -166,6 +195,51 @@ const speakerOptions = computed(() =>
     .to_string();
     std::fs::write(&vue_path, &source).expect("vue");
     SpeakerFixture { vue_path, source }
+}
+
+fn write_vue_import_fixture(root: &Path) {
+    let src = root.join("src");
+    std::fs::create_dir_all(&src).expect("src dir");
+    std::fs::write(
+        root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .expect("tsconfig");
+    std::fs::write(
+        src.join("Child.vue"),
+        r#"<script setup lang="ts">
+defineProps<{ label?: string }>();
+</script>
+
+<template>
+  <span>{{ label }}</span>
+</template>
+"#,
+    )
+    .expect("child vue");
+    std::fs::write(
+        src.join("Parent.vue"),
+        r#"<script setup lang="ts">
+import Child from "./Child.vue";
+
+const selected = Child;
+</script>
+
+<template>
+  <Child label="ready" />
+</template>
+"#,
+    )
+    .expect("parent vue");
 }
 
 fn write_corsa_config(root: &Path, corsa_path: &Path) {

--- a/crates/vize_maestro/src/ide/hover.rs
+++ b/crates/vize_maestro/src/ide/hover.rs
@@ -15,6 +15,8 @@
 
 #[cfg(feature = "native")]
 mod corsa;
+#[cfg(feature = "native")]
+mod html;
 mod script;
 mod template;
 
@@ -66,10 +68,6 @@ impl HoverService {
             BlockType::Art(_) => None,
         }
     }
-
-    // =========================================================================
-    // Style hover
-    // =========================================================================
 
     /// Get hover for style context.
     fn hover_style(ctx: &IdeContext, _index: usize) -> Option<Hover> {

--- a/crates/vize_maestro/src/ide/hover/html.rs
+++ b/crates/vize_maestro/src/ide/hover/html.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::Hover;
+use vize_canon::CorsaBridge;
+
+use super::HoverService;
+use crate::ide::IdeContext;
+
+impl HoverService {
+    pub(super) async fn hover_html_tag_with_corsa(
+        ctx: &IdeContext<'_>,
+        corsa_bridge: Option<&Arc<CorsaBridge>>,
+    ) -> Option<Hover> {
+        let tag_name =
+            crate::ide::definition::helpers::get_tag_at_offset(&ctx.content, ctx.offset)?;
+        if crate::ide::is_component_tag(&tag_name) {
+            return None;
+        }
+
+        let bridge = corsa_bridge?;
+        if !bridge.is_initialized() {
+            return None;
+        }
+
+        let doc = crate::ide::corsa_support::html_tag_virtual_document(&tag_name)?;
+        let request_path = crate::ide::corsa_support::html_tag_request_path(ctx.uri);
+        let request_uri = bridge
+            .open_or_update_virtual_document(&request_path, &doc.content)
+            .await
+            .ok()?;
+        let (line, character) = crate::ide::offset_to_position(&doc.content, doc.hover_offset);
+        let hover = bridge.hover(&request_uri, line, character).await.ok()??;
+
+        Some(Self::convert_lsp_hover(hover))
+    }
+}

--- a/crates/vize_maestro/src/ide/hover/script.rs
+++ b/crates/vize_maestro/src/ide/hover/script.rs
@@ -69,47 +69,28 @@ impl HoverService {
             return Some(hover);
         }
 
-        // Try to get type information from Corsa via virtual TypeScript.
-        if let Some(bridge) = corsa_bridge
-            && let Some(ref virtual_docs) = ctx.virtual_docs
+        // Try to get type information from Corsa via the canonical Vue virtual TS.
+        if let Some(bridge) = corsa_bridge.as_ref()
+            && bridge.is_initialized()
+            && let Some(doc) =
+                crate::ide::corsa_support::open_canonical_virtual_document(ctx, bridge).await
+            && let Some((line, character)) =
+                crate::ide::corsa_support::canonical_source_offset_to_position(&doc, ctx.offset)
+            && let Ok(Some(hover)) = bridge.hover(&doc.request_uri, line, character).await
         {
-            let script_doc = if is_setup {
-                virtual_docs.script_setup.as_ref()
-            } else {
-                virtual_docs.script.as_ref()
-            };
-
-            if let Some(script) = script_doc {
-                // Calculate position in virtual TS
-                if let Some(vts_offset) = Self::sfc_to_virtual_ts_script_offset(ctx, ctx.offset) {
-                    let (line, character) =
-                        crate::ide::offset_to_position(&script.content, vts_offset);
-                    let suffix = if is_setup { "setup.ts" } else { "script.ts" };
-
-                    // Open/update virtual document
-                    if bridge.is_initialized() {
-                        #[allow(clippy::disallowed_macros)]
-                        let doc_path = format!("{}.{suffix}", ctx.uri.path());
-                        let Ok(uri) = bridge
-                            .open_or_update_virtual_document(&doc_path, &script.content)
-                            .await
-                        else {
-                            return Self::hover_script(ctx, is_setup);
-                        };
-
-                        // Request hover from Corsa.
-                        if let Ok(Some(hover)) = bridge.hover(&uri, line, character).await {
-                            let converted = Self::convert_lsp_hover(hover);
-                            if hover_has_unknown_reactive_type(&converted)
-                                && let Some(fallback) = Self::hover_script(ctx, is_setup)
-                            {
-                                return Some(fallback);
-                            }
-                            return Some(converted);
-                        }
-                    }
-                }
+            let mapped_range = hover.range.as_ref().and_then(|range| {
+                crate::ide::corsa_support::map_canonical_lsp_range(ctx, &doc, range)
+            });
+            let mut converted = Self::convert_lsp_hover(hover);
+            if mapped_range.is_some() {
+                converted.range = mapped_range;
             }
+            if hover_has_unknown_reactive_type(&converted)
+                && let Some(fallback) = Self::hover_script(ctx, is_setup)
+            {
+                return Some(fallback);
+            }
+            return Some(converted);
         }
 
         // Fall back to croquis analysis

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -120,6 +120,9 @@ impl HoverService {
         }
 
         if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset) {
+            if let Some(hover) = Self::hover_html_tag_with_corsa(ctx, corsa_bridge.as_ref()).await {
+                return Some(hover);
+            }
             return None;
         }
 
@@ -129,33 +132,23 @@ impl HoverService {
             return Some(hover);
         }
 
-        // Try to get type information from Corsa via virtual TypeScript.
-        if let Some(bridge) = corsa_bridge
-            && let Some(ref virtual_docs) = ctx.virtual_docs
-            && let Some(ref template) = virtual_docs.template
+        // Try to get type information from Corsa via canonical virtual TypeScript.
+        if let Some(bridge) = corsa_bridge.as_ref()
+            && bridge.is_initialized()
+            && let Some(doc) =
+                crate::ide::corsa_support::open_canonical_virtual_document(ctx, bridge).await
+            && let Some((line, character)) =
+                crate::ide::corsa_support::canonical_source_offset_to_position(&doc, ctx.offset)
+            && let Ok(Some(hover)) = bridge.hover(&doc.request_uri, line, character).await
         {
-            // Calculate position in virtual TS
-            if let Some(vts_offset) = Self::sfc_to_virtual_ts_offset(ctx, ctx.offset) {
-                let (line, character) =
-                    crate::ide::offset_to_position(&template.content, vts_offset);
-
-                // Open/update virtual document
-                if bridge.is_initialized() {
-                    #[allow(clippy::disallowed_macros)]
-                    let vdoc_uri = format!("{}.template.ts", ctx.uri.path());
-                    let Ok(uri) = bridge
-                        .open_or_update_virtual_document(&vdoc_uri, &template.content)
-                        .await
-                    else {
-                        return Self::hover_template(ctx);
-                    };
-
-                    // Request hover from Corsa.
-                    if let Ok(Some(hover)) = bridge.hover(&uri, line, character).await {
-                        return Some(Self::convert_lsp_hover(hover));
-                    }
-                }
+            let mapped_range = hover.range.as_ref().and_then(|range| {
+                crate::ide::corsa_support::map_canonical_lsp_range(ctx, &doc, range)
+            });
+            let mut converted = Self::convert_lsp_hover(hover);
+            if mapped_range.is_some() {
+                converted.range = mapped_range;
             }
+            return Some(converted);
         }
 
         // Fall back to croquis analysis


### PR DESCRIPTION
## Summary
- route Vue template/script hover and definition Corsa requests through the canonical .vue.ts virtual document
- map canonical Corsa locations and ranges back to the source SFC, including rewritten .vue imports
- add a lib.dom-backed virtual query for native HTML element hover/definition
- cover canonical offset mapping and relative .vue import diagnostics regressions

## Validation
- cargo test -p vize_maestro
- cargo test -p vize_maestro --features native

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->