### PR TITLE
fix(patina): reject file input v-model

### DIFF
--- a/crates/vize_carton/src/i18n/en.json
+++ b/crates/vize_carton/src/i18n/en.json
@@ -38,6 +38,7 @@
   "vue/valid-v-model.description": "Enforce valid v-model directives",
   "vue/valid-v-model.missing_expression": "v-model requires an expression",
   "vue/valid-v-model.invalid_element": "v-model cannot be used on <{tag}> element",
+  "vue/valid-v-model.unsupported_file_input": "v-model cannot be used on file inputs",
   "vue/valid-v-model.unexpected_argument": "v-model arguments are not supported on native elements",
   "vue/valid-v-model.help": "**Supported elements:**\n- `<input>` (text, checkbox, radio, etc.)\n- `<textarea>`\n- `<select>`\n- Custom components with `modelValue` prop\n\n**Examples:**\n```vue\n<input v-model=\"message\">\n<input v-model.number=\"age\" type=\"number\">\n<input v-model.trim=\"name\">\n<MyComponent v-model=\"value\">\n```",
   "vue/valid-v-show.description": "Enforce valid v-show directives",

--- a/crates/vize_carton/src/i18n/ja.json
+++ b/crates/vize_carton/src/i18n/ja.json
@@ -38,6 +38,7 @@
   "vue/valid-v-model.description": "有効なv-modelディレクティブを強制する",
   "vue/valid-v-model.missing_expression": "v-modelには式が必要です",
   "vue/valid-v-model.invalid_element": "v-modelは<{tag}>要素では使用できません",
+  "vue/valid-v-model.unsupported_file_input": "v-modelはfile inputでは使用できません",
   "vue/valid-v-model.unexpected_argument": "ネイティブ要素のv-modelでは引数を使用できません",
   "vue/valid-v-model.help": "v-modelはinput、textarea、select、またはカスタムコンポーネントで使用できます",
   "vue/valid-v-show.description": "有効なv-showディレクティブを強制する",

--- a/crates/vize_carton/src/i18n/zh.json
+++ b/crates/vize_carton/src/i18n/zh.json
@@ -38,6 +38,7 @@
   "vue/valid-v-model.description": "强制有效的v-model指令",
   "vue/valid-v-model.missing_expression": "v-model需要一个表达式",
   "vue/valid-v-model.invalid_element": "v-model不能用于<{tag}>元素",
+  "vue/valid-v-model.unsupported_file_input": "v-model不能用于文件输入",
   "vue/valid-v-model.unexpected_argument": "原生元素上的v-model不支持参数",
   "vue/valid-v-model.help": "**支持的元素:**\n- `<input>` (text, checkbox, radio等)\n- `<textarea>`\n- `<select>`\n- 带有`modelValue` prop的自定义组件\n\n**示例:**\n```vue\n<input v-model=\"message\">\n<input v-model.number=\"age\" type=\"number\">\n<input v-model.trim=\"name\">\n<MyComponent v-model=\"value\">\n```",
   "vue/valid-v-show.description": "强制有效的v-show指令",

--- a/crates/vize_patina/src/rules/vue/valid_v_model.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_model.rs
@@ -27,7 +27,7 @@ use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_carton::is_html_tag;
-use vize_relief::{DirectiveNode, ElementNode, ElementType, ExpressionNode};
+use vize_relief::{DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/valid-v-model",
@@ -90,7 +90,16 @@ impl Rule for ValidVModel {
             return;
         }
 
-        // Check 3: Native v-model does not support arguments
+        // Check 3: v-model cannot read file inputs
+        if !is_component && is_static_file_input(element) {
+            ctx.error_with_help(
+                ctx.t("vue/valid-v-model.unsupported_file_input"),
+                &directive.loc,
+                ctx.t("vue/valid-v-model.help"),
+            );
+        }
+
+        // Check 4: Native v-model does not support arguments
         if !is_component && let Some(arg) = &directive.arg {
             let loc = match arg {
                 ExpressionNode::Simple(simple) => &simple.loc,
@@ -103,7 +112,7 @@ impl Rule for ValidVModel {
             );
         }
 
-        // Check 4: Validate modifiers (only for native elements)
+        // Check 5: Validate modifiers (only for native elements)
         if !is_component {
             for modifier in directive.modifiers.iter() {
                 let mod_name = modifier.content.as_str();
@@ -126,6 +135,23 @@ fn is_component_like_tag(element: &ElementNode<'_>) -> bool {
 
     let tag = element.tag.as_str();
     tag == "component" || (tag.contains('-') && !is_html_tag(tag))
+}
+
+fn is_static_file_input(element: &ElementNode<'_>) -> bool {
+    if !element.tag.as_str().eq_ignore_ascii_case("input") {
+        return false;
+    }
+
+    element.props.iter().any(|prop| {
+        let PropNode::Attribute(attr) = prop else {
+            return false;
+        };
+        attr.name.as_str().eq_ignore_ascii_case("type")
+            && attr
+                .value
+                .as_ref()
+                .is_some_and(|value| value.content.trim().eq_ignore_ascii_case("file"))
+    })
 }
 
 /// Check if expression is empty
@@ -211,6 +237,13 @@ mod tests {
     fn test_invalid_v_model_argument_on_native_element() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<input v-model:foo="value">"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_model_on_file_input() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<input type="file" v-model="file">"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 }


### PR DESCRIPTION
## Summary

- report `vue/valid-v-model` for static native `<input type="file">` usage
- keep the check scoped to native static file inputs
- add focused regression coverage and localized diagnostic text

Fixes #2357.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_patina valid_v_model -- --nocapture`
- CLI reproduction with `vize lint --preset essential --format json`
- `cargo test -p vize_patina`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->