### PR TITLE
fix(lsp): add native element template hover

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -169,7 +169,7 @@ pub fn pascal_to_kebab(name: &str) -> String {
 /// Check if a tag name is a component (starts with uppercase or contains hyphen).
 #[inline]
 pub fn is_component_tag(name: &str) -> bool {
-    if name.is_empty() {
+    if name.is_empty() || vize_carton::is_native_tag(name) {
         return false;
     }
     let Some(first) = name.chars().next() else {
@@ -576,18 +576,16 @@ mod tests {
 
     #[test]
     fn test_is_component_tag() {
-        // PascalCase components
         assert!(is_component_tag("MyComponent"));
         assert!(is_component_tag("Button"));
 
-        // kebab-case components
         assert!(is_component_tag("my-component"));
         assert!(is_component_tag("v-button"));
 
-        // HTML elements (not components)
         assert!(!is_component_tag("div"));
         assert!(!is_component_tag("span"));
         assert!(!is_component_tag("button"));
+        assert!(!is_component_tag("color-profile"));
     }
 
     #[test]

--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -18,7 +18,7 @@ pub(crate) use canonical::{
     open_canonical_virtual_document,
 };
 #[cfg(feature = "native")]
-pub(crate) use html_tag::{html_tag_request_path, html_tag_virtual_document};
+pub(crate) use html_tag::{html_tag_request_path, html_tag_virtual_document, native_dom_tag_info};
 pub(crate) use workspace_edit::map_corsa_workspace_edit;
 
 use vize_canon::LspLocation;

--- a/crates/vize_maestro/src/ide/corsa_support/html_tag.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_tag.rs
@@ -1,6 +1,12 @@
 use tower_lsp::lsp_types::Url;
 use vize_carton::{String, cstr};
 
+pub(crate) struct NativeDomTagInfo {
+    pub(crate) category: &'static str,
+    pub(crate) type_expression: String,
+    pub(crate) documentation_url: String,
+}
+
 pub(crate) struct HtmlTagVirtualDocument {
     pub(crate) content: String,
     pub(crate) hover_offset: usize,
@@ -12,20 +18,20 @@ pub(crate) fn html_tag_request_path(uri: &Url) -> String {
 }
 
 pub(crate) fn html_tag_virtual_document(tag_name: &str) -> Option<HtmlTagVirtualDocument> {
-    if !is_native_html_tag_candidate(tag_name) {
-        return None;
-    }
+    let info = native_dom_tag_info(tag_name)?;
 
+    let type_expression = info.type_expression.as_str();
     let content = cstr!(
         "/// <reference lib=\"es2022\" />\n\
          /// <reference lib=\"dom\" />\n\
          /// <reference lib=\"dom.iterable\" />\n\
-         type __VizeHtmlElement = HTMLElementTagNameMap[\"{tag_name}\"];\n\
-         declare const __vizeHtmlElement: __VizeHtmlElement;\n\
-         __vizeHtmlElement;\n"
+         type __VizeDomElement = {type_expression};\n\
+         declare const __vizeDomElement: __VizeDomElement;\n\
+         __vizeDomElement;\n"
     );
-    let definition_offset = content.find("HTMLElementTagNameMap")?;
-    let hover_offset = content.rfind("__vizeHtmlElement")?;
+    let definition_symbol = dom_definition_symbol(tag_name)?;
+    let definition_offset = content.find(definition_symbol)?;
+    let hover_offset = content.rfind("__vizeDomElement")?;
 
     Some(HtmlTagVirtualDocument {
         content,
@@ -34,15 +40,54 @@ pub(crate) fn html_tag_virtual_document(tag_name: &str) -> Option<HtmlTagVirtual
     })
 }
 
-fn is_native_html_tag_candidate(tag_name: &str) -> bool {
-    !tag_name.is_empty()
-        && !matches!(
-            tag_name,
-            "component" | "template" | "slot" | "teleport" | "suspense"
-        )
-        && tag_name
-            .bytes()
-            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+pub(crate) fn native_dom_tag_info(tag_name: &str) -> Option<NativeDomTagInfo> {
+    if matches!(
+        tag_name,
+        "component" | "template" | "slot" | "teleport" | "suspense"
+    ) {
+        return None;
+    }
+
+    if vize_carton::is_html_tag(tag_name) {
+        return Some(NativeDomTagInfo {
+            category: "HTML element",
+            type_expression: cstr!("HTMLElementTagNameMap[\"{tag_name}\"]"),
+            documentation_url: cstr!(
+                "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/{tag_name}"
+            ),
+        });
+    }
+    if vize_carton::is_svg_tag(tag_name) {
+        return Some(NativeDomTagInfo {
+            category: "SVG element",
+            type_expression: cstr!("SVGElementTagNameMap[\"{tag_name}\"]"),
+            documentation_url: cstr!(
+                "https://developer.mozilla.org/en-US/docs/Web/SVG/Element/{tag_name}"
+            ),
+        });
+    }
+    if vize_carton::is_math_ml_tag(tag_name) {
+        return Some(NativeDomTagInfo {
+            category: "MathML element",
+            type_expression: String::from("MathMLElement"),
+            documentation_url: cstr!(
+                "https://developer.mozilla.org/en-US/docs/Web/MathML/Element/{tag_name}"
+            ),
+        });
+    }
+    None
+}
+
+fn dom_definition_symbol(tag_name: &str) -> Option<&'static str> {
+    if vize_carton::is_html_tag(tag_name) {
+        Some("HTMLElementTagNameMap")
+    } else if vize_carton::is_svg_tag(tag_name) {
+        Some("SVGElementTagNameMap")
+    } else if vize_carton::is_math_ml_tag(tag_name) {
+        Some("MathMLElement")
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -58,8 +103,32 @@ mod tests {
             "HTMLElementTagNameMap",
         );
         assert_eq!(
-            &doc.content[doc.hover_offset..doc.hover_offset + "__vizeHtmlElement".len()],
-            "__vizeHtmlElement",
+            &doc.content[doc.hover_offset..doc.hover_offset + "__vizeDomElement".len()],
+            "__vizeDomElement",
         );
+    }
+
+    #[test]
+    fn html_tag_virtual_document_supports_svg_tags() {
+        let doc = super::html_tag_virtual_document("svg").expect("svg tag doc");
+
+        assert!(doc.content.contains("SVGElementTagNameMap[\"svg\"]"));
+        assert_eq!(
+            &doc.content
+                [doc.definition_offset..doc.definition_offset + "SVGElementTagNameMap".len()],
+            "SVGElementTagNameMap",
+        );
+    }
+
+    #[test]
+    fn native_dom_tag_info_rejects_custom_elements() {
+        assert!(super::native_dom_tag_info("my-element").is_none());
+    }
+
+    #[test]
+    fn native_dom_tag_info_rejects_vue_builtins() {
+        assert!(super::native_dom_tag_info("template").is_none());
+        assert!(super::native_dom_tag_info("slot").is_none());
+        assert!(super::native_dom_tag_info("component").is_none());
     }
 }

--- a/crates/vize_maestro/src/ide/hover/html.rs
+++ b/crates/vize_maestro/src/ide/hover/html.rs
@@ -1,12 +1,44 @@
+#![allow(clippy::disallowed_macros)]
+
 use std::sync::Arc;
 
 use tower_lsp::lsp_types::Hover;
 use vize_canon::CorsaBridge;
 
-use super::HoverService;
+use super::{HoverBuilder, HoverService};
 use crate::ide::IdeContext;
 
 impl HoverService {
+    pub(super) fn hover_native_dom_tag(ctx: &IdeContext<'_>) -> Option<Hover> {
+        let tag_name =
+            crate::ide::definition::helpers::get_tag_at_offset(&ctx.content, ctx.offset)?;
+        if crate::ide::is_component_tag(&tag_name) {
+            return None;
+        }
+
+        let info = crate::ide::corsa_support::native_dom_tag_info(&tag_name)?;
+        let signature = format!("const element: {}", info.type_expression);
+
+        Some(
+            HoverBuilder::new()
+                .title(&format!("<{tag_name}>"))
+                .meta(info.category)
+                .code("typescript", &signature)
+                .description(
+                    "Native DOM element recognized by the Vue template compiler. It is emitted as an element node, not resolved as a component.",
+                )
+                .bullets(
+                    "Editor behavior",
+                    &[
+                        "Go-to-definition uses TypeScript DOM lib data when the type service is available.",
+                        "Component resolution is skipped for this tag because it is part of the platform DOM surface.",
+                    ],
+                )
+                .link("MDN reference", &info.documentation_url)
+                .build(),
+        )
+    }
+
     pub(super) async fn hover_html_tag_with_corsa(
         ctx: &IdeContext<'_>,
         corsa_bridge: Option<&Arc<CorsaBridge>>,
@@ -32,5 +64,83 @@ impl HoverService {
         let hover = bridge.hover(&request_uri, line, character).await.ok()??;
 
         Some(Self::convert_lsp_hover(hover))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::HoverService;
+    use crate::{ide::IdeContext, server::ServerState};
+    use tower_lsp::lsp_types::{HoverContents, Url};
+
+    #[test]
+    fn test_hover_template_describes_native_html_element() {
+        let source = r#"<template>
+  <button type="button">Save</button>
+</template>
+"#;
+        let (state, uri) = state_with_document("NativeElementHover.vue", source);
+
+        let offset = source.find("button").unwrap() + "but".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let hover = HoverService::hover(&ctx).unwrap();
+        let value = hover_markdown(hover);
+
+        assert!(value.contains("<button>"), "got {value:?}");
+        assert!(value.contains("HTML element"), "got {value:?}");
+        assert!(
+            value.contains("HTMLElementTagNameMap[\"button\"]"),
+            "got {value:?}"
+        );
+        assert!(value.contains("MDN reference"), "got {value:?}");
+    }
+
+    #[test]
+    fn test_hover_template_does_not_describe_custom_element_as_native_dom() {
+        let source = r#"<template>
+  <my-widget />
+</template>
+"#;
+        let (state, uri) = state_with_document("CustomElementHover.vue", source);
+
+        let offset = source.find("my-widget").unwrap() + "my".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+
+        assert!(HoverService::hover(&ctx).is_none());
+    }
+
+    fn hover_markdown(hover: tower_lsp::lsp_types::Hover) -> String {
+        match hover.contents {
+            HoverContents::Markup(content) => content.value,
+            HoverContents::Scalar(marked) => match marked {
+                tower_lsp::lsp_types::MarkedString::String(value) => value,
+                tower_lsp::lsp_types::MarkedString::LanguageString(value) => value.value,
+            },
+            HoverContents::Array(items) => items
+                .into_iter()
+                .map(|item| match item {
+                    tower_lsp::lsp_types::MarkedString::String(value) => value,
+                    tower_lsp::lsp_types::MarkedString::LanguageString(value) => value.value,
+                })
+                .collect::<Vec<_>>()
+                .join("\n\n"),
+        }
+    }
+
+    fn state_with_document(name: &str, source: &str) -> (ServerState, Url) {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join(name);
+        fs::write(&source_path, source).unwrap();
+
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        (state, uri)
     }
 }

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -18,19 +18,22 @@ use crate::ide::IdeContext;
 impl HoverService {
     /// Get hover for template context.
     pub(super) fn hover_template(ctx: &IdeContext) -> Option<Hover> {
-        // Try to find what's under the cursor
         let word = Self::get_word_at_offset(&ctx.content, ctx.offset);
 
         if word.is_empty() {
             return None;
         }
 
-        // Check for Vue directives
         if let Some(hover) = Self::hover_directive(&word) {
             return Some(hover);
         }
 
         if let Some(hover) = super::component_prop::hover_attribute(ctx) {
+            return Some(hover);
+        }
+
+        #[cfg(feature = "native")]
+        if let Some(hover) = Self::hover_native_dom_tag(ctx) {
             return Some(hover);
         }
 
@@ -45,12 +48,10 @@ impl HoverService {
             return Some(hover);
         }
 
-        // Try to get TypeScript type information from croquis analysis
         if let Some(hover) = Self::hover_ts_binding(ctx, &word) {
             return Some(hover);
         }
 
-        // Try to get type information from vize_canon
         if let Some(type_info) = crate::ide::TypeService::get_type_at(ctx) {
             #[allow(clippy::disallowed_macros)]
             let signature = format!("{word}: {}", type_info.display);
@@ -66,7 +67,6 @@ impl HoverService {
             return Some(builder.build());
         }
 
-        // Check for template bindings from script setup
         if let Some(ref virtual_docs) = ctx.virtual_docs
             && let Some(ref script_setup) = virtual_docs.script_setup
         {
@@ -90,7 +90,6 @@ impl HoverService {
             }
         }
 
-        // Default: show it's a template expression
         Some(
             HoverBuilder::new()
                 .title(&word)


### PR DESCRIPTION
## Summary
- add native DOM element hover for Vue template tag names when Corsa is unavailable
- extend Corsa HTML tag virtual docs to SVG and MathML DOM tag metadata
- keep native hyphenated tags such as SVG color-profile out of component resolution

## Verification
- cargo fmt --all -- --check
- cargo test -p vize_maestro test_hover_template_describes_native_html_element
- cargo test -p vize_maestro test_hover_template_does_not_describe_custom_element_as_native_dom
- cargo test -p vize_maestro html_tag_virtual_document_supports_svg_tags
- cargo test -p vize_maestro native_dom_tag_info_rejects_vue_builtins
- cargo test -p vize_maestro test_is_component_tag
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785684104&installation_id=136613492&pr_number=2547&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2547&signature=aa6c79109d8dae60e7841c7213ae517cb6e6fbb61c3258230351aeba907692a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->