### PR TITLE
fix(canon): suppress unused Vue 2 emit helper

### DIFF
--- a/crates/vize/tests/check_legacy_vue2_no_unused_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_no_unused_cli.rs
@@ -5,61 +5,31 @@ use std::{path::Path, process::Command};
 use vize_carton::cstr;
 
 #[test]
-fn check_legacy_vue2_show_virtual_ts_omits_shared_helpers() {
+fn legacy_vue2_typed_emits_do_not_report_unused_loose_emit_helper() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
         return;
     };
-    let project_root = create_project("legacy-vue2-show-virtual-ts-no-shared-helpers");
-
-    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
-        .current_dir(&project_root)
-        .env("CORSA_PATH", corsa_path)
-        .args(["check", "src/App.vue", "--show-virtual-ts"])
-        .output()
-        .unwrap();
-
-    let stdout = std::str::from_utf8(&output.stdout).unwrap();
-    let stderr = std::str::from_utf8(&output.stderr).unwrap();
-    assert_eq!(
-        output.status.code(),
-        Some(0),
-        "stdout:\n{stdout}\nstderr:\n{stderr}"
-    );
-    assert!(
-        !stderr.contains(vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME),
-        "legacy Vue 2 should not show a shared helpers preamble:\n{stderr}"
-    );
-    assert!(
-        stderr.contains(
-            "declare function __vizeDefineComponent<T>(options: T & __VizeNuxt2PageOptions): T;"
-        ),
-        "expected per-file legacy defineComponent helper:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("type __VizeComponentProps<T>"),
-        "legacy Vue 2 virtual TS must define component props helpers inline:\n{stderr}"
-    );
-    for vue3_only_helper in [
-        "import('vue').Ref",
-        "import('vue').ShallowRef",
-        "import('vue').ComponentPublicInstance",
-        "import('vue').defineComponent",
-    ] {
-        assert!(
-            !stderr.contains(vue3_only_helper),
-            "legacy Vue 2 virtual TS must not contain {vue3_only_helper}:\n{stderr}"
-        );
-    }
-
-    let _ = std::fs::remove_dir_all(&project_root);
+    let project_root = create_project("legacy-vue2-no-unused-loose-emit-helper");
+    std::fs::write(
+        project_root.join("src/App.vue"),
+        r#"<script setup lang="ts">
+interface Emits {
+  (event: 'click', value: MouseEvent): void
 }
 
-#[test]
-fn check_legacy_vue2_targeted_json_keeps_component_props_helper_available() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
-        return;
-    };
-    let project_root = create_project("legacy-vue2-targeted-json-component-props-helper");
+const emit = defineEmits<Emits>()
+
+function handleClick(event: MouseEvent) {
+  emit('click', event)
+}
+</script>
+
+<template>
+  <button @click="handleClick">Click</button>
+</template>
+"#,
+    )
+    .unwrap();
 
     let output = Command::new(env!("CARGO_BIN_EXE_vize"))
         .current_dir(&project_root)
@@ -85,35 +55,30 @@ fn check_legacy_vue2_targeted_json_keeps_component_props_helper_available() {
     let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
     assert_eq!(
         json["errorCount"], 0,
-        "stdout:\n{stdout}\nstderr:\n{stderr}"
+        "generated loose emit helpers must not surface under noUnusedLocals:\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert!(
-        !stdout.contains("__VizeComponentProps"),
-        "targeted JSON check should not report missing component props helper:\n{stdout}"
+        !stdout.contains("__VizeVue2LooseEmitArgs"),
+        "JSON diagnostics should not mention the internal helper:\n{stdout}"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
 
 #[test]
-fn legacy_vue2_full_tsconfig_no_template_bindings_keeps_props_helper() {
+fn legacy_vue2_no_unused_locals_still_reports_user_unused_bindings() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
         return;
     };
-    let project_root = create_project("legacy-vue2-full-tsconfig-component-props-helper");
+    let project_root = create_project("legacy-vue2-no-unused-user-binding");
     std::fs::write(
-        project_root.join("src/Dialog.vue"),
-        r#"<script lang="ts">
-export default {
-  props: {
-    title: String,
-  },
-}
+        project_root.join("src/App.vue"),
+        r#"<script setup lang="ts">
+const used = 1
+const unusedLocal = 2
 </script>
 
-<template>
-  <section>{{ title }}</section>
-</template>
+<template>{{ used }}</template>
 "#,
     )
     .unwrap();
@@ -125,9 +90,9 @@ export default {
             "check",
             "--tsconfig",
             "tsconfig.json",
-            "--no-check-template-bindings",
             "--format",
             "json",
+            "src/App.vue",
         ])
         .output()
         .unwrap();
@@ -136,18 +101,21 @@ export default {
     let stderr = std::str::from_utf8(&output.stderr).unwrap();
     assert_eq!(
         output.status.code(),
-        Some(0),
-        "stdout:\n{stdout}\nstderr:\n{stderr}"
+        Some(1),
+        "user unused locals should still fail the check\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
     let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
     assert_eq!(
-        json["errorCount"], 0,
+        json["errorCount"], 1,
         "stdout:\n{stdout}\nstderr:\n{stderr}"
     );
-    assert_eq!(json["fileCount"], 2, "stdout:\n{stdout}\nstderr:\n{stderr}");
     assert!(
-        !stdout.contains("__VizeComponentProps"),
-        "full tsconfig check should not report missing component props helper:\n{stdout}"
+        stdout.contains("unusedLocal"),
+        "expected the user unused binding diagnostic:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("__VizeVue2LooseEmitArgs"),
+        "internal helper diagnostics must stay suppressed without hiding user diagnostics:\n{stdout}"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);
@@ -167,7 +135,8 @@ fn create_project(name: &str) -> std::path::PathBuf {
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "noEmit": true
+    "noEmit": true,
+    "noUnusedLocals": true
   },
   "include": ["src/**/*"]
 }"#,
@@ -180,22 +149,6 @@ fn create_project(name: &str) -> std::path::PathBuf {
     "legacyVue2": true
   }
 }"#,
-    )
-    .unwrap();
-    std::fs::write(
-        project_root.join("src/App.vue"),
-        r#"<script lang="ts">
-export default {
-  data() {
-    return { count: 0 }
-  },
-}
-</script>
-
-<template>
-  <div>{{ count }}</div>
-</template>
-"#,
     )
     .unwrap();
     project_root

