### PR TITLE
fix(canon): preserve generated GraphQL type identity through barrel re-exports (#2227)

### DIFF
--- a/crates/vize/tests/check_canon_graphql_cli.rs
+++ b/crates/vize/tests/check_canon_graphql_cli.rs
@@ -208,3 +208,141 @@ void childComponents
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+/// Regression for #2227: a `types/index.ts` barrel that re-exports a generated
+/// GraphQL `.d.ts` via a relative `export *` is materialized into canon, but the
+/// `.d.ts` is intentionally kept on its real path (#2047). Previously the
+/// barrel's relative `./codegen/schema` dangled inside the mirror, dropping the
+/// generated module's type identity so members re-exported through `~/types`
+/// were reported as missing/unrelated — a false positive vue-tsc does not raise.
+#[test]
+fn check_barrel_reexport_preserves_generated_graphql_identity() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("barrel");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("fragments")).unwrap();
+    std::fs::create_dir_all(project_root.join("pages")).unwrap();
+    std::fs::create_dir_all(project_root.join("types/codegen")).unwrap();
+    link_workspace_vue(&project_root).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["*"],
+      "@/*": ["*"]
+    },
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["fragments/**/*.vue", "pages/**/*.vue", "types/**/*.ts", "types/**/*.d.ts"]
+}"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        project_root.join("types/codegen/schema.d.ts"),
+        r#"// Generated GraphQL schema types.
+export type AimTextComponent = {
+  __typename: 'AimTextComponent'
+  text: string
+  children: AimContentsComponent[]
+}
+
+export type AimImageComponent = {
+  __typename: 'AimImageComponent'
+  url: string
+  children: AimContentsComponent[]
+}
+
+export type AimContentsComponent = AimTextComponent | AimImageComponent
+
+export type AimContentsMoshiQuery = {
+  components: AimContentsComponent[]
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("types/index.ts"),
+        r#"export * from './codegen/schema'
+
+export type UnwrapArray<T> = T extends Array<infer U> ? U : never
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("pages/_studyInfoId.vue"),
+        r#"<script setup lang="ts">
+import type { AimContentsMoshiQuery } from '~/types/codegen/schema'
+
+export type AimContentsMoshi = AimContentsMoshiQuery
+</script>
+
+<template><main /></template>
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("fragments/MoshiContentsSection.vue"),
+        r#"<script setup lang="ts">
+import { computed } from 'vue'
+import { type AimContentsMoshi } from '~/pages/_studyInfoId.vue'
+import { type UnwrapArray, type AimContentsComponent } from '~/types'
+
+type AimComponent = UnwrapArray<AimContentsMoshi['components']>
+
+const props = defineProps<{
+  component: { childMoshiContentsComponents: AimContentsComponent[] }
+}>()
+const childComponents = computed(
+  () => props.component.childMoshiContentsComponents satisfies AimComponent[],
+)
+void childComponents
+</script>
+
+<template><section /></template>
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "--no-check-props",
+            "--no-check-emits",
+            "--no-check-template-bindings",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        std::str::from_utf8(&output.stderr).unwrap_or("<non-utf8 stderr>")
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    assert!(
+        !project_root
+            .join("node_modules/.vize/canon/types/codegen/schema.d.ts")
+            .exists()
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -12,7 +12,14 @@ use vize_carton::cstr;
 
 #[path = "import_rewriter_virtual.rs"]
 mod virtual_rewrite;
-use virtual_rewrite::absolute_import_needs_virtual_rewrite;
+use virtual_rewrite::{
+    absolute_import_needs_virtual_rewrite, is_rewritable_project_specifier,
+    is_rewritable_vue_specifier,
+};
+
+#[path = "import_rewriter_dts.rs"]
+mod dts_rewrite;
+use dts_rewrite::{rewrite_relative_dts_specifier, source_contains_relative_specifier};
 
 #[derive(Debug, Clone)]
 pub struct OffsetAdjustment {
@@ -84,14 +91,18 @@ impl ImportRewriter {
         })
     }
 
+    /// Rewrite a script's module specifiers for the canon virtual project.
+    /// `source_dir` (when known) enables the generated-`.d.ts` redirect (#2227).
     pub fn rewrite_for_virtual_project(
         &self,
         source: &str,
         source_type: SourceType,
         roots: (&std::path::Path, &std::path::Path),
+        source_dir: Option<&std::path::Path>,
     ) -> RewriteResult {
         let project_root = roots.0.to_string_lossy();
-        if !source.contains(".vue") && !source.contains(project_root.as_ref()) {
+        let dts_candidate = source_dir.is_some() && source_contains_relative_specifier(source);
+        if !source.contains(".vue") && !source.contains(project_root.as_ref()) && !dts_candidate {
             return RewriteResult {
                 code: source.to_compact_string(),
                 source_map: ImportSourceMap::empty(),
@@ -99,7 +110,7 @@ impl ImportRewriter {
         }
 
         self.rewrite_with(source, source_type, |path| {
-            self.rewrite_virtual_project_specifier(path, roots)
+            self.rewrite_virtual_project_specifier(path, roots, source_dir)
         })
     }
 
@@ -256,7 +267,13 @@ impl ImportRewriter {
         &self,
         path: &str,
         roots: (&std::path::Path, &std::path::Path),
+        source_dir: Option<&std::path::Path>,
     ) -> Option<String> {
+        if let Some(source_dir) = source_dir
+            && let Some(rewritten) = rewrite_relative_dts_specifier(path, source_dir, roots.0)
+        {
+            return Some(rewritten);
+        }
         let candidate = std::path::Path::new(path);
         if candidate.is_absolute()
             && let Ok(relative) =
@@ -287,33 +304,6 @@ impl ImportRewriter {
         }
         None
     }
-}
-
-fn is_rewritable_project_specifier(path: &std::path::Path) -> bool {
-    if path
-        .components()
-        .next()
-        .is_some_and(|component| component.as_os_str() == "node_modules")
-    {
-        return false;
-    }
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_none_or(|extension| {
-            matches!(
-                extension,
-                "vue" | "ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs"
-            )
-        })
-}
-
-fn is_rewritable_vue_specifier(path: &str) -> bool {
-    path.ends_with(".vue")
-        && (path.starts_with("./")
-            || path.starts_with("../")
-            || path.starts_with("@/")
-            || path.starts_with("~/")
-            || std::path::Path::new(path).is_absolute())
 }
 
 impl Default for ImportRewriter {

--- a/crates/vize_canon/src/batch/import_rewriter_dts.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_dts.rs
@@ -1,0 +1,99 @@
+//! Redirecting relative re-exports/imports of generated declaration files to
+//! their real on-disk path when a non-`.vue` script is materialized into canon.
+//!
+//! Generated GraphQL `.d.ts` schemas are intentionally never mirrored into
+//! `node_modules/.vize/canon` (#2047). A barrel like `types/index.ts` reached
+//! transitively from a `.vue` *is* mirrored, but its relative
+//! `export * from './codegen/schema'` would then dangle inside the mirror where
+//! the schema is absent — dropping the generated module's type identity and
+//! producing false `TS2305`/`TS1360` diagnostics on `satisfies` checks (#2227).
+
+use std::path::{Path, PathBuf};
+
+use vize_carton::{String, cstr};
+
+use super::virtual_rewrite::append_extension;
+
+/// Cheap text gate: whether `source` has any relative module specifier worth
+/// resolving for the relative-`.d.ts` rewrite. Avoids parsing files that only
+/// import bare packages or aliases.
+pub(super) fn source_contains_relative_specifier(source: &str) -> bool {
+    source.contains("'./")
+        || source.contains("\"./")
+        || source.contains("'../")
+        || source.contains("\"../")
+}
+
+/// Rewrite a relative specifier that resolves to a generated `.d.ts` kept on its
+/// real path to that real (extensionless) path, so the re-exported identity is
+/// preserved inside the mirror.
+pub(super) fn rewrite_relative_dts_specifier(
+    path: &str,
+    source_dir: &Path,
+    project_root: &Path,
+) -> Option<String> {
+    if !(path.starts_with("./") || path.starts_with("../")) {
+        return None;
+    }
+    if path.ends_with(".vue") {
+        return None;
+    }
+    let resolved = resolve_relative_declaration_target(&source_dir.join(path))?;
+    // Only generated declarations that live inside the project (and would never
+    // be mirrored into canon) need redirecting; node_modules already resolves.
+    if !resolved.starts_with(project_root) {
+        return None;
+    }
+    // Drop the `.d.ts`/`.d.mts`/`.d.cts` suffix so the specifier resolves as a
+    // module (matching the original extensionless relative import). Importing a
+    // declaration extension directly is rejected with TS2846.
+    let resolved = strip_declaration_suffix(&resolved);
+    Some(cstr!("{}", resolved.display()))
+}
+
+/// Resolve a relative specifier base to an existing `.d.ts` file, mirroring
+/// TypeScript's `.d.ts` and `index.d.ts` probing. Returns `None` for any target
+/// that is not a declaration file so source files keep their relative spelling
+/// (the mirror preserves the directory layout for those).
+fn resolve_relative_declaration_target(base: &Path) -> Option<PathBuf> {
+    if is_declaration_path(base) && base.is_file() {
+        return Some(vize_carton::path::canonicalize_non_verbatim(base));
+    }
+    for ext in [".d.ts", ".d.mts", ".d.cts"] {
+        let candidate = append_extension(base, ext);
+        if candidate.is_file() {
+            return Some(vize_carton::path::canonicalize_non_verbatim(&candidate));
+        }
+    }
+    for ext in [".d.ts", ".d.mts", ".d.cts"] {
+        let candidate = base.join(cstr!("index{ext}").as_str());
+        if candidate.is_file() {
+            return Some(vize_carton::path::canonicalize_non_verbatim(&candidate));
+        }
+    }
+    None
+}
+
+/// Strip a `.d.ts`/`.d.mts`/`.d.cts` suffix, leaving the extensionless module
+/// path (e.g. `/p/codegen/schema.d.ts` → `/p/codegen/schema`).
+fn strip_declaration_suffix(path: &Path) -> PathBuf {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return path.to_path_buf();
+    };
+    let stem = name
+        .strip_suffix(".d.ts")
+        .or_else(|| name.strip_suffix(".d.mts"))
+        .or_else(|| name.strip_suffix(".d.cts"));
+    match stem {
+        Some(stem) => path.with_file_name(stem),
+        None => path.to_path_buf(),
+    }
+}
+
+fn is_declaration_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            name.ends_with(".d.ts") || name.ends_with(".d.mts") || name.ends_with(".d.cts")
+        })
+}

