### PR TITLE
fix(canon): preserve TSX SFC named exports

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -17,6 +17,7 @@ mod no_unused;
 mod options_api_required_props;
 mod package_exports_types;
 mod scan;
+mod tsx_sfc;
 #[test]
 fn batch_type_checker_snapshots_vue_diagnostics() {
     if resolve_test_tsgo_binary().is_none() {
@@ -55,7 +56,6 @@ const count: string = 0;
     .virtual_ts
     .expect("virtual ts should be generated");
     let relevant = corsa_type_mismatch_snapshot(&virtual_ts, "count: string", "= 0");
-
     assert_eq!(
         relevant.len(),
         2,

--- a/crates/vize_canon/src/batch/type_checker/tests/tsx_sfc.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/tsx_sfc.rs
@@ -1,0 +1,71 @@
+use super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
+
+#[test]
+fn batch_type_checker_preserves_named_exports_from_tsx_sfc() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "tsx-sfc-named-export-contextual-typing",
+        &[
+            (
+                "src/Widget.vue",
+                r#"<script lang="tsx">
+type WidgetOptions = {
+  render?: () => unknown;
+  slots: {
+    root: (context: { size: "small" | "large" }) => string;
+  };
+};
+
+export const WidgetConfig: WidgetOptions = {
+  render: () => <span />,
+  slots: {
+    root: ({ size }) => size,
+  },
+};
+</script>
+
+<template>
+  <div />
+</template>
+"#,
+            ),
+            (
+                "src/register-widget.ts",
+                r#"import { WidgetConfig } from "./Widget.vue";
+
+export type RegisteredWidgetConfig = typeof WidgetConfig;
+"#,
+            ),
+            (
+                "src/theme.ts",
+                r#"import type { RegisteredWidgetConfig } from "./register-widget";
+
+export const widgetTheme: RegisteredWidgetConfig = {
+  slots: {
+    root: ({ size }) => {
+      return size === "small" ? "text-sm" : "text-lg";
+    },
+  },
+};
+"#,
+            ),
+        ],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !(file == "src/register-widget.ts" && *code == Some(2614))
+                && !(file == "src/theme.ts" && *code == Some(7031) && message.contains("size"))
+        }),
+        "TSX SFC named exports should preserve downstream contextual typing, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -32,6 +32,7 @@ pub use document::{
     generate_vue_document_virtual_ts_with_options,
 };
 mod diagnostics;
+mod jsx_build;
 mod jsx_codegen;
 mod mapping;
 mod materialize;

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -19,6 +19,7 @@ use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 
 use super::VirtualFile;
 use super::diagnostics::collect_sfc_block_ranges;
+use super::jsx_build::build_jsx_registered_file;
 use super::passthrough::collect_passthrough_modules;
 use super::vue_codegen::{GeneratedVueFile, VueCodegenOptions, generate_vue_virtual_ts};
 
