### PR TITLE
feat(musea): add Nuxt preview mocks

### DIFF
--- a/docs/content/integrations/nuxt.md
+++ b/docs/content/integrations/nuxt.md
@@ -201,16 +201,45 @@ component scanner so colocated legacy files do not reach Nuxt's webpack or Vite 
 
 ### Preview Setup for Nuxt
 
-Nuxt projects often use features that need to be mocked in the Musea preview environment (vue-i18n, NuxtLink, useNuxtApp, etc.):
+Nuxt projects often use features that need to be available in the Musea preview environment
+(`NuxtLink`, `useRoute`, `useNuxtApp`, `useRuntimeConfig`, data composables, and built-in Nuxt
+components). Use `@vizejs/musea-nuxt` in the standalone Musea Vite config and install its preview
+mock layer from `previewSetup`:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import { musea } from "@vizejs/vite-plugin-musea";
+import { nuxtMusea } from "@vizejs/musea-nuxt";
+
+export default defineConfig({
+  plugins: [
+    nuxtMusea({
+      route: { path: "/preview" },
+      runtimeConfig: { public: { apiBase: "/api" } },
+      fetchMocks: {
+        "/api/user": { id: 1, name: "Ada" },
+      },
+    }),
+    musea({
+      previewSetup: "musea.preview.ts",
+    }),
+  ],
+});
+```
 
 ```ts
 // musea.preview.ts
+import { installNuxtMuseaMocks } from "@vizejs/musea-nuxt";
 import { createI18n } from "vue-i18n";
