### PR TITLE
fix(patina): ignore dynamic autofocus args

### DIFF
--- a/crates/vize_patina/src/rules/a11y/no_autofocus.rs
+++ b/crates/vize_patina/src/rules/a11y/no_autofocus.rs
@@ -87,7 +87,8 @@ impl Rule for NoAutofocus {
                     if dir.name == "bind"
                         && matches!(
                             &dir.arg,
-                            Some(ExpressionNode::Simple(arg)) if arg.content == "autofocus"
+                            Some(ExpressionNode::Simple(arg))
+                                if arg.is_static && arg.content == "autofocus"
                         ) =>
                 {
                     ctx.warn_with_help(
@@ -133,5 +134,15 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<input type="text" :autofocus="true" />"#, "test.vue");
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_valid_dynamic_autofocus_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<input type="text" :[autofocus]="enabled" />"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 0);
     }
 }


### PR DESCRIPTION
## Summary

- keep `a11y/no-autofocus` from treating `:[autofocus]` as a static `autofocus` attribute
- preserve warnings for static `autofocus` and `:autofocus`
- add focused coverage for dynamic autofocus arguments

Closes #2416.

## Verification

- `cargo test -p vize_patina no_autofocus -- --nocapture`
- CLI repro with dynamic `:[autofocus]` and static `:autofocus`
- `cargo fmt --all -- --check`
- `git diff --check`
