### PR TITLE
fix(release): verify musl cli linkage

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,11 +6,12 @@ chat:
   auto_reply: true
 
 reviews:
-  profile: chill
+  profile: assertive
   high_level_summary: true
   changed_files_summary: true
   review_status: true
-  request_changes_workflow: false
+  review_details: true
+  request_changes_workflow: true
   poem: false
 
   auto_review:
@@ -47,7 +48,7 @@ reviews:
 
     - path: ".github/workflows/**"
       instructions: |
-        Review release and CI changes for runner compatibility, least-privilege permissions, pinned actions, cache correctness, and whether workflow-shape tests cover the changed behavior.
+        Review release and CI changes for runner compatibility, least-privilege permissions, pinned actions, cache correctness, artifact/linkage verification, and whether workflow-shape tests cover the changed behavior.
 
     - path: "tests/tooling/**"
       instructions: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Create archive (Unix)
         if: runner.os != 'Windows'
         shell: bash
-        run: moon run --target native - -- ${{ matrix.settings.target }} ${{ matrix.settings.archive }} vize < tools/moon/scripts/github/create_cli_archive.mbtx
+        run: if [[ "${{ matrix.settings.target }}" == *-musl ]]; then bash tools/github/verify-musl-cli-binary.sh "${{ matrix.settings.target }}"; fi; moon run --target native - -- ${{ matrix.settings.target }} ${{ matrix.settings.archive }} vize < tools/moon/scripts/github/create_cli_archive.mbtx
 
       - name: Create archive (Windows)
         if: runner.os == 'Windows'

--- a/tests/tooling/github-workflows-release-build.test.ts
+++ b/tests/tooling/github-workflows-release-build.test.ts
@@ -242,6 +242,26 @@ test("release workflow tunes Windows production Rust builds for cold runners", (
   );
 });
 
