### PR TITLE
fix(vite): validate legacy host atelier setup

### DIFF
--- a/npm/builder/vite/src/plugin/index.test.ts
+++ b/npm/builder/vite/src/plugin/index.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 
-import { createLegacyVueCompatibilityPlugin, isLegacyVueCompatibilityMode } from "./vue-version.ts";
+import {
+  createLegacyVueCompatibilityPlugin,
+  hasHostVueSfcCompilerPlugin,
+  isLegacyVueCompatibilityMode,
+} from "./vue-version.ts";
 
 {
   const plugin = createLegacyVueCompatibilityPlugin({ vueVersion: 2 });
@@ -60,6 +64,19 @@ import { createLegacyVueCompatibilityPlugin, isLegacyVueCompatibilityMode } from
     "transform" in plugin,
     false,
     "Legacy Vue compatibility mode must not transform .vue code",
+  );
+  assert.equal(hasHostVueSfcCompilerPlugin([{ name: "vite:vue2" }]), true);
+  assert.equal(
+    hasHostVueSfcCompilerPlugin([{ name: "vite-plugin-vize:legacy-vue-compat" }]),
+    false,
+  );
+  assert.throws(
+    () =>
+      plugin.configResolved?.({
+        root: "/repo",
+        plugins: [{ name: "vite-plugin-vize:legacy-vue-compat" }],
+      } as never),
+    /host Vue SFC compiler plugin/,
   );
 }
 

--- a/npm/builder/vite/src/plugin/vue-version.ts
+++ b/npm/builder/vite/src/plugin/vue-version.ts
@@ -15,10 +15,28 @@ export function isLegacyVueCompatibilityMode(options: VizeOptions): boolean {
   return hostCompiler && isLegacyVueVersion(vueVersion);
 }
 
+export function hasHostVueSfcCompilerPlugin(plugins: readonly Pick<Plugin, "name">[]): boolean {
+  return plugins.some((plugin) => {
+    const name = plugin.name;
+    return (
+      name === "vite:vue" ||
+      name === "vite:vue2" ||
+      name.includes("plugin-vue") ||
+      name.includes("vue2")
+    );
+  });
+}
+
 export function createLegacyVueCompatibilityPlugin(options: VizeOptions): Plugin {
   return {
     name: "vite-plugin-vize:legacy-vue-compat",
     configResolved(resolvedConfig) {
+      if (!hasHostVueSfcCompilerPlugin(resolvedConfig.plugins)) {
+        throw new Error(
+          "vite-plugin-vize: legacy Vue host-compiler mode requires a host Vue SFC compiler plugin. Add @vitejs/plugin-vue2 (or your framework's Vue 2 Vite SFC plugin), or set compatibility.hostCompiler=false if this project can use Vize's compiler pipeline.",
+        );
+      }
+
       createLogger(options.debug ?? false).log(
         `Legacy Vue compatibility mode is active for ${resolvedConfig.root}; Vize will not compile .vue files.`,
       );


### PR DESCRIPTION
## Summary

- detect whether a host Vue SFC compiler plugin is present in legacy host-compiler mode
- fail with an actionable diagnostic when legacy compatibility lacks the required host compiler plugin
- add Vite plugin regression tests for detection and failure messaging

## Verification

- `CI=true corepack pnpm@10.0.0 --dir npm/builder/vite check`
- `CI=true corepack pnpm@10.0.0 --dir npm/builder/vite test`

Closes #2322