### PR TITLE
fix(patina): deduplicate logical property diagnostics

### DIFF
--- a/crates/vize_patina/src/rules/css/prefer_logical_properties.rs
+++ b/crates/vize_patina/src/rules/css/prefer_logical_properties.rs
@@ -6,6 +6,7 @@ use lightningcss::declaration::DeclarationBlock;
 use lightningcss::properties::PropertyId;
 use lightningcss::rules::CssRule as LCssRule;
 use lightningcss::stylesheet::StyleSheet;
+use vize_carton::FxHashSet;
 
 use crate::diagnostic::{LintDiagnostic, Severity};
 
@@ -32,31 +33,38 @@ impl CssRule for PreferLogicalProperties {
         offset: usize,
         result: &mut CssLintResult,
     ) {
+        let mut reported = FxHashSet::default();
         for rule in &stylesheet.rules.0 {
-            self.check_rule(rule, offset, result);
+            self.check_rule(rule, offset, result, &mut reported);
         }
     }
 }
 
 impl PreferLogicalProperties {
-    fn check_rule(&self, rule: &LCssRule, offset: usize, result: &mut CssLintResult) {
+    fn check_rule(
+        &self,
+        rule: &LCssRule,
+        offset: usize,
+        result: &mut CssLintResult,
+        reported: &mut FxHashSet<(u32, u32)>,
+    ) {
         match rule {
             LCssRule::Style(style_rule) => {
-                self.check_declarations(&style_rule.declarations, offset, result);
+                self.check_declarations(&style_rule.declarations, offset, result, reported);
             }
             LCssRule::Media(media) => {
                 for rule in &media.rules.0 {
-                    self.check_rule(rule, offset, result);
+                    self.check_rule(rule, offset, result, reported);
                 }
             }
             LCssRule::Supports(supports) => {
                 for rule in &supports.rules.0 {
-                    self.check_rule(rule, offset, result);
+                    self.check_rule(rule, offset, result, reported);
                 }
             }
             LCssRule::LayerBlock(layer) => {
                 for rule in &layer.rules.0 {
-                    self.check_rule(rule, offset, result);
+                    self.check_rule(rule, offset, result, reported);
                 }
             }
             _ => {}
@@ -68,18 +76,25 @@ impl PreferLogicalProperties {
         declarations: &DeclarationBlock,
         offset: usize,
         result: &mut CssLintResult,
+        reported: &mut FxHashSet<(u32, u32)>,
     ) {
         // Check all declarations (both regular and important)
         for decl in declarations.declarations.iter() {
-            self.check_property(decl.property_id(), offset, result);
+            self.check_property(decl.property_id(), offset, result, reported);
         }
         for decl in declarations.important_declarations.iter() {
-            self.check_property(decl.property_id(), offset, result);
+            self.check_property(decl.property_id(), offset, result, reported);
         }
     }
 
     #[inline]
-    fn check_property(&self, prop_id: PropertyId, offset: usize, result: &mut CssLintResult) {
+    fn check_property(
+        &self,
+        prop_id: PropertyId,
+        offset: usize,
+        result: &mut CssLintResult,
+        reported: &mut FxHashSet<(u32, u32)>,
+    ) {
         let (physical, logical) = match prop_id {
             PropertyId::MarginLeft => ("margin-left", "margin-inline-start"),
             PropertyId::MarginRight => ("margin-right", "margin-inline-end"),
@@ -93,13 +108,18 @@ impl PreferLogicalProperties {
         };
 
         // Report at offset since PropertyId doesn't provide precise location
-        let _ = (physical, logical); // suppress unused warnings
+        let start = offset as u32;
+        let end = (offset + physical.len()) as u32;
+        if !reported.insert((start, end)) {
+            return;
+        }
+        let _ = logical; // suppress unused warnings
         result.add_diagnostic(
             LintDiagnostic::warn(
                 META.name,
                 "Consider using logical properties for better RTL support",
-                offset as u32,
-                (offset + physical.len()) as u32,
+                start,
+                end,
             )
             .with_help("Use logical properties like margin-inline-start instead of margin-left"),
         );
@@ -129,5 +149,16 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint(".button { margin-left: 10px; }", 0);
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_deduplicates_same_fallback_range() {
+        let linter = create_linter();
+        let result = linter.lint(
+            ".button { margin-left: 10px; margin-left: 20px !important; }",
+            0,
+        );
+        assert_eq!(result.warning_count, 1);
+        assert_eq!(result.diagnostics.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

- deduplicate `css/prefer-logical-properties` diagnostics that report the same fallback range
- add a regression test for duplicate regular/important declarations

## Verification

- `cargo test -p vize_patina prefer_logical_properties`

Closes #2318

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->