### PR TITLE
fix(patina): ignore dynamic args for prop casing

### DIFF
--- a/crates/vize_patina/src/rules/vue/prop_name_casing.rs
+++ b/crates/vize_patina/src/rules/vue/prop_name_casing.rs
@@ -75,6 +75,7 @@ impl Rule for PropNameCasing {
                 PropNode::Directive(dir) => {
                     if dir.name == "bind"
                         && let Some(ExpressionNode::Simple(arg)) = &dir.arg
+                        && arg.is_static
                     {
                         let name = arg.content.as_ref();
                         // Skip standard bindings
@@ -167,6 +168,13 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<MyComponent :myProp="value" />"#, "test.vue");
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_valid_dynamic_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<MyComponent :[myProp]="value" />"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Skip dynamic `v-bind` arguments in `vue/prop-name-casing`.
- Keep reporting static camelCase bound prop names.
- Add regression coverage for `:[myProp]`.

## Root cause

Dynamic directive arguments are represented as simple expressions with `is_static = false`. The rule only checked the expression variant, so it treated `:[myProp]` as a literal prop name and suggested `my-prop`.

## Validation

- `cargo test -p vize_patina prop_name_casing -- --nocapture`
- CLI reproduction with `:[myProp]` and static `:myProp`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2395

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->