### PR TITLE
fix(unplugin): avoid empty SFC failures in Nuxt 2 webpack integration

### DIFF
--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -5,6 +5,7 @@
 //! is delegated to specialized modules.
 
 mod bindings;
+mod empty_component;
 mod helpers;
 mod normal_script;
 pub(crate) mod output_module;
@@ -647,18 +648,16 @@ fn compile_sfc_inner(
     }
 
     // Case 3: Script setup with inline template
-    // If we reach here without script_setup, it means the SFC has no content
-    let script_setup = match descriptor.script_setup.as_ref() {
-        Some(s) => s,
-        None => {
-            return Err(SfcError {
-                message:
-                    "At least one <template> or <script> is required in a single file component."
-                        .to_compact_string(),
-                code: None,
-                loc: None,
-            });
-        }
+    let Some(script_setup) = descriptor.script_setup.as_ref() else {
+        return Ok(empty_component::compile_empty_component(
+            is_vapor,
+            &compiled_styles,
+            css,
+            errors,
+            warnings,
+            macro_artifacts,
+            &options,
+        ));
     };
 
     // Extract normal script content if present (for type definitions, imports, etc.)

--- a/crates/vize_atelier_sfc/src/compile/empty_component.rs
+++ b/crates/vize_atelier_sfc/src/compile/empty_component.rs
@@ -1,0 +1,43 @@
+use crate::types::{SfcCompileOptions, SfcCompileResult, SfcError, SfcMacroArtifact};
+use vize_carton::String;
+
+use super::output_module::append_css_modules_assignment;
+use super::styles::CompiledStyles;
+use super::{finalize_output_mode, trim_trailing_newlines};
+
+pub(super) fn compile_empty_component(
+    is_vapor: bool,
+    compiled_styles: &CompiledStyles,
+    css: Option<String>,
+    errors: Vec<SfcError>,
+    mut warnings: Vec<SfcError>,
+    macro_artifacts: Vec<SfcMacroArtifact>,
+    options: &SfcCompileOptions,
+) -> SfcCompileResult {
+    // Nuxt/Vue projects can contain empty placeholder SFCs; the host compiler
+    // treats them as importable empty components, so Vize must not fail builds.
+    let mut code = String::from("const _sfc_main = ");
+    if is_vapor {
+        code.push_str("{ __vapor: true }");
+    } else {
+        code.push_str("{}");
+    }
+    if !compiled_styles.css_modules.is_empty() {
+        code.push('\n');
+        append_css_modules_assignment(&mut code, "_sfc_main", &compiled_styles.css_modules);
+    }
+    code.push_str("\nexport default _sfc_main\n");
+
+    finalize_output_mode(&mut code, &mut warnings, options);
+    trim_trailing_newlines(&mut code);
+
+    SfcCompileResult {
+        code,
+        css,
+        map: None,
+        errors,
+        warnings,
+        bindings: None,
+        macro_artifacts,
+    }
+}

--- a/crates/vize_atelier_sfc/tests/empty_component.rs
+++ b/crates/vize_atelier_sfc/tests/empty_component.rs
@@ -1,0 +1,21 @@
+use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sfc};
+
+#[test]
+fn empty_sfc_emits_empty_component() {
+    for source in ["", "\n"] {
+        let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("parse empty SFC");
+        let result = compile_sfc(&descriptor, SfcCompileOptions::default())
+            .expect("empty SFC placeholders should compile as empty components");
+
+        assert!(
+            result.errors.is_empty(),
+            "empty SFC should not report compile errors: {:?}",
+            result.errors
+        );
+        assert_eq!(result.css, None);
+        assert_eq!(
+            result.code, "const _sfc_main = {}\nexport default _sfc_main",
+            "empty SFC should emit a minimal component module"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2223.

Nuxt 2 webpack builds were failing when the Vize unplugin encountered empty or whitespace-only `*.vue` placeholders that Nuxt and `vue-loader` accept as importable empty components. The SFC compiler bailed with:

> At least one `<template>` or `<script>` is required in a single file component.

This change lets the compiler emit a minimal empty component module instead of erroring when the descriptor has no template, no script, and no `<script setup>`.

## Change Class

- [x] Compiler and codegen

## Behavior Reference

Vue 2 / Nuxt 2 `vue-loader` accepts empty SFCs as importable modules. Real project: `gitlab.com/mates-pay/app/new_reco/reco_for_teacher--vize` (see issue).

## Verification Evidence

- `cargo test -p vize_atelier_sfc --test empty_component` (new regression test, passes; reproduces the failure pre-fix).
- Snapshot suites (`snapshot_tests::*`) require the optional `pkl` binary and are unrelated; they fail with the same setup error on `main`.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

Behavioral change is scoped to descriptors that contain no `<template>`, no `<script>`, and no `<script setup>` — previously a hard error, now an empty component module. Same shape that Vue / `vue-loader` already accepts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->