### PR TITLE
feat: enable type-aware patina in oxlint bridge

### DIFF
--- a/crates/vize_vitrine/src/napi/lint.rs
+++ b/crates/vize_vitrine/src/napi/lint.rs
@@ -19,6 +19,12 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use vize_carton::append;
 
 use super::lint_fix::{is_lintable_extension, lint_file_with_optional_fix, lint_source};
+mod lint_options;
+use lint_options::{
+    LintOptionsNapi, LintResultNapi, PatinaLintOptionsNapi, configure_type_aware_lint,
+    create_patina_linter, patina_help_level_from_option, patina_locale_from_option,
+    patina_preset_from_option,
+};
 
 struct PatinaRuleMetaNapi<'a> {
     name: &'a str,
@@ -27,102 +33,6 @@ struct PatinaRuleMetaNapi<'a> {
     fixable: bool,
     default_severity: &'a str,
     presets: Vec<&'static str>,
-}
-
-/// Lint options for NAPI
-#[napi(object)]
-#[derive(Default)]
-pub struct LintOptionsNapi {
-    /// Output format: "text", "ansi", "plain", "json", "stylish", "markdown", "html", or "agent"
-    pub format: Option<String>,
-    /// Maximum number of warnings before failing
-    pub max_warnings: Option<u32>,
-    /// Quiet mode - only show summary
-    pub quiet: Option<bool>,
-    /// Automatically fix problems when diagnostics provide safe text edits
-    pub fix: Option<bool>,
-    /// Help display level: "full", "short", "none"
-    pub help_level: Option<String>,
-    /// Lint preset: "general-recommended", "essential", "incremental", "ecosystem", "opinionated", or "nuxt"
-    pub preset: Option<String>,
-}
-
-/// Lint result for NAPI
-#[napi(object)]
-pub struct LintResultNapi {
-    /// Formatted output string
-    pub output: String,
-    /// Total number of errors
-    pub error_count: u32,
-    /// Total number of warnings
-    pub warning_count: u32,
-    /// Number of files linted
-    pub file_count: u32,
-    /// Time in milliseconds
-    pub time_ms: f64,
-}
-
-/// Single-file Patina lint options for NAPI
-#[napi(object)]
-#[derive(Default)]
-pub struct PatinaLintOptionsNapi {
-    /// Filename used for diagnostics
-    pub filename: Option<String>,
-    /// Locale code: "en", "ja", or "zh"
-    pub locale: Option<String>,
-    /// Help display level: "full", "short", or "none"
-    pub help_level: Option<String>,
-    /// Lint preset: "general-recommended", "essential", "incremental", "ecosystem", "opinionated", or "nuxt"
-    pub preset: Option<String>,
-    /// Optional list of Patina rule names to enable
-    pub enabled_rules: Option<Vec<String>>,
-}
-
-fn patina_locale_from_option(locale: Option<&str>) -> vize_patina::Locale {
-    locale
-        .and_then(vize_patina::Locale::parse)
-        .unwrap_or_default()
-}
-
-fn patina_help_level_from_option(help_level: Option<&str>) -> vize_patina::HelpLevel {
-    match help_level {
-        Some("none") => vize_patina::HelpLevel::None,
-        Some("short") => vize_patina::HelpLevel::Short,
-        _ => vize_patina::HelpLevel::Full,
-    }
-}
-
-enum PatinaPresetSelection {
-    Builtin(vize_patina::LintPreset),
-    Ecosystem,
-}
-
-fn patina_preset_from_option(preset: Option<&str>) -> PatinaPresetSelection {
-    match preset {
-        Some("general-recommended" | "GeneralRecommended" | "generalRecommended")
-        | Some("happy-path" | "happy_path" | "happy" | "default" | "recommended") => {
-            PatinaPresetSelection::Builtin(vize_patina::LintPreset::HappyPath)
-        }
-        Some("essential" | "Essential") => {
-            PatinaPresetSelection::Builtin(vize_patina::LintPreset::Essential)
-        }
-        Some("incremental" | "Incremental") => {
-            PatinaPresetSelection::Builtin(vize_patina::LintPreset::Incremental)
-        }
-        Some("ecosystem" | "Ecosystem" | "eco" | "Eco") => PatinaPresetSelection::Ecosystem,
-        Some("opinionated" | "Opinionated" | "Opnionated" | "opnionated" | "strict" | "all") => {
-            PatinaPresetSelection::Builtin(vize_patina::LintPreset::Opinionated)
-        }
-        Some("nuxt" | "Nuxt") => PatinaPresetSelection::Builtin(vize_patina::LintPreset::Nuxt),
-        _ => PatinaPresetSelection::Builtin(vize_patina::LintPreset::default()),
-    }
-}
-
-fn create_patina_linter(preset: PatinaPresetSelection) -> vize_patina::Linter {
-    match preset {
-        PatinaPresetSelection::Builtin(preset) => vize_patina::Linter::with_preset(preset),
-        PatinaPresetSelection::Ecosystem => vize_patina::Linter::with_ecosystem(),
-    }
 }
 
 #[inline]
