### PR TITLE
fix(canon): make runtime package resolution pluggable

### DIFF
--- a/crates/vize_canon/src/batch/runtime_deps.rs
+++ b/crates/vize_canon/src/batch/runtime_deps.rs
@@ -1,175 +1,21 @@
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use super::error::CorsaResult;
 use super::materialize_fs::{ensure_dir, prune_dir_entries, remove_path, write_if_changed};
 use vize_carton::FxHashSet;
 
-const VIZE_VUE_PACKAGE_ENV: &str = "VIZE_VUE_PACKAGE";
-const VIZE_RUNTIME_NODE_MODULES_ENV: &str = "VIZE_RUNTIME_NODE_MODULES";
+mod resolver;
+mod stubs;
 #[cfg(test)]
-const VIZE_TEST_WORKSPACE_NODE_MODULES_ENV: &str = "VIZE_TEST_WORKSPACE_NODE_MODULES";
+mod tests;
 
-const VUE_FACADE_PACKAGE_JSON: &str = r#"{
-  "name": "vue",
-  "types": "index.d.ts"
-}
-"#;
-
-const VUE_FACADE_TYPES: &str = r#"export * from "@vue/runtime-dom";
-"#;
-
-const VUE_RUNTIME_DOM_STUB_PACKAGE_JSON: &str = r#"{
-  "name": "@vue/runtime-dom",
-  "types": "index.d.ts"
-}
-"#;
-
-const VUE_RUNTIME_DOM_STUB_TYPES: &str = r#"export interface ComponentPublicInstance<Props = {}> {
-  $props: Props;
-  $attrs: { [key: string]: unknown };
-  $slots: { [key: string]: unknown };
-  $refs: { [key: string]: unknown };
-  $emit: (...args: any[]) => void;
-}
-
-export type DefineComponent<
-  Props = {},
-  RawBindings = {},
-  D = {},
-  C = {},
-  M = {},
-  Mixin = {},
-  Extends = {},
-  E = {},
-  EE = string,
-  PP = Props,
-  PropsDefaults = {},
-  MakeDefaultsOptional = true,
-  Options = {},
-  S = {}
-> = {
-  new (): ComponentPublicInstance<Props>;
-} & ComponentOptions<Props, RawBindings, D, C, M>;
-
-export type ComponentOptions<
-  Props = {},
-  RawBindings = any,
-  D = any,
-  C = any,
-  M = any
-> = {
-  name?: string;
-  __name?: string;
-  __file?: string;
-  __vccOpts?: any;
-  props?: any;
-  emits?: any;
-  slots?: any;
-  setup?: any;
-  render?: Function;
-  components?: any;
-  directives?: any;
-  inheritAttrs?: boolean;
-  compatConfig?: any;
-  call?: (this: unknown, ...args: unknown[]) => never;
-  __isFragment?: never;
-  __isTeleport?: never;
-  __isSuspense?: never;
-  __defaults?: any;
-  __vapor?: boolean;
-  __multiRoot?: boolean;
-  __isKeepAlive?: boolean;
-  __isBuiltIn?: boolean;
+use resolver::{
+    VueRuntimePackages, resolve_package, resolve_vue_package, resolve_vue_runtime_packages,
 };
-
-export interface FunctionalComponent<
-  P = {},
-  E = {},
-  S = any
-> {
-  (props: P, ctx: any): any;
-  props?: any;
-  emits?: any;
-  slots?: any;
-  inheritAttrs?: boolean;
-  displayName?: string;
-  compatConfig?: any;
-}
-
-export type ConcreteComponent<
-  Props = {},
-  RawBindings = any,
-  D = any,
-  C = any,
-  M = any,
-  E = {},
-  S = any
-> = ComponentOptions<Props, RawBindings, D, C, M> | FunctionalComponent<Props, E, S>;
-
-export interface Ref<T = unknown, _Raw = T> {
-  value: T;
-}
-
-export interface ComputedRef<T = unknown> extends Ref<T> {
-  readonly value: T;
-}
-
-export interface WritableComputedRef<T = unknown> extends Ref<T> {
-  value: T;
-}
-
-export interface ShallowRef<T = unknown, _Raw = T> extends Ref<T, _Raw> {
-  readonly __v_isShallow?: true;
-}
-
-export type InjectionKey<T> = symbol & { readonly __v_vlsInjection?: T };
-export type PropType<T> = { new (...args: any[]): T & {} } | { (): T } | null;
-
-export declare const Transition: DefineComponent;
-export declare function defineComponent(options: any): DefineComponent;
-export declare function defineAsyncComponent(source: any): DefineComponent;
-export declare function defineProps<T = {}>(): T;
-export declare function computed<T>(getter: () => T): ComputedRef<T>;
-export declare function computed<T>(options: { get: () => T; set: (value: T) => void }): WritableComputedRef<T>;
-export declare function ref<T>(value: T): Ref<T>;
-export declare function reactive<T extends object>(target: T): T;
-export declare function shallowRef<T>(value: T): ShallowRef<T>;
-export declare function toRef<T extends object, K extends keyof T>(object: T, key: K): Ref<T[K]>;
-export declare function useTemplateRef<T = unknown>(key: string): ShallowRef<T | null>;
-export declare function useId(): string;
-export declare function watch<T>(source: T, callback: (...args: any[]) => void, options?: any): void;
-export declare function watchEffect(effect: (onCleanup: (cleanupFn: () => void) => void) => void): void;
-export declare function onMounted(callback: () => void): void;
-export declare function customRef<T>(factory: any): Ref<T>;
-export declare function provide<T>(key: InjectionKey<T> | string | symbol, value: T): void;
-export declare function inject<T>(key: InjectionKey<T> | string | symbol): T | undefined;
-export declare function inject<T>(key: InjectionKey<T> | string | symbol, defaultValue: T): T;
-export declare function markRaw<T extends object>(value: T): T;
-export declare function createApp(root: any): {
-  config: { globalProperties: { [key: string]: any }; };
-  mount(container: string | Element): ComponentPublicInstance; unmount(): void; use(plugin: any, ...options: any[]): any;
+use stubs::{
+    VITE_CLIENT_STUB, VITE_STUB_PACKAGE_JSON, VUE_FACADE_PACKAGE_JSON, VUE_FACADE_TYPES,
+    VUE_RUNTIME_DOM_STUB_PACKAGE_JSON, VUE_RUNTIME_DOM_STUB_TYPES,
 };
-"#;
-
-const VITE_STUB_PACKAGE_JSON: &str = r#"{
-  "name": "vite",
-  "types": "client.d.ts"
-}
-"#;
-
-const VITE_CLIENT_STUB: &str = r#"interface ImportMetaEnv {
-  readonly [key: string]: string | boolean | undefined;
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}
-
-export {};
-"#;
 
 pub(super) fn materialize_runtime_dependencies(
     project_root: &Path,
@@ -192,15 +38,16 @@ fn materialize_vue_support(project_root: &Path, node_modules_dir: &Path) -> std:
     if let Some(vue_source) = resolve_vue_package(project_root)
         && symlink_path(&package_link_source(&vue_source), &vue_target).is_ok()
     {
-        if let Some(vue_namespace_source) = resolve_vue_namespace_package(project_root, &vue_source)
-        {
-            if symlink_path(&vue_namespace_source, &vue_namespace_target).is_err() {
-                remove_path(&vue_namespace_target)?;
+        match resolve_vue_runtime_packages(project_root, &vue_source) {
+            VueRuntimePackages::Namespace(vue_namespace_source) => {
+                if symlink_path(&vue_namespace_source, &vue_namespace_target).is_err() {
+                    remove_path(&vue_namespace_target)?;
+                }
             }
-        } else if let Some(runtime_dom_source) = resolve_package(project_root, "@vue/runtime-dom") {
-            link_vue_runtime_dom_package(node_modules_dir, &runtime_dom_source)?;
-        } else {
-            write_vue_runtime_dom_stub(node_modules_dir)?;
+            VueRuntimePackages::RuntimeDom(runtime_dom_source) => {
+                link_vue_runtime_dom_package(node_modules_dir, &runtime_dom_source)?;
+            }
+            VueRuntimePackages::Stub => write_vue_runtime_dom_stub(node_modules_dir)?,
         }
         return Ok(());
     }
@@ -219,7 +66,7 @@ fn materialize_vue_support(project_root: &Path, node_modules_dir: &Path) -> std:
 fn materialize_vite_support(project_root: &Path, node_modules_dir: &Path) -> std::io::Result<()> {
     let vite_target = node_modules_dir.join("vite");
 
-    if let Some(vite_source) = resolve_ancestor_package(project_root, "vite")
+    if let Some(vite_source) = resolve_package(project_root, "vite")
         && symlink_path(&vite_source, &vite_target).is_ok()
     {
         return Ok(());
@@ -228,115 +75,8 @@ fn materialize_vite_support(project_root: &Path, node_modules_dir: &Path) -> std
     write_vite_stub(node_modules_dir)
 }
 
-fn resolve_vue_namespace_package(project_root: &Path, vue_source: &Path) -> Option<PathBuf> {
-    let adjacent = resolve_adjacent_vue_namespace_package(vue_source);
-    let ancestor = resolve_ancestor_package(project_root, "@vue");
-
-    adjacent
-        .filter(|path| is_vue_runtime_namespace(path))
-        .or_else(|| ancestor.filter(|path| is_vue_runtime_namespace(path)))
-        .or_else(|| {
-            resolve_package_from_runtime_node_modules("@vue")
-                .filter(|path| is_vue_runtime_namespace(path))
-        })
-        .or_else(|| {
-            resolve_test_workspace_package("@vue").filter(|path| is_vue_runtime_namespace(path))
-        })
-}
-
-fn resolve_adjacent_vue_namespace_package(vue_source: &Path) -> Option<PathBuf> {
-    let mut candidates = Vec::new();
-
-    if let Some(parent) = vue_source.parent() {
-        candidates.push(parent.join("@vue"));
-    }
-
-    if let Ok(real_vue_source) = std::fs::canonicalize(vue_source)
-        && let Some(parent) = real_vue_source.parent()
-    {
-        candidates.push(parent.join("@vue"));
-    }
-
-    candidates
-        .into_iter()
-        .find(|candidate| candidate.exists() && is_vue_runtime_namespace(candidate))
-}
-
-fn is_vue_runtime_namespace(path: &Path) -> bool {
-    path.join("runtime-dom").exists() || path.join("runtime-core").exists()
-}
-
-fn resolve_vue_package(project_root: &Path) -> Option<PathBuf> {
-    resolve_ancestor_package(project_root, "vue")
-        .or_else(|| resolve_explicit_package_env(VIZE_VUE_PACKAGE_ENV))
-        .or_else(|| resolve_package_from_runtime_node_modules("vue"))
-        .or_else(|| resolve_test_workspace_package("vue"))
-}
-
-fn resolve_package(project_root: &Path, package: &str) -> Option<PathBuf> {
-    resolve_ancestor_package(project_root, package)
-        .or_else(|| resolve_package_from_runtime_node_modules(package))
-        .or_else(|| resolve_test_workspace_package(package))
-}
-
 fn package_link_source(source: &Path) -> PathBuf {
     vize_carton::path::canonicalize_non_verbatim(source)
-}
-
-fn resolve_explicit_package_env(name: &str) -> Option<PathBuf> {
-    env::var_os(name)
-        .map(PathBuf::from)
-        .filter(|path| path.exists())
-}
-
-fn resolve_package_from_runtime_node_modules(package: &str) -> Option<PathBuf> {
-    env::var_os(VIZE_RUNTIME_NODE_MODULES_ENV)
-        .into_iter()
-        .flat_map(|paths| env::split_paths(&paths).collect::<Vec<_>>())
-        .map(|node_modules| node_modules.join(package_path(package)))
-        .find(|candidate| candidate.exists())
-}
-
-fn package_path(package: &str) -> PathBuf {
-    package.split('/').collect()
-}
-
-#[cfg(test)]
-fn resolve_test_workspace_package(package: &str) -> Option<PathBuf> {
-    if let Some(override_path) = env::var_os(VIZE_TEST_WORKSPACE_NODE_MODULES_ENV) {
-        if override_path.as_os_str() == "__none__" {
-            return None;
-        }
-        let candidate = PathBuf::from(override_path).join(package_path(package));
-        return candidate.exists().then_some(candidate);
-    }
-
-    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)?;
-    let candidate = workspace_root
-        .join("node_modules")
-        .join(package_path(package));
-    candidate.exists().then_some(candidate)
-}
-
-#[cfg(not(test))]
-fn resolve_test_workspace_package(_package: &str) -> Option<PathBuf> {
-    None
-}
-
-fn resolve_ancestor_package(project_root: &Path, package: &str) -> Option<PathBuf> {
-    let mut current = Some(project_root);
-
-    while let Some(dir) = current {
-        let candidate = dir.join("node_modules").join(package_path(package));
-        if candidate.exists() {
-            return Some(candidate);
-        }
-        current = dir.parent();
-    }
-
-    None
 }
 
 fn write_vue_facade(node_modules_dir: &Path) -> std::io::Result<()> {

--- a/crates/vize_canon/src/batch/runtime_deps/resolver.rs
+++ b/crates/vize_canon/src/batch/runtime_deps/resolver.rs
@@ -1,0 +1,165 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+const VIZE_VITE_PACKAGE_ENV: &str = "VIZE_VITE_PACKAGE";
+const VIZE_VUE_PACKAGE_ENV: &str = "VIZE_VUE_PACKAGE";
+const VIZE_VUE_NAMESPACE_PACKAGE_ENV: &str = "VIZE_VUE_NAMESPACE_PACKAGE";
+const VIZE_VUE_RUNTIME_DOM_PACKAGE_ENV: &str = "VIZE_VUE_RUNTIME_DOM_PACKAGE";
+const VIZE_RUNTIME_NODE_MODULES_ENV: &str = "VIZE_RUNTIME_NODE_MODULES";
+#[cfg(test)]
+const VIZE_TEST_WORKSPACE_NODE_MODULES_ENV: &str = "VIZE_TEST_WORKSPACE_NODE_MODULES";
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) enum VueRuntimePackages {
+    Namespace(PathBuf),
+    RuntimeDom(PathBuf),
+    Stub,
+}
+
+pub(super) fn resolve_vue_runtime_packages(
+    project_root: &Path,
+    vue_source: &Path,
+) -> VueRuntimePackages {
+    if let Some(namespace) =
+        resolve_explicit_package("@vue").filter(|path| is_vue_runtime_namespace(path))
+    {
+        return VueRuntimePackages::Namespace(namespace);
+    }
+    if let Some(runtime_dom) = resolve_explicit_package("@vue/runtime-dom") {
+        return VueRuntimePackages::RuntimeDom(runtime_dom);
+    }
+    if let Some(namespace) = resolve_inferred_vue_namespace_package(project_root, vue_source) {
+        return VueRuntimePackages::Namespace(namespace);
+    }
+    if let Some(runtime_dom) = resolve_inferred_package(project_root, "@vue/runtime-dom") {
+        return VueRuntimePackages::RuntimeDom(runtime_dom);
+    }
+    VueRuntimePackages::Stub
+}
+
+fn resolve_inferred_vue_namespace_package(
+    project_root: &Path,
+    vue_source: &Path,
+) -> Option<PathBuf> {
+    let adjacent = resolve_adjacent_vue_namespace_package(vue_source);
+    let ancestor = resolve_ancestor_package(project_root, "@vue");
+
+    adjacent
+        .filter(|path| is_vue_runtime_namespace(path))
+        .or_else(|| ancestor.filter(|path| is_vue_runtime_namespace(path)))
+        .or_else(|| {
+            resolve_package_from_runtime_node_modules("@vue")
+                .filter(|path| is_vue_runtime_namespace(path))
+        })
+        .or_else(|| {
+            resolve_test_workspace_package("@vue").filter(|path| is_vue_runtime_namespace(path))
+        })
+}
+
+fn resolve_adjacent_vue_namespace_package(vue_source: &Path) -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(parent) = vue_source.parent() {
+        candidates.push(parent.join("@vue"));
+    }
+
+    if let Ok(real_vue_source) = std::fs::canonicalize(vue_source)
+        && let Some(parent) = real_vue_source.parent()
+    {
+        candidates.push(parent.join("@vue"));
+    }
+
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.exists() && is_vue_runtime_namespace(candidate))
+}
+
+fn is_vue_runtime_namespace(path: &Path) -> bool {
+    path.join("runtime-dom").exists() || path.join("runtime-core").exists()
+}
+
+pub(super) fn resolve_vue_package(project_root: &Path) -> Option<PathBuf> {
+    resolve_package(project_root, "vue")
+}
+
+pub(super) fn resolve_package(project_root: &Path, package: &str) -> Option<PathBuf> {
+    resolve_explicit_package(package).or_else(|| resolve_inferred_package(project_root, package))
+}
+
+fn resolve_inferred_package(project_root: &Path, package: &str) -> Option<PathBuf> {
+    resolve_ancestor_package(project_root, package)
+        .or_else(|| resolve_package_from_runtime_node_modules(package))
+        .or_else(|| resolve_test_workspace_package(package))
+}
+
+fn resolve_explicit_package(package: &str) -> Option<PathBuf> {
+    explicit_package_env(package).and_then(resolve_explicit_package_env)
+}
+
+fn explicit_package_env(package: &str) -> Option<&'static str> {
+    match package {
+        "vue" => Some(VIZE_VUE_PACKAGE_ENV),
+        "@vue" => Some(VIZE_VUE_NAMESPACE_PACKAGE_ENV),
+        "@vue/runtime-dom" => Some(VIZE_VUE_RUNTIME_DOM_PACKAGE_ENV),
+        "vite" => Some(VIZE_VITE_PACKAGE_ENV),
+        _ => None,
+    }
+}
+
+fn resolve_explicit_package_env(name: &str) -> Option<PathBuf> {
+    env::var_os(name)
+        .map(PathBuf::from)
+        .filter(|path| path.exists())
+}
+
+fn resolve_package_from_runtime_node_modules(package: &str) -> Option<PathBuf> {
+    env::var_os(VIZE_RUNTIME_NODE_MODULES_ENV)
+        .into_iter()
+        .flat_map(|paths| env::split_paths(&paths).collect::<Vec<_>>())
+        .map(|node_modules| node_modules.join(package_path(package)))
+        .find(|candidate| candidate.exists())
+}
+
+fn package_path(package: &str) -> PathBuf {
+    package.split('/').collect()
+}
+
+#[cfg(test)]
+fn resolve_test_workspace_package(package: &str) -> Option<PathBuf> {
+    if let Some(override_path) = env::var_os(VIZE_TEST_WORKSPACE_NODE_MODULES_ENV) {
+        if override_path.as_os_str() == "__none__" {
+            return None;
+        }
+        let candidate = PathBuf::from(override_path).join(package_path(package));
+        return candidate.exists().then_some(candidate);
+    }
+
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)?;
+    let candidate = workspace_root
+        .join("node_modules")
+        .join(package_path(package));
+    candidate.exists().then_some(candidate)
+}
+
+#[cfg(not(test))]
+fn resolve_test_workspace_package(_package: &str) -> Option<PathBuf> {
+    None
+}
+
+fn resolve_ancestor_package(project_root: &Path, package: &str) -> Option<PathBuf> {
+    let mut current = Some(project_root);
+
+    while let Some(dir) = current {
+        let candidate = dir.join("node_modules").join(package_path(package));
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        current = dir.parent();
+    }
+
+    None
+}

