### PR TITLE
fix(patina): reject native v-model arguments

### DIFF
--- a/crates/vize_carton/src/i18n/en.json
+++ b/crates/vize_carton/src/i18n/en.json
@@ -36,6 +36,7 @@
   "vue/valid-v-model.description": "Enforce valid v-model directives",
   "vue/valid-v-model.missing_expression": "v-model requires an expression",
   "vue/valid-v-model.invalid_element": "v-model cannot be used on <{tag}> element",
+  "vue/valid-v-model.unexpected_argument": "v-model arguments are not supported on native elements",
   "vue/valid-v-model.help": "**Supported elements:**\n- `<input>` (text, checkbox, radio, etc.)\n- `<textarea>`\n- `<select>`\n- Custom components with `modelValue` prop\n\n**Examples:**\n```vue\n<input v-model=\"message\">\n<input v-model.number=\"age\" type=\"number\">\n<input v-model.trim=\"name\">\n<MyComponent v-model=\"value\">\n```",
   "vue/valid-v-show.description": "Enforce valid v-show directives",
   "vue/valid-v-show.missing_expression": "v-show directive requires an expression",

--- a/crates/vize_carton/src/i18n/ja.json
+++ b/crates/vize_carton/src/i18n/ja.json
@@ -36,6 +36,7 @@
   "vue/valid-v-model.description": "有効なv-modelディレクティブを強制する",
   "vue/valid-v-model.missing_expression": "v-modelには式が必要です",
   "vue/valid-v-model.invalid_element": "v-modelは<{tag}>要素では使用できません",
+  "vue/valid-v-model.unexpected_argument": "ネイティブ要素のv-modelでは引数を使用できません",
   "vue/valid-v-model.help": "v-modelはinput、textarea、select、またはカスタムコンポーネントで使用できます",
   "vue/valid-v-show.description": "有効なv-showディレクティブを強制する",
   "vue/valid-v-show.missing_expression": "v-showディレクティブには式が必要です",

--- a/crates/vize_carton/src/i18n/zh.json
+++ b/crates/vize_carton/src/i18n/zh.json
@@ -36,6 +36,7 @@
   "vue/valid-v-model.description": "强制有效的v-model指令",
   "vue/valid-v-model.missing_expression": "v-model需要一个表达式",
   "vue/valid-v-model.invalid_element": "v-model不能用于<{tag}>元素",
+  "vue/valid-v-model.unexpected_argument": "原生元素上的v-model不支持参数",
   "vue/valid-v-model.help": "**支持的元素:**\n- `<input>` (text, checkbox, radio等)\n- `<textarea>`\n- `<select>`\n- 带有`modelValue` prop的自定义组件\n\n**示例:**\n```vue\n<input v-model=\"message\">\n<input v-model.number=\"age\" type=\"number\">\n<input v-model.trim=\"name\">\n<MyComponent v-model=\"value\">\n```",
   "vue/valid-v-show.description": "强制有效的v-show指令",
   "vue/valid-v-show.missing_expression": "v-show指令需要一个表达式",

--- a/crates/vize_patina/src/rules/vue/valid_v_model.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_model.rs
@@ -90,7 +90,20 @@ impl Rule for ValidVModel {
             return;
         }
 
-        // Check 3: Validate modifiers (only for native elements)
+        // Check 3: Native v-model does not support arguments
+        if !is_component && let Some(arg) = &directive.arg {
+            let loc = match arg {
+                ExpressionNode::Simple(simple) => &simple.loc,
+                ExpressionNode::Compound(_) => &directive.loc,
+            };
+            ctx.error_with_help(
+                ctx.t("vue/valid-v-model.unexpected_argument"),
+                loc,
+                ctx.t("vue/valid-v-model.help"),
+            );
+        }
+
+        // Check 4: Validate modifiers (only for native elements)
         if !is_component {
             for modifier in directive.modifiers.iter() {
                 let mod_name = modifier.content.as_str();
@@ -191,6 +204,13 @@ mod tests {
     fn test_invalid_v_model_no_expression() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<input v-model>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_model_argument_on_native_element() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<input v-model:foo="value">"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 }


### PR DESCRIPTION
## Summary

- report `vue/valid-v-model` when native elements use a `v-model` argument
- keep component `v-model:foo` usage valid
- add focused regression coverage and localized diagnostic text

Fixes #2355.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_patina valid_v_model -- --nocapture`
- CLI reproduction with `vize lint --preset essential --format json`
- `cargo test -p vize_patina`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->