### PR TITLE
fix(patina): reject keyword v-on handlers

### DIFF
--- a/crates/vize_carton/src/i18n/en.json
+++ b/crates/vize_carton/src/i18n/en.json
@@ -32,6 +32,7 @@
   "vue/valid-v-bind.help": "**Fix:** Provide a value to bind:\n```vue\n<!-- Shorthand -->\n<img :src=\"imageUrl\" :alt=\"imageAlt\">\n\n<!-- Full syntax -->\n<img v-bind:src=\"imageUrl\">\n\n<!-- Bind multiple attributes -->\n<div v-bind=\"{ id: itemId, class: itemClass }\"></div>\n```",
   "vue/valid-v-on.description": "Enforce valid v-on directives",
   "vue/valid-v-on.missing_event": "v-on requires an event name",
+  "vue/valid-v-on.invalid_handler": "v-on handler must not be a JavaScript keyword",
   "vue/valid-v-on.help": "**Fix:** Specify the event name:\n```vue\n<!-- Shorthand -->\n<button @click=\"handleClick\">Click</button>\n\n<!-- Full syntax -->\n<button v-on:click=\"handleClick\">Click</button>\n\n<!-- With modifiers -->\n<form @submit.prevent=\"onSubmit\">...</form>\n<input @keyup.enter=\"onEnter\">\n```",
   "vue/valid-v-model.description": "Enforce valid v-model directives",
   "vue/valid-v-model.missing_expression": "v-model requires an expression",

--- a/crates/vize_carton/src/i18n/ja.json
+++ b/crates/vize_carton/src/i18n/ja.json
@@ -32,6 +32,7 @@
   "vue/valid-v-bind.help": "v-bindディレクティブに式を追加してください",
   "vue/valid-v-on.description": "有効なv-onディレクティブを強制する",
   "vue/valid-v-on.missing_event": "v-onにはイベント名が必要です",
+  "vue/valid-v-on.invalid_handler": "v-onハンドラーにはJavaScriptキーワードを使用できません",
   "vue/valid-v-on.help": "@clickやv-on:clickのようにイベント名を追加してください",
   "vue/valid-v-model.description": "有効なv-modelディレクティブを強制する",
   "vue/valid-v-model.missing_expression": "v-modelには式が必要です",

--- a/crates/vize_carton/src/i18n/zh.json
+++ b/crates/vize_carton/src/i18n/zh.json
@@ -32,6 +32,7 @@
   "vue/valid-v-bind.help": "**修复:** 提供要绑定的值:\n```vue\n<!-- 简写 -->\n<img :src=\"imageUrl\" :alt=\"imageAlt\">\n\n<!-- 完整语法 -->\n<img v-bind:src=\"imageUrl\">\n\n<!-- 绑定多个属性 -->\n<div v-bind=\"{ id: itemId, class: itemClass }\"></div>\n```",
   "vue/valid-v-on.description": "强制有效的v-on指令",
   "vue/valid-v-on.missing_event": "v-on需要一个事件名",
+  "vue/valid-v-on.invalid_handler": "v-on处理器不能使用JavaScript关键字",
   "vue/valid-v-on.help": "**修复:** 指定事件名:\n```vue\n<!-- 简写 -->\n<button @click=\"handleClick\">点击</button>\n\n<!-- 完整语法 -->\n<button v-on:click=\"handleClick\">点击</button>\n\n<!-- 带修饰符 -->\n<form @submit.prevent=\"onSubmit\">...</form>\n<input @keyup.enter=\"onEnter\">\n```",
   "vue/valid-v-model.description": "强制有效的v-model指令",
   "vue/valid-v-model.missing_expression": "v-model需要一个表达式",

--- a/crates/vize_patina/src/rules/vue/valid_v_on.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_on.rs
@@ -38,6 +38,51 @@ static META: RuleMeta = RuleMeta {
 /// Enforce valid v-on directives
 pub struct ValidVOn;
 
+const JAVASCRIPT_KEYWORDS: &[&str] = &[
+    "await",
+    "break",
+    "case",
+    "catch",
+    "class",
+    "const",
+    "continue",
+    "debugger",
+    "default",
+    "delete",
+    "do",
+    "else",
+    "enum",
+    "export",
+    "extends",
+    "finally",
+    "for",
+    "function",
+    "if",
+    "implements",
+    "import",
+    "in",
+    "instanceof",
+    "interface",
+    "let",
+    "new",
+    "package",
+    "private",
+    "protected",
+    "public",
+    "return",
+    "static",
+    "super",
+    "switch",
+    "throw",
+    "try",
+    "typeof",
+    "var",
+    "void",
+    "while",
+    "with",
+    "yield",
+];
+
 impl Rule for ValidVOn {
     fn meta(&self) -> &'static RuleMeta {
         &META
@@ -59,6 +104,15 @@ impl Rule for ValidVOn {
             .as_ref()
             .map(|e| !is_empty_expression(e))
             .unwrap_or(false);
+
+        if directive.exp.as_ref().is_some_and(is_keyword_expression) {
+            ctx.error_with_help(
+                ctx.t("vue/valid-v-on.invalid_handler"),
+                &directive.loc,
+                ctx.t("vue/valid-v-on.help"),
+            );
+            return;
+        }
 
         // Object syntax: v-on="{ click: handler }"
         if !has_arg && has_exp {
@@ -99,6 +153,15 @@ fn is_empty_expression(exp: &ExpressionNode) -> bool {
     }
 }
 
+fn is_keyword_expression(exp: &ExpressionNode) -> bool {
+    let ExpressionNode::Simple(simple) = exp else {
+        return false;
+    };
+
+    let candidate = simple.content.trim();
+    JAVASCRIPT_KEYWORDS.contains(&candidate)
+}
+
 #[cfg(test)]
 mod tests {
     use super::ValidVOn;
@@ -137,5 +200,26 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div @click></div>"#, "test.vue");
         assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_on_keyword_handler() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div @click="for"></div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_on_keyword_object_syntax() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div v-on="class"></div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_valid_v_on_literal_handler_expression() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div @click="true"></div>"#, "test.vue");
+        assert_eq!(result.error_count, 0);
     }
 }


### PR DESCRIPTION
## Summary

- report `vue/valid-v-on` when a handler value is a JavaScript reserved word
- keep expression literals such as `true` valid, matching eslint-plugin-vue behavior
- add focused regression tests and localized diagnostic text

Fixes #2349.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_patina valid_v_on -- --nocapture`
- CLI reproduction with `vize lint --preset essential --format json`
- `cargo test -p vize_patina`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->