### PR TITLE
fix(patina): require static Void Link href args

### DIFF
--- a/crates/vize_patina/src/rules/ecosystem/void_link_require_href.rs
+++ b/crates/vize_patina/src/rules/ecosystem/void_link_require_href.rs
@@ -73,7 +73,7 @@ fn is_named_bind_directive(directive: &DirectiveNode<'_>, name: &str) -> bool {
 
     matches!(
         directive.arg.as_ref(),
-        Some(ExpressionNode::Simple(arg)) if arg.content.as_str() == name
+        Some(ExpressionNode::Simple(arg)) if arg.is_static && arg.content.as_str() == name
     )
 }
 
@@ -113,6 +113,17 @@ import { Link } from "@void/vue";
 import { Link } from "@void/vue";
 </script>
 <template><Link>Settings</Link></template>"#;
+
+        let result = create_linter().lint_sfc(source, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn reports_dynamic_void_link_href_argument() {
+        let source = r#"<script setup>
+import { Link } from "@void/vue";
+</script>
+<template><Link :[href]="url">Settings</Link></template>"#;
 
         let result = create_linter().lint_sfc(source, "test.vue");
         assert_eq!(result.error_count, 1);


### PR DESCRIPTION
## Summary

- require static `href` directive arguments before accepting Void Link targets
- report `ecosystem/void-link-require-href` for dynamic `:[href]` arguments
- preserve valid static `href` and `:href` behavior

Closes #2434.

## Verification

- `cargo test -p vize_patina void_link_require_href -- --nocapture`
- CLI repro with dynamic `:[href]` and static `:href`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->