### PR TITLE
fix(patina): canon dynamic component prop casing

### DIFF
--- a/crates/vize_patina/src/rules/vue/prop_name_casing.rs
+++ b/crates/vize_patina/src/rules/vue/prop_name_casing.rs
@@ -20,6 +20,7 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
+use vize_carton::is_html_tag;
 use vize_croquis::naming::{hyphenate, is_camel_case};
 use vize_relief::{ElementNode, ElementType, ExpressionNode, PropNode};
 
@@ -42,7 +43,7 @@ impl Rule for PropNameCasing {
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
         // Only check props on components (native HTML elements use kebab-case attributes)
-        if element.tag_type != ElementType::Component {
+        if !is_component_like_tag(element) {
             return;
         }
 
@@ -103,6 +104,15 @@ impl Rule for PropNameCasing {
     }
 }
 
+fn is_component_like_tag(element: &ElementNode<'_>) -> bool {
+    if element.tag_type == ElementType::Component {
+        return true;
+    }
+
+    let tag = element.tag.as_str();
+    tag == "component" || (tag.contains('-') && !is_html_tag(tag))
+}
+
 #[cfg(test)]
 mod tests {
     use super::PropNameCasing;
@@ -138,9 +148,32 @@ mod tests {
     }
 
     #[test]
+    fn test_invalid_camel_case_prop_on_kebab_case_component() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<my-component myProp="value" />"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_camel_case_prop_on_dynamic_component() {
+        let linter = create_linter();
+        let result =
+            linter.lint_template(r#"<component :is="tagName" myProp="value" />"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
     fn test_invalid_camel_case_binding() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<MyComponent :myProp="value" />"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_camel_case_binding_on_dynamic_component() {
+        let linter = create_linter();
+        let result =
+            linter.lint_template(r#"<component :is="tagName" :myProp="value" />"#, "test.vue");
         assert_eq!(result.warning_count, 1);
     }
 


### PR DESCRIPTION
Fixes #2385.

Summary:
- treats Vue dynamic `<component>` and non-native kebab-case tags as component-like for `vue/prop-name-casing`
- keeps native elements excluded from component prop casing checks
- adds regression coverage for static and bound camelCase props on dynamic components

Checks:
- `cargo test -p vize_patina prop_name_casing -- --nocapture`
- `cargo run -q --bin vize -- lint --preset strongly-recommended --format json <prop casing fixtures>`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->