### PR TITLE
fix(musea): merge safe CSF meta args

### DIFF
--- a/crates/vize/src/commands/musea/migrate/csf.rs
+++ b/crates/vize/src/commands/musea/migrate/csf.rs
@@ -30,6 +30,8 @@ pub(super) struct CsfModule<'a> {
     pub component_path: Option<String>,
     /// Meta `title` value (raw, may contain `Category/Name`).
     pub title: Option<String>,
+    /// Default CSF `args` object from the module meta, if present.
+    pub meta_args: Option<&'a ObjectExpression<'a>>,
     /// Ordered stories.
     pub stories: Vec<CsfStory<'a>>,
 }
@@ -39,6 +41,7 @@ pub(super) fn extract_csf<'a>(program: &'a Program<'a>) -> CsfModule<'a> {
     let meta = find_meta_object(program);
     let component_local = meta.and_then(meta_component_local);
     let title = meta.and_then(meta_title);
+    let meta_args = meta.and_then(meta_args);
     let component_path = component_local
         .as_deref()
         .and_then(|local| find_import_source(program, local));
@@ -48,6 +51,7 @@ pub(super) fn extract_csf<'a>(program: &'a Program<'a>) -> CsfModule<'a> {
     CsfModule {
         component_path,
         title,
+        meta_args,
         stories,
     }
 }
@@ -133,6 +137,16 @@ fn meta_component_local(meta: &ObjectExpression<'_>) -> Option<String> {
 fn meta_title(meta: &ObjectExpression<'_>) -> Option<String> {
     let value = object_property_value(meta, "title")?;
     string_literal_value(value)
+}
+
+/// Read the meta `args` object literal.
+fn meta_args<'a>(meta: &'a ObjectExpression<'a>) -> Option<&'a ObjectExpression<'a>> {
+    let value = object_property_value(meta, "args")?;
+    if let Expression::ObjectExpression(object) = unwrap_expression(value) {
+        Some(&**object)
+    } else {
+        None
+    }
 }
 
 /// Find the import specifier source path for a given local identifier.
@@ -306,6 +320,7 @@ pub(super) fn unwrap_expression<'a>(expr: &'a Expression<'a>) -> &'a Expression<
         current = match current {
             Expression::TSSatisfiesExpression(inner) => &inner.expression,
             Expression::TSAsExpression(inner) => &inner.expression,
+            Expression::TSNonNullExpression(inner) => &inner.expression,
             Expression::ParenthesizedExpression(inner) => &inner.expression,
             other => return other,
         };

--- a/crates/vize/src/commands/musea/migrate/csf/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/tests.rs
@@ -59,7 +59,7 @@ export const Secondary: StoryObj = { args: { color: "secondary", label: "Hi" } }
 #[test]
 fn extracts_const_meta_default_export() {
     let source = r#"import Card from "../components/Card.vue";
-const meta = { component: Card, title: "Card" } satisfies Meta<typeof Card>;
+const meta = { component: Card, title: "Card", args: { tone: "neutral" } } satisfies Meta<typeof Card>;
 export default meta;
 export const Only = { args: {} };
 "#;
@@ -73,6 +73,7 @@ export const Only = { args: {} };
         module.component_path.as_deref(),
         Some("../components/Card.vue")
     );
+    assert!(module.meta_args.is_some());
     let stories: Vec<TestStory> = module
         .stories
         .iter()

--- a/crates/vize/src/commands/musea/migrate/emit.rs
+++ b/crates/vize/src/commands/musea/migrate/emit.rs
@@ -1,6 +1,8 @@
 //! Generate `.art.vue` text from extracted CSF metadata.
 
-use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, PropertyKey};
+use oxc_ast::ast::{
+    ArrayExpressionElement, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey,
+};
 use oxc_span::GetSpan;
 use vize_carton::{String, append};
 
