### PR TITLE
feat(lsp): surface croquis component usage in hovers

### DIFF
--- a/crates/vize_croquis/src/drawer/template/components.rs
+++ b/crates/vize_croquis/src/drawer/template/components.rs
@@ -3,9 +3,10 @@
 //! Collects props, events, and slots passed to child components
 //! during template traversal.
 
-use crate::croquis::{ComponentUsage, EventListener, PassedProp};
+use crate::croquis::{ComponentUsage, EventListener, PassedProp, SlotUsage};
+use crate::drawer::helpers::extract_slot_props;
 use vize_carton::{CompactString, SmallVec, cstr};
-use vize_relief::{ElementNode, ExpressionNode, PropNode};
+use vize_relief::{ElementNode, ExpressionNode, PropNode, TemplateChildNode};
 
 use super::super::Drawer;
 
@@ -121,5 +122,102 @@ impl Drawer {
                 },
             }
         }
+    }
+
+    /// Collect slot outlets provided by a component usage.
+    pub(super) fn collect_component_slots(&self, el: &ElementNode<'_>, usage: &mut ComponentUsage) {
+        for prop in &el.props {
+            if let PropNode::Directive(dir) = prop
+                && dir.name == "slot"
+            {
+                push_slot_usage(usage, dir);
+            }
+        }
+
+        for child in &el.children {
+            let TemplateChildNode::Element(child_el) = child else {
+                continue;
+            };
+            if child_el.tag != "template" {
+                continue;
+            }
+            for prop in &child_el.props {
+                if let PropNode::Directive(dir) = prop
+                    && dir.name == "slot"
+                {
+                    push_slot_usage(usage, dir);
+                }
+            }
+        }
+
+        if !usage.slots.iter().any(|slot| slot.name == "default")
+            && let Some((start, end)) = default_slot_child_span(el)
+        {
+            usage.slots.push(SlotUsage {
+                name: CompactString::const_new("default"),
+                scope_vars: SmallVec::new(),
+                start,
+                end,
+                has_scope: false,
+            });
+        }
+    }
+}
+
+fn push_slot_usage(usage: &mut ComponentUsage, dir: &vize_relief::DirectiveNode<'_>) {
+    let name = dir
+        .arg
+        .as_ref()
+        .map(expression_content)
+        .map(CompactString::new)
+        .unwrap_or_else(|| CompactString::const_new("default"));
+    let scope_vars = dir
+        .exp
+        .as_ref()
+        .map(expression_content)
+        .map(extract_slot_props)
+        .unwrap_or_default();
+
+    usage.slots.push(SlotUsage {
+        name,
+        has_scope: dir.exp.is_some(),
+        scope_vars,
+        start: dir.loc.start.offset,
+        end: dir.loc.end.offset,
+    });
+}
+
+fn default_slot_child_span(el: &ElementNode<'_>) -> Option<(u32, u32)> {
+    let mut span: Option<(u32, u32)> = None;
+    for child in &el.children {
+        if !is_default_slot_child(child) {
+            continue;
+        }
+        let loc = child.loc();
+        span = Some(match span {
+            Some((start, end)) => (start.min(loc.start.offset), end.max(loc.end.offset)),
+            None => (loc.start.offset, loc.end.offset),
+        });
+    }
+    span
+}
+
+fn is_default_slot_child(child: &TemplateChildNode<'_>) -> bool {
+    match child {
+        TemplateChildNode::Element(el) if el.tag == "template" => !el
+            .props
+            .iter()
+            .any(|prop| matches!(prop, PropNode::Directive(dir) if dir.name == "slot")),
+        TemplateChildNode::Text(text) => !text.content.trim().is_empty(),
+        TemplateChildNode::Comment(_) => false,
+        TemplateChildNode::Hoisted(_) => false,
+        _ => true,
+    }
+}
+
+fn expression_content<'a>(exp: &'a ExpressionNode<'_>) -> &'a str {
+    match exp {
+        ExpressionNode::Simple(s) => s.content.as_str(),
+        ExpressionNode::Compound(c) => c.loc.source.as_str(),
     }
 }

--- a/crates/vize_croquis/src/drawer/template/tests.rs
+++ b/crates/vize_croquis/src/drawer/template/tests.rs
@@ -104,6 +104,46 @@ fn component_v_bind_arg_is_not_an_undefined_template_ref() {
 }
 
 #[test]
