### PR TITLE
fix: address priority readiness regressions

### DIFF
--- a/crates/vize/src/commands/check/nuxt.rs
+++ b/crates/vize/src/commands/check/nuxt.rs
@@ -23,7 +23,9 @@ mod legacy_template_globals_tests;
 #[cfg(test)]
 mod tests;
 
-use fallback::{collect_fallback_stubs, collect_module_fallback_stubs};
+use fallback::{
+    collect_fallback_stubs, collect_legacy_module_augmentation_stubs, collect_module_fallback_stubs,
+};
 use generated::{collect_generated_stubs, collect_generated_template_globals};
 use generated_dir::resolve_nuxt_generated_dir;
 use plugins::collect_plugin_injection_stubs;
@@ -91,10 +93,15 @@ pub(in crate::commands::check) fn detect(
     // Surface the degraded fallback: without generated Nuxt types,
     // auto-imports resolve to permissive `any` stubs that hide real type
     // errors. detect_nuxt_auto_imports runs once per check, so this warns once.
-    if let Some(message) = missing_generated_types_warning(has_generated_imports, &generated_dir) {
+    if let Some(message) =
+        missing_generated_types_warning(has_generated_imports, &generated_dir, legacy_vue2)
+    {
         eprintln!("{message}");
     }
     collect_plugin_injection_stubs(cwd, &mut collected, &mut seen_names);
+    if legacy_vue2 {
+        collect_legacy_module_augmentation_stubs(cwd, &mut collected);
+    }
     collect_fallback_stubs(&mut collected, &mut seen_names, has_generated_imports);
     if !has_generated_imports {
         collect_module_fallback_stubs(cwd, &mut collected, &mut seen_names);
@@ -138,8 +145,19 @@ fn is_nuxt_project(cwd: &Path) -> bool {
 fn missing_generated_types_warning(
     has_generated_imports: bool,
     generated_dir: &generated_dir::NuxtGeneratedDir,
+    legacy_vue2: bool,
 ) -> Option<String> {
     (!has_generated_imports).then(|| {
+        if legacy_vue2 {
+            return format!(
+                "vize check: no generated `{}` types found; Nuxt auto-imports fall back to `any` \
+                 stubs and some type errors will be missed. For Nuxt 2/Bridge, run the project's \
+                 Nuxt type-generation step or build once so the generated type directory exists.",
+                generated_dir.display()
+            )
+            .into();
+        }
+
         format!(
             "vize check: no generated `{}` types found; Nuxt auto-imports fall back to `any` \
              stubs and some type errors will be missed. Run `nuxi prepare` to generate them.",

--- a/crates/vize/src/commands/check/nuxt/fallback.rs
+++ b/crates/vize/src/commands/check/nuxt/fallback.rs
@@ -23,6 +23,8 @@ use super::stubs::{
 };
 use fallback_values::fallback_value_stubs;
 
+const MODULE_AUGMENTATION_STUB_PREFIX: &str = "// @vize-module-augmentation\n";
+
 pub(super) fn collect_fallback_stubs(
     stubs: &mut Vec<String>,
     seen_names: &mut FxHashSet<String>,
@@ -82,6 +84,57 @@ fn push_fallback_stub_group(
         }
         stubs.push(stub);
     }
+}
+
+pub(super) fn collect_legacy_module_augmentation_stubs(cwd: &Path, stubs: &mut Vec<String>) {
+    let config_source = nuxt_config_source(cwd);
+    if config_source.is_empty() {
+        return;
+    }
+    let modules = parse_nuxt_config_modules(&config_source);
+    let has_gtm = modules.might_include(&["@nuxtjs/gtm", "nuxt-gtm"]);
+    let has_vuetify = modules.might_include(&["@nuxtjs/vuetify"]);
+    let has_i18n = modules.might_include(&["@nuxtjs/i18n", "@nuxt/i18n", "nuxt-i18n"]);
+    if !(has_gtm || has_vuetify || has_i18n) {
+        return;
+    }
+
+    stubs.push(render_legacy_module_augmentation_stub(
+        has_gtm,
+        has_vuetify,
+        has_i18n,
+    ));
+}
+
+fn render_legacy_module_augmentation_stub(
+    has_gtm: bool,
+    has_vuetify: bool,
+    has_i18n: bool,
+) -> String {
+    let mut injected_context = String::default();
+    let mut injected_app = String::default();
+    if has_gtm {
+        injected_context.push_str("    $gtm: any;\n");
+        injected_app.push_str("    $gtm: any;\n");
+    }
+    if has_vuetify {
+        injected_context.push_str("    $vuetify: any;\n");
+        injected_app.push_str("    $vuetify: any;\n");
+    }
+    if has_i18n {
+        injected_app.push_str("    i18n: __VizeNuxt2I18n;\n");
+    }
+
+    let i18n_alias = if has_i18n {
+        "type __VizeNuxt2I18n = { t: (...args: any[]) => any } & Record<string, any>;\n"
+    } else {
+        ""
+    };
+
+    format!(
+        "{MODULE_AUGMENTATION_STUB_PREFIX}{i18n_alias}declare module \"@nuxt/types\" {{\n  interface Context {{\n{injected_context}  }}\n  interface NuxtAppOptions {{\n{injected_app}  }}\n}}\ndeclare module \"@nuxtjs/composition-api\" {{\n  interface UseContextReturn {{\n{injected_context}  }}\n}}\ndeclare module \"#app\" {{\n  interface NuxtApp {{\n{injected_app}  }}\n}}\n"
+    )
+    .into()
 }
 
 pub(super) fn collect_module_fallback_stubs(

--- a/crates/vize/src/commands/check/nuxt/tests.rs
+++ b/crates/vize/src/commands/check/nuxt/tests.rs
@@ -8,11 +8,11 @@ use vize_canon::virtual_ts::VirtualTsOptions;
 use vize_carton::cstr;
 
 use super::super::dts::rewrite_relative_specifier;
-use super::detect_nuxt_auto_imports;
 use super::fallback::{fallback_stub_strings, parse_nuxt_config_modules};
 use super::parsing::{parse_export_names, parse_module_specifier};
 use super::plugins::extract_plugin_provide_keys_from_source;
 use super::stubs::declared_name;
+use super::{detect_legacy_nuxt_auto_imports, detect_nuxt_auto_imports};
 
 mod build_dir;
 
@@ -553,6 +553,43 @@ export default defineNuxtConfig({
         "expected i18n template globals, got: {:#?}",
         options.template_globals
     );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn detects_legacy_nuxt2_module_context_augmentations() {
+    let project_root = unique_case_dir("nuxt2-module-augmentations");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("pages")).unwrap();
+    std::fs::write(
+        project_root.join("nuxt.config.ts"),
+        r#"
+export default {
+  modules: ['@nuxtjs/gtm', '@nuxtjs/vuetify', 'nuxt-i18n'],
+}
+"#,
+    )
+    .unwrap();
+
+    let mut options = VirtualTsOptions::default();
+    let _ = detect_legacy_nuxt_auto_imports(&mut options, &project_root);
+    let stubs = options.auto_import_stubs.join("\n");
+
+    for expected in [
+        "declare module \"@nuxt/types\"",
+        "interface UseContextReturn",
+        "interface NuxtApp",
+        "$gtm: any;",
+        "$vuetify: any;",
+        "i18n: __VizeNuxt2I18n;",
+        "t: (...args: any[]) => any",
+    ] {
+        assert!(
+            stubs.contains(expected),
+            "expected legacy Nuxt2 module augmentation {expected:?}, got:\n{stubs}"
+        );
+    }
 
     let _ = std::fs::remove_dir_all(&project_root);
 }

--- a/crates/vize/src/commands/check/nuxt/tests/build_dir.rs
+++ b/crates/vize/src/commands/check/nuxt/tests/build_dir.rs
@@ -10,8 +10,8 @@ use super::unique_case_dir;
 #[test]
 fn warns_only_when_generated_nuxt_types_are_missing() {
     let generated_dir = resolve_nuxt_generated_dir(Path::new("/workspace"));
-    assert!(missing_generated_types_warning(true, &generated_dir).is_none());
-    let message = missing_generated_types_warning(false, &generated_dir)
+    assert!(missing_generated_types_warning(true, &generated_dir, false).is_none());
+    let message = missing_generated_types_warning(false, &generated_dir, false)
         .expect("missing generated types must warn");
     assert!(message.contains("nuxi prepare"));
     assert!(message.contains("`.nuxt`"));
@@ -155,13 +155,23 @@ fn warning_mentions_resolved_generated_dir() {
     .unwrap();
 
     let generated_dir = resolve_nuxt_generated_dir(&project_root);
-    let message = missing_generated_types_warning(false, &generated_dir)
+    let message = missing_generated_types_warning(false, &generated_dir, false)
         .expect("missing generated types must warn");
 
     assert!(message.contains("`.out/.nuxt`"), "{message}");
     assert!(!message.contains("`.nuxt` types"), "{message}");
 
     let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn legacy_nuxt_warning_avoids_nuxt3_prepare_guidance() {
+    let generated_dir = resolve_nuxt_generated_dir(Path::new("/workspace"));
+    let message = missing_generated_types_warning(false, &generated_dir, true)
+        .expect("missing generated types must warn");
+
+    assert!(!message.contains("nuxi prepare"), "{message}");
+    assert!(message.contains("Nuxt 2/Bridge"), "{message}");
 }
 
 #[test]

--- a/crates/vize/src/commands/musea/migrate.rs
+++ b/crates/vize/src/commands/musea/migrate.rs
@@ -90,7 +90,7 @@ pub fn run(args: MigrateArgs) {
 fn collect_story_files(patterns: &[std::string::String]) -> Vec<PathBuf> {
     collect_files(patterns, None)
         .into_iter()
-        .filter(|path| is_story_file(path))
+        .filter(|path| is_story_file(path) && !is_default_ignored_story_path(path))
         .collect()
 }
 
@@ -103,6 +103,17 @@ fn is_story_file(path: &Path) -> bool {
         name.rsplit_once('.'),
         Some((stem, "tsx" | "ts" | "jsx" | "js")) if stem.ends_with(".stories")
     )
+}
+
+fn is_default_ignored_story_path(path: &Path) -> bool {
+    path.components().any(|component| {
+        component.as_os_str().to_str().is_some_and(|name| {
+            matches!(
+                name,
+                "node_modules" | ".nuxt" | ".output" | "dist" | "storybook-static"
+            )
+        })
+    })
 }
 
 struct FileOutcome {

--- a/crates/vize/src/commands/musea/migrate/emit.rs
+++ b/crates/vize/src/commands/musea/migrate/emit.rs
@@ -6,7 +6,7 @@ use vize_carton::{String, append};
 
 use super::csf::{CsfModule, CsfStory, unwrap_expression};
 use super::jsx::convert_render;
-use super::text::{escape_attr, escape_js_string};
+use super::text::{escape_attr, escape_js_string, quote_directive_expression};
 
 const TODO_COMMENT: &str = "<!-- TODO(vize musea migrate): unsupported story; port manually -->";
 
@@ -91,16 +91,30 @@ fn emit_variant_inner(story: &CsfStory<'_>, component_tag: &str, source: &str) -
     }
 
     if let Some(args) = story.args {
-        return (emit_args_element(args, component_tag, source), false);
+        if args_contains_unmigrated_identifier(args) {
+            return (emit_todo_element(component_tag), true);
+        }
+        if let Some(element) = emit_args_element(args, component_tag, source) {
+            return (element, false);
+        }
+        return (emit_todo_element(component_tag), true);
     }
 
+    (emit_todo_element(component_tag), true)
+}
+
+fn emit_todo_element(component_tag: &str) -> String {
     let mut out = String::default();
     append!(out, "<{component_tag} />\n{TODO_COMMENT}");
-    (out, true)
+    out
 }
 
 /// Emit `<Component ...props />` from an `args` object literal.
-fn emit_args_element(args: &ObjectExpression<'_>, component_tag: &str, source: &str) -> String {
+fn emit_args_element(
+    args: &ObjectExpression<'_>,
+    component_tag: &str,
+    source: &str,
+) -> Option<String> {
     let mut out = String::default();
     append!(out, "<{component_tag}");
     for property in &args.properties {
@@ -114,23 +128,33 @@ fn emit_args_element(args: &ObjectExpression<'_>, component_tag: &str, source: &
             continue;
         };
         out.push(' ');
-        out.push_str(&attribute_from_value(name, &prop.value, source));
+        out.push_str(&attribute_from_value(name, &prop.value, source)?);
     }
     out.push_str(" />");
-    out
+    Some(out)
 }
 
 /// Map one `args` entry to an attribute: string literal -> `name="value"`,
 /// everything else -> `:name="<expr source>"`.
-fn attribute_from_value(name: &str, value: &Expression<'_>, source: &str) -> String {
+fn attribute_from_value(name: &str, value: &Expression<'_>, source: &str) -> Option<String> {
     let mut out = String::default();
     if let Expression::StringLiteral(literal) = unwrap_expression(value) {
         append!(out, "{name}=\"{}\"", escape_attr(literal.value.as_str()));
     } else {
         let text = value.span().source_text(source);
-        append!(out, ":{name}=\"{}\"", escape_attr(text));
+        let quoted = quote_directive_expression(text)?;
+        append!(out, ":{name}={}", quoted.as_str());
     }
-    out
+    Some(out)
+}
+
+fn args_contains_unmigrated_identifier(args: &ObjectExpression<'_>) -> bool {
+    args.properties.iter().any(|property| {
+        let ObjectPropertyKind::ObjectProperty(prop) = property else {
+            return false;
+        };
+        !prop.computed && matches!(unwrap_expression(&prop.value), Expression::Identifier(_))
+    })
 }
 
 fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {

--- a/crates/vize/src/commands/musea/migrate/emit/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/tests.rs
@@ -85,3 +85,33 @@ defineArt("./AfButton.vue", {
     assert_eq!(variants, 1);
     assert_eq!(todos, 0);
 }
+
+#[test]
+fn emits_todo_for_args_referencing_local_fixture_identifiers() {
+    let source = r#"import AfButton from "./AfButton.vue";
+const fixture = { label: "Hi" };
+export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;
+export const Big = { args: { data: fixture } };
+"#;
+    let (content, variants, todos) = emit(source);
+
+    assert!(content.contains("<AfButton />"));
+    assert!(content.contains("TODO(vize musea migrate)"));
+    assert!(!content.contains(":data=\"fixture\""));
+    assert_eq!(variants, 1);
+    assert_eq!(todos, 1);
+}
+
+#[test]
+fn emits_directive_expressions_without_quot_entities() {
+    let source = r#"import AfButton from "./AfButton.vue";
+export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;
+export const Big = { args: { to: { name: "students" } as NuxtRoute<"students", string>, field: { label: "Name" } } };
+"#;
+    let (content, _variants, todos) = emit(source);
+
+    assert!(content.contains(r#":to='{ name: "students" } as NuxtRoute<"students", string>'"#));
+    assert!(content.contains(r#":field='{ label: "Name" }'"#));
+    assert!(!content.contains("&quot;"));
+    assert_eq!(todos, 0);
+}

--- a/crates/vize/src/commands/musea/migrate/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/tests.rs
@@ -1,7 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use super::{
-    component_tag_from_path, derive_component_path, is_story_file, output_path, story_basename,
+    component_tag_from_path, derive_component_path, is_default_ignored_story_path, is_story_file,
+    output_path, story_basename,
 };
 
 #[test]
@@ -13,6 +14,19 @@ fn is_story_file_matches_only_story_extensions() {
     assert!(!is_story_file(Path::new("Button.tsx")));
     assert!(!is_story_file(Path::new("Button.stories.vue")));
     assert!(!is_story_file(Path::new("stories.ts")));
+}
+
+#[test]
+fn default_ignored_story_paths_skip_dependencies_and_outputs() {
+    assert!(is_default_ignored_story_path(Path::new(
+        "node_modules/pkg/Button.stories.tsx"
+    )));
+    assert!(is_default_ignored_story_path(Path::new(
+        ".output/public/Button.stories.tsx"
+    )));
+    assert!(!is_default_ignored_story_path(Path::new(
+        "src/Button.stories.tsx"
+    )));
 }
 
 #[test]

--- a/crates/vize/src/commands/musea/migrate/text.rs
+++ b/crates/vize/src/commands/musea/migrate/text.rs
@@ -18,6 +18,27 @@ pub(super) fn escape_attr(value: &str) -> String {
     out
 }
 
+/// Quote a Vue directive expression without HTML-escaping the expression's own
+/// string literals. Keep the existing double-quoted attribute form when
+/// possible; use single quotes only when the expression itself contains `"`.
+pub(super) fn quote_directive_expression(value: &str) -> Option<String> {
+    if !value.contains('"') {
+        let mut out = String::from("\"");
+        out.push_str(value);
+        out.push('"');
+        return Some(out);
+    }
+
+    if !value.contains('\'') {
+        let mut out = String::from("'");
+        out.push_str(value);
+        out.push('\'');
+        return Some(out);
+    }
+
+    None
+}
+
 /// Escape a value for a double-quoted JavaScript/TypeScript string literal (used
 /// in the generated `defineArt("...", { ... })` call).
 pub(super) fn escape_js_string(value: &str) -> String {
@@ -35,7 +56,7 @@ pub(super) fn escape_js_string(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{escape_attr, escape_js_string};
+    use super::{escape_attr, escape_js_string, quote_directive_expression};
 
     #[test]
     fn escape_attr_encodes_quotes_and_amp() {
@@ -53,5 +74,25 @@ mod tests {
     #[test]
     fn escape_js_string_encodes_backslash_quote_newline() {
         assert_eq!(escape_js_string("a\\b\"c\nd").as_str(), "a\\\\b\\\"c\\nd");
+    }
+
+    #[test]
+    fn quote_directive_expression_preserves_double_quotes() {
+        assert_eq!(
+            quote_directive_expression(r#"{ name: "students" }"#)
+                .unwrap()
+                .as_str(),
+            r#"'{ name: "students" }'"#
+        );
+    }
+
+    #[test]
+    fn quote_directive_expression_uses_double_quotes_for_single_quoted_text() {
+        assert_eq!(
+            quote_directive_expression("{ name: 'students' }")
+                .unwrap()
+                .as_str(),
+            r#""{ name: 'students' }""#
+        );
     }
 }

--- a/crates/vize/src/commands/musea/serve_plan.rs
+++ b/crates/vize/src/commands/musea/serve_plan.rs
@@ -25,7 +25,12 @@ pub(super) fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePla
         }
         None => PathBuf::from("vite"),
     };
-    validate_direct_vite_musea_setup(cwd)?;
+    if let Err(message) = validate_direct_vite_musea_setup(cwd) {
+        if let Some(nuxt_root) = find_nuxt_project_root(cwd) {
+            return Err(nuxt_musea_message(&nuxt_root, args.build));
+        }
+        return Err(message);
+    }
     let mut env = Vec::new();
     if let Some(config_path) = &args.config {
         env.push((

--- a/crates/vize/src/commands/musea/tests.rs
+++ b/crates/vize/src/commands/musea/tests.rs
@@ -220,6 +220,42 @@ fn serve_plan_rejects_nuxt_project_without_direct_vite() {
 }
 
 #[test]
+fn serve_plan_prefers_nuxt_guidance_when_vite_exists_but_config_is_nuxt_only() {
+    let temp = tempfile::tempdir().unwrap();
+    write_vite_bin(temp.path());
+    fs::write(
+        temp.path().join("nuxt.config.ts"),
+        r#"export default defineNuxtConfig({ modules: ["@vizejs/nuxt"], vize: { musea: true } })"#,
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("package.json"),
+        r#"{
+  "dependencies": {
+    "@vizejs/nuxt": "0.263.0",
+    "@vizejs/vite-plugin-musea": "0.263.0",
+    "nuxt": "3.19.3",
+    "vite": "7.0.0"
+  }
+}"#,
+    )
+    .unwrap();
+
+    let error = create_serve_plan(
+        &ServeArgs {
+            build: true,
+            ..ServeArgs::default()
+        },
+        temp.path(),
+    )
+    .unwrap_err();
+
+    assert!(error.contains("detected a Nuxt project using `@vizejs/nuxt`"));
+    assert!(error.contains("nuxi build"));
+    assert!(!error.contains("no vite.config"));
+}
+
+#[test]
 fn serve_plan_rejects_silent_stories_option() {
     let temp = tempfile::tempdir().unwrap();
     write_vite_bin(temp.path());

--- a/crates/vize_canon/src/batch/executor/diagnostics.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics.rs
@@ -299,16 +299,28 @@ fn parse_severity(severity: Option<i32>) -> u8 {
     }
 }
 
-pub(super) fn should_skip_diagnostic(code: Option<u32>, _message: &str) -> bool {
+pub(super) fn should_skip_diagnostic(code: Option<u32>, message: &str) -> bool {
     match code {
         // TS2666: virtual-TS generation injects helper bindings that can trip
         // this code outside the user's source — suppress to match vue-tsc.
         Some(2666) => true,
+        // Native TypeScript currently exposes Node Buffer backing stores as
+        // `ArrayBuffer | SharedArrayBuffer`, while projects pinned to older
+        // TypeScript/@types/node combinations accepted `buffer.slice(...)` as
+        // `ArrayBuffer`. Keep vize aligned with that project baseline until the
+        // native checker can select the project's exact lib surface.
+        Some(2322) if is_array_buffer_backing_store_lib_mismatch(message) => true,
         // TS7006/TS7043/TS7044 (noImplicitAny family) are user-facing errors
         // and must surface so `vize check` matches vue-tsc under
         // `noImplicitAny`/`strict`. They were previously suppressed (#966).
         _ => false,
     }
+}
+
+fn is_array_buffer_backing_store_lib_mismatch(message: &str) -> bool {
+    message
+        .contains("Type 'ArrayBuffer | SharedArrayBuffer' is not assignable to type 'ArrayBuffer'")
+        && message.contains("SharedArrayBuffer")
 }
 
 pub(super) fn should_skip_original_diagnostic(
@@ -619,6 +631,10 @@ mod tests {
         assert!(!should_skip_diagnostic(Some(7043), "any message"));
         assert!(!should_skip_diagnostic(Some(7044), "any message"));
         assert!(!should_skip_diagnostic(Some(2322), "any message"));
+        assert!(should_skip_diagnostic(
+            Some(2322),
+            "Type 'ArrayBuffer | SharedArrayBuffer' is not assignable to type 'ArrayBuffer'."
+        ));
         assert!(!should_skip_diagnostic(None, "any message"));
     }
 

--- a/crates/vize_canon/src/batch/virtual_project/passthrough.rs
+++ b/crates/vize_canon/src/batch/virtual_project/passthrough.rs
@@ -38,8 +38,19 @@ pub(super) fn collect_passthrough_modules(
         else {
             continue;
         };
+        let declaration_path = adjacent_declaration_path(&original_path);
         if seen.insert(virtual_path.clone()) {
             files.push((virtual_path, original_path));
+        }
+        if let Some(declaration_path) = declaration_path {
+            let Ok(virtual_path) =
+                mirrored_virtual_path(project_root, virtual_root, &declaration_path)
+            else {
+                continue;
+            };
+            if seen.insert(virtual_path.clone()) {
+                files.push((virtual_path, declaration_path));
+            }
         }
     }
     files
@@ -156,6 +167,20 @@ fn normalize_existing_path(path: &Path) -> PathBuf {
     vize_carton::path::canonicalize_non_verbatim(path)
 }
 
+fn adjacent_declaration_path(path: &Path) -> Option<PathBuf> {
+    let extension = path.extension().and_then(|extension| extension.to_str())?;
+    let declaration_extension = match extension {
+        "js" | "jsx" => "d.ts",
+        "mjs" => "d.mts",
+        "cjs" => "d.cts",
+        _ => return None,
+    };
+    let candidate = path.with_extension(declaration_extension);
+    candidate
+        .is_file()
+        .then(|| normalize_existing_path(&candidate))
+}
+
 fn is_javascript_passthrough(path: &Path) -> bool {
     path.extension()
         .and_then(|extension| extension.to_str())
@@ -230,6 +255,61 @@ mod tests {
                 (
                     PathBuf::from("tokens/colors.json"),
                     PathBuf::from("tokens/colors.json"),
+                ),
+            ]
+        );
+
+        let _ = std::fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn collects_adjacent_declaration_for_relative_js_module() {
+        let case_dir = unique_case_dir("js-adjacent-dts");
+        let _ = std::fs::remove_dir_all(&case_dir);
+        std::fs::create_dir_all(&case_dir).unwrap();
+        let root = vize_carton::path::canonicalize_non_verbatim(&case_dir);
+        let entry = write(
+            &root,
+            "src/main.ts",
+            "import { tokens } from './styles/tokens'\nvoid tokens\n",
+        );
+        write(&root, "src/styles/tokens.js", "export const tokens = {}\n");
+        write(
+            &root,
+            "src/styles/tokens.d.ts",
+            "export declare const tokens: Record<string, string>\n",
+        );
+        let virtual_root = root.join("node_modules/.vize/canon");
+
+        let mut files = collect_passthrough_modules(
+            &entry,
+            &std::fs::read_to_string(&entry).unwrap(),
+            &root,
+            &virtual_root,
+        );
+        files.sort();
+
+        assert_eq!(
+            files
+                .into_iter()
+                .map(|(virtual_path, original_path)| {
+                    (
+                        virtual_path
+                            .strip_prefix(&virtual_root)
+                            .unwrap()
+                            .to_path_buf(),
+                        original_path.strip_prefix(&root).unwrap().to_path_buf(),
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    PathBuf::from("src/styles/tokens.d.ts"),
+                    PathBuf::from("src/styles/tokens.d.ts"),
+                ),
+                (
+                    PathBuf::from("src/styles/tokens.js"),
+                    PathBuf::from("src/styles/tokens.js"),
                 ),
             ]
         );

--- a/crates/vize_canon/src/batch/virtual_project/tests/ref_arity.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/ref_arity.rs
@@ -177,7 +177,9 @@ export default {
         assert!(!content.contains("import('vue').ComponentPublicInstance"));
         assert!(!content.contains("import('vue').defineComponent"));
     }
-    assert!(options_content.contains("declare function __vizeDefineComponent<T>(options: T): T;"));
+    assert!(options_content.contains(
+        "declare function __vizeDefineComponent<T>(options: T & __VizeNuxt2PageOptions): T;",
+    ));
 
     project.materialize().unwrap();
     assert!(!project.virtual_root().join("__vize_helpers.d.ts").exists());

--- a/crates/vize_canon/src/batch/virtual_project/tests/snapshots/vize_canon__batch__virtual_project__tests__ref_arity__dialect_v2.snap
+++ b/crates/vize_canon/src/batch/virtual_project/tests/snapshots/vize_canon__batch__virtual_project__tests__ref_arity__dialect_v2.snap
@@ -42,6 +42,8 @@ type __VizeKebabCase<S extends string> = S extends `${infer Head}${infer Tail}` 
 type __VizeKebabProps<T> = { [K in keyof T & string as __VizeKebabCase<K>]: T[K] };
 type __VizeComponentProps<T> = T extends unknown ? T & Partial<__VizeKebabProps<T>> : never;
 type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
+type __VizeVue2LooseEventArg<T> = __VizeIsAny<T> extends true ? any : [T] extends [Object] ? ([Object] extends [T] ? any : T) : T;
+type __VizeVue2LooseEmitArgs<A extends readonly unknown[]> = { [K in keyof A]: __VizeVue2LooseEventArg<A[K]> };
 type __VForEntry<T> = __VizeIsAny<T> extends true ? [item: any, key: number, index: number] : T extends readonly (infer U)[] ? [item: U, key: number, index: number] : T extends number ? [item: number, key: number, index: number] : T extends string ? [item: string, key: number, index: number] : T extends Iterable<infer U> ? [item: U, key: number, index: number] : T extends object ? [item: T[keyof T], key: keyof T, index: number] : [item: any, key: number, index: number];
 declare function __vForList<T>(source: T | undefined | null): readonly __VForEntry<NonNullable<T>>[];
 import { ref } from 'vue'
@@ -82,7 +84,7 @@ function __setup() {
 
   const count = ref(0)
 
-  // @vize-map: 5502:5577 -> 0:84
+  // @vize-map: 5745:5820 -> 0:84
 
   // ========== Template Scope (inherits from setup) ==========
   // Ref type captures (before template scope shadows them)

--- a/crates/vize_canon/src/virtual_ts/generator/imports.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/imports.rs
@@ -307,6 +307,10 @@ pub(super) fn extract_declared_name(stub: &str) -> Option<&str> {
 
 fn extract_import_names(import_text: &str) -> Vec<&str> {
     let mut names = Vec::new();
+    let trimmed = import_text.trim_start();
+    if trimmed.starts_with("import type ") {
+        return names;
+    }
 
     if let Some(brace_start) = import_text.find('{') {
         if let Some(brace_end) = import_text.find('}') {

--- a/crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs
@@ -24,6 +24,8 @@ type __VizeKebabCase<S extends string> = S extends `${infer Head}${infer Tail}` 
 type __VizeKebabProps<T> = { [K in keyof T & string as __VizeKebabCase<K>]: T[K] };
 type __VizeComponentProps<T> = T extends unknown ? T & Partial<__VizeKebabProps<T>> : never;
 type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
+type __VizeVue2LooseEventArg<T> = __VizeIsAny<T> extends true ? any : [T] extends [Object] ? ([Object] extends [T] ? any : T) : T;
+type __VizeVue2LooseEmitArgs<A extends readonly unknown[]> = { [K in keyof A]: __VizeVue2LooseEventArg<A[K]> };
 type __VForEntry<T> = __VizeIsAny<T> extends true ? [item: any, key: number, index: number] : T extends readonly (infer U)[] ? [item: U, key: number, index: number] : T extends number ? [item: number, key: number, index: number] : T extends string ? [item: string, key: number, index: number] : T extends Iterable<infer U> ? [item: U, key: number, index: number] : T extends object ? [item: T[keyof T], key: keyof T, index: number] : [item: any, key: number, index: number];
 declare function __vForList<T>(source: T | undefined | null): readonly __VForEntry<NonNullable<T>>[];"#;
 const LEGACY_REF_UNWRAP_HELPER: &str =
@@ -32,8 +34,28 @@ const MODERN_REF_UNWRAP_HELPER: &str = r#"    type __VizeIsUnion<T, __U = T> = T
     type __VizeWidenTemplateRef<T> = __VizeIsUnion<T> extends true ? T : T extends string ? string : T extends number ? number : T extends boolean ? boolean : T;
     type __U<T> = T extends import('vue').Ref ? __VizeWidenTemplateRef<T['value']> : T;
 "#;
-const LEGACY_DEFINE_COMPONENT_HELPER: &str =
-    "declare function __vizeDefineComponent<T>(options: T): T;\n";
+const LEGACY_DEFINE_COMPONENT_HELPER: &str = r#"type __VizeNuxt2Context = {
+  app: any;
+  route: any;
+  params: Record<string, string>;
+  query: Record<string, string | string[] | undefined>;
+  store: any;
+  error: (...args: any[]) => any;
+  redirect: (...args: any[]) => any;
+  req?: any;
+  res?: any;
+  env?: Record<string, unknown>;
+  isDev?: boolean;
+  isHMR?: boolean;
+} & Record<string, any>;
+type __VizeNuxt2PageOptions = {
+  validate?: (context: __VizeNuxt2Context) => unknown;
+  asyncData?: (context: __VizeNuxt2Context) => any;
+  fetch?: (context: __VizeNuxt2Context) => any;
+  middleware?: any;
+};
+declare function __vizeDefineComponent<T>(options: T & __VizeNuxt2PageOptions): T;
+"#;
 pub(super) const LEGACY_COMPONENT_INSTANCE_HELPER: &str = r#"type __VizeVue2ComponentInstance = {
   $el: Element;
   $refs: Record<string, any>;

--- a/crates/vize_canon/src/virtual_ts/generator/script_module.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module.rs
@@ -146,6 +146,9 @@ fn collect_declaration_exports(
                 push_name(id.name.as_str(), seen, names);
             }
         }
+        Declaration::TSEnumDeclaration(enumeration) => {
+            push_name(enumeration.id.name.as_str(), seen, names);
+        }
         _ => {}
     }
 }
@@ -233,7 +236,7 @@ fn contains_ts_suppression_directive(comment: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::collect_line_module_import_spans;
+    use super::{CompactString, collect_line_module_import_spans, collect_named_value_exports};
 
     #[test]
     fn collect_import_span_includes_adjacent_ts_ignore_comment_group() {
@@ -257,5 +260,14 @@ mod tests {
             &script[spans[0].0 as usize..spans[0].1 as usize],
             "import Chart from \"chart.js/auto/auto\";"
         );
+    }
+
+    #[test]
+    fn collect_named_value_exports_includes_ts_enums() {
+        let names = collect_named_value_exports(
+            "export enum DiffDisplayMode { Hidden = 'hidden' }\nexport type Props = {}\n",
+        );
+
+        assert_eq!(names, vec![CompactString::new("DiffDisplayMode")]);
     }
 }

--- a/crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs
@@ -82,6 +82,24 @@ function updateDate(newDate: string) {
 }
 
 #[test]
+fn legacy_vue2_component_event_object_payloads_stay_permissive() {
+    let script = r#"type Manager = { id: string }
+declare const DataTable: { new (): { $props: { "onClick:Row"?: (item: Object) => unknown } } }
+function moveToDetail(item: Manager) {
+  void item
+}
+"#;
+    let template = r#"<DataTable @click:row="moveToDetail" />"#;
+
+    let legacy = legacy_virtual_ts(script, template, &VirtualTsOptions::default());
+    assert!(
+        legacy.contains("__VizeVue2LooseEventArg<__DataTable_")
+            && legacy.contains("__VizeVue2LooseEmitArgs<__DataTable_"),
+        "legacy Vue 2 broad Object component event payloads should be loosened:\n{legacy}"
+    );
+}
+
+#[test]
 fn legacy_vue2_skips_external_component_prop_checks() {
     let script = "const width = 320\n";
     let template = r#"<VDatePicker :width="width" />"#;

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -376,10 +376,17 @@ fn generate_scope_node(
                 // signature stays unresolved (`unknown[]`, e.g. a fallthrough
                 // DOM event on a component), fall back to the single `$event`
                 // parameter so those handlers keep type-checking.
-                append!(
-                    *ts,
-                    "{indent}type {listener_type} = unknown[] extends {args_type} ? (($event: {event_type}) => unknown) : ((...args: {args_type}) => unknown);\n",
-                );
+                if ctx.legacy_vue2 {
+                    append!(
+                        *ts,
+                        "{indent}type {listener_type} = unknown[] extends {args_type} ? (($event: {event_type}) => unknown) : ((...args: __VizeVue2LooseEmitArgs<{args_type}>) => unknown);\n",
+                    );
+                } else {
+                    append!(
+                        *ts,
+                        "{indent}type {listener_type} = unknown[] extends {args_type} ? (($event: {event_type}) => unknown) : ((...args: {args_type}) => unknown);\n",
+                    );
+                }
                 // Receive every listener argument via a rest parameter typed by
                 // `Parameters<listener>` (always a tuple, so the spread targets a
                 // rest parameter and avoids TS2556). `$event` stays bound to the

--- a/crates/vize_canon/src/virtual_ts/scope/component_events.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events.rs
@@ -113,15 +113,18 @@ pub(super) fn generate_component_event_types(
         );
     }
 
-    let fallback_event = if legacy_vue2 {
-        "any"
+    if legacy_vue2 {
+        append!(
+            *ts,
+            "{indent}type {event_type} = {args_type} extends [] ? any : unknown[] extends {args_type} ? any : __VizeVue2LooseEventArg<{args_type}[0]>;\n",
+        );
     } else {
-        get_dom_event_type(data.event_name.as_str())
-    };
-    append!(
-        *ts,
-        "{indent}type {event_type} = {args_type} extends [] ? any : unknown[] extends {args_type} ? {fallback_event} : {args_type}[0];\n",
-    );
+        let fallback_event = get_dom_event_type(data.event_name.as_str());
+        append!(
+            *ts,
+            "{indent}type {event_type} = {args_type} extends [] ? any : unknown[] extends {args_type} ? {fallback_event} : {args_type}[0];\n",
+        );
+    }
     Some(ComponentEventTypes {
         event_type,
         args_type,

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -772,6 +772,52 @@ const count = 1
 }
 
 #[test]
+fn test_type_only_imports_do_not_shadow_auto_imported_components() {
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let script = r#"/// <reference types="nuxt" />
+import type { Differences } from './types'
+const count = 1
+"#;
+    let template = r#"<Differences :count="count" />"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let options = VirtualTsOptions {
+        auto_import_stubs: vec![
+            "declare const Differences: typeof import('./components/Differences.vue')['default'];"
+                .into(),
+        ],
+        ..Default::default()
+    };
+
+    let output =
+        generate_virtual_ts_with_offsets(&summary, Some(script), Some(&root), 0, 0, &options);
+
+    assert!(
+        output
+            .code
+            .contains("declare const Differences: typeof import"),
+        "{}",
+        output.code
+    );
+    assert!(!output.code.contains("const Differences: any"));
+    assert!(
+        output
+            .code
+            .contains("type __Differences_Props_0 = typeof Differences"),
+        "{}",
+        output.code
+    );
+}
+
+#[test]
 fn test_external_template_bindings_do_not_shadow_auto_imported_components() {
     use vize_croquis::{Analyzer, AnalyzerOptions};
 
@@ -2033,6 +2079,50 @@ fn test_plain_options_object_default_export_is_wrapped_with_define_component() {
     assert!(
         output.code.contains("\n  })\n"),
         "expected the wrap to be closed after the options object:\n{}",
+        output.code
+    );
+}
+
+#[test]
+fn test_legacy_nuxt2_page_validate_gets_contextual_type() {
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let script = r#"export default {
+  name: 'StudentPage',
+  validate({ params }) {
+    return !Number.isNaN(Number(params.studentId))
+  }
+}
+"#;
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_plain(script);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts_with_offsets_and_checks(
+        &summary,
+        Some(script),
+        None,
+        0,
+        0,
+        &Default::default(),
+        VirtualTsGenerationOptions {
+            legacy_vue2: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        output
+            .code
+            .contains("validate?: (context: __VizeNuxt2Context) => unknown;"),
+        "legacy Nuxt 2 page options should declare a contextual validate type:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("const __default__ = __vizeDefineComponent({"),
+        "plain object exports should be wrapped by the legacy helper:\n{}",
         output.code
     );
 }

--- a/crates/vize_patina/src/rules/css/prefer_logical_properties.rs
+++ b/crates/vize_patina/src/rules/css/prefer_logical_properties.rs
@@ -6,6 +6,7 @@ use lightningcss::declaration::DeclarationBlock;
 use lightningcss::properties::PropertyId;
 use lightningcss::rules::CssRule as LCssRule;
 use lightningcss::stylesheet::StyleSheet;
+use vize_carton::FxHashSet;
 
 use crate::diagnostic::{LintDiagnostic, Severity};
 
@@ -32,31 +33,38 @@ impl CssRule for PreferLogicalProperties {
         offset: usize,
         result: &mut CssLintResult,
     ) {
+        let mut reported = FxHashSet::default();
         for rule in &stylesheet.rules.0 {
-            self.check_rule(rule, offset, result);
+            self.check_rule(rule, offset, result, &mut reported);
         }
     }
 }
 
 impl PreferLogicalProperties {
-    fn check_rule(&self, rule: &LCssRule, offset: usize, result: &mut CssLintResult) {
+    fn check_rule(
+        &self,
+        rule: &LCssRule,
+        offset: usize,
+        result: &mut CssLintResult,
+        reported: &mut FxHashSet<(u32, u32)>,
+    ) {
         match rule {
             LCssRule::Style(style_rule) => {
-                self.check_declarations(&style_rule.declarations, offset, result);
+                self.check_declarations(&style_rule.declarations, offset, result, reported);
             }
             LCssRule::Media(media) => {
                 for rule in &media.rules.0 {
-                    self.check_rule(rule, offset, result);
+                    self.check_rule(rule, offset, result, reported);
                 }
             }
             LCssRule::Supports(supports) => {
                 for rule in &supports.rules.0 {
-                    self.check_rule(rule, offset, result);
+                    self.check_rule(rule, offset, result, reported);
                 }
             }
             LCssRule::LayerBlock(layer) => {
                 for rule in &layer.rules.0 {
-                    self.check_rule(rule, offset, result);
+                    self.check_rule(rule, offset, result, reported);
                 }
             }
             _ => {}
@@ -68,18 +76,25 @@ impl PreferLogicalProperties {
         declarations: &DeclarationBlock,
         offset: usize,
         result: &mut CssLintResult,
+        reported: &mut FxHashSet<(u32, u32)>,
     ) {
         // Check all declarations (both regular and important)
         for decl in declarations.declarations.iter() {
-            self.check_property(decl.property_id(), offset, result);
+            self.check_property(decl.property_id(), offset, result, reported);
         }
         for decl in declarations.important_declarations.iter() {
-            self.check_property(decl.property_id(), offset, result);
+            self.check_property(decl.property_id(), offset, result, reported);
         }
     }
 
     #[inline]
-    fn check_property(&self, prop_id: PropertyId, offset: usize, result: &mut CssLintResult) {
+    fn check_property(
+        &self,
+        prop_id: PropertyId,
+        offset: usize,
+        result: &mut CssLintResult,
+        reported: &mut FxHashSet<(u32, u32)>,
+    ) {
         let (physical, logical) = match prop_id {
             PropertyId::MarginLeft => ("margin-left", "margin-inline-start"),
             PropertyId::MarginRight => ("margin-right", "margin-inline-end"),
@@ -93,13 +108,18 @@ impl PreferLogicalProperties {
         };
 
         // Report at offset since PropertyId doesn't provide precise location
-        let _ = (physical, logical); // suppress unused warnings
+        let start = offset as u32;
+        let end = (offset + physical.len()) as u32;
+        if !reported.insert((start, end)) {
+            return;
+        }
+        let _ = logical; // suppress unused warnings
         result.add_diagnostic(
             LintDiagnostic::warn(
                 META.name,
                 "Consider using logical properties for better RTL support",
-                offset as u32,
-                (offset + physical.len()) as u32,
+                start,
+                end,
             )
             .with_help("Use logical properties like margin-inline-start instead of margin-left"),
         );
@@ -129,5 +149,16 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint(".button { margin-left: 10px; }", 0);
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_deduplicates_same_fallback_range() {
+        let linter = create_linter();
+        let result = linter.lint(
+            ".button { margin-left: 10px; margin-left: 20px !important; }",
+            0,
+        );
+        assert_eq!(result.warning_count, 1);
+        assert_eq!(result.diagnostics.len(), 1);
     }
 }

--- a/crates/vize_patina/src/rules/vue/valid_v_else.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_else.rs
@@ -25,7 +25,9 @@
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, Severity, TextEdit};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{DirectiveNode, ElementNode, PropNode};
+use vize_relief::{
+    DirectiveNode, ElementNode, PropNode, RootNode, SourceLocation, TemplateChildNode,
+};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/valid-v-else",
@@ -41,6 +43,14 @@ pub struct ValidVElse;
 impl Rule for ValidVElse {
     fn meta(&self) -> &'static RuleMeta {
         &META
+    }
+
+    fn run_on_template<'a>(&self, ctx: &mut LintContext<'a>, root: &RootNode<'a>) {
+        check_adjacent_if_chain(ctx, &root.children);
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        check_adjacent_if_chain(ctx, &element.children);
     }
 
     fn check_directive<'a>(
@@ -85,6 +95,80 @@ impl Rule for ValidVElse {
     }
 }
 
+struct IfChainDirectiveInfo {
+    has_v_if: bool,
+    else_if_loc: Option<SourceLocation>,
+    else_loc: Option<SourceLocation>,
+}
+
+fn check_adjacent_if_chain(ctx: &mut LintContext, children: &[TemplateChildNode]) {
+    let mut can_follow_if = false;
+
+    for child in children {
+        match child {
+            TemplateChildNode::Element(element) => {
+                let info = get_if_chain_directive_info(element);
+
+                if info.has_v_if {
+                    can_follow_if = true;
+                    continue;
+                }
+
+                if let Some(loc) = info.else_if_loc {
+                    if !can_follow_if {
+                        report_missing_adjacent_if(ctx, &loc);
+                    }
+                    continue;
+                }
+
+                if let Some(loc) = info.else_loc {
+                    if !can_follow_if {
+                        report_missing_adjacent_if(ctx, &loc);
+                    }
+                    can_follow_if = false;
+                    continue;
+                }
+
+                can_follow_if = false;
+            }
+            TemplateChildNode::Text(text) if text.content.trim().is_empty() => {}
+            TemplateChildNode::Comment(_) => {}
+            _ => {
+                can_follow_if = false;
+            }
+        }
+    }
+}
+
+fn get_if_chain_directive_info(element: &ElementNode) -> IfChainDirectiveInfo {
+    let mut info = IfChainDirectiveInfo {
+        has_v_if: false,
+        else_if_loc: None,
+        else_loc: None,
+    };
+
+    for prop in element.props.iter() {
+        if let PropNode::Directive(dir) = prop {
+            match dir.name.as_str() {
+                "if" => info.has_v_if = true,
+                "else-if" => info.else_if_loc = Some(dir.loc.clone()),
+                "else" => info.else_loc = Some(dir.loc.clone()),
+                _ => {}
+            }
+        }
+    }
+
+    info
+}
+
+fn report_missing_adjacent_if(ctx: &mut LintContext, loc: &SourceLocation) {
+    ctx.error_with_help(
+        ctx.t("vue/valid-v-else.missing_v_if"),
+        loc,
+        ctx.t("vue/valid-v-else.help"),
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::ValidVElse;
@@ -106,6 +190,26 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_v_else_if_chain() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div v-if="foo"></div><div v-else-if="bar"></div><div v-else></div>"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_valid_v_else_after_comment() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div v-if="foo"></div><!-- fallback branch --><div v-else></div>"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
     fn test_invalid_v_else_with_expression() {
         let linter = create_linter();
         let result = linter.lint_template(
@@ -120,6 +224,32 @@ mod tests {
     fn test_invalid_v_else_with_v_if() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div v-if="foo" v-else></div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_else_without_adjacent_v_if() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div v-else></div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+        assert_eq!(result.diagnostics[0].rule_name, "vue/valid-v-else");
+    }
+
+    #[test]
+    fn test_invalid_v_else_if_without_adjacent_v_if() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div v-else-if="foo"></div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+        assert_eq!(result.diagnostics[0].rule_name, "vue/valid-v-else");
+    }
+
+    #[test]
+    fn test_invalid_v_else_after_text_gap() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div v-if="foo"></div> text <div v-else></div>"#,
+            "test.vue",
+        );
         assert_eq!(result.error_count, 1);
     }
 }

--- a/npm/builder/vite-musea/src/cli/commands.test.ts
+++ b/npm/builder/vite-musea/src/cli/commands.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { hasCiBlockingVrtResult } from "./commands.ts";
+import { hasCiBlockingVrtResult, isArtFileInput } from "./commands.ts";
 import type { VrtSummary } from "../vrt.ts";
 
 function summary(overrides: Partial<VrtSummary>): VrtSummary {
@@ -27,4 +27,9 @@ void test("VRT CI blocks on capture errors", () => {
 void test("VRT CI allows clean and newly-created baselines", () => {
   assert.equal(hasCiBlockingVrtResult(summary({})), false);
   assert.equal(hasCiBlockingVrtResult(summary({ passed: 0, new: 1 })), false);
+});
+
+void test("generate rejects existing art-file inputs", () => {
+  assert.equal(isArtFileInput("src/components/Button.art.vue"), true);
+  assert.equal(isArtFileInput("src/components/Button.vue"), false);
 });

--- a/npm/builder/vite-musea/src/cli/commands.ts
+++ b/npm/builder/vite-musea/src/cli/commands.ts
@@ -18,6 +18,10 @@ export function hasCiBlockingVrtResult(summary: VrtSummary): boolean {
   return summary.failed > 0 || summary.skipped > 0;
 }
 
+export function isArtFileInput(filePath: string): boolean {
+  return filePath.endsWith(".art.vue");
+}
+
 export async function runVrt(options: CliOptions, artFiles: ArtFileInfo[]): Promise<void> {
   const totalVariants = artFiles.reduce(
     (sum, art) => sum + art.variants.filter((v) => !v.skipVrt).length,
@@ -197,6 +201,13 @@ export async function runGenerate(options: CliOptions): Promise<void> {
   }
 
   const componentPath = path.resolve(options.componentPath);
+  if (isArtFileInput(componentPath)) {
+    console.error(
+      "  Error: musea-vrt generate expects a source .vue component, not a .art.vue file.",
+    );
+    console.error("  Pass the component file that the art file should wrap.\n");
+    process.exit(1);
+  }
 
   // Check file exists
   try {

--- a/npm/builder/vite-musea/src/native-loader.test.ts
+++ b/npm/builder/vite-musea/src/native-loader.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { analyzeSfcFallback } from "./native-loader.ts";
+
+void test("fallback SFC analysis reads defaults only from withDefaults", () => {
+  const result = analyzeSfcFallback(`
+<script setup lang="ts">
+const value = (event: Event) => {
+  return (event.target as HTMLInputElement).value;
+};
+
+const props = withDefaults(defineProps<{
+  value?: string;
+  inputId?: string;
+  type?: "text" | "number";
+}>(), {
+  value: "",
+  inputId: "field",
+  type: "text",
+});
+</script>
+`);
+
+  assert.deepEqual(
+    result.props.map((prop) => [prop.name, prop.default_value]),
+    [
+      ["value", '""'],
+      ["inputId", '"field"'],
+      ["type", '"text"'],
+    ],
+  );
+});

--- a/npm/builder/vite-musea/src/native-loader.ts
+++ b/npm/builder/vite-musea/src/native-loader.ts
@@ -157,6 +157,7 @@ export function analyzeSfcFallback(
     const propsMatch = scriptContent.match(/defineProps\s*<\s*\{([\s\S]*?)\}>\s*\(/);
     const propsMatch2 = scriptContent.match(/defineProps\s*<\s*\{([\s\S]*?)\}>/);
     const propsBody = propsMatch?.[1] || propsMatch2?.[1];
+    const withDefaults = extractWithDefaults(scriptContent);
 
     if (propsBody) {
       // Parse each prop line: name?: Type;  or  name: Type;
@@ -178,10 +179,7 @@ export function analyzeSfcFallback(
           const optional = !!propMatch[2];
           let type = propMatch[3].replace(/;$/, "").trim();
 
-          // Check for default value in destructured defineProps
-          const defaultPattern = new RegExp(`\\b${name}\\s*=\\s*([^,}\\n]+)`);
-          const defaultMatch = scriptContent.match(defaultPattern);
-          const defaultValue = defaultMatch ? defaultMatch[1].trim() : undefined;
+          const defaultValue = withDefaults.get(name);
 
           props.push({
             name,
@@ -209,4 +207,181 @@ export function analyzeSfcFallback(
   } catch {
     return { props: [], emits: [] };
   }
+}
+
+function extractWithDefaults(scriptContent: string): Map<string, string> {
+  const defaults = new Map<string, string>();
+  let searchIndex = 0;
+
+  while (searchIndex < scriptContent.length) {
+    const calleeIndex = scriptContent.indexOf("withDefaults", searchIndex);
+    if (calleeIndex === -1) break;
+    searchIndex = calleeIndex + "withDefaults".length;
+
+    if (!isIdentifierBoundary(scriptContent[calleeIndex - 1])) continue;
+    if (!isIdentifierBoundary(scriptContent[searchIndex])) continue;
+
+    const parenIndex = skipWhitespace(scriptContent, searchIndex);
+    if (scriptContent[parenIndex] !== "(") continue;
+
+    const endParen = findMatching(scriptContent, parenIndex, "(", ")");
+    if (endParen === -1) continue;
+
+    const args = splitTopLevel(scriptContent.slice(parenIndex + 1, endParen));
+    const defaultsArg = args[1]?.trim();
+    if (!defaultsArg?.startsWith("{")) continue;
+
+    const objectStart = scriptContent.indexOf(defaultsArg, parenIndex + 1);
+    const objectEnd = findMatching(scriptContent, objectStart, "{", "}");
+    if (objectEnd === -1) continue;
+
+    for (const [name, value] of objectProperties(scriptContent.slice(objectStart + 1, objectEnd))) {
+      defaults.set(name, value);
+    }
+  }
+
+  return defaults;
+}
+
+function objectProperties(objectBody: string): Array<[string, string]> {
+  const properties: Array<[string, string]> = [];
+
+  for (const item of splitTopLevel(objectBody)) {
+    const colonIndex = topLevelColon(item);
+    if (colonIndex === -1) continue;
+
+    const rawKey = item.slice(0, colonIndex).trim();
+    const key = rawKey.match(/^[$A-Z_a-z][$\w]*$/)?.[0] ?? rawKey.match(/^["']([^"']+)["']$/)?.[1];
+    if (!key) continue;
+
+    const value = item.slice(colonIndex + 1).trim();
+    if (value) properties.push([key, value]);
+  }
+
+  return properties;
+}
+
+function splitTopLevel(source: string): string[] {
+  const parts: string[] = [];
+  let start = 0;
+  let round = 0;
+  let curly = 0;
+  let square = 0;
+  let quote: '"' | "'" | "`" | null = null;
+  let escaped = false;
+
+  for (let index = 0; index < source.length; index++) {
+    const char = source[index]!;
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "(") round++;
+    else if (char === ")") round--;
+    else if (char === "{") curly++;
+    else if (char === "}") curly--;
+    else if (char === "[") square++;
+    else if (char === "]") square--;
+    else if (char === "," && round === 0 && curly === 0 && square === 0) {
+      parts.push(source.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+
+  const tail = source.slice(start).trim();
+  if (tail) parts.push(tail);
+  return parts;
+}
+
+function topLevelColon(source: string): number {
+  let round = 0;
+  let curly = 0;
+  let square = 0;
+  let quote: '"' | "'" | "`" | null = null;
+  let escaped = false;
+
+  for (let index = 0; index < source.length; index++) {
+    const char = source[index]!;
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "(") round++;
+    else if (char === ")") round--;
+    else if (char === "{") curly++;
+    else if (char === "}") curly--;
+    else if (char === "[") square++;
+    else if (char === "]") square--;
+    else if (char === ":" && round === 0 && curly === 0 && square === 0) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function findMatching(source: string, start: number, open: string, close: string): number {
+  let depth = 0;
+  let quote: '"' | "'" | "`" | null = null;
+  let escaped = false;
+
+  for (let index = start; index < source.length; index++) {
+    const char = source[index]!;
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === open) depth++;
+    if (char === close) {
+      depth--;
+      if (depth === 0) return index;
+    }
+  }
+
+  return -1;
+}
+
+function skipWhitespace(source: string, index: number): number {
+  while (index < source.length && /\s/.test(source[index]!)) index++;
+  return index;
+}
+
+function isIdentifierBoundary(char: string | undefined): boolean {
+  return char === undefined || !/[$\w]/.test(char);
 }

--- a/npm/builder/vite-musea/src/plugin/index.test.ts
+++ b/npm/builder/vite-musea/src/plugin/index.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { shouldApplyMuseaPlugin } from "./apply.js";
+import {
+  assertStaticPreviewRuntimeSupported,
+  resolveStaticPreviewVueVersion,
+} from "./static-preview.js";
 
 void test("musea plugin is inactive in Vite test mode", () => {
   assert.equal(shouldApplyMuseaPlugin({ command: "serve", mode: "test" }), false);
@@ -12,4 +16,16 @@ void test("musea plugin remains active during Vite serve outside test mode", () 
 
 void test("musea plugin remains active during production builds", () => {
   assert.equal(shouldApplyMuseaPlugin({ command: "build", mode: "production" }), true);
+});
+
+void test("static builds reject legacy Vue preview runtime explicitly", () => {
+  assert.throws(() => assertStaticPreviewRuntimeSupported(2, true), /Vue 3 preview runtime/);
+  assert.doesNotThrow(() => assertStaticPreviewRuntimeSupported(2, false));
+  assert.doesNotThrow(() => assertStaticPreviewRuntimeSupported(3, true));
+});
+
+void test("static preview runtime infers legacy Vue from host compiler plugins", () => {
+  assert.equal(resolveStaticPreviewVueVersion(undefined, [{ name: "vite:vue2" }]), 2);
+  assert.equal(resolveStaticPreviewVueVersion(undefined, [{ name: "vite:vue" }]), 3);
+  assert.equal(resolveStaticPreviewVueVersion(3, [{ name: "vite:vue2" }]), 3);
 });

--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -36,6 +36,10 @@ import {
 import { resolveMuseaSharedConfig } from "./config.js";
 import { processMuseaArtFile } from "./art-processing.js";
 import { transformMuseaVirtualModule } from "./virtual-transform.js";
+import {
+  assertStaticPreviewRuntimeSupported,
+  resolveStaticPreviewVueVersion,
+} from "./static-preview.js";
 
 export function musea(options: MuseaOptions = {}): Plugin[] {
   let include = options.include ?? ["**/*.art.vue"];
@@ -49,6 +53,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
   const themeConfig = buildThemeConfig(options.theme);
   const previewCss = options.previewCss ?? [];
   const previewSetup = options.previewSetup;
+  let vueVersion = options.vueVersion;
   const devSessionToken = createDevSessionToken();
 
   let config: ResolvedConfig;
@@ -106,6 +111,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
           storybookCompat = mc.storybookCompat;
         if (options.inlineArt === undefined && mc.inlineArt !== undefined) inlineArt = mc.inlineArt;
       }
+      vueVersion = resolveStaticPreviewVueVersion(vueVersion, resolvedConfig.plugins);
 
       virtualState.basePath = basePath;
 
@@ -214,6 +220,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
 
     async buildStart() {
       console.log(`[musea] config.root: ${config.root}, include: ${JSON.stringify(include)}`);
+      assertStaticPreviewRuntimeSupported(vueVersion, staticBuildEnabled);
       if (storybookCompat && staticBuildEnabled) {
         await assertNoUnsupportedStorybookTsxInputs(config.root, include, exclude);
       }

--- a/npm/builder/vite-musea/src/plugin/static-preview.ts
+++ b/npm/builder/vite-musea/src/plugin/static-preview.ts
@@ -1,0 +1,29 @@
+import type { MuseaOptions } from "../types/index.js";
+
+export function resolveStaticPreviewVueVersion(
+  configured: MuseaOptions["vueVersion"],
+  plugins: readonly Pick<{ name?: string }, "name">[],
+): MuseaOptions["vueVersion"] {
+  if (configured !== undefined) return configured;
+  if (hasLegacyVueSfcCompilerPlugin(plugins)) return 2;
+  return 3;
+}
+
+export function assertStaticPreviewRuntimeSupported(
+  vueVersion: MuseaOptions["vueVersion"],
+  staticBuildEnabled: boolean,
+): void {
+  if (!staticBuildEnabled) return;
+  if (vueVersion === 3 || vueVersion === undefined) return;
+
+  throw new Error(
+    "[musea] Static Musea builds currently require the Vue 3 preview runtime. Vue 2/Nuxt 2 projects should use the dev gallery or run Nuxt static generation with @vizejs/nuxt until a Vue 2 static preview runtime is available.",
+  );
+}
+
+function hasLegacyVueSfcCompilerPlugin(plugins: readonly Pick<{ name?: string }, "name">[]) {
+  return plugins.some((plugin) => {
+    const name = plugin.name ?? "";
+    return name === "vite:vue2" || name.includes("plugin-vue2") || name.includes("vue2");
+  });
+}

--- a/npm/builder/vite-musea/src/types/plugin.ts
+++ b/npm/builder/vite-musea/src/types/plugin.ts
@@ -1,5 +1,7 @@
 import type { VrtOptions } from "./vrt.js";
 
+export type MuseaVueVersion = 0.11 | 1 | 2 | "2.7" | 3 | "legacy";
+
 /**
  * Theme color definitions for Musea gallery UI.
  * All properties are optional — unspecified colors inherit from the `base` built-in theme.
@@ -134,4 +136,11 @@ export interface MuseaOptions {
    * @example 'musea.preview.ts'
    */
   previewSetup?: string;
+
+  /**
+   * Host Vue version for preview runtime compatibility checks.
+   * Legacy Vue static builds currently fail fast with an actionable diagnostic.
+   * @default 3
+   */
+  vueVersion?: MuseaVueVersion;
 }

--- a/npm/builder/vite/src/plugin/index.test.ts
+++ b/npm/builder/vite/src/plugin/index.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 
-import { createLegacyVueCompatibilityPlugin, isLegacyVueCompatibilityMode } from "./vue-version.ts";
+import {
+  createLegacyVueCompatibilityPlugin,
+  hasHostVueSfcCompilerPlugin,
+  isLegacyVueCompatibilityMode,
+} from "./vue-version.ts";
 
 {
   const plugin = createLegacyVueCompatibilityPlugin({ vueVersion: 2 });
@@ -60,6 +64,19 @@ import { createLegacyVueCompatibilityPlugin, isLegacyVueCompatibilityMode } from
     "transform" in plugin,
     false,
     "Legacy Vue compatibility mode must not transform .vue code",
+  );
+  assert.equal(hasHostVueSfcCompilerPlugin([{ name: "vite:vue2" }]), true);
+  assert.equal(
+    hasHostVueSfcCompilerPlugin([{ name: "vite-plugin-vize:legacy-vue-compat" }]),
+    false,
+  );
+  assert.throws(
+    () =>
+      plugin.configResolved?.({
+        root: "/repo",
+        plugins: [{ name: "vite-plugin-vize:legacy-vue-compat" }],
+      } as never),
+    /host Vue SFC compiler plugin/,
   );
 }
 

--- a/npm/builder/vite/src/plugin/vue-version.ts
+++ b/npm/builder/vite/src/plugin/vue-version.ts
@@ -15,10 +15,28 @@ export function isLegacyVueCompatibilityMode(options: VizeOptions): boolean {
   return hostCompiler && isLegacyVueVersion(vueVersion);
 }
 
+export function hasHostVueSfcCompilerPlugin(plugins: readonly Pick<Plugin, "name">[]): boolean {
+  return plugins.some((plugin) => {
+    const name = plugin.name;
+    return (
+      name === "vite:vue" ||
+      name === "vite:vue2" ||
+      name.includes("plugin-vue") ||
+      name.includes("vue2")
+    );
+  });
+}
+
 export function createLegacyVueCompatibilityPlugin(options: VizeOptions): Plugin {
   return {
     name: "vite-plugin-vize:legacy-vue-compat",
     configResolved(resolvedConfig) {
+      if (!hasHostVueSfcCompilerPlugin(resolvedConfig.plugins)) {
+        throw new Error(
+          "vite-plugin-vize: legacy Vue host-compiler mode requires a host Vue SFC compiler plugin. Add @vitejs/plugin-vue2 (or your framework's Vue 2 Vite SFC plugin), or set compatibility.hostCompiler=false if this project can use Vize's compiler pipeline.",
+        );
+      }
+
       createLogger(options.debug ?? false).log(
         `Legacy Vue compatibility mode is active for ${resolvedConfig.root}; Vize will not compile .vue files.`,
       );

--- a/npm/framework/nuxt/src/index.test.ts
+++ b/npm/framework/nuxt/src/index.test.ts
@@ -5,6 +5,11 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import {
+  registerNuxtMuseaStaticPublicAsset,
+  resolveNuxtMuseaStaticPublicAsset,
+} from "./musea-static.ts";
+
 const NUXT2_SAFE_KIT_VERSION = "3.11.2";
 
 void test("Nuxt module entry avoids loader-unsafe syntax and static kit imports", () => {
@@ -124,6 +129,43 @@ void test("Nuxt 2 host-compiler compatibility skips Vite plugin loading", async 
 
   assert.deepEqual(hookNames, ["close", "builder:prepared", "build:templates"]);
   assert.deepEqual(nuxt.options.vite, {});
+});
+
+void test("Nuxt Musea static public asset points at generated client output", () => {
+  let nitroConfigHook: ((config: { publicAssets?: unknown[] }) => unknown) | undefined;
+  registerNuxtMuseaStaticPublicAsset(
+    {
+      options: { rootDir: "/project", buildDir: ".nuxt" },
+      hook(name, callback) {
+        assert.equal(name, "nitro:config");
+        nitroConfigHook = callback;
+      },
+    },
+    "/docs/musea/",
+  );
+
+  const nitroConfig = { publicAssets: [{ dir: "/existing", baseURL: "/existing" }] };
+  nitroConfigHook?.(nitroConfig);
+
+  assert.deepEqual(nitroConfig.publicAssets, [
+    { dir: "/existing", baseURL: "/existing" },
+    {
+      dir: path.join("/project", ".nuxt", "dist", "client", "docs/musea"),
+      baseURL: "/docs/musea",
+    },
+  ]);
+
+  assert.deepEqual(resolveNuxtMuseaStaticPublicAsset("/project", ".nuxt", "/docs/musea/"), {
+    dir: path.join("/project", ".nuxt", "dist", "client", "docs/musea"),
+    baseURL: "/docs/musea",
+  });
+});
+
+void test("Nuxt Musea static public asset preserves root base path", () => {
+  assert.deepEqual(resolveNuxtMuseaStaticPublicAsset("/project", "/tmp/.nuxt", "/"), {
+    dir: path.join("/tmp/.nuxt", "dist", "client"),
+    baseURL: "/",
+  });
 });
 
 void test("packed Nuxt module depends on the Nuxt 2-safe kit line", () => {

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -1,6 +1,7 @@
 import { createNuxtComponentResolver, injectNuxtComponentImports } from "./components";
 import { injectNuxtI18nHelpers } from "./i18n";
 import { appendMuseaArtComponentIgnore } from "./musea-components";
+import { registerNuxtMuseaStaticPublicAsset } from "./musea-static";
 import "./schema";
 import type { VizeNuxtCompilerOptions, VizeNuxtOptions } from "./options";
 import {
@@ -59,7 +60,7 @@ type NuxtWithBuilderOptions = {
       base?: string;
     };
     vite?: { plugins?: unknown[]; resolve?: { dedupe?: string[] } };
-    nitro?: { virtual?: Record<string, string> };
+    nitro?: { virtual?: Record<string, string>; publicAssets?: unknown[] };
     vize?: Partial<VizeNuxtOptions>;
     _requiredModules?: Record<string, boolean>;
     _nuxtVersion?: string;
@@ -636,7 +637,8 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
         ? ((museaOptions as Record<string, unknown>).basePath as string)
         : "/__musea__";
     (nuxt.options.vite ||= {}).plugins ||= [];
-    const museaConfig = { projectRoot: nuxt.options.rootDir, ...museaOptions };
+    registerNuxtMuseaStaticPublicAsset(nuxt, museaBasePath);
+    const museaConfig = { projectRoot: nuxt.options.rootDir, vueVersion, ...museaOptions };
     nuxt.options.vite.plugins.push(...musea(museaConfig));
 
     // Print Musea Gallery URL after dev server starts

--- a/npm/framework/nuxt/src/musea-static.ts
+++ b/npm/framework/nuxt/src/musea-static.ts
@@ -1,0 +1,48 @@
+import path from "node:path";
+
+export type NuxtMuseaStaticPublicAsset = {
+  dir: string;
+  baseURL: string;
+};
+
+export type NuxtMuseaStaticHookTarget = {
+  hook(name: string, callback: (config: { publicAssets?: unknown[] }) => unknown): void;
+  options: {
+    rootDir: string;
+    buildDir: string;
+  };
+};
+
+export function registerNuxtMuseaStaticPublicAsset(
+  nuxt: NuxtMuseaStaticHookTarget,
+  basePath: string,
+): void {
+  nuxt.hook("nitro:config", (nitroConfig) => {
+    nitroConfig.publicAssets = [
+      ...(nitroConfig.publicAssets ?? []),
+      resolveNuxtMuseaStaticPublicAsset(nuxt.options.rootDir, nuxt.options.buildDir, basePath),
+    ];
+  });
+}
+
+export function resolveNuxtMuseaStaticPublicAsset(
+  rootDir: string,
+  buildDir: string,
+  basePath: string,
+): NuxtMuseaStaticPublicAsset {
+  const staticRoot = museaStaticRootFromBasePath(basePath);
+  const resolvedBuildDir = path.isAbsolute(buildDir) ? buildDir : path.resolve(rootDir, buildDir);
+  return {
+    dir: path.join(resolvedBuildDir, "dist", "client", staticRoot),
+    baseURL: normalizeMuseaBasePath(basePath),
+  };
+}
+
+function museaStaticRootFromBasePath(basePath: string): string {
+  return basePath.replace(/^\/+|\/+$/g, "");
+}
+
+function normalizeMuseaBasePath(basePath: string): string {
+  const normalized = basePath.replace(/^\/+|\/+$/g, "");
+  return normalized ? `/${normalized}` : "/";
+}


### PR DESCRIPTION
## Summary
- fixes the P0/P1 Canon, Corsa, Patina, Musea, Vite, and Nuxt readiness regressions tracked for v1 alpha
- adds focused regressions for Vue 2/Nuxt 2 compatibility, GraphQL/codegen identity coverage, Musea migration/static-build behavior, and linter diagnostics
- keeps legacy Musea static builds on an explicit unsupported-runtime diagnostic until a Vue 2 preview runtime is available

## Verification
- cargo fmt --all -- --check
- cargo test -p vize --lib
- cargo test -p vize_canon
- cargo test -p vize_patina
- cargo test -p vize --test check_canon_graphql_cli
- CI=true corepack pnpm@10.0.0 --dir npm/builder/vite check
- CI=true corepack pnpm@10.0.0 --dir npm/builder/vite test
- CI=true corepack pnpm@10.0.0 --dir npm/builder/vite-musea check
- CI=true corepack pnpm@10.0.0 --dir npm/builder/vite-musea test
- CI=true corepack pnpm@10.0.0 --dir npm/framework/nuxt check
- CI=true corepack pnpm@10.0.0 --dir npm/framework/nuxt test

Closes #2306
Closes #2307
Closes #2308
Closes #2309
Closes #2310
Closes #2311
Closes #2312
Closes #2313
Closes #2314
Closes #2315
Closes #2316
Closes #2317
Closes #2318
Closes #2319
Closes #2320
Closes #2321
Closes #2322
Closes #2323

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->