### PR TITLE
fix(patina): validate v-for key variables

### DIFF
--- a/crates/vize_carton/src/i18n/en.json
+++ b/crates/vize_carton/src/i18n/en.json
@@ -19,6 +19,7 @@
   "vue/valid-v-for.description": "Enforce valid v-for directives",
   "vue/valid-v-for.missing_expression": "v-for directive requires an expression",
   "vue/valid-v-for.invalid_syntax": "v-for has invalid syntax: expected 'item in items' or '(item, index) in items'",
+  "vue/valid-v-for.key_uses_variables": "v-for key should use variables defined by v-for",
   "vue/valid-v-for.help": "**Valid v-for syntax:**\n```vue\n<!-- Array iteration -->\n<li v-for=\"item in items\">{{ item }}</li>\n<li v-for=\"(item, index) in items\">{{ index }}: {{ item }}</li>\n\n<!-- Object iteration -->\n<li v-for=\"(value, key) in object\">{{ key }}: {{ value }}</li>\n<li v-for=\"(value, key, index) in object\">{{ index }}</li>\n\n<!-- Range -->\n<span v-for=\"n in 10\">{{ n }}</span>\n```",
   "vue/valid-v-if.description": "Enforce valid v-if directives",
   "vue/valid-v-if.missing_expression": "v-if directive requires an expression",

--- a/crates/vize_carton/src/i18n/ja.json
+++ b/crates/vize_carton/src/i18n/ja.json
@@ -19,6 +19,7 @@
   "vue/valid-v-for.description": "有効なv-forディレクティブを強制する",
   "vue/valid-v-for.missing_expression": "v-forディレクティブには式が必要です",
   "vue/valid-v-for.invalid_syntax": "v-forの構文が無効です: 'item in items' または '(item, index) in items' の形式が必要です",
+  "vue/valid-v-for.key_uses_variables": "v-forのkeyにはv-forで定義された変数を使用してください",
   "vue/valid-v-for.help": "構文: v-for=\"item in items\" または v-for=\"(item, index) in items\" を使用してください",
   "vue/valid-v-if.description": "有効なv-ifディレクティブを強制する",
   "vue/valid-v-if.missing_expression": "v-ifディレクティブには式が必要です",

--- a/crates/vize_carton/src/i18n/zh.json
+++ b/crates/vize_carton/src/i18n/zh.json
@@ -19,6 +19,7 @@
   "vue/valid-v-for.description": "强制有效的v-for指令",
   "vue/valid-v-for.missing_expression": "v-for指令需要一个表达式",
   "vue/valid-v-for.invalid_syntax": "v-for语法无效: 需要'item in items'或'(item, index) in items'格式",
+  "vue/valid-v-for.key_uses_variables": "v-for的key应使用v-for定义的变量",
   "vue/valid-v-for.help": "**有效的v-for语法:**\n```vue\n<!-- 数组迭代 -->\n<li v-for=\"item in items\">{{ item }}</li>\n<li v-for=\"(item, index) in items\">{{ index }}: {{ item }}</li>\n\n<!-- 对象迭代 -->\n<li v-for=\"(value, key) in object\">{{ key }}: {{ value }}</li>\n<li v-for=\"(value, key, index) in object\">{{ index }}</li>\n\n<!-- 范围 -->\n<span v-for=\"n in 10\">{{ n }}</span>\n```",
   "vue/valid-v-if.description": "强制有效的v-if指令",
   "vue/valid-v-if.missing_expression": "v-if指令需要一个表达式",

--- a/crates/vize_patina/src/rules/vue/valid_v_for.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_for.rs
@@ -25,7 +25,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{DirectiveNode, ElementNode, ExpressionNode};
+use crate::visitor::parse_v_for_variables;
+use vize_relief::{DirectiveNode, ElementNode, ExpressionNode, PropNode};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/valid-v-for",
@@ -46,7 +47,7 @@ impl Rule for ValidVFor {
     fn check_directive<'a>(
         &self,
         ctx: &mut LintContext<'a>,
-        _element: &ElementNode<'a>,
+        element: &ElementNode<'a>,
         directive: &DirectiveNode<'a>,
     ) {
         // Only check v-for directives
@@ -158,11 +159,89 @@ impl Rule for ValidVFor {
                         &directive.loc,
                         ctx.t("vue/valid-v-for.help"),
                     );
+                    return;
                 }
