### PR TITLE
fix(release): avoid zig musl crt duplication

### DIFF
--- a/tests/tooling/github-zig-musl-linkers.test.ts
+++ b/tests/tooling/github-zig-musl-linkers.test.ts
@@ -20,7 +20,7 @@ function parseGithubEnv(envFile: string): Record<string, string> {
   );
 }
 
-test("Zig musl linker wrappers normalize cc-rs target flags", () => {
+test("Zig musl wrappers normalize cc-rs flags and avoid duplicate CRT startup objects", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-zig-musl-linkers-"));
   const binDir = path.join(tempDir, "bin");
   const envFile = path.join(tempDir, "github-env");
@@ -46,6 +46,10 @@ test("Zig musl linker wrappers normalize cc-rs target flags", () => {
       return fs.readFileSync(logPath, "utf8").trim().split("\n");
     };
 
+    assert.notEqual(
+      githubEnv.CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER,
+      githubEnv.CC_x86_64_unknown_linux_musl,
+    );
     assert.deepEqual(
       runWrapper("CC_x86_64_unknown_linux_musl", [
         "--target=x86_64-unknown-linux-musl",
@@ -62,6 +66,15 @@ test("Zig musl linker wrappers normalize cc-rs target flags", () => {
         "-DMI_DEBUG=0",
       ]),
       ["cc", "-target", "aarch64-linux-musl", "-DMI_DEBUG=0"],
+    );
+    assert.deepEqual(
+      runWrapper("CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER", [
+        "-m64",
+        "--target=x86_64-unknown-linux-musl",
+        "rcrt1.o",
+        "-nostartfiles",
+      ]),
+      ["cc", "-target", "x86_64-linux-musl", "-nostdlib", "-m64", "rcrt1.o", "-nostartfiles"],
     );
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });

--- a/tools/github/configure-zig-musl-linkers.sh
+++ b/tools/github/configure-zig-musl-linkers.sh
@@ -8,13 +8,11 @@ mkdir -p "$linker_dir"
 printf '#!/usr/bin/env bash\nexec zig ar "$@"\n' > "$zig_ar"
 chmod +x "$zig_ar"
 
-write_cc() {
-  local rust_target="$1"
+write_zig_wrapper() {
+  local output="$1"
   local zig_target="$2"
-  local cc="$linker_dir/zig-cc-$zig_target"
-  local env_target
+  local mode="$3"
 
-  env_target="$(tr '[:upper:]' '[:lower:]' <<< "$rust_target")"
   {
     printf '#!/usr/bin/env bash\n'
     printf 'set -euo pipefail\n'
@@ -36,12 +34,28 @@ write_cc() {
     printf '      ;;\n'
     printf '  esac\n'
     printf 'done\n'
-    printf 'exec zig cc -target %s "${args[@]}"\n' "$zig_target"
-  } > "$cc"
-  chmod +x "$cc"
+    if [[ "$mode" == "link" ]]; then
+      printf 'exec zig cc -target %s -nostdlib "${args[@]}"\n' "$zig_target"
+    else
+      printf 'exec zig cc -target %s "${args[@]}"\n' "$zig_target"
+    fi
+  } > "$output"
+  chmod +x "$output"
+}
+
+write_cc() {
+  local rust_target="$1"
+  local zig_target="$2"
+  local cc="$linker_dir/zig-cc-$zig_target"
+  local linker="$linker_dir/zig-link-$zig_target"
+  local env_target
+
+  env_target="$(tr '[:upper:]' '[:lower:]' <<< "$rust_target")"
+  write_zig_wrapper "$cc" "$zig_target" "compile"
+  write_zig_wrapper "$linker" "$zig_target" "link"
 
   {
-    printf 'CARGO_TARGET_%s_LINKER=%s\n' "$rust_target" "$cc"
+    printf 'CARGO_TARGET_%s_LINKER=%s\n' "$rust_target" "$linker"
     printf 'CC_%s=%s\n' "$env_target" "$cc"
     printf 'AR_%s=%s\n' "$env_target" "$zig_ar"
   } >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- split the Zig musl C compiler wrapper from the Cargo linker wrapper
- pass -nostdlib only through the linker wrapper so Zig does not inject duplicate musl CRT startup objects
- extend fake-zig wrapper coverage for linker arguments

## Validation
- bash -n tools/github/configure-zig-musl-linkers.sh
- vp check --fix tests/tooling/github-zig-musl-linkers.test.ts
- node --test tests/tooling/github-zig-musl-linkers.test.ts tests/tooling/github-workflows-release-build.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785691219&installation_id=136613492&pr_number=2554&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2554&signature=b9186c1a9004e96d51362dd22da6b5ab5ca32c94b01d0815dedbeee79147d6a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Zig-based build support for musl targets by using separate compiler and linker wrappers.
  * Build settings now apply the right options for compilation vs. linking, making target configuration more reliable.

* **Bug Fixes**
  * Fixed environment variable handling so compiler and linker settings are no longer duplicated or mixed up.
  * Added stronger validation for the generated linker command to ensure the expected flags are passed in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->