### PR TITLE
feat(musea): prefer Vite OXC virtual transforms

### DIFF
--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -1,5 +1,4 @@
 import type { Plugin, ViteDevServer, ResolvedConfig } from "vite";
-import { transformWithEsbuild } from "vite";
 import fs from "node:fs";
 import path from "node:path";
 import type { MuseaOptions, ArtFileInfo } from "../types/index.js";
@@ -36,6 +35,7 @@ import {
 } from "../static-export.js";
 import { resolveMuseaSharedConfig } from "./config.js";
 import { processMuseaArtFile } from "./art-processing.js";
+import { transformMuseaVirtualModule } from "./virtual-transform.js";
 
 export function musea(options: MuseaOptions = {}): Plugin[] {
   let include = options.include ?? ["**/*.art.vue"];
@@ -271,12 +271,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
         .replace(/_+/g, "_");
       const loaderId = path.join(config.root, `.musea-${safeId}.ts`);
 
-      return transformWithEsbuild(code, loaderId, {
-        loader: "ts",
-        format: "esm",
-        sourcemap: config.command === "serve",
-        target: "esnext",
-      });
+      return transformMuseaVirtualModule(code, loaderId, config.command === "serve");
     },
     handleHotUpdate,
   };

--- a/npm/builder/vite-musea/src/plugin/virtual-transform.test.ts
+++ b/npm/builder/vite-musea/src/plugin/virtual-transform.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createMuseaVirtualTransformer } from "./virtual-transform.ts";
+
+void test("Musea virtual TS transform prefers Vite OXC when available", async () => {
+  let used = "";
+  const transform = createMuseaVirtualTransformer({
+    transformWithOxc: async (code, id, options) => {
+      used = "oxc";
+      assert.equal(code, "const value: number = 1");
+      assert.equal(id, "/repo/.musea-virtual.ts");
+      assert.deepEqual(options, { lang: "ts", sourcemap: true, target: "esnext" });
+      return { code: "const value = 1;" };
+    },
+    transformWithEsbuild: async () => {
+      used = "esbuild";
+      return { code: "" };
+    },
+  });
+
+  const result = await transform("const value: number = 1", "/repo/.musea-virtual.ts", true);
+  assert.equal(used, "oxc");
+  assert.equal(result.code, "const value = 1;");
+});
+
+void test("Musea virtual TS transform falls back to esbuild on Vite 7", async () => {
+  let used = "";
+  const transform = createMuseaVirtualTransformer({
+    transformWithEsbuild: async (code, id, options) => {
+      used = "esbuild";
+      assert.equal(code, "const value: number = 1");
+      assert.equal(id, "/repo/.musea-virtual.ts");
+      assert.deepEqual(options, {
+        loader: "ts",
+        format: "esm",
+        sourcemap: false,
+        target: "esnext",
+      });
+      return { code: "const value = 1;" };
+    },
+  });
+
+  const result = await transform("const value: number = 1", "/repo/.musea-virtual.ts", false);
+  assert.equal(used, "esbuild");
+  assert.equal(result.code, "const value = 1;");
+});

--- a/npm/builder/vite-musea/src/plugin/virtual-transform.ts
+++ b/npm/builder/vite-musea/src/plugin/virtual-transform.ts
@@ -1,0 +1,52 @@
+import * as vite from "vite";
+import type { Plugin } from "vite";
+
+type HookFunction<T> = T extends (...args: infer Args) => infer Result
+  ? (...args: Args) => Result
+  : T extends { handler: infer Handler }
+    ? Handler extends (...args: infer Args) => infer Result
+      ? (...args: Args) => Result
+      : never
+    : never;
+type PluginTransformReturn = Awaited<ReturnType<HookFunction<NonNullable<Plugin["transform"]>>>>;
+type TransformOutput = Exclude<PluginTransformReturn, string | null | void>;
+type OxcOptions = { lang: "ts"; sourcemap: boolean; target: "esnext" };
+type EsbuildOptions = { loader: "ts"; format: "esm"; sourcemap: boolean; target: "esnext" };
+type TransformWithOxc = (
+  code: string,
+  id: string,
+  options: OxcOptions,
+) => TransformOutput | Promise<TransformOutput>;
+type TransformWithEsbuild = (
+  code: string,
+  id: string,
+  options: EsbuildOptions,
+) => TransformOutput | Promise<TransformOutput>;
+
+interface ViteTransformApi {
+  transformWithOxc?: TransformWithOxc;
+  transformWithEsbuild?: TransformWithEsbuild;
+}
+
+export function createMuseaVirtualTransformer(viteApi: ViteTransformApi) {
+  return async (code: string, id: string, sourcemap: boolean): Promise<TransformOutput> => {
+    if (typeof viteApi.transformWithOxc === "function") {
+      return viteApi.transformWithOxc(code, id, {
+        lang: "ts",
+        sourcemap,
+        target: "esnext",
+      });
+    }
+    if (typeof viteApi.transformWithEsbuild === "function") {
+      return viteApi.transformWithEsbuild(code, id, {
+        loader: "ts",
+        format: "esm",
+        sourcemap,
+        target: "esnext",
+      });
+    }
+    throw new Error("Installed Vite does not expose transformWithOxc or transformWithEsbuild");
+  };
+}
+
+export const transformMuseaVirtualModule = createMuseaVirtualTransformer(vite);


### PR DESCRIPTION
Fixes #2300.

## Summary
- route Musea virtual TS modules through Vite's transformWithOxc when available
- keep transformWithEsbuild as the fallback for Vite 7 compatibility
- cover both transform paths with focused tests

## Validation
- CI=true corepack pnpm --dir npm/builder/vite-musea exec vp exec tsx --test src/plugin/virtual-transform.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->