+test("release workflow inspects musl CLI binaries while archiving", () => {
+  const workflow = readRepoFile(".github", "workflows", "release.yml");
+  const buildCliJob = workflowJobBody(workflow, "build-cli");
+  const verifier = readRepoFile("tools", "github", "verify-musl-cli-binary.sh");
+
+  const buildIndex = buildCliJob.indexOf("name: Build CLI");
+  const archiveIndex = buildCliJob.indexOf("name: Create archive (Unix)");
+
+  assert.notEqual(buildIndex, -1);
+  assert.notEqual(archiveIndex, -1);
+  assert.ok(buildIndex < archiveIndex, "the musl binary check must inspect the built CLI binary");
+  assert.match(
+    buildCliJob,
+    /Create archive \(Unix\)[\s\S]*if \[\[ "\$\{\{ matrix\.settings\.target \}\}" == \*-musl \]\]; then bash tools\/github\/verify-musl-cli-binary\.sh/,
+  );
+  assert.match(buildCliJob, /verify-musl-cli-binary\.sh[\s\S]*create_cli_archive\.mbtx/);
+  assert.match(verifier, /readelf -l "\$binary"[\s\S]*Requesting program interpreter/);
+  assert.match(verifier, /strings "\$binary" \| grep -Eq 'GLIBC_\[0-9\]'/);
+});
+
 test("release workflow runs GitHub helper scripts with the native target on every runner", () => {
   const workflow = readRepoFile(".github", "workflows", "release.yml");
 

--- a/tests/tooling/github-zig-musl-linkers.test.ts
+++ b/tests/tooling/github-zig-musl-linkers.test.ts
@@ -69,3 +69,64 @@ test("Zig musl wrappers use rust-lld for final links and normalize cc-rs flags",
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
+
+test("musl CLI verifier rejects dynamic interpreters and glibc symbol requirements", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-musl-verifier-"));
+  const binDir = path.join(tempDir, "bin");
+  const target = "x86_64-unknown-linux-musl";
+  const binary = path.join(tempDir, "target", target, "release", "vize");
+  const scriptPath = path.join(root, "tools", "github", "verify-musl-cli-binary.sh");
+
+  try {
+    fs.mkdirSync(path.dirname(binary), { recursive: true });
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(binary, "");
+    fs.writeFileSync(
+      path.join(binDir, "file"),
+      "#!/usr/bin/env bash\nprintf 'ELF static-pie\\n'\n",
+    );
+    fs.writeFileSync(
+      path.join(binDir, "readelf"),
+      [
+        "#!/usr/bin/env bash",
+        'if [[ "${VERIFY_MODE:-ok}" == "interpreter" ]]; then',
+        "  printf '[Requesting program interpreter: /lib64/ld-linux-x86-64.so.2]\\n'",
+        "else",
+        "  printf 'Program Headers:\\n'",
+        "fi",
+        "",
+      ].join("\n"),
+    );
+    fs.writeFileSync(
+      path.join(binDir, "strings"),
+      [
+        "#!/usr/bin/env bash",
+        'if [[ "${VERIFY_MODE:-ok}" == "glibc" ]]; then',
+        "  printf 'GLIBC_2.39\\n'",
+        "else",
+        "  printf 'musl\\n'",
+        "fi",
+        "",
+      ].join("\n"),
+    );
+    for (const command of ["file", "readelf", "strings"]) {
+      fs.chmodSync(path.join(binDir, command), 0o755);
+    }
+
+    const runVerifier = (mode: string) =>
+      execFileSync("bash", [scriptPath, target], {
+        cwd: tempDir,
+        env: {
+          ...process.env,
+          PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+          VERIFY_MODE: mode,
+        },
+      });
+
+    runVerifier("ok");
+    assert.throws(() => runVerifier("interpreter"));
+    assert.throws(() => runVerifier("glibc"));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/repo-governance.test.ts
+++ b/tests/tooling/repo-governance.test.ts
@@ -46,6 +46,16 @@ test("root quality gates ignore local generated environments", () => {
   }
 });
 
+test("CodeRabbit reviews run in strict mode with actionable workflow context", () => {
+  const coderabbit = readRepoFile(".coderabbit.yaml");
+
+  assert.match(coderabbit, /^  profile:\s*assertive$/m);
+  assert.match(coderabbit, /^  request_changes_workflow:\s*true$/m);
+  assert.match(coderabbit, /^  review_details:\s*true$/m);
+  assert.match(coderabbit, /artifact\/linkage verification/);
+  assert.match(coderabbit, /workflow-shape tests cover the changed behavior/);
+});
+
 test("socket.dev configuration scopes dependency and workflow scans", () => {
   const socket = readRepoFile("socket.yml");
 

--- a/tools/github/verify-musl-cli-binary.sh
+++ b/tools/github/verify-musl-cli-binary.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target="${1:?Usage: verify-musl-cli-binary.sh <rust-target>}"
+binary="target/$target/release/vize"
+
+file "$binary"
+
+if readelf -l "$binary" | grep -q 'Requesting program interpreter'; then
+  echo "::error ::musl CLI binary has a dynamic interpreter"
+  readelf -l "$binary"
+  exit 1
+fi
+
+if strings "$binary" | grep -Eq 'GLIBC_[0-9]'; then
+  echo "::error ::musl CLI binary contains glibc version requirements"
+  strings "$binary" | grep -E 'GLIBC_[0-9]' | sort -u
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add a release helper that rejects musl CLI binaries with a dynamic interpreter or GLIBC version requirements
- run that helper before archiving Linux musl CLI artifacts
- make CodeRabbit reviews stricter and keep governance tests covering the stricter settings

## Verification
- node --test tests/tooling/github-zig-musl-linkers.test.ts tests/tooling/github-workflows-release-build.test.ts tests/tooling/repo-governance.test.ts
- node --test tests/tooling/github-workflows.test.ts tests/tooling/github-workflows-release-build.test.ts tests/tooling/repo-governance.test.ts tests/tooling/release-platforms.test.ts tests/tooling/release-readiness.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- vp check --fix tests/tooling/github-zig-musl-linkers.test.ts tests/tooling/github-workflows-release-build.test.ts tests/tooling/repo-governance.test.ts
- bash -n tools/github/configure-zig-musl-linkers.sh tools/github/verify-musl-cli-binary.sh && git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785696515&installation_id=136613492&pr_number=2557&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2557&signature=dae5f05b0ae39541a5ae5c77f9fa37e94d519a25f3711ae44229140151fb72c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter review and workflow checks for repository automation.
  * Linux musl release builds now include an extra binary verification step during packaging.

* **Bug Fixes**
  * Improved release packaging to catch binaries with dynamic interpreter links or unwanted GLIBC references before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->