### PR TITLE
test: correct reka canon snapshot

### DIFF
--- a/tests/snapshots/check/__snapshots__/reka-ui-check.snap
+++ b/tests/snapshots/check/__snapshots__/reka-ui-check.snap
@@ -692,7 +692,7 @@
     {
       "file": "packages/core/src/Combobox/story/ComboboxBasic.story.vue",
       "diagnostics": [
-        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.\nType '\"as\"' is not assignable to type 'never'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'as' does not exist on type '__WithDefaultsResult<ContextMenuArrowProps, Pick<ContextMenuArrowProps, \"as\" | \"height\" | \"width\">>'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'asChild' does not exist on type '__WithDefaultsResult<ContextMenuArrowProps, Pick<ContextMenuArrowProps, \"as\" | \"height\" | \"width\">>'.\nProperty 'height' does not exist on type '__WithDefaultsResult<ContextMenuArrowProps, Pick<ContextMenuArrowProps, \"as\" | \"height\" | \"width\">>'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'rounded' does not exist on type '__WithDefaultsResult<ContextMenuArrowProps, Pick<ContextMenuArrowProps, \"as\" | \"height\" | \"width\">>'.\nProperty 'width' does not exist on type '__WithDefaultsResult<ContextMenuArrowProps, Pick<ContextMenuArrowProps, \"as\" | \"height\" | \"width\">>'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'defer' does not exist on type 'ContextMenuPortalProps'.\nProperty 'disabled' does not exist on type 'ContextMenuPortalProps'.\nProperty 'forceMount' does not exist on type 'ContextMenuPortalProps'.\nProperty 'to' does not exist on type 'ContextMenuPortalProps'."
+        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations."
       ]
     },
     {
@@ -710,7 +710,7 @@
     {
       "file": "packages/core/src/Combobox/story/ComboboxMultiple.story.vue",
       "diagnostics": [
-        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations."
+        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.\nType '\"as\"' is not assignable to type 'never'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'as' does not exist on type '__WithDefaultsResult<ContextMenuArrowProps, Pick<ContextMenuArrowProps, \"as\" | \"height\" | \"width\">>'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'asChild' does not exist on type '__WithDefaultsResult<ContextMenuArrowProps, Pick<ContextMenuArrowProps, \"as\" | \"height\" | \"width\">>'.\nProperty 'height' does not exist on type '__WithDefaultsResult<ContextMenuArrowProps, Pick<ContextMenuArrowProps, \"as\" | \"height\" | \"width\">>'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'rounded' does not exist on type '__WithDefaultsResult<ContextMenuArrowProps, Pick<ContextMenuArrowProps, \"as\" | \"height\" | \"width\">>'.\nProperty 'width' does not exist on type '__WithDefaultsResult<ContextMenuArrowProps, Pick<ContextMenuArrowProps, \"as\" | \"height\" | \"width\">>'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'defer' does not exist on type 'ContextMenuPortalProps'.\nProperty 'disabled' does not exist on type 'ContextMenuPortalProps'.\nProperty 'forceMount' does not exist on type 'ContextMenuPortalProps'.\nProperty 'to' does not exist on type 'ContextMenuPortalProps'."
       ]
     },
     {


### PR DESCRIPTION
## Summary
- correct the reka check snapshot entries for ComboboxBasic and ComboboxMultiple

## Verification
- git diff --check
- GITHUB_BASE_REF=main node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785572571&installation_id=136613492&pr_number=2481&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2481&signature=7685c021381907a1233992a7dc8c08404df7014a9dcfcfae346f461388a2fc6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->