### PR TITLE
fix(patina): ignore dynamic unsupported ARIA args

### DIFF
--- a/crates/vize_patina/src/rules/a11y/aria_unsupported_elements.rs
+++ b/crates/vize_patina/src/rules/a11y/aria_unsupported_elements.rs
@@ -49,6 +49,7 @@ impl Rule for AriaUnsupportedElements {
                 PropNode::Directive(dir)
                     if dir.name == "bind"
                         && let Some(ExpressionNode::Simple(arg)) = &dir.arg
+                        && arg.is_static
                         && Self::is_aria_or_role(arg.content.as_str()) =>
                 {
                     self.report_unsupported_attr(ctx, element, arg.content.as_str(), &dir.loc);
@@ -127,5 +128,12 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<script :role="role"></script>"#, "test.vue");
         assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_valid_script_with_dynamic_role_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<script :[role]="role"></script>"#, "test.vue");
+        assert_eq!(result.error_count, 0);
     }
 }


### PR DESCRIPTION
## Summary

- require static directive arguments before reporting unsupported ARIA/role attributes
- keep dynamic `:[role]` on unsupported elements from being treated as static `role`
- preserve diagnostics for static `role` / `:role`

Closes #2424.

## Verification

- `cargo test -p vize_patina aria_unsupported_elements -- --nocapture`
- CLI repro with dynamic `:[role]` and static `:role`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->