### PR TITLE
fix(patina): ignore dynamic args for v-on exact

### DIFF
--- a/crates/vize_patina/src/rules/opinionated/vue/use_v_on_exact.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/use_v_on_exact.rs
@@ -55,7 +55,7 @@ impl Rule for UseVOnExact {
                 }
 
                 let event_name = match &dir.arg {
-                    Some(ExpressionNode::Simple(arg)) => arg.content.as_str(),
+                    Some(ExpressionNode::Simple(arg)) if arg.is_static => arg.content.as_str(),
                     _ => continue,
                 };
 
@@ -131,6 +131,16 @@ mod tests {
             "test.vue",
         );
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_valid_dynamic_event_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<button @[click]="handleClick" @click.ctrl="handleCtrlClick">Click</button>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Skip dynamic event arguments in `vue/use-v-on-exact`.
- Keep reporting static `@click` / `@click.ctrl` overlaps.
- Add regression coverage for `@[click]`.

## Root cause

Dynamic event arguments are represented as simple expressions with `is_static = false`. The rule used the content string directly, so `@[click]` was treated as the static event name `click`.

## Validation

- `cargo test -p vize_patina use_v_on_exact -- --nocapture`
- CLI reproduction with `@[click]` and `@click.ctrl`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2406

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->