### PR TITLE
fix(musea): skip static gallery during storybook builds

### DIFF
--- a/npm/builder/vite-musea/src/plugin/index.test.ts
+++ b/npm/builder/vite-musea/src/plugin/index.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { Plugin } from "vite";
+import { MUSEA_STATIC_BUILD_ENV } from "../static-export.js";
 import { shouldApplyMuseaPlugin } from "./apply.js";
+import { musea } from "./index.js";
 import {
   assertStaticPreviewRuntimeSupported,
   resolveStaticPreviewVueVersion,
@@ -18,6 +21,43 @@ void test("musea plugin remains active during production builds", () => {
   assert.equal(shouldApplyMuseaPlugin({ command: "build", mode: "production" }), true);
 });
 
+void test("storybook compatibility build does not inject static gallery input by default", () => {
+  const previousEnv = process.env[MUSEA_STATIC_BUILD_ENV];
+  try {
+    Reflect.deleteProperty(process.env, MUSEA_STATIC_BUILD_ENV);
+    const plugin = musea({ storybookCompat: true })[0] as Plugin;
+    const result = runConfigHook(plugin);
+
+    assert.equal(Object.hasOwn(result, "build"), false);
+  } finally {
+    if (previousEnv === undefined) {
+      Reflect.deleteProperty(process.env, MUSEA_STATIC_BUILD_ENV);
+    } else {
+      process.env[MUSEA_STATIC_BUILD_ENV] = previousEnv;
+    }
+  }
+});
+
+void test("storybook compatibility keeps explicit Musea static builds", () => {
+  const previousEnv = process.env[MUSEA_STATIC_BUILD_ENV];
+  try {
+    process.env[MUSEA_STATIC_BUILD_ENV] = "1";
+    const plugin = musea({ storybookCompat: true })[0] as Plugin;
+    const result = runConfigHook(plugin);
+
+    assert.equal(
+      result.build?.rollupOptions?.input?.["musea-static-runtime"],
+      "virtual:musea-static-runtime",
+    );
+  } finally {
+    if (previousEnv === undefined) {
+      Reflect.deleteProperty(process.env, MUSEA_STATIC_BUILD_ENV);
+    } else {
+      process.env[MUSEA_STATIC_BUILD_ENV] = previousEnv;
+    }
+  }
+});
+
 void test("static builds reject legacy Vue preview runtime explicitly", () => {
   assert.throws(() => assertStaticPreviewRuntimeSupported(2, true), /Vue 3 preview runtime/);
   assert.doesNotThrow(() => assertStaticPreviewRuntimeSupported(2, false));
@@ -29,3 +69,19 @@ void test("static preview runtime infers legacy Vue from host compiler plugins",
   assert.equal(resolveStaticPreviewVueVersion(undefined, [{ name: "vite:vue" }]), 3);
   assert.equal(resolveStaticPreviewVueVersion(3, [{ name: "vite:vue2" }]), 3);
 });
+
+function runConfigHook(plugin: Plugin): {
+  build?: { rollupOptions?: { input?: Record<string, string> } };
+} {
+  assert.equal(typeof plugin.config, "function");
+  const configHook = plugin.config as (
+    config: { build: { rollupOptions: Record<string, unknown> } },
+    env: { command: "build"; mode: string },
+  ) => unknown;
+  const result = configHook(
+    { build: { rollupOptions: {} } },
+    { command: "build", mode: "production" },
+  );
+  assert.ok(result && typeof result === "object" && !("then" in result));
+  return result as { build?: { rollupOptions?: { input?: Record<string, string> } } };
+}

--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -30,7 +30,7 @@ import {
   loadStaticRuntimeModule,
   museaStaticBuildConfig,
   resolveStaticRuntimeId,
-  shouldEnableMuseaStaticBuild,
+  shouldEmitMuseaStaticGallery,
   type StaticBuildInput,
 } from "../static-export.js";
 import { resolveMuseaSharedConfig } from "./config.js";
@@ -91,7 +91,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
     },
 
     config(userConfig, env) {
-      staticBuildEnabled = shouldEnableMuseaStaticBuild(env.command);
+      staticBuildEnabled = shouldEmitMuseaStaticGallery(env.command, storybookCompat);
       const staticBuildConfig = staticBuildEnabled
         ? museaStaticBuildConfig(userConfig.build?.rollupOptions?.input as StaticBuildInput)
         : {};
@@ -115,6 +115,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
           tokenPreviewConfig = mc.tokenPreviews;
       }
       vueVersion = resolveStaticPreviewVueVersion(vueVersion, resolvedConfig.plugins);
+      staticBuildEnabled = shouldEmitMuseaStaticGallery(resolvedConfig.command, storybookCompat);
 
       virtualState.basePath = basePath;
 

--- a/npm/builder/vite-musea/src/static-build.test.ts
+++ b/npm/builder/vite-musea/src/static-build.test.ts
@@ -14,6 +14,7 @@ import {
   loadStaticRuntimeModule,
   resolveStaticRuntimeId,
   shouldEnableMuseaStaticBuild,
+  shouldEmitMuseaStaticGallery,
   VIRTUAL_STATIC_RUNTIME,
   type StaticBuildInput,
 } from "./static-export.js";
@@ -81,6 +82,27 @@ void test("static build mode is enabled for direct vite builds without env flag"
 
     process.env[MUSEA_STATIC_BUILD_ENV] = "1";
     assert.equal(shouldEnableMuseaStaticBuild("serve"), true);
+  } finally {
+    if (previousEnv === undefined) {
+      Reflect.deleteProperty(process.env, MUSEA_STATIC_BUILD_ENV);
+    } else {
+      process.env[MUSEA_STATIC_BUILD_ENV] = previousEnv;
+    }
+  }
+});
+
+void test("storybook compatibility suppresses implicit static gallery builds", () => {
+  const previousEnv = process.env[MUSEA_STATIC_BUILD_ENV];
+  try {
+    Reflect.deleteProperty(process.env, MUSEA_STATIC_BUILD_ENV);
+
+    assert.equal(shouldEmitMuseaStaticGallery("build", false), true);
+    assert.equal(shouldEmitMuseaStaticGallery("build", true), false);
+    assert.equal(shouldEmitMuseaStaticGallery("serve", true), false);
+
+    process.env[MUSEA_STATIC_BUILD_ENV] = "1";
+    assert.equal(shouldEmitMuseaStaticGallery("build", true), true);
+    assert.equal(shouldEmitMuseaStaticGallery("serve", true), true);
   } finally {
     if (previousEnv === undefined) {
       Reflect.deleteProperty(process.env, MUSEA_STATIC_BUILD_ENV);

--- a/npm/builder/vite-musea/src/static-export.ts
+++ b/npm/builder/vite-musea/src/static-export.ts
@@ -47,6 +47,11 @@ export function shouldEnableMuseaStaticBuild(command: string): boolean {
   return isMuseaStaticBuild() || command === "build";
 }
 
+export function shouldEmitMuseaStaticGallery(command: string, storybookCompat: boolean): boolean {
+  if (isMuseaStaticBuild()) return true;
+  return shouldEnableMuseaStaticBuild(command) && !storybookCompat;
+}
+
 export function museaStaticBuildInput(input: StaticBuildInput): Record<string, string> {
   const entries: Record<string, string> = {};
 


### PR DESCRIPTION
## Summary

- Do not enable Musea static gallery emission for normal Vite `build` runs when `storybookCompat` is enabled.
- Keep explicit Musea static builds working via `VIZE_MUSEA_STATIC_BUILD=1`.
- Add regression coverage for the static-gallery gating helper and Musea plugin config hook.

## Root Cause

`shouldEnableMuseaStaticBuild("build")` treated every Vite production build as a Musea static gallery build. Storybook also runs a Vite build, so `storybookCompat` builds could reach `emitStaticGallery` without the generated Musea static runtime entry and fail the Storybook preview build.

## Validation

- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

Attempted local package checks, but this checkout is missing JS package dependencies and `pnpm` refused a frozen install because the local lockfile config does not match the active pnpm overrides. The PR is set to auto-merge only after GitHub Actions `check-js` and package build jobs pass.

Closes #2501

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785672011&installation_id=136613492&pr_number=2528&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2528&signature=803764aad07eb010a826c18e21b1b10b1344a915a0e1ba28ed1fa90f2f7c0675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->