### PR TITLE
fix(lsp): align HTML attribute DOM properties

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
@@ -176,6 +176,8 @@ fn mapped_dom_attribute_property(attr_name: &str) -> Option<&'static str> {
         "crossorigin" => Some("crossOrigin"),
         "datetime" => Some("dateTime"),
         "enterkeyhint" => Some("enterKeyHint"),
+        "dirname" => Some("dirName"),
+        "fetchpriority" => Some("fetchPriority"),
         "for" => Some("htmlFor"),
         "formaction" => Some("formAction"),
         "formenctype" => Some("formEnctype"),
@@ -243,7 +245,7 @@ const GLOBAL_ATTRIBUTES: &[&str] = &[
 #[rustfmt::skip]
 const HTML_TAG_ATTRIBUTES: &[(&str, &[&str])] = &[
     ("a", &["download", "href", "hreflang", "ping", "referrerpolicy", "rel", "target"]),
-    ("area", &["download", "href", "hreflang", "ping", "referrerpolicy", "rel", "target"]),
+    ("area", &["download", "href", "ping", "referrerpolicy", "rel", "target"]),
     ("audio", &["autoplay", "controls", "crossorigin", "loop", "muted", "preload", "src"]),
     ("base", &["href", "target"]),
     ("blockquote", &["cite"]),
@@ -266,7 +268,7 @@ const HTML_TAG_ATTRIBUTES: &[(&str, &[&str])] = &[
     ("li", &["value"]),
     ("link", &["as", "crossorigin", "disabled", "fetchpriority", "href", "hreflang", "integrity", "media", "referrerpolicy", "rel", "sizes", "type"]),
     ("map", &["name"]),
-    ("meta", &["charset", "content", "http-equiv", "name"]),
+    ("meta", &["content", "http-equiv", "name"]),
     ("meter", &["high", "low", "max", "min", "optimum", "value"]),
     ("object", &["data", "form", "height", "name", "type", "usemap", "width"]),
     ("ol", &["reversed", "start", "type"]),

--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
@@ -21,6 +21,19 @@ fn native_dom_attribute_info_maps_html_attributes_to_dom_properties() {
     assert_eq!(aria.property_name.as_str(), "ariaLabel");
     let data = native_dom_attribute_info("div", "data-test-id").expect("data attribute");
     assert_eq!(data.property_name.as_str(), "dataset");
+    let fetch_priority =
+        native_dom_attribute_info("img", "fetchpriority").expect("fetchpriority attr");
+    assert_eq!(fetch_priority.property_name.as_str(), "fetchPriority");
+    assert_eq!(
+        fetch_priority.type_expression.as_str(),
+        "HTMLElementTagNameMap[\"img\"][\"fetchPriority\"]"
+    );
+    let dir_name = native_dom_attribute_info("textarea", "dirname").expect("dirname attr");
+    assert_eq!(dir_name.property_name.as_str(), "dirName");
+    assert_eq!(
+        dir_name.type_expression.as_str(),
+        "HTMLElementTagNameMap[\"textarea\"][\"dirName\"]"
+    );
 }
 
 #[test]
@@ -76,6 +89,8 @@ fn native_dom_attribute_info_rejects_unknown_and_component_attributes() {
     assert!(native_dom_attribute_info("div", "href").is_none());
     assert!(native_dom_attribute_info("div", "is").is_none());
     assert!(native_dom_attribute_info("div", "itemprop").is_none());
+    assert!(native_dom_attribute_info("area", "hreflang").is_none());
+    assert!(native_dom_attribute_info("meta", "charset").is_none());
     assert!(native_dom_attribute_info("svg", "not-real").is_none());
     assert!(native_dom_attribute_info("svg", "accesskey").is_none());
     assert!(native_dom_attribute_info("math", "contenteditable").is_none());


### PR DESCRIPTION
## Summary

- map `fetchpriority` to `fetchPriority`
- map `dirname` to `dirName`
- stop returning native DOM metadata for `area[hreflang]` and `meta[charset]`, which do not exist as TypeScript DOM properties

## Why

Native attribute metadata is backed by virtual TypeScript property lookups. These attribute cases either used the wrong DOM property casing or pointed at attributes without DOM properties, which made hover/definition metadata invalid.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vize_maestro native_dom_attribute_info -- --nocapture`
- `cargo clippy -p vize_maestro -- -D warnings -D clippy::wildcard_imports`
- `vp run --workspace-root check:ci`
- `git diff --check`
- checked changed HTML attribute property assumptions against TypeScript 6.0.3 DOM types
- checked 2,642 static HTML attribute lookups for TagNameMap-backed HTML tags with TypeScript 6.0.3 diagnostics 0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785741496&installation_id=136613492&pr_number=2565&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2565&signature=4f983c16481b58e92c9ffb3b1aa4dc088049dbe6b07697078e34b1467a3bb5e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML attribute handling so more native attributes are recognized correctly, including `dirname` and `fetchpriority`.
  * Adjusted attribute support for specific tags so unsupported combinations are no longer treated as native.
* **Tests**
  * Added coverage for the new attribute mappings.
  * Expanded checks to ensure unsupported attributes on certain elements are rejected as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->