--- a/crates/vize_canon/src/batch/import_rewriter_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_tests.rs
@@ -90,7 +90,7 @@ fn test_rewrite_absolute_export_from_for_virtual_project() {
     let rewriter = ImportRewriter::new();
     let source = r#"export * from '/p/src/App.vue';"#;
     let roots = (Path::new("/p"), Path::new("/p/v"));
-    let result = rewriter.rewrite_for_virtual_project(source, SourceType::ts(), roots);
+    let result = rewriter.rewrite_for_virtual_project(source, SourceType::ts(), roots, None);
     assert_eq!(result.code, r#"export * from '/p/v/src/App.vue.ts';"#);
 }
 
@@ -114,6 +114,7 @@ fn rewrite_absolute_vue_specifier_through_symlinked_project_path() {
         source.as_str(),
         SourceType::ts(),
         (roots.0.as_path(), roots.1.as_path()),
+        None,
     );
 
     assert_eq!(
@@ -142,7 +143,8 @@ fn test_keeps_plain_absolute_generated_graphql_import_for_virtual_project() {
     );
     let virtual_root = root.join("node_modules/.vize/canon");
     let roots = (root.as_path(), virtual_root.as_path());
-    let result = rewriter.rewrite_for_virtual_project(source.as_str(), SourceType::ts(), roots);
+    let result =
+        rewriter.rewrite_for_virtual_project(source.as_str(), SourceType::ts(), roots, None);
     assert_eq!(
         result.code.as_str(),
         cstr!(
@@ -151,6 +153,65 @@ fn test_keeps_plain_absolute_generated_graphql_import_for_virtual_project() {
         )
         .as_str()
     );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn test_rewrite_relative_generated_dts_reexport_to_real_path_for_virtual_project() {
+    // #2227: a `types/index.ts` barrel materialized into canon keeps a relative
+    // `export * from './codegen/schema'`, but the generated `.d.ts` is never
+    // mirrored. The relative specifier must be redirected to the real
+    // (extensionless) schema path so the re-exported identity is not dropped.
+    let raw_root = unique_case_dir("relative-generated-dts");
+    let _ = fs::remove_dir_all(&raw_root);
+    let schema = write(
+        &raw_root,
+        "types/codegen/schema.d.ts",
+        "export type AimContentsComponent = { __typename: 'A' }\n",
+    );
+    let barrel = write(
+        &raw_root,
+        "types/index.ts",
+        "export * from './codegen/schema'\n",
+    );
+    // `VirtualProject::new` canonicalizes the project root before building, so
+    // mirror that here for the `starts_with(project_root)` redirect check.
+    let root = vize_carton::path::canonicalize_non_verbatim(&raw_root);
+    let schema = vize_carton::path::canonicalize_non_verbatim(&schema);
+    let rewriter = ImportRewriter::new();
+    let source = "export * from './codegen/schema'";
+    let virtual_root = root.join("node_modules/.vize/canon");
+    let roots = (root.as_path(), virtual_root.as_path());
+    let result =
+        rewriter.rewrite_for_virtual_project(source, SourceType::ts(), roots, barrel.parent());
+    assert_eq!(
+        result.code.as_str(),
+        cstr!(
+            "export * from '{}'",
+            schema.with_file_name("schema").display()
+        )
+        .as_str()
+    );
+
+    let _ = fs::remove_dir_all(&raw_root);
+}
+
+#[test]
+fn test_keeps_relative_source_reexport_for_virtual_project() {
+    // A relative re-export to a real source file (not a generated `.d.ts`) keeps
+    // its relative spelling: the mirror preserves that file's directory layout.
+    let root = unique_case_dir("relative-source-reexport");
+    let _ = fs::remove_dir_all(&root);
+    write(&root, "types/helpers.ts", "export type Helper = number\n");
+    let barrel = write(&root, "types/index.ts", "export * from './helpers'\n");
+    let rewriter = ImportRewriter::new();
+    let source = "export * from './helpers'";
+    let virtual_root = root.join("node_modules/.vize/canon");
+    let roots = (root.as_path(), virtual_root.as_path());
+    let result =
+        rewriter.rewrite_for_virtual_project(source, SourceType::ts(), roots, barrel.parent());
+    assert_eq!(result.code.as_str(), "export * from './helpers'");
 
     let _ = fs::remove_dir_all(&root);
 }
@@ -181,7 +242,8 @@ fn test_rewrite_absolute_ts_import_that_needs_vue_rewrite_for_virtual_project() 
     );
     let virtual_root = root.join("node_modules/.vize/canon");
     let roots = (root.as_path(), virtual_root.as_path());
-    let result = rewriter.rewrite_for_virtual_project(source.as_str(), SourceType::ts(), roots);
+    let result =
+        rewriter.rewrite_for_virtual_project(source.as_str(), SourceType::ts(), roots, None);
     assert_eq!(
         result.code.as_str(),
         cstr!(
@@ -199,7 +261,7 @@ fn test_keeps_absolute_assets_for_virtual_project() {
     let rewriter = ImportRewriter::new();
     let source = r#"import '/p/assets/theme.css';"#;
     let roots = (Path::new("/p"), Path::new("/p/v"));
-    let result = rewriter.rewrite_for_virtual_project(source, SourceType::ts(), roots);
+    let result = rewriter.rewrite_for_virtual_project(source, SourceType::ts(), roots, None);
     assert_eq!(result.code, source);
 }
 
@@ -208,7 +270,7 @@ fn test_keeps_absolute_node_modules_for_virtual_project() {
     let rewriter = ImportRewriter::new();
     let source = r#"import '/p/node_modules/pkg/index.js';"#;
     let roots = (Path::new("/p"), Path::new("/p/v"));
-    let result = rewriter.rewrite_for_virtual_project(source, SourceType::ts(), roots);
+    let result = rewriter.rewrite_for_virtual_project(source, SourceType::ts(), roots, None);
     assert_eq!(result.code, source);
 }
 

--- a/crates/vize_canon/src/batch/import_rewriter_virtual.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_virtual.rs
@@ -92,11 +92,38 @@ fn resolve_source_path(path: &Path) -> Option<PathBuf> {
     None
 }
 
-fn append_extension(path: &Path, extension: &str) -> PathBuf {
+pub(super) fn append_extension(path: &Path, extension: &str) -> PathBuf {
     match path.file_name().and_then(|name| name.to_str()) {
         Some(name) => path.with_file_name(cstr!("{name}{extension}")),
         None => path.to_path_buf(),
     }
+}
+
+pub(super) fn is_rewritable_project_specifier(path: &Path) -> bool {
+    if path
+        .components()
+        .next()
+        .is_some_and(|component| component.as_os_str() == "node_modules")
+    {
+        return false;
+    }
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_none_or(|extension| {
+            matches!(
+                extension,
+                "vue" | "ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs"
+            )
+        })
+}
+
+pub(super) fn is_rewritable_vue_specifier(path: &str) -> bool {
+    path.ends_with(".vue")
+        && (path.starts_with("./")
+            || path.starts_with("../")
+            || path.starts_with("@/")
+            || path.starts_with("~/")
+            || Path::new(path).is_absolute())
 }
 
 fn is_relative_specifier(specifier: &str) -> bool {

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -69,8 +69,7 @@ pub(super) fn build_registered_file(
             path,
             content,
             SourceType::ts(),
-            context.project_root,
-            context.virtual_root,
+            (context.project_root, context.virtual_root),
             context.rewriter,
         );
     }
@@ -92,8 +91,7 @@ pub(super) fn build_registered_file(
         path,
         content,
         source_type,
-        context.project_root,
-        context.virtual_root,
+        (context.project_root, context.virtual_root),
         context.rewriter,
     )
 }
@@ -263,15 +261,14 @@ pub(super) fn build_script_registered_file(
     path: &Path,
     content: &str,
     source_type: SourceType,
-    project_root: &Path,
-    virtual_root: &Path,
+    roots: (&Path, &Path),
     rewriter: &ImportRewriter,
 ) -> CorsaResult<RegisteredFile> {
     let rewritten = profile!(
         "canon.import.rewrite.script",
-        rewriter.rewrite_for_virtual_project(content, source_type, (project_root, virtual_root))
+        rewriter.rewrite_for_virtual_project(content, source_type, roots, path.parent())
     );
-    let virtual_path = mirrored_virtual_path(project_root, virtual_root, path)?;
+    let virtual_path = mirrored_virtual_path(roots.0, roots.1, path)?;
 
     Ok(RegisteredFile {
         file: VirtualFile {
@@ -281,7 +278,7 @@ pub(super) fn build_script_registered_file(
             virtual_path,
         },
         original_content: content.to_compact_string(),
-        passthrough_files: collect_passthrough_modules(path, content, project_root, virtual_root),
+        passthrough_files: collect_passthrough_modules(path, content, roots.0, roots.1),
         diagnostics: Vec::new(),
     })
 }

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -255,8 +255,7 @@ impl VirtualProject {
             path,
             content,
             source_type,
-            &self.project_root,
-            &self.virtual_root,
+            (&self.project_root, &self.virtual_root),
             &self.rewriter,
         )?;
         self.absorb_registered_file(registered);


### PR DESCRIPTION
## What

Fixes the false-positive type errors #2227 describes: in a Nuxt 2 project where a `types/index.ts` barrel re-exports a generated GraphQL `.d.ts` schema and `.vue` files `satisfies` those generated types via `~`/`@` aliases, `vize check` raised errors that `vue-tsc` does not (the generated module's type identity was dropped).

## Root cause

A `types/index.ts` barrel reached transitively from a `.vue` is materialized into `node_modules/.vize/canon`, but the generated `.d.ts` it re-exports is intentionally **kept on its real path and never mirrored** (#2047). The materialized barrel kept its relative `export * from './codegen/schema'`, which then dangled inside the canon mirror (schema absent) — so the generated module's exported types became invisible/unrelated through `~/types`, yielding false `TS2305`/`TS1360` on `satisfies` checks.

## Fix (minimal, localized to the canon import-rewriter)

- New `import_rewriter_dts.rs`: when materializing a non-`.vue` script, a relative import/export specifier that resolves to a generated declaration file kept inside the project (and never mirrored) is redirected to that file's real **extensionless** path, preserving the re-exported type identity. TS-faithful `.d.ts`/`index.d.ts` probing; only project-internal generated declarations are redirected (node_modules already resolves).
- `import_rewriter.rs` / `virtual_project/{build,project}.rs`: thread the source file's directory into the rewrite (`rewrite_for_virtual_project` gains an optional `source_dir`). Helpers moved into `import_rewriter_virtual.rs` to keep files under the 350-line cap.

## Verification (reproduced + fixed, matches vue-tsc)

- New `check_canon_graphql_cli.rs::check_barrel_reexport_preserves_generated_graphql_identity` (full CLI via tsgo): **fails on `main`** with the false positive, **passes** with the fix; the equivalent project is clean under `vue-tsc`. Confirmed red→green by neutering/restoring the new logic.
- The prior #2047 regression `check_explicit_vue_keeps_generated_graphql_schema_out_of_canon` still passes (generated `.d.ts` stays out of canon).
- Plus 2 focused rewriter unit tests.
- `vize_canon` 453 lib tests + `vize` graphql-CLI tests pass; clippy `-D warnings`, rustfmt (edition/style 2024), and the source-length gate all clean.

## Scope

The issue's headline `TS1360` text depends on the exact private-project recursive-comparison topology, but the underlying dropped-identity channel that produces the false positive is reproduced and fixed. Tightly scoped to the barrel/`.d.ts`-redirect path; does not touch the component-prop-alias code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->