### PR TITLE
fix(musea): preserve CSF JSX children

### DIFF
--- a/crates/vize/src/commands/musea/migrate/csf.rs
+++ b/crates/vize/src/commands/musea/migrate/csf.rs
@@ -210,18 +210,28 @@ fn story_from_object<'a>(export_name: &str, object: &'a ObjectExpression<'a>) ->
 fn render_body<'a>(value: &'a Expression<'a>) -> Option<&'a Expression<'a>> {
     match unwrap_expression(value) {
         Expression::ArrowFunctionExpression(arrow) => {
-            if arrow.expression {
-                // `() => <expr>`: body holds a single expression statement.
+            let body = if arrow.expression {
                 first_expression_statement(&arrow.body.statements)
             } else {
                 first_return_argument(&arrow.body.statements)
-            }
+            }?;
+            render_expression(body)
         }
-        Expression::FunctionExpression(func) => func
-            .body
-            .as_ref()
-            .and_then(|body| first_return_argument(&body.statements)),
+        Expression::FunctionExpression(func) => render_expression(
+            func.body
+                .as_ref()
+                .and_then(|body| first_return_argument(&body.statements))?,
+        ),
         _ => None,
+    }
+}
+
+fn render_expression<'a>(expr: &'a Expression<'a>) -> Option<&'a Expression<'a>> {
+    match unwrap_expression(expr) {
+        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => {
+            render_body(expr)
+        }
+        other => Some(other),
     }
 }
 

--- a/crates/vize/src/commands/musea/migrate/emit.rs
+++ b/crates/vize/src/commands/musea/migrate/emit.rs
@@ -87,7 +87,10 @@ fn emit_variant_inner(story: &CsfStory<'_>, component_tag: &str, source: &str) -
     if let Some(render) = story.render
         && let Some(markup) = convert_render(render, source)
     {
-        return (markup, false);
+        return match inline_story_args_spread(markup, story.args, source) {
+            Some(markup) => (markup, false),
+            None => (emit_todo_element(component_tag), true),
+        };
     }
 
     if let Some(args) = story.args {
@@ -117,6 +120,13 @@ fn emit_args_element(
 ) -> Option<String> {
     let mut out = String::default();
     append!(out, "<{component_tag}");
+    out.push_str(&emit_args_attributes(args, source)?);
+    out.push_str(" />");
+    Some(out)
+}
+
+fn emit_args_attributes(args: &ObjectExpression<'_>, source: &str) -> Option<String> {
+    let mut out = String::default();
     for property in &args.properties {
         let ObjectPropertyKind::ObjectProperty(prop) = property else {
             continue;
@@ -130,8 +140,24 @@ fn emit_args_element(
         out.push(' ');
         out.push_str(&attribute_from_value(name, &prop.value, source)?);
     }
-    out.push_str(" />");
     Some(out)
+}
+
+fn inline_story_args_spread(
+    markup: String,
+    args: Option<&ObjectExpression<'_>>,
+    source: &str,
+) -> Option<String> {
+    let marker = " v-bind=\"args\"";
+    if !markup.contains(marker) {
+        return Some(markup);
+    }
+    let args = args?;
+    if args_contains_unmigrated_identifier(args) {
+        return None;
+    }
+    let attributes = emit_args_attributes(args, source)?;
+    Some(markup.replace(marker, attributes.as_str()).into())
 }
 
 /// Map one `args` entry to an attribute: string literal -> `name="value"`,

--- a/crates/vize/src/commands/musea/migrate/emit/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/tests.rs
@@ -60,6 +60,22 @@ defineArt("./AfButton.vue", {
 }
 
 #[test]
+fn emits_nested_render_children_with_story_args() {
+    let source = r#"import AfButton from "./AfButton.vue";
+export default { component: AfButton, title: "Base/AfButton" } satisfies Meta<typeof AfButton>;
+export const Primary = {
+  args: { color: "primary" },
+  render: args => () => <AfButton {...args}>Primary</AfButton>,
+};
+"#;
+    let (content, variants, todos) = emit(source);
+
+    assert!(content.contains(r#"<AfButton color="primary">Primary</AfButton>"#));
+    assert_eq!(variants, 1);
+    assert_eq!(todos, 0);
+}
+
+#[test]
 fn emits_plain_title_without_category() {
     let source = r#"import AfButton from "./AfButton.vue";
 export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;

--- a/crates/vize/tests/musea_migrate_cli.rs
+++ b/crates/vize/tests/musea_migrate_cli.rs
@@ -59,6 +59,37 @@ defineArt("./AfButton.vue", {
 }
 
 #[test]
+fn migrates_nested_render_function_jsx_children() {
+    let dir = tempfile::tempdir().unwrap();
+    let story = dir.path().join("AfButton.stories.tsx");
+    fs::write(
+        &story,
+        r#"import type { Meta, StoryObj } from "@storybook/vue3";
+import AfButton from "./AfButton.vue";
+const meta = { component: AfButton, title: "Base/AfButton" } satisfies Meta<typeof AfButton>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const Primary: Story = {
+  args: { color: "primary" },
+  render: args => () => <AfButton {...args}>Primary</AfButton>,
+};
+"#,
+    )
+    .unwrap();
+
+    let output = run_migrate(dir.path(), &["AfButton.stories.tsx"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        std::string::String::from_utf8_lossy(&output.stderr)
+    );
+
+    let generated = fs::read_to_string(dir.path().join("AfButton.art.vue")).unwrap();
+    assert!(generated.contains(r#"<AfButton color="primary">Primary</AfButton>"#));
+    assert!(!generated.contains("TODO(vize musea migrate)"));
+}
+
+#[test]
 fn dry_run_prints_without_writing() {
     let dir = tempfile::tempdir().unwrap();
     let story = dir.path().join("Box.stories.tsx");


### PR DESCRIPTION
## Summary
- unwrap nested CSF render functions so JSX children are migrated instead of falling back to args-only output
- inline safe story args spreads into generated attributes while preserving slot text
- add unit and CLI regressions for nested TSX render stories

## Validation
- cargo test -p vize commands::musea::migrate --lib
- cargo test -p vize --test musea_migrate_cli
- cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Fixes #2505

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785673146&installation_id=136613492&pr_number=2530&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2530&signature=e68b4cfa7d8f794ad6b6f8dc56955cdc977680893051e52c1dd95584e38a3c7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->