### PR TITLE
fix(release): normalize musl zig target flags

### DIFF
--- a/tests/tooling/github-zig-musl-linkers.test.ts
+++ b/tests/tooling/github-zig-musl-linkers.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { root } from "./support/github-workflows.ts";
+
+function parseGithubEnv(envFile: string): Record<string, string> {
+  return Object.fromEntries(
+    fs
+      .readFileSync(envFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => {
+        const index = line.indexOf("=");
+        return [line.slice(0, index), line.slice(index + 1)];
+      }),
+  );
+}
+
+test("Zig musl linker wrappers normalize cc-rs target flags", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-zig-musl-linkers-"));
+  const binDir = path.join(tempDir, "bin");
+  const envFile = path.join(tempDir, "github-env");
+  const fakeZig = path.join(binDir, "zig");
+  const scriptPath = path.join(root, "tools", "github", "configure-zig-musl-linkers.sh");
+
+  try {
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(fakeZig, '#!/usr/bin/env bash\nprintf \'%s\\n\' "$@" > "$ZIG_ARGS_LOG"\n');
+    fs.chmodSync(fakeZig, 0o755);
+
+    const pathEnv = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+    execFileSync("bash", [scriptPath], {
+      env: { ...process.env, GITHUB_ENV: envFile, PATH: pathEnv, RUNNER_TEMP: tempDir },
+    });
+
+    const githubEnv = parseGithubEnv(envFile);
+    const runWrapper = (envName: string, args: string[]) => {
+      const logPath = path.join(tempDir, `${envName}.log`);
+      execFileSync(githubEnv[envName], args, {
+        env: { ...process.env, PATH: pathEnv, ZIG_ARGS_LOG: logPath },
+      });
+      return fs.readFileSync(logPath, "utf8").trim().split("\n");
+    };
+
+    assert.deepEqual(
+      runWrapper("CC_x86_64_unknown_linux_musl", [
+        "--target=x86_64-unknown-linux-musl",
+        "-O3",
+        "-c",
+        "static.c",
+      ]),
+      ["cc", "-target", "x86_64-linux-musl", "-O3", "-c", "static.c"],
+    );
+    assert.deepEqual(
+      runWrapper("CC_aarch64_unknown_linux_musl", [
+        "--target",
+        "aarch64-unknown-linux-musl",
+        "-DMI_DEBUG=0",
+      ]),
+      ["cc", "-target", "aarch64-linux-musl", "-DMI_DEBUG=0"],
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tools/github/configure-zig-musl-linkers.sh
+++ b/tools/github/configure-zig-musl-linkers.sh
@@ -15,7 +15,29 @@ write_cc() {
   local env_target
 
   env_target="$(tr '[:upper:]' '[:lower:]' <<< "$rust_target")"
-  printf '#!/usr/bin/env bash\nexec zig cc -target %s "$@"\n' "$zig_target" > "$cc"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'set -euo pipefail\n'
+    printf 'args=()\n'
+    printf 'skip_next=0\n'
+    printf 'for arg in "$@"; do\n'
+    printf '  if (( skip_next )); then\n'
+    printf '    skip_next=0\n'
+    printf '    continue\n'
+    printf '  fi\n'
+    printf '  case "$arg" in\n'
+    printf '    --target=*)\n'
+    printf '      ;;\n'
+    printf '    --target)\n'
+    printf '      skip_next=1\n'
+    printf '      ;;\n'
+    printf '    *)\n'
+    printf '      args+=("$arg")\n'
+    printf '      ;;\n'
+    printf '  esac\n'
+    printf 'done\n'
+    printf 'exec zig cc -target %s "${args[@]}"\n' "$zig_target"
+  } > "$cc"
   chmod +x "$cc"
 
   {


### PR DESCRIPTION
## Summary
- normalize cc-rs --target flags in the Zig musl wrapper before invoking zig cc
- cover generated musl wrappers with a fake zig execution test

## Validation
- bash -n tools/github/configure-zig-musl-linkers.sh
- node --test tests/tooling/github-workflows-release-build.test.ts
- node --test tests/tooling/release-platforms.test.ts
- node --test tests/tooling/github-workflows.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785689472&installation_id=136613492&pr_number=2553&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2553&signature=33dee9e98cd3d432b49e11ebee47c8a4546d5dcc473f431b75c2a26be9f23fb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Zig-based C compiler wrappers so they consistently use the expected target setting and ignore conflicting `--target` flags.
  * Preserved other compiler arguments, including optimization flags and source file options, when invoking the wrapper.
* **Tests**
  * Added integration coverage to verify the generated wrapper scripts handle target normalization and argument forwarding correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->