--- a/crates/vize_canon/src/batch/virtual_project/tests/snapshots/vize_canon__batch__virtual_project__tests__ref_arity__dialect_v2.snap
+++ b/crates/vize_canon/src/batch/virtual_project/tests/snapshots/vize_canon__batch__virtual_project__tests__ref_arity__dialect_v2.snap
@@ -45,7 +45,7 @@ type __VizeKebabProps<T> = { [K in keyof T & string as __VizeKebabCase<K>]: T[K]
 type __VizeComponentProps<T> = T extends unknown ? T & Partial<__VizeKebabProps<T>> : never;
 type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
 type __VizeVue2LooseEventArg<T> = __VizeIsAny<T> extends true ? any : [T] extends [Object] ? ([Object] extends [T] ? any : T) : T;
-type __VizeVue2LooseEmitArgs<A extends readonly unknown[]> = { [K in keyof A]: __VizeVue2LooseEventArg<A[K]> };
+declare type __VizeVue2LooseEmitArgs<A extends readonly unknown[]> = { [K in keyof A]: __VizeVue2LooseEventArg<A[K]> };
 type __VForEntry<T> = __VizeIsAny<T> extends true ? [item: any, key: number, index: number] : T extends readonly (infer U)[] ? [item: U, key: number, index: number] : T extends number ? [item: number, key: number, index: number] : T extends string ? [item: string, key: number, index: number] : T extends Iterable<infer U> ? [item: U, key: number, index: number] : T extends object ? [item: T[keyof T], key: keyof T, index: number] : [item: any, key: number, index: number];
 declare function __vForList<T>(source: T | undefined | null): readonly __VForEntry<NonNullable<T>>[];
 import { ref } from 'vue'
@@ -86,7 +86,7 @@ function __setup() {
 
   const count = ref(0)
 
-  // @vize-map: 6242:6317 -> 0:84
+  // @vize-map: 6250:6325 -> 0:84
 
   // ========== Template Scope (inherits from setup) ==========
   // Ref type captures (before template scope shadows them)

--- a/crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs
@@ -27,7 +27,7 @@ type __VizeKebabProps<T> = { [K in keyof T & string as __VizeKebabCase<K>]: T[K]
 type __VizeComponentProps<T> = T extends unknown ? T & Partial<__VizeKebabProps<T>> : never;
 type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
 type __VizeVue2LooseEventArg<T> = __VizeIsAny<T> extends true ? any : [T] extends [Object] ? ([Object] extends [T] ? any : T) : T;
-type __VizeVue2LooseEmitArgs<A extends readonly unknown[]> = { [K in keyof A]: __VizeVue2LooseEventArg<A[K]> };
+declare type __VizeVue2LooseEmitArgs<A extends readonly unknown[]> = { [K in keyof A]: __VizeVue2LooseEventArg<A[K]> };
 type __VForEntry<T> = __VizeIsAny<T> extends true ? [item: any, key: number, index: number] : T extends readonly (infer U)[] ? [item: U, key: number, index: number] : T extends number ? [item: number, key: number, index: number] : T extends string ? [item: string, key: number, index: number] : T extends Iterable<infer U> ? [item: U, key: number, index: number] : T extends object ? [item: T[keyof T], key: keyof T, index: number] : [item: any, key: number, index: number];
 declare function __vForList<T>(source: T | undefined | null): readonly __VForEntry<NonNullable<T>>[];"#;
 const LEGACY_REF_UNWRAP_HELPER: &str =


### PR DESCRIPTION
## Summary
- mark the Vue 2 loose emit tuple helper as an ambient type so `noUnusedLocals` does not report internal generated TypeScript
- add legacy Vue 2 CLI regression coverage for typed emits under `noUnusedLocals`
- assert user unused-local diagnostics still surface, so internal suppression does not hide real user errors

Fixes #2503
Fixes #2513

## Validation
- cargo fmt --all -- --check
- cargo test -p vize --features legacy --test check_legacy_vue2_helpers_cli legacy_vue2
- cargo test -p vize_canon --features legacy ref_arity
- cargo test -p vize_canon --features legacy legacy_vue2_component_event_object_payloads_stay_permissive
- cargo clippy -p vize --features legacy --test check_legacy_vue2_helpers_cli -- -D warnings -D clippy::wildcard_imports
- cargo clippy -p vize_canon --features legacy -- -D warnings -D clippy::wildcard_imports
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785668805&installation_id=136613492&pr_number=2523&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2523&signature=120a0e30a5ed5eb199977ea22f1835c68100ee71897f130bf38e1d63310ec8e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->