### PR TITLE
fix(canon): preserve legacy Vue 2 Nuxt context types

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/tests/ref_arity.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/ref_arity.rs
@@ -177,7 +177,9 @@ export default {
         assert!(!content.contains("import('vue').ComponentPublicInstance"));
         assert!(!content.contains("import('vue').defineComponent"));
     }
-    assert!(options_content.contains("declare function __vizeDefineComponent<T>(options: T): T;"));
+    assert!(options_content.contains(
+        "declare function __vizeDefineComponent<T>(options: T & __VizeNuxt2PageOptions): T;",
+    ));
 
     project.materialize().unwrap();
     assert!(!project.virtual_root().join("__vize_helpers.d.ts").exists());

--- a/crates/vize_canon/src/batch/virtual_project/tests/snapshots/vize_canon__batch__virtual_project__tests__ref_arity__dialect_v2.snap
+++ b/crates/vize_canon/src/batch/virtual_project/tests/snapshots/vize_canon__batch__virtual_project__tests__ref_arity__dialect_v2.snap
@@ -42,6 +42,8 @@ type __VizeKebabCase<S extends string> = S extends `${infer Head}${infer Tail}` 
 type __VizeKebabProps<T> = { [K in keyof T & string as __VizeKebabCase<K>]: T[K] };
 type __VizeComponentProps<T> = T extends unknown ? T & Partial<__VizeKebabProps<T>> : never;
 type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
+type __VizeVue2LooseEventArg<T> = __VizeIsAny<T> extends true ? any : [T] extends [Object] ? ([Object] extends [T] ? any : T) : T;
+type __VizeVue2LooseEmitArgs<A extends readonly unknown[]> = { [K in keyof A]: __VizeVue2LooseEventArg<A[K]> };
 type __VForEntry<T> = __VizeIsAny<T> extends true ? [item: any, key: number, index: number] : T extends readonly (infer U)[] ? [item: U, key: number, index: number] : T extends number ? [item: number, key: number, index: number] : T extends string ? [item: string, key: number, index: number] : T extends Iterable<infer U> ? [item: U, key: number, index: number] : T extends object ? [item: T[keyof T], key: keyof T, index: number] : [item: any, key: number, index: number];
 declare function __vForList<T>(source: T | undefined | null): readonly __VForEntry<NonNullable<T>>[];
 import { ref } from 'vue'
@@ -82,7 +84,7 @@ function __setup() {
 
   const count = ref(0)
 
-  // @vize-map: 5502:5577 -> 0:84
+  // @vize-map: 5745:5820 -> 0:84
 
   // ========== Template Scope (inherits from setup) ==========
   // Ref type captures (before template scope shadows them)

--- a/crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs
@@ -24,6 +24,8 @@ type __VizeKebabCase<S extends string> = S extends `${infer Head}${infer Tail}` 
 type __VizeKebabProps<T> = { [K in keyof T & string as __VizeKebabCase<K>]: T[K] };
 type __VizeComponentProps<T> = T extends unknown ? T & Partial<__VizeKebabProps<T>> : never;
 type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
+type __VizeVue2LooseEventArg<T> = __VizeIsAny<T> extends true ? any : [T] extends [Object] ? ([Object] extends [T] ? any : T) : T;
+type __VizeVue2LooseEmitArgs<A extends readonly unknown[]> = { [K in keyof A]: __VizeVue2LooseEventArg<A[K]> };
 type __VForEntry<T> = __VizeIsAny<T> extends true ? [item: any, key: number, index: number] : T extends readonly (infer U)[] ? [item: U, key: number, index: number] : T extends number ? [item: number, key: number, index: number] : T extends string ? [item: string, key: number, index: number] : T extends Iterable<infer U> ? [item: U, key: number, index: number] : T extends object ? [item: T[keyof T], key: keyof T, index: number] : [item: any, key: number, index: number];
 declare function __vForList<T>(source: T | undefined | null): readonly __VForEntry<NonNullable<T>>[];"#;
 const LEGACY_REF_UNWRAP_HELPER: &str =
@@ -32,8 +34,28 @@ const MODERN_REF_UNWRAP_HELPER: &str = r#"    type __VizeIsUnion<T, __U = T> = T
     type __VizeWidenTemplateRef<T> = __VizeIsUnion<T> extends true ? T : T extends string ? string : T extends number ? number : T extends boolean ? boolean : T;
     type __U<T> = T extends import('vue').Ref ? __VizeWidenTemplateRef<T['value']> : T;
 "#;
-const LEGACY_DEFINE_COMPONENT_HELPER: &str =
-    "declare function __vizeDefineComponent<T>(options: T): T;\n";
+const LEGACY_DEFINE_COMPONENT_HELPER: &str = r#"type __VizeNuxt2Context = {
+  app: any;
+  route: any;
+  params: Record<string, string>;
+  query: Record<string, string | string[] | undefined>;
+  store: any;
+  error: (...args: any[]) => any;
+  redirect: (...args: any[]) => any;
+  req?: any;
+  res?: any;
+  env?: Record<string, unknown>;
+  isDev?: boolean;
+  isHMR?: boolean;
+} & Record<string, any>;
+type __VizeNuxt2PageOptions = {
+  validate?: (context: __VizeNuxt2Context) => unknown;
+  asyncData?: (context: __VizeNuxt2Context) => any;
+  fetch?: (context: __VizeNuxt2Context) => any;
+  middleware?: any;
+};
+declare function __vizeDefineComponent<T>(options: T & __VizeNuxt2PageOptions): T;
+"#;
 pub(super) const LEGACY_COMPONENT_INSTANCE_HELPER: &str = r#"type __VizeVue2ComponentInstance = {
   $el: Element;
   $refs: Record<string, any>;

