### PR TITLE
fix(glyph): preserve nested markdown fences

### DIFF
--- a/crates/vize/src/commands/fmt/data/plain.rs
+++ b/crates/vize/src/commands/fmt/data/plain.rs
@@ -64,16 +64,16 @@ fn normalize_yaml(source: &str) -> String {
 fn normalize_markdown(source: &str) -> String {
     let lf = to_lf(source);
     let mut out = String::with_capacity(lf.len());
-    let mut fence: Option<char> = None;
+    let mut fence: Option<FenceMarker> = None;
     for (index, line) in lf.split('\n').enumerate() {
         if index > 0 {
             out.push('\n');
         }
         let stripped = line.trim_start();
-        let fence_char = fence_marker(stripped);
-        if let Some(marker) = fence_char {
+        let marker = fence_marker(stripped);
+        if let Some(marker) = marker {
             match fence {
-                Some(open) if open == marker => fence = None,
+                Some(open) if marker.closes(open) => fence = None,
                 None => fence = Some(marker),
                 Some(_) => {}
             }
@@ -87,12 +87,31 @@ fn normalize_markdown(source: &str) -> String {
     ensure_final_newline(out)
 }
 
-/// The fence character if `stripped` opens/closes a fenced code block.
-fn fence_marker(stripped: &str) -> Option<char> {
-    if stripped.starts_with("```") {
-        Some('`')
-    } else if stripped.starts_with("~~~") {
-        Some('~')
+#[derive(Clone, Copy)]
+struct FenceMarker {
+    ch: char,
+    len: usize,
+}
+
+impl FenceMarker {
+    fn closes(self, open: Self) -> bool {
+        self.ch == open.ch && self.len >= open.len
+    }
+}
+
+/// The fence marker if `stripped` opens/closes a fenced code block.
+fn fence_marker(stripped: &str) -> Option<FenceMarker> {
+    let ch = match stripped.as_bytes().first().copied()? {
+        b'`' => '`',
+        b'~' => '~',
+        _ => return None,
+    };
+    let len = stripped
+        .chars()
+        .take_while(|candidate| *candidate == ch)
+        .count();
+    if len >= 3 {
+        Some(FenceMarker { ch, len })
     } else {
         None
     }

--- a/crates/vize/src/commands/fmt/data/plain/tests.rs
+++ b/crates/vize/src/commands/fmt/data/plain/tests.rs
@@ -58,6 +58,16 @@ fn markdown_preserves_fenced_code_block_verbatim() {
 }
 
 #[test]
+fn markdown_preserves_shorter_fence_inside_longer_fence() {
+    let source = "````md\n```ts\nconst value = 1   \n```\n````\ntext   \n";
+    let result = format_markdown(source);
+    assert_eq!(
+        result.code.as_str(),
+        "````md\n```ts\nconst value = 1   \n```\n````\ntext\n"
+    );
+}
+
+#[test]
 fn markdown_preserves_indented_code_block() {
     let source = "para\n\n    code with spaces   \n";
     let result = format_markdown(source);


### PR DESCRIPTION
## Summary
- Preserve Markdown lines inside longer fenced code blocks when they contain a shorter same-character fence.
- Track Markdown fence marker length so a 4-backtick fence is not closed by a 3-backtick example inside it.
- Add a regression test for nested Markdown fence examples.

## Validation
- cargo fmt --all -- --check
- cargo test -p vize --lib commands::fmt::data::plain
- cargo test -p vize --test fmt_plain_cli
- cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785667523&installation_id=136613492&pr_number=2512&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2512&signature=bff40ef7e827ad6ef10c62eb36e6269d53fb8b365daa797cab61970cc6b76f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->