### PR TITLE
fix(canon): anchor direct defineProps template usage

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/no_unused.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/no_unused.rs
@@ -27,21 +27,7 @@ function handleSubmit() {}
 "#,
         )],
     );
-    std::fs::write(
-        project_root.join("tsconfig.json"),
-        r#"{
-  "compilerOptions": {
-    "strict": true,
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "noEmit": true,
-    "noUnusedLocals": true
-  },
-  "include": ["src/**/*"]
-}"#,
-    )
-    .unwrap();
+    write_no_unused_tsconfig(&project_root);
 
     let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
         let _ = std::fs::remove_dir_all(&project_root);
@@ -97,21 +83,7 @@ defineEmits<{ save: [] }>()
             ),
         ],
     );
-    std::fs::write(
-        project_root.join("tsconfig.json"),
-        r#"{
-  "compilerOptions": {
-    "strict": true,
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "noEmit": true,
-    "noUnusedLocals": true
-  },
-  "include": ["src/**/*"]
-}"#,
-    )
-    .unwrap();
+    write_no_unused_tsconfig(&project_root);
 
     let Some(snapshot) = snapshot_project_diagnostics_without_template_checks(&project_root) else {
         let _ = std::fs::remove_dir_all(&project_root);
@@ -145,6 +117,127 @@ defineEmits<{ save: [] }>()
 }
 
 #[test]
+fn define_props_result_binding_is_used_when_template_reads_direct_props() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case_without_node_modules(
+        "define-props-result-template-props-no-unused-locals",
+        &[
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+interface Props {
+  width?: number
+  label: string
+  required?: boolean
+}
+
+const props = defineProps<Props>()
+const unusedLocal = 1
+</script>
+
+<template>
+  <label>
+    {{ label }} {{ width }} {{ required }}
+  </label>
+</template>
+"#,
+            ),
+            (
+                "src/WithDefaults.vue",
+                r#"<script setup lang="ts">
+interface Props {
+  count?: number
+  label: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  count: 0,
+})
+const unusedLocal = 1
+</script>
+
+<template>
+  <button>{{ label }}: {{ count }}</button>
+</template>
+"#,
+            ),
+        ],
+    );
+    write_no_unused_tsconfig(&project_root);
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !((*file == "src/App.vue" || *file == "src/WithDefaults.vue")
+                && *code == Some(6133)
+                && message.contains("props"))
+        }),
+        "defineProps result should count as used when template reads direct props, got: {snapshot:#?}"
+    );
+    assert!(
+        snapshot.iter().any(|(file, code, message)| {
+            file == "src/App.vue" && *code == Some(6133) && message.contains("unusedLocal")
+        }),
+        "unrelated unused locals should still report TS6133 for plain defineProps, got: {snapshot:#?}"
+    );
+    assert!(
+        snapshot.iter().any(|(file, code, message)| {
+            file == "src/WithDefaults.vue" && *code == Some(6133) && message.contains("unusedLocal")
+        }),
+        "unrelated unused locals should still report TS6133 for withDefaults, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn define_props_result_binding_still_reports_unused_without_template_prop_reads() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case_without_node_modules(
+        "define-props-result-unused-without-template-props",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+interface Props {
+  label: string
+}
+
+const props = defineProps<Props>()
+const used = 1
+</script>
+
+<template>{{ used }}</template>
+"#,
+        )],
+    );
+    write_no_unused_tsconfig(&project_root);
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().any(|(file, code, message)| {
+            file == "src/App.vue" && *code == Some(6133) && message.contains("props")
+        }),
+        "defineProps result should still report TS6133 when template does not read props, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn batch_type_checker_does_not_report_default_export_alias_as_unused() {
     if resolve_test_tsgo_binary().is_none() {
         return;
@@ -167,21 +260,7 @@ export default {
 "#,
         )],
     );
-    std::fs::write(
-        project_root.join("tsconfig.json"),
-        r#"{
-  "compilerOptions": {
-    "strict": true,
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "noEmit": true,
-    "noUnusedLocals": true
-  },
-  "include": ["src/**/*"]
-}"#,
-    )
-    .unwrap();
+    write_no_unused_tsconfig(&project_root);
 
     let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
         let _ = std::fs::remove_dir_all(&project_root);
@@ -230,4 +309,22 @@ fn snapshot_project_diagnostics_without_template_checks(
         .collect();
     snapshot.sort();
     Some(snapshot)
+}
+
+fn write_no_unused_tsconfig(project_root: &std::path::Path) {
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "noUnusedLocals": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
 }

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -6,6 +6,7 @@ mod legacy_vue2;
 mod options_api;
 mod options_api_props_identifiers;
 mod options_api_support;
