### PR TITLE
fix(canon): load module declaration ambient files

### DIFF
--- a/crates/vize/src/commands/check/tsconfig_inputs/ambient.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/ambient.rs
@@ -1,4 +1,4 @@
-//! Ambient declaration (`.d.ts`) collection for partial `vize check` runs.
+//! Ambient declaration collection for partial `vize check` runs.
 
 use std::{
     fs,
@@ -21,7 +21,7 @@ mod top_level;
 
 use top_level::has_top_level_import_or_export;
 
-/// Collect ambient declaration (`.d.ts`) files that belong to the tsconfig
+/// Collect ambient declaration files that belong to the tsconfig
 /// "program" so their global types stay in scope when only a subset of files is
 /// checked explicitly (e.g. `vize check src/App.vue`).
 ///
@@ -138,7 +138,9 @@ fn collect_tsconfig_type_declaration_files(
 pub(super) fn is_declaration_file(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".d.ts"))
+        .is_some_and(|name| {
+            name.ends_with(".d.ts") || name.ends_with(".d.mts") || name.ends_with(".d.cts")
+        })
 }
 
 /// Returns `true` when a declaration file would replace real Vue package types

--- a/crates/vize/src/commands/check/tsconfig_inputs/ambient/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/ambient/tests.rs
@@ -73,6 +73,53 @@ fn ambient_collection_skips_export_only_generated_declaration_modules() {
 }
 
 #[test]
