### PR TITLE
fix(atelier): preserve live Options API event lookups

### DIFF
--- a/crates/vize_atelier_core/src/codegen/props/events.rs
+++ b/crates/vize_atelier_core/src/codegen/props/events.rs
@@ -205,7 +205,9 @@ pub(super) fn generate_von_handler_value(ctx: &mut CodegenContext, dir: &Directi
         ctx.push("_withModifiers(");
     }
 
-    if let Some(exp) = &dir.exp {
+    if let Some(handler_name) = options_api_handler_name(ctx, dir) {
+        generate_options_api_handler_reference(ctx, handler_name);
+    } else if let Some(exp) = &dir.exp {
         generate_event_handler(ctx, exp, needs_cache);
     } else {
         ctx.push("() => {}");
@@ -244,6 +246,35 @@ pub(super) fn generate_von_handler_value(ctx: &mut CodegenContext, dir: &Directi
 
 fn needs_von_handler_cache(ctx: &CodegenContext, dir: &DirectiveNode<'_>) -> bool {
     ctx.cache_handlers_in_current_scope() && dir.exp.is_some() && !is_setup_const_handler(ctx, dir)
+}
+
+fn generate_options_api_handler_reference(ctx: &mut CodegenContext, name: &str) {
+    ctx.push("(...args) => (_ctx.");
+    ctx.push(name);
+    ctx.push(" && _ctx.");
+    ctx.push(name);
+    ctx.push("(...args))");
+}
+
+fn options_api_handler_name<'a>(
+    ctx: &CodegenContext,
+    dir: &'a DirectiveNode<'_>,
+) -> Option<&'a str> {
+    let ExpressionNode::Simple(simple) = dir.exp.as_ref()? else {
+        return None;
+    };
+
+    let name = simple.loc.source.as_str().trim();
+    if simple.is_static || !crate::steps::is_simple_identifier(name) {
+        return None;
+    }
+
+    ctx.options
+        .binding_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.bindings.get(name))
+        .filter(|binding| **binding == BindingType::Options)
+        .map(|_| name)
 }
 
 fn is_setup_const_handler(ctx: &CodegenContext, dir: &DirectiveNode<'_>) -> bool {

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -1,5 +1,5 @@
 mod define_props_regressions;
-
+mod options_api_events;
 use super::{compile_sfc, helpers, normal_script};
 use crate::types::{
     BindingType, ScriptCompileOptions, SfcCompileOptions, SfcCompileResult, TemplateCompileOptions,

--- a/crates/vize_atelier_sfc/src/compile/tests/options_api_events.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests/options_api_events.rs
@@ -1,0 +1,92 @@
+use super::super::compile_sfc;
+use crate::types::{SfcCompileOptions, TemplateCompileOptions};
+use crate::{SfcParseOptions, parse_sfc};
+
+#[test]
+fn test_options_api_method_handlers_use_live_instance_lookup() {
+    let source = r#"<script>
+export default {
+  methods: {
+    onFocus(event) {
+      this.$emit("focus", event)
+    },
+    onBlur(event) {
+      this.$emit("blur", event)
+    }
+  }
+}
+</script>
+
+<template>
+  <input id="test" @focus="onFocus" @blur.stop="onBlur" />
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result =
+        compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+
+    assert!(
+        result
+            .code
+            .contains("onFocus: (...args) => (_ctx.onFocus && _ctx.onFocus(...args))"),
+        "Options API method refs must read from the public instance proxy at event time:\n{}",
+        result.code
+    );
+    assert!(
+        result
+            .code
+            .contains("_withModifiers((...args) => (_ctx.onBlur && _ctx.onBlur(...args))"),
+        "Options API method refs wrapped with modifiers must still use live instance lookup:\n{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("$options.onFocus"),
+        "Options API v-on refs must not capture the original $options method:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn test_cached_options_api_method_handlers_keep_live_instance_lookup() {
+    let source = r#"<script>
+export default {
+  methods: {
+    onClick(event) {
+      this.$emit("click", event)
+    }
+  }
+}
+</script>
+
+<template>
+  <button @click="onClick">click</button>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let mut compiler_options = vize_atelier_dom::DomCompilerOptions::default();
+    compiler_options.cache_handlers = true;
+    let result = compile_sfc(
+        &descriptor,
+        SfcCompileOptions {
+            template: TemplateCompileOptions {
+                compiler_options: Some(compiler_options),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains(
+            "onClick: _cache[0] || (_cache[0] = (...args) => (_ctx.onClick && _ctx.onClick(...args)))",
+        ),
+        "Cached Options API handlers must keep a stable wrapper that performs a live lookup:\n{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("$options.onClick"),
+        "Cached Options API v-on refs must not capture the original $options method:\n{}",
+        result.code
+    );
+}

--- a/npm/builder/vite/src/options-api-events.test.ts
+++ b/npm/builder/vite/src/options-api-events.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+
+import { compileFile } from "./compiler.ts";
+
+const compiled = compileFile(
+  "/src/OptionsApiMethodHandler.vue",
+  new Map(),
+  { sourceMap: false, ssr: false, vapor: false },
+  `<script>
+export default {
+  methods: {
+    onFocus(event) {
+      this.$emit("focus", event);
+    }
+  }
+}
+</script>
+
+<template>
+  <input id="test" @focus="onFocus" />
+</template>`,
+);
+
+assert.match(
+  compiled.code,
+  /onFocus:\s*\(\.\.\.args\) => \(_ctx\.onFocus && _ctx\.onFocus\(\.\.\.args\)\)/,
+  "Options API v-on method refs must perform a live public instance lookup",
+);
+assert.doesNotMatch(
+  compiled.code,
+  /\$options\.onFocus/,
+  "Options API v-on method refs must not capture the original $options method",
+);
+
+console.log("vite-plugin-vize Options API event tests passed!");

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -1,6 +1,7 @@
 import "./hmr.test.ts";
 import "./compiler.test.ts";
 import "./config.test.ts";
+import "./options-api-events.test.ts";
 import "./utils.test.ts";
 import "./plugin/compat.test.ts";
 import "./plugin/css-modules.test.ts";

--- a/tests/snapshots/sfc/js/options_api__methods_with_event_handler.snap
+++ b/tests/snapshots/sfc/js/options_api__methods_with_event_handler.snap
@@ -17,7 +17,7 @@ const _sfc_main = {
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
-  return (_openBlock(), _createElementBlock("button", { onClick: $options.increment }, _toDisplayString($data.count), 9 /* TEXT, PROPS */, ["onClick"]))
+  return (_openBlock(), _createElementBlock("button", { onClick: (...args) => (_ctx.increment && _ctx.increment(...args)) }, _toDisplayString($data.count), 9 /* TEXT, PROPS */, ["onClick"]))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__methods_with_event_handler.snap
+++ b/tests/snapshots/sfc/ts/options_api__methods_with_event_handler.snap
@@ -17,7 +17,7 @@ const _sfc_main = {
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
-  return (_openBlock(), _createElementBlock("button", { onClick: $options.increment }, _toDisplayString($data.count), 9 /* TEXT, PROPS */, ["onClick"]))
+  return (_openBlock(), _createElementBlock("button", { onClick: (...args) => (_ctx.increment && _ctx.increment(...args)) }, _toDisplayString($data.count), 9 /* TEXT, PROPS */, ["onClick"]))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main


### PR DESCRIPTION
Fixes #2229.

## Summary
- emit Options API v-on method refs as live `_ctx.method(...args)` wrappers instead of `$options.method` references
- preserve live lookup through modifiers and cached handlers
- add SFC compile and Vite plugin compiler regressions

## Verification
- cargo test -p vize_atelier_sfc options_api_method_handlers -- --nocapture
- cargo test -p vize_atelier_core codegen -- --nocapture
- cargo clippy -p vize_atelier_core -p vize_atelier_sfc -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check
- cargo test -p vize_atelier_sfc
- corepack pnpm --dir npm/builder/vite test
- corepack pnpm --dir npm/builder/vite check
- git diff --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->