### PR TITLE
fix(canon): support module declaration inputs

### DIFF
--- a/crates/vize/src/commands/check.rs
+++ b/crates/vize/src/commands/check.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 #[derive(Args)]
 #[allow(clippy::disallowed_types)]
 pub struct CheckArgs {
-    /// Files or directories to type-check (`.vue`, `.ts`, `.tsx`, `.mts`, `.cts`, `.jsx`, `.d.ts`).
+    /// Files or directories to type-check (`.vue`, `.ts`, `.tsx`, `.mts`, `.cts`, `.jsx`, `.d.ts`, `.d.mts`, `.d.cts`).
     /// When omitted, `tsconfig.json` include/exclude/files are used if available.
     pub patterns: Vec<String>,
 

--- a/crates/vize/src/commands/check/patterns.rs
+++ b/crates/vize/src/commands/check/patterns.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
-pub(super) const CHECK_INPUTS_DISPLAY: &str = ".vue, .ts, .tsx, .mts, .cts, .jsx, or .d.ts";
+pub(super) const CHECK_INPUTS_DISPLAY: &str =
+    ".vue, .ts, .tsx, .mts, .cts, .jsx, .d.ts, .d.mts, or .d.cts";
 
 const CHECK_EXTENSIONS: &[&str] = &["vue", "ts", "tsx", "mts", "cts"];
 
@@ -17,7 +18,9 @@ pub(super) fn is_supported_check_file(path: &Path, include_jsx: bool) -> bool {
 fn is_declaration_path(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".d.ts"))
+        .is_some_and(|name| {
+            name.ends_with(".d.ts") || name.ends_with(".d.mts") || name.ends_with(".d.cts")
+        })
 }
 
 #[cfg(test)]
@@ -34,6 +37,8 @@ mod tests {
             "worker.mts",
             "config.cts",
             "env.d.ts",
+            "env.d.mts",
+            "env.d.cts",
         ] {
             assert!(is_supported_check_file(Path::new(file), false), "{file}");
         }
@@ -59,6 +64,14 @@ mod tests {
         assert!(
             CHECK_INPUTS_DISPLAY.contains(".d.ts"),
             "missing .d.ts from display text"
+        );
+        assert!(
+            CHECK_INPUTS_DISPLAY.contains(".d.mts"),
+            "missing .d.mts from display text"
+        );
+        assert!(
+            CHECK_INPUTS_DISPLAY.contains(".d.cts"),
+            "missing .d.cts from display text"
         );
     }
 }

--- a/crates/vize/src/commands/check/runner/collect_tests.rs
+++ b/crates/vize/src/commands/check/runner/collect_tests.rs
@@ -38,7 +38,7 @@ fn base_dir_from_glob_patterns() {
 }
 
 #[test]
