### PR TITLE
fix(musea): stabilize design token order

### DIFF
--- a/npm/builder/vite-musea/src/tokens.test.ts
+++ b/npm/builder/vite-musea/src/tokens.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { generateTokensHtml } from "./tokens/generator.ts";
+import { normalizeCategories } from "./tokens/native.ts";
 import { parseTokens } from "./tokens/parser.ts";
 import {
   buildTokenMap,
@@ -89,6 +90,30 @@ void test("token parsing keeps prototype-like token names as data", async () => 
   } finally {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   }
+});
+
+void test("normalizeCategories orders tokens by attributes.order and name", () => {
+  const categories = normalizeCategories([
+    {
+      name: "color",
+      tokens: {
+        tertiary: { value: "#333", type: "color", attributes: { order: 30 } },
+        secondary: { value: "#222", type: "color", attributes: { order: "20" } },
+        neutral: { value: "#999", type: "color" },
+        primary: { value: "#111", type: "color", attributes: { order: 10 } },
+        accent: { value: "#f0f", type: "color" },
+      },
+    },
+  ]);
+
+  assert.deepEqual(Object.keys(categories[0]!.tokens), [
+    "primary",
+    "secondary",
+    "tertiary",
+    "accent",
+    "neutral",
+  ]);
+  assert.equal(Object.getPrototypeOf(categories[0]!.tokens), null);
 });
 
 void test("parseTokens reads Tailwind CSS theme variables", async () => {

--- a/npm/builder/vite-musea/src/tokens/native.ts
+++ b/npm/builder/vite-musea/src/tokens/native.ts
@@ -86,12 +86,39 @@ function parseJsonResult<T>(value: unknown): T {
 
 export function normalizeCategories(categories: TokenCategory[]): TokenCategory[] {
   for (const category of categories) {
-    category.tokens = nullRecord(category.tokens);
+    category.tokens = nullRecord(Object.fromEntries(sortTokenEntries(category.tokens)));
     if (category.subcategories) {
       normalizeCategories(category.subcategories);
     }
   }
   return categories;
+}
+
+function sortTokenEntries(tokens: Record<string, DesignToken>): Array<[string, DesignToken]> {
+  return Object.entries(tokens).sort((a, b) => {
+    const order = compareTokenOrder(a[1], b[1]);
+    if (order !== 0) return order;
+    return a[0].localeCompare(b[0], undefined, { numeric: true });
+  });
+}
+
+function compareTokenOrder(a: DesignToken, b: DesignToken): number {
+  const aOrder = tokenOrder(a);
+  const bOrder = tokenOrder(b);
+  if (aOrder === undefined && bOrder === undefined) return 0;
+  if (aOrder === undefined) return 1;
+  if (bOrder === undefined) return -1;
+  return aOrder - bOrder;
+}
+
+function tokenOrder(token: DesignToken): number | undefined {
+  const order = token.attributes?.order;
+  if (typeof order === "number" && Number.isFinite(order)) return order;
+  if (typeof order === "string") {
+    const parsed = Number(order);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
 }
 
 export function nullRecord<T>(record: Record<string, T>): Record<string, T> {


### PR DESCRIPTION
## Summary
- sort design tokens during category normalization
- honor numeric attributes.order before falling back to stable token-name order
- preserve null-prototype token records after sorting

Closes #2456

## Validation
- vp exec tsx --test src/tokens.test.ts src/tokens/preview.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785500487&installation_id=136613492&pr_number=2465&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2465&signature=ca713f25f48aa111729315563357f07ec982258113756fd1bcaa0d422396d39b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->