### PR TITLE
fix(musea): preserve art script setup

### DIFF
--- a/npm/builder/vite-musea/src/art-module.test.ts
+++ b/npm/builder/vite-musea/src/art-module.test.ts
@@ -109,6 +109,72 @@ const count = ref(0)
   assert.doesNotMatch(code, /return \{ Button,/);
 });
 
+void test("generateArtModule does not register local PascalCase constants as components", () => {
+  const art: ArtFileInfo = {
+    path: "/repo/components/Foo.art.vue",
+    metadata: {
+      title: "Foo",
+      tags: [],
+      status: "ready",
+    },
+    variants: [
+      {
+        name: "Default",
+        template: `<Foo />`,
+        isDefault: true,
+        skipVrt: false,
+      },
+    ],
+    hasScriptSetup: true,
+    scriptSetupContent: `
+defineArt("./Foo.vue", { title: "Foo" });
+const SAMPLE = "hello";
+`.trim(),
+    hasScript: false,
+    styleCount: 0,
+  };
+
+  const code = generateArtModule(art, art.path);
+
+  assert.match(code, /components: \{ "Foo": Foo \}/);
+  assert.doesNotMatch(code, /"SAMPLE": SAMPLE/);
+  assert.match(code, /return \{ SAMPLE \};/);
+});
+
+void test("generateArtModule preserves multiline template literal indentation in script setup", () => {
+  const art: ArtFileInfo = {
+    path: "/repo/components/Markdown.art.vue",
+    metadata: {
+      title: "Markdown",
+      tags: [],
+      status: "ready",
+    },
+    variants: [
+      {
+        name: "Default",
+        template: `<MarkdownView :content="md" />`,
+        isDefault: true,
+        skipVrt: false,
+      },
+    ],
+    hasScriptSetup: true,
+    scriptSetupContent: [
+      `defineArt("./MarkdownView.vue", { title: "Markdown" });`,
+      "const md = `# Title",
+      "",
+      "- a",
+      "- b`;",
+    ].join("\n"),
+    hasScript: false,
+    styleCount: 0,
+  };
+
+  const code = generateArtModule(art, art.path);
+
+  assert.ok(code.includes("const md = `# Title\n\n- a\n- b`;"));
+  assert.doesNotMatch(code, /`# Title\n    \n    - a\n    - b`/);
+});
+
 void test("parseScriptSetupForArt infers defineArt component source literals", () => {
   const parsed = parseScriptSetupForArt(
     `

--- a/npm/builder/vite-musea/src/art-module.ts
+++ b/npm/builder/vite-musea/src/art-module.ts
@@ -113,11 +113,7 @@ function splitTopLevelCommaList(source: string): string[] {
   return parts;
 }
 
-function collectImportedNames(
-  statement: string,
-  returnNames: Set<string>,
-  componentNames?: Set<string>,
-): void {
+function collectImportedNames(statement: string, returnNames: Set<string>): void {
   const normalized = statement.replace(/\s+/g, " ").trim().replace(/;$/, "");
   const fromMatch = normalized.match(/^import\s+(type\s+)?(.+?)\s+from\s+['"][^'"]+['"]$/);
 
@@ -138,10 +134,8 @@ function collectImportedNames(
     const namespaceMatch = defaultOrNamespace.match(/^\*\s+as\s+([A-Za-z_$][\w$]*)$/);
     if (namespaceMatch) {
       returnNames.add(namespaceMatch[1]);
-      addComponentName(namespaceMatch[1], componentNames);
     } else if (!defaultOrNamespace.startsWith("type ")) {
       returnNames.add(defaultOrNamespace);
-      addComponentName(defaultOrNamespace, componentNames);
     }
   }
 
@@ -168,14 +162,7 @@ function collectImportedNames(
       ?.trim();
     if (alias) {
       returnNames.add(alias);
-      addComponentName(alias, componentNames);
     }
-  }
-}
-
-function addComponentName(name: string, componentNames: Set<string> | undefined): void {
-  if (componentNames && /^[A-Z]/.test(name)) {
-    componentNames.add(name);
   }
 }
 
@@ -319,7 +306,6 @@ export function parseScriptSetupForArt(content: string): {
   imports: string[];
   setupBody: string[];
   returnNames: string[];
-  componentNames: string[];
   defineArtComponentName?: string;
   defineArtComponentSource?: string;
 } {
@@ -327,7 +313,6 @@ export function parseScriptSetupForArt(content: string): {
   const imports: string[] = [];
   const setupBody: string[] = [];
   const returnNames: Set<string> = new Set();
-  const componentNames: Set<string> = new Set();
   let currentImport: string[] | null = null;
   const defineArtComponent = extractDefineArtComponent(content);
   let defineArtBalance = 0;
@@ -345,7 +330,7 @@ export function parseScriptSetupForArt(content: string): {
       const statement = currentImport.join("\n");
       if (isCompleteImportStatement(statement)) {
         imports.push(statement);
-        collectImportedNames(statement, returnNames, componentNames);
+        collectImportedNames(statement, returnNames);
         currentImport = null;
       }
       continue;
@@ -356,7 +341,7 @@ export function parseScriptSetupForArt(content: string): {
       const statement = currentImport.join("\n");
       if (isCompleteImportStatement(statement)) {
         imports.push(statement);
-        collectImportedNames(statement, returnNames, componentNames);
+        collectImportedNames(statement, returnNames);
         currentImport = null;
       }
       continue;
@@ -373,7 +358,7 @@ export function parseScriptSetupForArt(content: string): {
   if (currentImport) {
     const statement = currentImport.join("\n");
     imports.push(statement);
-    collectImportedNames(statement, returnNames, componentNames);
+    collectImportedNames(statement, returnNames);
   }
 
   collectTopLevelReturnNames(setupBody, returnNames);
@@ -388,7 +373,6 @@ export function parseScriptSetupForArt(content: string): {
     imports,
     setupBody,
     returnNames: [...returnNames],
-    componentNames: [...componentNames],
     defineArtComponentName: defineArtComponent.name,
     defineArtComponentSource: defineArtComponent.source,
   };
@@ -546,9 +530,9 @@ ${scriptSetup.setupBody.join("\n")}
     const componentNames = new Map<string, string>();
     if (componentTagName) componentNames.set(componentTagName, componentBindingName);
     if (scriptSetup) {
-      for (const name of scriptSetup.componentNames) {
-        componentNames.set(name, name);
-      }
+      for (const name of scriptSetup.returnNames)
+        if (/^[A-Z]/.test(name) && scriptSetup.imports.some((imp) => importDeclaresName(imp, name)))
+          componentNames.set(name, name);
     }
     const components =
       componentNames.size > 0

--- a/npm/builder/vite-musea/src/art-module.ts
+++ b/npm/builder/vite-musea/src/art-module.ts
@@ -113,7 +113,11 @@ function splitTopLevelCommaList(source: string): string[] {
   return parts;
 }
 
-function collectImportedNames(statement: string, returnNames: Set<string>): void {
+function collectImportedNames(
+  statement: string,
+  returnNames: Set<string>,
+  componentNames?: Set<string>,
+): void {
   const normalized = statement.replace(/\s+/g, " ").trim().replace(/;$/, "");
   const fromMatch = normalized.match(/^import\s+(type\s+)?(.+?)\s+from\s+['"][^'"]+['"]$/);
 
@@ -134,8 +138,10 @@ function collectImportedNames(statement: string, returnNames: Set<string>): void
     const namespaceMatch = defaultOrNamespace.match(/^\*\s+as\s+([A-Za-z_$][\w$]*)$/);
     if (namespaceMatch) {
       returnNames.add(namespaceMatch[1]);
+      addComponentName(namespaceMatch[1], componentNames);
     } else if (!defaultOrNamespace.startsWith("type ")) {
       returnNames.add(defaultOrNamespace);
+      addComponentName(defaultOrNamespace, componentNames);
     }
   }
 
@@ -162,7 +168,14 @@ function collectImportedNames(statement: string, returnNames: Set<string>): void
       ?.trim();
     if (alias) {
       returnNames.add(alias);
+      addComponentName(alias, componentNames);
     }
+  }
+}
+
+function addComponentName(name: string, componentNames: Set<string> | undefined): void {
+  if (componentNames && /^[A-Z]/.test(name)) {
+    componentNames.add(name);
   }
 }
 
@@ -306,6 +319,7 @@ export function parseScriptSetupForArt(content: string): {
   imports: string[];
   setupBody: string[];
   returnNames: string[];
+  componentNames: string[];
   defineArtComponentName?: string;
   defineArtComponentSource?: string;
 } {
@@ -313,6 +327,7 @@ export function parseScriptSetupForArt(content: string): {
   const imports: string[] = [];
   const setupBody: string[] = [];
   const returnNames: Set<string> = new Set();
+  const componentNames: Set<string> = new Set();
   let currentImport: string[] | null = null;
   const defineArtComponent = extractDefineArtComponent(content);
   let defineArtBalance = 0;
@@ -330,7 +345,7 @@ export function parseScriptSetupForArt(content: string): {
       const statement = currentImport.join("\n");
       if (isCompleteImportStatement(statement)) {
         imports.push(statement);
-        collectImportedNames(statement, returnNames);
+        collectImportedNames(statement, returnNames, componentNames);
         currentImport = null;
       }
       continue;
@@ -341,7 +356,7 @@ export function parseScriptSetupForArt(content: string): {
       const statement = currentImport.join("\n");
       if (isCompleteImportStatement(statement)) {
         imports.push(statement);
-        collectImportedNames(statement, returnNames);
+        collectImportedNames(statement, returnNames, componentNames);
         currentImport = null;
       }
       continue;
@@ -358,7 +373,7 @@ export function parseScriptSetupForArt(content: string): {
   if (currentImport) {
     const statement = currentImport.join("\n");
     imports.push(statement);
-    collectImportedNames(statement, returnNames);
+    collectImportedNames(statement, returnNames, componentNames);
   }
 
   collectTopLevelReturnNames(setupBody, returnNames);
@@ -373,6 +388,7 @@ export function parseScriptSetupForArt(content: string): {
     imports,
     setupBody,
     returnNames: [...returnNames],
+    componentNames: [...componentNames],
     defineArtComponentName: defineArtComponent.name,
     defineArtComponentSource: defineArtComponent.source,
   };
@@ -497,7 +513,7 @@ export const __styles__ = ${JSON.stringify(art.styleBlocks ?? [])};
   if (scriptSetup && hasSetup && !isolatedSetup) {
     code += `
 const __museaSharedSetup = (() => {
-${scriptSetup.setupBody.map((l) => `  ${l}`).join("\n")}
+${scriptSetup.setupBody.join("\n")}
   return ${setupReturn};
 })();
 `;
@@ -530,9 +546,8 @@ ${scriptSetup.setupBody.map((l) => `  ${l}`).join("\n")}
     const componentNames = new Map<string, string>();
     if (componentTagName) componentNames.set(componentTagName, componentBindingName);
     if (scriptSetup) {
-      for (const name of scriptSetup.returnNames) {
-        // PascalCase names starting with uppercase are likely components
-        if (/^[A-Z]/.test(name)) componentNames.set(name, name);
+      for (const name of scriptSetup.componentNames) {
+        componentNames.set(name, name);
       }
     }
     const components =
@@ -548,7 +563,7 @@ ${scriptSetup.setupBody.map((l) => `  ${l}`).join("\n")}
 export const ${variantComponentName} = defineComponent({
   name: '${variantComponentName}',
 ${components}  setup() {
-${scriptSetup.setupBody.map((l) => `    ${l}`).join("\n")}
+${scriptSetup.setupBody.join("\n")}
     return ${setupReturn};
   },
   template: \`${fullTemplate}\`,


### PR DESCRIPTION
## Summary
- avoid registering local PascalCase setup constants as variant components
- keep imported PascalCase bindings available in the components option
- preserve script setup body text when generating variant setup functions so multiline template literals are not re-indented

Closes #2457
Closes #2463

## Validation
- vp exec tsx --test src/art-module.test.ts
- vp check src vite.config.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785500692&installation_id=136613492&pr_number=2468&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2468&signature=0058f6b57053c88ef3c85b5206cac58a07492812b0b7504cfd44d0c0d7370d40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->