### PR TITLE
fix(musea): reject legacy static preview runtime

### DIFF
--- a/npm/builder/vite-musea/src/plugin/index.test.ts
+++ b/npm/builder/vite-musea/src/plugin/index.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { shouldApplyMuseaPlugin } from "./apply.js";
+import {
+  assertStaticPreviewRuntimeSupported,
+  resolveStaticPreviewVueVersion,
+} from "./static-preview.js";
 
 void test("musea plugin is inactive in Vite test mode", () => {
   assert.equal(shouldApplyMuseaPlugin({ command: "serve", mode: "test" }), false);
@@ -12,4 +16,16 @@ void test("musea plugin remains active during Vite serve outside test mode", () 
 
 void test("musea plugin remains active during production builds", () => {
   assert.equal(shouldApplyMuseaPlugin({ command: "build", mode: "production" }), true);
+});
+
+void test("static builds reject legacy Vue preview runtime explicitly", () => {
+  assert.throws(() => assertStaticPreviewRuntimeSupported(2, true), /Vue 3 preview runtime/);
+  assert.doesNotThrow(() => assertStaticPreviewRuntimeSupported(2, false));
+  assert.doesNotThrow(() => assertStaticPreviewRuntimeSupported(3, true));
+});
+
+void test("static preview runtime infers legacy Vue from host compiler plugins", () => {
+  assert.equal(resolveStaticPreviewVueVersion(undefined, [{ name: "vite:vue2" }]), 2);
+  assert.equal(resolveStaticPreviewVueVersion(undefined, [{ name: "vite:vue" }]), 3);
+  assert.equal(resolveStaticPreviewVueVersion(3, [{ name: "vite:vue2" }]), 3);
 });

--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -36,6 +36,10 @@ import {
 import { resolveMuseaSharedConfig } from "./config.js";
 import { processMuseaArtFile } from "./art-processing.js";
 import { transformMuseaVirtualModule } from "./virtual-transform.js";
+import {
+  assertStaticPreviewRuntimeSupported,
+  resolveStaticPreviewVueVersion,
+} from "./static-preview.js";
 
 export function musea(options: MuseaOptions = {}): Plugin[] {
   let include = options.include ?? ["**/*.art.vue"];
@@ -49,6 +53,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
   const themeConfig = buildThemeConfig(options.theme);
   const previewCss = options.previewCss ?? [];
   const previewSetup = options.previewSetup;
+  let vueVersion = options.vueVersion;
   const devSessionToken = createDevSessionToken();
 
   let config: ResolvedConfig;
@@ -106,6 +111,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
           storybookCompat = mc.storybookCompat;
         if (options.inlineArt === undefined && mc.inlineArt !== undefined) inlineArt = mc.inlineArt;
       }
+      vueVersion = resolveStaticPreviewVueVersion(vueVersion, resolvedConfig.plugins);
 
       virtualState.basePath = basePath;
 
@@ -214,6 +220,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
 
     async buildStart() {
       console.log(`[musea] config.root: ${config.root}, include: ${JSON.stringify(include)}`);
+      assertStaticPreviewRuntimeSupported(vueVersion, staticBuildEnabled);
       if (storybookCompat && staticBuildEnabled) {
         await assertNoUnsupportedStorybookTsxInputs(config.root, include, exclude);
       }

--- a/npm/builder/vite-musea/src/plugin/static-preview.ts
+++ b/npm/builder/vite-musea/src/plugin/static-preview.ts
@@ -1,0 +1,29 @@
+import type { MuseaOptions } from "../types/index.js";
+
+export function resolveStaticPreviewVueVersion(
+  configured: MuseaOptions["vueVersion"],
+  plugins: readonly Pick<{ name?: string }, "name">[],
+): MuseaOptions["vueVersion"] {
+  if (configured !== undefined) return configured;
+  if (hasLegacyVueSfcCompilerPlugin(plugins)) return 2;
+  return 3;
+}
+
+export function assertStaticPreviewRuntimeSupported(
+  vueVersion: MuseaOptions["vueVersion"],
+  staticBuildEnabled: boolean,
+): void {
+  if (!staticBuildEnabled) return;
+  if (vueVersion === 3 || vueVersion === undefined) return;
+
+  throw new Error(
+    "[musea] Static Musea builds currently require the Vue 3 preview runtime. Vue 2/Nuxt 2 projects should use the dev gallery or run Nuxt static generation with @vizejs/nuxt until a Vue 2 static preview runtime is available.",
+  );
+}
+
+function hasLegacyVueSfcCompilerPlugin(plugins: readonly Pick<{ name?: string }, "name">[]) {
+  return plugins.some((plugin) => {
+    const name = plugin.name ?? "";
+    return name === "vite:vue2" || name.includes("plugin-vue2") || name.includes("vue2");
+  });
+}

--- a/npm/builder/vite-musea/src/types/plugin.ts
+++ b/npm/builder/vite-musea/src/types/plugin.ts
@@ -1,5 +1,7 @@
 import type { VrtOptions } from "./vrt.js";
 
+export type MuseaVueVersion = 0.11 | 1 | 2 | "2.7" | 3 | "legacy";
+
 /**
  * Theme color definitions for Musea gallery UI.
  * All properties are optional — unspecified colors inherit from the `base` built-in theme.
@@ -134,4 +136,11 @@ export interface MuseaOptions {
    * @example 'musea.preview.ts'
    */
   previewSetup?: string;
+
+  /**
+   * Host Vue version for preview runtime compatibility checks.
+   * Legacy Vue static builds currently fail fast with an actionable diagnostic.
+   * @default 3
+   */
+  vueVersion?: MuseaVueVersion;
 }

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -636,7 +636,7 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
         ? ((museaOptions as Record<string, unknown>).basePath as string)
         : "/__musea__";
     (nuxt.options.vite ||= {}).plugins ||= [];
-    const museaConfig = { projectRoot: nuxt.options.rootDir, ...museaOptions };
+    const museaConfig = { projectRoot: nuxt.options.rootDir, vueVersion, ...museaOptions };
     nuxt.options.vite.plugins.push(...musea(museaConfig));
 
     // Print Musea Gallery URL after dev server starts


### PR DESCRIPTION
## Summary

- fail static Musea builds early when the configured or inferred preview runtime is legacy Vue
- infer legacy Vue from host Vue 2 compiler plugins when `vueVersion` is not configured
- pass the Nuxt module resolved `vueVersion` into Musea config

## Verification

- `CI=true corepack pnpm@10.0.0 --dir npm/builder/vite-musea check`
- `CI=true corepack pnpm@10.0.0 --dir npm/builder/vite-musea test`
- `CI=true corepack pnpm@10.0.0 --dir npm/framework/nuxt check`
- `CI=true corepack pnpm@10.0.0 --dir npm/framework/nuxt test`

Closes #2323