### PR TITLE
fix(musea): sort gallery arts by order

### DIFF
--- a/npm/builder/vite-musea/src/api-routes/arts-order.test.ts
+++ b/npm/builder/vite-musea/src/api-routes/arts-order.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import test from "node:test";
+import type { ResolvedConfig } from "vite";
+
+import { createApiMiddleware, type ApiRoutesContext } from "./index.js";
+import type { ArtFileInfo } from "../types/index.js";
+
+function art(title: string, order?: number): ArtFileInfo {
+  const pathname = `/repo/${title}.art.vue`;
+  return {
+    path: pathname,
+    metadata: { title, tags: [], status: "ready", order },
+    variants: [],
+    hasScriptSetup: false,
+    hasScript: false,
+    styleCount: 0,
+  };
+}
+
+async function fetchArts(artFiles: Map<string, ArtFileInfo>): Promise<ArtFileInfo[]> {
+  const ctx: ApiRoutesContext = {
+    config: { root: process.cwd() } as ResolvedConfig,
+    artFiles,
+    scanRoots: [process.cwd()],
+    tokensPath: undefined,
+    basePath: "/__musea__",
+    resolvedPreviewCss: [],
+    resolvedPreviewSetup: null,
+    devSessionToken: "test-session",
+    processArtFile: async () => {},
+    getDevServerPort: () => 5173,
+  };
+
+  return await new Promise((resolve, reject) => {
+    const req = Readable.from([]) as IncomingMessage;
+    req.method = "GET";
+    req.url = "/arts";
+    req.headers = {};
+
+    const res = {
+      statusCode: 200,
+      setHeader() {},
+      end(chunk?: Buffer | string) {
+        resolve(JSON.parse(String(chunk)) as ArtFileInfo[]);
+      },
+    } as unknown as ServerResponse;
+
+    Promise.resolve(
+      createApiMiddleware(ctx)(req, res, () => reject(new Error("next called"))),
+    ).catch(reject);
+  });
+}
+
+void test("arts API returns entries sorted by defineArt order", async () => {
+  const high = art("High", 30);
+  const fallback = art("Fallback");
+  const low = art("Low", 10);
+
+  const arts = await fetchArts(
+    new Map([
+      [high.path, high],
+      [fallback.path, fallback],
+      [low.path, low],
+    ]),
+  );
+
+  assert.deepEqual(
+    arts.map((item) => item.metadata.title),
+    ["Low", "High", "Fallback"],
+  );
+});

--- a/npm/builder/vite-musea/src/api-routes/index.test.ts
+++ b/npm/builder/vite-musea/src/api-routes/index.test.ts
@@ -117,38 +117,6 @@ void test("createApiMiddleware returns 400 for malformed encoded art paths", asy
   assert.match(response.body, /art path is not valid URL encoding/);
 });
 
-void test("createApiMiddleware returns arts sorted by defineArt order", async () => {
-  const low = createArt("/repo/Low.art.vue");
-  low.metadata.title = "Low";
-  low.metadata.order = 10;
-  const high = createArt("/repo/High.art.vue");
-  high.metadata.title = "High";
-  high.metadata.order = 30;
-  const fallback = createArt("/repo/Fallback.art.vue");
-  fallback.metadata.title = "Fallback";
-
-  const response = await invokeApi(
-    createContext(
-      process.cwd(),
-      new Map([
-        [high.path, high],
-        [fallback.path, fallback],
-        [low.path, low],
-      ]),
-    ),
-    {
-      method: "GET",
-      url: "/arts",
-    },
-  );
-
-  assert.equal(response.statusCode, 200);
-  assert.deepEqual(
-    (JSON.parse(response.body) as ArtFileInfo[]).map((art) => art.metadata.title),
-    ["Low", "High", "Fallback"],
-  );
-});
-
 void test("createApiMiddleware blocks source writes outside the configured root", async () => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-api-security-"));
   const root = path.join(tempDir, "root");

--- a/npm/builder/vite-musea/src/api-routes/index.test.ts
+++ b/npm/builder/vite-musea/src/api-routes/index.test.ts
@@ -117,6 +117,38 @@ void test("createApiMiddleware returns 400 for malformed encoded art paths", asy
   assert.match(response.body, /art path is not valid URL encoding/);
 });
 
