### PR TITLE
fix(canon): classify module declarations consistently

### DIFF
--- a/crates/vize/src/commands/check/runner/diagnostics/suppressions.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics/suppressions.rs
@@ -48,7 +48,9 @@ fn declaration_source_contains(path: &Path, needles: &[&str]) -> bool {
     if !path
         .file_name()
         .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".d.ts"))
+        .is_some_and(|name| {
+            name.ends_with(".d.ts") || name.ends_with(".d.mts") || name.ends_with(".d.cts")
+        })
     {
         return false;
     }
@@ -81,7 +83,7 @@ mod tests {
     #[test]
     fn suppresses_project_vue_wildcard_component_duplicates() {
         let temp = tempfile::tempdir().unwrap();
-        let shim = temp.path().join("ts-shim.d.ts");
+        let shim = temp.path().join("ts-shim.d.cts");
         std::fs::write(
             &shim,
             "declare module '*.vue' {\n  import Vue from 'vue';\n  export default Vue;\n}\n",
@@ -98,7 +100,7 @@ mod tests {
     #[test]
     fn suppresses_nuxt_bridge_injection_duplicates_against_any() {
         let temp = tempfile::tempdir().unwrap();
-        let shim = temp.path().join("gtag.d.ts");
+        let shim = temp.path().join("gtag.d.mts");
         std::fs::write(
             &shim,
             "declare module '@nuxt/bridge-schema' {\n  interface Context { $gtag: Gtag.Gtag; }\n}\n",

--- a/crates/vize/src/commands/check/runner/global_components.rs
+++ b/crates/vize/src/commands/check/runner/global_components.rs
@@ -183,7 +183,9 @@ struct GlobalComponentDeclarationSource {
 fn is_declaration_path(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".d.ts"))
+        .is_some_and(|name| {
+            name.ends_with(".d.ts") || name.ends_with(".d.mts") || name.ends_with(".d.cts")
+        })
 }
 
 fn collect_global_component_type_packages(
@@ -339,3 +341,6 @@ fn parse_dts_globals(
             .collect(),
     )
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize/src/commands/check/runner/global_components/tests.rs
+++ b/crates/vize/src/commands/check/runner/global_components/tests.rs
@@ -1,0 +1,58 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::collect_project_global_component_stubs;
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: AtomicUsize = AtomicUsize::new(0);
+
+    let case_id = NEXT_CASE_ID.fetch_add(1, Ordering::Relaxed);
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("vize-tests")
+        .join(format!(
+            "check-runner-global-components-{name}-{}-{case_id}",
+            std::process::id()
+        ))
+}
+
+#[test]
+fn collects_project_global_component_stubs_from_module_declarations() {
+    let project_root = unique_case_dir("module-declarations");
+    let _ = std::fs::remove_dir_all(&project_root);
+    let src_dir = project_root.join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    let dts_path = src_dir.join("components.d.mts");
+    std::fs::write(
+        &dts_path,
+        r#"import "vue";
+declare module "vue" {
+  export interface GlobalComponents {
+    ModernComponent: typeof import("./ModernComponent.vue")["default"]
+  }
+}
+export {};
+"#,
+    )
+    .unwrap();
+
+    let mut options = vize_canon::virtual_ts::VirtualTsOptions::default();
+    collect_project_global_component_stubs(
+        &mut options,
+        std::slice::from_ref(&dts_path),
+        &project_root,
+        None,
+    );
+
+    assert_eq!(options.external_template_bindings, ["ModernComponent"]);
+    assert!(
+        options.auto_import_stubs.iter().any(|stub| {
+            stub.contains("declare const ModernComponent:")
+                && stub.contains("./src/ModernComponent.vue.ts")
+        }),
+        "missing ModernComponent stub: {:?}",
+        options.auto_import_stubs
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize/src/commands/check/tsconfig_inputs/codegen_tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/codegen_tests.rs
@@ -52,8 +52,18 @@ fn default_collection_skips_generated_codegen_declaration_modules() {
     )
     .unwrap();
     fs::write(
+        case_dir.join("types/codegen/schema-module.d.mts"),
+        "export type ModuleSchema = { ok: true };\n",
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("types/codegen/schema-common.d.cts"),
+        "export type CommonSchema = { ok: true };\n",
+    )
+    .unwrap();
+    fs::write(
         case_dir.join("tsconfig.json"),
-        r#"{ "include": ["src/**/*.vue", "src/**/*.d.ts", "types/codegen/schema.d.ts"] }"#,
+        r#"{ "include": ["src/**/*.vue", "src/**/*.d.ts", "types/codegen/schema.d.ts", "types/codegen/schema-module.d.mts", "types/codegen/schema-common.d.cts"] }"#,
     )
     .unwrap();
 

--- a/crates/vize/src/commands/check/tsconfig_inputs/matching.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/matching.rs
@@ -95,7 +95,9 @@ pub(super) fn is_generated_codegen_declaration_path(path: &Path) -> bool {
     if !path
         .file_name()
         .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".d.ts"))
+        .is_some_and(|name| {
+            name.ends_with(".d.ts") || name.ends_with(".d.mts") || name.ends_with(".d.cts")
+        })
     {
         return false;
     }

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests/codegen.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests/codegen.rs
@@ -14,8 +14,18 @@ fn default_collection_skips_generated_codegen_declaration_modules() {
     )
     .unwrap();
     std::fs::write(
+        case_dir.join("types/codegen/schema-module.d.mts"),
+        "export type ModuleSchema = { ok: true };\n",
+    )
+    .unwrap();
+    std::fs::write(
+        case_dir.join("types/codegen/schema-common.d.cts"),
+        "export type CommonSchema = { ok: true };\n",
+    )
+    .unwrap();
+    std::fs::write(
         case_dir.join("tsconfig.json"),
-        r#"{ "include": ["src/**/*.vue", "src/**/*.d.ts", "types/codegen/schema.d.ts"] }"#,
+        r#"{ "include": ["src/**/*.vue", "src/**/*.d.ts", "types/codegen/schema.d.ts", "types/codegen/schema-module.d.mts", "types/codegen/schema-common.d.cts"] }"#,
     )
     .unwrap();
 

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -2850,7 +2850,7 @@ function eventHandler(eventArg: string) {
 "#,
             ),
             (
-                "src/components.d.ts",
+                "src/components.d.mts",
                 r#"import "vue";
 
 declare module "vue" {


### PR DESCRIPTION
## Summary
- classify `.d.mts` and `.d.cts` as declaration files for project GlobalComponents collection
- apply the same declaration suffix handling to known declaration-conflict suppressions
- skip generated codegen declaration modules with `.d.mts` and `.d.cts` suffixes
- cover the path through unit tests and the CLI global-components regression

## Validation
- `cargo fmt --all`
- `git diff --check`
- `cargo test -p vize collects_project_global_component_stubs_from_module_declarations --lib`
- `cargo test -p vize suppresses_project_vue_wildcard_component_duplicates --lib`
- `cargo test -p vize default_collection_skips_generated_codegen_declaration_modules --lib`
- `cargo test -p vize global_component --lib`
- `cargo test -p vize suppresses_nuxt_bridge_injection_duplicates_against_any --lib`
- `cargo test -p vize tsconfig_inputs --lib`
- `cargo test -p vize check_project_global_components_are_typed_from_ambient_dts --test check_cli`
- `node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785778829&installation_id=136613492&pr_number=2583&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2583&signature=afeccd768d5e98c277c482c4b5530f9f376b00bb07cdd9e51f94c09d93484c85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broadened TypeScript declaration handling so checks now recognize additional declaration file formats.
  * Global component discovery now works with more declaration file variants.

* **Bug Fixes**
  * Improved suppression and generated-file filtering to avoid missing valid declarations in alternate module formats.
  * Updated check behavior to correctly pick up ambient component typings from newer declaration extensions.

* **Tests**
  * Expanded regression coverage for the new declaration-file support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->