### PR TITLE
fix(canon): resolve module imports in shards

### DIFF
--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -14,7 +14,10 @@ use vize_carton::path::canonicalize_non_verbatim;
 use vize_carton::{FxHashMap, profile};
 use vize_carton::{String, cstr};
 
+mod import_resolution;
 mod project_diagnostics;
+
+use import_resolution::resolve_virtual_import;
 
 pub(super) fn check_with_cli(
     corsa_path: &Path,
@@ -409,25 +412,6 @@ fn is_ambient_declaration(path: &Path) -> bool {
 
 fn declares_program_wide_types(content: &str) -> bool {
     content.contains("declare module") || content.contains("declare global")
-}
-
-/// Resolve a normalized relative import target against the registered virtual
-/// files, trying the extension candidates TypeScript would.
-fn resolve_virtual_import(
-    target: &Path,
-    index_by_virtual: &FxHashMap<&Path, usize>,
-) -> Option<usize> {
-    if let Some(&index) = index_by_virtual.get(target) {
-        return Some(index);
-    }
-    let target_str = target.to_string_lossy();
-    for suffix in [".ts", ".tsx", ".d.ts", "/index.ts", "/index.tsx"] {
-        let candidate = PathBuf::from(cstr!("{target_str}{suffix}").as_str());
-        if let Some(&index) = index_by_virtual.get(candidate.as_path()) {
-            return Some(index);
-        }
-    }
-    None
 }
 
 fn run_cli_for_config(

--- a/crates/vize_canon/src/batch/executor/cli/import_resolution.rs
+++ b/crates/vize_canon/src/batch/executor/cli/import_resolution.rs
@@ -1,0 +1,85 @@
+//! TypeScript-like relative import resolution for CLI shard partitioning.
+
+use std::path::{Path, PathBuf};
+
+use vize_carton::{FxHashMap, cstr};
+
+const VIRTUAL_IMPORT_SUFFIXES: &[&str] = &[
+    ".ts",
+    ".tsx",
+    ".mts",
+    ".cts",
+    ".d.ts",
+    ".d.mts",
+    ".d.cts",
+    "/index.ts",
+    "/index.tsx",
+    "/index.mts",
+    "/index.cts",
+    "/index.d.ts",
+    "/index.d.mts",
+    "/index.d.cts",
+];
+
+/// Resolve a normalized relative import target against the registered virtual
+/// files, trying the extension candidates TypeScript would.
+pub(super) fn resolve_virtual_import(
+    target: &Path,
+    index_by_virtual: &FxHashMap<&Path, usize>,
+) -> Option<usize> {
+    if let Some(&index) = index_by_virtual.get(target) {
+        return Some(index);
+    }
+    let target_str = target.to_string_lossy();
+    for suffix in VIRTUAL_IMPORT_SUFFIXES {
+        let candidate = PathBuf::from(cstr!("{target_str}{suffix}").as_str());
+        if let Some(&index) = index_by_virtual.get(candidate.as_path()) {
+            return Some(index);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use vize_carton::FxHashMap;
+
+    use super::resolve_virtual_import;
+
+    #[test]
+    fn resolves_module_and_declaration_candidates() {
+        let paths = [
+            "src/module.mts",
+            "src/common.cts",
+            "src/schema.d.mts",
+            "src/legacy/index.d.cts",
+        ]
+        .into_iter()
+        .map(PathBuf::from)
+        .collect::<Vec<_>>();
+        let index_by_virtual = paths
+            .iter()
+            .enumerate()
+            .map(|(index, path)| (path.as_path(), index))
+            .collect::<FxHashMap<&Path, usize>>();
+
+        assert_eq!(
+            resolve_virtual_import(Path::new("src/module"), &index_by_virtual),
+            Some(0)
+        );
+        assert_eq!(
+            resolve_virtual_import(Path::new("src/common"), &index_by_virtual),
+            Some(1)
+        );
+        assert_eq!(
+            resolve_virtual_import(Path::new("src/schema"), &index_by_virtual),
+            Some(2)
+        );
+        assert_eq!(
+            resolve_virtual_import(Path::new("src/legacy"), &index_by_virtual),
+            Some(3)
+        );
+    }
+}

--- a/crates/vize_canon/src/batch/executor/cli/tests.rs
+++ b/crates/vize_canon/src/batch/executor/cli/tests.rs
@@ -134,6 +134,45 @@ fn shards_along_import_graph_components() {
 }
 
 #[test]
+fn shards_along_module_source_import_graph_components() {
+    use super::partition_virtual_files;
+
+    let case_dir = unique_case_dir("shard-module-components");
+    let _ = fs::remove_dir_all(&case_dir);
+    let src = case_dir.join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("A.vue"),
+        "<script setup lang=\"ts\">import value from './module'\nvoid value</script><template />",
+    )
+    .unwrap();
+    fs::write(src.join("module.mts"), "export default 1;\n").unwrap();
+    for name in ["C", "D"] {
+        fs::write(
+            src.join(cstr!("{name}.vue").as_str()),
+            "<script setup lang=\"ts\">const n = 1</script><template>{{ n }}</template>",
+        )
+        .unwrap();
+    }
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    let paths: Vec<_> = fs::read_dir(&src)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect();
+    project.register_paths(&paths).unwrap();
+
+    let plan = partition_virtual_files(&project, 2);
+    let owner_a = plan.owners.get(&src.join("A.vue")).copied();
+    let owner_module = plan.owners.get(&src.join("module.mts")).copied();
+
+    assert!(owner_a.is_some());
+    assert_eq!(owner_a, owner_module);
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
 fn recognizes_global_and_positioned_diagnostic_lines() {
     assert!(is_global_diagnostic_line(
         "error TS2688: Cannot find type definition file for 'vite/client'."


### PR DESCRIPTION
## Summary
- move CLI shard relative import resolution into a focused helper
- resolve extensionless `.mts`, `.cts`, `.d.mts`, and `.d.cts` candidates in shard import graphs
- add shard and helper coverage for module source and declaration candidates

## Validation
- `cargo test -p vize_canon resolves_module_and_declaration_candidates`
- `cargo test -p vize_canon shards_along_module_source_import_graph_components`
- `cargo test -p vize_canon batch::executor::cli`
- `node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785783037&installation_id=136613492&pr_number=2588&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2588&signature=dca78b4b22d3bb6462dd12ee3d06c4945cb418954581e39eeffeab1c05700cf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import handling for CLI shard assignment, making module resolution more reliable for relative, index, and TypeScript-style file paths.
  * Kept imported source files grouped with the components that use them during partitioning.

* **Tests**
  * Added coverage to verify shard assignment stays consistent for component-to-module imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->