### PR TITLE
fix(patina): reject trailing v-model tokens

### DIFF
--- a/crates/vize_patina/src/rules/vue/valid_v_model.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_model.rs
@@ -186,7 +186,7 @@ fn model_expression_error_key(exp: &Option<ExpressionNode<'_>>) -> Option<&'stat
         .ok()?;
 
     if expression.span().end as usize != source.len() {
-        return None;
+        return Some("vue/valid-v-model.invalid_expression");
     }
     if expression_contains_optional_chain(&expression) {
         return Some("vue/valid-v-model.optional_chain");

--- a/crates/vize_patina/src/rules/vue/valid_v_model/assignment_target_tests.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_model/assignment_target_tests.rs
@@ -37,6 +37,13 @@ fn invalid_v_model_this_expression() {
 }
 
 #[test]
+fn invalid_v_model_with_trailing_tokens() {
+    let linter = create_linter();
+    let result = linter.lint_template(r#"<input v-model="foo;bar">"#, "test.vue");
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
 fn valid_v_model_member_targets() {
     let linter = create_linter();
     for source in [


### PR DESCRIPTION
Fixes #2373.

Summary:
- treats partially parsed `v-model` expressions as invalid assignment targets
- keeps valid member targets such as `foo.bar` accepted
- adds a regression test for `v-model="foo;bar"`

Checks:
- `cargo test -p vize_patina invalid_v_model_with_trailing_tokens -- --nocapture`
- `cargo run -q --bin vize -- lint --preset essential --format json <v-model fixtures>`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_patina valid_v_model -- --nocapture`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->