### PR TITLE
fix(patina): detect component-like v-html targets

### DIFF
--- a/crates/vize_patina/src/rules/vue/no_v_text_v_html_on_component.rs
+++ b/crates/vize_patina/src/rules/vue/no_v_text_v_html_on_component.rs
@@ -23,6 +23,7 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
+use vize_carton::is_html_tag;
 use vize_relief::{DirectiveNode, ElementNode, ElementType};
 
 static META: RuleMeta = RuleMeta {
@@ -51,7 +52,7 @@ impl Rule for NoVTextVHtmlOnComponent {
             return;
         }
 
-        if element.tag_type != ElementType::Component {
+        if !is_component_like_tag(element) {
             return;
         }
 
@@ -67,6 +68,15 @@ impl Rule for NoVTextVHtmlOnComponent {
             ctx.t("vue/no-v-text-v-html-on-component.help"),
         );
     }
+}
+
+fn is_component_like_tag(element: &ElementNode<'_>) -> bool {
+    if element.tag_type == ElementType::Component {
+        return true;
+    }
+
+    let tag = element.tag.as_str();
+    tag == "component" || (tag.contains('-') && !is_html_tag(tag))
 }
 
 #[cfg(test)]
@@ -99,6 +109,23 @@ mod tests {
     fn test_invalid_v_html_on_component() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<MyComponent v-html="content" />"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_html_on_kebab_case_component() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<my-component v-html="content" />"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_html_on_dynamic_component() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<component :is="tagName" v-html="content" />"#,
+            "test.vue",
+        );
         assert_eq!(result.error_count, 1);
     }
 


### PR DESCRIPTION
Fixes #2383.

Summary:
- treats Vue dynamic `<component>` and non-native kebab-case tags as component-like for `vue/no-v-text-v-html-on-component`
- keeps native elements such as `<div v-html>` on the generic `vue/no-v-html` warning path
- adds focused regression coverage for kebab-case and dynamic component tags

Checks:
- `cargo test -p vize_patina no_v_text_v_html_on_component -- --nocapture`
- `cargo run -q --bin vize -- lint --preset essential --format json <v-html component fixtures>`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->