### PR TITLE
fix(canon): preserve nested v-for member-array aliases

### DIFF
--- a/crates/vize/tests/check_legacy_vue2_vfor_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_vfor_cli.rs
@@ -1,0 +1,199 @@
+#![cfg(feature = "legacy")]
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+#[test]
+fn legacy_vue2_nested_v_for_member_array_aliases_do_not_fall_back_to_object_keys() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project("legacy-vue2-nested-vfor-member-array-aliases");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+            "src/App.vue",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(
+        json["errorCount"], 0,
+        "nested member-array v-for aliases should type-check\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    for unexpected in [
+        "TS2339",
+        "TS2731",
+        "questionFieldInputType",
+        "`${i}question`",
+    ] {
+        assert!(
+            !stdout.contains(unexpected),
+            "nested member-array aliases regressed with {unexpected}:\n{stdout}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn create_project(name: &str) -> PathBuf {
+    let project_root = unique_case_dir(name);
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    write_test_vue2_stub(&project_root.join("node_modules")).unwrap();
+    write_test_vite_stub(&project_root.join("node_modules")).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        r#"{ "typeChecker": { "legacyVue2": true } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/App.vue"),
+        r#"<script lang="ts">
+import { defineComponent, ref } from 'vue'
+
+type QuestionFieldInputType = 'text' | 'number'
+interface QuestionField {
+  questionFieldInputType: QuestionFieldInputType
+  question: string
+  type: string
+}
+interface QuestionFormat {
+  id: string
+  questionField: QuestionField[]
+}
+
+export default defineComponent({
+  setup() {
+    const questionFormatsRef = ref<QuestionFormat[]>([
+      {
+        id: 'profile',
+        questionField: [
+          { questionFieldInputType: 'text', question: 'Name', type: 'label' },
+        ],
+      },
+    ])
+    const textInput: QuestionFieldInputType = 'text'
+    const wantsQuestion = (value: string) => value
+    const wantsType = (value: string) => value
+    return { questionFormatsRef, textInput, wantsQuestion, wantsType }
+  },
+})
+</script>
+
+<template>
+  <div v-for="questionFormat in questionFormatsRef" :key="questionFormat.id">
+    <span v-for="(answer, i) in questionFormat.questionField" :key="i">
+      <template v-if="answer.questionFieldInputType === textInput">
+        <span :key="`${i}question`">
+          {{ wantsQuestion(answer.question) }}
+          {{ wantsType(answer.type) }}
+        </span>
+      </template>
+    </span>
+  </div>
+</template>
+"#,
+    )
+    .unwrap();
+    project_root
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("{name}-{}", std::process::id()).as_str())
+}
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CORSA_PATH")
+        && Path::new(&path).exists()
+    {
+        return Some(PathBuf::from(path));
+    }
+
+    let workspace_root = workspace_root();
+    [
+        workspace_root.join("node_modules/.bin/tsgo"),
+        workspace_root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn write_test_vue2_stub(target: &Path) -> std::io::Result<()> {
+    let vue_types_dir = target.join("vue").join("types");
+    std::fs::create_dir_all(&vue_types_dir)?;
+    std::fs::write(
+        target.join("vue").join("package.json"),
+        r#"{ "name": "vue", "types": "types/index.d.ts" }"#,
+    )?;
+    std::fs::write(
+        vue_types_dir.join("index.d.ts"),
+        r#"export interface Vue {
+  $attrs: Record<string, unknown>;
+  $refs: Record<string, any>;
+  $slots: Record<string, unknown>;
+  $emit: (...args: any[]) => void;
+}
+export type Ref<T> = { value: T };
+export declare function ref<T>(value: T): Ref<T>;
+export declare function defineComponent<T>(options: T): T;
+export default { version: '2.7.16' };
+"#,
+    )?;
+    Ok(())
+}
+
+fn write_test_vite_stub(target: &Path) -> std::io::Result<()> {
+    let vite_dir = target.join("vite");
+    std::fs::create_dir_all(&vite_dir)?;
+    std::fs::write(
+        vite_dir.join("package.json"),
+        r#"{ "name": "vite", "types": "client.d.ts" }"#,
+    )?;
+    std::fs::write(vite_dir.join("client.d.ts"), "")?;
+    Ok(())
+}

