### PR TITLE
test(canon): cover legacy Vue 2 event aliases

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/camel_case_component_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/camel_case_component_props.rs
@@ -216,7 +216,7 @@ function updateDate(newDate: string) {
     :width="width"
     :hide-details="hideDetails"
     chips
-    @input="updateDate"
+    @input="updateDate($event)"
   />
 </template>
 "#,
@@ -249,7 +249,9 @@ function updateDate(newDate: string) {
         .filter(|diagnostic| relative_path(&project_root, &diagnostic.file) == "src/App.vue")
         .filter(|diagnostic| {
             diagnostic.code == Some(2345)
+                || diagnostic.code == Some(2552)
                 || diagnostic.message.contains("InputEvent")
+                || diagnostic.message.contains("$event")
                 || diagnostic.message.contains("keyof Props")
                 || diagnostic.message.contains("hideDetails")
                 || diagnostic.message.contains("width")

--- a/crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs
@@ -61,6 +61,27 @@ function updateDate(newDate: string) {
 }
 
 #[test]
+fn legacy_vue2_component_event_dollar_event_alias_stays_scoped() {
+    let script = r#"import VDatePicker from './VDatePicker.vue'
+function updateDate(newDate: string) {
+  void newDate
+}
+"#;
+    let template = r#"<VDatePicker @input="updateDate($event)" />"#;
+
+    let legacy = legacy_virtual_ts(script, template, &VirtualTsOptions::default());
+    assert!(
+        legacy.contains("const $event = __vize_args[0] as __VDatePicker_")
+            && legacy.contains("updateDate($event);  // handler expression"),
+        "legacy Vue 2 component events should scope explicit `$event` aliases:\n{legacy}"
+    );
+    assert!(
+        legacy.contains("? any :") && !legacy.contains("? InputEvent :"),
+        "legacy Vue 2 explicit `$event` should keep the permissive event fallback:\n{legacy}"
+    );
+}
+
+#[test]
 fn legacy_vue2_skips_external_component_prop_checks() {
     let script = "const width = 320\n";
     let template = r#"<VDatePicker :width="width" />"#;


### PR DESCRIPTION
## Summary
- add a Canon virtual TS regression for legacy Vue 2 component event `` aliases
- extend the Vuetify legacy Vue 2 type-checker regression to exercise explicit `` and catch TS2552

Closes #2224

## Verification
- cargo test -p vize_canon virtual_ts::legacy_vue2_vuetify_tests::legacy_vue2_component_event_dollar_event_alias_stays_scoped
- cargo test -p vize_canon batch::type_checker::tests::camel_case_component_props::batch_type_checker_legacy_vue2_accepts_vuetify_global_events_and_props
- cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
- node --test --test-concurrency=1 tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->