### PR TITLE
fix(fresco): size inputs from explicit width

### DIFF
--- a/crates/vize_fresco/src/napi.rs
+++ b/crates/vize_fresco/src/napi.rs
@@ -8,6 +8,7 @@
     clippy::disallowed_macros
 )]
 mod input;
+mod input_size;
 #[allow(
     clippy::disallowed_types,
     clippy::disallowed_methods,
@@ -20,6 +21,8 @@ mod layout;
     clippy::disallowed_macros
 )]
 mod render;
+#[cfg(test)]
+mod render_tests;
 #[allow(
     clippy::disallowed_types,
     clippy::disallowed_methods,

--- a/crates/vize_fresco/src/napi/input_size.rs
+++ b/crates/vize_fresco/src/napi/input_size.rs
@@ -1,0 +1,38 @@
+use super::types::{FlexStyleNapi, RenderNodeNapi};
+use crate::text::TextWidth;
+
+const DEFAULT_INPUT_WIDTH: usize = 30;
+
+pub(super) fn input_intrinsic_size(node: &RenderNodeNapi) -> (f32, f32) {
+    let value = node.value.as_deref().unwrap_or("");
+    let placeholder = node.placeholder.as_deref().unwrap_or("");
+    let content = if value.is_empty() { placeholder } else { value };
+    let input_width = input_wrap_width(node.style.as_ref());
+    let height = wrapped_line_count(TextWidth::width(content), input_width);
+
+    (input_width as f32, height as f32)
+}
+
+pub(super) fn wrapped_line_count(content_width: usize, wrap_width: usize) -> usize {
+    content_width.div_ceil(wrap_width.max(1)).max(1)
+}
+
+fn input_wrap_width(style: Option<&FlexStyleNapi>) -> usize {
+    style
+        .and_then(|style| style.width.as_deref())
+        .and_then(parse_positive_point_width)
+        .unwrap_or(DEFAULT_INPUT_WIDTH)
+}
+
+fn parse_positive_point_width(value: &str) -> Option<usize> {
+    if value == "auto" || value.ends_with('%') {
+        return None;
+    }
+
+    let value = value.parse::<f32>().ok()?;
+    if value.is_finite() && value > 0.0 {
+        Some(value.ceil() as usize)
+    } else {
+        None
+    }
+}

--- a/crates/vize_fresco/src/napi/render.rs
+++ b/crates/vize_fresco/src/napi/render.rs
@@ -4,6 +4,7 @@ use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use std::cell::RefCell;
 
+use super::input_size::input_intrinsic_size;
 use super::terminal::with_backend;
 use super::types::{LayoutResultNapi, RenderNodeNapi, StyleNapi};
 use crate::layout::Rect;
@@ -208,22 +209,9 @@ pub fn render_tree(nodes: Vec<RenderNodeNapi>) -> Result<()> {
                 render_node.style.height = Dimension::Points(text_height);
             }
 
-            // For input nodes, set size with text wrapping support
             if node.node_type == "input" {
-                use crate::text::TextWidth;
-                let value = node.value.as_deref().unwrap_or("");
-                let placeholder = node.placeholder.as_deref().unwrap_or("");
-                let content = if value.is_empty() { placeholder } else { value };
-
-                // Fixed width for wrapping (can be overridden by style)
-                let input_width = 30_usize;
-                let content_width = TextWidth::width(content);
-
-                // Calculate height based on wrapped lines
-                let num_lines = (content_width / input_width) + 1;
-                let height = num_lines.max(1) as f32;
-
-                render_node.style.width = Dimension::Points(input_width as f32);
+                let (input_width, height) = input_intrinsic_size(node);
+                render_node.style.width = Dimension::Points(input_width);
                 render_node.style.height = Dimension::Points(height);
             }
 
@@ -511,7 +499,7 @@ pub fn render_tree(nodes: Vec<RenderNodeNapi>) -> Result<()> {
                 use crate::text::SegmentedText;
                 let st = SegmentedText::new(value);
                 let cursor_col = st.column_at_index(cursor_idx.min(st.grapheme_count));
-                let area_width = layout.width as usize;
+                let area_width = usize::from(layout.width.max(1));
 
                 // Calculate cursor line and column with text wrapping
                 let cursor_line = cursor_col / area_width;

--- a/crates/vize_fresco/src/napi/render_tests.rs
+++ b/crates/vize_fresco/src/napi/render_tests.rs
@@ -1,0 +1,47 @@
+use super::input_size::{input_intrinsic_size, wrapped_line_count};
+use super::types::{FlexStyleNapi, RenderNodeNapi};
+
+fn input_node(value: &str, width: Option<&str>) -> RenderNodeNapi {
+    RenderNodeNapi {
+        id: 1,
+        node_type: "input".into(),
+        text: None,
+        wrap: None,
+        wrap_mode: None,
+        value: Some(value.into()),
+        placeholder: None,
+        focused: None,
+        cursor: None,
+        mask: None,
+        mask_char: None,
+        style: width.map(|width| FlexStyleNapi {
+            width: Some(width.into()),
+            ..FlexStyleNapi::default()
+        }),
+        appearance: None,
+        border: None,
+        children: None,
+    }
+}
+
+#[test]
+fn input_height_respects_explicit_point_width() {
+    let (_width, height) =
+        input_intrinsic_size(&input_node("abcdefghijklmnopqrstuvwxy", Some("10")));
+
+    assert_eq!(height, 3.0);
+}
+
+#[test]
+fn input_height_does_not_wrap_exact_width_content() {
+    assert_eq!(wrapped_line_count(30, 30), 1);
+}
+
+#[test]
+fn input_height_falls_back_for_non_point_widths() {
+    let (width, height) =
+        input_intrinsic_size(&input_node("abcdefghijklmnopqrstuvwxy", Some("50%")));
+
+    assert_eq!(width, 30.0);
+    assert_eq!(height, 1.0);
+}


### PR DESCRIPTION
## Summary

- Extract Fresco NAPI input intrinsic sizing into a focused helper module.
- Use an explicit point `style.width` as the input wrapping width instead of always calculating height from the legacy default width.
- Fix exact-width content so it stays on one line, and guard focused input cursor wrapping against zero-width layouts.

## Root Cause

Input height was computed before flex style application with a hardcoded width of 30 columns. When callers passed an explicit width, layout width changed later but the input height stayed based on the old width. Content exactly equal to the wrapping width also over-counted by one line.

## Validation

- `cargo test -p vize_fresco --features napi --profile ci`
- `cargo clippy -p vize_fresco --features napi --profile ci -- -D warnings`
- `cargo test -p vize_fresco --profile ci`
- `SOURCE_LENGTH_BASE_REF=origin/main moon run -q --target native - -- --check --max-lines 350 --limit 5 --base-ref origin/main < tools/moon/scripts/source_file_lengths.mbtx`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->