@@ -302,10 +212,14 @@ pub fn lint_patina_sfc(source: String, options: Option<PatinaLintOptionsNapi>) -
     let enabled_rules = opts
         .enabled_rules
         .map(|rules| rules.into_iter().map(Into::into).collect());
-    let linter = create_patina_linter(preset)
-        .with_locale(locale)
-        .with_help_level(help_level)
-        .with_enabled_rules(enabled_rules);
+    let linter = configure_type_aware_lint(
+        create_patina_linter(preset)
+            .with_locale(locale)
+            .with_help_level(help_level),
+        opts.type_aware,
+        opts.corsa_path,
+    )
+    .with_enabled_rules(enabled_rules);
     let result = lint_source(&linter, &source, &filename);
     let lsp_diagnostics = LspEmitter::to_lsp_diagnostics_with_source(&result, &source);
 
@@ -438,7 +352,11 @@ pub fn lint(patterns: Vec<String>, options: Option<LintOptionsNapi>) -> Result<L
         _ => HelpLevel::Full,
     };
     let preset = patina_preset_from_option(opts.preset.as_deref());
-    let linter = create_patina_linter(preset).with_help_level(help_level);
+    let linter = configure_type_aware_lint(
+        create_patina_linter(preset).with_help_level(help_level),
+        opts.type_aware,
+        opts.corsa_path,
+    );
     let error_count = AtomicUsize::new(0);
     let warning_count = AtomicUsize::new(0);
 

--- a/crates/vize_vitrine/src/napi/lint/lint_options.rs
+++ b/crates/vize_vitrine/src/napi/lint/lint_options.rs
@@ -1,0 +1,116 @@
+use napi_derive::napi;
+use std::path::PathBuf;
+
+/// Lint options for NAPI
+#[napi(object)]
+#[derive(Default)]
+pub struct LintOptionsNapi {
+    /// Output format: "text", "ansi", "plain", "json", "stylish", "markdown", "html", or "agent"
+    pub format: Option<String>,
+    /// Maximum number of warnings before failing
+    pub max_warnings: Option<u32>,
+    /// Quiet mode - only show summary
+    pub quiet: Option<bool>,
+    /// Automatically fix problems when diagnostics provide safe text edits
+    pub fix: Option<bool>,
+    /// Help display level: "full", "short", "none"
+    pub help_level: Option<String>,
+    /// Lint preset: "general-recommended", "essential", "incremental", "ecosystem", "opinionated", or "nuxt"
+    pub preset: Option<String>,
+    /// Enable native type-aware lint rules
+    pub type_aware: Option<bool>,
+    /// Path to the Corsa executable used by type-aware lint rules
+    pub corsa_path: Option<String>,
+}
+
+/// Lint result for NAPI
+#[napi(object)]
+pub struct LintResultNapi {
+    /// Formatted output string
+    pub output: String,
+    /// Total number of errors
+    pub error_count: u32,
+    /// Total number of warnings
+    pub warning_count: u32,
+    /// Number of files linted
+    pub file_count: u32,
+    /// Time in milliseconds
+    pub time_ms: f64,
+}
+
+/// Single-file Patina lint options for NAPI
+#[napi(object)]
+#[derive(Default)]
+pub struct PatinaLintOptionsNapi {
+    /// Filename used for diagnostics
+    pub filename: Option<String>,
+    /// Locale code: "en", "ja", or "zh"
+    pub locale: Option<String>,
+    /// Help display level: "full", "short", or "none"
+    pub help_level: Option<String>,
+    /// Lint preset: "general-recommended", "essential", "incremental", "ecosystem", "opinionated", or "nuxt"
+    pub preset: Option<String>,
+    /// Optional list of Patina rule names to enable
+    pub enabled_rules: Option<Vec<String>>,
+    /// Enable native type-aware lint rules
+    pub type_aware: Option<bool>,
+    /// Path to the Corsa executable used by type-aware lint rules
+    pub corsa_path: Option<String>,
+}
+
+pub(super) enum PatinaPresetSelection {
+    Builtin(vize_patina::LintPreset),
+    Ecosystem,
+}
+
+pub(super) fn patina_locale_from_option(locale: Option<&str>) -> vize_patina::Locale {
+    locale
+        .and_then(vize_patina::Locale::parse)
+        .unwrap_or_default()
+}
+
+pub(super) fn patina_help_level_from_option(help_level: Option<&str>) -> vize_patina::HelpLevel {
+    match help_level {
+        Some("none") => vize_patina::HelpLevel::None,
+        Some("short") => vize_patina::HelpLevel::Short,
+        _ => vize_patina::HelpLevel::Full,
+    }
+}
+
+pub(super) fn patina_preset_from_option(preset: Option<&str>) -> PatinaPresetSelection {
+    match preset {
+        Some("general-recommended" | "GeneralRecommended" | "generalRecommended")
+        | Some("happy-path" | "happy_path" | "happy" | "default" | "recommended") => {
+            PatinaPresetSelection::Builtin(vize_patina::LintPreset::HappyPath)
+        }
+        Some("essential" | "Essential") => {
+            PatinaPresetSelection::Builtin(vize_patina::LintPreset::Essential)
+        }
+        Some("incremental" | "Incremental") => {
+            PatinaPresetSelection::Builtin(vize_patina::LintPreset::Incremental)
+        }
+        Some("ecosystem" | "Ecosystem" | "eco" | "Eco") => PatinaPresetSelection::Ecosystem,
+        Some("opinionated" | "Opinionated" | "Opnionated" | "opnionated" | "strict" | "all") => {
+            PatinaPresetSelection::Builtin(vize_patina::LintPreset::Opinionated)
+        }
+        Some("nuxt" | "Nuxt") => PatinaPresetSelection::Builtin(vize_patina::LintPreset::Nuxt),
+        _ => PatinaPresetSelection::Builtin(vize_patina::LintPreset::default()),
+    }
+}
+
+pub(super) fn create_patina_linter(preset: PatinaPresetSelection) -> vize_patina::Linter {
+    match preset {
+        PatinaPresetSelection::Builtin(preset) => vize_patina::Linter::with_preset(preset),
+        PatinaPresetSelection::Ecosystem => vize_patina::Linter::with_ecosystem(),
+    }
+}
+
+pub(super) fn configure_type_aware_lint(
+    linter: vize_patina::Linter,
+    type_aware: Option<bool>,
+    corsa_path: Option<String>,
+) -> vize_patina::Linter {
+    linter
+        .with_type_aware_lint(type_aware.unwrap_or(false))
+        .with_corsa_path(corsa_path.map(PathBuf::from))
+}

