### PR TITLE
fix(canon): expose inherited generic props

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -11,6 +11,7 @@ use vize_carton::{String, cstr};
 mod camel_case_component_props;
 mod emit_object_recursion;
 mod generic_component_listener_payload;
+mod generic_props;
 mod no_check_props;
 mod no_unused;
 mod options_api_required_props;
@@ -32,7 +33,6 @@ const count: number = 'oops'
     .virtual_ts
     .expect("virtual ts should be generated");
     let snapshot = corsa_type_mismatch_snapshot(&virtual_ts, "count: number", "'oops'");
-
     insta::with_settings!({
         snapshot_path => "../../snapshots"
     }, {

--- a/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
@@ -1,0 +1,46 @@
+use super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
+
+#[test]
+fn batch_type_checker_exposes_generic_props_inherited_from_pick() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "generic-setup-props-inherited-pick-template",
+        &[(
+            "src/Foo.vue",
+            r#"<script lang="ts">
+interface BaseProps {
+  required?: boolean;
+}
+
+export interface FooProps<T = string> extends Pick<BaseProps, "required"> {
+  value?: T;
+}
+</script>
+
+<script setup lang="ts" generic="T = string">
+defineProps<FooProps<T>>();
+</script>
+
+<template>
+  <input :required />
+</template>
+"#,
+        )],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !(file == "src/Foo.vue" && *code == Some(2304) && message.contains("required"))
+        }),
+        "inherited type-based props should be exposed to generic SFC templates, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_croquis/src/drawer/template/tests.rs
+++ b/crates/vize_croquis/src/drawer/template/tests.rs
@@ -4,7 +4,12 @@ use super::super::{Drawer, DrawerOptions};
 
 /// Collect the `vif_guard` attached to each template interpolation, keyed by
 /// expression text. Used to pin sibling-aware `v-if` / `v-else` narrowing.
-fn interpolation_guards(template: &str) -> Vec<(std::string::String, Option<std::string::String>)> {
+fn interpolation_guards(
+    template: &str,
+) -> Vec<(
+    vize_carton::CompactString,
+    Option<vize_carton::CompactString>,
+)> {
     use vize_armature::parse;
     use vize_carton::Bump;
 
@@ -23,12 +28,7 @@ fn interpolation_guards(template: &str) -> Vec<(std::string::String, Option<std:
                 crate::croquis::TemplateExpressionKind::Interpolation
             )
         })
-        .map(|e| {
-            (
-                e.content.to_string(),
-                e.vif_guard.as_ref().map(|g| g.to_string()),
-            )
-        })
+        .map(|e| (e.content.clone(), e.vif_guard.clone()))
         .collect()
 }
 

