### PR TITLE
fix(release): ship musl cli archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,42 @@ jobs:
         if: matrix.settings.target == 'aarch64-unknown-linux-gnu'
         run: moon run --target native - -- < tools/moon/scripts/github/install_cross_compile_tools.mbtx
 
+      - name: Setup Zig (Linux musl CLI)
+        if: endsWith(matrix.settings.target, '-musl')
+        uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2
+
+      - name: Configure Zig linker (Linux musl CLI)
+        if: endsWith(matrix.settings.target, '-musl')
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/vize-zig-linkers"
+
+          cat > "$RUNNER_TEMP/vize-zig-linkers/zig-cc-x86_64-linux-musl" <<'EOF'
+          #!/usr/bin/env bash
+          exec zig cc -target x86_64-linux-musl "$@"
+          EOF
+
+          cat > "$RUNNER_TEMP/vize-zig-linkers/zig-cc-aarch64-linux-musl" <<'EOF'
+          #!/usr/bin/env bash
+          exec zig cc -target aarch64-linux-musl "$@"
+          EOF
+
+          cat > "$RUNNER_TEMP/vize-zig-linkers/zig-ar" <<'EOF'
+          #!/usr/bin/env bash
+          exec zig ar "$@"
+          EOF
+
+          chmod +x "$RUNNER_TEMP"/vize-zig-linkers/*
+
+          {
+            echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=$RUNNER_TEMP/vize-zig-linkers/zig-cc-x86_64-linux-musl"
+            echo "CC_x86_64_unknown_linux_musl=$RUNNER_TEMP/vize-zig-linkers/zig-cc-x86_64-linux-musl"
+            echo "AR_x86_64_unknown_linux_musl=$RUNNER_TEMP/vize-zig-linkers/zig-ar"
+            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=$RUNNER_TEMP/vize-zig-linkers/zig-cc-aarch64-linux-musl"
+            echo "CC_aarch64_unknown_linux_musl=$RUNNER_TEMP/vize-zig-linkers/zig-cc-aarch64-linux-musl"
+            echo "AR_aarch64_unknown_linux_musl=$RUNNER_TEMP/vize-zig-linkers/zig-ar"
+          } >> "$GITHUB_ENV"
+
       - name: Mount Rust sticky disks (Linux)
         if: runner.os == 'Linux'
         uses: ./.github/actions/setup-rust-sticky-cache
@@ -763,7 +799,10 @@ jobs:
     name: Release oxlint-plugin-vize to npm
     runs-on: ubuntu-24.04
     needs:
-      [plan-release-platforms, build-release-packages, release-npm-native, smoke-release-packages]
+      - plan-release-platforms
+      - build-release-packages
+      - release-npm-native
+      - smoke-release-packages
     timeout-minutes: 15
     environment: npm
     permissions:
@@ -973,14 +1012,12 @@ jobs:
     name: Release @vizejs/nuxt to npm
     runs-on: ubuntu-24.04
     needs:
-      [
-        build-release-packages,
-        release-npm-vite-plugin,
-        release-npm-vite-plugin-musea,
-        release-npm-musea-nuxt,
-        release-npm-cli,
-        smoke-release-packages,
-      ]
+      - build-release-packages
+      - release-npm-vite-plugin
+      - release-npm-vite-plugin-musea
+      - release-npm-musea-nuxt
+      - release-npm-cli
+      - smoke-release-packages
     timeout-minutes: 15
     environment: npm
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ jobs:
         id: platforms
         run: node tools/github/release-platforms.mjs github-output "${{ github.ref_name }}"
 
-  # Build CLI binaries for all platforms
   build-cli:
     name: Build CLI - ${{ matrix.settings.target }}
     needs: plan-release-platforms
@@ -80,35 +79,7 @@ jobs:
 
       - name: Configure Zig linker (Linux musl CLI)
         if: endsWith(matrix.settings.target, '-musl')
-        shell: bash
-        run: |
-          mkdir -p "$RUNNER_TEMP/vize-zig-linkers"
-
-          cat > "$RUNNER_TEMP/vize-zig-linkers/zig-cc-x86_64-linux-musl" <<'EOF'
-          #!/usr/bin/env bash
-          exec zig cc -target x86_64-linux-musl "$@"
-          EOF
-
-          cat > "$RUNNER_TEMP/vize-zig-linkers/zig-cc-aarch64-linux-musl" <<'EOF'
-          #!/usr/bin/env bash
-          exec zig cc -target aarch64-linux-musl "$@"
-          EOF
-
-          cat > "$RUNNER_TEMP/vize-zig-linkers/zig-ar" <<'EOF'
-          #!/usr/bin/env bash
-          exec zig ar "$@"
-          EOF
-
-          chmod +x "$RUNNER_TEMP"/vize-zig-linkers/*
-
-          {
-            echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=$RUNNER_TEMP/vize-zig-linkers/zig-cc-x86_64-linux-musl"
-            echo "CC_x86_64_unknown_linux_musl=$RUNNER_TEMP/vize-zig-linkers/zig-cc-x86_64-linux-musl"
-            echo "AR_x86_64_unknown_linux_musl=$RUNNER_TEMP/vize-zig-linkers/zig-ar"
-            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=$RUNNER_TEMP/vize-zig-linkers/zig-cc-aarch64-linux-musl"
-            echo "CC_aarch64_unknown_linux_musl=$RUNNER_TEMP/vize-zig-linkers/zig-cc-aarch64-linux-musl"
-            echo "AR_aarch64_unknown_linux_musl=$RUNNER_TEMP/vize-zig-linkers/zig-ar"
-          } >> "$GITHUB_ENV"
+        run: bash tools/github/configure-zig-musl-linkers.sh
 
       - name: Mount Rust sticky disks (Linux)
         if: runner.os == 'Linux'
@@ -156,7 +127,6 @@ jobs:
           if-no-files-found: error
           compression-level: 0
 
-  # Package editor extensions for GitHub Releases and registry validation
   build-editor-extensions:
     name: Build Editor Extensions
     runs-on: blacksmith-32vcpu-ubuntu-2404
@@ -248,7 +218,6 @@ jobs:
         continue-on-error: true
         run: moon run --target native - -- editor-extension-artifacts/editors/vscode/dist/vize.vsix < tools/moon/scripts/publish_vscode_extension.mbtx
 
-  # Build release npm packages once and reuse them across publish jobs
   build-release-packages:
     name: Build release npm packages
     runs-on: blacksmith-32vcpu-ubuntu-2404
@@ -350,7 +319,6 @@ jobs:
           if-no-files-found: error
           compression-level: 0
 
-  # Build WASM once on Blacksmith; the npm publish job only attaches provenance.
   build-wasm-package:
     name: Build @vizejs/wasm package
     runs-on: blacksmith-32vcpu-ubuntu-2404
@@ -403,7 +371,6 @@ jobs:
           if-no-files-found: error
           compression-level: 0
 
-  # Build native bindings (vize-native + fresco-native) for all platforms
   build-native-all:
     name: Build Native - ${{ matrix.settings.target }}
     needs: plan-release-platforms
@@ -631,7 +598,6 @@ jobs:
 
   # npm Trusted Publishing/provenance currently rejects self-hosted runners.
   # Keep the publish edge on GitHub-hosted runners; build and smoke jobs stay on Blacksmith.
-  # Publish native packages to npm (using Trusted Publishing / OIDC)
   release-npm-native:
     name: Release @vizejs/native to npm
     runs-on: ubuntu-24.04
@@ -688,7 +654,6 @@ jobs:
       - name: Publish
         run: moon run --target native - -- npm/native --provenance < tools/moon/scripts/publish_npm_package.mbtx
 
-  # Publish fresco native packages to npm (using Trusted Publishing / OIDC)
   release-npm-fresco-native:
     name: Release @vizejs/fresco-native to npm
     runs-on: ubuntu-24.04
@@ -765,7 +730,6 @@ jobs:
       - name: Publish @vizejs/wasm
         run: moon run --target native - -- npm/wasm --provenance < tools/moon/scripts/publish_npm_package.mbtx
 
-  # Build and publish Vite plugin (using Trusted Publishing / OIDC)
   release-npm-vite-plugin:
     name: Release @vizejs/vite-plugin to npm
     runs-on: ubuntu-24.04
@@ -794,7 +758,6 @@ jobs:
       - name: Publish @vizejs/vite-plugin
         run: moon run --target native - -- npm/builder/vite --provenance < tools/moon/scripts/publish_npm_package.mbtx
 
-  # Build and publish Oxlint plugin package (using Trusted Publishing / OIDC)
   release-npm-oxlint-plugin:
     name: Release oxlint-plugin-vize to npm
     runs-on: ubuntu-24.04

--- a/tests/tooling/github-workflows-release-build.test.ts
+++ b/tests/tooling/github-workflows-release-build.test.ts
@@ -261,6 +261,7 @@ test("release workflow configures Zig linkers for Linux musl CLI archives", () =
   const workflow = readRepoFile(".github", "workflows", "release.yml");
   const buildCliJob = workflowJobBody(workflow, "build-cli");
   const releasePlatforms = readRepoFile("tools", "github", "release-platforms.mjs");
+  const zigLinkerScript = readRepoFile("tools", "github", "configure-zig-musl-linkers.sh");
 
   for (const [target, archive] of [
     ["x86_64-unknown-linux-musl", "vize-x86_64-unknown-linux-musl.tar.gz"],
@@ -272,8 +273,8 @@ test("release workflow configures Zig linkers for Linux musl CLI archives", () =
 
   assert.match(buildCliJob, /name:\s*Setup Zig \(Linux musl CLI\)/);
   assert.match(buildCliJob, /if:\s*endsWith\(matrix\.settings\.target, '-musl'\)/);
-  assert.match(buildCliJob, /CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER/);
-  assert.match(buildCliJob, /CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER/);
-  assert.match(buildCliJob, /zig cc -target x86_64-linux-musl/);
-  assert.match(buildCliJob, /zig cc -target aarch64-linux-musl/);
+  assert.match(buildCliJob, /bash tools\/github\/configure-zig-musl-linkers\.sh/);
+  assert.match(zigLinkerScript, /CARGO_TARGET_%s_LINKER/);
+  assert.match(zigLinkerScript, /write_cc X86_64_UNKNOWN_LINUX_MUSL x86_64-linux-musl/);
+  assert.match(zigLinkerScript, /write_cc AARCH64_UNKNOWN_LINUX_MUSL aarch64-linux-musl/);
 });

--- a/tests/tooling/github-workflows-release-build.test.ts
+++ b/tests/tooling/github-workflows-release-build.test.ts
@@ -170,7 +170,9 @@ test("release workflow builds native targets on MoonBit-supported runners", () =
     [hostedOrBlacksmith("macos-15"), "x86_64-apple-darwin"],
     [hostedOrBlacksmith("macos-15"), "aarch64-apple-darwin"],
     [hostedOrBlacksmith("ubuntu-24.04"), "x86_64-unknown-linux-gnu"],
+    [hostedOrBlacksmith("ubuntu-24.04"), "x86_64-unknown-linux-musl"],
     [hostedOrBlacksmith("ubuntu-24.04-arm"), "aarch64-unknown-linux-gnu"],
+    [hostedOrBlacksmith("ubuntu-24.04"), "aarch64-unknown-linux-musl"],
     [hostedOrBlacksmith("windows-2025"), "x86_64-pc-windows-msvc"],
     ["windows-11-arm", "aarch64-pc-windows-msvc"],
   ] as const) {
@@ -253,4 +255,25 @@ test("release workflow runs GitHub helper scripts with the native target on ever
     /Create archive \(Windows\)[\s\S]*moon run --target native - -- \$\{\{ matrix\.settings\.target \}\} \$\{\{ matrix\.settings\.archive \}\} vize\.exe < tools\/moon\/scripts\/github\/create_cli_archive\.mbtx/,
   );
   assert.match(workflow, /Build vize-native[\s\S]*moon run --target native - -- npm\/native/);
+});
+
+test("release workflow configures Zig linkers for Linux musl CLI archives", () => {
+  const workflow = readRepoFile(".github", "workflows", "release.yml");
+  const buildCliJob = workflowJobBody(workflow, "build-cli");
+  const releasePlatforms = readRepoFile("tools", "github", "release-platforms.mjs");
+
+  for (const [target, archive] of [
+    ["x86_64-unknown-linux-musl", "vize-x86_64-unknown-linux-musl.tar.gz"],
+    ["aarch64-unknown-linux-musl", "vize-aarch64-unknown-linux-musl.tar.gz"],
+  ] as const) {
+    assert.match(releasePlatforms, new RegExp(`target:\\s*"${target}"`));
+    assert.match(releasePlatforms, new RegExp(`archive:\\s*"${archive}"`));
+  }
+
+  assert.match(buildCliJob, /name:\s*Setup Zig \(Linux musl CLI\)/);
+  assert.match(buildCliJob, /if:\s*endsWith\(matrix\.settings\.target, '-musl'\)/);
+  assert.match(buildCliJob, /CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER/);
+  assert.match(buildCliJob, /CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER/);
+  assert.match(buildCliJob, /zig cc -target x86_64-linux-musl/);
+  assert.match(buildCliJob, /zig cc -target aarch64-linux-musl/);
 });

--- a/tests/tooling/release-platforms.test.ts
+++ b/tests/tooling/release-platforms.test.ts
@@ -16,6 +16,8 @@ test("release platform plan includes slow targets on fifth minors", () => {
   assert.deepEqual(plan.skippedTargets, []);
   assert.ok(plan.cliMatrix.some((platform) => platform.target === "x86_64-apple-darwin"));
   assert.ok(plan.cliMatrix.some((platform) => platform.target === "aarch64-pc-windows-msvc"));
+  assert.ok(plan.cliMatrix.some((platform) => platform.target === "x86_64-unknown-linux-musl"));
+  assert.ok(plan.cliMatrix.some((platform) => platform.target === "aarch64-unknown-linux-musl"));
   assert.ok(plan.nativeMatrix.some((platform) => platform.target === "x86_64-apple-darwin"));
   assert.ok(plan.nativeMatrix.some((platform) => platform.target === "aarch64-pc-windows-msvc"));
 });
@@ -27,6 +29,8 @@ test("release platform plan includes slow targets outside fifth minors", () => {
   assert.deepEqual(plan.skippedTargets, []);
   assert.ok(plan.cliMatrix.some((platform) => platform.target === "x86_64-apple-darwin"));
   assert.ok(plan.cliMatrix.some((platform) => platform.target === "aarch64-pc-windows-msvc"));
+  assert.ok(plan.cliMatrix.some((platform) => platform.target === "x86_64-unknown-linux-musl"));
+  assert.ok(plan.cliMatrix.some((platform) => platform.target === "aarch64-unknown-linux-musl"));
   assert.ok(plan.nativeMatrix.some((platform) => platform.target === "x86_64-apple-darwin"));
   assert.ok(plan.nativeMatrix.some((platform) => platform.target === "aarch64-pc-windows-msvc"));
 });

--- a/tools/github/configure-zig-musl-linkers.sh
+++ b/tools/github/configure-zig-musl-linkers.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+linker_dir="$RUNNER_TEMP/vize-zig-linkers"
+zig_ar="$linker_dir/zig-ar"
+
+mkdir -p "$linker_dir"
+printf '#!/usr/bin/env bash\nexec zig ar "$@"\n' > "$zig_ar"
+chmod +x "$zig_ar"
+
+write_cc() {
+  local rust_target="$1"
+  local zig_target="$2"
+  local cc="$linker_dir/zig-cc-$zig_target"
+  local env_target
+
+  env_target="$(tr '[:upper:]' '[:lower:]' <<< "$rust_target")"
+  printf '#!/usr/bin/env bash\nexec zig cc -target %s "$@"\n' "$zig_target" > "$cc"
+  chmod +x "$cc"
+
+  {
+    printf 'CARGO_TARGET_%s_LINKER=%s\n' "$rust_target" "$cc"
+    printf 'CC_%s=%s\n' "$env_target" "$cc"
+    printf 'AR_%s=%s\n' "$env_target" "$zig_ar"
+  } >> "$GITHUB_ENV"
+}
+
+write_cc X86_64_UNKNOWN_LINUX_MUSL x86_64-linux-musl
+write_cc AARCH64_UNKNOWN_LINUX_MUSL aarch64-linux-musl

--- a/tools/github/release-platforms.mjs
+++ b/tools/github/release-platforms.mjs
@@ -42,8 +42,18 @@ export const cliReleasePlatforms = [
   },
   {
     host: "blacksmith-32vcpu-ubuntu-2404",
+    target: "x86_64-unknown-linux-musl",
+    archive: "vize-x86_64-unknown-linux-musl.tar.gz",
+  },
+  {
+    host: "blacksmith-32vcpu-ubuntu-2404",
     target: "aarch64-unknown-linux-gnu",
     archive: "vize-aarch64-unknown-linux-gnu.tar.gz",
+  },
+  {
+    host: "blacksmith-32vcpu-ubuntu-2404",
+    target: "aarch64-unknown-linux-musl",
+    archive: "vize-aarch64-unknown-linux-musl.tar.gz",
   },
 ];
 


### PR DESCRIPTION
## Summary

Add Linux musl CLI release archives for x64 and arm64 so users can choose a libc-independent build instead of only the glibc-linked GNU archives.

The release workflow now configures Zig linker wrappers for musl CLI builds, and the touched `needs` lists use block-list YAML so `actrun` can parse the workflow.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [x] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

Users installing standalone Linux CLI artifacts should not be forced onto a glibc-specific archive when a musl build can be shipped alongside native binding musl packages.

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [ ] Snapshot/baseline changes reviewed and explained
- [ ] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [ ] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

Commands run:

```sh
node --test tests/tooling/release-platforms.test.ts tests/tooling/github-workflows-release-build.test.ts
actrun lint .github/workflows/release.yml
actrun workflow run .github/workflows/release.yml --dry-run
git diff --check
```

## Risk

The release matrix gains two Linux CLI build jobs. The musl jobs use Zig only when the matrix target ends with `-musl`; existing GNU, macOS, and Windows paths are unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785683353&installation_id=136613492&pr_number=2545&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2545&signature=aa97f7f46b8336399cf910886c4ecb288bc2688de6038cc4b70b29706b5b6389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linux musl CLI release builds for both x86_64 and aarch64, expanding available download archives.
  * Improved release setup so musl builds automatically configure the required linker tools.
* **Bug Fixes**
  * Updated release workflow handling for Linux musl targets to support more reliable CLI packaging.
* **Tests**
  * Expanded release workflow and platform planning coverage to include Linux musl targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->