### PR TITLE
fix(lsp): improve native html template navigation

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -7,6 +7,10 @@ mod canonical;
 #[cfg(all(test, feature = "native"))]
 mod canonical_tests;
 #[cfg(feature = "native")]
+mod html_attribute;
+#[cfg(all(test, feature = "native"))]
+mod html_attribute_tests;
+#[cfg(feature = "native")]
 mod html_tag;
 #[cfg(feature = "native")]
 mod virtual_mirror;
@@ -16,6 +20,10 @@ mod workspace_edit;
 pub(crate) use canonical::{
     canonical_source_offset_to_position, map_canonical_corsa_locations, map_canonical_lsp_range,
     open_canonical_virtual_document,
+};
+#[cfg(feature = "native")]
+pub(crate) use html_attribute::{
+    html_attribute_request_path, html_attribute_virtual_document, native_dom_attribute_info,
 };
 #[cfg(feature = "native")]
 pub(crate) use html_tag::{html_tag_request_path, html_tag_virtual_document, native_dom_tag_info};

--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
@@ -1,0 +1,302 @@
+use tower_lsp::lsp_types::Url;
+use vize_carton::{String, cstr};
+
+use super::html_tag::native_dom_tag_info;
+
+pub(crate) struct NativeDomAttributeInfo {
+    pub(crate) category: &'static str,
+    pub(crate) property_name: String,
+    pub(crate) type_expression: String,
+    pub(crate) documentation_url: String,
+    pub(crate) is_boolean: bool,
+}
+
+pub(crate) struct HtmlAttributeVirtualDocument {
+    pub(crate) content: String,
+    pub(crate) hover_offset: usize,
+    pub(crate) definition_offset: usize,
+}
+
+pub(crate) fn html_attribute_request_path(uri: &Url) -> String {
+    cstr!("{}.html_attr.ts", uri.path())
+}
+
+pub(crate) fn html_attribute_virtual_document(
+    tag_name: &str,
+    attr_name: &str,
+) -> Option<HtmlAttributeVirtualDocument> {
+    let info = native_dom_attribute_info(tag_name, attr_name)?;
+    let tag_info = native_dom_tag_info(tag_name)?;
+    let element_type = tag_info.type_expression.as_str();
+    let property_name = info.property_name.as_str();
+    let content = cstr!(
+        "/// <reference lib=\"es2022\" />\n\
+         /// <reference lib=\"dom\" />\n\
+         /// <reference lib=\"dom.iterable\" />\n\
+         type __VizeDomElement = {element_type};\n\
+         declare const __vizeDomElement: __VizeDomElement;\n\
+         __vizeDomElement.{property_name};\n"
+    );
+    let property_offset = content.rfind(property_name)? + (property_name.len() / 2);
+
+    Some(HtmlAttributeVirtualDocument {
+        content,
+        hover_offset: property_offset,
+        definition_offset: property_offset,
+    })
+}
+
+pub(crate) fn native_dom_attribute_info(
+    tag_name: &str,
+    attr_name: &str,
+) -> Option<NativeDomAttributeInfo> {
+    if crate::ide::is_component_tag(tag_name) {
+        return None;
+    }
+
+    let tag_info = native_dom_tag_info(tag_name)?;
+    let normalized_attr = normalize_attribute_name(attr_name)?;
+    let property_name = dom_attribute_property_name(tag_name, &normalized_attr)?;
+    let is_boolean = vize_carton::is_boolean_attr(&normalized_attr);
+    let category = if vize_carton::is_html_tag(tag_name) {
+        "HTML attribute"
+    } else if vize_carton::is_svg_tag(tag_name) {
+        "SVG attribute"
+    } else {
+        "MathML attribute"
+    };
+    let documentation_url = if let Some(aria_name) = normalized_attr.strip_prefix("aria-") {
+        cstr!(
+            "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-{aria_name}"
+        )
+    } else if normalized_attr.starts_with("data-") {
+        String::from(
+            "https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes",
+        )
+    } else {
+        cstr!(
+            "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/{normalized_attr}"
+        )
+    };
+    let type_expression = cstr!(
+        "{}[\"{}\"]",
+        tag_info.type_expression.as_str(),
+        property_name.as_str()
+    );
+
+    Some(NativeDomAttributeInfo {
+        category,
+        property_name,
+        type_expression,
+        documentation_url,
+        is_boolean,
+    })
+}
+
+fn normalize_attribute_name(attr_name: &str) -> Option<String> {
+    let attr_name = attr_name.trim();
+    if attr_name.is_empty()
+        || attr_name.starts_with('@')
+        || attr_name.starts_with('#')
+        || attr_name.starts_with('[')
+    {
+        return None;
+    }
+
+    let attr_name = attr_name
+        .strip_prefix(':')
+        .or_else(|| attr_name.strip_prefix("v-bind:"))
+        .unwrap_or(attr_name);
+    if attr_name.starts_with("v-") {
+        return None;
+    }
+
+    let attr_name = attr_name
+        .split_once('.')
+        .map_or(attr_name, |(name, _)| name)
+        .trim();
+    if attr_name.is_empty() || attr_name.contains(':') {
+        return None;
+    }
+
+    Some(attr_name.to_ascii_lowercase().into())
+}
+
+fn dom_attribute_property_name(tag_name: &str, attr_name: &str) -> Option<String> {
+    if let Some(data_name) = attr_name.strip_prefix("data-")
+        && data_name
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        return Some(String::from("dataset"));
+    }
+
+    if let Some(aria_name) = attr_name.strip_prefix("aria-") {
+        return Some(cstr!("aria{}", kebab_to_pascal(aria_name)));
+    }
+
+    if let Some(mapped) = mapped_dom_attribute_property(attr_name)
+        && is_known_native_attribute_for_tag(tag_name, attr_name)
+    {
+        return Some(String::from(mapped));
+    }
+
+    if is_known_native_attribute_for_tag(tag_name, attr_name) {
+        return Some(kebab_to_camel(attr_name));
+    }
+
+    None
+}
+
+fn mapped_dom_attribute_property(attr_name: &str) -> Option<&'static str> {
+    match attr_name {
+        "accept-charset" => Some("acceptCharset"),
+        "allowfullscreen" => Some("allowFullscreen"),
+        "class" => Some("className"),
+        "colspan" => Some("colSpan"),
+        "contenteditable" => Some("contentEditable"),
+        "crossorigin" => Some("crossOrigin"),
+        "datetime" => Some("dateTime"),
+        "enterkeyhint" => Some("enterKeyHint"),
+        "for" => Some("htmlFor"),
+        "formaction" => Some("formAction"),
+        "formenctype" => Some("formEnctype"),
+        "formmethod" => Some("formMethod"),
+        "formnovalidate" => Some("formNoValidate"),
+        "formtarget" => Some("formTarget"),
+        "http-equiv" => Some("httpEquiv"),
+        "inputmode" => Some("inputMode"),
+        "ismap" => Some("isMap"),
+        "maxlength" => Some("maxLength"),
+        "minlength" => Some("minLength"),
+        "nomodule" => Some("noModule"),
+        "novalidate" => Some("noValidate"),
+        "playsinline" => Some("playsInline"),
+        "readonly" => Some("readOnly"),
+        "referrerpolicy" => Some("referrerPolicy"),
+        "rowspan" => Some("rowSpan"),
+        "tabindex" => Some("tabIndex"),
+        "usemap" => Some("useMap"),
+        _ => None,
+    }
+}
+
+fn is_known_native_attribute_for_tag(tag_name: &str, attr_name: &str) -> bool {
+    is_global_native_attribute(attr_name)
+        || vize_carton::is_html_tag(tag_name)
+            && HTML_TAG_ATTRIBUTES
+                .iter()
+                .any(|(tag, attrs)| *tag == tag_name && attrs.contains(&attr_name))
+}
+
+#[rustfmt::skip]
+const GLOBAL_ATTRIBUTES: &[&str] = &[
+    "accesskey",
+    "autocapitalize",
+    "autofocus",
+    "class",
+    "contenteditable",
+    "dir",
+    "draggable",
+    "enterkeyhint",
+    "hidden",
+    "id",
+    "inert",
+    "inputmode",
+    "is",
+    "itemid",
+    "itemprop",
+    "itemref",
+    "itemscope",
+    "itemtype",
+    "lang",
+    "nonce",
+    "popover",
+    "role",
+    "slot",
+    "spellcheck",
+    "style",
+    "tabindex",
+    "title",
+    "translate",
+];
+
+#[rustfmt::skip]
+const HTML_TAG_ATTRIBUTES: &[(&str, &[&str])] = &[
+    ("a", &["download", "href", "hreflang", "ping", "referrerpolicy", "rel", "target"]),
+    ("area", &["download", "href", "hreflang", "ping", "referrerpolicy", "rel", "target"]),
+    ("audio", &["autoplay", "controls", "crossorigin", "loop", "muted", "preload", "src"]),
+    ("base", &["href", "target"]),
+    ("blockquote", &["cite"]),
+    ("button", &["disabled", "form", "formaction", "formenctype", "formmethod", "formnovalidate", "formtarget", "name", "type", "value"]),
+    ("canvas", &["height", "width"]),
+    ("col", &["span"]),
+    ("colgroup", &["span"]),
+    ("data", &["value"]),
+    ("del", &["cite", "datetime"]),
+    ("details", &["open"]),
+    ("dialog", &["open"]),
+    ("embed", &["height", "src", "type", "width"]),
+    ("fieldset", &["disabled", "form", "name"]),
+    ("form", &["accept-charset", "action", "autocomplete", "enctype", "method", "name", "novalidate", "rel", "target"]),
+    ("iframe", &["allow", "allowfullscreen", "height", "loading", "name", "referrerpolicy", "sandbox", "src", "srcdoc", "width"]),
+    ("img", &["alt", "crossorigin", "decoding", "fetchpriority", "height", "ismap", "loading", "referrerpolicy", "sizes", "src", "srcset", "usemap", "width"]),
+    ("input", &["accept", "alt", "autocomplete", "capture", "checked", "dirname", "disabled", "form", "formaction", "formenctype", "formmethod", "formnovalidate", "formtarget", "height", "list", "max", "maxlength", "min", "minlength", "multiple", "name", "pattern", "placeholder", "readonly", "required", "size", "src", "step", "type", "value", "width"]),
+    ("ins", &["cite", "datetime"]),
+    ("label", &["for", "form"]),
+    ("li", &["value"]),
+    ("link", &["as", "crossorigin", "disabled", "fetchpriority", "href", "hreflang", "integrity", "media", "referrerpolicy", "rel", "sizes", "type"]),
+    ("map", &["name"]),
+    ("meta", &["charset", "content", "http-equiv", "name"]),
+    ("meter", &["high", "low", "max", "min", "optimum", "value"]),
+    ("object", &["data", "form", "height", "name", "type", "usemap", "width"]),
+    ("ol", &["reversed", "start", "type"]),
+    ("optgroup", &["disabled", "label"]),
+    ("option", &["disabled", "label", "selected", "value"]),
+    ("output", &["for", "form", "name"]),
+    ("param", &["name", "value"]),
+    ("progress", &["max", "value"]),
+    ("q", &["cite"]),
+    ("script", &["async", "crossorigin", "defer", "integrity", "nomodule", "referrerpolicy", "src", "type"]),
+    ("select", &["autocomplete", "disabled", "form", "multiple", "name", "required", "size"]),
+    ("source", &["height", "media", "sizes", "src", "srcset", "type", "width"]),
+    ("style", &["media"]),
+    ("td", &["colspan", "headers", "rowspan"]),
+    ("th", &["abbr", "colspan", "headers", "rowspan", "scope"]),
+    ("textarea", &["autocomplete", "cols", "dirname", "disabled", "form", "maxlength", "minlength", "name", "placeholder", "readonly", "required", "rows", "wrap"]),
+    ("time", &["datetime"]),
+    ("track", &["default", "kind", "label", "src", "srclang"]),
+    ("video", &["autoplay", "controls", "crossorigin", "height", "loop", "muted", "playsinline", "poster", "preload", "src", "width"]),
+];
+
+fn is_global_native_attribute(attr_name: &str) -> bool {
+    GLOBAL_ATTRIBUTES.contains(&attr_name)
+}
+
+fn kebab_to_camel(value: &str) -> String {
+    let mut result = String::with_capacity(value.len());
+    let mut uppercase_next = false;
+    for ch in value.chars() {
+        if ch == '-' {
+            uppercase_next = true;
+        } else if uppercase_next {
+            result.push(ch.to_ascii_uppercase());
+            uppercase_next = false;
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}
+
+fn kebab_to_pascal(value: &str) -> String {
+    let camel = kebab_to_camel(value);
+    let mut chars = camel.chars();
+    let Some(first) = chars.next() else {
+        return String::from("");
+    };
+    let mut result = String::with_capacity(camel.len());
+    result.push(first.to_ascii_uppercase());
+    result.extend(chars);
+    result
+}

--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
@@ -1,0 +1,40 @@
+use super::html_attribute::{html_attribute_virtual_document, native_dom_attribute_info};
+
+#[test]
+fn native_dom_attribute_info_maps_html_attributes_to_dom_properties() {
+    let disabled = native_dom_attribute_info("button", "disabled").expect("disabled attr");
+    assert_eq!(disabled.property_name.as_str(), "disabled");
+    assert_eq!(disabled.category, "HTML attribute");
+    assert!(disabled.is_boolean);
+    assert_eq!(
+        disabled.type_expression.as_str(),
+        "HTMLElementTagNameMap[\"button\"][\"disabled\"]"
+    );
+
+    let class_attr = native_dom_attribute_info("div", "class").expect("class attr");
+    assert_eq!(class_attr.property_name.as_str(), "className");
+    let bound = native_dom_attribute_info("button", "v-bind:disabled").expect("v-bind attr");
+    assert_eq!(bound.property_name.as_str(), "disabled");
+    let aria = native_dom_attribute_info("button", "aria-label").expect("aria-label attr");
+    assert_eq!(aria.property_name.as_str(), "ariaLabel");
+    let data = native_dom_attribute_info("div", "data-test-id").expect("data attribute");
+    assert_eq!(data.property_name.as_str(), "dataset");
+}
+
+#[test]
+fn native_dom_attribute_info_rejects_unknown_and_component_attributes() {
+    assert!(native_dom_attribute_info("button", "not-real").is_none());
+    assert!(native_dom_attribute_info("div", "href").is_none());
+    assert!(native_dom_attribute_info("my-element", "disabled").is_none());
+    assert!(native_dom_attribute_info("button", "@click").is_none());
+}
+
+#[test]
+fn html_attribute_virtual_document_queries_dom_property() {
+    let doc = html_attribute_virtual_document("button", "disabled").expect("disabled attr doc");
+    assert!(doc.content.contains("__vizeDomElement.disabled"));
+    let property_start = doc.content.rfind("disabled").expect("disabled property");
+    assert!(doc.hover_offset >= property_start);
+    assert!(doc.hover_offset < property_start + "disabled".len());
+    assert_eq!(doc.hover_offset, doc.definition_offset);
+}

--- a/crates/vize_maestro/src/ide/definition.rs
+++ b/crates/vize_maestro/src/ide/definition.rs
@@ -1,14 +1,13 @@
 //! Definition provider for Vue SFC files.
 //!
-//! Provides go-to-definition for:
-//! - Template expressions -> script bindings
-//! - Component usages -> component definitions
-//! - Import statements -> imported files
-//! - Real definitions from Corsa (when available)
+//! Provides go-to-definition for template bindings, components, imports, and Corsa.
 pub mod bindings;
 #[cfg(all(test, feature = "native"))]
 mod corsa_tests;
 pub(crate) mod helpers;
+mod html;
+#[cfg(all(test, feature = "native"))]
+mod html_tests;
 mod inline_art;
 pub(crate) mod script;
 mod service;

--- a/crates/vize_maestro/src/ide/definition/helpers.rs
+++ b/crates/vize_maestro/src/ide/definition/helpers.rs
@@ -1,7 +1,4 @@
 //! Helper utilities for the definition service.
-//!
-//! Provides word extraction, position conversion, import resolution,
-//! and attribute inspection helpers.
 #![allow(
     clippy::disallowed_types,
     clippy::disallowed_methods,
@@ -158,6 +155,9 @@ fn find_tag_name_span(content: &str, offset: usize) -> Option<(usize, usize, usi
     let mut cursor = offset.min(bytes.len());
     if cursor == bytes.len() {
         cursor = cursor.saturating_sub(1);
+    }
+    if cursor > 0 && bytes.get(cursor) == Some(&b'>') {
+        cursor -= 1;
     }
 
     let mut tag_start = None;

--- a/crates/vize_maestro/src/ide/definition/html.rs
+++ b/crates/vize_maestro/src/ide/definition/html.rs
@@ -1,0 +1,180 @@
+//! Native HTML/SVG/MathML definition helpers.
+#![allow(clippy::disallowed_types, clippy::disallowed_methods)]
+
+#[cfg(feature = "native")]
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::GotoDefinitionResponse;
+#[cfg(feature = "native")]
+use tower_lsp::lsp_types::{Location, Position, Range};
+
+#[cfg(feature = "native")]
+use vize_canon::CorsaBridge;
+
+#[cfg(feature = "native")]
+use super::helpers;
+use super::{DefinitionService, IdeContext, template};
+#[cfg(feature = "native")]
+use crate::ide::corsa_support;
+#[cfg(feature = "native")]
+use crate::ide::is_component_tag;
+
+impl DefinitionService {
+    pub(super) fn definition_in_template_sync(
+        ctx: &IdeContext<'_>,
+    ) -> Option<GotoDefinitionResponse> {
+        #[cfg(feature = "native")]
+        if let Some(definition) = Self::definition_for_native_html_tag(ctx) {
+            return Some(definition);
+        }
+
+        if let Some(definition) = template::find_component_prop_definition(ctx) {
+            return Some(definition);
+        }
+
+        #[cfg(feature = "native")]
+        if let Some(definition) = Self::definition_for_native_html_attribute(ctx) {
+            return Some(definition);
+        }
+
+        template::definition_in_template(ctx)
+    }
+
+    #[cfg(feature = "native")]
+    fn definition_for_native_html_tag(ctx: &IdeContext<'_>) -> Option<GotoDefinitionResponse> {
+        let tag_name = helpers::get_tag_at_offset(&ctx.content, ctx.offset)?;
+        if is_component_tag(&tag_name) {
+            return None;
+        }
+
+        let info = corsa_support::native_dom_tag_info(&tag_name)?;
+        external_uri_response(&info.documentation_url)
+    }
+
+    #[cfg(feature = "native")]
+    fn definition_for_native_html_attribute(
+        ctx: &IdeContext<'_>,
+    ) -> Option<GotoDefinitionResponse> {
+        let (attr_name, tag_name) = helpers::get_attribute_and_component_at_offset(ctx)?;
+        if is_component_tag(&tag_name) {
+            return None;
+        }
+
+        let info = corsa_support::native_dom_attribute_info(&tag_name, &attr_name)?;
+        external_uri_response(&info.documentation_url)
+    }
+
+    #[cfg(feature = "native")]
+    pub(super) async fn definition_for_html_tag_with_corsa(
+        ctx: &IdeContext<'_>,
+        corsa_bridge: Option<&Arc<CorsaBridge>>,
+    ) -> Option<GotoDefinitionResponse> {
+        let tag_name = helpers::get_tag_at_offset(&ctx.content, ctx.offset)?;
+        if is_component_tag(&tag_name) {
+            return None;
+        }
+
+        let bridge = corsa_bridge?;
+        if !bridge.is_initialized() {
+            return None;
+        }
+
+        let doc = corsa_support::html_tag_virtual_document(&tag_name)?;
+        let request_path = corsa_support::html_tag_request_path(ctx.uri);
+        let request_uri = bridge
+            .open_or_update_virtual_document(&request_path, &doc.content)
+            .await
+            .ok()?;
+        let (line, character) = crate::ide::offset_to_position(&doc.content, doc.definition_offset);
+        let locations = bridge
+            .definition(&request_uri, line, character)
+            .await
+            .ok()?;
+
+        external_lsp_locations_response(locations, &request_uri)
+    }
+
+    #[cfg(feature = "native")]
+    pub(super) async fn definition_for_html_attribute_with_corsa(
+        ctx: &IdeContext<'_>,
+        corsa_bridge: Option<&Arc<CorsaBridge>>,
+    ) -> Option<GotoDefinitionResponse> {
+        let (attr_name, tag_name) = helpers::get_attribute_and_component_at_offset(ctx)?;
+        if is_component_tag(&tag_name) {
+            return None;
+        }
+
+        let bridge = corsa_bridge?;
+        if !bridge.is_initialized() {
+            return None;
+        }
+
+        let doc = corsa_support::html_attribute_virtual_document(&tag_name, &attr_name)?;
+        let request_path = corsa_support::html_attribute_request_path(ctx.uri);
+        let request_uri = bridge
+            .open_or_update_virtual_document(&request_path, &doc.content)
+            .await
+            .ok()?;
+        let (line, character) = crate::ide::offset_to_position(&doc.content, doc.definition_offset);
+        let locations = bridge
+            .definition(&request_uri, line, character)
+            .await
+            .ok()?;
+
+        external_lsp_locations_response(locations, &request_uri)
+    }
+}
+
+#[cfg(feature = "native")]
+fn external_uri_response(uri: &str) -> Option<GotoDefinitionResponse> {
+    Some(GotoDefinitionResponse::Scalar(Location {
+        uri: tower_lsp::lsp_types::Url::parse(uri).ok()?,
+        range: Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 0,
+                character: 0,
+            },
+        },
+    }))
+}
+
+#[cfg(feature = "native")]
+fn external_lsp_locations_response(
+    locations: Vec<vize_canon::LspLocation>,
+    synthetic_request_uri: &str,
+) -> Option<GotoDefinitionResponse> {
+    let locations = locations
+        .into_iter()
+        .filter(|location| location.uri != synthetic_request_uri)
+        .filter_map(|location| {
+            Some(Location {
+                uri: tower_lsp::lsp_types::Url::parse(&location.uri).ok()?,
+                range: Range {
+                    start: Position {
+                        line: location.range.start.line,
+                        character: location.range.start.character,
+                    },
+                    end: Position {
+                        line: location.range.end.line,
+                        character: location.range.end.character,
+                    },
+                },
+            })
+        })
+        .collect();
+
+    locations_response(locations)
+}
+
+#[cfg(feature = "native")]
+fn locations_response(locations: Vec<Location>) -> Option<GotoDefinitionResponse> {
+    match locations.as_slice() {
+        [] => None,
+        [location] => Some(GotoDefinitionResponse::Scalar(location.clone())),
+        _ => Some(GotoDefinitionResponse::Array(locations)),
+    }
+}

--- a/crates/vize_maestro/src/ide/definition/html_tests.rs
+++ b/crates/vize_maestro/src/ide/definition/html_tests.rs
@@ -1,0 +1,96 @@
+use std::fs;
+
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Url};
+
+use super::{DefinitionService, helpers};
+use crate::{ide::IdeContext, server::ServerState};
+
+#[test]
+fn static_boolean_attribute_is_detected_at_identifier_end_boundary() {
+    let dir = tempfile::tempdir().unwrap();
+    let source_path = dir.path().join("Static.vue");
+    let source = r#"<template><button disabled></button></template>"#;
+    fs::write(&source_path, source).unwrap();
+
+    let uri = Url::from_file_path(&source_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    let offset = source.find("disabled").unwrap() + "disabled".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+
+    assert_eq!(
+        helpers::get_attribute_and_component_at_offset(&ctx),
+        Some(("disabled".to_string(), "button".to_string()))
+    );
+}
+
+#[test]
+fn definition_resolves_native_html_tag_to_mdn_reference() {
+    let (state, uri, source) = open_source(
+        "NativeTag.vue",
+        r#"<template>
+  <button disabled>Save</button>
+</template>
+"#,
+    );
+
+    let offset = source.find("button").unwrap() + "button".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let location = scalar_location(DefinitionService::definition(&ctx).unwrap());
+
+    assert_eq!(
+        location.uri.as_str(),
+        "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button"
+    );
+}
+
+#[test]
+fn definition_resolves_native_html_attribute_to_mdn_reference() {
+    let (state, uri, source) = open_source(
+        "NativeAttribute.vue",
+        r#"<template>
+  <button disabled>Save</button>
+</template>
+"#,
+    );
+
+    let offset = source.find("disabled").unwrap() + "disabled".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let location = scalar_location(DefinitionService::definition(&ctx).unwrap());
+
+    assert_eq!(
+        location.uri.as_str(),
+        "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/disabled"
+    );
+}
+
+fn open_source(filename: &str, source: &str) -> (ServerState, Url, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let dir_path = Box::leak(Box::new(dir)).path();
+    let source_path = dir_path.join(filename);
+    fs::write(&source_path, source).unwrap();
+
+    let uri = Url::from_file_path(&source_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    (state, uri, source.to_string())
+}
+
+fn scalar_location(response: GotoDefinitionResponse) -> Location {
+    match response {
+        GotoDefinitionResponse::Scalar(location) => location,
+        GotoDefinitionResponse::Array(mut locations) => {
+            assert_eq!(locations.len(), 1);
+            locations.remove(0)
+        }
+        GotoDefinitionResponse::Link(_) => panic!("expected location result"),
+    }
+}

--- a/crates/vize_maestro/src/ide/definition/service.rs
+++ b/crates/vize_maestro/src/ide/definition/service.rs
@@ -26,11 +26,11 @@ impl super::DefinitionService {
     /// Get definition for the symbol at the current position.
     pub fn definition(ctx: &IdeContext) -> Option<GotoDefinitionResponse> {
         match ctx.block_type? {
-            BlockType::Template => template::definition_in_template(ctx),
+            BlockType::Template => Self::definition_in_template_sync(ctx),
             BlockType::Script | BlockType::ScriptSetup => script::definition_in_script(ctx),
             BlockType::Style(_) => script::definition_in_style(ctx),
             BlockType::Art(ArtCursorPosition::VariantTemplate(_)) => {
-                template::definition_in_template(ctx)
+                Self::definition_in_template_sync(ctx)
             }
             BlockType::Art(_) => None,
         }
@@ -99,7 +99,7 @@ impl super::DefinitionService {
                     .open_or_update_virtual_document(&vdoc_uri, &tmpl.content)
                     .await
                 else {
-                    return template::definition_in_template(ctx);
+                    return Self::definition_in_template_sync(ctx);
                 };
 
                 if let Ok(locations) = bridge.definition(&uri, line, character).await
@@ -111,7 +111,7 @@ impl super::DefinitionService {
         }
 
         // Fall back to synchronous definition
-        template::definition_in_template(ctx)
+        Self::definition_in_template_sync(ctx)
     }
 
     /// Find definition in template with Corsa and component jump support.
@@ -129,6 +129,12 @@ impl super::DefinitionService {
 
         if let Some(definition) =
             Self::definition_via_canonical_corsa(ctx, corsa_bridge.as_ref()).await
+        {
+            return Some(definition);
+        }
+
+        if let Some(definition) =
+            Self::definition_for_html_attribute_with_corsa(ctx, corsa_bridge.as_ref()).await
         {
             return Some(definition);
         }
@@ -157,7 +163,7 @@ impl super::DefinitionService {
         }
 
         if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset) {
-            return None;
+            return Self::definition_in_template_sync(ctx);
         }
 
         // Check if this is a props property access
@@ -179,7 +185,7 @@ impl super::DefinitionService {
         }
 
         // Fall back to synchronous definition
-        template::definition_in_template(ctx)
+        Self::definition_in_template_sync(ctx)
     }
 
     /// Find definition in script with Corsa support.
@@ -266,35 +272,5 @@ impl super::DefinitionService {
             [location] => Some(GotoDefinitionResponse::Scalar(location.clone())),
             _ => Some(GotoDefinitionResponse::Array(locations)),
         }
-    }
-
-    #[cfg(feature = "native")]
-    async fn definition_for_html_tag_with_corsa(
-        ctx: &IdeContext<'_>,
-        corsa_bridge: Option<&Arc<CorsaBridge>>,
-    ) -> Option<GotoDefinitionResponse> {
-        let tag_name = helpers::get_tag_at_offset(&ctx.content, ctx.offset)?;
-        if is_component_tag(&tag_name) {
-            return None;
-        }
-
-        let bridge = corsa_bridge?;
-        if !bridge.is_initialized() {
-            return None;
-        }
-
-        let doc = corsa_support::html_tag_virtual_document(&tag_name)?;
-        let request_path = corsa_support::html_tag_request_path(ctx.uri);
-        let request_uri = bridge
-            .open_or_update_virtual_document(&request_path, &doc.content)
-            .await
-            .ok()?;
-        let (line, character) = crate::ide::offset_to_position(&doc.content, doc.definition_offset);
-        let locations = bridge
-            .definition(&request_uri, line, character)
-            .await
-            .ok()?;
-
-        Self::convert_lsp_locations(locations, ctx)
     }
 }

--- a/crates/vize_maestro/src/ide/hover/corsa.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa.rs
@@ -131,6 +131,13 @@ impl HoverService {
         }
 
         if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset)
