### PR TITLE
fix(patina): allow dotted data table slots

### DIFF
--- a/crates/vize_patina/src/rules/vue/valid_v_slot.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_slot.rs
@@ -252,7 +252,14 @@ fn has_component_parent(ctx: &LintContext) -> bool {
 fn static_slot_name(directive: &DirectiveNode) -> Option<String> {
     match &directive.arg {
         None => Some("default".into()),
-        Some(ExpressionNode::Simple(arg)) => Some(arg.content.to_compact_string()),
+        Some(ExpressionNode::Simple(arg)) => {
+            let mut name = arg.content.to_compact_string();
+            for modifier in &directive.modifiers {
+                name.push('.');
+                name.push_str(modifier.content.as_str());
+            }
+            Some(name)
+        }
         Some(ExpressionNode::Compound(_)) => None,
     }
 }
@@ -264,84 +271,4 @@ mod location_tests;
 mod mixed_default_tests;
 
 #[cfg(test)]
-mod tests {
-    use super::ValidVSlot;
-    use crate::linter::Linter;
-    use crate::rule::RuleRegistry;
-
-    fn create_linter() -> Linter {
-        let mut registry = RuleRegistry::new();
-        registry.register(Box::new(ValidVSlot));
-        Linter::with_registry(registry)
-    }
-
-    #[test]
-    fn test_valid_default_slot() {
-        let linter = create_linter();
-        let result = linter.lint_template(
-            r#"<MyComponent v-slot="{ item }">{{ item }}</MyComponent>"#,
-            "test.vue",
-        );
-        assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_valid_named_slot_template() {
-        let linter = create_linter();
-        let result = linter.lint_template(
-            r#"<MyComponent><template #header>Header</template></MyComponent>"#,
-            "test.vue",
-        );
-        assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_valid_default_slot_argument_on_component() {
-        let linter = create_linter();
-        let result = linter.lint_template(
-            r#"<MyComponent v-slot:default="{ item }">{{ item }}</MyComponent>"#,
-            "test.vue",
-        );
-        assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_valid_dynamic_component_slot() {
-        let linter = create_linter();
-        let result = linter.lint_template(
-            r#"<component :is="to ? NuxtLinkLocale : 'button'" #="scoped">{{ scoped }}</component>"#,
-            "test.vue",
-        );
-        assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_invalid_on_html_element() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<div v-slot:header></div>"#, "test.vue");
-        assert_eq!(result.error_count, 1);
-    }
-
-    #[test]
-    fn test_invalid_named_slot_on_component() {
-        let linter = create_linter();
-        let result = linter.lint_template(
-            r#"<MyComponent v-slot:header>Header</MyComponent>"#,
-            "test.vue",
-        );
-        assert_eq!(result.error_count, 1);
-    }
-
-    #[test]
-    fn test_valid_multiple_named_slots() {
-        let linter = create_linter();
-        let result = linter.lint_template(
-            r#"<MyComponent>
-                <template #header>Header</template>
-                <template #footer>Footer</template>
-            </MyComponent>"#,
-            "test.vue",
-        );
-        assert_eq!(result.error_count, 0);
-    }
-}
+mod tests;

--- a/crates/vize_patina/src/rules/vue/valid_v_slot/tests.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_slot/tests.rs
@@ -1,0 +1,105 @@
+use super::ValidVSlot;
+use crate::linter::Linter;
+use crate::rule::RuleRegistry;
+
+fn create_linter() -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(Box::new(ValidVSlot));
+    Linter::with_registry(registry)
+}
+
+#[test]
+fn test_valid_default_slot() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<MyComponent v-slot="{ item }">{{ item }}</MyComponent>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_named_slot_template() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<MyComponent><template #header>Header</template></MyComponent>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_default_slot_argument_on_component() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<MyComponent v-slot:default="{ item }">{{ item }}</MyComponent>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_dynamic_component_slot() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<component :is="to ? NuxtLinkLocale : 'button'" #="scoped">{{ scoped }}</component>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_invalid_on_html_element() {
+    let linter = create_linter();
+    let result = linter.lint_template(r#"<div v-slot:header></div>"#, "test.vue");
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_invalid_named_slot_on_component() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<MyComponent v-slot:header>Header</MyComponent>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_valid_multiple_named_slots() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<MyComponent>
+            <template #header>Header</template>
+            <template #footer>Footer</template>
+        </MyComponent>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_dotted_vuetify_data_table_slots() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<v-data-table>
+            <template v-slot:item.tagName="{ item }">{{ item.tagName }}</template>
+            <template v-slot:item.memo="{ item }">{{ item.memo }}</template>
+        </v-data-table>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_invalid_duplicate_dotted_slot_name() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<v-data-table>
+            <template v-slot:item.memo="{ item }">{{ item.memo }}</template>
+            <template v-slot:item.memo="{ item }">{{ item.memo }}</template>
+        </v-data-table>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 1);
+}


### PR DESCRIPTION
## Summary
- Preserve Vue slot modifiers when computing static `v-slot` names.
- Move the existing `vue/valid-v-slot` unit tests into a module file and add dotted Vuetify data-table slot regressions.

## Root cause
Vue parses `v-slot:item.tagName` as argument `item` plus modifier `tagName`. The duplicate-slot check only used the argument text, so distinct data-table slots such as `item.tagName` and `item.memo` both collapsed to `item` and were reported as duplicates.

## Validation
- `cargo test -p vize_patina valid_v_slot --lib -- --nocapture`
- `cargo clippy -p vize_patina --lib -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `node --test tests/tooling/source-file-lengths.test.ts`
- Manual CLI repro: dotted Vuetify data-table slots now report `errorCount: 0` with only `vue/v-slot-style` warnings.

Fixes #2518

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785677696&installation_id=136613492&pr_number=2541&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2541&signature=921af2150d0ebd735a031386f0c4672463736f434208a7f85878a1a7388455ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->