### PR TITLE
fix(musea): skip generated paths during migration

### DIFF
--- a/crates/vize/src/commands/musea/migrate.rs
+++ b/crates/vize/src/commands/musea/migrate.rs
@@ -90,7 +90,7 @@ pub fn run(args: MigrateArgs) {
 fn collect_story_files(patterns: &[std::string::String]) -> Vec<PathBuf> {
     collect_files(patterns, None)
         .into_iter()
-        .filter(|path| is_story_file(path))
+        .filter(|path| is_story_file(path) && !is_default_ignored_story_path(path))
         .collect()
 }
 
@@ -103,6 +103,17 @@ fn is_story_file(path: &Path) -> bool {
         name.rsplit_once('.'),
         Some((stem, "tsx" | "ts" | "jsx" | "js")) if stem.ends_with(".stories")
     )
+}
+
+fn is_default_ignored_story_path(path: &Path) -> bool {
+    path.components().any(|component| {
+        component.as_os_str().to_str().is_some_and(|name| {
+            matches!(
+                name,
+                "node_modules" | ".nuxt" | ".output" | "dist" | "storybook-static"
+            )
+        })
+    })
 }
 
 struct FileOutcome {

--- a/crates/vize/src/commands/musea/migrate/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/tests.rs
@@ -1,7 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use super::{
-    component_tag_from_path, derive_component_path, is_story_file, output_path, story_basename,
+    component_tag_from_path, derive_component_path, is_default_ignored_story_path, is_story_file,
+    output_path, story_basename,
 };
 
 #[test]
@@ -13,6 +14,19 @@ fn is_story_file_matches_only_story_extensions() {
     assert!(!is_story_file(Path::new("Button.tsx")));
     assert!(!is_story_file(Path::new("Button.stories.vue")));
     assert!(!is_story_file(Path::new("stories.ts")));
+}
+
+#[test]
+fn default_ignored_story_paths_skip_dependencies_and_outputs() {
+    assert!(is_default_ignored_story_path(Path::new(
+        "node_modules/pkg/Button.stories.tsx"
+    )));
+    assert!(is_default_ignored_story_path(Path::new(
+        ".output/public/Button.stories.tsx"
+    )));
+    assert!(!is_default_ignored_story_path(Path::new(
+        "src/Button.stories.tsx"
+    )));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- skip default generated/dependency paths while collecting Storybook files for Musea migration
- prevent migrate output from being written into `node_modules`, `.nuxt`, `.output`, `dist`, or `storybook-static`
- add a collector regression test

## Verification

- `cargo test -p vize default_ignored_story_paths_skip_dependencies_and_outputs`

Closes #2312

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->