### PR TITLE
fix(lsp): omit unmapped HTML DOM tags

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
@@ -91,6 +91,8 @@ fn native_dom_attribute_info_rejects_unknown_and_component_attributes() {
     assert!(native_dom_attribute_info("div", "itemprop").is_none());
     assert!(native_dom_attribute_info("area", "hreflang").is_none());
     assert!(native_dom_attribute_info("meta", "charset").is_none());
+    assert!(native_dom_attribute_info("param", "name").is_none());
+    assert!(native_dom_attribute_info("param", "value").is_none());
     assert!(native_dom_attribute_info("svg", "not-real").is_none());
     assert!(native_dom_attribute_info("svg", "accesskey").is_none());
     assert!(native_dom_attribute_info("math", "contenteditable").is_none());

--- a/crates/vize_maestro/src/ide/corsa_support/html_tag.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_tag.rs
@@ -48,7 +48,7 @@ pub(crate) fn native_dom_tag_info(tag_name: &str) -> Option<NativeDomTagInfo> {
         return None;
     }
 
-    if vize_carton::is_html_tag(tag_name) {
+    if has_html_element_tag_name_map_entry(tag_name) {
         return Some(NativeDomTagInfo {
             category: "HTML element",
             type_expression: cstr!("HTMLElementTagNameMap[\"{tag_name}\"]"),
@@ -79,7 +79,7 @@ pub(crate) fn native_dom_tag_info(tag_name: &str) -> Option<NativeDomTagInfo> {
 }
 
 fn dom_definition_symbol(tag_name: &str) -> Option<&'static str> {
-    if vize_carton::is_html_tag(tag_name) {
+    if has_html_element_tag_name_map_entry(tag_name) {
         Some("HTMLElementTagNameMap")
     } else if vize_carton::is_svg_tag(tag_name) {
         Some("SVGElementTagNameMap")
@@ -88,6 +88,10 @@ fn dom_definition_symbol(tag_name: &str) -> Option<&'static str> {
     } else {
         None
     }
+}
+
+fn has_html_element_tag_name_map_entry(tag_name: &str) -> bool {
+    vize_carton::is_html_tag(tag_name) && !matches!(tag_name, "param")
 }
 
 #[cfg(test)]
@@ -130,5 +134,11 @@ mod tests {
         assert!(super::native_dom_tag_info("template").is_none());
         assert!(super::native_dom_tag_info("slot").is_none());
         assert!(super::native_dom_tag_info("component").is_none());
+    }
+
+    #[test]
+    fn native_dom_tag_info_rejects_html_tags_missing_dom_map_entries() {
+        assert!(super::native_dom_tag_info("param").is_none());
+        assert!(super::html_tag_virtual_document("param").is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Skip HTML tags that are absent from TypeScript's HTMLElementTagNameMap in LSP DOM metadata
- Reject param tag/attribute virtual DOM metadata to avoid invalid lib.dom lookups

## Validation
- cargo fmt --all -- --check
- cargo test -p vize_maestro native_dom -- --nocapture
- cargo clippy -p vize_maestro -- -D warnings -D clippy::wildcard_imports
- vp run --workspace-root check:ci
- TypeScript 6.0.3 lib.dom.d.ts check: HTMLElementTagNameMap does not include param

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785742905&installation_id=136613492&pr_number=2566&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2566&signature=dd3ccc81ee0d448dedeee605df3ee72ccc83e81716a61bd3804c8625c3bf711a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML tag handling so unsupported tags like `param` are no longer treated as standard DOM elements.
  * Fixed attribute validation so `param`-related attributes such as `name` and `value` are correctly rejected where they aren’t supported.
  * This helps reduce incorrect tag/attribute suggestions and related editor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->