### PR TITLE
test(canon): cover GraphQL type identity regression

### DIFF
--- a/crates/vize/tests/check_canon_graphql_cli.rs
+++ b/crates/vize/tests/check_canon_graphql_cli.rs
@@ -209,12 +209,13 @@ void childComponents
     let _ = std::fs::remove_dir_all(&project_root);
 }
 
-/// Regression for #2227: a `types/index.ts` barrel that re-exports a generated
-/// GraphQL `.d.ts` via a relative `export *` is materialized into canon, but the
-/// `.d.ts` is intentionally kept on its real path (#2047). Previously the
-/// barrel's relative `./codegen/schema` dangled inside the mirror, dropping the
-/// generated module's type identity so members re-exported through `~/types`
-/// were reported as missing/unrelated — a false positive vue-tsc does not raise.
+/// Regression for #2227/#2307: a `types/index.ts` barrel that re-exports a
+/// generated GraphQL `.d.ts` via a relative `export *` is materialized into
+/// canon, but the `.d.ts` is intentionally kept on its real path (#2047).
+/// Previously the barrel's relative `./codegen/schema` dangled inside the
+/// mirror, dropping the generated module's type identity so members re-exported
+/// through `~/types` were reported as missing/unrelated, including TS1360 false
+/// positives vue-tsc does not raise.
 #[test]
 fn check_barrel_reexport_preserves_generated_graphql_identity() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
@@ -338,6 +339,10 @@ void childComponents
     );
     let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
     assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    assert!(
+        !stdout.contains("TS1360"),
+        "generated GraphQL symbols should keep one type identity:\n{stdout}"
+    );
     assert!(
         !project_root
             .join("node_modules/.vize/canon/types/codegen/schema.d.ts")

--- a/crates/vize/tests/check_canon_graphql_cli.rs
+++ b/crates/vize/tests/check_canon_graphql_cli.rs
@@ -84,6 +84,37 @@ fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
     }
 }
 
+/// Runs `vize check` against `project_root` in JSON mode, asserts the run
+/// succeeded with zero errors, and returns its stdout for further inspection.
+fn run_check_json(project_root: &Path, corsa_path: &Path) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "--no-check-props",
+            "--no-check-emits",
+            "--no-check-template-bindings",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        std::str::from_utf8(&output.stderr).unwrap_or("<non-utf8 stderr>")
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    stdout.to_string()
+}
+
 #[test]
 fn check_explicit_vue_keeps_generated_graphql_schema_out_of_canon() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
@@ -170,31 +201,7 @@ void childComponents
     )
     .unwrap();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
-        .current_dir(&project_root)
-        .env("CORSA_PATH", &corsa_path)
-        .args([
-            "check",
-            "--tsconfig",
-            "tsconfig.json",
-            "--no-check-props",
-            "--no-check-emits",
-            "--no-check-template-bindings",
-            "--format",
-            "json",
-        ])
-        .output()
-        .unwrap();
-
-    let stdout = std::str::from_utf8(&output.stdout).unwrap();
-    assert!(
-        output.status.success(),
-        "check failed\nstdout:\n{}\nstderr:\n{}",
-        stdout,
-        std::str::from_utf8(&output.stderr).unwrap_or("<non-utf8 stderr>")
-    );
-    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
-    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    run_check_json(&project_root, &corsa_path);
     assert!(
         project_root
             .join("node_modules/.vize/canon/pages/_studyInfoId.vue.ts")
@@ -314,31 +321,7 @@ void childComponents
     )
     .unwrap();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
-        .current_dir(&project_root)
-        .env("CORSA_PATH", &corsa_path)
-        .args([
-            "check",
-            "--tsconfig",
-            "tsconfig.json",
-            "--no-check-props",
-            "--no-check-emits",
-            "--no-check-template-bindings",
-            "--format",
-            "json",
-        ])
-        .output()
-        .unwrap();
-
-    let stdout = std::str::from_utf8(&output.stdout).unwrap();
-    assert!(
-        output.status.success(),
-        "check failed\nstdout:\n{}\nstderr:\n{}",
-        stdout,
-        std::str::from_utf8(&output.stderr).unwrap_or("<non-utf8 stderr>")
-    );
-    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
-    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    let stdout = run_check_json(&project_root, &corsa_path);
     assert!(
         !stdout.contains("TS1360"),
         "generated GraphQL symbols should keep one type identity:\n{stdout}"


### PR DESCRIPTION
## Summary

- mark the GraphQL generated type identity fixture as a #2307 regression
- assert that the representative recursive union case does not emit TS1360

## Verification

- `cargo test -p vize --test check_canon_graphql_cli`

Closes #2307

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->