--- a/crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs
@@ -82,6 +82,24 @@ function updateDate(newDate: string) {
 }
 
 #[test]
+fn legacy_vue2_component_event_object_payloads_stay_permissive() {
+    let script = r#"type Manager = { id: string }
+declare const DataTable: { new (): { $props: { "onClick:Row"?: (item: Object) => unknown } } }
+function moveToDetail(item: Manager) {
+  void item
+}
+"#;
+    let template = r#"<DataTable @click:row="moveToDetail" />"#;
+
+    let legacy = legacy_virtual_ts(script, template, &VirtualTsOptions::default());
+    assert!(
+        legacy.contains("__VizeVue2LooseEventArg<__DataTable_")
+            && legacy.contains("__VizeVue2LooseEmitArgs<__DataTable_"),
+        "legacy Vue 2 broad Object component event payloads should be loosened:\n{legacy}"
+    );
+}
+
+#[test]
 fn legacy_vue2_skips_external_component_prop_checks() {
     let script = "const width = 320\n";
     let template = r#"<VDatePicker :width="width" />"#;

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -376,10 +376,17 @@ fn generate_scope_node(
                 // signature stays unresolved (`unknown[]`, e.g. a fallthrough
                 // DOM event on a component), fall back to the single `$event`
                 // parameter so those handlers keep type-checking.
-                append!(
-                    *ts,
-                    "{indent}type {listener_type} = unknown[] extends {args_type} ? (($event: {event_type}) => unknown) : ((...args: {args_type}) => unknown);\n",
-                );
+                if ctx.legacy_vue2 {
+                    append!(
+                        *ts,
+                        "{indent}type {listener_type} = unknown[] extends {args_type} ? (($event: {event_type}) => unknown) : ((...args: __VizeVue2LooseEmitArgs<{args_type}>) => unknown);\n",
+                    );
+                } else {
+                    append!(
+                        *ts,
+                        "{indent}type {listener_type} = unknown[] extends {args_type} ? (($event: {event_type}) => unknown) : ((...args: {args_type}) => unknown);\n",
+                    );
+                }
                 // Receive every listener argument via a rest parameter typed by
                 // `Parameters<listener>` (always a tuple, so the spread targets a
                 // rest parameter and avoids TS2556). `$event` stays bound to the

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -370,23 +370,17 @@ fn generate_scope_node(
                 .expect("component event handler should have a target component");
                 let event_type = event_types.event_type;
                 let args_type = event_types.args_type;
+                let listener_args_type = event_types.listener_args_type;
                 let listener_type = event_types.listener_type;
                 // Type the listener against the FULL emit argument tuple so
                 // multi-arg emits keep every parameter (#1512). When the emit
                 // signature stays unresolved (`unknown[]`, e.g. a fallthrough
                 // DOM event on a component), fall back to the single `$event`
                 // parameter so those handlers keep type-checking.
-                if ctx.legacy_vue2 {
-                    append!(
-                        *ts,
-                        "{indent}type {listener_type} = unknown[] extends {args_type} ? (($event: {event_type}) => unknown) : ((...args: __VizeVue2LooseEmitArgs<{args_type}>) => unknown);\n",
-                    );
-                } else {
-                    append!(
-                        *ts,
-                        "{indent}type {listener_type} = unknown[] extends {args_type} ? (($event: {event_type}) => unknown) : ((...args: {args_type}) => unknown);\n",
-                    );
-                }
+                append!(
+                    *ts,
+                    "{indent}type {listener_type} = unknown[] extends {args_type} ? (($event: {event_type}) => unknown) : ((...args: {listener_args_type}) => unknown);\n",
+                );
                 // Receive every listener argument via a rest parameter typed by
                 // `Parameters<listener>` (always a tuple, so the spread targets a
                 // rest parameter and avoids TS2556). `$event` stays bound to the

--- a/crates/vize_canon/src/virtual_ts/scope/component_events.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events.rs
@@ -113,15 +113,18 @@ pub(super) fn generate_component_event_types(
         );
     }
 
-    let fallback_event = if legacy_vue2 {
-        "any"
+    if legacy_vue2 {
+        append!(
+            *ts,
+            "{indent}type {event_type} = {args_type} extends [] ? any : unknown[] extends {args_type} ? any : __VizeVue2LooseEventArg<{args_type}[0]>;\n",
+        );
     } else {
-        get_dom_event_type(data.event_name.as_str())
-    };
-    append!(
-        *ts,
-        "{indent}type {event_type} = {args_type} extends [] ? any : unknown[] extends {args_type} ? {fallback_event} : {args_type}[0];\n",
-    );
+        let fallback_event = get_dom_event_type(data.event_name.as_str());
+        append!(
+            *ts,
+            "{indent}type {event_type} = {args_type} extends [] ? any : unknown[] extends {args_type} ? {fallback_event} : {args_type}[0];\n",
+        );
+    }
     Some(ComponentEventTypes {
         event_type,
         args_type,

--- a/crates/vize_canon/src/virtual_ts/scope/component_events.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events.rs
@@ -14,6 +14,7 @@ use crate::virtual_ts::{
 pub(super) struct ComponentEventTypes {
     pub(super) event_type: String,
     pub(super) args_type: String,
+    pub(super) listener_args_type: String,
     pub(super) listener_type: String,
 }
 
@@ -113,21 +114,27 @@ pub(super) fn generate_component_event_types(
         );
     }
 
-    if legacy_vue2 {
+    // In legacy Vue 2 mode the listener rest args go through the loose emit
+    // wrapper so object payload callbacks stay permissive; otherwise they use
+    // the resolved emit argument tuple directly.
+    let listener_args_type = if legacy_vue2 {
         append!(
             *ts,
             "{indent}type {event_type} = {args_type} extends [] ? any : unknown[] extends {args_type} ? any : __VizeVue2LooseEventArg<{args_type}[0]>;\n",
         );
+        cstr!("__VizeVue2LooseEmitArgs<{args_type}>")
     } else {
         let fallback_event = get_dom_event_type(data.event_name.as_str());
         append!(
             *ts,
             "{indent}type {event_type} = {args_type} extends [] ? any : unknown[] extends {args_type} ? {fallback_event} : {args_type}[0];\n",
         );
-    }
+        args_type.clone()
+    };
     Some(ComponentEventTypes {
         event_type,
         args_type,
+        listener_args_type,
         listener_type,
     })
 }

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -2038,6 +2038,50 @@ fn test_plain_options_object_default_export_is_wrapped_with_define_component() {
 }
 
 #[test]
+fn test_legacy_nuxt2_page_validate_gets_contextual_type() {
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let script = r#"export default {
+  name: 'StudentPage',
+  validate({ params }) {
+    return !Number.isNaN(Number(params.studentId))
+  }
+}
+"#;
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_plain(script);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts_with_offsets_and_checks(
+        &summary,
+        Some(script),
+        None,
+        0,
+        0,
+        &Default::default(),
+        VirtualTsGenerationOptions {
+            legacy_vue2: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        output
+            .code
+            .contains("validate?: (context: __VizeNuxt2Context) => unknown;"),
+        "legacy Nuxt 2 page options should declare a contextual validate type:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("const __default__ = __vizeDefineComponent({"),
+        "plain object exports should be wrapped by the legacy helper:\n{}",
+        output.code
+    );
+}
+
+#[test]
 fn test_single_line_options_object_default_export_wrap_keeps_trailing_text() {
     use vize_croquis::{Analyzer, AnalyzerOptions};
 

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -7,6 +7,7 @@ use super::{
 use vize_carton::config::VueVersion;
 mod component_navigation;
 mod define_props_scope;
+mod legacy_nuxt2_page_context;
 mod no_check_template_bindings;
 mod options_api_props_spread;
 mod options_api_setup_spread;
@@ -2033,50 +2034,6 @@ fn test_plain_options_object_default_export_is_wrapped_with_define_component() {
     assert!(
         output.code.contains("\n  })\n"),
         "expected the wrap to be closed after the options object:\n{}",
-        output.code
-    );
-}
-
-#[test]
-fn test_legacy_nuxt2_page_validate_gets_contextual_type() {
-    use vize_croquis::{Analyzer, AnalyzerOptions};
-
-    let script = r#"export default {
-  name: 'StudentPage',
-  validate({ params }) {
-    return !Number.isNaN(Number(params.studentId))
-  }
-}
-"#;
-    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
-    analyzer.analyze_script_plain(script);
-    let summary = analyzer.finish();
-
-    let output = generate_virtual_ts_with_offsets_and_checks(
-        &summary,
-        Some(script),
-        None,
-        0,
-        0,
-        &Default::default(),
-        VirtualTsGenerationOptions {
-            legacy_vue2: true,
-            ..Default::default()
-        },
-    );
-
-    assert!(
-        output
-            .code
-            .contains("validate?: (context: __VizeNuxt2Context) => unknown;"),
-        "legacy Nuxt 2 page options should declare a contextual validate type:\n{}",
-        output.code
-    );
-    assert!(
-        output
-            .code
-            .contains("const __default__ = __vizeDefineComponent({"),
-        "plain object exports should be wrapped by the legacy helper:\n{}",
         output.code
     );
 }

--- a/crates/vize_canon/src/virtual_ts/tests/legacy_nuxt2_page_context.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/legacy_nuxt2_page_context.rs
@@ -1,0 +1,45 @@
+use super::{VirtualTsGenerationOptions, generate_virtual_ts_with_offsets_and_checks};
+
+#[test]
+fn test_legacy_nuxt2_page_validate_gets_contextual_type() {
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let script = r#"export default {
+  name: 'StudentPage',
+  validate({ params }) {
+    return !Number.isNaN(Number(params.studentId))
+  }
+}
+"#;
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_plain(script);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts_with_offsets_and_checks(
+        &summary,
+        Some(script),
+        None,
+        0,
+        0,
+        &Default::default(),
+        VirtualTsGenerationOptions {
+            legacy_vue2: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        output
+            .code
+            .contains("validate?: (context: __VizeNuxt2Context) => unknown;"),
+        "legacy Nuxt 2 page options should declare a contextual validate type:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("const __default__ = __vizeDefineComponent({"),
+        "plain object exports should be wrapped by the legacy helper:\n{}",
+        output.code
+    );
+}


### PR DESCRIPTION
## Summary

- keep legacy Vue 2 component event payloads permissive for object payload callbacks
- add Nuxt 2 page option context typing for plain `export default` page objects
- update legacy Vue 2 helper snapshots for the new helper types

## Verification

- `cargo test -p vize_canon legacy_vue2_component_event_object_payloads_stay_permissive`
- `cargo test -p vize_canon test_legacy_nuxt2_page_validate_gets_contextual_type`
- `cargo test -p vize_canon ref_arity`

Closes #2306
Closes #2309

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->