### PR TITLE
fix(canon): report module declaration outputs

### DIFF
--- a/crates/vize/tests/check_declaration_emit_cli.rs
+++ b/crates/vize/tests/check_declaration_emit_cli.rs
@@ -1,0 +1,166 @@
+use std::{path::Path, process::Command};
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn unique_case_dir(name: &str) -> std::path::PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(format!("{name}-{}-{case_id}", std::process::id()))
+}
+
+fn link_workspace_node_modules(project_root: &Path) {
+    let source = workspace_root().join("node_modules");
+    let target = project_root.join("node_modules");
+    if target.exists() {
+        return;
+    }
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, target).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(source, target).unwrap();
+}
+
+fn create_cli_project(name: &str, files: &[(&str, &str)]) -> std::path::PathBuf {
+    let project_root = unique_case_dir(name);
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    link_workspace_node_modules(&project_root);
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+
+    for (path, source) in files {
+        let file_path = project_root.join(path);
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(file_path, source).unwrap();
+    }
+
+    project_root
+}
+
+fn resolve_test_corsa_path() -> Option<String> {
+    let workspace_root = workspace_root();
+    let sibling_cache = workspace_root.parent()?.join("corsa-bind/.cache/tsgo");
+    if sibling_cache.exists() {
+        return Some(sibling_cache.display().to_string());
+    }
+
+    let workspace_bin = workspace_root.join("node_modules/.bin/tsgo");
+    workspace_bin
+        .exists()
+        .then(|| workspace_bin.display().to_string())
+}
+
+#[test]
+fn check_declaration_emit_reports_module_declaration_outputs() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "module-declaration-emit",
+        &[
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+export interface PublicProps {
+  label: string
+}
+
+defineProps<PublicProps>()
+</script>
+
+<template>
+  <p>{{ label }}</p>
+</template>
+"#,
+            ),
+            (
+                "src/modern.mts",
+                r#"export { default as App } from "./App.vue";
+export const answer = 42;
+"#,
+            ),
+            (
+                "src/legacy.cts",
+                r#"export const legacy = "ok";
+"#,
+            ),
+        ],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            ".",
+            "--format",
+            "json",
+            "--declaration",
+            "--declaration-dir",
+            "types",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let declarations = json["declarations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|path| path.as_str().unwrap())
+        .collect::<Vec<_>>();
+
+    assert!(
+        declarations.contains(&"types/modern.d.mts"),
+        "missing .d.mts declaration output: {declarations:#?}"
+    );
+    assert!(
+        declarations.contains(&"types/legacy.d.cts"),
+        "missing .d.cts declaration output: {declarations:#?}"
+    );
+
+    let modern_declaration = std::fs::read_to_string(project_root.join("types/modern.d.mts"))
+        .expect("modern declaration should be emitted");
+    assert!(
+        modern_declaration.contains("./App.vue"),
+        "declaration import should point at .vue:\n{modern_declaration}"
+    );
+    assert!(
+        !modern_declaration.contains(".vue.ts"),
+        "declaration import should not leak virtual .vue.ts paths:\n{modern_declaration}"
+    );
+    assert!(project_root.join("types/legacy.d.cts").is_file());
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -5,6 +5,7 @@
 //! project in `node_modules/.vize/canon/`, and requests diagnostics from
 //! Corsa's LSP instead of parsing CLI text output.
 
+mod declaration_path;
 mod error;
 mod executor;
 mod import_rewriter;

--- a/crates/vize_canon/src/batch/declaration_path.rs
+++ b/crates/vize_canon/src/batch/declaration_path.rs
@@ -1,0 +1,11 @@
+use std::path::Path;
+
+pub(super) fn is_declaration_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(is_declaration_file_name)
+}
+
+pub(super) fn is_declaration_file_name(name: &str) -> bool {
+    name.ends_with(".d.ts") || name.ends_with(".d.mts") || name.ends_with(".d.cts")
+}

