### PR TITLE
fix(vscode): resolve vue imports in tsserver

### DIFF
--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,4 +1,5 @@
 node_modules/
+typescript-vue-plugin/
 src/
 .vscode-test/
 .vscode/

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -29,16 +29,16 @@
   "publisher": "ubugeeei",
   "main": "./dist/extension.cjs",
   "scripts": {
-    "vscode:prepublish": "vp pack",
-    "build": "vp pack",
-    "watch": "vp pack --watch",
+    "vscode:prepublish": "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && vp pack",
+    "build": "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && vp pack",
+    "watch": "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && vp pack --watch",
     "check": "tsgo --noEmit && vp check src vite.config.ts",
     "check:fix": "vp check --fix src vite.config.ts && tsgo --noEmit",
     "fmt": "vp fmt --write src vite.config.ts",
-    "package": "vsce package --no-dependencies --out dist/vize.vsix",
+    "package": "vsce package --no-dependencies --out dist/vize.vsix && node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix",
     "test:host": "node test/run-extension-host.mjs",
-    "publish": "vsce publish --no-dependencies",
-    "publish:pre": "vsce publish --no-dependencies --pre-release"
+    "publish": "npm run package && vsce publish --packagePath dist/vize.vsix",
+    "publish:pre": "npm run package && vsce publish --pre-release --packagePath dist/vize.vsix"
   },
   "dependencies": {
     "vscode-languageclient": "9.0.1"
@@ -83,6 +83,12 @@
           "light": "./icons/vue.svg",
           "dark": "./icons/vue.svg"
         }
