### PR TITLE
fix(patina): ignore dynamic args for array index keys

### DIFF
--- a/crates/vize_patina/src/rules/opinionated/vue/no_array_index_key.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/no_array_index_key.rs
@@ -63,6 +63,7 @@ impl Rule for NoArrayIndexKey {
                 "bind" => {
                     // `:key` / `v-bind:key` with a dynamic expression.
                     if let Some(ExpressionNode::Simple(arg)) = &dir.arg
+                        && arg.is_static
                         && arg.content.as_str() == "key"
                         && let Some(ExpressionNode::Simple(exp)) = &dir.exp
                     {
@@ -188,6 +189,16 @@ mod tests {
         );
         assert_eq!(result.warning_count, 1);
         insta::assert_debug_snapshot!(result.diagnostics);
+    }
+
+    #[test]
+    fn allows_dynamic_key_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<li v-for="(item, index) in list" :[key]="index">{{ item }}</li>"#,
+            "App.vue",
+        );
+        assert_eq!(result.warning_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Require the `:key` directive argument to be static before applying `vue/no-array-index-key`.
- Keep reporting static `:key="index"` and `v-bind:key="index"`.
- Add regression coverage for `:[key]="index"`.

## Root cause

Dynamic directive arguments are represented as simple expressions with `is_static = false`. The rule checked only the content string, so `:[key]="index"` was treated as the special static `:key` binding.

## Validation

- `cargo test -p vize_patina no_array_index_key -- --nocapture`
- CLI reproduction with `:[key]="index"`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2401

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->