### PR TITLE
fix(musea): detect Nuxt-only build config

### DIFF
--- a/crates/vize/src/commands/musea/serve_plan.rs
+++ b/crates/vize/src/commands/musea/serve_plan.rs
@@ -25,7 +25,12 @@ pub(super) fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePla
         }
         None => PathBuf::from("vite"),
     };
-    validate_direct_vite_musea_setup(cwd)?;
+    if let Err(message) = validate_direct_vite_musea_setup(cwd) {
+        if let Some(nuxt_root) = find_nuxt_project_root(cwd) {
+            return Err(nuxt_musea_message(&nuxt_root, args.build));
+        }
+        return Err(message);
+    }
     let mut env = Vec::new();
     if let Some(config_path) = &args.config {
         env.push((

--- a/crates/vize/src/commands/musea/tests.rs
+++ b/crates/vize/src/commands/musea/tests.rs
@@ -220,6 +220,42 @@ fn serve_plan_rejects_nuxt_project_without_direct_vite() {
 }
 
 #[test]
+fn serve_plan_prefers_nuxt_guidance_when_vite_exists_but_config_is_nuxt_only() {
+    let temp = tempfile::tempdir().unwrap();
+    write_vite_bin(temp.path());
+    fs::write(
+        temp.path().join("nuxt.config.ts"),
+        r#"export default defineNuxtConfig({ modules: ["@vizejs/nuxt"], vize: { musea: true } })"#,
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("package.json"),
+        r#"{
+  "dependencies": {
+    "@vizejs/nuxt": "0.263.0",
+    "@vizejs/vite-plugin-musea": "0.263.0",
+    "nuxt": "3.19.3",
+    "vite": "7.0.0"
+  }
+}"#,
+    )
+    .unwrap();
+
+    let error = create_serve_plan(
+        &ServeArgs {
+            build: true,
+            ..ServeArgs::default()
+        },
+        temp.path(),
+    )
+    .unwrap_err();
+
+    assert!(error.contains("detected a Nuxt project using `@vizejs/nuxt`"));
+    assert!(error.contains("nuxi build"));
+    assert!(!error.contains("no vite.config"));
+}
+
+#[test]
 fn serve_plan_rejects_silent_stories_option() {
     let temp = tempfile::tempdir().unwrap();
     write_vite_bin(temp.path());


### PR DESCRIPTION
## Summary

- prefer Nuxt module setup guidance when a direct Vite Musea plan fails because the config is Nuxt-only
- keep Vite binary detection from hiding the Nuxt-specific remediation path
- add a serve-plan regression test

## Verification

- `cargo test -p vize serve_plan_prefers_nuxt_guidance_when_vite_exists_but_config_is_nuxt_only`

Closes #2314

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->