### PR TITLE
fix: stabilize main source coverage

### DIFF
--- a/crates/vize_canon/src/lsp_client.rs
+++ b/crates/vize_canon/src/lsp_client.rs
@@ -16,6 +16,7 @@ mod bootstrap;
 mod diagnostics;
 mod diagnostics_api;
 mod lifecycle;
+mod lifecycle_setup;
 pub(crate) mod paths;
 mod queries;
 mod session;

--- a/crates/vize_canon/src/lsp_client/lifecycle.rs
+++ b/crates/vize_canon/src/lsp_client/lifecycle.rs
@@ -1,12 +1,10 @@
-mod setup;
-use setup::{
-    cleanup_stale_sessions, install_node_modules_link, write_session_meta,
-    write_shared_helper_decls, write_temp_tsconfig, write_vue_module_stubs,
-};
-
 use super::{
     CorsaProjectClient,
     bootstrap::resolve_corsa_executable,
+    lifecycle_setup::{
+        cleanup_stale_sessions, install_node_modules_link, write_session_meta,
+        write_shared_helper_decls, write_temp_tsconfig, write_vue_module_stubs,
+    },
     paths::resolve_temp_dir_base,
     session::{materialize_session_document, uri_document_identifier},
     virtual_overlay,

--- a/crates/vize_canon/src/lsp_client/lifecycle_setup.rs
+++ b/crates/vize_canon/src/lsp_client/lifecycle_setup.rs
@@ -1,4 +1,4 @@
-use super::super::paths::find_node_modules_with_vue;
+use super::paths::find_node_modules_with_vue;
 use serde_json::json;
 use std::{
     path::Path,

--- a/crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs
@@ -120,6 +120,7 @@ fn write_speaker_fixture(root: &Path) -> SpeakerFixture {
     std::fs::create_dir_all(&components).expect("components dir");
     std::fs::create_dir_all(&utils).expect("utils dir");
     std::fs::create_dir_all(&types).expect("types dir");
+    write_vue_test_package(root);
     std::fs::write(
         root.join("tsconfig.json"),
         r#"{
@@ -134,16 +135,6 @@ fn write_speaker_fixture(root: &Path) -> SpeakerFixture {
 }"#,
     )
     .expect("tsconfig");
-    std::fs::write(
-        src.join("vue.d.ts"),
-        r#"declare module "vue" {
-  export interface Ref<T = unknown, _Raw = T> { value: T }
-  export interface ComputedRef<T = unknown> extends Ref<T> {}
-  export function computed<T>(getter: () => T): ComputedRef<T>;
-}
-"#,
-    )
-    .expect("vue shim");
     std::fs::write(
         types.join("index.ts"),
         "export interface SpeakerWithYear { name: string; year: number; title: string }\n",
@@ -200,6 +191,7 @@ const speakerOptions = computed(() =>
 fn write_vue_import_fixture(root: &Path) {
     let src = root.join("src");
     std::fs::create_dir_all(&src).expect("src dir");
+    write_vue_test_package(root);
     std::fs::write(
         root.join("tsconfig.json"),
         r#"{
@@ -215,22 +207,6 @@ fn write_vue_import_fixture(root: &Path) {
 }"#,
     )
     .expect("tsconfig");
-    std::fs::write(
-        src.join("vue.d.ts"),
-        r#"declare module "vue" {
-  export type DefineComponent<P = any, _B = any, _D = any> = { new(): { $props: P } };
-  export interface ComponentPublicInstance {
-    $attrs: Record<string, unknown>;
-    $slots: Record<string, unknown>;
-    $refs: Record<string, unknown>;
-    $emit: (...args: unknown[]) => void;
-  }
-  export interface Ref<T = unknown> { value: T }
-  export interface ShallowRef<T = unknown> extends Ref<T> {}
-}
-"#,
-    )
-    .expect("vue shim");
     std::fs::write(
         src.join("Child.vue"),
         r#"<script setup lang="ts">
@@ -257,6 +233,32 @@ const selected = Child;
 "#,
     )
     .expect("parent vue");
+}
+
+fn write_vue_test_package(root: &Path) {
+    let vue_dir = root.join("node_modules/vue");
+    std::fs::create_dir_all(&vue_dir).expect("vue package dir");
+    std::fs::write(
+        vue_dir.join("package.json"),
+        r#"{"name":"vue","version":"3.0.0","types":"index.d.ts"}"#,
+    )
+    .expect("vue package json");
+    std::fs::write(
+        vue_dir.join("index.d.ts"),
+        r#"export type DefineComponent<P = any, _B = any, _D = any> = { new(): { $props: P } };
+export interface ComponentPublicInstance {
+  $attrs: Record<string, unknown>;
+  $slots: Record<string, unknown>;
+  $refs: Record<string, unknown>;
+  $emit: (...args: unknown[]) => void;
+}
+export interface Ref<T = unknown, _Raw = T> { value: T }
+export interface ComputedRef<T = unknown> extends Ref<T> {}
+export interface ShallowRef<T = unknown> extends Ref<T> {}
+export function computed<T>(getter: () => T): ComputedRef<T>;
+"#,
+    )
+    .expect("vue types");
 }
 
 fn write_corsa_config(root: &Path, corsa_path: &Path) {


### PR DESCRIPTION
## Summary
- move Corsa lifecycle helper modules out of mod.rs files
- make editor typecheck fixtures resolve Vue through a real node_modules/vue package

## Verification
- cargo fmt --all -- --check
- cargo test -p vize_maestro --lib async_collect -- --nocapture
- cargo llvm-cov test -p vize_maestro --lib async_collect --no-report -- --nocapture
- cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test --test-concurrency=1 tests/tooling/source-file-lengths.test.ts
- cargo test -p vize_canon --test lsp_import_resolution -- --nocapture
- cargo llvm-cov --workspace --json --summary-only --output-path target/llvm-cov/source-summary.json --fail-under-lines 70 --fail-under-functions 70 --fail-under-regions 70 && node tools/coverage/enforce-rust-source-coverage.mjs --json target/llvm-cov/source-summary.json --min-lines 70 --min-functions 70 --min-regions 70

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->