### PR TITLE
fix(patina): reject nested v-memo in v-for

### DIFF
--- a/crates/vize_carton/src/i18n/en.json
+++ b/crates/vize_carton/src/i18n/en.json
@@ -307,6 +307,7 @@
   "vue/valid-v-memo.description": "Enforce valid v-memo directives",
   "vue/valid-v-memo.missing_expression": "v-memo requires a dependency array expression",
   "vue/valid-v-memo.expected_array": "v-memo requires an array-like dependency expression",
+  "vue/valid-v-memo.inside_v_for": "v-memo must be placed on the same element as v-for",
   "vue/valid-v-memo.unexpected_argument": "v-memo does not accept an argument",
   "vue/valid-v-memo.unexpected_modifier": "v-memo does not accept modifiers",
   "vue/valid-v-memo.help": "**Usage:**\n```vue\n<div v-memo=\"[valueA, valueB]\">\n  <!-- Only re-renders when valueA or valueB changes -->\n</div>\n```\n\n**Note:** `v-memo` accepts an array of dependencies, similar to React's `useMemo`.",

--- a/crates/vize_carton/src/i18n/ja.json
+++ b/crates/vize_carton/src/i18n/ja.json
@@ -307,6 +307,7 @@
   "vue/valid-v-memo.description": "有効なv-memoディレクティブを強制する",
   "vue/valid-v-memo.missing_expression": "v-memoには依存配列の式が必要です",
   "vue/valid-v-memo.expected_array": "v-memoには配列形式の依存式が必要です",
+  "vue/valid-v-memo.inside_v_for": "v-memoはv-forと同じ要素に配置する必要があります",
   "vue/valid-v-memo.unexpected_argument": "v-memoは引数を受け付けません",
   "vue/valid-v-memo.unexpected_modifier": "v-memoは修飾子を受け付けません",
   "vue/valid-v-memo.help": "v-memo=\"[valueA, valueB]\"のように依存配列を指定してください",

--- a/crates/vize_carton/src/i18n/zh.json
+++ b/crates/vize_carton/src/i18n/zh.json
@@ -307,6 +307,7 @@
   "vue/valid-v-memo.description": "强制有效的v-memo指令",
   "vue/valid-v-memo.missing_expression": "v-memo需要依赖数组表达式",
   "vue/valid-v-memo.expected_array": "v-memo需要类似数组的依赖表达式",
+  "vue/valid-v-memo.inside_v_for": "v-memo必须放在与v-for相同的元素上",
   "vue/valid-v-memo.unexpected_argument": "v-memo不接受参数",
   "vue/valid-v-memo.unexpected_modifier": "v-memo不接受修饰符",
   "vue/valid-v-memo.help": "请使用v-memo=\"[valueA, valueB]\"的形式指定依赖数组",

--- a/crates/vize_patina/src/rules/vue/valid_v_memo.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_memo.rs
@@ -5,7 +5,7 @@
 //! `v-memo` (Vue 3.2+) memoizes a sub-tree of the template. It requires:
 //! - An expression (the dependency array)
 //! - The expression should be an array
-//! - Cannot be used on `v-for` elements (should use on parent)
+//! - When used with `v-for`, it must be placed on the same element
 //!
 //! ## Examples
 //!
@@ -66,6 +66,14 @@ impl Rule for ValidVMemo {
                 ctx.t("vue/valid-v-memo.help"),
             );
             return;
+        }
+
+        if ctx.has_ancestor(|ancestor| ancestor.has_v_for) {
+            ctx.error_with_help(
+                ctx.t("vue/valid-v-memo.inside_v_for"),
+                &directive.loc,
+                ctx.t("vue/valid-v-memo.help"),
+            );
         }
 
         if let Some(exp) = &directive.exp
@@ -164,6 +172,26 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div v-memo="count++">content</div>"#, "test.vue");
         assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_memo_inside_v_for() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div v-for="item in items" :key="item.id"><span v-memo="[item]"></span></div>"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_valid_v_memo_on_same_element_as_v_for() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div v-for="item in items" :key="item.id" v-memo="[item]"></div>"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2365.

Checks:
- cargo test -p vize_patina valid_v_memo -- --nocapture
- cargo run -q --bin vize -- lint --preset essential --format json <nested and same-element v-memo fixtures>
- cargo fmt --all -- --check
- git diff --check
- cargo test -p vize_patina

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->