### PR TITLE
fix(canon): suppress legacy shim duplicate diagnostics

### DIFF
--- a/crates/vize/src/commands/check/runner/diagnostics.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics.rs
@@ -8,6 +8,10 @@ use vize_carton::{FxHashSet, String as CompactString, cstr, profile, profiler::g
 use crate::commands::check::path_cache::CanonicalPathCache;
 use crate::commands::check::reporting::JsonOutput;
 
+mod suppressions;
+
+pub(super) use suppressions::is_suppressed_false_positive;
+
 pub(super) fn emit_json_output(json_output: JsonOutput) {
     match serde_json::to_string_pretty(&json_output) {
         Ok(output) => println!("{output}"),
@@ -44,15 +48,6 @@ fn is_source_path(path: &Path) -> bool {
                 "vue" | "ts" | "tsx" | "mts" | "cts" | "js" | "jsx"
             )
         })
-}
-
-pub(super) fn is_suppressed_false_positive(diagnostic: &vize_canon::BatchDiagnostic) -> bool {
-    diagnostic.code == Some(2320)
-        && diagnostic
-            .message
-            .contains("Interface 'ImportMeta' cannot simultaneously extend types")
-        && diagnostic.message.contains("NitroStaticBuildFlags")
-        && diagnostic.message.contains("NitroImportMeta")
 }
 
 #[allow(clippy::disallowed_types)]

--- a/crates/vize/src/commands/check/runner/diagnostics/suppressions.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics/suppressions.rs
@@ -1,0 +1,131 @@
+use std::{fs, path::Path};
+
+pub(in crate::commands::check::runner) fn is_suppressed_false_positive(
+    diagnostic: &vize_canon::BatchDiagnostic,
+) -> bool {
+    is_nitro_import_meta_conflict(diagnostic)
+        || is_vue_wildcard_component_duplicate(diagnostic)
+        || is_nuxt_bridge_injected_property_duplicate(diagnostic)
+}
+
+fn is_nitro_import_meta_conflict(diagnostic: &vize_canon::BatchDiagnostic) -> bool {
+    diagnostic.code == Some(2320)
+        && diagnostic
+            .message
+            .contains("Interface 'ImportMeta' cannot simultaneously extend types")
+        && diagnostic.message.contains("NitroStaticBuildFlags")
+        && diagnostic.message.contains("NitroImportMeta")
+}
+
+fn is_vue_wildcard_component_duplicate(diagnostic: &vize_canon::BatchDiagnostic) -> bool {
+    diagnostic.code == Some(2300)
+        && diagnostic
+            .message
+            .contains("Duplicate identifier 'component'")
+        && declaration_source_contains(
+            &diagnostic.file,
+            &["declare module \"*.vue\"", "declare module '*.vue'"],
+        )
+}
+
+fn is_nuxt_bridge_injected_property_duplicate(diagnostic: &vize_canon::BatchDiagnostic) -> bool {
+    diagnostic.code == Some(2717)
+        && diagnostic
+            .message
+            .contains("Subsequent property declarations must have the same type")
+        && diagnostic.message.contains("Property '$")
+        && diagnostic.message.contains("must be of type 'any'")
+        && declaration_source_contains(
+            &diagnostic.file,
+            &[
+                "declare module \"@nuxt/bridge-schema\"",
+                "declare module '@nuxt/bridge-schema'",
+            ],
+        )
+}
+
+fn declaration_source_contains(path: &Path, needles: &[&str]) -> bool {
+    if !path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".d.ts"))
+    {
+        return false;
+    }
+    let Ok(source) = fs::read_to_string(path) else {
+        return false;
+    };
+    needles.iter().any(|needle| source.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use vize_canon::BatchDiagnostic;
+
+    use super::is_suppressed_false_positive;
+
+    fn diagnostic(file: PathBuf, code: u32, message: &str) -> BatchDiagnostic {
+        BatchDiagnostic {
+            file,
+            line: 0,
+            column: 0,
+            message: message.into(),
+            code: Some(code),
+            severity: 1,
+            block_type: None,
+        }
+    }
+
+    #[test]
+    fn suppresses_project_vue_wildcard_component_duplicates() {
+        let temp = tempfile::tempdir().unwrap();
+        let shim = temp.path().join("ts-shim.d.ts");
+        std::fs::write(
+            &shim,
+            "declare module '*.vue' {\n  import Vue from 'vue';\n  export default Vue;\n}\n",
+        )
+        .unwrap();
+
+        assert!(is_suppressed_false_positive(&diagnostic(
+            shim,
+            2300,
+            "Duplicate identifier 'component'.",
+        )));
+    }
+
+    #[test]
+    fn suppresses_nuxt_bridge_injection_duplicates_against_any() {
+        let temp = tempfile::tempdir().unwrap();
+        let shim = temp.path().join("gtag.d.ts");
+        std::fs::write(
+            &shim,
+            "declare module '@nuxt/bridge-schema' {\n  interface Context { $gtag: Gtag.Gtag; }\n}\n",
+        )
+        .unwrap();
+
+        assert!(is_suppressed_false_positive(&diagnostic(
+            shim,
+            2717,
+            "Subsequent property declarations must have the same type.  Property '$gtag' must be of type 'any', but here has type 'Gtag'.",
+        )));
+    }
+
+    #[test]
+    fn keeps_unrelated_declaration_conflicts_visible() {
+        let temp = tempfile::tempdir().unwrap();
+        let declaration = temp.path().join("conflict.d.ts");
+        std::fs::write(
+            &declaration,
+            "declare module 'local' {\n  interface Context { value: string; }\n}\n",
+        )
+        .unwrap();
+
+        assert!(!is_suppressed_false_positive(&diagnostic(
+            declaration,
+            2717,
+            "Subsequent property declarations must have the same type.  Property 'value' must be of type 'number', but here has type 'string'.",
+        )));
+    }
+}

