### PR TITLE
fix(canon): expose deeply destructured setup bindings

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/tests/define_props_regressions.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests/define_props_regressions.rs
@@ -1,5 +1,5 @@
 use super::super::compile_sfc;
-use crate::types::SfcCompileOptions;
+use crate::types::{BindingType, SfcCompileOptions};
 use crate::{SfcParseOptions, parse_sfc};
 
 #[test]
@@ -53,4 +53,57 @@ const { a, b } = defineProps<{ label: string, a: string, b: string }>()
         "type-only props must not fall back to instance context:\n{}",
         result.code
     );
+}
+
+#[test]
+fn test_script_setup_deep_destructure_bindings_are_available_to_template() {
+    let source = r#"<script setup lang="ts">
+const {
+  public: { contactFormUrl },
+  nested: { label: inquiryLabel = "Inquiry" },
+  urls: [firstUrl, { href: secondUrl }],
+  ...runtimeRest
+} = useRuntimeConfig()
+</script>
+
+<template>
+  <a
+    :href="contactFormUrl"
+    :aria-label="inquiryLabel"
+    :data-first="firstUrl"
+    :data-second="secondUrl"
+    :data-rest="runtimeRest"
+  >
+    {{ inquiryLabel }}
+  </a>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result =
+        compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+
+    let bindings = result
+        .bindings
+        .as_ref()
+        .expect("script setup output should include bindings");
+    for name in [
+        "contactFormUrl",
+        "inquiryLabel",
+        "firstUrl",
+        "secondUrl",
+        "runtimeRest",
+    ] {
+        assert!(
+            matches!(
+                bindings.bindings.get(name),
+                Some(BindingType::SetupMaybeRef)
+            ),
+            "{name} should be collected from the deep destructure pattern"
+        );
+        assert!(
+            !result.code.contains(&format!("_ctx.{name}")),
+            "{name} should be compiled as a setup binding, not as an instance property:\n{}",
+            result.code
+        );
+    }
 }

--- a/crates/vize_atelier_sfc/src/script/context/helpers.rs
+++ b/crates/vize_atelier_sfc/src/script/context/helpers.rs
@@ -2,10 +2,12 @@
 //!
 //! Free functions used by the parsing and props extraction logic.
 
-use oxc_ast::ast::{CallExpression, Expression, ImportDeclaration, VariableDeclarationKind};
+use oxc_ast::ast::{
+    BindingPattern, CallExpression, Expression, ImportDeclaration, VariableDeclarationKind,
+};
 use oxc_span::GetSpan;
 
-use crate::types::BindingType;
+use crate::types::{BindingMetadata, BindingType};
 use vize_croquis::macros::is_builtin_macro;
 
 use super::super::MacroCall;
@@ -170,4 +172,57 @@ pub(super) fn is_import_type_only(import_decl: &ImportDeclaration<'_>, source: &
     }
     let raw = &source[start..end];
     raw.trim_start().starts_with("import type")
+}
+
+pub(super) fn macro_binding_name(id: &BindingPattern<'_>) -> Option<String> {
+    match id {
+        BindingPattern::BindingIdentifier(id) => Some(id.name.to_compact_string()),
+        BindingPattern::ArrayPattern(pattern) => pattern
+            .elements
+            .first()
+            .and_then(|elem| elem.as_ref())
+            .and_then(simple_binding_name),
+        _ => None,
+    }
+}
+
+pub(super) fn register_binding_pattern(
+    bindings: &mut BindingMetadata,
+    pattern: &BindingPattern<'_>,
+    binding_type: BindingType,
+) {
+    match pattern {
+        BindingPattern::BindingIdentifier(id) => {
+            bindings
+                .bindings
+                .insert(id.name.to_compact_string(), binding_type);
+        }
+        BindingPattern::ObjectPattern(object) => {
+            for property in object.properties.iter() {
+                register_binding_pattern(bindings, &property.value, binding_type);
+            }
+            if let Some(rest) = &object.rest {
+                register_binding_pattern(bindings, &rest.argument, binding_type);
+            }
+        }
+        BindingPattern::ArrayPattern(array) => {
+            for element in array.elements.iter().flatten() {
+                register_binding_pattern(bindings, element, binding_type);
+            }
+            if let Some(rest) = &array.rest {
+                register_binding_pattern(bindings, &rest.argument, binding_type);
+            }
+        }
+        BindingPattern::AssignmentPattern(assign) => {
+            register_binding_pattern(bindings, &assign.left, binding_type);
+        }
+    }
+}
+
+fn simple_binding_name(id: &BindingPattern<'_>) -> Option<String> {
+    match id {
+        BindingPattern::BindingIdentifier(id) => Some(id.name.to_compact_string()),
+        BindingPattern::AssignmentPattern(pattern) => simple_binding_name(&pattern.left),
+        _ => None,
+    }
 }

