### PR TITLE
chore: release v0.275.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3391,7 +3391,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vize"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "clap",
  "dirs",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "vize_armature"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "compact_str",
  "htmlize",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_core"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_dom"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "insta",
  "phf 0.13.1",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_jsx"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_sfc"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_ssr"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "insta",
  "serde",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_vapor"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "insta",
  "oxc_allocator",
@@ -3570,7 +3570,7 @@ dependencies = [
 
 [[package]]
 name = "vize_canon"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "corsa",
  "dashmap 6.1.0",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "vize_carton"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "bitflags 2.11.1",
  "bumpalo",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "vize_croquis"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "dashmap 6.1.0",
  "insta",
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "vize_croquis_cf"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "vize_curator"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "insta",
  "serde",
@@ -3672,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "vize_fresco"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "vize_glyph"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3713,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "vize_maestro"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "async-trait",
  "dashmap 6.1.0",
@@ -3748,7 +3748,7 @@ dependencies = [
 
 [[package]]
 name = "vize_musea"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "vize_patina"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "corsa",
  "criterion",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "vize_relief"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "vize_test_runner"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "pklrust",
  "serde",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "vize_vitrine"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "getrandom 0.3.4",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.274.0"
+version = "0.275.0"
 edition = "2024"
 rust-version = "1.95.0"
 license = "MIT"
@@ -33,21 +33,21 @@ repository = "https://github.com/ubugeeei-prod/vize"
 
 [workspace.dependencies]
 # Publishable internal crates (path for local dev, version fallback for crates.io)
-vize_carton = { path = "crates/vize_carton", version = "=0.274.0" }
-vize_relief = { path = "crates/vize_relief", version = "=0.274.0" }
-vize_armature = { path = "crates/vize_armature", version = "=0.274.0" }
-vize_croquis = { path = "crates/vize_croquis", version = "=0.274.0" }
-vize_croquis_cf = { path = "crates/vize_croquis_cf", version = "=0.274.0" }
-vize_atelier_core = { path = "crates/vize_atelier_core", version = "=0.274.0" }
-vize_atelier_dom = { path = "crates/vize_atelier_dom", version = "=0.274.0" }
-vize_atelier_vapor = { path = "crates/vize_atelier_vapor", version = "=0.274.0" }
-vize_atelier_ssr = { path = "crates/vize_atelier_ssr", version = "=0.274.0" }
-vize_atelier_sfc = { path = "crates/vize_atelier_sfc", version = "=0.274.0", default-features = false }
-vize_atelier_jsx = { path = "crates/vize_atelier_jsx", version = "=0.274.0" }
-vize_musea = { path = "crates/vize_musea", version = "=0.274.0" }
-vize_patina = { path = "crates/vize_patina", version = "=0.274.0" }
-vize_canon = { path = "crates/vize_canon", version = "=0.274.0", default-features = false }
-vize_fresco = { path = "crates/vize_fresco", version = "=0.274.0", default-features = false }
+vize_carton = { path = "crates/vize_carton", version = "=0.275.0" }
+vize_relief = { path = "crates/vize_relief", version = "=0.275.0" }
+vize_armature = { path = "crates/vize_armature", version = "=0.275.0" }
+vize_croquis = { path = "crates/vize_croquis", version = "=0.275.0" }
+vize_croquis_cf = { path = "crates/vize_croquis_cf", version = "=0.275.0" }
+vize_atelier_core = { path = "crates/vize_atelier_core", version = "=0.275.0" }
+vize_atelier_dom = { path = "crates/vize_atelier_dom", version = "=0.275.0" }
+vize_atelier_vapor = { path = "crates/vize_atelier_vapor", version = "=0.275.0" }
+vize_atelier_ssr = { path = "crates/vize_atelier_ssr", version = "=0.275.0" }
+vize_atelier_sfc = { path = "crates/vize_atelier_sfc", version = "=0.275.0", default-features = false }
+vize_atelier_jsx = { path = "crates/vize_atelier_jsx", version = "=0.275.0" }
+vize_musea = { path = "crates/vize_musea", version = "=0.275.0" }
+vize_patina = { path = "crates/vize_patina", version = "=0.275.0" }
+vize_canon = { path = "crates/vize_canon", version = "=0.275.0", default-features = false }
+vize_fresco = { path = "crates/vize_fresco", version = "=0.275.0", default-features = false }
 
 # Workspace-only internal crates (always use the local path)
 vize_vitrine = { path = "crates/vize_vitrine", default-features = false }

--- a/editors/vscode-art/package.json
+++ b/editors/vscode-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vize-art",
   "displayName": "Vize Art",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "Syntax highlighting for Vize Art files (*.art.vue)",
   "categories": [
     "Programming Languages"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vize",
   "displayName": "Vize",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "Vue Language Support powered by Vize - A high-performance language server for Vue SFC",
   "categories": [
     "Formatters",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -570,7 +570,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vize-zed-extension"
-version = "0.274.0"
+version = "0.275.0"
 dependencies = [
  "zed_extension_api",
 ]

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vize-zed-extension"
-version = "0.274.0"
+version = "0.275.0"
 edition = "2024"
 license = "MIT"
 publish = false

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "vize"
 name = "Vize"
-version = "0.274.0"
+version = "0.275.0"
 schema_version = 1
 authors = ["Vize contributors"]
 description = "Opt-in Vue diagnostics and language support powered by Vize"

--- a/npm/builder/rspack/package.json
+++ b/npm/builder/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/rspack-plugin",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "High-performance Rspack plugin for Vue SFC compilation powered by Vize",
   "keywords": [
     "compiler",

--- a/npm/builder/unplugin/package.json
+++ b/npm/builder/unplugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/unplugin",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "Experimental Vue SFC integrations for Rollup, Rolldown, Webpack, esbuild, and Babel powered by Vize",
   "keywords": [
     "babel",

--- a/npm/builder/vite-musea/package.json
+++ b/npm/builder/vite-musea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/vite-plugin-musea",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "Vite plugin for Musea - Component gallery for Vue components",
   "keywords": [
     "component-gallery",

--- a/npm/builder/vite/package.json
+++ b/npm/builder/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/vite-plugin",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "High-performance native Vite plugin for Vue SFC compilation powered by Vize",
   "keywords": [
     "compiler",

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vize",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "Vize - High-performance Vue.js toolchain in Rust",
   "keywords": [
     "cli",

--- a/npm/framework/musea-nuxt/package.json
+++ b/npm/framework/musea-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/musea-nuxt",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "Nuxt mock layer for Musea - enables Nuxt component isolation in galleries",
   "keywords": [
     "component-gallery",

--- a/npm/framework/nuxt/package.json
+++ b/npm/framework/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/nuxt",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "Nuxt module for Vize - compiler, musea gallery, linter, and type checker",
   "keywords": [
     "compiler",

--- a/npm/fresco-native/package.json
+++ b/npm/fresco-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/fresco-native",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "Vue TUI framework - Native bindings",
   "keywords": [
     "fresco",

--- a/npm/fresco/package.json
+++ b/npm/fresco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/fresco",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "Vue TUI framework - Build terminal UIs with Vue.js",
   "keywords": [
     "cli",

--- a/npm/mcp-musea/package.json
+++ b/npm/mcp-musea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/musea-mcp-server",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "MCP server for building Vue.js design systems - component analysis, documentation, variant generation, and design tokens",
   "keywords": [
     "ai",

--- a/npm/native/package.json
+++ b/npm/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/native",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "High-performance Vue.js compiler - Native bindings",
   "keywords": [
     "compiler",

--- a/npm/oxint/package.json
+++ b/npm/oxint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-plugin-vize",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "Oxlint JS plugin bridge for Vize Patina",
   "keywords": [
     "lint",

--- a/npm/wasm/package.json
+++ b/npm/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizejs/wasm",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "Vize WASM bindings for browser environments",
   "homepage": "https://github.com/ubugeeei-prod/vize",
   "bugs": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,28 +71,28 @@ catalogs:
       version: 1.64.0
   native-binaries:
     '@vizejs/native-darwin-arm64':
-      specifier: 0.274.0
+      specifier: 0.275.0
       version: 0.108.0
     '@vizejs/native-darwin-x64':
-      specifier: 0.274.0
+      specifier: 0.275.0
       version: 0.108.0
     '@vizejs/native-linux-arm64-gnu':
-      specifier: 0.274.0
+      specifier: 0.275.0
       version: 0.108.0
     '@vizejs/native-linux-arm64-musl':
-      specifier: 0.274.0
+      specifier: 0.275.0
       version: 0.108.0
     '@vizejs/native-linux-x64-gnu':
-      specifier: 0.274.0
+      specifier: 0.275.0
       version: 0.108.0
     '@vizejs/native-linux-x64-musl':
-      specifier: 0.274.0
+      specifier: 0.275.0
       version: 0.108.0
     '@vizejs/native-win32-arm64-msvc':
-      specifier: 0.274.0
+      specifier: 0.275.0
       version: 0.108.0
     '@vizejs/native-win32-x64-msvc':
-      specifier: 0.274.0
+      specifier: 0.275.0
       version: 0.108.0
   nuxt-module:
     '@nuxt/kit':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -109,14 +109,14 @@ catalogs:
 
   # Published native binary packages that are installed optionally at runtime.
   native-binaries:
-    "@vizejs/native-darwin-arm64": "0.274.0"
-    "@vizejs/native-darwin-x64": "0.274.0"
-    "@vizejs/native-linux-arm64-gnu": "0.274.0"
-    "@vizejs/native-linux-arm64-musl": "0.274.0"
-    "@vizejs/native-linux-x64-gnu": "0.274.0"
-    "@vizejs/native-linux-x64-musl": "0.274.0"
-    "@vizejs/native-win32-arm64-msvc": "0.274.0"
-    "@vizejs/native-win32-x64-msvc": "0.274.0"
+    "@vizejs/native-darwin-arm64": "0.275.0"
+    "@vizejs/native-darwin-x64": "0.275.0"
+    "@vizejs/native-linux-arm64-gnu": "0.275.0"
+    "@vizejs/native-linux-arm64-musl": "0.275.0"
+    "@vizejs/native-linux-x64-gnu": "0.275.0"
+    "@vizejs/native-linux-x64-musl": "0.275.0"
+    "@vizejs/native-win32-arm64-msvc": "0.275.0"
+    "@vizejs/native-win32-x64-msvc": "0.275.0"
 
 peerDependencyRules:
   allowAny:


### PR DESCRIPTION
## Summary
- bump workspace, npm, editor, and native catalog versions from 0.274.0 to 0.275.0
- update Cargo and pnpm lockfiles for the release version

## Validation
- node --test tests/tooling/package-manifests.test.ts
- cargo metadata --locked --format-version 1 --no-deps
- cargo metadata --manifest-path editors/zed/Cargo.toml --locked --format-version 1 --no-deps
- git diff --check

## Release Plan
- merge this release bump PR after CI passes
- push tag v0.275.0 from the merged commit
- monitor the tag-triggered Release workflow to completion

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785688187&installation_id=136613492&pr_number=2552&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2552&signature=16c7ded857b8aea83341c7830c5698c7558995aee2a303d1715371c1457e0460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the project release version to **0.275.0** across the workspace and published packages.
  * Updated extension, CLI, framework, native, WASM, and editor package manifests to match the new version.
  * Synced platform-specific native binary package references to the same release number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->