### PR TITLE
fix(canon): make virtual ts libs pluggable

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -242,8 +242,7 @@ pub(super) fn virtual_ts_options_for_descriptor(
         })
         .collect();
     let css_modules = if css_modules.is_empty() {
-        // No `<style module>` blocks: reuse the global css_modules (typically
-        // also empty) rather than the freshly collected empty Vec.
+        // No `<style module>` blocks: reuse the global css_modules.
         base.css_modules.clone()
     } else {
         css_modules

--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -213,6 +213,7 @@ pub(super) fn generate_vue_virtual_ts(
                     TemplateSyntaxMode::Quirks
                 ),
                 hoist_shared_preamble,
+                lib_references: None,
             },
         )
     );

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -31,3 +31,26 @@ pub use helpers::{DECLARATION_HELPERS_DTS, SHARED_PREAMBLE_DTS, SHARED_PREAMBLE_
 pub use types::{TemplateGlobal, VirtualTsOptions, VirtualTsOutput, VizeMapping};
 #[cfg(any(test, feature = "native"))]
 pub(crate) use types::{VirtualTsCheckOptions, VirtualTsGenerationOptions};
+
+pub fn generate_virtual_ts_with_offsets_and_lib_references(
+    summary: &vize_croquis::Croquis,
+    script_content: Option<&str>,
+    template_ast: Option<&vize_relief::RootNode<'_>>,
+    script_offset: u32,
+    template_offset: u32,
+    options: &VirtualTsOptions,
+    lib_references: &[&str],
+) -> VirtualTsOutput {
+    generator::generate_virtual_ts_with_offsets_and_checks(
+        summary,
+        script_content,
+        template_ast,
+        script_offset,
+        template_offset,
+        options,
+        types::VirtualTsGenerationOptions {
+            lib_references: Some(lib_references),
+            ..Default::default()
+        },
+    )
+}

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -43,7 +43,10 @@ use super::{
         extract_generic_names, strip_const_modifiers,
     },
     scope::{ScopeGenerationOptions, generate_scope_closures},
-    types::{VirtualTsGenerationOptions, VirtualTsOptions, VirtualTsOutput, VizeMapping},
+    types::{
+        DEFAULT_LIB_REFERENCES, VirtualTsGenerationOptions, VirtualTsOptions, VirtualTsOutput,
+        VizeMapping, emit_lib_reference_directives,
+    },
 };
 use vize_carton::{FxHashMap, FxHashSet, String, append, cstr, profile};
 use vize_croquis::{Croquis, ScopeData, ScopeKind};
@@ -147,11 +150,10 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         "Reference setup bindings (used in template/CSS v-bind)"
     };
 
-    // Header with ES target library references.
-    // These ensure import.meta, Promise, Array.includes(), etc. are available.
-    ts.push_str("/// <reference lib=\"es2022\" />\n");
-    ts.push_str("/// <reference lib=\"dom\" />\n");
-    ts.push_str("/// <reference lib=\"dom.iterable\" />\n");
+    let lib_references = generation_options
+        .lib_references
+        .unwrap_or(DEFAULT_LIB_REFERENCES);
+    emit_lib_reference_directives(&mut ts, lib_references);
     let has_script_reference_types = emit_reference_type_directives(&mut ts, script_content);
     ts.push_str("// ============================================\n");
     ts.push_str("// Virtual TypeScript for Vue SFC Type Checking\n");

--- a/crates/vize_canon/src/virtual_ts/types.rs
+++ b/crates/vize_canon/src/virtual_ts/types.rs
@@ -81,6 +81,25 @@ impl Default for VirtualTsOptions {
     }
 }
 
+pub(crate) const DEFAULT_LIB_REFERENCES: &[&str] = &["es2022", "dom", "dom.iterable"];
+
+pub(crate) fn emit_lib_reference_directives(output: &mut String, lib_references: &[&str]) {
+    for lib in lib_references {
+        let lib = lib.trim();
+        if lib.is_empty() || !is_safe_ts_lib_reference(lib) {
+            continue;
+        }
+        output.push_str("/// <reference lib=\"");
+        output.push_str(lib);
+        output.push_str("\" />\n");
+    }
+}
+
+pub(crate) fn is_safe_ts_lib_reference(lib: &str) -> bool {
+    lib.bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_'))
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct VirtualTsCheckOptions {
     pub(crate) check_props: bool,
@@ -134,6 +153,8 @@ pub(crate) struct VirtualTsGenerationOptions<'a> {
     /// TypeScript program. Off by default so standalone single-document
     /// consumers keep self-contained output.
     pub(crate) hoist_shared_preamble: bool,
+    /// Override standard library triple-slash references for this generation.
+    pub(crate) lib_references: Option<&'a [&'a str]>,
 }
 
 /// Default plugin globals.
@@ -141,6 +162,23 @@ pub(crate) struct VirtualTsGenerationOptions<'a> {
 /// or `typeChecker.globalsFile`.
 fn default_plugin_globals() -> Vec<TemplateGlobal> {
     vec![]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::emit_lib_reference_directives;
+    use vize_carton::String;
+
+    #[test]
+    fn virtual_ts_lib_references_are_pluggable() {
+        let mut output = String::default();
+        emit_lib_reference_directives(&mut output, &["es2021", "webworker", "bad\" />"]);
+
+        assert_eq!(
+            output.as_str(),
+            "/// <reference lib=\"es2021\" />\n/// <reference lib=\"webworker\" />\n"
+        );
+    }
 }
 
 /// Output of virtual TypeScript generation.


### PR DESCRIPTION
## Summary
- add a semver-safe virtual TS generation entry point that accepts custom TypeScript lib references
- keep the existing es2022/dom/dom.iterable default path unchanged
- generate triple-slash lib directives from caller-provided libs when using the new entry point
- filter unsafe lib reference names before writing directives

## Validation
- cargo fmt --all -- --check
- cargo test -p vize_canon virtual_ts_lib_references_are_pluggable
- cargo test -p vize_canon test_vue_template_context
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo semver-checks check-release --package vize_canon --baseline-rev origin/main
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TypeScript virtual generation now supports configurable built-in library references, controlling which `/// <reference lib="..."/>` directives are emitted.
  * Added a new generation entry point that accepts library reference overrides.

* **Bug Fixes**
  * Reference directives are no longer hardcoded; they’re produced from configured values with safe defaults.
  * Library reference values are validated so unsafe entries are excluded.

* **Tests**
  * Added tests to confirm only safe library reference names result in emitted directives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->