### PR TITLE
fix(lsp): avoid invalid global attribute metadata

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
@@ -168,6 +168,7 @@ fn dom_attribute_property_name(tag_name: &str, attr_name: &str) -> Option<String
 fn mapped_dom_attribute_property(attr_name: &str) -> Option<&'static str> {
     match attr_name {
         "accept-charset" => Some("acceptCharset"),
+        "accesskey" => Some("accessKey"),
         "allowfullscreen" => Some("allowFullscreen"),
         "class" => Some("className"),
         "colspan" => Some("colSpan"),
@@ -199,11 +200,18 @@ fn mapped_dom_attribute_property(attr_name: &str) -> Option<&'static str> {
 }
 
 fn is_known_native_attribute_for_tag(tag_name: &str, attr_name: &str) -> bool {
-    is_global_native_attribute(attr_name)
-        || vize_carton::is_html_tag(tag_name)
-            && HTML_TAG_ATTRIBUTES
+    if vize_carton::is_html_tag(tag_name) {
+        return is_html_global_native_attribute(attr_name)
+            || HTML_TAG_ATTRIBUTES
                 .iter()
-                .any(|(tag, attrs)| *tag == tag_name && attrs.contains(&attr_name))
+                .any(|(tag, attrs)| *tag == tag_name && attrs.contains(&attr_name));
+    }
+
+    if vize_carton::is_svg_tag(tag_name) || vize_carton::is_math_ml_tag(tag_name) {
+        return is_dom_element_global_attribute(attr_name);
+    }
+
+    false
 }
 
 #[rustfmt::skip]
@@ -220,12 +228,6 @@ const GLOBAL_ATTRIBUTES: &[&str] = &[
     "id",
     "inert",
     "inputmode",
-    "is",
-    "itemid",
-    "itemprop",
-    "itemref",
-    "itemscope",
-    "itemtype",
     "lang",
     "nonce",
     "popover",
@@ -286,8 +288,15 @@ const HTML_TAG_ATTRIBUTES: &[(&str, &[&str])] = &[
     ("video", &["autoplay", "controls", "crossorigin", "height", "loop", "muted", "playsinline", "poster", "preload", "src", "width"]),
 ];
 
-fn is_global_native_attribute(attr_name: &str) -> bool {
+fn is_html_global_native_attribute(attr_name: &str) -> bool {
     GLOBAL_ATTRIBUTES.contains(&attr_name)
+}
+
+fn is_dom_element_global_attribute(attr_name: &str) -> bool {
+    matches!(
+        attr_name,
+        "class" | "id" | "nonce" | "role" | "slot" | "style" | "tabindex"
+    )
 }
 
 fn kebab_to_camel(value: &str) -> String {

--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
@@ -13,6 +13,8 @@ fn native_dom_attribute_info_maps_html_attributes_to_dom_properties() {
 
     let class_attr = native_dom_attribute_info("div", "class").expect("class attr");
     assert_eq!(class_attr.property_name.as_str(), "className");
+    let access_key = native_dom_attribute_info("div", "accesskey").expect("accesskey attr");
+    assert_eq!(access_key.property_name.as_str(), "accessKey");
     let bound = native_dom_attribute_info("button", "v-bind:disabled").expect("v-bind attr");
     assert_eq!(bound.property_name.as_str(), "disabled");
     let aria = native_dom_attribute_info("button", "aria-label").expect("aria-label attr");
@@ -53,13 +55,30 @@ fn native_dom_attribute_info_preserves_svg_dom_property_names() {
         text_path_href.type_expression.as_str(),
         "SVGElementTagNameMap[\"textPath\"][\"href\"]"
     );
+
+    let svg_class = native_dom_attribute_info("svg", "class").expect("svg class attr");
+    assert_eq!(svg_class.property_name.as_str(), "className");
+    assert_eq!(
+        svg_class.type_expression.as_str(),
+        "SVGElementTagNameMap[\"svg\"][\"className\"]"
+    );
+    let math_tabindex = native_dom_attribute_info("math", "tabindex").expect("math tabindex attr");
+    assert_eq!(math_tabindex.property_name.as_str(), "tabIndex");
+    assert_eq!(
+        math_tabindex.type_expression.as_str(),
+        "MathMLElement[\"tabIndex\"]"
+    );
 }
 
 #[test]
 fn native_dom_attribute_info_rejects_unknown_and_component_attributes() {
     assert!(native_dom_attribute_info("button", "not-real").is_none());
     assert!(native_dom_attribute_info("div", "href").is_none());
+    assert!(native_dom_attribute_info("div", "is").is_none());
+    assert!(native_dom_attribute_info("div", "itemprop").is_none());
     assert!(native_dom_attribute_info("svg", "not-real").is_none());
+    assert!(native_dom_attribute_info("svg", "accesskey").is_none());
+    assert!(native_dom_attribute_info("math", "contenteditable").is_none());
     assert!(native_dom_attribute_info("textPath", "x").is_none());
     assert!(native_dom_attribute_info("animate", "href").is_none());
     assert!(native_dom_attribute_info("my-element", "disabled").is_none());


### PR DESCRIPTION
## Summary

- map HTML `accesskey` to the DOM property `accessKey`
- stop returning DOM metadata for global attributes that do not have DOM properties (`is` and microdata `item*` attributes)
- restrict SVG/MathML global attribute metadata to properties shared by DOM elements

## Why

Native attribute hover/definition support emits virtual TypeScript property lookups. Returning attributes whose property does not exist in `lib.dom.d.ts` creates invalid virtual documents instead of useful metadata.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vize_maestro native_dom_attribute_info -- --nocapture`
- `cargo clippy -p vize_maestro -- -D warnings -D clippy::wildcard_imports`
- `vp run --workspace-root check:ci`
- `git diff --check`
- checked the changed global-attribute assumptions against TypeScript 6.0.3 DOM types

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785740248&installation_id=136613492&pr_number=2564&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2564&signature=c9b723b4035f3a5ff02cc25f1270446dc45c981c18f73b0d5f1057bf99020d4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of native attributes across HTML, SVG, and MathML elements.
  * Added support for the `accesskey` attribute being mapped correctly to its DOM property name.
  * Tightened attribute validation so unsupported attributes are rejected more consistently.
  * Refined handling of globally allowed attributes for better accuracy in element-specific attribute suggestions and mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->