--- a/crates/vize_atelier_sfc/src/script/context/parse.rs
+++ b/crates/vize_atelier_sfc/src/script/context/parse.rs
@@ -19,7 +19,8 @@ use super::super::define_props_destructure::process_props_destructure;
 use super::ScriptCompileContext;
 use super::helpers::{
     extract_args_from_call, extract_macro_from_expr, extract_type_args_from_call,
-    infer_binding_type, is_call_of, is_import_type_only,
+    infer_binding_type, is_call_of, is_import_type_only, macro_binding_name,
+    register_binding_pattern,
 };
 use crate::script::build_interface_type_source;
 
@@ -331,13 +332,11 @@ impl ScriptCompileContext {
                                         _ => BindingType::SetupLet,
                                     }
                                 };
-                                for prop in obj_pat.properties.iter() {
-                                    if let BindingPattern::BindingIdentifier(id) = &prop.value {
-                                        self.bindings
-                                            .bindings
-                                            .insert(id.name.to_compact_string(), destructure_type);
-                                    }
-                                }
+                                register_binding_pattern(
+                                    &mut self.bindings,
+                                    &decl.id,
+                                    destructure_type,
+                                );
                             }
                         }
                         BindingPattern::ArrayPattern(arr_pat) => {
@@ -358,26 +357,31 @@ impl ScriptCompileContext {
                                 let Some(elem) = elem else {
                                     continue;
                                 };
-                                if let Some(name) = simple_binding_name(elem) {
-                                    let binding_type = if is_define_model {
-                                        if index == 0 {
-                                            BindingType::SetupRef
-                                        } else {
-                                            BindingType::SetupConst
-                                        }
+                                let binding_type = if is_define_model {
+                                    if index == 0 {
+                                        BindingType::SetupRef
                                     } else {
-                                        destructure_type
-                                    };
-                                    self.bindings.bindings.insert(name, binding_type);
-                                }
+                                        BindingType::SetupConst
+                                    }
+                                } else {
+                                    destructure_type
+                                };
+                                register_binding_pattern(&mut self.bindings, elem, binding_type);
+                            }
+                            if let Some(rest) = arr_pat.rest.as_ref() {
+                                register_binding_pattern(
+                                    &mut self.bindings,
+                                    &rest.argument,
+                                    destructure_type,
+                                );
                             }
                         }
                         BindingPattern::AssignmentPattern(assign_pat) => {
-                            if let BindingPattern::BindingIdentifier(id) = &assign_pat.left {
-                                self.bindings
-                                    .bindings
-                                    .insert(id.name.to_compact_string(), BindingType::SetupConst);
-                            }
+                            register_binding_pattern(
+                                &mut self.bindings,
+                                &assign_pat.left,
+                                BindingType::SetupConst,
+                            );
                         }
                     }
                 }
@@ -458,25 +462,5 @@ impl ScriptCompileContext {
             }
             _ => {}
         }
-    }
-}
-
-fn macro_binding_name(id: &BindingPattern<'_>) -> Option<String> {
-    match id {
-        BindingPattern::BindingIdentifier(id) => Some(id.name.to_compact_string()),
-        BindingPattern::ArrayPattern(pattern) => pattern
-            .elements
-            .first()
-            .and_then(|elem| elem.as_ref())
-            .and_then(simple_binding_name),
-        _ => None,
-    }
-}
-
-fn simple_binding_name(id: &BindingPattern<'_>) -> Option<String> {
-    match id {
-        BindingPattern::BindingIdentifier(id) => Some(id.name.to_compact_string()),
-        BindingPattern::AssignmentPattern(pattern) => simple_binding_name(&pattern.left),
-        _ => None,
     }
 }

