### PR TITLE
fix(musea): rewrite script-setup imports in Storybook compatibility output

### DIFF
--- a/npm/builder/vite-musea/src/utils.test.ts
+++ b/npm/builder/vite-musea/src/utils.test.ts
@@ -4,7 +4,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { resolveScanRoots, rewriteStorybookComponentImport, scanArtFiles } from "./utils.ts";
+import {
+  resolveScanRoots,
+  rewriteStorybookComponentImport,
+  rewriteStorybookScriptImports,
+  scanArtFiles,
+} from "./utils.ts";
+import { loadNative } from "./native-loader.ts";
 
 void test("resolveScanRoots preserves include bases outside the Vite root", () => {
   const root = "/workspace/apps/website";
@@ -57,4 +63,72 @@ void test("rewriteStorybookComponentImport rebases component path from story out
   );
 
   assert.match(result, /from '\.\.\/\.\.\/src\/AfsButton\.vue';/);
+});
+
+void test("rewriteStorybookScriptImports rebases relative imports lifted from script setup", () => {
+  const root = "/workspace";
+  const artPath = path.join(root, "src", "AfsButton.art.vue");
+  const outputPath = path.join(root, ".storybook", "generated", "AfsButton.stories.ts");
+  const code = [
+    "import type { Meta, StoryObj } from '@storybook/vue3';",
+    "import __museaComponent from '../../src/AfsButton.vue';",
+    "import AfsButton from './AfsButton.vue';",
+    'import { fixture } from "./fixtures";',
+    "",
+  ].join("\n");
+
+  const result = rewriteStorybookScriptImports(code, artPath, outputPath);
+
+  // `__museaComponent` is already correct — must be preserved.
+  assert.match(result, /import __museaComponent from '\.\.\/\.\.\/src\/AfsButton\.vue';/);
+  // Lifted script-setup imports must be rebased relative to the generated file.
+  assert.match(result, /import AfsButton from '\.\.\/\.\.\/src\/AfsButton\.vue';/);
+  assert.match(result, /import \{ fixture \} from "\.\.\/\.\.\/src\/fixtures";/);
+  // Bare specifiers (npm packages) must be left untouched.
+  assert.match(result, /import type \{ Meta, StoryObj \} from '@storybook\/vue3';/);
+  // The stale, broken specifier must no longer appear.
+  assert.doesNotMatch(result, /from '\.\/AfsButton\.vue';/);
+});
+
+void test("CSF output for an art file rewrites script-setup imports relative to the generated file (issue #2228)", () => {
+  const binding = loadNative();
+  const root = "/workspace";
+  const artPath = path.join(root, "src", "AfsButton.art.vue");
+  const outputPath = path.join(root, ".storybook", "generated", "AfsButton.stories.ts");
+
+  const source = `
+<script setup lang="ts">
+import AfsButton from './AfsButton.vue'
+</script>
+
+<art title="AfsButton" category="Components" component="./AfsButton.vue">
+  <variant name="Primary" default>
+    <AfsButton color="primary">Primary</AfsButton>
+  </variant>
+</art>
+`;
+
+  const csf = binding.artToCsf(source, { filename: artPath });
+
+  const art = {
+    path: artPath,
+    metadata: {
+      title: "AfsButton",
+      component: "./AfsButton.vue",
+      tags: ["button", "action"],
+      status: "ready" as const,
+    },
+    variants: [],
+    hasScriptSetup: true,
+    hasScript: false,
+    styleCount: 0,
+  };
+
+  const rewritten = rewriteStorybookComponentImport(csf.code, art, artPath, outputPath);
+  const code = rewriteStorybookScriptImports(rewritten, artPath, outputPath);
+
+  // The stale `./AfsButton.vue` lifted from script-setup must be gone.
+  assert.doesNotMatch(code, /from ['"]\.\/AfsButton\.vue['"]/);
+  // The lifted import must be rebased relative to the generated file's location.
+  assert.match(code, /import AfsButton from ['"]\.\.\/\.\.\/src\/AfsButton\.vue['"]/);
 });

--- a/npm/builder/vite-musea/src/utils.ts
+++ b/npm/builder/vite-musea/src/utils.ts
@@ -178,7 +178,8 @@ export async function generateStorybookFiles(
       const csf = binding.artToCsf(source, { filename: filePath });
 
       const outputPath = path.join(outputDir, csf.filename);
-      const code = rewriteStorybookComponentImport(csf.code, art, filePath, outputPath);
+      const rewritten = rewriteStorybookComponentImport(csf.code, art, filePath, outputPath);
+      const code = rewriteStorybookScriptImports(rewritten, filePath, outputPath);
       await fs.promises.writeFile(outputPath, code, "utf-8");
 
       console.log(`[musea] Generated: ${path.relative(root, outputPath)}`);
@@ -217,6 +218,48 @@ export function rewriteStorybookComponentImport(
 
 function isBareImport(source: string): boolean {
   return !source.startsWith(".") && !path.isAbsolute(source);
+}
+
+/**
+ * Rewrite relative import specifiers in the generated Storybook CSF file so that
+ * imports lifted verbatim from the art file's `<script setup>` resolve against
+ * the generated file's location instead of the original art file's directory.
+ *
+ * The `__museaComponent` import is already rebased by
+ * `rewriteStorybookComponentImport` and is skipped here.
+ */
+export function rewriteStorybookScriptImports(
+  code: string,
+  artPath: string,
+  outputPath: string,
+): string {
+  const artDir = path.dirname(artPath);
+  const outDir = path.dirname(outputPath);
+
+  // Matches: import <clause> from '<specifier>';  (single or double quotes)
+  // `<clause>` is a non-greedy capture so we keep the original binding text intact.
+  const importRe = /(import\s+(?:[\s\S]*?)\s+from\s+)(['"])([^'"]+)\2(\s*;?)/g;
+
+  return code.replace(importRe, (match, head, quote, specifier, tail) => {
+    // Skip bare specifiers (npm packages, virtual modules, etc.).
+    if (!specifier.startsWith(".")) {
+      return match;
+    }
+
+    // Skip the `__museaComponent` import — it is rebased separately by
+    // `rewriteStorybookComponentImport` against the metadata component path.
+    if (/\b__museaComponent\b/.test(head)) {
+      return match;
+    }
+
+    const resolved = path.resolve(artDir, specifier);
+    let rebased = normalizeGlobPath(path.relative(outDir, resolved));
+    if (!rebased.startsWith(".")) {
+      rebased = `./${rebased}`;
+    }
+
+    return `${head}${quote}${rebased}${quote}${tail}`;
+  });
 }
 
 export function toPascalCase(str: string): string {


### PR DESCRIPTION
## Summary

Musea's Storybook compatibility output (`storybookCompat: true`) writes generated CSF files under `<root>/.storybook/generated/<Name>.stories.ts`, but the imports lifted from the source art file's `<script setup>` were emitted with their original specifiers. Because the generated file lives in a different directory than the art file, those specifiers no longer resolved (e.g. `import AfsButton from './AfsButton.vue'` pointed at `.storybook/generated/AfsButton.vue`).

The fix rebases every relative specifier in the generated CSF code against the generated file's location, while preserving:

- bare specifiers (npm packages, virtual modules), and
- the `__museaComponent` import, which is already rebased by `rewriteStorybookComponentImport`.

## Change Class

- [x] Compiler and codegen

## Behavior Reference

Closes #2228

## Verification Evidence

- Added `rewriteStorybookScriptImports` unit test covering bare specifiers, dual-quote handling, and the `__museaComponent` skip.
- Added an end-to-end regression test that drives the actual `binding.artToCsf` native binding with a minimal art fixture and asserts the generated CSF contains `'../../src/AfsButton.vue'` (not `'./AfsButton.vue'`).
- `vp exec tsx --test 'src/*.test.ts' 'src/**/*.test.ts'` — 66 passed.
- `vp check src vite.config.ts` — format and lint clean.
- `rtk cargo test -p vize_musea` — 88 passed (no Rust changes; sanity check).

- [x] Minimal fixture or focused regression test added or updated
- [ ] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [ ] Security/audit impact considered
- [ ] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

Low. The rewrite only fires inside `generateStorybookFiles` (i.e. when `storybookCompat: true`) and is bounded to specifiers that already start with `.`. Bare specifiers and the previously-rebased `__museaComponent` import are explicitly skipped, so existing valid outputs are unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->