### PR TITLE
fix(release): link musl cli with rust-lld

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         run: rustup target add ${{ matrix.settings.target }}
 
       - name: Setup Wild linker (Linux)
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && !endsWith(matrix.settings.target, '-musl')
         uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:
           wild-version: "0.9.0"

--- a/tests/tooling/github-workflows-release-build.test.ts
+++ b/tests/tooling/github-workflows-release-build.test.ts
@@ -273,8 +273,12 @@ test("release workflow configures Zig linkers for Linux musl CLI archives", () =
 
   assert.match(buildCliJob, /name:\s*Setup Zig \(Linux musl CLI\)/);
   assert.match(buildCliJob, /if:\s*endsWith\(matrix\.settings\.target, '-musl'\)/);
+  assert.match(
+    buildCliJob,
+    /Setup Wild linker \(Linux\)[\s\S]*if:\s*runner\.os == 'Linux' && !endsWith\(matrix\.settings\.target, '-musl'\)/,
+  );
   assert.match(buildCliJob, /bash tools\/github\/configure-zig-musl-linkers\.sh/);
-  assert.match(zigLinkerScript, /CARGO_TARGET_%s_LINKER/);
+  assert.match(zigLinkerScript, /CARGO_TARGET_%s_LINKER=rust-lld/);
   assert.match(zigLinkerScript, /write_cc X86_64_UNKNOWN_LINUX_MUSL x86_64-linux-musl/);
   assert.match(zigLinkerScript, /write_cc AARCH64_UNKNOWN_LINUX_MUSL aarch64-linux-musl/);
 });

--- a/tests/tooling/github-zig-musl-linkers.test.ts
+++ b/tests/tooling/github-zig-musl-linkers.test.ts
@@ -20,7 +20,7 @@ function parseGithubEnv(envFile: string): Record<string, string> {
   );
 }
 
