### PR TITLE
fix(nuxt): expose legacy template globals

### DIFF
--- a/crates/vize/src/commands/check/nuxt/legacy_template_globals.rs
+++ b/crates/vize/src/commands/check/nuxt/legacy_template_globals.rs
@@ -3,11 +3,15 @@ use vize_carton::ToCompactString;
 
 pub(super) fn collect(options: &mut VirtualTsOptions) {
     for (name, type_annotation) in [
+        ("$config", "any"),
         (
             "$fetchState",
             "{ pending: boolean; error: any; timestamp: number; [key: string]: any }",
         ),
+        ("$nuxt", "any"),
         ("$route", "any"),
+        ("$router", "any"),
+        ("$store", "any"),
     ] {
         if options
             .template_globals

--- a/crates/vize/src/commands/check/nuxt/legacy_template_globals_tests.rs
+++ b/crates/vize/src/commands/check/nuxt/legacy_template_globals_tests.rs
@@ -26,7 +26,14 @@ fn detects_legacy_nuxt2_fetch_state_and_route_template_globals() {
 
     let mut legacy_options = VirtualTsOptions::default();
     let _ = detect_legacy_nuxt_auto_imports(&mut legacy_options, &project_root);
-    for expected in ["$fetchState", "$route"] {
+    for expected in [
+        "$config",
+        "$fetchState",
+        "$nuxt",
+        "$route",
+        "$router",
+        "$store",
+    ] {
         assert!(
             legacy_options
                 .template_globals

--- a/crates/vize/tests/check_nuxt2_template_globals_cli.rs
+++ b/crates/vize/tests/check_nuxt2_template_globals_cli.rs
@@ -5,6 +5,8 @@ use std::{
     process::Command,
 };
 
+use vize_carton::cstr;
+
 #[test]
 fn check_legacy_nuxt2_template_fetch_state_and_route_globals() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
@@ -39,7 +41,10 @@ fn check_legacy_nuxt2_template_fetch_state_and_route_globals() {
 export default {}
 </script>
 <template>
-  <section v-if="$fetchState.pending">{{ $route.path }}</section>
+  <section v-if="$fetchState.pending && $store && $nuxt && $config">
+    {{ $route.path }}
+    {{ $router.push($route.path) }}
+  </section>
 </template>
 "#,
     )
@@ -58,9 +63,9 @@ export default {}
         .output()
         .unwrap();
 
-    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
-    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
-    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap_or_else(|error| {
         panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
     });
     assert_eq!(
@@ -77,6 +82,12 @@ export default {}
         stderr.contains("const $route:"),
         "expected $route declaration in virtual TS:\n{stderr}"
     );
+    for expected in ["$config", "$nuxt", "$router", "$store"] {
+        assert!(
+            stderr.contains(cstr!("const {expected}:").as_str()),
+            "expected {expected} declaration in virtual TS:\n{stderr}"
+        );
+    }
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
@@ -94,14 +105,14 @@ fn unique_case_dir(name: &str) -> PathBuf {
         .join("target")
         .join("vize-tests")
         .join("tests")
-        .join(format!("{name}-{}", std::process::id()))
+        .join(cstr!("{name}-{}", std::process::id()).as_str())
 }
 
-fn resolve_test_corsa_path() -> Option<String> {
+fn resolve_test_corsa_path() -> Option<PathBuf> {
     if let Ok(path) = std::env::var("CORSA_PATH")
         && Path::new(&path).exists()
     {
-        return Some(path);
+        return Some(PathBuf::from(path));
     }
 
     let workspace_root = workspace_root();
@@ -111,5 +122,4 @@ fn resolve_test_corsa_path() -> Option<String> {
     ]
     .into_iter()
     .find(|candidate| candidate.exists())
-    .map(|candidate| candidate.to_string_lossy().into_owned())
 }


### PR DESCRIPTION
## Summary
- Add the remaining Nuxt 2 legacy template globals (`$config`, `$nuxt`, `$router`, `$store`) to the virtual TS globals injected by `vize check`.
- Keep the existing `$fetchState`/`$route` behavior and align this list with croquis' legacy template binding set.
- Strengthen the legacy CLI regression to type-check `$router.push($route.path)` and assert all generated global declarations.

Refs #2224

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports`
- `cargo clippy -p vize --features legacy --test check_nuxt2_template_globals_cli -- -D warnings -D clippy::wildcard_imports`
- `cargo test -p vize detects_legacy_nuxt2_fetch_state_and_route_template_globals -- --nocapture`
- `cargo test -p vize --features legacy --test check_nuxt2_template_globals_cli -- --nocapture`
- `cargo test -p vize`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->