### PR TITLE
fix(canon): resolve module declaration siblings

### DIFF
--- a/crates/vize_canon/src/batch/executor/diagnostics/module_resolution.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics/module_resolution.rs
@@ -43,7 +43,7 @@ pub(crate) fn relative_module_resolves_on_disk(message: &str, importer: &Path) -
 }
 
 /// Source extensions a relative specifier may resolve to.
-const SOURCE_EXTENSIONS: &[&str] = &["ts", "tsx", "d.ts", "mts", "cts", "vue"];
+const SOURCE_EXTENSIONS: &[&str] = &["ts", "tsx", "d.ts", "d.mts", "d.cts", "mts", "cts", "vue"];
 
 /// Resolve `specifier` against `dir` the way TypeScript would for a Vue/TS
 /// project: an explicit supported extension, an extension appended to the
@@ -84,6 +84,8 @@ fn relative_specifier_resolves(dir: &Path, specifier: &str) -> bool {
 fn specifier_has_source_extension(specifier: &str) -> bool {
     specifier.ends_with(".vue")
         || specifier.ends_with(".d.ts")
+        || specifier.ends_with(".d.mts")
+        || specifier.ends_with(".d.cts")
         || specifier.ends_with(".ts")
         || specifier.ends_with(".tsx")
         || specifier.ends_with(".mts")
@@ -102,15 +104,22 @@ mod tests {
         let importer = dir.path().join("App.vue");
         std::fs::write(&importer, "").unwrap();
         std::fs::write(dir.path().join("types.ts"), "").unwrap();
+        std::fs::write(dir.path().join("module-types.d.mts"), "").unwrap();
         std::fs::write(dir.path().join("Panel.vue"), "<template />").unwrap();
         std::fs::create_dir_all(dir.path().join("util")).unwrap();
         std::fs::write(dir.path().join("util").join("index.ts"), "").unwrap();
+        std::fs::create_dir_all(dir.path().join("common")).unwrap();
+        std::fs::write(dir.path().join("common").join("index.d.cts"), "").unwrap();
 
         let resolvable_ts = "Cannot find module './types' or its corresponding type declarations.";
         let resolvable_vue_ts =
             "Cannot find module './Panel.vue.ts' or its corresponding type declarations.";
         let resolvable_index =
             "Cannot find module './util' or its corresponding type declarations.";
+        let resolvable_dmts =
+            "Cannot find module './module-types' or its corresponding type declarations.";
+        let resolvable_index_dcts =
+            "Cannot find module './common' or its corresponding type declarations.";
         let resolvable_js_to_ts =
             "Cannot find module './types.js' or its corresponding type declarations.";
         let missing_relative =
@@ -124,6 +133,11 @@ mod tests {
         ));
         assert!(relative_module_resolves_on_disk(
             resolvable_index,
+            &importer
+        ));
+        assert!(relative_module_resolves_on_disk(resolvable_dmts, &importer));
+        assert!(relative_module_resolves_on_disk(
+            resolvable_index_dcts,
             &importer
         ));
         assert!(relative_module_resolves_on_disk(


### PR DESCRIPTION
## Summary
- probe `.d.mts` and `.d.cts` files when suppressing partial-check TS2307 false positives
- recognize explicit module declaration specifiers as source-like inputs
- add coverage for extensionless and index module declaration siblings

## Validation
- `cargo test -p vize_canon ts2307_for_resolvable_relative_siblings_is_suppressed`
- `node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785782573&installation_id=136613492&pr_number=2587&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2587&signature=187d1f4ee3f84db9ec83fdd04b829e6777a57969bc4b4b329d8bed9a4ed28b4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript module resolution so unresolved relative imports now recognize additional source file types.
  * TS2307 warnings are now suppressed for relative imports that point to `d.mts` and `d.cts` files when those files exist on disk.
  * Broadened support for sibling resolution in projects using these newer declaration file extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->