--- a/crates/vize_croquis/src/script_parser/process/bindings.rs
+++ b/crates/vize_croquis/src/script_parser/process/bindings.rs
@@ -4,11 +4,12 @@
 //! and classifying expressions as literals or functions.
 
 use oxc_ast::ast::{BindingPattern, Expression, VariableDeclarationKind};
+use vize_carton::{CompactString, String, ToCompactString};
 use vize_relief::BindingType;
 
+use crate::croquis::BindingMetadata;
+
 use super::super::extract::get_binding_type_from_kind;
-use vize_carton::String;
-use vize_carton::ToCompactString;
 
 /// Get binding name from binding pattern kind
 pub(in crate::script_parser) fn get_binding_pattern_name(
@@ -18,6 +19,46 @@ pub(in crate::script_parser) fn get_binding_pattern_name(
         BindingPattern::BindingIdentifier(id) => Some(id.name.to_compact_string()),
         BindingPattern::AssignmentPattern(assign) => get_binding_pattern_name(&assign.left),
         _ => None,
+    }
+}
+
+pub(in crate::script_parser) fn add_binding_pattern_names(
+    bindings: &mut BindingMetadata,
+    pattern: &BindingPattern<'_>,
+    binding_type: BindingType,
+) {
+    for_each_binding_pattern_name(pattern, &mut |name| bindings.add(name, binding_type));
+}
+
+pub(in crate::script_parser) fn push_binding_pattern_names(
+    pattern: &BindingPattern<'_>,
+    target: &mut Vec<CompactString>,
+) {
+    for_each_binding_pattern_name(pattern, &mut |name| target.push(CompactString::new(name)));
+}
+
+fn for_each_binding_pattern_name(pattern: &BindingPattern<'_>, visit: &mut impl FnMut(&str)) {
+    match pattern {
+        BindingPattern::BindingIdentifier(id) => visit(id.name.as_str()),
+        BindingPattern::ObjectPattern(object) => {
+            for property in object.properties.iter() {
+                for_each_binding_pattern_name(&property.value, visit);
+            }
+            if let Some(rest) = &object.rest {
+                for_each_binding_pattern_name(&rest.argument, visit);
+            }
+        }
+        BindingPattern::ArrayPattern(array) => {
+            for element in array.elements.iter().flatten() {
+                for_each_binding_pattern_name(element, visit);
+            }
+            if let Some(rest) = &array.rest {
+                for_each_binding_pattern_name(&rest.argument, visit);
+            }
+        }
+        BindingPattern::AssignmentPattern(assign) => {
+            for_each_binding_pattern_name(&assign.left, visit);
+        }
     }
 }
 

