### PR TITLE
fix(atelier): prefix scoped slot default expressions

### DIFF
--- a/crates/vize_atelier_core/src/codegen/slots/params.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/params.rs
@@ -1,7 +1,16 @@
 //! Slot parameter helpers (scoped slot props parsing and prefixing).
 
 use crate::{DirectiveNode, ExpressionNode};
-use vize_carton::String;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{BindingPattern, Expression};
+use oxc_ast_visit::{
+    Visit,
+    walk::{walk_arrow_function_expression, walk_function, walk_object_property},
+};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{FxHashSet, String, ToCompactString};
+use vize_croquis::builtins::is_global_allowed;
 
 /// Get slot props expression as raw source (not transformed)
 pub(super) fn get_slot_props(dir: &DirectiveNode<'_>) -> Option<vize_carton::String> {
@@ -13,55 +22,206 @@ pub(super) fn get_slot_props(dir: &DirectiveNode<'_>) -> Option<vize_carton::Str
 
 /// Add _ctx. prefix to default value identifiers in destructuring patterns.
 /// e.g., "{ item = defaultItem }" -> "{ item = _ctx.defaultItem }"
-/// Only processes identifiers after `=` (default values), not the param names.
+/// Only processes default value expressions, not the param names.
 pub(super) fn prefix_slot_defaults(source: &str) -> String {
-    let bytes = source.as_bytes();
-    let len = bytes.len();
-    let mut result = String::with_capacity(len + 20);
-    let mut i = 0;
+    if crate::steps::expression::expression_exceeds_max_depth(source) {
+        return String::new(source);
+    }
 
-    while i < len {
-        if bytes[i] == b'=' {
-            // Skip == and =>
-            if i + 1 < len && (bytes[i + 1] == b'=' || bytes[i + 1] == b'>') {
-                result.push(bytes[i] as char);
-                result.push(bytes[i + 1] as char);
-                i += 2;
-                continue;
-            }
-            result.push('=');
-            i += 1;
-            // Skip whitespace after =
-            while i < len && (bytes[i] == b' ' || bytes[i] == b'\t') {
-                result.push(bytes[i] as char);
-                i += 1;
-            }
-            // Check if next is a simple identifier (not a literal/number/string/object)
-            if i < len && (bytes[i].is_ascii_alphabetic() || bytes[i] == b'_' || bytes[i] == b'$') {
-                // Collect the identifier
-                let start = i;
-                while i < len
-                    && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_' || bytes[i] == b'$')
-                {
-                    i += 1;
-                }
-                let ident = &source[start..i];
-                // Don't prefix keywords/literals
-                if !matches!(
-                    ident,
-                    "true" | "false" | "null" | "undefined" | "NaN" | "Infinity"
-                ) {
-                    result.push_str("_ctx.");
-                }
-                result.push_str(ident);
-            }
-        } else {
-            result.push(bytes[i] as char);
-            i += 1;
+    let mut wrapped = String::with_capacity(source.len() + 10);
+    wrapped.push('(');
+    wrapped.push_str(source);
+    wrapped.push_str(") => null");
+
+    let allocator = Allocator::default();
+    let parser = Parser::new(&allocator, &wrapped, SourceType::ts().with_module(true));
+    let Ok(Expression::ArrowFunctionExpression(arrow)) = parser.parse_expression() else {
+        return String::new(source);
+    };
+
+    let mut slot_params = FxHashSet::default();
+    for param in &arrow.params.items {
+        collect_binding_names(&param.pattern, &mut slot_params);
+    }
+
+    let mut visitor = SlotDefaultPrefixVisitor::new(slot_params, 1);
+    for param in &arrow.params.items {
+        collect_default_rewrites(&param.pattern, &mut visitor);
+    }
+
+    if visitor.insertions.is_empty() {
+        return String::new(source);
+    }
+
+    visitor
+        .insertions
+        .sort_by_key(|(pos, _)| std::cmp::Reverse(*pos));
+
+    let mut result = String::new(source);
+    for (pos, text) in visitor.insertions {
+        if pos <= result.len() {
+            result.insert_str(pos, &text);
+        }
+    }
+    result
+}
+
+struct SlotDefaultPrefixVisitor {
+    local_scopes: std::vec::Vec<FxHashSet<String>>,
+    offset: u32,
+    insertions: std::vec::Vec<(usize, String)>,
+}
+
+impl SlotDefaultPrefixVisitor {
+    fn new(slot_params: FxHashSet<String>, offset: u32) -> Self {
+        Self {
+            local_scopes: vec![slot_params],
+            offset,
+            insertions: std::vec::Vec::new(),
         }
     }
 
-    result
+    fn push_scope(&mut self) {
+        self.local_scopes.push(FxHashSet::default());
+    }
+
+    fn pop_scope(&mut self) {
+        self.local_scopes.pop();
+    }
+
+    fn is_local(&self, name: &str) -> bool {
+        self.local_scopes
+            .iter()
+            .rev()
+            .any(|scope| scope.contains(name))
+    }
+
+    fn collect_function_params(&mut self, params: &oxc_ast::ast::FormalParameters<'_>) {
+        if let Some(scope) = self.local_scopes.last_mut() {
+            for param in &params.items {
+                collect_binding_names(&param.pattern, scope);
+            }
+            if let Some(rest) = &params.rest {
+                collect_binding_names(&rest.rest.argument, scope);
+            }
+        }
+    }
+
+    fn push_prefix(&mut self, span_start: u32) {
+        let pos = span_start.saturating_sub(self.offset) as usize;
+        self.insertions.push((pos, String::new("_ctx.")));
+    }
+}
+
+impl<'a> Visit<'a> for SlotDefaultPrefixVisitor {
+    fn visit_identifier_reference(&mut self, ident: &oxc_ast::ast::IdentifierReference<'a>) {
+        let name = ident.name.as_str();
+        if !self.is_local(name) && !is_global_allowed(name) {
+            self.push_prefix(ident.span.start);
+        }
+    }
+
+    fn visit_object_property(&mut self, prop: &oxc_ast::ast::ObjectProperty<'a>) {
+        if prop.shorthand
+            && let oxc_ast::ast::PropertyKey::StaticIdentifier(ident) = &prop.key
+        {
+            let name = ident.name.as_str();
+            if !self.is_local(name) && !is_global_allowed(name) {
+                let pos = ident.span.end.saturating_sub(self.offset) as usize;
+                let mut suffix = String::with_capacity(name.len() + 8);
+                suffix.push_str(": _ctx.");
+                suffix.push_str(name);
+                self.insertions.push((pos, suffix));
+                return;
+            }
+        }
+
+        walk_object_property(self, prop);
+    }
+
+    fn visit_arrow_function_expression(
+        &mut self,
+        arrow: &oxc_ast::ast::ArrowFunctionExpression<'a>,
+    ) {
+        self.push_scope();
+        self.collect_function_params(&arrow.params);
+        walk_arrow_function_expression(self, arrow);
+        self.pop_scope();
+    }
+
+    fn visit_function(
+        &mut self,
+        func: &oxc_ast::ast::Function<'a>,
+        flags: oxc_syntax::scope::ScopeFlags,
+    ) {
+        self.push_scope();
+        self.collect_function_params(&func.params);
+        walk_function(self, func, flags);
+        self.pop_scope();
+    }
+
+    fn visit_variable_declarator(&mut self, declarator: &oxc_ast::ast::VariableDeclarator<'a>) {
+        if let Some(init) = &declarator.init {
+            self.visit_expression(init);
+        }
+        collect_default_rewrites(&declarator.id, self);
+        if let Some(scope) = self.local_scopes.last_mut() {
+            collect_binding_names(&declarator.id, scope);
+        }
+    }
+}
+
+fn collect_default_rewrites(pattern: &BindingPattern<'_>, visitor: &mut SlotDefaultPrefixVisitor) {
+    match pattern {
+        BindingPattern::BindingIdentifier(_) => {}
+        BindingPattern::ObjectPattern(obj) => {
+            for prop in &obj.properties {
+                collect_default_rewrites(&prop.value, visitor);
+            }
+            if let Some(rest) = &obj.rest {
+                collect_default_rewrites(&rest.argument, visitor);
+            }
+        }
+        BindingPattern::ArrayPattern(arr) => {
+            for elem in arr.elements.iter().flatten() {
+                collect_default_rewrites(elem, visitor);
+            }
+            if let Some(rest) = &arr.rest {
+                collect_default_rewrites(&rest.argument, visitor);
+            }
+        }
+        BindingPattern::AssignmentPattern(assign) => {
+            visitor.visit_expression(&assign.right);
+            collect_default_rewrites(&assign.left, visitor);
+        }
+    }
+}
+
+fn collect_binding_names(pattern: &BindingPattern<'_>, names: &mut FxHashSet<String>) {
+    match pattern {
+        BindingPattern::BindingIdentifier(id) => {
+            names.insert(id.name.as_str().to_compact_string());
+        }
+        BindingPattern::ObjectPattern(obj) => {
+            for prop in &obj.properties {
+                collect_binding_names(&prop.value, names);
+            }
+            if let Some(rest) = &obj.rest {
+                collect_binding_names(&rest.argument, names);
+            }
+        }
+        BindingPattern::ArrayPattern(arr) => {
+            for elem in arr.elements.iter().flatten() {
+                collect_binding_names(elem, names);
+            }
+            if let Some(rest) = &arr.rest {
+                collect_binding_names(&rest.argument, names);
+            }
+        }
+        BindingPattern::AssignmentPattern(assign) => {
+            collect_binding_names(&assign.left, names);
+        }
+    }
 }
 
 /// Extract parameter names from slot props expression

--- a/crates/vize_atelier_core/src/codegen/slots/tests.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/tests.rs
@@ -67,6 +67,45 @@ fn test_prefix_slot_defaults() {
         prefix_slot_defaults("{ x = undefined }"),
         "{ x = undefined }"
     );
+    assert_eq!(
+        prefix_slot_defaults("{ item = fallback.item }"),
+        "{ item = _ctx.fallback.item }"
+    );
+    assert_eq!(
+        prefix_slot_defaults("{ item, active = item.active }"),
+        "{ item, active = item.active }"
+    );
+    assert_eq!(
+        prefix_slot_defaults("{ label = makeLabel(seed) }"),
+        "{ label = _ctx.makeLabel(_ctx.seed) }"
+    );
+    assert_eq!(
+        prefix_slot_defaults("{ item = { label } }"),
+        "{ item = { label: _ctx.label } }"
+    );
+    assert_eq!(
+        prefix_slot_defaults("{ id = Math.random(), value = Number(seed) }"),
+        "{ id = Math.random(), value = Number(_ctx.seed) }"
+    );
+    assert_eq!(
+        prefix_slot_defaults("{ mapper = item => item.label, label = () => labelText }"),
+        "{ mapper = item => item.label, label = () => _ctx.labelText }"
+    );
+}
+
+#[test]
+fn scoped_slot_default_expressions_prefix_context_only() {
+    let result = compile!(
+        r#"<Comp v-slot="{ item, active = item.active, label = fallback.label, meta = { text }, id = Math.random() }">{{ active }}{{ label }}</Comp>"#
+    );
+    let output = result_output(&result);
+
+    assert!(output.contains("active = item.active"), "{output}");
+    assert!(output.contains("label = _ctx.fallback.label"), "{output}");
+    assert!(output.contains("meta = { text: _ctx.text }"), "{output}");
+    assert!(output.contains("id = Math.random()"), "{output}");
+    assert!(!output.contains("_ctx.item.active"), "{output}");
+    assert!(!output.contains("_ctx.Math"), "{output}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Replace the scoped slot default-value string scanner with an OXC-backed binding-pattern pass.
- Prefix context reads inside default expressions while keeping slot locals and JavaScript globals unprefixed.
- Add regression coverage for member, call, object-shorthand, global, and nested-arrow defaults.

## Change Class

- [x] Compiler and codegen

## Behavior Reference

Vue compiler parity: scoped slot default expressions such as `{ item = fallback.item }` should emit `_ctx.fallback.item`, while `{ item, active = item.active }` keeps `item` local and globals like `Math` unprefixed.

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [ ] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [ ] Security/audit impact considered
- [ ] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

Commands run:

- `cargo test -p vize_atelier_core codegen::slots::tests`
- `cargo test -p vize_atelier_core`
- `cargo test -p vize_atelier_sfc --test scoped_slot_shadowing`
- `cargo test -p vize_atelier_sfc test_typescript_scoped_slot_props_are_accepted`
- `cargo clippy -p vize_atelier_core --lib -- -D warnings`
- `git diff --check`

Note: `cargo clippy -p vize_atelier_core --all-targets -- -D warnings` still fails on existing unrelated test/helper disallowed-type and disallowed-macro warnings outside this change.

## Risk

Low. The new path only changes scoped slot props default-expression prefixing; parse failures and excessive expression depth fall back to the original source.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785651635&installation_id=136613492&pr_number=2494&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2494&signature=acfc966bbdab69cbbf1b3fbcb81ccedbc6560adaa0f431c11e702e7148d250fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->