### PR TITLE
fix(canon): preserve Vue 2 branch alias narrowing

### DIFF
--- a/crates/vize/tests/check_legacy_vue2_template_scope_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_template_scope_cli.rs
@@ -1,0 +1,172 @@
+#![cfg(feature = "legacy")]
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+#[test]
+fn legacy_vue2_v_for_template_branch_keeps_alias_narrowing_in_scope() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project("legacy-vue2-template-branch-scope");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+            "src/Branch.vue",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(
+        json["errorCount"], 0,
+        "template branch aliases should type-check\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    for unexpected in ["TS2304", "TS2339", "aimAtReport", "guidanceTests"] {
+        assert!(
+            !stdout.contains(unexpected),
+            "template branch scope regressed with {unexpected}:\n{stdout}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn create_project(name: &str) -> PathBuf {
+    let project_root = unique_case_dir(name);
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    write_test_vue2_stub(&project_root.join("node_modules")).unwrap();
+    write_test_vite_stub(&project_root.join("node_modules")).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*.vue"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        r#"{ "typeChecker": { "legacyVue2": true } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/Branch.vue"),
+        r#"<script setup lang="ts">
+type GuidanceTest =
+  | { testResult: 'Pass'; retestFlag: boolean; passOnly: string }
+  | { testResult: 'Fail'; retestFlag?: false; reason: string }
+
+type AimAtReport =
+  | { kind: 'summary'; title: string }
+  | { kind: 'history'; title: string; guidanceTests: GuidanceTest[] }
+
+const aimAtReports: AimAtReport[] = []
+</script>
+
+<template>
+  <template v-for="aimAtReport in aimAtReports">
+    <template v-if="aimAtReport.kind === 'summary'">
+      <span>{{ aimAtReport.title }}</span>
+    </template>
+    <template v-else>
+      <template v-for="guidanceTest in aimAtReport.guidanceTests">
+        <span v-if="guidanceTest.retestFlag" class="retest-label mr-2">再 {{ aimAtReport.title }}</span>
+        <span v-if="guidanceTest.testResult === 'Pass'" class="test-result-label__pass">{{ guidanceTest.passOnly }}</span>
+      </template>
+    </template>
+  </template>
+</template>
+"#,
+    )
+    .unwrap();
+    project_root
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("{name}-{}", std::process::id()).as_str())
+}
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CORSA_PATH")
+        && Path::new(&path).exists()
+    {
+        return Some(PathBuf::from(path));
+    }
+
+    let workspace_root = workspace_root();
+    [
+        workspace_root.join("node_modules/.bin/tsgo"),
+        workspace_root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn write_test_vue2_stub(target: &Path) -> std::io::Result<()> {
+    let vue_types_dir = target.join("vue").join("types");
+    std::fs::create_dir_all(&vue_types_dir)?;
+    std::fs::write(
+        target.join("vue").join("package.json"),
+        r#"{ "name": "vue", "types": "types/index.d.ts" }"#,
+    )?;
+    std::fs::write(
+        vue_types_dir.join("index.d.ts"),
+        r#"export interface Vue {
+  $attrs: Record<string, unknown>;
+  $refs: Record<string, any>;
+  $slots: Record<string, unknown>;
+  $emit: (...args: any[]) => void;
+}
+export default { version: '2.7.16' };
+"#,
+    )?;
+    Ok(())
+}
+
+fn write_test_vite_stub(target: &Path) -> std::io::Result<()> {
+    let vite_dir = target.join("vite");
+    std::fs::create_dir_all(&vite_dir)?;
+    std::fs::write(
+        vite_dir.join("package.json"),
+        r#"{ "name": "vite", "types": "client.d.ts" }"#,
+    )?;
+    std::fs::write(vite_dir.join("client.d.ts"), "")?;
+    Ok(())
+}

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -25,7 +25,7 @@ use super::emit::{
 };
 use super::event_handler::generate_event_handler_expressions;
 use super::globals::{generate_instance_global_refs, generate_undefined_refs};
-use super::vif_guard::common_vif_guard_prefix;
+use super::vif_guard::common_vif_guard_prefix_outside_v_for_scope;
 
 /// Generate scope closures from Croquis scope chain.
 /// Uses recursive tree-based generation so nested v-for/v-slot scopes
@@ -86,7 +86,9 @@ pub(crate) fn generate_scope_closures(
                         let scope_id = scope.id.as_u32();
                         expressions_by_scope
                             .get(&scope_id)
-                            .and_then(|exprs| common_vif_guard_prefix(exprs))
+                            .and_then(|exprs| {
+                                common_vif_guard_prefix_outside_v_for_scope(exprs, scope)
+                            })
                             .map(|guard| (scope_id, guard))
                     })
                     .collect()
