### PR TITLE
fix(patina): require static anchor href args

### DIFF
--- a/crates/vize_patina/src/rules/a11y/anchor_is_valid.rs
+++ b/crates/vize_patina/src/rules/a11y/anchor_is_valid.rs
@@ -85,6 +85,7 @@ impl Rule for AnchorIsValid {
                 }
                 PropNode::Directive(dir) if dir.name == "bind" => {
                     if let Some(ExpressionNode::Simple(arg)) = &dir.arg
+                        && arg.is_static
                         && arg.content == "href"
                     {
                         // Dynamic binding - assume valid
@@ -129,6 +130,13 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<a :href="url">Link</a>"#, "test.vue");
         assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_invalid_dynamic_href_argument() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<a :[href]="url">Link</a>"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- require static `href` directive arguments before accepting anchors as having href
- report `a11y/anchor-is-valid` for dynamic `:[href]` arguments
- preserve valid static `:href` behavior

Closes #2430.

## Verification

- `cargo test -p vize_patina anchor_is_valid -- --nocapture`
- CLI repro with dynamic `:[href]` and static `:href`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->