### PR TITLE
fix(canon): avoid Nuxt 3 prepare guidance in legacy checks

### DIFF
--- a/crates/vize/src/commands/check/nuxt.rs
+++ b/crates/vize/src/commands/check/nuxt.rs
@@ -91,7 +91,9 @@ pub(in crate::commands::check) fn detect(
     // Surface the degraded fallback: without generated Nuxt types,
     // auto-imports resolve to permissive `any` stubs that hide real type
     // errors. detect_nuxt_auto_imports runs once per check, so this warns once.
-    if let Some(message) = missing_generated_types_warning(has_generated_imports, &generated_dir) {
+    if let Some(message) =
+        missing_generated_types_warning(has_generated_imports, &generated_dir, legacy_vue2)
+    {
         eprintln!("{message}");
     }
     collect_plugin_injection_stubs(cwd, &mut collected, &mut seen_names);
@@ -138,8 +140,19 @@ fn is_nuxt_project(cwd: &Path) -> bool {
 fn missing_generated_types_warning(
     has_generated_imports: bool,
     generated_dir: &generated_dir::NuxtGeneratedDir,
+    legacy_vue2: bool,
 ) -> Option<String> {
     (!has_generated_imports).then(|| {
+        if legacy_vue2 {
+            return format!(
+                "vize check: no generated `{}` types found; Nuxt auto-imports fall back to `any` \
+                 stubs and some type errors will be missed. For Nuxt 2/Bridge, run the project's \
+                 Nuxt type-generation step or build once so the generated type directory exists.",
+                generated_dir.display()
+            )
+            .into();
+        }
+
         format!(
             "vize check: no generated `{}` types found; Nuxt auto-imports fall back to `any` \
              stubs and some type errors will be missed. Run `nuxi prepare` to generate them.",

--- a/crates/vize/src/commands/check/nuxt/tests/build_dir.rs
+++ b/crates/vize/src/commands/check/nuxt/tests/build_dir.rs
@@ -10,8 +10,8 @@ use super::unique_case_dir;
 #[test]
 fn warns_only_when_generated_nuxt_types_are_missing() {
     let generated_dir = resolve_nuxt_generated_dir(Path::new("/workspace"));
-    assert!(missing_generated_types_warning(true, &generated_dir).is_none());
-    let message = missing_generated_types_warning(false, &generated_dir)
+    assert!(missing_generated_types_warning(true, &generated_dir, false).is_none());
+    let message = missing_generated_types_warning(false, &generated_dir, false)
         .expect("missing generated types must warn");
     assert!(message.contains("nuxi prepare"));
     assert!(message.contains("`.nuxt`"));
@@ -155,13 +155,23 @@ fn warning_mentions_resolved_generated_dir() {
     .unwrap();
 
     let generated_dir = resolve_nuxt_generated_dir(&project_root);
-    let message = missing_generated_types_warning(false, &generated_dir)
+    let message = missing_generated_types_warning(false, &generated_dir, false)
         .expect("missing generated types must warn");
 
     assert!(message.contains("`.out/.nuxt`"), "{message}");
     assert!(!message.contains("`.nuxt` types"), "{message}");
 
     let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn legacy_nuxt_warning_avoids_nuxt3_prepare_guidance() {
+    let generated_dir = resolve_nuxt_generated_dir(Path::new("/workspace"));
+    let message = missing_generated_types_warning(false, &generated_dir, true)
+        .expect("missing generated types must warn");
+
+    assert!(!message.contains("nuxi prepare"), "{message}");
+    assert!(message.contains("Nuxt 2/Bridge"), "{message}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- thread legacy Vue 2 mode into the missing Nuxt generated types warning
- avoid recommending `nuxi prepare` for Nuxt 2/Bridge checks
- add a regression test for the legacy warning text

## Verification

- `cargo test -p vize legacy_nuxt_warning_avoids_nuxt3_prepare_guidance`

Closes #2320