### PR TITLE
fix(lsp): omit unmapped SVG DOM tags

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
@@ -98,6 +98,8 @@ fn native_dom_attribute_info_rejects_unknown_and_component_attributes() {
     assert!(native_dom_attribute_info("math", "contenteditable").is_none());
     assert!(native_dom_attribute_info("textPath", "x").is_none());
     assert!(native_dom_attribute_info("animate", "href").is_none());
+    assert!(native_dom_attribute_info("mesh", "id").is_none());
+    assert!(native_dom_attribute_info("unknown", "id").is_none());
     assert!(native_dom_attribute_info("my-element", "disabled").is_none());
     assert!(native_dom_attribute_info("button", "@click").is_none());
 }

--- a/crates/vize_maestro/src/ide/corsa_support/html_tag.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_tag.rs
@@ -57,7 +57,7 @@ pub(crate) fn native_dom_tag_info(tag_name: &str) -> Option<NativeDomTagInfo> {
             ),
         });
     }
-    if vize_carton::is_svg_tag(tag_name) {
+    if has_svg_element_tag_name_map_entry(tag_name) {
         return Some(NativeDomTagInfo {
             category: "SVG element",
             type_expression: cstr!("SVGElementTagNameMap[\"{tag_name}\"]"),
@@ -81,7 +81,7 @@ pub(crate) fn native_dom_tag_info(tag_name: &str) -> Option<NativeDomTagInfo> {
 fn dom_definition_symbol(tag_name: &str) -> Option<&'static str> {
     if has_html_element_tag_name_map_entry(tag_name) {
         Some("HTMLElementTagNameMap")
-    } else if vize_carton::is_svg_tag(tag_name) {
+    } else if has_svg_element_tag_name_map_entry(tag_name) {
         Some("SVGElementTagNameMap")
     } else if vize_carton::is_math_ml_tag(tag_name) {
         Some("MathMLElement")
@@ -92,6 +92,23 @@ fn dom_definition_symbol(tag_name: &str) -> Option<&'static str> {
 
 fn has_html_element_tag_name_map_entry(tag_name: &str) -> bool {
     vize_carton::is_html_tag(tag_name) && !matches!(tag_name, "param")
+}
+
+fn has_svg_element_tag_name_map_entry(tag_name: &str) -> bool {
+    vize_carton::is_svg_tag(tag_name)
+        && !matches!(
+            tag_name,
+            "color-profile"
+                | "discard"
+                | "hatch"
+                | "hatchpath"
+                | "mesh"
+                | "meshgradient"
+                | "meshpatch"
+                | "meshrow"
+                | "solidcolor"
+                | "unknown"
+        )
 }
 
 #[cfg(test)]
@@ -140,5 +157,27 @@ mod tests {
     fn native_dom_tag_info_rejects_html_tags_missing_dom_map_entries() {
         assert!(super::native_dom_tag_info("param").is_none());
         assert!(super::html_tag_virtual_document("param").is_none());
+    }
+
+    #[test]
+    fn native_dom_tag_info_rejects_svg_tags_missing_dom_map_entries() {
+        for tag_name in [
+            "color-profile",
+            "discard",
+            "hatch",
+            "hatchpath",
+            "mesh",
+            "meshgradient",
+            "meshpatch",
+            "meshrow",
+            "solidcolor",
+            "unknown",
+        ] {
+            assert!(super::native_dom_tag_info(tag_name).is_none(), "{tag_name}");
+            assert!(
+                super::html_tag_virtual_document(tag_name).is_none(),
+                "{tag_name}",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Skip SVG tags that are absent from TypeScript's SVGElementTagNameMap in LSP DOM metadata
- Reject DOM attribute metadata for SVG tags that cannot produce valid lib.dom lookups

## Validation
- cargo fmt --all -- --check
- cargo test -p vize_maestro native_dom -- --nocapture
- cargo clippy -p vize_maestro -- -D warnings -D clippy::wildcard_imports
- vp run --workspace-root check:ci
- TypeScript 6.0.3 lib.dom.d.ts check: SVGElementTagNameMap missing set matches the excluded SVG tags

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785744317&installation_id=136613492&pr_number=2567&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2567&signature=0cda70eb177a6292ac78961b2a8fa8980a6e88ce7c9ab419304fe32f47952496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SVG tag handling so only supported tags appear in generated typing/documentation, reducing incorrect suggestions for excluded SVG elements.
  * Tightened attribute validation to reject unsupported or component-like attributes on additional elements, including invalid `id` cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->