### PR TITLE
fix(lsp): refine MathML tag DOM references

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
@@ -79,6 +79,14 @@ fn native_dom_attribute_info_preserves_svg_dom_property_names() {
     assert_eq!(math_tabindex.property_name.as_str(), "tabIndex");
     assert_eq!(
         math_tabindex.type_expression.as_str(),
+        "MathMLElementTagNameMap[\"math\"][\"tabIndex\"]"
+    );
+
+    let menclose_tabindex =
+        native_dom_attribute_info("menclose", "tabindex").expect("menclose tabindex attr");
+    assert_eq!(menclose_tabindex.property_name.as_str(), "tabIndex");
+    assert_eq!(
+        menclose_tabindex.type_expression.as_str(),
         "MathMLElement[\"tabIndex\"]"
     );
 }

--- a/crates/vize_maestro/src/ide/corsa_support/html_tag.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_tag.rs
@@ -66,6 +66,15 @@ pub(crate) fn native_dom_tag_info(tag_name: &str) -> Option<NativeDomTagInfo> {
             ),
         });
     }
+    if has_math_ml_element_tag_name_map_entry(tag_name) {
+        return Some(NativeDomTagInfo {
+            category: "MathML element",
+            type_expression: cstr!("MathMLElementTagNameMap[\"{tag_name}\"]"),
+            documentation_url: cstr!(
+                "https://developer.mozilla.org/en-US/docs/Web/MathML/Element/{tag_name}"
+            ),
+        });
+    }
     if vize_carton::is_math_ml_tag(tag_name) {
         return Some(NativeDomTagInfo {
             category: "MathML element",
@@ -83,6 +92,8 @@ fn dom_definition_symbol(tag_name: &str) -> Option<&'static str> {
         Some("HTMLElementTagNameMap")
     } else if has_svg_element_tag_name_map_entry(tag_name) {
         Some("SVGElementTagNameMap")
+    } else if has_math_ml_element_tag_name_map_entry(tag_name) {
+        Some("MathMLElementTagNameMap")
     } else if vize_carton::is_math_ml_tag(tag_name) {
         Some("MathMLElement")
     } else {
@@ -108,6 +119,43 @@ fn has_svg_element_tag_name_map_entry(tag_name: &str) -> bool {
                 | "meshrow"
                 | "solidcolor"
                 | "unknown"
+        )
+}
+
+fn has_math_ml_element_tag_name_map_entry(tag_name: &str) -> bool {
+    vize_carton::is_math_ml_tag(tag_name)
+        && matches!(
+            tag_name,
+            "annotation"
+                | "annotation-xml"
+                | "maction"
+                | "math"
+                | "merror"
+                | "mfrac"
+                | "mi"
+                | "mmultiscripts"
+                | "mn"
+                | "mo"
+                | "mover"
+                | "mpadded"
+                | "mphantom"
+                | "mprescripts"
+                | "mroot"
+                | "mrow"
+                | "ms"
+                | "mspace"
+                | "msqrt"
+                | "mstyle"
+                | "msub"
+                | "msubsup"
+                | "msup"
+                | "mtable"
+                | "mtd"
+                | "mtext"
+                | "mtr"
+                | "munder"
+                | "munderover"
+                | "semantics"
         )
 }
 
@@ -138,6 +186,32 @@ mod tests {
             &doc.content
                 [doc.definition_offset..doc.definition_offset + "SVGElementTagNameMap".len()],
             "SVGElementTagNameMap",
+        );
+    }
+
+    #[test]
+    fn html_tag_virtual_document_supports_mathml_tag_map_entries() {
+        let doc = super::html_tag_virtual_document("math").expect("math tag doc");
+
+        assert!(doc.content.contains("MathMLElementTagNameMap[\"math\"]"));
+        assert_eq!(
+            &doc.content
+                [doc.definition_offset..doc.definition_offset + "MathMLElementTagNameMap".len()],
+            "MathMLElementTagNameMap",
+        );
+    }
+
+    #[test]
+    fn html_tag_virtual_document_uses_mathml_fallback_for_unmapped_tags() {
+        let doc = super::html_tag_virtual_document("menclose").expect("menclose tag doc");
+
+        assert!(
+            doc.content
+                .contains("type __VizeDomElement = MathMLElement;")
+        );
+        assert_eq!(
+            &doc.content[doc.definition_offset..doc.definition_offset + "MathMLElement".len()],
+            "MathMLElement",
         );
     }
 


### PR DESCRIPTION
## Summary
- resolve MathML tag virtual documents through `MathMLElementTagNameMap` when TypeScript lib.dom has a tag entry
- keep the existing `MathMLElement` fallback for MathML tags not covered by `MathMLElementTagNameMap`
- update MathML attribute tests for both mapped and fallback tag paths

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p vize_maestro corsa_support -- --nocapture`
- TypeScript 6.0.3 `MathMLElementTagNameMap` coverage check against `MATH_TAGS`
- TypeScript 6.0.3 semantic diagnostic check for mapped and fallback MathML DOM snippets
- `cargo clippy -p vize_maestro -- -D warnings -D clippy::wildcard_imports`
- `git diff --check`
- `vp run --workspace-root check:ci`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785745661&installation_id=136613492&pr_number=2568&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2568&signature=34190a0a49e1efa87c101e7835161c99f75e24379ffb639074ead7405cecb94d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for MathML elements so tag information and attribute behavior are resolved more accurately.
  * Fixed `tabindex` handling for additional MathML elements, including correct property mappings.
  * Updated related documentation links shown for supported MathML tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->