### PR TITLE
fix(musea-vrt): reject art-file generate inputs

### DIFF
--- a/npm/builder/vite-musea/src/cli/commands.test.ts
+++ b/npm/builder/vite-musea/src/cli/commands.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { hasCiBlockingVrtResult } from "./commands.ts";
+import { hasCiBlockingVrtResult, isArtFileInput } from "./commands.ts";
 import type { VrtSummary } from "../vrt.ts";
 
 function summary(overrides: Partial<VrtSummary>): VrtSummary {
@@ -27,4 +27,9 @@ void test("VRT CI blocks on capture errors", () => {
 void test("VRT CI allows clean and newly-created baselines", () => {
   assert.equal(hasCiBlockingVrtResult(summary({})), false);
   assert.equal(hasCiBlockingVrtResult(summary({ passed: 0, new: 1 })), false);
+});
+
+void test("generate rejects existing art-file inputs", () => {
+  assert.equal(isArtFileInput("src/components/Button.art.vue"), true);
+  assert.equal(isArtFileInput("src/components/Button.vue"), false);
 });

--- a/npm/builder/vite-musea/src/cli/commands.ts
+++ b/npm/builder/vite-musea/src/cli/commands.ts
@@ -18,6 +18,10 @@ export function hasCiBlockingVrtResult(summary: VrtSummary): boolean {
   return summary.failed > 0 || summary.skipped > 0;
 }
 
+export function isArtFileInput(filePath: string): boolean {
+  return filePath.endsWith(".art.vue");
+}
+
 export async function runVrt(options: CliOptions, artFiles: ArtFileInfo[]): Promise<void> {
   const totalVariants = artFiles.reduce(
     (sum, art) => sum + art.variants.filter((v) => !v.skipVrt).length,
@@ -197,6 +201,13 @@ export async function runGenerate(options: CliOptions): Promise<void> {
   }
 
   const componentPath = path.resolve(options.componentPath);
+  if (isArtFileInput(componentPath)) {
+    console.error(
+      "  Error: musea-vrt generate expects a source .vue component, not a .art.vue file.",
+    );
+    console.error("  Pass the component file that the art file should wrap.\n");
+    process.exit(1);
+  }
 
   // Check file exists
   try {


### PR DESCRIPTION
## Summary

- reject `.art.vue` files as `musea generate` component inputs
- keep generation pointed at source components instead of existing art files
- add a CLI regression test

## Verification

- `CI=true corepack pnpm@10.0.0 --dir npm/builder/vite-musea test`

Closes #2311

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->