+      }
+    ],
+    "typescriptServerPlugins": [
+      {
+        "name": "@vizejs/typescript-vue-plugin",
+        "enableForWorkspaceTypeScriptVersions": true
       }
     ],
     "grammars": [

--- a/editors/vscode/typescript-vue-plugin/index.cjs
+++ b/editors/vscode/typescript-vue-plugin/index.cjs
@@ -1,0 +1,135 @@
+"use strict";
+
+const path = require("node:path");
+
+const vueExtension = ".vue";
+const virtualDtsSuffix = ".d.ts";
+
+function init({ typescript: ts }) {
+  return {
+    create(info) {
+      installVueImportResolver(ts, info);
+      return info.languageService;
+    },
+  };
+}
+
+function installVueImportResolver(ts, info) {
+  const host = info.languageServiceHost;
+  if (!host || host.__vizeVueImportResolverInstalled) {
+    return;
+  }
+  Object.defineProperty(host, "__vizeVueImportResolverInstalled", {
+    value: true,
+  });
+
+  const serverHost = info.serverHost || ts.sys;
+  const originalFileExists = bind(host.fileExists, host) || bind(serverHost.fileExists, serverHost);
+  const originalReadFile = bind(host.readFile, host) || bind(serverHost.readFile, serverHost);
+  const originalGetScriptSnapshot = bind(host.getScriptSnapshot, host);
+  const originalGetScriptKind = bind(host.getScriptKind, host);
+  const originalResolveModuleNameLiterals = bind(host.resolveModuleNameLiterals, host);
+  const originalResolveModuleNames = bind(host.resolveModuleNames, host);
+
+  host.fileExists = (fileName) => {
+    const vuePath = realVuePathFromVirtual(fileName);
+    if (vuePath) {
+      return originalFileExists(vuePath);
+    }
+    return originalFileExists(fileName);
+  };
+
+  host.readFile = (fileName) => {
+    const vuePath = realVuePathFromVirtual(fileName);
+    if (vuePath && originalFileExists(vuePath)) {
+      return virtualVueDts();
+    }
+    return originalReadFile(fileName);
+  };
+
+  host.getScriptSnapshot = (fileName) => {
+    const vuePath = realVuePathFromVirtual(fileName);
+    if (vuePath && originalFileExists(vuePath)) {
+      return ts.ScriptSnapshot.fromString(virtualVueDts());
+    }
+    return originalGetScriptSnapshot(fileName);
+  };
+
+  host.getScriptKind = (fileName) => {
+    if (realVuePathFromVirtual(fileName)) {
+      return ts.ScriptKind.TS;
+    }
+    return originalGetScriptKind ? originalGetScriptKind(fileName) : ts.ScriptKind.Unknown;
+  };
+
+  host.resolveModuleNameLiterals = (...args) => {
+    const [moduleLiterals, containingFile] = args;
+    const previous = originalResolveModuleNameLiterals
+      ? originalResolveModuleNameLiterals(...args)
+      : [];
+
+    return moduleLiterals.map((literal, index) => {
+      if (previous[index] && previous[index].resolvedModule) {
+        return previous[index];
+      }
+
+      const resolvedModule = resolveVueModule(ts, literal.text, containingFile, originalFileExists);
+      return resolvedModule ? { resolvedModule } : previous[index] || { resolvedModule: undefined };
+    });
+  };
+
+  host.resolveModuleNames = (...args) => {
+    const [moduleNames, containingFile] = args;
+    const previous = originalResolveModuleNames ? originalResolveModuleNames(...args) : [];
+
+    return moduleNames.map((moduleName, index) => {
+      if (previous[index]) {
+        return previous[index];
+      }
+      return resolveVueModule(ts, moduleName, containingFile, originalFileExists);
+    });
+  };
+}
+
+function resolveVueModule(ts, specifier, containingFile, fileExists) {
+  if (!isRelativeVueSpecifier(specifier)) {
+    return undefined;
+  }
+
+  const vuePath = path.resolve(path.dirname(containingFile), specifier);
+  if (!fileExists(vuePath)) {
+    return undefined;
+  }
+
+  return {
+    extension: ts.Extension.Dts,
+    isExternalLibraryImport: false,
+    resolvedFileName: virtualVueDtsPath(vuePath),
+  };
+}
+
+function bind(fn, thisArg) {
+  return typeof fn === "function" ? fn.bind(thisArg) : undefined;
+}
+
+function isRelativeVueSpecifier(specifier) {
+  return (
+    specifier.endsWith(vueExtension) && (specifier.startsWith("./") || specifier.startsWith("../"))
+  );
+}
+
+function realVuePathFromVirtual(fileName) {
+  return fileName.endsWith(`${vueExtension}${virtualDtsSuffix}`)
+    ? fileName.slice(0, -virtualDtsSuffix.length)
+    : undefined;
+}
+
+function virtualVueDtsPath(vuePath) {
+  return `${vuePath}${virtualDtsSuffix}`;
+}
+
+function virtualVueDts() {
+  return "declare const component: any;\nexport default component;\n";
+}
+
+module.exports = init;

--- a/editors/vscode/typescript-vue-plugin/package.json
+++ b/editors/vscode/typescript-vue-plugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@vizejs/typescript-vue-plugin",
+  "version": "0.0.0",
+  "private": true,
+  "main": "index.cjs"
+}

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -74,6 +74,7 @@ test("check workflow runs declared Node engine compatibility matrix", () => {
     job,
     /node --test tests\/tooling\/node-engine-matrix\.test\.ts tests\/tooling\/package-manifests\.test\.ts/,
   );
+  assert.doesNotMatch(job, /vscode-typescript-vue-plugin\.test\.ts/);
 });
 
 test("check workflow comments a detailed PR test report for each head push", () => {

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -468,9 +468,6 @@ test("editor extension manifests keep expected defaults and version alignment", 
     vscodePackage.contributes?.configuration?.properties?.["vize.formatting.enable"]?.default,
     false,
   );
-  assert.equal(vscodePackage.scripts?.["vscode:prepublish"], "vp pack");
-  assert.equal(vscodePackage.scripts?.build, "vp pack");
-  assert.equal(vscodePackage.scripts?.watch, "vp pack --watch");
   assert.equal(vscodePackage.scripts?.check, "tsgo --noEmit && vp check src vite.config.ts");
   assert.equal(
     vscodePackage.scripts?.["check:fix"],

--- a/tests/tooling/vscode-typescript-vue-plugin.test.ts
+++ b/tests/tooling/vscode-typescript-vue-plugin.test.ts
@@ -8,8 +8,13 @@ import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const require = createRequire(import.meta.url);
+// Prefer the TypeScript the VS Code extension bundles, but fall back to the
+// workspace copy: editors/vscode is excluded from the pnpm workspace, so its
+// node_modules is empty in CI while tests/node_modules pins the same version.
 const ts = require(
-  require.resolve("typescript", { paths: [path.join(root, "editors/vscode")] }),
+  require.resolve("typescript", {
+    paths: [path.join(root, "editors/vscode"), path.join(root, "tests")],
+  }),
 ) as typeof import("typescript");
 const initVuePlugin = require(
   path.join(root, "editors/vscode/typescript-vue-plugin/index.cjs"),

--- a/tests/tooling/vscode-typescript-vue-plugin.test.ts
+++ b/tests/tooling/vscode-typescript-vue-plugin.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const require = createRequire(import.meta.url);
+const ts = require(
+  require.resolve("typescript", { paths: [path.join(root, "editors/vscode")] }),
+) as typeof import("typescript");
+const initVuePlugin = require(
+  path.join(root, "editors/vscode/typescript-vue-plugin/index.cjs"),
+) as (modules: { typescript: typeof ts }) => {
+  create(info: {
+    languageService: import("typescript").LanguageService;
+    languageServiceHost: import("typescript").LanguageServiceHost;
+    serverHost: typeof ts.sys;
+  }): import("typescript").LanguageService;
+};
+
+test("VS Code extension ships the TypeScript Vue plugin", () => {
+  const manifest = readJson<{
+    contributes?: {
+      typescriptServerPlugins?: Array<{
+        enableForWorkspaceTypeScriptVersions?: boolean;
+        name?: string;
+      }>;
+    };
+    scripts?: Record<string, string>;
+  }>("editors/vscode/package.json");
+  const plugin = manifest.contributes?.typescriptServerPlugins?.find(
+    (entry) => entry.name === "@vizejs/typescript-vue-plugin",
+  );
+  const stageScript = "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && vp pack";
+
+  assert.ok(plugin, "manifest should contribute the Vue TypeScript plugin");
+  assert.equal(plugin.enableForWorkspaceTypeScriptVersions, true);
+  assert.equal(manifest.scripts?.["vscode:prepublish"], stageScript);
+  assert.equal(manifest.scripts?.build, stageScript);
+  assert.equal(manifest.scripts?.watch, `${stageScript} --watch`);
+  assert.equal(
+    manifest.scripts?.package,
+    "vsce package --no-dependencies --out dist/vize.vsix && node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix",
+  );
+  assert.ok(
+    fs.existsSync(path.join(root, "editors/vscode/typescript-vue-plugin/index.cjs")),
+    "plugin package source must exist for the local file dependency",
+  );
+  assert.match(readFile("editors/vscode/.vscodeignore"), /^typescript-vue-plugin\/$/m);
+  assert.match(
+    readFile("tools/vite-plus/tasks/build.ts"),
+    /package:vscode-extension[\s\S]*vscode-typescript-vue-plugin\.test\.ts/,
+  );
+  assert.match(
+    readFile("tools/vite-plus/tasks/build.ts"),
+    /package:editor-extensions[\s\S]*vscode-typescript-vue-plugin\.test\.ts/,
+  );
+});
+
+test("TypeScript Vue plugin resolves existing relative .vue imports", () => {
+  const project = createVueProject('import App from "./app.vue";\nApp;\n', {
+    "app.vue": "<template />\n",
+  });
+  try {
+    const withoutPlugin = collectDiagnostics(project.mainTs, false);
+    assert.ok(hasCannotFindVueModule(withoutPlugin, "./app.vue"), formatDiagnostics(withoutPlugin));
+
+    const withPlugin = collectDiagnostics(project.mainTs, true);
+    assert.equal(
+      hasCannotFindVueModule(withPlugin, "./app.vue"),
+      false,
+      formatDiagnostics(withPlugin),
+    );
+  } finally {
+    fs.rmSync(project.root, { force: true, recursive: true });
+  }
+});
+
+test("TypeScript Vue plugin keeps missing .vue imports diagnostic", () => {
+  const project = createVueProject('import Missing from "./missing.vue";\nMissing;\n', {});
+  try {
+    const diagnostics = collectDiagnostics(project.mainTs, true);
+    assert.ok(hasCannotFindVueModule(diagnostics, "./missing.vue"), formatDiagnostics(diagnostics));
+  } finally {
+    fs.rmSync(project.root, { force: true, recursive: true });
+  }
+});
+
+function createVueProject(mainSource: string, vueFiles: Record<string, string>) {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-vscode-vue-plugin-"));
+  const srcDir = path.join(rootDir, "src");
+  fs.mkdirSync(srcDir, { recursive: true });
+  const mainTs = path.join(srcDir, "main.ts");
+  fs.writeFileSync(mainTs, mainSource);
+  for (const [fileName, content] of Object.entries(vueFiles)) {
+    fs.writeFileSync(path.join(srcDir, fileName), content);
+  }
+  return { root: rootDir, mainTs };
+}
+
+function collectDiagnostics(mainTs: string, enablePlugin: boolean) {
+  const host = createHost(path.dirname(path.dirname(mainTs)), mainTs);
+  const service = ts.createLanguageService(host);
+  const activeService = enablePlugin
+    ? initVuePlugin({ typescript: ts }).create({
+        languageService: service,
+        languageServiceHost: host,
+        serverHost: ts.sys,
+      })
+    : service;
+
+  return activeService.getSemanticDiagnostics(mainTs);
+}
+
+function createHost(rootDir: string, mainTs: string): import("typescript").LanguageServiceHost {
+  const options: import("typescript").CompilerOptions = {
+    allowSyntheticDefaultImports: true,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2022,
+  };
+
+  return {
+    directoryExists: (directoryName) => ts.sys.directoryExists(directoryName),
+    fileExists: (fileName) => ts.sys.fileExists(fileName),
+    getCompilationSettings: () => options,
+    getCurrentDirectory: () => rootDir,
+    getDefaultLibFileName: (compilerOptions) => ts.getDefaultLibFilePath(compilerOptions),
+    getDirectories: (directoryName) => ts.sys.getDirectories(directoryName),
+    getScriptFileNames: () => [mainTs],
+    getScriptSnapshot(fileName) {
+      if (!fs.existsSync(fileName)) return undefined;
+      return ts.ScriptSnapshot.fromString(fs.readFileSync(fileName, "utf8"));
+    },
+    getScriptVersion: () => "0",
+    readDirectory: (rootDir, extensions, excludes, includes, depth) =>
+      ts.sys.readDirectory(rootDir, extensions, excludes, includes, depth),
+    readFile: (fileName, encoding) => ts.sys.readFile(fileName, encoding),
+    useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
+  };
+}
+
+function hasCannotFindVueModule(
+  diagnostics: readonly import("typescript").Diagnostic[],
+  specifier: string,
+) {
+  return diagnostics.some((diagnostic) => {
+    const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+    return message.includes(`Cannot find module '${specifier}'`);
+  });
+}
+
+function formatDiagnostics(diagnostics: readonly import("typescript").Diagnostic[]) {
+  return diagnostics
+    .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))
+    .join("\n");
+}
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(readFile(relativePath)) as T;
+}
+
+function readFile(relativePath: string) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}

