### PR TITLE
fix(canon): merge component class bindings

### DIFF
--- a/crates/vize/tests/check_legacy_vue2_class_bindings_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_class_bindings_cli.rs
@@ -1,0 +1,185 @@
+#![cfg(feature = "legacy")]
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+#[test]
+fn legacy_vue2_merges_static_and_dynamic_component_class_bindings() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project("legacy-vue2-component-class-bindings");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "src",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(
+        json["errorCount"], 0,
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    for unexpected in ["TS1117", "multiple properties with the same name"] {
+        assert!(
+            !stdout.contains(unexpected) && !stderr.contains(unexpected),
+            "static and dynamic class bindings must not produce duplicate object keys:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn create_project(name: &str) -> PathBuf {
+    let project_root = unique_case_dir(name);
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    write_test_vue2_6_stub(&project_root.join("node_modules")).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        r#"{
+  "typeChecker": {
+    "legacyVue2": true
+  }
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/TeacherCard.vue"),
+        r#"<script lang="ts">
+export default {
+  props: {
+    teacher: Object,
+  },
+}
+</script>
+
+<template>
+  <article />
+</template>
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/App.vue"),
+        r#"<script lang="ts">
+import TeacherCard from "./TeacherCard.vue"
+
+export default {
+  components: { TeacherCard },
+  data() {
+    return {
+      teacher: { name: "Ada" },
+      isLoading: false,
+    }
+  },
+}
+</script>
+
+<template>
+  <TeacherCard
+    class="ma-1"
+    :teacher="teacher"
+    :class="{ 'loading-place-holder': isLoading }"
+  />
+</template>
+"#,
+    )
+    .unwrap();
+    project_root
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("{name}-{}", std::process::id()).as_str())
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CORSA_PATH")
+        && Path::new(&path).exists()
+    {
+        return Some(path.into());
+    }
+
+    let root = workspace_root();
+    [
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn write_test_vue2_6_stub(target: &Path) -> std::io::Result<()> {
+    let vue_types_dir = target.join("vue").join("types");
+    std::fs::create_dir_all(&vue_types_dir)?;
+    std::fs::write(
+        target.join("vue").join("package.json"),
+        r#"{
+  "name": "vue",
+  "types": "types/index.d.ts"
+}"#,
+    )?;
+    std::fs::write(
+        vue_types_dir.join("index.d.ts"),
+        r#"export interface Vue {
+  $attrs: Record<string, unknown>;
+  $refs: Record<string, any>;
+  $slots: Record<string, unknown>;
+  $emit: (...args: any[]) => void;
+}
+
+declare const VueConstructor: {
+  version: string;
+};
+
+export default VueConstructor;
+"#,
+    )?;
+    Ok(())
+}

--- a/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
@@ -61,6 +61,43 @@ fn has_inference_props(usage: &ComponentUsage) -> bool {
         .any(|prop| prop.name.as_str() != "key" && prop.name.as_str() != "ref")
 }
 
