### PR TITLE
fix(lsp): reuse croquis prop metadata in hover

### DIFF
--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -25,7 +25,7 @@ use bindings::analyzed_template_binding_completions;
 use components::builtin_component_completions;
 
 pub(crate) use art::{complete_art, complete_inline_art};
-pub(crate) use component_meta::CachedComponentMetadata;
+pub(crate) use component_meta::{CachedComponentMetadata, component_metadata};
 pub(crate) use directives::{contextual_directive_completions, vize_directive_completions};
 // Consumed via `template::*` by unit tests in the parent completion module; the
 // `allow` keeps non-test builds warning-free while preserving the public path.

--- a/crates/vize_maestro/src/ide/completion/template/component_meta.rs
+++ b/crates/vize_maestro/src/ide/completion/template/component_meta.rs
@@ -65,7 +65,7 @@ pub(crate) fn component_surface_completions(ctx: &IdeContext) -> Vec<CompletionI
 
 #[derive(Debug, Clone)]
 pub(crate) struct ComponentMetadata {
-    props: Vec<ComponentProp>,
+    pub(crate) props: Vec<ComponentProp>,
     slots: Vec<ComponentSlot>,
 }
 
@@ -79,14 +79,12 @@ pub(crate) struct CachedComponentMetadata {
 }
 
 #[derive(Debug, Clone)]