--- a/tools/moon/scripts/source_file_lengths.mbtx
+++ b/tools/moon/scripts/source_file_lengths.mbtx
@@ -99,6 +99,7 @@ fn compare_failures(a : CheckFailure, b : CheckFailure) -> Int {
     1
   }
 }
+fn allowed_manifest_growth(path : String, lines : Int) -> Bool { path == "editors/vscode/package.json" && lines <= 415 }
 fn allowed_growth(path : String, lines : Int) -> Bool { (path == "crates/vize/tests/check_cli.rs" && lines <= 4187) || (path == "crates/vize_atelier_sfc/src/compile/tests.rs" && lines <= 3063) || (path == "crates/vize_canon/src/virtual_ts/tests.rs" && lines <= 2268) || (path == "crates/vize_maestro/src/ide/hover.rs" && lines <= 1043) || (path == "crates/vize_canon/src/virtual_ts/generator.rs" && lines <= 1039) || (path == "crates/vize_atelier_sfc/src/compile.rs" && lines <= 1018) || (path == "crates/vize_patina/src/linter/engine.rs" && lines <= 967) || (path == "crates/vize_canon/src/virtual_ts/generator/options_api.rs" && lines <= 902) || (path == "crates/vize_maestro/src/ide/definition.rs" && lines <= 892) || (path == "crates/vize_glyph/src/template/formatter.rs" && lines <= 839) || (path == "crates/vize_atelier_sfc/src/compile_script/tests.rs" && lines <= 800) || (path == "crates/vize_patina/src/visitor.rs" && lines <= 777) || (path == "crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs" && lines <= 727) || (path == "crates/vize_canon/src/lsp_client/session.rs" && lines <= 726) || (path == "crates/vize/src/commands/check/runner.rs" && lines <= 724) || (path == "npm/framework/nuxt/src/index.ts" && lines <= 691) || (path == "crates/vize_patina/src/rules/ssr/no_browser_globals_in_ssr.rs" && lines <= 671) || (path == "crates/vize_canon/src/virtual_ts/helpers.rs" && lines <= 616) || (path == "crates/vize_canon/src/batch/virtual_project/build.rs" && lines <= 367) || (path == "crates/vize/tests/check_tsx_sfc_attrs_cli.rs" && lines <= 360) || (path == "crates/vize_glyph/src/template.rs" && lines <= 601) || (path == "npm/framework/nuxt/src/components.ts" && lines <= 601) || (path == "crates/vize_patina/src/linter/tests/sfc.rs" && lines <= 566) || (path == "crates/vize_atelier_core/src/codegen/source_map.rs" && lines <= 564) || (path == "npm/framework/nuxt/src/components.test.ts" && lines <= 549) || (path == "crates/vize_patina/src/linter/tests/basic.rs" && lines <= 532) || (path == "crates/vize_atelier_sfc/src/compile_script/artifacts.rs" && lines <= 524) || (path == "crates/vize_canon/src/virtual_ts/scope/component_props.rs" && lines <= 517) || (path == "crates/vize/src/commands/build/runner.rs" && lines <= 509) || (path == "crates/vize_canon/src/virtual_ts/scope/closures.rs" && lines <= 486) || (path == "crates/vize_canon/src/tests.rs" && lines <= 482) || (path == "crates/vize_maestro/src/ide/hover/template.rs" && lines <= 474) || (path == "crates/vize_glyph/src/lib.rs" && lines <= 472) || (path == "crates/vize_patina/src/linter/config.rs" && lines <= 471) || (path == "crates/vize/src/commands/ide.rs" && lines <= 461) || (path == "crates/vize/src/commands/lint.rs" && lines <= 414) || (path == "npm/builder/vite/src/plugin/hmr.test.ts" && lines <= 412) || (path == "npm/builder/vite-musea/src/plugin/index.ts" && lines <= 393) || (path == "crates/vize_patina/src/context.rs" && lines <= 386) || (path == "crates/vize_carton/src/config/loader/tests.rs" && lines <= 380) || (path == "crates/vize/src/commands/check/runner/tests.rs" && lines <= 360) || (path == "crates/vize_carton/src/config/loader.rs" && lines <= 358) || (path == "crates/vize_maestro/src/ide/corsa_support/canonical.rs" && lines <= 356) || (path == "crates/vize_canon/src/virtual_ts/generator/imports.rs" && lines <= 354) }
 fn collect_current_files(paths : Array[String]) -> Array[SourceFile] {
   let files = []
@@ -155,7 +156,6 @@ async fn base_rename_paths(base_ref : String) -> Map[String, String] {
   }
   renames
 }
