### PR TITLE
fix(lsp): update declaration import renames

### DIFF
--- a/crates/vize_maestro/src/ide/file_rename/manual.rs
+++ b/crates/vize_maestro/src/ide/file_rename/manual.rs
@@ -19,8 +19,9 @@ use tower_lsp::lsp_types::{FileRename, Range, TextEdit, Url, WorkspaceEdit};
 use crate::{ide::offset_to_position, server::ServerState};
 
 const SCRIPT_EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"];
-const RESOLVABLE_SCRIPT_EXTENSIONS: &[&str] =
-    &["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs", "vue"];
+const RESOLVABLE_SCRIPT_EXTENSIONS: &[&str] = &[
+    "ts", "tsx", "d.ts", "js", "jsx", "mts", "cts", "mjs", "cjs", "vue",
+];
 
 #[derive(Clone)]
 struct RenameTarget {
@@ -714,8 +715,9 @@ fn normalize_path_buf(path: &Path) -> PathBuf {
 
 fn strip_extension(path: &Path) -> PathBuf {
     let mut stripped = normalize_path_buf(path);
-    if stripped.extension().is_some() {
-        stripped.set_extension("");
+    let extension_depth = 1 + usize::from(stripped.to_string_lossy().ends_with(".d.ts"));
+    for _ in 0..extension_depth {
+        let _ = stripped.set_extension("");
     }
     stripped
 }
@@ -741,11 +743,9 @@ fn workspace_root(_state: &ServerState) -> PathBuf {
 #[cfg(all(test, feature = "native"))]
 #[allow(clippy::disallowed_macros)]
 mod tests {
-    use std::{
-        collections::BTreeMap,
-        fs,
-        path::{Path, PathBuf},
-    };
+    use std::collections::BTreeMap;
+    use std::fs;
+    use std::path::{Path, PathBuf};
 
     use insta::assert_snapshot;
     use tower_lsp::lsp_types::{FileRename, Url, WorkspaceEdit};

--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -210,7 +210,7 @@ fn file_rename_registration_options() -> FileOperationRegistrationOptions {
             FileOperationFilter {
                 scheme: Some("file".to_string()),
                 pattern: FileOperationPattern {
-                    glob: "**/*.{vue,ts,tsx,js,jsx,mts,cts,mjs,cjs}".to_string(),
+                    glob: "**/*.{vue,ts,tsx,d.ts,js,jsx,mts,cts,mjs,cjs}".to_string(),
                     matches: Some(FileOperationPatternKind::File),
                     options: None,
                 },
@@ -304,6 +304,17 @@ mod tests {
                 .workspace
                 .and_then(|workspace| workspace.file_operations)
                 .is_some()
+        );
+    }
+
+    #[test]
+    fn file_rename_registration_mentions_declaration_files() {
+        let options = file_rename_registration_options();
+        let file_glob = &options.filters[0].pattern.glob;
+
+        assert!(
+            file_glob.contains("d.ts"),
+            "rename operations should include declaration shims: {file_glob}"
         );
     }
 }

--- a/crates/vize_maestro/tests/file_rename_declarations.rs
+++ b/crates/vize_maestro/tests/file_rename_declarations.rs
@@ -1,0 +1,108 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use tower_lsp::lsp_types::{FileRename, RenameFilesParams, Url};
+use vize_maestro::ide::FileRenameService;
+use vize_maestro::runtime;
+use vize_maestro::server::ServerState;
+
+fn file_uri(path: &Path) -> String {
+    Url::from_file_path(path).unwrap().to_string()
+}
+
+fn normalize_edit(root: &Path, edit: &tower_lsp::lsp_types::WorkspaceEdit) -> serde_json::Value {
+    let mut files = BTreeMap::<String, Vec<serde_json::Value>>::new();
+
+    for (uri, edits) in edit.changes.as_ref().unwrap() {
+        let path = uri.to_file_path().unwrap();
+        let label = path
+            .strip_prefix(root)
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        let items = edits
+            .iter()
+            .map(|edit| {
+                serde_json::json!({
+                    "range": {
+                        "start": {
+                            "line": edit.range.start.line,
+                            "character": edit.range.start.character,
+                        },
+                        "end": {
+                            "line": edit.range.end.line,
+                            "character": edit.range.end.character,
+                        }
+                    },
+                    "newText": edit.new_text
+                })
+            })
+            .collect::<Vec<_>>();
+
+        files.insert(label, items);
+    }
+
+    serde_json::json!(files)
+}
+
+#[test]
+fn rewrites_extensionless_declaration_imports_for_renamed_dts() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let src_dir = root.join("src");
+    let types_dir = src_dir.join("types");
+    fs::create_dir_all(&types_dir).unwrap();
+
+    let entry_path = src_dir.join("entry.ts");
+    let old_declaration = types_dir.join("schema.d.ts");
+    let new_declaration = types_dir.join("generated-schema.d.ts");
+
+    fs::write(
+        &entry_path,
+        "import type { Schema } from \"./types/schema\";\ntype Lazy = import(\"./types/schema\").Schema;\n",
+    )
+    .unwrap();
+    fs::write(
+        &old_declaration,
+        "export interface Schema { value: string }\n",
+    )
+    .unwrap();
+
+    let state = ServerState::new();
+    state.set_workspace_root(root.to_path_buf());
+
+    let edit = runtime::block_on(FileRenameService::will_rename_files(
+        &state,
+        &RenameFilesParams {
+            files: vec![FileRename {
+                old_uri: file_uri(&old_declaration),
+                new_uri: file_uri(&new_declaration),
+            }],
+        },
+    ))
+    .unwrap();
+
+    assert_eq!(
+        normalize_edit(root, &edit),
+        serde_json::json!({
+            "src/entry.ts": [
+                {
+                    "range": {
+                        "start": { "line": 0, "character": 29 },
+                        "end": { "line": 0, "character": 43 }
+                    },
+                    "newText": "./types/generated-schema"
+                },
+                {
+                    "range": {
+                        "start": { "line": 1, "character": 20 },
+                        "end": { "line": 1, "character": 34 }
+                    },
+                    "newText": "./types/generated-schema"
+                }
+            ]
+        })
+    );
+}


### PR DESCRIPTION
## Summary
- include declaration shims in LSP file-rename registration
- resolve extensionless imports to `.d.ts` during manual rename fallback
- cover `import type` and TS `import(...)` declaration references in an integration test

## Validation
- `cargo test -p vize_maestro rewrites_extensionless_declaration_imports_for_renamed_dts`
- `cargo test -p vize_maestro file_rename`
- `cargo test -p vize_maestro --test file_rename_declarations`
- `cargo build --profile ci -p vize_maestro`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785771879&installation_id=136613492&pr_number=2579&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2579&signature=514370a41211380aaec6f402514bdb65354688721c69b164715503dde4acdf68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File renaming now recognizes additional script types, including declaration files and Vue components, when updating import paths.
  * Renames involving declaration files now preserve the expected extensionless module paths in rewritten imports.

* **Bug Fixes**
  * Improved handling of multi-part extensions so renamed declaration imports are rewritten correctly.
  * Expanded rename availability so declaration-file renames are covered in supported rename operations.

* **Tests**
  * Added regression coverage for declaration-file renames and import rewriting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->