--- a/crates/vize_canon/src/batch/virtual_project/tests/snapshots/vize_canon__batch__virtual_project__tests__ref_arity__dialect_v2.snap
+++ b/crates/vize_canon/src/batch/virtual_project/tests/snapshots/vize_canon__batch__virtual_project__tests__ref_arity__dialect_v2.snap
@@ -41,11 +41,9 @@ type __ShallowRef<T> = __Ref<T> & { readonly __v_isShallow?: true };
 type __VizeKebabCase<S extends string> = S extends `${infer Head}${infer Tail}` ? Head extends Lowercase<Head> ? `${Head}${__VizeKebabCase<Tail>}` : `-${Lowercase<Head>}${__VizeKebabCase<Tail>}` : S;
 type __VizeKebabProps<T> = { [K in keyof T & string as __VizeKebabCase<K>]: T[K] };
 type __VizeComponentProps<T> = T extends unknown ? T & Partial<__VizeKebabProps<T>> : never;
-declare function __vForList<T>(source: readonly T[] | undefined | null): readonly [item: T, key: number, index: number][];
-declare function __vForList(source: number | undefined | null): readonly [item: number, key: number, index: number][];
-declare function __vForList(source: string | undefined | null): readonly [item: string, key: number, index: number][];
-declare function __vForList<T>(source: Iterable<T> | undefined | null): readonly [item: T, key: number, index: number][];
-declare function __vForList<T extends object>(source: T | undefined | null): readonly [item: T[keyof T], key: keyof T, index: number][];
+type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
+type __VForEntry<T> = __VizeIsAny<T> extends true ? [item: any, key: number, index: number] : T extends readonly (infer U)[] ? [item: U, key: number, index: number] : T extends number ? [item: number, key: number, index: number] : T extends string ? [item: string, key: number, index: number] : T extends Iterable<infer U> ? [item: U, key: number, index: number] : T extends object ? [item: T[keyof T], key: keyof T, index: number] : [item: any, key: number, index: number];
+declare function __vForList<T>(source: T | undefined | null): readonly __VForEntry<NonNullable<T>>[];
 import { ref } from 'vue'
 
 // ========== Exported Types ==========