+
+                check_key_uses_v_for_variables(ctx, element, exp);
             }
         }
     }
 }
+
+fn check_key_uses_v_for_variables(
+    ctx: &mut LintContext<'_>,
+    element: &ElementNode<'_>,
+    v_for_exp: &ExpressionNode<'_>,
+) {
+    let Some(key_directive) = bound_key_directive(element) else {
+        return;
+    };
+    let Some(ExpressionNode::Simple(key_expression)) = &key_directive.exp else {
+        return;
+    };
+
+    let vars = parse_v_for_variables(v_for_exp);
+    if vars.is_empty() {
+        return;
+    }
+    if vars
+        .iter()
+        .any(|var| expression_references_identifier(key_expression.content.as_str(), var.as_str()))
+    {
+        return;
+    }
+
+    ctx.error_with_help(
+        ctx.t("vue/valid-v-for.key_uses_variables"),
+        &key_directive.loc,
+        ctx.t("vue/valid-v-for.help"),
+    );
+}
+
+fn bound_key_directive<'a>(element: &'a ElementNode<'a>) -> Option<&'a DirectiveNode<'a>> {
+    element.props.iter().find_map(|prop| match prop {
+        PropNode::Directive(dir)
+            if dir.name.as_str() == "bind"
+                && matches!(
+                    dir.arg.as_ref(),
+                    Some(ExpressionNode::Simple(arg)) if arg.content.as_str() == "key"
+                ) =>
+        {
+            Some(dir.as_ref())
+        }
+        _ => None,
+    })
+}
+
+fn expression_references_identifier(expression: &str, name: &str) -> bool {
+    if name.is_empty() || expression.is_empty() {
+        return false;
+    }
+    let bytes = expression.as_bytes();
+    let needle = name.as_bytes();
+    let mut i = 0;
+    while i + needle.len() <= bytes.len() {
+        if bytes[i..i + needle.len()] == *needle {
+            let prev_is_ident = i > 0 && is_ident_byte(bytes[i - 1]);
+            let next_is_ident = bytes
+                .get(i + needle.len())
+                .is_some_and(|byte| is_ident_byte(*byte));
+            if !prev_is_ident && !next_is_ident {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+#[inline]
+fn is_ident_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+}
+
+#[cfg(test)]
+mod key_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/vize_patina/src/rules/vue/valid_v_for/key_tests.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_for/key_tests.rs
@@ -1,0 +1,59 @@
+use super::ValidVFor;
+use crate::linter::Linter;
+use crate::rule::RuleRegistry;
+
+fn create_linter() -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(Box::new(ValidVFor));
+    Linter::with_registry(registry)
+}
+
+#[test]
+fn valid_v_for_key_uses_alias() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<div v-for="item in items" :key="item.id"></div>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn valid_v_for_key_uses_second_alias() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<div v-for="(value, key, index) in items" :key="key"></div>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn valid_v_for_static_key_is_ignored() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<div v-for="item in items" key="static"></div>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn invalid_v_for_key_without_alias_reference() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<div v-for="item in items" :key="other"></div>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn invalid_v_for_key_does_not_match_substring() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<div v-for="item in items" :key="itemId"></div>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 1);
+}


### PR DESCRIPTION
Fixes #2371.

Summary:
- reports `vue/valid-v-for` when a bound `:key` in a `v-for` element ignores every loop variable
- keeps static keys and keys referencing any v-for alias accepted
- adds focused regression coverage for alias, second alias, substring, and unrelated-key cases

Checks:
- `cargo test -p vize_patina valid_v_for -- --nocapture`
- `cargo run -q --bin vize -- lint --preset essential --format json <v-for key fixtures>`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_patina`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->