### PR TITLE
fix(patina): gate script/no-next-tick off opinionated preset for non-Vapor projects

### DIFF
--- a/crates/vize/tests/lint_config_cli.rs
+++ b/crates/vize/tests/lint_config_cli.rs
@@ -249,6 +249,41 @@ const items = [{ id: 1, name: 'One' }]
 }
 
 #[test]
+fn lint_opinionated_preset_allows_next_tick_for_non_vapor_projects() {
+    // Regression for #2239: opinionated is the recommended preset for non-Vapor
+    // Vue 3 design systems, where `nextTick()` is a legitimate runtime API. The
+    // Vapor-oriented `script/no-next-tick` rule must remain opt-in.
+    let project_root = temp_project_dir("opinionated-non-vapor-next-tick");
+    let sfc = r#"<script setup lang="ts">
+import { nextTick } from 'vue'
+
+await nextTick()
+</script>
+"#;
+    write_project_file(&project_root, "src/Dialog.vue", sfc);
+
+    let opinionated_default = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args([
+            "lint",
+            "--preset",
+            "opinionated",
+            "--no-config",
+            "src/Dialog.vue",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        opinionated_default.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&opinionated_default.stdout),
+        String::from_utf8_lossy(&opinionated_default.stderr)
+    );
+
+    let _ = fs::remove_dir_all(project_root);
+}
+
+#[test]
 fn lint_nuxt_preset_allows_next_tick_by_default_and_when_compiler_vapor_is_false() {
     let project_root = temp_project_dir("nuxt-non-vapor-next-tick");
     let sfc = r#"<script setup lang="ts">

--- a/crates/vize_patina/src/linter/script_rules/registry/rules.rs
+++ b/crates/vize_patina/src/linter/script_rules/registry/rules.rs
@@ -61,7 +61,7 @@ static NO_DEEP_DESTRUCTURE_IN_PROPS_RULE: NoDeepDestructureInProps =
 pub(in crate::linter::script_rules) static BUILTIN_SCRIPT_RULES: &[BuiltinScriptRuleEntry] = &[
     BuiltinScriptRuleEntry { rule_name: RULE_NO_OPTIONS_API, profile_name: "patina.script_rule.no_options_api", category: "Vapor", fixable: false, presets: OPINIONATED_ONLY_SCRIPT_PRESETS, rule: &NoOptionsApi },
     BuiltinScriptRuleEntry { rule_name: RULE_NO_GET_CURRENT_INSTANCE, profile_name: "patina.script_rule.no_get_current_instance", category: "Vapor", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &NoGetCurrentInstance },
-    BuiltinScriptRuleEntry { rule_name: RULE_NO_NEXT_TICK, profile_name: "patina.script_rule.no_next_tick", category: "Vapor", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &NoNextTick },
+    BuiltinScriptRuleEntry { rule_name: RULE_NO_NEXT_TICK, profile_name: "patina.script_rule.no_next_tick", category: "Vapor", fixable: false, presets: OPT_IN_SCRIPT_PRESETS, rule: &NoNextTick },
     BuiltinScriptRuleEntry { rule_name: RULE_PINIA_PREFER_STORE_TO_REFS, profile_name: "patina.script_rule.pinia_prefer_store_to_refs", category: "Ecosystem", fixable: false, presets: ECOSYSTEM_SCRIPT_PRESETS, rule: &PiniaPreferStoreToRefs },
     BuiltinScriptRuleEntry { rule_name: RULE_VUE_ROUTER_PREFER_NAMED_PUSH, profile_name: "patina.script_rule.vue_router_prefer_named_push", category: "Ecosystem", fixable: false, presets: ECOSYSTEM_SCRIPT_PRESETS, rule: &VueRouterPreferNamedPush },
     BuiltinScriptRuleEntry { rule_name: RULE_VUE_TEST_UTILS_NO_HTML_SNAPSHOT, profile_name: "patina.script_rule.vue_test_utils_no_html_snapshot", category: "Ecosystem", fixable: false, presets: ECOSYSTEM_SCRIPT_PRESETS, rule: &VueTestUtilsNoHtmlSnapshot },

--- a/crates/vize_patina/src/linter/tests/script.rs
+++ b/crates/vize_patina/src/linter/tests/script.rs
@@ -14,7 +14,10 @@ await nextTick()
             "test.vue",
         );
     assert!(
-        result.diagnostics.iter().any(|d| d.rule_name == "script/no-next-tick"),
+        result
+            .diagnostics
+            .iter()
+            .any(|d| d.rule_name == "script/no-next-tick"),
         "explicit script/no-next-tick should still report, got {:?}",
         result.diagnostics
     );

--- a/crates/vize_patina/src/linter/tests/script.rs
+++ b/crates/vize_patina/src/linter/tests/script.rs
@@ -1,6 +1,26 @@
 use super::{LintPreset, Linter};
 
 #[test]
+fn test_lint_sfc_opinionated_reports_no_next_tick_when_rule_is_enabled() {
+    let result = Linter::with_preset(LintPreset::Opinionated)
+        .with_additional_rules(vec!["script/no-next-tick".into()])
+        .lint_sfc(
+            r#"<script setup lang="ts">
+import { nextTick } from 'vue'
+
+await nextTick()
+</script>
+"#,
+            "test.vue",
+        );
+    assert!(
+        result.diagnostics.iter().any(|d| d.rule_name == "script/no-next-tick"),
+        "explicit script/no-next-tick should still report, got {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn lint_script_runs_script_rules() {
     let result = Linter::with_preset(LintPreset::Opinionated).lint_script(
         r#"import { getCurrentInstance } from "vue";

--- a/crates/vize_patina/src/linter/tests/sfc.rs
+++ b/crates/vize_patina/src/linter/tests/sfc.rs
@@ -138,10 +138,7 @@ fn test_lint_sfc_css_diagnostic_uses_file_offsets() {
 
 #[test]
 fn test_lint_sfc_opinionated_allows_next_tick_by_default() {
-    // Regression for #2239: opinionated is the recommended preset for non-Vapor
-    // Vue 3 projects, so `nextTick()` (a legitimate runtime API outside Vapor)
-    // must not flag unless the host explicitly opts into the Vapor-oriented
-    // `script/no-next-tick` rule.
+    // Regression for #2239: opinionated must not flag nextTick() without explicit opt-in.
     let linter = Linter::with_preset(LintPreset::Opinionated);
     let sfc = r#"<script setup lang="ts">
 import { nextTick } from 'vue'
@@ -151,33 +148,8 @@ await nextTick()
 "#;
     let result = linter.lint_sfc(sfc, "test.vue");
     assert!(
-        !result
-            .diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.rule_name == "script/no-next-tick"),
-        "opinionated preset should not report script/no-next-tick by default, got {:?}",
-        result.diagnostics
-    );
-}
-
-#[test]
-fn test_lint_sfc_opinionated_reports_no_next_tick_when_rule_is_enabled() {
-    let linter = Linter::with_preset(LintPreset::Opinionated)
-        .with_additional_rules(vec!["script/no-next-tick".into()]);
-    let sfc = r#"<script setup lang="ts">
-import { nextTick } from 'vue'
-
-await nextTick()
-</script>
-"#;
-    let result = linter.lint_sfc(sfc, "test.vue");
-    assert!(
-        result
-            .diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.rule_name == "script/no-next-tick"),
-        "explicit script/no-next-tick should still report, got {:?}",
-        result.diagnostics
+        !result.diagnostics.iter().any(|d| d.rule_name == "script/no-next-tick"),
+        "opinionated preset must not report script/no-next-tick without explicit opt-in"
     );
 }
 

--- a/crates/vize_patina/src/linter/tests/sfc.rs
+++ b/crates/vize_patina/src/linter/tests/sfc.rs
@@ -137,8 +137,33 @@ fn test_lint_sfc_css_diagnostic_uses_file_offsets() {
 }
 
 #[test]
-fn test_lint_sfc_opinionated_reports_no_next_tick() {
+fn test_lint_sfc_opinionated_allows_next_tick_by_default() {
+    // Regression for #2239: opinionated is the recommended preset for non-Vapor
+    // Vue 3 projects, so `nextTick()` (a legitimate runtime API outside Vapor)
+    // must not flag unless the host explicitly opts into the Vapor-oriented
+    // `script/no-next-tick` rule.
     let linter = Linter::with_preset(LintPreset::Opinionated);
+    let sfc = r#"<script setup lang="ts">
+import { nextTick } from 'vue'
+
+await nextTick()
+</script>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+    assert!(
+        !result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.rule_name == "script/no-next-tick"),
+        "opinionated preset should not report script/no-next-tick by default, got {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn test_lint_sfc_opinionated_reports_no_next_tick_when_rule_is_enabled() {
+    let linter = Linter::with_preset(LintPreset::Opinionated)
+        .with_additional_rules(vec!["script/no-next-tick".into()]);
     let sfc = r#"<script setup lang="ts">
 import { nextTick } from 'vue'
 
@@ -150,7 +175,9 @@ await nextTick()
         result
             .diagnostics
             .iter()
-            .any(|diagnostic| diagnostic.rule_name == "script/no-next-tick")
+            .any(|diagnostic| diagnostic.rule_name == "script/no-next-tick"),
+        "explicit script/no-next-tick should still report, got {:?}",
+        result.diagnostics
     );
 }
 

--- a/crates/vize_patina/src/linter/tests/sfc.rs
+++ b/crates/vize_patina/src/linter/tests/sfc.rs
@@ -138,17 +138,18 @@ fn test_lint_sfc_css_diagnostic_uses_file_offsets() {
 
 #[test]
 fn test_lint_sfc_opinionated_allows_next_tick_by_default() {
-    // Regression for #2239: opinionated must not flag nextTick() without explicit opt-in.
-    let linter = Linter::with_preset(LintPreset::Opinionated);
     let sfc = r#"<script setup lang="ts">
 import { nextTick } from 'vue'
 
 await nextTick()
 </script>
 "#;
-    let result = linter.lint_sfc(sfc, "test.vue");
+    let result = Linter::with_preset(LintPreset::Opinionated).lint_sfc(sfc, "test.vue");
     assert!(
-        !result.diagnostics.iter().any(|d| d.rule_name == "script/no-next-tick"),
+        !result
+            .diagnostics
+            .iter()
+            .any(|d| d.rule_name == "script/no-next-tick"),
         "opinionated preset must not report script/no-next-tick without explicit opt-in"
     );
 }

--- a/crates/vize_patina/src/preset.rs
+++ b/crates/vize_patina/src/preset.rs
@@ -60,11 +60,8 @@ const ECOSYSTEM_SCRIPT_RULE_NAMES: &[&str] = &[
     "ecosystem/vue-router-prefer-named-push",
     "ecosystem/vue-test-utils-no-html-snapshot",
 ];
-const OPINIONATED_SCRIPT_RULE_NAMES: &[&str] = &[
-    "script/no-options-api",
-    "script/no-get-current-instance",
-    "script/no-next-tick",
-];
+const OPINIONATED_SCRIPT_RULE_NAMES: &[&str] =
+    &["script/no-options-api", "script/no-get-current-instance"];
 const NUXT_SCRIPT_RULE_NAMES: &[&str] = &[];
 
 pub(crate) const fn builtin_script_rule_names(preset: LintPreset) -> &'static [&'static str] {
@@ -230,7 +227,7 @@ mod tests {
                 .contains(&"script/no-get-current-instance")
         );
         assert!(
-            super::builtin_script_rule_names(LintPreset::Opinionated)
+            !super::builtin_script_rule_names(LintPreset::Opinionated)
                 .contains(&"script/no-next-tick")
         );
         assert!(

--- a/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
+++ b/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
@@ -513,7 +513,6 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
     "type/no-unsafe-template-binding",
     "script/no-options-api",
     "script/no-get-current-instance",
-    "script/no-next-tick",
     "css/no-important",
     "css/no-id-selectors",
     "css/prefer-logical-properties",

--- a/npm/cli/src/types/rules.ts
+++ b/npm/cli/src/types/rules.ts
@@ -87,7 +87,6 @@ export const LINT_RULE_NAMES = [
   "script/no-import-compiler-macros",
   "script/no-internal-imports",
   "script/no-multiple-slot-args",
-  "script/no-next-tick",
   "script/no-options-api",
   "script/no-potential-component-option-typo",
   "script/no-reactive-destructure",

--- a/playground/e2e/__snapshots__/wasm.test.ts.snap
+++ b/playground/e2e/__snapshots__/wasm.test.ts.snap
@@ -10,10 +10,7 @@ exports[`WASM Module > should expose lint rules with preset membership 1`] = `
     "nuxt",
     "opinionated",
   ],
-  "noNextTick": [
-    "opinionated",
-    "nuxt",
-  ],
+  "noNextTick": [],
   "noOptionsApi": [
     "opinionated",
   ],

--- a/playground/e2e/wasm.test.ts
+++ b/playground/e2e/wasm.test.ts
@@ -146,7 +146,8 @@ export default {
     ).toBe(true);
   });
 
-  it("should report no-next-tick for opinionated preset", () => {
+  it("should not report no-next-tick for opinionated preset by default", () => {
+    // Regression for #2239: opinionated must not flag nextTick() without explicit opt-in.
     const wasm = getWasm();
     expect(wasm).not.toBeNull();
     if (!wasm) {
@@ -177,7 +178,7 @@ await nextTick()
     ).toBe(false);
     expect(
       opinionated.diagnostics.some((diagnostic) => diagnostic.rule === "script/no-next-tick"),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("should report no-get-current-instance for opinionated preset", () => {

--- a/playground/e2e/wasm.test.ts
+++ b/playground/e2e/wasm.test.ts
@@ -147,7 +147,6 @@ export default {
   });
 
   it("should not report no-next-tick for opinionated preset by default", () => {
-    // Regression for #2239: opinionated must not flag nextTick() without explicit opt-in.
     const wasm = getWasm();
     expect(wasm).not.toBeNull();
     if (!wasm) {


### PR DESCRIPTION
## Summary

The `opinionated` preset is the recommended bundle for ordinary non-Vapor Vue 3 projects (design systems, app code that mixes Options/Composition API). Forcing `script/no-next-tick` on by default flagged any legitimate `nextTick()` import or call as an error, leaving the reporter of #2239 stuck on the weaker `essential` preset to keep CI green.

Mirror the Nuxt-preset fix from #2161 and drop `script/no-next-tick` from `OPINIONATED_SCRIPT_RULE_NAMES`. The rule stays available as an explicit opt-in via `linter.rules` / `with_additional_rules`, and the Vapor-aware gating in `Linter::with_vapor_mode(Some(false))` continues to apply for hosts that do turn it on.

Closes #2239

## Change Class

- [x] Semantic analysis, lint, and cross-file analysis

## Behavior Reference

- Issue #2239 (opinionated preset incorrectly errors on legitimate non-Vapor `nextTick()` usage)
- Prior fix #2161 (`fix(patina): keep vapor script rules out of nuxt preset`) — mirrored here

## Verification Evidence

Commands:
- `rtk cargo test -p vize_patina` → 1990 passed, 1 ignored
- `rtk cargo test -p vize --test lint_config_cli` → 6 passed
- `rtk cargo fmt --check -p vize_patina`, `-p vize` → clean
- `rtk cargo clippy -p vize_patina --no-deps -- -D warnings` → clean

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [ ] Parity or real-world fixture coverage considered
- [ ] Security/audit impact considered
- [ ] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [ ] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

Snapshot: removed `script/no-next-tick` from the `opinionated` block in `vize_patina__preset__tests__lint_preset_rule_membership.snap`, matching the new preset membership.

Regression coverage:
- `test_lint_sfc_opinionated_allows_next_tick_by_default` — confirms the default opinionated preset no longer reports `script/no-next-tick` for non-Vapor SFCs.
- `test_lint_sfc_opinionated_reports_no_next_tick_when_rule_is_enabled` — confirms explicit opt-in still works.
- `lint_opinionated_preset_allows_next_tick_for_non_vapor_projects` — CLI smoke test mirroring the Nuxt regression test from #2161.

## Risk

Behavior change: hosts already on the `opinionated` preset that relied on the implicit Vapor-oriented `script/no-next-tick` gate will need to opt in explicitly (add `script/no-next-tick` to `linter.rules`). This matches how the Nuxt preset already behaves since #2161 and unblocks the much larger set of non-Vapor users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->