### PR TITLE
fix: stabilize app e2e gates

### DIFF
--- a/crates/vize/src/commands/check/runner/resolve.rs
+++ b/crates/vize/src/commands/check/runner/resolve.rs
@@ -56,7 +56,10 @@ pub(super) fn resolve_project_root(
             .parent()
             .map(|parent| parent.to_path_buf())
             .unwrap_or_else(|| cwd.to_path_buf());
-        if files.is_empty() || project_root_has_package_boundary(&tsconfig_dir) {
+        if files.is_empty()
+            || (project_root_has_package_boundary(&tsconfig_dir)
+                && !has_source_input_outside_root(&tsconfig_dir, files))
+        {
             return tsconfig_dir;
         }
 
@@ -118,6 +121,22 @@ pub(super) fn explicit_input_root(project_root: &Path, cwd: &Path) -> PathBuf {
 
 pub(super) fn project_root_has_package_boundary(project_root: &Path) -> bool {
     project_root.join("package.json").is_file()
+}
+
+fn has_source_input_outside_root(root: &Path, files: &[PathBuf]) -> bool {
+    files.iter().any(|file| {
+        !path_has_component(file, "node_modules")
+            && !is_declaration_file(file)
+            && !file.starts_with(root)
+    })
+}
+
+fn is_declaration_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            name.ends_with(".d.ts") || name.ends_with(".d.mts") || name.ends_with(".d.cts")
+        })
 }
 
 pub(super) fn exit_if_inputs_outside_root(root: &Path, files: &[PathBuf], enabled: bool) {
@@ -287,6 +306,31 @@ mod tests {
         );
 
         assert_eq!(resolved, package_root);
+        let _ = std::fs::remove_dir_all(&workspace);
+    }
+
+    #[test]
+    fn explicit_tsconfig_with_package_boundary_widens_for_source_inputs_outside_package() {
+        let workspace = unique_case_dir("package-boundary-source-outside");
+        let _ = std::fs::remove_dir_all(&workspace);
+        let package_root = workspace.join("packages/primevue");
+        let sibling_root = workspace.join("packages/icons");
+        std::fs::create_dir_all(package_root.join("src")).unwrap();
+        std::fs::create_dir_all(sibling_root.join("src")).unwrap();
+        std::fs::write(package_root.join("package.json"), "{}").unwrap();
+        std::fs::write(package_root.join("tsconfig.json"), "{}").unwrap();
+        let app = package_root.join("src/Button.vue");
+        let sibling = sibling_root.join("src/Icon.vue");
+        std::fs::write(&app, "").unwrap();
+        std::fs::write(&sibling, "").unwrap();
+
+        let resolved = resolve_project_root(
+            Some(Path::new("packages/primevue/tsconfig.json")),
+            &workspace,
+            &[app, sibling],
+        );
+
+        assert_eq!(resolved, workspace.join("packages"));
         let _ = std::fs::remove_dir_all(&workspace);
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
               };
               coreSrc = pkgs.fetchurl {
                 url = "https://cli.moonbitlang.com/cores/core-latest.tar.gz";
-                hash = "sha256-LMOHyw9HPsEBp+BnOAAUnIhHgSFkRfBgTtXx4RDPc+o=";
+                hash = "sha256-b8JYDhPvsLfeZq891FMoQYclpQhduaRF1Y1V/nk8TUU=";
               };
               nativeBuildInputs = lib.optionals pkgs.stdenv.isLinux [ pkgs.patchelf ];
               dontUnpack = true;

