### PR TITLE
refactor(analysis): clarify analysis and analyzer naming (#1581)

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/bindings.rs
+++ b/crates/vize_atelier_sfc/src/compile/bindings.rs
@@ -13,7 +13,7 @@ use crate::types::{BindingMetadata, BindingType};
 
 /// Convert Croquis BindingMetadata (CompactString keys) to legacy BindingMetadata (String keys)
 pub(super) fn croquis_to_legacy_bindings(
-    src: &vize_croquis::analysis::BindingMetadata,
+    src: &vize_croquis::croquis::BindingMetadata,
 ) -> BindingMetadata {
     let mut dst = BindingMetadata::default();
     dst.is_script_setup = src.is_script_setup;

--- a/crates/vize_atelier_sfc/src/compile/helpers.rs
+++ b/crates/vize_atelier_sfc/src/compile/helpers.rs
@@ -52,7 +52,7 @@ pub(super) fn demote_v_model_reactive_const_bindings(
     script_content: &str,
     ctx: &mut ScriptCompileContext,
     script_bindings: &mut BindingMetadata,
-    croquis: &mut vize_croquis::analysis::Croquis,
+    croquis: &mut vize_croquis::croquis::Croquis,
 ) -> Option<(String, Vec<String>)> {
     if !template_content.contains("v-model") {
         return None;
@@ -180,7 +180,7 @@ fn update_binding_to_setup_let(
     binding_name: &str,
     ctx: &mut ScriptCompileContext,
     script_bindings: &mut BindingMetadata,
-    croquis: &mut vize_croquis::analysis::Croquis,
+    croquis: &mut vize_croquis::croquis::Croquis,
 ) {
     script_bindings
         .bindings

--- a/crates/vize_atelier_sfc/src/compile_template.rs
+++ b/crates/vize_atelier_sfc/src/compile_template.rs
@@ -59,7 +59,7 @@ pub(crate) struct TemplateBlockCompileContext<'a> {
     pub(crate) inline: bool,
     pub(crate) component_name: Option<&'a str>,
     pub(crate) bindings: Option<&'a BindingMetadata>,
-    pub(crate) croquis: Option<vize_croquis::analysis::Croquis>,
+    pub(crate) croquis: Option<vize_croquis::croquis::Croquis>,
 }
 
 /// Compile template block

--- a/crates/vize_atelier_sfc/src/script.rs
+++ b/crates/vize_atelier_sfc/src/script.rs
@@ -51,7 +51,7 @@ pub use define_props::{DEFINE_PROPS, WITH_DEFAULTS};
 pub use define_slots::DEFINE_SLOTS;
 
 use crate::types::BindingMetadata;
-use vize_croquis::analysis::Croquis as CroquisSummary;
+use vize_croquis::croquis::Croquis as CroquisSummary;
 use vize_croquis::script_parser::ScriptParseResult;
 
 /// Analyze script setup and extract bindings

--- a/crates/vize_atelier_sfc/src/script/context.rs
+++ b/crates/vize_atelier_sfc/src/script/context.rs
@@ -12,7 +12,7 @@ pub use external_types::begin_type_resolution_batch;
 
 use crate::types::{BindingMetadata, BindingType};
 use vize_carton::{CompactString, String, ToCompactString};
-use vize_croquis::analysis::Croquis;
+use vize_croquis::croquis::Croquis;
 use vize_croquis::macros::{EmitDefinition, ModelDefinition, PropDefinition};
 
 use super::ScriptSetupMacros;

--- a/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
@@ -13,8 +13,8 @@ use vize_carton::String;
 use vize_carton::append;
 use vize_carton::cstr;
 use vize_carton::profile;
-use vize_croquis::analysis::ComponentUsage;
-use vize_croquis::analyzer::strip_js_comments;
+use vize_croquis::croquis::ComponentUsage;
+use vize_croquis::drawer::strip_js_comments;
 
 /// Generate component prop value checks at the given indentation level.
 pub(crate) fn generate_component_prop_checks(

--- a/crates/vize_canon/src/virtual_ts/expressions/statements.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/statements.rs
@@ -15,8 +15,8 @@ use vize_carton::String;
 use vize_carton::append;
 use vize_carton::cstr;
 use vize_carton::profile;
-use vize_croquis::analysis::{TemplateExpression, TemplateExpressionKind};
-use vize_croquis::analyzer::strip_js_comments;
+use vize_croquis::croquis::{TemplateExpression, TemplateExpressionKind};
+use vize_croquis::drawer::strip_js_comments;
 
 /// Generate template expressions, compacting recognized v-if chains into
 /// TypeScript control-flow blocks.

--- a/crates/vize_canon/src/virtual_ts/expressions/vif_chain.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/vif_chain.rs
@@ -6,8 +6,8 @@ use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::append;
 use vize_carton::cstr;
-use vize_croquis::analysis::{TemplateExpression, TemplateExpressionKind};
-use vize_croquis::analyzer::strip_js_comments;
+use vize_croquis::croquis::{TemplateExpression, TemplateExpressionKind};
+use vize_croquis::drawer::strip_js_comments;
 
 #[derive(Clone, Copy)]
 struct GuardTerm<'a> {

--- a/crates/vize_canon/src/virtual_ts/generator/options_api.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api.rs
@@ -237,7 +237,7 @@ fn collect_unresolved_extends_expression_names(
     type_export_names: &FxHashSet<&str>,
     used_components: &FxHashSet<&str>,
 ) {
-    for identifier in vize_croquis::analyzer::extract_identifiers_oxc(expression) {
+    for identifier in vize_croquis::drawer::extract_identifiers_oxc(expression) {
         let name = identifier.as_str();
         if summary.bindings.bindings.contains_key(name)
             || configured_globals.contains(name)

--- a/crates/vize_canon/src/virtual_ts/generator/spans.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/spans.rs
@@ -87,7 +87,7 @@ fn collect_template_referenced_names(
 }
 
 fn collect_expression_identifiers(names: &mut FxHashSet<String>, expression: &str) {
-    for identifier in vize_croquis::analyzer::extract_identifiers_oxc(expression) {
+    for identifier in vize_croquis::drawer::extract_identifiers_oxc(expression) {
         names.insert(identifier.as_str().into());
     }
 }

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
@@ -1,5 +1,5 @@
 use vize_carton::{String, append};
-use vize_croquis::analysis::ComponentUsage;
+use vize_croquis::croquis::ComponentUsage;
 
 use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier_fragment};
 

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
@@ -1,7 +1,7 @@
 use std::ops::Range;
 
 use vize_carton::{String, append, cstr};
-use vize_croquis::analysis::{ComponentUsage, PassedProp};
+use vize_croquis::croquis::{ComponentUsage, PassedProp};
 
 use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier, to_safe_identifier_fragment};
 use crate::virtual_ts::types::VizeMapping;

--- a/crates/vize_croquis_cf/src/rules/element_id.rs
+++ b/crates/vize_croquis_cf/src/rules/element_id.rs
@@ -9,7 +9,7 @@
 use crate::diagnostics::{CrossFileDiagnostic, CrossFileDiagnosticKind, DiagnosticSeverity};
 use crate::registry::{FileId, ModuleRegistry};
 use vize_carton::{CompactString, FxHashMap, cstr};
-use vize_croquis::analysis::ElementIdKind;
+use vize_croquis::croquis::ElementIdKind;
 
 /// Information about a unique ID issue.
 #[derive(Debug, Clone)]

--- a/crates/vize_maestro/src/ide/completion/template/component_meta.rs
+++ b/crates/vize_maestro/src/ide/completion/template/component_meta.rs
@@ -228,22 +228,22 @@ fn extract_component_metadata(
                 .map(|script| script.content.as_ref())
         })
     {
-        let analyzer_options = DrawerOptions {
+        let drawer_options = DrawerOptions {
             analyze_script: true,
             ..Default::default()
         };
-        let mut analyzer = Drawer::with_options(analyzer_options);
+        let mut drawer = Drawer::with_options(drawer_options);
         if legacy_vue2 {
-            analyzer = analyzer.with_legacy_vue2();
+            drawer = drawer.with_legacy_vue2();
         } else if options_api {
-            analyzer = analyzer.with_options_api();
+            drawer = drawer.with_options_api();
         }
         if descriptor.script_setup.is_some() {
-            analyzer.analyze_script_setup(script_content);
+            drawer.analyze_script_setup(script_content);
         } else {
-            analyzer.analyze_script_plain(script_content);
+            drawer.analyze_script_plain(script_content);
         }
-        let summary = analyzer.finish();
+        let summary = drawer.finish();
 
         for prop in summary.macros.props() {
             if seen_props.insert(prop.name.to_string()) {

--- a/crates/vize_maestro/src/ide/hover/script.rs
+++ b/crates/vize_maestro/src/ide/hover/script.rs
@@ -115,22 +115,22 @@ impl HoverService {
             .or_else(|| descriptor.script.as_ref().map(|s| s.content.as_ref()));
 
         // Create a drawer and analyze script.
-        let analyzer_options = DrawerOptions::full();
-        let mut analyzer = Drawer::with_options(analyzer_options);
+        let drawer_options = DrawerOptions::full();
+        let mut drawer = Drawer::with_options(drawer_options);
         if ctx.state.lsp_features().legacy_vue2 {
-            analyzer = analyzer.with_legacy_vue2();
+            drawer = drawer.with_legacy_vue2();
         } else if ctx.state.options_api_enabled() {
-            analyzer = analyzer.with_options_api();
+            drawer = drawer.with_options_api();
         }
 
         if let Some(ref script) = descriptor.script {
-            analyzer.analyze_script_plain(&script.content);
+            drawer.analyze_script_plain(&script.content);
         }
         if let Some(ref script_setup) = descriptor.script_setup {
-            analyzer.analyze_script_setup(&script_setup.content);
+            drawer.analyze_script_setup(&script_setup.content);
         }
 
-        let summary = analyzer.finish();
+        let summary = drawer.finish();
 
         // Look up the binding in the analysis summary
         let binding_type = summary.get_binding_type(word)?;

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -118,29 +118,29 @@ impl HoverService {
             .or_else(|| descriptor.script.as_ref().map(|s| s.content.as_ref()));
 
         // Create a drawer and analyze script.
-        let analyzer_options = DrawerOptions::full();
-        let mut analyzer = Drawer::with_options(analyzer_options);
+        let drawer_options = DrawerOptions::full();
+        let mut drawer = Drawer::with_options(drawer_options);
         if ctx.state.lsp_features().legacy_vue2 {
-            analyzer = analyzer.with_legacy_vue2();
+            drawer = drawer.with_legacy_vue2();
         } else if ctx.state.options_api_enabled() {
-            analyzer = analyzer.with_options_api();
+            drawer = drawer.with_options_api();
         }
 
         if let Some(ref script) = descriptor.script {
-            analyzer.analyze_script_plain(&script.content);
+            drawer.analyze_script_plain(&script.content);
         }
         if let Some(ref script_setup) = descriptor.script_setup {
-            analyzer.analyze_script_setup(&script_setup.content);
+            drawer.analyze_script_setup(&script_setup.content);
         }
 
         // Analyze template if present
         if let Some(ref template) = descriptor.template {
             let allocator = vize_carton::Bump::new();
             let (root, _) = vize_armature::parse(&allocator, &template.content);
-            analyzer.analyze_template(&root);
+            drawer.analyze_template(&root);
         }
 
-        let summary = analyzer.finish();
+        let summary = drawer.finish();
 
         // Look up the binding in the analysis summary
         let binding_type = summary.get_binding_type(word)?;

--- a/crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs
+++ b/crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs
@@ -31,7 +31,7 @@ use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::ToCompactString;
-use vize_croquis::analysis::ElementIdKind;
+use vize_croquis::croquis::ElementIdKind;
 use vize_relief::RootNode;
 
 static META: RuleMeta = RuleMeta {

--- a/crates/vize_vitrine/src/wasm/analyze.rs
+++ b/crates/vize_vitrine/src/wasm/analyze.rs
@@ -328,8 +328,8 @@ pub fn analyze_sfc_wasm(source: &str, options: JsValue) -> Result<JsValue, JsVal
                 serde_json::json!({
                 "name": te.name.as_str(),
                 "kind": match te.kind {
-                    vize_croquis::analysis::TypeExportKind::Type => "type",
-                    vize_croquis::analysis::TypeExportKind::Interface => "interface",
+                    vize_croquis::croquis::TypeExportKind::Type => "type",
+                    vize_croquis::croquis::TypeExportKind::Interface => "interface",
                 },
                 "start": start,
                 "end": end,
@@ -341,12 +341,12 @@ pub fn analyze_sfc_wasm(source: &str, options: JsValue) -> Result<JsValue, JsVal
                 serde_json::json!({
                 "name": ie.name.as_str(),
                 "kind": match ie.kind {
-                    vize_croquis::analysis::InvalidExportKind::Const => "const",
-                    vize_croquis::analysis::InvalidExportKind::Let => "let",
-                    vize_croquis::analysis::InvalidExportKind::Var => "var",
-                    vize_croquis::analysis::InvalidExportKind::Function => "function",
-                    vize_croquis::analysis::InvalidExportKind::Class => "class",
-                    vize_croquis::analysis::InvalidExportKind::Default => "default",
+                    vize_croquis::croquis::InvalidExportKind::Const => "const",
+                    vize_croquis::croquis::InvalidExportKind::Let => "let",
+                    vize_croquis::croquis::InvalidExportKind::Var => "var",
+                    vize_croquis::croquis::InvalidExportKind::Function => "function",
+                    vize_croquis::croquis::InvalidExportKind::Class => "class",
+                    vize_croquis::croquis::InvalidExportKind::Default => "default",
                 },
                 "start": start,
                 "end": end,


### PR DESCRIPTION
## What

Continues #1581 (and the alias pattern of #1607/#1613): migrates remaining internal call sites off the deprecated `analysis`/`analyzer` compatibility module paths onto the canonical names, so the data-vs-driver split is consistent.

## Naming rule

Matches what `vize_croquis` already canonicalized:
- produced data → `croquis` / `Croquis` (the `analysis` module is a compat alias)
- pass/driver → `drawer` / `Drawer` / `DrawerOptions` (the `analyzer` module is a compat alias)

## Changes (non-breaking, +48/-48 across 18 files)

- `vize_croquis::analysis::X` → `vize_croquis::croquis::X` and `vize_croquis::analyzer::Y` → `vize_croquis::drawer::Y` at internal call sites in `vize_atelier_sfc`, `vize_canon`, `vize_croquis_cf`, `vize_patina`*, `vize_vitrine`.
- Local `analyzer`/`analyzer_options` variables → `drawer`/`drawer_options` in `vize_maestro` IDE services where the type is already `Drawer`/`DrawerOptions`.
- **No** public symbols renamed/removed — the `analysis`/`analyzer`/`Analyzer`/`AnalyzerOptions`/`AnalysisStats` aliases and the `pub analyzer_options` field stay, so semver-checks pass.

## Scope

Test files/benches still use the public compat names; migrating those is cosmetic and left for the issue's separate "update tests" step.

## Verification

`cargo build`/`clippy -D warnings -D clippy::wildcard_imports` clean on all touched crates; rustfmt (1.95.0, edition/style 2024) clean; source-length gate clean; touched-crate tests green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->