--- a/crates/vize_canon/src/batch/runtime_deps/stubs.rs
+++ b/crates/vize_canon/src/batch/runtime_deps/stubs.rs
@@ -1,0 +1,158 @@
+pub(super) const VUE_FACADE_PACKAGE_JSON: &str = r#"{
+  "name": "vue",
+  "types": "index.d.ts"
+}
+"#;
+
+pub(super) const VUE_FACADE_TYPES: &str = r#"export * from "@vue/runtime-dom";
+"#;
+
+pub(super) const VUE_RUNTIME_DOM_STUB_PACKAGE_JSON: &str = r#"{
+  "name": "@vue/runtime-dom",
+  "types": "index.d.ts"
+}
+"#;
+
+pub(super) const VUE_RUNTIME_DOM_STUB_TYPES: &str = r#"export interface ComponentPublicInstance<Props = {}> {
+  $props: Props;
+  $attrs: { [key: string]: unknown };
+  $slots: { [key: string]: unknown };
+  $refs: { [key: string]: unknown };
+  $emit: (...args: any[]) => void;
+}
+
+export type DefineComponent<
+  Props = {},
+  RawBindings = {},
+  D = {},
+  C = {},
+  M = {},
+  Mixin = {},
+  Extends = {},
+  E = {},
+  EE = string,
+  PP = Props,
+  PropsDefaults = {},
+  MakeDefaultsOptional = true,
+  Options = {},
+  S = {}
+> = {
+  new (): ComponentPublicInstance<Props>;
+} & ComponentOptions<Props, RawBindings, D, C, M>;
+
+export type ComponentOptions<
+  Props = {},
+  RawBindings = any,
+  D = any,
+  C = any,
+  M = any
+> = {
+  name?: string;
+  __name?: string;
+  __file?: string;
+  __vccOpts?: any;
+  props?: any;
+  emits?: any;
+  slots?: any;
+  setup?: any;
+  render?: Function;
+  components?: any;
+  directives?: any;
+  inheritAttrs?: boolean;
+  compatConfig?: any;
+  call?: (this: unknown, ...args: unknown[]) => never;
+  __isFragment?: never;
+  __isTeleport?: never;
+  __isSuspense?: never;
+  __defaults?: any;
+  __vapor?: boolean;
+  __multiRoot?: boolean;
+  __isKeepAlive?: boolean;
+  __isBuiltIn?: boolean;
+};
+
+export interface FunctionalComponent<
+  P = {},
+  E = {},
+  S = any
+> {
+  (props: P, ctx: any): any;
+  props?: any;
+  emits?: any;
+  slots?: any;
+  inheritAttrs?: boolean;
+  displayName?: string;
+  compatConfig?: any;
+}
+
+export type ConcreteComponent<
+  Props = {},
+  RawBindings = any,
+  D = any,
+  C = any,
+  M = any,
+  E = {},
+  S = any
+> = ComponentOptions<Props, RawBindings, D, C, M> | FunctionalComponent<Props, E, S>;
+
+export interface Ref<T = unknown, _Raw = T> {
+  value: T;
+}
+
+export interface ComputedRef<T = unknown> extends Ref<T> {
+  readonly value: T;
+}
+
+export interface WritableComputedRef<T = unknown> extends Ref<T> {
+  value: T;
+}
+
+export interface ShallowRef<T = unknown, _Raw = T> extends Ref<T, _Raw> {
+  readonly __v_isShallow?: true;
+}
+
+export type InjectionKey<T> = symbol & { readonly __v_vlsInjection?: T };
+export type PropType<T> = { new (...args: any[]): T & {} } | { (): T } | null;
+
+export declare const Transition: DefineComponent;
+export declare function defineComponent(options: any): DefineComponent;
+export declare function defineAsyncComponent(source: any): DefineComponent;
+export declare function defineProps<T = {}>(): T;
+export declare function computed<T>(getter: () => T): ComputedRef<T>;
+export declare function computed<T>(options: { get: () => T; set: (value: T) => void }): WritableComputedRef<T>;
+export declare function ref<T>(value: T): Ref<T>;
+export declare function reactive<T extends object>(target: T): T;
+export declare function shallowRef<T>(value: T): ShallowRef<T>;
+export declare function toRef<T extends object, K extends keyof T>(object: T, key: K): Ref<T[K]>;
+export declare function useTemplateRef<T = unknown>(key: string): ShallowRef<T | null>;
+export declare function useId(): string;
+export declare function watch<T>(source: T, callback: (...args: any[]) => void, options?: any): void;
+export declare function watchEffect(effect: (onCleanup: (cleanupFn: () => void) => void) => void): void;
+export declare function onMounted(callback: () => void): void;
+export declare function customRef<T>(factory: any): Ref<T>;
+export declare function provide<T>(key: InjectionKey<T> | string | symbol, value: T): void;
+export declare function inject<T>(key: InjectionKey<T> | string | symbol): T | undefined;
+export declare function inject<T>(key: InjectionKey<T> | string | symbol, defaultValue: T): T;
+export declare function markRaw<T extends object>(value: T): T;
+export declare function createApp(root: any): {
+  config: { globalProperties: { [key: string]: any }; };
+  mount(container: string | Element): ComponentPublicInstance; unmount(): void; use(plugin: any, ...options: any[]): any;
+};
+"#;
+
+pub(super) const VITE_STUB_PACKAGE_JSON: &str = r#"{
+  "name": "vite",
+  "types": "client.d.ts"
+}
+"#;
+
+pub(super) const VITE_CLIENT_STUB: &str = r#"interface ImportMetaEnv {
+  readonly [key: string]: string | boolean | undefined;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
+export {};
+"#;

