### PR TITLE
feat(musea): add Storybook CSF to art migration command (#2076)

### DIFF
--- a/crates/vize/src/cli.rs
+++ b/crates/vize/src/cli.rs
@@ -169,7 +169,9 @@ mod tests {
             let serve_args = match args.command {
                 Some(MuseaCommand::Serve(serve_args)) => serve_args,
                 None => args.serve,
-                Some(MuseaCommand::New(_)) => panic!("expected musea serve args"),
+                Some(MuseaCommand::New(_)) | Some(MuseaCommand::Migrate(_)) => {
+                    panic!("expected musea serve args")
+                }
             };
             assert!(serve_args.strict_port);
         }

--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -27,7 +27,7 @@ mod files;
 mod ignores;
 mod patterns;
 
-use files::collect_files;
+pub(crate) use files::collect_files;
 use ignores::load_fmt_ignore_set;
 use patterns::default_fmt_patterns;
 

--- a/crates/vize/src/commands/fmt/files.rs
+++ b/crates/vize/src/commands/fmt/files.rs
@@ -8,7 +8,7 @@ const NODE_MODULES_DIR: &str = "node_modules";
 const VIZE_CACHE_DIR: &str = ".vize";
 
 #[allow(clippy::disallowed_types)]
-pub(super) fn collect_files(
+pub(crate) fn collect_files(
     patterns: &[impl AsRef<str>],
     ignore_set: Option<&FmtIgnoreSet>,
 ) -> Vec<PathBuf> {

--- a/crates/vize/src/commands/fmt/ignores.rs
+++ b/crates/vize/src/commands/fmt/ignores.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use super::{FmtArgs, files::FmtPattern};
 use crate::config;
 
-pub(super) struct FmtIgnoreSet {
+pub(crate) struct FmtIgnoreSet {
     patterns: Vec<FmtPattern>,
 }
 

--- a/crates/vize/src/commands/musea.rs
+++ b/crates/vize/src/commands/musea.rs
@@ -1,8 +1,10 @@
+mod migrate;
 mod new;
 mod serve_plan;
 mod setup;
 
 use clap::{Args, Subcommand};
+use migrate::MigrateArgs;
 use new::NewArgs;
 use serve_plan::create_serve_plan;
 use std::path::PathBuf;
@@ -25,6 +27,9 @@ pub enum MuseaCommand {
 
     /// Create a new Musea art project
     New(NewArgs),
+
+    /// Migrate Storybook CSF stories into Musea `.art.vue` files
+    Migrate(MigrateArgs),
 }
 
 #[derive(Args, Clone, Debug, PartialEq, Eq)]
@@ -76,6 +81,7 @@ pub fn run(args: MuseaArgs) {
     match args.command {
         Some(MuseaCommand::Serve(serve_args)) => run_serve(serve_args),
         Some(MuseaCommand::New(new_args)) => new::run(new_args),
+        Some(MuseaCommand::Migrate(migrate_args)) => migrate::run(migrate_args),
         None => run_serve(args.serve),
     }
 }

--- a/crates/vize/src/commands/musea/migrate/csf.rs
+++ b/crates/vize/src/commands/musea/migrate/csf.rs
@@ -1,0 +1,304 @@
+//! Extract Storybook CSF (Component Story Format) metadata from a parsed module.
+//!
+//! Walks the oxc AST of a `*.stories.*` file to recover the component identifier
+//! and its import path, the meta `title`, and an ordered list of named-export
+//! stories. The story payloads (`render` arrow body and `args` object) are kept
+//! as borrowed AST references so the JSX/template emitter can slice the original
+//! source by span.
+
+use oxc_ast::ast::{
+    Declaration, ExportDefaultDeclarationKind, Expression, ImportDeclarationSpecifier,
+    ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement, VariableDeclarator,
+};
+use vize_carton::String;
+
+/// A single CSF story (named export) ready for template emission.
+pub(super) struct CsfStory<'a> {
+    /// Variant name (the `name:` override if present, else the export name).
+    pub name: String,
+    /// `render` arrow/function body expression (a JSX element/fragment), if any.
+    pub render: Option<&'a Expression<'a>>,
+    /// `args` object literal, if present.
+    pub args: Option<&'a ObjectExpression<'a>>,
+}
+
+/// Everything migration needs from one CSF module.
+pub(super) struct CsfModule<'a> {
+    /// Module specifier the component was imported from (e.g. `./AfButton.vue`).
+    pub component_path: Option<String>,
+    /// Meta `title` value (raw, may contain `Category/Name`).
+    pub title: Option<String>,
+    /// Ordered stories.
+    pub stories: Vec<CsfStory<'a>>,
+}
+
+/// Extract CSF metadata from a parsed program.
+pub(super) fn extract_csf<'a>(program: &'a Program<'a>) -> CsfModule<'a> {
+    let meta = find_meta_object(program);
+    let component_local = meta.and_then(meta_component_local);
+    let title = meta.and_then(meta_title);
+    let component_path = component_local
+        .as_deref()
+        .and_then(|local| find_import_source(program, local));
+
+    let stories = collect_stories(program);
+
+    CsfModule {
+        component_path,
+        title,
+        stories,
+    }
+}
+
+/// Find the meta object literal: either the `export default {...}` expression or
+/// the `const meta = {...}` that is later `export default meta`.
+fn find_meta_object<'a>(program: &'a Program<'a>) -> Option<&'a ObjectExpression<'a>> {
+    let mut default_export_name: Option<&str> = None;
+
+    for stmt in &program.body {
+        if let Statement::ExportDefaultDeclaration(decl) = stmt {
+            match unwrap_default_kind(&decl.declaration) {
+                DefaultTarget::Object(object) => return Some(object),
+                DefaultTarget::Identifier(name) => default_export_name = Some(name),
+                DefaultTarget::Other => {}
+            }
+        }
+    }
+
+    let name = default_export_name?;
+    for stmt in &program.body {
+        if let Statement::VariableDeclaration(decl) = stmt {
+            for declarator in &decl.declarations {
+                if binding_name(declarator) == Some(name)
+                    && let Some(init) = declarator.init.as_ref()
+                    && let Some(object) = unwrap_object(init)
+                {
+                    return Some(object);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// What an `export default ...` resolves to after peeling TS/paren wrappers.
+enum DefaultTarget<'a> {
+    Object(&'a ObjectExpression<'a>),
+    Identifier(&'a str),
+    Other,
+}
+
+/// Peel `satisfies`/`as`/parentheses on an `export default` declaration to reach
+/// either an object literal or a bare identifier reference.
+fn unwrap_default_kind<'a>(decl: &'a ExportDefaultDeclarationKind<'a>) -> DefaultTarget<'a> {
+    match decl {
+        ExportDefaultDeclarationKind::ObjectExpression(object) => DefaultTarget::Object(object),
+        ExportDefaultDeclarationKind::Identifier(ident) => {
+            DefaultTarget::Identifier(ident.name.as_str())
+        }
+        ExportDefaultDeclarationKind::TSSatisfiesExpression(inner) => {
+            unwrap_expression_target(&inner.expression)
+        }
+        ExportDefaultDeclarationKind::TSAsExpression(inner) => {
+            unwrap_expression_target(&inner.expression)
+        }
+        ExportDefaultDeclarationKind::ParenthesizedExpression(inner) => {
+            unwrap_expression_target(&inner.expression)
+        }
+        _ => DefaultTarget::Other,
+    }
+}
+
+fn unwrap_expression_target<'a>(expr: &'a Expression<'a>) -> DefaultTarget<'a> {
+    match unwrap_expression(expr) {
+        Expression::ObjectExpression(object) => DefaultTarget::Object(object),
+        Expression::Identifier(ident) => DefaultTarget::Identifier(ident.name.as_str()),
+        _ => DefaultTarget::Other,
+    }
+}
+
+/// Read the meta `component` property's local identifier name.
+fn meta_component_local(meta: &ObjectExpression<'_>) -> Option<String> {
+    let value = object_property_value(meta, "component")?;
+    if let Expression::Identifier(ident) = unwrap_expression(value) {
+        Some(ident.name.as_str().into())
+    } else {
+        None
+    }
+}
+
+/// Read the meta `title` string literal.
+fn meta_title(meta: &ObjectExpression<'_>) -> Option<String> {
+    let value = object_property_value(meta, "title")?;
+    string_literal_value(value)
+}
+
+/// Find the import specifier source path for a given local identifier.
+fn find_import_source(program: &Program<'_>, local: &str) -> Option<String> {
+    for stmt in &program.body {
+        if let Statement::ImportDeclaration(decl) = stmt
+            && let Some(specifiers) = decl.specifiers.as_ref()
+        {
+            for specifier in specifiers {
+                let matches = match specifier {
+                    ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
+                        spec.local.name.as_str() == local
+                    }
+                    ImportDeclarationSpecifier::ImportSpecifier(spec) => {
+                        spec.local.name.as_str() == local
+                    }
+                    ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
+                        spec.local.name.as_str() == local
+                    }
+                };
+                if matches {
+                    return Some(decl.source.value.as_str().into());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Collect `export const NAME = {...}` stories in source order.
+fn collect_stories<'a>(program: &'a Program<'a>) -> Vec<CsfStory<'a>> {
+    let mut stories = Vec::new();
+
+    for stmt in &program.body {
+        let Statement::ExportNamedDeclaration(decl) = stmt else {
+            continue;
+        };
+        let Some(Declaration::VariableDeclaration(var)) = decl.declaration.as_ref() else {
+            continue;
+        };
+        for declarator in &var.declarations {
+            let Some(export_name) = binding_name(declarator) else {
+                continue;
+            };
+            let Some(init) = declarator.init.as_ref() else {
+                continue;
+            };
+            let Some(object) = unwrap_object(init) else {
+                continue;
+            };
+            stories.push(story_from_object(export_name, object));
+        }
+    }
+
+    stories
+}
+
+/// Build a [`CsfStory`] from a story object literal.
+fn story_from_object<'a>(export_name: &str, object: &'a ObjectExpression<'a>) -> CsfStory<'a> {
+    let name = object_property_value(object, "name")
+        .and_then(string_literal_value)
+        .unwrap_or_else(|| export_name.into());
+
+    let render = object_property_value(object, "render").and_then(render_body);
+    let args = object_property_value(object, "args").and_then(|value| {
+        if let Expression::ObjectExpression(object) = unwrap_expression(value) {
+            Some(&**object)
+        } else {
+            None
+        }
+    });
+
+    CsfStory { name, render, args }
+}
+
+/// Reach the single JSX-returning expression of a `render` arrow/function.
+fn render_body<'a>(value: &'a Expression<'a>) -> Option<&'a Expression<'a>> {
+    match unwrap_expression(value) {
+        Expression::ArrowFunctionExpression(arrow) => {
+            if arrow.expression {
+                // `() => <expr>`: body holds a single expression statement.
+                first_expression_statement(&arrow.body.statements)
+            } else {
+                first_return_argument(&arrow.body.statements)
+            }
+        }
+        Expression::FunctionExpression(func) => func
+            .body
+            .as_ref()
+            .and_then(|body| first_return_argument(&body.statements)),
+        _ => None,
+    }
+}
+
+fn first_expression_statement<'a>(statements: &'a [Statement<'a>]) -> Option<&'a Expression<'a>> {
+    match statements.first()? {
+        Statement::ExpressionStatement(stmt) => Some(&stmt.expression),
+        _ => None,
+    }
+}
+
+fn first_return_argument<'a>(statements: &'a [Statement<'a>]) -> Option<&'a Expression<'a>> {
+    match statements.first()? {
+        Statement::ReturnStatement(stmt) => stmt.argument.as_ref(),
+        _ => None,
+    }
+}
+
+/// Look up an object property value by its static identifier or string key.
+pub(super) fn object_property_value<'a>(
+    object: &'a ObjectExpression<'a>,
+    key: &str,
+) -> Option<&'a Expression<'a>> {
+    for property in &object.properties {
+        if let ObjectPropertyKind::ObjectProperty(prop) = property
+            && !prop.computed
+            && property_key_name(&prop.key) == Some(key)
+        {
+            return Some(&prop.value);
+        }
+    }
+    None
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(ident) => Some(ident.name.as_str()),
+        PropertyKey::StringLiteral(literal) => Some(literal.value.as_str()),
+        _ => None,
+    }
+}
+
+/// Strip `satisfies`/`as`/parenthesized wrappers to reach the underlying object.
+pub(super) fn unwrap_object<'a>(expr: &'a Expression<'a>) -> Option<&'a ObjectExpression<'a>> {
+    if let Expression::ObjectExpression(object) = unwrap_expression(expr) {
+        Some(&**object)
+    } else {
+        None
+    }
+}
+
+/// Peel `TSSatisfiesExpression`, `TSAsExpression`, and parentheses.
+pub(super) fn unwrap_expression<'a>(expr: &'a Expression<'a>) -> &'a Expression<'a> {
+    let mut current = expr;
+    loop {
+        current = match current {
+            Expression::TSSatisfiesExpression(inner) => &inner.expression,
+            Expression::TSAsExpression(inner) => &inner.expression,
+            Expression::ParenthesizedExpression(inner) => &inner.expression,
+            other => return other,
+        };
+    }
+}
+
+fn string_literal_value(expr: &Expression<'_>) -> Option<String> {
+    if let Expression::StringLiteral(literal) = unwrap_expression(expr) {
+        Some(literal.value.as_str().into())
+    } else {
+        None
+    }
+}
+
+fn binding_name<'a>(declarator: &'a VariableDeclarator<'a>) -> Option<&'a str> {
+    match &declarator.id {
+        oxc_ast::ast::BindingPattern::BindingIdentifier(ident) => Some(ident.name.as_str()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize/src/commands/musea/migrate/csf/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/tests.rs
@@ -1,0 +1,121 @@
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+use super::extract_csf;
+
+/// One story reduced to the fields the unit tests assert on.
+#[derive(Debug, PartialEq, Eq)]
+struct TestStory<'a> {
+    name: &'a str,
+    has_render: bool,
+    has_args: bool,
+}
+
+#[test]
+fn extracts_satisfies_meta_and_stories() {
+    let source = r#"import AfButton from "./AfButton.vue";
+export default { component: AfButton, title: "Base/AfButton" } satisfies Meta<typeof AfButton>;
+export const Primary = { render: () => <AfButton color="primary">Primary</AfButton> };
+export const Secondary: StoryObj = { args: { color: "secondary", label: "Hi" } };
+"#;
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+    assert!(!parsed.panicked);
+    let module = extract_csf(&parsed.program);
+
+    assert_eq!(module.title.as_deref(), Some("Base/AfButton"));
+    assert_eq!(module.component_path.as_deref(), Some("./AfButton.vue"));
+    let stories: Vec<TestStory> = module
+        .stories
+        .iter()
+        .map(|story| TestStory {
+            name: story.name.as_str(),
+            has_render: story.render.is_some(),
+            has_args: story.args.is_some(),
+        })
+        .collect();
+    assert_eq!(
+        stories,
+        vec![
+            TestStory {
+                name: "Primary",
+                has_render: true,
+                has_args: false,
+            },
+            TestStory {
+                name: "Secondary",
+                has_render: false,
+                has_args: true,
+            },
+        ]
+    );
+}
+
+#[test]
+fn extracts_const_meta_default_export() {
+    let source = r#"import Card from "../components/Card.vue";
+const meta = { component: Card, title: "Card" } satisfies Meta<typeof Card>;
+export default meta;
+export const Only = { args: {} };
+"#;
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+    assert!(!parsed.panicked);
+    let module = extract_csf(&parsed.program);
+
+    assert_eq!(module.title.as_deref(), Some("Card"));
+    assert_eq!(
+        module.component_path.as_deref(),
+        Some("../components/Card.vue")
+    );
+    let stories: Vec<TestStory> = module
+        .stories
+        .iter()
+        .map(|story| TestStory {
+            name: story.name.as_str(),
+            has_render: story.render.is_some(),
+            has_args: story.args.is_some(),
+        })
+        .collect();
+    assert_eq!(
+        stories,
+        vec![TestStory {
+            name: "Only",
+            has_render: false,
+            has_args: true,
+        }]
+    );
+}
+
+#[test]
+fn extracts_as_meta_and_name_override() {
+    let source = r#"import Box from "./Box.vue";
+export default { component: Box, title: "Box" } as Meta;
+export const First = { name: "Custom Name", render: () => <Box /> };
+"#;
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+    assert!(!parsed.panicked);
+    let module = extract_csf(&parsed.program);
+
+    assert_eq!(module.title.as_deref(), Some("Box"));
+    assert_eq!(module.component_path.as_deref(), Some("./Box.vue"));
+    let stories: Vec<TestStory> = module
+        .stories
+        .iter()
+        .map(|story| TestStory {
+            name: story.name.as_str(),
+            has_render: story.render.is_some(),
+            has_args: story.args.is_some(),
+        })
+        .collect();
+    assert_eq!(
+        stories,
+        vec![TestStory {
+            name: "Custom Name",
+            has_render: true,
+            has_args: false,
+        }]
+    );
+}

--- a/crates/vize/src/commands/musea/migrate/emit.rs
+++ b/crates/vize/src/commands/musea/migrate/emit.rs
@@ -1,0 +1,159 @@
+//! Generate `.art.vue` text from extracted CSF metadata.
+
+use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, PropertyKey};
+use oxc_span::GetSpan;
+use vize_carton::{String, append};
+
+use super::csf::{CsfModule, CsfStory, unwrap_expression};
+use super::jsx::convert_render;
+use super::text::{escape_attr, escape_js_string};
+
+const TODO_COMMENT: &str = "<!-- TODO(vize musea migrate): unsupported story; port manually -->";
+
+/// Outcome of generating one `.art.vue` file.
+pub(super) struct EmitResult {
+    /// Full `.art.vue` file content.
+    pub content: String,
+    /// Number of variants emitted.
+    pub variants: usize,
+    /// Number of variants that fell back to the manual-port TODO.
+    pub todos: usize,
+}
+
+/// Render the `.art.vue` content for a CSF module.
+///
+/// `component_tag` is the element name used inside variants (the component's
+/// local import name, or a fallback derived from the title).
+pub(super) fn emit_art(
+    module: &CsfModule<'_>,
+    component_tag: &str,
+    component_path: &str,
+    source: &str,
+) -> EmitResult {
+    let mut content = String::default();
+
+    content.push_str("<script setup lang=\"ts\">\n");
+    append!(
+        content,
+        "defineArt(\"{}\", {{\n",
+        escape_js_string(component_path)
+    );
+    let (category, title) = split_title(module.title.as_deref(), component_tag);
+    if let Some(category) = category {
+        append!(content, "  category: \"{}\",\n", escape_js_string(category));
+    }
+    append!(content, "  title: \"{}\",\n", escape_js_string(title));
+    content.push_str("});\n");
+    content.push_str("</script>\n\n");
+
+    content.push_str("<art>\n");
+
+    let mut variants = 0usize;
+    let mut todos = 0usize;
+    for (index, story) in module.stories.iter().enumerate() {
+        let is_default = index == 0;
+        let (inner, is_todo) = emit_variant_inner(story, component_tag, source);
+        if is_todo {
+            todos += 1;
+        }
+        variants += 1;
+
+        if is_default {
+            append!(content, "  <variant name=\"{}\" default>\n", story.name);
+        } else {
+            append!(content, "  <variant name=\"{}\">\n", story.name);
+        }
+        for line in inner.lines() {
+            if line.is_empty() {
+                content.push('\n');
+            } else {
+                append!(content, "    {line}\n");
+            }
+        }
+        content.push_str("  </variant>\n");
+    }
+
+    content.push_str("</art>\n");
+
+    EmitResult {
+        content,
+        variants,
+        todos,
+    }
+}
+
+/// Build the inner markup of a `<variant>`. Returns `(markup, is_todo)`.
+fn emit_variant_inner(story: &CsfStory<'_>, component_tag: &str, source: &str) -> (String, bool) {
+    if let Some(render) = story.render
+        && let Some(markup) = convert_render(render, source)
+    {
+        return (markup, false);
+    }
+
+    if let Some(args) = story.args {
+        return (emit_args_element(args, component_tag, source), false);
+    }
+
+    let mut out = String::default();
+    append!(out, "<{component_tag} />\n{TODO_COMMENT}");
+    (out, true)
+}
+
+/// Emit `<Component ...props />` from an `args` object literal.
+fn emit_args_element(args: &ObjectExpression<'_>, component_tag: &str, source: &str) -> String {
+    let mut out = String::default();
+    append!(out, "<{component_tag}");
+    for property in &args.properties {
+        let ObjectPropertyKind::ObjectProperty(prop) = property else {
+            continue;
+        };
+        if prop.computed {
+            continue;
+        }
+        let Some(name) = property_key_name(&prop.key) else {
+            continue;
+        };
+        out.push(' ');
+        out.push_str(&attribute_from_value(name, &prop.value, source));
+    }
+    out.push_str(" />");
+    out
+}
+
+/// Map one `args` entry to an attribute: string literal -> `name="value"`,
+/// everything else -> `:name="<expr source>"`.
+fn attribute_from_value(name: &str, value: &Expression<'_>, source: &str) -> String {
+    let mut out = String::default();
+    if let Expression::StringLiteral(literal) = unwrap_expression(value) {
+        append!(out, "{name}=\"{}\"", escape_attr(literal.value.as_str()));
+    } else {
+        let text = value.span().source_text(source);
+        append!(out, ":{name}=\"{}\"", escape_attr(text));
+    }
+    out
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(ident) => Some(ident.name.as_str()),
+        PropertyKey::StringLiteral(literal) => Some(literal.value.as_str()),
+        _ => None,
+    }
+}
+
+/// Split a CSF title `Category/Name` into `(Some(category), name)`; a plain
+/// title yields `(None, title)`. Falls back to `component_tag` if no title.
+fn split_title<'a>(title: Option<&'a str>, component_tag: &'a str) -> (Option<&'a str>, &'a str) {
+    let Some(title) = title else {
+        return (None, component_tag);
+    };
+    match title.rsplit_once('/') {
+        Some((category, name)) if !category.is_empty() && !name.is_empty() => {
+            (Some(category), name)
+        }
+        _ => (None, title),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize/src/commands/musea/migrate/emit/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/tests.rs
@@ -1,0 +1,87 @@
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+use super::super::csf::extract_csf;
+use super::emit_art;
+
+fn emit(source: &str) -> (std::string::String, usize, usize) {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+    assert!(!parsed.panicked, "fixture should parse");
+    let module = extract_csf(&parsed.program);
+    let component_path = module
+        .component_path
+        .clone()
+        .unwrap_or_else(|| "./Component.vue".into());
+    let result = emit_art(&module, "AfButton", component_path.as_str(), source);
+    (
+        result.content.as_str().to_owned(),
+        result.variants,
+        result.todos,
+    )
+}
+
+#[test]
+fn emits_render_and_args_and_todo() {
+    let source = r#"import AfButton from "./AfButton.vue";
+export default { component: AfButton, title: "Base/AfButton" } satisfies Meta<typeof AfButton>;
+export const Primary = { render: () => <AfButton color="primary">Primary</AfButton> };
+export const Secondary: StoryObj = { args: { color: "secondary", label: "Hi" } };
+export const Mystery = { decorators: [withFoo] };
+"#;
+    let (content, variants, todos) = emit(source);
+
+    assert_eq!(
+        content,
+        r#"<script setup lang="ts">
+defineArt("./AfButton.vue", {
+  category: "Base",
+  title: "AfButton",
+});
+</script>
+
+<art>
+  <variant name="Primary" default>
+    <AfButton color="primary">Primary</AfButton>
+  </variant>
+  <variant name="Secondary">
+    <AfButton color="secondary" label="Hi" />
+  </variant>
+  <variant name="Mystery">
+    <AfButton />
+    <!-- TODO(vize musea migrate): unsupported story; port manually -->
+  </variant>
+</art>
+"#
+    );
+    assert_eq!(variants, 3);
+    assert_eq!(todos, 1);
+}
+
+#[test]
+fn emits_plain_title_without_category() {
+    let source = r#"import AfButton from "./AfButton.vue";
+export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;
+export const Big = { args: { size: "lg", count: 3, active: true } };
+"#;
+    let (content, variants, todos) = emit(source);
+
+    assert_eq!(
+        content,
+        r#"<script setup lang="ts">
+defineArt("./AfButton.vue", {
+  title: "AfButton",
+});
+</script>
+
+<art>
+  <variant name="Big" default>
+    <AfButton size="lg" :count="3" :active="true" />
+  </variant>
+</art>
+"#
+    );
+    assert_eq!(variants, 1);
+    assert_eq!(todos, 0);
+}

--- a/crates/vize/src/commands/musea/migrate/jsx.rs
+++ b/crates/vize/src/commands/musea/migrate/jsx.rs
@@ -1,0 +1,156 @@
+//! Convert a JSX element/fragment subtree into a Vue template string.
+//!
+//! The conversion is intentionally conservative: anything that cannot be mapped
+//! confidently returns `None` so the caller emits a manual-port TODO instead of
+//! silently-wrong markup. Expression source is recovered by slicing the original
+//! file by oxc byte spans.
+
+use super::text::escape_attr;
+use oxc_ast::ast::{
+    Expression, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXChild, JSXElement,
+    JSXElementName, JSXExpression, JSXFragment, JSXMemberExpression, JSXMemberExpressionObject,
+};
+use vize_carton::{String, append};
+
+/// Convert a JSX expression (element or fragment) to Vue template markup.
+///
+/// `source` is the full original file text; spans index into it.
+pub(super) fn convert_render(expr: &Expression<'_>, source: &str) -> Option<String> {
+    match expr {
+        Expression::JSXElement(element) => convert_element(element, source),
+        Expression::JSXFragment(fragment) => convert_fragment(fragment, source),
+        _ => None,
+    }
+}
+
+/// A fragment `<>...</>` emits only its children (no wrapper element).
+fn convert_fragment(fragment: &JSXFragment<'_>, source: &str) -> Option<String> {
+    convert_children(&fragment.children, source)
+}
+
+fn convert_element(element: &JSXElement<'_>, source: &str) -> Option<String> {
+    let tag = element_name(&element.opening_element.name)?;
+
+    let mut attributes = String::default();
+    for item in &element.opening_element.attributes {
+        attributes.push(' ');
+        attributes.push_str(&convert_attribute(item, source)?);
+    }
+
+    let children = convert_children(&element.children, source)?;
+
+    let mut out = String::default();
+    if children.is_empty() {
+        append!(out, "<{tag}{attributes} />");
+    } else {
+        append!(out, "<{tag}{attributes}>{children}</{tag}>");
+    }
+    Some(out)
+}
+
+fn convert_children(children: &[JSXChild<'_>], source: &str) -> Option<String> {
+    let mut out = String::default();
+    for child in children {
+        match child {
+            JSXChild::Text(text) => {
+                let trimmed = text.value.as_str().trim();
+                if !trimmed.is_empty() {
+                    out.push_str(trimmed);
+                }
+            }
+            JSXChild::Element(element) => out.push_str(&convert_element(element, source)?),
+            JSXChild::Fragment(fragment) => out.push_str(&convert_fragment(fragment, source)?),
+            JSXChild::ExpressionContainer(container) => match &container.expression {
+                JSXExpression::EmptyExpression(_) => {}
+                expression => {
+                    let text = jsx_expression_source(expression, source)?;
+                    append!(out, "{{{{ {text} }}}}");
+                }
+            },
+            // `{...spread}` children and anything unexpected: bail out.
+            JSXChild::Spread(_) => return None,
+        }
+    }
+    Some(out)
+}
+
+fn convert_attribute(item: &JSXAttributeItem<'_>, source: &str) -> Option<String> {
+    match item {
+        JSXAttributeItem::Attribute(attribute) => {
+            let name = attribute_name(&attribute.name)?;
+            match attribute.value.as_ref() {
+                None => Some(name.into()),
+                Some(JSXAttributeValue::StringLiteral(literal)) => {
+                    let mut out = String::default();
+                    append!(out, "{name}=\"{}\"", escape_attr(literal.value.as_str()));
+                    Some(out)
+                }
+                Some(JSXAttributeValue::ExpressionContainer(container)) => {
+                    match &container.expression {
+                        JSXExpression::EmptyExpression(_) => None,
+                        expression => {
+                            let text = jsx_expression_source(expression, source)?;
+                            let mut out = String::default();
+                            append!(out, ":{name}=\"{}\"", escape_attr(text.as_str()));
+                            Some(out)
+                        }
+                    }
+                }
+                // `prop=<Element/>` and `prop=<></>` are not convertible.
+                Some(_) => None,
+            }
+        }
+        JSXAttributeItem::SpreadAttribute(spread) => {
+            let text = expression_source(&spread.argument, source)?;
+            let mut out = String::default();
+            append!(out, "v-bind=\"{}\"", escape_attr(text.as_str()));
+            Some(out)
+        }
+    }
+}
+
+/// Element tag name. Supports identifiers and dotted member names.
+fn element_name(name: &JSXElementName<'_>) -> Option<String> {
+    match name {
+        JSXElementName::Identifier(ident) => Some(ident.name.as_str().into()),
+        JSXElementName::IdentifierReference(ident) => Some(ident.name.as_str().into()),
+        JSXElementName::MemberExpression(member) => member_name(member),
+        JSXElementName::NamespacedName(_) | JSXElementName::ThisExpression(_) => None,
+    }
+}
+
+fn member_name(member: &JSXMemberExpression<'_>) -> Option<String> {
+    let mut out = match &member.object {
+        JSXMemberExpressionObject::IdentifierReference(ident) => String::from(ident.name.as_str()),
+        JSXMemberExpressionObject::MemberExpression(inner) => member_name(inner)?,
+        JSXMemberExpressionObject::ThisExpression(_) => return None,
+    };
+    out.push('.');
+    out.push_str(member.property.name.as_str());
+    Some(out)
+}
+
+fn attribute_name<'a>(name: &'a JSXAttributeName<'a>) -> Option<&'a str> {
+    match name {
+        JSXAttributeName::Identifier(ident) => Some(ident.name.as_str()),
+        // Namespaced attribute names (`foo:bar`) have no clean Vue mapping.
+        JSXAttributeName::NamespacedName(_) => None,
+    }
+}
+
+/// Source text of a `JSXExpression` (the expression inside `{...}`).
+fn jsx_expression_source(expression: &JSXExpression<'_>, source: &str) -> Option<String> {
+    use oxc_span::GetSpan;
+    let span = expression.span();
+    Some(span.source_text(source).into())
+}
+
+/// Source text of an `Expression`.
+fn expression_source(expression: &Expression<'_>, source: &str) -> Option<String> {
+    use oxc_span::GetSpan;
+    let span = expression.span();
+    Some(span.source_text(source).into())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize/src/commands/musea/migrate/jsx/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/jsx/tests.rs
@@ -1,0 +1,99 @@
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Expression, Statement};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::String;
+
+use super::convert_render;
+
+/// Wrap a JSX expression in `const x = (<JSX>);` and convert it to template.
+fn convert(jsx: &str) -> Option<String> {
+    let mut source = std::string::String::from("const x = (");
+    source.push_str(jsx);
+    source.push_str(");\n");
+
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, &source, SourceType::tsx()).parse();
+    assert!(!parsed.panicked, "fixture should parse: {source}");
+
+    let Some(Statement::VariableDeclaration(decl)) = parsed.program.body.first() else {
+        panic!("expected variable declaration");
+    };
+    let init = decl.declarations[0]
+        .init
+        .as_ref()
+        .expect("declarator initializer");
+    let expr = match init {
+        Expression::ParenthesizedExpression(inner) => &inner.expression,
+        other => other,
+    };
+    convert_render(expr, &source)
+}
+
+#[test]
+fn converts_element_with_string_attr_and_text() {
+    assert_eq!(
+        convert(r#"<AfButton color="primary">Primary</AfButton>"#).as_deref(),
+        Some(r#"<AfButton color="primary">Primary</AfButton>"#)
+    );
+}
+
+#[test]
+fn converts_self_closing_element() {
+    assert_eq!(convert("<AfButton />").as_deref(), Some("<AfButton />"));
+}
+
+#[test]
+fn converts_expression_attr_and_bare_attr() {
+    assert_eq!(
+        convert("<AfButton count={1 + 2} disabled />").as_deref(),
+        Some(r#"<AfButton :count="1 + 2" disabled />"#)
+    );
+}
+
+#[test]
+fn converts_spread_attr_to_v_bind() {
+    assert_eq!(
+        convert("<AfButton {...props} />").as_deref(),
+        Some(r#"<AfButton v-bind="props" />"#)
+    );
+}
+
+#[test]
+fn converts_expression_child_to_mustache() {
+    assert_eq!(
+        convert("<AfButton>{label}</AfButton>").as_deref(),
+        Some("<AfButton>{{ label }}</AfButton>")
+    );
+}
+
+#[test]
+fn fragment_emits_children_without_wrapper() {
+    assert_eq!(
+        convert("<><AfButton a=\"x\" /><AfButton b=\"y\" /></>").as_deref(),
+        Some(r#"<AfButton a="x" /><AfButton b="y" />"#)
+    );
+}
+
+#[test]
+fn converts_dotted_member_element_name() {
+    assert_eq!(
+        convert("<Form.Item label=\"name\" />").as_deref(),
+        Some(r#"<Form.Item label="name" />"#)
+    );
+}
+
+#[test]
+fn escapes_quotes_in_expression_attr() {
+    // An expression attribute whose source contains `"` must be HTML-escaped so
+    // it cannot break out of the double-quoted Vue binding.
+    assert_eq!(
+        convert(r#"<AfButton onClick={() => alert("hi")} />"#).as_deref(),
+        Some(r#"<AfButton :onClick="() => alert(&quot;hi&quot;)" />"#)
+    );
+}
+
+#[test]
+fn non_jsx_render_returns_none() {
+    assert_eq!(convert("42").as_deref(), None);
+}

--- a/crates/vize/src/commands/musea/migrate/mod.rs
+++ b/crates/vize/src/commands/musea/migrate/mod.rs
@@ -1,0 +1,224 @@
+//! `vize musea migrate` - convert Storybook CSF stories to Musea `.art.vue`.
+
+#![allow(clippy::disallowed_macros)]
+
+mod csf;
+mod emit;
+mod jsx;
+mod text;
+
+use clap::Args;
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use std::fs;
+use std::path::{Path, PathBuf};
+use vize_carton::String as CartonString;
+use vize_carton::append;
+
+use crate::commands::fmt::collect_files;
+use csf::extract_csf;
+use emit::emit_art;
+
+#[derive(Args)]
+#[allow(clippy::disallowed_types)]
+pub struct MigrateArgs {
+    /// Glob pattern(s) matching Storybook CSF story files
+    #[arg(default_values_t = default_migrate_patterns())]
+    pub patterns: Vec<std::string::String>,
+
+    /// Directory to write `.art.vue` files into (default: alongside each source)
+    #[arg(long, value_name = "DIR")]
+    pub out_dir: Option<PathBuf>,
+
+    /// Print generated content to stdout instead of writing files
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[allow(clippy::disallowed_types)]
+fn default_migrate_patterns() -> Vec<std::string::String> {
+    vec![
+        "**/*.stories.tsx".into(),
+        "**/*.stories.ts".into(),
+        "**/*.stories.jsx".into(),
+        "**/*.stories.js".into(),
+    ]
+}
+
+#[derive(Default)]
+struct Summary {
+    files: usize,
+    variants: usize,
+    todos: usize,
+    errors: usize,
+}
+
+pub fn run(args: MigrateArgs) {
+    let files = collect_story_files(&args.patterns);
+    if files.is_empty() {
+        eprintln!("vize musea migrate: no story files matched the patterns");
+        return;
+    }
+
+    let mut summary = Summary::default();
+    for path in &files {
+        match migrate_file(path, args.out_dir.as_deref(), args.dry_run) {
+            Ok(Some(outcome)) => {
+                summary.files += 1;
+                summary.variants += outcome.variants;
+                summary.todos += outcome.todos;
+            }
+            Ok(None) => {}
+            Err(message) => {
+                summary.errors += 1;
+                eprintln!("vize musea migrate: {}: {}", path.display(), message);
+            }
+        }
+    }
+
+    eprintln!(
+        "vize musea migrate: {} file(s) migrated, {} variant(s) generated, {} TODO fallback(s)",
+        summary.files, summary.variants, summary.todos
+    );
+    if summary.errors > 0 {
+        eprintln!("  {} file(s) could not be migrated", summary.errors);
+    }
+}
+
+#[allow(clippy::disallowed_types)]
+fn collect_story_files(patterns: &[std::string::String]) -> Vec<PathBuf> {
+    collect_files(patterns, None)
+        .into_iter()
+        .filter(|path| is_story_file(path))
+        .collect()
+}
+
+fn is_story_file(path: &Path) -> bool {
+    let name = match path.file_name().and_then(|name| name.to_str()) {
+        Some(name) => name,
+        None => return false,
+    };
+    matches!(
+        name.rsplit_once('.'),
+        Some((stem, "tsx" | "ts" | "jsx" | "js")) if stem.ends_with(".stories")
+    )
+}
+
+struct FileOutcome {
+    variants: usize,
+    todos: usize,
+}
+
+fn migrate_file(
+    path: &Path,
+    out_dir: Option<&Path>,
+    dry_run: bool,
+) -> Result<Option<FileOutcome>, CartonString> {
+    let source = fs::read_to_string(path).map_err(|error| {
+        let mut message = CartonString::from("failed to read file: ");
+        append!(message, "{error}");
+        message
+    })?;
+
+    let source_type = source_type_for_path(path);
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, &source, source_type).parse();
+    if parsed.panicked {
+        return Err("failed to parse story file".into());
+    }
+
+    let module = extract_csf(&parsed.program);
+
+    let component_path = module
+        .component_path
+        .clone()
+        .unwrap_or_else(|| derive_component_path(path));
+    let component_tag = component_tag_from_path(&component_path);
+
+    let result = emit_art(&module, &component_tag, &component_path, &source);
+
+    let target = output_path(path, out_dir);
+
+    if dry_run {
+        println!("// {}", target.display());
+        print!("{}", result.content);
+    } else {
+        if let Some(parent) = target.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent).map_err(|error| {
+                let mut message = CartonString::from("failed to create output directory: ");
+                append!(message, "{error}");
+                message
+            })?;
+        }
+        fs::write(&target, result.content.as_str()).map_err(|error| {
+            let mut message = CartonString::from("failed to write file: ");
+            append!(message, "{error}");
+            message
+        })?;
+        eprintln!("vize musea migrate: wrote {}", target.display());
+    }
+
+    Ok(Some(FileOutcome {
+        variants: result.variants,
+        todos: result.todos,
+    }))
+}
+
+fn source_type_for_path(path: &Path) -> SourceType {
+    match path.extension().and_then(|extension| extension.to_str()) {
+        Some("tsx") => SourceType::tsx(),
+        Some("jsx") => SourceType::jsx(),
+        Some("ts") => SourceType::ts(),
+        _ => SourceType::mjs(),
+    }
+}
+
+/// Strip the `.stories.<ext>` suffix to get the output basename.
+fn story_basename(path: &Path) -> CartonString {
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("Component");
+    let stem = name.rsplit_once('.').map(|(stem, _)| stem).unwrap_or(name);
+    let base = stem.strip_suffix(".stories").unwrap_or(stem);
+    base.into()
+}
+
+fn output_path(path: &Path, out_dir: Option<&Path>) -> PathBuf {
+    let mut file_name = story_basename(path);
+    file_name.push_str(".art.vue");
+    let dir = out_dir
+        .map(Path::to_path_buf)
+        .or_else(|| path.parent().map(Path::to_path_buf))
+        .unwrap_or_else(|| PathBuf::from("."));
+    dir.join(file_name.as_str())
+}
+
+/// Fallback component import path when the CSF has no resolvable component.
+fn derive_component_path(path: &Path) -> CartonString {
+    let mut out = CartonString::from("./");
+    out.push_str(story_basename(path).as_str());
+    out.push_str(".vue");
+    out
+}
+
+/// Derive the component element tag (PascalCase file stem) from an import path.
+fn component_tag_from_path(component_path: &str) -> CartonString {
+    let file = component_path
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(component_path);
+    let stem = file.split(['?', '#']).next().unwrap_or(file);
+    let stem = stem.strip_suffix(".vue").unwrap_or(stem);
+    let stem = stem.rsplit_once('.').map(|(base, _)| base).unwrap_or(stem);
+    if stem.is_empty() {
+        return "Component".into();
+    }
+    stem.into()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize/src/commands/musea/migrate/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/tests.rs
@@ -1,0 +1,71 @@
+use std::path::{Path, PathBuf};
+
+use super::{
+    component_tag_from_path, derive_component_path, is_story_file, output_path, story_basename,
+};
+
+#[test]
+fn is_story_file_matches_only_story_extensions() {
+    assert!(is_story_file(Path::new("Button.stories.tsx")));
+    assert!(is_story_file(Path::new("a/b/Button.stories.ts")));
+    assert!(is_story_file(Path::new("Button.stories.jsx")));
+    assert!(is_story_file(Path::new("Button.stories.js")));
+    assert!(!is_story_file(Path::new("Button.tsx")));
+    assert!(!is_story_file(Path::new("Button.stories.vue")));
+    assert!(!is_story_file(Path::new("stories.ts")));
+}
+
+#[test]
+fn story_basename_strips_stories_suffix() {
+    assert_eq!(
+        story_basename(Path::new("a/AfButton.stories.tsx")).as_str(),
+        "AfButton"
+    );
+    assert_eq!(
+        story_basename(Path::new("Card.stories.ts")).as_str(),
+        "Card"
+    );
+}
+
+#[test]
+fn output_path_alongside_source_by_default() {
+    assert_eq!(
+        output_path(Path::new("src/AfButton.stories.tsx"), None),
+        PathBuf::from("src/AfButton.art.vue")
+    );
+}
+
+#[test]
+fn output_path_uses_out_dir_when_given() {
+    assert_eq!(
+        output_path(
+            Path::new("src/AfButton.stories.tsx"),
+            Some(Path::new("out/art"))
+        ),
+        PathBuf::from("out/art/AfButton.art.vue")
+    );
+}
+
+#[test]
+fn derive_component_path_falls_back_to_basename() {
+    assert_eq!(
+        derive_component_path(Path::new("src/AfButton.stories.tsx")).as_str(),
+        "./AfButton.vue"
+    );
+}
+
+#[test]
+fn component_tag_from_path_uses_file_stem() {
+    assert_eq!(
+        component_tag_from_path("./AfButton.vue").as_str(),
+        "AfButton"
+    );
+    assert_eq!(
+        component_tag_from_path("../components/Card.vue").as_str(),
+        "Card"
+    );
+    assert_eq!(
+        component_tag_from_path("./Widget.vue?raw").as_str(),
+        "Widget"
+    );
+}

--- a/crates/vize/src/commands/musea/migrate/text.rs
+++ b/crates/vize/src/commands/musea/migrate/text.rs
@@ -1,0 +1,57 @@
+//! Escaping helpers for emitting valid `.art.vue` output.
+
+use vize_carton::String;
+
+/// HTML-escape a value for placement inside a double-quoted attribute, so an
+/// expression or string containing `"` (e.g. `onClick={() => alert("hi")}`)
+/// cannot break out of the attribute. Vue decodes the entities before parsing
+/// the binding expression, so the round-trip is lossless.
+pub(super) fn escape_attr(value: &str) -> String {
+    let mut out = String::default();
+    for ch in value.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '"' => out.push_str("&quot;"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Escape a value for a double-quoted JavaScript/TypeScript string literal (used
+/// in the generated `defineArt("...", { ... })` call).
+pub(super) fn escape_js_string(value: &str) -> String {
+    let mut out = String::default();
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{escape_attr, escape_js_string};
+
+    #[test]
+    fn escape_attr_encodes_quotes_and_amp() {
+        assert_eq!(
+            escape_attr("() => alert(\"hi\" & bye)").as_str(),
+            "() => alert(&quot;hi&quot; &amp; bye)"
+        );
+    }
+
+    #[test]
+    fn escape_attr_leaves_plain_text() {
+        assert_eq!(escape_attr("1 + 2").as_str(), "1 + 2");
+    }
+
+    #[test]
+    fn escape_js_string_encodes_backslash_quote_newline() {
+        assert_eq!(escape_js_string("a\\b\"c\nd").as_str(), "a\\\\b\\\"c\\nd");
+    }
+}

--- a/crates/vize/tests/musea_migrate_cli.rs
+++ b/crates/vize/tests/musea_migrate_cli.rs
@@ -1,0 +1,139 @@
+//! Integration tests for `vize musea migrate`.
+
+use std::fs;
+use std::process::Command;
+
+fn run_migrate(dir: &std::path::Path, extra: &[&str]) -> std::process::Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vize"));
+    command.current_dir(dir).args(["musea", "migrate"]);
+    command.args(extra);
+    command.output().expect("failed to run vize musea migrate")
+}
+
+#[test]
+fn migrates_render_args_and_unsupported_story() {
+    let dir = tempfile::tempdir().unwrap();
+    let story = dir.path().join("AfButton.stories.tsx");
+    fs::write(
+        &story,
+        r#"import AfButton from "./AfButton.vue";
+export default { component: AfButton, title: "Base/AfButton" } satisfies Meta<typeof AfButton>;
+export const Primary = { render: () => <AfButton color="primary">Primary</AfButton> };
+export const Secondary: StoryObj = { args: { color: "secondary", label: "Hi" } };
+export const Mystery = { decorators: [withFoo] };
+"#,
+    )
+    .unwrap();
+
+    let output = run_migrate(dir.path(), &["AfButton.stories.tsx"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        std::string::String::from_utf8_lossy(&output.stderr)
+    );
+
+    let generated = fs::read_to_string(dir.path().join("AfButton.art.vue")).unwrap();
+    assert_eq!(
+        generated,
+        r#"<script setup lang="ts">
+defineArt("./AfButton.vue", {
+  category: "Base",
+  title: "AfButton",
+});
+</script>
+
+<art>
+  <variant name="Primary" default>
+    <AfButton color="primary">Primary</AfButton>
+  </variant>
+  <variant name="Secondary">
+    <AfButton color="secondary" label="Hi" />
+  </variant>
+  <variant name="Mystery">
+    <AfButton />
+    <!-- TODO(vize musea migrate): unsupported story; port manually -->
+  </variant>
+</art>
+"#
+    );
+}
+
+#[test]
+fn dry_run_prints_without_writing() {
+    let dir = tempfile::tempdir().unwrap();
+    let story = dir.path().join("Box.stories.tsx");
+    fs::write(
+        &story,
+        r#"import Box from "./Box.vue";
+export default { component: Box, title: "Box" } as Meta;
+export const First = { name: "Custom Name", render: () => <Box a="x" /> };
+"#,
+    )
+    .unwrap();
+
+    let output = run_migrate(dir.path(), &["--dry-run", "Box.stories.tsx"]);
+    assert!(output.status.success());
+
+    let stdout = std::string::String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        r#"// Box.art.vue
+<script setup lang="ts">
+defineArt("./Box.vue", {
+  title: "Box",
+});
+</script>
+
+<art>
+  <variant name="Custom Name" default>
+    <Box a="x" />
+  </variant>
+</art>
+"#
+    );
+
+    assert!(
+        !dir.path().join("Box.art.vue").exists(),
+        "--dry-run must not write files"
+    );
+}
+
+#[test]
+fn out_dir_redirects_generated_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let story = dir.path().join("Plain.stories.ts");
+    fs::write(
+        &story,
+        r#"import Plain from "./Plain.vue";
+export default { component: Plain, title: "Group/Plain" } satisfies Meta<typeof Plain>;
+export const Big = { args: { size: "lg", count: 3 } };
+"#,
+    )
+    .unwrap();
+
+    let output = run_migrate(dir.path(), &["--out-dir", "art", "Plain.stories.ts"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        std::string::String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(!dir.path().join("Plain.art.vue").exists());
+    let generated = fs::read_to_string(dir.path().join("art/Plain.art.vue")).unwrap();
+    assert_eq!(
+        generated,
+        r#"<script setup lang="ts">
+defineArt("./Plain.vue", {
+  category: "Group",
+  title: "Plain",
+});
+</script>
+
+<art>
+  <variant name="Big" default>
+    <Plain size="lg" :count="3" />
+  </variant>
+</art>
+"#
+    );
+}


### PR DESCRIPTION
## What

Adds `vize musea migrate [PATTERNS]...` (defaults to `**/*.stories.{tsx,ts,jsx,js}`) — a first-pass migration tool that converts Storybook CSF stories into Musea `.art.vue` files, so existing component libraries can adopt Musea without hand-porting every story. Closes #2076.

## How

- **Meta**: parses `export default {…} satisfies/as Meta` and the `const meta = {…}; export default meta` indirection for the component import path and `title` (a `Category/Name` title → `category` + `title`).
- **Stories**: one `<variant>` per `export const` story (first → `default`), honoring a `name:` override.
- **Templates**: converts `render: () => <JSX/>` to a Vue template (elements, fragments, dotted tags, string/expression/spread attrs, text + `{expr}` children). Falls back to `<Component …/>` built from `args`, or a `<!-- TODO(vize musea migrate): … -->` comment when a story can't be converted confidently — it never emits silently-wrong markup.
- **Safety**: attribute values and `defineArt` strings are escaped (HTML entities / JS-string escapes) so quotes in expressions or args can't break the output. Per-file parse failures are reported to stderr and skipped, never aborting the run.
- `--out-dir` redirects output; `--dry-run` prints instead of writing.

Built in the CLI layer (`crates/vize/src/commands/musea/migrate/`, split into `csf`/`jsx`/`emit`/`text`/`mod`, each ≤304 lines) using the oxc parser already available to the `vize` crate. `collect_files`/`FmtIgnoreSet` were made `pub(crate)` to reuse the gitignore-aware file collector.

## Tests

- Unit: CSF extraction (meta shapes, import resolution, story collection, name override), JSX→template conversion (incl. quote escaping), emit output, escaping helpers.
- Integration (`musea_migrate_cli.rs`): render-JSX story, args-only story, TODO fallback, `--dry-run`, `--out-dir`.

## Scope / follow-ups

First-pass MVP per the issue (it explicitly accepts TODO comments for unsupported decorators/loaders/play). Not yet handled (→ TODO fallback): non-trivial render bodies, namespaced tags/attrs, element-valued attrs. `.stories.js` with JSX isn't parsed as JSX (use `.jsx`).

## Verification

`cargo build/clippy -p vize -- -D warnings -D clippy::wildcard_imports` clean; rustfmt (1.95.0, edition/style 2024) clean; source-length gate clean; `vize` lib (211) + migrate/fmt integration tests green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->