### PR TITLE
fix(patina): dedupe logical property diagnostics

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -3,6 +3,7 @@ use crate::LintPreset;
 use vize_carton::{Allocator, ToCompactString};
 
 mod basic;
+mod css;
 mod directives;
 mod jsx;
 mod jsx_fallback;

--- a/crates/vize_patina/src/linter/tests/css.rs
+++ b/crates/vize_patina/src/linter/tests/css.rs
@@ -1,0 +1,32 @@
+use super::Linter;
+
+#[test]
+fn test_lint_sfc_css_logical_properties_after_import_reports_once() {
+    let linter =
+        Linter::new().with_enabled_rules(Some(vec!["css/prefer-logical-properties".into()]));
+    let sfc = r#"<template><div/></template>
+<style scoped>
+@import "~/design/styles/breakpoint.css";
+
+.mp-snackbar {
+  position: fixed;
+  top: var(--space-4);
+  left: var(--space-4);
+  right: var(--space-4);
+}
+</style>
+"#;
+    let result = linter.lint_sfc(sfc, "Snackbar.vue");
+    let logical_diags: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.rule_name == "css/prefer-logical-properties")
+        .collect();
+
+    assert_eq!(
+        logical_diags.len(),
+        1,
+        "logical property diagnostics should be deduplicated: {:?}",
+        result.diagnostics
+    );
+}

--- a/crates/vize_patina/src/rules/css/prefer_logical_properties.rs
+++ b/crates/vize_patina/src/rules/css/prefer_logical_properties.rs
@@ -46,7 +46,7 @@ impl PreferLogicalProperties {
         rule: &LCssRule,
         offset: usize,
         result: &mut CssLintResult,
-        reported: &mut FxHashSet<(u32, u32)>,
+        reported: &mut FxHashSet<u32>,
     ) {
         match rule {
             LCssRule::Style(style_rule) => {
@@ -76,7 +76,7 @@ impl PreferLogicalProperties {
         declarations: &DeclarationBlock,
         offset: usize,
         result: &mut CssLintResult,
-        reported: &mut FxHashSet<(u32, u32)>,
+        reported: &mut FxHashSet<u32>,
     ) {
         // Check all declarations (both regular and important)
         for decl in declarations.declarations.iter() {
@@ -93,7 +93,7 @@ impl PreferLogicalProperties {
         prop_id: PropertyId,
         offset: usize,
         result: &mut CssLintResult,
-        reported: &mut FxHashSet<(u32, u32)>,
+        reported: &mut FxHashSet<u32>,
     ) {
         let (physical, logical) = match prop_id {
             PropertyId::MarginLeft => ("margin-left", "margin-inline-start"),
@@ -110,7 +110,7 @@ impl PreferLogicalProperties {
         // Report at offset since PropertyId doesn't provide precise location
         let start = offset as u32;
         let end = (offset + physical.len()) as u32;
-        if !reported.insert((start, end)) {
+        if !reported.insert(start) {
             return;
         }
         let _ = logical; // suppress unused warnings


### PR DESCRIPTION
## Summary
- deduplicate `css/prefer-logical-properties` diagnostics by fallback start offset instead of `(start,end)`
- add an SFC regression with an `@import` followed by physical `left`/`right` properties
- keep the existing rule-level fallback dedupe coverage

## Validation
- cargo test -p vize_patina linter::tests::sfc --lib
- cargo test -p vize_patina rules::css::prefer_logical_properties --lib
- cargo clippy -p vize_patina -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Fixes #2511

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785674330&installation_id=136613492&pr_number=2534&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2534&signature=ac846b9b4e1520e3cdeb4825d1d2a6418649111af9e900afb3acc5706a7bf43b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->