### PR TITLE
fix(canon): preserve Vue 2 prop aliases

### DIFF
--- a/crates/vize/tests/check_vue2_vuetify_props_cli.rs
+++ b/crates/vize/tests/check_vue2_vuetify_props_cli.rs
@@ -1,0 +1,137 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+#[test]
+fn check_vue2_dialect_allows_vuetify_style_prop_aliases() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project("vue2-vuetify-prop-aliases");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--config",
+            "vize.config.json",
+            "--tsconfig",
+            "tsconfig.json",
+            "src/App.vue",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(
+        json["errorCount"], 0,
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    for unexpected in ["keyof Props", "isMini", "hideDetails", "chips", "width"] {
+        assert!(
+            !stdout.contains(unexpected),
+            "Vue 2 dialect should not report Vuetify alias props through keyed Props fallback:\n{stdout}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn create_project(name: &str) -> PathBuf {
+    let project_root = unique_case_dir(name);
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    write_test_vite_stub(&project_root.join("node_modules")).unwrap();
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        r#"{ "vue": { "version": "2.7" } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/App.vue"),
+        r#"<script setup lang="ts">
+type Props = { mini?: boolean } & { dense?: boolean }
+defineProps<Props>()
+</script>
+
+<template>
+  <div>{{ isMini }} {{ hideDetails }} {{ chips }} {{ width }}</div>
+</template>
+"#,
+    )
+    .unwrap();
+    project_root
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("{name}-{}", std::process::id()).as_str())
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CORSA_PATH")
+        && Path::new(&path).exists()
+    {
+        return Some(path.into());
+    }
+
+    let root = workspace_root();
+    [
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn write_test_vite_stub(target: &Path) -> std::io::Result<()> {
+    let vite_dir = target.join("vite");
+    std::fs::create_dir_all(&vite_dir)?;
+    std::fs::write(
+        vite_dir.join("package.json"),
+        r#"{
+  "name": "vite",
+  "types": "client.d.ts"
+}"#,
+    )?;
+    std::fs::write(vite_dir.join("client.d.ts"), "")?;
+    Ok(())
+}

--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -157,10 +157,12 @@ pub(super) fn generate_vue_virtual_ts(
     }
 
     let croquis_options = SfcCroquisOptions::full();
+    let vue2_compat = codegen_options.legacy_vue2
+        || matches!(codegen_options.dialect, VueVersion::V2 | VueVersion::V2_7);
 
     let analysis = profile!(
         "canon.croquis.analyze_sfc",
-        if codegen_options.legacy_vue2 {
+        if vue2_compat {
             analyze_sfc_descriptor_with_context_legacy_vue2(
                 descriptor,
                 template_ast.as_ref(),
@@ -189,9 +191,7 @@ pub(super) fn generate_vue_virtual_ts(
         collect_art_template_referenced_names(descriptor, codegen_options.template_syntax)
     });
 
-    let hoist_shared_preamble = codegen_options.hoist_shared_preamble
-        && !codegen_options.legacy_vue2
-        && !matches!(codegen_options.dialect, VueVersion::V2 | VueVersion::V2_7);
+    let hoist_shared_preamble = codegen_options.hoist_shared_preamble && !vue2_compat;
     let output = profile!(
         "canon.virtual_ts.generate",
         generate_virtual_ts_with_offsets_and_checks(
@@ -206,8 +206,8 @@ pub(super) fn generate_vue_virtual_ts(
                 dialect: codegen_options.dialect,
                 preserve_unused_diagnostics: codegen_options.preserve_unused_diagnostics,
                 extra_template_referenced_names: extra_template_referenced_names.as_ref(),
-                options_api: codegen_options.options_api,
-                legacy_vue2: codegen_options.legacy_vue2,
+                options_api: codegen_options.options_api || vue2_compat,
+                legacy_vue2: vue2_compat,
                 template_syntax_quirks: matches!(
                     codegen_options.template_syntax,
                     TemplateSyntaxMode::Quirks

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -128,7 +128,11 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     // (e.g. a Vue 2 `this`/template shape with `$listeners`,
     // `$children`, `$on`, ... that Vue 3's `ComponentPublicInstance` lacks).
     let dialect = generation_options.dialect;
-    let legacy_vue2 = generation_options.legacy_vue2;
+    let legacy_vue2 = generation_options.legacy_vue2
+        || matches!(
+            dialect,
+            vize_carton::config::VueVersion::V2 | vize_carton::config::VueVersion::V2_7
+        );
     let _ = generation_options.template_syntax_quirks;
     let options_api = generation_options.options_api || legacy_vue2;
     let hoist_shared_preamble = generation_options.hoist_shared_preamble;

--- a/crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs
@@ -1,3 +1,4 @@
+use vize_carton::config::VueVersion;
 use vize_croquis::{Analyzer, AnalyzerOptions};
 
 use super::{
@@ -31,6 +32,33 @@ fn legacy_virtual_ts(script: &str, template: &str, options: &VirtualTsOptions) -
         options,
         VirtualTsGenerationOptions {
             legacy_vue2: true,
+            ..Default::default()
+        },
+    )
+    .code
+    .to_string()
+}
+
+fn dialect_virtual_ts(
+    script: &str,
+    template: &str,
+    options: &VirtualTsOptions,
+    dialect: VueVersion,
+) -> String {
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    generate_virtual_ts_with_offsets_and_checks(
+        &analyzer.finish(),
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        options,
+        VirtualTsGenerationOptions {
+            dialect,
             ..Default::default()
         },
     )
@@ -143,5 +171,35 @@ defineProps<Props>()
         legacy.contains("(props as Record<string, unknown>)[\"width\"]")
             && !legacy.contains("satisfies keyof Props"),
         "legacy Vue 2 keyed prop fallback should not reject Vuetify/mixin names:\n{legacy}"
+    );
+}
+
+#[test]
+fn vue2_dialect_unresolved_keyed_props_are_unchecked() {
+    let script = r#"
+type Props = { mini?: boolean } & { dense?: boolean }
+defineProps<Props>()
+"#;
+    let template = r#"<div>{{ isMini }} {{ hideDetails }} {{ chips }} {{ width }}</div>"#;
+
+    let standard = standard_virtual_ts(script, template, &VirtualTsOptions::default());
+    assert!(
+        standard.contains("\"isMini\" satisfies keyof Props"),
+        "standard keyed prop fallback should still catch unknown props:\n{standard}"
+    );
+
+    let vue2 = dialect_virtual_ts(
+        script,
+        template,
+        &VirtualTsOptions::default(),
+        VueVersion::V2_7,
+    );
+    assert!(
+        vue2.contains("(props as Record<string, unknown>)[\"isMini\"]")
+            && vue2.contains("(props as Record<string, unknown>)[\"hideDetails\"]")
+            && vue2.contains("(props as Record<string, unknown>)[\"chips\"]")
+            && vue2.contains("(props as Record<string, unknown>)[\"width\"]")
+            && !vue2.contains("satisfies keyof Props"),
+        "Vue 2 dialect keyed prop fallback should not reject Vuetify/mixin names:\n{vue2}"
     );
 }


### PR DESCRIPTION
## Summary
- Treat configured Vue 2 / 2.7 dialect as effective Vue 2 compatibility during virtual TS generation.
- Route Vue 2 dialect SFC analysis through the legacy Options API-aware path.
- Add unit and CLI regressions for Vuetify-style alias props such as `isMini`, `hideDetails`, `chips`, and `width`.

## Root cause
`vue.version: "2.7"` already selected Vue 2 helpers, but strict template prop fallback still used `satisfies keyof Props` unless `typeChecker.legacyVue2` was also set. Nuxt 2 / Vuetify 2 projects can infer or configure Vue 2 dialect without that exact flag, so accepted Vuetify aliases were reported as invalid prop keys.

## Validation
- `cargo test -p vize_canon vue2_dialect_unresolved_keyed_props_are_unchecked --lib -- --nocapture`
- `cargo test -p vize_canon keyed_props_are_unchecked --lib -- --nocapture`
- `cargo test -p vize_canon configured_dialect_drives_instance_typing_without_ref_arity --lib -- --nocapture`
- `cargo test -p vize --test check_vue2_vuetify_props_cli -- --nocapture`
- `cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports`
- `cargo clippy -p vize --test check_vue2_vuetify_props_cli -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `git diff --check`
- `node --test tests/tooling/source-file-lengths.test.ts`

Fixes #2515

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785676800&installation_id=136613492&pr_number=2539&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2539&signature=43674a508f0163da0340d5096e8778a87d778179ca7bad9e5bb444c02c6f43ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->