### PR TITLE
feat(glyph): glyph tsconfig/.vscode config JSON as JSONC

### DIFF
--- a/crates/vize/src/commands/fmt/data.rs
+++ b/crates/vize/src/commands/fmt/data.rs
@@ -4,30 +4,96 @@ use std::path::Path;
 use vize_carton::profile;
 use vize_glyph::{FormatOptions, FormatResult};
 
-/// Format `source` as JSON or JSONC based on `path`'s extension.
+/// Format `source` as JSON or JSONC based on `path`.
 ///
-/// Returns `None` when `path` is neither `.json` nor `.jsonc`, letting the
-/// caller fall through to the SFC formatter.
+/// `.jsonc` files and comment-bearing config files (`tsconfig*.json`,
+/// `jsconfig*.json`, `.vscode/*.json`, `*.code-workspace`) are formatted as
+/// JSONC so their comments and trailing commas survive; every other `.json`
+/// file uses strict JSON. Returns `None` when `path` is neither `.json` nor
+/// `.jsonc`, letting the caller fall through to the SFC formatter.
 pub(super) fn format_data_file(
     path: &Path,
     source: &str,
     options: &FormatOptions,
 ) -> Option<Result<FormatResult, vize_glyph::FormatError>> {
-    let code = match path.extension().and_then(|extension| extension.to_str())? {
-        "json" => profile!(
+    let jsonc = match path.extension().and_then(|extension| extension.to_str())? {
+        "jsonc" => true,
+        "json" => is_jsonc_config_file(path),
+        _ => return None,
+    };
+    let code = if jsonc {
+        profile!(
+            "cli.fmt.file.format_jsonc",
+            vize_glyph::format_jsonc(source, options)
+        )
+    } else {
+        profile!(
             "cli.fmt.file.format_json",
             vize_glyph::format_json(source, options)
-        ),
-        "jsonc" => {
-            profile!(
-                "cli.fmt.file.format_jsonc",
-                vize_glyph::format_jsonc(source, options)
-            )
-        }
-        _ => return None,
+        )
     };
     Some(code.map(|code| FormatResult {
         changed: code.as_str() != source,
         code,
     }))
+}
+
+/// Whether a `.json` file conventionally allows comments and trailing commas
+/// and should be formatted as JSONC, matching Prettier's `jsonc` parser
+/// defaults for TypeScript and editor config files.
+fn is_jsonc_config_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    if name.ends_with(".code-workspace") {
+        return true;
+    }
+    if (name.starts_with("tsconfig.") || name.starts_with("jsconfig.")) && name.ends_with(".json") {
+        return true;
+    }
+    path.parent()
+        .and_then(Path::file_name)
+        .and_then(|parent| parent.to_str())
+        == Some(".vscode")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_jsonc_config_file;
+    use std::path::Path;
+
+    #[test]
+    fn treats_typescript_and_editor_config_json_as_jsonc() {
+        for path in [
+            "tsconfig.json",
+            "tsconfig.app.json",
+            "packages/ui/tsconfig.build.json",
+            "jsconfig.json",
+            "jsconfig.node.json",
+            "acme.code-workspace",
+            ".vscode/settings.json",
+            "repo/.vscode/launch.json",
+        ] {
+            assert!(
+                is_jsonc_config_file(Path::new(path)),
+                "expected JSONC: {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn keeps_plain_json_strict() {
+        for path in [
+            "package.json",
+            "tsconfig.json.bak",
+            "src/data/tsconfig.json/oops",
+            "settings.json",
+            "config/eslintrc.json",
+        ] {
+            assert!(
+                !is_jsonc_config_file(Path::new(path)),
+                "expected strict JSON: {path}"
+            );
+        }
+    }
 }

--- a/crates/vize/tests/fmt_jsonc_config_cli.rs
+++ b/crates/vize/tests/fmt_jsonc_config_cli.rs
@@ -1,0 +1,60 @@
+//! `vize fmt` routes comment-bearing config JSON (tsconfig, .vscode, …) through
+//! the JSONC formatter while keeping plain `.json` strict.
+
+use std::{fs, path::Path, process::Command};
+
+fn write_project_file(root: &Path, rel: &str, content: &str) {
+    let path = root.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, content).unwrap();
+}
+
+#[test]
+fn fmt_formats_tsconfig_json_as_jsonc_preserving_comments() {
+    let project = tempfile::tempdir().unwrap();
+    write_project_file(
+        project.path(),
+        "tsconfig.json",
+        "{\n// ts compiler options\n\"compilerOptions\":{\"strict\":true, // be strict\n\"target\":\"ES2022\",},\n}",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args(["fmt", "--write", "tsconfig.json"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(0), "stderr: {stderr}");
+    let contents = fs::read_to_string(project.path().join("tsconfig.json")).unwrap();
+    assert_eq!(
+        contents,
+        "{\n  // ts compiler options\n  \"compilerOptions\": {\n    \"strict\": true, // be strict\n    \"target\": \"ES2022\"\n  }\n}\n",
+    );
+}
+
+#[test]
+fn fmt_keeps_plain_json_strict_rejecting_comments() {
+    // A non-config `.json` file stays strict JSON: comments are a parse error,
+    // so the file is reported as errored rather than silently reformatted. This
+    // guards the routing boundary (only known config filenames get JSONC).
+    let project = tempfile::tempdir().unwrap();
+    let original = "{\n// not allowed here\n\"a\": 1\n}\n";
+    write_project_file(project.path(), "data.json", original);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args(["fmt", "--check", "data.json"])
+        .output()
+        .unwrap();
+
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "strict JSON comments must error"
+    );
+    let contents = fs::read_to_string(project.path().join("data.json")).unwrap();
+    assert_eq!(contents, original, "errored file must be left untouched");
+}


### PR DESCRIPTION
## What

`vize fmt` treated every `.json` file as strict JSON, so it errored on the comment-bearing config files real projects keep — `tsconfig.json`, `.vscode/settings.json`, etc. This routes well-known config JSON filenames through the JSONC formatter so their comments and trailing commas survive a format pass.

Matched (→ JSONC), following Prettier's `jsonc` parser defaults:
- `tsconfig.json`, `tsconfig.*.json`, `jsconfig.json`, `jsconfig.*.json`
- `*.code-workspace`
- any `.json` directly under `.vscode/`

Everything else stays strict JSON.

## Safety

- Comment-free config files are unaffected: JSONC formats them byte-identically to strict JSON (covered by the existing `jsonc_without_comments_matches_strict_json` test).
- Plain `.json` (e.g. `package.json`, `data.json`) stays strict — comments are still a parse error there.

## Tests

- `fmt/data.rs`: filename-predicate units (positive + negative cases incl. `tsconfig.json.bak`, nested dirs).
- New `fmt_jsonc_config_cli.rs`: `tsconfig.json` with comments + trailing comma round-trips via `fmt --write`; a plain `.json` with comments still errors and is left untouched.

## Verification

clippy `-D warnings` clean; rustfmt (1.95.0, edition/style 2024) clean; source-length gate clean. Builds on the `fmt/data.rs` dispatch from #2285. Follow-up to #2249.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->