--- a/crates/vize_croquis/src/script_parser/process/macros.rs
+++ b/crates/vize_croquis/src/script_parser/process/macros.rs
@@ -28,8 +28,8 @@ use super::super::extract::{
 use super::super::walk::{walk_call_arguments, walk_expression};
 use super::super::{ReactiveValueOrigin, ScriptParseResult};
 use super::bindings::{
-    get_binding_pattern_name, infer_destructure_binding_type, is_function_expression,
-    is_literal_expression,
+    add_binding_pattern_names, get_binding_pattern_name, infer_destructure_binding_type,
+    is_function_expression, is_literal_expression, push_binding_pattern_names,
 };
 
 /// Process a variable declarator
@@ -430,37 +430,38 @@ pub(in crate::script_parser) fn process_variable_declarator(
                     _ => None,
                 };
 
-                if let Some(local_name) = get_binding_pattern_name(&prop.value) {
-                    // If destructuring from defineProps, use Props binding type
-                    let binding_type = if is_define_props {
-                        BindingType::Props
-                    } else {
-                        infer_destructure_binding_type(kind, declarator.init.as_ref())
-                    };
-                    result.bindings.add(local_name.as_str(), binding_type);
+                // If destructuring from defineProps, use Props binding type
+                let binding_type = if is_define_props {
+                    BindingType::Props
+                } else {
+                    infer_destructure_binding_type(kind, declarator.init.as_ref())
+                };
 
-                    // Track destructure binding
-                    if let Some(ref mut destructure) = props_destructure {
-                        let key = key_name
-                            .map(CompactString::new)
-                            .unwrap_or_else(|| CompactString::new(&local_name));
+                if is_define_props {
+                    if let Some(local_name) = get_binding_pattern_name(&prop.value) {
+                        result.bindings.add(local_name.as_str(), binding_type);
 
-                        // Extract default value if present (assignment pattern), including
-                        // renamed destructures such as `{ source: local = fallback }`.
-                        let default_value =
-                            if let BindingPattern::AssignmentPattern(assign) = &prop.value {
-                                Some(CompactString::new(
-                                    &source[assign.right.span().start as usize
-                                        ..assign.right.span().end as usize],
-                                ))
-                            } else {
-                                None
-                            };
+                        // Track destructure binding
+                        if let Some(ref mut destructure) = props_destructure {
+                            let key = key_name
+                                .map(CompactString::new)
+                                .unwrap_or_else(|| CompactString::new(&local_name));
 
-                        destructure.insert(key, CompactString::new(&local_name), default_value);
-                    }
+                            // Extract default value if present (assignment pattern), including
+                            // renamed destructures such as `{ source: local = fallback }`.
+                            let default_value =
+                                if let BindingPattern::AssignmentPattern(assign) = &prop.value {
+                                    Some(CompactString::new(
+                                        &source[assign.right.span().start as usize
+                                            ..assign.right.span().end as usize],
+                                    ))
+                                } else {
+                                    None
+                                };
 
-                    if is_define_props {
+                            destructure.insert(key, CompactString::new(&local_name), default_value);
+                        }
+
                         let key = key_name
                             .map(CompactString::new)
                             .unwrap_or_else(|| CompactString::new(&local_name));
@@ -471,32 +472,37 @@ pub(in crate::script_parser) fn process_variable_declarator(
                             },
                         );
                     }
+                } else {
+                    add_binding_pattern_names(&mut result.bindings, &prop.value, binding_type);
                 }
             }
 
             // Handle rest element
-            if let Some(rest) = &obj.rest
-                && let Some(name) = get_binding_pattern_name(&rest.argument)
-            {
+            if let Some(rest) = &obj.rest {
                 let binding_type = if is_define_props {
                     BindingType::Props
                 } else {
                     infer_destructure_binding_type(kind, declarator.init.as_ref())
                 };
-                result.bindings.add(name.as_str(), binding_type);
-
-                // Track rest binding
-                if let Some(ref mut destructure) = props_destructure {
-                    destructure.rest_id = Some(CompactString::new(&name));
-                }
 
                 if is_define_props {
-                    result.reactive_value_origins.insert(
-                        CompactString::new(&name),
-                        ReactiveValueOrigin::PropsDestructure {
-                            prop_name: CompactString::new("(rest)"),
-                        },
-                    );
+                    if let Some(name) = get_binding_pattern_name(&rest.argument) {
+                        result.bindings.add(name.as_str(), binding_type);
+
+                        // Track rest binding
+                        if let Some(ref mut destructure) = props_destructure {
+                            destructure.rest_id = Some(CompactString::new(&name));
+                        }
+
+                        result.reactive_value_origins.insert(
+                            CompactString::new(&name),
+                            ReactiveValueOrigin::PropsDestructure {
+                                prop_name: CompactString::new("(rest)"),
+                            },
+                        );
+                    }
+                } else {
+                    add_binding_pattern_names(&mut result.bindings, &rest.argument, binding_type);
                 }
             }
 
@@ -542,14 +548,10 @@ pub(in crate::script_parser) fn process_variable_declarator(
             if let Some(call) = inject_call {
                 let mut destructured_items: Vec<CompactString> = Vec::new();
                 for elem in arr.elements.iter().flatten() {
-                    if let Some(name) = get_binding_pattern_name(elem) {
-                        destructured_items.push(CompactString::new(&name));
-                    }
+                    push_binding_pattern_names(elem, &mut destructured_items);
                 }
-                if let Some(rest) = &arr.rest
-                    && let Some(name) = get_binding_pattern_name(&rest.argument)
-                {
-                    destructured_items.push(CompactString::new(&name));
+                if let Some(rest) = &arr.rest {
+                    push_binding_pattern_names(&rest.argument, &mut destructured_items);
                 }
 
                 if let Some(key) = call
@@ -592,14 +594,10 @@ pub(in crate::script_parser) fn process_variable_declarator(
             } else if let Some((inject_var, offset)) = indirect_inject_var {
                 let mut destructured_items: Vec<CompactString> = Vec::new();
                 for elem in arr.elements.iter().flatten() {
-                    if let Some(name) = get_binding_pattern_name(elem) {
-                        destructured_items.push(CompactString::new(&name));
-                    }
+                    push_binding_pattern_names(elem, &mut destructured_items);
                 }
-                if let Some(rest) = &arr.rest
-                    && let Some(name) = get_binding_pattern_name(&rest.argument)
-                {
-                    destructured_items.push(CompactString::new(&name));
+                if let Some(rest) = &arr.rest {
+                    push_binding_pattern_names(&rest.argument, &mut destructured_items);
                 }
 
                 result.provide_inject.add_indirect_destructure(
@@ -612,22 +610,16 @@ pub(in crate::script_parser) fn process_variable_declarator(
             // Handle array destructuring
             let arr_binding_type = infer_destructure_binding_type(kind, declarator.init.as_ref());
             for elem in arr.elements.iter().flatten() {
-                if let Some(name) = get_binding_pattern_name(elem) {
-                    result.bindings.add(name.as_str(), arr_binding_type);
-                }
+                add_binding_pattern_names(&mut result.bindings, elem, arr_binding_type);
             }
-            if let Some(rest) = &arr.rest
-                && let Some(name) = get_binding_pattern_name(&rest.argument)
-            {
-                result.bindings.add(name.as_str(), arr_binding_type);
+            if let Some(rest) = &arr.rest {
+                add_binding_pattern_names(&mut result.bindings, &rest.argument, arr_binding_type);
             }
         }
 
         BindingPattern::AssignmentPattern(assign) => {
-            if let Some(name) = get_binding_pattern_name(&assign.left) {
-                let binding_type = get_binding_type_from_kind(kind);
-                result.bindings.add(name.as_str(), binding_type);
-            }
+            let binding_type = get_binding_type_from_kind(kind);
+            add_binding_pattern_names(&mut result.bindings, &assign.left, binding_type);
         }
     }
 }

--- a/crates/vize_croquis/src/script_parser/props_destructure_tests.rs
+++ b/crates/vize_croquis/src/script_parser/props_destructure_tests.rs
@@ -38,3 +38,31 @@ fn test_parse_define_props_destructure_tracks_aliased_defaults() {
     assert_eq!(result.bindings.get("label"), Some(BindingType::Props));
     assert_eq!(result.bindings.get("rest"), Some(BindingType::Props));
 }
+
+#[test]
+fn test_parse_script_setup_tracks_deep_non_props_destructure_bindings() {
+    let result = parse_script_setup(
+        r#"
+            const {
+                public: { contactFormUrl },
+                nested: { label: inquiryLabel = "Inquiry" },
+                urls: [firstUrl, { href: secondUrl }],
+                ...runtimeRest
+            } = useRuntimeConfig()
+        "#,
+    );
+
+    for name in [
+        "contactFormUrl",
+        "inquiryLabel",
+        "firstUrl",
+        "secondUrl",
+        "runtimeRest",
+    ] {
+        assert_eq!(
+            result.bindings.get(name),
+            Some(BindingType::SetupMaybeRef),
+            "{name} should be exposed as a top-level script setup binding"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2248.

- Collect every local binding from nested non-props destructuring patterns in Croquis script setup analysis.
- Register the same nested object, array, default-value, and rest destructure bindings in `ScriptCompileContext` so inline SFC output treats them as setup bindings.
- Add regression coverage for the Nuxt `useRuntimeConfig()` deep destructure case and neighboring nested patterns.

## Root Cause

`<script setup>` non-props object destructuring only registered direct property identifiers in one binding path, while deeply nested identifiers such as `public: { contactFormUrl }` were skipped. The template then treated the identifier as an instance property (`_ctx.contactFormUrl`) instead of a setup binding, causing Vue runtime warnings.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_croquis -p vize_atelier_sfc`
- `cargo test -p vize_canon`
- `cargo clippy -p vize_croquis -p vize_atelier_sfc -p vize_canon -- -D warnings -D clippy::wildcard_imports`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->