### PR TITLE
fix(lsp): cover image legacy attributes

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
@@ -273,7 +273,7 @@ const HTML_TAG_ATTRIBUTES: &[(&str, &[&str])] = &[
     ("fieldset", &["disabled", "form", "name"]),
     ("form", &["accept-charset", "action", "autocomplete", "enctype", "method", "name", "novalidate", "rel", "target"]),
     ("iframe", &["align", "allow", "allowfullscreen", "frameborder", "height", "loading", "longdesc", "marginheight", "marginwidth", "name", "referrerpolicy", "sandbox", "scrolling", "src", "srcdoc", "width"]),
-    ("img", &["alt", "crossorigin", "decoding", "fetchpriority", "height", "ismap", "loading", "referrerpolicy", "sizes", "src", "srcset", "usemap", "width"]),
+    ("img", &["align", "alt", "border", "crossorigin", "decoding", "fetchpriority", "height", "hspace", "ismap", "loading", "longdesc", "lowsrc", "name", "referrerpolicy", "sizes", "src", "srcset", "usemap", "vspace", "width"]),
     ("input", &["accept", "alt", "autocomplete", "capture", "checked", "dirname", "disabled", "form", "formaction", "formenctype", "formmethod", "formnovalidate", "formtarget", "height", "list", "max", "maxlength", "min", "minlength", "multiple", "name", "pattern", "placeholder", "readonly", "required", "size", "src", "step", "type", "value", "width"]),
     ("ins", &["cite", "datetime"]),
     ("label", &["for", "form"]),

--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
@@ -38,6 +38,23 @@ fn native_dom_attribute_info_maps_html_attributes_to_dom_properties() {
         fetch_priority.type_expression.as_str(),
         "HTMLElementTagNameMap[\"img\"][\"fetchPriority\"]"
     );
+    let image_long_desc = native_dom_attribute_info("img", "longdesc").expect("img longdesc attr");
+    assert_eq!(image_long_desc.property_name.as_str(), "longDesc");
+    assert_eq!(
+        image_long_desc.type_expression.as_str(),
+        "HTMLElementTagNameMap[\"img\"][\"longDesc\"]"
+    );
+    for (attr_name, property_name) in [
+        ("align", "align"),
+        ("border", "border"),
+        ("hspace", "hspace"),
+        ("lowsrc", "lowsrc"),
+        ("name", "name"),
+        ("vspace", "vspace"),
+    ] {
+        let image_attr = native_dom_attribute_info("img", attr_name).expect("img legacy attr");
+        assert_eq!(image_attr.property_name.as_str(), property_name);
+    }
     let dir_name = native_dom_attribute_info("textarea", "dirname").expect("dirname attr");
     assert_eq!(dir_name.property_name.as_str(), "dirName");
     assert_eq!(


### PR DESCRIPTION
## Summary
- add DOM-backed legacy `<img>` attributes to native HTML attribute metadata
- map `longdesc` through the existing `longDesc` DOM property conversion
- cover the newly accepted image attributes in unit tests

## Verification
- cargo fmt --all -- --check
- git diff --check
- TypeScript semantic check for `HTMLElementTagNameMap["img"]` legacy properties
- cargo test -p vize_maestro native_dom_attribute_info -- --nocapture
- cargo clippy -p vize_maestro -- -D warnings -D clippy::wildcard_imports
- vp run --workspace-root check:ci

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785752454&installation_id=136613492&pr_number=2573&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2573&signature=ac6835279e09341473d154b65ce0d7aac8a3c990f9fd5ccf83feb44dbec0bbed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded support for legacy `<img>` HTML attributes so they’re now recognized as native attributes.
  * Improved DOM property mapping for additional image-related attributes, including `longdesc`, `align`, `border`, `hspace`, `lowsrc`, `name`, and `vspace`.
  * Added test coverage to verify the updated attribute-to-property behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->