### PR TITLE
fix: stabilize source coverage vue import test

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs
@@ -208,12 +208,23 @@ fn write_vue_import_fixture(root: &Path) {
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "noEmit": true
   },
   "include": ["src/**/*"]
 }"#,
     )
     .expect("tsconfig");
+    std::fs::write(
+        src.join("vue.d.ts"),
+        r#"declare module "vue" {
+  export type DefineComponent<P = any, _B = any, _D = any> = { new(): { $props: P } };
+  export interface Ref<T = unknown> { value: T }
+  export interface ShallowRef<T = unknown> extends Ref<T> {}
+}
+"#,
+    )
+    .expect("vue shim");
     std::fs::write(
         src.join("Child.vue"),
         r#"<script setup lang="ts">
@@ -270,6 +281,9 @@ fn assert_no_import_or_unknown_record_diagnostics(
 fn resolve_test_tsgo_binary() -> Option<PathBuf> {
     if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
         return None;
+    }
+    if let Some(path) = std::env::var_os("VIZE_TEST_TSGO_PATH") {
+        return Some(PathBuf::from(path));
     }
 
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
## Summary
- make the editor relative .vue import fixture self-contained for source coverage runs
- allow the test to pin the tsgo binary via VIZE_TEST_TSGO_PATH when reproducing CI

## Verification
- cargo fmt --all -- --check
- VIZE_TEST_TSGO_PATH="/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.bin/tsgo" cargo llvm-cov test -p vize_maestro --lib async_collect_resolves_relative_vue_imports_in_script_setup --no-report -- --nocapture
- cargo llvm-cov test -p vize_maestro --lib --no-report
- vp run --workspace-root coverage:source

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->