-struct ComponentProp {
-    name: String,
-    type_detail: Option<String>,
-    required: bool,
-    /// Default value source — populated from `withDefaults` or per-prop
-    /// `default` config. Renders into the completion documentation so the
-    /// user knows what the prop falls back to.
-    default_value: Option<String>,
+pub(crate) struct ComponentProp {
+    pub(crate) name: String,
+    pub(crate) type_detail: Option<String>,
+    pub(crate) required: bool,
+    /// Default value source rendered into completion and hover docs.
+    pub(crate) default_value: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -95,7 +93,10 @@ struct ComponentSlot {
     props_type: Option<String>,
 }
 
-fn component_metadata(ctx: &IdeContext, component_name: &str) -> Option<Arc<ComponentMetadata>> {
+pub(crate) fn component_metadata(
+    ctx: &IdeContext,
+    component_name: &str,
+) -> Option<Arc<ComponentMetadata>> {
     if let Some(metadata) = super::self_component::metadata(ctx, component_name) {
         return Some(metadata);
     }
@@ -122,10 +123,7 @@ fn component_metadata(ctx: &IdeContext, component_name: &str) -> Option<Arc<Comp
     None
 }
 
-/// Return parsed metadata for the component at `resolved`, reusing a cached
-/// parse when the file's length + modification time are unchanged. Only the
-/// `fs::metadata` stat runs on the hot (cache-hit) path; the disk read, SFC
-/// parse, and Croquis analysis happen solely on a miss.
+/// Return parsed metadata, reusing it while length + mtime stay unchanged.
 pub(super) fn cached_component_metadata(
     ctx: &IdeContext,
     resolved: &std::path::Path,

--- a/crates/vize_maestro/src/ide/hover/component_prop.rs
+++ b/crates/vize_maestro/src/ide/hover/component_prop.rs
@@ -2,12 +2,38 @@ use tower_lsp::lsp_types::Hover;
 
 use super::HoverBuilder;
 use crate::ide::IdeContext;
+use crate::ide::completion::template::component_metadata;
 
 pub(super) fn hover_attribute(ctx: &IdeContext<'_>) -> Option<Hover> {
     let (attr_name, component_name) =
         crate::ide::definition::helpers::get_attribute_and_component_at_offset(ctx)?;
     if !crate::ide::is_component_tag(&component_name) {
         return None;
+    }
+
+    let prop_name = crate::ide::definition::helpers::kebab_to_camel(&attr_name);
+    if let Some(metadata) = component_metadata(ctx, &component_name)
+        && let Some(prop) = metadata.props.iter().find(|prop| prop.name == prop_name)
+    {
+        let type_detail = prop.type_detail.as_deref().unwrap_or("unknown");
+        let optional = if prop.required { "" } else { "?" };
+        let signature = format!("{}{}: {}", prop.name, optional, type_detail);
+        let requirement = if prop.required {
+            "Required"
+        } else {
+            "Optional"
+        };
+        let mut builder = HoverBuilder::new()
+            .title(&prop.name)
+            .meta("Component prop")
+            .code("typescript", &signature)
+            .section("Requirement", requirement);
+
+        if let Some(default) = prop.default_value.as_deref() {
+            builder = builder.section("Default", &format!("`{default}`"));
+        }
+
+        return Some(builder.build());
     }
 
     let import_path = crate::ide::definition::helpers::find_import_path(ctx, &component_name)?;
@@ -24,7 +50,6 @@ pub(super) fn hover_attribute(ctx: &IdeContext<'_>) -> Option<Hover> {
     .ok()?;
     let script_setup = descriptor.script_setup.as_ref()?;
     let script = script_setup.content.as_ref();
-    let prop_name = crate::ide::definition::helpers::kebab_to_camel(&attr_name);
     let define_props_pos = script.find("defineProps")?;
     let after_define_props = &script[define_props_pos..];
     let prop_pos =
@@ -57,5 +82,72 @@ fn prop_signature_at(script: &str, offset: usize, prop_name: &str) -> String {
         prop_name.to_string()
     } else {
         line.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::super::{HoverContents, HoverService};
+    use crate::{ide::IdeContext, server::ServerState};
+    use tower_lsp::lsp_types::Url;
+
+    #[test]
+    fn hover_component_prop_uses_croquis_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let child_path = dir.path().join("Child.vue");
+        let parent_path = dir.path().join("Parent.vue");
+
+        fs::write(
+            &child_path,
+            r#"<script setup lang="ts">
+defineModel<string>({ required: true })
+</script>
+"#,
+        )
+        .unwrap();
+        let source = r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template>
+  <Child model-value="draft" />
+</template>
+"#;
+        fs::write(&parent_path, source).unwrap();
+
+        let uri = Url::from_file_path(&parent_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        let offset = source.find("model-value").unwrap() + "model-value".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let hover = HoverService::hover(&ctx).unwrap();
+        let value = hover_markdown(hover);
+
+        assert!(value.contains("modelValue: string"), "got {value:?}");
+        assert!(value.contains("Required"), "got {value:?}");
+    }
+
+    fn hover_markdown(hover: tower_lsp::lsp_types::Hover) -> String {
+        match hover.contents {
+            HoverContents::Markup(content) => content.value,
+            HoverContents::Scalar(marked) => match marked {
+                tower_lsp::lsp_types::MarkedString::String(value) => value,
+                tower_lsp::lsp_types::MarkedString::LanguageString(value) => value.value,
+            },
+            HoverContents::Array(items) => items
+                .into_iter()
+                .map(|item| match item {
+                    tower_lsp::lsp_types::MarkedString::String(value) => value,
+                    tower_lsp::lsp_types::MarkedString::LanguageString(value) => value.value,
+                })
+                .collect::<Vec<_>>()
+                .join("\n\n"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- reuse component metadata extracted through Croquis for component prop hover
- surface defineModel props, required state, and defaults in hover markdown
- keep the previous defineProps string fallback for unsupported metadata cases

## Validation
- cargo fmt --all -- --check
- cargo test -p vize_maestro hover_component_prop_uses_croquis_metadata
- cargo test -p vize_maestro component_metadata_cache_hits_then_invalidates_on_change
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785685479&installation_id=136613492&pr_number=2550&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2550&signature=d21a85511ca4939c1dc1e0117a441c8eb54e39fa03ccbf13c129fcabc36dcd9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Component prop hover now shows richer, metadata-based details, including type, required/optional status, requirement notes, and default values when available.
* **Bug Fixes**
  * Hover information is more reliable for component props and model bindings, especially when source parsing is incomplete or unavailable.
  * Matching now uses the resolved prop name from the attribute, improving hover results for camel-cased props.
* **Tests**
  * Added coverage for hover behavior on a required model prop in a parent/child component setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->