### PR TITLE
fix(patina): ignore dynamic href args for focusable checks

### DIFF
--- a/crates/vize_patina/src/rules/a11y/helpers.rs
+++ b/crates/vize_patina/src/rules/a11y/helpers.rs
@@ -111,7 +111,7 @@ fn has_named_prop(element: &ElementNode, name: &str) -> bool {
         PropNode::Directive(dir) if dir.name == "bind" => {
             matches!(
                 dir.arg.as_ref(),
-                Some(ExpressionNode::Simple(arg)) if arg.content == name
+                Some(ExpressionNode::Simple(arg)) if arg.is_static && arg.content == name
             )
         }
         _ => false,

--- a/crates/vize_patina/src/rules/a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/vize_patina/src/rules/a11y/no_aria_hidden_on_focusable.rs
@@ -92,6 +92,16 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_aria_hidden_on_anchor_with_dynamic_href_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<a :[href]="url" aria-hidden="true">Home</a>"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
     fn test_invalid_aria_hidden_on_button() {
         let linter = create_linter();
         let result =

--- a/crates/vize_patina/src/rules/a11y/no_role_presentation_on_focusable.rs
+++ b/crates/vize_patina/src/rules/a11y/no_role_presentation_on_focusable.rs
@@ -93,6 +93,16 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_role_presentation_on_anchor_with_dynamic_href_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<a :[href]="url" role="presentation">Home</a>"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
     fn test_invalid_role_presentation_on_button() {
         let linter = create_linter();
         let result =


### PR DESCRIPTION
## Summary

- require static `href` arguments in the shared a11y focusable helper
- keep dynamic `:[href]` from making anchors statically focusable
- cover `no-aria-hidden-on-focusable` and `no-role-presentation-on-focusable` regressions

Closes #2420.

## Verification

- `cargo test -p vize_patina no_aria_hidden_on_focusable -- --nocapture`
- `cargo test -p vize_patina no_role_presentation_on_focusable -- --nocapture`
- CLI repro with dynamic `:[href]` and static `:href`
- `cargo fmt --all -- --check`
- `git diff --check`