+            && let Some(hover) =
+                Self::hover_html_attribute_with_corsa(ctx, corsa_bridge.as_ref()).await
+        {
+            return Some(hover);
+        }
+
+        if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset)
             && let Some(hover) = Self::hover_html_tag_with_corsa(ctx, corsa_bridge.as_ref()).await
         {
             return Some(hover);

--- a/crates/vize_maestro/src/ide/hover/html.rs
+++ b/crates/vize_maestro/src/ide/hover/html.rs
@@ -9,6 +9,42 @@ use super::{HoverBuilder, HoverService};
 use crate::ide::IdeContext;
 
 impl HoverService {
+    pub(super) fn hover_native_dom_attribute(ctx: &IdeContext<'_>) -> Option<Hover> {
+        let (attr_name, tag_name) =
+            crate::ide::definition::helpers::get_attribute_and_component_at_offset(ctx)?;
+        if crate::ide::is_component_tag(&tag_name) {
+            return None;
+        }
+
+        let info = crate::ide::corsa_support::native_dom_attribute_info(&tag_name, &attr_name)?;
+        let signature = format!("{}: {}", info.property_name, info.type_expression);
+        let value_kind = if info.is_boolean {
+            "Boolean HTML attribute"
+        } else {
+            "DOM reflected attribute"
+        };
+
+        Some(
+            HoverBuilder::new()
+                .title(&format!("{attr_name} on <{tag_name}>"))
+                .meta(info.category)
+                .code("typescript", &signature)
+                .description(
+                    "Native DOM attribute recognized by the Vue template compiler. Vue patches it on the platform element rather than resolving it as a component prop.",
+                )
+                .section("Runtime surface", value_kind)
+                .bullets(
+                    "Editor behavior",
+                    &[
+                        "Hover and go-to-definition use the DOM library type for the reflected property when the type service is available.",
+                        "Component prop lookup is skipped because the enclosing tag is a native element.",
+                    ],
+                )
+                .link("MDN reference", &info.documentation_url)
+                .build(),
+        )
+    }
+
     pub(super) fn hover_native_dom_tag(ctx: &IdeContext<'_>) -> Option<Hover> {
         let tag_name =
             crate::ide::definition::helpers::get_tag_at_offset(&ctx.content, ctx.offset)?;
@@ -37,6 +73,34 @@ impl HoverService {
                 .link("MDN reference", &info.documentation_url)
                 .build(),
         )
+    }
+
+    pub(super) async fn hover_html_attribute_with_corsa(
+        ctx: &IdeContext<'_>,
+        corsa_bridge: Option<&Arc<CorsaBridge>>,
+    ) -> Option<Hover> {
+        let (attr_name, tag_name) =
+            crate::ide::definition::helpers::get_attribute_and_component_at_offset(ctx)?;
+        if crate::ide::is_component_tag(&tag_name) {
+            return None;
+        }
+
+        let bridge = corsa_bridge?;
+        if !bridge.is_initialized() {
+            return None;
+        }
+
+        let doc =
+            crate::ide::corsa_support::html_attribute_virtual_document(&tag_name, &attr_name)?;
+        let request_path = crate::ide::corsa_support::html_attribute_request_path(ctx.uri);
+        let request_uri = bridge
+            .open_or_update_virtual_document(&request_path, &doc.content)
+            .await
+            .ok()?;
+        let (line, character) = crate::ide::offset_to_position(&doc.content, doc.hover_offset);
+        let hover = bridge.hover(&request_uri, line, character).await.ok()??;
+
+        Some(Self::convert_lsp_hover(hover))
     }
 
     pub(super) async fn hover_html_tag_with_corsa(
@@ -98,6 +162,51 @@ mod tests {
     }
 
     #[test]
+    fn test_hover_template_describes_native_html_attribute() {
+        let source = r#"<template>
+  <button disabled>Save</button>
+</template>
+"#;
+        let (state, uri) = state_with_document("NativeAttributeHover.vue", source);
+
+        let offset = source.find("disabled").unwrap() + "disabled".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let hover = HoverService::hover(&ctx).unwrap();
+        let value = hover_markdown(hover);
+
+        assert!(value.contains("disabled on <button>"), "got {value:?}");
+        assert!(value.contains("HTML attribute"), "got {value:?}");
+        assert!(
+            value.contains("HTMLElementTagNameMap[\"button\"][\"disabled\"]"),
+            "got {value:?}"
+        );
+        assert!(value.contains("Boolean HTML attribute"), "got {value:?}");
+    }
+
+    #[test]
+    fn test_hover_template_describes_native_html_bound_attribute_name() {
+        let source = r#"<script setup>
+const disabled = true
+</script>
+<template>
+  <button :disabled="disabled">Save</button>
+</template>
+"#;
+        let (state, uri) = state_with_document("NativeBoundAttributeHover.vue", source);
+
+        let offset = source.find(":disabled").unwrap() + ":disabled".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let hover = HoverService::hover(&ctx).unwrap();
+        let value = hover_markdown(hover);
+
+        assert!(value.contains("disabled on <button>"), "got {value:?}");
+        assert!(
+            value.contains("HTMLElementTagNameMap[\"button\"][\"disabled\"]"),
+            "got {value:?}"
+        );
+    }
+
+    #[test]
     fn test_hover_template_does_not_describe_custom_element_as_native_dom() {
         let source = r#"<template>
   <my-widget />
@@ -106,6 +215,20 @@ mod tests {
         let (state, uri) = state_with_document("CustomElementHover.vue", source);
 
         let offset = source.find("my-widget").unwrap() + "my".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+
+        assert!(HoverService::hover(&ctx).is_none());
+    }
+
+    #[test]
+    fn test_hover_template_does_not_describe_unknown_native_attribute() {
+        let source = r#"<template>
+  <button not-real>Save</button>
+</template>
+"#;
+        let (state, uri) = state_with_document("UnknownNativeAttributeHover.vue", source);
+
+        let offset = source.find("not-real").unwrap() + "not".len();
         let ctx = IdeContext::new(&state, &uri, offset).unwrap();
 
         assert!(HoverService::hover(&ctx).is_none());

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -33,6 +33,11 @@ impl HoverService {
         }
 
         #[cfg(feature = "native")]
+        if let Some(hover) = Self::hover_native_dom_attribute(ctx) {
+            return Some(hover);
+        }
+
+        #[cfg(feature = "native")]
         if let Some(hover) = Self::hover_native_dom_tag(ctx) {
             return Some(hover);
         }


### PR DESCRIPTION
## Summary
- Add native DOM attribute metadata for Vue template hover and MDN definition fallback.
- Improve native HTML element and attribute definition fallback when the type service has no useful result.
- Fix static boolean attribute cursor detection at tag-end boundaries and cover the behavior with tests.

## Validation
- `cargo test -p vize_maestro --features native`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --check --package vize_maestro`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785698965&installation_id=136613492&pr_number=2558&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2558&signature=37a03717a5d5a8738c6cba78fd2d2d48dc262f41f2665d74be63211dadf908bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native hover and “go to definition” support for HTML, SVG, and MathML tags and attributes in templates.
  * Native attributes now show clearer type information, runtime behavior details, and documentation links.
  * Definition lookups can now open relevant external documentation or resolve to richer results when available.

* **Bug Fixes**
  * Improved detection of template tag spans and attribute positions for more reliable hover/definition behavior.
  * Expanded support for bound and boolean attributes while filtering out unsupported or invalid attribute patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->