+fn component_usage_records_slots() {
+    use vize_armature::parse;
+    use vize_carton::Bump;
+
+    let template = r#"<Child :message="msg" @save.once="save">
+  <template #item="{ row, index }">
+    <span>{{ row }}</span>
+  </template>
+  <span>fallback</span>
+</Child>"#;
+
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, template);
+    assert!(errors.is_empty(), "Template should parse without errors");
+
+    let mut drawer = Drawer::with_options(DrawerOptions::full());
+    drawer.draw_template(&root);
+    let summary = drawer.finish();
+    let usage = summary
+        .component_usages
+        .iter()
+        .find(|usage| usage.name == "Child")
+        .expect("Child usage must be collected");
+
+    assert_eq!(usage.props.len(), 1);
+    assert_eq!(usage.events.len(), 1);
+    assert!(usage.slots.iter().any(|slot| {
+        slot.name == "item"
+            && slot.has_scope
+            && slot.scope_vars.iter().any(|var| var == "row")
+            && slot.scope_vars.iter().any(|var| var == "index")
+    }));
+    assert!(
+        usage.slots.iter().any(|slot| {
+            slot.name == "default" && !slot.has_scope && slot.scope_vars.is_empty()
+        })
+    );
+}
+
+#[test]
 fn nested_v_scope_shadows_outer() {
     use vize_armature::parse;
     use vize_carton::Bump;

--- a/crates/vize_croquis/src/drawer/template/visit_element.rs
+++ b/crates/vize_croquis/src/drawer/template/visit_element.rs
@@ -88,6 +88,10 @@ impl Drawer {
                 "croquis.template.component.props_events",
                 self.collect_component_props_events(el, usage)
             );
+            profile!(
+                "croquis.template.component.slots",
+                self.collect_component_slots(el, usage)
+            );
         }
 
         if let Some(usage) = component_usage {

--- a/crates/vize_maestro/src/ide/hover.rs
+++ b/crates/vize_maestro/src/ide/hover.rs
@@ -13,19 +13,23 @@
     clippy::disallowed_macros
 )]
 
+mod builder;
 mod component_prop;
+mod component_tag;
 #[cfg(feature = "native")]
 mod corsa;
 #[cfg(all(test, feature = "native"))]
 mod corsa_tests;
 #[cfg(feature = "native")]
 mod html;
+mod petite_vue;
 mod script;
 mod template;
 
+pub use builder::HoverBuilder;
 #[cfg(feature = "native")]
 use std::sync::Arc;
-use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Range};
+use tower_lsp::lsp_types::Hover;
 use vize_relief::BindingType;
 
 use super::IdeContext;
@@ -447,113 +451,13 @@ impl HoverService {
     }
 }
 
-/// Hover content builder for creating rich hover information.
-pub struct HoverBuilder {
-    sections: Vec<String>,
-}
-
-impl HoverBuilder {
-    /// Create a new hover builder.
-    pub fn new() -> Self {
-        Self {
-            sections: Vec::new(),
-        }
-    }
-
-    /// Add a title.
-    #[allow(clippy::disallowed_macros)]
-    pub fn title(mut self, title: &str) -> Self {
-        self.sections.push(format!("**{}**", title));
-        self
-    }
-
-    /// Add compact metadata under the title.
-    #[allow(clippy::disallowed_macros)]
-    pub fn meta(mut self, text: &str) -> Self {
-        self.sections.push(format!("_{}_", text));
-        self
-    }
-
-    /// Add a code block.
-    #[allow(clippy::disallowed_macros)]
-    pub fn code(mut self, language: &str, code: &str) -> Self {
-        self.sections
-            .push(format!("```{}\n{}\n```", language, code));
-        self
-    }
-
-    /// Add a named text section.
-    #[allow(clippy::disallowed_macros)]
-    pub fn section(mut self, heading: &str, text: &str) -> Self {
-        self.sections.push(format!("**{}**\n\n{}", heading, text));
-        self
-    }
-
-    /// Add a named bullet list.
-    #[allow(clippy::disallowed_macros)]
-    pub fn bullets(mut self, heading: &str, items: &[&str]) -> Self {
-        if items.is_empty() {
-            return self;
-        }
-
-        let body = items
-            .iter()
-            .map(|item| format!("- {}", item))
-            .collect::<Vec<_>>()
-            .join("\n");
-        self.sections.push(format!("**{}**\n{}", heading, body));
-        self
-    }
-
-    /// Add a description.
-    pub fn description(mut self, text: &str) -> Self {
-        self.sections.push(text.to_string());
-        self
-    }
-
-    /// Add a documentation link.
-    #[allow(clippy::disallowed_macros)]
-    pub fn link(mut self, text: &str, url: &str) -> Self {
-        self.sections.push(format!("[{}]({})", text, url));
-        self
-    }
-
-    /// Build the hover.
-    pub fn build(self) -> Hover {
-        Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                value: self.sections.join("\n\n"),
-            }),
-            range: None,
-        }
-    }
-
-    /// Build the hover with a range.
-    pub fn build_with_range(self, range: Range) -> Hover {
-        Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                value: self.sections.join("\n\n"),
-            }),
-            range: Some(range),
-        }
-    }
-}
-
-impl Default for HoverBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::fs;
 
