### PR TITLE
fix(musea): respect spacing token units

### DIFF
--- a/npm/builder/vite-musea/gallery/components/tokens/SpacingPreview.vue
+++ b/npm/builder/vite-musea/gallery/components/tokens/SpacingPreview.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { cssLengthToPx } from "../../../src/tokens/css-length.js";
 
 const props = defineProps<{
   value: string | number;
 }>();
 
 const numericValue = computed(() => {
-  if (typeof props.value === "number") return props.value;
-  const parsed = parseFloat(props.value);
-  return isNaN(parsed) ? 0 : parsed;
+  return cssLengthToPx(props.value) ?? 0;
 });
 
 const label = computed(() => {

--- a/npm/builder/vite-musea/src/tokens/css-length.test.ts
+++ b/npm/builder/vite-musea/src/tokens/css-length.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { cssLengthToPx } from "./css-length.js";
+
+void test("cssLengthToPx converts common CSS length units for previews", () => {
+  assert.equal(cssLengthToPx(12), 12);
+  assert.equal(cssLengthToPx("12px"), 12);
+  assert.equal(cssLengthToPx("1.5rem"), 24);
+  assert.equal(cssLengthToPx("4em"), 64);
+  assert.equal(cssLengthToPx("var(--space)"), null);
+});

--- a/npm/builder/vite-musea/src/tokens/css-length.ts
+++ b/npm/builder/vite-musea/src/tokens/css-length.ts
@@ -1,0 +1,20 @@
+export function cssLengthToPx(value: string | number, baseFontSize = 16): number | null {
+  if (typeof value === "number") return value;
+
+  const match = value.trim().match(/^(-?(?:\d+|\d*\.\d+))([a-z%]*)$/i);
+  if (!match) return null;
+
+  const amount = Number.parseFloat(match[1]);
+  if (!Number.isFinite(amount)) return null;
+
+  switch (match[2]?.toLowerCase()) {
+    case "":
+    case "px":
+      return amount;
+    case "rem":
+    case "em":
+      return amount * baseFontSize;
+    default:
+      return amount;
+  }
+}


### PR DESCRIPTION
## Summary
- convert spacing preview CSS lengths to pixel values before sizing bars
- cover px, rem, em, numeric, and unsupported values with a focused unit test

Closes #2455

## Validation
- vp exec tsx --test src/tokens/css-length.test.ts src/tokens/preview.test.ts
- vp build --config gallery-vite.config.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785500427&installation_id=136613492&pr_number=2464&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2464&signature=260bc6bbec6bf4238b99a786ee7f9df40603d02220720c0a221dc608db1bd54e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->