### PR TITLE
fix(musea): honor Vite base in static gallery

### DIFF
--- a/npm/builder/vite-musea/src/static-export.test.ts
+++ b/npm/builder/vite-musea/src/static-export.test.ts
@@ -148,6 +148,89 @@ void test("emitStaticGallery packages browser-facing static output", async () =>
   }
 });
 
+void test("emitStaticGallery prefixes browser URLs with Vite base without nesting output", async () => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-static-base-"));
+  try {
+    const artPath = path.join(tempDir, "src", "Button.art.vue");
+    await fs.promises.mkdir(path.dirname(artPath), { recursive: true });
+    await fs.promises.writeFile(artPath, "<art></art>", "utf8");
+    const art = createArt(artPath);
+    const assets = new Map<string, string>();
+
+    await emitStaticGallery(
+      (asset) => {
+        assets.set(
+          asset.fileName,
+          typeof asset.source === "string"
+            ? asset.source
+            : Buffer.from(asset.source).toString("utf8"),
+        );
+      },
+      {
+        "assets/musea-static-runtime.js": {
+          type: "chunk",
+          name: "musea-static-runtime",
+          fileName: "assets/musea-static-runtime.js",
+          facadeModuleId: null,
+        },
+      },
+      {
+        config: {
+          root: tempDir,
+          base: "/app/aim/aim-front/design-system/",
+        } as ResolvedConfig,
+        artFiles: new Map([[art.path, art]]),
+        scanRoots: [tempDir],
+        tokensPath: undefined,
+        basePath: "/__musea__",
+        resolvedPreviewCss: [],
+        resolvedPreviewSetup: null,
+        devSessionToken: "static-test",
+        themeConfig: undefined,
+      },
+    );
+
+    const previewId = staticPreviewId(art.path, "Default");
+    const publicBasePath = "/app/aim/aim-front/design-system/__musea__";
+    const staticPayload = JSON.parse(assetText(assets, "__musea__/api/static.json")) as {
+      previews: Record<string, Record<string, string>>;
+    };
+
+    assert.ok(assets.has("__musea__/index.html"));
+    assert.ok(assets.has(`__musea__/preview/${previewId}.html`));
+    assert.equal(
+      [...assets.keys()].some((fileName) => fileName.startsWith("app/aim/")),
+      false,
+    );
+    assert.deepEqual(staticPayload.previews, {
+      [art.path]: {
+        Default: `${publicBasePath}/preview/${previewId}.html`,
+      },
+    });
+
+    const galleryHtml = assetText(assets, "__musea__/index.html");
+    assert.match(galleryHtml, /\/app\/aim\/aim-front\/design-system\/__musea__\//u);
+    assert.doesNotMatch(galleryHtml, /"\/__musea__\//u);
+
+    const globals = executeStaticGlobals(galleryHtml);
+    assert.equal(globals.__MUSEA_BASE_PATH__, publicBasePath);
+    assert.deepEqual(globals.__MUSEA_STATIC_PREVIEWS__, {
+      [art.path]: {
+        Default: `${publicBasePath}/preview/${previewId}.html`,
+      },
+    });
+
+    const rootRedirect = assetText(assets, "index.html");
+    assert.match(rootRedirect, /url=\/app\/aim\/aim-front\/design-system\/__musea__\//u);
+    assert.match(
+      assetText(assets, `__musea__/preview/${previewId}.html`),
+      /window\.__MUSEA_BASE_PATH__="\/app\/aim\/aim-front\/design-system\/__musea__"/u,
+    );
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 void test("static gallery runtime reports static-mode mutation and missing detail errors", async () => {
   const originalWindow = Reflect.get(globalThis, "window");
   const originalFetch = globalThis.fetch;

--- a/npm/builder/vite-musea/src/static-export.ts
+++ b/npm/builder/vite-musea/src/static-export.ts
@@ -125,22 +125,24 @@ export async function emitStaticGallery(
     throw new Error("musea static build could not find its generated runtime entry");
   }
 
-  const payload = await createStaticGalleryPayload(ctx);
   const staticRoot = staticRootFromBasePath(ctx.basePath);
-  await emitGalleryShell(emitFile, staticRoot, ctx, payload);
+  const publicBasePath = publicBasePathFromViteBase(ctx.config.base, ctx.basePath);
+  const publicCtx = { ...ctx, basePath: publicBasePath };
+  const publicPayload = await createStaticGalleryPayload(publicCtx);
+  await emitGalleryShell(emitFile, staticRoot, publicCtx, publicPayload);
   emitFile({
     type: "asset",
     fileName: joinFileName(staticRoot, "api", "static.json"),
-    source: JSON.stringify(payload, null, 2),
+    source: JSON.stringify(publicPayload, null, 2),
   });
   emitFile({
     type: "asset",
     fileName: joinFileName(staticRoot, "api", "arts"),
-    source: JSON.stringify(payload.arts, null, 2),
+    source: JSON.stringify(publicPayload.arts, null, 2),
   });
   await emitAxeVendor(emitFile, staticRoot);
-  emitPreviewHtml(emitFile, staticRoot, runtimeFileName, ctx.basePath, payload, ctx.artFiles);
-  emitRootRedirect(emitFile, staticRoot, ctx.basePath);
+  emitPreviewHtml(emitFile, staticRoot, runtimeFileName, publicBasePath, ctx.artFiles);
+  emitRootRedirect(emitFile, staticRoot, publicBasePath);
 }
 
 function findRuntimeFileName(bundle: OutputBundle): string | null {
@@ -176,10 +178,6 @@ async function emitGalleryShell(
       emitFile({ type: "asset", fileName: target, source: content });
     }
   }
-
-  if (payload.arts.length === 0) {
-    return;
-  }
 }
 
 function generateStaticFallbackGalleryHtml(basePath: string): string {
@@ -204,7 +202,6 @@ function emitPreviewHtml(
   staticRoot: string,
   runtimeFileName: string,
   basePath: string,
-  payload: StaticGalleryPayload,
   artFiles: Map<string, ArtFileInfo>,
 ): void {
   const previewDir = joinFileName(staticRoot, "preview");
@@ -217,8 +214,6 @@ function emitPreviewHtml(
       emitFile({ type: "asset", fileName: joinFileName(previewDir, `${id}.html`), source: html });
     }
   }
-
-  void payload;
 }
 
 function generateStaticPreviewHtml(
@@ -276,6 +271,12 @@ function injectStaticGlobals(
 
 function rewriteGalleryBase(html: string, basePath: string): string {
   return html.replaceAll("/__musea__/", `${basePath.replace(/\/?$/, "/")}`);
+}
+
+function publicBasePathFromViteBase(viteBase: string | undefined, basePath: string): string {
+  return viteBase && viteBase !== "/" && viteBase !== "./"
+    ? joinUrlPath(viteBase, basePath)
+    : basePath;
 }
 
 function emitRootRedirect(


### PR DESCRIPTION
## Summary

- prefix Musea static-gallery browser URLs with Vite `config.base`
- keep the emitted on-disk gallery layout rooted at the configured Musea `basePath`
- cover the sub-path deployment regression from #2485

Fixes #2485

## Validation

- `vp run --filter './npm/builder/vite-musea' check`
- `vp run --filter './npm/builder/vite-musea' test`
- `vp run --filter './npm/builder/vite-musea' build`
- `node tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785582338&installation_id=136613492&pr_number=2486&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2486&signature=abe35b33d247c5debc37f79edf7ad7ae6bef2fbacf9f2b170be1c5f2564cb715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->