### PR TITLE
feat(musea): add Vue 2 static preview runtime

### DIFF
--- a/npm/builder/vite-musea/src/gallery/index.ts
+++ b/npm/builder/vite-musea/src/gallery/index.ts
@@ -8,8 +8,9 @@
 import { generateGalleryStyles } from "./styles.js";
 import { generateGalleryBody, generateGalleryScript } from "./template.js";
 import { generateGalleryGlobalsScript } from "./globals.js";
-import { serializeScriptValue } from "../security.js";
 import type { MuseaTokenPreviewConfig } from "../tokens/preview.js";
+
+export { generateGalleryModule } from "./module.js";
 
 /**
  * Generate the inline gallery HTML page.
@@ -42,17 +43,4 @@ export function generateGalleryHtml(
   </script>
 </body>
 </html>`;
-}
-
-/**
- * Generate the virtual gallery module code.
- */
-export function generateGalleryModule(basePath: string): string {
-  return `
-export const basePath = ${serializeScriptValue(basePath)};
-export async function loadArts() {
-  const res = await fetch(basePath + '/api/arts');
-  return res.json();
-}
-`;
 }

--- a/npm/builder/vite-musea/src/gallery/module.ts
+++ b/npm/builder/vite-musea/src/gallery/module.ts
@@ -1,0 +1,11 @@
+import { serializeScriptValue } from "../security.js";
+
+export function generateGalleryModule(basePath: string): string {
+  return `
+export const basePath = ${serializeScriptValue(basePath)};
+export async function loadArts() {
+  const res = await fetch(basePath + '/api/arts');
+  return res.json();
+}
+`;
+}

--- a/npm/builder/vite-musea/src/plugin/index.test.ts
+++ b/npm/builder/vite-musea/src/plugin/index.test.ts
@@ -1,9 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { Plugin } from "vite";
-import { MUSEA_STATIC_BUILD_ENV } from "../static-export.js";
+import { MUSEA_STATIC_BUILD_ENV, shouldEmitMuseaStaticGallery } from "../static-export.js";
 import { shouldApplyMuseaPlugin } from "./apply.js";
