### PR TITLE
fix(musea): resolve vue runtime from project root

### DIFF
--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -93,7 +93,17 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
       const staticBuildConfig = staticBuildEnabled
         ? museaStaticBuildConfig(userConfig.build?.rollupOptions?.input as StaticBuildInput)
         : {};
-      return { resolve: { alias: [createVueRuntimeCompilerAlias()] }, ...staticBuildConfig };
+      return {
+        resolve: {
+          alias: [
+            createVueRuntimeCompilerAlias({
+              root: userConfig.root ? path.resolve(userConfig.root) : process.cwd(),
+              runtimeCompiler: options.vueRuntimeCompiler,
+            }),
+          ],
+        },
+        ...staticBuildConfig,
+      };
     },
 
     options: applyMuseaStaticBuildInput,

--- a/npm/builder/vite-musea/src/plugin/vue-alias.test.ts
+++ b/npm/builder/vite-musea/src/plugin/vue-alias.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import { createVueRuntimeCompilerAlias } from "./vue-alias.js";
@@ -9,4 +12,24 @@ void test("Vue runtime compiler alias only matches the bare vue import", () => {
   assert.equal(alias.find.test("vue/server-renderer"), false);
   assert.equal(alias.find.test("vue/dist/vue.runtime.esm-bundler.js"), false);
   assert.match(alias.replacement, /vue[\\/]dist[\\/]vue\.esm-bundler\.js$/);
+});
+
+void test("Vue runtime compiler alias resolves from the project root", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "musea-vue-alias-"));
+  const runtime = path.join(root, "node_modules", "vue", "dist", "vue.esm-bundler.js");
+  fs.mkdirSync(path.dirname(runtime), { recursive: true });
+  fs.writeFileSync(path.join(root, "package.json"), "{}\n");
+  fs.writeFileSync(runtime, "export {}\n");
+
+  const alias = createVueRuntimeCompilerAlias({ root });
+  assert.equal(alias.replacement, fs.realpathSync(runtime));
+});
+
+void test("Vue runtime compiler alias accepts an explicit replacement", () => {
+  const alias = createVueRuntimeCompilerAlias({
+    root: "/workspace/app",
+    runtimeCompiler: "./vendor/vue-compiler.js",
+  });
+
+  assert.equal(alias.replacement, path.resolve("/workspace/app/vendor/vue-compiler.js"));
 });

--- a/npm/builder/vite-musea/src/plugin/vue-alias.ts
+++ b/npm/builder/vite-musea/src/plugin/vue-alias.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import path from "node:path";
 
 const require = createRequire(import.meta.url);
 
@@ -7,14 +8,40 @@ export interface VueRuntimeCompilerAlias {
   replacement: string;
 }
 
-export function createVueRuntimeCompilerAlias(): VueRuntimeCompilerAlias {
-  return { find: /^vue$/, replacement: resolveVueRuntimeCompiler() };
+export interface VueRuntimeCompilerAliasOptions {
+  root?: string;
+  runtimeCompiler?: string;
 }
 
-function resolveVueRuntimeCompiler(): string {
+export function createVueRuntimeCompilerAlias(
+  options: VueRuntimeCompilerAliasOptions = {},
+): VueRuntimeCompilerAlias {
+  return { find: /^vue$/, replacement: resolveVueRuntimeCompiler(options) };
+}
+
+function resolveVueRuntimeCompiler(options: VueRuntimeCompilerAliasOptions): string {
+  if (options.runtimeCompiler) {
+    return normalizeRuntimeCompilerOverride(options.runtimeCompiler, options.root);
+  }
+
+  const root = options.root ?? process.cwd();
+  const projectRequire = createRequire(path.join(root, "package.json"));
+  try {
+    return projectRequire.resolve("vue/dist/vue.esm-bundler.js");
+  } catch {
+    // Fall through to package-local/bare resolution below.
+  }
+
   try {
     return require.resolve("vue/dist/vue.esm-bundler.js");
   } catch {
     return "vue/dist/vue.esm-bundler.js";
   }
+}
+
+function normalizeRuntimeCompilerOverride(value: string, root: string | undefined): string {
+  if (path.isAbsolute(value) || !value.startsWith(".")) {
+    return value;
+  }
+  return path.resolve(root ?? process.cwd(), value);
 }

--- a/npm/builder/vite-musea/src/types/plugin.ts
+++ b/npm/builder/vite-musea/src/types/plugin.ts
@@ -149,4 +149,13 @@ export interface MuseaOptions {
    * @default 3
    */
   vueVersion?: MuseaVueVersion;
+
+  /**
+   * Vue runtime compiler entry used by the static preview alias for bare `vue`.
+   * Defaults to resolving `vue/dist/vue.esm-bundler.js` from the Vite project root.
+   *
+   * Use this when a workspace needs a custom Vue build or a non-standard package
+   * manager layout.
+   */
+  vueRuntimeCompiler?: string;
 }


### PR DESCRIPTION
## Summary
- resolve Musea's static preview Vue compiler alias from the Vite project root instead of the package copy
- add a vueRuntimeCompiler override for workspaces with custom Vue builds or non-standard layouts

## Verification
- vp exec tsx --test src/plugin/vue-alias.test.ts
- vp check src vite.config.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check