+mod props_anchors;
 mod script_module;
 mod setup_props;
 mod spans;
@@ -24,6 +25,7 @@ use self::options_api::{
     generate_options_api_variables,
 };
 use self::options_api_props_identifiers::PropsConstAssertions;
+use self::props_anchors::emit_setup_scope_prop_anchors;
 use self::setup_props::SetupPropsPlan;
 use self::spans::{
     DEFINE_COMPONENT_REF, merge_overlapping_spans, preserved_template_usage,
@@ -850,29 +852,13 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         );
     }
 
-    // Reference props destructure bindings at setup scope level.
-    // These variables are declared in user script (e.g., `const { foo } = defineProps<...>()`)
-    // but shadowed inside __template() by generate_props_variables, so void them here.
-    if let Some(destructure) = summary.macros.props_destructure()
-        && !destructure.bindings.is_empty()
-    {
-        ts.push_str("\n  // Reference destructured props (prevent TS6133)\n  ");
-        let mut first = true;
-        for binding in destructure.bindings.values() {
-            if !first {
-                ts.push(' ');
-            }
-            append!(ts, "void {};", binding.local);
-            first = false;
-        }
-        if let Some(ref rest) = destructure.rest_id {
-            if !first {
-                ts.push(' ');
-            }
-            append!(ts, "void {};", rest);
-        }
-        ts.push('\n');
-    }
+    emit_setup_scope_prop_anchors(
+        &mut ts,
+        summary,
+        script_content,
+        template_referenced_names.as_ref(),
+        preserve_unused_diagnostics,
+    );
 
     let define_emits_runtime_args = summary.macros.define_emits().and_then(|call| {
         if call.type_args.is_none() {

--- a/crates/vize_canon/src/virtual_ts/generator/props_anchors.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/props_anchors.rs
@@ -1,0 +1,188 @@
+//! Setup-scope anchors for props bindings shadowed by template generation.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Argument, BindingPattern, CallExpression, Expression, VariableDeclarator};
+use oxc_ast_visit::{Visit, walk};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{CompactString, FxHashSet, String, append, profile};
+use vize_croquis::{
+    Croquis,
+    macros::{DEFINE_PROPS, WITH_DEFAULTS},
+};
+
+use crate::virtual_ts::props::{strip_outer_angle_brackets, type_reference_lookup_key};
+
+pub(super) fn emit_setup_scope_prop_anchors(
+    ts: &mut String,
+    summary: &Croquis,
+    script_content: Option<&str>,
+    template_referenced_names: Option<&FxHashSet<String>>,
+    preserve_unused_diagnostics: bool,
+) {
+    if preserve_unused_diagnostics {
+        let bindings = profile!(
+            "canon.virtual_ts.collect_define_props_result_anchors",
+            collect_define_props_result_anchor_names(
+                summary,
+                script_content,
+                template_referenced_names,
+            )
+        );
+        if !bindings.is_empty() {
+            ts.push_str("\n  // Reference defineProps result (prevent TS6133)\n  ");
+            for (index, binding) in bindings.iter().enumerate() {
+                if index > 0 {
+                    ts.push(' ');
+                }
+                append!(*ts, "void {binding};");
+            }
+            ts.push('\n');
+        }
+    }
+
+    if let Some(destructure) = summary.macros.props_destructure()
+        && !destructure.bindings.is_empty()
+    {
+        ts.push_str("\n  // Reference destructured props (prevent TS6133)\n  ");
+        let mut first = true;
+        for binding in destructure.bindings.values() {
+            if !first {
+                ts.push(' ');
+            }
+            append!(*ts, "void {};", binding.local);
+            first = false;
+        }
+        if let Some(ref rest) = destructure.rest_id {
+            if !first {
+                ts.push(' ');
+            }
+            append!(*ts, "void {};", rest);
+        }
+        ts.push('\n');
+    }
+}
+
+fn collect_define_props_result_anchor_names<'a>(
+    summary: &'a Croquis,
+    script_content: Option<&str>,
+    template_referenced_names: Option<&FxHashSet<String>>,
+) -> Vec<&'a str> {
+    if !template_referenced_names
+        .is_some_and(|names| template_references_define_props_binding(summary, names))
+    {
+        return Vec::new();
+    }
+    let Some(script) = script_content else {
+        return Vec::new();
+    };
+
+    let bindings = collect_define_props_result_bindings(script);
+    let mut names = summary
+        .bindings
+        .bindings
+        .keys()
+        .map(|name| name.as_str())
+        .filter(|name| bindings.iter().any(|candidate| candidate.as_str() == *name))
+        .collect::<Vec<_>>();
+    names.sort_unstable();
+    names
+}
+
+fn template_references_define_props_binding(
+    summary: &Croquis,
+    template_referenced_names: &FxHashSet<String>,
+) -> bool {
+    if summary.macros.define_props().is_none() {
+        return false;
+    }
+
+    if summary
+        .macros
+        .props()
+        .iter()
+        .any(|prop| template_referenced_names.contains(prop.name.as_str()))
+    {
+        return true;
+    }
+
+    if summary
+        .macros
+        .models()
+        .iter()
+        .any(|model| template_referenced_names.contains(model.name.as_str()))
+    {
+        return true;
+    }
+
+    let Some(type_args) = summary
+        .macros
+        .define_props()
+        .and_then(|macro_call| macro_call.type_args.as_ref())
+    else {
+        return false;
+    };
+    let type_name = strip_outer_angle_brackets(type_args.trim());
+    summary
+        .types
+        .extract_properties(type_reference_lookup_key(type_name))
+        .iter()
+        .any(|prop| template_referenced_names.contains(prop.name.as_str()))
+}
+
+fn collect_define_props_result_bindings(script: &str) -> FxHashSet<CompactString> {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
+    let mut collector = DefinePropsResultBindingCollector::default();
+    collector.visit_program(&parsed.program);
+    collector.bindings
+}
+
+#[derive(Default)]
+struct DefinePropsResultBindingCollector {
+    bindings: FxHashSet<CompactString>,
+}
+
+impl<'a> Visit<'a> for DefinePropsResultBindingCollector {
+    fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'a>) {
+        if let BindingPattern::BindingIdentifier(binding) = &declarator.id
+            && declarator
+                .init
+                .as_ref()
+                .is_some_and(is_define_props_result_expression)
+        {
+            self.bindings
+                .insert(CompactString::new(binding.name.as_str()));
+        }
+
+        walk::walk_variable_declarator(self, declarator);
+    }
+}
+
+fn is_define_props_result_expression(expr: &Expression<'_>) -> bool {
+    let Expression::CallExpression(call) = expr else {
+        return false;
+    };
+    is_define_props_call(call) || is_with_defaults_define_props_call(call)
+}
+
+fn is_define_props_call(call: &CallExpression<'_>) -> bool {
+    matches!(
+        &call.callee,
+        Expression::Identifier(ident) if ident.name.as_str() == DEFINE_PROPS
+    )
+}
+
+fn is_with_defaults_define_props_call(call: &CallExpression<'_>) -> bool {
+    if !matches!(
+        &call.callee,
+        Expression::Identifier(ident) if ident.name.as_str() == WITH_DEFAULTS
+    ) {
+        return false;
+    }
+
+    matches!(
+        call.arguments.first(),
+        Some(Argument::CallExpression(inner)) if is_define_props_call(inner)
+    )
+}

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -508,7 +508,7 @@ pub(crate) fn generate_props_variables(
 /// resolver parses them directly. A type *reference* may carry a generic
 /// instantiation (`Foo<T>`); the resolver registers local types under their
 /// bare declaration name, so strip the arguments to recover `Foo`.
-fn type_reference_lookup_key(type_name: &str) -> &str {
+pub(crate) fn type_reference_lookup_key(type_name: &str) -> &str {
     if type_name.trim_start().starts_with('{') {
         type_name
     } else {
@@ -518,7 +518,7 @@ fn type_reference_lookup_key(type_name: &str) -> &str {
 
 /// Strip the outermost `<...>` pair from a type_args string, handling nested generics.
 /// e.g., `"<Props>"` → `"Props"`, `"<Foo<T>>"` → `"Foo<T>"`, `"Props"` → `"Props"`
-fn strip_outer_angle_brackets(s: &str) -> &str {
+pub(crate) fn strip_outer_angle_brackets(s: &str) -> &str {
     let s = s.trim();
     if !s.starts_with('<') {
         return s;


### PR DESCRIPTION
## Summary
- anchor setup-scope defineProps result bindings only when templates read direct prop identifiers
- keep TS6133 for defineProps result bindings when templates do not read props
- add strict noUnusedLocals regressions for plain defineProps and withDefaults

Refs #2224

## Tests
- cargo fmt --all -- --check
- git diff --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo test -p vize_canon no_unused -- --nocapture
- cargo test -p vize_canon
- cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->