### PR TITLE
fix(musea): flag unsupported TSX stories

### DIFF
--- a/crates/vize/src/commands/musea/migrate/csf.rs
+++ b/crates/vize/src/commands/musea/migrate/csf.rs
@@ -20,6 +20,8 @@ pub(super) struct CsfStory<'a> {
     pub render: Option<&'a Expression<'a>>,
     /// `args` object literal, if present.
     pub args: Option<&'a ObjectExpression<'a>>,
+    /// Story shape was recognized as CSF but cannot be migrated safely.
+    pub unsupported: bool,
 }
 
 /// Everything migration needs from one CSF module.
@@ -178,10 +180,10 @@ fn collect_stories<'a>(program: &'a Program<'a>) -> Vec<CsfStory<'a>> {
             let Some(init) = declarator.init.as_ref() else {
                 continue;
             };
-            let Some(object) = unwrap_object(init) else {
-                continue;
-            };
-            stories.push(story_from_object(export_name, object));
+            let story = unwrap_object(init)
+                .map(|object| story_from_object(export_name, object))
+                .unwrap_or_else(|| unsupported_story(export_name));
+            stories.push(story);
         }
     }
 
@@ -194,7 +196,8 @@ fn story_from_object<'a>(export_name: &str, object: &'a ObjectExpression<'a>) ->
         .and_then(string_literal_value)
         .unwrap_or_else(|| export_name.into());
 
-    let render = object_property_value(object, "render").and_then(render_body);
+    let render_value = object_property_value(object, "render");
+    let render = render_value.and_then(render_body);
     let args = object_property_value(object, "args").and_then(|value| {
         if let Expression::ObjectExpression(object) = unwrap_expression(value) {
             Some(&**object)
@@ -203,7 +206,21 @@ fn story_from_object<'a>(export_name: &str, object: &'a ObjectExpression<'a>) ->
         }
     });
 
-    CsfStory { name, render, args }
+    CsfStory {
+        name,
+        render,
+        args,
+        unsupported: render_value.is_some() && render.is_none(),
+    }
+}
+
+fn unsupported_story(export_name: &str) -> CsfStory<'_> {
+    CsfStory {
+        name: export_name.into(),
+        render: None,
+        args: None,
+        unsupported: true,
+    }
 }
 
 /// Reach the single JSX-returning expression of a `render` arrow/function.

--- a/crates/vize/src/commands/musea/migrate/csf/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/tests.rs
@@ -10,6 +10,7 @@ struct TestStory<'a> {
     name: &'a str,
     has_render: bool,
     has_args: bool,
+    unsupported: bool,
 }
 
 #[test]
@@ -33,6 +34,7 @@ export const Secondary: StoryObj = { args: { color: "secondary", label: "Hi" } }
             name: story.name.as_str(),
             has_render: story.render.is_some(),
             has_args: story.args.is_some(),
+            unsupported: story.unsupported,
         })
         .collect();
     assert_eq!(
@@ -42,11 +44,13 @@ export const Secondary: StoryObj = { args: { color: "secondary", label: "Hi" } }
                 name: "Primary",
                 has_render: true,
                 has_args: false,
+                unsupported: false,
             },
             TestStory {
                 name: "Secondary",
                 has_render: false,
                 has_args: true,
+                unsupported: false,
             },
         ]
     );
@@ -76,6 +80,7 @@ export const Only = { args: {} };
             name: story.name.as_str(),
             has_render: story.render.is_some(),
             has_args: story.args.is_some(),
+            unsupported: story.unsupported,
         })
         .collect();
     assert_eq!(
@@ -84,6 +89,7 @@ export const Only = { args: {} };
             name: "Only",
             has_render: false,
             has_args: true,
+            unsupported: false,
         }]
     );
 }
@@ -108,6 +114,7 @@ export const First = { name: "Custom Name", render: () => <Box /> };
             name: story.name.as_str(),
             has_render: story.render.is_some(),
             has_args: story.args.is_some(),
+            unsupported: story.unsupported,
         })
         .collect();
     assert_eq!(
@@ -116,6 +123,41 @@ export const First = { name: "Custom Name", render: () => <Box /> };
             name: "Custom Name",
             has_render: true,
             has_args: false,
+            unsupported: false,
+        }]
+    );
+}
+
+#[test]
+fn extracts_template_bind_exports_as_unsupported_stories() {
+    let source = r#"import Toggle from "./Toggle.vue";
+export default { component: Toggle, title: "Toggle" } satisfies Meta<typeof Toggle>;
+const Template: StoryFn = (args) => <Toggle {...args} />;
+export const Checked = Template.bind({});
+Checked.args = { checked: true };
+"#;
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+    assert!(!parsed.panicked);
+    let module = extract_csf(&parsed.program);
+
+    let stories: Vec<TestStory> = module
+        .stories
+        .iter()
+        .map(|story| TestStory {
+            name: story.name.as_str(),
+            has_render: story.render.is_some(),
+            has_args: story.args.is_some(),
+            unsupported: story.unsupported,
+        })
+        .collect();
+    assert_eq!(
+        stories,
+        vec![TestStory {
+            name: "Checked",
+            has_render: false,
+            has_args: false,
+            unsupported: true,
         }]
     );
 }

