### PR TITLE
fix(patina): ignore dynamic accesskey args

### DIFF
--- a/crates/vize_patina/src/rules/a11y/no_access_key.rs
+++ b/crates/vize_patina/src/rules/a11y/no_access_key.rs
@@ -87,7 +87,8 @@ impl Rule for NoAccessKey {
                     if dir.name == "bind"
                         && matches!(
                             &dir.arg,
-                            Some(ExpressionNode::Simple(arg)) if arg.content == "accesskey"
+                            Some(ExpressionNode::Simple(arg))
+                                if arg.is_static && arg.content == "accesskey"
                         ) =>
                 {
                     ctx.warn_with_help(
@@ -133,5 +134,13 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div :accesskey="'h'">Content</div>"#, "test.vue");
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_valid_dynamic_accesskey_argument() {
+        let linter = create_linter();
+        let result =
+            linter.lint_template(r#"<div :[accesskey]="shortcut">Content</div>"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
     }
 }


### PR DESCRIPTION
## Summary

- keep `a11y/no-access-key` from treating `:[accesskey]` as a static `accesskey` attribute
- preserve warnings for static `accesskey` and `:accesskey`
- add focused coverage for dynamic accesskey arguments

Closes #2414.

## Verification

- `cargo test -p vize_patina no_access_key -- --nocapture`
- CLI repro with dynamic `:[accesskey]` and static `:accesskey`
- `cargo fmt --all -- --check`
- `git diff --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
