### PR TITLE
fix(patina): reject unsupported v-bind modifiers

### DIFF
--- a/crates/vize_carton/src/i18n/en.json
+++ b/crates/vize_carton/src/i18n/en.json
@@ -29,6 +29,7 @@
   "vue/valid-v-else.help": "**Correct usage:**\n```vue\n<div v-if=\"type === 'A'\">A</div>\n<div v-else-if=\"type === 'B'\">B</div>\n<div v-else>Other</div>\n```\n\n**Rules:**\n- `v-else` takes no expression\n- Must immediately follow `v-if` or `v-else-if`\n- No other elements between them",
   "vue/valid-v-bind.description": "Enforce valid v-bind directives",
   "vue/valid-v-bind.missing_expression": "v-bind requires an expression",
+  "vue/valid-v-bind.unsupported_modifier": "v-bind does not support this modifier",
   "vue/valid-v-bind.help": "**Fix:** Provide a value to bind:\n```vue\n<!-- Shorthand -->\n<img :src=\"imageUrl\" :alt=\"imageAlt\">\n\n<!-- Full syntax -->\n<img v-bind:src=\"imageUrl\">\n\n<!-- Bind multiple attributes -->\n<div v-bind=\"{ id: itemId, class: itemClass }\"></div>\n```",
   "vue/valid-v-on.description": "Enforce valid v-on directives",
   "vue/valid-v-on.missing_event": "v-on requires an event name",

--- a/crates/vize_carton/src/i18n/ja.json
+++ b/crates/vize_carton/src/i18n/ja.json
@@ -29,6 +29,7 @@
   "vue/valid-v-else.help": "v-elseはv-ifまたはv-else-if要素の直後に配置してください",
   "vue/valid-v-bind.description": "有効なv-bindディレクティブを強制する",
   "vue/valid-v-bind.missing_expression": "v-bindには式が必要です",
+  "vue/valid-v-bind.unsupported_modifier": "v-bindではこの修飾子を使用できません",
   "vue/valid-v-bind.help": "v-bindディレクティブに式を追加してください",
   "vue/valid-v-on.description": "有効なv-onディレクティブを強制する",
   "vue/valid-v-on.missing_event": "v-onにはイベント名が必要です",

--- a/crates/vize_carton/src/i18n/zh.json
+++ b/crates/vize_carton/src/i18n/zh.json
@@ -29,6 +29,7 @@
   "vue/valid-v-else.help": "**正确用法:**\n```vue\n<div v-if=\"type === 'A'\">A</div>\n<div v-else-if=\"type === 'B'\">B</div>\n<div v-else>其他</div>\n```\n\n**规则:**\n- `v-else`不需要表达式\n- 必须紧跟在`v-if`或`v-else-if`之后\n- 它们之间不能有其他元素",
   "vue/valid-v-bind.description": "强制有效的v-bind指令",
   "vue/valid-v-bind.missing_expression": "v-bind需要一个表达式",
+  "vue/valid-v-bind.unsupported_modifier": "v-bind不支持此修饰符",
   "vue/valid-v-bind.help": "**修复:** 提供要绑定的值:\n```vue\n<!-- 简写 -->\n<img :src=\"imageUrl\" :alt=\"imageAlt\">\n\n<!-- 完整语法 -->\n<img v-bind:src=\"imageUrl\">\n\n<!-- 绑定多个属性 -->\n<div v-bind=\"{ id: itemId, class: itemClass }\"></div>\n```",
   "vue/valid-v-on.description": "强制有效的v-on指令",
   "vue/valid-v-on.missing_event": "v-on需要一个事件名",

--- a/crates/vize_patina/src/rules/vue/valid_v_bind.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_bind.rs
@@ -38,6 +38,8 @@ static META: RuleMeta = RuleMeta {
 /// Enforce valid v-bind directives
 pub struct ValidVBind;
 
+const VALID_MODIFIERS: &[&str] = &["attr", "camel", "prop", "sync"];
+
 impl Rule for ValidVBind {
     fn meta(&self) -> &'static RuleMeta {
         &META
@@ -51,6 +53,16 @@ impl Rule for ValidVBind {
     ) {
         if directive.name.as_str() != "bind" {
             return;
+        }
+
+        for modifier in directive.modifiers.iter() {
+            if !VALID_MODIFIERS.contains(&modifier.content.as_str()) {
+                ctx.error_with_help(
+                    ctx.t("vue/valid-v-bind.unsupported_modifier"),
+                    &modifier.loc,
+                    ctx.t("vue/valid-v-bind.help"),
+                );
+            }
         }
 
         let has_arg = directive.arg.is_some();
@@ -132,9 +144,26 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_v_bind_supported_modifiers() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div :id.camel="id" :value.prop="value" :aria-label.attr="label" :title.sync="title"></div>"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
     fn test_invalid_v_bind_no_arg_no_exp() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div v-bind></div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_bind_unsupported_modifier() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div :foo.bar="value"></div>"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 }


### PR DESCRIPTION
## Summary

- report `vue/valid-v-bind` for unsupported modifiers such as `.bar`
- keep Vue-supported modifiers `.attr`, `.camel`, `.prop`, and `.sync` valid
- add focused regression coverage and localized diagnostic text

Fixes #2353.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_patina valid_v_bind -- --nocapture`
- CLI reproduction with `vize lint --preset essential --format json`
- `cargo test -p vize_patina`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->