--- a/crates/vize/src/commands/musea/migrate/emit.rs
+++ b/crates/vize/src/commands/musea/migrate/emit.rs
@@ -84,9 +84,14 @@ pub(super) fn emit_art(
 
 /// Build the inner markup of a `<variant>`. Returns `(markup, is_todo)`.
 fn emit_variant_inner(story: &CsfStory<'_>, component_tag: &str, source: &str) -> (String, bool) {
-    if let Some(render) = story.render
-        && let Some(markup) = convert_render(render, source)
-    {
+    if story.unsupported {
+        return (emit_todo_element(component_tag), true);
+    }
+
+    if let Some(render) = story.render {
+        let Some(markup) = convert_render(render, source) else {
+            return (emit_todo_element(component_tag), true);
+        };
         return match inline_story_args_spread(markup, story.args, source) {
             Some(markup) => (markup, false),
             None => (emit_todo_element(component_tag), true),

--- a/crates/vize/src/commands/musea/migrate/emit/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/tests.rs
@@ -76,6 +76,46 @@ export const Primary = {
 }
 
 #[test]
+fn emits_todo_for_template_bind_storyfn_exports() {
+    let source = r#"import AfButton from "./AfButton.vue";
+export default { component: AfButton, title: "Base/AfButton" } satisfies Meta<typeof AfButton>;
+const Template: StoryFn = (args) => <AfButton {...args} />;
+export const Primary = Template.bind({});
+Primary.args = { color: "primary" };
+"#;
+    let (content, variants, todos) = emit(source);
+
+    assert!(content.contains(r#"<variant name="Primary" default>"#));
+    assert!(content.contains("TODO(vize musea migrate)"));
+    assert_eq!(variants, 1);
+    assert_eq!(todos, 1);
+}
+
+#[test]
+fn emits_todo_when_render_object_would_drop_state_or_slots() {
+    let source = r#"import AfButton from "./AfButton.vue";
+export default { component: AfButton, title: "Base/AfButton" } satisfies Meta<typeof AfButton>;
+export const Stateful = {
+  args: { color: "primary" },
+  render: args => ({
+    setup() {
+      const open = ref(false);
+      return { args, open };
+    },
+    template: '<AfButton v-bind="args"><span>Primary</span></AfButton>',
+  }),
+};
+"#;
+    let (content, variants, todos) = emit(source);
+
+    assert!(content.contains(r#"<variant name="Stateful" default>"#));
+    assert!(content.contains("TODO(vize musea migrate)"));
+    assert!(!content.contains(r#"<AfButton color="primary" />"#));
+    assert_eq!(variants, 1);
+    assert_eq!(todos, 1);
+}
+
+#[test]
 fn emits_plain_title_without_category() {
     let source = r#"import AfButton from "./AfButton.vue";
 export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;

--- a/crates/vize/tests/musea_migrate_cli.rs
+++ b/crates/vize/tests/musea_migrate_cli.rs
@@ -90,6 +90,34 @@ export const Primary: Story = {
 }
 
 #[test]
+fn migrates_unsupported_tsx_storyfn_as_todo_variant() {
+    let dir = tempfile::tempdir().unwrap();
+    let story = dir.path().join("Toggle.stories.tsx");
+    fs::write(
+        &story,
+        r#"import type { Meta, StoryFn } from "@storybook/vue3";
+import Toggle from "./Toggle.vue";
+export default { component: Toggle, title: "Controls/Toggle" } satisfies Meta<typeof Toggle>;
+const Template: StoryFn = (args) => <Toggle {...args} />;
+export const Checked = Template.bind({});
+Checked.args = { checked: true };
+"#,
+    )
+    .unwrap();
+
+    let output = run_migrate(dir.path(), &["Toggle.stories.tsx"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        std::string::String::from_utf8_lossy(&output.stderr)
+    );
+
+    let generated = fs::read_to_string(dir.path().join("Toggle.art.vue")).unwrap();
+    assert!(generated.contains(r#"<variant name="Checked" default>"#));
+    assert!(generated.contains("TODO(vize musea migrate)"));
+}
+
+#[test]
 fn dry_run_prints_without_writing() {
     let dir = tempfile::tempdir().unwrap();
     let story = dir.path().join("Box.stories.tsx");


### PR DESCRIPTION
## Summary
- keep non-object CSF exports such as `Template.bind({})` as TODO variants instead of dropping them from generated art
- treat render stories that cannot be converted to JSX as TODO variants instead of falling back to incomplete args-only output
- add CSF extraction, emit, and CLI regressions for unsupported TSX StoryFn/render shapes

## Validation
- cargo test -p vize commands::musea::migrate --lib
- cargo test -p vize --test musea_migrate_cli
- cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Fixes #2509

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785673669&installation_id=136613492&pr_number=2532&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2532&signature=53559a2fa18c1f975c5e7a0f65c05530f1b1b3499a00459556ce1402689b97f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->