### PR TITLE
fix(glyph): require blank markdown closing fences

### DIFF
--- a/crates/vize/src/commands/fmt/data/plain.rs
+++ b/crates/vize/src/commands/fmt/data/plain.rs
@@ -91,11 +91,12 @@ fn normalize_markdown(source: &str) -> String {
 struct FenceMarker {
     ch: char,
     len: usize,
+    blank_tail: bool,
 }
 
 impl FenceMarker {
     fn closes(self, open: Self) -> bool {
-        self.ch == open.ch && self.len >= open.len
+        self.ch == open.ch && self.len >= open.len && self.blank_tail
     }
 }
 
@@ -111,7 +112,11 @@ fn fence_marker(stripped: &str) -> Option<FenceMarker> {
         .take_while(|candidate| *candidate == ch)
         .count();
     if len >= 3 {
-        Some(FenceMarker { ch, len })
+        Some(FenceMarker {
+            ch,
+            len,
+            blank_tail: stripped[len..].trim().is_empty(),
+        })
     } else {
         None
     }

--- a/crates/vize/src/commands/fmt/data/plain/tests.rs
+++ b/crates/vize/src/commands/fmt/data/plain/tests.rs
@@ -68,6 +68,16 @@ fn markdown_preserves_shorter_fence_inside_longer_fence() {
 }
 
 #[test]
+fn markdown_preserves_info_string_fence_inside_same_length_fence() {
+    let source = "```md\n```ts\nconst value = 1   \nexample done   \n```\ntext   \n";
+    let result = format_markdown(source);
+    assert_eq!(
+        result.code.as_str(),
+        "```md\n```ts\nconst value = 1   \nexample done   \n```\ntext\n"
+    );
+}
+
+#[test]
 fn markdown_preserves_indented_code_block() {
     let source = "para\n\n    code with spaces   \n";
     let result = format_markdown(source);


### PR DESCRIPTION
## Summary
- Require Markdown closing fences to have only whitespace after the marker.
- Preserve info-string fence examples inside an active fenced code block.
- Add a regression test covering same-length fence examples inside Markdown code fences.

## Validation
- cargo fmt --all -- --check
- cargo test -p vize --lib commands::fmt::data::plain
- cargo test -p vize --test fmt_plain_cli
- cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785668145&installation_id=136613492&pr_number=2522&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2522&signature=7bca7b6aa52e4a0130e6a0eaf55576507222cfbc22d75d5587dd1e0e158e381c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->