-test("Zig musl wrappers normalize cc-rs flags and avoid duplicate CRT startup objects", () => {
+test("Zig musl wrappers use rust-lld for final links and normalize cc-rs flags", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-zig-musl-linkers-"));
   const binDir = path.join(tempDir, "bin");
   const envFile = path.join(tempDir, "github-env");
@@ -38,7 +38,7 @@ test("Zig musl wrappers normalize cc-rs flags and avoid duplicate CRT startup ob
     });
 
     const githubEnv = parseGithubEnv(envFile);
-    const runWrapper = (envName: string, args: string[]) => {
+    const runCcWrapper = (envName: string, args: string[]) => {
       const logPath = path.join(tempDir, `${envName}.log`);
       execFileSync(githubEnv[envName], args, {
         env: { ...process.env, PATH: pathEnv, ZIG_ARGS_LOG: logPath },
@@ -46,12 +46,10 @@ test("Zig musl wrappers normalize cc-rs flags and avoid duplicate CRT startup ob
       return fs.readFileSync(logPath, "utf8").trim().split("\n");
     };
 
-    assert.notEqual(
-      githubEnv.CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER,
-      githubEnv.CC_x86_64_unknown_linux_musl,
-    );
+    assert.equal(githubEnv.CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER, "rust-lld");
+    assert.equal(githubEnv.CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER, "rust-lld");
     assert.deepEqual(
-      runWrapper("CC_x86_64_unknown_linux_musl", [
+      runCcWrapper("CC_x86_64_unknown_linux_musl", [
         "--target=x86_64-unknown-linux-musl",
         "-O3",
         "-c",
@@ -60,32 +58,12 @@ test("Zig musl wrappers normalize cc-rs flags and avoid duplicate CRT startup ob
       ["cc", "-target", "x86_64-linux-musl", "-O3", "-c", "static.c"],
     );
     assert.deepEqual(
-      runWrapper("CC_aarch64_unknown_linux_musl", [
+      runCcWrapper("CC_aarch64_unknown_linux_musl", [
         "--target",
         "aarch64-unknown-linux-musl",
         "-DMI_DEBUG=0",
       ]),
       ["cc", "-target", "aarch64-linux-musl", "-DMI_DEBUG=0"],
-    );
-    assert.deepEqual(
-      runWrapper("CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER", [
-        "-m64",
-        "--target=x86_64-unknown-linux-musl",
-        "rcrt1.o",
-        "-nostartfiles",
-        "-static-pie",
-      ]),
-      [
-        "cc",
-        "-target",
-        "x86_64-linux-musl",
-        "-m64",
-        "rcrt1.o",
-        "-nostartfiles",
-        "-static-pie",
-        "-nostdlib",
-        "-nostartfiles",
-      ],
     );
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });

--- a/tools/github/configure-zig-musl-linkers.sh
+++ b/tools/github/configure-zig-musl-linkers.sh
@@ -8,10 +8,9 @@ mkdir -p "$linker_dir"
 printf '#!/usr/bin/env bash\nexec zig ar "$@"\n' > "$zig_ar"
 chmod +x "$zig_ar"
 
-write_zig_wrapper() {
+write_zig_cc_wrapper() {
   local output="$1"
   local zig_target="$2"
-  local mode="$3"
 
   {
     printf '#!/usr/bin/env bash\n'
@@ -34,11 +33,7 @@ write_zig_wrapper() {
     printf '      ;;\n'
     printf '  esac\n'
     printf 'done\n'
-    if [[ "$mode" == "link" ]]; then
-      printf 'exec zig cc -target %s "${args[@]}" -nostdlib -nostartfiles\n' "$zig_target"
-    else
-      printf 'exec zig cc -target %s "${args[@]}"\n' "$zig_target"
-    fi
+    printf 'exec zig cc -target %s "${args[@]}"\n' "$zig_target"
   } > "$output"
   chmod +x "$output"
 }
@@ -47,15 +42,13 @@ write_cc() {
   local rust_target="$1"
   local zig_target="$2"
   local cc="$linker_dir/zig-cc-$zig_target"
-  local linker="$linker_dir/zig-link-$zig_target"
   local env_target
 
   env_target="$(tr '[:upper:]' '[:lower:]' <<< "$rust_target")"
-  write_zig_wrapper "$cc" "$zig_target" "compile"
-  write_zig_wrapper "$linker" "$zig_target" "link"
+  write_zig_cc_wrapper "$cc" "$zig_target"
 
   {
-    printf 'CARGO_TARGET_%s_LINKER=%s\n' "$rust_target" "$linker"
+    printf 'CARGO_TARGET_%s_LINKER=rust-lld\n' "$rust_target"
     printf 'CC_%s=%s\n' "$env_target" "$cc"
     printf 'AR_%s=%s\n' "$env_target" "$zig_ar"
   } >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- use Rust's bundled `rust-lld` for final Linux musl CLI links
- keep Zig only for musl C compilation and archive tooling
- skip Wild linker setup for musl CLI jobs so `--ld-path` is not passed to `rust-lld`

## Verification
- `bash -n tools/github/configure-zig-musl-linkers.sh`
- `node --test tests/tooling/github-zig-musl-linkers.test.ts tests/tooling/github-workflows-release-build.test.ts tests/tooling/github-workflows.test.ts`
- `vp check --fix tests/tooling/github-zig-musl-linkers.test.ts tests/tooling/github-workflows-release-build.test.ts`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`
- local `rustc` smoke links with `-C linker=rust-lld` for `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`

Follow-up for failed Release run https://github.com/ubugeeei-prod/vize/actions/runs/28676150445.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785693823&installation_id=136613492&pr_number=2556&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2556&signature=dda58748db065bb8d74059e636dc44f63c2f33a5c76ad7b52d05b61ebe1437f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Linux build workflows now skip the “Wild linker” setup for musl targets, preventing the wrong linker configuration from being applied.
  * MUSL builds now consistently use `rust-lld` for Rust linking, improving linker behavior and reducing build mismatches.
  * Updated CI checks to validate the new Linux non-musl and MUSL linker setup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->