### PR TITLE
fix(patina): ignore dynamic click event args

### DIFF
--- a/crates/vize_patina/src/rules/a11y/click_events_have_key_events.rs
+++ b/crates/vize_patina/src/rules/a11y/click_events_have_key_events.rs
@@ -77,6 +77,7 @@ impl ClickEventsHaveKeyEvents {
             if let PropNode::Directive(dir) = prop
                 && dir.name == "on"
                 && let Some(ExpressionNode::Simple(arg)) = &dir.arg
+                && arg.is_static
                 && arg.content == "click"
             {
                 return true;
@@ -91,6 +92,7 @@ impl ClickEventsHaveKeyEvents {
             if let PropNode::Directive(dir) = prop
                 && dir.name == "on"
                 && let Some(ExpressionNode::Simple(arg)) = &dir.arg
+                && arg.is_static
                 && matches!(arg.content.as_ref(), "keydown" | "keyup" | "keypress")
             {
                 return true;
@@ -178,6 +180,13 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div @click="handleClick">Click</div>"#, "test.vue");
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_valid_dynamic_click_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div @[click]="handleClick">Click</div>"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Ignore dynamic event arguments in `a11y/click-events-have-key-events`.
- Keep reporting static `@click` handlers without keyboard handlers.
- Add regression coverage for `@[click]`.

## Root cause

Dynamic event arguments are represented as simple expressions with `is_static = false`. The rule only compared the content string, so `@[click]` was treated as a static `@click` handler.

## Validation

- `cargo test -p vize_patina click_events_have_key_events -- --nocapture`
- CLI reproduction with `@[click]` and static `@click`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2410

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->