--- a/docs/content/guide/oxlint.md
+++ b/docs/content/guide/oxlint.md
@@ -58,9 +58,10 @@ export default {
     vize: {
       helpLevel: "short",
       preset: "opinionated",
+      typeAware: true,
     },
   },
-  rules: configs.opinionated,
+  rules: configs.opinionatedWithTypeAware,
 };
 ```
 
@@ -72,6 +73,7 @@ Available preset exports include:
 - `configs.nuxt`
 - `configs.all`
 - `configs.recommendedWithTypeAware`
+- `configs.ecosystemWithTypeAware`
 - `configs.opinionatedWithTypeAware`
 
 ## Recommended Command
@@ -93,17 +95,21 @@ Settings are passed through `settings.vize`:
     "vize": {
       "locale": "ja",
       "preset": "general-recommended",
-      "helpLevel": "short"
+      "helpLevel": "short",
+      "typeAware": true,
+      "corsaPath": "./node_modules/.bin/tsgo"
     }
   }
 }
 ```
 
 - `locale` controls the diagnostic language.
-- `preset` accepts `"general-recommended"`, `"essential"`, `"incremental"`, `"opinionated"`, or `"nuxt"`.
+- `preset` accepts `"general-recommended"`, `"essential"`, `"ecosystem"`, `"incremental"`, `"opinionated"`, or `"nuxt"`.
 - `preset` defaults to `"general-recommended"`.
 - `incremental` runs only the rules you explicitly configure.
 - `helpLevel` accepts `"full"`, `"short"`, or `"none"`.
+- `typeAware: true` enables Corsa-backed `vize/type/*` rules during shared Patina passes.
+- `corsaPath` selects the Corsa or `tsgo` executable for type-aware linting.
 - `showHelp` and `settings.patina` are still accepted for backward compatibility.
 
 ## Current Limitations
@@ -115,6 +121,8 @@ Settings are passed through `settings.vize`:
 - `stylish` is currently the best human-readable formatter for mixed Oxlint + Vize output. JSON and
   other machine-readable formats should be treated as best-effort for original template/style
   positions.
+- Type-aware rule exports are experimental. Use a `*WithTypeAware` config and set
+  `settings.vize.typeAware: true` when you want the shared full-file pass to run those rules eagerly.
 
 ## Local Development
 

