### PR TITLE
fix(canon): avoid Nuxt 2 prepare guidance

### DIFF
--- a/crates/vize/src/commands/check/nuxt.rs
+++ b/crates/vize/src/commands/check/nuxt.rs
@@ -5,7 +5,7 @@
 use std::path::Path;
 
 use vize_canon::virtual_ts::VirtualTsOptions;
-use vize_carton::{FxHashSet, String, ToCompactString};
+use vize_carton::{FxHashSet, String, ToCompactString, config::VueVersion};
 
 mod fallback;
 mod generated;
@@ -43,7 +43,7 @@ pub(in crate::commands::check) fn detect_nuxt_auto_imports(
     options: &mut VirtualTsOptions,
     cwd: &Path,
 ) -> Vec<NuxtPathAlias> {
-    detect(options, cwd, None, false)
+    detect(options, cwd, None, false, VueVersion::V3)
 }
 
 #[cfg(test)]
@@ -51,7 +51,7 @@ pub(in crate::commands::check) fn detect_legacy_nuxt_auto_imports(
     options: &mut VirtualTsOptions,
     cwd: &Path,
 ) -> Vec<NuxtPathAlias> {
-    detect(options, cwd, None, true)
+    detect(options, cwd, None, true, VueVersion::V2_7)
 }
 
 pub(in crate::commands::check) fn detect(
@@ -59,6 +59,7 @@ pub(in crate::commands::check) fn detect(
     cwd: &Path,
     tsconfig_path: Option<&Path>,
     legacy_vue2: bool,
+    dialect: VueVersion,
 ) -> Vec<NuxtPathAlias> {
     if !is_nuxt_project(cwd) {
         return Vec::new();
@@ -91,9 +92,13 @@ pub(in crate::commands::check) fn detect(
     // Surface the degraded fallback: without generated Nuxt types,
     // auto-imports resolve to permissive `any` stubs that hide real type
     // errors. detect_nuxt_auto_imports runs once per check, so this warns once.
-    if let Some(message) =
-        missing_generated_types_warning(has_generated_imports, &generated_dir, legacy_vue2)
-    {
+    let legacy_generated_type_guidance =
+        legacy_vue2 || matches!(dialect, VueVersion::V2 | VueVersion::V2_7);
+    if let Some(message) = missing_generated_types_warning(
+        has_generated_imports,
+        &generated_dir,
+        legacy_generated_type_guidance,
+    ) {
         eprintln!("{message}");
     }
     collect_plugin_injection_stubs(cwd, &mut collected, &mut seen_names);

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -102,17 +102,9 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         .source_path
         .as_deref()
         .and_then(|path| crate::config::load_compiler_template_syntax(Some(path)));
-    // Configured Vue dialect (`vue.version`) threads into dialect-aware virtual TS.
     let dialect = dialect_from_features(loaded_config.features.vue_version);
-    // Vue 3 Options API binding resolution is officially supported and is a
-    // standard-build opt-in (not the `legacy` feature).
     let options_api = loaded_config.features.type_checker_options_api;
-    // Opt-in type-checking of `.jsx`/`.tsx` Vize components (#1497). Default-off
-    // so React `.tsx` is not accidentally routed through the Vue JSX checker.
     let jsx_typecheck = loaded_config.features.type_checker_jsx_typecheck;
-    // Legacy Vue 2.7 / Nuxt 2 Options-API type checking is opt-in and compiled out
-    // of the default Vue 3 binary. Without the `legacy` feature, honor the config
-    // flag by warning instead of silently ignoring it.
     let legacy_vue2 = cfg!(feature = "legacy") && loaded_config.features.type_checker_legacy_vue2;
     #[cfg(not(feature = "legacy"))]
     if loaded_config.features.type_checker_legacy_vue2 {
@@ -256,7 +248,13 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let mut virtual_ts_options = build_virtual_ts_options(&config, config_dir);
     let tsconfig = program_tsconfig_path.as_deref();
     let nuxt_root = &nuxt_project_root;
-    let nuxt_path_aliases = nuxt::detect(&mut virtual_ts_options, nuxt_root, tsconfig, legacy_vue2);
+    let nuxt_path_aliases = nuxt::detect(
+        &mut virtual_ts_options,
+        nuxt_root,
+        tsconfig,
+        legacy_vue2,
+        dialect,
+    );
     collect_project_global_component_stubs(
         &mut virtual_ts_options,
         &files,

--- a/crates/vize/tests/check_nuxt2_fallback_guidance_cli.rs
+++ b/crates/vize/tests/check_nuxt2_fallback_guidance_cli.rs
@@ -1,0 +1,149 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+#[test]
+fn check_nuxt2_compiler_compat_warning_does_not_suggest_nuxi_prepare() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project("nuxt2-fallback-guidance");
+
+    write_file(&project_root, "nuxt.config.ts", "export default {};\n");
+    write_file(
+        &project_root,
+        "vize.config.json",
+        r#"{
+  "compiler": {
+    "compatibility": {
+      "vueVersion": "2",
+      "hostCompiler": true
+    }
+  },
+  "typeChecker": {
+    "tsconfig": "tsconfig.json"
+  }
+}
+"#,
+    );
+    write_file(
+        &project_root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["components/**/*.vue"]
+}
+"#,
+    );
+    write_file(
+        &project_root,
+        "components/AppLink.vue",
+        r#"<template>
+  <NuxtLink to="/">{{ label }}</NuxtLink>
+</template>
+
+<script lang="ts">
+export default {
+  data() {
+    return { label: "home" };
+  },
+};
+</script>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", "--config", "vize.config.json", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "Nuxt 2 fallback check should still complete\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("no generated `.nuxt` types found"),
+        "missing generated Nuxt types should still be surfaced:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Nuxt 2/Bridge"),
+        "Vue 2 compatibility config should select Nuxt 2 guidance:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("nuxi prepare"),
+        "Nuxt 2 guidance must not suggest Nuxt 3 prepare:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn create_project(name: &str) -> PathBuf {
+    let project_root = workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join(cstr!("{name}-{}", std::process::id()).as_str());
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    link_workspace_node_modules(&project_root);
+    project_root
+}
+
+fn write_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(file_path, content).unwrap();
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn link_workspace_node_modules(project_root: &Path) {
+    let source = workspace_root().join("node_modules");
+    if source.exists() {
+        symlink_path(&source, &project_root.join("node_modules")).unwrap();
+    }
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("CORSA_PATH") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let workspace_root = workspace_root();
+    [workspace_root.join("node_modules/.bin/tsgo")]
+        .into_iter()
+        .find(|candidate| candidate.exists())
+}
+
+fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(source, target)
+    }
+}


### PR DESCRIPTION
## Summary

- Keep Nuxt generated-type fallback guidance separate from the legacy Vue 2 template-global switch.
- Select Nuxt 2/Bridge guidance when config selects Vue 2 through `compiler.compatibility.vueVersion`.
- Add a CLI regression test that fails if Nuxt 2 compatibility config suggests `nuxi prepare`.

Closes #2499

## Validation

- `cargo test -p vize --test check_nuxt2_fallback_guidance_cli -- check_nuxt2_compiler_compat_warning_does_not_suggest_nuxi_prepare --nocapture`
- `cargo test -p vize nuxt --lib`
- `cargo clippy -p vize --lib --test check_nuxt2_fallback_guidance_cli -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check origin/main...HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785670328&installation_id=136613492&pr_number=2525&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2525&signature=84582b047c4bb42e83b243c44f4ce01920aa5ae6267bb222baa2b2fb55332652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->