### PR TITLE
fix(nuxt): trust empty generated path aliases

### DIFF
--- a/crates/vize/src/commands/check/nuxt/tests/build_dir.rs
+++ b/crates/vize/src/commands/check/nuxt/tests/build_dir.rs
@@ -227,6 +227,35 @@ fn path_aliases_come_from_custom_generated_nuxt_tsconfig_when_present() {
 }
 
 #[test]
+fn generated_nuxt_tsconfig_without_paths_does_not_use_guessed_aliases() {
+    let project_root = unique_case_dir("nuxt-empty-generated-tsconfig-aliases");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join(".nuxt")).unwrap();
+    std::fs::create_dir_all(project_root.join("app")).unwrap();
+    std::fs::create_dir_all(project_root.join("shared")).unwrap();
+    std::fs::write(project_root.join("nuxt.config.ts"), "export default {}").unwrap();
+    std::fs::write(
+        project_root.join(".nuxt/tsconfig.json"),
+        r#"{ "compilerOptions": {} }"#,
+    )
+    .unwrap();
+
+    let mut options = VirtualTsOptions::default();
+    let aliases = detect_nuxt_auto_imports(&mut options, &project_root);
+
+    for guessed in ["~/*", "@/*", "~~/*", "@@/*", "#shared/*"] {
+        assert!(
+            !aliases
+                .iter()
+                .any(|alias| alias.pattern.as_str() == guessed),
+            "generated tsconfig should suppress guessed alias {guessed:?}: {aliases:#?}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn default_generated_dir_remains_dot_nuxt() {
     let generated_dir = resolve_nuxt_generated_dir(Path::new("/workspace"));
 

--- a/crates/vize/src/commands/check/nuxt/virtual_modules.rs
+++ b/crates/vize/src/commands/check/nuxt/virtual_modules.rs
@@ -47,10 +47,8 @@ pub(super) fn collect_fallback_path_aliases(
     // into the generated `tsconfig.json`. When present, consume those aliases
     // verbatim instead of guessing, so user-configured aliases (e.g. custom
     // `srcDir`, extra `alias` entries) are honoured.
-    let mut aliases = match collect_generated_path_aliases(cwd, generated_dir) {
-        Some(aliases) if !aliases.is_empty() => aliases,
-        _ => collect_guessed_path_aliases(cwd),
-    };
+    let mut aliases = collect_generated_path_aliases(cwd, generated_dir)
+        .unwrap_or_else(|| collect_guessed_path_aliases(cwd));
     push_nuxt_composition_api_alias(cwd, &mut aliases);
     aliases
 }
@@ -59,8 +57,8 @@ pub(super) fn collect_fallback_path_aliases(
 /// `compilerOptions.paths` into [`NuxtPathAlias`]es. Targets in the generated
 /// config are relative to the generated dir, so they are rebased to be relative
 /// to the project root (`cwd`) to match how downstream `tsconfig` synthesis
-/// interprets alias targets. Returns `None` when the file is absent or unparseable so the
-/// caller can fall back to the hardcoded guesses.
+/// interprets alias targets. Returns `None` only when the file is absent or
+/// unparseable so the caller can fall back to the hardcoded guesses.
 fn collect_generated_path_aliases(
     cwd: &Path,
     generated_dir: &NuxtGeneratedDir,
@@ -69,11 +67,14 @@ fn collect_generated_path_aliases(
     let content = tracked_read_to_string(&tsconfig_path).ok()?;
     let value = parse_jsonc_value(content.as_str()).ok()?;
 
-    let paths = value
+    let Some(paths) = value
         .get("compilerOptions")
         .and_then(Value::as_object)
         .and_then(|compiler_options| compiler_options.get("paths"))
-        .and_then(Value::as_object)?;
+        .and_then(Value::as_object)
+    else {
+        return Some(Vec::new());
+    };
 
     let mut aliases: Vec<NuxtPathAlias> = Vec::new();
     for (pattern, targets) in paths {


### PR DESCRIPTION
## Summary
- Treat a readable generated Nuxt tsconfig as authoritative even when `compilerOptions.paths` is absent.
- Fall back to guessed aliases only when the generated tsconfig is missing or cannot be parsed.
- Add a regression test for generated tsconfig files without paths.

## Verification
- `cargo fmt --all --check`
- `cargo test -p vize --profile ci commands::check::nuxt -- --nocapture`
- `SOURCE_LENGTH_BASE_REF=origin/main moon run -q --target native - -- --check --max-lines 350 --limit 5 --base-ref origin/main < tools/moon/scripts/source_file_lengths.mbtx`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->