@@ -236,7 +238,7 @@ fn generate_scope_node(
                 .expressions_by_scope
                 .get(&scope_id)
                 .filter(|_| ctx.check_options.check_template_bindings)
-                .and_then(|exprs| common_vif_guard_prefix(exprs));
+                .and_then(|exprs| common_vif_guard_prefix_outside_v_for_scope(exprs, scope));
             let enclosing_guard = enclosing_guard.as_deref();
             let (loop_indent, vfor_inner_indent) = if enclosing_guard.is_some() {
                 (cstr!("{indent}  "), cstr!("{inner_indent}  "))

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -22,6 +22,7 @@ use super::context::{ComponentPropsContext, VForPropsContext};
 use super::emit::{
     append_v_for_comment, emit_slot_function_open, emit_v_for_loop_open, slot_props_type,
 };
+use super::vif_guard::common_vif_guard_prefix_for_guards_outside_v_for;
 
 /// Generate component props type checks (scope-aware).
 /// Type declarations are at template level, value checks are in their scope.
@@ -157,6 +158,30 @@ pub(super) fn generate_component_props(
         .map(|s| s.id.as_u32())
         .collect();
 
+    let vfor_enclosing_guards: FxHashMap<u32, String> = summary
+        .scopes
+        .iter()
+        .filter(|scope| matches!(scope.kind, ScopeKind::VFor))
+        .filter_map(|scope| {
+            let scope_id = scope.id.as_u32();
+            let ScopeData::VFor(data) = scope.data() else {
+                return None;
+            };
+            ctx.vfor_enclosing_guards
+                .get(&scope_id)
+                .map(|guard| (scope_id, guard.clone()))
+                .or_else(|| {
+                    let usages = components_by_scope.get(&scope_id)?;
+                    let mut guards = Vec::new();
+                    for (_, usage) in usages {
+                        guards.push(usage.vif_guard.as_ref()?.as_str());
+                    }
+                    common_vif_guard_prefix_for_guards_outside_v_for(guards.as_slice(), data)
+                        .map(|guard| (scope_id, guard))
+                })
+        })
+        .collect();
+
     ts.push_str("\n  // Component props value checks (template scope)\n");
     for &(idx, usage) in &checkable_usages {
         if closure_scope_ids.contains(&usage.scope_id.as_u32()) {
@@ -189,7 +214,7 @@ pub(super) fn generate_component_props(
             summary,
             components_by_scope: &components_by_scope,
             children_map: ctx.children_map,
-            vfor_enclosing_guards: ctx.vfor_enclosing_guards,
+            vfor_enclosing_guards: &vfor_enclosing_guards,
             template_prop_names: ctx.template_prop_names,
             template_offset: ctx.template_offset,
         };

--- a/crates/vize_canon/src/virtual_ts/scope/vif_guard.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/vif_guard.rs
@@ -1,15 +1,32 @@
 use vize_carton::String;
-use vize_croquis::TemplateExpression;
+use vize_croquis::{
+    Scope, ScopeData, TemplateExpression, VForScopeData, drawer::extract_identifiers_oxc,
+};
 
 /// Compute the enclosing v-if guard shared by all expressions in a v-for scope.
 pub(super) fn common_vif_guard_prefix(exprs: &[&TemplateExpression]) -> Option<String> {
     let mut iter = exprs.iter();
     let first = iter.next()?.vif_guard.as_ref()?;
-    let mut common: Vec<&str> = split_guard_terms(first.as_str());
-
+    let mut rest = Vec::new();
     for expr in iter {
-        let guard = expr.vif_guard.as_ref()?;
-        let terms = split_guard_terms(guard.as_str());
+        rest.push(expr.vif_guard.as_ref()?.as_str());
+    }
+    common_guard_prefix_from_terms(first.as_str(), rest.into_iter())
+}
+
+pub(super) fn common_vif_guard_prefix_for_guards(guards: &[&str]) -> Option<String> {
+    let (first, rest) = guards.split_first()?;
+    common_guard_prefix_from_terms(first, rest.iter().copied())
+}
+
+fn common_guard_prefix_from_terms<'a>(
+    first: &'a str,
+    rest: impl Iterator<Item = &'a str>,
+) -> Option<String> {
+    let mut common: Vec<&str> = split_guard_terms(first);
+
+    for guard in rest {
+        let terms = split_guard_terms(guard);
         let shared = common
             .iter()
             .zip(terms.iter())
@@ -22,6 +39,47 @@ pub(super) fn common_vif_guard_prefix(exprs: &[&TemplateExpression]) -> Option<S
     }
 
     (!common.is_empty()).then(|| String::from(common.join(" && ").as_str()))
+}
+
+pub(super) fn common_vif_guard_prefix_outside_v_for(
+    exprs: &[&TemplateExpression],
+    data: &VForScopeData,
+) -> Option<String> {
+    let guard = common_vif_guard_prefix(exprs)?;
+    trim_v_for_alias_guard_prefix(guard, data)
+}
+
+pub(super) fn common_vif_guard_prefix_outside_v_for_scope(
+    exprs: &[&TemplateExpression],
+    scope: &Scope,
+) -> Option<String> {
+    let ScopeData::VFor(data) = scope.data() else {
+        return None;
+    };
+    common_vif_guard_prefix_outside_v_for(exprs, data)
+}
+
+pub(super) fn common_vif_guard_prefix_for_guards_outside_v_for(
+    guards: &[&str],
+    data: &VForScopeData,
+) -> Option<String> {
+    let guard = common_vif_guard_prefix_for_guards(guards)?;
+    trim_v_for_alias_guard_prefix(guard, data)
+}
+
+fn trim_v_for_alias_guard_prefix(guard: String, data: &VForScopeData) -> Option<String> {
+    let own_aliases = v_for_aliases(data);
+    if own_aliases.is_empty() {
+        return Some(guard);
+    }
+
+    let terms = split_guard_terms(guard.as_str());
+    let outside_terms: Vec<&str> = terms
+        .into_iter()
+        .take_while(|term| !references_any_alias(term, own_aliases.as_slice()))
+        .collect();
+
+    (!outside_terms.is_empty()).then(|| String::from(outside_terms.join(" && ").as_str()))
 }
 
 fn split_guard_terms(guard: &str) -> Vec<&str> {
@@ -53,4 +111,25 @@ fn split_guard_terms(guard: &str) -> Vec<&str> {
 
     terms.push(guard[start..].trim());
     terms
+}
+
+fn v_for_aliases(data: &VForScopeData) -> Vec<&str> {
+    let mut aliases: Vec<&str> = data
+        .value_bindings
+        .iter()
+        .map(|alias| alias.as_str())
+        .collect();
+    if let Some(alias) = data.key_alias.as_ref() {
+        aliases.push(alias.as_str());
+    }
+    if let Some(alias) = data.index_alias.as_ref() {
+        aliases.push(alias.as_str());
+    }
+    aliases
+}
+
+fn references_any_alias(term: &str, aliases: &[&str]) -> bool {
+    extract_identifiers_oxc(term)
+        .iter()
+        .any(|identifier| aliases.iter().any(|alias| identifier.as_str() == *alias))
 }

--- a/crates/vize_canon/src/virtual_ts/tests/vif_chain.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/vif_chain.rs
@@ -34,3 +34,49 @@ const navItems: Item[] = []
         output.code
     );
 }
+
+#[test]
+fn test_v_for_enclosing_guard_does_not_reference_own_alias() {
+    let script = r#"type GuidanceTest =
+  | { testResult: 'Pass'; retestFlag: boolean; passOnly: string }
+  | { testResult: 'Fail'; retestFlag?: false; reason: string }
+type AimAtReport =
+  | { kind: 'summary'; title: string }
+  | { kind: 'history'; title: string; guidanceTests: GuidanceTest[] }
+const aimAtReports: AimAtReport[] = []
+"#;
+    let template = r#"<template v-for="aimAtReport in aimAtReports">
+  <template v-if="aimAtReport.kind === 'summary'">
+    <span>{{ aimAtReport.title }}</span>
+  </template>
+  <template v-else>
+    <template v-for="guidanceTest in aimAtReport.guidanceTests">
+      <span v-if="guidanceTest.retestFlag">{{ aimAtReport.title }}</span>
+      <span v-if="guidanceTest.testResult === 'Pass'">{{ guidanceTest.passOnly }}</span>
+    </template>
+  </template>
+</template>"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+
+    assert!(
+        output
+            .code
+            .contains("__vForList(aimAtReports).forEach(([aimAtReport]) => {"),
+        "expected parent v-for to declare aimAtReport before branch guards:\n{}",
+        output.code
+    );
+    assert!(
+        !output.code.contains("if ((aimAtReport.kind === 'summary')) {\n\n    // v-for scope: aimAtReport in aimAtReports"),
+        "v-for enclosing guard must not reference its own alias before declaration:\n{}",
+        output.code
+    );
+}


### PR DESCRIPTION
## Summary

- avoid wrapping v-for loops in guards that reference aliases introduced by that same v-for
- keep component prop checks aligned with the same outside-guard calculation
- add unit and legacy CLI regressions for Vue 2 template branch alias narrowing

Fixes #2521

## Checks

- cargo test -p vize_canon vif_chain -- --nocapture
- cargo test -p vize --features legacy legacy_vue2_v_for_template_branch_keeps_alias_narrowing_in_scope -- --nocapture
- cargo clippy -p vize_canon -p vize --features legacy -- -D warnings
- node --test tests/tooling/source-file-lengths.test.ts && git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785680464&installation_id=136613492&pr_number=2544&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2544&signature=8c9fde31e1f7b921594667a80564d313b1d44657501998fa1d2c033ee7ea7df5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->