-
 async fn base_file_lines(
   base_ref : String,
   path : String,
@@ -186,7 +186,7 @@ async fn collect_failures(
     if file.lines <= max_lines {
       continue
     }
-    if allowed_growth(file.path, file.lines) { continue }
+    if allowed_manifest_growth(file.path, file.lines) || allowed_growth(file.path, file.lines) { continue }
     let base_lines = base_file_lines(base_ref, file.path, base_paths)
     match base_lines {
       None =>

--- a/tools/vite-plus/tasks/build.ts
+++ b/tools/vite-plus/tasks/build.ts
@@ -58,7 +58,9 @@ export const buildTasks = defineTasks({
   "package:vscode-extension": noCacheTask(
     runInVscodeExtension(
       "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
+      "node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix",
       "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
+      "node --test ../../tests/tooling/vscode-typescript-vue-plugin.test.ts",
     ),
   ),
   "check:zed-extension": task("cargo check --manifest-path editors/zed/Cargo.toml", {
@@ -84,7 +86,9 @@ export const buildTasks = defineTasks({
       "pnpm exec tsgo --noEmit",
       "pnpm exec vp check src vite.config.ts",
       "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
+      "node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix",
       "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
+      "node --test ../../tests/tooling/vscode-typescript-vue-plugin.test.ts",
     )} && ${runTask("check:zed-extension")} && ${runTask(
       "test:zed-extension:unit",
     )} && ${runTask("package:zed-extension")} && ${runTask(

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -92,6 +92,7 @@ export const testAndBenchmarkTasks = defineTasks({
   "test:vscode-extension:vsix": noCacheTask(
     runInVscodeExtension(
       "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
+      "node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix",
       "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
     ),
   ),

--- a/tools/vscode-vize/assert-vsix-package.mjs
+++ b/tools/vscode-vize/assert-vsix-package.mjs
@@ -48,6 +48,8 @@ const requiredFiles = [
   "extension/icons/logo.png",
   "extension/icons/vue.svg",
   "extension/language-configuration.json",
+  "extension/node_modules/@vizejs/typescript-vue-plugin/index.cjs",
+  "extension/node_modules/@vizejs/typescript-vue-plugin/package.json",
   "extension/package.json",
   "extension/readme.md",
   "extension/syntaxes/art-vue.tmLanguage.json",
@@ -65,6 +67,7 @@ const allowedExtensionEntries = [
   /^extension\/dist\/extension\.cjs$/,
   /^extension\/icons\/(?:logo\.png|vue\.svg)$/,
   /^extension\/language-configuration\.json$/,
+  /^extension\/node_modules\/@vizejs\/typescript-vue-plugin\/(?:index\.cjs|package\.json)$/,
   /^extension\/package\.json$/,
   /^extension\/readme\.md$/,
   /^extension\/syntaxes\/(?:art-vue|vue)\.tmLanguage\.json$/,
@@ -82,7 +85,7 @@ const forbiddenEntries = [
   /^extension\/\.vscode-test\//,
   /^extension\/\.vscode\//,
   /^extension\/dist\/.*\.map$/,
-  /^extension\/node_modules\//,
+  /^extension\/node_modules\/(?!@vizejs\/typescript-vue-plugin\/(?:index\.cjs|package\.json)$)/,
   /^extension\/package-lock\.json$/,
   /^extension\/pnpm-lock\.yaml$/,
   /^extension\/src\//,
@@ -127,6 +130,12 @@ for (const command of packageJson.contributes.commands) {
 
 assert.ok(packageJson.activationEvents.includes("onLanguage:vue"));
 assert.ok(packageJson.activationEvents.includes("onLanguage:art-vue"));
+assert.deepEqual(packageJson.contributes.typescriptServerPlugins, [
+  {
+    name: "@vizejs/typescript-vue-plugin",
+    enableForWorkspaceTypeScriptVersions: true,
+  },
+]);
 
 const languages = new Map(
   packageJson.contributes.languages.map((language) => [language.id, language]),

--- a/tools/vscode-vize/sync-typescript-plugin.mjs
+++ b/tools/vscode-vize/sync-typescript-plugin.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const extensionDir = path.join(root, "editors/vscode");
+const sourceDir = path.join(extensionDir, "typescript-vue-plugin");
+const packagePath = "node_modules/@vizejs/typescript-vue-plugin";
+const pluginFiles = ["index.cjs", "package.json"];
+
+const command = process.argv[2];
+
+if (command === "stage") {
+  stagePlugin(path.join(extensionDir, packagePath));
+} else if (command === "inject") {
+  const vsixPath = path.resolve(process.cwd(), process.argv[3] ?? "dist/vize.vsix");
+  injectPlugin(vsixPath);
+} else {
+  console.error("Usage: sync-typescript-plugin.mjs <stage|inject> [vsix]");
+  process.exit(2);
+}
+
+function stagePlugin(targetDir) {
+  fs.rmSync(targetDir, { force: true, recursive: true });
+  fs.mkdirSync(targetDir, { recursive: true });
+  for (const file of pluginFiles) {
+    fs.copyFileSync(path.join(sourceDir, file), path.join(targetDir, file));
+  }
+}
+
+function injectPlugin(vsixPath) {
+  if (!fs.existsSync(vsixPath)) {
+    throw new Error(`VSIX does not exist: ${vsixPath}`);
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-vsix-plugin-"));
+  try {
+    const targetDir = path.join(tempDir, "extension", packagePath);
+    stagePlugin(targetDir);
+    const entries = pluginFiles.map((file) => path.posix.join("extension", packagePath, file));
+    const result = spawnSync("zip", ["-q", vsixPath, ...entries], {
+      cwd: tempDir,
+      encoding: "utf8",
+    });
+    if (result.error) {
+      throw result.error;
+    }
+    if (result.status !== 0) {
+      throw new Error(
+        `zip failed with status ${result.status ?? "null"}\n${result.stderr}${result.stdout}`,
+      );
+    }
+  } finally {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  }
+}


### PR DESCRIPTION
## Summary
- Add a VS Code TypeScript server plugin that resolves existing relative `.vue` imports from `.ts` files through in-memory `.vue.d.ts` virtual modules.
- Keep missing `.vue` imports as real TS2307 diagnostics instead of filtering errors globally.
- Package the plugin into the VSIX and run the plugin language-service test from the editor-extension packaging path.

## Verification
- `node --test tests/tooling/node-engine-matrix.test.ts tests/tooling/package-manifests.test.ts tests/tooling/github-workflows-check.test.ts tests/tooling/editor-integrations.test.ts tests/tooling/vscode-typescript-vue-plugin.test.ts`
- `moon run --target native - -- --check --base-ref main < tools/moon/scripts/source_file_lengths.mbtx`
- `vp run --workspace-root check:ci`
- `vp run --workspace-root package:vscode-extension`
- `vp run --workspace-root package:editor-extensions`