### PR TITLE
fix(canon): skip declaration emit after type errors

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -1,5 +1,4 @@
 //! Check command execution logic.
-//!
 //! The direct runner delegates to `vize_canon`'s project-backed Corsa type checker so Vue SFCs,
 //! TypeScript sources, ambient declarations, and emitted declarations share one virtual project.
 
@@ -391,8 +390,30 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     };
     let check_time = check_start.elapsed();
 
+    let diagnostics_render_start = Instant::now();
+    let reported_raw = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            if !is_reported(&reported_files, &diagnostic.file, &mut canonical_paths) {
+                return false;
+            }
+            !is_suppressed_false_positive(diagnostic)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let diagnostics = render_diagnostics(&reported_raw);
+    let diagnostics_render_time = diagnostics_render_start.elapsed();
+    let total_errors = reported_raw
+        .iter()
+        .filter(|diagnostic| diagnostic.severity == 1)
+        .count();
+    let total_warnings = reported_raw
+        .iter()
+        .filter(|diagnostic| diagnostic.severity == 2)
+        .count();
     let emit_start = Instant::now();
-    let emitted_declarations = if args.declaration {
+    let emitted_declarations = if args.declaration && total_errors == 0 {
         let declaration_options = resolve_declaration_emit_options(
             args.declaration_dir.as_deref(),
             program_tsconfig_path.as_deref(),
@@ -407,34 +428,13 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             }
         }
     } else {
+        if args.declaration && total_errors > 0 && !args.quiet {
+            eprintln!("Skipping declaration emit because type errors were reported.");
+        }
         None
     };
     let emit_time = emit_start.elapsed();
-    let diagnostics_render_start = Instant::now();
-    // Restrict diagnostics to the requested files for an explicit subset; the
-    // ambient/transitive files were registered only to resolve cross-file types.
-    let reported_raw = result
-        .diagnostics
-        .iter()
-        .filter(|diagnostic| {
-            if !is_reported(&reported_files, &diagnostic.file, &mut canonical_paths) {
-                return false;
-            }
-            !is_suppressed_false_positive(diagnostic)
-        })
-        .cloned()
-        .collect::<Vec<_>>();
-    let diagnostics = render_diagnostics(&reported_raw);
-    let diagnostics_render_time = diagnostics_render_start.elapsed();
     let total_time = start.elapsed();
