### PR TITLE
fix(patina): ignore dynamic args for class object arrays

### DIFF
--- a/crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs
@@ -55,6 +55,9 @@ impl Rule for NoMultipleObjectsInClass {
         let Some(ExpressionNode::Simple(arg)) = &directive.arg else {
             return;
         };
+        if !arg.is_static {
+            return;
+        }
         if arg.content.as_str() != "class" {
             return;
         }
@@ -125,6 +128,13 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div :class="[{ a }, { b }]"></div>"#, "App.vue");
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn allows_dynamic_class_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div :[class]="[{ a }, { b }]"></div>"#, "App.vue");
+        assert_eq!(result.warning_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Require the `:class` argument to be static before applying `vue/no-multiple-objects-in-class`.
- Keep reporting static `:class="[{ a }, { b }]"`.
- Add regression coverage for `:[class]`.

## Root cause

Dynamic directive arguments are represented as simple expressions with `is_static = false`. The rule checked only the content string, so `:[class]` was treated as the static class binding.

## Validation

- `cargo test -p vize_patina no_multiple_objects_in_class -- --nocapture`
- CLI reproduction with `:[class]` and static `:class`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2403

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->