### PR TITLE
chore: add coderabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: en-US
+
+chat:
+  auto_reply: true
+
+reviews:
+  profile: chill
+  high_level_summary: true
+  changed_files_summary: true
+  review_status: true
+  request_changes_workflow: false
+  poem: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+    ignore_title_keywords:
+      - WIP
+      - Draft
+
+  path_filters:
+    - "!**/node_modules/**"
+    - "!**/target/**"
+    - "!**/dist/**"
+    - "!**/.nuxt/**"
+    - "!**/.cache/**"
+    - "!tests/_fixtures/_git/**"
+    - "!tests/snapshots/**"
+    - "!crates/**/src/snapshots/**"
+    - "!npm/**/src/__snapshots__/**"
+    - "!**/*.snap"
+    - "!**/*.tar.gz"
+    - "!**/*.vsix"
+
+  path_instructions:
+    - path: "crates/**"
+      instructions: |
+        Focus on parser/compiler correctness, source locations, UTF-8/UTF-16 offset handling, and panic-free LSP behavior. Flag changes that only work for small fixtures but break real Vue/Nuxt projects.
+
+    - path: "npm/**"
+      instructions: |
+        Check package boundaries, peer/optional dependency behavior, ESM/CJS compatibility, and whether published files stay usable from a consumer project rather than only inside the monorepo.
+
+    - path: ".github/workflows/**"
+      instructions: |
+        Review release and CI changes for runner compatibility, least-privilege permissions, pinned actions, cache correctness, and whether workflow-shape tests cover the changed behavior.
+
+    - path: "tests/tooling/**"
+      instructions: |
+        Ensure workflow and release tests assert observable behavior rather than incidental formatting. Prefer focused assertions that keep PRs small and failures easy to diagnose.


### PR DESCRIPTION
## Summary

Add a repository-level CodeRabbit configuration file so automatic PR reviews run against `main` with focused path filters and path-specific review guidance.

The config keeps generated fixtures, snapshots, build outputs, and packaged archives out of review noise while adding focused instructions for Rust compiler/LSP code, npm package boundaries, workflow changes, and workflow-shape tests.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [x] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

CodeRabbit detects `.coderabbit.yaml` at the repository root and uses `reviews.auto_review`, `reviews.path_filters`, and `reviews.path_instructions` to control review behavior.

## Verification Evidence

- [ ] Minimal fixture or focused regression test added or updated
- [ ] Snapshot/baseline changes reviewed and explained
- [ ] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [ ] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

Commands run:

```sh
ruby -e 'require "yaml"; data = YAML.load_file(".coderabbit.yaml"); raise "missing reviews" unless data.fetch("reviews").is_a?(Hash); puts "ok"'
git diff --check
```

## Risk

This only configures CodeRabbit review behavior. The GitHub App still needs to be installed/enabled for the repository before reviews can run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785683503&installation_id=136613492&pr_number=2546&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2546&signature=fc6ae001a72173e719642061192325222f2e8f6547f412d577de69c9ce95d7dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->