### PR TITLE
test(canon): cover subproject directory inputs

### DIFF
--- a/crates/vize/tests/check_package_cwd_cli.rs
+++ b/crates/vize/tests/check_package_cwd_cli.rs
@@ -163,6 +163,93 @@ void rootOnly;
 }
 
 #[test]
+fn check_from_workspace_root_accepts_subproject_directory_input() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+
+    let workspace = unique_case_dir("workspace-root-subproject-dir");
+    let _ = std::fs::remove_dir_all(&workspace);
+    std::fs::create_dir_all(&workspace).unwrap();
+    link_workspace_node_modules(&workspace);
+
+    write_file(
+        &workspace,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["types/**/*.d.ts"]
+}"#,
+    );
+    write_file(
+        &workspace,
+        "types/root.d.ts",
+        r#"export {};
+declare global {
+  const rootValue: string;
+}
+"#,
+    );
+    write_file(
+        &workspace,
+        "devtools/tsconfig.json",
+        r#"{
+  "extends": "../tsconfig.json",
+  "include": ["src/**/*.vue", "../types/**/*.d.ts"]
+}"#,
+    );
+    write_file(
+        &workspace,
+        "devtools/src/App.vue",
+        r#"<script setup lang="ts">
+const msg: string = rootValue;
+</script>
+
+<template>{{ msg }}</template>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&workspace)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "devtools/tsconfig.json",
+            "devtools/src",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "workspace-root subproject check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Failed to strip prefix from path"),
+        "subproject directory inputs must not crash during virtual path mirroring:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], 0, "{stdout}\n{stderr}");
+    assert_eq!(json["warningCount"], 0, "{stdout}\n{stderr}");
+    assert_eq!(json["fileCount"], 1, "{stdout}\n{stderr}");
+    assert_eq!(json["files"][0]["file"], "devtools/src/App.vue");
+
+    let _ = std::fs::remove_dir_all(&workspace);
+}
+
+#[test]
 fn check_from_package_cwd_resolves_package_local_dependencies() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
         return;


### PR DESCRIPTION
## Summary
- Add a CLI regression for `vize check` from a workspace root using a subproject `--tsconfig` plus that subproject's source directory.
- Include a parent ambient declaration from the subproject tsconfig so the test covers the path-root recalculation shape that previously could hit `strip_prefix` during virtual project mirroring.
- Assert JSON output remains scoped to the requested subproject file and stderr never contains the strip-prefix crash.

## Validation
- `cargo test -p vize --test check_package_cwd_cli check_from_workspace_root_accepts_subproject_directory_input -- --nocapture`
- `cargo test -p vize --test check_package_cwd_cli`
- `cargo fmt --all -- --check`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

Fixes #2507

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785675379&installation_id=136613492&pr_number=2536&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2536&signature=7d58e99cb89b07b126dc3c0e5c4e8a09de6b48446be84d5f17bd0eb70dfd5de6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->