### PR TITLE
fix(patina): ignore dynamic args for attribute hyphenation

### DIFF
--- a/crates/vize_patina/src/rules/vue/attribute_hyphenation.rs
+++ b/crates/vize_patina/src/rules/vue/attribute_hyphenation.rs
@@ -115,7 +115,7 @@ impl Rule for AttributeHyphenation {
                     if dir.name.as_str() == "bind" {
                         if let Some(arg) = &dir.arg {
                             match arg {
-                                vize_relief::ExpressionNode::Simple(s) => {
+                                vize_relief::ExpressionNode::Simple(s) if s.is_static => {
                                     (s.content.as_str(), &dir.loc)
                                 }
                                 _ => continue,
@@ -186,6 +186,13 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<MyComponent myProp="value" />"#, "test.vue");
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_valid_dynamic_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<MyComponent :[myProp]="value" />"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Skip dynamic `v-bind` arguments in `vue/attribute-hyphenation`.
- Keep reporting static camelCase bound attribute names.
- Add regression coverage for `:[myProp]`.

## Root cause

The rule treated `ExpressionNode::Simple` directive arguments as literal attribute names. Dynamic arguments are also simple expressions, but with `is_static = false`, so `:[myProp]` was reported as if it were a static attribute.

## Validation

- `cargo test -p vize_patina attribute_hyphenation -- --nocapture`
- CLI reproduction with `:[myProp]` and static `:myProp`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2397

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->