### PR TITLE
fix(musea): align static build wrapper

### DIFF
--- a/crates/vize/src/commands/musea.rs
+++ b/crates/vize/src/commands/musea.rs
@@ -9,7 +9,7 @@ use new::NewArgs;
 use serve_plan::create_serve_plan;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use vize_carton::{String, cstr};
+use vize_carton::{String, append, cstr};
 
 #[derive(Args)]
 pub struct MuseaArgs {
@@ -113,6 +113,16 @@ fn run_serve(args: ServeArgs) {
             .collect::<Vec<_>>()
             .join(" ")
     );
+    if !plan.env.is_empty() {
+        let mut env = String::default();
+        for (index, (key, value)) in plan.env.iter().enumerate() {
+            if index > 0 {
+                env.push(' ');
+            }
+            append!(env, "{key}={value}");
+        }
+        eprintln!("  env: {}", env);
+    }
     if args.build {
         eprintln!("  output: Musea static gallery entry is emitted under /__musea__/");
     } else {
@@ -132,6 +142,9 @@ fn run_serve(args: ServeArgs) {
         .status();
     match status {
         Ok(status) => {
+            if !status.success() {
+                eprintln!("vize musea: Vite exited with status {}", status);
+            }
             std::process::exit(status.code().unwrap_or(1));
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {

--- a/crates/vize/src/commands/musea/serve_plan.rs
+++ b/crates/vize/src/commands/musea/serve_plan.rs
@@ -40,7 +40,6 @@ pub(super) fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePla
     }
 
     if args.build {
-        env.push((cstr!("VIZE_MUSEA_STATIC_BUILD"), cstr!("1")));
         return Ok(ServePlan {
             program,
             args: vec![cstr!("build")],

--- a/crates/vize/src/commands/musea/tests.rs
+++ b/crates/vize/src/commands/musea/tests.rs
@@ -92,7 +92,7 @@ fn serve_plan_rejects_missing_musea_vite_plugin_setup() {
 }
 
 #[test]
-fn serve_plan_runs_static_build_with_musea_environment() {
+fn serve_plan_runs_static_build_without_forcing_musea_environment() {
     let temp = tempfile::tempdir().unwrap();
     let vite_bin = write_vite_bin(temp.path());
     write_musea_vite_setup(temp.path());
@@ -110,7 +110,7 @@ fn serve_plan_runs_static_build_with_musea_environment() {
 
     assert_eq!(plan.program, vite_bin);
     assert_eq!(plan.args, ["build"]);
-    assert_eq!(plan.env, [("VIZE_MUSEA_STATIC_BUILD".into(), "1".into())]);
+    assert!(plan.env.is_empty());
 }
 
 #[test]
@@ -153,10 +153,7 @@ fn serve_plan_combines_shared_config_with_static_build_environment() {
 
     assert_eq!(
         plan.env,
-        [
-            ("VIZE_CONFIG_FILE".into(), "../vize.config.ts".into()),
-            ("VIZE_MUSEA_STATIC_BUILD".into(), "1".into())
-        ]
+        [("VIZE_CONFIG_FILE".into(), "../vize.config.ts".into())]
     );
 }
 


### PR DESCRIPTION
## Summary
- stop forcing `VIZE_MUSEA_STATIC_BUILD=1` from `vize musea --build`; normal Vite build mode already enables static Musea output
- preserve explicit shared config forwarding without bypassing plugin-level storybook/static build guards
- print forwarded environment overrides and non-zero Vite status so wrapper differences are visible when debugging failures

## Validation
- cargo test -p vize commands::musea --lib
- cargo test -p vize commands::musea::tests --lib
- cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Fixes #2504

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785673464&installation_id=136613492&pr_number=2531&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2531&signature=4d677ed9a39ad7e9189febe48683e89d862c05170d04132a339d4e3006682ffa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->