### PR TITLE
fix(musea): avoid art helper collisions

### DIFF
--- a/npm/builder/vite-musea/src/art-module-helper-collisions.test.ts
+++ b/npm/builder/vite-musea/src/art-module-helper-collisions.test.ts
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { generateArtModule } from "./art-module.ts";
+import type { ArtFileInfo } from "./types/art.ts";
+
+void test("generateArtModule avoids Vue helper collisions with script setup imports", () => {
+  const art: ArtFileInfo = {
+    path: "/repo/components/StoryResult.art.vue",
+    metadata: {
+      title: "Story Result",
+      component: "./StoryResult.vue",
+      tags: [],
+      status: "ready",
+    },
+    variants: [
+      {
+        name: "Default",
+        template: `<StoryResult :result="renderStoryResult(result)" />`,
+        isDefault: true,
+        skipVrt: false,
+      },
+    ],
+    hasScriptSetup: true,
+    scriptSetupContent: `
+import { computed, h, isVNode, defineComponent } from "vue";
+
+const result = computed(() => StoryResult);
+
+function renderStoryResult(value) {
+  return isVNode(value) ? value : h(value);
+}
+`.trim(),
+    hasScript: false,
+    styleCount: 0,
+  };
+
+  const code = generateArtModule(art, art.path);
+
+  assert.match(code, /import \{ defineComponent as __museaDefineComponent \} from 'vue';/);
+  assert.match(code, /import \{ computed, h, isVNode, defineComponent \} from "vue";/);
+  assert.doesNotMatch(code, /import \{ defineComponent, h \} from 'vue';/);
+  assert.match(code, /export const Default = __museaDefineComponent\(\{/);
+});

--- a/npm/builder/vite-musea/src/art-module.test.ts
+++ b/npm/builder/vite-musea/src/art-module.test.ts
@@ -104,8 +104,14 @@ const count = ref(0)
   assert.match(code, /import Button from "\/repo\/components\/Button\.vue";/);
   assert.doesNotMatch(code, /\bdefineArt\s*\(/);
   assert.match(code, /components: \{ "Button": Button \}/);
-  assert.match(code, /export const Primary = defineComponent\(\{[\s\S]*const count = ref\(0\)/);
-  assert.match(code, /export const Secondary = defineComponent\(\{[\s\S]*const count = ref\(0\)/);
+  assert.match(
+    code,
+    /export const Primary = __museaDefineComponent\(\{[\s\S]*const count = ref\(0\)/,
+  );
+  assert.match(
+    code,
+    /export const Secondary = __museaDefineComponent\(\{[\s\S]*const count = ref\(0\)/,
+  );
   assert.doesNotMatch(code, /return \{ Button,/);
 });
 

--- a/npm/builder/vite-musea/src/art-module.ts
+++ b/npm/builder/vite-musea/src/art-module.ts
@@ -459,7 +459,7 @@ export function generateArtModule(
 
   let code = `
 // Auto-generated module for: ${path.basename(filePath)}
-import { defineComponent, h } from 'vue';
+import { defineComponent as __museaDefineComponent } from 'vue';
 `;
 
   // Add script setup imports at module level
@@ -544,7 +544,7 @@ ${scriptSetup.setupBody.join("\n")}
     if (scriptSetup && hasSetup && isolatedSetup) {
       // Generate variant with setup function from art file's <script setup>
       code += `
-export const ${variantComponentName} = defineComponent({
+export const ${variantComponentName} = __museaDefineComponent({
   name: '${variantComponentName}',
 ${components}  setup() {
 ${scriptSetup.setupBody.join("\n")}
@@ -555,7 +555,7 @@ ${scriptSetup.setupBody.join("\n")}
 `;
     } else if (scriptSetup && hasSetup) {
       code += `
-export const ${variantComponentName} = defineComponent({
+export const ${variantComponentName} = __museaDefineComponent({
   name: '${variantComponentName}',
 ${components}  setup() {
     return __museaSharedSetup;


### PR DESCRIPTION
## Summary
- alias the generated Musea `defineComponent` helper import instead of using a public local binding
- remove the unused generated `h` import so user script setup imports such as `import { h } from "vue"` do not collide
- add an art module regression covering user `h` and `defineComponent` imports

## Validation
- ./node_modules/.bin/tsx --test npm/builder/vite-musea/src/art-module.test.ts
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Fixes #2510

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785673971&installation_id=136613492&pr_number=2533&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2533&signature=a1b5aeb48f95874db0b690356c413d26e57bc45e73e82ae4b48e8722a4f0b50a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->