### PR TITLE
feat(glyph): glyph YAML and Markdown inputs (#2249, #2177)

### DIFF
--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -34,7 +34,7 @@ use patterns::default_fmt_patterns;
 #[derive(Args)]
 #[allow(clippy::disallowed_types)]
 pub struct FmtArgs {
-    /// Glob pattern(s) to match .vue, .js, .ts, .jsx, .tsx, .json, and .jsonc files
+    /// Glob pattern(s) to match .vue, .js, .ts, .jsx, .tsx, .json, .jsonc, .yaml, .yml, .md, and .markdown files
     #[arg(default_values_t = default_fmt_patterns())]
     pub patterns: Vec<String>,
 

--- a/crates/vize/src/commands/fmt/data.rs
+++ b/crates/vize/src/commands/fmt/data.rs
@@ -1,22 +1,31 @@
-//! Formatting for non-SFC data files (currently JSON and JSONC).
+//! Formatting for non-SFC files: JSON, JSONC, YAML, and Markdown.
 
 use std::path::Path;
 use vize_carton::profile;
 use vize_glyph::{FormatOptions, FormatResult};
 
-/// Format `source` as JSON or JSONC based on `path`.
+mod plain;
+
+/// Format `source` based on `path`'s extension.
 ///
-/// `.jsonc` files and comment-bearing config files (`tsconfig*.json`,
-/// `jsconfig*.json`, `.vscode/*.json`, `*.code-workspace`) are formatted as
-/// JSONC so their comments and trailing commas survive; every other `.json`
-/// file uses strict JSON. Returns `None` when `path` is neither `.json` nor
-/// `.jsonc`, letting the caller fall through to the SFC formatter.
+/// `.yaml`/`.yml` and `.md`/`.markdown` get conservative, lossless
+/// normalization (see [`plain`]). `.jsonc` and comment-bearing config files
+/// (`tsconfig*.json`, `jsconfig*.json`, `.vscode/*.json`, `*.code-workspace`)
+/// are formatted as JSONC so their comments and trailing commas survive; every
+/// other `.json` file uses strict JSON. Returns `None` for any other extension,
+/// letting the caller fall through to the SFC formatter.
 pub(super) fn format_data_file(
     path: &Path,
     source: &str,
     options: &FormatOptions,
 ) -> Option<Result<FormatResult, vize_glyph::FormatError>> {
-    let jsonc = match path.extension().and_then(|extension| extension.to_str())? {
+    let extension = path.extension().and_then(|extension| extension.to_str())?;
+    match extension {
+        "yaml" | "yml" => return Some(Ok(plain::format_yaml(source))),
+        "md" | "markdown" => return Some(Ok(plain::format_markdown(source))),
+        _ => {}
+    }
+    let jsonc = match extension {
         "jsonc" => true,
         "json" => is_jsonc_config_file(path),
         _ => return None,

--- a/crates/vize/src/commands/fmt/data/plain.rs
+++ b/crates/vize/src/commands/fmt/data/plain.rs
@@ -1,0 +1,122 @@
+//! Conservative formatting for plain config/doc files: YAML and Markdown.
+//!
+//! These formats have no comment-preserving parser available here, so the
+//! transforms are deliberately lossless:
+//!
+//! - **YAML** (`.yaml`/`.yml`): normalize line endings to `\n` and ensure a
+//!   single trailing newline. Line content is preserved byte-for-byte, so
+//!   comments, anchors/aliases, and block scalars (`|`/`>`, including
+//!   `+`-chomped trailing blanks) are never altered.
+//! - **Markdown** (`.md`/`.markdown`): the above, plus trailing-whitespace
+//!   trimming outside fenced (```` ``` ````/`~~~`) and indented code blocks,
+//!   preserving two-space hard line breaks.
+//!
+//! Richer, structure-aware formatting is a follow-up that needs real parsers.
+
+use vize_carton::String;
+use vize_glyph::FormatResult;
+
+/// Format a YAML document (lossless newline normalization).
+pub(super) fn format_yaml(source: &str) -> FormatResult {
+    finish(normalize_yaml(source), source)
+}
+
+/// Format a Markdown document (newline normalization + safe trailing-ws trim).
+pub(super) fn format_markdown(source: &str) -> FormatResult {
+    finish(normalize_markdown(source), source)
+}
+
+fn finish(code: String, source: &str) -> FormatResult {
+    FormatResult {
+        changed: code.as_str() != source,
+        code,
+    }
+}
+
+/// Convert `\r\n` and lone `\r` line endings to `\n`.
+fn to_lf(source: &str) -> String {
+    let mut out = String::with_capacity(source.len());
+    let mut chars = source.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\r' {
+            if chars.peek() == Some(&'\n') {
+                chars.next();
+            }
+            out.push('\n');
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn ensure_final_newline(mut text: String) -> String {
+    if !text.is_empty() && !text.ends_with('\n') {
+        text.push('\n');
+    }
+    text
+}
+
+fn normalize_yaml(source: &str) -> String {
+    ensure_final_newline(to_lf(source))
+}
+
+fn normalize_markdown(source: &str) -> String {
+    let lf = to_lf(source);
+    let mut out = String::with_capacity(lf.len());
+    let mut fence: Option<char> = None;
+    for (index, line) in lf.split('\n').enumerate() {
+        if index > 0 {
+            out.push('\n');
+        }
+        let stripped = line.trim_start();
+        let fence_char = fence_marker(stripped);
+        if let Some(marker) = fence_char {
+            match fence {
+                Some(open) if open == marker => fence = None,
+                None => fence = Some(marker),
+                Some(_) => {}
+            }
+            out.push_str(line);
+        } else if fence.is_some() || is_indented_code(line) {
+            out.push_str(line);
+        } else {
+            out.push_str(trim_trailing(line).as_str());
+        }
+    }
+    ensure_final_newline(out)
+}
+
+/// The fence character if `stripped` opens/closes a fenced code block.
+fn fence_marker(stripped: &str) -> Option<char> {
+    if stripped.starts_with("```") {
+        Some('`')
+    } else if stripped.starts_with("~~~") {
+        Some('~')
+    } else {
+        None
+    }
+}
+
+/// CommonMark indented code blocks start at >= 4 spaces or a tab. Treating any
+/// such line as code is conservative: it never strips significant whitespace.
+fn is_indented_code(line: &str) -> bool {
+    line.starts_with("    ") || line.starts_with('\t')
+}
+
+/// Trim trailing whitespace, preserving a hard line break (exactly two trailing
+/// spaces). Three-or-more or mixed trailing whitespace is trimmed in full.
+fn trim_trailing(line: &str) -> String {
+    let trimmed = line.trim_end();
+    if trimmed.is_empty() {
+        return String::default();
+    }
+    let mut out = String::from(trimmed);
+    if &line[trimmed.len()..] == "  " {
+        out.push_str("  ");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize/src/commands/fmt/data/plain/tests.rs
+++ b/crates/vize/src/commands/fmt/data/plain/tests.rs
@@ -1,0 +1,73 @@
+use super::{format_markdown, format_yaml};
+
+// -- YAML ---------------------------------------------------------------
+
+#[test]
+fn yaml_normalizes_crlf_and_adds_final_newline() {
+    let result = format_yaml("a: 1\r\nb: 2");
+    assert_eq!(result.code.as_str(), "a: 1\nb: 2\n");
+    assert!(result.changed);
+}
+
+#[test]
+fn yaml_preserves_block_scalar_trailing_whitespace() {
+    // Trailing spaces inside a literal block scalar are significant; YAML must
+    // never touch line content.
+    let source = "key: |\n  line with spaces   \n  next\n";
+    let result = format_yaml(source);
+    assert_eq!(result.code.as_str(), source);
+    assert!(!result.changed);
+}
+
+#[test]
+fn yaml_is_idempotent_and_noop_when_clean() {
+    let source = "# comment\nname: vize\nlist:\n  - a\n  - b\n";
+    let first = format_yaml(source);
+    assert_eq!(first.code.as_str(), source);
+    let second = format_yaml(first.code.as_str());
+    assert_eq!(first.code, second.code);
+}
+
+#[test]
+fn yaml_empty_stays_empty() {
+    assert_eq!(format_yaml("").code.as_str(), "");
+}
+
+// -- Markdown -----------------------------------------------------------
+
+#[test]
+fn markdown_trims_trailing_whitespace() {
+    let result = format_markdown("# Title   \n\nText with space \n");
+    assert_eq!(result.code.as_str(), "# Title\n\nText with space\n");
+}
+
+#[test]
+fn markdown_preserves_two_space_hard_break() {
+    let source = "line one  \nline two\n";
+    let result = format_markdown(source);
+    assert_eq!(result.code.as_str(), source);
+    assert!(!result.changed);
+}
+
+#[test]
+fn markdown_preserves_fenced_code_block_verbatim() {
+    let source = "```sh\necho hi   \n```\ntext   \n";
+    let result = format_markdown(source);
+    // Trailing spaces inside the fence are kept; outside is trimmed.
+    assert_eq!(result.code.as_str(), "```sh\necho hi   \n```\ntext\n");
+}
+
+#[test]
+fn markdown_preserves_indented_code_block() {
+    let source = "para\n\n    code with spaces   \n";
+    let result = format_markdown(source);
+    assert_eq!(result.code.as_str(), source);
+}
+
+#[test]
+fn markdown_adds_final_newline_and_is_idempotent() {
+    let first = format_markdown("# Title");
+    assert_eq!(first.code.as_str(), "# Title\n");
+    let second = format_markdown(first.code.as_str());
+    assert_eq!(first.code, second.code);
+}

--- a/crates/vize/src/commands/fmt/files.rs
+++ b/crates/vize/src/commands/fmt/files.rs
@@ -71,31 +71,9 @@ fn should_include_format_file(path: &Path, ignore_set: Option<&FmtIgnoreSet>) ->
 
 #[inline]
 fn should_walk_with_gitignore(pattern: &str) -> bool {
-    matches!(
-        pattern,
-        "**/*"
-            | "./**/*"
-            | "**/*.vue"
-            | "./**/*.vue"
-            | "**/*.jsx"
-            | "./**/*.jsx"
-            | "**/*.tsx"
-            | "./**/*.tsx"
-            | "**/*.js"
-            | "./**/*.js"
-            | "**/*.mjs"
-            | "./**/*.mjs"
-            | "**/*.cjs"
-            | "./**/*.cjs"
-            | "**/*.ts"
-            | "./**/*.ts"
-            | "**/*.mts"
-            | "./**/*.mts"
-            | "**/*.cts"
-            | "./**/*.cts"
-            | "**/*.json"
-            | "**/*.jsonc"
-    )
+    // `normalize_fmt_pattern` strips leading `./`, but accept it defensively.
+    let bare = pattern.strip_prefix("./").unwrap_or(pattern);
+    bare == "**/*" || bare.strip_prefix("**/*.").is_some_and(is_format_extension)
 }
 
 pub(super) struct FmtPattern {
@@ -155,12 +133,31 @@ fn normalize_fmt_pattern(pattern: &str) -> vize_carton::String {
 
 #[inline]
 fn is_format_target(path: &Path) -> bool {
-    const EXTENSIONS: [&str; 11] = [
-        "vue", "jsx", "tsx", "js", "mjs", "cjs", "ts", "mts", "cts", "json", "jsonc",
-    ];
     path.extension()
         .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| EXTENSIONS.contains(&extension))
+        .is_some_and(is_format_extension)
+}
+
+/// File extensions `vize fmt` knows how to format.
+fn is_format_extension(extension: &str) -> bool {
+    matches!(
+        extension,
+        "vue"
+            | "jsx"
+            | "tsx"
+            | "js"
+            | "mjs"
+            | "cjs"
+            | "ts"
+            | "mts"
+            | "cts"
+            | "json"
+            | "jsonc"
+            | "yaml"
+            | "yml"
+            | "md"
+            | "markdown"
+    )
 }
 
 #[inline]
@@ -257,6 +254,7 @@ mod tests {
         fs::write(src.join("Widget.tsx"), "const Widget=()=> <div />").unwrap();
         fs::write(src.join("types.d.ts"), "export type Widget = {}").unwrap();
         fs::write(src.join("package.json"), r#"{"name":"acme"}"#).unwrap();
+        fs::write(src.join("config.yaml"), "a: 1\n").unwrap();
         fs::write(src.join("notes.md"), "# notes").unwrap();
 
         let pattern = root.to_string_lossy().into_owned();
@@ -270,6 +268,8 @@ mod tests {
                 src.join("Panel.jsx"),
                 src.join("Widget.tsx"),
                 src.join("config.js"),
+                src.join("config.yaml"),
+                src.join("notes.md"),
                 src.join("package.json"),
                 src.join("store.ts"),
                 src.join("types.d.ts"),

--- a/crates/vize/src/commands/fmt/patterns.rs
+++ b/crates/vize/src/commands/fmt/patterns.rs
@@ -12,6 +12,10 @@ pub(super) fn default_fmt_patterns() -> Vec<std::string::String> {
         "./**/*.tsx".into(),
         "./**/*.json".into(),
         "./**/*.jsonc".into(),
+        "./**/*.yaml".into(),
+        "./**/*.yml".into(),
+        "./**/*.md".into(),
+        "./**/*.markdown".into(),
     ]
 }
 

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_fmt_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_fmt_help.snap
@@ -8,9 +8,9 @@ Usage: fmt [OPTIONS] [PATTERNS]...
 
 Arguments:
   [PATTERNS]...
-          Glob pattern(s) to match .vue, .js, .ts, .jsx, .tsx, .json, and .jsonc files
+          Glob pattern(s) to match .vue, .js, .ts, .jsx, .tsx, .json, .jsonc, .yaml, .yml, .md, and .markdown files
 
-          [default: ./**/*.vue ./**/*.js ./**/*.mjs ./**/*.cjs ./**/*.ts ./**/*.mts ./**/*.cts ./**/*.jsx ./**/*.tsx ./**/*.json ./**/*.jsonc]
+          [default: ./**/*.vue ./**/*.js ./**/*.mjs ./**/*.cjs ./**/*.ts ./**/*.mts ./**/*.cts ./**/*.jsx ./**/*.tsx ./**/*.json ./**/*.jsonc ./**/*.yaml ./**/*.yml ./**/*.md ./**/*.markdown]
 
 Options:
       --check

--- a/crates/vize/tests/fmt_plain_cli.rs
+++ b/crates/vize/tests/fmt_plain_cli.rs
@@ -1,0 +1,64 @@
+//! `vize fmt` applies conservative YAML/Markdown normalization end to end.
+
+use std::{fs, path::Path, process::Command};
+
+fn write_project_file(root: &Path, rel: &str, content: &str) {
+    let path = root.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, content).unwrap();
+}
+
+fn run_fmt(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(dir)
+        .args(["fmt"].iter().chain(args).copied().collect::<Vec<_>>())
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn fmt_normalizes_yaml_line_endings_and_final_newline() {
+    let project = tempfile::tempdir().unwrap();
+    write_project_file(project.path(), "config.yaml", "a: 1\r\nb: 2");
+
+    let output = run_fmt(project.path(), &["--write", "config.yaml"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(0), "stderr: {stderr}");
+
+    let contents = fs::read_to_string(project.path().join("config.yaml")).unwrap();
+    assert_eq!(contents, "a: 1\nb: 2\n");
+}
+
+#[test]
+fn fmt_trims_markdown_trailing_whitespace_outside_code() {
+    let project = tempfile::tempdir().unwrap();
+    write_project_file(
+        project.path(),
+        "README.md",
+        "# Title   \n\n```sh\necho hi   \n```\ntext \n",
+    );
+
+    let output = run_fmt(project.path(), &["--write", "README.md"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(0), "stderr: {stderr}");
+
+    let contents = fs::read_to_string(project.path().join("README.md")).unwrap();
+    // Heading + text trimmed; trailing spaces inside the fence preserved.
+    assert_eq!(contents, "# Title\n\n```sh\necho hi   \n```\ntext\n");
+}
+
+#[test]
+fn fmt_check_passes_on_already_normalized_yaml() {
+    let project = tempfile::tempdir().unwrap();
+    write_project_file(project.path(), "ok.yaml", "name: vize\n");
+
+    let output = run_fmt(project.path(), &["--check", "ok.yaml"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(0), "stderr: {stderr}");
+    assert!(
+        stderr.contains("1 file(s) already formatted"),
+        "expected already-formatted summary, got: {stderr}",
+    );
+}


### PR DESCRIPTION
## What

`vize fmt` now accepts `.yaml`/`.yml` and `.md`/`.markdown`, so projects can fold them into the format gate instead of keeping Prettier just for those. Completes the file-type coverage requested in #2249 (YAML) and #2177 (Markdown); JSON/JSONC already landed (#2284, #2286).

## How (deliberately lossless — no comment-preserving parser available here yet)

- **YAML**: normalize line endings to `\n` and ensure a single trailing newline. Line content is preserved byte-for-byte, so comments, anchors/aliases, and block scalars (`|`/`>`, including `+`-chomped trailing blanks) are never altered.
- **Markdown**: the above, plus trailing-whitespace trimming **outside** fenced (```` ``` ````/`~~~`) and indented code blocks, preserving two-space hard line breaks.

New `crates/vize/src/commands/fmt/data/plain.rs`, wired through the existing `format_data_file` dispatch (so `fmt.rs` is unchanged). `is_format_target` and `should_walk_with_gitignore` now share a compact `is_format_extension` helper (also shrinks `files.rs`). Default patterns, help text + snapshot, and the file collector cover the new extensions.

## Tests
- Unit (`plain/tests.rs`): YAML line-ending + final-newline normalization, block-scalar trailing-whitespace preserved, idempotency; Markdown trailing-trim, hard-break preserved, fenced + indented code preserved, idempotency.
- File collection (`files.rs`): `.yaml`/`.md` now matched.
- CLI integration (`fmt_plain_cli.rs`): `--write` normalizes `.yaml` CRLF and trims `.md` outside fences; `--check` passes on already-normalized YAML.

## Scope
Conservative first step (mirrors how JSON started minimal). Richer structure-aware YAML/Markdown formatting (key reflow, list normalization, etc.) is a follow-up that needs real parsers.

## Verification
clippy `-D warnings -D clippy::wildcard_imports` clean; rustfmt (1.95.0, edition/style 2024) clean; source-length gate clean; `vize` fmt unit + integration tests green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->