### PR TITLE
fix(patina): validate v-model assignment targets

### DIFF
--- a/crates/vize_carton/src/i18n/en.json
+++ b/crates/vize_carton/src/i18n/en.json
@@ -40,6 +40,8 @@
   "vue/valid-v-model.description": "Enforce valid v-model directives",
   "vue/valid-v-model.missing_expression": "v-model requires an expression",
   "vue/valid-v-model.invalid_element": "v-model cannot be used on <{tag}> element",
+  "vue/valid-v-model.invalid_expression": "v-model requires an assignable expression",
+  "vue/valid-v-model.optional_chain": "Optional chaining cannot be used in v-model",
   "vue/valid-v-model.unsupported_file_input": "v-model cannot be used on file inputs",
   "vue/valid-v-model.unexpected_argument": "v-model arguments are not supported on native elements",
   "vue/valid-v-model.help": "**Supported elements:**\n- `<input>` (text, checkbox, radio, etc.)\n- `<textarea>`\n- `<select>`\n- Custom components with `modelValue` prop\n\n**Examples:**\n```vue\n<input v-model=\"message\">\n<input v-model.number=\"age\" type=\"number\">\n<input v-model.trim=\"name\">\n<MyComponent v-model=\"value\">\n```",

--- a/crates/vize_carton/src/i18n/ja.json
+++ b/crates/vize_carton/src/i18n/ja.json
@@ -40,6 +40,8 @@
   "vue/valid-v-model.description": "有効なv-modelディレクティブを強制する",
   "vue/valid-v-model.missing_expression": "v-modelには式が必要です",
   "vue/valid-v-model.invalid_element": "v-modelは<{tag}>要素では使用できません",
+  "vue/valid-v-model.invalid_expression": "v-modelには代入可能な式が必要です",
+  "vue/valid-v-model.optional_chain": "v-modelではオプショナルチェーンを使用できません",
   "vue/valid-v-model.unsupported_file_input": "v-modelはfile inputでは使用できません",
   "vue/valid-v-model.unexpected_argument": "ネイティブ要素のv-modelでは引数を使用できません",
   "vue/valid-v-model.help": "v-modelはinput、textarea、select、またはカスタムコンポーネントで使用できます",

--- a/crates/vize_carton/src/i18n/zh.json
+++ b/crates/vize_carton/src/i18n/zh.json
@@ -40,6 +40,8 @@
   "vue/valid-v-model.description": "强制有效的v-model指令",
   "vue/valid-v-model.missing_expression": "v-model需要一个表达式",
   "vue/valid-v-model.invalid_element": "v-model不能用于<{tag}>元素",
+  "vue/valid-v-model.invalid_expression": "v-model需要可赋值的表达式",
+  "vue/valid-v-model.optional_chain": "v-model不能使用可选链",
   "vue/valid-v-model.unsupported_file_input": "v-model不能用于文件输入",
   "vue/valid-v-model.unexpected_argument": "原生元素上的v-model不支持参数",
   "vue/valid-v-model.help": "**支持的元素:**\n- `<input>` (text, checkbox, radio等)\n- `<textarea>`\n- `<select>`\n- 带有`modelValue` prop的自定义组件\n\n**示例:**\n```vue\n<input v-model=\"message\">\n<input v-model.number=\"age\" type=\"number\">\n<input v-model.trim=\"name\">\n<MyComponent v-model=\"value\">\n```",

--- a/crates/vize_patina/src/rules/vue/valid_v_model.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_model.rs
@@ -26,6 +26,10 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Expression as OxcExpression;
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
 use vize_carton::is_html_tag;
 use vize_relief::{DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode};
 
@@ -74,6 +78,14 @@ impl Rule for ValidVModel {
                 ctx.t("vue/valid-v-model.help"),
             );
             return;
+        }
+
+        if let Some(expression_error_key) = model_expression_error_key(&directive.exp) {
+            ctx.error_with_help(
+                ctx.t(expression_error_key),
+                &directive.loc,
+                ctx.t("vue/valid-v-model.help"),
+            );
         }
 
         // Check 2: v-model must be on valid elements
@@ -161,6 +173,88 @@ fn is_empty_expression(exp: &ExpressionNode) -> bool {
         ExpressionNode::Compound(c) => c.children.is_empty(),
     }
 }
