### PR TITLE
fix(patina): ignore dynamic URL attr args

### DIFF
--- a/crates/vize_patina/src/rules/vue/no_unsafe_url.rs
+++ b/crates/vize_patina/src/rules/vue/no_unsafe_url.rs
@@ -213,7 +213,7 @@ impl Rule for NoUnsafeUrl {
 
         // Get the attribute name
         let attr_name = match &directive.arg {
-            Some(ExpressionNode::Simple(s)) => s.content.as_str(),
+            Some(ExpressionNode::Simple(s)) if s.is_static => s.content.as_str(),
             _ => return,
         };
 

--- a/crates/vize_patina/src/rules/vue/no_unsafe_url_tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_unsafe_url_tests.rs
@@ -94,6 +94,13 @@ fn test_warns_dynamic_href() {
 }
 
 #[test]
+fn test_allows_dynamic_href_argument() {
+    let linter = create_linter();
+    let result = linter.lint_template(r#"<a :[href]="userUrl">Link</a>"#, "test.vue");
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
 fn test_allows_hash_template_href_binding() {
     let linter = create_linter();
     let result = linter.lint_template(r##"<a :href="`#${props.id}`">Link</a>"##, "test.vue");
@@ -175,5 +182,12 @@ fn test_allows_dynamic_action_prop_on_component() {
     // `:action` on a component is a prop; it is a URL only on <form>.
     let linter = create_linter();
     let result = linter.lint_template(r#"<MyForm :action="doThing" />"#, "test.vue");
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_allows_dynamic_action_argument() {
+    let linter = create_linter();
+    let result = linter.lint_template(r#"<form :[action]="url"></form>"#, "test.vue");
     assert_eq!(result.warning_count, 0);
 }


### PR DESCRIPTION
## Summary

- require static directive arguments before treating a `v-bind` as URL-bearing
- keep dynamic `:[href]` and `:[action]` from triggering `vue/no-unsafe-url`
- preserve warnings for static `:href` and `:action`

Closes #2422.

## Verification

- `cargo test -p vize_patina no_unsafe_url -- --nocapture`
- CLI repro with dynamic `:[href]` / `:[action]` and static `:href` / `:action`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->