### PR TITLE
fix(vite-plugin): preserve optional chaining in virtual Vue modules

### DIFF
--- a/crates/vize_atelier_core/src/codegen/slots/tests.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/tests.rs
@@ -1,5 +1,15 @@
 use super::super::helpers::is_valid_js_identifier;
 use super::params::prefix_slot_defaults;
+use crate::compile;
+
+fn result_output(result: &super::super::CodegenResult) -> vize_carton::String {
+    let mut output =
+        vize_carton::String::with_capacity(result.preamble.len() + result.code.len() + 1);
+    output.push_str(&result.preamble);
+    output.push('\n');
+    output.push_str(&result.code);
+    output
+}
 
 #[test]
 fn test_is_valid_js_identifier_valid() {
@@ -56,5 +66,22 @@ fn test_prefix_slot_defaults() {
     assert_eq!(
         prefix_slot_defaults("{ x = undefined }"),
         "{ x = undefined }"
+    );
+}
+
+#[test]
+fn slot_outlet_vbind_object_preserves_optional_chaining() {
+    let result = compile!(
+        r#"<slot v-bind="external ? { isActive: undefined } : { isActive: scope?.isActive }" />"#
+    );
+    let output = result_output(&result);
+
+    assert!(
+        output.contains(r#"external ? { isActive: undefined } : { isActive: scope?.isActive }"#),
+        "slot outlet ternary v-bind object must preserve optional chaining:\n{output}"
+    );
+    assert!(
+        !output.contains(r#"{ isActive: scope.isActive }"#),
+        "slot outlet ternary v-bind object must not emit an unguarded member access:\n{output}"
     );
 }

--- a/crates/vize_atelier_sfc/src/compile/tests/define_props_regressions.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests/define_props_regressions.rs
@@ -107,3 +107,34 @@ const {
         );
     }
 }
+
+#[test]
+fn test_template_ternary_vbind_preserves_optional_chaining() {
+    let source = r#"<script setup lang="ts">
+const external = false
+const to = "/login"
+</script>
+
+<template>
+  <NuxtLinkLocale v-slot="scope" :to="to">
+    <slot v-bind="external ? { isActive: undefined } : { isActive: scope?.isActive }" />
+  </NuxtLinkLocale>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result =
+        compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+
+    assert!(
+        result
+            .code
+            .contains("external ? { isActive: undefined } : { isActive: scope?.isActive }"),
+        "template ternary v-bind must preserve optional chaining:\n{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("{ isActive: scope.isActive }"),
+        "template ternary v-bind must not emit an unguarded member access:\n{}",
+        result.code
+    );
+}

--- a/crates/vize_canon/src/sfc_typecheck/tests/optional_chain_props.rs
+++ b/crates/vize_canon/src/sfc_typecheck/tests/optional_chain_props.rs
@@ -61,3 +61,27 @@ void props
         result.diagnostics
     );
 }
+
+#[test]
+fn optional_chain_inside_slot_vbind_object_stays_guarded() {
+    let source = r#"<script setup lang="ts">
+const external = false
+const scope: { isActive: boolean } | undefined = undefined
+</script>
+
+<template>
+  <slot v-bind="external ? { isActive: undefined } : { isActive: scope?.isActive }" />
+</template>"#;
+    let options = SfcTypeCheckOptions::new("SlotForwarder.vue").with_virtual_ts();
+    let result = type_check_sfc(source, &options);
+    let virtual_ts = result.virtual_ts.expect("virtual ts should be generated");
+
+    assert!(
+        virtual_ts.contains("external ? { isActive: undefined } : { isActive: scope?.isActive }"),
+        "slot v-bind ternary object must preserve optional chaining:\n{virtual_ts}"
+    );
+    assert!(
+        !virtual_ts.contains("{ isActive: scope.isActive }"),
+        "slot v-bind ternary object must not emit an unguarded member access:\n{virtual_ts}"
+    );
+}

--- a/npm/builder/vite/src/plugin/vite-transform.test.ts
+++ b/npm/builder/vite/src/plugin/vite-transform.test.ts
@@ -9,7 +9,7 @@ import { createVirtualTypeScriptTransformer } from "./vite-transform.ts";
       used = "oxc";
       assert.equal(code, "const value: number = 1");
       assert.equal(id, "/src/App.vue");