--- a/crates/vize/tests/check_nuxt_bridge_shims_cli.rs
+++ b/crates/vize/tests/check_nuxt_bridge_shims_cli.rs
@@ -1,0 +1,172 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(format!(
+            "check-nuxt-bridge-shims-{name}-{}",
+            std::process::id()
+        ))
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn write(root: &Path, rel: &str, content: &str) {
+    let path = root.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, content).unwrap();
+}
+
+#[test]
+fn check_suppresses_legacy_vue_shim_and_nuxt_bridge_global_duplicates() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("gtag");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src/types/thirdParty")).unwrap();
+    std::fs::create_dir_all(project_root.join("plugins")).unwrap();
+    write(
+        &project_root,
+        "node_modules/vue/package.json",
+        r#"{ "name": "vue", "types": "types/index.d.ts" }"#,
+    );
+    write(
+        &project_root,
+        "node_modules/vue/types/index.d.ts",
+        r#"export interface Vue { $attrs: Record<string, unknown>; }
+declare const VueConstructor: { version: string };
+export default VueConstructor;
+"#,
+    );
+    write(
+        &project_root,
+        "node_modules/@nuxt/types/package.json",
+        r#"{ "name": "@nuxt/types", "types": "index.d.ts" }"#,
+    );
+    write(
+        &project_root,
+        "node_modules/@nuxt/types/index.d.ts",
+        r#"declare module "@nuxt/types" {
+  export interface Context {}
+  export interface NuxtAppOptions {}
+}
+"#,
+    );
+    write(
+        &project_root,
+        "node_modules/@nuxt/bridge-schema/package.json",
+        r#"{ "name": "@nuxt/bridge-schema", "types": "index.d.ts" }"#,
+    );
+    write(
+        &project_root,
+        "node_modules/@nuxt/bridge-schema/index.d.ts",
+        r#"declare module "@nuxt/bridge-schema" {
+  export interface Context { $gtag: any; }
+}
+"#,
+    );
+    write(
+        &project_root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["@nuxt/types", "@nuxt/bridge-schema"]
+  },
+  "include": ["ts-shim.d.ts", "plugins/**/*", "src/**/*"]
+}"#,
+    );
+    write(
+        &project_root,
+        "ts-shim.d.ts",
+        r#"declare module "*.vue" {
+  import Vue from "vue";
+  export default Vue;
+}
+"#,
+    );
+    write(
+        &project_root,
+        "plugins/gtag.ts",
+        r#"export default (_ctx: unknown, inject: (key: string, value: unknown) => void) => {
+  inject("gtag", () => {});
+};
+"#,
+    );
+    write(
+        &project_root,
+        "src/types/thirdParty/gtag.d.ts",
+        r#"declare namespace Gtag { type Gtag = (event: string) => void; }
+declare module "@nuxt/bridge-schema" {
+  export interface Context { $gtag: Gtag.Gtag; }
+}
+"#,
+    );
+    write(
+        &project_root,
+        "src/App.vue",
+        r#"<script lang="ts">
+export default { mounted() { const ready = true; void ready; } };
+</script>
+<template><div /></template>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    for unexpected in ["TS2300", "TS2717", "Duplicate identifier", "$gtag"] {
+        assert!(
+            !stdout.contains(unexpected) && !stderr.contains(unexpected),
+            "diagnostics should not mention {unexpected}:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
## Summary
- Move known Corsa/Vize false-positive diagnostic suppression into a dedicated helper module.
- Suppress project Vue wildcard shim `component` duplicate diagnostics only when the diagnostic belongs to a `.d.ts` that declares `*.vue`.
- Suppress Nuxt bridge injected-property `TS2717` diagnostics only for typed `@nuxt/bridge-schema` augmentations colliding with Vize's conservative `any` plugin injection fallback.

## Root Cause
Legacy Nuxt/Vue projects can carry their own compatibility declaration files that the native checker accepts, while Vize also adds broad compatibility shims for virtual project checking. Those broad shims can surface duplicate diagnostics even though the project declarations should remain accepted.

## Validation
- `cargo test -p vize commands::check::runner::diagnostics::suppressions --lib`
- `cargo test -p vize --test check_nuxt_bridge_shims_cli -- --nocapture`
- `cargo test -p vize --test check_sfc_import_suppressions_cli`
- `cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

Fixes #2517

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785675895&installation_id=136613492&pr_number=2537&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2537&signature=2c4a0f05e62e5483525bf28a283198c923795fe8b395e55e3250e3ac4a405e85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->