### PR TITLE
fix(patina): ignore dynamic mouse event args

### DIFF
--- a/crates/vize_patina/src/rules/a11y/helpers.rs
+++ b/crates/vize_patina/src/rules/a11y/helpers.rs
@@ -211,6 +211,7 @@ pub fn has_event_handler(element: &ElementNode, event_name: &str) -> bool {
         if let PropNode::Directive(dir) = prop
             && dir.name == "on"
             && let Some(ExpressionNode::Simple(arg)) = &dir.arg
+            && arg.is_static
             && arg.content == event_name
         {
             return true;

--- a/crates/vize_patina/src/rules/a11y/mouse_events_have_key_events.rs
+++ b/crates/vize_patina/src/rules/a11y/mouse_events_have_key_events.rs
@@ -128,6 +128,23 @@ mod tests {
     }
 
     #[test]
+    fn test_invalid_mouseenter_with_dynamic_focus_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div @mouseenter="show" @[focus]="show">Content</div>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_valid_dynamic_mouseenter_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div @[mouseenter]="show">Content</div>"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
     fn test_valid_component_skipped() {
         let linter = create_linter();
         let result = linter.lint_template(


### PR DESCRIPTION
## Summary

- require static event arguments in the shared a11y event-handler helper
- keep dynamic `@[focus]` from satisfying the required static focus companion
- keep dynamic `@[mouseenter]` from being reported as a static mouse event

Closes #2417.

## Verification

- `cargo test -p vize_patina mouse_events_have_key_events -- --nocapture`
- CLI repro with static `@mouseenter`, dynamic `@[focus]`, and dynamic `@[mouseenter]`
- `cargo fmt --all -- --check`
- `git diff --check`
