### PR TITLE
fix(patina): ignore dynamic events for static interactions

### DIFF
--- a/crates/vize_patina/src/rules/a11y/no_static_element_interactions.rs
+++ b/crates/vize_patina/src/rules/a11y/no_static_element_interactions.rs
@@ -52,6 +52,7 @@ fn has_interactive_event(element: &ElementNode) -> bool {
         if let PropNode::Directive(dir) = prop
             && dir.name == "on"
             && let Some(ExpressionNode::Simple(arg)) = &dir.arg
+            && arg.is_static
             && INTERACTIVE_EVENTS.contains(&arg.content.as_ref())
         {
             return true;
@@ -135,6 +136,13 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div @click="handle">Click</div>"#, "test.vue");
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_valid_dynamic_event_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div @[click]="handle">Click</div>"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Ignore dynamic event arguments in `a11y/no-static-element-interactions`.
- Keep reporting static interactive events on static elements.
- Add regression coverage for `@[click]`.

## Root cause

Dynamic event arguments are represented as simple expressions with `is_static = false`. The rule only checked the content string, so `@[click]` was treated as a known interactive `click` event.

## Validation

- `cargo test -p vize_patina no_static_element_interactions -- --nocapture`
- CLI reproduction with `@[click]` and static `@click`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2412

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->