### PR TITLE
fix(canon): preserve Vue 2 event arity

### DIFF
--- a/crates/vize/tests/check_legacy_vue2_event_payload_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_event_payload_cli.rs
@@ -1,0 +1,197 @@
+#![cfg(feature = "legacy")]
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+#[test]
+fn legacy_vue2_component_event_payloads_stay_variadic_when_unresolved() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project("legacy-vue2-event-payload-arity");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+            "src/App.vue",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(
+        json["errorCount"], 0,
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    for unexpected in ["TS2345", "Target signature provides too few arguments"] {
+        assert!(
+            !stdout.contains(unexpected),
+            "Vue 2 custom event handler arity should stay loose:\n{stdout}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn create_project(name: &str) -> PathBuf {
+    let project_root = unique_case_dir(name);
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src/components")).unwrap();
+    write_test_vue2_stub(&project_root.join("node_modules")).unwrap();
+    write_test_vite_stub(&project_root.join("node_modules")).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*.vue"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        r#"{ "typeChecker": { "legacyVue2": true } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/components/CalendarRange.vue"),
+        r#"<script lang="ts">
+import { defineComponent } from "vue"
+
+export default defineComponent({
+  emits: {
+    "range-change": null,
+    submit() {
+      return true
+    },
+  },
+})
+</script>
+
+<template>
+  <button type="button" />
+</template>
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/App.vue"),
+        r#"<script lang="ts">
+import { defineComponent } from "vue"
+import CalendarRange from "./components/CalendarRange.vue"
+
+export default defineComponent({
+  components: { CalendarRange },
+  setup() {
+    function updateRange(
+      calendarDate: { start: string; end: string },
+      highlightSelectedDate: () => void,
+    ) {
+      void calendarDate
+      highlightSelectedDate()
+    }
+    function submitHooks(hooks: { before?: () => void; after?: () => void }) {
+      hooks.before?.()
+    }
+    return { updateRange, submitHooks }
+  },
+})
+</script>
+
+<template>
+  <CalendarRange
+    @range-change="updateRange"
+    @submit="submitHooks"
+  />
+</template>
+"#,
+    )
+    .unwrap();
+    project_root
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("{name}-{}", std::process::id()).as_str())
+}
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CORSA_PATH")
+        && Path::new(&path).exists()
+    {
+        return Some(PathBuf::from(path));
+    }
+
+    let workspace_root = workspace_root();
+    [
+        workspace_root.join("node_modules/.bin/tsgo"),
+        workspace_root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn write_test_vue2_stub(target: &Path) -> std::io::Result<()> {
+    let vue_types_dir = target.join("vue").join("types");
+    std::fs::create_dir_all(&vue_types_dir)?;
+    std::fs::write(
+        target.join("vue").join("package.json"),
+        r#"{ "name": "vue", "types": "types/index.d.ts" }"#,
+    )?;
+    std::fs::write(
+        vue_types_dir.join("index.d.ts"),
+        r#"export interface Vue {
+  $attrs: Record<string, unknown>;
+  $refs: Record<string, any>;
+  $slots: Record<string, unknown>;
+  $emit: (...args: any[]) => void;
+}
+export declare function defineComponent<T>(options: T): T;
+export default { version: '2.7.16' };
+"#,
+    )?;
+    Ok(())
+}
+
+fn write_test_vite_stub(target: &Path) -> std::io::Result<()> {
+    let vite_dir = target.join("vite");
+    std::fs::create_dir_all(&vite_dir)?;
+    std::fs::write(
+        vite_dir.join("package.json"),
+        r#"{ "name": "vite", "types": "client.d.ts" }"#,
+    )?;
+    std::fs::write(vite_dir.join("client.d.ts"), "")?;
+    Ok(())
+}

--- a/crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs
@@ -128,6 +128,35 @@ function moveToDetail(item: Manager) {
 }
 
 #[test]
+fn legacy_vue2_unresolved_component_event_payloads_stay_variadic() {
+    let script = r#"import CalendarRange from './CalendarRange.vue'
+function updateRange(
+  calendarDate: { start: string; end: string },
+  highlightSelectedDate: () => void,
+) {
+  void calendarDate
+  highlightSelectedDate()
+}
+function submitHooks(hooks: { before?: () => void; after?: () => void }) {
+  hooks.before?.()
+}
+"#;
+    let template = r#"<CalendarRange @range-change="updateRange" @submit="submitHooks" />"#;
+
+    let legacy = legacy_virtual_ts(script, template, &VirtualTsOptions::default());
+    assert!(
+        legacy.contains("_range_change_legacy_args")
+            && legacy.contains("_submit_legacy_args")
+            && legacy.contains("extends [] ? any[] : unknown[] extends"),
+        "legacy Vue 2 unresolved/empty component event args should become variadic any[]:\n{legacy}"
+    );
+    assert!(
+        !legacy.contains(" ? (($event: "),
+        "legacy Vue 2 component listeners should not collapse unresolved events to one $event:\n{legacy}"
+    );
+}
+
+#[test]
 fn legacy_vue2_skips_external_component_prop_checks() {
     let script = "const width = 320\n";
     let template = r#"<VDatePicker :width="width" />"#;

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -369,17 +369,16 @@ fn generate_scope_node(
                 )
                 .expect("component event handler should have a target component");
                 let event_type = event_types.event_type;
-                let args_type = event_types.args_type;
-                let listener_args_type = event_types.listener_args_type;
                 let listener_type = event_types.listener_type;
+                let listener_type_expr = event_types.listener_type_expr;
                 // Type the listener against the FULL emit argument tuple so
                 // multi-arg emits keep every parameter (#1512). When the emit
                 // signature stays unresolved (`unknown[]`, e.g. a fallthrough
-                // DOM event on a component), fall back to the single `$event`
-                // parameter so those handlers keep type-checking.
+                // DOM event on a component), standard mode falls back to one
+                // `$event`; legacy Vue 2 keeps custom event args variadic.
                 append!(
                     *ts,
-                    "{indent}type {listener_type} = unknown[] extends {args_type} ? (($event: {event_type}) => unknown) : ((...args: {listener_args_type}) => unknown);\n",
+                    "{indent}type {listener_type} = {listener_type_expr};\n",
                 );
                 // Receive every listener argument via a rest parameter typed by
                 // `Parameters<listener>` (always a tuple, so the spread targets a

--- a/crates/vize_canon/src/virtual_ts/scope/component_events.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events.rs
@@ -14,9 +14,8 @@ use crate::virtual_ts::{
 
 pub(super) struct ComponentEventTypes {
     pub(super) event_type: String,
-    pub(super) args_type: String,
-    pub(super) listener_args_type: String,
     pub(super) listener_type: String,
+    pub(super) listener_type_expr: String,
 }
 
 pub(super) fn generate_component_event_types(
@@ -119,11 +118,17 @@ pub(super) fn generate_component_event_types(
     // wrapper so object payload callbacks stay permissive; otherwise they use
     // the resolved emit argument tuple directly.
     let listener_args_type = if legacy_vue2 {
+        let legacy_args_type =
+            cstr!("__{component_type_name}_{scope_id}_{safe_event_name}_legacy_args");
         append!(
             *ts,
             "{indent}type {event_type} = {args_type} extends [] ? any : unknown[] extends {args_type} ? any : __VizeVue2LooseEventArg<{args_type}[0]>;\n",
         );
-        cstr!("__VizeVue2LooseEmitArgs<{args_type}>")
+        append!(
+            *ts,
+            "{indent}type {legacy_args_type} = {args_type} extends [] ? any[] : unknown[] extends {args_type} ? any[] : __VizeVue2LooseEmitArgs<{args_type}>;\n",
+        );
+        legacy_args_type
     } else {
         let fallback_event = get_dom_event_type(data.event_name.as_str());
         append!(
@@ -132,11 +137,17 @@ pub(super) fn generate_component_event_types(
         );
         args_type.clone()
     };
+    let listener_type_expr = if legacy_vue2 {
+        cstr!("(...args: {listener_args_type}) => unknown")
+    } else {
+        cstr!(
+            "unknown[] extends {args_type} ? (($event: {event_type}) => unknown) : ((...args: {listener_args_type}) => unknown)"
+        )
+    };
     Some(ComponentEventTypes {
         event_type,
-        args_type,
-        listener_args_type,
         listener_type,
+        listener_type_expr,
     })
 }
 


### PR DESCRIPTION
## Summary
- Keep legacy Vue 2 component listener fallbacks variadic instead of collapsing unresolved payloads to one `$event`.
- Treat empty legacy event payload tuples as loose `any[]`, preserving Vue 2 custom event handler arity.
- Add unit and CLI regressions for multi-argument and apparent zero-argument Vue 2 custom event handlers.

## Root cause
When component emit args stayed unresolved or looked empty, the generated listener type could become `($event: any) => unknown` or `() => unknown`. Vue 2 custom events often carry payloads without complete type metadata, so valid handlers with one or more required parameters were rejected with TS2345.

## Validation
- `cargo test -p vize_canon legacy_vue2_unresolved_component_event_payloads_stay_variadic --lib -- --nocapture`
- `cargo test -p vize_canon test_component_event_listener_uses_full_emit_arg_tuple --lib -- --nocapture`
- `cargo test -p vize_canon test_component_event_fallback_uses_dom_event_type_when_args_stay_unknown --lib -- --nocapture`
- `cargo test -p vize --test check_legacy_vue2_event_payload_cli --features legacy -- --nocapture`
- `cargo test -p vize --test check_legacy_vue2_event_alias_cli --features legacy -- --nocapture`
- `cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports`
- `cargo clippy -p vize --test check_legacy_vue2_event_payload_cli --features legacy -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `git diff --check`
- `node --test tests/tooling/source-file-lengths.test.ts`

Fixes #2516

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785677208&installation_id=136613492&pr_number=2540&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2540&signature=abb5a3eebfe9d29bd6c138f5b0c3c6706b273cc4f239a2e9de463f8f62853d1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->