### PR TITLE
fix(patina): ignore dynamic ARIA prop args

### DIFF
--- a/crates/vize_patina/src/rules/a11y/aria_props.rs
+++ b/crates/vize_patina/src/rules/a11y/aria_props.rs
@@ -177,6 +177,7 @@ impl Rule for AriaProps {
                     // Check v-bind:aria-* or :aria-*
                     if dir.name == "bind"
                         && let Some(vize_relief::ExpressionNode::Simple(arg)) = &dir.arg
+                        && arg.is_static
                     {
                         let name = arg.content.as_str();
                         if Self::is_aria_attr(name) && !Self::is_valid_aria_attr(name) {
@@ -301,6 +302,13 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<input :aria-labeledby="labelId" />"#, "test.vue");
         assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_valid_dynamic_aria_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div :[aria-bogus]="value"></div>"#, "test.vue");
+        assert_eq!(result.error_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- require static directive arguments before validating ARIA property names
- keep dynamic `:[aria-*]` arguments from being reported as invalid static ARIA attributes
- preserve diagnostics for static invalid `:aria-*` bindings

Closes #2426.

## Verification

- `cargo test -p vize_patina aria_props -- --nocapture`
- CLI repro with dynamic `:[aria-bogus]` and static `:aria-bogus`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->