--- a/tests/_helpers/nuxtRuntime.ts
+++ b/tests/_helpers/nuxtRuntime.ts
@@ -1,0 +1,76 @@
+import type { Page } from "@playwright/test";
+
+export async function disableViteHmrClient(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const global = globalThis as typeof globalThis & {
+      [key: string]: unknown;
+      process?: { env?: Record<string, string>; test?: boolean };
+    };
+    const defineGlobal = (key: string, value: unknown) => {
+      Object.defineProperty(global, key, { configurable: true, value, writable: true });
+    };
+
+    global.process ??= {};
+    global.process.env ??= {};
+    global.process.test = true;
+    for (const [key, value] of Object.entries({
+      __DEFAULT_COOKIE_KEY__: "i18n_redirected",
+      __DEFAULT_DIRECTION__: "ltr",
+      __DIFFERENT_DOMAINS__: false,
+      __DYNAMIC_PARAMS_KEY__: "__nuxt_i18n_params",
+      __I18N_CACHE__: false,
+      __I18N_CACHE_LIFETIME__: 3_600,
+      __I18N_FULL_STATIC__: false,
+      __I18N_HASH__: "dev",
+      __I18N_PRELOAD__: false,
+      __I18N_ROUTING__: false,
+      __I18N_SERVER_REDIRECT__: false,
+      __I18N_STRATEGY__: "no_prefix",
+      __I18N_STRICT_SEO__: false,
+      __I18N_STRIP_UNUSED__: false,
+      __IS_SSG__: false,
+      __IS_SSR__: false,
+      __MULTI_DOMAIN_LOCALES__: false,
+      __NUXT_ASYNC_CONTEXT__: false,
+      __NUXT_I18N_VERSION__: "10.1.0",
+      __NUXT_VERSION__: "4.1.2",
+      __PARALLEL_PLUGIN__: false,
+      __ROUTE_NAME_DEFAULT_SUFFIX__: "default",
+      __ROUTE_NAME_SEPARATOR__: "___",
+      __SWITCH_LOCALE_PATH_LINK_IDENTIFIER__: "nuxt-i18n-slp",
+      __TRAILING_SLASH__: false,
+      __VUE_OPTIONS_API__: true,
+      __VUE_PROD_DEVTOOLS__: false,
+      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
+    })) {
+      defineGlobal(key, value);
+    }
+  });
+  await page.route("**/_nuxt/@vite/client", (route) =>
+    route.fulfill({
+      body: [
+        "const noop = () => {};",
+        "const hotContext = {",
+        "  accept: noop,",
+        "  acceptExports: noop,",
+        "  data: {},",
+        "  decline: noop,",
+        "  dispose: noop,",
+        "  invalidate: noop,",
+        "  off: noop,",
+        "  on: noop,",
+        "  prune: noop,",
+        "  send: noop,",
+        "};",
+        "export const createHotContext = () => hotContext;",
+        "export const injectQuery = (url) => url;",
+        "export const removeStyle = noop;",
+        "export const updateStyle = noop;",
+        "export default {};",
+        "",
+      ].join("\n"),
+      contentType: "text/javascript",
+      status: 200,
+    }),
+  );
+}