+fn ambient_collection_loads_module_declaration_suffixes() {
+    let root = unique_case_dir("module-suffixes");
+    let _ = std::fs::remove_dir_all(&root);
+    write(&root, "src/App.vue", "<template><div /></template>\n");
+    write(
+        &root,
+        "src/env.d.mts",
+        "/// <reference path=\"./feature-flags.d.cts\" />\nexport {};\n",
+    );
+    write(
+        &root,
+        "src/feature-flags.d.cts",
+        "export {};\ndeclare global { interface ImportMeta { vfFeature: boolean } }\n",
+    );
+    write(
+        &root,
+        "src/globals.d.mts",
+        "declare const APP_VERSION: string;\n",
+    );
+    write(
+        &root,
+        "src/generated.d.cts",
+        "export type GeneratedOnly = { ok: true };\n",
+    );
+    write(
+        &root,
+        "tsconfig.json",
+        r#"{
+  "include": ["src/**/*"]
+}"#,
+    );
+
+    let project_root = root.canonicalize().unwrap();
+    let files = collect_ambient_declaration_files(
+        &project_root,
+        Some(&project_root.join("tsconfig.json")),
+        &mut TsconfigInputCache::default(),
+    );
+
+    assert_eq!(
+        relative_paths(&project_root, &files),
+        vec!["src/feature-flags.d.cts", "src/globals.d.mts"]
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
 fn ambient_collection_loads_compiler_options_type_packages() {
     let root = unique_case_dir("compiler-options-types");
     let _ = std::fs::remove_dir_all(&root);
@@ -122,6 +169,56 @@ fn ambient_collection_loads_compiler_options_type_packages() {
     );
     assert!(
         relative.contains(&"node_modules/nuxt-i18n/index.d.ts".to_string()),
+        "{relative:?}"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn ambient_collection_loads_compiler_options_module_declaration_packages() {
+    let root = unique_case_dir("compiler-options-module-types");
+    let _ = std::fs::remove_dir_all(&root);
+    write(&root, "src/App.vue", "<template><div /></template>\n");
+    write(
+        &root,
+        "node_modules/modern-env/package.json",
+        r#"{ "types": "index.d.mts" }"#,
+    );
+    write(
+        &root,
+        "node_modules/modern-env/index.d.mts",
+        "/// <reference path=\"./globals.d.cts\" />\nexport {};\n",
+    );
+    write(
+        &root,
+        "node_modules/modern-env/globals.d.cts",
+        "export {};\ndeclare global { const MODERN_ENV: true }\n",
+    );
+    write(
+        &root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "types": ["modern-env"]
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+
+    let project_root = root.canonicalize().unwrap();
+    let files = collect_ambient_declaration_files(
+        &project_root,
+        Some(&project_root.join("tsconfig.json")),
+        &mut TsconfigInputCache::default(),
+    );
+
+    let relative = relative_paths(&project_root, &files);
+    assert!(
+        relative.contains(&"node_modules/modern-env/index.d.mts".to_string()),
+        "{relative:?}"
+    );
+    assert!(
+        relative.contains(&"node_modules/modern-env/globals.d.cts".to_string()),
         "{relative:?}"
     );
     let _ = std::fs::remove_dir_all(&root);

--- a/crates/vize/src/commands/check/tsconfig_inputs/type_references.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/type_references.rs
@@ -248,7 +248,11 @@ fn push_declaration_entry_candidate(candidates: &mut Vec<PathBuf>, path: PathBuf
     push_unique_candidate(candidates, path.clone());
     if path.extension().is_none() {
         push_unique_candidate(candidates, path.with_extension("d.ts"));
+        push_unique_candidate(candidates, path.with_extension("d.mts"));
+        push_unique_candidate(candidates, path.with_extension("d.cts"));
         push_unique_candidate(candidates, path.join("index.d.ts"));
+        push_unique_candidate(candidates, path.join("index.d.mts"));
+        push_unique_candidate(candidates, path.join("index.d.cts"));
     }
 }
 
@@ -318,7 +322,9 @@ fn reference_path_attribute(line: &str) -> Option<&str> {
 fn is_declaration_path(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".d.ts"))
+        .is_some_and(|name| {
+            name.ends_with(".d.ts") || name.ends_with(".d.mts") || name.ends_with(".d.cts")
+        })
 }
 
 #[cfg(test)]

--- a/crates/vize/src/commands/check/tsconfig_inputs/type_references/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/type_references/tests.rs
@@ -92,6 +92,49 @@ fn type_reference_resolution_supports_subpaths_exports_and_graphs() {
 }
 
 #[test]
+fn type_reference_resolution_supports_module_declaration_suffixes() {
+    let root = unique_case_dir("module-suffixes");
+    let _ = std::fs::remove_dir_all(&root);
+    write(
+        &root,
+        "node_modules/modern-env/package.json",
+        r#"{ "types": "index.d.mts" }"#,
+    );
+    write(
+        &root,
+        "node_modules/modern-env/index.d.mts",
+        "/// <reference path=\"./globals.d.cts\" />\nexport {};\n",
+    );
+    write(
+        &root,
+        "node_modules/modern-env/globals.d.cts",
+        "declare const MODERN_ENV: true;\n",
+    );
+    write(
+        &root,
+        "node_modules/modern-subpath/worker.d.cts",
+        "declare const WORKER_ENV: true;\n",
+    );
+
+    let root = root.canonicalize().unwrap();
+    let modern_env = resolve_type_reference_declaration_files(&root, "modern-env");
+    assert_eq!(
+        relative_paths(&root, &modern_env),
+        vec![
+            "node_modules/modern-env/index.d.mts",
+            "node_modules/modern-env/globals.d.cts",
+        ]
+    );
+    let modern_subpath = resolve_type_reference_declaration_files(&root, "modern-subpath/worker");
+    assert_eq!(
+        relative_paths(&root, &modern_subpath),
+        vec!["node_modules/modern-subpath/worker.d.cts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
 fn tsconfig_type_packages_follow_extends_and_local_overrides() {
     let root = unique_case_dir("tsconfig-types");
     let _ = std::fs::remove_dir_all(&root);


### PR DESCRIPTION
## Summary
- treat `.d.mts` and `.d.cts` as ambient declaration files during partial `vize check` runs
- resolve package `types` and `/// <reference types>` declaration graphs through `.d.mts` and `.d.cts` files
- add regressions for tsconfig include, reference path, and compilerOptions.types module declaration packages

## Validation
- `cargo fmt --all`
- `git diff --check`
- `cargo test -p vize module_declaration --lib`
- `cargo test -p vize ambient_collection --lib`
- `cargo test -p vize type_reference_resolution --lib`
- `cargo test -p vize tsconfig_inputs --lib`
- `node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785777445&installation_id=136613492&pr_number=2582&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2582&signature=1fde225c79f8e33a863632dbaee41b27ee4593069481114b8151fbf610bf2ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of TypeScript declaration files so modern declaration formats are recognized during ambient collection and type reference resolution.
  * Expanded support for package and reference lookups to include `.d.mts` and `.d.cts` files, not just `.d.ts`.
  * Updated ambient file collection to correctly include module-style declaration files and their referenced globals where expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->