### PR TITLE
fix(lsp): handle module declaration renames

### DIFF
--- a/crates/vize_maestro/src/ide/file_rename/manual.rs
+++ b/crates/vize_maestro/src/ide/file_rename/manual.rs
@@ -20,9 +20,8 @@ use crate::{ide::offset_to_position, server::ServerState};
 
 const SCRIPT_EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"];
 const RESOLVABLE_SCRIPT_EXTENSIONS: &[&str] = &[
-    "ts", "tsx", "d.ts", "js", "jsx", "mts", "cts", "mjs", "cjs", "vue",
+    "ts", "tsx", "d.ts", "d.mts", "d.cts", "js", "jsx", "mts", "cts", "mjs", "cjs", "vue",
 ];
-
 #[derive(Clone)]
 struct RenameTarget {
     old_path: PathBuf,
@@ -715,7 +714,10 @@ fn normalize_path_buf(path: &Path) -> PathBuf {
 
 fn strip_extension(path: &Path) -> PathBuf {
     let mut stripped = normalize_path_buf(path);
-    let extension_depth = 1 + usize::from(stripped.to_string_lossy().ends_with(".d.ts"));
+    let path = stripped.to_string_lossy();
+    let extension_depth = 1 + usize::from(
+        path.ends_with(".d.ts") || path.ends_with(".d.mts") || path.ends_with(".d.cts"),
+    );
     for _ in 0..extension_depth {
         let _ = stripped.set_extension("");
     }
@@ -743,15 +745,13 @@ fn workspace_root(_state: &ServerState) -> PathBuf {
 #[cfg(all(test, feature = "native"))]
 #[allow(clippy::disallowed_macros)]
 mod tests {
+    use super::{collect_import_rename_edits, rename_open_documents};
+    use crate::server::ServerState;
+    use insta::assert_snapshot;
     use std::collections::BTreeMap;
     use std::fs;
     use std::path::{Path, PathBuf};
-
-    use insta::assert_snapshot;
     use tower_lsp::lsp_types::{FileRename, Url, WorkspaceEdit};
-
-    use super::{collect_import_rename_edits, rename_open_documents};
-    use crate::server::ServerState;
 
     fn test_dir() -> tempfile::TempDir {
         let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -210,7 +210,7 @@ fn file_rename_registration_options() -> FileOperationRegistrationOptions {
             FileOperationFilter {
                 scheme: Some("file".to_string()),
                 pattern: FileOperationPattern {
-                    glob: "**/*.{vue,ts,tsx,d.ts,js,jsx,mts,cts,mjs,cjs}".to_string(),
+                    glob: "**/*.{vue,ts,tsx,d.ts,d.mts,d.cts,js,jsx,mts,cts,mjs,cjs}".to_string(),
                     matches: Some(FileOperationPatternKind::File),
                     options: None,
                 },

--- a/crates/vize_maestro/tests/file_rename_declarations.rs
+++ b/crates/vize_maestro/tests/file_rename_declarations.rs
@@ -49,6 +49,20 @@ fn normalize_edit(root: &Path, edit: &tower_lsp::lsp_types::WorkspaceEdit) -> se
 
 #[test]
 fn rewrites_extensionless_declaration_imports_for_renamed_dts() {
+    assert_declaration_rename("d.ts");
+}
+
+#[test]
+fn rewrites_extensionless_declaration_imports_for_renamed_dmts() {
+    assert_declaration_rename("d.mts");
+}
+
+#[test]
+fn rewrites_extensionless_declaration_imports_for_renamed_dcts() {
+    assert_declaration_rename("d.cts");
+}
+
+fn assert_declaration_rename(extension: &str) {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
     let src_dir = root.join("src");
@@ -56,8 +70,8 @@ fn rewrites_extensionless_declaration_imports_for_renamed_dts() {
     fs::create_dir_all(&types_dir).unwrap();
 
     let entry_path = src_dir.join("entry.ts");
-    let old_declaration = types_dir.join("schema.d.ts");
-    let new_declaration = types_dir.join("generated-schema.d.ts");
+    let old_declaration = types_dir.join(format!("schema.{extension}"));
+    let new_declaration = types_dir.join(format!("generated-schema.{extension}"));
 
     fs::write(
         &entry_path,


### PR DESCRIPTION
## Summary
- resolve extensionless imports to `.d.mts` and `.d.cts` in the LSP rename fallback
- strip two extension segments for `.d.ts`, `.d.mts`, and `.d.cts` when preserving extensionless import style
- advertise declaration-module files in LSP file-rename registration

## Validation
- `cargo test -p vize_maestro --test file_rename_declarations`
- `cargo test -p vize_maestro file_rename_registration_mentions_declaration_files`
- `cargo build --profile ci -p vize_maestro`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785773327&installation_id=136613492&pr_number=2580&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2580&signature=172478e4dac118c1a0de9fbcbe6115ba99b50dc7d57365e530c4ed01d4d9223e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-rename import rewriting for TypeScript declaration files, including `.d.mts` and `.d.cts`, so related imports are updated correctly when files are renamed.
  * Expanded supported file types for rename detection to include Vue files and additional declaration shims.
* **Tests**
  * Added coverage for renaming `.d.ts`, `.d.mts`, and `.d.cts` declaration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->