### PR TITLE
fix(patina): reject dynamic v-bind shorthand

### DIFF
--- a/crates/vize_patina/src/rules/vue/valid_v_bind.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_bind.rs
@@ -79,9 +79,16 @@ impl Rule for ValidVBind {
         }
 
         // Attribute syntax: :class="foo" or Vue 3.4+ same-name shorthand: :loading
-        if has_arg {
-            // Vue 3.4+ same-name shorthand allows :attr without expression
-            // It's equivalent to :attr="attr"
+        if let Some(arg) = &directive.arg {
+            // Vue 3.4+ same-name shorthand allows static :attr without expression.
+            // Dynamic arguments still need an explicit expression.
+            if !has_exp && !is_static_argument(arg) {
+                ctx.error_with_help(
+                    ctx.t("vue/valid-v-bind.missing_expression"),
+                    &directive.loc,
+                    ctx.t("vue/valid-v-bind.help"),
+                );
+            }
             return;
         }
 
@@ -100,6 +107,10 @@ fn is_empty_expression(exp: &ExpressionNode) -> bool {
         ExpressionNode::Simple(s) => s.content.trim().is_empty(),
         ExpressionNode::Compound(c) => c.children.is_empty(),
     }
+}
+
+fn is_static_argument(arg: &ExpressionNode) -> bool {
+    matches!(arg, ExpressionNode::Simple(simple) if simple.is_static)
 }
 
 #[cfg(test)]
@@ -144,6 +155,13 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_v_bind_dynamic_argument_with_expression() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div :[name]="value"></div>"#, "test.vue");
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
     fn test_valid_v_bind_supported_modifiers() {
         let linter = create_linter();
         let result = linter.lint_template(
@@ -157,6 +175,13 @@ mod tests {
     fn test_invalid_v_bind_no_arg_no_exp() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div v-bind></div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_bind_dynamic_shorthand() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div :[name]></div>"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 


### PR DESCRIPTION
Fixes #2379.

Summary:
- rejects expression-less `v-bind` directives when the argument is dynamic
- keeps Vue 3.4 static same-name shorthand such as `:loading` valid
- keeps dynamic arguments with explicit expressions valid

Checks:
- `cargo test -p vize_patina valid_v_bind -- --nocapture`
- `cargo run -q --bin vize -- lint --preset essential --format json <v-bind fixtures>`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->