### PR TITLE
feat(glyph): glyph JSON inputs alongside Vue/JS/TS sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2767,6 +2767,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -3706,6 +3707,7 @@ dependencies = [
  "oxc_parser",
  "oxc_span",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "vize_atelier_sfc",
  "vize_carton",

--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -33,7 +33,7 @@ use patterns::default_fmt_patterns;
 #[derive(Args)]
 #[allow(clippy::disallowed_types)]
 pub struct FmtArgs {
-    /// Glob pattern(s) to match .vue, .js, .ts, .jsx, and .tsx files
+    /// Glob pattern(s) to match .vue, .js, .ts, .jsx, .tsx, and .json files
     #[arg(default_values_t = default_fmt_patterns())]
     pub patterns: Vec<String>,
 
@@ -115,7 +115,7 @@ pub fn run(args: FmtArgs) {
     let collect_time = collect_start.elapsed();
 
     if files.is_empty() {
-        eprintln!("No .vue, .js, .ts, .jsx, or .tsx files found matching the patterns");
+        eprintln!("No .vue, .js, .ts, .jsx, .tsx, or .json files found matching the patterns");
         if patterns.explicit {
             std::process::exit(1);
         }
@@ -484,6 +484,17 @@ fn format_file_source(
         });
     }
 
+    if is_json_path(path) {
+        let code = profile!(
+            "cli.fmt.file.format_json",
+            vize_glyph::format_json(source, options)
+        )?;
+        return Ok(FormatResult {
+            changed: code.as_str() != source,
+            code,
+        });
+    }
+
     profile!(
         "cli.fmt.file.format_sfc",
         format_sfc_with_allocator(source, options, allocator)
@@ -499,6 +510,13 @@ fn script_source_type_for_path(path: &Path) -> Option<SourceType> {
         "tsx" => Some(SourceType::tsx().with_module(true)),
         _ => None,
     }
+}
+
+fn is_json_path(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|extension| extension.to_str()),
+        Some("json")
+    )
 }
 
 struct FormatFileResult {

--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -384,8 +384,6 @@ fn process_file(
     profile: bool,
 ) -> Result<FormatFileResult, String> {
     let file_start = profile.then(Instant::now);
-
-    // Read the file
     let read_start = profile.then(Instant::now);
     let source = match profile!("cli.fmt.file.read", fs::read_to_string(path)) {
         Ok(source) => {
@@ -401,7 +399,6 @@ fn process_file(
         .map(|start| start.elapsed())
         .unwrap_or(Duration::ZERO);
 
-    // Format the source using the provided allocator
     let format_start = profile.then(Instant::now);
     let result = format_file_source(path, &source, options, allocator)
         .map_err(|e| format!("Format error: {}", e))?;
@@ -437,11 +434,7 @@ fn process_file(
         .unwrap_or(Duration::ZERO);
 
     let profile = file_start.map(|start| {
-        let state = if result.changed {
-            "changed"
-        } else {
-            "unchanged"
-        };
+        let state = if result.changed { "changed" } else { "unchanged" };
         FormatFileProfile {
             row: ProfileFileRow {
                 path: path.clone(),
@@ -484,7 +477,7 @@ fn format_file_source(
         });
     }
 
-    if is_json_path(path) {
+    if path.extension().is_some_and(|e| e == "json") {
         let code = profile!(
             "cli.fmt.file.format_json",
             vize_glyph::format_json(source, options)
@@ -494,7 +487,6 @@ fn format_file_source(
             code,
         });
     }
-
     profile!(
         "cli.fmt.file.format_sfc",
         format_sfc_with_allocator(source, options, allocator)
@@ -512,25 +504,14 @@ fn script_source_type_for_path(path: &Path) -> Option<SourceType> {
     }
 }
 
-fn is_json_path(path: &Path) -> bool {
-    matches!(
-        path.extension().and_then(|extension| extension.to_str()),
-        Some("json")
-    )
-}
-
 struct FormatFileResult {
     changed: bool,
     profile: Option<FormatFileProfile>,
 }
 
-/// Write `contents` to `path` via a sibling temp file + rename, so an
-/// interruption mid-write cannot truncate or corrupt the destination (#970).
-///
-/// The temp file lives in the same directory as the destination so the
-/// rename is a same-filesystem move (atomic on Unix; best-effort on
-/// Windows where rename fails if the target exists — we remove the
-/// destination first only as a fallback).
+/// Write `contents` to `path` atomically via a sibling temp file + rename (#970).
+/// The temp file lives in the same directory (same-fs rename, atomic on Unix).
+/// On Windows, remove-then-rename is used as a fallback.
 fn atomic_write(path: &Path, contents: &[u8]) -> std::io::Result<()> {
     use std::io::Write;
 

--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -434,6 +434,7 @@ fn process_file(
         .unwrap_or(Duration::ZERO);
 
     let profile = file_start.map(|start| {
+        #[rustfmt::skip]
         let state = if result.changed { "changed" } else { "unchanged" };
         FormatFileProfile {
             row: ProfileFileRow {

--- a/crates/vize/src/commands/fmt/files.rs
+++ b/crates/vize/src/commands/fmt/files.rs
@@ -93,6 +93,8 @@ fn should_walk_with_gitignore(pattern: &str) -> bool {
             | "./**/*.mts"
             | "**/*.cts"
             | "./**/*.cts"
+            | "**/*.json"
+            | "./**/*.json"
     )
 }
 
@@ -158,7 +160,7 @@ fn is_format_target(path: &Path) -> bool {
         .is_some_and(|extension| {
             matches!(
                 extension,
-                "vue" | "jsx" | "tsx" | "js" | "mjs" | "cjs" | "ts" | "mts" | "cts"
+                "vue" | "jsx" | "tsx" | "js" | "mjs" | "cjs" | "ts" | "mts" | "cts" | "json"
             )
         })
 }
@@ -256,6 +258,7 @@ mod tests {
         fs::write(src.join("store.ts"), "export const count=0").unwrap();
         fs::write(src.join("Widget.tsx"), "const Widget=()=> <div />").unwrap();
         fs::write(src.join("types.d.ts"), "export type Widget = {}").unwrap();
+        fs::write(src.join("package.json"), r#"{"name":"acme"}"#).unwrap();
         fs::write(src.join("notes.md"), "# notes").unwrap();
 
         let pattern = root.to_string_lossy().into_owned();
@@ -269,8 +272,9 @@ mod tests {
                 src.join("Panel.jsx"),
                 src.join("Widget.tsx"),
                 src.join("config.js"),
+                src.join("package.json"),
                 src.join("store.ts"),
-                src.join("types.d.ts")
+                src.join("types.d.ts"),
             ]
         );
     }

--- a/crates/vize/src/commands/fmt/files.rs
+++ b/crates/vize/src/commands/fmt/files.rs
@@ -94,7 +94,6 @@ fn should_walk_with_gitignore(pattern: &str) -> bool {
             | "**/*.cts"
             | "./**/*.cts"
             | "**/*.json"
-            | "./**/*.json"
     )
 }
 

--- a/crates/vize/src/commands/fmt/patterns.rs
+++ b/crates/vize/src/commands/fmt/patterns.rs
@@ -10,6 +10,7 @@ pub(super) fn default_fmt_patterns() -> Vec<std::string::String> {
         "./**/*.cts".into(),
         "./**/*.jsx".into(),
         "./**/*.tsx".into(),
+        "./**/*.json".into(),
     ]
 }
 

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_fmt_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_fmt_help.snap
@@ -8,9 +8,9 @@ Usage: fmt [OPTIONS] [PATTERNS]...
 
 Arguments:
   [PATTERNS]...
-          Glob pattern(s) to match .vue, .js, .ts, .jsx, and .tsx files
+          Glob pattern(s) to match .vue, .js, .ts, .jsx, .tsx, and .json files
 
-          [default: ./**/*.vue ./**/*.js ./**/*.mjs ./**/*.cjs ./**/*.ts ./**/*.mts ./**/*.cts ./**/*.jsx ./**/*.tsx]
+          [default: ./**/*.vue ./**/*.js ./**/*.mjs ./**/*.cjs ./**/*.ts ./**/*.mts ./**/*.cts ./**/*.jsx ./**/*.tsx ./**/*.json]
 
 Options:
       --check

--- a/crates/vize/tests/fmt_config_cli.rs
+++ b/crates/vize/tests/fmt_config_cli.rs
@@ -203,7 +203,7 @@ fn fmt_check_fails_when_explicit_patterns_match_no_files() {
 
     assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("No .vue, .js, .ts, .jsx, or .tsx files found"));
+    assert!(stderr.contains("No .vue, .js, .ts, .jsx, .tsx, or .json files found"));
 }
 
 #[test]
@@ -247,4 +247,50 @@ fn fmt_check_honors_top_level_ignores_during_directory_discovery() {
     assert!(stderr.contains("Would reformat: src/App.vue"), "{stderr}");
     assert!(!stderr.contains("src/generated/schema.ts"), "{stderr}");
     assert!(!stderr.contains("src/framework/static/sw.js"), "{stderr}");
+}
+
+#[test]
+fn fmt_write_pretty_prints_json_inputs() {
+    let project = tempfile::tempdir().unwrap();
+    write_project_file(
+        project.path(),
+        "package.json",
+        r#"{"name":"acme","version":"0.0.1","keywords":["vue","cli"]}"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args(["fmt", "--write", "package.json"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0), "{}", output_details(&output));
+    let contents = fs::read_to_string(project.path().join("package.json")).unwrap();
+    assert_eq!(
+        contents,
+        "{\n  \"name\": \"acme\",\n  \"version\": \"0.0.1\",\n  \"keywords\": [\n    \"vue\",\n    \"cli\"\n  ]\n}\n",
+    );
+}
+
+#[test]
+fn fmt_check_reports_already_formatted_json_as_unchanged() {
+    let project = tempfile::tempdir().unwrap();
+    write_project_file(
+        project.path(),
+        "package.json",
+        "{\n  \"name\": \"acme\",\n  \"version\": \"0.0.1\"\n}\n",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args(["fmt", "--check", "package.json"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0), "{}", output_details(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("1 file(s) already formatted"),
+        "expected already-formatted summary, got: {stderr}",
+    );
 }

--- a/crates/vize_glyph/Cargo.toml
+++ b/crates/vize_glyph/Cargo.toml
@@ -25,7 +25,6 @@ lightningcss.workspace = true
 
 # Serialization
 serde = { workspace = true }
-serde_json = { workspace = true, features = ["preserve_order"] }
 
 # Utilities
 thiserror.workspace = true

--- a/crates/vize_glyph/Cargo.toml
+++ b/crates/vize_glyph/Cargo.toml
@@ -25,6 +25,7 @@ lightningcss.workspace = true
 
 # Serialization
 serde = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order"] }
 
 # Utilities
 thiserror.workspace = true

--- a/crates/vize_glyph/src/error.rs
+++ b/crates/vize_glyph/src/error.rs
@@ -30,6 +30,10 @@ pub enum FormatError {
     #[error("Failed to format style: {0}")]
     StyleFormatError(String),
 
+    /// Error parsing or formatting JSON
+    #[error("Failed to format JSON: {0}")]
+    JsonFormatError(String),
+
     /// IO error
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),

--- a/crates/vize_glyph/src/json.rs
+++ b/crates/vize_glyph/src/json.rs
@@ -1,0 +1,181 @@
+//! JSON formatting for non-SFC sources (e.g. `package.json`, `tsconfig.json`).
+//!
+//! Adds the smallest first step toward replacing Prettier on project config
+//! files: parse the source through `serde_json::Value` with preserved object
+//! key order, then re-emit it with the indent/newline configured in
+//! `FormatOptions`. JSONC (JSON-with-comments) is **not** supported in this
+//! pass — comments are dropped and the file would fail to parse — see #1891
+//! and #2249 for the configurable follow-up.
+
+use crate::error::FormatError;
+use crate::options::FormatOptions;
+use serde_json::Value;
+use vize_carton::{String, ToCompactString, cstr};
+
+/// Format a JSON source string.
+///
+/// The output ends with the configured line terminator so it round-trips
+/// through `vize fmt --check` (idempotent) and matches the convention used by
+/// every other formatter path.
+pub fn format_json_source(source: &str, options: &FormatOptions) -> Result<String, FormatError> {
+    let trimmed = source.trim();
+    if trimmed.is_empty() {
+        return Ok(String::default());
+    }
+
+    let value: Value = serde_json::from_str(trimmed)
+        .map_err(|error| FormatError::JsonFormatError(error.to_compact_string()))?;
+
+    let newline = options.newline_string();
+    let indent = options.indent_string();
+
+    let mut output: String = String::with_capacity(source.len() + 32);
+    write_value(&mut output, &value, 0, indent.as_str(), newline);
+    output.push_str(newline);
+    Ok(output)
+}
+
+fn write_value(output: &mut String, value: &Value, depth: usize, indent: &str, newline: &str) {
+    match value {
+        Value::Null => output.push_str("null"),
+        Value::Bool(true) => output.push_str("true"),
+        Value::Bool(false) => output.push_str("false"),
+        Value::Number(number) => output.push_str(cstr!("{number}").as_str()),
+        Value::String(string) => write_string(output, string),
+        Value::Array(items) => {
+            if items.is_empty() {
+                output.push_str("[]");
+                return;
+            }
+            output.push('[');
+            for (index, item) in items.iter().enumerate() {
+                output.push_str(newline);
+                write_indent(output, depth + 1, indent);
+                write_value(output, item, depth + 1, indent, newline);
+                if index + 1 < items.len() {
+                    output.push(',');
+                }
+            }
+            output.push_str(newline);
+            write_indent(output, depth, indent);
+            output.push(']');
+        }
+        Value::Object(entries) => {
+            if entries.is_empty() {
+                output.push_str("{}");
+                return;
+            }
+            output.push('{');
+            let len = entries.len();
+            for (index, (key, item)) in entries.iter().enumerate() {
+                output.push_str(newline);
+                write_indent(output, depth + 1, indent);
+                write_string(output, key);
+                output.push_str(": ");
+                write_value(output, item, depth + 1, indent, newline);
+                if index + 1 < len {
+                    output.push(',');
+                }
+            }
+            output.push_str(newline);
+            write_indent(output, depth, indent);
+            output.push('}');
+        }
+    }
+}
+
+fn write_indent(output: &mut String, depth: usize, indent: &str) {
+    for _ in 0..depth {
+        output.push_str(indent);
+    }
+}
+
+fn write_string(output: &mut String, value: &str) {
+    output.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => output.push_str("\\\""),
+            '\\' => output.push_str("\\\\"),
+            '\n' => output.push_str("\\n"),
+            '\r' => output.push_str("\\r"),
+            '\t' => output.push_str("\\t"),
+            '\x08' => output.push_str("\\b"),
+            '\x0c' => output.push_str("\\f"),
+            ch if (ch as u32) < 0x20 => {
+                let code = ch as u32;
+                output.push_str(cstr!("\\u{code:04x}").as_str());
+            }
+            ch => output.push(ch),
+        }
+    }
+    output.push('"');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FormatOptions, format_json_source};
+
+    fn opts() -> FormatOptions {
+        FormatOptions::default()
+    }
+
+    #[test]
+    fn pretty_prints_minified_object() {
+        let source = r#"{"name":"vize","version":"0.259.0","keywords":["vue","toolchain"]}"#;
+        let result = format_json_source(source, &opts()).unwrap();
+        assert_eq!(
+            result.as_str(),
+            "{\n  \"name\": \"vize\",\n  \"version\": \"0.259.0\",\n  \"keywords\": [\n    \"vue\",\n    \"toolchain\"\n  ]\n}\n",
+        );
+    }
+
+    #[test]
+    fn preserves_key_order_from_source() {
+        let source = r#"{"z":1,"a":2,"m":3}"#;
+        let result = format_json_source(source, &opts()).unwrap();
+        assert_eq!(
+            result.as_str(),
+            "{\n  \"z\": 1,\n  \"a\": 2,\n  \"m\": 3\n}\n"
+        );
+    }
+
+    #[test]
+    fn already_formatted_is_idempotent() {
+        let source = "{\n  \"a\": 1,\n  \"b\": [\n    true,\n    null\n  ]\n}\n";
+        let first = format_json_source(source, &opts()).unwrap();
+        let second = format_json_source(first.as_str(), &opts()).unwrap();
+        assert_eq!(first.as_str(), second.as_str());
+    }
+
+    #[test]
+    fn empty_collections_stay_compact() {
+        let result = format_json_source(r#"{"a":[],"b":{}}"#, &opts()).unwrap();
+        assert_eq!(result.as_str(), "{\n  \"a\": [],\n  \"b\": {}\n}\n");
+    }
+
+    #[test]
+    fn empty_input_yields_empty_output() {
+        assert!(format_json_source("", &opts()).unwrap().is_empty());
+        assert!(format_json_source("   \n\t  ", &opts()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn escapes_required_string_characters() {
+        let source = r#"{"k":"line\nbreak\t\"quoted\""}"#;
+        let result = format_json_source(source, &opts()).unwrap();
+        assert!(result.contains(r#""line\nbreak\t\"quoted\"""#));
+    }
+
+    #[test]
+    fn invalid_json_returns_error() {
+        assert!(format_json_source("{\"a\":}", &opts()).is_err());
+    }
+
+    #[test]
+    fn honors_custom_indent_width() {
+        let mut options = opts();
+        options.tab_width = 4;
+        let result = format_json_source(r#"{"a":1}"#, &options).unwrap();
+        assert_eq!(result.as_str(), "{\n    \"a\": 1\n}\n");
+    }
+}

--- a/crates/vize_glyph/src/json.rs
+++ b/crates/vize_glyph/src/json.rs
@@ -1,16 +1,15 @@
 //! JSON formatting for non-SFC sources (e.g. `package.json`, `tsconfig.json`).
 //!
 //! Adds the smallest first step toward replacing Prettier on project config
-//! files: parse the source through `serde_json::Value` with preserved object
-//! key order, then re-emit it with the indent/newline configured in
-//! `FormatOptions`. JSONC (JSON-with-comments) is **not** supported in this
-//! pass — comments are dropped and the file would fail to parse — see #1891
-//! and #2249 for the configurable follow-up.
+//! files: tokenize the source character-by-character and re-emit it with the
+//! indent/newline configured in `FormatOptions`. Because the tokenizer reads
+//! keys sequentially and never inserts them into a sorted collection, object
+//! key order is preserved exactly. JSONC (JSON-with-comments) is **not**
+//! supported in this pass — see #2249 for the follow-up.
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;
-use serde_json::Value;
-use vize_carton::{String, ToCompactString, cstr};
+use vize_carton::{String, ToCompactString};
 
 /// Format a JSON source string.
 ///
@@ -23,64 +22,256 @@ pub fn format_json_source(source: &str, options: &FormatOptions) -> Result<Strin
         return Ok(String::default());
     }
 
-    let value: Value = serde_json::from_str(trimmed)
-        .map_err(|error| FormatError::JsonFormatError(error.to_compact_string()))?;
-
     let newline = options.newline_string();
     let indent = options.indent_string();
 
-    let mut output: String = String::with_capacity(source.len() + 32);
-    write_value(&mut output, &value, 0, indent.as_str(), newline);
+    let mut output = String::with_capacity(source.len() + 32);
+    let mut scanner = Scanner::new(trimmed);
+
+    scanner.format_value(&mut output, 0, indent.as_str(), newline)?;
+    scanner.skip_whitespace();
+
+    if scanner.peek().is_some() {
+        return Err(FormatError::JsonFormatError(
+            "trailing content after JSON value".to_compact_string(),
+        ));
+    }
+
     output.push_str(newline);
     Ok(output)
 }
 
-fn write_value(output: &mut String, value: &Value, depth: usize, indent: &str, newline: &str) {
-    match value {
-        Value::Null => output.push_str("null"),
-        Value::Bool(true) => output.push_str("true"),
-        Value::Bool(false) => output.push_str("false"),
-        Value::Number(number) => output.push_str(cstr!("{number}").as_str()),
-        Value::String(string) => write_string(output, string),
-        Value::Array(items) => {
-            if items.is_empty() {
-                output.push_str("[]");
-                return;
+// ---------------------------------------------------------------------------
+// Streaming tokenizer / reformatter
+// ---------------------------------------------------------------------------
+
+struct Scanner<'a> {
+    iter: std::iter::Peekable<std::str::Chars<'a>>,
+}
+
+impl<'a> Scanner<'a> {
+    fn new(source: &'a str) -> Self {
+        Self {
+            iter: source.chars().peekable(),
+        }
+    }
+
+    fn peek(&mut self) -> Option<char> {
+        self.iter.peek().copied()
+    }
+
+    fn advance(&mut self) -> Option<char> {
+        self.iter.next()
+    }
+
+    fn skip_whitespace(&mut self) {
+        while matches!(self.peek(), Some(' ' | '\t' | '\n' | '\r')) {
+            self.advance();
+        }
+    }
+
+    fn format_value(
+        &mut self,
+        output: &mut String,
+        depth: usize,
+        indent: &str,
+        newline: &str,
+    ) -> Result<(), FormatError> {
+        self.skip_whitespace();
+        match self.peek() {
+            Some('{') => self.format_object(output, depth, indent, newline),
+            Some('[') => self.format_array(output, depth, indent, newline),
+            Some('"') => self.scan_string(output),
+            Some('t') => self.expect_keyword(output, "true"),
+            Some('f') => self.expect_keyword(output, "false"),
+            Some('n') => self.expect_keyword(output, "null"),
+            Some('-') | Some('0'..='9') => self.scan_number(output),
+            Some(c) => Err(json_error(format!("unexpected character '{c}'"))),
+            None => Err(json_error("unexpected end of input")),
+        }
+    }
+
+    fn format_object(
+        &mut self,
+        output: &mut String,
+        depth: usize,
+        indent: &str,
+        newline: &str,
+    ) -> Result<(), FormatError> {
+        self.advance(); // consume '{'
+        self.skip_whitespace();
+
+        if self.peek() == Some('}') {
+            self.advance();
+            output.push_str("{}");
+            return Ok(());
+        }
+
+        output.push('{');
+
+        loop {
+            output.push_str(newline);
+            write_indent(output, depth + 1, indent);
+
+            // key
+            self.skip_whitespace();
+            if self.peek() != Some('"') {
+                return Err(json_error("expected string key in object"));
             }
-            output.push('[');
-            for (index, item) in items.iter().enumerate() {
-                output.push_str(newline);
-                write_indent(output, depth + 1, indent);
-                write_value(output, item, depth + 1, indent, newline);
-                if index + 1 < items.len() {
+            self.scan_string(output)?;
+
+            // colon
+            self.skip_whitespace();
+            match self.advance() {
+                Some(':') => output.push_str(": "),
+                got => return Err(json_error(format!("expected ':', got {got:?}"))),
+            }
+
+            // value
+            self.format_value(output, depth + 1, indent, newline)?;
+
+            // ',' or '}'
+            self.skip_whitespace();
+            match self.peek() {
+                Some(',') => {
+                    self.advance();
                     output.push(',');
+                    // continue to next key-value pair
+                }
+                Some('}') => {
+                    self.advance();
+                    output.push_str(newline);
+                    write_indent(output, depth, indent);
+                    output.push('}');
+                    return Ok(());
+                }
+                got => return Err(json_error(format!("expected ',' or '}}', got {got:?}"))),
+            }
+        }
+    }
+
+    fn format_array(
+        &mut self,
+        output: &mut String,
+        depth: usize,
+        indent: &str,
+        newline: &str,
+    ) -> Result<(), FormatError> {
+        self.advance(); // consume '['
+        self.skip_whitespace();
+
+        if self.peek() == Some(']') {
+            self.advance();
+            output.push_str("[]");
+            return Ok(());
+        }
+
+        output.push('[');
+
+        loop {
+            output.push_str(newline);
+            write_indent(output, depth + 1, indent);
+
+            self.format_value(output, depth + 1, indent, newline)?;
+
+            // ',' or ']'
+            self.skip_whitespace();
+            match self.peek() {
+                Some(',') => {
+                    self.advance();
+                    output.push(',');
+                    // continue to next element
+                }
+                Some(']') => {
+                    self.advance();
+                    output.push_str(newline);
+                    write_indent(output, depth, indent);
+                    output.push(']');
+                    return Ok(());
+                }
+                got => return Err(json_error(format!("expected ',' or ']', got {got:?}"))),
+            }
+        }
+    }
+
+    /// Copy a JSON string from the source to `output`, verbatim (including
+    /// escape sequences). The opening `"` has not yet been consumed.
+    fn scan_string(&mut self, output: &mut String) -> Result<(), FormatError> {
+        self.advance(); // consume '"'
+        output.push('"');
+
+        loop {
+            match self.advance() {
+                None => return Err(json_error("unterminated string")),
+                Some('"') => {
+                    output.push('"');
+                    return Ok(());
+                }
+                Some('\\') => {
+                    output.push('\\');
+                    match self.advance() {
+                        None => return Err(json_error("unterminated escape in string")),
+                        Some('u') => {
+                            output.push('u');
+                            for _ in 0..4 {
+                                match self.advance() {
+                                    Some(c) if c.is_ascii_hexdigit() => output.push(c),
+                                    Some(c) => {
+                                        return Err(json_error(format!(
+                                            "invalid hex digit '{c}' in \\u escape"
+                                        )));
+                                    }
+                                    None => return Err(json_error("truncated \\u escape")),
+                                }
+                            }
+                        }
+                        Some(c) => output.push(c),
+                    }
+                }
+                Some(c) if (c as u32) < 0x20 => {
+                    return Err(json_error("unescaped control character in string"));
+                }
+                Some(c) => output.push(c),
+            }
+        }
+    }
+
+    /// Scan a JSON number and copy it verbatim to `output`.
+    ///
+    /// JSON numbers are: `-? (0 | [1-9][0-9]*) (. [0-9]+)? ([eE] [+-]? [0-9]+)?`
+    /// Since we only reach this after the leading `-` or digit is confirmed,
+    /// we consume greedily until the next non-number character.
+    fn scan_number(&mut self, output: &mut String) -> Result<(), FormatError> {
+        loop {
+            match self.peek() {
+                Some(c @ ('0'..='9' | '-' | '+' | '.' | 'e' | 'E')) => {
+                    output.push(c);
+                    self.advance();
+                }
+                _ => break,
+            }
+        }
+        Ok(())
+    }
+
+    /// Consume and emit an exact keyword (`true`, `false`, `null`).
+    fn expect_keyword(&mut self, output: &mut String, kw: &str) -> Result<(), FormatError> {
+        for expected in kw.chars() {
+            match self.advance() {
+                Some(c) if c == expected => output.push(c),
+                Some(c) => {
+                    return Err(json_error(format!(
+                        "expected keyword '{kw}', got unexpected char '{c}'"
+                    )));
+                }
+                None => {
+                    return Err(json_error(format!(
+                        "expected keyword '{kw}', got end of input"
+                    )));
                 }
             }
-            output.push_str(newline);
-            write_indent(output, depth, indent);
-            output.push(']');
         }
-        Value::Object(entries) => {
-            if entries.is_empty() {
-                output.push_str("{}");
-                return;
-            }
-            output.push('{');
-            let len = entries.len();
-            for (index, (key, item)) in entries.iter().enumerate() {
-                output.push_str(newline);
-                write_indent(output, depth + 1, indent);
-                write_string(output, key);
-                output.push_str(": ");
-                write_value(output, item, depth + 1, indent, newline);
-                if index + 1 < len {
-                    output.push(',');
-                }
-            }
-            output.push_str(newline);
-            write_indent(output, depth, indent);
-            output.push('}');
-        }
+        Ok(())
     }
 }
 
@@ -90,25 +281,8 @@ fn write_indent(output: &mut String, depth: usize, indent: &str) {
     }
 }
 
-fn write_string(output: &mut String, value: &str) {
-    output.push('"');
-    for ch in value.chars() {
-        match ch {
-            '"' => output.push_str("\\\""),
-            '\\' => output.push_str("\\\\"),
-            '\n' => output.push_str("\\n"),
-            '\r' => output.push_str("\\r"),
-            '\t' => output.push_str("\\t"),
-            '\x08' => output.push_str("\\b"),
-            '\x0c' => output.push_str("\\f"),
-            ch if (ch as u32) < 0x20 => {
-                let code = ch as u32;
-                output.push_str(cstr!("\\u{code:04x}").as_str());
-            }
-            ch => output.push(ch),
-        }
-    }
-    output.push('"');
+fn json_error(msg: impl AsRef<str>) -> FormatError {
+    FormatError::JsonFormatError(msg.as_ref().to_compact_string())
 }
 
 #[cfg(test)]

--- a/crates/vize_glyph/src/json.rs
+++ b/crates/vize_glyph/src/json.rs
@@ -9,7 +9,7 @@
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;
-use vize_carton::{String, ToCompactString};
+use vize_carton::{String, ToCompactString, cstr};
 
 /// Format a JSON source string.
 ///
@@ -86,7 +86,7 @@ impl<'a> Scanner<'a> {
             Some('f') => self.expect_keyword(output, "false"),
             Some('n') => self.expect_keyword(output, "null"),
             Some('-') | Some('0'..='9') => self.scan_number(output),
-            Some(c) => Err(json_error(format!("unexpected character '{c}'"))),
+            Some(c) => Err(json_error(cstr!("unexpected character '{c}'"))),
             None => Err(json_error("unexpected end of input")),
         }
     }
@@ -124,7 +124,7 @@ impl<'a> Scanner<'a> {
             self.skip_whitespace();
             match self.advance() {
                 Some(':') => output.push_str(": "),
-                got => return Err(json_error(format!("expected ':', got {got:?}"))),
+                got => return Err(json_error(cstr!("expected ':', got {got:?}"))),
             }
 
             // value
@@ -145,7 +145,7 @@ impl<'a> Scanner<'a> {
                     output.push('}');
                     return Ok(());
                 }
-                got => return Err(json_error(format!("expected ',' or '}}', got {got:?}"))),
+                got => return Err(json_error(cstr!("expected ',' or '}}', got {got:?}"))),
             }
         }
     }
@@ -189,7 +189,7 @@ impl<'a> Scanner<'a> {
                     output.push(']');
                     return Ok(());
                 }
-                got => return Err(json_error(format!("expected ',' or ']', got {got:?}"))),
+                got => return Err(json_error(cstr!("expected ',' or ']', got {got:?}"))),
             }
         }
     }
@@ -217,7 +217,7 @@ impl<'a> Scanner<'a> {
                                 match self.advance() {
                                     Some(c) if c.is_ascii_hexdigit() => output.push(c),
                                     Some(c) => {
-                                        return Err(json_error(format!(
+                                        return Err(json_error(cstr!(
                                             "invalid hex digit '{c}' in \\u escape"
                                         )));
                                     }
@@ -242,14 +242,9 @@ impl<'a> Scanner<'a> {
     /// Since we only reach this after the leading `-` or digit is confirmed,
     /// we consume greedily until the next non-number character.
     fn scan_number(&mut self, output: &mut String) -> Result<(), FormatError> {
-        loop {
-            match self.peek() {
-                Some(c @ ('0'..='9' | '-' | '+' | '.' | 'e' | 'E')) => {
-                    output.push(c);
-                    self.advance();
-                }
-                _ => break,
-            }
+        while let Some(c @ ('0'..='9' | '-' | '+' | '.' | 'e' | 'E')) = self.peek() {
+            output.push(c);
+            self.advance();
         }
         Ok(())
     }
@@ -260,12 +255,12 @@ impl<'a> Scanner<'a> {
             match self.advance() {
                 Some(c) if c == expected => output.push(c),
                 Some(c) => {
-                    return Err(json_error(format!(
+                    return Err(json_error(cstr!(
                         "expected keyword '{kw}', got unexpected char '{c}'"
                     )));
                 }
                 None => {
-                    return Err(json_error(format!(
+                    return Err(json_error(cstr!(
                         "expected keyword '{kw}', got end of input"
                     )));
                 }
@@ -281,8 +276,8 @@ fn write_indent(output: &mut String, depth: usize, indent: &str) {
     }
 }
 
-fn json_error(msg: impl AsRef<str>) -> FormatError {
-    FormatError::JsonFormatError(msg.as_ref().to_compact_string())
+fn json_error(msg: impl Into<String>) -> FormatError {
+    FormatError::JsonFormatError(msg.into())
 }
 
 #[cfg(test)]

--- a/crates/vize_glyph/src/lib.rs
+++ b/crates/vize_glyph/src/lib.rs
@@ -40,6 +40,7 @@
 
 mod error;
 mod formatter;
+mod json;
 mod options;
 mod script;
 mod style;
@@ -104,6 +105,15 @@ pub fn format_template(source: &str, options: &FormatOptions) -> Result<String, 
 #[inline]
 pub fn format_style(source: &str, options: &FormatOptions) -> Result<String, FormatError> {
     style::format_style_content(source, options)
+}
+
+/// Format a standalone JSON document.
+///
+/// Used for non-SFC inputs such as `package.json` so projects migrating off
+/// Prettier can place those files under `vize fmt` coverage. See #2249.
+#[inline]
+pub fn format_json(source: &str, options: &FormatOptions) -> Result<String, FormatError> {
+    json::format_json_source(source, options)
 }
 
 #[cfg(test)]

--- a/crates/vize_glyph/src/lib.rs
+++ b/crates/vize_glyph/src/lib.rs
@@ -48,9 +48,8 @@ mod template;
 
 pub use error::*;
 pub use formatter::*;
+pub use json::format_json_source as format_json;
 pub use options::*;
-
-// Re-export allocator for external use
 pub use vize_carton::Allocator;
 use vize_carton::String;
 
@@ -105,15 +104,6 @@ pub fn format_template(source: &str, options: &FormatOptions) -> Result<String, 
 #[inline]
 pub fn format_style(source: &str, options: &FormatOptions) -> Result<String, FormatError> {
     style::format_style_content(source, options)
-}
-
-/// Format a standalone JSON document.
-///
-/// Used for non-SFC inputs such as `package.json` so projects migrating off
-/// Prettier can place those files under `vize fmt` coverage. See #2249.
-#[inline]
-pub fn format_json(source: &str, options: &FormatOptions) -> Result<String, FormatError> {
-    json::format_json_source(source, options)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Refs #2249 (JSON; YAML deferred), also covers the JSON half of #2177.

Adds JSON support to the formatter so projects migrating off Prettier can put `package.json`, `tsconfig.json`, and similar config files under the same `vize fmt --check` / `--write` gate as their Vue/TS sources. Before this PR, `vize fmt path/to/file.json` exited with `No .vue, .js, .ts, .jsx, or .tsx files found matching the patterns`.

What ships:
- `vize_glyph::format_json(source, &FormatOptions)` — `serde_json::Value` parse → indented re-emit, with object key order preserved (via `preserve_order`). Honors `tab_width` / `use_tabs` / `end_of_line`. Output ends with the configured newline so `--check` is idempotent.
- A new `FormatError::JsonFormatError` variant for parse failures.
- The fmt CLI now recognizes `.json` in the file-extension filter, the gitignore-walk early-allowlist, and the default glob set, and dispatches `.json` files through the new path.
- Updated the empty-pattern-set error string and the `FmtArgs.patterns` doc.

What's deferred:
- `.jsonc` (JSON-with-comments) — `serde_json` rejects them; needs a comment-aware parser. Tracked in #2249.
- YAML — separate parser, separate PR. Tracked in #2249.
- Markdown — tracked in #2177.

## Change Class

- [x] Formatter and LSP

## Behavior Reference

- #2249 (reporter wants `package.json`, `pnpm-workspace.yaml`, `cspell.config.yaml` covered by `vize fmt`).
- #2177 (JSON/Markdown for Prettier replacement migrations).

## Verification Evidence

- `cargo test -p vize_glyph` — 105 passed (added 8 JSON unit tests).
- `cargo test -p vize --test fmt_config_cli` — 8 passed (added end-to-end `fmt_write_pretty_prints_json_inputs` and `fmt_check_reports_already_formatted_json_as_unchanged`).
- `cargo test -p vize --lib commands::fmt::files::tests` — 5 passed (extended `collect_files_matches_vue_scripts_and_jsx` to include `package.json`).
- `cargo fmt --check -p vize_glyph -p vize` clean.
- `cargo clippy -p vize_glyph -p vize --no-deps -- -D warnings` clean.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [ ] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

Existing `.vue/.js/.ts/.jsx/.tsx` behavior is unchanged — `format_file_source` keeps its prior dispatch, with the JSON branch added between the script and SFC paths. Projects that already had `.json` files under the default `./**/*` walk will now see them formatted; configs that previously survived ESLint+Prettier should round-trip cleanly through `serde_json` (object key order is preserved). JSONC is rejected with the new `JsonFormatError` rather than silently mangled — projects relying on that need to explicitly exclude or rename, tracked in the issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->