### PR TITLE
fix(vscode): harden TypeScript plugin fallback

### DIFF
--- a/editors/vscode/typescript-vue-plugin/index.cjs
+++ b/editors/vscode/typescript-vue-plugin/index.cjs
@@ -4,24 +4,34 @@ const path = require("node:path");
 
 const vueExtension = ".vue";
 const virtualDtsSuffix = ".d.ts";
+const installedHosts = new WeakSet();
 
 function init({ typescript: ts }) {
   return {
     create(info) {
-      installVueImportResolver(ts, info);
-      return createLanguageServiceProxy(ts, info.languageService);
+      if (!info?.languageService) {
+        return info?.languageService;
+      }
+      try {
+        return installVueImportResolver(ts, info)
+          ? createLanguageServiceProxy(ts, info.languageService)
+          : info.languageService;
+      } catch (error) {
+        logPluginError(info, "create", error);
+        return info.languageService;
+      }
     },
   };
 }
 
 function installVueImportResolver(ts, info) {
   const host = info.languageServiceHost;
-  if (!host || host.__vizeVueImportResolverInstalled) {
-    return;
+  if (!host) {
+    return false;
   }
-  Object.defineProperty(host, "__vizeVueImportResolverInstalled", {
-    value: true,
-  });
+  if (installedHosts.has(host)) {
+    return true;
+  }
 
   const serverHost = info.serverHost || ts.sys;
   const originalFileExists = bind(host.fileExists, host) || bind(serverHost.fileExists, serverHost);
@@ -31,66 +41,107 @@ function installVueImportResolver(ts, info) {
   const originalResolveModuleNameLiterals = bind(host.resolveModuleNameLiterals, host);
   const originalResolveModuleNames = bind(host.resolveModuleNames, host);
 
-  host.fileExists = (fileName) => {
-    const vuePath = realVuePathFromVirtual(fileName);
-    if (vuePath) {
-      return originalFileExists(vuePath);
-    }
-    return originalFileExists(fileName);
-  };
+  if (!originalFileExists || !originalReadFile || !originalGetScriptSnapshot) {
+    return false;
+  }
 
-  host.readFile = (fileName) => {
-    const vuePath = realVuePathFromVirtual(fileName);
-    if (vuePath && originalFileExists(vuePath)) {
-      return virtualVueDts();
-    }
-    return originalReadFile(fileName);
-  };
+  const replacements = {
+    fileExists(fileName) {
+      const vuePath = realVuePathFromVirtual(fileName);
+      if (vuePath) {
+        return originalFileExists(vuePath);
+      }
+      return originalFileExists(fileName);
+    },
+    readFile(fileName) {
+      const vuePath = realVuePathFromVirtual(fileName);
+      if (vuePath && originalFileExists(vuePath)) {
+        return virtualVueDts();
+      }
+      return originalReadFile(fileName);
+    },
+    getScriptSnapshot(fileName) {
+      const vuePath = realVuePathFromVirtual(fileName);
+      if (vuePath && originalFileExists(vuePath)) {
+        return ts.ScriptSnapshot.fromString(virtualVueDts());
+      }
+      return originalGetScriptSnapshot(fileName);
+    },
+    getScriptKind(fileName) {
+      if (realVuePathFromVirtual(fileName)) {
+        return ts.ScriptKind.TS;
+      }
+      return originalGetScriptKind ? originalGetScriptKind(fileName) : ts.ScriptKind.Unknown;
+    },
+    resolveModuleNameLiterals(...args) {
+      const [moduleLiterals, containingFile] = args;
+      const previous = toArray(originalResolveModuleNameLiterals?.(...args));
 
-  host.getScriptSnapshot = (fileName) => {
-    const vuePath = realVuePathFromVirtual(fileName);
-    if (vuePath && originalFileExists(vuePath)) {
-      return ts.ScriptSnapshot.fromString(virtualVueDts());
-    }
-    return originalGetScriptSnapshot(fileName);
-  };
-
-  host.getScriptKind = (fileName) => {
-    if (realVuePathFromVirtual(fileName)) {
-      return ts.ScriptKind.TS;
-    }
-    return originalGetScriptKind ? originalGetScriptKind(fileName) : ts.ScriptKind.Unknown;
-  };
-
-  host.resolveModuleNameLiterals = (...args) => {
-    const [moduleLiterals, containingFile] = args;
-    const previous = toArray(originalResolveModuleNameLiterals?.(...args));
-
-    return moduleLiterals.map((literal, index) => {
-      if (previous[index] && previous[index].resolvedModule) {
-        return previous[index];
+      if (!Array.isArray(moduleLiterals)) {
+        return previous;
       }
 
-      const resolvedModule = resolveVueModule(ts, literal.text, containingFile, originalFileExists);
-      return resolvedModule ? { resolvedModule } : previous[index] || { resolvedModule: undefined };
-    });
-  };
+      return moduleLiterals.map((literal, index) => {
+        if (previous[index] && previous[index].resolvedModule) {
+          return previous[index];
+        }
 
-  host.resolveModuleNames = (...args) => {
-    const [moduleNames, containingFile] = args;
-    const previous = toArray(originalResolveModuleNames?.(...args));
+        const resolvedModule = resolveVueModule(
+          ts,
+          literal?.text,
+          containingFile,
+          originalFileExists,
+        );
+        return resolvedModule
+          ? { resolvedModule }
+          : previous[index] || { resolvedModule: undefined };
+      });
+    },
+    resolveModuleNames(...args) {
+      const [moduleNames, containingFile] = args;
+      const previous = toArray(originalResolveModuleNames?.(...args));
 
-    return moduleNames.map((moduleName, index) => {
-      if (previous[index]) {
-        return previous[index];
+      if (!Array.isArray(moduleNames)) {
+        return previous;
       }
-      return resolveVueModule(ts, moduleName, containingFile, originalFileExists);
-    });
+
+      return moduleNames.map((moduleName, index) => {
+        if (previous[index]) {
+          return previous[index];
+        }
+        return resolveVueModule(ts, moduleName, containingFile, originalFileExists);
+      });
+    },
   };
+
+  const replacementEntries = Object.entries(replacements);
+  if (!replacementEntries.every(([name]) => canAssignProperty(host, name))) {
+    return false;
+  }
+
+  const originals = new Map(replacementEntries.map(([name]) => [name, host[name]]));
+  try {
+    for (const [name, replacement] of replacementEntries) {
+      host[name] = replacement;
+    }
+  } catch (error) {
+    for (const [name, original] of originals) {
+      try {
+        host[name] = original;
+      } catch {
+        // Best effort rollback only; create() will return the unproxied service.
+      }
+    }
+    logPluginError(info, "install", error);
+    return false;
+  }
+
+  installedHosts.add(host);
+  return true;
 }
 
 function resolveVueModule(ts, specifier, containingFile, fileExists) {
-  if (!isRelativeVueSpecifier(specifier)) {
+  if (!isRelativeVueSpecifier(specifier) || typeof containingFile !== "string") {
     return undefined;
   }
 
@@ -137,7 +188,7 @@ function createLanguageServiceProxy(ts, languageService) {
     }
 
     const vuePaths = vuePathsFromDefinitions(
-      languageService.getDefinitionAtPosition(fileName, position),
+      safeCall(() => languageService.getDefinitionAtPosition(fileName, position), undefined),
     );
     if (vuePaths.length === 0) {
       return quickInfo;
@@ -156,6 +207,56 @@ function createLanguageServiceProxy(ts, languageService) {
   };
 
   return proxy;
+}
+
+function canAssignProperty(target, key) {
+  const descriptor = findPropertyDescriptor(target, key);
+  if (!descriptor) {
+    return isExtensible(target);
+  }
+  if ("writable" in descriptor) {
+    return descriptor.writable;
+  }
+  return typeof descriptor.set === "function";
+}
+
+function findPropertyDescriptor(target, key) {
+  let current = target;
+  while (current) {
+    const descriptor = Object.getOwnPropertyDescriptor(current, key);
+    if (descriptor) {
+      return descriptor;
+    }
+    current = Object.getPrototypeOf(current);
+  }
+  return undefined;
+}
+
+function isExtensible(target) {
+  try {
+    return Object.isExtensible(target);
+  } catch {
+    return false;
+  }
+}
+
+function safeCall(fn, fallback) {
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}
+
+function logPluginError(info, phase, error) {
+  try {
+    const message = error instanceof Error ? error.message : String(error);
+    info?.project?.projectService?.logger?.info?.(
+      `[vize] TypeScript Vue plugin ${phase} failed: ${message}`,
+    );
+  } catch {
+    // Logging must never be the reason the TypeScript server exits.
+  }
 }
 
 function remapVueVirtualDefinitions(ts, definitions) {

--- a/tests/tooling/vscode-typescript-vue-plugin.test.ts
+++ b/tests/tooling/vscode-typescript-vue-plugin.test.ts
@@ -152,6 +152,56 @@ test("TypeScript Vue plugin keeps plain .ts projects crash-free with unresolved 
   }
 });
 
+test("TypeScript Vue plugin falls back when the tsserver host cannot be patched", () => {
+  const project = createVueProject("const value = 1;\nvalue;\n", {});
+  try {
+    const host = createHost(path.dirname(path.dirname(project.mainTs)), project.mainTs);
+    Object.freeze(host);
+    const service = ts.createLanguageService(host);
+    const plugin = initVuePlugin({ typescript: ts });
+    let wrapped: import("typescript").LanguageService | undefined;
+
+    assert.doesNotThrow(() => {
+      wrapped = plugin.create({
+        languageService: service,
+        languageServiceHost: host,
+        serverHost: ts.sys,
+      });
+    });
+    assert.equal(wrapped, service);
+    assert.doesNotThrow(() => wrapped?.getSemanticDiagnostics(project.mainTs));
+  } finally {
+    fs.rmSync(project.root, { force: true, recursive: true });
+  }
+});
+
+test("TypeScript Vue plugin tolerates resolver calls without a containing file", () => {
+  const project = createVueProject('import App from "./app.vue";\nApp;\n', {
+    "app.vue": "<template />\n",
+  });
+  try {
+    const host = createHost(path.dirname(path.dirname(project.mainTs)), project.mainTs);
+    const service = ts.createLanguageService(host);
+    const plugin = initVuePlugin({ typescript: ts });
+
+    plugin.create({
+      languageService: service,
+      languageServiceHost: host,
+      serverHost: ts.sys,
+    });
+
+    assert.doesNotThrow(() => {
+      const result = (host.resolveModuleNameLiterals as unknown as (...args: unknown[]) => unknown)(
+        [{ text: "./app.vue" }],
+        undefined,
+      );
+      assert.deepEqual(result, [{ resolvedModule: undefined }]);
+    });
+  } finally {
+    fs.rmSync(project.root, { force: true, recursive: true });
+  }
+});
+
 function createVueProject(mainSource: string, vueFiles: Record<string, string>) {
   const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-vscode-vue-plugin-"));
   const srcDir = path.join(rootDir, "src");


### PR DESCRIPTION
## Summary
- make the VS Code TypeScript Vue plugin fall back to the original language service when tsserver host patching is unavailable
- avoid mutating hosts with a marker property and guard resolver calls with missing containing-file data
- add regression coverage for unpatchable tsserver hosts and resolver API drift

## Root Cause
The extension still installed the TypeScript server plugin into JS/TS projects and assumed the tsserver host could always be extended and patched. If that host shape differed from the test host, plugin initialization could still throw out of `create()` and take down the JS/TS language service.

## Verification
- `node --test tests/tooling/vscode-typescript-vue-plugin.test.ts`
- `node --check editors/vscode/typescript-vue-plugin/index.cjs`
- `vp run --workspace-root package:editor-extensions`
- `vp run --workspace-root package:vscode-extension`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785648795&installation_id=136613492&pr_number=2490&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2490&signature=e779c744584e6255bb8b6e8620b61a49b828e4db98bf7c48a78c850e95c27382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->