### PR TITLE
fix(canon): classify Nuxt module import manifests

### DIFF
--- a/crates/vize/src/commands/check/nuxt/generated_dir.rs
+++ b/crates/vize/src/commands/check/nuxt/generated_dir.rs
@@ -151,7 +151,7 @@ fn generated_dir_from_imports_target(cwd: &Path, target: &str) -> Option<PathBuf
 
     let file_name = path.file_name().and_then(|name| name.to_str())?;
     let mut dir = match file_name {
-        "imports" | "imports.d.ts" => path.parent()?.to_path_buf(),
+        "imports" => path.parent()?.to_path_buf(),
         "*" => {
             let parent = path.parent()?;
             if parent.file_name().and_then(|name| name.to_str()) == Some("imports") {
@@ -160,6 +160,7 @@ fn generated_dir_from_imports_target(cwd: &Path, target: &str) -> Option<PathBuf
                 parent.to_path_buf()
             }
         }
+        _ if is_imports_declaration(&path) => path.parent()?.to_path_buf(),
         _ => return None,
     };
 

--- a/crates/vize/src/commands/check/nuxt/tests/build_dir.rs
+++ b/crates/vize/src/commands/check/nuxt/tests/build_dir.rs
@@ -144,6 +144,62 @@ export {}
 }
 
 #[test]