@@ -26,6 +27,7 @@ use super::vue_codegen::{GeneratedVueFile, VueCodegenOptions, generate_vue_virtu
 /// independent of any `&mut VirtualProject` so it can be produced in parallel.
 pub(super) struct RegisteredFile {
     pub(super) file: VirtualFile,
+    pub(super) extra_virtual_files: Vec<VirtualFile>,
     /// Original source text as registered, retained for offset<->line/col
     /// mapping without a disk re-read. Stored on the project, not the public
     /// `VirtualFile`.
@@ -158,103 +160,34 @@ pub(super) fn build_vue_registered_file(
         path,
         use_tsx_virtual,
     )?;
-
-    Ok(RegisteredFile {
-        file: VirtualFile {
-            content: rewritten.code,
-            source_map,
-            original_path: path.to_path_buf(),
-            virtual_path,
-        },
-        original_content: content.to_compact_string(),
-        passthrough_files: collect_passthrough_modules(
-            path,
-            content,
+    let extra_virtual_files = if use_tsx_virtual {
+        vec![build_tsx_vue_import_shim(
             context.project_root,
             context.virtual_root,
-        ),
-        diagnostics,
-    })
-}
-
-/// Build a virtual file for a `.jsx`/`.tsx` Vize component (#1497, opt-in).
-///
-/// Parallels [`build_vue_registered_file`]: lower the JSX/TSX to plain virtual
-/// TypeScript (props from the typed first parameter + setup scope + JSX
-/// expressions), rewrite imports, and mirror the file to `<name>.ts` so Corsa
-/// type-checks it as plain TypeScript. Reached only when `jsx_typecheck` is on.
-pub(super) fn build_jsx_registered_file(
-    path: &Path,
-    content: &str,
-    context: VirtualBuildContext<'_>,
-) -> CorsaResult<RegisteredFile> {
-    let lang = jsx_lang_for_path(path);
-    let generated = profile!(
-        "canon.jsx.virtual_ts",
-        super::jsx_codegen::generate_jsx_virtual_ts(path, content, lang)
-    )?;
-    let super::jsx_codegen::GeneratedJsxFile {
-        code,
-        mappings,
-        diagnostics,
-    } = generated;
-
-    let rewritten = profile!(
-        "canon.import.rewrite.jsx",
-        context.rewriter.rewrite(&code, SourceType::ts())
-    );
-
-    // The whole `.jsx`/`.tsx` body is one Script block for block-type recovery.
-    let blocks = vec![crate::batch::source_map::SfcBlockRange {
-        start: 0,
-        end: content.len() as u32,
-        block_type: crate::batch::SfcBlockType::Script,
-    }];
-    let source_map =
-        CompositeSourceMap::new_vue(SfcSourceMap::new(mappings, blocks), rewritten.source_map);
-    let virtual_path = virtual_jsx_path(context.project_root, context.virtual_root, path)?;
-
-    Ok(RegisteredFile {
-        file: VirtualFile {
-            content: rewritten.code,
-            source_map,
-            original_path: path.to_path_buf(),
-            virtual_path,
-        },
-        original_content: content.to_compact_string(),
-        passthrough_files: collect_passthrough_modules(
             path,
-            content,
-            context.project_root,
-            context.virtual_root,
-        ),
-        diagnostics,
-    })
-}
-
-fn jsx_lang_for_path(path: &Path) -> vize_atelier_jsx::JsxLang {
-    let is_tsx = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".tsx"));
-    if is_tsx {
-        vize_atelier_jsx::JsxLang::Tsx
+            &virtual_path,
+        )?]
     } else {
-        vize_atelier_jsx::JsxLang::Jsx
-    }
-}
+        Vec::new()
+    };
 
