### PR TITLE
fix(release): allow manual Open VSX publish

### DIFF
--- a/.github/workflows/release-open-vsx.yml
+++ b/.github/workflows/release-open-vsx.yml
@@ -3,6 +3,12 @@ name: Release Open VSX
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Release tag to publish to Open VSX
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -29,10 +35,18 @@ jobs:
           run-install: false
       - uses: ./.github/actions/setup-moonbit
 
+      - name: Resolve release tag
+        id: release
+        env:
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name || inputs.tag_name }}
+        run: |
+          test -n "$RELEASE_TAG_NAME"
+          printf 'tag_name=%s\n' "$RELEASE_TAG_NAME" >> "$GITHUB_OUTPUT"
+
       - name: Download VSIX from GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release download "${{ github.event.release.tag_name }}" --pattern "*.vsix" --dir open-vsx-artifacts
+        run: gh release download "${{ steps.release.outputs.tag_name }}" --pattern "*.vsix" --dir open-vsx-artifacts
 
       - name: Skip publish when OVSX_PAT is absent
         if: env.OVSX_PAT == ''
@@ -40,7 +54,6 @@ jobs:
 
       - name: Publish Open VSX extension
         if: env.OVSX_PAT != ''
-        continue-on-error: true
         run: |
           vsix=$(find open-vsx-artifacts -name '*.vsix' -print -quit)
           test -n "$vsix"

--- a/tests/tooling/github-workflows-release-publish.test.ts
+++ b/tests/tooling/github-workflows-release-publish.test.ts
@@ -177,14 +177,25 @@ test("Open VSX workflow publishes the VS Code extension when configured", () => 
   const publishJob = workflowJobBody(workflow, "release-open-vsx-extension");
 
   assert.match(workflow, /on:\s*\n\s*release:\s*\n\s*types:\s*\[published\]/);
+  assert.match(
+    workflow,
+    /workflow_dispatch:\s*\n\s*inputs:\s*\n\s*tag_name:\s*\n\s*description:\s*Release tag to publish to Open VSX[\s\S]*required:\s*true[\s\S]*type:\s*string/,
+  );
   assert.match(publishJob, /environment:\s*open-vsx-registry/);
   assert.match(workflow, /OVSX_PAT:\s*\$\{\{ secrets\.OVSX_PAT \}\}/);
+  assert.match(publishJob, /name:\s*Resolve release tag/);
+  assert.match(
+    publishJob,
+    /RELEASE_TAG_NAME:\s*\$\{\{ github\.event\.release\.tag_name \|\| inputs\.tag_name \}\}/,
+  );
+  assert.match(publishJob, /tag_name=%s\\n/);
   assert.match(publishJob, /name:\s*Download VSIX from GitHub Release/);
-  assert.match(publishJob, /gh release download/);
+  assert.match(publishJob, /gh release download "\$\{\{ steps\.release\.outputs\.tag_name \}\}"/);
   assert.match(publishJob, /--pattern "\*\.vsix"/);
   assert.match(publishJob, /name:\s*Skip publish when OVSX_PAT is absent/);
   assert.match(
     publishJob,
-    /name:\s*Publish Open VSX extension[\s\S]*if:\s*env\.OVSX_PAT != ''[\s\S]*continue-on-error:\s*true[\s\S]*publish_open_vsx_extension\.mbtx/,
+    /name:\s*Publish Open VSX extension[\s\S]*if:\s*env\.OVSX_PAT != ''[\s\S]*publish_open_vsx_extension\.mbtx/,
   );
+  assert.doesNotMatch(publishJob, /continue-on-error:\s*true/);
 });


### PR DESCRIPTION
## Summary
- add workflow_dispatch with tag_name to Release Open VSX
- resolve the release tag for both release events and manual runs
- fail the Open VSX publish job on real publish errors

## Verification
- node --test tests/tooling/github-workflows-release-publish.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785759353&installation_id=136613492&pr_number=2577&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2577&signature=25607acaba072415afa8e63a254feb370b801a54ee1c0ee7db60e73ed397c75d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual run support for the Open VSX release workflow, including a release tag input.
  * The workflow now uses the selected release tag to fetch the correct extension package.

* **Bug Fixes**
  * Publish failures are now reported properly instead of being silently ignored.
  * Existing behavior still skips publishing when no Open VSX token is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->