### PR TITLE
fix(patina): ignore boolean attrs on custom components

### DIFF
--- a/crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs
@@ -28,7 +28,8 @@ use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use crate::rules::html::helpers::BOOLEAN_ATTRIBUTES;
-use vize_relief::{ElementNode, ElementType, PropNode};
+use vize_carton::is_native_tag;
+use vize_relief::{ElementNode, PropNode};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-boolean-attr-value",
@@ -47,7 +48,7 @@ impl Rule for NoBooleanAttrValue {
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if element.tag_type == ElementType::Component {
+        if !is_native_tag(element.tag.as_str()) {
             return;
         }
 
@@ -109,6 +110,16 @@ mod tests {
     fn test_valid_dynamic_binding() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<input :disabled="isDisabled" />"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_valid_component_like_custom_tag() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<my-button disabled="disabled" /><MyButton hidden="hidden" />"#,
+            "test.vue",
+        );
         assert_eq!(result.warning_count, 0);
     }
 


### PR DESCRIPTION
## Summary

- Treat `vue/no-boolean-attr-value` as an HTML-only rule by skipping non-native/component-like tags.
- Add a regression test for kebab and PascalCase component tags with boolean-looking props.

## Root cause

The rule skipped only parser-promoted `ElementType::Component` nodes. Kebab custom component tags can still arrive as normal elements, so `disabled="disabled"` was treated as a native HTML boolean attribute.

## Validation

- `cargo test -p vize_patina no_boolean_attr_value -- --nocapture`
- CLI reproduction with `<my-button>`, `<MyButton>`, and native `<button>`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2387

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->