--- a/crates/vize_canon/src/batch/runtime_deps/tests.rs
+++ b/crates/vize_canon/src/batch/runtime_deps/tests.rs
@@ -1,0 +1,154 @@
+use std::path::{Path, PathBuf};
+
+use super::resolver::{
+    VueRuntimePackages, resolve_package, resolve_vue_package, resolve_vue_runtime_packages,
+};
+
+#[test]
+fn explicit_runtime_packages_override_project_packages() {
+    let temp = tempfile::tempdir().unwrap();
+    let project = temp.path().join("project");
+    let explicit = temp.path().join("explicit");
+    create_package(&project, "node_modules/vue");
+    create_package(&project, "node_modules/@vue/runtime-dom");
+    create_package(&project, "node_modules/vite");
+    let explicit_vue = create_package(&explicit, "vue");
+    let explicit_runtime_dom = create_package(&explicit, "@vue/runtime-dom");
+    let explicit_vite = create_package(&explicit, "vite");
+
+    with_env_overrides(
+        &[
+            ("VIZE_VUE_PACKAGE", Some(explicit_vue.as_path())),
+            ("VIZE_VUE_NAMESPACE_PACKAGE", None),
+            (
+                "VIZE_VUE_RUNTIME_DOM_PACKAGE",
+                Some(explicit_runtime_dom.as_path()),
+            ),
+            ("VIZE_VITE_PACKAGE", Some(explicit_vite.as_path())),
+            ("VIZE_RUNTIME_NODE_MODULES", None),
+            (
+                "VIZE_TEST_WORKSPACE_NODE_MODULES",
+                Some(Path::new("__none__")),
+            ),
+        ],
+        || {
+            assert_eq!(resolve_vue_package(&project), Some(explicit_vue.clone()));
+            assert_eq!(
+                resolve_vue_runtime_packages(&project, &explicit_vue),
+                VueRuntimePackages::RuntimeDom(explicit_runtime_dom.clone())
+            );
+            assert_eq!(
+                resolve_package(&project, "vite"),
+                Some(explicit_vite.clone())
+            );
+        },
+    );
+}
+
+#[test]
+fn explicit_vue_namespace_overrides_explicit_runtime_dom() {
+    let temp = tempfile::tempdir().unwrap();
+    let project = temp.path().join("project");
+    let vue = create_package(&project, "node_modules/vue");
+    let namespace = create_package(&temp.path().join("explicit"), "@vue");
+    create_package(&namespace, "runtime-dom");
+    let runtime_dom = create_package(&temp.path().join("explicit"), "@vue-runtime-dom");
+
+    with_env_overrides(
+        &[
+            ("VIZE_VUE_PACKAGE", None),
+            ("VIZE_VUE_NAMESPACE_PACKAGE", Some(namespace.as_path())),
+            ("VIZE_VUE_RUNTIME_DOM_PACKAGE", Some(runtime_dom.as_path())),
+            ("VIZE_VITE_PACKAGE", None),
+            ("VIZE_RUNTIME_NODE_MODULES", None),
+            (
+                "VIZE_TEST_WORKSPACE_NODE_MODULES",
+                Some(Path::new("__none__")),
+            ),
+        ],
+        || {
+            assert_eq!(
+                resolve_vue_runtime_packages(&project, &vue),
+                VueRuntimePackages::Namespace(namespace.clone())
+            );
+        },
+    );
+}
+
+#[test]
+fn runtime_node_modules_supply_vue_and_vite_fallbacks() {
+    let temp = tempfile::tempdir().unwrap();
+    let project = temp.path().join("project");
+    let runtime_node_modules = temp.path().join("runtime_node_modules");
+    let runtime_vue = create_package(&runtime_node_modules, "vue");
+    let runtime_dom = create_package(&runtime_node_modules, "@vue/runtime-dom");
+    let runtime_vite = create_package(&runtime_node_modules, "vite");
+
+    with_env_overrides(
+        &[
+            ("VIZE_VUE_PACKAGE", None),
+            ("VIZE_VUE_NAMESPACE_PACKAGE", None),
+            ("VIZE_VUE_RUNTIME_DOM_PACKAGE", None),
+            ("VIZE_VITE_PACKAGE", None),
+            (
+                "VIZE_RUNTIME_NODE_MODULES",
+                Some(runtime_node_modules.as_path()),
+            ),
+            (
+                "VIZE_TEST_WORKSPACE_NODE_MODULES",
+                Some(Path::new("__none__")),
+            ),
+        ],
+        || {
+            assert_eq!(resolve_vue_package(&project), Some(runtime_vue.clone()));
+            assert_eq!(
+                resolve_package(&project, "@vue/runtime-dom"),
+                Some(runtime_dom.clone())
+            );
+            assert_eq!(
+                resolve_package(&project, "vite"),
+                Some(runtime_vite.clone())
+            );
+        },
+    );
+}
+
+fn create_package(root: &Path, relative: &str) -> PathBuf {
+    let dir = root.join(relative);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("package.json"), "{}").unwrap();
+    dir
+}
+
+fn with_env_overrides<T>(vars: &[(&str, Option<&Path>)], run: impl FnOnce() -> T) -> T {
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct EnvGuard {
+        previous: Vec<(String, Option<std::ffi::OsString>)>,
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in self.previous.drain(..).rev() {
+                match value {
+                    Some(value) => unsafe { std::env::set_var(name, value) },
+                    None => unsafe { std::env::remove_var(name) },
+                }
+            }
+        }
+    }
+
+    let _lock = ENV_LOCK.lock().unwrap();
+    let previous = vars
+        .iter()
+        .map(|(name, _)| ((*name).to_owned(), std::env::var_os(name)))
+        .collect();
+    for (name, value) in vars {
+        match value {
+            Some(value) => unsafe { std::env::set_var(name, value) },
+            None => unsafe { std::env::remove_var(name) },
+        }
+    }
+    let _guard = EnvGuard { previous };
+    run()
+}