--- a/crates/vize_canon/src/batch/executor.rs
+++ b/crates/vize_canon/src/batch/executor.rs
@@ -7,6 +7,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use super::declaration_path::is_declaration_file;
 use super::error::{CorsaError, CorsaNotFoundError, CorsaResult};
 use super::import_rewriter::ImportRewriter;
 use super::materialize_lock::MaterializeLock;
@@ -269,11 +270,7 @@ fn collect_declaration_outputs(out_dir: &Path) -> CorsaResult<Vec<DeclarationOut
         if !path.is_file() {
             continue;
         }
-        if !path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| name.ends_with(".d.ts"))
-        {
+        if !is_declaration_file(path) {
             continue;
         }
 
@@ -306,7 +303,7 @@ fn rewrite_declaration_outputs(out_dir: &Path) -> CorsaResult<()> {
         let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
             continue;
         };
-        if !name.ends_with(".d.ts") {
+        if !is_declaration_file(path) {
             continue;
         }
 

--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use super::super::{Diagnostic, TypeCheckResult, VirtualProject};
+use crate::batch::declaration_path::is_declaration_file;
 use crate::batch::error::{CorsaError, CorsaResult};
 use crate::batch::executor::diagnostics::{
     DiagnosticMapper, dedup_diagnostics, relative_module_resolves_on_disk, should_skip_diagnostic,
@@ -403,9 +404,7 @@ fn is_vue_original(path: &Path) -> bool {
 }
 
 fn is_ambient_declaration(path: &Path) -> bool {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".d.ts"))
+    is_declaration_file(path)
 }
 
 fn declares_program_wide_types(content: &str) -> bool {

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use super::Diagnostic;
+use super::declaration_path::is_declaration_file;
 use super::error::{CorsaError, CorsaResult};
 use super::executor::CorsaExecutor;
 use super::virtual_project::VirtualProject;
@@ -325,10 +326,7 @@ fn is_supported_input(path: &Path) -> bool {
     path.extension()
         .and_then(|extension| extension.to_str())
         .is_some_and(|extension| matches!(extension, "vue" | "ts" | "tsx" | "mts" | "cts"))
-        || path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| name.ends_with(".d.ts"))
+        || is_declaration_file(path)
 }
 
 #[cfg(test)]

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -12,6 +12,7 @@ use vize_carton::{String as CompactString, ToCompactString, cstr, profile};
 use vize_atelier_sfc::{SfcDescriptor, SfcParseOptions, parse_sfc};
 
 use crate::batch::Diagnostic;
+use crate::batch::declaration_path::is_declaration_file;
 use crate::batch::error::{CorsaError, CorsaResult};
 use crate::batch::import_rewriter::ImportRewriter;
 use crate::batch::source_map::{CompositeSourceMap, SfcSourceMap};
@@ -64,11 +65,7 @@ pub(super) fn build_registered_file(
         return build_vue_registered_file(path, content, context);
     }
 
-    if path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".d.ts"))
-    {
+    if is_declaration_file(path) {
         return build_script_registered_file(
             path,
             content,


### PR DESCRIPTION
## Summary
- collect and rewrite emitted `.d.mts` and `.d.cts` declaration outputs alongside `.d.ts`
- share declaration suffix detection across batch input, sharding, and virtual project registration
- add a CLI regression test for `.mts` and `.cts` declaration emit output plus `.vue.ts` import rewrite

## Validation
- `cargo test -p vize check_declaration_emit_reports_module_declaration_outputs --test check_declaration_emit_cli`
- `cargo test -p vize check_declaration_emit --test check_cli`
- `cargo test -p vize_canon collects_emitted_declaration_outputs`
- `node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785781239&installation_id=136613492&pr_number=2585&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2585&signature=ea64c796f1e961d9f0836cdb443ffcfb4569a1bdf868c6d35c909fab5486c7e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of TypeScript declaration files, including `.d.ts`, `.d.mts`, and `.d.cts`.
  * Declaration output reporting is now more reliable when generating files for mixed Vue/TypeScript projects.
  * Updated CLI behavior to better recognize declaration inputs during analysis and file grouping.

* **Tests**
  * Added coverage for declaration output generation and verification in a temporary project setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->