### PR TITLE
fix(musea): preserve CSF migration bindings

### DIFF
--- a/crates/vize/src/commands/musea/migrate/emit.rs
+++ b/crates/vize/src/commands/musea/migrate/emit.rs
@@ -6,7 +6,7 @@ use vize_carton::{String, append};
 
 use super::csf::{CsfModule, CsfStory, unwrap_expression};
 use super::jsx::convert_render;
-use super::text::{escape_attr, escape_js_string};
+use super::text::{escape_attr, escape_js_string, quote_directive_expression};
 
 const TODO_COMMENT: &str = "<!-- TODO(vize musea migrate): unsupported story; port manually -->";
 
@@ -91,16 +91,30 @@ fn emit_variant_inner(story: &CsfStory<'_>, component_tag: &str, source: &str) -
     }
 
     if let Some(args) = story.args {
-        return (emit_args_element(args, component_tag, source), false);
+        if args_contains_unmigrated_identifier(args) {
+            return (emit_todo_element(component_tag), true);
+        }
+        if let Some(element) = emit_args_element(args, component_tag, source) {
+            return (element, false);
+        }
+        return (emit_todo_element(component_tag), true);
     }
 
+    (emit_todo_element(component_tag), true)
+}
+
+fn emit_todo_element(component_tag: &str) -> String {
     let mut out = String::default();
     append!(out, "<{component_tag} />\n{TODO_COMMENT}");
-    (out, true)
+    out
 }
 
 /// Emit `<Component ...props />` from an `args` object literal.
-fn emit_args_element(args: &ObjectExpression<'_>, component_tag: &str, source: &str) -> String {
+fn emit_args_element(
+    args: &ObjectExpression<'_>,
+    component_tag: &str,
+    source: &str,
+) -> Option<String> {
     let mut out = String::default();
     append!(out, "<{component_tag}");
     for property in &args.properties {
@@ -114,23 +128,33 @@ fn emit_args_element(args: &ObjectExpression<'_>, component_tag: &str, source: &
             continue;
         };
         out.push(' ');
-        out.push_str(&attribute_from_value(name, &prop.value, source));
+        out.push_str(&attribute_from_value(name, &prop.value, source)?);
     }
     out.push_str(" />");
-    out
+    Some(out)
 }
 
 /// Map one `args` entry to an attribute: string literal -> `name="value"`,
 /// everything else -> `:name="<expr source>"`.
-fn attribute_from_value(name: &str, value: &Expression<'_>, source: &str) -> String {
+fn attribute_from_value(name: &str, value: &Expression<'_>, source: &str) -> Option<String> {
     let mut out = String::default();
     if let Expression::StringLiteral(literal) = unwrap_expression(value) {
         append!(out, "{name}=\"{}\"", escape_attr(literal.value.as_str()));
     } else {
         let text = value.span().source_text(source);
-        append!(out, ":{name}=\"{}\"", escape_attr(text));
+        let quoted = quote_directive_expression(text)?;
+        append!(out, ":{name}={}", quoted.as_str());
     }
-    out
+    Some(out)
+}
+
+fn args_contains_unmigrated_identifier(args: &ObjectExpression<'_>) -> bool {
+    args.properties.iter().any(|property| {
+        let ObjectPropertyKind::ObjectProperty(prop) = property else {
+            return false;
+        };
+        !prop.computed && matches!(unwrap_expression(&prop.value), Expression::Identifier(_))
+    })
 }
 
 fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {

--- a/crates/vize/src/commands/musea/migrate/emit/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/tests.rs
@@ -85,3 +85,33 @@ defineArt("./AfButton.vue", {
     assert_eq!(variants, 1);
     assert_eq!(todos, 0);
 }
+
+#[test]
+fn emits_todo_for_args_referencing_local_fixture_identifiers() {
+    let source = r#"import AfButton from "./AfButton.vue";
+const fixture = { label: "Hi" };
+export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;
+export const Big = { args: { data: fixture } };
+"#;
+    let (content, variants, todos) = emit(source);
+
+    assert!(content.contains("<AfButton />"));
+    assert!(content.contains("TODO(vize musea migrate)"));
+    assert!(!content.contains(":data=\"fixture\""));
+    assert_eq!(variants, 1);
+    assert_eq!(todos, 1);
+}
+
+#[test]
+fn emits_directive_expressions_without_quot_entities() {
+    let source = r#"import AfButton from "./AfButton.vue";
+export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;
+export const Big = { args: { to: { name: "students" } as NuxtRoute<"students", string>, field: { label: "Name" } } };
+"#;
+    let (content, _variants, todos) = emit(source);
+
+    assert!(content.contains(r#":to='{ name: "students" } as NuxtRoute<"students", string>'"#));
+    assert!(content.contains(r#":field='{ label: "Name" }'"#));
+    assert!(!content.contains("&quot;"));
+    assert_eq!(todos, 0);
+}

--- a/crates/vize/src/commands/musea/migrate/text.rs
+++ b/crates/vize/src/commands/musea/migrate/text.rs
@@ -18,6 +18,27 @@ pub(super) fn escape_attr(value: &str) -> String {
     out
 }
 
+/// Quote a Vue directive expression without HTML-escaping the expression's own
+/// string literals. Keep the existing double-quoted attribute form when
+/// possible; use single quotes only when the expression itself contains `"`.
+pub(super) fn quote_directive_expression(value: &str) -> Option<String> {
+    if !value.contains('"') {
+        let mut out = String::from("\"");
+        out.push_str(value);
+        out.push('"');
+        return Some(out);
+    }
+
+    if !value.contains('\'') {
+        let mut out = String::from("'");
+        out.push_str(value);
+        out.push('\'');
+        return Some(out);
+    }
+
+    None
+}
+
 /// Escape a value for a double-quoted JavaScript/TypeScript string literal (used
 /// in the generated `defineArt("...", { ... })` call).
 pub(super) fn escape_js_string(value: &str) -> String {
@@ -35,7 +56,7 @@ pub(super) fn escape_js_string(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{escape_attr, escape_js_string};
+    use super::{escape_attr, escape_js_string, quote_directive_expression};
 
     #[test]
     fn escape_attr_encodes_quotes_and_amp() {
@@ -53,5 +74,25 @@ mod tests {
     #[test]
     fn escape_js_string_encodes_backslash_quote_newline() {
         assert_eq!(escape_js_string("a\\b\"c\nd").as_str(), "a\\\\b\\\"c\\nd");
+    }
+
+    #[test]
+    fn quote_directive_expression_preserves_double_quotes() {
+        assert_eq!(
+            quote_directive_expression(r#"{ name: "students" }"#)
+                .unwrap()
+                .as_str(),
+            r#"'{ name: "students" }'"#
+        );
+    }
+
+    #[test]
+    fn quote_directive_expression_uses_double_quotes_for_single_quoted_text() {
+        assert_eq!(
+            quote_directive_expression("{ name: 'students' }")
+                .unwrap()
+                .as_str(),
+            r#""{ name: 'students' }""#
+        );
     }
 }


### PR DESCRIPTION
## Summary

- emit TODO fallbacks instead of invalid bindings when CSF args reference local fixture identifiers
- preserve directive expression quotes without HTML-escaping string literal quotes
- add regression tests for fixture args and directive expression output

## Verification

- `cargo test -p vize emits_todo_for_args_referencing_local_fixture_identifiers`
- `cargo test -p vize directive_expression`

Closes #2315

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->