### PR TITLE
fix(release): append musl zig crt suppression flags

### DIFF
--- a/tests/tooling/github-zig-musl-linkers.test.ts
+++ b/tests/tooling/github-zig-musl-linkers.test.ts
@@ -73,8 +73,19 @@ test("Zig musl wrappers normalize cc-rs flags and avoid duplicate CRT startup ob
         "--target=x86_64-unknown-linux-musl",
         "rcrt1.o",
         "-nostartfiles",
+        "-static-pie",
       ]),
-      ["cc", "-target", "x86_64-linux-musl", "-nostdlib", "-m64", "rcrt1.o", "-nostartfiles"],
+      [
+        "cc",
+        "-target",
+        "x86_64-linux-musl",
+        "-m64",
+        "rcrt1.o",
+        "-nostartfiles",
+        "-static-pie",
+        "-nostdlib",
+        "-nostartfiles",
+      ],
     );
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });

--- a/tools/github/configure-zig-musl-linkers.sh
+++ b/tools/github/configure-zig-musl-linkers.sh
@@ -35,7 +35,7 @@ write_zig_wrapper() {
     printf '  esac\n'
     printf 'done\n'
     if [[ "$mode" == "link" ]]; then
-      printf 'exec zig cc -target %s -nostdlib "${args[@]}"\n' "$zig_target"
+      printf 'exec zig cc -target %s "${args[@]}" -nostdlib -nostartfiles\n' "$zig_target"
     else
       printf 'exec zig cc -target %s "${args[@]}"\n' "$zig_target"
     fi


### PR DESCRIPTION
## Summary
- append `-nostdlib -nostartfiles` after Rust linker args in the Zig musl linker wrapper
- keep Zig as the musl C compiler/archiver while preventing Zig from adding duplicate startup CRT objects during final CLI links
- cover the post-`-static-pie` flag order in the wrapper test

## Verification
- `bash -n tools/github/configure-zig-musl-linkers.sh`
- `node --test tests/tooling/github-zig-musl-linkers.test.ts tests/tooling/github-workflows-release-build.test.ts`
- `vp check --fix tests/tooling/github-zig-musl-linkers.test.ts`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

Follow-up for failed Release run https://github.com/ubugeeei-prod/vize/actions/runs/28675269627.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785692544&installation_id=136613492&pr_number=2555&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2555&signature=23a9302e54b23e943d2cea3311c64ed8512d12a681c665c2305fad86775ff42d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Zig musl linker wrapper so generated link commands include the expected startup flags.
  * Adjusted the linker argument handling to better match `cc` command-line behavior, including static PIE support and flag ordering.
  * Fixed test expectations to reflect the revised linker invocation output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->