+fn is_checkable_prop(prop: &PassedProp) -> bool {
+    prop.name.as_str() != "key" && prop.name.as_str() != "ref"
+}
+
+fn collect_generated_class_bindings<'a>(
+    usage: &'a ComponentUsage,
+    template_prop_names: &FxHashSet<String>,
+) -> Vec<(&'a PassedProp, String)> {
+    usage
+        .props
+        .iter()
+        .filter(|prop| is_checkable_prop(prop) && prop.name.as_str() == "class")
+        .filter_map(|prop| {
+            generated_prop_value(prop, template_prop_names).map(|value| (prop, value))
+        })
+        .collect()
+}
+
+fn merged_class_binding_value(bindings: &[(&PassedProp, String)]) -> Option<String> {
+    match bindings {
+        [] => None,
+        [(_, value)] => Some(value.clone()),
+        _ => {
+            let mut value = String::default();
+            value.push('[');
+            for (index, (_, binding_value)) in bindings.iter().enumerate() {
+                if index > 0 {
+                    value.push_str(", ");
+                }
+                value.push_str(binding_value.as_str());
+            }
+            value.push(']');
+            Some(value)
+        }
+    }
+}
+
 /// Generate component prop value checks at the given indentation level.
 pub(crate) fn generate_component_prop_checks(
     ts: &mut String,
@@ -168,16 +205,49 @@ fn generate_generic_props_call(
         "{expr_indent}(undefined as unknown as __{component_type_name}_Check_{idx})({{\n",
     );
 
+    let class_bindings = collect_generated_class_bindings(usage, template_prop_names);
+    let merge_class_bindings = class_bindings.len() > 1;
+    let mut emitted_merged_class = false;
     for prop in &usage.props {
-        if prop.name.as_str() == "key" || prop.name.as_str() == "ref" {
+        if !is_checkable_prop(prop) {
             continue;
         }
-        let Some(generated_value) = generated_prop_value(prop, template_prop_names) else {
+
+        let generated_value = if merge_class_bindings && prop.name.as_str() == "class" {
+            if emitted_merged_class {
+                continue;
+            }
+            emitted_merged_class = true;
+            merged_class_binding_value(&class_bindings)
+        } else {
+            generated_prop_value(prop, template_prop_names)
+        };
+        let Some(generated_value) = generated_value else {
             continue;
         };
 
-        let prop_src_start = (template_offset + prop.start) as usize;
-        let prop_src_end = (template_offset + prop.end) as usize;
+        let (prop_src_start, prop_src_end) =
+            if merge_class_bindings && prop.name.as_str() == "class" {
+                let start = class_bindings
+                    .iter()
+                    .map(|(binding, _)| binding.start)
+                    .min()
+                    .unwrap_or(prop.start);
+                let end = class_bindings
+                    .iter()
+                    .map(|(binding, _)| binding.end)
+                    .max()
+                    .unwrap_or(prop.end);
+                (
+                    (template_offset + start) as usize,
+                    (template_offset + end) as usize,
+                )
+            } else {
+                (
+                    (template_offset + prop.start) as usize,
+                    (template_offset + prop.end) as usize,
+                )
+            };
         let camel_prop_name = to_camel_case(prop.name.as_str());
 
         append!(*ts, "{expr_indent}  ");
@@ -200,5 +270,48 @@ fn generate_generic_props_call(
 
     if usage.vif_guard.is_some() {
         append!(*ts, "{indent}}}\n");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    use crate::virtual_ts::generate_virtual_ts;
+
+    #[test]
+    fn generic_props_call_merges_static_and_dynamic_class_bindings() {
+        let script = r#"import TeacherCard from "./TeacherCard.vue"
+const teacher = { name: "Ada" }
+const isLoading = false
+"#;
+        let template = r#"<TeacherCard
+  class="ma-1"
+  :teacher="teacher"
+  :class="{ 'loading-place-holder': isLoading }"
+/>"#;
+
+        let allocator = vize_carton::Bump::new();
+        let (root, _) = vize_armature::parse(&allocator, template);
+        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+        analyzer.analyze_script_setup(script);
+        analyzer.analyze_template(&root);
+        let summary = analyzer.finish();
+
+        let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+
+        assert!(
+            output
+                .code
+                .contains("\"class\": [\"ma-1\", { 'loading-place-holder': isLoading }]"),
+            "expected merged class binding in generic props call:\n{}",
+            output.code
+        );
+        assert_eq!(
+            output.code.matches("\"class\":").count(),
+            1,
+            "class should be emitted once in the props object:\n{}",
+            output.code
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Merge duplicate static and dynamic `class` bindings before emitting the generic component props object.
- Add a virtual TS unit test for the generated object literal shape.
- Add a legacy Vue 2 CLI regression that fails if TS1117 duplicate keys return.

## Root cause
Vue permits static `class` and dynamic `:class` on the same component and merges them at runtime. Vize emitted both bindings as separate `"class"` object-literal entries in the generic props call, so TypeScript reported TS1117 before useful prop checking could run.

## Validation
- `cargo test -p vize_canon generic_props_call_merges_static_and_dynamic_class_bindings --lib`
- `cargo test -p vize --test check_legacy_vue2_class_bindings_cli --features legacy -- --nocapture`
- `cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports`
- `cargo clippy -p vize --test check_legacy_vue2_class_bindings_cli --features legacy -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `git diff --check`
- `node --test tests/tooling/source-file-lengths.test.ts`

Fixes #2514

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785676406&installation_id=136613492&pr_number=2538&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2538&signature=33b538f07ffcb9b745b9f95aceb1bbf43e1569c9288532e21515246c8fa64863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->