### PR TITLE
fix(musea): preview letter spacing tokens

### DIFF
--- a/npm/builder/vite-musea/gallery/components/tokens/TokenPreview.vue
+++ b/npm/builder/vite-musea/gallery/components/tokens/TokenPreview.vue
@@ -94,6 +94,11 @@ function zLevel(input: string | number): number {
         :value="value"
         token-type="lineHeight"
       />
+      <TypographyPreview
+        v-else-if="preview.kind === 'letterSpacing'"
+        :value="value"
+        token-type="letterSpacing"
+      />
       <div
         v-else-if="preview.kind === 'shadow'"
         class="shadow-swatch"

--- a/npm/builder/vite-musea/gallery/components/tokens/TypographyPreview.vue
+++ b/npm/builder/vite-musea/gallery/components/tokens/TypographyPreview.vue
@@ -3,7 +3,7 @@ import { computed } from "vue";
 
 const props = defineProps<{
   value: string | number;
-  tokenType: "fontSize" | "fontWeight" | "lineHeight";
+  tokenType: "fontSize" | "fontWeight" | "lineHeight" | "letterSpacing";
 }>();
 
 const style = computed(() => {
@@ -18,12 +18,23 @@ const style = computed(() => {
       return { fontWeight: val };
     case "lineHeight":
       return { lineHeight: val };
+    case "letterSpacing":
+      return { letterSpacing: cssLength(val) };
     default:
       return {};
   }
 });
 
 const isLineHeight = computed(() => props.tokenType === "lineHeight");
+
+function cssLength(value: string): string {
+  if (value === "0") return value;
+  return /^-?(?:\d+|\d*\.\d+)(?:px|rem|em|ch|ex|lh|rlh|vw|vh|vmin|vmax|cm|mm|q|in|pc|pt)$/i.test(
+    value,
+  )
+    ? value
+    : `${value}px`;
+}
 </script>
 
 <template>

--- a/npm/builder/vite-musea/src/tokens/preview.test.ts
+++ b/npm/builder/vite-musea/src/tokens/preview.test.ts
@@ -30,12 +30,13 @@ void test("token preview uses referenced token metadata and resolved value", () 
   });
 });
 
-void test("token preview includes default spacing, opacity, radius, and z-index previews", () => {
+void test("token preview includes default spacing, opacity, radius, z-index, and letter-spacing previews", () => {
   const cases: Array<[string, DesignToken, string]> = [
     ["spacing.4", { value: "1rem", type: "dimension" }, "spacing"],
     ["opacity.disabled", { value: 0.48 }, "opacity"],
     ["shape.round.full", { value: "9999px", type: "dimension" }, "radius"],
     ["zIndex.modal", { value: 1000 }, "zIndex"],
+    ["typography.tracking.tight", { value: "-0.02em", type: "letter-spacing" }, "letterSpacing"],
   ];
 
   for (const [tokenPath, token, expectedKind] of cases) {

--- a/npm/builder/vite-musea/src/tokens/preview.ts
+++ b/npm/builder/vite-musea/src/tokens/preview.ts
@@ -6,6 +6,7 @@ export type MuseaTokenPreviewKind =
   | "fontSize"
   | "fontWeight"
   | "lineHeight"
+  | "letterSpacing"
   | "shadow"
   | "radius"
   | "opacity"
@@ -163,6 +164,12 @@ function inferPreviewKind(
     hasSignal(candidates, ["border-radius", "borderradius", "radius", "round", "rounded"])
   ) {
     return "radius";
+  }
+  if (
+    hasType(candidates, ["letterspacing", "letter-spacing"]) ||
+    hasSignal(candidates, ["letter-spacing", "letterspacing", "tracking"])
+  ) {
+    return "letterSpacing";
   }
   if (
     hasType(candidates, ["spacing", "space"]) ||


### PR DESCRIPTION
## Summary
- add a letterSpacing token preview kind
- infer letter-spacing/tracking tokens before the generic spacing heuristic
- render letter-spacing tokens with the typography preview sample

Closes #2459

## Validation
- vp exec tsx --test src/tokens/preview.test.ts
- vp build --config gallery-vite.config.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785500613&installation_id=136613492&pr_number=2467&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2467&signature=82fe63652f2b0db169c49a44527618ecb0a0db1bccbf66b2cb6e38a1e7271d71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->