--- a/npm/native/index.d.ts
+++ b/npm/native/index.d.ts
@@ -612,10 +612,10 @@ export interface LintOptionsNapi {
   quiet?: boolean;
   /** Automatically fix problems when diagnostics provide safe text edits */
   fix?: boolean;
-  /** Help display level: "full", "short", "none" */
   helpLevel?: string;
-  /** Lint preset: "general-recommended", "essential", "incremental", "ecosystem", "opinionated", or "nuxt" */
   preset?: string;
+  typeAware?: boolean;
+  corsaPath?: string;
 }
 
 /** Lint a single Vue SFC with Patina and return structured diagnostics. */
@@ -725,12 +725,12 @@ export interface PatinaLintOptionsNapi {
   filename?: string;
   /** Locale code: "en", "ja", or "zh" */
   locale?: string;
-  /** Help display level: "full", "short", or "none" */
   helpLevel?: string;
-  /** Lint preset: "general-recommended", "essential", "incremental", "ecosystem", "opinionated", or "nuxt" */
   preset?: string;
   /** Optional list of Patina rule names to enable */
   enabledRules?: Array<string>;
+  typeAware?: boolean;
+  corsaPath?: string;
 }
 
 export declare function printCssAst(

--- a/npm/native/types/lint.d.ts
+++ b/npm/native/types/lint.d.ts
@@ -14,6 +14,10 @@ export interface LintOptionsNapi {
   helpLevel?: string;
   /** Lint preset: "general-recommended", "essential", "incremental", "ecosystem", "opinionated", or "nuxt" */
   preset?: string;
+  /** Enable native type-aware lint rules */
+  typeAware?: boolean;
+  /** Path to the Corsa executable used by type-aware lint rules */
+  corsaPath?: string;
 }
 
 /** Lint result for NAPI */
@@ -42,6 +46,10 @@ export interface PatinaLintOptionsNapi {
   preset?: string;
   /** Optional list of Patina rule names to enable */
   enabledRules?: Array<string>;
+  /** Enable native type-aware lint rules */
+  typeAware?: boolean;
+  /** Path to the Corsa executable used by type-aware lint rules */
+  corsaPath?: string;
 }
 
 /** Get Patina's currently registered rule metadata. */

--- a/npm/oxint/README.md
+++ b/npm/oxint/README.md
@@ -75,13 +75,14 @@ export default {
     vize: {
       helpLevel: "short",
       preset: "opinionated",
+      typeAware: true,
     },
   },
-  rules: configs.opinionated,
+  rules: configs.opinionatedWithTypeAware,
 };
 ```
 
-`configs.recommended`, `configs.essential`, `configs.ecosystem`, `configs.opinionated`, `configs.nuxt`, and `configs.all` intentionally skip Vize's unstable type-aware rules for now. If you explicitly want those experimental rules too, use `configs.recommendedWithTypeAware`, `configs.ecosystemWithTypeAware`, `configs.opinionatedWithTypeAware`, or `createVizeRuleConfig({ includeTypeAware: true, preset: ... })`.
+`configs.recommended`, `configs.essential`, `configs.ecosystem`, `configs.opinionated`, `configs.nuxt`, and `configs.all` intentionally skip Vize's unstable type-aware rules for now. If you explicitly want those experimental rules too, use `configs.recommendedWithTypeAware`, `configs.ecosystemWithTypeAware`, `configs.opinionatedWithTypeAware`, or `createVizeRuleConfig({ includeTypeAware: true, preset: ... })`. Set `settings.vize.typeAware: true` to run the shared full-file Patina pass with Corsa enabled; explicitly configured `vize/type/*` rules also opt in when they are queried one by one.
 
 You can pass Patina settings through `settings.vize`:
 
@@ -91,7 +92,9 @@ You can pass Patina settings through `settings.vize`:
     "vize": {
       "locale": "ja",
       "preset": "essential",
-      "helpLevel": "short"
+      "helpLevel": "short",
+      "typeAware": true,
+      "corsaPath": "./node_modules/.bin/tsgo"
     }
   }
 }
@@ -106,6 +109,8 @@ You can pass Patina settings through `settings.vize`:
 - Legacy aliases such as `"GeneralRecommended"`, `"Essential"`, `"Ecosystem"`, `"Incremental"`, `"Opinionated"`, `"Nuxt"`, and `"happy-path"` are still accepted for compatibility.
 - `helpLevel` accepts `"full"`, `"short"`, or `"none"`.
 - `helpLevel: "full"` only expands the Patina remediation text. It does not restore original-SFC formatter anchors or machine-readable range fidelity.
+- `typeAware: true` enables Corsa-backed `vize/type/*` rules during shared Patina passes.
+- `corsaPath` selects the Corsa or `tsgo` executable for type-aware linting. Omit it to use Vize's normal resolver.
 - `showHelp` is still accepted for backward compatibility, but `helpLevel` is the preferred setting.
 
 For example, this keeps Oxlint focused on correctness-only Vize diagnostics while still allowing your existing Oxlint rules to run unchanged:
@@ -145,7 +150,7 @@ vp exec oxlint-vize -c .oxlintrc.json -f stylish src
 - Formatter parity is not there yet. `stylish` is recommended for human-readable terminal output, while `json` and other machine-readable outputs are best treated as debugging aids for original template/style positions.
 - Oxlint core rules that need JavaScript bindings extracted from Vue templates, such as template-aware unused-variable checks, still depend on upstream work in [Oxc's Better Vue Support](https://github.com/oxc-project/oxc/issues/15761).
 - Vize's own SFC diagnostics can run through the plugin, but precise original-SFC ranges across all Oxlint formatters depend on the JS plugin reporting work tracked in [oxc-project/oxc#20465](https://github.com/oxc-project/oxc/issues/20465).
-- Type-aware Vize rules are experimental and excluded from the default exported configs. Opt into them explicitly with `configs.recommendedWithTypeAware`, `configs.opinionatedWithTypeAware`, or `createVizeRuleConfig({ includeTypeAware: true, preset: ... })`.
+- Type-aware Vize rules are experimental and excluded from the default exported configs. Opt into them explicitly with `configs.recommendedWithTypeAware`, `configs.opinionatedWithTypeAware`, or `createVizeRuleConfig({ includeTypeAware: true, preset: ... })`, and use `settings.vize.typeAware: true` when you want the shared full-file pass to run them eagerly.
 
 ## Current expectations
 

--- a/npm/oxint/src/binding.ts
+++ b/npm/oxint/src/binding.ts
@@ -13,6 +13,8 @@ export function lintPatina(
     helpLevel: settings.helpLevel,
     preset: settings.preset,
     enabledRules: enabledRules ? [...enabledRules] : undefined,
+    typeAware: settings.typeAware,
+    corsaPath: settings.corsaPath,
   });
 }
 

--- a/npm/oxint/src/file-state.ts
+++ b/npm/oxint/src/file-state.ts
@@ -6,7 +6,12 @@ import { lintPatina } from "./binding.js";
 import type { PatinaDiagnostic, SfcBlock, SingleScriptMap } from "./model.js";
 import { extractSfcBlocks } from "./sfc-blocks.js";
 import { createSingleScriptMap } from "./script-map.js";
-import { getCacheKey, getVizeSettings, isIncrementalPreset } from "./settings.js";
+import {
+  getCacheKey,
+  getVizeSettings,
+  isIncrementalPreset,
+  isTypeAwareRuleName,
+} from "./settings.js";
 import { resolveWorkaroundSource } from "./workaround.js";
 
 export interface FileState {
@@ -18,12 +23,15 @@ export interface FileState {
   sfcBlocks: readonly SfcBlock[] | undefined;
   scriptMap: SingleScriptMap | null | undefined;
   allDiagnosticsByRule: Map<string, PatinaDiagnostic[]> | null;
+  allDiagnosticsIncludesTypeAware: boolean;
   partialDiagnosticsByRule: Map<string, readonly PatinaDiagnostic[]>;
   requestedRules: Set<string>;
+  reportedTypeAwareRuntimeDiagnostic: boolean;
 }
 
 const fileStateCache = new Map<string, FileState>();
 const EMPTY_DIAGNOSTICS: readonly PatinaDiagnostic[] = [];
+const TYPE_AWARE_RUNTIME_RULE = "type/corsa-runtime";
 
 export function getFileState(context: Context): FileState {
   const settings = getVizeSettings(context);
@@ -44,8 +52,10 @@ export function getFileState(context: Context): FileState {
     sfcBlocks: undefined,
     scriptMap: undefined,
     allDiagnosticsByRule: null,
+    allDiagnosticsIncludesTypeAware: false,
     partialDiagnosticsByRule: new Map(),
     requestedRules: new Set(),
+    reportedTypeAwareRuntimeDiagnostic: false,
   };
   fileStateCache.set(cacheKey, state);
   return state;
@@ -57,7 +67,15 @@ export function getDiagnosticsForRule(
   ruleName: string,
 ): readonly PatinaDiagnostic[] {
   if (state.allDiagnosticsByRule) {
-    return state.allDiagnosticsByRule.get(ruleName) ?? EMPTY_DIAGNOSTICS;
+    if (isTypeAwareRuleName(ruleName) && !state.allDiagnosticsIncludesTypeAware) {
+      const settings = getVizeSettings(context);
+      state.allDiagnosticsByRule = indexDiagnosticsByRule(
+        lintPatina(state.source, state.filename, { ...settings, typeAware: true }).diagnostics,
+      );
+      state.allDiagnosticsIncludesTypeAware = true;
+    }
+
+    return diagnosticsForRule(state, state.allDiagnosticsByRule, ruleName);
   }
 
   const cached = state.partialDiagnosticsByRule.get(ruleName);
@@ -66,28 +84,39 @@ export function getDiagnosticsForRule(
   }
 
   const settings = getVizeSettings(context);
+  const ruleSettings = isTypeAwareRuleName(ruleName) ? { ...settings, typeAware: true } : settings;
   if (isIncrementalPreset(settings)) {
-    const diagnostics = lintPatina(state.source, state.filename, settings, [ruleName]).diagnostics;
+    const diagnostics = lintPatina(state.source, state.filename, ruleSettings, [
+      ruleName,
+    ]).diagnostics;
     const indexedDiagnostics = indexDiagnosticsByRule(diagnostics);
-    const ruleDiagnostics = indexedDiagnostics.get(ruleName) ?? EMPTY_DIAGNOSTICS;
+    const ruleDiagnostics = diagnosticsForRule(state, indexedDiagnostics, ruleName);
     state.partialDiagnosticsByRule.set(ruleName, ruleDiagnostics);
     return ruleDiagnostics;
   }
 
   if (state.requestedRules.size === 0) {
     state.requestedRules.add(ruleName);
-    const diagnostics = lintPatina(state.source, state.filename, settings, [ruleName]).diagnostics;
+    const diagnostics = lintPatina(state.source, state.filename, ruleSettings, [
+      ruleName,
+    ]).diagnostics;
     const indexedDiagnostics = indexDiagnosticsByRule(diagnostics);
-    const ruleDiagnostics = indexedDiagnostics.get(ruleName) ?? EMPTY_DIAGNOSTICS;
+    const ruleDiagnostics = diagnosticsForRule(state, indexedDiagnostics, ruleName);
     state.partialDiagnosticsByRule.set(ruleName, ruleDiagnostics);
     return ruleDiagnostics;
   }
 
   state.requestedRules.add(ruleName);
-  const allDiagnostics = lintPatina(state.source, state.filename, settings).diagnostics;
+  const fullPassTypeAware =
+    settings.typeAware === true || Array.from(state.requestedRules).some(isTypeAwareRuleName);
+  const allDiagnostics = lintPatina(state.source, state.filename, {
+    ...settings,
+    typeAware: fullPassTypeAware,
+  }).diagnostics;
   state.allDiagnosticsByRule = indexDiagnosticsByRule(allDiagnostics);
+  state.allDiagnosticsIncludesTypeAware = fullPassTypeAware;
   state.partialDiagnosticsByRule.clear();
-  return state.allDiagnosticsByRule.get(ruleName) ?? EMPTY_DIAGNOSTICS;
+  return diagnosticsForRule(state, state.allDiagnosticsByRule, ruleName);
 }
 
 export function getScriptMap(state: FileState): SingleScriptMap | null {
@@ -133,4 +162,27 @@ function indexDiagnosticsByRule(
   }
 
   return grouped;
+}
+
+function diagnosticsForRule(
+  state: FileState,
+  diagnosticsByRule: Map<string, PatinaDiagnostic[]>,
+  ruleName: string,
+): readonly PatinaDiagnostic[] {
+  const directDiagnostics = diagnosticsByRule.get(ruleName);
+  if (directDiagnostics && directDiagnostics.length > 0) {
+    return directDiagnostics;
+  }
+
+  if (!isTypeAwareRuleName(ruleName) || state.reportedTypeAwareRuntimeDiagnostic) {
+    return EMPTY_DIAGNOSTICS;
+  }
+
+  const runtimeDiagnostics = diagnosticsByRule.get(TYPE_AWARE_RUNTIME_RULE);
+  if (!runtimeDiagnostics || runtimeDiagnostics.length === 0) {
+    return EMPTY_DIAGNOSTICS;
+  }
+
+  state.reportedTypeAwareRuntimeDiagnostic = true;
+  return runtimeDiagnostics;
 }

--- a/npm/oxint/src/model.ts
+++ b/npm/oxint/src/model.ts
@@ -42,6 +42,8 @@ export interface PatinaBinding {
       helpLevel?: HelpLevel;
       preset?: PatinaPreset;
       enabledRules?: string[];
+      typeAware?: boolean;
+      corsaPath?: string;
     },
   ): PatinaLintResult;
   getPatinaRules(): PatinaRuleMeta[];
@@ -60,6 +62,8 @@ export interface PatinaSettings {
   locale?: string;
   helpLevel?: HelpLevel;
   preset?: PatinaPreset;
+  typeAware?: boolean;
+  corsaPath?: string;
 }
 
 export interface LineColumn {

--- a/npm/oxint/src/nuxt-preset.test.ts
+++ b/npm/oxint/src/nuxt-preset.test.ts
@@ -65,6 +65,7 @@ assert.equal(run.exitCode, 0, "nuxt preset should allow Options API components")
 assert.doesNotMatch(run.output, /vize\(script\/no-options-api\)/);
 
 console.log("oxlint-plugin-vize Nuxt preset tests passed!");
+await import("./type-aware.test.ts");
 
 function findOxlintBin() {
   const pnpmStoreDir = path.join(workspaceRoot, "node_modules", ".pnpm");

--- a/npm/oxint/src/settings.ts
+++ b/npm/oxint/src/settings.ts
@@ -3,6 +3,7 @@ import type { Context } from "@oxlint/plugins";
 import type { HelpLevel, PatinaPreset, PatinaSettings } from "./model.js";
 
 const HELP_LEVELS = new Set<HelpLevel>(["none", "short", "full"]);
+const TYPE_AWARE_RULE_PREFIX = "type/";
 const PRESET_ALIASES = new Map<string, PatinaPreset>([
   ["generalrecommended", "general-recommended"],
   ["happypath", "general-recommended"],
@@ -39,6 +40,8 @@ export function parseVizeSettings(vize: unknown): PatinaSettings {
   const helpLevel = vizeRecord.helpLevel;
   const preset = vizeRecord.preset;
   const showHelp = vizeRecord.showHelp;
+  const typeAware = vizeRecord.typeAware;
+  const corsaPath = vizeRecord.corsaPath;
   const resolved: PatinaSettings = {};
 
   if (typeof locale === "string") {
@@ -50,6 +53,14 @@ export function parseVizeSettings(vize: unknown): PatinaSettings {
     if (normalizedPreset) {
       resolved.preset = normalizedPreset;
     }
+  }
+
+  if (typeof typeAware === "boolean") {
+    resolved.typeAware = typeAware;
+  }
+
+  if (typeof corsaPath === "string") {
+    resolved.corsaPath = corsaPath;
   }
 
   if (typeof helpLevel === "string" && HELP_LEVELS.has(helpLevel as HelpLevel)) {
@@ -73,7 +84,18 @@ export function isIncrementalPreset(settings: PatinaSettings): boolean {
 }
 
 export function getCacheKey(filename: string, settings: PatinaSettings): string {
-  return `${filename}::${settings.locale ?? ""}::${settings.helpLevel ?? ""}::${getActivePreset(settings)}`;
+  return [
+    filename,
+    settings.locale ?? "",
+    settings.helpLevel ?? "",
+    getActivePreset(settings),
+    settings.typeAware ? "type-aware" : "",
+    settings.corsaPath ?? "",
+  ].join("::");
+}
+
+export function isTypeAwareRuleName(ruleName: string): boolean {
+  return ruleName.startsWith(TYPE_AWARE_RULE_PREFIX);
 }
 
 function normalizePreset(value: string): PatinaPreset | undefined {
@@ -84,11 +106,21 @@ if (import.meta.vitest) {
   const { describe, expect, it } = import.meta.vitest;
 
   describe("parseVizeSettings", () => {
-    it("reads locale, help level, and preset", () => {
-      expect(parseVizeSettings({ locale: "ja", helpLevel: "short", preset: "essential" })).toEqual({
+    it("reads locale, help level, preset, and type-aware settings", () => {
+      expect(
+        parseVizeSettings({
+          locale: "ja",
+          helpLevel: "short",
+          preset: "essential",
+          typeAware: true,
+          corsaPath: "./node_modules/.bin/tsgo",
+        }),
+      ).toEqual({
         locale: "ja",
         helpLevel: "short",
         preset: "essential",
+        typeAware: true,
+        corsaPath: "./node_modules/.bin/tsgo",
       });
     });
 
@@ -120,7 +152,14 @@ if (import.meta.vitest) {
 
     it("ignores invalid values", () => {
       expect(
-        parseVizeSettings({ locale: 1, showHelp: "no", helpLevel: "verbose", preset: "wide" }),
+        parseVizeSettings({
+          locale: 1,
+          showHelp: "no",
+          helpLevel: "verbose",
+          preset: "wide",
+          typeAware: "yes",
+          corsaPath: false,
+        }),
       ).toEqual({});
     });
 

--- a/npm/oxint/src/type-aware.test.ts
+++ b/npm/oxint/src/type-aware.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = path.dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = path.resolve(packageDir, "../../..");
+const pluginEntry = path.join(workspaceRoot, "npm/oxint/dist/index.mjs");
+const fixtureDir = path.join(
+  workspaceRoot,
+  "target",
+  "vize-tests",
+  "oxlint-plugin-vize-type-aware-test",
+);
+const ansiEscapePattern = new RegExp(String.raw`\u001B\[[0-9;]*m`, "gu");
+const oxlintEnv = { ...process.env };
+delete oxlintEnv.GITHUB_ACTIONS;
+
+function findOxlintBin() {
+  const pnpmStoreDir = path.join(workspaceRoot, "node_modules", ".pnpm");
+  const match = fs
+    .readdirSync(pnpmStoreDir)
+    .filter((entry) => entry.startsWith("oxlint@"))
+    .sort((left, right) => right.localeCompare(left))
+    .map((entry) => path.join(pnpmStoreDir, entry, "node_modules", "oxlint", "bin", "oxlint"))
+    .find((entry) => fs.existsSync(entry));
+
+  if (match == null) {
+    throw new Error(`Unable to locate the oxlint binary in ${pnpmStoreDir}`);
+  }
+
+  return match;
+}
+
+function runOxlint(args: readonly string[]) {
+  let output = "";
+  let exitCode = 0;
+
+  try {
+    output = String(
+      execFileSync(findOxlintBin(), args, {
+        cwd: fixtureDir,
+        encoding: "utf8",
+        env: oxlintEnv,
+        stdio: "pipe",
+      }),
+    );
+  } catch (error) {
+    const execError = error as {
+      status?: number;
+      stdout?: string | Buffer;
+      stderr?: string | Buffer;
+    };
+    exitCode = execError.status ?? 1;
+    output = String(execError.stdout ?? "") + String(execError.stderr ?? "");
+  }
+
+  return {
+    exitCode,
+    output: output.replace(ansiEscapePattern, "").trim(),
+  };
+}
+
+fs.rmSync(fixtureDir, { force: true, recursive: true });
+fs.mkdirSync(fixtureDir, { recursive: true });
+fs.writeFileSync(
+  path.join(fixtureDir, ".oxlintrc.json"),
+  JSON.stringify(
+    {
+      plugins: ["vue"],
+      jsPlugins: [pluginEntry],
+      settings: {
+        vize: {
+          helpLevel: "none",
+          preset: "opinionated",
+          corsaPath: path.join(fixtureDir, "__missing_tsgo__"),
+        },
+      },
+      rules: {
+        "no-unused-vars": "off",
+        "vize/type/no-floating-promises": "error",
+      },
+    },
+    null,
+    2,
+  ),
+);
+fs.writeFileSync(
+  path.join(fixtureDir, "TypeAwarePromise.vue"),
+  `<script setup lang="ts">
+async function loadData(): Promise<number> {
+  return 1
+}
+
+loadData()
+</script>
+`,
+);
+
+const typeAwareMissingCorsaRun = runOxlint(["-c", ".oxlintrc.json", "-f", "stylish", "."]);
+assert.notEqual(
+  typeAwareMissingCorsaRun.exitCode,
+  0,
+  "type-aware rules should surface Corsa runtime failures through Oxlint",
+);
+assert.match(
+  typeAwareMissingCorsaRun.output,
+  /vize\(type\/no-floating-promises\)/u,
+  "type-aware runtime failures should be attached to the configured type-aware rule",
+);
+assert.match(
+  typeAwareMissingCorsaRun.output,
+  /Configured Corsa executable does not exist[\s\S]*__missing_tsgo__/u,
+  "settings.vize.corsaPath should be passed to the native type-aware lint runtime",
+);


### PR DESCRIPTION
## Summary

- Add `typeAware` and `corsaPath` support to the Patina N-API lint options.
- Pass Oxlint `settings.vize` type-aware options through to native linting and keep cache entries separated by those settings.
- Surface Corsa runtime failures through configured `vize/type/*` rules instead of dropping the internal diagnostic.
- Document Oxlint type-aware settings and add integration coverage for configured Corsa paths.

## Validation

- `cargo check -p vize_vitrine --features napi`
- `vp run --filter './npm/oxint' check`
- `cargo test -p vize_vitrine --features napi`
- `vp run --filter './npm/native' build`
- `vp run --filter './npm/oxint' test`
- Direct native smoke test with `../corsa-bind/ref/corsa-upstream/.cache/tsgo` reporting `type/no-floating-promises`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785575476&installation_id=136613492&pr_number=2484&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2484&signature=e5c9d1a2dc5eb8b9c6387e60ec679ab1529204de8b2f607f16615b9f20d81f08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->