### PR TITLE
fix(patina): reject v-if arguments

### DIFF
--- a/crates/vize_carton/src/i18n/en.json
+++ b/crates/vize_carton/src/i18n/en.json
@@ -22,6 +22,8 @@
   "vue/valid-v-for.help": "**Valid v-for syntax:**\n```vue\n<!-- Array iteration -->\n<li v-for=\"item in items\">{{ item }}</li>\n<li v-for=\"(item, index) in items\">{{ index }}: {{ item }}</li>\n\n<!-- Object iteration -->\n<li v-for=\"(value, key) in object\">{{ key }}: {{ value }}</li>\n<li v-for=\"(value, key, index) in object\">{{ index }}</li>\n\n<!-- Range -->\n<span v-for=\"n in 10\">{{ n }}</span>\n```",
   "vue/valid-v-if.description": "Enforce valid v-if directives",
   "vue/valid-v-if.missing_expression": "v-if directive requires an expression",
+  "vue/valid-v-if.unexpected_argument": "v-if does not support arguments",
+  "vue/valid-v-if.unexpected_modifier": "v-if does not support modifiers",
   "vue/valid-v-if.help": "**Fix:** Add a boolean expression:\n```vue\n<div v-if=\"isVisible\">Content</div>\n<div v-if=\"items.length > 0\">Has items</div>\n```\n\n**Note:** Use `v-show` for frequent toggling (better performance), `v-if` for conditions that rarely change.",
   "vue/valid-v-else.description": "Enforce valid v-else directives",
   "vue/valid-v-else.unexpected_expression": "v-else directives require no expression",

--- a/crates/vize_carton/src/i18n/ja.json
+++ b/crates/vize_carton/src/i18n/ja.json
@@ -22,6 +22,8 @@
   "vue/valid-v-for.help": "構文: v-for=\"item in items\" または v-for=\"(item, index) in items\" を使用してください",
   "vue/valid-v-if.description": "有効なv-ifディレクティブを強制する",
   "vue/valid-v-if.missing_expression": "v-ifディレクティブには式が必要です",
+  "vue/valid-v-if.unexpected_argument": "v-ifは引数を受け付けません",
+  "vue/valid-v-if.unexpected_modifier": "v-ifは修飾子を受け付けません",
   "vue/valid-v-if.help": "v-ifディレクティブに式を追加してください",
   "vue/valid-v-else.description": "有効なv-elseディレクティブを強制する",
   "vue/valid-v-else.unexpected_expression": "v-elseディレクティブには式を指定できません",

--- a/crates/vize_carton/src/i18n/zh.json
+++ b/crates/vize_carton/src/i18n/zh.json
@@ -22,6 +22,8 @@
   "vue/valid-v-for.help": "**有效的v-for语法:**\n```vue\n<!-- 数组迭代 -->\n<li v-for=\"item in items\">{{ item }}</li>\n<li v-for=\"(item, index) in items\">{{ index }}: {{ item }}</li>\n\n<!-- 对象迭代 -->\n<li v-for=\"(value, key) in object\">{{ key }}: {{ value }}</li>\n<li v-for=\"(value, key, index) in object\">{{ index }}</li>\n\n<!-- 范围 -->\n<span v-for=\"n in 10\">{{ n }}</span>\n```",
   "vue/valid-v-if.description": "强制有效的v-if指令",
   "vue/valid-v-if.missing_expression": "v-if指令需要一个表达式",
+  "vue/valid-v-if.unexpected_argument": "v-if不支持参数",
+  "vue/valid-v-if.unexpected_modifier": "v-if不支持修饰符",
   "vue/valid-v-if.help": "**修复:** 添加布尔表达式:\n```vue\n<div v-if=\"isVisible\">内容</div>\n<div v-if=\"items.length > 0\">有项目</div>\n```\n\n**注意:** 频繁切换使用`v-show`（性能更好），很少改变的条件使用`v-if`。",
   "vue/valid-v-else.description": "强制有效的v-else指令",
   "vue/valid-v-else.unexpected_expression": "v-else指令不需要表达式",

--- a/crates/vize_patina/src/rules/vue/valid_v_if.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_if.rs
@@ -66,7 +66,29 @@ impl Rule for ValidVIf {
             );
         }
 
-        // Check 2: v-if should not be used with v-else or v-else-if
+        // Check 2: v-if does not support arguments
+        if let Some(arg) = &directive.arg {
+            let loc = match arg {
+                ExpressionNode::Simple(simple) => &simple.loc,
+                ExpressionNode::Compound(_) => &directive.loc,
+            };
+            ctx.error_with_help(
+                ctx.t("vue/valid-v-if.unexpected_argument"),
+                loc,
+                ctx.t("vue/valid-v-if.help"),
+            );
+        }
+
+        // Check 3: v-if does not support modifiers
+        for modifier in directive.modifiers.iter() {
+            ctx.error_with_help(
+                ctx.t("vue/valid-v-if.unexpected_modifier"),
+                &modifier.loc,
+                ctx.t("vue/valid-v-if.help"),
+            );
+        }
+
+        // Check 4: v-if should not be used with v-else or v-else-if
         let has_v_else = element.props.iter().any(|p| {
             matches!(p, PropNode::Directive(d) if d.name.as_str() == "else" || d.name.as_str() == "else-if")
         });
@@ -125,6 +147,20 @@ mod tests {
     fn test_invalid_v_if_empty_expression() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div v-if=""></div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_if_with_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div v-if:foo="visible"></div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_if_with_modifier() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div v-if.foo="visible"></div>"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 }


### PR DESCRIPTION
## Summary

- report `vue/valid-v-if` when `v-if` uses an argument
- report `vue/valid-v-if` when `v-if` uses modifiers
- add focused regression coverage and localized diagnostic text

Fixes #2361.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_patina valid_v_if -- --nocapture`
- CLI reproduction with `vize lint --preset essential --format json`
- `cargo test -p vize_patina`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->