--- a/docs/content/guide/troubleshooting.md
+++ b/docs/content/guide/troubleshooting.md
@@ -48,3 +48,12 @@ export default {
 Use `"strict"` to fail on invalid syntax, or `"quirks"` when a project relies on Vue accepting those
 tags as self-closing leaves. Valid void elements such as `<input />`, `<img />`, `<br />`, and
 `<meta />` do not need quirks.
+
+## Native Type Package Resolution
+
+`vize check` resolves Vue and Vite type packages from the checked project before it uses bundled
+fallbacks, so the project's own `vue`, `@vue/runtime-dom`, `@vue`, and `vite` versions drive the
+generated virtual project. For unusual package-manager layouts, set `VIZE_VUE_PACKAGE`,
+`VIZE_VUE_NAMESPACE_PACKAGE`, `VIZE_VUE_RUNTIME_DOM_PACKAGE`, or `VIZE_VITE_PACKAGE` to explicit
+package roots. `VIZE_RUNTIME_NODE_MODULES` can also point at one or more `node_modules` roots as a
+fallback search path.


### PR DESCRIPTION
## Summary

- make Canon runtime package resolution explicit and pluggable for Vue, @vue, @vue/runtime-dom, and Vite
- use the same resolver for Vite so VIZE_RUNTIME_NODE_MODULES can supply Vite types before falling back to a stub
- split large runtime dependency materialization internals into focused resolver/stub/test modules and document the override variables

## Validation

- cargo test -p vize_canon --lib
- cargo test -p vize --test check_cli check_options_api_can_import_define_component_from_bundled_vue
- cargo fmt --check --package vize_canon
- git diff --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- node --test tests/tooling/package-manifests.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785701205&installation_id=136613492&pr_number=2559&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2559&signature=9bc62179405bf01b223d6c99dd2348c21b4785545bf36018111964f80fa758cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection of Vue and Vite type packages from the checked project, with support for environment-based overrides and fallback search paths.
  * Added clearer troubleshooting guidance for native type package resolution.

* **Bug Fixes**
  * More reliably chooses the correct Vue runtime types when multiple package layouts are present.
  * Improves fallback behavior when package roots are missing or not explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->