### PR TITLE
fix(patina): reject misplaced slot templates

### DIFF
--- a/crates/vize_patina/src/rules/vue/valid_v_slot.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_slot.rs
@@ -114,6 +114,14 @@ impl Rule for ValidVSlot {
             );
         }
 
+        if tag == "template" && !has_component_parent(ctx) {
+            ctx.error_with_help(
+                ctx.t("vue/valid-v-slot.invalid_location"),
+                &directive.loc,
+                ctx.t("vue/valid-v-slot.help"),
+            );
+        }
+
         // Check for duplicate v-slot directives
         let (default_count, named_count) = Self::count_slot_directives(element);
 
@@ -236,6 +244,11 @@ fn has_directive(element: &ElementNode, name: &str) -> bool {
         .any(|prop| matches!(prop, PropNode::Directive(dir) if dir.name.as_str() == name))
 }
 
+fn has_component_parent(ctx: &LintContext) -> bool {
+    ctx.parent_element()
+        .is_some_and(|parent| ValidVSlot::is_custom_component(parent.tag.as_str()))
+}
+
 fn static_slot_name(directive: &DirectiveNode) -> Option<String> {
     match &directive.arg {
         None => Some("default".into()),
@@ -277,6 +290,16 @@ mod tests {
             "test.vue",
         );
         assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_invalid_slot_template_under_plain_element() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div><template #header>Header</template></div>"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 1);
     }
 
     #[test]

--- a/crates/vize_patina/src/rules/vue/valid_v_slot.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_slot.rs
@@ -258,6 +258,9 @@ fn static_slot_name(directive: &DirectiveNode) -> Option<String> {
 }
 
 #[cfg(test)]
+mod location_tests;
+
+#[cfg(test)]
 mod mixed_default_tests;
 
 #[cfg(test)]
@@ -290,16 +293,6 @@ mod tests {
             "test.vue",
         );
         assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_invalid_slot_template_under_plain_element() {
-        let linter = create_linter();
-        let result = linter.lint_template(
-            r#"<div><template #header>Header</template></div>"#,
-            "test.vue",
-        );
-        assert_eq!(result.error_count, 1);
     }
 
     #[test]

--- a/crates/vize_patina/src/rules/vue/valid_v_slot/location_tests.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_slot/location_tests.rs
@@ -1,0 +1,19 @@
+use super::ValidVSlot;
+use crate::linter::Linter;
+use crate::rule::RuleRegistry;
+
+fn create_linter() -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(Box::new(ValidVSlot));
+    Linter::with_registry(registry)
+}
+
+#[test]
+fn invalid_slot_template_under_plain_element() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<div><template #header>Header</template></div>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 1);
+}


### PR DESCRIPTION
Fixes #2381.

Summary:
- rejects `<template v-slot>` / `#slot` templates whose direct parent is not a component-like element
- keeps slot templates under component owners valid
- adds focused regression coverage for a plain-element parent

Checks:
- `cargo test -p vize_patina valid_v_slot -- --nocapture`
- `cargo run -q --bin vize -- lint --preset essential --format json <v-slot fixtures>`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->