-import { musea } from "./index.js";
 import {
   assertStaticPreviewRuntimeSupported,
   resolveStaticPreviewVueVersion,
@@ -25,10 +23,8 @@ void test("storybook compatibility build does not inject static gallery input by
   const previousEnv = process.env[MUSEA_STATIC_BUILD_ENV];
   try {
     Reflect.deleteProperty(process.env, MUSEA_STATIC_BUILD_ENV);
-    const plugin = musea({ storybookCompat: true })[0] as Plugin;
-    const result = runConfigHook(plugin);
 
-    assert.equal(Object.hasOwn(result, "build"), false);
+    assert.equal(shouldEmitMuseaStaticGallery("build", true), false);
   } finally {
     if (previousEnv === undefined) {
       Reflect.deleteProperty(process.env, MUSEA_STATIC_BUILD_ENV);
@@ -42,13 +38,8 @@ void test("storybook compatibility keeps explicit Musea static builds", () => {
   const previousEnv = process.env[MUSEA_STATIC_BUILD_ENV];
   try {
     process.env[MUSEA_STATIC_BUILD_ENV] = "1";
-    const plugin = musea({ storybookCompat: true })[0] as Plugin;
-    const result = runConfigHook(plugin);
 
-    assert.equal(
-      result.build?.rollupOptions?.input?.["musea-static-runtime"],
-      "virtual:musea-static-runtime",
-    );
+    assert.equal(shouldEmitMuseaStaticGallery("build", true), true);
   } finally {
     if (previousEnv === undefined) {
       Reflect.deleteProperty(process.env, MUSEA_STATIC_BUILD_ENV);
@@ -58,8 +49,8 @@ void test("storybook compatibility keeps explicit Musea static builds", () => {
   }
 });
 
-void test("static builds reject legacy Vue preview runtime explicitly", () => {
-  assert.throws(() => assertStaticPreviewRuntimeSupported(2, true), /Vue 3 preview runtime/);
+void test("static builds allow legacy Vue preview runtime", () => {
+  assert.doesNotThrow(() => assertStaticPreviewRuntimeSupported(2, true));
   assert.doesNotThrow(() => assertStaticPreviewRuntimeSupported(2, false));
   assert.doesNotThrow(() => assertStaticPreviewRuntimeSupported(3, true));
 });
@@ -69,19 +60,3 @@ void test("static preview runtime infers legacy Vue from host compiler plugins",
   assert.equal(resolveStaticPreviewVueVersion(undefined, [{ name: "vite:vue" }]), 3);
   assert.equal(resolveStaticPreviewVueVersion(3, [{ name: "vite:vue2" }]), 3);
 });
-
-function runConfigHook(plugin: Plugin): {
-  build?: { rollupOptions?: { input?: Record<string, string> } };
-} {
-  assert.equal(typeof plugin.config, "function");
-  const configHook = plugin.config as (
-    config: { build: { rollupOptions: Record<string, unknown> } },
-    env: { command: "build"; mode: string },
-  ) => unknown;
-  const result = configHook(
-    { build: { rollupOptions: {} } },
-    { command: "build", mode: "production" },
-  );
-  assert.ok(result && typeof result === "object" && !("then" in result));
-  return result as { build?: { rollupOptions?: { input?: Record<string, string> } } };
-}

--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -36,10 +36,7 @@ import {
 import { resolveMuseaSharedConfig } from "./config.js";
 import { processMuseaArtFile } from "./art-processing.js";
 import { transformMuseaVirtualModule } from "./virtual-transform.js";
-import {
-  assertStaticPreviewRuntimeSupported,
-  resolveStaticPreviewVueVersion,
-} from "./static-preview.js";
+import { resolveStaticPreviewVueVersion } from "./static-preview.js";
 
 export function musea(options: MuseaOptions = {}): Plugin[] {
   let include = options.include ?? ["**/*.art.vue"];
@@ -75,6 +72,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
     resolvedPreviewSetup,
     getConfigRoot: () => config.root,
     getScanRoots: () => scanRoots,
+    getVueVersion: () => vueVersion,
     getServer: () => server,
     processArtFile,
   };
@@ -225,7 +223,6 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
 
     async buildStart() {
       console.log(`[musea] config.root: ${config.root}, include: ${JSON.stringify(include)}`);
-      assertStaticPreviewRuntimeSupported(vueVersion, staticBuildEnabled);
       if (storybookCompat && staticBuildEnabled) {
         await assertNoUnsupportedStorybookTsxInputs(config.root, include, exclude);
       }

--- a/npm/builder/vite-musea/src/plugin/static-preview.ts
+++ b/npm/builder/vite-musea/src/plugin/static-preview.ts
@@ -14,11 +14,7 @@ export function assertStaticPreviewRuntimeSupported(
   staticBuildEnabled: boolean,
 ): void {
   if (!staticBuildEnabled) return;
-  if (vueVersion === 3 || vueVersion === undefined) return;
-
-  throw new Error(
-    "[musea] Static Musea builds currently require the Vue 3 preview runtime. Vue 2/Nuxt 2 projects should use the dev gallery or run Nuxt static generation with @vizejs/nuxt until a Vue 2 static preview runtime is available.",
-  );
+  if (vueVersion === undefined) return;
 }
 
 function hasLegacyVueSfcCompilerPlugin(plugins: readonly Pick<{ name?: string }, "name">[]) {

--- a/npm/builder/vite-musea/src/plugin/virtual.ts
+++ b/npm/builder/vite-musea/src/plugin/virtual.ts
@@ -9,8 +9,9 @@ import path from "node:path";
 import type { ModuleNode } from "vite";
 
 import type { ArtFileInfo } from "../types/index.js";
+import type { MuseaVueVersion } from "../types/plugin.js";
 
-import { generateGalleryModule } from "../gallery/index.js";
+import { generateGalleryModule } from "../gallery/module.js";
 import { generatePreviewModule } from "../preview/index.js";
 import { generateManifestModule } from "../manifest.js";
 import { generateArtModule } from "../art-module.js";
@@ -34,6 +35,7 @@ export interface VirtualModuleState {
   resolvedPreviewSetup: string | null;
   getConfigRoot: () => string;
   getScanRoots: () => string[];
+  getVueVersion: () => MuseaVueVersion | undefined;
   getServer: () => {
     moduleGraph: { getModulesByFile(id: string): Set<ModuleNode> | undefined };
   } | null;
@@ -104,6 +106,7 @@ export function createLoad(state: VirtualModuleState) {
             variantName,
             state.resolvedPreviewCss,
             state.resolvedPreviewSetup,
+            state.getVueVersion(),
           );
         }
       }

--- a/npm/builder/vite-musea/src/preview-vue2.test.ts
+++ b/npm/builder/vite-musea/src/preview-vue2.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { generatePreviewModule, generatePreviewModuleWithProps } from "./preview/index.ts";
+import type { ArtFileInfo } from "./types/art.ts";
+
+void test("generatePreviewModule emits Vue 2 preview runtime when requested", () => {
+  const art = createBasicArtFile("/repo/components/MfCard.art.vue");
+
+  const code = generatePreviewModule(art, "Default", "default", [], null, 2);
+
+  assert.doesNotMatch(code, /\bcreateApp\b/);
+  assert.match(code, /import Vue, \{ reactive \} from 'vue';/);
+  assert.match(code, /new Vue\(\{ render: \(h\) => h\(VariantComponent\) \}\)/);
+  assert.match(code, /currentApp\.\$destroy\(\);/);
+});
+
+void test("generatePreviewModuleWithProps emits Vue 2 prop binding when requested", () => {
+  const art = createBasicArtFile("/repo/components/MfCard.art.vue");
+
+  const code = generatePreviewModuleWithProps(
+    art,
+    "Default",
+    "default",
+    { label: "OK" },
+    [],
+    null,
+    2,
+  );
+
+  assert.doesNotMatch(code, /\bcreateApp\b/);
+  assert.match(code, /import Vue from 'vue';/);
+  assert.match(code, /return h\(VariantComponent, \{ props: propsOverride \}\);/);
+  assert.match(code, /app\.\$mount\(mountPoint\);/);
+});
+
+function createBasicArtFile(path: string): ArtFileInfo {
+  return {
+    path,
+    metadata: {
+      title: "Card",
+      tags: [],
+      status: "ready",
+    },
+    variants: [
+      {
+        name: "default",
+        template: "<div />",
+        isDefault: true,
+        skipVrt: false,
+      },
+    ],
+    hasScriptSetup: false,
+    hasScript: false,
+    styleCount: 0,
+  };
+}

--- a/npm/builder/vite-musea/src/preview/index.ts
+++ b/npm/builder/vite-musea/src/preview/index.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ArtFileInfo } from "../types/index.js";
+import type { MuseaVueVersion } from "../types/plugin.js";
 import { MUSEA_ADDONS_INIT_CODE } from "./addons.js";
 
 export { generatePreviewHtml } from "./html.js";
@@ -16,6 +17,7 @@ export function generatePreviewModule(
   variantName: string,
   cssImports: string[] = [],
   previewSetup: string | null = null,
+  vueVersion: MuseaVueVersion = 3,
 ): string {
   const artModuleId = `virtual:musea-art:${art.path}`;
   const artModuleIdLiteral = JSON.stringify(artModuleId);
@@ -31,11 +33,24 @@ export function generatePreviewModule(
   const actionEvents = JSON.stringify(art.metadata.actionEvents ?? []);
   const artStyleId = `musea-art-styles-${art.path.replace(/[^\w-]+/g, "_")}`;
   const artStyleIdLiteral = JSON.stringify(artStyleId);
+  const legacyVue = isLegacyVueVersion(vueVersion);
+  const vueImport = legacyVue
+    ? "import Vue, { reactive } from 'vue';"
+    : "import { createApp, reactive, h } from 'vue';";
+  const destroyCurrentApp = legacyVue ? "currentApp.$destroy();" : "currentApp.unmount();";
+  const mountInitialApp = legacyVue
+    ? "const app = new Vue({ render: (h) => h(VariantComponent) });"
+    : "const app = createApp(VariantComponent);";
+  const mountCurrentApp = legacyVue
+    ? "mountVue2App(app);"
+    : "app.mount(container);\n    currentApp = app;";
+  const mountHelper = legacyVue ? vue2MountHelperSnippet() : "";
+  const remountApp = legacyVue ? vue2RemountAppSnippet() : vue3RemountAppSnippet();
 
   return `
 ${cssImportStatements}
 ${setupImport}
-import { createApp, reactive, h } from 'vue';
+${vueImport}
 import * as artModule from ${artModuleIdLiteral};
 
 const container = document.getElementById('app');
@@ -88,6 +103,8 @@ function renderError(title, error) {
   container.appendChild(root);
 }
 
+${mountHelper}
+
 window.__museaSetProps = (props) => {
   // Clear old keys
   for (const key of Object.keys(propsOverride)) {
@@ -114,13 +131,12 @@ async function mount() {
     }
 
     // Create and mount the app
-    const app = createApp(VariantComponent);
+    ${mountInitialApp}
     ensureArtStyles(artModule.__styles__);
     ${setupCall}
     container.innerHTML = '';
     container.className = 'musea-variant';
-    app.mount(container);
-    currentApp = app;
+    ${mountCurrentApp}
 
     console.log('[musea-preview] Mounted variant:', ${variantNameLiteral});
     __museaInitAddons(container, ${variantNameLiteral}, ${actionEvents});
@@ -149,9 +165,53 @@ async function mount() {
 
 async function remountWithProps(Component) {
   if (currentApp) {
-    currentApp.unmount();
+    ${destroyCurrentApp}
   }
-  const app = createApp({
+  ${remountApp}
+  ensureArtStyles(artModule.__styles__);
+  ${setupCall}
+  container.innerHTML = '';
+  ${mountCurrentApp}
+}
+
+mount();
+`;
+}
+
+function isLegacyVueVersion(version: MuseaVueVersion | undefined): boolean {
+  return (
+    version === 0.11 || version === 1 || version === 2 || version === "2.7" || version === "legacy"
+  );
+}
+
+function vue2MountHelperSnippet(): string {
+  return `function mountVue2App(app) {
+  container.innerHTML = '';
+  const mountPoint = document.createElement('div');
+  container.appendChild(mountPoint);
+  app.$mount(mountPoint);
+  currentApp = app;
+}`;
+}
+
+function vue2RemountAppSnippet(): string {
+  return `const app = new Vue({
+    render(h) {
+      const slotFns = {};
+      const children = [];
+      for (const [name, content] of Object.entries(slotsOverride)) {
+        if (!content) continue;
+        const slot = () => [h('span', String(content))];
+        slotFns[name] = slot;
+        if (name === 'default') children.push(...slot());
+      }
+      return h(Component, { props: { ...propsOverride }, scopedSlots: slotFns }, children);
+    }
+  });`;
+}
+
+function vue3RemountAppSnippet(): string {
+  return `const app = createApp({
     setup() {
       return () => {
         const slotFns = {};
@@ -161,16 +221,7 @@ async function remountWithProps(Component) {
         return h(Component, { ...propsOverride }, slotFns);
       };
     }
-  });
-  ensureArtStyles(artModule.__styles__);
-  ${setupCall}
-  container.innerHTML = '';
-  app.mount(container);
-  currentApp = app;
-}
-
-mount();
-`;
+  });`;
 }
 
 export function generatePreviewModuleWithProps(
@@ -180,6 +231,7 @@ export function generatePreviewModuleWithProps(
   propsOverride: Record<string, unknown>,
   cssImports: string[] = [],
   previewSetup: string | null = null,
+  vueVersion: MuseaVueVersion = 3,
 ): string {
   const artModuleId = `virtual:musea-art:${art.path}`;
   const artModuleIdLiteral = JSON.stringify(artModuleId);
@@ -196,11 +248,30 @@ export function generatePreviewModuleWithProps(
   const actionEvents = JSON.stringify(art.metadata.actionEvents ?? []);
   const artStyleId = `musea-art-styles-${art.path.replace(/[^\w-]+/g, "_")}`;
   const artStyleIdLiteral = JSON.stringify(artStyleId);
+  const legacyVue = isLegacyVueVersion(vueVersion);
+  const vueImport = legacyVue ? "import Vue from 'vue';" : "import { createApp, h } from 'vue';";
+  const wrappedComponent = legacyVue
+    ? `const WrappedComponent = {
+      render(h) {
+        return h(VariantComponent, { props: propsOverride });
+      }
+    };`
+    : `const WrappedComponent = {
+      render() {
+        return h(VariantComponent, propsOverride);
+      }
+    };`;
+  const appCreate = legacyVue
+    ? "const app = new Vue(WrappedComponent);"
+    : "const app = createApp(WrappedComponent);";
+  const appMount = legacyVue
+    ? "const mountPoint = document.createElement('div');\n    container.appendChild(mountPoint);\n    app.$mount(mountPoint);"
+    : "app.mount(container);";
 
   return `
 ${cssImportStatements}
 ${setupImport}
-import { createApp, h } from 'vue';
+${vueImport}
 import * as artModule from ${artModuleIdLiteral};
 
 const container = document.getElementById('app');
@@ -250,18 +321,14 @@ async function mount() {
       throw new Error('Variant component ' + ${variantComponentNameLiteral} + ' not found');
     }
 
-    const WrappedComponent = {
-      render() {
-        return h(VariantComponent, propsOverride);
-      }
-    };
+    ${wrappedComponent}
 
-    const app = createApp(WrappedComponent);
+    ${appCreate}
     ensureArtStyles(artModule.__styles__);
     ${setupCall}
     container.innerHTML = '';
     container.className = 'musea-variant';
-    app.mount(container);
+    ${appMount}
     console.log('[musea-preview] Mounted variant with props override:', ${variantNameLiteral});
     __museaInitAddons(container, ${variantNameLiteral}, ${actionEvents});
   } catch (error) {

--- a/npm/builder/vite-musea/src/static-build-vue2.test.ts
+++ b/npm/builder/vite-musea/src/static-build-vue2.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { build, type Plugin, type ResolvedConfig } from "vite";
+
+import { generateArtModule } from "./art-module.js";
+import { generatePreviewModule } from "./preview/index.js";
+import {
+  emitStaticGallery,
+  loadStaticRuntimeModule,
+  museaStaticBuildConfig,
+  resolveStaticRuntimeId,
+  type StaticBuildInput,
+} from "./static-export.js";
+import type { ArtFileInfo } from "./types/index.js";
+
+void test("Vue 2 static preview builds without a createApp runtime export", async () => {
+  const tempDir = await fs.promises.mkdtemp(path.join(process.cwd(), ".tmp-musea-vue2-static-"));
+  try {
+    const artPath = path.join(tempDir, "stories", "Tag.art.vue");
+    const outDir = path.join(tempDir, "dist");
+    await fs.promises.mkdir(path.dirname(artPath), { recursive: true });
+    await fs.promises.writeFile(
+      artPath,
+      '<art><variant name="Default" default><span>{{ tag }}</span></variant></art>',
+      "utf8",
+    );
+
+    const art = createVue2Art(artPath);
+    const artFiles = new Map([[art.path, art]]);
+    let resolvedConfig: ResolvedConfig | undefined;
+
+    await build({
+      configFile: false,
+      root: tempDir,
+      logLevel: "silent",
+      build: {
+        outDir,
+        emptyOutDir: true,
+        minify: false,
+      },
+      plugins: [
+        createVue2StaticBuildPlugin(
+          artFiles,
+          () => resolvedConfig,
+          (config) => {
+            resolvedConfig = config;
+          },
+        ),
+      ],
+    });
+
+    const bundledJs = await readOutputJs(outDir);
+    assert.doesNotMatch(bundledJs, /\bcreateApp\b/);
+    assert.match(bundledJs, /\bnew Vue\b/);
+    assert.equal(await fileExists(path.join(outDir, "__musea__", "api", "static.json")), true);
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+function createVue2Art(pathname: string): ArtFileInfo {
+  return {
+    path: pathname,
+    metadata: { title: "Tag", tags: [], status: "ready" },
+    variants: [{ name: "Default", template: "<span>{{ tag }}</span>", isDefault: true }],
+    hasScriptSetup: true,
+    scriptSetupContent: 'const tag = "ok"',
+    hasScript: false,
+    styleCount: 0,
+    isInline: false,
+  };
+}
+
+function createVue2StaticBuildPlugin(
+  artFiles: Map<string, ArtFileInfo>,
+  getConfig: () => ResolvedConfig | undefined,
+  setConfig: (config: ResolvedConfig) => void,
+): Plugin {
+  return {
+    name: "musea-vue2-static-build-test",
+    enforce: "pre",
+    config(userConfig) {
+      return museaStaticBuildConfig(userConfig.build?.rollupOptions?.input as StaticBuildInput);
+    },
+    configResolved(config) {
+      setConfig(config);
+    },
+    resolveId(id) {
+      if (id === "vue") return "\0musea-test-vue2";
+      if (id.startsWith("virtual:musea-preview:")) {
+        return "\0musea-preview-test:" + id.slice("virtual:musea-preview:".length);
+      }
+      if (id.startsWith("virtual:musea-art:")) {
+        return "\0musea-art-test:" + id.slice("virtual:musea-art:".length);
+      }
+      return resolveStaticRuntimeId(id);
+    },
+    load(id) {
+      if (id === "\0musea-test-vue2") return fakeVue2Runtime();
+      if (id.startsWith("\0musea-preview-test:")) {
+        const { art, variantName } = resolvePreview(id, artFiles);
+        return generatePreviewModule(art, "Default", variantName, [], null, 2);
+      }
+      if (id.startsWith("\0musea-art-test:")) {
+        const artPath = id.slice("\0musea-art-test:".length);
+        return generateArtModule(artFiles.get(artPath)!, artPath);
+      }
+      return loadStaticRuntimeModule(id, artFiles);
+    },
+    async generateBundle(_options, bundle) {
+      const config = getConfig();
+      assert.ok(config);
+      await emitStaticGallery((asset) => void this.emitFile(asset), bundle, {
+        config,
+        artFiles,
+        scanRoots: [config.root],
+        tokensPath: undefined,
+        basePath: "/__musea__",
+        resolvedPreviewCss: [],
+        resolvedPreviewSetup: null,
+        devSessionToken: "vue2-static-test",
+        themeConfig: undefined,
+      });
+    },
+  };
+}
+
+function resolvePreview(
+  id: string,
+  artFiles: Map<string, ArtFileInfo>,
+): { art: ArtFileInfo; variantName: string } {
+  const rest = id.slice("\0musea-preview-test:".length);
+  const lastColonIndex = rest.lastIndexOf(":");
+  assert.notEqual(lastColonIndex, -1);
+  const artPath = rest.slice(0, lastColonIndex);
+  const variantName = rest.slice(lastColonIndex + 1);
+  return { art: artFiles.get(artPath)!, variantName };
+}
+
+function fakeVue2Runtime(): string {
+  return `
+export default class Vue {
+  constructor(options) { this.options = options; }
+  $mount() {}
+  $destroy() {}
+}
+export const defineComponent = (options) => options;
+export const reactive = (value) => value;
+export const h = (...args) => ({ args });
+`;
+}
+
+async function readOutputJs(dir: string): Promise<string> {
+  const chunks: string[] = [];
+  for (const file of await collectFiles(dir)) {
+    if (file.endsWith(".js")) chunks.push(await fs.promises.readFile(file, "utf8"));
+  }
+  return chunks.join("\n");
+}
+
+async function collectFiles(dir: string): Promise<string[]> {
+  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const filePath = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...(await collectFiles(filePath)));
+    else files.push(filePath);
+  }
+  return files;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  return fs.promises.access(filePath).then(
+    () => true,
+    () => false,
+  );
+}

--- a/npm/builder/vite-musea/src/types/plugin.ts
+++ b/npm/builder/vite-musea/src/types/plugin.ts
@@ -146,7 +146,6 @@ export interface MuseaOptions {
 
   /**
    * Host Vue version for preview runtime compatibility checks.
-   * Legacy Vue static builds currently fail fast with an actionable diagnostic.
    * @default 3
    */
   vueVersion?: MuseaVueVersion;


### PR DESCRIPTION
## Summary
- add a Vue 2 static preview runtime path for Musea builds
- thread the configured Vue version into generated preview modules
- add unit coverage and a Vite build regression test that uses a Vue 2 runtime without createApp

## Validation
- vp run --filter './npm/builder/vite-musea' test
- vp run --filter './npm/builder/vite-musea' check
- vp run --filter './npm/builder/vite-musea' build
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Fixes #2520

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785678923&installation_id=136613492&pr_number=2543&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2543&signature=4f0d77d30841f102b15ebd6e753c4db1017d8e1b556877242faa8d4f7c050160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->