### PR TITLE
fix(patina): reject invalid v-memo expressions

### DIFF
--- a/crates/vize_carton/src/i18n/en.json
+++ b/crates/vize_carton/src/i18n/en.json
@@ -304,6 +304,7 @@
   "vue/no-useless-template-attributes.help": "**Why:** `<template>` is not rendered to the DOM. Only structural directives (v-if, v-for, v-slot) and `:key` are meaningful.\n\n**Fix:** Move attributes to a child element or remove them.",
   "vue/valid-v-memo.description": "Enforce valid v-memo directives",
   "vue/valid-v-memo.missing_expression": "v-memo requires a dependency array expression",
+  "vue/valid-v-memo.expected_array": "v-memo requires an array-like dependency expression",
   "vue/valid-v-memo.unexpected_argument": "v-memo does not accept an argument",
   "vue/valid-v-memo.unexpected_modifier": "v-memo does not accept modifiers",
   "vue/valid-v-memo.help": "**Usage:**\n```vue\n<div v-memo=\"[valueA, valueB]\">\n  <!-- Only re-renders when valueA or valueB changes -->\n</div>\n```\n\n**Note:** `v-memo` accepts an array of dependencies, similar to React's `useMemo`.",

--- a/crates/vize_carton/src/i18n/ja.json
+++ b/crates/vize_carton/src/i18n/ja.json
@@ -304,6 +304,7 @@
   "vue/no-useless-template-attributes.help": "`<template>`はDOMにレンダリングされません。構造的ディレクティブ（v-if、v-for、v-slot）と`:key`のみが有効です",
   "vue/valid-v-memo.description": "有効なv-memoディレクティブを強制する",
   "vue/valid-v-memo.missing_expression": "v-memoには依存配列の式が必要です",
+  "vue/valid-v-memo.expected_array": "v-memoには配列形式の依存式が必要です",
   "vue/valid-v-memo.unexpected_argument": "v-memoは引数を受け付けません",
   "vue/valid-v-memo.unexpected_modifier": "v-memoは修飾子を受け付けません",
   "vue/valid-v-memo.help": "v-memo=\"[valueA, valueB]\"のように依存配列を指定してください",

--- a/crates/vize_carton/src/i18n/zh.json
+++ b/crates/vize_carton/src/i18n/zh.json
@@ -304,6 +304,7 @@
   "vue/no-useless-template-attributes.help": "`<template>`不会渲染到DOM。只有结构性指令（v-if、v-for、v-slot）和`:key`有效",
   "vue/valid-v-memo.description": "强制有效的v-memo指令",
   "vue/valid-v-memo.missing_expression": "v-memo需要依赖数组表达式",
+  "vue/valid-v-memo.expected_array": "v-memo需要类似数组的依赖表达式",
   "vue/valid-v-memo.unexpected_argument": "v-memo不接受参数",
   "vue/valid-v-memo.unexpected_modifier": "v-memo不接受修饰符",
   "vue/valid-v-memo.help": "请使用v-memo=\"[valueA, valueB]\"的形式指定依赖数组",

--- a/crates/vize_patina/src/rules/vue/valid_v_memo.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_memo.rs
@@ -68,6 +68,16 @@ impl Rule for ValidVMemo {
             return;
         }
 
+        if let Some(exp) = &directive.exp
+            && is_definitely_non_array_expression(exp)
+        {
+            ctx.error_with_help(
+                ctx.t("vue/valid-v-memo.expected_array"),
+                &directive.loc,
+                ctx.t("vue/valid-v-memo.help"),
+            );
+        }
+
         // v-memo should not have an argument
         if directive.arg.is_some() {
             ctx.error_with_help(
@@ -86,6 +96,31 @@ impl Rule for ValidVMemo {
             );
         }
     }
+}
+
+fn is_definitely_non_array_expression(exp: &ExpressionNode) -> bool {
+    let ExpressionNode::Simple(simple) = exp else {
+        return false;
+    };
+    let expr = simple.content.trim();
+    if expr.starts_with('[') {
+        return false;
+    }
+    expr.starts_with('"')
+        || expr.starts_with('\'')
+        || expr.starts_with('`')
+        || expr.starts_with('{')
+        || expr.starts_with("function")
+        || expr.starts_with("class")
+        || expr.ends_with("++")
+        || expr.ends_with("--")
+        || contains_binary_operator(expr)
+}
+
+fn contains_binary_operator(expr: &str) -> bool {
+    ["+", "-", "*", "/", "%"]
+        .iter()
+        .any(|operator| expr.contains(operator))
 }
 
 #[cfg(test)]
@@ -115,6 +150,20 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div v-memo="deps">content</div>"#, "test.vue");
         assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_invalid_v_memo_with_binary_expression() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div v-memo="count + 1">content</div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_memo_with_update_expression() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div v-memo="count++">content</div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- report `vue/valid-v-memo` for definitely non-array binary expressions
- report `vue/valid-v-memo` for update expressions
- keep identifier and array dependency expressions valid

Fixes #2363.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_patina valid_v_memo -- --nocapture`
- CLI reproduction with `vize lint --preset essential --format json`
- `cargo test -p vize_patina`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->