### PR TITLE
fix(vite): preserve plain JSX modules

### DIFF
--- a/npm/builder/vite/src/plugin/load-jsx-passthrough.test.ts
+++ b/npm/builder/vite/src/plugin/load-jsx-passthrough.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+
+import { transformHook } from "./load.ts";
+import type { VizePluginState } from "./state.ts";
+
+const state = {
+  filter: () => true,
+  mergedOptions: { vapor: false },
+  root: "/src",
+  logger: {
+    log() {},
+    info() {},
+    warn() {},
+    error() {},
+  },
+} as unknown as VizePluginState;
+
+const result = await transformHook(
+  state,
+  `export const App = () => <div>Hello</div>;\n`,
+  "/src/App.jsx",
+  { ssr: false },
+);
+
+assert.equal(
+  result,
+  null,
+  "Plain JSX modules should stay on Vite's regular JSX pipeline unless include opts them into Vize",
+);
+
+console.log("vite-plugin-vize JSX passthrough tests passed!");

--- a/npm/builder/vite/src/plugin/load.test.ts
+++ b/npm/builder/vite/src/plugin/load.test.ts
@@ -889,7 +889,7 @@ const jsxState: VizePluginState = {
   ...hmrState,
   cache: new Map(),
   ssrCache: new Map(),
-  mergedOptions: { vapor: false },
+  mergedOptions: { vapor: false, include: /\.[jt]sx$/ },
 };
 
 const jsxTransform = await transformHook(jsxState, jsxFixtureSource, jsxFixturePath, {
@@ -926,7 +926,7 @@ assert.equal(
 
 const jsxVaporState: VizePluginState = {
   ...jsxState,
-  mergedOptions: { vapor: true },
+  mergedOptions: { ...jsxState.mergedOptions, vapor: true },
 };
 
 const jsxVaporTransform = await transformHook(jsxVaporState, jsxFixtureSource, jsxFixturePath, {

--- a/npm/builder/vite/src/plugin/load.ts
+++ b/npm/builder/vite/src/plugin/load.ts
@@ -389,9 +389,8 @@ function shouldTransformJsxRequest(
       return false;
     }
   }
-  // Honor an explicit user exclude (e.g. third-party JSX), but JSX/TSX is not
-  // covered by the default `**/*.vue` filter, so a bare extension match is enough.
-  if (state.mergedOptions.exclude && !state.filter(request.path)) {
+  // JSX/TSX modules are valid plain Vite inputs; only compile explicit includes.
+  if (!state.mergedOptions.include || !state.filter(request.path)) {
     return false;
   }
   return true;

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -8,6 +8,7 @@ import "./plugin/css-modules.test.ts";
 import "./plugin/external-sfc-hmr.test.ts";
 import "./plugin/hmr.test.ts";
 import "./plugin/index.test.ts";
+import "./plugin/load-jsx-passthrough.test.ts";
 import "./plugin/load-storybook.test.ts";
 import "./plugin/load.test.ts";
 import "./plugin/load-dependency-sfc.test.ts";


### PR DESCRIPTION
Fixes #2298.

## Summary
- keep ordinary .jsx/.tsx modules on Vite's normal JSX pipeline by default
- require an explicit include match before routing JSX/TSX through Vize's component compiler
- keep the existing opt-in Vize JSX component behavior covered by tests

## Validation
- node npm/builder/vite/src/plugin/load.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->