### PR TITLE
fix(patina): report invalid standalone v-else chains

### DIFF
--- a/crates/vize_patina/src/rules/vue/valid_v_else.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_else.rs
@@ -25,7 +25,9 @@
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, Severity, TextEdit};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{DirectiveNode, ElementNode, PropNode};
+use vize_relief::{
+    DirectiveNode, ElementNode, PropNode, RootNode, SourceLocation, TemplateChildNode,
+};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/valid-v-else",
@@ -41,6 +43,14 @@ pub struct ValidVElse;
 impl Rule for ValidVElse {
     fn meta(&self) -> &'static RuleMeta {
         &META
+    }
+
+    fn run_on_template<'a>(&self, ctx: &mut LintContext<'a>, root: &RootNode<'a>) {
+        check_adjacent_if_chain(ctx, &root.children);
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        check_adjacent_if_chain(ctx, &element.children);
     }
 
     fn check_directive<'a>(
@@ -85,6 +95,80 @@ impl Rule for ValidVElse {
     }
 }
 
+struct IfChainDirectiveInfo {
+    has_v_if: bool,
+    else_if_loc: Option<SourceLocation>,
+    else_loc: Option<SourceLocation>,
+}
+
+fn check_adjacent_if_chain(ctx: &mut LintContext, children: &[TemplateChildNode]) {
+    let mut can_follow_if = false;
+
+    for child in children {
+        match child {
+            TemplateChildNode::Element(element) => {
+                let info = get_if_chain_directive_info(element);
+
+                if info.has_v_if {
+                    can_follow_if = true;
+                    continue;
+                }
+
+                if let Some(loc) = info.else_if_loc {
+                    if !can_follow_if {
+                        report_missing_adjacent_if(ctx, &loc);
+                    }
+                    continue;
+                }
+
+                if let Some(loc) = info.else_loc {
+                    if !can_follow_if {
+                        report_missing_adjacent_if(ctx, &loc);
+                    }
+                    can_follow_if = false;
+                    continue;
+                }
+
+                can_follow_if = false;
+            }
+            TemplateChildNode::Text(text) if text.content.trim().is_empty() => {}
+            TemplateChildNode::Comment(_) => {}
+            _ => {
+                can_follow_if = false;
+            }
+        }
+    }
+}
+
+fn get_if_chain_directive_info(element: &ElementNode) -> IfChainDirectiveInfo {
+    let mut info = IfChainDirectiveInfo {
+        has_v_if: false,
+        else_if_loc: None,
+        else_loc: None,
+    };
+
+    for prop in element.props.iter() {
+        if let PropNode::Directive(dir) = prop {
+            match dir.name.as_str() {
+                "if" => info.has_v_if = true,
+                "else-if" => info.else_if_loc = Some(dir.loc.clone()),
+                "else" => info.else_loc = Some(dir.loc.clone()),
+                _ => {}
+            }
+        }
+    }
+
+    info
+}
+
+fn report_missing_adjacent_if(ctx: &mut LintContext, loc: &SourceLocation) {
+    ctx.error_with_help(
+        ctx.t("vue/valid-v-else.missing_v_if"),
+        loc,
+        ctx.t("vue/valid-v-else.help"),
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::ValidVElse;
@@ -106,6 +190,26 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_v_else_if_chain() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div v-if="foo"></div><div v-else-if="bar"></div><div v-else></div>"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_valid_v_else_after_comment() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div v-if="foo"></div><!-- fallback branch --><div v-else></div>"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
     fn test_invalid_v_else_with_expression() {
         let linter = create_linter();
         let result = linter.lint_template(
@@ -120,6 +224,32 @@ mod tests {
     fn test_invalid_v_else_with_v_if() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div v-if="foo" v-else></div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_else_without_adjacent_v_if() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div v-else></div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+        assert_eq!(result.diagnostics[0].rule_name, "vue/valid-v-else");
+    }
+
+    #[test]
+    fn test_invalid_v_else_if_without_adjacent_v_if() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div v-else-if="foo"></div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+        assert_eq!(result.diagnostics[0].rule_name, "vue/valid-v-else");
+    }
+
+    #[test]
+    fn test_invalid_v_else_after_text_gap() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div v-if="foo"></div> text <div v-else></div>"#,
+            "test.vue",
+        );
         assert_eq!(result.error_count, 1);
     }
 }


### PR DESCRIPTION
## Summary

- require `v-else` and `v-else-if` chains to be adjacent to a previous `v-if` branch
- keep comments valid while treating text gaps and standalone chains as invalid
- add focused regression tests for the adjacency cases

## Verification

- `cargo test -p vize_patina valid_v_else`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->