### PR TITLE
fix(lsp): cover input image attributes

### DIFF
--- a/crates/vize_carton/src/dom_tag_config.rs
+++ b/crates/vize_carton/src/dom_tag_config.rs
@@ -91,7 +91,8 @@ pub static BOOLEAN_ATTRS: phf::Set<&'static str> = phf_set! {
     "readonly",
     "required",
     "reversed",
-    "selected"
+    "selected",
+    "webkitdirectory"
 };
 
 /// Check if tag is a valid HTML tag
@@ -187,6 +188,7 @@ mod tests {
         assert!(is_boolean_attr("declare"));
         assert!(is_boolean_attr("disabled"));
         assert!(is_boolean_attr("nowrap"));
+        assert!(is_boolean_attr("webkitdirectory"));
         assert!(!is_boolean_attr("aria-label"));
     }
 

--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
@@ -281,7 +281,7 @@ const HTML_TAG_ATTRIBUTES: &[(&str, &[&str])] = &[
     ("form", &["accept-charset", "action", "autocomplete", "enctype", "method", "name", "novalidate", "rel", "target"]),
     ("iframe", &["align", "allow", "allowfullscreen", "frameborder", "height", "loading", "longdesc", "marginheight", "marginwidth", "name", "referrerpolicy", "sandbox", "scrolling", "src", "srcdoc", "width"]),
     ("img", &["align", "alt", "border", "crossorigin", "decoding", "fetchpriority", "height", "hspace", "ismap", "loading", "longdesc", "lowsrc", "name", "referrerpolicy", "sizes", "src", "srcset", "usemap", "vspace", "width"]),
-    ("input", &["accept", "alt", "autocomplete", "capture", "checked", "dirname", "disabled", "form", "formaction", "formenctype", "formmethod", "formnovalidate", "formtarget", "height", "list", "max", "maxlength", "min", "minlength", "multiple", "name", "pattern", "placeholder", "readonly", "required", "size", "src", "step", "type", "value", "width"]),
+    ("input", &["accept", "align", "alt", "autocomplete", "capture", "checked", "dirname", "disabled", "form", "formaction", "formenctype", "formmethod", "formnovalidate", "formtarget", "height", "list", "max", "maxlength", "min", "minlength", "multiple", "name", "pattern", "placeholder", "readonly", "required", "size", "src", "step", "type", "usemap", "value", "webkitdirectory", "width"]),
     ("ins", &["cite", "datetime"]),
     ("label", &["for", "form"]),
     ("li", &["value"]),

--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute_tests.rs
@@ -44,6 +44,21 @@ fn native_dom_attribute_info_maps_html_attributes_to_dom_properties() {
         image_long_desc.type_expression.as_str(),
         "HTMLElementTagNameMap[\"img\"][\"longDesc\"]"
     );
+    let input_use_map = native_dom_attribute_info("input", "usemap").expect("input usemap attr");
+    assert_eq!(input_use_map.property_name.as_str(), "useMap");
+    assert_eq!(
+        input_use_map.type_expression.as_str(),
+        "HTMLElementTagNameMap[\"input\"][\"useMap\"]"
+    );
+    let input_webkit_directory =
+        native_dom_attribute_info("input", "webkitdirectory").expect("input webkitdirectory attr");
+    assert_eq!(
+        input_webkit_directory.property_name.as_str(),
+        "webkitdirectory"
+    );
+    assert!(input_webkit_directory.is_boolean);
+    let input_align = native_dom_attribute_info("input", "align").expect("input align attr");
+    assert_eq!(input_align.property_name.as_str(), "align");
     for (attr_name, property_name) in [
         ("align", "align"),
         ("border", "border"),


### PR DESCRIPTION
## Summary
- Add DOM metadata for `<input>` attributes backed by `HTMLInputElement`
- Cover legacy `align` and `usemap` on image inputs
- Treat `webkitdirectory` as a boolean reflected attribute

## Verification
- cargo fmt --all -- --check
- git diff --check
- TypeScript semantic check for `HTMLElementTagNameMap["input"]` properties
- cargo test -p vize_maestro native_dom_attribute_info -- --nocapture
- cargo test -p vize_carton test_boolean_attrs -- --nocapture
- cargo clippy -p vize_carton -p vize_maestro -- -D warnings -D clippy::wildcard_imports
- vp run --workspace-root check:ci

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785756390&installation_id=136613492&pr_number=2576&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2576&signature=d1b7a16bf67942aee572d4355c13fd4a06f191f88f7840220eb764c67eddf9a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of common HTML input attributes, including `align` and `webkitdirectory`.
  * Fixed attribute-to-property mapping so `webkitdirectory` is treated as a boolean attribute and `usemap` resolves correctly.
  * Expanded validation coverage to better reflect supported input attribute behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->