-fn collect_check_files_includes_ts_and_vue_and_dts() {
+fn collect_check_files_includes_ts_vue_and_declarations() {
     let case_dir = unique_case_dir("collect-check");
     let _ = fs::remove_dir_all(&case_dir);
     fs::create_dir_all(case_dir.join("src")).unwrap();
@@ -46,6 +46,8 @@ fn collect_check_files_includes_ts_and_vue_and_dts() {
     fs::write(case_dir.join("src/Component.jsx"), "").unwrap();
     fs::write(case_dir.join("src/main.ts"), "").unwrap();
     fs::write(case_dir.join("src/env.d.ts"), "").unwrap();
+    fs::write(case_dir.join("src/env.d.mts"), "").unwrap();
+    fs::write(case_dir.join("src/env.d.cts"), "").unwrap();
     fs::write(case_dir.join("src/skip.js"), "").unwrap();
 
     let files = collect_check_files(&vec![case_dir.display().to_string()], false);
@@ -54,6 +56,8 @@ fn collect_check_files_includes_ts_and_vue_and_dts() {
         files,
         vec![
             case_dir.join("src/App.vue"),
+            case_dir.join("src/env.d.cts"),
+            case_dir.join("src/env.d.mts"),
             case_dir.join("src/env.d.ts"),
             case_dir.join("src/main.ts"),
         ]

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_check_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_check_help.snap
@@ -8,7 +8,7 @@ Usage: check [OPTIONS] [PATTERNS]...
 
 Arguments:
   [PATTERNS]...
-          Files or directories to type-check (`.vue`, `.ts`, `.tsx`, `.mts`, `.cts`, `.jsx`, `.d.ts`). When omitted, `tsconfig.json` include/exclude/files are used if available
+          Files or directories to type-check (`.vue`, `.ts`, `.tsx`, `.mts`, `.cts`, `.jsx`, `.d.ts`, `.d.mts`, `.d.cts`). When omitted, `tsconfig.json` include/exclude/files are used if available
 
 Options:
   -c, --config <CONFIG>

--- a/tests/tooling/cli-check-args.test.ts
+++ b/tests/tooling/cli-check-args.test.ts
@@ -96,7 +96,7 @@ test("vize check --no-config bypasses validation of an invalid -c path", () => {
     assert.equal(result.stdout, "");
     assert.equal(
       result.stderr,
-      'No .vue, .ts, .tsx, .mts, .cts, .jsx, or .d.ts files found matching inputs: ["zzz.vue"]\n',
+      'No .vue, .ts, .tsx, .mts, .cts, .jsx, .d.ts, .d.mts, or .d.cts files found matching inputs: ["zzz.vue"]\n',
     );
   });
 });

--- a/tests/tooling/cli-check-collection.test.ts
+++ b/tests/tooling/cli-check-collection.test.ts
@@ -120,7 +120,7 @@ test("no-match text run prints the notice to stderr, leaves stdout empty, exits 
     assert.equal(result.stdout.trim(), "");
     assert.equal(
       result.stderr,
-      'No .vue, .ts, .tsx, .mts, .cts, .jsx, or .d.ts files found matching inputs: ["zzz.vue"]\n',
+      'No .vue, .ts, .tsx, .mts, .cts, .jsx, .d.ts, .d.mts, or .d.cts files found matching inputs: ["zzz.vue"]\n',
     );
   });
 });

--- a/tests/tooling/cli-check-contract.test.ts
+++ b/tests/tooling/cli-check-contract.test.ts
@@ -105,7 +105,7 @@ test("vize check exits 0 when explicit inputs match no supported files", () => {
     assert.equal(result.stdout, "");
     assert.equal(
       result.stderr,
-      'No .vue, .ts, .tsx, .mts, .cts, .jsx, or .d.ts files found matching inputs: ["does-not-exist.vue"]\n',
+      'No .vue, .ts, .tsx, .mts, .cts, .jsx, .d.ts, .d.mts, or .d.cts files found matching inputs: ["does-not-exist.vue"]\n',
     );
   });
 });
@@ -117,7 +117,7 @@ test("vize check exits 0 in an empty project with no inputs", () => {
     assert.equal(result.stdout, "");
     assert.equal(
       result.stderr,
-      "No .vue, .ts, .tsx, .mts, .cts, .jsx, or .d.ts files found matching inputs: []\n",
+      "No .vue, .ts, .tsx, .mts, .cts, .jsx, .d.ts, .d.mts, or .d.cts files found matching inputs: []\n",
     );
   });
 });


### PR DESCRIPTION
## Summary
- accept `.d.mts` and `.d.cts` as declaration inputs for `vize check`
- update CLI help and no-match contract text for the expanded input set
- cover directory collection for `.d.ts`, `.d.mts`, and `.d.cts` declarations

## Validation
- `cargo fmt --all`
- `git diff --check`
- `cargo build --profile ci -p vize`
- `cargo test -p vize supported_check_files_cover_ts_family_and_optional_jsx`
- `cargo test -p vize display_text_mentions_each_supported_input_kind`
- `cargo test -p vize check_help_snapshot --lib`
- `cargo test -p vize collect_check_files_includes_ts_vue_and_declarations --lib`
- `node --test tests/tooling/cli-check-contract.test.ts tests/tooling/cli-check-args.test.ts tests/tooling/cli-check-collection.test.ts`
- `node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785776070&installation_id=136613492&pr_number=2581&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2581&signature=f382e71037dde2092a52827002cb3708d1c6fcd3fa7b2111939716ffc284018b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded file matching for check commands to recognize additional TypeScript declaration formats.
  * Updated error and no-input messages to list the full set of supported file extensions.
  * Improved collection of test and source files so the new declaration variants are included.

* **Tests**
  * Updated check-related tests to cover the newly supported declaration file extensions and revised messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->