### PR TITLE
fix(lsp): cover anchor image-map attributes

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
@@ -250,8 +250,8 @@ const GLOBAL_ATTRIBUTES: &[&str] = &[
 
 #[rustfmt::skip]
 const HTML_TAG_ATTRIBUTES: &[(&str, &[&str])] = &[
-    ("a", &["download", "href", "hreflang", "ping", "referrerpolicy", "rel", "target"]),
-    ("area", &["download", "href", "ping", "referrerpolicy", "rel", "target"]),
+    ("a", &["charset", "coords", "download", "href", "hreflang", "name", "ping", "referrerpolicy", "rel", "rev", "shape", "target", "type"]),
+    ("area", &["alt", "coords", "download", "href", "ping", "referrerpolicy", "rel", "shape", "target"]),
     ("audio", &["autoplay", "controls", "crossorigin", "loop", "muted", "preload", "src"]),
     ("base", &["href", "target"]),
     ("blockquote", &["cite"]),

--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
@@ -44,6 +44,23 @@ fn native_dom_attribute_info_maps_html_attributes_to_dom_properties() {
         dir_name.type_expression.as_str(),
         "HTMLElementTagNameMap[\"textarea\"][\"dirName\"]"
     );
+
+    let anchor_type = native_dom_attribute_info("a", "type").expect("anchor type attr");
+    assert_eq!(anchor_type.property_name.as_str(), "type");
+    assert_eq!(
+        anchor_type.type_expression.as_str(),
+        "HTMLElementTagNameMap[\"a\"][\"type\"]"
+    );
+    let area_alt = native_dom_attribute_info("area", "alt").expect("area alt attr");
+    assert_eq!(area_alt.property_name.as_str(), "alt");
+    assert_eq!(
+        area_alt.type_expression.as_str(),
+        "HTMLElementTagNameMap[\"area\"][\"alt\"]"
+    );
+    let area_coords = native_dom_attribute_info("area", "coords").expect("area coords attr");
+    assert_eq!(area_coords.property_name.as_str(), "coords");
+    let area_shape = native_dom_attribute_info("area", "shape").expect("area shape attr");
+    assert_eq!(area_shape.property_name.as_str(), "shape");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add DOM-backed metadata for legacy anchor attributes still exposed on HTMLAnchorElement
- add DOM-backed metadata for image-map area attributes exposed on HTMLAreaElement
- cover the new attribute lookups with native DOM attribute tests

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo test -p vize_maestro native_dom_attribute_info -- --nocapture
- TypeScript semantic check against lib.dom.d.ts for the added anchor and area properties
- cargo clippy -p vize_maestro -- -D warnings -D clippy::wildcard_imports
- vp run --workspace-root check:ci

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785748326&installation_id=136613492&pr_number=2570&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2570&signature=5114374858381645c3014b4e7f528475212dfbb3f918d50a364be0e9c47e1887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML attribute recognition for links, so more valid `a` tag attributes are treated as known and mapped correctly.
  * Expanded support for additional native attributes on related elements, helping attribute-to-property behavior stay accurate.

* **Tests**
  * Added broader coverage for attribute mapping across multiple HTML elements to reduce regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->