### PR TITLE
fix(canon): preserve TS enum virtual module exports

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator/script_module.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module.rs
@@ -146,6 +146,9 @@ fn collect_declaration_exports(
                 push_name(id.name.as_str(), seen, names);
             }
         }
+        Declaration::TSEnumDeclaration(enumeration) => {
+            push_name(enumeration.id.name.as_str(), seen, names);
+        }
         _ => {}
     }
 }
@@ -233,7 +236,7 @@ fn contains_ts_suppression_directive(comment: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::collect_line_module_import_spans;
+    use super::{CompactString, collect_line_module_import_spans, collect_named_value_exports};
 
     #[test]
     fn collect_import_span_includes_adjacent_ts_ignore_comment_group() {
@@ -257,5 +260,14 @@ mod tests {
             &script[spans[0].0 as usize..spans[0].1 as usize],
             "import Chart from \"chart.js/auto/auto\";"
         );
+    }
+
+    #[test]
+    fn collect_named_value_exports_includes_ts_enums() {
+        let names = collect_named_value_exports(
+            "export enum DiffDisplayMode { Hidden = 'hidden' }\nexport type Props = {}\n",
+        );
+
+        assert_eq!(names, vec![CompactString::new("DiffDisplayMode")]);
     }
 }


### PR DESCRIPTION
## Summary

- treat TypeScript enum declarations as value exports when generating SFC virtual modules
- add a regression test for named enum exports

## Verification

- `cargo test -p vize_canon collect_named_value_exports_includes_ts_enums`

Closes #2316

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->