### PR TITLE
fix(vite-plugin): invalidate external SFC virtual modules

### DIFF
--- a/npm/builder/vite/src/plugin/external-sfc-hmr.test.ts
+++ b/npm/builder/vite/src/plugin/external-sfc-hmr.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import type { HmrContext } from "vite";
+
+import type { VizePluginState } from "./state.ts";
+import { handleHotUpdateHook } from "./hmr.ts";
+import { compileFile } from "../compiler.ts";
+
+{
+  const vueFile = "/repo/design/components/Link.vue";
+  const previousSource = `<template><h1>Before</h1></template>`;
+  const nextSource = `<template><h1>After</h1></template>`;
+  const previousCompiled = compileFile(
+    vueFile,
+    new Map(),
+    { sourceMap: false, ssr: false, vapor: false },
+    previousSource,
+  );
+  const fsVirtualFileModule = { url: `/@fs${vueFile}.ts?vue&vize` };
+  const invalidatedModules: unknown[] = [];
+  const state = {
+    cache: new Map([[vueFile, previousCompiled]]),
+    ssrCache: new Map(),
+    collectedCss: new Map(),
+    precompileMetadata: new Map(),
+    pendingHmrUpdateTypes: new Map(),
+    isProduction: false,
+    mergedOptions: {},
+    cssAliasRules: [],
+    clientViteBase: "/_nuxt/",
+    root: "/repo/app",
+    filter: () => true,
+    logger: {
+      log() {},
+      error() {},
+    },
+  } as unknown as VizePluginState;
+  const ctx = {
+    file: vueFile,
+    server: {
+      moduleGraph: {
+        getModulesByFile(id: string) {
+          return id === `/@fs${vueFile}.ts` ? new Set([fsVirtualFileModule]) : undefined;
+        },
+        invalidateModule(receivedModule: unknown) {
+          invalidatedModules.push(receivedModule);
+        },
+      },
+      ws: {
+        send() {},
+      },
+    },
+    read: async () => nextSource,
+  } as unknown as HmrContext;
+
+  const modules = await handleHotUpdateHook(state, ctx);
+
+  assert.deepEqual(
+    modules,
+    [fsVirtualFileModule],
+    "External design SFC edits should return Vite's /@fs virtual module file",
+  );
+  assert.equal(
+    state.pendingHmrUpdateTypes.get(vueFile),
+    "template-only",
+    "External design SFC edits should keep granular HMR when the /@fs virtual module is found",
+  );
+  assert.deepEqual(
+    invalidatedModules,
+    [fsVirtualFileModule],
+    "External design SFC edits should invalidate Vite's stale /@fs transformed module",
+  );
+}
+
+console.log("vite-plugin-vize external SFC HMR tests passed!");

--- a/npm/builder/vite/src/plugin/hmr.ts
+++ b/npm/builder/vite/src/plugin/hmr.ts
@@ -51,15 +51,30 @@ function unique(values: string[]): string[] {
   return [...new Set(values)];
 }
 
+function toViteFsFileId(fileId: string): string | null {
+  if (!path.isAbsolute(fileId)) {
+    return null;
+  }
+
+  const normalized = fileId.replace(/\\/g, "/");
+  return normalized.startsWith("/") ? `/@fs${normalized}` : `/@fs/${normalized}`;
+}
+
 function getVueModuleFileCandidates(vueFile: string): string[] {
-  return unique([
+  const candidates = [
     toVirtualId(vueFile),
     toPluginVisibleVirtualId(vueFile),
     toVirtualId(vueFile, true),
     toPluginVisibleVirtualId(vueFile, true),
     toPluginVisibleVirtualId(vueFile).split("?")[0],
     vueFile,
-  ]);
+  ];
+  const viteFsCandidates = candidates.flatMap((candidate) => {
+    const viteFsId = toViteFsFileId(candidate);
+    return viteFsId ? [viteFsId] : [];
+  });
+
+  return unique([...candidates, ...viteFsCandidates]);
 }
 
 function getStyleModuleFileCandidates(styleId: string): string[] {

--- a/npm/builder/vite/src/plugin/load.test.ts
+++ b/npm/builder/vite/src/plugin/load.test.ts
@@ -402,8 +402,8 @@ const watchedLoad = loadHook(watchedState, toVirtualId(watchedPath), {
 assert.ok(watchedLoad && typeof watchedLoad === "object", "Watched SFC should load");
 assert.deepEqual(
   watchedFiles,
-  [watchedDependency],
-  "SFC src dependencies should be registered with Vite's watcher",
+  [watchedPath, watchedDependency],
+  "Virtual SFC loads should register the real source file and src dependencies with Vite's watcher",
 );
 
 const inlinePath = "/src/InlineHmr.vue";

--- a/npm/builder/vite/src/plugin/load.ts
+++ b/npm/builder/vite/src/plugin/load.ts
@@ -139,8 +139,8 @@ function loadCompiledSfcModule(
     return null;
   }
 
-  for (const dependency of compiled.dependencies ?? []) {
-    loadOptions?.addWatchFile?.(dependency);
+  for (const watchFile of new Set([realPath, ...(compiled.dependencies ?? [])])) {
+    loadOptions?.addWatchFile?.(watchFile);
   }
 
   const hasDelegated = hasDelegatedStyles(compiled);

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -3,6 +3,7 @@ import "./compiler.test.ts";
 import "./utils.test.ts";
 import "./plugin/compat.test.ts";
 import "./plugin/css-modules.test.ts";
+import "./plugin/external-sfc-hmr.test.ts";
 import "./plugin/hmr.test.ts";
 import "./plugin/index.test.ts";
 import "./plugin/load-storybook.test.ts";


### PR DESCRIPTION
## Summary

- Register the real Vue SFC file as a watcher dependency when Vize loads virtual SFC modules.
- Include Vite `/@fs` virtual module keys when invalidating Vize-compiled SFC modules after edits.
- Add regression coverage for external design SFC HMR invalidation and watcher registration.

Fixes #2242

## Validation

- `node src/plugin/external-sfc-hmr.test.ts && node src/plugin/load.test.ts && node src/plugin/hmr.test.ts` from `npm/builder/vite`
- `corepack pnpm --dir npm/builder/vite check`
- `corepack pnpm --dir npm/builder/vite test`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->