@@ -84,7 +82,7 @@ function __setup() {
 
   const count = ref(0)
 
-  // @vize-map: 5489:5564 -> 0:84
+  // @vize-map: 5502:5577 -> 0:84
 
   // ========== Template Scope (inherits from setup) ==========
   // Ref type captures (before template scope shadows them)

--- a/crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs
@@ -23,11 +23,9 @@ type __ShallowRef<T> = __Ref<T> & { readonly __v_isShallow?: true };
 type __VizeKebabCase<S extends string> = S extends `${infer Head}${infer Tail}` ? Head extends Lowercase<Head> ? `${Head}${__VizeKebabCase<Tail>}` : `-${Lowercase<Head>}${__VizeKebabCase<Tail>}` : S;
 type __VizeKebabProps<T> = { [K in keyof T & string as __VizeKebabCase<K>]: T[K] };
 type __VizeComponentProps<T> = T extends unknown ? T & Partial<__VizeKebabProps<T>> : never;
-declare function __vForList<T>(source: readonly T[] | undefined | null): readonly [item: T, key: number, index: number][];
-declare function __vForList(source: number | undefined | null): readonly [item: number, key: number, index: number][];
-declare function __vForList(source: string | undefined | null): readonly [item: string, key: number, index: number][];
-declare function __vForList<T>(source: Iterable<T> | undefined | null): readonly [item: T, key: number, index: number][];
-declare function __vForList<T extends object>(source: T | undefined | null): readonly [item: T[keyof T], key: keyof T, index: number][];"#;
+type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
+type __VForEntry<T> = __VizeIsAny<T> extends true ? [item: any, key: number, index: number] : T extends readonly (infer U)[] ? [item: U, key: number, index: number] : T extends number ? [item: number, key: number, index: number] : T extends string ? [item: string, key: number, index: number] : T extends Iterable<infer U> ? [item: U, key: number, index: number] : T extends object ? [item: T[keyof T], key: keyof T, index: number] : [item: any, key: number, index: number];
+declare function __vForList<T>(source: T | undefined | null): readonly __VForEntry<NonNullable<T>>[];"#;
 const LEGACY_REF_UNWRAP_HELPER: &str =
     "    type __U<T> = T extends { value: infer __V } ? __V : T;\n";
 const MODERN_REF_UNWRAP_HELPER: &str = r#"    type __VizeIsUnion<T, __U = T> = T extends unknown ? ([__U] extends [T] ? false : true) : false;
@@ -134,4 +132,104 @@ pub fn generate_virtual_ts_with_offsets_legacy_vue2(
             ..Default::default()
         },
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        path::{Path, PathBuf},
+        process::Command,
+    };
+
+    use vize_carton::{String, append, config::VueVersion, cstr};
+
+    use super::vue_type_helpers;
+
+    #[test]
+    fn v_for_helper_preserves_member_array_aliases_without_losing_object_keys() {
+        let Some(tsgo) = resolve_test_tsgo_binary() else {
+            return;
+        };
+        let case_dir = std::env::temp_dir()
+            .join(cstr!("vize-legacy-vfor-helper-{}", std::process::id()).as_str());
+        let _ = std::fs::remove_dir_all(&case_dir);
+        std::fs::create_dir_all(&case_dir).unwrap();
+        let test_path = case_dir.join("vfor-helper.ts");
+        let mut source = String::new("");
+        append!(source, "{}\n\n", vue_type_helpers(true, VueVersion::V2));
+        source.push_str(
+            r#"interface QuestionField {
+  questionFieldInputType: string;
+  question: string;
+  type: string;
+}
+interface QuestionFormat {
+  id: string;
+  questionField: QuestionField[];
+}
+
+declare const anySource: any;
+for (const [answer, i] of __vForList(anySource.questionField)) {
+  const keyText = `${i}question`;
+  answer.questionFieldInputType;
+  void keyText;
+}
+
+const obj: { foo: number; bar: number } = { foo: 1, bar: 2 };
+for (const [value, key] of __vForList(obj)) {
+  const valueCheck: number = value;
+  const keyCheck: "foo" | "bar" = key;
+  void valueCheck;
+  void keyCheck;
+}
+
+declare const questionFormat: QuestionFormat;
+for (const [answer, i] of __vForList(questionFormat.questionField)) {
+  const inputType: string = answer.questionFieldInputType;
+  const index: number = i;
+  void inputType;
+  void index;
+}
+"#,
+        );
+        std::fs::write(&test_path, source.as_bytes()).unwrap();
+
+        let output = Command::new(tsgo)
+            .args([
+                "--ignoreConfig",
+                "--noEmit",
+                "--strict",
+                "--target",
+                "ES2022",
+            ])
+            .arg(&test_path)
+            .output()
+            .unwrap();
+        let stdout = std::str::from_utf8(&output.stdout).unwrap();
+        let stderr = std::str::from_utf8(&output.stderr).unwrap();
+        assert!(
+            output.status.success(),
+            "legacy v-for helper should keep any/member-array aliases off the object overload while preserving object key types\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+
+        let _ = std::fs::remove_dir_all(&case_dir);
+    }
+
+    fn resolve_test_tsgo_binary() -> Option<PathBuf> {
+        if let Ok(path) = std::env::var("CORSA_PATH")
+            && Path::new(&path).exists()
+        {
+            return Some(PathBuf::from(path));
+        }
+
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)?;
+        [
+            root.join("node_modules/.bin/tsgo"),
+            root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+        ]
+        .into_iter()
+        .find(|candidate| candidate.exists())
+    }
 }


### PR DESCRIPTION
## Summary
- Replace the legacy Vue 2 `__vForList` overload stack with a conditional tuple helper so `any`/member-array sources do not fall through to object-key iteration.
- Preserve object `v-for` key/value typing with an explicit helper-level regression.
- Add a legacy CLI regression for nested `v-for` over `questionFormat.questionField` with template-literal keys and member reads.

Fixes #2236

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo clippy -p vize_canon -p vize -- -D warnings -D clippy::wildcard_imports`
- `cargo clippy -p vize --features legacy --test check_legacy_vue2_vfor_cli -- -D warnings -D clippy::wildcard_imports`
- `cargo test -p vize_canon v_for_helper_preserves_member_array_aliases_without_losing_object_keys -- --nocapture`
- `cargo test -p vize --features legacy --test check_legacy_vue2_vfor_cli -- --nocapture`
- `cargo test -p vize_canon -p vize`

## Notes
- `cargo clippy -p vize_canon -p vize --tests -- -D warnings -D clippy::wildcard_imports` is currently blocked by pre-existing test-target lint violations outside this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->