+
+fn model_expression_error_key(exp: &Option<ExpressionNode<'_>>) -> Option<&'static str> {
+    let Some(ExpressionNode::Simple(simple)) = exp else {
+        return None;
+    };
+    let source = simple.content.trim();
+    let allocator = Allocator::default();
+    let source_type = SourceType::default().with_typescript(true);
+    let expression = Parser::new(&allocator, source, source_type)
+        .parse_expression()
+        .ok()?;
+
+    if expression.span().end as usize != source.len() {
+        return None;
+    }
+    if expression_contains_optional_chain(&expression) {
+        return Some("vue/valid-v-model.optional_chain");
+    }
+    (!is_assignable_model_target(&expression)).then_some("vue/valid-v-model.invalid_expression")
+}
+
+fn is_assignable_model_target(expression: &OxcExpression<'_>) -> bool {
+    match expression {
+        OxcExpression::Identifier(_)
+        | OxcExpression::StaticMemberExpression(_)
+        | OxcExpression::ComputedMemberExpression(_)
+        | OxcExpression::PrivateFieldExpression(_) => true,
+        OxcExpression::ParenthesizedExpression(parenthesized) => {
+            is_assignable_model_target(&parenthesized.expression)
+        }
+        OxcExpression::TSNonNullExpression(ts_non_null) => {
+            is_assignable_model_target(&ts_non_null.expression)
+        }
+        OxcExpression::TSAsExpression(ts_as) => is_assignable_model_target(&ts_as.expression),
+        OxcExpression::TSSatisfiesExpression(ts_satisfies) => {
+            is_assignable_model_target(&ts_satisfies.expression)
+        }
+        OxcExpression::TSTypeAssertion(ts_assertion) => {
+            is_assignable_model_target(&ts_assertion.expression)
+        }
+        _ => false,
+    }
+}
+
+fn expression_contains_optional_chain(expression: &OxcExpression<'_>) -> bool {
+    match expression {
+        OxcExpression::ChainExpression(_) => true,
+        OxcExpression::StaticMemberExpression(member) => {
+            member.optional || expression_contains_optional_chain(&member.object)
+        }
+        OxcExpression::ComputedMemberExpression(member) => {
+            member.optional
+                || expression_contains_optional_chain(&member.object)
+                || expression_contains_optional_chain(&member.expression)
+        }
+        OxcExpression::PrivateFieldExpression(member) => {
+            member.optional || expression_contains_optional_chain(&member.object)
+        }
+        OxcExpression::CallExpression(call) => {
+            call.optional || expression_contains_optional_chain(&call.callee)
+        }
+        OxcExpression::ParenthesizedExpression(parenthesized) => {
+            expression_contains_optional_chain(&parenthesized.expression)
+        }
+        OxcExpression::TSNonNullExpression(ts_non_null) => {
+            expression_contains_optional_chain(&ts_non_null.expression)
+        }
+        OxcExpression::TSAsExpression(ts_as) => {
+            expression_contains_optional_chain(&ts_as.expression)
+        }
+        OxcExpression::TSSatisfiesExpression(ts_satisfies) => {
+            expression_contains_optional_chain(&ts_satisfies.expression)
+        }
+        OxcExpression::TSTypeAssertion(ts_assertion) => {
+            expression_contains_optional_chain(&ts_assertion.expression)
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod assignment_target_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/vize_patina/src/rules/vue/valid_v_model/assignment_target_tests.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_model/assignment_target_tests.rs
@@ -1,0 +1,51 @@
+use super::ValidVModel;
+use crate::linter::Linter;
+use crate::rule::RuleRegistry;
+
+fn create_linter() -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(Box::new(ValidVModel));
+    Linter::with_registry(registry)
+}
+
+#[test]
+fn invalid_v_model_call_expression() {
+    let linter = create_linter();
+    let result = linter.lint_template(r#"<input v-model="foo()">"#, "test.vue");
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn invalid_v_model_binary_expression() {
+    let linter = create_linter();
+    let result = linter.lint_template(r#"<input v-model="foo + bar">"#, "test.vue");
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn invalid_v_model_optional_chain() {
+    let linter = create_linter();
+    let result = linter.lint_template(r#"<input v-model="foo?.bar">"#, "test.vue");
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn invalid_v_model_this_expression() {
+    let linter = create_linter();
+    let result = linter.lint_template(r#"<input v-model="this">"#, "test.vue");
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn valid_v_model_member_targets() {
+    let linter = create_linter();
+    for source in [
+        r#"<input v-model="foo.bar">"#,
+        r#"<input v-model="foo[bar]">"#,
+        r#"<input v-model="foo().bar">"#,
+        r#"<input v-model="(foo)">"#,
+    ] {
+        let result = linter.lint_template(source, "test.vue");
+        assert_eq!(result.error_count, 0, "{source}");
+    }
+}


### PR DESCRIPTION
Fixes #2369.

Checks:
- cargo test -p vize_patina valid_v_model -- --nocapture
- cargo run -q --bin vize -- lint --preset essential --format json <v-model assignment target fixtures>
- cargo fmt --all -- --check
- git diff --check
- cargo test -p vize_patina

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->