--- a/tests/app/dev/elk.spec.ts
+++ b/tests/app/dev/elk.spec.ts
@@ -3,6 +3,7 @@ import type { ChildProcess } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { elkApp, SCREENSHOT_DIR } from "../../_helpers/apps";
+import { disableViteHmrClient } from "../../_helpers/nuxtRuntime";
 import {
   waitForServerReady,
   startDevServer,
@@ -47,6 +48,7 @@ test.describe("elk dev", () => {
     await waitForHttpReady(app.url, app.port);
     const warmupPage = await browser.newPage();
     try {
+      await disableViteHmrClient(warmupPage);
       await warmupPage.goto(app.url, {
         waitUntil: app.waitUntil ?? "networkidle",
         timeout: 30_000,
@@ -56,6 +58,10 @@ test.describe("elk dev", () => {
       await warmupPage.close();
     }
     console.log(`${app.name} server is ready`);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await disableViteHmrClient(page);
   });
 
   test.afterAll(async () => {

--- a/tests/app/vrt/elk.spec.ts
+++ b/tests/app/vrt/elk.spec.ts
@@ -3,6 +3,7 @@ import type { ChildProcess } from "node:child_process";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createElkVisualParityApps, type AppConfig } from "../../_helpers/apps";
+import { disableViteHmrClient } from "../../_helpers/nuxtRuntime";
 import {
   ensurePortFree,
   killProcess,
@@ -162,6 +163,7 @@ async function warmUpApp(browser: Browser, app: AppConfig): Promise<void> {
 }
 
 async function setupPage(page: Page, route: VisualRoute): Promise<void> {
+  await disableViteHmrClient(page);
   await installVisualStabilityHooks(page);
   await page.addInitScript(
     (storage) => {

--- a/tests/snapshots/lint/__snapshots__/ant-design-vue-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/ant-design-vue-lint.snap
@@ -5652,17 +5652,6 @@
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       },
       {
-        "ruleId": "vue/no-v-for-template-key-on-child",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/no-v-for-template-key-on-child] the `key` for a `<template v-for>` must be on the `<template>`, not on its child",
-        "line": 22,
-        "column": 27,
-        "endLine": 22,
-        "endColumn": 37,
-        "help": "Move the :key up onto the <template v-for> element. In Vue 3 the key lives on the template, not the child (the reverse of Vue 2)."
-      },
-      {
         "ruleId": "vue/sfc-element-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -5674,7 +5663,7 @@
         "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
-    "errorCount": 1,
+    "errorCount": 0,
     "warningCount": 2
   },
   {
@@ -5699,6 +5688,39 @@
     "file": "components/icon/demo/custom.vue",
     "messages": [
       {
+        "ruleId": "vue/valid-v-slot",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 2,
+        "message": "[vize:vue/valid-v-slot] v-slot can only be used on components or template elements",
+        "line": 22,
+        "column": 17,
+        "endLine": 22,
+        "endColumn": 27,
+        "help": "Use v-slot on a component or a template element inside a component"
+      },
+      {
+        "ruleId": "vue/valid-v-slot",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 2,
+        "message": "[vize:vue/valid-v-slot] v-slot can only be used on components or template elements",
+        "line": 32,
+        "column": 17,
+        "endLine": 32,
+        "endColumn": 38,
+        "help": "Use v-slot on a component or a template element inside a component"
+      },
+      {
+        "ruleId": "vue/valid-v-slot",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 2,
+        "message": "[vize:vue/valid-v-slot] v-slot can only be used on components or template elements",
+        "line": 78,
+        "column": 17,
+        "endLine": 78,
+        "endColumn": 27,
+        "help": "Use v-slot on a component or a template element inside a component"
+      },
+      {
         "ruleId": "vue/sfc-element-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -5710,7 +5732,7 @@
         "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
-    "errorCount": 0,
+    "errorCount": 3,
     "warningCount": 1
   },
   {
@@ -12085,17 +12107,6 @@
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       },
       {
-        "ruleId": "vue/no-v-for-template-key-on-child",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/no-v-for-template-key-on-child] the `key` for a `<template v-for>` must be on the `<template>`, not on its child",
-        "line": 64,
-        "column": 13,
-        "endLine": 64,
-        "endColumn": 21,
-        "help": "Move the :key up onto the <template v-for> element. In Vue 3 the key lives on the template, not the child (the reverse of Vue 2)."
-      },
-      {
         "ruleId": "vue/sfc-element-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -12107,7 +12118,7 @@
         "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
-    "errorCount": 1,
+    "errorCount": 0,
     "warningCount": 2
   },
   {
@@ -14780,17 +14791,6 @@
     "file": "components/tree-select/demo/highlight.vue",
     "messages": [
       {
-        "ruleId": "vue/no-v-for-template-key-on-child",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/no-v-for-template-key-on-child] the `key` for a `<template v-for>` must be on the `<template>`, not on its child",
-        "line": 42,
-        "column": 13,
-        "endLine": 42,
-        "endColumn": 21,
-        "help": "Move the :key up onto the <template v-for> element. In Vue 3 the key lives on the template, not the child (the reverse of Vue 2)."
-      },
-      {
         "ruleId": "vue/sfc-element-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -14802,7 +14802,7 @@
         "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
-    "errorCount": 1,
+    "errorCount": 0,
     "warningCount": 1
   },
   {
@@ -16522,17 +16522,6 @@
     "file": "site/src/layouts/Menu.vue",
     "messages": [
       {
-        "ruleId": "vue/no-v-for-template-key-on-child",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/no-v-for-template-key-on-child] the `key` for a `<template v-for>` must be on the `<template>`, not on its child",
-        "line": 31,
-        "column": 42,
-        "endLine": 31,
-        "endColumn": 55,
-        "help": "Move the :key up onto the <template v-for> element. In Vue 3 the key lives on the template, not the child (the reverse of Vue 2)."
-      },
-      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -16566,7 +16555,7 @@
         "help": "Recommended order: <script> -> <template> -> <style>"
       }
     ],
-    "errorCount": 1,
+    "errorCount": 0,
     "warningCount": 3
   },
   {

--- a/tests/snapshots/lint/__snapshots__/elk-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/elk-lint.snap
@@ -441,20 +441,9 @@
         "column": 7,
         "endLine": 191,
         "endColumn": 89
-      },
-      {
-        "ruleId": "vue/no-v-for-template-key-on-child",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/no-v-for-template-key-on-child] the `key` for a `<template v-for>` must be on the `<template>`, not on its child",
-        "line": 222,
-        "column": 43,
-        "endLine": 222,
-        "endColumn": 60,
-        "help": "Move the :key up onto the <template v-for> element. In Vue 3 the key lives on the template, not the child (the reverse of Vue 2)."
       }
     ],
-    "errorCount": 3,
+    "errorCount": 2,
     "warningCount": 0
   },
   {
@@ -1877,8 +1866,31 @@
   },
   {
     "file": "app/components/notification/NotificationGroupedLikes.vue",
-    "messages": [],
-    "errorCount": 0,
+    "messages": [
+      {
+        "ruleId": "vue/valid-v-for",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 2,
+        "message": "[vize:vue/valid-v-for] v-for key should use variables defined by v-for",
+        "line": 25,
+        "column": 47,
+        "endLine": 25,
+        "endColumn": 57,
+        "help": "Valid v-for syntax:\n  <!-- Array iteration -->\n  <li v-for=\"item in items\">{{ item }}</li>\n  <li v-for=\"(item, index) in items\">{{ index }}: {{ item }}</li>\n  \n  <!-- Object iteration -->\n  <li v-for=\"(value, key) in object\">{{ key }}: {{ value }}</li>\n  <li v-for=\"(value, key, index) in object\">{{ index }}</li>\n  \n  <!-- Range -->\n  <span v-for=\"n in 10\">{{ n }}</span>"
+      },
+      {
+        "ruleId": "vue/valid-v-for",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 2,
+        "message": "[vize:vue/valid-v-for] v-for key should use variables defined by v-for",
+        "line": 41,
+        "column": 45,
+        "endLine": 41,
+        "endColumn": 55,
+        "help": "Valid v-for syntax:\n  <!-- Array iteration -->\n  <li v-for=\"item in items\">{{ item }}</li>\n  <li v-for=\"(item, index) in items\">{{ index }}: {{ item }}</li>\n  \n  <!-- Object iteration -->\n  <li v-for=\"(value, key) in object\">{{ key }}: {{ value }}</li>\n  <li v-for=\"(value, key, index) in object\">{{ index }}</li>\n  \n  <!-- Range -->\n  <span v-for=\"n in 10\">{{ n }}</span>"
+      }
+    ],
+    "errorCount": 2,
     "warningCount": 0
   },
   {
@@ -2187,6 +2199,17 @@
         "help": "Use CSS border instead."
       },
       {
+        "ruleId": "vue/valid-v-for",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 2,
+        "message": "[vize:vue/valid-v-for] v-for key should use variables defined by v-for",
+        "line": 420,
+        "column": 48,
+        "endLine": 420,
+        "endColumn": 56,
+        "help": "Valid v-for syntax:\n  <!-- Array iteration -->\n  <li v-for=\"item in items\">{{ item }}</li>\n  <li v-for=\"(item, index) in items\">{{ index }}: {{ item }}</li>\n  \n  <!-- Object iteration -->\n  <li v-for=\"(value, key) in object\">{{ key }}: {{ value }}</li>\n  <li v-for=\"(value, key, index) in object\">{{ index }}</li>\n  \n  <!-- Range -->\n  <span v-for=\"n in 10\">{{ n }}</span>"
+      },
+      {
         "ruleId": "a11y/form-control-has-label",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -2316,7 +2339,7 @@
         "endColumn": 59
       }
     ],
-    "errorCount": 4,
+    "errorCount": 5,
     "warningCount": 11
   },
   {


### PR DESCRIPTION
## Summary
- update the MoonBit core hash used by the Nix check
- widen explicit tsconfig project roots when app check inputs span sibling packages
- refresh affected lint snapshots and stabilize Elk dev/VRT browser runtime setup

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo test -p vize explicit_tsconfig_with_package_boundary
- node --test --test-concurrency=1 snapshots/check/primevue.ts snapshots/check/reka-ui.ts
- node --test --test-concurrency=1 snapshots/lint/ant-design-vue.ts snapshots/lint/elk.ts
- VIZE_TEST_WORKTREE_ID=ci-dev-fix vp exec --filter './tests' -- playwright test --config app/playwright.config.ts app/dev/elk.spec.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785570795&installation_id=136613492&pr_number=2479&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2479&signature=3f6b2f3d9d18db1e67606736468863fb8c5a190142b82c3b275806acc0a69980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->