### PR TITLE
fix: publish release packages and unique JSX renders

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,6 @@ jobs:
           if-no-files-found: error
           compression-level: 0
 
-  # Publish VS Code extension when VSCE_PAT is configured
   release-vscode-extension:
     name: Release VS Code extension
     runs-on: blacksmith-32vcpu-ubuntu-2404
@@ -210,6 +209,7 @@ jobs:
 
       - name: Publish VS Code extension
         if: env.VSCE_PAT != ''
+        continue-on-error: true
         run: moon run --target native - -- editor-extension-artifacts/editors/vscode/dist/vize.vsix < tools/moon/scripts/publish_vscode_extension.mbtx
 
   # Build release npm packages once and reuse them across publish jobs

--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -10,6 +10,7 @@
 //! VDOM and Vapor components.
 
 mod component;
+mod render_exports;
 
 use vize_carton::{Bump, FxHashSet, String};
 use vize_croquis::Croquis;
@@ -67,19 +68,7 @@ impl JsxCompileOutput {
     /// and report an empty preamble, so they pass through untouched.
     pub fn module_code(&self) -> String {
         let preamble = merge_preambles(self.components.iter().map(JsxComponent::preamble));
-
-        let mut module = preamble;
-        for component in &self.components {
-            let code = component.code();
-            if code.is_empty() {
-                continue;
-            }
-            if !module.is_empty() && !module.ends_with('\n') {
-                module.push('\n');
-            }
-            module.push_str(code);
-        }
-        module
+        render_exports::module_code(&self.components, preamble)
     }
 
     /// The v3 source map (JSON) for the module's render code, when source-map

--- a/crates/vize_atelier_jsx/src/compile/render_exports.rs
+++ b/crates/vize_atelier_jsx/src/compile/render_exports.rs
@@ -1,0 +1,127 @@
+use vize_carton::{FxHashSet, String, ToCompactString};
+
+use super::JsxComponent;
+
+pub(super) fn module_code(components: &[JsxComponent], preamble: String) -> String {
+    let mut module = preamble;
+    let multi_component = components.len() > 1;
+    let mut render_export_names: FxHashSet<String> = FxHashSet::default();
+    for (index, component) in components.iter().enumerate() {
+        let code = component.code();
+        if code.is_empty() {
+            continue;
+        }
+        if !module.is_empty() && !module.ends_with('\n') {
+            module.push('\n');
+        }
+        if multi_component {
+            let export_name = unique_render_export_name(
+                component.component_name(),
+                index,
+                &mut render_export_names,
+            );
+            module.push_str(&rename_render_export(code, &export_name));
+        } else {
+            module.push_str(code);
+        }
+    }
+    module
+}
+
+pub(super) fn unique_render_export_name(
+    component_name: Option<&str>,
+    index: usize,
+    used_names: &mut FxHashSet<String>,
+) -> String {
+    let mut candidate = component_name
+        .filter(|name| is_ascii_js_identifier(name))
+        .map(|name| name.to_compact_string())
+        .unwrap_or_else(|| format_args!("render_{}", index + 1).to_compact_string());
+
+    if used_names.insert(candidate.clone()) {
+        return candidate;
+    }
+
+    let base = candidate;
+    let mut suffix = 2;
+    loop {
+        candidate = format_args!("{}_{}", base, suffix).to_compact_string();
+        if used_names.insert(candidate.clone()) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
+pub(super) fn rename_render_export(code: &str, export_name: &str) -> String {
+    let replacements = [
+        ("export function render(", "export function "),
+        ("function ssrRender(", "export function "),
+    ];
+    for (needle, replacement_prefix) in replacements {
+        if let Some(start) = code.find(needle) {
+            let mut renamed = String::default();
+            renamed.push_str(&code[..start]);
+            renamed.push_str(replacement_prefix);
+            renamed.push_str(export_name);
+            renamed.push('(');
+            renamed.push_str(&code[start + needle.len()..]);
+            return renamed;
+        }
+    }
+    String::from(code)
+}
+
+fn is_ascii_js_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !is_ascii_js_identifier_start(first) {
+        return false;
+    }
+    chars.all(is_ascii_js_identifier_continue)
+}
+
+fn is_ascii_js_identifier_start(c: char) -> bool {
+    c == '_' || c == '$' || c.is_ascii_alphabetic()
+}
+
+fn is_ascii_js_identifier_continue(c: char) -> bool {
+    is_ascii_js_identifier_start(c) || c.is_ascii_digit()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_export_names_prefer_component_names_and_fallbacks() {
+        let mut used = FxHashSet::default();
+        assert_eq!(
+            unique_render_export_name(Some("InspectTable"), 0, &mut used),
+            "InspectTable"
+        );
+        assert_eq!(
+            unique_render_export_name(Some("InspectTable"), 1, &mut used),
+            "InspectTable_2"
+        );
+        assert_eq!(
+            unique_render_export_name(Some("値"), 2, &mut used),
+            "render_3"
+        );
+        assert_eq!(unique_render_export_name(None, 3, &mut used), "render_4");
+    }
+
+    #[test]
+    fn renames_vdom_and_ssr_render_exports() {
+        assert_eq!(
+            rename_render_export("export function render(_ctx, _cache) {\n}", "App"),
+            "export function App(_ctx, _cache) {\n}"
+        );
+        assert_eq!(
+            rename_render_export("function ssrRender(_ctx, _push) {\n}", "App"),
+            "export function App(_ctx, _push) {\n}"
+        );
+    }
+}

--- a/crates/vize_atelier_jsx/tests/compile.rs
+++ b/crates/vize_atelier_jsx/tests/compile.rs
@@ -108,6 +108,27 @@ fn one_module_can_mix_vdom_and_vapor_components() {
 }
 
 #[test]
+fn module_code_renames_multiple_render_exports_to_component_names() {
+    let bump = Bump::new();
+    let out = compile_jsx(
+        &bump,
+        r#"
+        export const InspectTable = () => <table>{rows}</table>;
+        const LabelContent = () => <span>{label}</span>;
+        export const InspectTableRow = () => <tr>{row}</tr>;
+        "#,
+        JsxLang::Tsx,
+        &JsxCompileConfig::default(),
+    );
+    let module = out.module_code();
+
+    assert!(module.contains("export function InspectTable("));
+    assert!(module.contains("export function LabelContent("));
+    assert!(module.contains("export function InspectTableRow("));
+    assert!(!module.contains("export function render("));
+}
+
+#[test]
 fn ssr_config_routes_components_to_ssr_and_preserves_client_mode_metadata() {
     let config = JsxCompileConfig {
         ssr: true,

--- a/crates/vize_atelier_jsx/tests/snapshots/adversarial_snapshots__mode_aware_multi_component_module.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/adversarial_snapshots__mode_aware_multi_component_module.snap
@@ -3,18 +3,18 @@ source: crates/vize_atelier_jsx/tests/adversarial_snapshots.rs
 expression: output.module_code().as_str()
 ---
 import { openBlock as _openBlock, createElementBlock as _createElementBlock, toDisplayString as _toDisplayString } from "vue"
-export function render(_ctx, _cache) {
+export function DefaultMode(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("main", null, "default"))
 }
 import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<section> </section>", true)
 
-export function render(_ctx) {
+export function VaporOnly(_ctx) {
   const n0 = t0()
   const x0 = _txt(n0)
   _renderEffect(() => _setText(x0, _toDisplayString(message)))
   return n0
 }
-export function render(_ctx, _cache) {
+export function VdomOnly(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("aside", null, _toDisplayString(count), 1 /* TEXT */))
 }

--- a/npm/builder/rspack/package.json
+++ b/npm/builder/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/rspack-plugin",
-  "version": "0.250.0",
+  "version": "0.262.0",
   "description": "High-performance Rspack plugin for Vue SFC compilation powered by Vize",
   "keywords": [
     "compiler",

--- a/npm/builder/unplugin/package.json
+++ b/npm/builder/unplugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/unplugin",
-  "version": "0.250.0",
+  "version": "0.262.0",
   "description": "Experimental Vue SFC integrations for Rollup, Rolldown, Webpack, esbuild, and Babel powered by Vize",
   "keywords": [
     "babel",

--- a/npm/builder/vite-musea/package.json
+++ b/npm/builder/vite-musea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/vite-plugin-musea",
-  "version": "0.250.0",
+  "version": "0.262.0",
   "description": "Vite plugin for Musea - Component gallery for Vue components",
   "keywords": [
     "component-gallery",

--- a/npm/builder/vite/package.json
+++ b/npm/builder/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/vite-plugin",
-  "version": "0.250.0",
+  "version": "0.262.0",
   "description": "High-performance native Vite plugin for Vue SFC compilation powered by Vize",
   "keywords": [
     "compiler",

--- a/npm/framework/musea-nuxt/package.json
+++ b/npm/framework/musea-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/musea-nuxt",
-  "version": "0.250.0",
+  "version": "0.262.0",
   "description": "Nuxt mock layer for Musea - enables Nuxt component isolation in galleries",
   "keywords": [
     "component-gallery",

--- a/npm/framework/nuxt/package.json
+++ b/npm/framework/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/nuxt",
-  "version": "0.250.0",
+  "version": "0.262.0",
   "description": "Nuxt module for Vize - compiler, musea gallery, linter, and type checker",
   "keywords": [
     "compiler",

--- a/tests/tooling/github-workflows-release-publish.test.ts
+++ b/tests/tooling/github-workflows-release-publish.test.ts
@@ -160,3 +160,14 @@ test("release workflow creates GitHub Releases only after registry publishing su
   const createRelease = releaseJob.indexOf("name: Create Release");
   assert.notEqual(createRelease, -1);
 });
+
+test("release workflow does not block GitHub releases on VS Code Marketplace token expiry", () => {
+  const workflow = readRepoFile(".github", "workflows", "release.yml");
+  const publishJob = workflowJobBody(workflow, "release-vscode-extension");
+
+  assert.match(publishJob, /name:\s*Skip publish when VSCE_PAT is absent/);
+  assert.match(
+    publishJob,
+    /name:\s*Publish VS Code extension[\s\S]*if:\s*env\.VSCE_PAT != ''[\s\S]*continue-on-error:\s*true[\s\S]*publish_vscode_extension\.mbtx/,
+  );
+});

--- a/tests/tooling/moonbit-release.test.ts
+++ b/tests/tooling/moonbit-release.test.ts
@@ -163,13 +163,22 @@ test("release script rewrites only the native-binaries catalog block in pnpm-loc
   assert.ok(out.includes("resolution: {integrity: sha512-AAA==}"), "integrity hash preserved");
 });
 
-test("release script includes editor extension packages in extra synced manifests", () => {
+test("release script includes nested release packages in extra synced manifests", () => {
   const result = runMoonScript("release", ["--print-extra-package-json-paths"]);
 
   assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
   const paths = result.stdout.split("\n");
 
-  for (const manifestPath of ["editors/vscode/package.json", "editors/vscode-art/package.json"]) {
+  for (const manifestPath of [
+    "editors/vscode/package.json",
+    "editors/vscode-art/package.json",
+    "npm/builder/rspack/package.json",
+    "npm/builder/unplugin/package.json",
+    "npm/builder/vite/package.json",
+    "npm/builder/vite-musea/package.json",
+    "npm/framework/musea-nuxt/package.json",
+    "npm/framework/nuxt/package.json",
+  ]) {
     assert.ok(
       paths.includes(manifestPath),
       `${manifestPath} version must be bumped with release commits`,

--- a/tests/tooling/release-package-versions.test.ts
+++ b/tests/tooling/release-package-versions.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const releasePackageJsonPaths = [
+  "npm/builder/rspack/package.json",
+  "npm/builder/unplugin/package.json",
+  "npm/builder/vite/package.json",
+  "npm/builder/vite-musea/package.json",
+  "npm/cli/package.json",
+  "npm/fresco/package.json",
+  "npm/fresco-native/package.json",
+  "npm/framework/musea-nuxt/package.json",
+  "npm/framework/nuxt/package.json",
+  "npm/mcp-musea/package.json",
+  "npm/native/package.json",
+  "npm/oxint/package.json",
+  "npm/wasm/package.json",
+];
+
+function readRepoFile(filePath: string): string {
+  return fs.readFileSync(path.join(root, filePath), "utf-8");
+}
+
+function workspaceVersion(): string {
+  const version = readRepoFile("Cargo.toml").match(/^version = "(.+)"$/m)?.[1];
+  assert.ok(version, "workspace version");
+  return version;
+}
+
+test("release package manifests stay aligned with the workspace version", () => {
+  const version = workspaceVersion();
+  const failures: string[] = [];
+
+  for (const packageJsonPath of releasePackageJsonPaths) {
+    const packageJson = JSON.parse(readRepoFile(packageJsonPath)) as {
+      name?: string;
+      version?: string;
+    };
+    if (packageJson.version !== version) {
+      failures.push(
+        `${packageJson.name ?? packageJsonPath}: version ${packageJson.version ?? "<missing>"} does not match ${version}`,
+      );
+    }
+  }
+
+  assert.deepEqual(failures, []);
+});

--- a/tests/tooling/release-platforms.test.ts
+++ b/tests/tooling/release-platforms.test.ts
@@ -9,28 +9,29 @@ import {
   releasePlatformPlan,
 } from "../../tools/github/release-platforms.mjs";
 
-test("release platform cadence keeps slow targets every fifth minor", () => {
+test("release platform plan includes slow targets on fifth minors", () => {
   const plan = releasePlatformPlan("v1.200.0");
 
   assert.equal(plan.includeSlowPlatforms, true);
+  assert.deepEqual(plan.skippedTargets, []);
   assert.ok(plan.cliMatrix.some((platform) => platform.target === "x86_64-apple-darwin"));
   assert.ok(plan.cliMatrix.some((platform) => platform.target === "aarch64-pc-windows-msvc"));
   assert.ok(plan.nativeMatrix.some((platform) => platform.target === "x86_64-apple-darwin"));
   assert.ok(plan.nativeMatrix.some((platform) => platform.target === "aarch64-pc-windows-msvc"));
 });
 
-test("release platform cadence skips slow targets outside fifth minors", () => {
+test("release platform plan includes slow targets outside fifth minors", () => {
   const plan = releasePlatformPlan("v1.201.0-rc.1");
 
-  assert.equal(plan.includeSlowPlatforms, false);
-  assert.deepEqual(plan.skippedTargets, ["x86_64-apple-darwin", "aarch64-pc-windows-msvc"]);
-  assert.ok(!plan.cliMatrix.some((platform) => platform.target === "x86_64-apple-darwin"));
-  assert.ok(!plan.cliMatrix.some((platform) => platform.target === "aarch64-pc-windows-msvc"));
-  assert.ok(!plan.nativeMatrix.some((platform) => platform.target === "x86_64-apple-darwin"));
-  assert.ok(!plan.nativeMatrix.some((platform) => platform.target === "aarch64-pc-windows-msvc"));
+  assert.equal(plan.includeSlowPlatforms, true);
+  assert.deepEqual(plan.skippedTargets, []);
+  assert.ok(plan.cliMatrix.some((platform) => platform.target === "x86_64-apple-darwin"));
+  assert.ok(plan.cliMatrix.some((platform) => platform.target === "aarch64-pc-windows-msvc"));
+  assert.ok(plan.nativeMatrix.some((platform) => platform.target === "x86_64-apple-darwin"));
+  assert.ok(plan.nativeMatrix.some((platform) => platform.target === "aarch64-pc-windows-msvc"));
 });
 
-test("release platform cadence removes skipped native manifest entries", () => {
+test("release platform cadence preserves native manifest entries when all platforms are included", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-release-platforms-"));
   const packageDir = path.join(tempDir, "npm", "native");
   const packageJsonPath = path.join(packageDir, "package.json");
@@ -68,13 +69,19 @@ test("release platform cadence removes skipped native manifest entries", () => {
     const result = applyReleasePlatformCadence("v1.201.0", packageJsonPath);
     const updated = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
 
-    assert.equal(result.changed, true);
-    assert.equal(updated.optionalDependencies["@vizejs/native-darwin-x64"], undefined);
-    assert.equal(updated.optionalDependencies["@vizejs/native-win32-arm64-msvc"], undefined);
+    assert.equal(result.changed, false);
+    assert.deepEqual(result.skippedTargets, []);
+    assert.equal(updated.optionalDependencies["@vizejs/native-darwin-x64"], "1.201.0");
+    assert.equal(updated.optionalDependencies["@vizejs/native-win32-arm64-msvc"], "1.201.0");
     assert.equal(updated.optionalDependencies["@vizejs/native-darwin-arm64"], "1.201.0");
     assert.equal(updated.optionalDependencies["@vizejs/native-win32-x64-msvc"], "1.201.0");
-    assert.deepEqual(updated.napi.targets, ["aarch64-apple-darwin", "x86_64-pc-windows-msvc"]);
-    assert.equal(fs.existsSync(skippedDir), false);
+    assert.deepEqual(updated.napi.targets, [
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "aarch64-pc-windows-msvc",
+      "x86_64-pc-windows-msvc",
+    ]);
+    assert.equal(fs.existsSync(skippedDir), true);
     assert.equal(fs.existsSync(keptDir), true);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });

--- a/tools/github/release-platforms.mjs
+++ b/tools/github/release-platforms.mjs
@@ -105,15 +105,14 @@ export function parseReleaseVersion(refName) {
 
 export function releasePlatformPlan(refName) {
   const version = parseReleaseVersion(refName);
-  const includeSlowPlatforms = version.minor % 5 === 0;
-  const isEnabled = (platform) => includeSlowPlatforms || !slowReleaseTargets.has(platform.target);
+  const includeSlowPlatforms = true;
 
   return {
     version,
     includeSlowPlatforms,
-    skippedTargets: includeSlowPlatforms ? [] : [...slowReleaseTargets],
-    cliMatrix: cliReleasePlatforms.filter(isEnabled),
-    nativeMatrix: nativeReleasePlatforms.filter(isEnabled),
+    skippedTargets: [],
+    cliMatrix: cliReleasePlatforms,
+    nativeMatrix: nativeReleasePlatforms,
   };
 }
 

--- a/tools/moon/scripts/release.mbtx
+++ b/tools/moon/scripts/release.mbtx
@@ -353,7 +353,7 @@ fn replace_package_json_version(
 /// globs but still ship release artifacts and must stay aligned with the
 /// workspace version.
 fn extra_release_package_json_paths() -> Array[String] {
-  ["editors/vscode/package.json", "editors/vscode-art/package.json"]
+  ["editors/vscode/package.json", "editors/vscode-art/package.json", "npm/builder/rspack/package.json", "npm/builder/unplugin/package.json", "npm/builder/vite/package.json", "npm/builder/vite-musea/package.json", "npm/framework/musea-nuxt/package.json", "npm/framework/nuxt/package.json"]
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Rename multi-component JSX/TSX module render exports to stable component names, while preserving the existing single-component `render` export.
- Sync nested release package manifests so builder/framework npm packages bump with release commits instead of publishing stale versions.
- Include all native release platforms on every tag and keep VS Code Marketplace token failures from blocking GitHub/npm/crates release completion.

Closes #2281
Closes #2295

## Validation

- `cargo test -p vize_atelier_jsx`
- `node --test tests/tooling/release-platforms.test.ts tests/tooling/package-manifests.test.ts tests/tooling/moonbit-release.test.ts tests/tooling/github-workflows-release-publish.test.ts tests/tooling/github-workflows-release-build.test.ts`
- `vp check tools/github/release-platforms.mjs tests/tooling/release-platforms.test.ts tests/tooling/package-manifests.test.ts tests/tooling/moonbit-release.test.ts tests/tooling/github-workflows-release-publish.test.ts tests/tooling/github-workflows-release-build.test.ts`
- `moon run --target native - -- < tools/moon/scripts/source_file_lengths.mbtx`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->