### PR TITLE
fix(canon): suppress legacy inline prop implicit any

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/camel_case_component_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/camel_case_component_props.rs
@@ -264,3 +264,51 @@ function updateDate(newDate: string) {
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn batch_type_checker_legacy_vue2_suppresses_vuetify_inline_function_prop_implicit_any() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "legacy-vue2-vuetify-inline-function-props",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const message = "Required";
+</script>
+
+<template>
+  <v-text-field :rules="[(v) => !!v || message]" />
+</template>
+"#,
+        )],
+    );
+
+    let mut checker = match BatchTypeChecker::new(&project_root) {
+        Ok(checker) => checker,
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        }
+    };
+    checker.enable_legacy_vue2();
+    checker.scan_project().unwrap();
+    let result = checker.check_project().unwrap();
+    let unexpected = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            relative_path(&project_root, &diagnostic.file) == "src/App.vue"
+                && (diagnostic.code == Some(7006)
+                    || diagnostic.message.contains("implicitly has an 'any' type"))
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        unexpected.is_empty(),
+        "legacy Vue 2 Vuetify inline function props should not report implicit any: {unexpected:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_expressions.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_expressions.rs
@@ -22,13 +22,14 @@ pub(super) fn collect_component_prop_expression_ranges(
         .collect();
     let mut ranges = FxHashSet::default();
     for usage in &summary.component_usages {
-        if !component_usage_has_checkable_binding(
+        let has_checkable_binding = component_usage_has_checkable_binding(
             summary,
             usage,
             &external_template_bindings,
             options.check_unresolved_global_components,
             options.legacy_vue2,
-        ) {
+        );
+        if !has_checkable_binding && !options.legacy_vue2 {
             continue;
         }
         for prop in &usage.props {
@@ -42,6 +43,10 @@ pub(super) fn collect_component_prop_expression_ranges(
             if !is_inline_function_prop_value(value) {
                 continue;
             }
+            // Checkable components validate inline function props through the
+            // prop checker. Legacy Vue 2 library globals are intentionally not
+            // prop-checked, so emitting those callbacks standalone would leave
+            // parameters uncontextualized and report TS7006 false positives.
             for expr in &summary.template_expressions {
                 if expr.kind == TemplateExpressionKind::VBind
                     && expr.scope_id == usage.scope_id


### PR DESCRIPTION
## Summary
- skip standalone template emission for inline function props on legacy Vue 2 library/global components that are intentionally not prop-checked
- add a legacy Vue 2 Vuetify regression for `:rules="[(v) => ...]"` not reporting TS7006

Refs #2224

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p vize_canon batch_type_checker_legacy_vue2_suppresses_vuetify_inline_function_prop_implicit_any -- --nocapture`
- `cargo test -p vize_canon legacy_vue2 -- --nocapture`
- `cargo test -p vize_canon`
- `cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports`
- `git diff --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->