-      assert.deepEqual(options, { lang: "ts", sourcemap: false });
+      assert.deepEqual(options, { lang: "ts", sourcemap: false, target: "esnext" });
       return { code: "const value = 1;" };
     },
     transformWithEsbuild: async () => {
@@ -30,7 +30,7 @@ import { createVirtualTypeScriptTransformer } from "./vite-transform.ts";
       used = "esbuild";
       assert.equal(code, "const value: number = 1");
       assert.equal(id, "/src/App.vue");
-      assert.deepEqual(options, { loader: "ts", sourcemap: false });
+      assert.deepEqual(options, { loader: "ts", sourcemap: false, target: "esnext" });
       return { code: "const value = 1;" };
     },
   });
@@ -38,4 +38,26 @@ import { createVirtualTypeScriptTransformer } from "./vite-transform.ts";
   const result = await transform("const value: number = 1", "/src/App.vue");
   assert.equal(used, "esbuild", "Vite 7 should fall back to transformWithEsbuild");
   assert.equal(result.code, "const value = 1;");
+}
+
+{
+  const code = "const value = external ? { isActive: undefined } : { isActive: scope?.isActive };";
+  const transform = createVirtualTypeScriptTransformer({
+    transformWithOxc: async (_code, _id, options) => ({
+      code: options.target === "esnext" ? code : code.replace("scope?.isActive", "scope.isActive"),
+    }),
+  });
+
+  const result = await transform(code, "/src/Link.vue");
+
+  assert.match(
+    result.code,
+    /scope\?\.isActive/,
+    "virtual Vue module TS stripping must preserve template optional chaining",
+  );
+  assert.doesNotMatch(
+    result.code,
+    /scope\.isActive/,
+    "virtual Vue module TS stripping must not emit an unguarded slot-scope access",
+  );
 }

--- a/npm/builder/vite/src/plugin/vite-transform.ts
+++ b/npm/builder/vite/src/plugin/vite-transform.ts
@@ -1,8 +1,8 @@
 import * as vite from "vite";
 
 type TransformOutput = { code: string; map?: unknown };
-type OxcOptions = { lang: "ts"; sourcemap: false };
-type EsbuildOptions = { loader: "ts"; sourcemap: false };
+type OxcOptions = { lang: "ts"; sourcemap: false; target: "esnext" };
+type EsbuildOptions = { loader: "ts"; sourcemap: false; target: "esnext" };
 type TransformWithOxc = (
   code: string,
   id: string,
@@ -21,16 +21,20 @@ interface ViteTransformApi {
 
 export function createVirtualTypeScriptTransformer(viteApi: ViteTransformApi) {
   return async (code: string, id: string): Promise<TransformOutput> => {
+    // This pass only strips TypeScript from Vize virtual Vue modules.
+    // Syntax lowering belongs to Vite's normal build target transform.
     if (typeof viteApi.transformWithOxc === "function") {
       return viteApi.transformWithOxc(code, id, {
         lang: "ts",
         sourcemap: false,
+        target: "esnext",
       });
     }
     if (typeof viteApi.transformWithEsbuild === "function") {
       return viteApi.transformWithEsbuild(code, id, {
         loader: "ts",
         sourcemap: false,
+        target: "esnext",
       });
     }
     throw new Error("Installed Vite does not expose transformWithOxc or transformWithEsbuild");


### PR DESCRIPTION
## Summary
- keep Vize virtual Vue module TS stripping at `target: "esnext"` so Vite/OXC only removes TypeScript and does not lower template optional chaining in dev
- add focused regression coverage for slot outlet ternary `v-bind` expressions across core codegen, SFC compile, canon virtual TS, and the Vite transformer

## Root cause
The Vite plugin re-runs Vite's TS transform on Vize-generated `.vue.ts` virtual modules without an explicit target. That pass is only meant to strip TypeScript; leaving target lowering implicit can rewrite runtime template syntax before Vite's normal build pipeline handles it.

Fixes #2241

## Tests
- `node src/plugin/vite-transform.test.ts`
- `corepack pnpm --dir npm/builder/vite check`
- `corepack pnpm --dir npm/builder/vite test`
- `cargo test -p vize_atelier_core -p vize_atelier_sfc -p vize_canon`
- `cargo clippy -p vize_atelier_core -p vize_atelier_sfc -p vize_canon -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->