### PR TITLE
fix(nuxt): lazy load vite plugin config helpers

### DIFF
--- a/npm/builder/vite/src/config.test.ts
+++ b/npm/builder/vite/src/config.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  CONFIG_FILES,
+  VIZE_CONFIG_JSON_SCHEMA_PATH,
+  VIZE_CONFIG_PKL_SCHEMA_PATH,
+  defineConfig,
+} from "./config.ts";
+
+const configSource = fs.readFileSync(
+  fileURLToPath(new URL("./config.ts", import.meta.url)),
+  "utf8",
+);
+
+assert.doesNotMatch(
+  configSource,
+  /from\s+["']vize["']/,
+  "vite plugin config must not statically import the vize root entrypoint",
+);
+assert.match(
+  configSource,
+  /import\(["']vize\/config["']\)/,
+  "vite plugin config should lazy-load the exported vize/config subpath",
+);
+
+const bundledPath = fileURLToPath(new URL("../dist/index.mjs", import.meta.url));
+if (fs.existsSync(bundledPath)) {
+  const bundledSource = fs.readFileSync(bundledPath, "utf8");
+  assert.doesNotMatch(
+    bundledSource,
+    /(?:from\s+["']vize["']|import\(["']vize["']\))/,
+    "bundled vite plugin must not import the vize root entrypoint",
+  );
+  assert.match(
+    bundledSource,
+    /import\(["']vize\/config["']\)/,
+    "bundled vite plugin should keep vize/config lazy-loaded",
+  );
+}
+
+const inlineConfig = {
+  compiler: {
+    vapor: true,
+  },
+};
+
+assert.equal(defineConfig(inlineConfig), inlineConfig, "defineConfig should remain identity");
+assert.ok(CONFIG_FILES.includes("vize.config.ts"), "config file names should stay exported");
+assert.ok(
+  VIZE_CONFIG_JSON_SCHEMA_PATH.endsWith("vize.config.schema.json"),
+  "JSON schema path should resolve through the exported vize schema subpath",
+);
+assert.ok(
+  VIZE_CONFIG_PKL_SCHEMA_PATH.endsWith("vize.pkl"),
+  "Pkl schema path should resolve through the exported vize pkl subpath",
+);
+
+console.log("vite-plugin-vize config tests passed!");

--- a/npm/builder/vite/src/config.ts
+++ b/npm/builder/vite/src/config.ts
@@ -1,27 +1,54 @@
+import type { ResolvedVizeConfig } from "./types.ts";
+import type { ConfigEnv, LoadConfigOptions, UserConfigExport } from "./types.ts";
+import { createRequire } from "node:module";
+
 /**
  * Shared Vize configuration helpers for the Vite plugin package.
  *
- * The canonical loader lives in the `vize` package so the Vite plugin and the
- * npm CLI resolve the same `vize.config.*` files with the same behavior.
+ * The canonical loader lives in the `vize` package, but Nuxt 2 executes ESM
+ * modules through Jiti/CJS resolution. Keep this module import-safe by avoiding
+ * a top-level `vize` root import; load `vize/config` only when config IO runs.
  */
 
-import type { ResolvedVizeConfig } from "./types.ts";
-import {
-  CONFIG_FILE_NAMES,
-  defineConfig,
-  loadConfig,
-  resolveConfigExport,
-  VIZE_CONFIG_JSON_SCHEMA_PATH,
-  VIZE_CONFIG_PKL_SCHEMA_PATH,
-} from "vize";
+type VizeConfigModule = typeof import("vize/config");
 
-export {
-  defineConfig,
-  loadConfig,
-  resolveConfigExport,
-  VIZE_CONFIG_JSON_SCHEMA_PATH,
-  VIZE_CONFIG_PKL_SCHEMA_PATH,
-};
+const require = createRequire(import.meta.url);
+
+export const CONFIG_FILE_NAMES = [
+  "vize.config.pkl",
+  "vize.config.ts",
+  "vize.config.js",
+  "vize.config.mjs",
+  "vize.config.json",
+] as const;
+
+let vizeConfigModulePromise: Promise<VizeConfigModule> | null = null;
+
+function loadVizeConfigModule(): Promise<VizeConfigModule> {
+  vizeConfigModulePromise ??= import("vize/config");
+  return vizeConfigModulePromise;
+}
+
+export function defineConfig(config: UserConfigExport): UserConfigExport {
+  return config;
+}
+
+export async function loadConfig(
+  root: string,
+  options?: LoadConfigOptions,
+): Promise<ResolvedVizeConfig | null> {
+  return (await loadVizeConfigModule()).loadConfig(root, options);
+}
+
+export async function resolveConfigExport(
+  exported: UserConfigExport,
+  env?: ConfigEnv,
+): Promise<ResolvedVizeConfig> {
+  return (await loadVizeConfigModule()).resolveConfigExport(exported, env);
+}
+
+export const VIZE_CONFIG_JSON_SCHEMA_PATH = require.resolve("vize/schemas/vize.config.schema.json");
+export const VIZE_CONFIG_PKL_SCHEMA_PATH = require.resolve("vize/pkl/vize.pkl");
 
 export const CONFIG_FILES = [...CONFIG_FILE_NAMES];
 export const VIZE_CONFIG_FILE_ENV = "VIZE_CONFIG_FILE";

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -1,5 +1,6 @@
 import "./hmr.test.ts";
 import "./compiler.test.ts";
+import "./config.test.ts";
 import "./utils.test.ts";
 import "./plugin/compat.test.ts";
 import "./plugin/css-modules.test.ts";


### PR DESCRIPTION
## Summary
- remove the vite plugin's top-level root `vize` import from config helpers
- lazy-load `vize/config` only when config loading or inline config resolution runs
- add regression coverage for source and bundled output so root `vize` imports do not return

Refs #2230

## Tests
- node npm/builder/vite/src/config.test.ts
- corepack pnpm --dir npm/builder/vite check
- corepack pnpm --dir npm/builder/vite build
- rg 'from \"vize\"|from '\''vize'\''|require\([\'\"]vize[\'\"]\)|import\([\'\"]vize[\'\"]\)|vize/config' npm/builder/vite/dist/index.mjs npm/builder/vite/dist/index.d.mts -n
- corepack pnpm --dir npm/framework/nuxt check
- corepack pnpm --dir npm/framework/nuxt build
- corepack pnpm --dir npm/framework/nuxt test
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check
- corepack pnpm --dir npm/builder/vite test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->