### PR TITLE
fix(canon): preserve non-ascii template literals

### DIFF
--- a/crates/vize_canon/src/virtual_ts/expressions/reserved_props.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/reserved_props.rs
@@ -72,8 +72,12 @@ pub(crate) fn rewrite_reserved_template_prop(
             continue;
         }
 
-        output.push(current as char);
-        i += 1;
+        let ch = expression[i..]
+            .chars()
+            .next()
+            .expect("valid UTF-8 boundary");
+        output.push(ch);
+        i += ch.len_utf8();
     }
 
     changed.then_some(output)

--- a/crates/vize_canon/src/virtual_ts/expressions/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/tests.rs
@@ -59,6 +59,18 @@ fn leaves_literals_and_regexes_alone() {
 }
 
 #[test]
+fn preserves_non_ascii_literals_when_rewriting_reserved_props() {
+    assert_eq!(
+        rewrite_reserved_template_prop(
+            "static ? 'アカウント' : `コンテンツ管理`",
+            &reserved_props(),
+        )
+        .as_deref(),
+        Some("props[\"static\"] ? 'アカウント' : `コンテンツ管理`")
+    );
+}
+
+#[test]
 fn ignores_non_reserved_props() {
     let props = ["count"].into_iter().map(Into::into).collect();
     assert_eq!(rewrite_reserved_template_prop("count + 1", &props), None);

--- a/crates/vize_canon/src/virtual_ts/tests/component_navigation.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/component_navigation.rs
@@ -1,5 +1,27 @@
 use super::generate_virtual_ts;
 
+fn generate(script: &str, template: &str, script_setup: bool) -> super::super::VirtualTsOutput {
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let allocator = vize_carton::Bump::new();
+    let (root, errors) = vize_armature::parse(&allocator, template);
+    assert!(
+        errors.is_empty(),
+        "template should parse without errors: {errors:?}"
+    );
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    if script_setup {
+        analyzer.analyze_script_setup(script);
+    } else {
+        analyzer.analyze_script_plain(script);
+    }
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    generate_virtual_ts(&summary, Some(script), Some(&root), 0)
+}
+
 #[test]
 fn component_template_navigation_mappings() {
     use vize_croquis::{Analyzer, AnalyzerOptions};
@@ -46,5 +68,55 @@ const count = 1
     assert_eq!(
         &output.code[dynamic_prop_mapping.gen_range.clone()],
         "count"
+    );
+}
+
+#[test]
+fn non_ascii_template_string_literals_are_preserved() {
+    let script = r#"import { defineComponent } from '@nuxtjs/composition-api';
+
+const NAVIGATION_ITEMS = [
+  { header: 'アカウント' },
+  { header: 'コンテンツ管理' },
+] as const;
+
+export default defineComponent({
+  setup() {
+    return { NAVIGATION_ITEMS };
+  },
+});
+"#;
+    let template = r#"<template v-for="menu in NAVIGATION_ITEMS">
+  <v-list-item :disabled="menu.header === 'アカウント'">
+    {{ menu.header }}
+  </v-list-item>
+</template>"#;
+
+    let output = generate(script, template, false);
+
+    assert!(output.code.contains("menu.header === 'アカウント'"));
+    assert!(output.code.contains("header: 'コンテンツ管理'"));
+    assert!(
+        !output.code.contains("ã"),
+        "virtual TS must not contain mojibake:\n{}",
+        output.code
+    );
+}
+
+#[test]
+fn non_ascii_template_string_literals_survive_comment_stripping() {
+    let script = r#"const menu = { header: 'アカウント' }"#;
+    let template =
+        r#"<div :title="/* leading */ menu.header === 'アカウント' ? '選択中' : '通常'"></div>"#;
+
+    let output = generate(script, template, true);
+
+    assert!(output.code.contains("menu.header === 'アカウント'"));
+    assert!(output.code.contains("'選択中'"));
+    assert!(output.code.contains("'通常'"));
+    assert!(
+        !output.code.contains("ã"),
+        "comment stripping must keep UTF-8 literals intact:\n{}",
+        output.code
     );
 }

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/comments.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/comments.rs
@@ -18,26 +18,16 @@ pub fn strip_js_comments(expr: &str) -> Cow<'_, str> {
         let c = bytes[i];
 
         if c == b'\'' || c == b'"' || c == b'`' {
+            let literal_start = i;
             let quote = c;
-            if changed {
-                out.push(quote as char);
-            }
             i += 1;
 
             while i < len {
                 let current = bytes[i];
-                if changed {
-                    out.push(current as char);
-                }
                 i += 1;
 
                 if current == b'\\' {
-                    if i < len {
-                        if changed {
-                            out.push(bytes[i] as char);
-                        }
-                        i += 1;
-                    }
+                    i = (i + 1).min(len);
                     continue;
                 }
 
@@ -46,6 +36,9 @@ pub fn strip_js_comments(expr: &str) -> Cow<'_, str> {
                 }
             }
 
+            if changed {
+                out.push_str(&expr[literal_start..i]);
+            }
             continue;
         }
 
@@ -95,9 +88,12 @@ pub fn strip_js_comments(expr: &str) -> Cow<'_, str> {
         }
 
         if changed {
-            out.push(c as char);
+            let ch = expr[i..].chars().next().expect("valid UTF-8 boundary");
+            out.push(ch);
+            i += ch.len_utf8();
+        } else {
+            i += 1;
         }
-        i += 1;
     }
 
     if changed {

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
@@ -1,4 +1,6 @@
-use super::{IdentifierRef, extract_identifier_refs_oxc, extract_identifiers_oxc};
+use super::{
+    IdentifierRef, extract_identifier_refs_oxc, extract_identifiers_oxc, strip_js_comments,
+};
 use vize_carton::CompactString;
 
 #[test]
@@ -33,6 +35,17 @@ fn test_extract_identifiers_ignores_comment_words() {
         "/** comment words should disappear */ disabled ? true : undefined",
     ));
     assert_eq!(ids, vec!["disabled", "true", "undefined"]);
+}
+
+#[test]
+fn test_strip_js_comments_preserves_non_ascii_literals_after_comments() {
+    let expr = "/* hidden */ menu.header === 'アカウント' ? '選択中' : '通常'";
+    let stripped = strip_js_comments(expr);
+
+    assert_eq!(
+        stripped.as_ref(),
+        "  menu.header === 'アカウント' ? '選択中' : '通常'"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Preserve UTF-8 while stripping JS comments from template expressions.
- Preserve UTF-8 while rewriting reserved template prop identifiers.
- Add regressions for the Nuxt 2-style non-ASCII template literal case and comment-stripped literals.

## Root Cause

Two byte-oriented scanners copied bytes back into Rust `char`s with `as char`. Once a template expression had already allocated an output buffer, non-ASCII literal bytes could be re-emitted as mojibake in virtual TS.

## Validation

- `cargo test -p vize_croquis drawer::helpers::identifiers --lib`
- `cargo test -p vize_canon virtual_ts::tests::component_navigation --lib`
- `cargo test -p vize_canon virtual_ts::expressions --lib`
- `cargo clippy -p vize_croquis -p vize_canon -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `node --test tests/tooling/source-file-lengths.test.ts`

Closes #2498

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785671638&installation_id=136613492&pr_number=2527&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2527&signature=a21ddfa1d08f51dcfb9db202e20387308f01a3ce5affdb5ff5319a8c522608b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->