@@ -52,7 +54,7 @@ pub(super) fn emit_art(
     let mut todos = 0usize;
     for (index, story) in module.stories.iter().enumerate() {
         let is_default = index == 0;
-        let (inner, is_todo) = emit_variant_inner(story, component_tag, source);
+        let (inner, is_todo) = emit_variant_inner(story, module.meta_args, component_tag, source);
         if is_todo {
             todos += 1;
         }
@@ -83,7 +85,12 @@ pub(super) fn emit_art(
 }
 
 /// Build the inner markup of a `<variant>`. Returns `(markup, is_todo)`.
-fn emit_variant_inner(story: &CsfStory<'_>, component_tag: &str, source: &str) -> (String, bool) {
+fn emit_variant_inner(
+    story: &CsfStory<'_>,
+    meta_args: Option<&ObjectExpression<'_>>,
+    component_tag: &str,
+    source: &str,
+) -> (String, bool) {
     if story.unsupported {
         return (emit_todo_element(component_tag), true);
     }
@@ -92,17 +99,17 @@ fn emit_variant_inner(story: &CsfStory<'_>, component_tag: &str, source: &str) -
         let Some(markup) = convert_render(render, source) else {
             return (emit_todo_element(component_tag), true);
         };
-        return match inline_story_args_spread(markup, story.args, source) {
+        return match inline_story_args_spread(markup, meta_args, story.args, source) {
             Some(markup) => (markup, false),
             None => (emit_todo_element(component_tag), true),
         };
     }
 
-    if let Some(args) = story.args {
-        if args_contains_unmigrated_identifier(args) {
+    if meta_args.is_some() || story.args.is_some() {
+        if args_contain_unmigrated_bindings(meta_args, story.args) {
             return (emit_todo_element(component_tag), true);
         }
-        if let Some(element) = emit_args_element(args, component_tag, source) {
+        if let Some(element) = emit_args_element(meta_args, story.args, component_tag, source) {
             return (element, false);
         }
         return (emit_todo_element(component_tag), true);
@@ -119,19 +126,39 @@ fn emit_todo_element(component_tag: &str) -> String {
 
 /// Emit `<Component ...props />` from an `args` object literal.
 fn emit_args_element(
-    args: &ObjectExpression<'_>,
+    meta_args: Option<&ObjectExpression<'_>>,
+    story_args: Option<&ObjectExpression<'_>>,
     component_tag: &str,
     source: &str,
 ) -> Option<String> {
     let mut out = String::default();
     append!(out, "<{component_tag}");
-    out.push_str(&emit_args_attributes(args, source)?);
+    out.push_str(&emit_args_attributes(meta_args, story_args, source)?);
     out.push_str(" />");
     Some(out)
 }
 
-fn emit_args_attributes(args: &ObjectExpression<'_>, source: &str) -> Option<String> {
+fn emit_args_attributes(
+    meta_args: Option<&ObjectExpression<'_>>,
+    story_args: Option<&ObjectExpression<'_>>,
+    source: &str,
+) -> Option<String> {
     let mut out = String::default();
+    if let Some(args) = meta_args {
+        emit_args_object_attributes(args, story_args, source, &mut out)?;
+    }
+    if let Some(args) = story_args {
+        emit_args_object_attributes(args, None, source, &mut out)?;
+    }
+    Some(out)
+}
+
+fn emit_args_object_attributes(
+    args: &ObjectExpression<'_>,
+    overrides: Option<&ObjectExpression<'_>>,
+    source: &str,
+    out: &mut String,
+) -> Option<()> {
     for property in &args.properties {
         let ObjectPropertyKind::ObjectProperty(prop) = property else {
             continue;
@@ -142,26 +169,30 @@ fn emit_args_attributes(args: &ObjectExpression<'_>, source: &str) -> Option<Str
         let Some(name) = property_key_name(&prop.key) else {
             continue;
         };
+        if overrides.is_some_and(|object| args_has_static_property(object, name)) {
+            continue;
+        }
         out.push(' ');
         out.push_str(&attribute_from_value(name, &prop.value, source)?);
     }
-    Some(out)
+    Some(())
 }
 
 fn inline_story_args_spread(
     markup: String,
-    args: Option<&ObjectExpression<'_>>,
+    meta_args: Option<&ObjectExpression<'_>>,
+    story_args: Option<&ObjectExpression<'_>>,
     source: &str,
 ) -> Option<String> {
     let marker = " v-bind=\"args\"";
     if !markup.contains(marker) {
         return Some(markup);
     }
-    let args = args?;
-    if args_contains_unmigrated_identifier(args) {
+    meta_args.or(story_args)?;
+    if args_contain_unmigrated_bindings(meta_args, story_args) {
         return None;
     }
-    let attributes = emit_args_attributes(args, source)?;
+    let attributes = emit_args_attributes(meta_args, story_args, source)?;
     Some(markup.replace(marker, attributes.as_str()).into())
 }
 
@@ -179,12 +210,71 @@ fn attribute_from_value(name: &str, value: &Expression<'_>, source: &str) -> Opt
     Some(out)
 }
 
-fn args_contains_unmigrated_identifier(args: &ObjectExpression<'_>) -> bool {
+fn args_contain_unmigrated_bindings(
+    meta_args: Option<&ObjectExpression<'_>>,
+    story_args: Option<&ObjectExpression<'_>>,
+) -> bool {
+    if let Some(args) = meta_args
+        && args_object_contains_unmigrated_bindings(args, story_args)
+    {
+        return true;
+    }
+    story_args.is_some_and(|args| args_object_contains_unmigrated_bindings(args, None))
+}
+
+fn args_object_contains_unmigrated_bindings(
+    args: &ObjectExpression<'_>,
+    overrides: Option<&ObjectExpression<'_>>,
+) -> bool {
+    args.properties.iter().any(|property| {
+        let ObjectPropertyKind::ObjectProperty(prop) = property else {
+            return true;
+        };
+        if prop.computed {
+            return true;
+        }
+        let Some(name) = property_key_name(&prop.key) else {
+            return true;
+        };
+        if overrides.is_some_and(|object| args_has_static_property(object, name)) {
+            return false;
+        }
+        expression_needs_module_binding(&prop.value)
+    })
+}
+
+fn expression_needs_module_binding(expression: &Expression<'_>) -> bool {
+    match unwrap_expression(expression) {
+        Expression::StringLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_) => false,
+        Expression::TemplateLiteral(template) => !template.expressions.is_empty(),
+        Expression::UnaryExpression(unary) => expression_needs_module_binding(&unary.argument),
+        Expression::ArrayExpression(array) => array.elements.iter().any(|element| match element {
+            ArrayExpressionElement::Elision(_) => false,
+            ArrayExpressionElement::SpreadElement(_) => true,
+            _ => element
+                .as_expression()
+                .is_none_or(expression_needs_module_binding),
+        }),
+        Expression::ObjectExpression(object) => {
+            args_object_contains_unmigrated_bindings(object, None)
+        }
+        Expression::Identifier(_)
+        | Expression::StaticMemberExpression(_)
+        | Expression::ComputedMemberExpression(_)
+        | Expression::CallExpression(_) => true,
+        _ => true,
+    }
+}
+
+fn args_has_static_property(args: &ObjectExpression<'_>, name: &str) -> bool {
     args.properties.iter().any(|property| {
         let ObjectPropertyKind::ObjectProperty(prop) = property else {
             return false;
         };
-        !prop.computed && matches!(unwrap_expression(&prop.value), Expression::Identifier(_))
+        !prop.computed && property_key_name(&prop.key) == Some(name)
     })
 }
 

--- a/crates/vize/src/commands/musea/migrate/emit/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/tests.rs
@@ -159,6 +159,72 @@ export const Big = { args: { data: fixture } };
 }
 
 #[test]
+fn emits_meta_args_and_lets_story_args_override() {
+    let source = r#"import AfButton from "./AfButton.vue";
+export default { component: AfButton, title: "AfButton", args: { color: "primary", disabled: true, count: 1 } } satisfies Meta<typeof AfButton>;
+export const Primary = { args: {} };
+export const Secondary = { args: { color: "secondary", label: "Hi" } };
+"#;
+    let (content, variants, todos) = emit(source);
+
+    assert!(content.contains(r#"<AfButton color="primary" :disabled="true" :count="1" />"#));
+    assert!(
+        content
+            .contains(r#"<AfButton :disabled="true" :count="1" color="secondary" label="Hi" />"#)
+    );
+    assert!(!content.contains(r#"color="primary" :disabled="true" :count="1" color="secondary""#));
+    assert_eq!(variants, 2);
+    assert_eq!(todos, 0);
+}
+
+#[test]
+fn emits_meta_args_inside_render_args_spread() {
+    let source = r#"import AfButton from "./AfButton.vue";
+export default { component: AfButton, title: "AfButton", args: { color: "primary", disabled: true } } satisfies Meta<typeof AfButton>;
+export const Primary = {
+  args: { color: "secondary" },
+  render: args => () => <AfButton {...args}>Primary</AfButton>,
+};
+"#;
+    let (content, _variants, todos) = emit(source);
+
+    assert!(content.contains(r#"<AfButton :disabled="true" color="secondary">Primary</AfButton>"#));
+    assert_eq!(todos, 0);
+}
+
+#[test]
+fn emits_todo_for_meta_args_referencing_module_bindings() {
+    let source = r#"import AfButton from "./AfButton.vue";
+const base = createFixture();
+export default { component: AfButton, title: "AfButton", args: { data: base } } satisfies Meta<typeof AfButton>;
+export const Primary = { args: {} };
+"#;
+    let (content, variants, todos) = emit(source);
+
+    assert!(content.contains("<AfButton />"));
+    assert!(content.contains("TODO(vize musea migrate)"));
+    assert!(!content.contains(":data"));
+    assert_eq!(variants, 1);
+    assert_eq!(todos, 1);
+}
+
+#[test]
+fn emits_todo_for_nested_story_args_module_bindings() {
+    let source = r#"import AfButton from "./AfButton.vue";
+const base = createFixture();
+export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;
+export const Primary = { args: { data: { ...base, status: Status.Ready } } };
+"#;
+    let (content, variants, todos) = emit(source);
+
+    assert!(content.contains("<AfButton />"));
+    assert!(content.contains("TODO(vize musea migrate)"));
+    assert!(!content.contains(":data"));
+    assert_eq!(variants, 1);
+    assert_eq!(todos, 1);
+}
+
+#[test]
 fn emits_directive_expressions_without_quot_entities() {
     let source = r#"import AfButton from "./AfButton.vue";
 export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;

--- a/crates/vize/tests/musea_migrate_cli.rs
+++ b/crates/vize/tests/musea_migrate_cli.rs
@@ -90,6 +90,49 @@ export const Primary: Story = {
 }
 
 #[test]
+fn migrates_meta_args_or_todos_unsafe_bindings() {
+    let dir = tempfile::tempdir().unwrap();
+    let safe_story = dir.path().join("SafeButton.stories.tsx");
+    fs::write(
+        &safe_story,
+        r#"import SafeButton from "./SafeButton.vue";
+export default { component: SafeButton, title: "Base/SafeButton", args: { color: "primary", disabled: true } } satisfies Meta<typeof SafeButton>;
+export const Primary = { args: {} };
+export const Secondary = { args: { color: "secondary" } };
+"#,
+    )
+    .unwrap();
+    let unsafe_story = dir.path().join("UnsafeCard.stories.tsx");
+    fs::write(
+        &unsafe_story,
+        r#"import UnsafeCard from "./UnsafeCard.vue";
+const base = createFixture();
+export default { component: UnsafeCard, title: "Base/UnsafeCard", args: { data: base } } satisfies Meta<typeof UnsafeCard>;
+export const Primary = { args: {} };
+"#,
+    )
+    .unwrap();
+
+    let output = run_migrate(
+        dir.path(),
+        &["SafeButton.stories.tsx", "UnsafeCard.stories.tsx"],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        std::string::String::from_utf8_lossy(&output.stderr)
+    );
+
+    let safe_generated = fs::read_to_string(dir.path().join("SafeButton.art.vue")).unwrap();
+    assert!(safe_generated.contains(r#"<SafeButton color="primary" :disabled="true" />"#));
+    assert!(safe_generated.contains(r#"<SafeButton :disabled="true" color="secondary" />"#));
+
+    let unsafe_generated = fs::read_to_string(dir.path().join("UnsafeCard.art.vue")).unwrap();
+    assert!(unsafe_generated.contains("TODO(vize musea migrate)"));
+    assert!(!unsafe_generated.contains(":data"));
+}
+
+#[test]
 fn migrates_unsupported_tsx_storyfn_as_todo_variant() {
     let dir = tempfile::tempdir().unwrap();
     let story = dir.path().join("Toggle.stories.tsx");


### PR DESCRIPTION
## Summary
- Preserve CSF `meta.args` during Musea story migration and merge them into story variants.
- Let story args override meta defaults while keeping stable attribute order.
- Emit a manual-port TODO instead of broken generated art when merged args depend on module-scope bindings, spreads, member expressions, calls, or computed keys.

## Root Cause
The CSF extractor kept per-story `args` but dropped `meta.args`. The emitter also only rejected top-level bare identifiers, so nested spreads or enum/member references could be emitted into `.art.vue` without the source module bindings that made them valid.

## Validation
- `cargo test -p vize commands::musea::migrate --lib`
- `cargo test -p vize --test musea_migrate_cli`
- `cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

Fixes #2508

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785674945&installation_id=136613492&pr_number=2535&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2535&signature=d0ab0cd01fbc469ec603ab246f5a37ab4d96df0c691c14b49d5f8793a0bb3da5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->