+fn detects_generated_imports_from_tsconfig_module_imports_path() {
+    let cases = [
+        ("imports.d.mts", "useImportsPathDmts"),
+        ("types/imports.d.cts", "useImportsPathDcts"),
+    ];
+
+    for (target, imported_name) in cases {
+        let project_root = unique_case_dir(&format!(
+            "nuxt-tsconfig-module-imports-path-{imported_name}"
+        ));
+        let _ = std::fs::remove_dir_all(&project_root);
+        let declaration_path = project_root.join(".out/.nuxt").join(target);
+        std::fs::create_dir_all(declaration_path.parent().unwrap()).unwrap();
+        std::fs::write(project_root.join("nuxt.config.ts"), "export default {}").unwrap();
+        std::fs::write(
+            project_root.join("tsconfig.json"),
+            format!(
+                r##"{{
+  "compilerOptions": {{
+    "paths": {{
+      "#imports": [".out/.nuxt/{target}"]
+    }}
+  }}
+}}
+"##
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            declaration_path,
+            format!(
+                r#"declare global {{
+  const {imported_name}: () => number
+}}
+export {{}}
+"#,
+            ),
+        )
+        .unwrap();
+
+        let mut options = VirtualTsOptions::default();
+        let _ = detect_nuxt_auto_imports(&mut options, &project_root);
+
+        assert!(
+            options.auto_import_stubs.iter().any(|stub| {
+                stub.as_str() == format!("declare const {imported_name}: () => number;")
+            }),
+            "expected generated import from tsconfig #imports path, got: {:#?}",
+            options.auto_import_stubs
+        );
+
+        let _ = std::fs::remove_dir_all(&project_root);
+    }
+}
+
+#[test]
 fn warning_mentions_resolved_generated_dir() {
     let project_root = unique_case_dir("nuxt-warning-custom-build-dir");
     let _ = std::fs::remove_dir_all(&project_root);

--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -22,6 +22,8 @@ mod type_references;
 #[cfg(test)]
 mod codegen_tests;
 #[cfg(test)]
+mod nuxt_manifest_tests;
+#[cfg(test)]
 mod tests;
 
 pub(crate) use ambient::{

--- a/crates/vize/src/commands/check/tsconfig_inputs/matching.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/matching.rs
@@ -75,7 +75,13 @@ fn is_generated_component(previous: Option<&str>, name: &str) -> bool {
 }
 
 pub(super) fn is_nuxt_import_manifest_path(path: &Path) -> bool {
-    if path.file_name().and_then(|name| name.to_str()) != Some("imports.d.ts") {
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    if !matches!(
+        file_name,
+        "imports.d.ts" | "imports.d.mts" | "imports.d.cts"
+    ) {
         return false;
     }
 
@@ -85,10 +91,10 @@ pub(super) fn is_nuxt_import_manifest_path(path: &Path) -> bool {
         .collect::<Vec<_>>();
     components
         .windows(2)
-        .any(|window| window == [".nuxt", "imports.d.ts"])
+        .any(|window| window[0] == ".nuxt" && window[1] == file_name)
         || components
             .windows(3)
-            .any(|window| window == [".nuxt", "types", "imports.d.ts"])
+            .any(|window| window[0] == ".nuxt" && window[1] == "types" && window[2] == file_name)
 }
 
 pub(super) fn is_generated_codegen_declaration_path(path: &Path) -> bool {

--- a/crates/vize/src/commands/check/tsconfig_inputs/nuxt_manifest_tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/nuxt_manifest_tests.rs
@@ -1,0 +1,78 @@
+//! Nuxt manifest filtering tests split out from the large tsconfig suite.
+
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use vize_carton::cstr;
+
+use super::TsconfigInputCache;
+
+fn collect_default_check_files(project_root: &Path, tsconfig_path: &Path) -> Vec<PathBuf> {
+    super::collect_default_check_files(
+        project_root,
+        Some(tsconfig_path),
+        false,
+        &mut TsconfigInputCache::default(),
+    )
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("vize-tests")
+        .join(cstr!("{name}-{}-{case_id}", std::process::id()).as_str())
+}
+
+fn relative_paths(root: &Path, files: &[PathBuf]) -> Vec<String> {
+    files
+        .iter()
+        .map(|path| {
+            path.strip_prefix(root)
+                .unwrap()
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
+        .collect()
+}
+
+#[test]
+fn default_collection_skips_nuxt_module_import_manifest_files_entries() {
+    let case_dir = unique_case_dir("tsconfig-nuxt-module-import-manifest-files");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join(".nuxt/types")).unwrap();
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    fs::write(case_dir.join("src/App.vue"), "<template />").unwrap();
+    fs::write(
+        case_dir.join(".nuxt/imports.d.mts"),
+        "export { useModuleImport } from '../composables/useModuleImport'\n",
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join(".nuxt/types/imports.d.cts"),
+        "declare global { const useModuleImport: () => string }\nexport {}\n",
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{
+  "files": [
+    "src/App.vue",
+    ".nuxt/imports.d.mts",
+    ".nuxt/types/imports.d.cts"
+  ]
+}"#,
+    )
+    .unwrap();
+
+    let files = collect_default_check_files(&case_dir, &case_dir.join("tsconfig.json"));
+
+    assert_eq!(relative_paths(&case_dir, &files), vec!["src/App.vue"]);
+
+    let _ = fs::remove_dir_all(&case_dir);
+}


### PR DESCRIPTION
## Summary
- classify Nuxt `imports.d.mts` and `imports.d.cts` as generated import manifests
- resolve Nuxt generated directories from `#imports` paths that target module declaration manifests
- add regression tests for module declaration Nuxt import manifests

## Validation
- `cargo test -p vize default_collection_skips_nuxt_module_import_manifest_files_entries --lib`
- `cargo test -p vize detects_generated_imports_from_tsconfig_module_imports_path --lib`
- `cargo test -p vize nuxt --lib`
- `node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785782102&installation_id=136613492&pr_number=2586&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2586&signature=aa78bb3cd9349c1a50449e0824ebd39d85e11cad4bdb7d5298d38b96a5d84104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Nuxt auto-import stubs across more generated declaration formats, including additional module-style variants.
  * Expanded Nuxt manifest recognition so generated import files are filtered out more reliably from default checks.
  * Added coverage for Nuxt `#imports` path resolution to ensure generated files are found in more project setups.

* **Tests**
  * Added new tests for Nuxt-generated import and manifest handling to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->