### PR TITLE
fix(lsp): link global attribute docs correctly

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
@@ -78,6 +78,12 @@ pub(crate) fn native_dom_attribute_info(
         cstr!(
             "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/{normalized_attr}"
         )
+    } else if is_html_global_native_attribute(&normalized_attr)
+        || is_dom_element_global_attribute(&normalized_attr)
+    {
+        cstr!(
+            "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/{normalized_attr}"
+        )
     } else {
         cstr!(
             "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/{normalized_attr}"

--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
@@ -10,9 +10,19 @@ fn native_dom_attribute_info_maps_html_attributes_to_dom_properties() {
         disabled.type_expression.as_str(),
         "HTMLElementTagNameMap[\"button\"][\"disabled\"]"
     );
+    assert!(
+        disabled
+            .documentation_url
+            .ends_with("/Web/HTML/Reference/Attributes/disabled")
+    );
 
     let class_attr = native_dom_attribute_info("div", "class").expect("class attr");
     assert_eq!(class_attr.property_name.as_str(), "className");
+    assert!(
+        class_attr
+            .documentation_url
+            .ends_with("/Web/HTML/Reference/Global_attributes/class")
+    );
     let access_key = native_dom_attribute_info("div", "accesskey").expect("accesskey attr");
     assert_eq!(access_key.property_name.as_str(), "accessKey");
     let bound = native_dom_attribute_info("button", "v-bind:disabled").expect("v-bind attr");
@@ -80,6 +90,11 @@ fn native_dom_attribute_info_preserves_svg_dom_property_names() {
     assert_eq!(
         math_tabindex.type_expression.as_str(),
         "MathMLElementTagNameMap[\"math\"][\"tabIndex\"]"
+    );
+    assert!(
+        math_tabindex
+            .documentation_url
+            .ends_with("/Web/HTML/Reference/Global_attributes/tabindex")
     );
 
     let menclose_tabindex =


### PR DESCRIPTION
## Summary
- point accepted HTML global attributes to MDN `Global_attributes` pages
- apply the same global attribute URL path for MathML DOM global attributes
- keep element-specific HTML attribute links on `Reference/Attributes`

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p vize_maestro native_dom_attribute_info -- --nocapture`
- `cargo clippy -p vize_maestro -- -D warnings -D clippy::wildcard_imports`
- `git diff --check`
- `vp run --workspace-root check:ci`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785746930&installation_id=136613492&pr_number=2569&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2569&signature=23e1c2c3edcbdd14d1ecf5a8561cdbbcb3a3a30bbf8646043e1afbe649e75440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation links for common HTML attributes so they now point to the correct global attributes reference.
  * Fixed link handling for attributes like `class`, `id`, `role`, `style`, and similar DOM-wide attributes.
  * Updated coverage to verify the expected documentation URLs for selected HTML and SVG-related attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->