### PR TITLE
fix(patina): ignore dynamic args for true shorthand

### DIFF
--- a/crates/vize_patina/src/rules/opinionated/vue/prefer_true_attribute_shorthand.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/prefer_true_attribute_shorthand.rs
@@ -55,6 +55,9 @@ impl Rule for PreferTrueAttributeShorthand {
         let Some(ExpressionNode::Simple(arg)) = &directive.arg else {
             return;
         };
+        if !arg.is_static {
+            return;
+        }
         let name = arg.content.as_str();
         if is_native_tag(element.tag.as_str()) && !BOOLEAN_ATTRIBUTES.contains(&name) {
             return;
@@ -102,6 +105,16 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<input :disabled="true" />"#, "App.vue");
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn allows_dynamic_arguments() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<MyComponent :[prop]="true" v-bind:[other]="true" />"#,
+            "App.vue",
+        );
+        assert_eq!(result.warning_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Skip dynamic `v-bind` arguments in `vue/prefer-true-attribute-shorthand`.
- Keep reporting static component prop bindings such as `:visible="true"`.
- Add regression coverage for shorthand and longhand dynamic arguments.

## Root cause

Dynamic directive arguments are represented as `ExpressionNode::Simple`, but their `is_static` flag is false. The rule only checked the expression node variant, so `:[prop]="true"` was treated as if it could become a static `prop` shorthand.

## Validation

- `cargo test -p vize_patina prefer_true_attribute_shorthand -- --nocapture`
- CLI reproduction with `:[prop]="true"` and static `:visible="true"`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->