### PR TITLE
fix(patina): reject v-show arguments

### DIFF
--- a/crates/vize_carton/src/i18n/en.json
+++ b/crates/vize_carton/src/i18n/en.json
@@ -43,6 +43,8 @@
   "vue/valid-v-show.description": "Enforce valid v-show directives",
   "vue/valid-v-show.missing_expression": "v-show directive requires an expression",
   "vue/valid-v-show.on_template": "v-show cannot be used on <template> element",
+  "vue/valid-v-show.unexpected_argument": "v-show does not support arguments",
+  "vue/valid-v-show.unexpected_modifier": "v-show does not support modifiers",
   "vue/valid-v-show.help": "Add an expression to the v-show directive",
   "vue/valid-v-slot.description": "Enforce valid v-slot directives",
   "vue/valid-v-slot.invalid_location": "v-slot can only be used on components or template elements",

--- a/crates/vize_carton/src/i18n/ja.json
+++ b/crates/vize_carton/src/i18n/ja.json
@@ -43,6 +43,8 @@
   "vue/valid-v-show.description": "有効なv-showディレクティブを強制する",
   "vue/valid-v-show.missing_expression": "v-showディレクティブには式が必要です",
   "vue/valid-v-show.on_template": "v-showは<template>要素では使用できません",
+  "vue/valid-v-show.unexpected_argument": "v-showは引数を受け付けません",
+  "vue/valid-v-show.unexpected_modifier": "v-showは修飾子を受け付けません",
   "vue/valid-v-show.help": "v-showディレクティブに式を追加してください",
   "vue/valid-v-slot.description": "有効なv-slotディレクティブを強制する",
   "vue/valid-v-slot.invalid_location": "v-slotはコンポーネントまたはtemplate要素でのみ使用できます",

--- a/crates/vize_carton/src/i18n/zh.json
+++ b/crates/vize_carton/src/i18n/zh.json
@@ -43,6 +43,8 @@
   "vue/valid-v-show.description": "强制有效的v-show指令",
   "vue/valid-v-show.missing_expression": "v-show指令需要一个表达式",
   "vue/valid-v-show.on_template": "v-show不能用于<template>元素",
+  "vue/valid-v-show.unexpected_argument": "v-show不支持参数",
+  "vue/valid-v-show.unexpected_modifier": "v-show不支持修饰符",
   "vue/valid-v-show.help": "**修复:** 添加布尔表达式:\n```vue\n<div v-show=\"isVisible\">内容</div>\n```\n\n**v-show vs v-if:**\n- `v-show`: 总是渲染，通过CSS切换显示（频繁切换时更好）\n- `v-if`: 条件渲染，完全添加/移除DOM",
   "vue/valid-v-slot.description": "强制有效的v-slot指令",
   "vue/valid-v-slot.invalid_location": "v-slot只能用于组件或template元素",

--- a/crates/vize_patina/src/rules/vue/valid_v_show.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_show.rs
@@ -66,7 +66,29 @@ impl Rule for ValidVShow {
             return;
         }
 
-        // Check 2: v-show cannot be used on <template>
+        // Check 2: v-show does not support arguments
+        if let Some(arg) = &directive.arg {
+            let loc = match arg {
+                ExpressionNode::Simple(simple) => &simple.loc,
+                ExpressionNode::Compound(_) => &directive.loc,
+            };
+            ctx.error_with_help(
+                ctx.t("vue/valid-v-show.unexpected_argument"),
+                loc,
+                ctx.t("vue/valid-v-show.help"),
+            );
+        }
+
+        // Check 3: v-show does not support modifiers
+        for modifier in directive.modifiers.iter() {
+            ctx.error_with_help(
+                ctx.t("vue/valid-v-show.unexpected_modifier"),
+                &modifier.loc,
+                ctx.t("vue/valid-v-show.help"),
+            );
+        }
+
+        // Check 4: v-show cannot be used on <template>
         if element.tag.as_str() == "template" {
             ctx.error_with_help(
                 ctx.t("vue/valid-v-show.on_template"),
@@ -108,6 +130,20 @@ mod tests {
     fn test_invalid_v_show_no_expression() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div v-show></div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_show_with_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div v-show:foo="visible"></div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_show_with_modifier() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div v-show.foo="visible"></div>"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 


### PR DESCRIPTION
## Summary

- report `vue/valid-v-show` when `v-show` uses an argument
- report `vue/valid-v-show` when `v-show` uses modifiers
- add focused regression coverage and localized diagnostic text

Fixes #2359.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_patina valid_v_show -- --nocapture`
- CLI reproduction with `vize lint --preset essential --format json`
- `cargo test -p vize_patina`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->