### PR TITLE
fix(glyph): keep nested template indentation stable

### DIFF
--- a/crates/vize_glyph/src/template.rs
+++ b/crates/vize_glyph/src/template.rs
@@ -302,6 +302,12 @@ mod tests {
         assert!(is_void_element_str("input"));
         assert!(!is_void_element_str("div"));
         assert!(!is_void_element_str("span"));
+        // Vue components (PascalCase) must never be treated as HTML void
+        // elements, even when they share a name with one (e.g. `<Link>` vs
+        // `<link>`). See #2244.
+        assert!(!is_void_element_str("Link"));
+        assert!(!is_void_element_str("Input"));
+        assert!(!is_void_element_str("Img"));
     }
 
     #[test]

--- a/crates/vize_glyph/src/template.rs
+++ b/crates/vize_glyph/src/template.rs
@@ -290,7 +290,6 @@ mod tests {
         options.single_attribute_per_line = true;
         let result = format_template_content(source, &options).unwrap();
 
-        // Each attribute should be on its own line
         let lines: Vec<&str> = result.lines().collect();
         assert!(lines.len() > 2, "Should have multiple lines for attributes");
     }
@@ -302,9 +301,6 @@ mod tests {
         assert!(is_void_element_str("input"));
         assert!(!is_void_element_str("div"));
         assert!(!is_void_element_str("span"));
-        // Vue components (PascalCase) must never be treated as HTML void
-        // elements, even when they share a name with one (e.g. `<Link>` vs
-        // `<link>`). See #2244.
         assert!(!is_void_element_str("Link"));
         assert!(!is_void_element_str("Input"));
         assert!(!is_void_element_str("Img"));
@@ -474,7 +470,6 @@ mod tests {
         options.max_attributes_per_line = Some(2);
         let result = format_template_content(source, &options).unwrap();
 
-        // Should wrap: multiple lines with at most 2 attrs per line
         let lines: Vec<&str> = result.lines().collect();
         assert!(
             lines.len() >= 3,
@@ -489,7 +484,6 @@ mod tests {
         options.max_attributes_per_line = Some(3);
         let result = format_template_content(source, &options).unwrap();
 
-        // 2 attrs <= 3 limit, no wrapping
         let lines: Vec<&str> = result.lines().collect();
         assert_eq!(lines.len(), 1, "Should keep the empty element inline");
     }

--- a/crates/vize_glyph/src/template/helpers.rs
+++ b/crates/vize_glyph/src/template/helpers.rs
@@ -54,11 +54,20 @@ pub(crate) fn is_whitespace(b: u8) -> bool {
 ///
 /// Alloc-free: void element names are 2..=6 ASCII bytes, so a length guard
 /// plus case-insensitive comparison avoids the lowercasing allocation.
+///
+/// Vue treats tags that start with an uppercase ASCII letter as components
+/// (e.g. `<Link>`, `<Input>`), never as their HTML void-element namesakes.
+/// Without that guard, `<Link>` would collapse to a void element here, so
+/// the formatter would skip the child-depth increment and emit the
+/// component's children flush with their parent. (#2244)
 pub(crate) fn is_void_element_str(tag: &str) -> bool {
     const VOID_ELEMENTS: [&str; 14] = [
         "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param",
         "source", "track", "wbr",
     ];
+    if tag.as_bytes().first().is_some_and(u8::is_ascii_uppercase) {
+        return false;
+    }
     matches!(tag.len(), 2..=6) && VOID_ELEMENTS.iter().any(|v| tag.eq_ignore_ascii_case(v))
 }
 

--- a/crates/vize_glyph/tests/template_nested_component_indent.rs
+++ b/crates/vize_glyph/tests/template_nested_component_indent.rs
@@ -1,0 +1,51 @@
+use vize_glyph::{FormatOptions, format_template};
+
+/// Regression test for https://github.com/ubugeeei-prod/vize/issues/2244.
+///
+/// `<Link>` (PascalCase Vue component) used to collide with HTML `<link>`
+/// inside `is_void_element_str`, so the formatter skipped the child-depth
+/// increment and emitted the component's children flush with their parent.
+/// The fix treats any tag starting with an uppercase ASCII letter as a
+/// component, never a void element.
+#[test]
+fn nested_component_with_attrs_keeps_child_indent_stable() {
+    let source = r#"<template>
+  <div>
+    <Link :to='{ name: "signup" }'>
+      {{ t("general.signUp._") }}
+    </Link>
+  </div>
+  <div>
+    <span>
+      {{ t("general.password.reset.description") }}
+    </span>
+    <Link :to='{ name: "password-reset" }'>
+      {{ t("general.password.reset._") }}
+    </Link>
+  </div>
+</template>"#;
+
+    let options = FormatOptions::default();
+    let first = format_template(source, &options).unwrap();
+    let second = format_template(&first, &options).unwrap();
+
+    assert_eq!(
+        first.as_str(),
+        r#"<template>
+  <div>
+    <Link :to='{ name: "signup" }'>
+      {{ t("general.signUp._") }}
+    </Link>
+  </div>
+  <div>
+    <span>
+      {{ t("general.password.reset.description") }}
+    </span>
+    <Link :to='{ name: "password-reset" }'>
+      {{ t("general.password.reset._") }}
+    </Link>
+  </div>
+</template>"#
+    );
+    assert_eq!(first, second, "should be idempotent");
+}


### PR DESCRIPTION
## Summary

Vue components named after HTML void elements (e.g. `<Link>`, `<Input>`, `<Img>`) used to collide with their HTML namesakes inside the template formatter's void-element check. Because `is_void_element_str` compared case-insensitively, `<Link>` matched `<link>` and the formatter skipped the child-depth increment for the component — so the component's children were emitted flush with their parent, and every sibling underneath cascaded one level too shallow.

This change makes `is_void_element_str` return `false` for any tag whose first character is an uppercase ASCII letter. Vue's tag convention treats `PascalCase` as a component, so PascalCase tags are never the HTML void elements they happen to share a name with. Lowercase HTML tags continue to be matched case-insensitively, matching prior behavior.

## Change Class

- [x] Formatter and LSP

## Behavior Reference

Closes #2244. Vue's parser treats tags starting with an uppercase ASCII letter as components, never as their HTML namesakes — see Vue's [component naming](https://vuejs.org/style-guide/rules-strongly-recommended.html#component-name-casing-in-templates) guidance.

## Verification Evidence

Commands run:

- `cargo test -p vize_glyph` (all 95 tests pass, including the new regression test)
- `cargo test -p vize_maestro --features glyph` (392 tests pass)
- `cargo fmt --check -p vize_glyph` (clean)
- `cargo clippy -p vize_glyph --no-deps -- -D warnings` (clean)

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [ ] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

The regression test (`crates/vize_glyph/tests/template_nested_component_indent.rs`) reproduces the exact failure from the issue (nested `<Link>` components with `:to` attributes) and asserts both correct indentation and idempotence. Unit tests in `src/template.rs` also assert PascalCase variants of void-element names are not collapsed.

## Risk

Low. Lowercase HTML tag behavior is unchanged. PascalCase variants previously routed through the void-element fast path (skipping the close-tag scan in whitespace-significant elements and the depth increment); now they route through the normal child-emission path, which is what users already expect.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->