### PR TITLE
fix(nuxt): skip Musea setup on Nuxt 2

### DIFF
--- a/npm/framework/nuxt/src/index-nuxt2-musea.test.ts
+++ b/npm/framework/nuxt/src/index-nuxt2-musea.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+void test("Nuxt 2 musea options do not load the ESM-only Musea Vite plugin", async () => {
+  const { default: nuxtModule } = await import(new URL("../dist/index.mjs", import.meta.url).href);
+  const hookNames: string[] = [];
+  const nuxt = {
+    _version: "2.17.3",
+    options: {
+      rootDir: process.cwd(),
+      build: { publicPath: "/_nuxt/" },
+      router: { base: "/" },
+      modules: [],
+      buildDir: ".nuxt",
+      dev: false,
+      vite: {},
+    },
+    hook(name: string, callback: (...args: unknown[]) => unknown) {
+      assert.equal(typeof callback, "function");
+      hookNames.push(name);
+    },
+  };
+
+  await nuxtModule(
+    {
+      compiler: false,
+      musea: {
+        include: ["stories/**/*.art.vue"],
+        basePath: "/__musea__",
+      },
+      compatibility: {
+        nuxtVersion: 2,
+        vueVersion: "2.7",
+        hostCompiler: true,
+        webpackVersion: 4,
+      },
+    },
+    nuxt,
+  );
+
+  assert.deepEqual(hookNames, ["close", "builder:prepared", "build:templates"]);
+  assert.deepEqual(nuxt.options.vite, {});
+});

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -353,7 +353,7 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
   const buildAssetsDir = getNuxtBuildAssetsDir(nuxtWithBuilderOptions);
   const bridgeOptions = resolveNuxtBridgeOptions(options.bridge);
   const devOptions = resolveNuxtDevOptions(options.dev);
-  const museaOptions = resolveNuxtMuseaOptions(options.musea);
+  const museaOptions = detectedNuxtMajor === 2 ? false : resolveNuxtMuseaOptions(options.musea);
   const unocssOptions = resolveNuxtUnoCssOptions(options.unocss);
 
   if (museaOptions !== false) nuxt.hook("components:dirs", appendMuseaArtComponentIgnore);


### PR DESCRIPTION
## Summary
- Treat Musea as disabled inside the Nuxt module when the host is Nuxt 2.
- Add a Nuxt 2 regression test that passes `musea` options and verifies no Musea Vite plugin/static hooks are registered.

## Root cause
Nuxt 2/JITI can route `import("@vizejs/vite-plugin-musea")` through CommonJS resolution. `@vizejs/vite-plugin-musea` exposes its root entry through ESM package exports only, so that CJS resolution fails before webpack compilation with `No "exports" main defined`.

## Validation
- `vp run --filter './npm/framework/nuxt' build`
- `vp run --filter './npm/framework/nuxt' test`
- `vp run --filter './npm/framework/nuxt' check`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

Fixes #2519

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785678115&installation_id=136613492&pr_number=2542&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2542&signature=17bb444b679159971afd2a3bbd76c0d4c35ec24ce512469bfba8e40c4f132112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->