### PR TITLE
fix: complete template component props

### DIFF
--- a/crates/vize_canon/src/lsp_client.rs
+++ b/crates/vize_canon/src/lsp_client.rs
@@ -20,6 +20,7 @@ pub(crate) mod paths;
 mod queries;
 mod session;
 mod utils;
+mod virtual_overlay;
 
 #[cfg(test)]
 mod tests;

--- a/crates/vize_canon/src/lsp_client/session.rs
+++ b/crates/vize_canon/src/lsp_client/session.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::disallowed_types)]
 
-use super::{CorsaProjectClient, utils::remap_serialized_uris};
+use super::{CorsaProjectClient, utils::remap_serialized_uris, virtual_overlay};
 use crate::file_uri::{file_uri_to_path, path_to_file_uri};
 use corsa::{
     CorsaError,
@@ -181,7 +181,7 @@ impl CorsaProjectClient {
         }
 
         if document_uri == uri && !self.supports_overlay_api() {
-            return if virtual_overlay_uri_inside_project(uri, &self.project_root) {
+            return if virtual_overlay::uri_inside_project(uri, &self.project_root) {
                 Ok(())
             } else {
                 self.sync_materialized_overlay_document(uri, content)
@@ -190,7 +190,7 @@ impl CorsaProjectClient {
 
         let file_changes = materialize_session_document(uri, document_uri.as_str(), content)
             .or_else(|| {
-                virtual_overlay_upsert_file_changes(
+                virtual_overlay::upsert_file_changes(
                     uri,
                     document_uri.as_str(),
                     &self.project_root,
@@ -220,7 +220,7 @@ impl CorsaProjectClient {
             Ok(()) => Ok(()),
             Err(error) if overlay_changes_error_is_unsupported(&error) => {
                 self.overlay_api_disabled = true;
-                if virtual_overlay_uri_inside_project(uri, &self.project_root) {
+                if virtual_overlay::uri_inside_project(uri, &self.project_root) {
                     Ok(())
                 } else {
                     self.sync_materialized_overlay_document(uri, content)
@@ -252,7 +252,7 @@ impl CorsaProjectClient {
             .unwrap_or_else(|| self.session_document_uri(uri));
         self.external_document_uris.remove(document_uri.as_str());
         let file_changes = remove_session_document(uri, document_uri.as_str()).or_else(|| {
-            virtual_overlay_delete_file_changes(uri, document_uri.as_str(), &self.project_root)
+            virtual_overlay::delete_file_changes(uri, document_uri.as_str(), &self.project_root)
         });
         if document_uri != uri {
             return block_on(self.session.refresh(file_changes))
@@ -343,7 +343,7 @@ pub(super) fn build_session_document_uri(
 
     // Keep in-project real files and virtual mirrors at real paths.
     if external_path.starts_with(project_root)
-        && (external_path.exists() || virtual_overlay_target_exists(&external_path))
+        && (external_path.exists() || virtual_overlay::target_exists(&external_path))
     {
         return path_to_file_uri(&external_path);
     }
@@ -373,24 +373,6 @@ fn materialized_session_path(external_path: &Path, project_root: &Path) -> PathB
     session_path
 }
 
-fn virtual_overlay_uri_inside_project(uri: &str, project_root: &Path) -> bool {
-    external_document_path(uri)
-        .is_some_and(|path| path.starts_with(project_root) && virtual_overlay_target_exists(&path))
-}
-
-fn virtual_overlay_target_exists(external_path: &Path) -> bool {
-    let Some(name) = external_path.file_name().and_then(|name| name.to_str()) else {
-        return false;
-    };
-    let Some(real_name) = name.strip_suffix(".ts") else {
-        return false;
-    };
-    if !real_name.ends_with(".vue") && !real_name.ends_with(".html") {
-        return false;
-    }
-    external_path.with_file_name(real_name).is_file()
-}
-
 fn overlay_root_for_project(project_root: &Path) -> PathBuf {
     if is_under_node_modules_vize(project_root) {
         return project_root.join("overlays");
@@ -417,7 +399,7 @@ fn is_under_node_modules_vize(path: &Path) -> bool {
     false
 }
 
-fn external_document_path(uri: &str) -> Option<PathBuf> {
+pub(super) fn external_document_path(uri: &str) -> Option<PathBuf> {
     if let Some(path) = file_uri_to_path(uri) {
         return Some(path);
     }
@@ -470,54 +452,6 @@ pub(super) fn materialize_session_document(
     }))
 }
 
-fn virtual_overlay_upsert_file_changes(
-    external_uri: &str,
-    document_uri: &str,
-    project_root: &Path,
-    was_open: bool,
-) -> Option<FileChanges> {
-    if document_uri != external_uri
-        || !virtual_overlay_missing_from_disk(external_uri, project_root)
-    {
-        return None;
-    }
-
-    let document = uri_document_identifier(document_uri);
-    Some(FileChanges::Summary(FileChangeSummary {
-        changed: if was_open {
-            vec![document.clone()]
-        } else {
-            Vec::new()
-        },
-        created: if was_open { Vec::new() } else { vec![document] },
-        deleted: Vec::new(),
-    }))
-}
-
-fn virtual_overlay_delete_file_changes(
-    external_uri: &str,
-    document_uri: &str,
-    project_root: &Path,
-) -> Option<FileChanges> {
-    if document_uri != external_uri
-        || !virtual_overlay_missing_from_disk(external_uri, project_root)
-    {
-        return None;
-    }
-
-    Some(FileChanges::Summary(FileChangeSummary {
-        changed: Vec::new(),
-        created: Vec::new(),
-        deleted: vec![uri_document_identifier(document_uri)],
-    }))
-}
-
-fn virtual_overlay_missing_from_disk(uri: &str, project_root: &Path) -> bool {
-    external_document_path(uri).is_some_and(|path| {
-        path.starts_with(project_root) && !path.exists() && virtual_overlay_target_exists(&path)
-    })
-}
-
 fn remove_session_document(external_uri: &str, document_uri: &str) -> Option<FileChanges> {
     if document_uri == external_uri {
         return None;
@@ -561,11 +495,10 @@ mod tests {
     use super::{
         api_mode_for_executable, build_session_document_uri, line_character_to_utf16_offset,
         overlay_changes_error_is_unsupported, path_to_file_uri, should_retry_json_rpc,
-        uri_document_identifier, virtual_overlay_delete_file_changes,
-        virtual_overlay_upsert_file_changes,
+        uri_document_identifier,
     };
     use corsa::CorsaError;
-    use corsa::api::{ApiMode, DocumentIdentifier, FileChanges};
+    use corsa::api::{ApiMode, DocumentIdentifier};
 
     // Keep in-project virtual `.vue.ts` overlays at real paths so relative
     // script imports resolve against the source tree.
@@ -597,55 +530,6 @@ mod tests {
         let outside_uri = path_to_file_uri(&outside);
         let mapped_outside = build_session_document_uri(&outside_uri, &project, true);
         assert_ne!(mapped_outside, outside_uri);
-
-        let _ = std::fs::remove_dir_all(project);
-    }
-
-    #[test]
-    fn virtual_vue_overlay_file_changes_do_not_materialize_sibling_files() {
-        let nonce = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let project = std::env::temp_dir().join(format!(
-            "vize-canon-virtual-overlay-changes-{}-{nonce}",
-            std::process::id()
-        ));
-        let src = project.join("src");
-        std::fs::create_dir_all(&src).unwrap();
-        std::fs::write(src.join("Panel.vue"), "<template><div /></template>").unwrap();
-
-        let virtual_path = src.join("Panel.vue.ts");
-        let uri = path_to_file_uri(&virtual_path);
-
-        let created = virtual_overlay_upsert_file_changes(&uri, &uri, &project, false)
-            .expect("created file change");
-        let created = match created {
-            FileChanges::Summary(summary) => summary,
-            FileChanges::InvalidateAll { .. } => panic!("expected summary file changes"),
-        };
-        assert_eq!(created.created.len(), 1);
-        assert!(created.changed.is_empty());
-        assert!(!virtual_path.exists());
-
-        let changed = virtual_overlay_upsert_file_changes(&uri, &uri, &project, true)
-            .expect("changed file change");
-        let changed = match changed {
-            FileChanges::Summary(summary) => summary,
-            FileChanges::InvalidateAll { .. } => panic!("expected summary file changes"),
-        };
-        assert_eq!(changed.changed.len(), 1);
-        assert!(changed.created.is_empty());
-        assert!(!virtual_path.exists());
-
-        let deleted =
-            virtual_overlay_delete_file_changes(&uri, &uri, &project).expect("deleted file change");
-        let deleted = match deleted {
-            FileChanges::Summary(summary) => summary,
-            FileChanges::InvalidateAll { .. } => panic!("expected summary file changes"),
-        };
-        assert_eq!(deleted.deleted.len(), 1);
-        assert!(!virtual_path.exists());
 
         let _ = std::fs::remove_dir_all(project);
     }

--- a/crates/vize_canon/src/lsp_client/virtual_overlay.rs
+++ b/crates/vize_canon/src/lsp_client/virtual_overlay.rs
@@ -1,0 +1,121 @@
+use std::path::Path;
+
+use corsa::api::{FileChangeSummary, FileChanges};
+
+use super::session::{external_document_path, uri_document_identifier};
+
+pub(super) fn uri_inside_project(uri: &str, project_root: &Path) -> bool {
+    external_document_path(uri)
+        .is_some_and(|path| path.starts_with(project_root) && target_exists(&path))
+}
+
+pub(super) fn target_exists(external_path: &Path) -> bool {
+    let Some(name) = external_path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let Some(real_name) = name.strip_suffix(".ts") else {
+        return false;
+    };
+    if !real_name.ends_with(".vue") && !real_name.ends_with(".html") {
+        return false;
+    }
+    external_path.with_file_name(real_name).is_file()
+}
+
+pub(super) fn upsert_file_changes(
+    external_uri: &str,
+    document_uri: &str,
+    project_root: &Path,
+    was_open: bool,
+) -> Option<FileChanges> {
+    if document_uri != external_uri || !missing_from_disk(external_uri, project_root) {
+        return None;
+    }
+
+    let document = uri_document_identifier(document_uri);
+    Some(FileChanges::Summary(FileChangeSummary {
+        changed: if was_open {
+            vec![document.clone()]
+        } else {
+            Vec::new()
+        },
+        created: if was_open { Vec::new() } else { vec![document] },
+        deleted: Vec::new(),
+    }))
+}
+
+pub(super) fn delete_file_changes(
+    external_uri: &str,
+    document_uri: &str,
+    project_root: &Path,
+) -> Option<FileChanges> {
+    if document_uri != external_uri || !missing_from_disk(external_uri, project_root) {
+        return None;
+    }
+
+    Some(FileChanges::Summary(FileChangeSummary {
+        changed: Vec::new(),
+        created: Vec::new(),
+        deleted: vec![uri_document_identifier(document_uri)],
+    }))
+}
+
+fn missing_from_disk(uri: &str, project_root: &Path) -> bool {
+    external_document_path(uri).is_some_and(|path| {
+        path.starts_with(project_root) && !path.exists() && target_exists(&path)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use corsa::api::FileChanges;
+
+    use super::{delete_file_changes, upsert_file_changes};
+    use crate::file_uri::path_to_file_uri;
+
+    #[test]
+    fn virtual_vue_overlay_file_changes_do_not_materialize_sibling_files() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let project = std::env::temp_dir().join(format!(
+            "vize-canon-virtual-overlay-changes-{}-{nonce}",
+            std::process::id()
+        ));
+        let src = project.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("Panel.vue"), "<template><div /></template>").unwrap();
+
+        let virtual_path = src.join("Panel.vue.ts");
+        let uri = path_to_file_uri(&virtual_path);
+
+        let created = upsert_file_changes(&uri, &uri, &project, false).expect("created change");
+        let created = match created {
+            FileChanges::Summary(summary) => summary,
+            FileChanges::InvalidateAll { .. } => panic!("expected summary file changes"),
+        };
+        assert_eq!(created.created.len(), 1);
+        assert!(created.changed.is_empty());
+        assert!(!virtual_path.exists());
+
+        let changed = upsert_file_changes(&uri, &uri, &project, true).expect("changed change");
+        let changed = match changed {
+            FileChanges::Summary(summary) => summary,
+            FileChanges::InvalidateAll { .. } => panic!("expected summary file changes"),
+        };
+        assert_eq!(changed.changed.len(), 1);
+        assert!(changed.created.is_empty());
+        assert!(!virtual_path.exists());
+
+        let deleted = delete_file_changes(&uri, &uri, &project).expect("deleted change");
+        let deleted = match deleted {
+            FileChanges::Summary(summary) => summary,
+            FileChanges::InvalidateAll { .. } => panic!("expected summary file changes"),
+        };
+        assert_eq!(deleted.deleted.len(), 1);
+        assert!(!virtual_path.exists());
+
+        let _ = std::fs::remove_dir_all(project);
+    }
+}

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -763,7 +763,6 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                 "canon.virtual_ts.collect_template_prop_names",
                 collect_template_prop_names(summary)
             );
-
             // Generate scope closures
             if check_options.any_enabled() {
                 profile!(
@@ -772,12 +771,12 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                         &mut ts,
                         &mut mappings,
                         summary,
-                        template_ast.map(|root| root.source.as_str()),
                         &template_prop_names,
                         template_offset,
                         ScopeGenerationOptions {
                             check_options,
                             virtual_ts_options: options,
+                            template_source: template_ast.map(|root| root.source.as_str()),
                             check_unresolved_global_components: has_script_reference_types,
                             legacy_vue2,
                         },

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -34,7 +34,6 @@ pub(crate) fn generate_scope_closures(
     ts: &mut String,
     mappings: &mut Vec<VizeMapping>,
     summary: &Croquis,
-    template_source: Option<&str>,
     template_prop_names: &FxHashSet<String>,
     template_offset: u32,
     options: ScopeGenerationOptions<'_>,
@@ -184,7 +183,6 @@ pub(crate) fn generate_scope_closures(
             generate_undefined_refs(ts, mappings, summary, template_offset)
         );
     }
-
     if check_options.check_props {
         profile!(
             "canon.virtual_ts.component_props",
@@ -193,7 +191,7 @@ pub(crate) fn generate_scope_closures(
                 mappings,
                 &ComponentPropsContext {
                     summary,
-                    template_source,
+                    template_source: options.template_source,
                     children_map: &children_map,
                     vfor_enclosing_guards: &vfor_enclosing_guards,
                     template_prop_names,

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
@@ -8,6 +8,15 @@ pub(super) fn is_inline_function_prop_value(value: &str) -> bool {
     value.contains("=>") || value.starts_with("function") || value.starts_with("async function")
 }
 
+pub(super) fn has_dynamic_props(usage: &ComponentUsage) -> bool {
+    usage.props.iter().any(|prop| {
+        prop.name.as_str() != "key"
+            && prop.name.as_str() != "ref"
+            && prop.value.is_some()
+            && prop.is_dynamic
+    })
+}
+
 pub(super) fn append_prop_checker_alias(
     ts: &mut String,
     usage: &ComponentUsage,

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
@@ -1,0 +1,149 @@
+use std::ops::Range;
+
+use vize_carton::{String, append, cstr};
+use vize_croquis::analysis::{ComponentUsage, PassedProp};
+
+use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier, to_safe_identifier_fragment};
+use crate::virtual_ts::types::VizeMapping;
+
+use super::context::ComponentPropsContext;
+
+pub(super) fn has_navigable_props(ctx: &ComponentPropsContext<'_>, usage: &ComponentUsage) -> bool {
+    usage.props.iter().any(|prop| {
+        prop.name.as_str() != "key"
+            && prop.name.as_str() != "ref"
+            && prop_navigation_source_range(ctx.template_source, prop).is_some()
+    })
+}
+
+pub(super) fn emit_references(
+    ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    ctx: &ComponentPropsContext<'_>,
+    checkable_usages: &[(usize, &ComponentUsage)],
+) {
+    ts.push_str("\n  // Component template navigation references\n");
+    for &(idx, usage) in checkable_usages {
+        let component_ref = to_safe_identifier(usage.name.as_str());
+        let component_type_name = to_safe_identifier_fragment(usage.name.as_str());
+        let tag_src_start = (ctx.template_offset + usage.start + 1) as usize;
+        let tag_src_end = tag_src_start + usage.name.len();
+
+        ts.push_str("  void ");
+        let tag_gen_start = ts.len();
+        ts.push_str(&component_ref);
+        let tag_gen_end = ts.len();
+        ts.push_str(";\n");
+        mappings.push(VizeMapping {
+            gen_range: tag_gen_start..tag_gen_end,
+            src_range: tag_src_start..tag_src_end,
+            sub_spans: Vec::new(),
+        });
+
+        emit_prop_references(ts, mappings, ctx, idx, usage, component_type_name.as_str());
+    }
+}
+
+fn emit_prop_references(
+    ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    ctx: &ComponentPropsContext<'_>,
+    idx: usize,
+    usage: &ComponentUsage,
+    component_type_name: &str,
+) {
+    let props_ref = cstr!("__vize_props_nav_{idx}");
+    let mut emitted_props_ref = false;
+    for prop in &usage.props {
+        if prop.name.as_str() == "key" || prop.name.as_str() == "ref" {
+            continue;
+        }
+        let Some(source_range) = prop_navigation_source_range(ctx.template_source, prop) else {
+            continue;
+        };
+
+        if !emitted_props_ref {
+            append!(
+                *ts,
+                "  const {props_ref} = undefined as unknown as __{component_type_name}_Props_{idx} & Record<string, unknown>;\n"
+            );
+            emitted_props_ref = true;
+        }
+
+        let camel_prop_name = to_camel_case(prop.name.as_str());
+        append!(*ts, "  void {props_ref}");
+        let prop_gen_range = if is_ts_identifier(camel_prop_name.as_str()) {
+            ts.push('.');
+            let prop_gen_start = ts.len();
+            ts.push_str(camel_prop_name.as_str());
+            prop_gen_start..ts.len()
+        } else {
+            ts.push('[');
+            let range = push_ts_single_quoted_literal(ts, camel_prop_name.as_str());
+            ts.push(']');
+            range
+        };
+        ts.push_str(";\n");
+        mappings.push(VizeMapping {
+            gen_range: prop_gen_range,
+            src_range: (ctx.template_offset as usize + source_range.start)
+                ..(ctx.template_offset as usize + source_range.end),
+            sub_spans: Vec::new(),
+        });
+    }
+}
+
+fn prop_navigation_source_range(
+    template_source: Option<&str>,
+    prop: &PassedProp,
+) -> Option<Range<usize>> {
+    let name = prop.name.as_str();
+    if name.is_empty() {
+        return None;
+    }
+
+    let start = prop.start as usize;
+    let end = prop.end as usize;
+    let source = template_source?;
+    let raw = source.get(start..end)?;
+    if let Some(relative_start) = raw.find(name) {
+        return Some(start + relative_start..start + relative_start + name.len());
+    }
+
+    if name == "modelValue"
+        && let Some(relative_start) = raw.find("v-model")
+    {
+        return Some(start + relative_start..start + relative_start + "v-model".len());
+    }
+
+    None
+}
+
+fn push_ts_single_quoted_literal(ts: &mut String, value: &str) -> Range<usize> {
+    ts.push('\'');
+    let start = ts.len();
+    for ch in value.chars() {
+        match ch {
+            '\\' => ts.push_str("\\\\"),
+            '\'' => ts.push_str("\\'"),
+            '\n' => ts.push_str("\\n"),
+            '\r' => ts.push_str("\\r"),
+            '\t' => ts.push_str("\\t"),
+            _ => ts.push(ch),
+        }
+    }
+    let end = ts.len();
+    ts.push('\'');
+    start..end
+}
+
+fn is_ts_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+    chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
+}

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -8,16 +8,14 @@ use vize_carton::append;
 use vize_carton::cstr;
 use vize_carton::profile;
 
-use vize_croquis::{
-    Croquis, Scope, ScopeData, ScopeKind,
-    analysis::{ComponentUsage, PassedProp},
-};
+use vize_croquis::{Croquis, Scope, ScopeData, ScopeKind, analysis::ComponentUsage};
 
 use crate::virtual_ts::expressions::generate_component_prop_checks;
 use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier, to_safe_identifier_fragment};
 use crate::virtual_ts::types::VizeMapping;
 
-use super::component_prop_checker::append_prop_checker_alias;
+use super::component_prop_checker::{append_prop_checker_alias, has_dynamic_props};
+use super::component_prop_navigation;
 use super::context::{ComponentPropsContext, VForPropsContext};
 use super::emit::{
     append_v_for_comment, emit_slot_function_open, emit_v_for_loop_open, slot_props_type,
@@ -94,17 +92,8 @@ pub(super) fn generate_component_props(
         let component_ref = to_safe_identifier(usage.name.as_str());
         let component_type_name = to_safe_identifier_fragment(usage.name.as_str());
 
-        let has_dynamic_props = usage.props.iter().any(|p| {
-            p.name.as_str() != "key"
-                && p.name.as_str() != "ref"
-                && p.value.is_some()
-                && p.is_dynamic
-        });
-        let has_navigable_props = usage.props.iter().any(|p| {
-            p.name.as_str() != "key"
-                && p.name.as_str() != "ref"
-                && prop_navigation_source_range(ctx.template_source, p).is_some()
-        });
+        let has_dynamic_props = has_dynamic_props(usage);
+        let has_navigable_props = component_prop_navigation::has_navigable_props(ctx, usage);
         if !has_dynamic_props && !has_navigable_props {
             continue;
         }
@@ -143,7 +132,7 @@ pub(super) fn generate_component_props(
         }
     }
 
-    emit_component_navigation_references(ts, mappings, ctx, &checkable_usages);
+    component_prop_navigation::emit_references(ts, mappings, ctx, &checkable_usages);
 
     // Collect all closure scope IDs (v-for and v-slot)
     let closure_scope_ids: FxHashSet<u32> = summary
@@ -212,127 +201,6 @@ pub(super) fn generate_component_props(
             generate_closure_component_props_recursive(ts, mappings, &props_ctx, scope, "  ")
         );
     }
-}
-
-fn emit_component_navigation_references(
-    ts: &mut String,
-    mappings: &mut Vec<VizeMapping>,
-    ctx: &ComponentPropsContext<'_>,
-    checkable_usages: &[(usize, &ComponentUsage)],
-) {
-    ts.push_str("\n  // Component template navigation references\n");
-    for &(idx, usage) in checkable_usages {
-        let component_ref = to_safe_identifier(usage.name.as_str());
-        let component_type_name = to_safe_identifier_fragment(usage.name.as_str());
-        let tag_src_start = (ctx.template_offset + usage.start + 1) as usize;
-        let tag_src_end = tag_src_start + usage.name.len();
-
-        ts.push_str("  void ");
-        let tag_gen_start = ts.len();
-        ts.push_str(&component_ref);
-        let tag_gen_end = ts.len();
-        ts.push_str(";\n");
-        mappings.push(VizeMapping {
-            gen_range: tag_gen_start..tag_gen_end,
-            src_range: tag_src_start..tag_src_end,
-            sub_spans: Vec::new(),
-        });
-
-        let props_ref = cstr!("__vize_props_nav_{idx}");
-        let mut emitted_props_ref = false;
-        for prop in &usage.props {
-            if prop.name.as_str() == "key" || prop.name.as_str() == "ref" {
-                continue;
-            }
-            let Some(source_range) = prop_navigation_source_range(ctx.template_source, prop) else {
-                continue;
-            };
-
-            if !emitted_props_ref {
-                append!(
-                    *ts,
-                    "  const {props_ref} = undefined as unknown as __{component_type_name}_Props_{idx} & Record<string, unknown>;\n"
-                );
-                emitted_props_ref = true;
-            }
-
-            let camel_prop_name = to_camel_case(prop.name.as_str());
-            append!(*ts, "  void {props_ref}");
-            let prop_gen_range = if is_ts_identifier(camel_prop_name.as_str()) {
-                ts.push('.');
-                let prop_gen_start = ts.len();
-                ts.push_str(camel_prop_name.as_str());
-                prop_gen_start..ts.len()
-            } else {
-                ts.push('[');
-                let range = push_ts_single_quoted_literal(ts, camel_prop_name.as_str());
-                ts.push(']');
-                range
-            };
-            ts.push_str(";\n");
-            mappings.push(VizeMapping {
-                gen_range: prop_gen_range,
-                src_range: (ctx.template_offset as usize + source_range.start)
-                    ..(ctx.template_offset as usize + source_range.end),
-                sub_spans: Vec::new(),
-            });
-        }
-    }
-}
-
-fn prop_navigation_source_range(
-    template_source: Option<&str>,
-    prop: &PassedProp,
-) -> Option<std::ops::Range<usize>> {
-    let name = prop.name.as_str();
-    if name.is_empty() {
-        return None;
-    }
-
-    let start = prop.start as usize;
-    let end = prop.end as usize;
-    let source = template_source?;
-    let raw = source.get(start..end)?;
-    if let Some(relative_start) = raw.find(name) {
-        return Some(start + relative_start..start + relative_start + name.len());
-    }
-
-    if name == "modelValue"
-        && let Some(relative_start) = raw.find("v-model")
-    {
-        return Some(start + relative_start..start + relative_start + "v-model".len());
-    }
-
-    None
-}
-
-fn push_ts_single_quoted_literal(ts: &mut String, value: &str) -> std::ops::Range<usize> {
-    ts.push('\'');
-    let start = ts.len();
-    for ch in value.chars() {
-        match ch {
-            '\\' => ts.push_str("\\\\"),
-            '\'' => ts.push_str("\\'"),
-            '\n' => ts.push_str("\\n"),
-            '\r' => ts.push_str("\\r"),
-            '\t' => ts.push_str("\\t"),
-            _ => ts.push(ch),
-        }
-    }
-    let end = ts.len();
-    ts.push('\'');
-    start..end
-}
-
-fn is_ts_identifier(value: &str) -> bool {
-    let mut chars = value.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
-        return false;
-    }
-    chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
 }
 
 pub(super) fn component_usage_has_checkable_binding(

--- a/crates/vize_canon/src/virtual_ts/scope/context.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/context.rs
@@ -23,6 +23,7 @@ pub(crate) struct ScopeGenContext<'a> {
 pub(crate) struct ScopeGenerationOptions<'a> {
     pub(crate) check_options: VirtualTsCheckOptions,
     pub(crate) virtual_ts_options: &'a VirtualTsOptions,
+    pub(crate) template_source: Option<&'a str>,
     pub(crate) check_unresolved_global_components: bool,
     pub(crate) legacy_vue2: bool,
 }

--- a/crates/vize_canon/src/virtual_ts/scope/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/mod.rs
@@ -8,6 +8,7 @@ mod closures;
 mod component_events;
 mod component_prop_checker;
 mod component_prop_expressions;
+mod component_prop_navigation;
 mod component_props;
 mod context;
 mod emit;

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -5,7 +5,7 @@ use super::{
     generate_virtual_ts_with_offsets_and_checks, generate_virtual_ts_with_offsets_options_api,
 };
 use vize_carton::config::VueVersion;
-
+mod component_navigation;
 mod define_props_scope;
 mod no_check_template_bindings;
 mod options_api_props_spread;
@@ -1745,55 +1745,6 @@ const inputRef = useTemplateRef<HTMLInputElement>('input')
         .expect("should map the template expression");
 
     assert_eq!(&output.code[mapping.gen_range.clone()], expression);
-}
-
-#[test]
-fn test_component_template_navigation_mappings() {
-    use vize_croquis::{Analyzer, AnalyzerOptions};
-
-    let script = r#"import Child from './Child.vue'
-const count = 1
-"#;
-    let template = r#"<Child label="ready" :count="count" />"#;
-
-    let allocator = vize_carton::Bump::new();
-    let (root, _) = vize_armature::parse(&allocator, template);
-
-    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
-    analyzer.analyze_script_setup(script);
-    analyzer.analyze_template(&root);
-    let summary = analyzer.finish();
-
-    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
-
-    let tag_start = template.find("Child").unwrap();
-    let tag_mapping = output
-        .mappings
-        .iter()
-        .find(|mapping| mapping.src_range == (tag_start..tag_start + "Child".len()))
-        .expect("component tag should map to a generated component reference");
-    assert_eq!(&output.code[tag_mapping.gen_range.clone()], "Child");
-
-    let static_prop_start = template.find("label").unwrap();
-    let static_prop_mapping = output
-        .mappings
-        .iter()
-        .find(|mapping| mapping.src_range == (static_prop_start..static_prop_start + "label".len()))
-        .expect("static prop name should map to a generated prop type reference");
-    assert_eq!(&output.code[static_prop_mapping.gen_range.clone()], "label");
-
-    let dynamic_prop_start = template.find(":count").unwrap() + 1;
-    let dynamic_prop_mapping = output
-        .mappings
-        .iter()
-        .find(|mapping| {
-            mapping.src_range == (dynamic_prop_start..dynamic_prop_start + "count".len())
-        })
-        .expect("dynamic prop name should map to a generated prop type reference");
-    assert_eq!(
-        &output.code[dynamic_prop_mapping.gen_range.clone()],
-        "count"
-    );
 }
 
 #[test]

--- a/crates/vize_canon/src/virtual_ts/tests/component_navigation.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/component_navigation.rs
@@ -1,0 +1,50 @@
+use super::generate_virtual_ts;
+
+#[test]
+fn component_template_navigation_mappings() {
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let script = r#"import Child from './Child.vue'
+const count = 1
+"#;
+    let template = r#"<Child label="ready" :count="count" />"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+
+    let tag_start = template.find("Child").unwrap();
+    let tag_mapping = output
+        .mappings
+        .iter()
+        .find(|mapping| mapping.src_range == (tag_start..tag_start + "Child".len()))
+        .expect("component tag should map to a generated component reference");
+    assert_eq!(&output.code[tag_mapping.gen_range.clone()], "Child");
+
+    let static_prop_start = template.find("label").unwrap();
+    let static_prop_mapping = output
+        .mappings
+        .iter()
+        .find(|mapping| mapping.src_range == (static_prop_start..static_prop_start + "label".len()))
+        .expect("static prop name should map to a generated prop type reference");
+    assert_eq!(&output.code[static_prop_mapping.gen_range.clone()], "label");
+
+    let dynamic_prop_start = template.find(":count").unwrap() + 1;
+    let dynamic_prop_mapping = output
+        .mappings
+        .iter()
+        .find(|mapping| {
+            mapping.src_range == (dynamic_prop_start..dynamic_prop_start + "count".len())
+        })
+        .expect("dynamic prop name should map to a generated prop type reference");
+    assert_eq!(
+        &output.code[dynamic_prop_mapping.gen_range.clone()],
+        "count"
+    );
+}

--- a/crates/vize_maestro/src/ide/completion.rs
+++ b/crates/vize_maestro/src/ide/completion.rs
@@ -18,6 +18,8 @@ mod style;
 pub(crate) mod template;
 
 #[cfg(test)]
+mod component_props_tests;
+#[cfg(test)]
 mod tests;
 
 // Cross-module reuse: inlay-hint code resolves reactive binding types with

--- a/crates/vize_maestro/src/ide/completion/component_props_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/component_props_tests.rs
@@ -1,0 +1,176 @@
+use std::fs;
+
+use tower_lsp::lsp_types::{CompletionResponse, Url};
+
+use super::CompletionService;
+use crate::{ide::IdeContext, server::ServerState};
+
+#[test]
+fn template_component_prop_completion_resolves_imported_script_setup_props() {
+    let dir = tempfile::tempdir().unwrap();
+    let child_path = dir.path().join("Child.vue");
+    fs::write(
+        &child_path,
+        r#"<script setup lang="ts">
+defineProps<{
+  someMessage: string
+  disabled?: boolean
+}>()
+</script>
+"#,
+    )
+    .unwrap();
+
+    let source = r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template>
+  <Child  />
+</template>
+"#;
+    let parent_path = dir.path().join("Parent.vue");
+    fs::write(&parent_path, source).unwrap();
+
+    let uri = Url::from_file_path(&parent_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    let offset = source.find("<Child  />").unwrap() + "<Child ".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+    assert!(has_label(&labels, "some-message"), "{labels:?}");
+    assert!(has_label(&labels, "disabled"), "{labels:?}");
+}
+
+#[cfg(feature = "native")]
+#[test]
+fn template_component_prop_completion_is_preserved_with_corsa() {
+    crate::runtime::block_on(async {
+        let Some(corsa_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(
+            dir.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .unwrap();
+        fs::write(
+            src.join("vue.d.ts"),
+            r#"declare module "vue" {
+  export type DefineComponent<P = any, _B = any, _D = any> = { new(): { $props: P } };
+  export interface Ref<T = unknown> { value: T }
+  export interface ShallowRef<T = unknown> extends Ref<T> {}
+}
+"#,
+        )
+        .unwrap();
+        fs::write(
+            src.join("Child.vue"),
+            r#"<script setup lang="ts">
+defineProps<{
+  someMessage: string
+  count?: number
+}>()
+</script>
+"#,
+        )
+        .unwrap();
+
+        let source = r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template>
+  <Child :so />
+</template>
+"#;
+        let parent_path = src.join("Parent.vue");
+        fs::write(&parent_path, source).unwrap();
+
+        let uri = Url::from_file_path(&parent_path).unwrap();
+        let state = ServerState::new();
+        state.set_workspace_root(dir.path().to_path_buf());
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        let bridge = std::sync::Arc::new(vize_canon::CorsaBridge::with_config(
+            vize_canon::CorsaBridgeConfig {
+                corsa_path: Some(corsa_path),
+                working_dir: Some(dir.path().to_path_buf()),
+                timeout_ms: 30_000,
+                ..Default::default()
+            },
+        ));
+        bridge.spawn().await.unwrap();
+
+        let offset = source.find(":so").unwrap() + ":so".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let labels = completion_labels(
+            CompletionService::complete_with_corsa(&ctx, Some(bridge.clone()))
+                .await
+                .unwrap(),
+        );
+        let _ = bridge.shutdown().await;
+
+        assert!(has_label(&labels, "someMessage"), "{labels:?}");
+        assert!(has_label(&labels, "count"), "{labels:?}");
+    });
+}
+
+fn completion_labels(response: CompletionResponse) -> Vec<String> {
+    match response {
+        CompletionResponse::Array(items) => items,
+        CompletionResponse::List(list) => list.items,
+    }
+    .into_iter()
+    .map(|item| item.label)
+    .collect()
+}
+
+fn has_label(labels: &[String], expected: &str) -> bool {
+    labels.iter().any(|label| label == expected)
+}
+
+#[cfg(feature = "native")]
+fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return None;
+    }
+
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)?;
+    for candidate in [
+        workspace_root.parent()?.join("corsa-bind/.cache/tsgo"),
+        workspace_root
+            .parent()?
+            .join("corsa-bind/ref/corsa-upstream/.cache/tsgo"),
+        workspace_root.join("node_modules/.bin/tsgo"),
+    ] {
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+
+    vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
+}

--- a/crates/vize_maestro/src/ide/completion/service.rs
+++ b/crates/vize_maestro/src/ide/completion/service.rs
@@ -176,11 +176,7 @@ impl super::CompletionService {
             if !corsa_items.is_empty() {
                 let mut items = corsa_items;
                 items.extend(match block_type {
-                    BlockType::Template => {
-                        let mut extras = template::contextual_directive_completions(ctx);
-                        extras.extend(template::legacy_vue2_template_completions(ctx));
-                        extras
-                    }
+                    BlockType::Template => template::corsa_template_completions(ctx),
                     BlockType::Script => script::composition_api_completions(),
                     BlockType::ScriptSetup => {
                         let mut v = script::composition_api_completions();

--- a/crates/vize_maestro/src/ide/completion/template/mod.rs
+++ b/crates/vize_maestro/src/ide/completion/template/mod.rs
@@ -70,6 +70,13 @@ pub(crate) fn complete_template(ctx: &IdeContext) -> Vec<CompletionItem> {
     items_vec
 }
 
+pub(crate) fn corsa_template_completions(ctx: &IdeContext) -> Vec<CompletionItem> {
+    let mut items = contextual_directive_completions(ctx);
+    items.extend(component_meta::component_surface_completions(ctx));
+    items.extend(legacy_vue2_template_completions(ctx));
+    items
+}
+
 /// Corsa-path supplement for Vue 2.7 / Nuxt 2 constructs that the TypeScript
 /// virtual document cannot express: Nuxt 2 built-in components (`<nuxt-link>`,
 /// `<client-only>`, …) and the legacy-filtered Options API bindings. This stays

--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -8,6 +8,8 @@ mod canonical;
 mod canonical_tests;
 #[cfg(feature = "native")]
 mod html_tag;
+#[cfg(feature = "native")]
+mod virtual_mirror;
 mod workspace_edit;
 
 #[cfg(feature = "native")]

--- a/crates/vize_maestro/src/ide/corsa_support/canonical.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical.rs
@@ -145,7 +145,7 @@ pub(crate) fn map_canonical_corsa_location(
         });
     }
 
-    if let Some(location) = map_vue_virtual_mirror_location(ctx, location) {
+    if let Some(location) = super::virtual_mirror::map_location(ctx, location) {
         return Some(location);
     }
 
@@ -173,7 +173,7 @@ pub(crate) fn map_canonical_lsp_range(
     map_lsp_range_to_source(&ctx.content, doc, range)
 }
 
-fn map_lsp_range_to_source(
+pub(super) fn map_lsp_range_to_source(
     source: &str,
     doc: &CanonicalVirtualDocument,
     range: &vize_canon::LspRange,
@@ -277,80 +277,4 @@ fn location_matches_uri(actual: &str, expected: &str) -> bool {
     actual == expected
         || super::virtual_document_path(actual).as_deref()
             == super::virtual_document_path(expected).as_deref()
-}
-
-fn map_vue_virtual_mirror_location(
-    ctx: &IdeContext<'_>,
-    location: &LspLocation,
-) -> Option<Location> {
-    let parsed = Url::parse(&location.uri).ok()?;
-    let path = parsed.to_file_path().ok()?;
-    let file_name = path.file_name()?.to_str()?;
-    let vue_file_name = file_name
-        .strip_suffix(".tsx")
-        .or_else(|| file_name.strip_suffix(".ts"))?;
-    if !vue_file_name.ends_with(".vue") {
-        return None;
-    }
-
-    let source_path = path.with_file_name(vue_file_name);
-    if !source_path.is_file() {
-        return None;
-    }
-
-    let uri = Url::from_file_path(source_path).ok()?;
-    if let Some(range) = map_vue_virtual_mirror_range(ctx, &uri, &location.range) {
-        return Some(Location { uri, range });
-    }
-
-    Some(Location {
-        uri,
-        range: Range {
-            start: tower_lsp::lsp_types::Position {
-                line: 0,
-                character: 0,
-            },
-            end: tower_lsp::lsp_types::Position {
-                line: 0,
-                character: 0,
-            },
-        },
-    })
-}
-
-fn map_vue_virtual_mirror_range(
-    ctx: &IdeContext<'_>,
-    source_uri: &Url,
-    range: &vize_canon::LspRange,
-) -> Option<Range> {
-    let source_path = source_uri.to_file_path().ok()?;
-    let source = std::fs::read_to_string(&source_path).ok()?;
-    let rewriter = vize_canon::ImportRewriter::new();
-    let generated = vize_canon::batch::generate_vue_document_virtual_ts_with_options(
-        &source_path,
-        &source,
-        &vize_canon::virtual_ts::VirtualTsOptions::default(),
-        &rewriter,
-        false,
-        vize_canon::batch::VueDocumentVirtualTsOptions {
-            options_api: ctx.state.options_api_enabled(),
-            legacy_vue2: ctx.state.legacy_vue2_enabled(),
-        },
-    )
-    .ok()?;
-
-    let mirror_doc = CanonicalVirtualDocument {
-        request_uri: cstr!("{}{}", source_uri.path(), generated.virtual_suffix),
-        virtual_result: VirtualTsResult {
-            code: generated.code.to_string(),
-            source_mappings: generated.mappings,
-            import_source_map: generated.import_source_map,
-            user_code_start_line: 0,
-            sfc_script_start_line: 0,
-            template_scope_start_line: 0,
-            line_mappings: Vec::new(),
-            skipped_import_lines: 0,
-        },
-    };
-    map_lsp_range_to_source(&source, &mirror_doc, range)
 }

--- a/crates/vize_maestro/src/ide/corsa_support/virtual_mirror.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/virtual_mirror.rs
@@ -1,0 +1,83 @@
+use tower_lsp::lsp_types::{Location, Range, Url};
+use vize_carton::cstr;
+
+use crate::ide::IdeContext;
+use crate::ide::diagnostics::VirtualTsResult;
+
+use super::canonical::{CanonicalVirtualDocument, map_lsp_range_to_source};
+
+pub(super) fn map_location(
+    ctx: &IdeContext<'_>,
+    location: &vize_canon::LspLocation,
+) -> Option<Location> {
+    let parsed = Url::parse(&location.uri).ok()?;
+    let path = parsed.to_file_path().ok()?;
+    let file_name = path.file_name()?.to_str()?;
+    let vue_file_name = file_name
+        .strip_suffix(".tsx")
+        .or_else(|| file_name.strip_suffix(".ts"))?;
+    if !vue_file_name.ends_with(".vue") {
+        return None;
+    }
+
+    let source_path = path.with_file_name(vue_file_name);
+    if !source_path.is_file() {
+        return None;
+    }
+
+    let uri = Url::from_file_path(source_path).ok()?;
+    if let Some(range) = map_range(ctx, &uri, &location.range) {
+        return Some(Location { uri, range });
+    }
+
+    Some(Location {
+        uri,
+        range: Range {
+            start: tower_lsp::lsp_types::Position {
+                line: 0,
+                character: 0,
+            },
+            end: tower_lsp::lsp_types::Position {
+                line: 0,
+                character: 0,
+            },
+        },
+    })
+}
+
+fn map_range(
+    ctx: &IdeContext<'_>,
+    source_uri: &Url,
+    range: &vize_canon::LspRange,
+) -> Option<Range> {
+    let source_path = source_uri.to_file_path().ok()?;
+    let source = std::fs::read_to_string(&source_path).ok()?;
+    let rewriter = vize_canon::ImportRewriter::new();
+    let generated = vize_canon::batch::generate_vue_document_virtual_ts_with_options(
+        &source_path,
+        &source,
+        &vize_canon::virtual_ts::VirtualTsOptions::default(),
+        &rewriter,
+        false,
+        vize_canon::batch::VueDocumentVirtualTsOptions {
+            options_api: ctx.state.options_api_enabled(),
+            legacy_vue2: ctx.state.legacy_vue2_enabled(),
+        },
+    )
+    .ok()?;
+
+    let mirror_doc = CanonicalVirtualDocument {
+        request_uri: cstr!("{}{}", source_uri.path(), generated.virtual_suffix),
+        virtual_result: VirtualTsResult {
+            code: generated.code.to_string(),
+            source_mappings: generated.mappings,
+            import_source_map: generated.import_source_map,
+            user_code_start_line: 0,
+            sfc_script_start_line: 0,
+            template_scope_start_line: 0,
+            line_mappings: Vec::new(),
+            skipped_import_lines: 0,
+        },
+    };
+    map_lsp_range_to_source(&source, &mirror_doc, range)
+}

--- a/crates/vize_maestro/src/ide/definition.rs
+++ b/crates/vize_maestro/src/ide/definition.rs
@@ -6,16 +6,16 @@
 //! - Import statements -> imported files
 //! - Real definitions from Corsa (when available)
 pub mod bindings;
+#[cfg(all(test, feature = "native"))]
+mod corsa_tests;
 pub(crate) mod helpers;
 mod inline_art;
 pub(crate) mod script;
 mod service;
 mod template;
 
-pub use bindings::{BindingKind, BindingLocation, extract_bindings_with_locations};
-
 use super::IdeContext;
-
+pub use bindings::{BindingKind, BindingLocation, extract_bindings_with_locations};
 /// Definition service for providing go-to-definition functionality.
 pub struct DefinitionService;
 
@@ -459,120 +459,6 @@ const count = ref(0)
         });
     }
 
-    #[cfg(feature = "native")]
-    #[test]
-    fn test_definition_with_corsa_resolves_component_prop_attribute_to_child_prop() {
-        crate::runtime::block_on(async {
-            let Some(corsa_path) = resolve_definition_test_tsgo_binary() else {
-                return;
-            };
-            let dir = tempfile::tempdir().unwrap();
-            let src = dir.path().join("src");
-            fs::create_dir_all(&src).unwrap();
-            fs::write(
-                dir.path().join("tsconfig.json"),
-                r#"{
-  "compilerOptions": {
-    "strict": true,
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "noEmit": true
-  },
-  "include": ["src/**/*"]
-}"#,
-            )
-            .unwrap();
-            fs::write(
-                src.join("vue.d.ts"),
-                r#"declare module "vue" {
-  export type DefineComponent<P = any, _B = any, _D = any> = { new(): { $props: P } };
-  export interface Ref<T = unknown> { value: T }
-  export interface ShallowRef<T = unknown> extends Ref<T> {}
-}
-"#,
-            )
-            .unwrap();
-
-            let child_source = r#"<script setup lang="ts">
-defineProps<{
-  message: string
-}>()
-</script>
-
-<template><span /></template>
-"#;
-            let child_path = src.join("Child.vue");
-            fs::write(&child_path, child_source).unwrap();
-
-            let parent_source = r#"<script setup lang="ts">
-import Child from './Child.vue'
-const msg = 'hello'
-</script>
-
-<template>
-  <Child :message="msg" />
-</template>
-"#;
-            let parent_path = src.join("Parent.vue");
-            fs::write(&parent_path, parent_source).unwrap();
-
-            let uri = Url::from_file_path(&parent_path).unwrap();
-            let state = ServerState::new();
-            state.set_workspace_root(dir.path().to_path_buf());
-            state
-                .documents
-                .open(uri.clone(), parent_source.to_string(), 1, "vue".to_string());
-            state.update_virtual_docs(&uri, parent_source);
-
-            let bridge = std::sync::Arc::new(vize_canon::CorsaBridge::with_config(
-                vize_canon::CorsaBridgeConfig {
-                    corsa_path: Some(corsa_path),
-                    working_dir: Some(dir.path().to_path_buf()),
-                    timeout_ms: 30_000,
-                    ..Default::default()
-                },
-            ));
-            bridge.spawn().await.unwrap();
-
-            let tag_offset = parent_source.find("<Child").unwrap() + 1;
-            let tag_ctx = IdeContext::new(&state, &uri, tag_offset).unwrap();
-            let tag_response =
-                DefinitionService::definition_with_corsa(&tag_ctx, Some(bridge.clone()))
-                    .await
-                    .unwrap();
-            let tag_location = scalar_location(tag_response);
-            assert_eq!(
-                tag_location
-                    .uri
-                    .to_file_path()
-                    .unwrap()
-                    .canonicalize()
-                    .unwrap(),
-                child_path.canonicalize().unwrap()
-            );
-
-            let offset = parent_source.find(":message").unwrap() + 1;
-            let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-            let response = DefinitionService::definition_with_corsa(&ctx, Some(bridge.clone()))
-                .await
-                .unwrap();
-            let _ = bridge.shutdown().await;
-
-            let location = scalar_location(response);
-            let expected_offset = child_source.find("message: string").unwrap();
-            let (line, character) = crate::ide::offset_to_position(child_source, expected_offset);
-
-            assert_eq!(
-                location.uri.to_file_path().unwrap().canonicalize().unwrap(),
-                child_path.canonicalize().unwrap()
-            );
-            assert_eq!(location.range.start.line, line);
-            assert_eq!(location.range.start.character, character);
-        });
-    }
-
     #[test]
     fn test_definition_resolves_art_variant_binding_at_identifier_boundary() {
         let dir = tempfile::tempdir().unwrap();
@@ -864,29 +750,5 @@ export default {
             }
             GotoDefinitionResponse::Link(_) => panic!("expected location result"),
         }
-    }
-
-    #[cfg(feature = "native")]
-    fn resolve_definition_test_tsgo_binary() -> Option<std::path::PathBuf> {
-        if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
-            return None;
-        }
-
-        let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .and_then(std::path::Path::parent)?;
-        for candidate in [
-            workspace_root.parent()?.join("corsa-bind/.cache/tsgo"),
-            workspace_root
-                .parent()?
-                .join("corsa-bind/ref/corsa-upstream/.cache/tsgo"),
-            workspace_root.join("node_modules/.bin/tsgo"),
-        ] {
-            if candidate.exists() {
-                return Some(candidate);
-            }
-        }
-
-        vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
     }
 }

--- a/crates/vize_maestro/src/ide/definition/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/definition/corsa_tests.rs
@@ -1,0 +1,152 @@
+use std::fs;
+
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Url};
+
+use super::DefinitionService;
+use crate::{ide::IdeContext, server::ServerState};
+
+#[test]
+fn definition_with_corsa_resolves_component_prop_attribute_to_child_prop() {
+    crate::runtime::block_on(async {
+        let Some(corsa_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(
+            dir.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .unwrap();
+        fs::write(
+            src.join("vue.d.ts"),
+            r#"declare module "vue" {
+  export type DefineComponent<P = any, _B = any, _D = any> = { new(): { $props: P } };
+  export interface Ref<T = unknown> { value: T }
+  export interface ShallowRef<T = unknown> extends Ref<T> {}
+}
+"#,
+        )
+        .unwrap();
+
+        let child_source = r#"<script setup lang="ts">
+defineProps<{
+  message: string
+}>()
+</script>
+
+<template><span /></template>
+"#;
+        let child_path = src.join("Child.vue");
+        fs::write(&child_path, child_source).unwrap();
+
+        let parent_source = r#"<script setup lang="ts">
+import Child from './Child.vue'
+const msg = 'hello'
+</script>
+
+<template>
+  <Child :message="msg" />
+</template>
+"#;
+        let parent_path = src.join("Parent.vue");
+        fs::write(&parent_path, parent_source).unwrap();
+
+        let uri = Url::from_file_path(&parent_path).unwrap();
+        let state = ServerState::new();
+        state.set_workspace_root(dir.path().to_path_buf());
+        state
+            .documents
+            .open(uri.clone(), parent_source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, parent_source);
+
+        let bridge = std::sync::Arc::new(vize_canon::CorsaBridge::with_config(
+            vize_canon::CorsaBridgeConfig {
+                corsa_path: Some(corsa_path),
+                working_dir: Some(dir.path().to_path_buf()),
+                timeout_ms: 30_000,
+                ..Default::default()
+            },
+        ));
+        bridge.spawn().await.unwrap();
+
+        let tag_offset = parent_source.find("<Child").unwrap() + 1;
+        let tag_ctx = IdeContext::new(&state, &uri, tag_offset).unwrap();
+        let tag_response = DefinitionService::definition_with_corsa(&tag_ctx, Some(bridge.clone()))
+            .await
+            .unwrap();
+        let tag_location = scalar_location(tag_response);
+        assert_eq!(
+            tag_location
+                .uri
+                .to_file_path()
+                .unwrap()
+                .canonicalize()
+                .unwrap(),
+            child_path.canonicalize().unwrap()
+        );
+
+        let offset = parent_source.find(":message").unwrap() + 1;
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let response = DefinitionService::definition_with_corsa(&ctx, Some(bridge.clone()))
+            .await
+            .unwrap();
+        let _ = bridge.shutdown().await;
+
+        let location = scalar_location(response);
+        let expected_offset = child_source.find("message: string").unwrap();
+        let (line, character) = crate::ide::offset_to_position(child_source, expected_offset);
+
+        assert_eq!(
+            location.uri.to_file_path().unwrap().canonicalize().unwrap(),
+            child_path.canonicalize().unwrap()
+        );
+        assert_eq!(location.range.start.line, line);
+        assert_eq!(location.range.start.character, character);
+    });
+}
+
+fn scalar_location(response: GotoDefinitionResponse) -> Location {
+    match response {
+        GotoDefinitionResponse::Scalar(location) => location,
+        GotoDefinitionResponse::Array(mut locations) => {
+            assert_eq!(locations.len(), 1);
+            locations.remove(0)
+        }
+        GotoDefinitionResponse::Link(_) => panic!("expected location result"),
+    }
+}
+
+fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return None;
+    }
+
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)?;
+    for candidate in [
+        workspace_root.parent()?.join("corsa-bind/.cache/tsgo"),
+        workspace_root
+            .parent()?
+            .join("corsa-bind/ref/corsa-upstream/.cache/tsgo"),
+        workspace_root.join("node_modules/.bin/tsgo"),
+    ] {
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+
+    vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
+}

--- a/crates/vize_maestro/src/ide/hover.rs
+++ b/crates/vize_maestro/src/ide/hover.rs
@@ -13,8 +13,11 @@
     clippy::disallowed_macros
 )]
 
+mod component_prop;
 #[cfg(feature = "native")]
 mod corsa;
+#[cfg(all(test, feature = "native"))]
+mod corsa_tests;
 #[cfg(feature = "native")]
 mod html;
 mod script;
@@ -22,16 +25,13 @@ mod template;
 
 #[cfg(feature = "native")]
 use std::sync::Arc;
-
 use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Range};
 use vize_relief::BindingType;
 
-#[cfg(feature = "native")]
-use vize_canon::CorsaBridge;
-
 use super::IdeContext;
 use crate::virtual_code::{ArtCursorPosition, BlockType};
-
+#[cfg(feature = "native")]
+use vize_canon::CorsaBridge;
 /// Hover service for providing contextual information.
 pub struct HoverService;
 
@@ -894,96 +894,6 @@ const count = ref(0)
         });
     }
 
-    #[cfg(feature = "native")]
-    #[test]
-    fn test_hover_with_corsa_resolves_component_prop_attribute() {
-        crate::runtime::block_on(async {
-            let Some(corsa_path) = resolve_hover_test_tsgo_binary() else {
-                return;
-            };
-            let dir = tempfile::tempdir().unwrap();
-            let src = dir.path().join("src");
-            fs::create_dir_all(&src).unwrap();
-            fs::write(
-                dir.path().join("tsconfig.json"),
-                r#"{
-  "compilerOptions": {
-    "strict": true,
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "noEmit": true
-  },
-  "include": ["src/**/*"]
-}"#,
-            )
-            .unwrap();
-            fs::write(
-                src.join("vue.d.ts"),
-                r#"declare module "vue" {
-  export type DefineComponent<P = any, _B = any, _D = any> = { new(): { $props: P } };
-  export interface Ref<T = unknown> { value: T }
-  export interface ShallowRef<T = unknown> extends Ref<T> {}
-}
-"#,
-            )
-            .unwrap();
-            fs::write(
-                src.join("Child.vue"),
-                r#"<script setup lang="ts">
-defineProps<{
-  message: string
-}>()
-</script>
-<template><span /></template>
-"#,
-            )
-            .unwrap();
-
-            let source = r#"<script setup lang="ts">
-import Child from './Child.vue'
-const msg = 'hello'
-</script>
-
-<template>
-  <Child :message="msg" />
-</template>
-"#;
-            let source_path = src.join("Parent.vue");
-            fs::write(&source_path, source).unwrap();
-
-            let uri = Url::from_file_path(&source_path).unwrap();
-            let state = ServerState::new();
-            state.set_workspace_root(dir.path().to_path_buf());
-            state
-                .documents
-                .open(uri.clone(), source.to_string(), 1, "vue".to_string());
-            state.update_virtual_docs(&uri, source);
-
-            let bridge = std::sync::Arc::new(vize_canon::CorsaBridge::with_config(
-                vize_canon::CorsaBridgeConfig {
-                    corsa_path: Some(corsa_path),
-                    working_dir: Some(dir.path().to_path_buf()),
-                    timeout_ms: 30_000,
-                    ..Default::default()
-                },
-            ));
-            bridge.spawn().await.unwrap();
-
-            let offset = source.find(":message").unwrap() + 1;
-            let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-            let hover = HoverService::hover_with_corsa(&ctx, Some(bridge.clone()))
-                .await
-                .unwrap();
-            let _ = bridge.shutdown().await;
-
-            let value = hover_markdown(hover);
-            assert!(value.contains("message"), "{value}");
-            assert!(value.contains("string"), "{value}");
-        });
-    }
-
     fn hover_markdown(hover: tower_lsp::lsp_types::Hover) -> String {
         match hover.contents {
             HoverContents::Markup(content) => content.value,
@@ -1000,30 +910,6 @@ const msg = 'hello'
                 .collect::<Vec<_>>()
                 .join("\n\n"),
         }
-    }
-
-    #[cfg(feature = "native")]
-    fn resolve_hover_test_tsgo_binary() -> Option<std::path::PathBuf> {
-        if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
-            return None;
-        }
-
-        let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .and_then(std::path::Path::parent)?;
-        for candidate in [
-            workspace_root.parent()?.join("corsa-bind/.cache/tsgo"),
-            workspace_root
-                .parent()?
-                .join("corsa-bind/ref/corsa-upstream/.cache/tsgo"),
-            workspace_root.join("node_modules/.bin/tsgo"),
-        ] {
-            if candidate.exists() {
-                return Some(candidate);
-            }
-        }
-
-        vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
     }
 
     fn state_with_document(name: &str, source: &str) -> (ServerState, Url) {

--- a/crates/vize_maestro/src/ide/hover/component_prop.rs
+++ b/crates/vize_maestro/src/ide/hover/component_prop.rs
@@ -1,0 +1,61 @@
+use tower_lsp::lsp_types::Hover;
+
+use super::HoverBuilder;
+use crate::ide::IdeContext;
+
+pub(super) fn hover_attribute(ctx: &IdeContext<'_>) -> Option<Hover> {
+    let (attr_name, component_name) =
+        crate::ide::definition::helpers::get_attribute_and_component_at_offset(ctx)?;
+    if !crate::ide::is_component_tag(&component_name) {
+        return None;
+    }
+
+    let import_path = crate::ide::definition::helpers::find_import_path(ctx, &component_name)?;
+    let resolved_path =
+        crate::ide::definition::helpers::resolve_import_path(ctx.uri, &import_path)?;
+    let component_content = std::fs::read_to_string(&resolved_path).ok()?;
+    let descriptor = vize_atelier_sfc::parse_sfc(
+        &component_content,
+        vize_atelier_sfc::SfcParseOptions {
+            filename: resolved_path.to_string_lossy().to_string().into(),
+            ..Default::default()
+        },
+    )
+    .ok()?;
+    let script_setup = descriptor.script_setup.as_ref()?;
+    let script = script_setup.content.as_ref();
+    let prop_name = crate::ide::definition::helpers::kebab_to_camel(&attr_name);
+    let define_props_pos = script.find("defineProps")?;
+    let after_define_props = &script[define_props_pos..];
+    let prop_pos =
+        crate::ide::definition::helpers::find_prop_in_define_props(after_define_props, &prop_name)?;
+    let signature = prop_signature_at(script, define_props_pos + prop_pos, &prop_name);
+
+    Some(
+        HoverBuilder::new()
+            .title(&prop_name)
+            .meta("Component prop")
+            .code("typescript", &signature)
+            .build(),
+    )
+}
+
+fn prop_signature_at(script: &str, offset: usize, prop_name: &str) -> String {
+    let line_start = script[..offset]
+        .rfind('\n')
+        .map(|index| index + 1)
+        .unwrap_or(0);
+    let line_end = script[offset..]
+        .find('\n')
+        .map(|index| offset + index)
+        .unwrap_or(script.len());
+    let line = script[line_start..line_end]
+        .trim()
+        .trim_end_matches(',')
+        .trim();
+    if line.is_empty() {
+        prop_name.to_string()
+    } else {
+        line.to_string()
+    }
+}

--- a/crates/vize_maestro/src/ide/hover/corsa.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa.rs
@@ -116,6 +116,59 @@ impl HoverService {
         None
     }
 
+    /// Get hover for template context with Corsa support.
+    pub(super) async fn hover_template_with_corsa(
+        ctx: &IdeContext<'_>,
+        corsa_bridge: Option<Arc<CorsaBridge>>,
+    ) -> Option<Hover> {
+        let word = Self::get_word_at_offset(&ctx.content, ctx.offset);
+
+        // Check for Vue directives first; these do not need Corsa.
+        if !word.is_empty()
+            && let Some(hover) = Self::hover_directive(&word)
+        {
+            return Some(hover);
+        }
+
+        if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset)
+            && let Some(hover) = Self::hover_html_tag_with_corsa(ctx, corsa_bridge.as_ref()).await
+        {
+            return Some(hover);
+        }
+
+        // petite-vue standalone HTML `v-scope` bindings have no virtual TS
+        // declaration for Corsa to resolve; surface them from the scope chain.
+        if !word.is_empty()
+            && let Some(hover) = Self::hover_petite_vue_scope_binding(ctx, &word)
+        {
+            return Some(hover);
+        }
+
+        if let Some(bridge) = corsa_bridge.as_ref()
+            && bridge.is_initialized()
+            && let Some(doc) =
+                crate::ide::corsa_support::open_canonical_virtual_document(ctx, bridge).await
+            && let Some((line, character)) =
+                crate::ide::corsa_support::canonical_source_offset_to_position(&doc, ctx.offset)
+            && let Ok(Some(hover)) = bridge.hover(&doc.request_uri, line, character).await
+        {
+            let mapped_range = hover.range.as_ref().and_then(|range| {
+                crate::ide::corsa_support::map_canonical_lsp_range(ctx, &doc, range)
+            });
+            let mut converted = Self::convert_lsp_hover(hover);
+            if mapped_range.is_some() {
+                converted.range = mapped_range;
+            }
+            return Some(converted);
+        }
+
+        if word.is_empty() {
+            return None;
+        }
+
+        Self::hover_template(ctx)
+    }
+
     /// Get hover for an art variant template with Corsa.
     ///
     /// Maps the art variant offset to the virtual TS offset and requests hover from Corsa.

--- a/crates/vize_maestro/src/ide/hover/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa_tests.rs
@@ -1,0 +1,137 @@
+use std::fs;
+
+use tower_lsp::lsp_types::{Hover, HoverContents, MarkedString, Url};
+
+use super::HoverService;
+use crate::{ide::IdeContext, server::ServerState};
+
+#[test]
+fn hover_with_corsa_resolves_component_prop_attribute() {
+    crate::runtime::block_on(async {
+        let Some(corsa_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(
+            dir.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .unwrap();
+        fs::write(
+            src.join("vue.d.ts"),
+            r#"declare module "vue" {
+  export type DefineComponent<P = any, _B = any, _D = any> = { new(): { $props: P } };
+  export interface Ref<T = unknown> { value: T }
+  export interface ShallowRef<T = unknown> extends Ref<T> {}
+}
+"#,
+        )
+        .unwrap();
+        fs::write(
+            src.join("Child.vue"),
+            r#"<script setup lang="ts">
+defineProps<{
+  message: string
+}>()
+</script>
+<template><span /></template>
+"#,
+        )
+        .unwrap();
+
+        let source = r#"<script setup lang="ts">
+import Child from './Child.vue'
+const msg = 'hello'
+</script>
+
+<template>
+  <Child :message="msg" />
+</template>
+"#;
+        let source_path = src.join("Parent.vue");
+        fs::write(&source_path, source).unwrap();
+
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state.set_workspace_root(dir.path().to_path_buf());
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        let bridge = std::sync::Arc::new(vize_canon::CorsaBridge::with_config(
+            vize_canon::CorsaBridgeConfig {
+                corsa_path: Some(corsa_path),
+                working_dir: Some(dir.path().to_path_buf()),
+                timeout_ms: 30_000,
+                ..Default::default()
+            },
+        ));
+        bridge.spawn().await.unwrap();
+
+        let offset = source.find(":message").unwrap() + 1;
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let hover = HoverService::hover_with_corsa(&ctx, Some(bridge.clone()))
+            .await
+            .unwrap();
+        let _ = bridge.shutdown().await;
+
+        let value = hover_markdown(hover);
+        assert!(value.contains("message"), "{value}");
+        assert!(value.contains("string"), "{value}");
+    });
+}
+
+fn hover_markdown(hover: Hover) -> String {
+    match hover.contents {
+        HoverContents::Markup(content) => content.value,
+        HoverContents::Scalar(value) => marked_string_value(value),
+        HoverContents::Array(parts) => parts
+            .into_iter()
+            .map(marked_string_value)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    }
+}
+
+fn marked_string_value(value: MarkedString) -> String {
+    match value {
+        MarkedString::String(value) => value,
+        MarkedString::LanguageString(value) => value.value,
+    }
+}
+
+fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return None;
+    }
+
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)?;
+    for candidate in [
+        workspace_root.parent()?.join("corsa-bind/.cache/tsgo"),
+        workspace_root
+            .parent()?
+            .join("corsa-bind/ref/corsa-upstream/.cache/tsgo"),
+        workspace_root.join("node_modules/.bin/tsgo"),
+    ] {
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+
+    vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
+}

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -12,12 +12,6 @@ use tower_lsp::lsp_types::Hover;
 use vize_croquis::{Drawer, DrawerOptions};
 use vize_relief::BindingType;
 
-#[cfg(feature = "native")]
-use std::sync::Arc;
-
-#[cfg(feature = "native")]
-use vize_canon::CorsaBridge;
-
 use super::{HoverBuilder, HoverService};
 use crate::ide::IdeContext;
 
@@ -36,7 +30,7 @@ impl HoverService {
             return Some(hover);
         }
 
-        if let Some(hover) = Self::hover_component_prop_attribute(ctx) {
+        if let Some(hover) = super::component_prop::hover_attribute(ctx) {
             return Some(hover);
         }
 
@@ -104,121 +98,6 @@ impl HoverService {
                 .description("Expression evaluated against the component template scope.")
                 .build(),
         )
-    }
-
-    fn hover_component_prop_attribute(ctx: &IdeContext<'_>) -> Option<Hover> {
-        let (attr_name, component_name) =
-            crate::ide::definition::helpers::get_attribute_and_component_at_offset(ctx)?;
-        if !crate::ide::is_component_tag(&component_name) {
-            return None;
-        }
-
-        let import_path = crate::ide::definition::helpers::find_import_path(ctx, &component_name)?;
-        let resolved_path =
-            crate::ide::definition::helpers::resolve_import_path(ctx.uri, &import_path)?;
-        let component_content = std::fs::read_to_string(&resolved_path).ok()?;
-        let descriptor = vize_atelier_sfc::parse_sfc(
-            &component_content,
-            vize_atelier_sfc::SfcParseOptions {
-                filename: resolved_path.to_string_lossy().to_string().into(),
-                ..Default::default()
-            },
-        )
-        .ok()?;
-        let script_setup = descriptor.script_setup.as_ref()?;
-        let script = script_setup.content.as_ref();
-        let prop_name = crate::ide::definition::helpers::kebab_to_camel(&attr_name);
-        let define_props_pos = script.find("defineProps")?;
-        let after_define_props = &script[define_props_pos..];
-        let prop_pos = crate::ide::definition::helpers::find_prop_in_define_props(
-            after_define_props,
-            &prop_name,
-        )?;
-        let signature = Self::prop_signature_at(script, define_props_pos + prop_pos, &prop_name);
-
-        Some(
-            HoverBuilder::new()
-                .title(&prop_name)
-                .meta("Component prop")
-                .code("typescript", &signature)
-                .build(),
-        )
-    }
-
-    fn prop_signature_at(script: &str, offset: usize, prop_name: &str) -> String {
-        let line_start = script[..offset]
-            .rfind('\n')
-            .map(|index| index + 1)
-            .unwrap_or(0);
-        let line_end = script[offset..]
-            .find('\n')
-            .map(|index| offset + index)
-            .unwrap_or(script.len());
-        let line = script[line_start..line_end]
-            .trim()
-            .trim_end_matches(',')
-            .trim();
-        if line.is_empty() {
-            prop_name.to_string()
-        } else {
-            line.to_string()
-        }
-    }
-
-    /// Get hover for template context with Corsa support.
-    #[cfg(feature = "native")]
-    pub(super) async fn hover_template_with_corsa(
-        ctx: &IdeContext<'_>,
-        corsa_bridge: Option<Arc<CorsaBridge>>,
-    ) -> Option<Hover> {
-        let word = Self::get_word_at_offset(&ctx.content, ctx.offset);
-
-        // Check for Vue directives first; these do not need Corsa.
-        if !word.is_empty()
-            && let Some(hover) = Self::hover_directive(&word)
-        {
-            return Some(hover);
-        }
-
-        if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset)
-            && let Some(hover) = Self::hover_html_tag_with_corsa(ctx, corsa_bridge.as_ref()).await
-        {
-            return Some(hover);
-        }
-
-        // petite-vue standalone HTML `v-scope` bindings have no virtual TS
-        // declaration for Corsa to resolve; surface them from the scope chain.
-        if !word.is_empty()
-            && let Some(hover) = Self::hover_petite_vue_scope_binding(ctx, &word)
-        {
-            return Some(hover);
-        }
-
-        // Try to get type information from Corsa via canonical virtual TypeScript.
-        if let Some(bridge) = corsa_bridge.as_ref()
-            && bridge.is_initialized()
-            && let Some(doc) =
-                crate::ide::corsa_support::open_canonical_virtual_document(ctx, bridge).await
-            && let Some((line, character)) =
-                crate::ide::corsa_support::canonical_source_offset_to_position(&doc, ctx.offset)
-            && let Ok(Some(hover)) = bridge.hover(&doc.request_uri, line, character).await
-        {
-            let mapped_range = hover.range.as_ref().and_then(|range| {
-                crate::ide::corsa_support::map_canonical_lsp_range(ctx, &doc, range)
-            });
-            let mut converted = Self::convert_lsp_hover(hover);
-            if mapped_range.is_some() {
-                converted.range = mapped_range;
-            }
-            return Some(converted);
-        }
-
-        if word.is_empty() {
-            return None;
-        }
-
-        // Fall back to croquis analysis
-        Self::hover_template(ctx)
     }
 
     /// Get hover for TypeScript binding using croquis analysis.


### PR DESCRIPTION
## Summary
- preserve component prop and attr completions when Corsa returns template completions
- map template component tags and prop attributes through canonical virtual TypeScript for definition and hover
- keep in-project Vue virtual overlays at real URIs without materializing `.vue.ts` sibling files
- split the added navigation/overlay/test logic out of existing over-limit files

## Root Cause
The Corsa completion path returned early with TypeScript completions, so template structural completions for component props were not merged back in. Template navigation also lacked generated source mappings for component tag and prop-name tokens, and in-project virtual `.vue.ts` overlays were being treated like files that needed to exist on disk.

## Verification
- `cargo test -p vize_maestro --features native template_component_prop_completion -- --nocapture`
- `cargo test -p vize_canon --features native component_template_navigation_mappings -- --nocapture`
- `cargo test -p vize_canon --features native virtual_vue_overlay_file_changes_do_not_materialize_sibling_files -- --nocapture`
- `cargo test -p vize_maestro --features native definition_with_corsa_resolves_component_prop_attribute_to_child_prop -- --nocapture`
- `cargo test -p vize_maestro --features native hover_with_corsa_resolves_component_prop_attribute -- --nocapture`
- `cargo test -p vize_canon --features native --lib`
- `cargo test -p vize_maestro --features native --lib`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `vp run --workspace-root source:lengths --check --base-ref origin/main`
- `vp run --workspace-root test:scripts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->