### PR TITLE
fix(lsp): remove invalid SVG DOM attribute mappings

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
@@ -46,6 +46,13 @@ fn native_dom_attribute_info_preserves_svg_dom_property_names() {
         circle_center.type_expression.as_str(),
         "SVGElementTagNameMap[\"circle\"][\"cx\"]"
     );
+
+    let text_path_href = native_dom_attribute_info("textPath", "href").expect("textPath href");
+    assert_eq!(text_path_href.property_name.as_str(), "href");
+    assert_eq!(
+        text_path_href.type_expression.as_str(),
+        "SVGElementTagNameMap[\"textPath\"][\"href\"]"
+    );
 }
 
 #[test]
@@ -53,6 +60,8 @@ fn native_dom_attribute_info_rejects_unknown_and_component_attributes() {
     assert!(native_dom_attribute_info("button", "not-real").is_none());
     assert!(native_dom_attribute_info("div", "href").is_none());
     assert!(native_dom_attribute_info("svg", "not-real").is_none());
+    assert!(native_dom_attribute_info("textPath", "x").is_none());
+    assert!(native_dom_attribute_info("animate", "href").is_none());
     assert!(native_dom_attribute_info("my-element", "disabled").is_none());
     assert!(native_dom_attribute_info("button", "@click").is_none());
 }

--- a/crates/vize_maestro/src/ide/corsa_support/svg_attribute.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/svg_attribute.rs
@@ -33,14 +33,7 @@ pub(super) fn mapped_svg_dom_attribute_property(
         "y1" if tag_name == "line" => Some("y1"),
         "x2" if tag_name == "line" => Some("x2"),
         "y2" if tag_name == "line" => Some("y2"),
-        "href"
-            if matches!(
-                tag_name,
-                "a" | "animate" | "animateMotion" | "image" | "mpath" | "textPath" | "use"
-            ) =>
-        {
-            Some("href")
-        }
+        "href" if matches!(tag_name, "a" | "image" | "mpath" | "textPath" | "use") => Some("href"),
         _ => None,
     }
 }
@@ -70,7 +63,7 @@ fn svg_has_text_length(tag_name: &str) -> bool {
 fn svg_has_x_y(tag_name: &str) -> bool {
     matches!(
         tag_name,
-        "svg" | "rect" | "image" | "use" | "text" | "textPath" | "tspan"
+        "svg" | "rect" | "image" | "use" | "text" | "tspan"
     )
 }
 


### PR DESCRIPTION
## Summary

- remove SVG DOM attribute mappings that are not present on TypeScript's `SVGElementTagNameMap`
- keep valid `textPath.href` support and cover it with a regression test
- add negative coverage for `textPath.x` and `animate.href`

## Why

The native DOM metadata path builds TypeScript property lookups from these mappings. Mapping SVG attributes to properties that do not exist in `lib.dom.d.ts` can produce invalid virtual TypeScript queries for hover/definition support.

## Validation

- `vp run --workspace-root check:ci`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `cargo test -p vize_maestro native_dom_attribute_info -- --nocapture`
- `cargo test --workspace`
- `git diff --check`
- checked all 65 handwritten SVG DOM property mappings against TypeScript 6.0.3 `SVGElementTagNameMap` semantic diagnostics

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785738689&installation_id=136613492&pr_number=2563&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2563&signature=4bda896f3ffa098db41b2c19d7807d2e9a26cca60556738eeae6c35267988aa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SVG attribute handling so `href` is preserved on supported elements like `textPath`, while unsupported cases are correctly rejected.
  * Updated attribute mapping for `textPath` so `x` and `y` are no longer treated as valid mapped properties.
  * Strengthened validation for unknown or invalid attributes on SVG elements, reducing incorrect attribute acceptance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->