### PR TITLE
fix(patina): reject mixed owner default slots

### DIFF
--- a/crates/vize_carton/src/i18n/en.json
+++ b/crates/vize_carton/src/i18n/en.json
@@ -51,6 +51,7 @@
   "vue/valid-v-show.help": "Add an expression to the v-show directive",
   "vue/valid-v-slot.description": "Enforce valid v-slot directives",
   "vue/valid-v-slot.invalid_location": "v-slot can only be used on components or template elements",
+  "vue/valid-v-slot.mixed_default_and_child_slots": "Default slot must use a template element when child slot templates are present",
   "vue/valid-v-slot.help": "Use v-slot on a component or a template element inside a component",
   "vue/no-use-v-if-with-v-for.description": "Disallow using v-if on the same element as v-for",
   "vue/no-use-v-if-with-v-for.message_access": "Avoid using v-if with v-for on the same element. The v-if condition does not have access to v-for scope variables",

--- a/crates/vize_carton/src/i18n/ja.json
+++ b/crates/vize_carton/src/i18n/ja.json
@@ -51,6 +51,7 @@
   "vue/valid-v-show.help": "v-showディレクティブに式を追加してください",
   "vue/valid-v-slot.description": "有効なv-slotディレクティブを強制する",
   "vue/valid-v-slot.invalid_location": "v-slotはコンポーネントまたはtemplate要素でのみ使用できます",
+  "vue/valid-v-slot.mixed_default_and_child_slots": "子のスロットtemplateがある場合、デフォルトスロットはtemplate要素で指定する必要があります",
   "vue/valid-v-slot.help": "コンポーネント内のコンポーネントまたはtemplate要素でv-slotを使用してください",
   "vue/no-use-v-if-with-v-for.description": "v-forと同じ要素でのv-ifの使用を禁止する",
   "vue/no-use-v-if-with-v-for.message_access": "同じ要素でv-ifとv-forを使用しないでください。v-if条件からv-forスコープ変数にアクセスできません",

--- a/crates/vize_carton/src/i18n/zh.json
+++ b/crates/vize_carton/src/i18n/zh.json
@@ -51,6 +51,7 @@
   "vue/valid-v-show.help": "**修复:** 添加布尔表达式:\n```vue\n<div v-show=\"isVisible\">内容</div>\n```\n\n**v-show vs v-if:**\n- `v-show`: 总是渲染，通过CSS切换显示（频繁切换时更好）\n- `v-if`: 条件渲染，完全添加/移除DOM",
   "vue/valid-v-slot.description": "强制有效的v-slot指令",
   "vue/valid-v-slot.invalid_location": "v-slot只能用于组件或template元素",
+  "vue/valid-v-slot.mixed_default_and_child_slots": "存在子插槽template时，默认插槽必须使用template元素",
   "vue/valid-v-slot.help": "**正确用法:**\n```vue\n<!-- 默认插槽 -->\n<MyComponent v-slot=\"{ item }\">\n  {{ item }}\n</MyComponent>\n\n<!-- 具名插槽 -->\n<MyComponent>\n  <template #header>标题</template>\n  <template #footer>页脚</template>\n</MyComponent>\n```",
   "vue/no-use-v-if-with-v-for.description": "禁止在同一元素上使用v-if和v-for",
   "vue/no-use-v-if-with-v-for.message_access": "避免在同一元素上使用v-if和v-for。v-if条件无法访问v-for作用域变量",

