### PR TITLE
fix(patina): reject malformed v-model expressions

### DIFF
--- a/crates/vize_patina/src/rules/vue/valid_v_model.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_model.rs
@@ -181,9 +181,9 @@ fn model_expression_error_key(exp: &Option<ExpressionNode<'_>>) -> Option<&'stat
     let source = simple.content.trim();
     let allocator = Allocator::default();
     let source_type = SourceType::default().with_typescript(true);
-    let expression = Parser::new(&allocator, source, source_type)
-        .parse_expression()
-        .ok()?;
+    let Ok(expression) = Parser::new(&allocator, source, source_type).parse_expression() else {
+        return Some("vue/valid-v-model.invalid_expression");
+    };
 
     if expression.span().end as usize != source.len() {
         return Some("vue/valid-v-model.invalid_expression");

--- a/crates/vize_patina/src/rules/vue/valid_v_model/assignment_target_tests.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_model/assignment_target_tests.rs
@@ -44,6 +44,13 @@ fn invalid_v_model_with_trailing_tokens() {
 }
 
 #[test]
+fn invalid_v_model_malformed_expression() {
+    let linter = create_linter();
+    let result = linter.lint_template(r#"<input v-model="foo(">"#, "test.vue");
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
 fn valid_v_model_member_targets() {
     let linter = create_linter();
     for source in [


### PR DESCRIPTION
Fixes #2375.

Summary:
- reports malformed `v-model` expressions that fail JavaScript expression parsing
- keeps valid assignable member expressions accepted
- adds a regression test for `v-model="foo("`

Checks:
- `cargo test -p vize_patina invalid_v_model_malformed_expression -- --nocapture`
- `cargo run -q --bin vize -- lint --preset essential --format json <v-model fixtures>`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_patina valid_v_model -- --nocapture`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->