+void test("createApiMiddleware returns arts sorted by defineArt order", async () => {
+  const low = createArt("/repo/Low.art.vue");
+  low.metadata.title = "Low";
+  low.metadata.order = 10;
+  const high = createArt("/repo/High.art.vue");
+  high.metadata.title = "High";
+  high.metadata.order = 30;
+  const fallback = createArt("/repo/Fallback.art.vue");
+  fallback.metadata.title = "Fallback";
+
+  const response = await invokeApi(
+    createContext(
+      process.cwd(),
+      new Map([
+        [high.path, high],
+        [fallback.path, fallback],
+        [low.path, low],
+      ]),
+    ),
+    {
+      method: "GET",
+      url: "/arts",
+    },
+  );
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(
+    (JSON.parse(response.body) as ArtFileInfo[]).map((art) => art.metadata.title),
+    ["Low", "High", "Fallback"],
+  );
+});
+
 void test("createApiMiddleware blocks source writes outside the configured root", async () => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-api-security-"));
   const root = path.join(tempDir, "root");

--- a/npm/builder/vite-musea/src/api-routes/index.ts
+++ b/npm/builder/vite-musea/src/api-routes/index.ts
@@ -15,6 +15,7 @@ import type { ResolvedConfig } from "vite";
 import fs from "node:fs";
 
 import type { ArtFileInfo } from "../types/index.js";
+import { sortedArts } from "../art-order.js";
 import {
   handleTokensUsage,
   handleTokensGet,
@@ -100,7 +101,7 @@ export function createApiMiddleware(ctx: ApiRoutesContext) {
 
       // --- GET /api/arts ---
       if (url === "/arts" && req.method === "GET") {
-        sendJson(Array.from(ctx.artFiles.values()));
+        sendJson(sortedArts(ctx.artFiles.values()));
         return;
       }
 

--- a/npm/builder/vite-musea/src/art-order.test.ts
+++ b/npm/builder/vite-musea/src/art-order.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sortedArts } from "./art-order.js";
+import type { ArtFileInfo } from "./types/index.js";
+
+function art(title: string, order?: number): ArtFileInfo {
+  return {
+    path: `/repo/${title}.art.vue`,
+    metadata: { title, tags: [], status: "ready", order },
+    variants: [],
+    hasScriptSetup: false,
+    hasScript: false,
+    styleCount: 0,
+  };
+}
+
+void test("sortedArts orders by metadata order before title", () => {
+  const arts = sortedArts([art("Tertiary", 30), art("Neutral"), art("Primary", 10), art("Alpha")]);
+
+  assert.deepEqual(
+    arts.map((item) => item.metadata.title),
+    ["Primary", "Tertiary", "Alpha", "Neutral"],
+  );
+});

--- a/npm/builder/vite-musea/src/art-order.ts
+++ b/npm/builder/vite-musea/src/art-order.ts
@@ -1,0 +1,22 @@
+import type { ArtFileInfo } from "./types/index.js";
+
+export function sortedArts(arts: Iterable<ArtFileInfo>): ArtFileInfo[] {
+  return [...arts].sort(compareArtFiles);
+}
+
+export function compareArtFiles(a: ArtFileInfo, b: ArtFileInfo): number {
+  const order = compareOrder(a.metadata.order, b.metadata.order);
+  if (order !== 0) return order;
+
+  const title = a.metadata.title.localeCompare(b.metadata.title, undefined, { numeric: true });
+  if (title !== 0) return title;
+
+  return a.path.localeCompare(b.path, undefined, { numeric: true });
+}
+
+function compareOrder(a: number | undefined, b: number | undefined): number {
+  if (a === undefined && b === undefined) return 0;
+  if (a === undefined) return 1;
+  if (b === undefined) return -1;
+  return a - b;
+}

--- a/npm/builder/vite-musea/src/manifest.ts
+++ b/npm/builder/vite-musea/src/manifest.ts
@@ -6,11 +6,12 @@
  */
 
 import type { ArtFileInfo } from "./types/index.js";
+import { sortedArts } from "./art-order.js";
 
 /**
  * Generate the virtual manifest module code containing all art file metadata.
  */
 export function generateManifestModule(artFiles: Map<string, ArtFileInfo>): string {
-  const arts = Array.from(artFiles.values());
+  const arts = sortedArts(artFiles.values());
   return `export const arts = ${JSON.stringify(arts, null, 2)};`;
 }

--- a/npm/builder/vite-musea/src/static-data.ts
+++ b/npm/builder/vite-musea/src/static-data.ts
@@ -10,6 +10,7 @@ import {
   handleArtPalette,
   handleArtSource,
 } from "./api-routes/handlers.js";
+import { sortedArts } from "./art-order.js";
 import type { ApiRoutesContext, SendError, SendJson } from "./api-routes/index.js";
 import type { ArtFileInfo } from "./types/index.js";
 
@@ -68,7 +69,7 @@ export async function createStaticGalleryPayload(
   ctx: StaticGalleryDataContext,
 ): Promise<StaticGalleryPayload> {
   const apiCtx = createApiContext(ctx);
-  const arts = Array.from(ctx.artFiles.values());
+  const arts = sortedArts(ctx.artFiles.values());
   const previews: StaticGalleryPayload["previews"] = {};
   const details: StaticGalleryPayload["details"] = {};
 


### PR DESCRIPTION
## Summary
- add a shared art ordering helper for Musea gallery payloads
- honor defineArt metadata.order before falling back to title/path order
- return sorted arts from API, static payloads, and virtual manifest modules

Closes #2458

## Validation
- vp exec tsx --test src/art-order.test.ts src/api-routes/index.test.ts src/static-export.test.ts
- vp check src vite.config.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785500548&installation_id=136613492&pr_number=2466&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2466&signature=5db10382566b8c8f1376fcb04d4d4649854291a49362b598d37a034842c618ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->