### PR TITLE
chore: add socket.dev configuration

### DIFF
--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,41 @@
+version: 2
+
+projectIgnorePaths:
+  - "/.cache"
+  - "/.nuxt"
+  - "/_build"
+  - "/dist"
+  - "/node_modules"
+  - "/target"
+  - "/tests/_fixtures"
+
+triggerPaths:
+  - "/package.json"
+  - "/pnpm-lock.yaml"
+  - "/pnpm-workspace.yaml"
+  - "/Cargo.toml"
+  - "/Cargo.lock"
+  - "/bench/package.json"
+  - "/docs/package.json"
+  - "/docs/pnpm-lock.yaml"
+  - "/npm/**/package.json"
+  - "/editors/**/package.json"
+  - "/editors/**/Cargo.toml"
+  - "/editors/**/Cargo.lock"
+  - "/crates/**/Cargo.toml"
+  - "/examples/**/package.json"
+  - "/playground/**/package.json"
+  - "/tests/package.json"
+  - "/tests/fuzz/Cargo.toml"
+  - "/tests/fuzz/Cargo.lock"
+  - "/tests/vize_test_runner/Cargo.toml"
+  - "/.github/workflows/*.yml"
+  - "/.github/workflows/*.yaml"
+  - "/socket.yml"
+
+githubApp:
+  enabled: true
+  pullRequestAlertsEnabled: true
+  dependencyOverviewEnabled: true
+  projectReportsEnabled: true
+  disableCommentsAndCheckRuns: false

--- a/tests/tooling/repo-governance.test.ts
+++ b/tests/tooling/repo-governance.test.ts
@@ -46,6 +46,27 @@ test("root quality gates ignore local generated environments", () => {
   }
 });
 
+test("socket.dev configuration scopes dependency and workflow scans", () => {
+  const socket = readRepoFile("socket.yml");
+
+  assert.match(socket, /^version:\s*2$/m);
+  assert.match(socket, /projectIgnorePaths:\n(?:\s+- .+\n)+/);
+  assert.match(socket, /triggerPaths:\n(?:\s+- .+\n)+/);
+  assert.match(socket, /githubApp:\n/);
+  assert.match(socket, /\s+enabled:\s*true/);
+  assert.match(socket, /\s+pullRequestAlertsEnabled:\s*true/);
+  assert.match(socket, /\s+projectReportsEnabled:\s*true/);
+
+  for (const pattern of [
+    "/tests/_fixtures",
+    "/pnpm-lock.yaml",
+    "/Cargo.lock",
+    "/.github/workflows/*.yml",
+  ]) {
+    assert.match(socket, new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+});
+
 function readRepoFile(...segments: string[]): string {
   return fs.readFileSync(path.join(root, ...segments), "utf8");
 }


### PR DESCRIPTION
## Summary
- add Socket.dev v2 repository configuration
- scope scans to workspace dependency manifests and GitHub Actions workflows
- ignore local/generated and fixture dependency trees
- add a governance test that guards the config shape

## Validation
- ruby -ryaml parses socket.yml
- node --test tests/tooling/repo-governance.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785685109&installation_id=136613492&pr_number=2549&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2549&signature=65e7ede2ac00ce3ae8fd9ea08375a1b8152e26bc3c462eafbfa26c3f41317237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repository-level analysis settings to better control which files are scanned and when scans are triggered.
  * Enabled pull request alerts and project reporting for supported GitHub integrations.

* **Tests**
  * Added coverage to verify the new analysis settings are present and correctly scoped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->