### PR TITLE
fix: stabilize editor Vue virtual imports

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 
 use oxc_span::SourceType;
-use vize_carton::{FxHashSet, String, ToCompactString};
+use vize_carton::{FxHashSet, String, ToCompactString, cstr};
 
 use super::bridge::normalize_document_uri;
 use super::vue_document::{
@@ -12,6 +12,9 @@ use super::vue_document::{
 };
 use crate::batch::ImportRewriter;
 use crate::file_uri::path_to_file_uri;
+
+const VUE_DEPENDENCY_FALLBACK: &str =
+    "const component: any = undefined;\nexport default component;\n";
 
 pub(super) fn collect_dependency_documents(
     documents: &mut Vec<(String, String)>,
@@ -118,8 +121,15 @@ fn queue_vue_imports(
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };
-        let Ok(generated) = generate_vue_document(&path, &content, options, rewriter) else {
-            continue;
+        let generated = match generate_vue_document(&path, &content, options, rewriter) {
+            Ok(generated) => generated,
+            Err(_) => {
+                imports.documents.push((
+                    fallback_vue_virtual_uri(&path),
+                    VUE_DEPENDENCY_FALLBACK.into(),
+                ));
+                continue;
+            }
         };
         imports.documents.push((
             generated.virtual_uri.clone(),
@@ -131,6 +141,16 @@ fn queue_vue_imports(
             pre_rewrite_code: generated.generated.pre_rewrite_code,
         });
     }
+}
+
+fn fallback_vue_virtual_uri(path: &Path) -> String {
+    let virtual_path = path.with_file_name(cstr!(
+        "{}.ts",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+    ));
+    path_to_file_uri(&virtual_path)
 }
 
 fn queue_ts_imports(

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -153,7 +153,9 @@ mod tests {
 
         let host_path = src.join("Host.vue");
         let child_path = src.join("Child.vue");
+        let grand_child_path = src.join("GrandChild.vue");
         let util_path = src.join("util.ts");
+        let child_util_path = src.join("childUtil.ts");
         std::fs::write(
             &host_path,
             r#"<script setup lang="ts">
@@ -168,13 +170,27 @@ const current = value;
         std::fs::write(
             &child_path,
             r#"<script setup lang="ts">
+import GrandChild from "./GrandChild.vue";
+import { childValue } from "./childUtil";
 defineProps<{ value: number }>();
+const _grandChild = GrandChild;
+const _childValue = childValue;
+</script>
+<template><GrandChild /></template>
+"#,
+        )
+        .expect("child");
+        std::fs::write(
+            &grand_child_path,
+            r#"<script setup lang="ts">
+defineProps<{ label?: string }>();
 </script>
 <template><span /></template>
 "#,
         )
-        .expect("child");
+        .expect("grand child");
         std::fs::write(&util_path, "export const value = 1;\n").expect("util");
+        std::fs::write(&child_util_path, "export const childValue = 2;\n").expect("child util");
 
         let host = std::fs::read_to_string(&host_path).expect("host source");
         let virtual_project =
@@ -189,10 +205,69 @@ defineProps<{ value: number }>();
         assert!(virtual_project.host.code.contains("\"./Child.vue.ts\""));
         assert!(uris.contains(&path_to_file_uri(&src.join("Host.vue.ts")).as_str()));
         assert!(uris.contains(&path_to_file_uri(&src.join("Child.vue.ts")).as_str()));
+        assert!(uris.contains(&path_to_file_uri(&src.join("GrandChild.vue.ts")).as_str()));
         assert!(
             uris.contains(&path_to_file_uri(&util_path).as_str()),
             "uris: {uris:?}\n{}",
             virtual_project.host.pre_rewrite_code,
+        );
+        assert!(
+            uris.contains(&path_to_file_uri(&child_util_path).as_str()),
+            "nested dependency imports must be synced too: {uris:?}",
+        );
+        assert_eq!(
+            uris.iter()
+                .filter(|uri| **uri == path_to_file_uri(&src.join("Child.vue.ts")).as_str())
+                .count(),
+            1,
+            "Vue dependency documents must be de-duplicated: {uris:?}",
+        );
+    }
+
+    #[test]
+    fn vue_virtual_project_stubs_existing_unparseable_vue_dependencies() {
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = project.path().join("src");
+        std::fs::create_dir_all(&src).expect("src dir");
+
+        let host_path = src.join("Host.vue");
+        let broken_path = src.join("Broken.vue");
+        std::fs::write(
+            &host_path,
+            r#"<script setup lang="ts">
+import Broken from "./Broken.vue";
+const _broken = Broken;
+</script>
+<template><Broken /></template>
+"#,
+        )
+        .expect("host");
+        std::fs::write(&broken_path, "<template><div></div>").expect("broken dependency");
+
+        let host = std::fs::read_to_string(&host_path).expect("host source");
+        let virtual_project =
+            build_vue_virtual_project(&host_path, &host, CorsaVueVirtualDocumentOptions::default())
+                .expect("host virtual project");
+        let broken_virtual_uri = path_to_file_uri(&src.join("Broken.vue.ts"));
+        let broken_document = virtual_project
+            .documents
+            .iter()
+            .find(|(uri, _)| uri == broken_virtual_uri.as_str())
+            .map(|(_, content)| content.as_str())
+            .expect("existing malformed Vue dependency still needs a virtual module");
+
+        assert!(
+            virtual_project.host.code.contains("\"./Broken.vue.ts\""),
+            "host import must target the virtual Vue mirror:\n{}",
+            virtual_project.host.code,
+        );
+        assert_eq!(
+            broken_document,
+            "const component: any = undefined;\nexport default component;\n"
+        );
+        assert!(
+            !src.join("Broken.vue.ts").exists(),
+            "fallback dependency must be synced in-memory, not written next to the source file"
         );
     }
 }

--- a/crates/vize_canon/src/lsp_client/session.rs
+++ b/crates/vize_canon/src/lsp_client/session.rs
@@ -181,11 +181,7 @@ impl CorsaProjectClient {
         }
 
         if document_uri == uri && !self.supports_overlay_api() {
-            return if virtual_overlay::uri_inside_project(uri, &self.project_root) {
-                Ok(())
-            } else {
-                self.sync_materialized_overlay_document(uri, content)
-            };
+            return self.sync_materialized_overlay_document(uri, content);
         }
 
         let file_changes = materialize_session_document(uri, document_uri.as_str(), content)
@@ -220,11 +216,7 @@ impl CorsaProjectClient {
             Ok(()) => Ok(()),
             Err(error) if overlay_changes_error_is_unsupported(&error) => {
                 self.overlay_api_disabled = true;
-                if virtual_overlay::uri_inside_project(uri, &self.project_root) {
-                    Ok(())
-                } else {
-                    self.sync_materialized_overlay_document(uri, content)
-                }
+                self.sync_materialized_overlay_document(uri, content)
             }
             Err(error) => Err(cstr!("Failed to sync Corsa overlay: {error}")),
         }
@@ -335,15 +327,19 @@ fn load_file_text(uri: &str) -> Option<String> {
 pub(super) fn build_session_document_uri(
     uri: &str,
     project_root: &Path,
-    _overlay_confirmed: bool,
+    overlay_confirmed: bool,
 ) -> String {
     let Some(external_path) = external_document_path(uri) else {
         return uri.into();
     };
 
-    // Keep in-project real files and virtual mirrors at real paths.
+    // Keep real in-project files at real paths. Virtual mirrors (`*.vue.ts`,
+    // `*.html.ts`) can also stay there when Corsa overlay support is confirmed;
+    // otherwise materialize them under the session overlay root so imports
+    // never point at non-existent workspace files.
     if external_path.starts_with(project_root)
-        && (external_path.exists() || virtual_overlay::target_exists(&external_path))
+        && (external_path.exists()
+            || (overlay_confirmed && virtual_overlay::target_exists(&external_path)))
     {
         return path_to_file_uri(&external_path);
     }
@@ -523,7 +519,11 @@ mod tests {
         assert_eq!(mapped, uri, "in-project .vue.ts overlay must keep its path");
 
         let mapped_no_overlay = build_session_document_uri(&uri, &project, false);
-        assert_eq!(mapped_no_overlay, uri);
+        assert_ne!(mapped_no_overlay, uri);
+        assert!(
+            mapped_no_overlay.contains("/node_modules/.vize/corsa-overlay/"),
+            "in-project .vue.ts overlay must materialize under the session overlay root without overlay support: {mapped_no_overlay}"
+        );
 
         // A path outside the project is still remapped into the overlay tree.
         let outside = std::env::temp_dir().join(format!("vize-outside-{nonce}/Other.vue.ts"));

--- a/crates/vize_canon/src/lsp_client/tests.rs
+++ b/crates/vize_canon/src/lsp_client/tests.rs
@@ -209,6 +209,16 @@ fn keeps_encoded_vue_virtual_overlay_uri_at_real_path_inside_project() {
         materialize_session_document(&uri, &mapped, "export {};").is_none(),
         "stable overlay URIs must not materialize sibling files"
     );
+
+    let mapped_without_overlay = build_session_document_uri(&uri, &project, false);
+    assert_ne!(
+        mapped_without_overlay, uri,
+        "without overlay support, virtual mirrors must move into the session overlay root"
+    );
+    assert!(
+        mapped_without_overlay.contains("/node_modules/.vize/corsa-overlay/"),
+        "unexpected materialized overlay URI: {mapped_without_overlay}"
+    );
     assert!(!virtual_path.exists());
 
     let _ = std::fs::remove_dir_all(project);

--- a/crates/vize_canon/src/lsp_client/virtual_overlay.rs
+++ b/crates/vize_canon/src/lsp_client/virtual_overlay.rs
@@ -4,11 +4,6 @@ use corsa::api::{FileChangeSummary, FileChanges};
 
 use super::session::{external_document_path, uri_document_identifier};
 
-pub(super) fn uri_inside_project(uri: &str, project_root: &Path) -> bool {
-    external_document_path(uri)
-        .is_some_and(|path| path.starts_with(project_root) && target_exists(&path))
-}
-
 pub(super) fn target_exists(external_path: &Path) -> bool {
     let Some(name) = external_path.file_name().and_then(|name| name.to_str()) else {
         return false;

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/message.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/message.rs
@@ -9,6 +9,16 @@ use vize_carton::cstr;
 /// what TypeScript reported. The added hint points at the most common Vue
 /// cause for that error shape.
 pub(super) fn rewrite_corsa_message(message: &str) -> String {
+    let normalized_message;
+    let message = if message.contains(".vue.ts") {
+        normalized_message = message
+            .replace(".vue.tsx", ".vue")
+            .replace(".vue.ts", ".vue");
+        normalized_message.as_str()
+    } else {
+        message
+    };
+
     if let Some(prop) = property_does_not_exist_property(message)
         && prop != "value"
     {
@@ -68,6 +78,55 @@ mod hint_tests {
         let rewritten = rewrite_corsa_message(original);
         assert!(rewritten.contains(original));
         assert!(rewritten.contains("Did you forget `.value`"));
+    }
+
+    #[test]
+    fn rewrites_internal_vue_ts_imports_back_to_vue() {
+        let original = "Cannot find module '../logo/MfMatesLogo.vue.ts' or its corresponding type declarations.";
+        let rewritten = rewrite_corsa_message(original);
+
+        assert_eq!(
+            rewritten,
+            "Cannot find module '../logo/MfMatesLogo.vue' or its corresponding type declarations."
+        );
+        assert!(!rewritten.contains(".vue.ts"));
+    }
+
+    #[test]
+    fn rewrites_internal_vue_tsx_imports_back_to_vue() {
+        let original =
+            "Cannot find module './Panel.vue.tsx' or its corresponding type declarations.";
+        let rewritten = rewrite_corsa_message(original);
+
+        assert_eq!(
+            rewritten,
+            "Cannot find module './Panel.vue' or its corresponding type declarations."
+        );
+        assert!(!rewritten.contains(".vue.tsx"));
+    }
+
+    #[test]
+    fn rewrites_every_internal_vue_virtual_suffix_in_message() {
+        let original = "Cannot find module '../logo/MfMatesLogo.vue.ts'. Related import './Panel.vue.tsx' also failed.";
+        let rewritten = rewrite_corsa_message(original);
+
+        assert_eq!(
+            rewritten,
+            "Cannot find module '../logo/MfMatesLogo.vue'. Related import './Panel.vue' also failed."
+        );
+        assert!(!rewritten.contains(".vue.ts"));
+        assert!(!rewritten.contains(".vue.tsx"));
+    }
+
+    #[test]
+    fn rewrites_internal_vue_suffix_before_adding_value_hint() {
+        let original =
+            "Property 'toFixed' does not exist on type 'typeof import(\"./Panel.vue.ts\")'.";
+        let rewritten = rewrite_corsa_message(original);
+
+        assert!(rewritten.contains("./Panel.vue"));
+        assert!(!rewritten.contains(".vue.ts"));
+        assert!(rewritten.contains(".value"));
     }
 
     #[test]

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/mod.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/mod.rs
@@ -13,4 +13,6 @@ mod virtual_ts_art;
 mod virtual_ts_inline_art;
 
 #[cfg(test)]
+mod relative_import_tests;
+#[cfg(test)]
 mod tests;

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/relative_import_tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/relative_import_tests.rs
@@ -1,0 +1,210 @@
+use super::collect_virtual::collect_synced_virtual_result_diagnostics;
+use crate::DiagnosticService;
+use tower_lsp::lsp_types::Url;
+use vize_canon::{CorsaBridge, CorsaBridgeConfig, CorsaVueVirtualDocumentOptions};
+
+#[test]
+fn editor_relative_vue_imports_resolve_existing_siblings() {
+    let Some(corsa_path) = resolve_test_tsgo_binary() else {
+        return;
+    };
+
+    let project = tempfile::TempDir::new().expect("temp project");
+    let root = project.path();
+    let src = root.join("src");
+    let layout = src.join("layout");
+    let logo = src.join("logo");
+    let tag = src.join("tag");
+    std::fs::create_dir_all(&layout).expect("layout dir");
+    std::fs::create_dir_all(&logo).expect("logo dir");
+    std::fs::create_dir_all(&tag).expect("tag dir");
+
+    std::fs::write(
+        root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .expect("tsconfig");
+    std::fs::write(
+        src.join("vue.d.ts"),
+        r#"declare module "vue" {
+  export interface Ref<T = unknown, _Raw = T> { value: T }
+  export interface ComputedRef<T = unknown> extends Ref<T> {}
+  export interface ShallowRef<T = unknown, _Raw = T> extends Ref<T> {}
+  export interface ComponentPublicInstance {
+    $attrs: Record<string, unknown>;
+    $slots: Record<string, (...args: any[]) => any>;
+    $refs: Record<string, any>;
+    $emit: (...args: any[]) => void;
+  }
+  export type DefineComponent<P = any, B = any, D = any, C = any, M = any, Mixins = any, Extends = any, E = any> = {
+    new (): { $props: P };
+  };
+}
+"#,
+    )
+    .expect("vue shim");
+
+    std::fs::write(
+        logo.join("MfMatesLogo.vue"),
+        r#"<script setup lang="ts">
+defineProps<{ label?: string }>();
+</script>
+<template><svg aria-hidden="true" /></template>
+"#,
+    )
+    .expect("logo sfc");
+    std::fs::write(
+        tag.join("MfTag.vue"),
+        r#"<script setup lang="ts">
+defineProps<{ tone?: "neutral" | "accent" }>();
+</script>
+<template><span /></template>
+"#,
+    )
+    .expect("tag sfc");
+
+    let host_path = layout.join("MfPageShell.vue");
+    let host_content = r#"<script setup lang="ts">
+import MfMatesLogo from "../logo/MfMatesLogo.vue";
+import MfTag from "../tag/MfTag.vue";
+
+const {
+  brandAriaLabel = "Go to Mates Internal top",
+  eyebrow,
+  footerCopy = null,
+  lead,
+  meta = [],
+  title,
+} = defineProps<{
+  brandAriaLabel?: string;
+  eyebrow?: string;
+  footerCopy?: string | null;
+  lead?: string;
+  meta?: readonly string[];
+  title: string;
+}>();
+
+defineSlots<{
+  actions?: () => unknown;
+  brand?: () => unknown;
+  default?: () => unknown;
+}>();
+</script>
+<template>
+  <header>
+    <MfMatesLogo :label="brandAriaLabel" />
+    <MfTag v-if="eyebrow" tone="accent">{{ eyebrow }}</MfTag>
+    <h1>{{ title }}</h1>
+    <p v-if="lead">{{ lead }}</p>
+    <small v-if="footerCopy">{{ footerCopy }}</small>
+    <span v-for="item in meta" :key="item">{{ item }}</span>
+  </header>
+</template>
+"#;
+    std::fs::write(&host_path, host_content).expect("host sfc");
+
+    let host_uri = Url::from_file_path(&host_path).expect("host uri");
+    let virtual_result =
+        DiagnosticService::generate_virtual_ts(&host_uri, host_content, false, false)
+            .expect("virtual ts generated");
+    assert!(
+        virtual_result.code.contains("../logo/MfMatesLogo.vue.ts")
+            && virtual_result.code.contains("../tag/MfTag.vue.ts"),
+        "editor virtual TS must rewrite sibling Vue imports to virtual mirrors:\n{}",
+        virtual_result.code,
+    );
+    let bridge = std::sync::Arc::new(CorsaBridge::with_config(CorsaBridgeConfig {
+        corsa_path: Some(corsa_path),
+        working_dir: Some(root.to_path_buf()),
+        timeout_ms: 30_000,
+        ..Default::default()
+    }));
+
+    let diagnostics = crate::runtime::block_on(async {
+        if bridge.spawn().await.is_err() {
+            return None;
+        }
+        let result = async {
+            let opened = bridge
+                .open_vue_virtual_document(
+                    &host_path,
+                    host_content,
+                    CorsaVueVirtualDocumentOptions::default(),
+                )
+                .await
+                .ok()?;
+            let expected_virtual_uri =
+                Url::from_file_path(host_path.with_file_name("MfPageShell.vue.ts"))
+                    .expect("expected virtual URI")
+                    .to_string();
+            assert_eq!(
+                opened.request_uri, expected_virtual_uri,
+                "Corsa must query the generated .vue.ts document"
+            );
+            assert!(
+                opened.code.contains("../logo/MfMatesLogo.vue.ts")
+                    && opened.code.contains("../tag/MfTag.vue.ts"),
+                "Corsa-opened Vue document must keep rewritten sibling imports:\n{}",
+                opened.code,
+            );
+            let (virtual_uri, virtual_result) =
+                DiagnosticService::virtual_ts_result_from_corsa_vue_document(
+                    &host_uri,
+                    host_content,
+                    opened,
+                )?;
+            let diagnostics = collect_synced_virtual_result_diagnostics(
+                &bridge,
+                &host_uri,
+                host_content,
+                virtual_uri,
+                virtual_result,
+            )
+            .await;
+            Some(diagnostics)
+        }
+        .await;
+        let _ = bridge.shutdown().await;
+        result
+    });
+
+    let Some(diagnostics) = diagnostics else {
+        return;
+    };
+    assert!(
+        diagnostics.is_empty(),
+        "existing sibling Vue imports must not produce any editor Corsa diagnostics: {diagnostics:#?}",
+    );
+    assert!(
+        diagnostics.iter().all(|diagnostic| {
+            !diagnostic.message.contains("Cannot find module")
+                && !diagnostic.message.contains(".vue.ts")
+        }),
+        "existing .vue imports must not surface .vue.ts module-resolution diagnostics: {diagnostics:#?}",
+    );
+}
+
+fn resolve_test_tsgo_binary() -> Option<std::path::PathBuf> {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return None;
+    }
+
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)?;
+    let sibling_cache = workspace_root.parent()?.join("corsa-bind/.cache/tsgo");
+    if sibling_cache.exists() {
+        return Some(sibling_cache);
+    }
+
+    vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
+}


### PR DESCRIPTION
## Summary
- Materialize editor virtual Vue overlays when Corsa overlay support is unavailable instead of leaving in-project `.vue.ts` mirrors unresolved.
- Sync existing relative Vue dependencies, including fallback stubs for unparseable sibling SFCs, so editor imports do not surface internal `.vue.ts` module-resolution errors.
- Rewrite raw Corsa diagnostic messages so internal `.vue.ts` / `.vue.tsx` suffixes are never shown to users.
- Add regression coverage for the exact sibling Vue import shape that produced `Cannot find module '../logo/MfMatesLogo.vue.ts'` in the editor.

## Tests
- `cargo test -p vize_canon corsa_bridge::vue_document::tests -- --nocapture`
- `cargo test -p vize_maestro --features native ide::diagnostics::corsa::message::hint_tests -- --nocapture`
- `cargo test -p vize_maestro --features native ide::diagnostics::corsa::tests -- --nocapture`
- `cargo test -p vize_maestro --features native ide::diagnostics::corsa::relative_import_tests -- --nocapture`
- `cargo test -p vize_maestro --features native ide::diagnostics::corsa -- --nocapture`
- `cargo test -p vize_canon lsp_client::session::tests -- --nocapture`
- `cargo test -p vize_canon lsp_client::tests -- --nocapture`
- `cargo test -p vize_canon --test lsp_import_resolution -- bridge_vue_virtual_overlay_keeps_real_relative_import_base --nocapture`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --package vize_canon --package vize_maestro`
- `git diff --check --cached`

## CI
- Required PR checks are passing on `417e52bf231b026ca091883ba21fda68c60c8ec3`.
- `criterion-ab` also passed after the final force-push.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->