### PR TITLE
fix: centralize Vue Corsa virtual project sync

### DIFF
--- a/crates/vize_canon/src/corsa_bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge.rs
@@ -6,6 +6,8 @@
 
 mod bridge;
 mod types;
+mod vue_dependencies;
+mod vue_document;
 
 pub use bridge::{BatchTypeChecker, CorsaBridge};
 pub use types::{
@@ -14,6 +16,8 @@ pub use types::{
     LspHoverContents, LspLocation, LspLocationLink, LspMarkedString, LspMarkupContent, LspPosition,
     LspRange, TypeCheckResult, VIRTUAL_URI_SCHEME,
 };
+pub use vue_document::{CorsaVueVirtualDocument, CorsaVueVirtualDocumentOptions};
+pub(crate) use vue_document::{CorsaVueVirtualProject, build_vue_virtual_project};
 
 #[cfg(test)]
 mod tests {

--- a/crates/vize_canon/src/corsa_bridge/bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge.rs
@@ -439,7 +439,7 @@ impl CorsaBridge {
         Ok(Vec::new())
     }
 
-    async fn with_client<R, F>(&self, f: F) -> Result<R, CorsaBridgeError>
+    pub(super) async fn with_client<R, F>(&self, f: F) -> Result<R, CorsaBridgeError>
     where
         F: FnOnce(&mut CorsaProjectClient) -> Result<R, CorsaBridgeError>,
     {

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -1,0 +1,288 @@
+//! Dependency graph collection for Vue editor virtual documents.
+
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+
+use oxc_span::SourceType;
+use vize_carton::{FxHashSet, String, ToCompactString};
+
+use super::bridge::normalize_document_uri;
+use super::vue_document::{
+    CorsaVueVirtualDocumentOptions, GeneratedVueDocument, generate_vue_document,
+};
+use crate::batch::ImportRewriter;
+use crate::file_uri::path_to_file_uri;
+
+pub(super) fn collect_dependency_documents(
+    documents: &mut Vec<(String, String)>,
+    host: &GeneratedVueDocument,
+    options: CorsaVueVirtualDocumentOptions,
+    rewriter: &ImportRewriter,
+) {
+    let mut visited_vue = FxHashSet::<PathBuf>::default();
+    visited_vue.insert(host.source_path.clone());
+    let mut visited_ts = FxHashSet::<PathBuf>::default();
+    let mut queue = VecDeque::<DependencyScan>::new();
+    queue.push_back(DependencyScan::Vue {
+        dir: parent_dir(&host.source_path),
+        source_type: host.generated.source_type,
+        pre_rewrite_code: host.generated.pre_rewrite_code.clone(),
+    });
+
+    while let Some(scan) = queue.pop_front() {
+        match scan {
+            DependencyScan::Vue {
+                dir,
+                source_type,
+                pre_rewrite_code,
+            } => queue_imports(
+                ImportQueue {
+                    documents,
+                    queue: &mut queue,
+                    visited_vue: &mut visited_vue,
+                    visited_ts: &mut visited_ts,
+                },
+                options,
+                rewriter,
+                &dir,
+                &pre_rewrite_code,
+                source_type,
+            ),
+            DependencyScan::Script {
+                path,
+                source_type,
+                content,
+            } => queue_imports(
+                ImportQueue {
+                    documents,
+                    queue: &mut queue,
+                    visited_vue: &mut visited_vue,
+                    visited_ts: &mut visited_ts,
+                },
+                options,
+                rewriter,
+                &parent_dir(&path),
+                &content,
+                source_type,
+            ),
+        }
+    }
+}
+
+struct ImportQueue<'a> {
+    documents: &'a mut Vec<(String, String)>,
+    queue: &'a mut VecDeque<DependencyScan>,
+    visited_vue: &'a mut FxHashSet<PathBuf>,
+    visited_ts: &'a mut FxHashSet<PathBuf>,
+}
+
+enum DependencyScan {
+    Vue {
+        dir: PathBuf,
+        source_type: SourceType,
+        pre_rewrite_code: String,
+    },
+    Script {
+        path: PathBuf,
+        source_type: SourceType,
+        content: String,
+    },
+}
+
+fn queue_imports(
+    mut imports: ImportQueue<'_>,
+    options: CorsaVueVirtualDocumentOptions,
+    rewriter: &ImportRewriter,
+    dir: &Path,
+    code: &str,
+    source_type: SourceType,
+) {
+    queue_vue_imports(&mut imports, options, rewriter, dir, code, source_type);
+    queue_ts_imports(&mut imports, dir, code, source_type);
+}
+
+fn queue_vue_imports(
+    imports: &mut ImportQueue<'_>,
+    options: CorsaVueVirtualDocumentOptions,
+    rewriter: &ImportRewriter,
+    dir: &Path,
+    code: &str,
+    source_type: SourceType,
+) {
+    for specifier in rewriter.collect_relative_vue_specifiers(code, source_type) {
+        let path = normalize_path(&dir.join(specifier.as_str()));
+        let key = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+        if !imports.visited_vue.insert(key) {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(generated) = generate_vue_document(&path, &content, options, rewriter) else {
+            continue;
+        };
+        imports.documents.push((
+            generated.virtual_uri.clone(),
+            generated.generated.code.clone(),
+        ));
+        imports.queue.push_back(DependencyScan::Vue {
+            dir: parent_dir(&generated.source_path),
+            source_type: generated.generated.source_type,
+            pre_rewrite_code: generated.generated.pre_rewrite_code,
+        });
+    }
+}
+
+fn queue_ts_imports(
+    imports: &mut ImportQueue<'_>,
+    dir: &Path,
+    code: &str,
+    source_type: SourceType,
+) {
+    for specifier in collect_relative_ts_specifiers(code, source_type) {
+        let Some(path) = resolve_relative_script_import(dir, specifier.as_str()) else {
+            continue;
+        };
+        let key = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+        if !imports.visited_ts.insert(key) {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let uri = normalize_document_uri(path_to_file_uri(&path).as_str());
+        imports.documents.push((uri, content.to_compact_string()));
+        imports.queue.push_back(DependencyScan::Script {
+            path: path.clone(),
+            source_type: source_type_for_path(&path),
+            content: content.into(),
+        });
+    }
+}
+
+fn collect_relative_ts_specifiers(code: &str, source_type: SourceType) -> Vec<String> {
+    use oxc_allocator::Allocator;
+    use oxc_ast::ast::{Expression, Statement};
+    use oxc_ast_visit::Visit;
+    use oxc_parser::Parser;
+
+    let allocator = Allocator::default();
+    let result = Parser::new(&allocator, code, source_type).parse();
+    let mut specifiers = Vec::new();
+    let mut push = |path: &str| {
+        if (path.starts_with("./") || path.starts_with("../"))
+            && !path.ends_with(".vue")
+            && !path.ends_with(".vue.ts")
+            && !specifiers.iter().any(|known| known == path)
+        {
+            specifiers.push(path.to_compact_string());
+        }
+    };
+
+    for stmt in &result.program.body {
+        match stmt {
+            Statement::ImportDeclaration(decl) => push(&decl.source.value),
+            Statement::ExportNamedDeclaration(decl) => {
+                if let Some(source) = &decl.source {
+                    push(&source.value);
+                }
+            }
+            Statement::ExportAllDeclaration(decl) => push(&decl.source.value),
+            _ => {}
+        }
+    }
+
+    struct DynamicImportCollector {
+        imports: Vec<String>,
+    }
+    impl<'a> Visit<'a> for DynamicImportCollector {
+        fn visit_import_expression(&mut self, expr: &oxc_ast::ast::ImportExpression<'a>) {
+            if let Expression::StringLiteral(lit) = &expr.source {
+                self.imports.push(lit.value.as_str().to_compact_string());
+            }
+            oxc_ast_visit::walk::walk_import_expression(self, expr);
+        }
+    }
+
+    let mut collector = DynamicImportCollector {
+        imports: Vec::new(),
+    };
+    collector.visit_program(&result.program);
+    for path in collector.imports {
+        push(&path);
+    }
+
+    specifiers
+}
+
+fn resolve_relative_script_import(dir: &Path, specifier: &str) -> Option<PathBuf> {
+    let base = dir.join(specifier);
+    if base.extension().is_some() {
+        return known_script_path(&base).then(|| normalize_path(&base));
+    }
+
+    for ext in ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"] {
+        let candidate = base.with_extension(ext);
+        if candidate.exists() {
+            return Some(normalize_path(&candidate));
+        }
+    }
+    for name in [
+        "index.ts",
+        "index.tsx",
+        "index.mts",
+        "index.cts",
+        "index.js",
+        "index.jsx",
+        "index.mjs",
+        "index.cjs",
+        "index.d.ts",
+    ] {
+        let candidate = base.join(name);
+        if candidate.exists() {
+            return Some(normalize_path(&candidate));
+        }
+    }
+    None
+}
+
+fn known_script_path(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    path.exists()
+        && (name.ends_with(".ts")
+            || name.ends_with(".tsx")
+            || name.ends_with(".mts")
+            || name.ends_with(".cts")
+            || name.ends_with(".js")
+            || name.ends_with(".jsx")
+            || name.ends_with(".mjs")
+            || name.ends_with(".cjs"))
+}
+
+fn source_type_for_path(path: &Path) -> SourceType {
+    SourceType::from_path(path).unwrap_or_else(|_| SourceType::ts())
+}
+
+fn parent_dir(path: &Path) -> PathBuf {
+    path.parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| path.to_path_buf())
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push("..");
+                }
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -1,0 +1,198 @@
+//! Vue virtual-document synchronization for editor Corsa sessions.
+
+use std::path::{Path, PathBuf};
+
+use oxc_span::SourceType;
+use vize_carton::{String, cstr};
+
+use super::bridge::CorsaBridge;
+use super::types::CorsaBridgeError;
+use super::vue_dependencies::collect_dependency_documents;
+use crate::batch::{
+    ImportRewriter, ImportSourceMap, VueDocumentVirtualTs, VueDocumentVirtualTsOptions,
+    generate_vue_document_virtual_ts_with_options,
+};
+use crate::file_uri::path_to_file_uri;
+use crate::virtual_ts::{VirtualTsOptions, VizeMapping};
+
+/// Options for opening a Vue SFC as a canonical Corsa virtual document.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CorsaVueVirtualDocumentOptions {
+    pub options_api: bool,
+    pub legacy_vue2: bool,
+}
+
+/// A Vue SFC projected into the TypeScript document queried by Corsa.
+pub struct CorsaVueVirtualDocument {
+    pub request_uri: String,
+    pub code: String,
+    pub pre_rewrite_code: String,
+    pub mappings: Vec<VizeMapping>,
+    pub import_source_map: ImportSourceMap,
+    pub source_type: SourceType,
+    pub virtual_suffix: &'static str,
+}
+
+pub(crate) struct CorsaVueVirtualProject {
+    pub(crate) host: CorsaVueVirtualDocument,
+    pub(crate) documents: Vec<(String, String)>,
+}
+
+pub(super) struct GeneratedVueDocument {
+    pub(super) source_path: PathBuf,
+    pub(super) virtual_uri: String,
+    pub(super) generated: VueDocumentVirtualTs,
+}
+
+impl CorsaBridge {
+    /// Generate, sync, and return the canonical `.vue.{ts,tsx}` document used
+    /// for editor diagnostics, hover, definition, references, and rename.
+    pub async fn open_vue_virtual_document(
+        &self,
+        source_path: &Path,
+        content: &str,
+        options: CorsaVueVirtualDocumentOptions,
+    ) -> Result<CorsaVueVirtualDocument, CorsaBridgeError> {
+        let project = build_vue_virtual_project(source_path, content, options)?;
+        self.open_virtual_documents_batch(&project.documents)
+            .await?;
+        Ok(project.host)
+    }
+
+    async fn open_virtual_documents_batch(
+        &self,
+        documents: &[(String, String)],
+    ) -> Result<(), CorsaBridgeError> {
+        let docs: Vec<(&str, &str)> = documents
+            .iter()
+            .map(|(uri, content)| (uri.as_str(), content.as_str()))
+            .collect();
+        let cache_len = self
+            .with_client(move |client| {
+                client
+                    .did_open_batch_fast(&docs)
+                    .map_err(CorsaBridgeError::CommunicationError)?;
+                Ok(client.diagnostics_cache_len())
+            })
+            .await?;
+        self.cache_stats().set_entries(cache_len as u64);
+        Ok(())
+    }
+}
+
+pub(crate) fn build_vue_virtual_project(
+    source_path: &Path,
+    content: &str,
+    options: CorsaVueVirtualDocumentOptions,
+) -> Result<CorsaVueVirtualProject, CorsaBridgeError> {
+    let rewriter = ImportRewriter::new();
+    let host = generate_vue_document(source_path, content, options, &rewriter)?;
+    let mut documents = vec![(host.virtual_uri.clone(), host.generated.code.clone())];
+    collect_dependency_documents(&mut documents, &host, options, &rewriter);
+
+    let generated = host.generated;
+    Ok(CorsaVueVirtualProject {
+        host: CorsaVueVirtualDocument {
+            request_uri: host.virtual_uri,
+            code: generated.code,
+            pre_rewrite_code: generated.pre_rewrite_code,
+            mappings: generated.mappings,
+            import_source_map: generated.import_source_map,
+            source_type: generated.source_type,
+            virtual_suffix: generated.virtual_suffix,
+        },
+        documents,
+    })
+}
+
+pub(super) fn generate_vue_document(
+    source_path: &Path,
+    content: &str,
+    options: CorsaVueVirtualDocumentOptions,
+    rewriter: &ImportRewriter,
+) -> Result<GeneratedVueDocument, CorsaBridgeError> {
+    let generated = generate_vue_document_virtual_ts_with_options(
+        source_path,
+        content,
+        &VirtualTsOptions::default(),
+        rewriter,
+        false,
+        VueDocumentVirtualTsOptions {
+            options_api: options.options_api,
+            legacy_vue2: options.legacy_vue2,
+        },
+    )
+    .map_err(|error| CorsaBridgeError::CommunicationError(cstr!("{error}")))?;
+    let virtual_path = source_path.with_file_name(cstr!(
+        "{}{}",
+        source_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default(),
+        generated.virtual_suffix
+    ));
+    let virtual_uri = path_to_file_uri(&virtual_path);
+
+    Ok(GeneratedVueDocument {
+        source_path: source_path.to_path_buf(),
+        virtual_uri,
+        generated,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CorsaVueVirtualDocumentOptions, build_vue_virtual_project};
+    use crate::file_uri::path_to_file_uri;
+
+    #[test]
+    fn vue_virtual_project_syncs_relative_vue_and_ts_dependencies() {
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = project.path().join("src");
+        std::fs::create_dir_all(&src).expect("src dir");
+
+        let host_path = src.join("Host.vue");
+        let child_path = src.join("Child.vue");
+        let util_path = src.join("util.ts");
+        std::fs::write(
+            &host_path,
+            r#"<script setup lang="ts">
+import Child from "./Child.vue";
+import { value } from "./util";
+const current = value;
+</script>
+<template><Child :value="current" /></template>
+"#,
+        )
+        .expect("host");
+        std::fs::write(
+            &child_path,
+            r#"<script setup lang="ts">
+defineProps<{ value: number }>();
+</script>
+<template><span /></template>
+"#,
+        )
+        .expect("child");
+        std::fs::write(&util_path, "export const value = 1;\n").expect("util");
+
+        let host = std::fs::read_to_string(&host_path).expect("host source");
+        let virtual_project =
+            build_vue_virtual_project(&host_path, &host, CorsaVueVirtualDocumentOptions::default())
+                .expect("virtual project");
+        let uris: Vec<&str> = virtual_project
+            .documents
+            .iter()
+            .map(|(uri, _)| uri.as_str())
+            .collect();
+
+        assert!(virtual_project.host.code.contains("\"./Child.vue.ts\""));
+        assert!(uris.contains(&path_to_file_uri(&src.join("Host.vue.ts")).as_str()));
+        assert!(uris.contains(&path_to_file_uri(&src.join("Child.vue.ts")).as_str()));
+        assert!(
+            uris.contains(&path_to_file_uri(&util_path).as_str()),
+            "uris: {uris:?}\n{}",
+            virtual_project.host.pre_rewrite_code,
+        );
+    }
+}

--- a/crates/vize_canon/src/corsa_server.rs
+++ b/crates/vize_canon/src/corsa_server.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 #[allow(clippy::disallowed_types)]
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use vize_carton::{FxHashMap, FxHashSet, String, cstr};
+use vize_carton::{FxHashMap, String, cstr};
 
 /// JSON-RPC Request
 #[derive(Debug, Deserialize)]
@@ -106,8 +106,6 @@ pub struct CorsaServer {
     cache: FxHashMap<String, String>,
     /// Project-session client for Corsa (lazy initialized).
     corsa_client: Option<crate::corsa_client::CorsaProjectClient>,
-    /// Virtual documents currently synced into the persistent Corsa session.
-    open_virtual_documents: FxHashSet<String>,
 }
 
 impl CorsaServer {
@@ -124,7 +122,6 @@ impl CorsaServer {
             running: Arc::new(AtomicBool::new(false)),
             cache: FxHashMap::default(),
             corsa_client: None,
-            open_virtual_documents: FxHashSet::default(),
         }
     }
 
@@ -314,27 +311,15 @@ impl CorsaServer {
     fn check_vue_sfc(&mut self, uri: &str, content: &str) -> Result<CheckResult, String> {
         use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
 
-        // Reuse the canon batch virtual-TS pipeline (issue #1389) so the
-        // socket-mode single-document path and `vize check` generate identical
-        // virtual TS for the same input. The shared generator keeps the shared
-        // preamble inline (`hoist_shared_preamble = false`) because this session
-        // overlays standalone documents and has no program-wide helpers file.
-        let rewriter = crate::batch::ImportRewriter::new();
-        let generated = crate::batch::generate_vue_document_virtual_ts(
-            Path::new(uri),
+        let source_path =
+            uri_to_path(uri, &self.working_dir()).unwrap_or_else(|| PathBuf::from(uri));
+        let project = crate::corsa_bridge::build_vue_virtual_project(
+            &source_path,
             content,
-            &crate::virtual_ts::VirtualTsOptions::default(),
-            &rewriter,
-            false,
+            Default::default(),
         )
         .map_err(|e| cstr!("Failed to generate virtual TS: {e}"))?;
-
-        // Issue #752: the rewritten form resolves `.vue` siblings via the same
-        // `.vue.ts` virtual mirrors used by the batch path. The cached
-        // `virtual_ts` intentionally reflects what we ship to Corsa (rewritten
-        // form), so consumers that introspect the cache see the same
-        // coordinates.
-        let virtual_ts: String = generated.code;
+        let virtual_ts = project.host.code.clone();
         self.cache.insert(uri.into(), virtual_ts.clone());
 
         // The SFC compile diagnostic still needs the descriptor; parse it once
@@ -348,17 +333,8 @@ impl CorsaServer {
         )
         .map_err(|e| cstr!("Failed to parse SFC: {}", e.message))?;
 
-        // Overlay sibling .vue.ts mirrors discovered from the host's imports.
-        let relative_specifiers = rewriter.collect_relative_vue_specifiers(
-            generated.pre_rewrite_code.as_str(),
-            generated.source_type,
-        );
-        if !relative_specifiers.is_empty() {
-            self.overlay_sibling_vue_mirrors(uri, &relative_specifiers);
-        }
-
         // Run Corsa on the virtual TypeScript through the project-session API.
-        let mut diagnostics = self.run_corsa(uri, &virtual_ts, generated.virtual_suffix)?;
+        let mut diagnostics = self.run_corsa(&project)?;
 
         // Merge in Vue-specific compile errors (e.g. props destructure default type
         // mismatch) so the socket-mode check matches the direct `vize check` runner.
@@ -378,9 +354,7 @@ impl CorsaServer {
     /// Run Corsa on TypeScript content and parse diagnostics via project sessions.
     fn run_corsa(
         &mut self,
-        uri: &str,
-        content: &str,
-        virtual_suffix: &str,
+        project: &crate::corsa_bridge::CorsaVueVirtualProject,
     ) -> Result<Vec<Diagnostic>, String> {
         if self.corsa_client.is_none() {
             let client = crate::corsa_client::CorsaProjectClient::new(
@@ -390,19 +364,18 @@ impl CorsaServer {
             self.corsa_client = Some(client);
         }
 
-        let virtual_uri = self.virtual_uri_for(uri, virtual_suffix);
         let client = self
             .corsa_client
             .as_mut()
             .expect("corsa_client must be initialized above");
 
-        if self.open_virtual_documents.contains(virtual_uri.as_str()) {
-            client.did_change(&virtual_uri, content)?;
-        } else {
-            client.did_open(&virtual_uri, content)?;
-            self.open_virtual_documents.insert(virtual_uri.clone());
-        }
-        let corsa_diagnostics = client.request_diagnostics(&virtual_uri)?;
+        let documents: Vec<(&str, &str)> = project
+            .documents
+            .iter()
+            .map(|(uri, content)| (uri.as_str(), content.as_str()))
+            .collect();
+        client.did_open_batch_fast(&documents)?;
+        let corsa_diagnostics = client.request_diagnostics(&project.host.request_uri)?;
 
         // Convert Corsa's editor-style diagnostics to the server payload.
         let diagnostics = corsa_diagnostics
@@ -433,124 +406,6 @@ impl CorsaServer {
         Ok(diagnostics)
     }
 
-    /// Overlay sibling `.vue.ts` mirrors for every relative `.vue` import,
-    /// recursively, so socket-mode Corsa can resolve `import App from
-    /// './app.vue'` (issue #752). Errors are logged and skipped so a missing
-    /// sibling still surfaces as TS2307 from the host check.
-    fn overlay_sibling_vue_mirrors(&mut self, host_uri: &str, initial_specifiers: &[String]) {
-        let Some(host_path) = uri_to_path(host_uri, &self.working_dir()) else {
-            tracing::debug!("overlay_sibling_vue_mirrors: cannot resolve host path: {host_uri}");
-            return;
-        };
-        let host_dir = match host_path.parent() {
-            Some(dir) => dir.to_path_buf(),
-            None => return,
-        };
-
-        let mut visited: FxHashSet<PathBuf> = FxHashSet::default();
-        visited.insert(host_path.clone());
-
-        let mut queue: Vec<(PathBuf, Vec<String>)> = vec![(
-            host_dir,
-            initial_specifiers
-                .iter()
-                .map(|s| s.as_str().into())
-                .collect(),
-        )];
-        let rewriter = crate::batch::ImportRewriter::new();
-
-        while let Some((dir, specifiers)) = queue.pop() {
-            for specifier in specifiers {
-                let resolved = dir.join(&specifier);
-                let canonical = std::fs::canonicalize(&resolved).unwrap_or(resolved);
-                if !visited.insert(canonical.clone()) {
-                    continue;
-                }
-
-                let sibling_content = match std::fs::read_to_string(&canonical) {
-                    Ok(text) => text,
-                    Err(err) => {
-                        tracing::debug!(
-                            "socket overlay sibling skipped — read failed for {}: {err}",
-                            canonical.display(),
-                        );
-                        continue;
-                    }
-                };
-
-                // Reuse the shared canon batch generator (issue #1389) so
-                // overlaid siblings are byte-identical to the host document and
-                // to `vize check`.
-                let Ok(sibling_generated) = crate::batch::generate_vue_document_virtual_ts(
-                    canonical.as_path(),
-                    &sibling_content,
-                    &crate::virtual_ts::VirtualTsOptions::default(),
-                    &rewriter,
-                    false,
-                ) else {
-                    continue;
-                };
-                let sibling_uri = crate::file_uri::path_to_file_uri(&canonical);
-                let sibling_virtual_uri =
-                    self.virtual_uri_for(&sibling_uri, sibling_generated.virtual_suffix);
-                let sibling_virtual_ts: String = sibling_generated.code;
-
-                let client = match self.corsa_client.as_mut() {
-                    Some(client) => client,
-                    None => return,
-                };
-
-                let result = if self
-                    .open_virtual_documents
-                    .contains(sibling_virtual_uri.as_str())
-                {
-                    client.did_change(&sibling_virtual_uri, &sibling_virtual_ts)
-                } else {
-                    let r = client.did_open(&sibling_virtual_uri, &sibling_virtual_ts);
-                    if r.is_ok() {
-                        self.open_virtual_documents
-                            .insert(sibling_virtual_uri.clone());
-                    }
-                    r
-                };
-                if let Err(err) = result {
-                    tracing::debug!(
-                        "socket overlay sibling failed for {}: {err}",
-                        canonical.display(),
-                    );
-                    continue;
-                }
-
-                let next_specifiers = rewriter.collect_relative_vue_specifiers(
-                    sibling_generated.pre_rewrite_code.as_str(),
-                    sibling_generated.source_type,
-                );
-                if !next_specifiers.is_empty() {
-                    let next_dir = canonical
-                        .parent()
-                        .map(|p| p.to_path_buf())
-                        .unwrap_or_else(|| canonical.clone());
-                    queue.push((next_dir, next_specifiers));
-                }
-            }
-        }
-    }
-
-    fn virtual_uri_for(&self, uri: &str, virtual_suffix: &str) -> String {
-        if uri.starts_with("file://") || uri.contains("://") {
-            return cstr!("{uri}{virtual_suffix}");
-        }
-
-        let virtual_path = cstr!("{uri}{virtual_suffix}");
-        let path = Path::new(virtual_path.as_str());
-        let path = if path.is_absolute() {
-            path.to_path_buf()
-        } else {
-            self.working_dir().join(path)
-        };
-        crate::file_uri::path_to_file_uri(&path)
-    }
-
     fn working_dir(&self) -> PathBuf {
         self.config
             .working_dir
@@ -577,10 +432,9 @@ impl Default for CorsaServer {
 /// entry point so the socket-mode check stays as fast as the Virtual TS path.
 /// Resolve a URI (file:// or plain path) to an absolute filesystem path.
 /// Returns None when the URI is a non-`file` scheme, the path cannot be
-/// extracted, or percent-decoding yields invalid UTF-8. Used by socket-mode
-/// sibling overlay to read siblings from disk. `file://` URIs go through the
-/// shared converter in `crate::file_uri` so percent-escapes are decoded as
-/// UTF-8 byte sequences (not per-byte chars, which garbles non-ASCII paths).
+/// extracted, or percent-decoding yields invalid UTF-8. `file://` URIs go
+/// through the shared converter in `crate::file_uri` so percent-escapes are
+/// decoded as UTF-8 byte sequences.
 fn uri_to_path(uri: &str, working_dir: &Path) -> Option<PathBuf> {
     if uri.starts_with("file://") {
         return crate::file_uri::file_uri_to_path(uri);
@@ -659,8 +513,7 @@ fn offset_to_line_column(source: &str, offset: usize) -> (u32, u32) {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use super::{CorsaServer, JsonRpcRequest, ServerConfig, uri_to_path};
-    use vize_carton::String;
+    use super::{JsonRpcRequest, uri_to_path};
 
     #[test]
     fn test_json_rpc_request_parse() {
@@ -668,39 +521,6 @@ mod tests {
         let request: JsonRpcRequest = serde_json::from_str(json).unwrap();
         assert_eq!(request.method, "check");
         assert_eq!(request.id, Some(1));
-    }
-
-    #[test]
-    fn relative_virtual_uris_are_rooted_in_working_dir() {
-        let server = CorsaServer::with_config(ServerConfig {
-            corsa_path: None,
-            working_dir: Some("/workspace/project".into()),
-        });
-
-        assert_eq!(
-            server.virtual_uri_for("src/App.vue", ".ts"),
-            String::from("file:///workspace/project/src/App.vue.ts")
-        );
-    }
-
-    #[test]
-    fn absolute_virtual_uris_are_file_uris() {
-        let server = CorsaServer::new();
-
-        assert_eq!(
-            server.virtual_uri_for("/workspace/pages/[name] #1.vue", ".ts"),
-            String::from("file:///workspace/pages/%5Bname%5D%20%231.vue.ts")
-        );
-    }
-
-    #[test]
-    fn existing_file_uris_keep_their_scheme() {
-        let server = CorsaServer::new();
-
-        assert_eq!(
-            server.virtual_uri_for("file:///workspace/src/App.vue", ".tsx"),
-            String::from("file:///workspace/src/App.vue.tsx")
-        );
     }
 
     #[test]

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -109,10 +109,11 @@ pub use vize_carton::i18n::Locale;
 
 #[cfg(feature = "native")]
 pub use corsa_bridge::{
-    CorsaBridge, CorsaBridgeConfig, CorsaBridgeError, LspCompletionItem, LspCompletionList,
-    LspCompletionResponse, LspDefinitionResponse, LspDiagnostic, LspDocumentation, LspHover,
-    LspHoverContents, LspLocation, LspLocationLink, LspMarkedString, LspMarkupContent, LspPosition,
-    LspRange, VIRTUAL_URI_SCHEME,
+    CorsaBridge, CorsaBridgeConfig, CorsaBridgeError, CorsaVueVirtualDocument,
+    CorsaVueVirtualDocumentOptions, LspCompletionItem, LspCompletionList, LspCompletionResponse,
+    LspDefinitionResponse, LspDiagnostic, LspDocumentation, LspHover, LspHoverContents,
+    LspLocation, LspLocationLink, LspMarkedString, LspMarkupContent, LspPosition, LspRange,
+    VIRTUAL_URI_SCHEME,
 };
 
 // Re-export batch type checker

--- a/crates/vize_maestro/src/ide/corsa_support/canonical.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use tower_lsp::lsp_types::{Location, Range, Url};
-use vize_canon::{CorsaBridge, LspLocation};
+use vize_canon::{CorsaBridge, CorsaVueVirtualDocumentOptions, LspLocation};
 use vize_carton::{String, cstr};
 
 use crate::ide::IdeContext;
@@ -24,38 +24,31 @@ pub(crate) async fn open_canonical_virtual_document(
         return None;
     }
 
-    let options_api = ctx.state.options_api_enabled();
-    let legacy_vue2 = ctx.state.legacy_vue2_enabled();
-    let virtual_result = crate::ide::DiagnosticService::generate_virtual_ts(
-        ctx.uri,
-        &ctx.content,
-        options_api,
-        legacy_vue2,
-    )?;
-
-    crate::ide::diagnostics::corsa::collect::overlay_sibling_vue_mirrors(
-        bridge,
-        ctx.uri,
-        &virtual_result.relative_vue_imports,
-        options_api,
-        legacy_vue2,
-    )
-    .await;
-    crate::ide::diagnostics::corsa::collect::overlay_relative_ts_imports(
-        bridge,
-        ctx.uri,
-        &virtual_result.relative_ts_imports,
-    )
-    .await;
-
-    let request_uri = bridge
-        .open_or_update_virtual_document(&canonical_request_path(ctx.uri), &virtual_result.code)
+    let source_path = ctx.uri.to_file_path().ok()?;
+    let opened = bridge
+        .open_vue_virtual_document(
+            &source_path,
+            &ctx.content,
+            CorsaVueVirtualDocumentOptions {
+                options_api: ctx.state.options_api_enabled(),
+                legacy_vue2: ctx.state.legacy_vue2_enabled(),
+            },
+        )
         .await
         .ok()?;
 
     Some(CanonicalVirtualDocument {
-        request_uri,
-        virtual_result,
+        request_uri: opened.request_uri,
+        virtual_result: VirtualTsResult {
+            code: opened.code.to_string(),
+            source_mappings: opened.mappings,
+            import_source_map: opened.import_source_map,
+            user_code_start_line: 0,
+            sfc_script_start_line: 0,
+            template_scope_start_line: 0,
+            line_mappings: Vec::new(),
+            skipped_import_lines: 0,
+        },
     })
 }
 

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
@@ -5,238 +5,11 @@ use tower_lsp::lsp_types::{Diagnostic, Url};
 use crate::server::ServerState;
 
 use super::super::DiagnosticService;
-use super::collect_virtual::collect_virtual_result_diagnostics;
-use super::virtual_ts::collect_relative_ts_specifiers;
+use super::collect_virtual::{
+    collect_synced_virtual_result_diagnostics, collect_virtual_result_diagnostics,
+};
+use vize_canon::CorsaVueVirtualDocumentOptions;
 use vize_carton::cstr;
-
-/// Overlay the virtual TS for every relative `.vue` import of `host_uri`
-/// into the editor's Corsa session so TypeScript module resolution can find
-/// them (issue #752). Each sibling is opened at `<sibling_abs_path>.ts`,
-/// matching the `.vue.ts` suffix produced by `ImportRewriter`. Transitive
-/// `.vue` imports are followed recursively; cycles are avoided via a
-/// visited set keyed on the canonicalized sibling path. Failures are
-/// logged and skipped — a missing sibling falls through to the existing
-/// TS2307 surface, which is the desired behavior for genuinely missing
-/// modules.
-pub(in crate::ide) async fn overlay_sibling_vue_mirrors(
-    bridge: &std::sync::Arc<vize_canon::CorsaBridge>,
-    host_uri: &Url,
-    initial_specifiers: &[std::string::String],
-    options_api: bool,
-    legacy_vue2: bool,
-) {
-    use std::collections::HashSet;
-    use std::path::PathBuf;
-
-    if initial_specifiers.is_empty() {
-        return;
-    }
-
-    let Ok(host_path) = host_uri.to_file_path() else {
-        tracing::debug!("overlay_sibling_vue_mirrors: host URI is not a file path: {host_uri}",);
-        return;
-    };
-    let host_dir = match host_path.parent() {
-        Some(dir) => dir.to_path_buf(),
-        None => return,
-    };
-
-    let mut visited: HashSet<PathBuf> = HashSet::new();
-    visited.insert(host_path.clone());
-
-    let mut queue: Vec<(PathBuf, Vec<std::string::String>)> =
-        vec![(host_dir, initial_specifiers.to_vec())];
-
-    while let Some((dir, specifiers)) = queue.pop() {
-        for specifier in specifiers {
-            let resolved = normalize_path_lexically(&dir.join(specifier.as_str()));
-            let visited_key = std::fs::canonicalize(&resolved).unwrap_or_else(|_| resolved.clone());
-            if !visited.insert(visited_key) {
-                continue;
-            }
-
-            let sibling_content = match std::fs::read_to_string(&resolved) {
-                Ok(text) => text,
-                Err(err) => {
-                    tracing::debug!(
-                        "overlay sibling skipped — read failed for {}: {err}",
-                        resolved.display(),
-                    );
-                    continue;
-                }
-            };
-
-            let sibling_uri = match Url::from_file_path(&resolved) {
-                Ok(uri) => uri,
-                Err(_) => continue,
-            };
-
-            let sibling_virtual = if resolved.to_string_lossy().ends_with(".art.vue") {
-                DiagnosticService::generate_virtual_ts_for_art(&sibling_uri, &sibling_content)
-            } else {
-                DiagnosticService::generate_virtual_ts(
-                    &sibling_uri,
-                    &sibling_content,
-                    options_api,
-                    legacy_vue2,
-                )
-            };
-            let Some(sibling_virtual) = sibling_virtual else {
-                continue;
-            };
-
-            let sibling_name = cstr!("{}.ts", resolved.to_string_lossy());
-            if let Err(err) = bridge
-                .open_or_update_virtual_document(&sibling_name, &sibling_virtual.code)
-                .await
-            {
-                tracing::debug!("overlay sibling failed for {}: {err}", resolved.display(),);
-                continue;
-            }
-            overlay_relative_ts_imports(bridge, &sibling_uri, &sibling_virtual.relative_ts_imports)
-                .await;
-
-            let next_dir = resolved
-                .parent()
-                .map(|p| p.to_path_buf())
-                .unwrap_or_else(|| resolved.clone());
-            if !sibling_virtual.relative_vue_imports.is_empty() {
-                queue.push((next_dir, sibling_virtual.relative_vue_imports));
-            }
-        }
-    }
-}
-
-pub(in crate::ide) async fn overlay_relative_ts_imports(
-    bridge: &std::sync::Arc<vize_canon::CorsaBridge>,
-    host_uri: &Url,
-    initial_specifiers: &[std::string::String],
-) {
-    use std::collections::HashSet;
-    use std::path::PathBuf;
-
-    if initial_specifiers.is_empty() {
-        return;
-    }
-
-    let Ok(host_path) = host_uri.to_file_path() else {
-        tracing::debug!("overlay_relative_ts_imports: host URI is not a file path: {host_uri}",);
-        return;
-    };
-    let Some(host_dir) = host_path.parent().map(|dir| dir.to_path_buf()) else {
-        return;
-    };
-    let mut visited = HashSet::<PathBuf>::new();
-    let mut queue = vec![(host_dir, initial_specifiers.to_vec())];
-
-    while let Some((dir, specifiers)) = queue.pop() {
-        for specifier in specifiers {
-            let Some(resolved) = resolve_relative_script_import(&dir, specifier.as_str()) else {
-                continue;
-            };
-            let visited_key = std::fs::canonicalize(&resolved).unwrap_or_else(|_| resolved.clone());
-            if !visited.insert(visited_key) {
-                continue;
-            }
-
-            let content = match std::fs::read_to_string(&resolved) {
-                Ok(content) => content,
-                Err(err) => {
-                    tracing::debug!(
-                        "overlay ts import skipped — read failed for {}: {err}",
-                        resolved.display(),
-                    );
-                    continue;
-                }
-            };
-
-            if let Err(err) = bridge
-                .open_or_update_virtual_document(&resolved.to_string_lossy(), &content)
-                .await
-            {
-                tracing::debug!("overlay ts import failed for {}: {err}", resolved.display(),);
-                continue;
-            }
-
-            let source_type = source_type_for_path(&resolved);
-            let next_specifiers = collect_relative_ts_specifiers(&content, source_type);
-            if !next_specifiers.is_empty()
-                && let Some(next_dir) = resolved.parent().map(|p| p.to_path_buf())
-            {
-                queue.push((next_dir, next_specifiers));
-            }
-        }
-    }
-}
-
-fn resolve_relative_script_import(
-    dir: &std::path::Path,
-    specifier: &str,
-) -> Option<std::path::PathBuf> {
-    let base = dir.join(specifier);
-    if base.extension().is_some() {
-        return known_script_path(&base).then(|| normalize_path_lexically(&base));
-    }
-
-    for ext in ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"] {
-        let candidate = base.with_extension(ext);
-        if candidate.exists() {
-            return Some(normalize_path_lexically(&candidate));
-        }
-    }
-    for name in [
-        "index.ts",
-        "index.tsx",
-        "index.mts",
-        "index.cts",
-        "index.js",
-        "index.jsx",
-        "index.mjs",
-        "index.cjs",
-        "index.d.ts",
-    ] {
-        let candidate = base.join(name);
-        if candidate.exists() {
-            return Some(normalize_path_lexically(&candidate));
-        }
-    }
-    None
-}
-
-fn normalize_path_lexically(path: &std::path::Path) -> std::path::PathBuf {
-    let mut normalized = std::path::PathBuf::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                if !normalized.pop() {
-                    normalized.push("..");
-                }
-            }
-            other => normalized.push(other.as_os_str()),
-        }
-    }
-    normalized
-}
-
-fn known_script_path(path: &std::path::Path) -> bool {
-    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
-        return false;
-    };
-    path.exists()
-        && (name.ends_with(".ts")
-            || name.ends_with(".tsx")
-            || name.ends_with(".mts")
-            || name.ends_with(".cts")
-            || name.ends_with(".js")
-            || name.ends_with(".jsx")
-            || name.ends_with(".mjs")
-            || name.ends_with(".cjs"))
-}
-
-fn source_type_for_path(path: &std::path::Path) -> oxc_span::SourceType {
-    oxc_span::SourceType::from_path(path).unwrap_or_else(|_| oxc_span::SourceType::ts())
-}
 
 impl DiagnosticService {
     /// Collect diagnostics from the Corsa project-session backend.
@@ -271,25 +44,56 @@ impl DiagnosticService {
         let is_art_file = uri.path().ends_with(".art.vue");
         let options_api = state.options_api_enabled();
         let legacy_vue2 = state.legacy_vue2_enabled();
-        let virtual_result = if is_art_file {
-            Self::generate_virtual_ts_for_art(uri, &content)
+        let mut diagnostics = if is_art_file {
+            let Some(virtual_result) = Self::generate_virtual_ts_for_art(uri, &content) else {
+                tracing::warn!("failed to generate virtual ts for {}", uri);
+                return vec![];
+            };
+            collect_virtual_result_diagnostics(
+                &bridge,
+                uri,
+                content.as_str(),
+                cstr!("{}.ts", uri.path()).to_string(),
+                virtual_result,
+            )
+            .await
         } else {
-            Self::generate_virtual_ts(uri, &content, options_api, legacy_vue2)
+            let Ok(source_path) = uri.to_file_path() else {
+                tracing::warn!("cannot derive source path for {}", uri);
+                return vec![];
+            };
+            let opened = match bridge
+                .open_vue_virtual_document(
+                    &source_path,
+                    &content,
+                    CorsaVueVirtualDocumentOptions {
+                        options_api,
+                        legacy_vue2,
+                    },
+                )
+                .await
+            {
+                Ok(opened) => opened,
+                Err(err) => {
+                    tracing::warn!("failed to open Vue virtual document for {uri}: {err}");
+                    return vec![];
+                }
+            };
+            let Some((virtual_uri, virtual_result)) =
+                Self::virtual_ts_result_from_corsa_vue_document(uri, &content, opened)
+            else {
+                tracing::warn!("failed to map virtual ts metadata for {}", uri);
+                return vec![];
+            };
+            collect_synced_virtual_result_diagnostics(
+                &bridge,
+                uri,
+                content.as_str(),
+                virtual_uri,
+                virtual_result,
+            )
+            .await
         };
-        let Some(virtual_result) = virtual_result else {
-            tracing::warn!("failed to generate virtual ts for {}", uri);
-            return vec![];
-        };
-        let mut diagnostics = collect_virtual_result_diagnostics(
-            &bridge,
-            uri,
-            content.as_str(),
-            cstr!("{}.ts", uri.path()).to_string(),
-            virtual_result,
-            options_api,
-            legacy_vue2,
-        )
-        .await;
 
         if !is_art_file {
             for (variant_index, inline_virtual) in Self::generate_virtual_ts_for_inline_art_variants(
@@ -305,8 +109,6 @@ impl DiagnosticService {
                         content.as_str(),
                         cstr!("{}.inline_art_{variant_index}.ts", uri.path()).to_string(),
                         inline_virtual,
-                        options_api,
-                        legacy_vue2,
                     )
                     .await,
                 );

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
@@ -3,7 +3,6 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Url};
 
 use super::super::{VirtualTsResult, sources};
-use super::collect::{overlay_relative_ts_imports, overlay_sibling_vue_mirrors};
 use super::mapping::{map_diagnostic_with_source_mappings, source_offset_to_position};
 use super::message::rewrite_corsa_message;
 
@@ -13,8 +12,34 @@ pub(super) async fn collect_virtual_result_diagnostics(
     content: &str,
     virtual_name: String,
     virtual_result: VirtualTsResult,
-    options_api: bool,
-    legacy_vue2: bool,
+) -> Vec<Diagnostic> {
+    let virtual_uri = match bridge
+        .open_or_update_virtual_document(&virtual_name, &virtual_result.code)
+        .await
+    {
+        Ok(uri) => uri,
+        Err(e) => {
+            tracing::warn!("failed to open/update virtual document: {}", e);
+            return vec![];
+        }
+    };
+
+    collect_synced_virtual_result_diagnostics(
+        bridge,
+        host_uri,
+        content,
+        virtual_uri.to_string(),
+        virtual_result,
+    )
+    .await
+}
+
+pub(super) async fn collect_synced_virtual_result_diagnostics(
+    bridge: &std::sync::Arc<vize_canon::CorsaBridge>,
+    _host_uri: &Url,
+    content: &str,
+    virtual_uri: String,
+    virtual_result: VirtualTsResult,
 ) -> Vec<Diagnostic> {
     let virtual_ts = &virtual_result.code;
     let user_code_start_line = virtual_result.user_code_start_line;
@@ -30,31 +55,6 @@ pub(super) async fn collect_virtual_result_diagnostics(
         template_scope_start_line,
         line_mappings.iter().filter(|m| m.is_some()).count()
     );
-
-    overlay_sibling_vue_mirrors(
-        bridge,
-        host_uri,
-        &virtual_result.relative_vue_imports,
-        options_api,
-        legacy_vue2,
-    )
-    .await;
-    overlay_relative_ts_imports(bridge, host_uri, &virtual_result.relative_ts_imports).await;
-
-    tracing::info!("opening/updating virtual document: {}", virtual_name);
-    let virtual_uri = match bridge
-        .open_or_update_virtual_document(&virtual_name, virtual_ts)
-        .await
-    {
-        Ok(uri) => {
-            tracing::info!("virtual document opened/updated successfully: {}", uri);
-            uri
-        }
-        Err(e) => {
-            tracing::warn!("failed to open/update virtual document: {}", e);
-            return vec![];
-        }
-    };
 
     tracing::info!(
         "waiting for diagnostics from corsa bridge for {}",

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs
@@ -74,29 +74,6 @@ fn editor_virtual_ts_rewrites_dot_vue_imports() {
         "expected rewritten alias specifier, got:\n{}",
         result.code,
     );
-    // Only relative specifiers feed the sibling overlay; alias and bare
-    // imports are excluded since they resolve via tsconfig paths and the
-    // ambient stub respectively.
-    assert!(
-        result.relative_vue_imports.iter().any(|s| s == "./app.vue"),
-        "expected ./app.vue in relative_vue_imports, got {:?}",
-        result.relative_vue_imports,
-    );
-    assert!(
-        result
-            .relative_vue_imports
-            .iter()
-            .any(|s| s == "../shared/Sib.vue"),
-        "expected ../shared/Sib.vue in relative_vue_imports, got {:?}",
-        result.relative_vue_imports,
-    );
-    assert!(
-        !result
-            .relative_vue_imports
-            .iter()
-            .any(|s| s == "@/Alias.vue"),
-        "alias specifier must not appear in relative_vue_imports",
-    );
 }
 
 #[test]
@@ -161,14 +138,6 @@ defineArt("./Button.vue", { title: "Button" });
             .contains("import __VizeArtTarget_Button from \"./Button.vue.ts\";"),
         "expected defineArt component import, got:\n{}",
         result.code,
-    );
-    assert!(
-        result
-            .relative_vue_imports
-            .iter()
-            .any(|s| s == "./Button.vue"),
-        "expected ./Button.vue to be overlaid, got {:?}",
-        result.relative_vue_imports,
     );
     assert!(
         result

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts.rs
@@ -3,7 +3,15 @@
 use tower_lsp::lsp_types::Url;
 
 use super::super::{DiagnosticService, SourceMapping, VirtualTsResult};
-use vize_canon::{ImportRewriter, ImportSourceMap};
+use vize_canon::{CorsaVueVirtualDocument, ImportRewriter, ImportSourceMap};
+
+struct VirtualTsMetadata {
+    user_code_start_line: u32,
+    sfc_script_start_line: u32,
+    template_scope_start_line: u32,
+    line_mappings: Vec<Option<SourceMapping>>,
+    skipped_import_lines: u32,
+}
 
 /// Apply `ImportRewriter` to the generated virtual TS so `.vue` imports
 /// resolve to the generated `.vue.ts` mirrors in the editor Corsa session.
@@ -21,76 +29,30 @@ pub(super) fn rewrite_vue_imports(code: &str) -> (std::string::String, ImportSou
     (result.code.to_string(), result.source_map)
 }
 
-pub(super) fn collect_relative_vue_specifiers(code: &str) -> Vec<std::string::String> {
-    use oxc_span::SourceType;
-    #[allow(clippy::disallowed_methods)]
-    ImportRewriter::new()
-        .collect_relative_vue_specifiers(code, SourceType::ts())
-        .into_iter()
-        .map(|s| s.to_string())
-        .collect()
-}
-
-pub(super) fn collect_relative_ts_specifiers(
-    code: &str,
-    source_type: oxc_span::SourceType,
-) -> Vec<std::string::String> {
-    use oxc_allocator::Allocator;
-    use oxc_ast::ast::{Expression, Statement};
-    use oxc_ast_visit::Visit;
-    use oxc_parser::Parser;
-
-    let allocator = Allocator::default();
-    let result = Parser::new(&allocator, code, source_type).parse();
-    let mut specifiers = Vec::new();
-    let mut push = |path: &str| {
-        if (path.starts_with("./") || path.starts_with("../"))
-            && !path.ends_with(".vue")
-            && !path.ends_with(".vue.ts")
-            && !specifiers.iter().any(|s: &std::string::String| s == path)
-        {
-            specifiers.push(path.to_string());
-        }
-    };
-
-    for stmt in &result.program.body {
-        match stmt {
-            Statement::ImportDeclaration(decl) => push(&decl.source.value),
-            Statement::ExportNamedDeclaration(decl) => {
-                if let Some(source) = &decl.source {
-                    push(&source.value);
-                }
-            }
-            Statement::ExportAllDeclaration(decl) => push(&decl.source.value),
-            _ => {}
-        }
-    }
-
-    struct DynamicImportCollector {
-        imports: Vec<std::string::String>,
-    }
-    impl<'a> Visit<'a> for DynamicImportCollector {
-        fn visit_import_expression(&mut self, expr: &oxc_ast::ast::ImportExpression<'a>) {
-            if let Expression::StringLiteral(lit) = &expr.source {
-                self.imports.push(lit.value.as_str().to_string());
-            }
-            oxc_ast_visit::walk::walk_import_expression(self, expr);
-        }
-    }
-
-    let mut collector = DynamicImportCollector {
-        imports: Vec::new(),
-    };
-    collector.visit_program(&result.program);
-    for path in collector.imports {
-        push(&path);
-    }
-
-    specifiers
-}
-
 impl DiagnosticService {
+    pub(in crate::ide) fn virtual_ts_result_from_corsa_vue_document(
+        uri: &Url,
+        content: &str,
+        opened: CorsaVueVirtualDocument,
+    ) -> Option<(std::string::String, VirtualTsResult)> {
+        let metadata = Self::virtual_ts_metadata(uri, content, &opened.pre_rewrite_code)?;
+        Some((
+            opened.request_uri.to_string(),
+            VirtualTsResult {
+                code: opened.code.to_string(),
+                source_mappings: opened.mappings,
+                import_source_map: opened.import_source_map,
+                user_code_start_line: metadata.user_code_start_line,
+                sfc_script_start_line: metadata.sfc_script_start_line,
+                template_scope_start_line: metadata.template_scope_start_line,
+                line_mappings: metadata.line_mappings,
+                skipped_import_lines: metadata.skipped_import_lines,
+            },
+        ))
+    }
+
     /// Generate virtual TypeScript for a Vue SFC.
+    #[cfg(test)]
     pub(in crate::ide) fn generate_virtual_ts(
         uri: &Url,
         content: &str,
@@ -98,29 +60,9 @@ impl DiagnosticService {
         legacy_vue2: bool,
     ) -> Option<VirtualTsResult> {
         use std::path::Path;
-        use vize_atelier_sfc::{
-            SfcParseOptions,
-            croquis::{SfcCroquisOptions, script_content_for_descriptor},
-            parse_sfc,
-        };
         use vize_canon::{
             batch::{VueDocumentVirtualTsOptions, generate_vue_document_virtual_ts_with_options},
             virtual_ts::VirtualTsOptions,
-        };
-
-        let options = SfcParseOptions {
-            filename: uri.path().to_string().into(),
-            ..Default::default()
-        };
-
-        let descriptor = parse_sfc(content, options).ok()?;
-
-        let (script_content, script_offset) =
-            script_content_for_descriptor(&descriptor, SfcCroquisOptions::full());
-        let sfc_script_start_line = if script_content.as_ref().is_some_and(|s| s.is_empty()) {
-            1
-        } else {
-            crate::ide::offset_to_position(content, script_offset as usize).0 + 1
         };
 
         let virtual_ts_options = VirtualTsOptions::default();
@@ -138,61 +80,67 @@ impl DiagnosticService {
         )
         .ok()?;
         let code = generated.pre_rewrite_code;
+        let metadata = Self::virtual_ts_metadata(uri, content, &code)?;
 
-        // Count import lines in script content (these are moved to module scope)
-        // Import lines are skipped from user setup code section
-        let skipped_import_lines =
-            Self::count_import_lines(script_content.as_deref().unwrap_or_default());
+        // The generated code is the same rewritten `.vue.ts` document that
+        // CorsaBridge syncs for editor sessions; this helper keeps the mapping
+        // metadata available to tests without owning dependency synchronization.
+        Some(VirtualTsResult {
+            code: generated.code.to_string(),
+            source_mappings: generated.mappings,
+            import_source_map: generated.import_source_map,
+            user_code_start_line: metadata.user_code_start_line,
+            sfc_script_start_line: metadata.sfc_script_start_line,
+            template_scope_start_line: metadata.template_scope_start_line,
+            line_mappings: metadata.line_mappings,
+            skipped_import_lines: metadata.skipped_import_lines,
+        })
+    }
 
-        // Find where user code starts in generated virtual TS
-        // Look for "// User setup code" comment
-        let user_code_start_line = code
+    fn virtual_ts_metadata(
+        uri: &Url,
+        content: &str,
+        pre_rewrite_code: &str,
+    ) -> Option<VirtualTsMetadata> {
+        use vize_atelier_sfc::{
+            SfcParseOptions,
+            croquis::{SfcCroquisOptions, script_content_for_descriptor},
+            parse_sfc,
+        };
+
+        let options = SfcParseOptions {
+            filename: uri.path().to_string().into(),
+            ..Default::default()
+        };
+        let descriptor = parse_sfc(content, options).ok()?;
+        let (script_content, script_offset) =
+            script_content_for_descriptor(&descriptor, SfcCroquisOptions::full());
+        let sfc_script_start_line = if script_content.as_ref().is_some_and(|s| s.is_empty()) {
+            1
+        } else {
+            crate::ide::offset_to_position(content, script_offset as usize).0 + 1
+        };
+        let user_code_start_line = pre_rewrite_code
             .lines()
             .enumerate()
             .find(|(_, line)| line.contains("// User setup code"))
-            .map(|(i, _)| i as u32 + 1) // +1 because user code is on next line
+            .map(|(i, _)| i as u32 + 1)
             .unwrap_or(0);
-
-        // Find where template scope starts in generated virtual TS
-        // Look for "// Template Scope" or "// ========== Template Scope" comment
-        let template_scope_start_line = code
+        let template_scope_start_line = pre_rewrite_code
             .lines()
             .enumerate()
             .find(|(_, line)| line.contains("Template Scope"))
             .map(|(i, _)| i as u32)
             .unwrap_or(u32::MAX);
 
-        // Parse @vize-map comments to build line mappings
-        // Format: // @vize-map: TYPE -> START:END
-        // Where START:END are byte offsets in the SFC
-        // @vize-map comments are inserted by the generator on dedicated lines,
-        // so line indices survive the `.vue` → `.vue.ts` import rewrite below
-        // (which only edits bytes inside string literals on import lines).
-        let line_mappings = Self::parse_vize_map_comments(&code);
-
-        // Issue #752: rewrite `.vue` import specifiers to `.vue.ts` so the
-        // editor's Corsa session resolves sibling SFCs via the same virtual
-        // mirrors used by the batch path. Collect the relative specifiers
-        // from the pre-rewrite code so the caller can overlay siblings.
-        let relative_vue_imports = rewriter
-            .collect_relative_vue_specifiers(code.as_str(), generated.source_type)
-            .into_iter()
-            .map(|s| s.to_string())
-            .collect();
-        let relative_ts_imports =
-            collect_relative_ts_specifiers(code.as_str(), generated.source_type);
-
-        Some(VirtualTsResult {
-            code: generated.code.to_string(),
-            source_mappings: generated.mappings,
-            import_source_map: generated.import_source_map,
-            relative_vue_imports,
-            relative_ts_imports,
+        Some(VirtualTsMetadata {
             user_code_start_line,
             sfc_script_start_line,
             template_scope_start_line,
-            line_mappings,
-            skipped_import_lines,
+            line_mappings: Self::parse_vize_map_comments(pre_rewrite_code),
+            skipped_import_lines: Self::count_import_lines(
+                script_content.as_deref().unwrap_or_default(),
+            ),
         })
     }
 

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs
@@ -5,9 +5,7 @@ use vize_canon::virtual_ts::{VirtualTsOptions, generate_virtual_ts_with_offsets}
 use vize_croquis::{Drawer, DrawerOptions};
 
 use super::super::{DiagnosticService, VirtualTsResult};
-use super::virtual_ts::{
-    collect_relative_ts_specifiers, collect_relative_vue_specifiers, rewrite_vue_imports,
-};
+use super::virtual_ts::rewrite_vue_imports;
 
 fn quote_ts_string(value: &str) -> String {
     let mut quoted = String::from("\"");
@@ -299,16 +297,12 @@ impl DiagnosticService {
         );
         let code = output.code;
         let line_mappings = Self::parse_vize_map_comments(&code);
-        let relative_vue_imports = collect_relative_vue_specifiers(&code);
-        let relative_ts_imports = collect_relative_ts_specifiers(&code, oxc_span::SourceType::ts());
         let (rewritten_code, import_source_map) = rewrite_vue_imports(&code);
 
         Some(VirtualTsResult {
             code: rewritten_code,
             source_mappings: output.mappings,
             import_source_map,
-            relative_vue_imports,
-            relative_ts_imports,
             user_code_start_line: code
                 .lines()
                 .enumerate()

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs
@@ -7,9 +7,7 @@ use vize_canon::virtual_ts::{
 };
 
 use super::super::{DiagnosticService, VirtualTsResult};
-use super::virtual_ts::{
-    collect_relative_ts_specifiers, collect_relative_vue_specifiers, rewrite_vue_imports,
-};
+use super::virtual_ts::rewrite_vue_imports;
 
 fn add_inline_self_component_binding(
     options: &mut VirtualTsOptions,
@@ -115,9 +113,6 @@ impl DiagnosticService {
                 );
                 let code = output.code;
                 let line_mappings = Self::parse_vize_map_comments(&code);
-                let relative_vue_imports = collect_relative_vue_specifiers(&code);
-                let relative_ts_imports =
-                    collect_relative_ts_specifiers(&code, oxc_span::SourceType::ts());
                 let (rewritten_code, import_source_map) = rewrite_vue_imports(&code);
 
                 results.push((
@@ -126,8 +121,6 @@ impl DiagnosticService {
                         code: rewritten_code,
                         source_mappings: output.mappings,
                         import_source_map,
-                        relative_vue_imports,
-                        relative_ts_imports,
                         user_code_start_line: code
                             .lines()
                             .enumerate()

--- a/crates/vize_maestro/src/ide/diagnostics/service.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/service.rs
@@ -30,11 +30,6 @@ pub(in crate::ide) struct VirtualTsResult {
     /// Byte-offset mapping from post-rewrite to pre-rewrite virtual TS.
     /// Empty when no `.vue` import specifiers were rewritten.
     pub(in crate::ide) import_source_map: vize_canon::ImportSourceMap,
-    /// Relative `.vue` import specifiers found in the SFC's script. The
-    /// editor session overlays each sibling's virtual TS so relative
-    /// imports resolve under the temp-dir Corsa session (issue #752).
-    pub(in crate::ide) relative_vue_imports: Vec<std::string::String>,
-    pub(in crate::ide) relative_ts_imports: Vec<std::string::String>,
     /// Line number where user code starts in virtual TS (0-indexed)
     pub(in crate::ide) user_code_start_line: u32,
     /// Line number where script starts in original SFC (1-indexed)


### PR DESCRIPTION
## Summary

- Add a CorsaBridge-level Vue virtual project sync path that builds the canonical `.vue.ts` document and its relative Vue/TS dependencies as one graph.
- Route LSP hover, definition, and editor diagnostics through that shared sync instead of duplicating dependency overlay logic in Maestro.
- Reuse the same virtual project builder from the socket-mode Corsa server.

## Why

The previous implementation made individual IDE features manually open sibling virtual files. That leaked dependency graph knowledge into Maestro and left multiple implementations of the same import-resolution behavior.

This moves the import graph and Corsa document synchronization into `vize_canon::corsa_bridge`, leaving Maestro responsible for editor request mapping only.

## Validation

- `cargo test -p vize_maestro --features native`
- `cargo test -p vize_canon --features native`
- `cargo test -p vize_maestro`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->