### PR TITLE
fix(canon): load Nuxt module declarations

### DIFF
--- a/crates/vize/src/commands/check/nuxt.rs
+++ b/crates/vize/src/commands/check/nuxt.rs
@@ -19,6 +19,8 @@ mod tsconfig_aliases;
 mod virtual_modules;
 
 #[cfg(test)]
+mod generated_tests;
+#[cfg(test)]
 mod legacy_template_globals_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/vize/src/commands/check/nuxt/generated.rs
+++ b/crates/vize/src/commands/check/nuxt/generated.rs
@@ -10,7 +10,9 @@ use super::super::dts::{
     parse_declared_global_values, parse_interface_members_with_rewritten_imports,
     rewrite_relative_specifier,
 };
-use super::generated_dir::NuxtGeneratedDir;
+use super::generated_dir::{
+    NuxtGeneratedDir, is_declaration_file, is_imports_declaration, is_nitro_imports_declaration,
+};
 use super::parsing::{
     normalize_component_binding_name, parse_export_names, parse_module_specifier,
 };
@@ -34,22 +36,14 @@ pub(super) fn collect_generated_stubs(
 
         for entry in walker.flatten() {
             let path = entry.path();
-            let is_dts = path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.ends_with(".d.ts"));
-            if !path.is_file() || !is_dts {
+            if !path.is_file() || !is_declaration_file(path) {
                 continue;
             }
 
-            let file_name = path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or("");
-            if file_name == "nitro-imports.d.ts" {
+            if is_nitro_imports_declaration(path) {
                 continue;
             }
-            if file_name == "imports.d.ts" {
+            if is_imports_declaration(path) {
                 found_import_manifest = true;
             }
 
@@ -261,7 +255,7 @@ fn module_path_exists(path: &Path) -> bool {
     }
 
     for extension in [
-        "ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs", "vue", "d.ts",
+        "ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs", "vue", "d.ts", "d.mts", "d.cts",
     ] {
         if path.with_extension(extension).is_file() {
             return true;
@@ -270,7 +264,7 @@ fn module_path_exists(path: &Path) -> bool {
 
     if path.is_dir() {
         for extension in [
-            "ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs", "vue", "d.ts",
+            "ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs", "vue", "d.ts", "d.mts", "d.cts",
         ] {
             if path.join("index").with_extension(extension).is_file() {
                 return true;

--- a/crates/vize/src/commands/check/nuxt/generated_dir.rs
+++ b/crates/vize/src/commands/check/nuxt/generated_dir.rs
@@ -17,6 +17,8 @@ use super::parsing::{
 };
 use crate::commands::check::tsconfig_inputs::parse_jsonc_value;
 
+const DECLARATION_SUFFIXES: &[&str] = &[".d.ts", ".d.mts", ".d.cts"];
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct NuxtGeneratedDir {
     path: PathBuf,
@@ -33,6 +35,12 @@ impl NuxtGeneratedDir {
     }
 
     pub(super) fn imports_path(&self) -> PathBuf {
+        for suffix in DECLARATION_SUFFIXES {
+            let path = self.path.join(format!("imports{suffix}"));
+            if path.is_file() {
+                return path;
+            }
+        }
         self.path.join("imports.d.ts")
     }
 
@@ -52,13 +60,7 @@ impl NuxtGeneratedDir {
         entries
             .flatten()
             .map(|entry| entry.path())
-            .filter(|path| {
-                path.is_file()
-                    && path
-                        .file_name()
-                        .and_then(|name| name.to_str())
-                        .is_some_and(|name| name.ends_with(".d.ts"))
-            })
+            .filter(|path| path.is_file() && is_declaration_file(path))
             .collect()
     }
 
@@ -73,17 +75,32 @@ impl NuxtGeneratedDir {
 
             for entry in walker.flatten() {
                 let path = entry.path();
-                let is_dts = path
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .is_some_and(|name| name.ends_with(".d.ts"));
-                if path.is_file() && is_dts {
+                if path.is_file() && is_declaration_file(path) {
                     files.push(path.to_path_buf());
                 }
             }
         }
         files
     }
+}
+
+pub(super) fn is_declaration_file(path: &Path) -> bool {
+    declaration_stem(path).is_some()
+}
+
+pub(super) fn is_imports_declaration(path: &Path) -> bool {
+    declaration_stem(path) == Some("imports")
+}
+
+pub(super) fn is_nitro_imports_declaration(path: &Path) -> bool {
+    declaration_stem(path) == Some("nitro-imports")
+}
+
+fn declaration_stem(path: &Path) -> Option<&str> {
+    let file_name = path.file_name().and_then(|name| name.to_str())?;
+    DECLARATION_SUFFIXES
+        .iter()
+        .find_map(|suffix| file_name.strip_suffix(suffix))
 }
 
 pub(super) fn resolve_nuxt_generated_dir(cwd: &Path) -> NuxtGeneratedDir {

--- a/crates/vize/src/commands/check/nuxt/generated_tests.rs
+++ b/crates/vize/src/commands/check/nuxt/generated_tests.rs
@@ -1,0 +1,131 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use vize_canon::virtual_ts::VirtualTsOptions;
+
+use super::detect_nuxt_auto_imports;
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: AtomicUsize = AtomicUsize::new(0);
+
+    let case_id = NEXT_CASE_ID.fetch_add(1, Ordering::Relaxed);
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("vize-tests")
+        .join(format!(
+            "check-nuxt-generated-{name}-{}-{case_id}",
+            std::process::id()
+        ))
+}
+
+#[test]
+fn detects_module_declaration_generated_imports() {
+    let project_root = unique_case_dir("module-declaration-imports");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join(".nuxt/types")).unwrap();
+    std::fs::create_dir_all(project_root.join("app/composables")).unwrap();
+    std::fs::write(project_root.join("nuxt.config.ts"), "export default {}").unwrap();
+    std::fs::write(
+        project_root.join("app/composables/modern.ts"),
+        "export const useModernImport = () => 'ok';\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join(".nuxt/types/imports.d.mts"),
+        r#"declare global {
+  const useModernImport: typeof import('../../app/composables/modern')['useModernImport']
+}
+export {}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join(".nuxt/types/components.d.cts"),
+        r#"declare module 'vue' {
+  export interface GlobalComponents {
+    ModernCard: typeof import('../../app/components/ModernCard.vue')['default']
+  }
+  export interface ComponentCustomProperties {
+    $modern: string
+  }
+}
+export {}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join(".nuxt/types/nitro-imports.d.mts"),
+        r#"declare global {
+  const shouldNotAppear: typeof import('../../app/composables/nitro')['shouldNotAppear']
+}
+export {}
+"#,
+    )
+    .unwrap();
+
+    let mut options = VirtualTsOptions::default();
+    let _ = detect_nuxt_auto_imports(&mut options, &project_root);
+    let stubs = options.auto_import_stubs.join("\n");
+
+    assert!(
+        stubs.contains("declare const useModernImport: typeof import("),
+        "expected imports.d.mts auto-import stub, got:\n{stubs}"
+    );
+    assert!(
+        stubs.contains("declare const ModernCard: typeof import("),
+        "expected components.d.cts component stub, got:\n{stubs}"
+    );
+    assert!(
+        !stubs.contains("shouldNotAppear"),
+        "nitro-imports.d.mts should stay skipped, got:\n{stubs}"
+    );
+    assert!(
+        !stubs.contains("declare function useRouter(): any;"),
+        "imports.d.mts should count as generated imports and suppress fallback stubs:\n{stubs}"
+    );
+    assert!(
+        options
+            .template_globals
+            .iter()
+            .any(|global| global.name == "$modern"),
+        "expected ComponentCustomProperties from .d.cts, got: {:#?}",
+        options.template_globals
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn detects_root_module_declaration_import_manifest() {
+    let project_root = unique_case_dir("root-module-declaration-imports");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join(".nuxt")).unwrap();
+    std::fs::create_dir_all(project_root.join("app/composables")).unwrap();
+    std::fs::write(project_root.join("nuxt.config.ts"), "export default {}").unwrap();
+    std::fs::write(
+        project_root.join("app/composables/root.ts"),
+        "export const useRootImport = () => 'ok';\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join(".nuxt/imports.d.cts"),
+        r#"export { useRootImport } from '../app/composables/root';
+"#,
+    )
+    .unwrap();
+
+    let mut options = VirtualTsOptions::default();
+    let _ = detect_nuxt_auto_imports(&mut options, &project_root);
+    let stubs = options.auto_import_stubs.join("\n");
+
+    assert!(
+        stubs.contains("declare const useRootImport: typeof import("),
+        "expected root imports.d.cts auto-import stub, got:\n{stubs}"
+    );
+    assert!(
+        !stubs.contains("declare function useRouter(): any;"),
+        "root imports.d.cts should suppress fallback stubs:\n{stubs}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
## Summary
- load Nuxt generated `.d.mts` and `.d.cts` files wherever generated declarations are scanned
- treat `imports.d.mts` and `imports.d.cts` as generated import manifests while keeping `nitro-imports.*` skipped
- resolve generated import type existence against module declaration suffixes too

## Validation
- `cargo test -p vize module_declaration_import --lib`
- `cargo test -p vize nuxt --lib`
- `cargo test -p vize nuxt --test check_cli`
- `node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785780483&installation_id=136613492&pr_number=2584&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2584&signature=71968a4bc7a085c6591d7195a8088b2c96566a28f8c70962b1be0d28d5354e2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Nuxt auto-import detection to recognize more TypeScript declaration formats and handle generated files more reliably.
  * Fixed scanning so standard import manifests and Nitro-specific declarations are correctly ignored when assembling stubs.
  * Updated module resolution to find declarations in both direct files and index-based directories.
* **Tests**
  * Added coverage for Nuxt projects using multiple declaration file variants and root-level import re-exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->