-fn virtual_jsx_path(project_root: &Path, virtual_root: &Path, path: &Path) -> CorsaResult<PathBuf> {
-    let mut virtual_path = mirrored_virtual_path(project_root, virtual_root, path)?;
-    let file_name = virtual_path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .map(|name| cstr!("{name}.ts"))
-        .ok_or_else(|| CorsaError::PathError {
-            path: path.to_path_buf(),
-        })?;
-    virtual_path.set_file_name(file_name.as_str());
-    Ok(virtual_path)
+    Ok(RegisteredFile {
+        file: VirtualFile {
+            content: rewritten.code,
+            source_map,
+            original_path: path.to_path_buf(),
+            virtual_path,
+        },
+        extra_virtual_files,
+        original_content: content.to_compact_string(),
+        passthrough_files: collect_passthrough_modules(
+            path,
+            content,
+            context.project_root,
+            context.virtual_root,
+        ),
+        diagnostics,
+    })
 }
 
 pub(super) fn build_script_registered_file(
@@ -277,6 +210,7 @@ pub(super) fn build_script_registered_file(
             original_path: path.to_path_buf(),
             virtual_path,
         },
+        extra_virtual_files: Vec::new(),
         original_content: content.to_compact_string(),
         passthrough_files: collect_passthrough_modules(path, content, roots.0, roots.1),
         diagnostics: Vec::new(),
@@ -325,6 +259,31 @@ pub(super) fn mirrored_virtual_path(
 ) -> CorsaResult<PathBuf> {
     let relative = path.strip_prefix(project_root)?;
     Ok(virtual_root.join(relative))
+}
+
+fn build_tsx_vue_import_shim(
+    project_root: &Path,
+    virtual_root: &Path,
+    path: &Path,
+    target_path: &Path,
+) -> CorsaResult<VirtualFile> {
+    let shim_path = virtual_vue_path(project_root, virtual_root, path, false)?;
+    let target_name = target_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| CorsaError::PathError {
+            path: path.to_path_buf(),
+        })?;
+    let content = cstr!(
+        "export {{ default }} from \"./{target_name}\";\nexport * from \"./{target_name}\";\n"
+    );
+
+    Ok(VirtualFile {
+        content,
+        source_map: CompositeSourceMap::empty(),
+        original_path: shim_path.clone(),
+        virtual_path: shim_path,
+    })
 }
 
 fn virtual_vue_path(

--- a/crates/vize_canon/src/batch/virtual_project/jsx_build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_build.rs
@@ -1,0 +1,86 @@
+use std::path::{Path, PathBuf};
+
+use oxc_span::SourceType;
+use vize_carton::{ToCompactString, cstr, profile};
+
+use crate::batch::error::{CorsaError, CorsaResult};
+use crate::batch::source_map::{CompositeSourceMap, SfcSourceMap};
+
+use super::VirtualFile;
+use super::build::{RegisteredFile, VirtualBuildContext, mirrored_virtual_path};
+use super::passthrough::collect_passthrough_modules;
+
+/// Build a virtual file for a `.jsx`/`.tsx` Vize component (#1497, opt-in).
+pub(super) fn build_jsx_registered_file(
+    path: &Path,
+    content: &str,
+    context: VirtualBuildContext<'_>,
+) -> CorsaResult<RegisteredFile> {
+    let lang = jsx_lang_for_path(path);
+    let generated = profile!(
+        "canon.jsx.virtual_ts",
+        super::jsx_codegen::generate_jsx_virtual_ts(path, content, lang)
+    )?;
+    let super::jsx_codegen::GeneratedJsxFile {
+        code,
+        mappings,
+        diagnostics,
+    } = generated;
+
+    let rewritten = profile!(
+        "canon.import.rewrite.jsx",
+        context.rewriter.rewrite(&code, SourceType::ts())
+    );
+
+    let blocks = vec![crate::batch::source_map::SfcBlockRange {
+        start: 0,
+        end: content.len() as u32,
+        block_type: crate::batch::SfcBlockType::Script,
+    }];
+    let source_map =
+        CompositeSourceMap::new_vue(SfcSourceMap::new(mappings, blocks), rewritten.source_map);
+    let virtual_path = virtual_jsx_path(context.project_root, context.virtual_root, path)?;
+
+    Ok(RegisteredFile {
+        file: VirtualFile {
+            content: rewritten.code,
+            source_map,
+            original_path: path.to_path_buf(),
+            virtual_path,
+        },
+        extra_virtual_files: Vec::new(),
+        original_content: content.to_compact_string(),
+        passthrough_files: collect_passthrough_modules(
+            path,
+            content,
+            context.project_root,
+            context.virtual_root,
+        ),
+        diagnostics,
+    })
+}
+
+fn jsx_lang_for_path(path: &Path) -> vize_atelier_jsx::JsxLang {
+    if path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".tsx"))
+    {
+        vize_atelier_jsx::JsxLang::Tsx
+    } else {
+        vize_atelier_jsx::JsxLang::Jsx
+    }
+}
+
+fn virtual_jsx_path(project_root: &Path, virtual_root: &Path, path: &Path) -> CorsaResult<PathBuf> {
+    let mut virtual_path = mirrored_virtual_path(project_root, virtual_root, path)?;
+    let file_name = virtual_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| cstr!("{name}.ts"))
+        .ok_or_else(|| CorsaError::PathError {
+            path: path.to_path_buf(),
+        })?;
+    virtual_path.set_file_name(file_name.as_str());
+    Ok(virtual_path)
+}

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -286,6 +286,9 @@ impl VirtualProject {
         for (virtual_path, original_path) in registered.passthrough_files {
             self.passthrough_files.insert(virtual_path, original_path);
         }
+        for file in registered.extra_virtual_files {
+            self.virtual_files.insert(file.virtual_path.clone(), file);
+        }
         self.virtual_files
             .insert(registered.file.virtual_path.clone(), registered.file);
     }

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -193,7 +193,8 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     let has_plain_script_scope = summary
         .scopes
         .iter()
-        .any(|scope| matches!(scope.kind, ScopeKind::NonScriptSetup));
+        .any(|scope| matches!(scope.kind, ScopeKind::NonScriptSetup))
+        || (script_content.is_some() && !has_script_setup);
     let named_value_exports = self::script_module::collect_normal_script_named_value_exports(
         script_content,
         has_script_setup,

--- a/crates/vize_canon/src/virtual_ts/generator/script_module.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module.rs
@@ -90,8 +90,13 @@ impl<'a> Visit<'a> for ConstEnumNames {
 
 fn collect_named_value_exports(script: &str) -> Vec<CompactString> {
     let allocator = Allocator::default();
-    let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
-    if parsed.panicked {
+    let parsed = Parser::new(&allocator, script, SourceType::ts().with_module(true)).parse();
+    let parsed = if parsed.panicked || !parsed.errors.is_empty() {
+        Parser::new(&allocator, script, SourceType::tsx().with_module(true)).parse()
+    } else {
+        parsed
+    };
+    if parsed.panicked || !parsed.errors.is_empty() {
         return Vec::new();
     }
 


### PR DESCRIPTION
Fixes #2299.

## Summary
- parse normal script named exports with TSX fallback
- keep TSX SFC imports resolving through a .vue.ts shim that re-exports the generated .vue.tsx module
- preserve contextual typing for downstream imports of named SFC exports

## Validation
- cargo test -p vize_canon batch::type_checker::tests::tsx_sfc

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->