-import { createRouter, createMemoryHistory } from "vue-router";
 import type { MuseaPreviewSetup } from "@vizejs/vite-plugin-musea";
 
 export default ((app) => {
-  // Mock vue-i18n
+  installNuxtMuseaMocks(app, {
+    route: { path: "/preview" },
+    runtimeConfig: { public: { apiBase: "/api" } },
+  });
+
   const i18n = createI18n({
     locale: "ja",
     messages: {
@@ -223,28 +252,6 @@ export default ((app) => {
     },
   });
   app.use(i18n);
-
-  // Mock vue-router (for NuxtLink compatibility)
-  const router = createRouter({
-    history: createMemoryHistory(),
-    routes: [
-      { path: "/", component: { template: "<div />" } },
-      { path: "/about", component: { template: "<div />" } },
-    ],
-  });
-  app.use(router);
-
-  // Register NuxtLink as RouterLink
-  app.component("NuxtLink", app.component("RouterLink"));
-
-  // Mock useNuxtApp if needed
-  app.provide("nuxt-app", {
-    $config: {
-      public: {
-        /* ... */
-      },
-    },
-  });
 }) satisfies MuseaPreviewSetup;
 ```
 

--- a/npm/framework/musea-nuxt/package.json
+++ b/npm/framework/musea-nuxt/package.json
@@ -38,6 +38,7 @@
   "scripts": {
     "build": "vp pack",
     "dev": "vp pack --watch",
+    "test": "pnpm build && node --test src/*.test.ts src/**/*.test.ts",
     "check": "vp check src vite.config.ts",
     "check:fix": "vp check --fix src vite.config.ts",
     "fmt": "vp fmt --write src vite.config.ts"

--- a/npm/framework/musea-nuxt/src/app.ts
+++ b/npm/framework/musea-nuxt/src/app.ts
@@ -1,0 +1,55 @@
+import type { App } from "vue";
+
+import {
+  ClientOnly,
+  NuxtClientFallback,
+  NuxtErrorBoundary,
+  NuxtImg,
+  NuxtIsland,
+  NuxtLayout,
+  NuxtLink,
+  NuxtLoadingIndicator,
+  NuxtPage,
+  NuxtPicture,
+  NuxtRouteAnnouncer,
+  NuxtWelcome,
+} from "./mocks/components.js";
+import { useRoute, useRouter } from "./mocks/composables.js";
+import { useNuxtApp, useRuntimeConfig } from "./mocks/runtime.js";
+import { configureNuxtMuseaMocks } from "./context.js";
+import type { NuxtMuseaOptions } from "./types.js";
+
+const builtInComponents = {
+  NuxtLink,
+  NuxtPage,
+  ClientOnly,
+  NuxtLayout,
+  NuxtLoadingIndicator,
+  NuxtErrorBoundary,
+  NuxtRouteAnnouncer,
+  NuxtWelcome,
+  NuxtIsland,
+  NuxtClientFallback,
+  NuxtImg,
+  NuxtPicture,
+};
+
+export function installNuxtMuseaMocks(app: App, options: NuxtMuseaOptions = {}): App {
+  configureNuxtMuseaMocks(options);
+
+  for (const [name, component] of Object.entries(builtInComponents)) {
+    app.component(name, component);
+  }
+
+  app.config.globalProperties.$config = useRuntimeConfig();
+  app.config.globalProperties.$route = useRoute();
+  app.config.globalProperties.$router = useRouter();
+  app.provide("nuxt-app", useNuxtApp());
+  return app;
+}
+
+export function createNuxtMuseaPreviewSetup(options: NuxtMuseaOptions = {}) {
+  return (app: App) => {
+    installNuxtMuseaMocks(app, options);
+  };
+}

--- a/npm/framework/musea-nuxt/src/auto-imports.ts
+++ b/npm/framework/musea-nuxt/src/auto-imports.ts
@@ -4,12 +4,33 @@
  */
 
 export { useRoute, useRouter } from "./mocks/composables.js";
-export { useFetch, useAsyncData, useLazyFetch, useLazyAsyncData } from "./mocks/data.js";
-export { navigateTo, abortNavigation, defineNuxtRouteMiddleware } from "./mocks/navigation.js";
+export {
+  useFetch,
+  useAsyncData,
+  useLazyFetch,
+  useLazyAsyncData,
+  useNuxtData,
+  refreshNuxtData,
+  clearNuxtData,
+  useRequestFetch,
+} from "./mocks/data.js";
+export {
+  navigateTo,
+  abortNavigation,
+  defineNuxtRouteMiddleware,
+  definePageMeta,
+  setPageLayout,
+  prefetchComponents,
+  preloadComponents,
+  preloadRouteComponents,
+} from "./mocks/navigation.js";
 export { useHead, useSeoMeta, useHeadSafe, useServerSeoMeta } from "./mocks/head.js";
+export { createError, showError, clearError, useError } from "./mocks/error.js";
 export {
   useNuxtApp,
   useRuntimeConfig,
+  useAppConfig,
+  updateAppConfig,
   useState,
   useRequestHeaders,
   useRequestEvent,
@@ -17,6 +38,11 @@ export {
   useCookie,
   clearNuxtState,
   defineNuxtPlugin,
+  defineNuxtComponent,
+  onNuxtReady,
+  callOnce,
+  useId,
+  reloadNuxtApp,
 } from "./mocks/runtime.js";
 
 // Re-export Vue core composables that Nuxt auto-imports

--- a/npm/framework/musea-nuxt/src/context.ts
+++ b/npm/framework/musea-nuxt/src/context.ts
@@ -1,0 +1,237 @@
+import { reactive, ref, type Ref } from "vue";
+
+import type {
+  NuxtMuseaNavigationTarget,
+  NuxtMuseaOptions,
+  NuxtMuseaRouteLocation,
+  NuxtMuseaRouteQueryValue,
+} from "./types.js";
+
+const DEFAULT_REQUEST_URL = "http://localhost:3000/";
+
+const routeState = reactive<NuxtMuseaRouteLocation>(createRoute({}));
+const runtimeConfigState = reactive<Record<string, unknown>>({ public: {} });
+const appConfigState = reactive<Record<string, unknown>>({});
+const requestState = reactive<{ url: string; headers: Record<string, string> }>({
+  url: DEFAULT_REQUEST_URL,
+  headers: {},
+});
+
+const stateRefs = new Map<string, Ref<unknown>>();
+const cookieRefs = new Map<string, Ref<unknown>>();
+const callOnceKeys = new Set<string>();
+const fetchMocksState: Record<string, unknown> = {};
+const errorRef = ref<Error | null>(null);
+let idCounter = 0;
+
+export function configureNuxtMuseaMocks(options: NuxtMuseaOptions = {}): void {
+  setRouteConfig(options.route ?? {});
+  setRuntimeConfig(options.runtimeConfig ?? {});
+  setAppConfig(options.appConfig ?? {});
+  setFetchMocks(options.fetchMocks ?? {});
+  setStateMocks(options.stateMocks ?? {});
+  setCookieMocks(options.cookieMocks ?? {});
+  setRequestConfig(options.request ?? {});
+}
+
+export function resetNuxtMuseaMocks(): void {
+  setRouteConfig({});
+  setRuntimeConfig({});
+  setAppConfig({});
+  setFetchMocks({});
+  setRequestConfig({});
+  stateRefs.clear();
+  cookieRefs.clear();
+  callOnceKeys.clear();
+  errorRef.value = null;
+  idCounter = 0;
+}
+
+export function getRouteState(): NuxtMuseaRouteLocation {
+  return routeState;
+}
+
+export function setRouteConfig(config: Partial<NuxtMuseaRouteLocation>): void {
+  Object.assign(routeState, createRoute(config));
+}
+
+export function resolveNavigationTarget(target: NuxtMuseaNavigationTarget): NuxtMuseaRouteLocation {
+  if (typeof target === "string") {
+    return createRoute({ path: target });
+  }
+
+  return createRoute({
+    path: target.path,
+    name: target.name ?? null,
+    params: target.params,
+    query: target.query,
+    hash: target.hash,
+    meta: typeof target.meta === "object" && target.meta != null ? target.meta : undefined,
+  });
+}
+
+export function getRuntimeConfigState(): Record<string, unknown> {
+  return runtimeConfigState;
+}
+
+export function setRuntimeConfig(config: NuxtMuseaOptions["runtimeConfig"]): void {
+  replaceRecord(runtimeConfigState, { public: {}, ...config });
+}
+
+export function getAppConfigState(): Record<string, unknown> {
+  return appConfigState;
+}
+
+export function setAppConfig(config: Record<string, unknown>): void {
+  replaceRecord(appConfigState, config);
+}
+
+export function updateAppConfigState(config: Record<string, unknown>): void {
+  Object.assign(appConfigState, config);
+}
+
+export function getFetchMocks(): Record<string, unknown> {
+  return fetchMocksState;
+}
+
+export function setFetchMocks(mocks: Record<string, unknown>): void {
+  replaceRecord(fetchMocksState, mocks);
+}
+
+export function getStateRef<T>(key: string, init?: () => T): Ref<T | undefined> {
+  const existing = stateRefs.get(key);
+  if (existing) {
+    return existing as Ref<T | undefined>;
+  }
+
+  const value = init ? init() : undefined;
+  const state = ref(value) as Ref<T | undefined>;
+  stateRefs.set(key, state as Ref<unknown>);
+  return state;
+}
+
+export function setStateMocks(mocks: Record<string, unknown>): void {
+  stateRefs.clear();
+  for (const [key, value] of Object.entries(mocks)) {
+    stateRefs.set(key, ref(value));
+  }
+}
+
+export function clearStateRefs(keys?: string | string[]): void {
+  if (keys == null) {
+    stateRefs.clear();
+    return;
+  }
+
+  for (const key of Array.isArray(keys) ? keys : [keys]) {
+    stateRefs.delete(key);
+  }
+}
+
+export function getCookieRef<T>(name: string, init?: () => T): Ref<T | undefined> {
+  const existing = cookieRefs.get(name);
+  if (existing) {
+    return existing as Ref<T | undefined>;
+  }
+
+  const value = init ? init() : undefined;
+  const cookie = ref(value) as Ref<T | undefined>;
+  cookieRefs.set(name, cookie as Ref<unknown>);
+  return cookie;
+}
+
+export function setCookieMocks(mocks: Record<string, unknown>): void {
+  cookieRefs.clear();
+  for (const [key, value] of Object.entries(mocks)) {
+    cookieRefs.set(key, ref(value));
+  }
+}
+
+export function getRequestState(): { url: string; headers: Record<string, string> } {
+  return requestState;
+}
+
+export function setRequestConfig(request: NonNullable<NuxtMuseaOptions["request"]>): void {
+  requestState.url = request.url ?? DEFAULT_REQUEST_URL;
+  requestState.headers = { ...request.headers };
+}
+
+export function getErrorRef(): Ref<Error | null> {
+  return errorRef;
+}
+
+export function setError(error: Error | null): void {
+  errorRef.value = error;
+}
+
+export function nextNuxtId(): string {
+  idCounter += 1;
+  return `musea-nuxt-${idCounter}`;
+}
+
+export async function runCallOnce<T>(
+  key: string,
+  fn: () => T | Promise<T>,
+): Promise<T | undefined> {
+  if (callOnceKeys.has(key)) {
+    return undefined;
+  }
+
+  callOnceKeys.add(key);
+  return await fn();
+}
+
+function createRoute(config: Partial<NuxtMuseaRouteLocation>): NuxtMuseaRouteLocation {
+  const path = config.path ?? "/";
+  const query = { ...config.query };
+  const hash = normalizeHash(config.hash ?? "");
+  return {
+    path,
+    name: config.name ?? inferRouteName(path),
+    params: { ...config.params },
+    query,
+    hash,
+    fullPath: config.fullPath ?? buildFullPath(path, query, hash),
+    meta: { ...config.meta },
+    matched: [...(config.matched ?? [])],
+    redirectedFrom: config.redirectedFrom,
+  };
+}
+
+function inferRouteName(path: string): string {
+  const normalized = path.replace(/^\/+|\/+$/g, "");
+  return normalized.length === 0 ? "index" : normalized.replace(/[^A-Za-z0-9_]+/g, "-");
+}
+
+function buildFullPath(
+  path: string,
+  query: Record<string, NuxtMuseaRouteQueryValue>,
+  hash: string,
+): string {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value == null) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        searchParams.append(key, item);
+      }
+      continue;
+    }
+    searchParams.set(key, value);
+  }
+
+  const search = searchParams.toString();
+  return `${path}${search ? `?${search}` : ""}${hash}`;
+}
+
+function normalizeHash(hash: string): string {
+  if (!hash) return "";
+  return hash.startsWith("#") ? hash : `#${hash}`;
+}
+
+function replaceRecord(target: Record<string, unknown>, value: Record<string, unknown>): void {
+  for (const key of Object.keys(target)) {
+    delete target[key];
+  }
+  Object.assign(target, value);
+}

--- a/npm/framework/musea-nuxt/src/index.ts
+++ b/npm/framework/musea-nuxt/src/index.ts
@@ -34,13 +34,57 @@ export function nuxtMusea(options: NuxtMuseaOptions = {}): Plugin {
 }
 
 export type { NuxtMuseaOptions } from "./types.js";
+export {
+  configureNuxtMuseaMocks,
+  resetNuxtMuseaMocks,
+  getRouteState,
+  getRuntimeConfigState,
+  getAppConfigState,
+} from "./context.js";
+export { installNuxtMuseaMocks, createNuxtMuseaPreviewSetup } from "./app.js";
 
 // Re-export mock composables for direct use
 export { useRoute, useRouter } from "./mocks/composables.js";
-export { useFetch, useAsyncData, useLazyFetch, useLazyAsyncData } from "./mocks/data.js";
-export { navigateTo, abortNavigation } from "./mocks/navigation.js";
-export { useHead, useSeoMeta } from "./mocks/head.js";
-export { useNuxtApp, useRuntimeConfig, useState, useCookie } from "./mocks/runtime.js";
+export {
+  useFetch,
+  useAsyncData,
+  useLazyFetch,
+  useLazyAsyncData,
+  useNuxtData,
+  refreshNuxtData,
+  clearNuxtData,
+  useRequestFetch,
+} from "./mocks/data.js";
+export {
+  navigateTo,
+  abortNavigation,
+  defineNuxtRouteMiddleware,
+  definePageMeta,
+  setPageLayout,
+  prefetchComponents,
+  preloadComponents,
+  preloadRouteComponents,
+} from "./mocks/navigation.js";
+export { useHead, useSeoMeta, useHeadSafe, useServerSeoMeta } from "./mocks/head.js";
+export { createError, showError, clearError, useError } from "./mocks/error.js";
+export {
+  useNuxtApp,
+  useRuntimeConfig,
+  useAppConfig,
+  updateAppConfig,
+  useState,
+  useRequestHeaders,
+  useRequestEvent,
+  useRequestURL,
+  useCookie,
+  clearNuxtState,
+  defineNuxtPlugin,
+  defineNuxtComponent,
+  onNuxtReady,
+  callOnce,
+  useId,
+  reloadNuxtApp,
+} from "./mocks/runtime.js";
 export {
   NuxtLink,
   NuxtPage,
@@ -48,4 +92,10 @@ export {
   NuxtLayout,
   NuxtLoadingIndicator,
   NuxtErrorBoundary,
+  NuxtRouteAnnouncer,
+  NuxtWelcome,
+  NuxtIsland,
+  NuxtClientFallback,
+  NuxtImg,
+  NuxtPicture,
 } from "./mocks/components.js";

--- a/npm/framework/musea-nuxt/src/mocks.test.ts
+++ b/npm/framework/musea-nuxt/src/mocks.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp, h } from "vue";
+
+type MuseaNuxtRuntime = typeof import("./index.ts");
+
+async function loadRuntime(): Promise<MuseaNuxtRuntime> {
+  return (await import(new URL("../dist/index.mjs", import.meta.url).href)) as MuseaNuxtRuntime;
+}
+
+void test("Nuxt Musea mocks configure route, runtime, app, state, cookie, and fetch data", async () => {
+  const {
+    configureNuxtMuseaMocks,
+    resetNuxtMuseaMocks,
+    useAppConfig,
+    useCookie,
+    useFetch,
+    useRequestHeaders,
+    useRequestURL,
+    useRoute,
+    useRuntimeConfig,
+    useState,
+  } = await loadRuntime();
+  resetNuxtMuseaMocks();
+  configureNuxtMuseaMocks({
+    route: {
+      path: "/users/42",
+      params: { id: "42" },
+      query: { tab: "profile" },
+      meta: { auth: true },
+    },
+    runtimeConfig: {
+      public: { apiBase: "/api" },
+      secret: "server-only",
+    },
+    appConfig: {
+      ui: { primary: "green" },
+    },
+    stateMocks: {
+      count: 3,
+    },
+    cookieMocks: {
+      session: "abc",
+    },
+    fetchMocks: {
+      "/api/users/42": { id: 42, name: "Ada" },
+    },
+    request: {
+      url: "https://example.test/stories",
+      headers: { "x-preview": "1" },
+    },
+  });
+
+  assert.equal(useRoute().fullPath, "/users/42?tab=profile");
+  assert.deepEqual(useRoute().params, { id: "42" });
+  assert.deepEqual(useRoute().meta, { auth: true });
+  assert.deepEqual(useRuntimeConfig(), {
+    public: { apiBase: "/api" },
+    secret: "server-only",
+  });
+  assert.deepEqual(useAppConfig(), { ui: { primary: "green" } });
+  assert.equal(useState<number>("count").value, 3);
+  assert.equal(useState<number>("count"), useState<number>("count"));
+  assert.equal(useCookie<string>("session").value, "abc");
+  assert.equal(useCookie<string>("session"), useCookie<string>("session"));
+  assert.deepEqual(useFetch<{ id: number; name: string }>("/api/users/42").data.value, {
+    id: 42,
+    name: "Ada",
+  });
+  assert.deepEqual(useRequestHeaders(), { "x-preview": "1" });
+  assert.equal(useRequestURL().href, "https://example.test/stories");
+});
+
+void test("navigation mocks mutate the shared route state", async () => {
+  const { navigateTo, resetNuxtMuseaMocks, useRoute, useRouter } = await loadRuntime();
+  resetNuxtMuseaMocks();
+
+  await navigateTo({ path: "/settings", query: { panel: "profile" }, hash: "top" });
+
+  assert.equal(useRoute().fullPath, "/settings?panel=profile#top");
+
+  await useRouter().push("/dashboard");
+
+  assert.equal(useRoute().path, "/dashboard");
+  assert.equal(
+    useRouter().resolve({ path: "/dashboard", query: { page: "1" } }).href,
+    "/dashboard?page=1",
+  );
+});
+
+void test("NuxtLink uses href as its navigation target when provided", async () => {
+  const { NuxtLink, resetNuxtMuseaMocks, useRoute } = await loadRuntime();
+  resetNuxtMuseaMocks();
+
+  const render = (
+    NuxtLink as unknown as {
+      setup: (
+        props: Record<string, unknown>,
+        context: { slots: Record<string, () => string> },
+      ) => () => { props: { onClick: (event: MouseEvent) => void; href: string } };
+    }
+  ).setup(
+    {
+      href: "/from-href",
+      to: "/from-to",
+      external: false,
+      replace: false,
+      custom: false,
+    },
+    { slots: { default: () => "link" } },
+  );
+  const vnode = render();
+  let prevented = false;
+
+  vnode.props.onClick({
+    preventDefault: () => {
+      prevented = true;
+    },
+  } as MouseEvent);
+
+  assert.equal(vnode.props.href, "/from-href");
+  assert.equal(prevented, true);
+  assert.equal(useRoute().path, "/from-href");
+});
+
+void test("runtime helpers keep app config and error state reactive", async () => {
+  const { clearError, resetNuxtMuseaMocks, showError, updateAppConfig, useAppConfig, useError } =
+    await loadRuntime();
+  resetNuxtMuseaMocks();
+
+  updateAppConfig({ theme: "dark" });
+  assert.equal(useAppConfig().theme, "dark");
+
+  const error = showError({ statusCode: 404, statusMessage: "Not found" });
+  assert.equal(useError().value, error);
+  assert.equal(useError().value?.message, "Not found");
+
+  await clearError();
+  assert.equal(useError().value, null);
+});
+
+void test("installNuxtMuseaMocks registers Nuxt built-ins and global properties", async () => {
+  const { installNuxtMuseaMocks, resetNuxtMuseaMocks } = await loadRuntime();
+  resetNuxtMuseaMocks();
+  const app = createApp({
+    render: () => h("div"),
+  });
+
+  installNuxtMuseaMocks(app, {
+    route: { path: "/preview" },
+    runtimeConfig: { public: { baseURL: "/mock" } },
+  });
+
+  assert.ok(app.component("NuxtLink"));
+  assert.ok(app.component("NuxtPage"));
+  assert.ok(app.component("ClientOnly"));
+  assert.equal(app.config.globalProperties.$route.path, "/preview");
+  assert.deepEqual(app.config.globalProperties.$config, { public: { baseURL: "/mock" } });
+});

--- a/npm/framework/musea-nuxt/src/mocks/components.ts
+++ b/npm/framework/musea-nuxt/src/mocks/components.ts
@@ -3,6 +3,12 @@
  */
 
 import { defineComponent, h } from "vue";
+import type { PropType } from "vue";
+
+import { resolveNavigationTarget } from "../context.js";
+import { navigateTo } from "./navigation.js";
+import { useRoute } from "./composables.js";
+import type { NuxtMuseaNavigationTarget } from "../types.js";
 
 /**
  * Mock NuxtLink - renders as <RouterLink> or <a>.
@@ -10,7 +16,7 @@ import { defineComponent, h } from "vue";
 export const NuxtLink = defineComponent({
   name: "NuxtLink",
   props: {
-    to: { type: [String, Object], default: "/" },
+    to: { type: [String, Object] as PropType<NuxtMuseaNavigationTarget>, default: "/" },
     href: { type: String, default: undefined },
     target: { type: String, default: undefined },
     rel: { type: String, default: undefined },
@@ -20,39 +26,39 @@ export const NuxtLink = defineComponent({
     noPrefetch: { type: Boolean, default: false },
     activeClass: { type: String, default: "router-link-active" },
     exactActiveClass: { type: String, default: "router-link-exact-active" },
+    custom: { type: Boolean, default: false },
   },
   setup(props, { slots }) {
     return () => {
-      const to = props.href || props.to;
-      if (props.external || (typeof to === "string" && to.startsWith("http"))) {
-        return h(
-          "a",
-          {
-            href: typeof to === "string" ? to : "/",
-            target: props.target,
-            rel: props.rel ?? (props.target === "_blank" ? "noopener noreferrer" : undefined),
-          },
-          slots.default?.(),
-        );
+      const target = props.href ?? props.to;
+      const href = typeof target === "string" ? target : routeTargetToHref(target);
+      const navigate = () => navigateTo(target, { replace: props.replace });
+
+      if (props.custom) {
+        return slots.default?.({
+          href,
+          navigate,
+          route: useRoute(),
+          isActive: false,
+          isExactActive: false,
+        });
       }
 
-      // Try to use RouterLink if available
-      try {
-        const { RouterLink } = require("vue-router");
-        return h(
-          RouterLink,
-          {
-            to,
-            replace: props.replace,
-            activeClass: props.activeClass,
-            exactActiveClass: props.exactActiveClass,
+      return h(
+        "a",
+        {
+          "data-nuxt-link": "",
+          href,
+          target: props.target,
+          rel: props.rel ?? (props.target === "_blank" ? "noopener noreferrer" : undefined),
+          onClick: (event: MouseEvent) => {
+            if (props.external || props.target === "_blank" || isExternalHref(href)) return;
+            event.preventDefault();
+            void navigate();
           },
-          slots,
-        );
-      } catch {
-        // Fallback to <a> if vue-router is not available
-        return h("a", { href: typeof to === "string" ? to : "/" }, slots.default?.());
-      }
+        },
+        slots.default?.(),
+      );
     };
   },
 });
@@ -73,12 +79,7 @@ export const NuxtPage = defineComponent({
       if (slots.default) {
         return slots.default();
       }
-      try {
-        const { RouterView } = require("vue-router");
-        return h(RouterView, { name: props.name });
-      } catch {
-        return h("div", { "data-nuxt-page": "" }, "NuxtPage placeholder");
-      }
+      return h("div", { "data-nuxt-page": props.name }, "NuxtPage placeholder");
     };
   },
 });
@@ -126,3 +127,78 @@ export const NuxtErrorBoundary = defineComponent({
     return () => slots.default?.() ?? null;
   },
 });
+
+export const NuxtRouteAnnouncer = defineComponent({
+  name: "NuxtRouteAnnouncer",
+  props: {
+    politeness: { type: String, default: "polite" },
+  },
+  setup(props) {
+    return () =>
+      h("span", {
+        "aria-live": props.politeness,
+        "data-nuxt-route-announcer": "",
+        style: "position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);",
+      });
+  },
+});
+
+export const NuxtWelcome = defineComponent({
+  name: "NuxtWelcome",
+  setup() {
+    return () => h("div", { "data-nuxt-welcome": "" }, "NuxtWelcome placeholder");
+  },
+});
+
+export const NuxtIsland = defineComponent({
+  name: "NuxtIsland",
+  setup(_props, { slots }) {
+    return () => slots.default?.() ?? null;
+  },
+});
+
+export const NuxtClientFallback = defineComponent({
+  name: "NuxtClientFallback",
+  setup(_props, { slots }) {
+    return () => slots.default?.() ?? slots.fallback?.() ?? null;
+  },
+});
+
+export const NuxtImg = defineComponent({
+  name: "NuxtImg",
+  props: {
+    src: { type: String, required: true },
+    alt: { type: String, default: "" },
+    width: { type: [String, Number], default: undefined },
+    height: { type: [String, Number], default: undefined },
+  },
+  setup(props, { attrs }) {
+    return () =>
+      h("img", {
+        ...attrs,
+        src: props.src,
+        alt: props.alt,
+        width: props.width,
+        height: props.height,
+      });
+  },
+});
+
+export const NuxtPicture = defineComponent({
+  name: "NuxtPicture",
+  props: {
+    src: { type: String, required: true },
+    alt: { type: String, default: "" },
+  },
+  setup(props, { attrs }) {
+    return () => h("picture", {}, [h("img", { ...attrs, src: props.src, alt: props.alt })]);
+  },
+});
+
+function routeTargetToHref(to: NuxtMuseaNavigationTarget): string {
+  return resolveNavigationTarget(to).fullPath;
+}
+
+function isExternalHref(href: string): boolean {
+  return /^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test(href);
+}

--- a/npm/framework/musea-nuxt/src/mocks/composables.ts
+++ b/npm/framework/musea-nuxt/src/mocks/composables.ts
@@ -2,45 +2,43 @@
  * Mock Nuxt routing composables.
  */
 
-import { reactive, computed } from "vue";
-import type { NuxtMuseaOptions } from "../types.js";
+import { computed } from "vue";
 
-let _routeConfig: NuxtMuseaOptions["route"] = {};
+import { getRouteState, resolveNavigationTarget, setRouteConfig } from "../context.js";
+import type { NuxtMuseaNavigationTarget } from "../types.js";
 
-export function _setRouteConfig(config: NuxtMuseaOptions["route"]): void {
-  _routeConfig = config;
-}
+export { setRouteConfig as _setRouteConfig };
 
 /**
  * Mock useRoute - returns a reactive route object.
  */
 export function useRoute() {
-  return reactive({
-    path: _routeConfig?.path ?? "/",
-    name: _routeConfig?.name ?? "index",
-    params: _routeConfig?.params ?? {},
-    query: _routeConfig?.query ?? {},
-    hash: _routeConfig?.hash ?? "",
-    fullPath: _routeConfig?.fullPath ?? _routeConfig?.path ?? "/",
-    meta: _routeConfig?.meta ?? {},
-    matched: [],
-    redirectedFrom: undefined,
-  });
+  return getRouteState();
 }
 
 /**
  * Mock useRouter - returns a router-like object with no-op navigation.
  */
 export function useRouter() {
+  const navigate = async (to: NuxtMuseaNavigationTarget) => {
+    setRouteConfig(resolveNavigationTarget(to));
+  };
+
   return {
-    push: async (_to: unknown) => {},
-    replace: async (_to: unknown) => {},
-    back: () => {},
-    forward: () => {},
-    go: (_delta: number) => {},
-    resolve: (to: unknown) => ({
-      href: typeof to === "string" ? to : "/",
-      route: useRoute(),
+    push: navigate,
+    replace: navigate,
+    back: () => {
+      // no browser history in isolated previews
+    },
+    forward: () => {
+      // no browser history in isolated previews
+    },
+    go: (_delta: number) => {
+      // no browser history in isolated previews
+    },
+    resolve: (to: NuxtMuseaNavigationTarget) => ({
+      href: resolveNavigationTarget(to).fullPath,
+      route: resolveNavigationTarget(to),
     }),
     currentRoute: computed(() => useRoute()),
     addRoute: () => () => {},

--- a/npm/framework/musea-nuxt/src/mocks/data.ts
+++ b/npm/framework/musea-nuxt/src/mocks/data.ts
@@ -2,52 +2,50 @@
  * Mock Nuxt data-fetching composables.
  */
 
-import { ref } from "vue";
+import { ref, toValue, type MaybeRefOrGetter, type Ref } from "vue";
 
-let _fetchMocks: Record<string, unknown> = {};
+import { getFetchMocks, setFetchMocks } from "../context.js";
 
-export function _setFetchMocks(mocks: Record<string, unknown>): void {
-  _fetchMocks = mocks;
-}
+export { setFetchMocks as _setFetchMocks };
 
-function findMockData(key: string): unknown {
+export function findMockData(key: string): unknown {
+  const fetchMocks = getFetchMocks();
   // Exact match first
-  if (key in _fetchMocks) return _fetchMocks[key];
+  if (key in fetchMocks) return fetchMocks[key];
   // Pattern match
-  for (const [pattern, data] of Object.entries(_fetchMocks)) {
+  for (const [pattern, data] of Object.entries(fetchMocks)) {
     if (key.includes(pattern)) return data;
   }
   return undefined;
 }
 
+interface AsyncDataOptions<T> {
+  default?: () => T;
+  lazy?: boolean;
+  immediate?: boolean;
+  transform?: (input: unknown) => T;
+  pick?: string[];
+}
+
 interface AsyncDataResult<T> {
-  data: ReturnType<typeof ref<T | null>>;
-  pending: ReturnType<typeof ref<boolean>>;
-  error: ReturnType<typeof ref<Error | null>>;
+  data: Ref<T | null>;
+  pending: Ref<boolean>;
+  error: Ref<Error | null>;
   refresh: () => Promise<void>;
   execute: () => Promise<void>;
-  status: ReturnType<typeof ref<string>>;
+  clear: () => void;
+  status: Ref<"idle" | "pending" | "success" | "error">;
 }
 
 /**
  * Mock useFetch - returns reactive data based on mock config.
  */
 export function useFetch<T = unknown>(
-  url: string | (() => string),
-  _opts?: Record<string, unknown>,
+  url: MaybeRefOrGetter<string | URL>,
+  opts?: AsyncDataOptions<T>,
 ): AsyncDataResult<T> {
-  const key = typeof url === "function" ? url() : url;
-  const mockData = findMockData(key);
-
-  const data = ref(mockData ?? null) as ReturnType<typeof ref<T | null>>;
-  const pending = ref(false);
-  const error = ref(null) as ReturnType<typeof ref<Error | null>>;
-  const status = ref("success");
-
-  const refresh = async () => {};
-  const execute = async () => {};
-
-  return { data, pending, error, refresh, execute, status };
+  const key = stringifyDataKey(toValue(url));
+  return createAsyncDataResult<T>(key, undefined, opts);
 }
 
 /**
@@ -55,28 +53,18 @@ export function useFetch<T = unknown>(
  */
 export function useAsyncData<T = unknown>(
   key: string,
-  _handler?: () => Promise<T>,
-  _opts?: Record<string, unknown>,
+  handler?: () => T | Promise<T>,
+  opts?: AsyncDataOptions<T>,
 ): AsyncDataResult<T> {
-  const mockData = findMockData(key);
-
-  const data = ref(mockData ?? null) as ReturnType<typeof ref<T | null>>;
-  const pending = ref(false);
-  const error = ref(null) as ReturnType<typeof ref<Error | null>>;
-  const status = ref("success");
-
-  const refresh = async () => {};
-  const execute = async () => {};
-
-  return { data, pending, error, refresh, execute, status };
+  return createAsyncDataResult<T>(key, handler, opts);
 }
 
 /**
  * Mock useLazyFetch - lazy variant of useFetch.
  */
 export function useLazyFetch<T = unknown>(
-  url: string | (() => string),
-  opts?: Record<string, unknown>,
+  url: MaybeRefOrGetter<string | URL>,
+  opts?: AsyncDataOptions<T>,
 ): AsyncDataResult<T> {
   return useFetch<T>(url, { ...opts, lazy: true });
 }
@@ -86,8 +74,105 @@ export function useLazyFetch<T = unknown>(
  */
 export function useLazyAsyncData<T = unknown>(
   key: string,
-  handler?: () => Promise<T>,
-  opts?: Record<string, unknown>,
+  handler?: () => T | Promise<T>,
+  opts?: AsyncDataOptions<T>,
 ): AsyncDataResult<T> {
   return useAsyncData<T>(key, handler, { ...opts, lazy: true });
+}
+
+export function refreshNuxtData(_keys?: string | string[]): Promise<void> {
+  return Promise.resolve();
+}
+
+export function clearNuxtData(_keys?: string | string[]): void {
+  // no-op: each mock result owns its local refs.
+}
+
+export function useNuxtData<T = unknown>(key: string): { data: Ref<T | null> } {
+  const mockData = findMockData(key);
+  return {
+    data: ref((mockData ?? null) as T | null),
+  };
+}
+
+export function useRequestFetch() {
+  return async <T = unknown>(url: string | URL): Promise<T> => {
+    const mockData = findMockData(stringifyDataKey(url));
+    return mockData as T;
+  };
+}
+
+function createAsyncDataResult<T>(
+  key: string,
+  handler: (() => T | Promise<T>) | undefined,
+  opts: AsyncDataOptions<T> = {},
+): AsyncDataResult<T> {
+  const initial = resolveInitialData<T>(key, opts);
+  const data = ref(initial) as Ref<T | null>;
+  const pending = ref(false);
+  const error = ref<Error | null>(null);
+  const status = ref<"idle" | "pending" | "success" | "error">(
+    initial == null ? "idle" : "success",
+  );
+
+  const execute = async () => {
+    pending.value = true;
+    status.value = "pending";
+    error.value = null;
+    try {
+      const mockData = findMockData(key);
+      const value = mockData !== undefined ? mockData : handler ? await handler() : data.value;
+      data.value = applyDataOptions(value, opts);
+      status.value = "success";
+    } catch (caught) {
+      error.value = caught instanceof Error ? caught : new Error(String(caught));
+      status.value = "error";
+    } finally {
+      pending.value = false;
+    }
+  };
+
+  if (opts.immediate !== false && opts.lazy !== true && initial == null && handler) {
+    void execute();
+  }
+
+  return {
+    data,
+    pending,
+    error,
+    refresh: execute,
+    execute,
+    clear: () => {
+      data.value = null;
+      error.value = null;
+      pending.value = false;
+      status.value = "idle";
+    },
+    status,
+  };
+}
+
+function resolveInitialData<T>(key: string, opts: AsyncDataOptions<T>): T | null {
+  const mockData = findMockData(key);
+  if (mockData !== undefined) {
+    return applyDataOptions(mockData, opts);
+  }
+  return opts.default ? opts.default() : null;
+}
+
+function applyDataOptions<T>(value: unknown, opts: AsyncDataOptions<T>): T {
+  const transformed = opts.transform ? opts.transform(value) : value;
+  if (!opts.pick || typeof transformed !== "object" || transformed == null) {
+    return transformed as T;
+  }
+
+  const picked: Record<string, unknown> = {};
+  for (const key of opts.pick) {
+    picked[key] = (transformed as Record<string, unknown>)[key];
+  }
+  return picked as T;
+}
+
+function stringifyDataKey(value: string | URL): string {
+  return typeof value === "string" ? value : value.toString();
 }

--- a/npm/framework/musea-nuxt/src/mocks/error.ts
+++ b/npm/framework/musea-nuxt/src/mocks/error.ts
@@ -1,0 +1,33 @@
+import { getErrorRef, setError } from "../context.js";
+
+export interface NuxtError extends Error {
+  data?: unknown;
+  fatal?: boolean;
+  statusCode?: number;
+  statusMessage?: string;
+}
+
+export function createError(input: string | Partial<NuxtError>): NuxtError {
+  const message =
+    typeof input === "string" ? input : (input.message ?? input.statusMessage ?? "Error");
+  const error = new Error(message) as NuxtError;
+  if (typeof input === "object") {
+    Object.assign(error, input);
+  }
+  return error;
+}
+
+export function showError(input: string | Partial<NuxtError>): NuxtError {
+  const error = createError(input);
+  setError(error);
+  return error;
+}
+
+export function clearError(_options?: { redirect?: string }): Promise<void> {
+  setError(null);
+  return Promise.resolve();
+}
+
+export function useError() {
+  return getErrorRef();
+}

--- a/npm/framework/musea-nuxt/src/mocks/head.ts
+++ b/npm/framework/musea-nuxt/src/mocks/head.ts
@@ -3,30 +3,46 @@
  * All are no-ops in the gallery context.
  */
 
+interface HeadEntry {
+  dispose: () => void;
+  patch: (_input: Record<string, unknown>) => void;
+  pause: () => void;
+  resume: () => void;
+}
+
+function createHeadEntry(): HeadEntry {
+  return {
+    dispose: () => {},
+    patch: (_input: Record<string, unknown>) => {},
+    pause: () => {},
+    resume: () => {},
+  };
+}
+
 /**
  * Mock useHead - no-op.
  */
-export function useHead(_input: Record<string, unknown>): void {
-  // no-op in gallery context
+export function useHead(_input: Record<string, unknown>): HeadEntry {
+  return createHeadEntry();
 }
 
 /**
  * Mock useSeoMeta - no-op.
  */
-export function useSeoMeta(_input: Record<string, unknown>): void {
-  // no-op in gallery context
+export function useSeoMeta(_input: Record<string, unknown>): HeadEntry {
+  return createHeadEntry();
 }
 
 /**
  * Mock useHeadSafe - no-op.
  */
-export function useHeadSafe(_input: Record<string, unknown>): void {
-  // no-op in gallery context
+export function useHeadSafe(_input: Record<string, unknown>): HeadEntry {
+  return createHeadEntry();
 }
 
 /**
  * Mock useServerSeoMeta - no-op.
  */
-export function useServerSeoMeta(_input: Record<string, unknown>): void {
-  // no-op in gallery context
+export function useServerSeoMeta(_input: Record<string, unknown>): HeadEntry {
+  return createHeadEntry();
 }

--- a/npm/framework/musea-nuxt/src/mocks/navigation.ts
+++ b/npm/framework/musea-nuxt/src/mocks/navigation.ts
@@ -2,13 +2,17 @@
  * Mock Nuxt navigation utilities.
  */
 
+import { setRouteConfig, resolveNavigationTarget } from "../context.js";
+import type { NuxtMuseaNavigationTarget } from "../types.js";
+
 /**
- * Mock navigateTo - no-op in gallery context.
+ * Mock navigateTo - updates the shared route state in gallery context.
  */
 export function navigateTo(
-  _to: string | Record<string, unknown>,
+  to: NuxtMuseaNavigationTarget,
   _opts?: { replace?: boolean; redirectCode?: number; external?: boolean },
 ): Promise<void> {
+  setRouteConfig(resolveNavigationTarget(to));
   return Promise.resolve();
 }
 
@@ -24,4 +28,30 @@ export function abortNavigation(_err?: string | Error): void {
  */
 export function defineNuxtRouteMiddleware(middleware: unknown): unknown {
   return middleware;
+}
+
+/**
+ * Mock definePageMeta - page metadata is handled by Nuxt at build time.
+ */
+export function definePageMeta(_meta: Record<string, unknown>): void {
+  // no-op
+}
+
+/**
+ * Mock setPageLayout - no layout switching in isolated previews.
+ */
+export function setPageLayout(_layout: string | false): void {
+  // no-op
+}
+
+export function prefetchComponents(_to: NuxtMuseaNavigationTarget): Promise<void> {
+  return Promise.resolve();
+}
+
+export function preloadComponents(_to: NuxtMuseaNavigationTarget): Promise<void> {
+  return Promise.resolve();
+}
+
+export function preloadRouteComponents(_to: NuxtMuseaNavigationTarget): Promise<void> {
+  return Promise.resolve();
 }

--- a/npm/framework/musea-nuxt/src/mocks/runtime.ts
+++ b/npm/framework/musea-nuxt/src/mocks/runtime.ts
@@ -2,30 +2,34 @@
  * Mock Nuxt runtime composables.
  */
 
-import { reactive, ref } from "vue";
+import { reactive } from "vue";
 import type { Ref } from "vue";
-import type { NuxtMuseaOptions } from "../types.js";
 
-let _runtimeConfig: NuxtMuseaOptions["runtimeConfig"] = {};
-let _stateMocks: Record<string, unknown> = {};
+import {
+  getAppConfigState,
+  getCookieRef,
+  getRequestState,
+  getRuntimeConfigState,
+  getStateRef,
+  nextNuxtId,
+  runCallOnce,
+  setRuntimeConfig,
+  setStateMocks,
+  clearStateRefs,
+  updateAppConfigState,
+} from "../context.js";
+import { useRoute, useRouter } from "./composables.js";
 
-export function _setRuntimeConfig(config: NuxtMuseaOptions["runtimeConfig"]): void {
-  _runtimeConfig = config;
-}
-
-export function _setStateMocks(mocks: Record<string, unknown>): void {
-  _stateMocks = mocks;
-}
+export { setRuntimeConfig as _setRuntimeConfig, setStateMocks as _setStateMocks };
 
 /**
  * Mock useNuxtApp - returns a minimal Nuxt app-like object.
  */
 export function useNuxtApp() {
   return {
-    $config: reactive({
-      public: _runtimeConfig?.public ?? {},
-      ..._runtimeConfig,
-    }),
+    $config: useRuntimeConfig(),
+    $router: useRouter(),
+    $route: useRoute(),
     provide: (_name: string, _value: unknown) => {},
     hook: (_name: string, _fn: (...args: unknown[]) => void) => {},
     callHook: async (_name: string, ..._args: unknown[]) => {},
@@ -40,27 +44,29 @@ export function useNuxtApp() {
  * Mock useRuntimeConfig - returns the configured runtime config.
  */
 export function useRuntimeConfig() {
-  return reactive({
-    public: _runtimeConfig?.public ?? {},
-    ..._runtimeConfig,
-  });
+  return getRuntimeConfigState();
+}
+
+export function useAppConfig() {
+  return getAppConfigState();
+}
+
+export function updateAppConfig(config: Record<string, unknown>): void {
+  updateAppConfigState(config);
 }
 
 /**
  * Mock useState - returns a ref initialized from mock config or init function.
  */
 export function useState<T = unknown>(key: string, init?: () => T): Ref<T | undefined> {
-  if (key in _stateMocks) {
-    return ref(_stateMocks[key] as T);
-  }
-  return ref(init ? init() : undefined) as Ref<T | undefined>;
+  return getStateRef(key, init);
 }
 
 /**
  * Mock useRequestHeaders - returns empty headers in gallery context.
  */
 export function useRequestHeaders(_include?: string[]): Record<string, string> {
-  return {};
+  return { ...getRequestState().headers };
 }
 
 /**
@@ -77,25 +83,24 @@ export function useRequestURL(): URL {
   if (typeof window !== "undefined") {
     return new URL(window.location.href);
   }
-  return new URL("http://localhost:3000");
+  return new URL(getRequestState().url);
 }
 
 /**
  * Mock useCookie - returns a ref-like cookie mock.
  */
 export function useCookie<T = unknown>(
-  _name: string,
-  _opts?: Record<string, unknown>,
+  name: string,
+  opts?: { default?: () => T },
 ): Ref<T | undefined> {
-  const value = ref<T | undefined>(undefined);
-  return value;
+  return getCookieRef(name, opts?.default);
 }
 
 /**
  * Mock clearNuxtState - no-op.
  */
-export function clearNuxtState(_keys?: string | string[]): void {
-  // no-op
+export function clearNuxtState(keys?: string | string[]): void {
+  clearStateRefs(keys);
 }
 
 /**
@@ -103,4 +108,34 @@ export function clearNuxtState(_keys?: string | string[]): void {
  */
 export function defineNuxtPlugin(plugin: unknown): unknown {
   return plugin;
+}
+
+export function defineNuxtComponent<T>(component: T): T {
+  return component;
+}
+
+export function onNuxtReady(callback: () => void): void {
+  if (typeof queueMicrotask === "function") {
+    queueMicrotask(callback);
+    return;
+  }
+  void Promise.resolve().then(callback);
+}
+
+export function callOnce<T>(
+  keyOrFn: string | (() => T | Promise<T>),
+  fn?: () => T | Promise<T>,
+): Promise<T | undefined> {
+  if (typeof keyOrFn === "function") {
+    return runCallOnce("__default__", keyOrFn);
+  }
+  return runCallOnce(keyOrFn, fn ?? (() => undefined as T));
+}
+
+export function useId(): string {
+  return nextNuxtId();
+}
+
+export function reloadNuxtApp(_options?: Record<string, unknown>): Promise<void> {
+  return Promise.resolve();
 }

--- a/npm/framework/musea-nuxt/src/plugin.test.ts
+++ b/npm/framework/musea-nuxt/src/plugin.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+
+type MuseaNuxtRuntime = typeof import("./index.ts");
+
+async function loadRuntime(): Promise<MuseaNuxtRuntime> {
+  return (await import(new URL("../dist/index.mjs", import.meta.url).href)) as MuseaNuxtRuntime;
+}
+
+void test("Nuxt Musea plugin resolves Nuxt virtual imports to mock modules", async () => {
+  const { nuxtMusea } = await loadRuntime();
+  const plugin = nuxtMusea({
+    route: { path: "/mock" },
+    runtimeConfig: { public: { apiBase: "/api" } },
+    stateMocks: { ready: true },
+  });
+  assert.equal(plugin.name, "vite-plugin-musea-nuxt");
+  assert.equal(typeof plugin.resolveId, "function");
+  assert.equal(typeof plugin.load, "function");
+
+  const importsId = await plugin.resolveId.call(null, "#imports", undefined, {
+    assertions: {},
+    custom: {},
+    isEntry: false,
+    ssr: false,
+  });
+  assert.equal(importsId, "\0musea-nuxt:imports");
+
+  const importsCode = await plugin.load.call(null, importsId, { ssr: false });
+  assert.equal(typeof importsCode, "string");
+  assert.match(importsCode, /export \* from '.+auto-imports\.js';/);
+  assert.match(importsCode, /configureNuxtMuseaMocks\(_config\);/);
+  assert.match(importsCode, /"path":"\/mock"/);
+  assert.match(importsCode, /"ready":true/);
+
+  const appSubpathId = await plugin.resolveId.call(null, "#app/composables/router", undefined, {
+    assertions: {},
+    custom: {},
+    isEntry: false,
+    ssr: false,
+  });
+  assert.equal(appSubpathId, "\0musea-nuxt:imports");
+});
+
+void test("Nuxt Musea plugin exposes built-in component mocks through #components", async () => {
+  const { nuxtMusea } = await loadRuntime();
+  const plugin = nuxtMusea();
+  assert.equal(typeof plugin.resolveId, "function");
+  assert.equal(typeof plugin.load, "function");
+
+  const componentsId = await plugin.resolveId.call(null, "#components", undefined, {
+    assertions: {},
+    custom: {},
+    isEntry: false,
+    ssr: false,
+  });
+  assert.equal(componentsId, "\0musea-nuxt:components");
+
+  const buildComponentsId = await plugin.resolveId.call(null, "#build/components", undefined, {
+    assertions: {},
+    custom: {},
+    isEntry: false,
+    ssr: false,
+  });
+  assert.equal(buildComponentsId, "\0musea-nuxt:components");
+
+  const componentsCode = await plugin.load.call(null, componentsId, { ssr: false });
+  assert.equal(typeof componentsCode, "string");
+  for (const exportName of [
+    "NuxtLink",
+    "NuxtPage",
+    "ClientOnly",
+    "NuxtRouteAnnouncer",
+    "NuxtImg",
+  ]) {
+    assert.match(componentsCode, new RegExp(`\\b${exportName}\\b`));
+  }
+});
+
+void test("Nuxt component mocks stay ESM-only", () => {
+  const source = fs.readFileSync(path.join(import.meta.dirname, "mocks/components.ts"), "utf-8");
+
+  assert.doesNotMatch(source, /\brequire\s*\(/);
+});

--- a/npm/framework/musea-nuxt/src/plugin.ts
+++ b/npm/framework/musea-nuxt/src/plugin.ts
@@ -8,8 +8,13 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const VIRTUAL_IMPORTS_ID = "\0musea-nuxt:imports";
-const VIRTUAL_IMPORTS_MODULE = "#imports";
 const VIRTUAL_NUXT_COMPONENTS_ID = "\0musea-nuxt:components";
+const NUXT_IMPORT_IDS = new Set(["#imports", "#app", "#build", "nuxt/app"]);
+const NUXT_COMPONENT_IDS = new Set([
+  "#components",
+  "#build/components",
+  "nuxt/dist/app/components",
+]);
 
 export function createNuxtMuseaPlugin(options: NuxtMuseaOptions = {}): Plugin {
   const srcDir = path.dirname(fileURLToPath(import.meta.url));
@@ -18,30 +23,15 @@ export function createNuxtMuseaPlugin(options: NuxtMuseaOptions = {}): Plugin {
     name: "vite-plugin-musea-nuxt",
     enforce: "pre",
 
-    config() {
-      return {
-        resolve: {
-          alias: {
-            // Resolve #imports to our auto-imports module
-            "#imports": VIRTUAL_IMPORTS_MODULE,
-            // Resolve #app to our auto-imports (subset)
-            "#app": VIRTUAL_IMPORTS_MODULE,
-            // Resolve #build to empty module
-            "#build": VIRTUAL_IMPORTS_MODULE,
-          },
-        },
-      };
-    },
-
     resolveId(id) {
-      // Resolve #imports and related aliases
-      if (id === VIRTUAL_IMPORTS_MODULE || id === "#imports" || id === "#app" || id === "#build") {
-        return VIRTUAL_IMPORTS_ID;
+      // Resolve Nuxt component imports before the broad #build/* import alias.
+      if (NUXT_COMPONENT_IDS.has(id)) {
+        return VIRTUAL_NUXT_COMPONENTS_ID;
       }
 
-      // Resolve Nuxt component imports
-      if (id === "#components" || id === "nuxt/dist/app/components") {
-        return VIRTUAL_NUXT_COMPONENTS_ID;
+      // Resolve #imports and related aliases
+      if (NUXT_IMPORT_IDS.has(id) || id.startsWith("#app/") || id.startsWith("#build/")) {
+        return VIRTUAL_IMPORTS_ID;
       }
 
       return null;
@@ -58,27 +48,6 @@ export function createNuxtMuseaPlugin(options: NuxtMuseaOptions = {}): Plugin {
 
       return null;
     },
-
-    transform(code, id) {
-      // Auto-resolve Nuxt global components in Vue SFC templates
-      if (id.endsWith(".vue") || id.endsWith(".art.vue")) {
-        // Replace <NuxtLink> with mock component import
-        if (code.includes("<NuxtLink") || code.includes("<nuxt-link")) {
-          // Check if NuxtLink is already imported
-          if (!code.includes("NuxtLink")) {
-            const importLine = `import { NuxtLink } from '${VIRTUAL_IMPORTS_MODULE}';\n`;
-            // Insert import after last import statement or at the top
-            const lastImportIdx = code.lastIndexOf("import ");
-            if (lastImportIdx !== -1) {
-              const lineEnd = code.indexOf("\n", lastImportIdx);
-              code = code.slice(0, lineEnd + 1) + importLine + code.slice(lineEnd + 1);
-            }
-          }
-        }
-      }
-
-      return code;
-    },
   };
 }
 
@@ -91,15 +60,10 @@ function generateImportsModule(srcDir: string, options: NuxtMuseaOptions): strin
 export * from '${autoImportsPath}';
 
 // Configure mocks with provided options
-import { _setRouteConfig } from '${path.join(srcDir, "mocks", "composables.js").replace(/\\/g, "/")}';
-import { _setFetchMocks } from '${path.join(srcDir, "mocks", "data.js").replace(/\\/g, "/")}';
-import { _setRuntimeConfig, _setStateMocks } from '${path.join(srcDir, "mocks", "runtime.js").replace(/\\/g, "/")}';
+import { configureNuxtMuseaMocks } from '${path.join(srcDir, "context.js").replace(/\\/g, "/")}';
 
 const _config = ${configJson};
-_setRouteConfig(_config.route);
-_setFetchMocks(_config.fetchMocks ?? {});
-_setRuntimeConfig(_config.runtimeConfig);
-_setStateMocks(_config.stateMocks ?? {});
+configureNuxtMuseaMocks(_config);
 `;
 }
 
@@ -115,6 +79,12 @@ export {
   NuxtLayout,
   NuxtLoadingIndicator,
   NuxtErrorBoundary,
+  NuxtRouteAnnouncer,
+  NuxtWelcome,
+  NuxtIsland,
+  NuxtClientFallback,
+  NuxtImg,
+  NuxtPicture,
 } from '${componentsPath}';
 `;
 }

--- a/npm/framework/musea-nuxt/src/types.ts
+++ b/npm/framework/musea-nuxt/src/types.ts
@@ -1,19 +1,37 @@
 /**
  * NuxtMusea plugin options.
  */
+export type NuxtMuseaRouteQueryValue = string | string[] | null | undefined;
+
+export interface NuxtMuseaRouteLocation {
+  path: string;
+  name: string | null;
+  params: Record<string, string | string[]>;
+  query: Record<string, NuxtMuseaRouteQueryValue>;
+  hash: string;
+  fullPath: string;
+  meta: Record<string, unknown>;
+  matched: unknown[];
+  redirectedFrom?: unknown;
+}
+
+export type NuxtMuseaNavigationTarget =
+  | string
+  | {
+      path?: string;
+      name?: string;
+      params?: Record<string, string | string[]>;
+      query?: Record<string, NuxtMuseaRouteQueryValue>;
+      hash?: string;
+      replace?: boolean;
+      [key: string]: unknown;
+    };
+
 export interface NuxtMuseaOptions {
   /**
    * Mock route data.
    */
-  route?: {
-    path?: string;
-    name?: string;
-    params?: Record<string, string>;
-    query?: Record<string, string>;
-    hash?: string;
-    fullPath?: string;
-    meta?: Record<string, unknown>;
-  };
+  route?: Partial<NuxtMuseaRouteLocation>;
 
   /**
    * Mock runtime config.
@@ -34,4 +52,23 @@ export interface NuxtMuseaOptions {
    * Key is the state key, value is the initial state.
    */
   stateMocks?: Record<string, unknown>;
+
+  /**
+   * Mock useCookie initial values.
+   * Key is the cookie name, value is the initial cookie value.
+   */
+  cookieMocks?: Record<string, unknown>;
+
+  /**
+   * Mock app config exposed through useAppConfig().
+   */
+  appConfig?: Record<string, unknown>;
+
+  /**
+   * Request information exposed by server-oriented composables.
+   */
+  request?: {
+    url?: string;
+    headers?: Record<string, string>;
+  };
 }


### PR DESCRIPTION
## Summary

- Add a shared mock context for Nuxt route, runtime config, app config, state, cookies, request data, fetch data, and errors.
- Expose Nuxt built-in component and composable mocks through the Musea Nuxt Vite plugin, including `#imports`, `#app/*`, `#components`, and Nuxt component aliases.
- Document the Nuxt preview setup with `@vizejs/musea-nuxt` and add focused package tests for runtime mocks and plugin resolution.

## Validation

- `vp run --filter './npm/framework/musea-nuxt' fmt`
- `vp run --filter './npm/framework/musea-nuxt' check`
- `vp run --filter './npm/framework/musea-nuxt' test`
- `vp run --workspace-root test:js`
- `vp run --workspace-root test:scripts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->