-    use super::{HoverBuilder, HoverContents, HoverService};
+    use super::{HoverBuilder, HoverService};
     use crate::{ide::IdeContext, server::ServerState};
-    use tower_lsp::lsp_types::Url;
+    use tower_lsp::lsp_types::{HoverContents, Url};
     use vize_relief::BindingType;
 
     #[test]

--- a/crates/vize_maestro/src/ide/hover/builder.rs
+++ b/crates/vize_maestro/src/ide/hover/builder.rs
@@ -1,0 +1,101 @@
+use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Range};
+
+/// Hover content builder for creating rich hover information.
+pub struct HoverBuilder {
+    sections: Vec<String>,
+}
+
+impl HoverBuilder {
+    /// Create a new hover builder.
+    pub fn new() -> Self {
+        Self {
+            sections: Vec::new(),
+        }
+    }
+
+    /// Add a title.
+    #[allow(clippy::disallowed_macros)]
+    pub fn title(mut self, title: &str) -> Self {
+        self.sections.push(format!("**{}**", title));
+        self
+    }
+
+    /// Add compact metadata under the title.
+    #[allow(clippy::disallowed_macros)]
+    pub fn meta(mut self, text: &str) -> Self {
+        self.sections.push(format!("_{}_", text));
+        self
+    }
+
+    /// Add a code block.
+    #[allow(clippy::disallowed_macros)]
+    pub fn code(mut self, language: &str, code: &str) -> Self {
+        self.sections
+            .push(format!("```{}\n{}\n```", language, code));
+        self
+    }
+
+    /// Add a named text section.
+    #[allow(clippy::disallowed_macros)]
+    pub fn section(mut self, heading: &str, text: &str) -> Self {
+        self.sections.push(format!("**{}**\n\n{}", heading, text));
+        self
+    }
+
+    /// Add a named bullet list.
+    #[allow(clippy::disallowed_macros)]
+    pub fn bullets(mut self, heading: &str, items: &[&str]) -> Self {
+        if items.is_empty() {
+            return self;
+        }
+
+        let body = items
+            .iter()
+            .map(|item| format!("- {}", item))
+            .collect::<Vec<_>>()
+            .join("\n");
+        self.sections.push(format!("**{}**\n{}", heading, body));
+        self
+    }
+
+    /// Add a description.
+    pub fn description(mut self, text: &str) -> Self {
+        self.sections.push(text.to_string());
+        self
+    }
+
+    /// Add a documentation link.
+    #[allow(clippy::disallowed_macros)]
+    pub fn link(mut self, text: &str, url: &str) -> Self {
+        self.sections.push(format!("[{}]({})", text, url));
+        self
+    }
+
+    /// Build the hover.
+    pub fn build(self) -> Hover {
+        Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: self.sections.join("\n\n"),
+            }),
+            range: None,
+        }
+    }
+
+    /// Build the hover with a range.
+    pub fn build_with_range(self, range: Range) -> Hover {
+        Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: self.sections.join("\n\n"),
+            }),
+            range: Some(range),
+        }
+    }
+}
+
+impl Default for HoverBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/vize_maestro/src/ide/hover/component_prop.rs
+++ b/crates/vize_maestro/src/ide/hover/component_prop.rs
@@ -89,9 +89,9 @@ fn prop_signature_at(script: &str, offset: usize, prop_name: &str) -> String {
 mod tests {
     use std::fs;
 
-    use super::super::{HoverContents, HoverService};
+    use super::super::HoverService;
     use crate::{ide::IdeContext, server::ServerState};
-    use tower_lsp::lsp_types::Url;
+    use tower_lsp::lsp_types::{HoverContents, Url};
 
     #[test]
     fn hover_component_prop_uses_croquis_metadata() {

--- a/crates/vize_maestro/src/ide/hover/component_tag.rs
+++ b/crates/vize_maestro/src/ide/hover/component_tag.rs
@@ -1,0 +1,274 @@
+use tower_lsp::lsp_types::Hover;
+use vize_croquis::croquis::{ComponentUsage, PassedProp, SlotUsage};
+use vize_croquis::{Drawer, DrawerOptions};
+
+use super::{HoverBuilder, HoverService};
+use crate::ide::completion::template::component_metadata;
+use crate::ide::definition::helpers;
+use crate::ide::{IdeContext, is_component_tag};
+use crate::virtual_code::{ArtCursorPosition, BlockType};
+
+impl HoverService {
+    pub(super) fn hover_component_tag(ctx: &IdeContext<'_>) -> Option<Hover> {
+        let tag_name = helpers::get_tag_at_offset(&ctx.content, ctx.offset)?;
+        if !is_component_tag(&tag_name) {
+            return None;
+        }
+
+        let metadata = component_metadata(ctx, &tag_name);
+        if metadata.is_none() && !starts_with_uppercase(&tag_name) {
+            return None;
+        }
+
+        let usage = component_usage_at_cursor(ctx, &tag_name)?;
+        let mut builder = HoverBuilder::new().title(&tag_name).meta("Component usage");
+
+        let props = prop_items(&usage);
+        if !props.is_empty() {
+            builder = section_from_items(builder, "Passed props", &props);
+        }
+
+        let events = event_items(&usage);
+        if !events.is_empty() {
+            builder = section_from_items(builder, "Listeners", &events);
+        }
+
+        let slots = slot_items(&usage);
+        if !slots.is_empty() {
+            builder = section_from_items(builder, "Slots", &slots);
+        }
+
+        if usage.has_spread_attrs {
+            builder = builder.section("Spread attrs", "`v-bind` receives an object expression.");
+        }
+
+        if let Some(guard) = usage.vif_guard.as_ref() {
+            builder = builder.section("Rendered when", &format!("`{}`", guard.as_str()));
+        }
+
+        if let Some(metadata) = metadata {
+            let missing_required = metadata
+                .props
+                .iter()
+                .filter(|prop| prop.required)
+                .filter(|prop| {
+                    !usage
+                        .props
+                        .iter()
+                        .any(|passed| prop_names_match(passed, prop.name.as_str()))
+                })
+                .map(|prop| prop.name.clone())
+                .collect::<Vec<_>>();
+            if !missing_required.is_empty() {
+                builder =
+                    section_from_items(builder, "Required props not passed", &missing_required);
+            }
+        }
+
+        Some(builder.build())
+    }
+}
+
+fn component_usage_at_cursor(ctx: &IdeContext<'_>, tag_name: &str) -> Option<ComponentUsage> {
+    let template = template_view(ctx)?;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = if template.is_document {
+        vize_armature::parse_document(&allocator, template.content)
+    } else {
+        vize_armature::parse(&allocator, template.content)
+    };
+    let mut drawer = Drawer::with_options(DrawerOptions {
+        analyze_template_scopes: true,
+        track_usage: true,
+        ..Default::default()
+    });
+    drawer.draw_template(&root);
+    let croquis = drawer.finish();
+
+    croquis
+        .component_usages
+        .iter()
+        .filter(|usage| {
+            usage.name == tag_name
+                && usage.start <= template.relative_offset
+                && template.relative_offset <= usage.end
+        })
+        .min_by_key(|usage| usage.end.saturating_sub(usage.start))
+        .cloned()
+}
+
+struct TemplateView<'a> {
+    content: &'a str,
+    relative_offset: u32,
+    is_document: bool,
+}
+
+fn template_view<'a>(ctx: &'a IdeContext<'_>) -> Option<TemplateView<'a>> {
+    match ctx.block_type? {
+        BlockType::Template if crate::utils::is_standalone_html_path(ctx.uri.path()) => {
+            Some(TemplateView {
+                content: &ctx.content,
+                relative_offset: ctx.offset.min(ctx.content.len()) as u32,
+                is_document: true,
+            })
+        }
+        BlockType::Template => {
+            let descriptor = vize_atelier_sfc::parse_sfc(
+                &ctx.content,
+                vize_atelier_sfc::SfcParseOptions {
+                    filename: ctx.uri.path().to_string().into(),
+                    ..Default::default()
+                },
+            )
+            .ok()?;
+            let template = descriptor.template?;
+            Some(TemplateView {
+                content: ctx.content.get(template.loc.start..template.loc.end)?,
+                relative_offset: ctx.offset.saturating_sub(template.loc.start) as u32,
+                is_document: false,
+            })
+        }
+        BlockType::Art(ArtCursorPosition::VariantTemplate(info)) => Some(TemplateView {
+            content: ctx.content.get(info.template_start..info.template_end)?,
+            relative_offset: info.relative_offset as u32,
+            is_document: false,
+        }),
+        _ => None,
+    }
+}
+
+fn prop_items(usage: &ComponentUsage) -> Vec<String> {
+    usage
+        .props
+        .iter()
+        .filter(|prop| prop.name != "key" && prop.name != "ref")
+        .map(format_prop)
+        .collect()
+}
+
+fn format_prop(prop: &PassedProp) -> String {
+    match (prop.is_dynamic, prop.value.as_ref()) {
+        (true, Some(value)) => format!("`:{}=\"{}\"`", prop.name, value),
+        (true, None) => format!("`:{}=\"{}\"`", prop.name, prop.name),
+        (false, Some(value)) => format!("`{}=\"{}\"`", prop.name, value),
+        (false, None) => format!("`{}`", prop.name),
+    }
+}
+
+fn event_items(usage: &ComponentUsage) -> Vec<String> {
+    usage
+        .events
+        .iter()
+        .map(|event| {
+            let modifiers = event
+                .modifiers
+                .iter()
+                .map(|modifier| format!(".{modifier}"))
+                .collect::<String>();
+            match event.handler.as_ref() {
+                Some(handler) => format!("`@{}{modifiers}=\"{}\"`", event.name, handler),
+                None => format!("`@{}{modifiers}`", event.name),
+            }
+        })
+        .collect()
+}
+
+fn slot_items(usage: &ComponentUsage) -> Vec<String> {
+    usage.slots.iter().map(format_slot).collect()
+}
+
+fn format_slot(slot: &SlotUsage) -> String {
+    if slot.scope_vars.is_empty() {
+        return format!("`#{}`", slot.name);
+    }
+
+    let vars = slot
+        .scope_vars
+        .iter()
+        .map(|name| name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("`#{} {{ {} }}`", slot.name, vars)
+}
+
+fn section_from_items(builder: HoverBuilder, heading: &str, items: &[String]) -> HoverBuilder {
+    let refs = items.iter().map(String::as_str).collect::<Vec<_>>();
+    builder.bullets(heading, &refs)
+}
+
+fn prop_names_match(passed: &PassedProp, declared_name: &str) -> bool {
+    passed.name == declared_name || helpers::kebab_to_camel(passed.name.as_str()) == declared_name
+}
+
+fn starts_with_uppercase(tag_name: &str) -> bool {
+    tag_name
+        .chars()
+        .next()
+        .is_some_and(|first| first.is_ascii_uppercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::HoverService;
+    use crate::{ide::IdeContext, server::ServerState};
+    use tower_lsp::lsp_types::{HoverContents, Url};
+
+    #[test]
+    fn hover_component_tag_uses_croquis_usage() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join("Parent.vue");
+        let source = r#"<script setup lang="ts">
+const msg = 'hello'
+function save() {}
+</script>
+
+<template>
+  <Child :message="msg" @save.once="save">
+    <template #item="{ row, index }">
+      <span>{{ row }}</span>
+    </template>
+    <span>fallback</span>
+  </Child>
+</template>
+"#;
+        fs::write(&source_path, source).unwrap();
+
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        let offset = source.find("<Child").unwrap() + "<Ch".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let hover = HoverService::hover(&ctx).unwrap();
+        let value = hover_markdown(hover);
+
+        assert!(value.contains("Component usage"), "got {value:?}");
+        assert!(value.contains(":message=\"msg\""), "got {value:?}");
+        assert!(value.contains("@save.once=\"save\""), "got {value:?}");
+        assert!(value.contains("#item { row, index }"), "got {value:?}");
+        assert!(value.contains("#default"), "got {value:?}");
+    }
+
+    fn hover_markdown(hover: tower_lsp::lsp_types::Hover) -> String {
+        match hover.contents {
+            HoverContents::Markup(content) => content.value,
+            HoverContents::Scalar(marked) => match marked {
+                tower_lsp::lsp_types::MarkedString::String(value) => value,
+                tower_lsp::lsp_types::MarkedString::LanguageString(value) => value.value,
+            },
+            HoverContents::Array(items) => items
+                .into_iter()
+                .map(|item| match item {
+                    tower_lsp::lsp_types::MarkedString::String(value) => value,
+                    tower_lsp::lsp_types::MarkedString::LanguageString(value) => value.value,
+                })
+                .collect::<Vec<_>>()
+                .join("\n\n"),
+        }
+    }
+}

--- a/crates/vize_maestro/src/ide/hover/petite_vue.rs
+++ b/crates/vize_maestro/src/ide/hover/petite_vue.rs
@@ -1,0 +1,72 @@
+use tower_lsp::lsp_types::Hover;
+use vize_croquis::{Drawer, DrawerOptions, ScopeKind};
+
+use super::{HoverBuilder, HoverService};
+use crate::ide::IdeContext;
+
+impl HoverService {
+    /// Get hover for a petite-vue `v-scope` binding in a standalone HTML
+    /// document.
+    pub(super) fn hover_petite_vue_scope_binding(ctx: &IdeContext, word: &str) -> Option<Hover> {
+        if !crate::utils::is_standalone_html_path(ctx.uri.path()) || !ctx.dialect().is_petite_vue()
+        {
+            return None;
+        }
+
+        let allocator = vize_carton::Bump::new();
+        let (root, _errors) = vize_armature::parse_document(&allocator, &ctx.content);
+
+        let mut drawer = Drawer::with_options(DrawerOptions::full());
+        drawer.draw_template(&root);
+        let croquis = drawer.finish();
+
+        let offset = ctx.offset.min(ctx.content.len()) as u32;
+        let (binding, scope_kind) = croquis
+            .scopes
+            .bindings_visible_at(offset)
+            .into_iter()
+            .find(|(name, _, scope_kind)| {
+                *name == word
+                    && matches!(
+                        scope_kind,
+                        ScopeKind::VSlot
+                            | ScopeKind::VFor
+                            | ScopeKind::EventHandler
+                            | ScopeKind::Callback
+                    )
+            })
+            .map(|(_, binding, scope_kind)| (binding, scope_kind))?;
+
+        let inferred_type = Self::binding_type_to_ts_display(binding.binding_type);
+        #[allow(clippy::disallowed_macros)]
+        let signature = format!("{word}: {inferred_type}");
+
+        let scope_note = match scope_kind {
+            ScopeKind::VFor => {
+                "Local binding introduced by a `v-for` inside the `v-scope` subtree."
+            }
+            ScopeKind::EventHandler | ScopeKind::Callback => {
+                "Local binding visible inside the `v-scope` subtree."
+            }
+            _ => "Reactive key declared by the enclosing `v-scope` object.",
+        };
+
+        Some(
+            HoverBuilder::new()
+                .title(word)
+                .meta("petite-vue scope binding")
+                .code("typescript", &signature)
+                .description(
+                    "Resolved from the petite-vue `v-scope` chain of this standalone HTML document.",
+                )
+                .bullets(
+                    "Behavior",
+                    &[
+                        scope_note,
+                        "Visible only inside its `v-scope` subtree's expressions and directives.",
+                    ],
+                )
+                .build(),
+        )
+    }
+}

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -28,6 +28,10 @@ impl HoverService {
             return Some(hover);
         }
 
+        if let Some(hover) = Self::hover_component_tag(ctx) {
+            return Some(hover);
+        }
+
         if let Some(hover) = super::component_prop::hover_attribute(ctx) {
             return Some(hover);
         }
@@ -191,84 +195,6 @@ impl HoverService {
                     &[
                         "Ref values are automatically unwrapped in templates.",
                         resolved_from,
-                    ],
-                )
-                .build(),
-        )
-    }
-
-    /// Get hover for a petite-vue `v-scope` binding in a standalone HTML
-    /// document.
-    ///
-    /// petite-vue documents have no SFC `<template>` block, so the whole
-    /// document is the template. We parse it with the document parser
-    /// (`<!DOCTYPE>`-tolerant, raw-text `<script>`/`<style>`) and run Croquis
-    /// over the resulting AST. `v-scope` keys are modeled as `v-slot`-kind
-    /// scopes, so the identifier under the cursor resolves through the same
-    /// `bindings_visible_at` walk the completion path uses. Offsets are
-    /// document-absolute (no `<template>` block offset to subtract).
-    ///
-    /// Gated on `is_standalone_html_path` + petite-vue dialect, so `.vue` SFC
-    /// hover is unaffected.
-    pub(super) fn hover_petite_vue_scope_binding(ctx: &IdeContext, word: &str) -> Option<Hover> {
-        use vize_croquis::{Drawer, DrawerOptions, ScopeKind};
-
-        if !crate::utils::is_standalone_html_path(ctx.uri.path()) || !ctx.dialect().is_petite_vue()
-        {
-            return None;
-        }
-
-        let allocator = vize_carton::Bump::new();
-        let (root, _errors) = vize_armature::parse_document(&allocator, &ctx.content);
-
-        let mut drawer = Drawer::with_options(DrawerOptions::full());
-        drawer.draw_template(&root);
-        let croquis = drawer.finish();
-
-        let offset = ctx.offset.min(ctx.content.len()) as u32;
-        let (binding, scope_kind) = croquis
-            .scopes
-            .bindings_visible_at(offset)
-            .into_iter()
-            .find(|(name, _, scope_kind)| {
-                *name == word
-                    && matches!(
-                        scope_kind,
-                        ScopeKind::VSlot
-                            | ScopeKind::VFor
-                            | ScopeKind::EventHandler
-                            | ScopeKind::Callback
-                    )
-            })
-            .map(|(_, binding, scope_kind)| (binding, scope_kind))?;
-
-        let inferred_type = Self::binding_type_to_ts_display(binding.binding_type);
-        #[allow(clippy::disallowed_macros)]
-        let signature = format!("{word}: {inferred_type}");
-
-        let scope_note = match scope_kind {
-            ScopeKind::VFor => {
-                "Local binding introduced by a `v-for` inside the `v-scope` subtree."
-            }
-            ScopeKind::EventHandler | ScopeKind::Callback => {
-                "Local binding visible inside the `v-scope` subtree."
-            }
-            _ => "Reactive key declared by the enclosing `v-scope` object.",
-        };
-
-        Some(
-            HoverBuilder::new()
-                .title(word)
-                .meta("petite-vue scope binding")
-                .code("typescript", &signature)
-                .description(
-                    "Resolved from the petite-vue `v-scope` chain of this standalone HTML document.",
-                )
-                .bullets(
-                    "Behavior",
-                    &[
-                        scope_note,
-                        "Visible only inside its `v-scope` subtree's expressions and directives.",
                     ],
                 )
                 .build(),


### PR DESCRIPTION
## Summary
- populate Croquis component slot usage for direct and named slots
- show component tag hover details from Croquis usage: props, listeners, slots, guards, and missing required props
- split hover helper modules to keep file-size governance green

## Verification
- cargo test -p vize_croquis --lib
- cargo test -p vize_maestro --features native
- cargo test -p vize_canon --lib
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo fmt --check --package vize_croquis --package vize_maestro
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785703118&installation_id=136613492&pr_number=2560&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2560&signature=87c5c0143aaaeec81723d5ff507ed586af6234c9d7913f0b3cfcd54c5898e9b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hover now provides expanded “Component usage” for component tags, including passed props, listeners, slots, spread attributes, conditional rendering, and missing required props.
  * Added dedicated hover support for petite-vue scope bindings in standalone HTML.
* **Bug Fixes**
  * Component template analysis now records slot details more completely, including default slots and scoped slot variables.
* **Tests**
  * Added coverage for recording named and default slots in component usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->