### PR TITLE
fix(patina): reject dynamic component is args

### DIFF
--- a/crates/vize_patina/src/rules/vue/require_component_is.rs
+++ b/crates/vize_patina/src/rules/vue/require_component_is.rs
@@ -48,6 +48,7 @@ impl RequireComponentIs {
                     // Check for :is or v-bind:is
                     if dir.name == "bind"
                         && let Some(ExpressionNode::Simple(arg)) = &dir.arg
+                        && arg.is_static
                         && arg.content == "is"
                     {
                         return true;
@@ -109,6 +110,13 @@ mod tests {
     fn test_invalid_no_is() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<component />"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_dynamic_is_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<component :[is]="currentComponent" />"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 


### PR DESCRIPTION
## Summary

- Require the `is` binding argument on `<component>` to be static.
- Keep accepting static `is` and `:is`.
- Add regression coverage for `:[is]`.

## Root cause

Dynamic directive arguments are represented as simple expressions with `is_static = false`. The rule checked only the content string, so `:[is]` was treated as the required static `:is` binding.

## Validation

- `cargo test -p vize_patina require_component_is -- --nocapture`
- CLI reproduction with `:[is]` and static `:is`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2408

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->