### PR TITLE
fix(oxint): rewrite escaped output paths

### DIFF
--- a/npm/oxint/src/cli/output.test.ts
+++ b/npm/oxint/src/cli/output.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { rewriteReportedPaths } from "./output.ts";
+
+void test("rewriteReportedPaths rewrites both absolute and relative temporary filenames", () => {
+  const replacements = new Map<string, string>([
+    ["/repo/node_modules/.vize/oxlint-plugin-vize/100-abcd/0-Example.vue", "/repo/src/Example.vue"],
+    ["node_modules/.vize/oxlint-plugin-vize/100-abcd/0-Example.vue", "/repo/src/Example.vue"],
+  ]);
+
+  assert.equal(
+    rewriteReportedPaths(
+      [
+        "node_modules/.vize/oxlint-plugin-vize/100-abcd/0-Example.vue",
+        "/repo/node_modules/.vize/oxlint-plugin-vize/100-abcd/0-Example.vue",
+      ].join("\n"),
+      replacements,
+    ),
+    ["/repo/src/Example.vue", "/repo/src/Example.vue"].join("\n"),
+  );
+});
+
+void test("rewriteReportedPaths rewrites Windows paths embedded in JSON string values", () => {
+  const tempFilename = String.raw`C:\repo\node_modules\.vize\oxlint-plugin-vize\100-abcd\0-Example.vue`;
+  const originalFilename = String.raw`C:\repo\src\Example.vue`;
+  const replacements = new Map<string, string>([[tempFilename, originalFilename]]);
+  const output = JSON.stringify({
+    filename: tempFilename,
+    message: `reported from ${tempFilename}`,
+  });
+
+  const rewritten = rewriteReportedPaths(output, replacements);
+
+  assert.deepEqual(JSON.parse(rewritten), {
+    filename: originalFilename,
+    message: `reported from ${originalFilename}`,
+  });
+  assert.doesNotMatch(rewritten, /node_modules/u);
+  assert.doesNotMatch(rewritten, /\.vize/u);
+});
+
+void test("rewriteReportedPaths rewrites quoted POSIX paths embedded in JSON string values", () => {
+  const tempFilename = '/repo/node_modules/.vize/oxlint-plugin-vize/100-abcd/0-"Example".vue';
+  const originalFilename = '/repo/src/"Example".vue';
+  const replacements = new Map<string, string>([[tempFilename, originalFilename]]);
+  const output = JSON.stringify({
+    filename: tempFilename,
+  });
+
+  const rewritten = rewriteReportedPaths(output, replacements);
+
+  assert.deepEqual(JSON.parse(rewritten), {
+    filename: originalFilename,
+  });
+  assert.doesNotMatch(rewritten, /node_modules/u);
+  assert.doesNotMatch(rewritten, /\.vize/u);
+});

--- a/npm/oxint/src/cli/output.ts
+++ b/npm/oxint/src/cli/output.ts
@@ -4,7 +4,7 @@ export function rewriteReportedPaths(
 ): string {
   let rewritten = output;
 
-  const orderedReplacements = [...replacements].sort(
+  const orderedReplacements = buildReplacementVariants(replacements).sort(
     (left, right) => right[0].length - left[0].length,
   );
 
@@ -15,28 +15,31 @@ export function rewriteReportedPaths(
   return rewritten;
 }
 
-if (import.meta.vitest) {
-  const { describe, expect, it } = import.meta.vitest;
+function buildReplacementVariants(
+  replacements: ReadonlyMap<string, string>,
+): Array<[string, string]> {
+  const variants = new Map<string, string>();
 
-  describe("rewriteReportedPaths", () => {
-    it("rewrites both absolute and relative temporary filenames", () => {
-      const replacements = new Map<string, string>([
-        [
-          "/repo/node_modules/.vize/oxlint-plugin-vize/100-abcd/0-Example.vue",
-          "/repo/src/Example.vue",
-        ],
-        ["node_modules/.vize/oxlint-plugin-vize/100-abcd/0-Example.vue", "/repo/src/Example.vue"],
-      ]);
+  for (const [from, to] of replacements) {
+    registerReplacementVariant(variants, from, to);
+    registerReplacementVariant(
+      variants,
+      escapeJsonStringSegment(from),
+      escapeJsonStringSegment(to),
+    );
+  }
 
-      expect(
-        rewriteReportedPaths(
-          [
-            "node_modules/.vize/oxlint-plugin-vize/100-abcd/0-Example.vue",
-            "/repo/node_modules/.vize/oxlint-plugin-vize/100-abcd/0-Example.vue",
-          ].join("\n"),
-          replacements,
-        ),
-      ).toBe(["/repo/src/Example.vue", "/repo/src/Example.vue"].join("\n"));
-    });
-  });
+  return [...variants];
+}
+
+function registerReplacementVariant(variants: Map<string, string>, from: string, to: string): void {
+  if (!from || !to) {
+    return;
+  }
+
+  variants.set(from, to);
+}
+
+function escapeJsonStringSegment(value: string): string {
+  return JSON.stringify(value).slice(1, -1);
 }

--- a/npm/oxint/src/test.ts
+++ b/npm/oxint/src/test.ts
@@ -879,5 +879,5 @@ assert.equal(
   "<template>",
   "Diagnostics should map back to their containing SFC block",
 );
-await import("./nuxt-preset.test.ts");
+await Promise.all([import("./cli/output.test.ts"), import("./nuxt-preset.test.ts")]);
 console.log("✅ oxlint-plugin-vize integration tests passed!");


### PR DESCRIPTION
## Summary

- Rewrite temporary oxlint-vize paths through raw and JSON-escaped variants.
- Move output path rewrite coverage into a Node test that runs in the package test script.
- Cover Windows-style escaped paths and quoted POSIX paths so temporary workaround paths do not leak from JSON formatter output.

## Validation

- `vp run --filter './npm/oxint' check`
- `vp run --filter './npm/oxint' test`
- `SOURCE_LENGTH_BASE_REF=origin/main moon run -q --target native - -- --check --max-lines 350 --limit 5 --base-ref origin/main < tools/moon/scripts/source_file_lengths.mbtx`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->