--- a/crates/vize_patina/src/rules/vue/valid_v_slot.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_slot.rs
@@ -146,6 +146,8 @@ impl Rule for ValidVSlot {
 }
 
 fn check_child_slot_templates(ctx: &mut LintContext, owner: &ElementNode) {
+    let owner_default_slot = owner_default_slot_directive(owner);
+    let mut has_child_slot_template = false;
     let mut seen_slots: FxHashSet<String> = FxHashSet::default();
     let mut current_group_slots: FxHashSet<String> = FxHashSet::default();
     let mut in_if_chain = false;
@@ -160,6 +162,7 @@ fn check_child_slot_templates(ctx: &mut LintContext, owner: &ElementNode) {
             in_if_chain = false;
             continue;
         };
+        has_child_slot_template = true;
 
         let starts_chain = has_directive(child, "if");
         let continues_chain =
@@ -188,10 +191,31 @@ fn check_child_slot_templates(ctx: &mut LintContext, owner: &ElementNode) {
     }
 
     finish_slot_group(&mut seen_slots, &mut current_group_slots);
+
+    if let Some(default_slot) = owner_default_slot
+        && has_child_slot_template
+    {
+        ctx.error_with_help(
+            ctx.t("vue/valid-v-slot.mixed_default_and_child_slots"),
+            &default_slot.loc,
+            ctx.t("vue/valid-v-slot.help"),
+        );
+    }
 }
 
 fn finish_slot_group(seen_slots: &mut FxHashSet<String>, group_slots: &mut FxHashSet<String>) {
     seen_slots.extend(group_slots.drain());
+}
+
+fn owner_default_slot_directive<'a>(element: &'a ElementNode<'a>) -> Option<&'a DirectiveNode<'a>> {
+    element.props.iter().find_map(|prop| match prop {
+        PropNode::Directive(dir)
+            if dir.name.as_str() == "slot" && !ValidVSlot::is_named_slot(dir) =>
+        {
+            Some(dir.as_ref())
+        }
+        _ => None,
+    })
 }
 
 fn child_slot_directive<'a>(element: &'a ElementNode<'a>) -> Option<&'a DirectiveNode<'a>> {
@@ -219,6 +243,9 @@ fn static_slot_name(directive: &DirectiveNode) -> Option<String> {
         Some(ExpressionNode::Compound(_)) => None,
     }
 }
+
+#[cfg(test)]
+mod mixed_default_tests;
 
 #[cfg(test)]
 mod tests {
@@ -300,31 +327,5 @@ mod tests {
             "test.vue",
         );
         assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_valid_duplicate_named_slot_in_if_else_chain() {
-        let linter = create_linter();
-        let result = linter.lint_template(
-            r#"<MyComponent>
-                <template v-if="ok" #header>Header A</template>
-                <template v-else #header>Header B</template>
-            </MyComponent>"#,
-            "test.vue",
-        );
-        assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_invalid_duplicate_named_slot_templates() {
-        let linter = create_linter();
-        let result = linter.lint_template(
-            r#"<MyComponent>
-                <template #header>Header A</template>
-                <template #header>Header B</template>
-            </MyComponent>"#,
-            "test.vue",
-        );
-        assert_eq!(result.error_count, 1);
     }
 }

--- a/crates/vize_patina/src/rules/vue/valid_v_slot/mixed_default_tests.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_slot/mixed_default_tests.rs
@@ -1,0 +1,87 @@
+use super::ValidVSlot;
+use crate::linter::Linter;
+use crate::rule::RuleRegistry;
+
+fn create_linter() -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(Box::new(ValidVSlot));
+    Linter::with_registry(registry)
+}
+
+#[test]
+fn invalid_default_owner_slot_with_named_child_slot() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<MyComponent v-slot="slotProps">
+            <template #header>Header</template>
+            {{ slotProps }}
+        </MyComponent>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn invalid_default_owner_slot_argument_with_named_child_slot() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<MyComponent v-slot:default="slotProps">
+            <template #header>Header</template>
+            {{ slotProps }}
+        </MyComponent>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn valid_default_template_slot_with_named_child_slot() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<MyComponent>
+            <template #default="slotProps">{{ slotProps }}</template>
+            <template #header>Header</template>
+        </MyComponent>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn valid_duplicate_named_slot_in_if_else_chain() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<MyComponent>
+            <template v-if="ok" #header>Header A</template>
+            <template v-else #header>Header B</template>
+        </MyComponent>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn invalid_duplicate_named_slot_templates() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<MyComponent>
+            <template #header>Header A</template>
+            <template #header>Header B</template>
+        </MyComponent>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn invalid_default_owner_slot_with_default_child_slot() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<MyComponent v-slot="slotProps">
+            <template #default>Fallback</template>
+            {{ slotProps }}
+        </MyComponent>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 1);
+}


### PR DESCRIPTION
Fixes #2367.

Checks:
- cargo test -p vize_patina valid_v_slot -- --nocapture
- cargo run -q --bin vize -- lint --preset essential --format json <mixed default/named slot fixtures>
- cargo fmt --all -- --check
- git diff --check
- cargo test -p vize_patina