### PR TITLE
fix(patina): ignore dynamic v-bind names for static attrs

### DIFF
--- a/crates/vize_patina/src/rules/opinionated/vue/no_useless_v_bind.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/no_useless_v_bind.rs
@@ -55,6 +55,9 @@ impl Rule for NoUselessVBind {
         let Some(ExpressionNode::Simple(arg)) = &directive.arg else {
             return;
         };
+        if !arg.is_static {
+            return;
+        }
         // Modifiers such as `.prop` change semantics; leave them alone.
         if !directive.modifiers.is_empty() {
             return;
@@ -123,6 +126,16 @@ mod tests {
     fn allows_dynamic_binding() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div :foo="bar"></div>"#, "App.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn allows_dynamic_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div :[attr]="'bar'" v-bind:[other]="'baz'"></div>"#,
+            "App.vue",
+        );
         assert_eq!(result.warning_count, 0);
     }
 


### PR DESCRIPTION
## Summary

- Skip dynamic `v-bind` arguments in `vue/no-useless-v-bind`.
- Keep reporting static arguments bound to constant string literals.
- Add regression coverage for both shorthand and longhand dynamic arguments.

## Root cause

The rule treated every `ExpressionNode::Simple` directive argument as a static attribute name. Dynamic arguments are also represented as simple expressions, but with `is_static = false`, so `:[attr]="'bar'"` was incorrectly reported as if it could become `attr="bar"`.

## Validation

- `cargo test -p vize_patina no_useless_v_bind -- --nocapture`
- CLI reproduction with `:[attr]="'bar'"` and static `:title="'bar'"`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2392
