### PR TITLE
fix(patina): require static router link to args

### DIFF
--- a/crates/vize_patina/src/rules/ecosystem/router_link_require_to.rs
+++ b/crates/vize_patina/src/rules/ecosystem/router_link_require_to.rs
@@ -57,7 +57,7 @@ fn is_to_bind_directive(directive: &DirectiveNode<'_>) -> bool {
 
     matches!(
         directive.arg.as_ref(),
-        Some(ExpressionNode::Simple(arg)) if arg.content.as_str() == "to"
+        Some(ExpressionNode::Simple(arg)) if arg.is_static && arg.content.as_str() == "to"
     )
 }
 
@@ -85,6 +85,12 @@ mod tests {
         let result =
             create_linter().lint_template(r#"<router-link :to="{ name: 'home' }" />"#, "test.vue");
         assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn reports_dynamic_to_argument() {
+        let result = create_linter().lint_template(r#"<router-link :[to]="route" />"#, "test.vue");
+        assert_eq!(result.error_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- require static `to` directive arguments before accepting RouterLink targets
- report `ecosystem/router-link-require-to` for dynamic `:[to]` arguments
- preserve valid static `to` and `:to` behavior

Closes #2432.

## Verification

- `cargo test -p vize_patina router_link_require_to -- --nocapture`
- CLI repro with dynamic `:[to]` and static `:to`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->