### PR TITLE
fix(patina): allow v-* Vuetify tags in Nuxt preset casing/self-closing rules

### DIFF
--- a/crates/vize_patina/src/linter/tests/jsx_fallback.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_fallback.rs
@@ -46,7 +46,7 @@ fn fallback_no_duplicate_attributes_fires_on_jsx() {
 
 #[test]
 fn fallback_html_self_closing_fires_on_jsx() {
-    let linter = linter_with(Box::new(HtmlSelfClosing));
+    let linter = linter_with(Box::new(HtmlSelfClosing::default()));
     let result = linter.lint_jsx(
         "const A = () => <MyWidget></MyWidget>;",
         "test.jsx",

--- a/crates/vize_patina/src/linter/tests/nuxt.rs
+++ b/crates/vize_patina/src/linter/tests/nuxt.rs
@@ -71,6 +71,47 @@ await nextTick();
 }
 
 #[test]
+fn nuxt_preset_allows_vuetify_kebab_components() {
+    let linter = Linter::with_preset(LintPreset::Nuxt);
+    let sfc = r#"<template>
+  <v-dialog>
+    <v-btn />
+    <v-icon />
+    <v-spacer />
+  </v-dialog>
+</template>
+"#;
+    let result = linter.lint_sfc(sfc, "components/Dialog.vue");
+
+    for diagnostic in &result.diagnostics {
+        assert!(
+            diagnostic.rule_name != "vue/component-name-in-template-casing"
+                && diagnostic.rule_name != "vue/html-self-closing",
+            "Nuxt preset should not flag Vuetify v-* tags, got {diagnostic:?}",
+        );
+    }
+}
+
+#[test]
+fn opinionated_preset_still_flags_vuetify_kebab_components() {
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let sfc = r#"<template>
+  <v-btn />
+</template>
+"#;
+    let result = linter.lint_sfc(sfc, "components/Dialog.vue");
+
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|d| d.rule_name == "vue/component-name-in-template-casing"),
+        "Opinionated preset should still flag Vuetify v-* tags as kebab-case, got {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn nuxt_preset_reports_next_tick_when_rule_is_enabled() {
     let linter = Linter::with_preset(LintPreset::Nuxt)
         .with_additional_rules(vec!["script/no-next-tick".into()]);

--- a/crates/vize_patina/src/rules/opinionated/vue.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue.rs
@@ -69,22 +69,31 @@ pub use warn_custom_block::WarnCustomBlock;
 pub use warn_custom_directive::WarnCustomDirective;
 
 pub(crate) fn register(registry: &mut RuleRegistry) {
-    register_shared(registry);
+    register_shared(registry, PresetFlavor::Default);
     registry.register(Box::new(RequireComponentRegistration::default()));
 }
 
 pub(crate) fn register_nuxt(registry: &mut RuleRegistry) {
-    register_shared(registry);
+    register_shared(registry, PresetFlavor::Nuxt);
 }
 
-fn register_shared(registry: &mut RuleRegistry) {
+#[derive(Clone, Copy)]
+enum PresetFlavor {
+    Default,
+    Nuxt,
+}
+
+fn register_shared(registry: &mut RuleRegistry, flavor: PresetFlavor) {
     registry.register(Box::new(MultiWordComponentNames::default()));
     registry.register(Box::new(UseVOnExact));
 
     registry.register(Box::new(NoTemplateShadow));
     registry.register(Box::new(VBindStyle::default()));
     registry.register(Box::new(VOnHandlerStyle));
-    registry.register(Box::new(HtmlSelfClosing));
+    match flavor {
+        PresetFlavor::Default => registry.register(Box::new(HtmlSelfClosing::default())),
+        PresetFlavor::Nuxt => registry.register(Box::new(HtmlSelfClosing::nuxt())),
+    }
     registry.register(Box::new(HtmlButtonHasType));
     registry.register(Box::new(ScopedEventNames));
     registry.register(Box::new(PreferPropsShorthand));
@@ -92,7 +101,12 @@ fn register_shared(registry: &mut RuleRegistry) {
 
     registry.register(Box::new(UseUniqueElementIds::default()));
 
-    registry.register(Box::new(ComponentNameInTemplateCasing::default()));
+    match flavor {
+        PresetFlavor::Default => {
+            registry.register(Box::new(ComponentNameInTemplateCasing::default()))
+        }
+        PresetFlavor::Nuxt => registry.register(Box::new(ComponentNameInTemplateCasing::nuxt())),
+    }
     registry.register(Box::new(NoPreprocessorLang));
     registry.register(Box::new(NoScriptNonStandardLang));
     registry.register(Box::new(NoTemplateLang));

--- a/crates/vize_patina/src/rules/opinionated/vue/component_name_in_template_casing.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/component_name_in_template_casing.rs
@@ -46,12 +46,31 @@ pub enum ComponentCasing {
 /// Component name in template casing rule
 pub struct ComponentNameInTemplateCasing {
     pub casing: ComponentCasing,
+    /// Whether to exempt framework-registered Vuetify components (`v-*` tags).
+    ///
+    /// Vuetify auto-registers a large set of kebab-case components (`v-btn`,
+    /// `v-dialog`, ...) that the linter cannot see in source. Enabling this in
+    /// the Nuxt preset keeps real projects out of a `vue/component-name-in-template-casing`
+    /// warning storm without loosening the rule for non-Nuxt presets.
+    pub allow_vuetify_tags: bool,
 }
 
 impl Default for ComponentNameInTemplateCasing {
     fn default() -> Self {
         Self {
             casing: ComponentCasing::PascalCase,
+            allow_vuetify_tags: false,
+        }
+    }
+}
+
+impl ComponentNameInTemplateCasing {
+    /// Variant tuned for the Nuxt preset: exempts `v-*` tags so framework-registered
+    /// Vuetify 2 components stop tripping casing diagnostics.
+    pub fn nuxt() -> Self {
+        Self {
+            casing: ComponentCasing::PascalCase,
+            allow_vuetify_tags: true,
         }
     }
 }
@@ -75,6 +94,7 @@ impl Rule for ComponentNameInTemplateCasing {
                 || is_svg_tag(tag)
                 || is_builtin_component(tag)
                 || is_nuxt_builtin_component(tag)
+                || (self.allow_vuetify_tags && is_vuetify_tag(tag))
             {
                 return;
             }
@@ -137,6 +157,18 @@ fn is_nuxt_builtin_component(tag: &str) -> bool {
     )
 }
 
+/// Matches the Vuetify `v-*` tag convention (e.g. `v-btn`, `v-dialog`).
+///
+/// Vuetify components are framework-registered globally, so they appear in
+/// templates without an explicit local import. The linter cannot infer this
+/// from source, so the Nuxt preset opts in to treating any tag starting with
+/// `v-` followed by a lowercase ASCII letter as a known component name and
+/// skips casing/self-closing diagnostics for it.
+fn is_vuetify_tag(tag: &str) -> bool {
+    let bytes = tag.as_bytes();
+    bytes.len() >= 3 && bytes[0] == b'v' && bytes[1] == b'-' && bytes[2].is_ascii_lowercase()
+}
+
 #[cfg(test)]
 mod tests {
     use super::ComponentNameInTemplateCasing;
@@ -182,5 +214,35 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<nuxt-child id="index" />"#, "test.vue");
         assert_eq!(result.warning_count, 0);
+    }
+
+    fn create_nuxt_linter() -> Linter {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(ComponentNameInTemplateCasing::nuxt()));
+        Linter::with_registry(registry)
+    }
+
+    #[test]
+    fn test_nuxt_preset_allows_vuetify_tags() {
+        let linter = create_nuxt_linter();
+        let result = linter.lint_template(
+            r#"<v-dialog><v-btn /><v-icon /><v-spacer /></v-dialog>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_default_still_flags_vuetify_tags() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<v-btn />"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_nuxt_preset_still_flags_other_kebab() {
+        let linter = create_nuxt_linter();
+        let result = linter.lint_template(r#"<my-component />"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
     }
 }

--- a/crates/vize_patina/src/rules/opinionated/vue/html_self_closing.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/html_self_closing.rs
@@ -93,7 +93,25 @@ const MATHML_ELEMENTS: &[&str] = &[
 
 /// HTML self-closing style rule
 #[derive(Default)]
-pub struct HtmlSelfClosing;
+pub struct HtmlSelfClosing {
+    /// Whether to exempt framework-registered Vuetify components (`v-*` tags).
+    ///
+    /// Vuetify components are framework-registered globally so the linter has
+    /// no way to know their preferred closing style. The Nuxt preset opts in
+    /// to skipping `v-*` tags here to match `vue/component-name-in-template-casing`
+    /// and keep real Nuxt+Vuetify projects out of a self-closing warning storm.
+    pub allow_vuetify_tags: bool,
+}
+
+impl HtmlSelfClosing {
+    /// Variant tuned for the Nuxt preset: exempts `v-*` tags so framework-registered
+    /// Vuetify 2 components stop tripping self-closing diagnostics.
+    pub fn nuxt() -> Self {
+        Self {
+            allow_vuetify_tags: true,
+        }
+    }
+}
 
 impl Rule for HtmlSelfClosing {
     fn meta(&self) -> &'static RuleMeta {
@@ -102,6 +120,9 @@ impl Rule for HtmlSelfClosing {
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
         let tag = element.tag.as_str();
+        if self.allow_vuetify_tags && is_vuetify_tag(tag) {
+            return;
+        }
         let is_void = VOID_ELEMENTS.contains(&tag);
         let is_svg = SVG_ELEMENTS.contains(&tag);
         let is_mathml = MATHML_ELEMENTS.contains(&tag);
@@ -169,6 +190,12 @@ fn is_nuxt_builtin_component(tag: &str) -> bool {
     )
 }
 
+/// Matches the Vuetify `v-*` tag convention (e.g. `v-btn`, `v-dialog`).
+fn is_vuetify_tag(tag: &str) -> bool {
+    let bytes = tag.as_bytes();
+    bytes.len() >= 3 && bytes[0] == b'v' && bytes[1] == b'-' && bytes[2].is_ascii_lowercase()
+}
+
 #[cfg(test)]
 mod tests {
     use super::HtmlSelfClosing;
@@ -177,7 +204,7 @@ mod tests {
 
     fn create_linter() -> Linter {
         let mut registry = RuleRegistry::new();
-        registry.register(Box::new(HtmlSelfClosing));
+        registry.register(Box::new(HtmlSelfClosing::default()));
         Linter::with_registry(registry)
     }
 
@@ -221,5 +248,35 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<nuxt-child id="index"></nuxt-child>"#, "test.vue");
         assert_eq!(result.warning_count, 0);
+    }
+
+    fn create_nuxt_linter() -> Linter {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(HtmlSelfClosing::nuxt()));
+        Linter::with_registry(registry)
+    }
+
+    #[test]
+    fn test_nuxt_preset_allows_vuetify_tags() {
+        let linter = create_nuxt_linter();
+        let result = linter.lint_template(
+            r#"<v-dialog><v-btn></v-btn><v-icon></v-icon><v-spacer /></v-dialog>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_default_still_flags_empty_vuetify_tags() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<v-btn></v-btn>"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_nuxt_preset_still_flags_other_components() {
+        let linter = create_nuxt_linter();
+        let result = linter.lint_template(r#"<MyComponent></MyComponent>"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
     }
 }


### PR DESCRIPTION
## Summary

Real Nuxt + Vuetify 2 projects were drowning in `vue/component-name-in-template-casing` (wants PascalCase) and `vue/html-self-closing` (wants paired close tags) warnings because the Nuxt preset treated Vuetify's framework-registered `v-btn`, `v-dialog`, `v-spacer`, `v-icon` tags as user-defined components. Reporter saw 3156 warnings across 567 files dominated by these false positives.

Add an opt-in `allow_vuetify_tags` flag to both rules plus a `::nuxt()` constructor that enables it. The Nuxt preset registers the Nuxt-flavored variants, mirroring how the existing Nuxt builtin list (`nuxt-link`, etc.) is already handled in these rules. Other presets (`HappyPath`, `Opinionated`, `Ecosystem`) keep the strict behavior so non-Vuetify projects aren't affected.

The `v-*` prefix (`v-` + ASCII lowercase letter) is a strong Vuetify 2 convention; this scoped exemption is preferred over removing the rules from the Nuxt preset entirely.

Closes #2232

## Change Class

- [x] Semantic analysis, lint, and cross-file analysis

## Behavior Reference

GitHub issue #2232. Vuetify 2 component naming conventions (`v-*` prefix).

## Verification Evidence

- `rtk cargo test -p vize_patina` (1997 passed)
- `rtk cargo fmt --check -p vize_patina`
- `rtk cargo clippy -p vize_patina --no-deps -- -D warnings`

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

New tests:
- `component_name_in_template_casing::tests::test_nuxt_preset_allows_vuetify_tags`
- `component_name_in_template_casing::tests::test_default_still_flags_vuetify_tags`
- `component_name_in_template_casing::tests::test_nuxt_preset_still_flags_other_kebab`
- `html_self_closing::tests::test_nuxt_preset_allows_vuetify_tags`
- `html_self_closing::tests::test_default_still_flags_empty_vuetify_tags`
- `html_self_closing::tests::test_nuxt_preset_still_flags_other_components`
- `linter/tests/nuxt::nuxt_preset_allows_vuetify_kebab_components`
- `linter/tests/nuxt::opinionated_preset_still_flags_vuetify_kebab_components`

Preset membership snapshot unchanged: the rule names are identical, only their internal configuration differs in the Nuxt preset.

## Risk

Behavior change is opt-in to the Nuxt preset only. The `v-*` prefix is well-established as Vuetify's component convention; there's a small chance a Nuxt user has a non-Vuetify component named `v-something` that they wanted PascalCase-flagged, but that's a rare collision and the trade-off is dramatically better DX for the much larger Nuxt+Vuetify population.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->