-    let total_errors = reported_raw
-        .iter()
-        .filter(|diagnostic| diagnostic.severity == 1)
-        .count();
-    let total_warnings = reported_raw
-        .iter()
-        .filter(|diagnostic| diagnostic.severity == 2)
-        .count();
 
     if args.profile {
         let profiler = global_profiler();
@@ -716,7 +716,7 @@ fn resolve_nuxt_project_root(
 }
 
 fn is_nuxt_project_root(path: &Path) -> bool {
-    path.join("nuxt.config.ts").exists()
-        || path.join("nuxt.config.js").exists()
-        || path.join("nuxt.config.mts").exists()
+    ["nuxt.config.ts", "nuxt.config.js", "nuxt.config.mts"]
+        .iter()
+        .any(|file| path.join(file).exists())
 }

--- a/tests/tooling/cli-check-json-shape.test.ts
+++ b/tests/tooling/cli-check-json-shape.test.ts
@@ -77,10 +77,11 @@ function withWorkspace<T>(run: (dir: string) => T): T {
 }
 
 type CheckJson = {
-  files: Array<{ file: string; virtualTs: string; diagnostics: string[] }>;
+  files: Array<{ file: string; virtualTs?: string; diagnostics: string[] }>;
   errorCount: number;
   warningCount: number;
   fileCount: number;
+  declarations?: string[];
 };
 
 function parseJson(result: CheckResult): CheckJson {
@@ -91,6 +92,7 @@ function parseJson(result: CheckResult): CheckJson {
 // to exercise the JSON envelope when diagnostics are present; the cases below
 // never assert the checker's message text, only the stable JSON shape.
 const BAD_TS = "export const x: string = 123;";
+const GOOD_TS = "export const answer = 42 as const;\n";
 
 test(
   "vize check --format json has a stable top-level shape and key names",
@@ -130,6 +132,75 @@ test(
       assert.equal(typeof parsed.errorCount, "number");
       assert.equal(typeof parsed.warningCount, "number");
       assert.equal(typeof parsed.fileCount, "number");
+    });
+  },
+);
+
+test(
+  "vize check --format json exposes declaration outputs when --declaration succeeds",
+  {
+    skip: CHECKER == null ? "no corsa/tsgo checker discoverable" : false,
+  },
+  () => {
+    withWorkspace((dir) => {
+      fs.writeFileSync(path.join(dir, "good.ts"), GOOD_TS, "utf8");
+      const result = runCheck(
+        [
+          "good.ts",
+          "--declaration",
+          "--declaration-dir",
+          "types",
+          "--format",
+          "json",
+          "--corsa-path",
+          CHECKER as string,
+        ],
+        dir,
+      );
+      assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+      const parsed = parseJson(result);
+      assert.deepEqual(parsed.declarations, ["types/good.d.ts"]);
+      const declarationPath = path.join(dir, parsed.declarations[0] as string);
+      assert.equal(fs.existsSync(declarationPath), true, "declaration file should exist on disk");
+      const declaration = fs.readFileSync(declarationPath, "utf8");
+      assert.match(declaration, /export declare const answer/u);
+      assert.equal(parsed.declarations[0]?.includes("\\"), false, "path should use '/'");
+    });
+  },
+);
+
+test(
+  "vize check --format json skips declaration outputs when type errors exist",
+  {
+    skip: CHECKER == null ? "no corsa/tsgo checker discoverable" : false,
+  },
+  () => {
+    withWorkspace((dir) => {
+      fs.writeFileSync(path.join(dir, "bad.ts"), BAD_TS, "utf8");
+      const result = runCheck(
+        [
+          "bad.ts",
+          "--declaration",
+          "--declaration-dir",
+          "types",
+          "--format",
+          "json",
+          "--corsa-path",
+          CHECKER as string,
+        ],
+        dir,
+      );
+      assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
+
+      const parsed = parseJson(result);
+      assert.equal("declarations" in parsed, false, "failed checks must not report d.ts outputs");
+      assert.match(result.stderr, /Skipping declaration emit because type errors were reported\./u);
+      assert.equal(
+        fs.existsSync(path.join(dir, "types", "bad.d.ts")),
+        false,
+        "failed checks must not leave a declaration file",
+      );
     });
   },
 );


### PR DESCRIPTION
## Summary

- Skip `vize check --declaration` emit when the reported type-check result has errors.
- Keep JSON declaration output tied to actual emitted `.d.ts` files, and add success/failure contract coverage.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [x] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

Type-check errors should prevent publishing generated declaration files from an invalid program.

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [ ] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [x] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

Commands run:

- `cargo build --profile ci -p vize`
- `node --test tests/tooling/cli-check-json-shape.test.ts`
- `cargo test -p vize --lib`
- `git diff --check`

## Risk

Low. This changes `--declaration` behavior only when the check result is already failing; successful declaration emit keeps returning emitted paths.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785768950&installation_id=136613492&pr_number=2578&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2578&signature=76491462f7abebf59869d79e3ea525ab59020a53594dfcbf999b3a3b5311274f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Declarations are now generated only after type checking confirms success, avoiding incomplete or invalid `.d.ts` output after errors.
  * `vize check --format json` more accurately represents declaration results, including omitting `declarations` when emission is skipped.
  * Diagnostics/status timing is updated so reporting appears after diagnostics are processed.
  * Improved Nuxt project root detection logic while preserving the same supported filenames.
* **Tests**
  * Extended CLI JSON shape tests to cover both successful and skipped declaration emission scenarios, including on-disk `.d.ts` expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->