--- a/crates/vize_croquis/src/script_parser/result.rs
+++ b/crates/vize_croquis/src/script_parser/result.rs
@@ -150,9 +150,17 @@ impl ScriptParseResult {
     pub(crate) fn register_local_type(&mut self, decl: &Declaration<'_>, source: &str) {
         match decl {
             Declaration::TSInterfaceDeclaration(interface) => {
-                self.types.add_interface(
+                let extends = interface
+                    .extends
+                    .iter()
+                    .map(|heritage| heritage.span.source_text(source).trim())
+                    .filter(|heritage| !heritage.is_empty())
+                    .map(vize_carton::CompactString::new)
+                    .collect();
+                self.types.add_interface_with_extends(
                     interface.id.name.as_str(),
                     interface.body.span.source_text(source),
+                    extends,
                 );
             }
             Declaration::TSTypeAliasDeclaration(alias) => {

--- a/crates/vize_croquis/src/types.rs
+++ b/crates/vize_croquis/src/types.rs
@@ -6,7 +6,11 @@
 //! - Type references: `defineProps<Props>()`
 //! - External imports (future): `import type { Props } from './types'`
 
-use vize_carton::{CompactString, FxHashMap, String};
+mod props;
+
+use vize_carton::{CompactString, FxHashMap, cstr};
+
+const INTERFACE_EXTENDS_PREFIX: &str = "\0vize:interface_extends:";
 
 /// Resolved type information
 #[derive(Debug, Clone)]
@@ -55,7 +59,24 @@ impl TypeDefinitions {
         name: impl Into<CompactString>,
         body: impl Into<CompactString>,
     ) {
-        self.interfaces.insert(name.into(), body.into());
+        self.add_interface_with_extends(name, body, Vec::new());
+    }
+
+    /// Add an interface definition with its heritage clauses.
+    #[inline]
+    pub fn add_interface_with_extends(
+        &mut self,
+        name: impl Into<CompactString>,
+        body: impl Into<CompactString>,
+        extends: Vec<CompactString>,
+    ) {
+        let name = name.into();
+        if !extends.is_empty() {
+            let key = interface_extends_key(&name);
+            self.type_aliases
+                .insert(key, CompactString::new(extends.join("\n")));
+        }
+        self.interfaces.insert(name, body.into());
     }
 
     /// Add a type alias definition
@@ -111,6 +132,20 @@ impl TypeDefinitions {
             self.imported_types.entry(name).or_insert(source);
         }
     }
+
+    fn interface_extends(&self, name: &str) -> Vec<CompactString> {
+        let key = interface_extends_key(name);
+        self.type_aliases
+            .get(key.as_str())
+            .map(|value| {
+                value
+                    .lines()
+                    .filter(|line| !line.is_empty())
+                    .map(CompactString::new)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
 }
 
 /// Type resolver for Vue compiler macros
@@ -149,6 +184,18 @@ impl TypeResolver {
         self.definitions.add_interface(name, body);
     }
 
+    /// Add an interface definition with its heritage clauses.
+    #[inline]
+    pub fn add_interface_with_extends(
+        &mut self,
+        name: impl Into<CompactString>,
+        body: impl Into<CompactString>,
+        extends: Vec<CompactString>,
+    ) {
+        self.definitions
+            .add_interface_with_extends(name, body, extends);
+    }
+
     /// Add a type alias definition
     #[inline]
     pub fn add_type_alias(
@@ -165,106 +212,6 @@ impl TypeResolver {
     #[inline]
     pub fn merge_keep_existing(&mut self, other: TypeResolver) {
         self.definitions.merge_keep_existing(other.definitions);
-    }
-
-    /// Extract properties from type arguments
-    ///
-    /// Handles:
-    /// - Inline object types: `{ msg: string, count?: number }`
-    /// - Type references: `Props` (resolved via definitions)
-    pub fn extract_properties(&self, type_args: &str) -> Vec<TypeProperty> {
-        let content = type_args.trim();
-
-        // Resolve type reference if not an inline object type
-        let resolved_content = if content.starts_with('{') {
-            // Inline object type - strip braces
-            if content.ends_with('}') {
-                &content[1..content.len() - 1]
-            } else {
-                content
-            }
-        } else {
-            // Type reference - look up in definitions
-            if let Some(body) = self.definitions.resolve(content) {
-                let body = body.trim();
-                if body.starts_with('{') && body.ends_with('}') {
-                    &body[1..body.len() - 1]
-                } else {
-                    body
-                }
-            } else {
-                // Unresolved type reference - return empty
-                return Vec::new();
-            }
-        };
-
-        self.parse_type_members(resolved_content)
-    }
-
-    /// Parse type members from a type body string
-    fn parse_type_members(&self, content: &str) -> Vec<TypeProperty> {
-        let mut properties = Vec::new();
-        let mut depth = 0;
-        let mut current = String::default();
-        let mut prev = '\0';
-
-        for c in content.chars() {
-            match c {
-                '{' | '<' | '(' | '[' => {
-                    depth += 1;
-                    current.push(c);
-                }
-                '}' | ')' | ']' => {
-                    depth -= 1;
-                    current.push(c);
-                }
-                '>' if prev != '=' => {
-                    depth -= 1;
-                    current.push(c);
-                }
-                ',' | ';' | '\n' if depth == 0 => {
-                    if let Some(prop) = self.parse_single_property(&current) {
-                        properties.push(prop);
-                    }
-                    current.clear();
-                }
-                _ => current.push(c),
-            }
-            prev = c;
-        }
-
-        // Process last segment
-        if let Some(prop) = self.parse_single_property(&current) {
-            properties.push(prop);
-        }
-
-        properties
-    }
-
-    /// Parse a single property from a type definition segment
-    fn parse_single_property(&self, segment: &str) -> Option<TypeProperty> {
-        let trimmed = segment.trim();
-        if trimmed.is_empty() {
-            return None;
-        }
-
-        // Parse "name?: Type" or "name: Type"
-        let colon_pos = trimmed.find(':')?;
-        let name_part = &trimmed[..colon_pos];
-        let type_part = &trimmed[colon_pos + 1..];
-
-        let optional = name_part.ends_with('?');
-        let name = name_part.trim().trim_end_matches('?').trim();
-
-        if name.is_empty() || !is_valid_identifier(name) {
-            return None;
-        }
-
-        Some(TypeProperty {
-            name: CompactString::new(name),
-            prop_type: Some(CompactString::new(type_part.trim())),
-            optional,
-        })
     }
 
     /// Extract emit event names from emit type arguments
@@ -323,6 +270,10 @@ impl TypeResolver {
 
         emits
     }
+}
+
+fn interface_extends_key(name: &str) -> CompactString {
+    cstr!("{INTERFACE_EXTENDS_PREFIX}{name}")
 }
 
 /// Extract event name from a call signature like `(e: 'click', payload: number): void`

--- a/crates/vize_croquis/src/types/props.rs
+++ b/crates/vize_croquis/src/types/props.rs
@@ -1,0 +1,229 @@
+use vize_carton::{CompactString, FxHashSet, String};
+
+use super::{TypeProperty, TypeResolver, is_valid_identifier};
+
+impl TypeResolver {
+    /// Extract properties from type arguments.
+    ///
+    /// Handles inline object types and type references resolved from the local
+    /// type definition store.
+    pub fn extract_properties(&self, type_args: &str) -> Vec<TypeProperty> {
+        let mut resolving = FxHashSet::default();
+        let mut seen = FxHashSet::default();
+        self.extract_properties_inner(type_args, &mut resolving, &mut seen)
+    }
+
+    fn extract_properties_inner(
+        &self,
+        type_args: &str,
+        resolving: &mut FxHashSet<CompactString>,
+        seen: &mut FxHashSet<CompactString>,
+    ) -> Vec<TypeProperty> {
+        let content = type_args.trim();
+        if let Some((base, picked)) = parse_pick_type(content) {
+            let mut local_seen = FxHashSet::default();
+            return self
+                .extract_properties_inner(base, resolving, &mut local_seen)
+                .into_iter()
+                .filter(|prop| {
+                    picked
+                        .iter()
+                        .any(|name| name.as_str() == prop.name.as_str())
+                })
+                .collect();
+        }
+
+        let (resolved_name, resolved_content) = if content.starts_with('{') {
+            let body = if content.ends_with('}') {
+                &content[1..content.len() - 1]
+            } else {
+                content
+            };
+            (None, body)
+        } else {
+            let lookup = strip_generic_params(content);
+            if let Some(body) = self.definitions.resolve(lookup) {
+                let body = body.trim();
+                let body = if body.starts_with('{') && body.ends_with('}') {
+                    &body[1..body.len() - 1]
+                } else {
+                    body
+                };
+                (Some(CompactString::new(lookup)), body)
+            } else {
+                return Vec::new();
+            }
+        };
+
+        let mut properties = Vec::new();
+        if let Some(name) = resolved_name {
+            if !resolving.insert(name.clone()) {
+                return Vec::new();
+            }
+            for heritage in self.definitions.interface_extends(&name) {
+                push_unique_properties(
+                    &mut properties,
+                    self.extract_properties_inner(heritage.as_str(), resolving, seen),
+                    seen,
+                );
+            }
+            resolving.remove(&name);
+        }
+
+        push_unique_properties(
+            &mut properties,
+            self.parse_type_members(resolved_content),
+            seen,
+        );
+        properties
+    }
+
+    fn parse_type_members(&self, content: &str) -> Vec<TypeProperty> {
+        let mut properties = Vec::new();
+        let mut depth = 0;
+        let mut current = String::default();
+        let mut prev = '\0';
+
+        for c in content.chars() {
+            match c {
+                '{' | '<' | '(' | '[' => {
+                    depth += 1;
+                    current.push(c);
+                }
+                '}' | ')' | ']' => {
+                    depth -= 1;
+                    current.push(c);
+                }
+                '>' if prev != '=' => {
+                    depth -= 1;
+                    current.push(c);
+                }
+                ',' | ';' | '\n' if depth == 0 => {
+                    if let Some(prop) = self.parse_single_property(&current) {
+                        properties.push(prop);
+                    }
+                    current.clear();
+                }
+                _ => current.push(c),
+            }
+            prev = c;
+        }
+
+        if let Some(prop) = self.parse_single_property(&current) {
+            properties.push(prop);
+        }
+
+        properties
+    }
+
+    fn parse_single_property(&self, segment: &str) -> Option<TypeProperty> {
+        let trimmed = segment.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        let colon_pos = trimmed.find(':')?;
+        let name_part = &trimmed[..colon_pos];
+        let type_part = &trimmed[colon_pos + 1..];
+        let optional = name_part.ends_with('?');
+        let name = name_part.trim().trim_end_matches('?').trim();
+
+        if name.is_empty() || !is_valid_identifier(name) {
+            return None;
+        }
+
+        Some(TypeProperty {
+            name: CompactString::new(name),
+            prop_type: Some(CompactString::new(type_part.trim())),
+            optional,
+        })
+    }
+}
+
+fn push_unique_properties(
+    out: &mut Vec<TypeProperty>,
+    properties: Vec<TypeProperty>,
+    seen: &mut FxHashSet<CompactString>,
+) {
+    for property in properties {
+        if seen.insert(property.name.clone()) {
+            out.push(property);
+        }
+    }
+}
+
+fn strip_generic_params(type_name: &str) -> &str {
+    match type_name.find('<') {
+        Some(pos) => type_name[..pos].trim(),
+        None => type_name.trim(),
+    }
+}
+
+fn parse_pick_type(source: &str) -> Option<(&str, Vec<CompactString>)> {
+    let inner = source.strip_prefix("Pick<")?.strip_suffix('>')?;
+    let args = split_top_level_comma(inner);
+    if args.len() != 2 {
+        return None;
+    }
+    let keys = extract_string_literal_union(args[1]);
+    (!keys.is_empty()).then_some((args[0].trim(), keys))
+}
+
+fn split_top_level_comma(source: &str) -> Vec<&str> {
+    let mut args = Vec::new();
+    let mut depth = 0i32;
+    let mut start = 0usize;
+    let mut quote = None;
+    let mut escape = false;
+    for (index, ch) in source.char_indices() {
+        if let Some(quote_ch) = quote {
+            if escape {
+                escape = false;
+            } else if ch == '\\' {
+                escape = true;
+            } else if ch == quote_ch {
+                quote = None;
+            }
+            continue;
+        }
+        match ch {
+            '"' | '\'' => quote = Some(ch),
+            '<' | '{' | '(' | '[' => depth += 1,
+            '>' | '}' | ')' | ']' => depth -= 1,
+            ',' if depth == 0 => {
+                args.push(source[start..index].trim());
+                start = index + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    args.push(source[start..].trim());
+    args
+}
+
+fn extract_string_literal_union(source: &str) -> Vec<CompactString> {
+    let mut names = Vec::new();
+    let mut chars = source.char_indices();
+    while let Some((start, ch)) = chars.next() {
+        if ch != '"' && ch != '\'' {
+            continue;
+        }
+        let quote = ch;
+        let mut escape = false;
+        for (end, inner) in chars.by_ref() {
+            if escape {
+                escape = false;
+                continue;
+            }
+            if inner == '\\' {
+                escape = true;
+                continue;
+            }
+            if inner == quote {
+                names.push(CompactString::new(&source[start + quote.len_utf8()..end]));
+                break;
+            }
+        }
+    }
+    names
+}

--- a/crates/vize_croquis/src/types/tests.rs
+++ b/crates/vize_croquis/src/types/tests.rs
@@ -24,6 +24,25 @@ fn test_extract_props_from_reference() {
 }
 
 #[test]
+fn extract_properties_includes_interface_pick_heritage() {
+    let mut resolver = TypeResolver::new();
+    resolver.add_interface("BaseProps", "{ required?: boolean; disabled?: boolean }");
+    resolver.add_interface_with_extends(
+        "FooProps",
+        "{ value?: T }",
+        vec!["Pick<BaseProps, \"required\">".into()],
+    );
+
+    let props = resolver.extract_properties("FooProps<T>");
+    let names = props
+        .iter()
+        .map(|prop| prop.name.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(names, ["required", "value"]);
+}
+
+#[test]
 fn extract_properties_keeps_union_members_nested() {
     let mut resolver = TypeResolver::new();
     resolver.add_interface(


### PR DESCRIPTION
Fixes #2297.

## Summary
- track interface heritage clauses while parsing local script types
- resolve Pick<T, K> heritage properties for type-based props
- expose inherited generic SFC props to template checks

## Validation
- cargo test -p vize_canon batch::type_checker::tests::generic_props
- cargo test -p vize_croquis types::tests::extract_properties_includes_interface_pick_heritage

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->