### PR TITLE
fix(canon): rewrite declaration virtual imports

### DIFF
--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -11,6 +11,8 @@ mod executor;
 mod import_rewriter;
 #[cfg(test)]
 mod import_rewriter_tests;
+#[cfg(test)]
+mod import_rewriter_virtual_tests;
 mod materialize_fs;
 mod materialize_lock;
 mod runtime_deps;

--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -275,9 +275,12 @@ impl ImportRewriter {
             return Some(rewritten);
         }
         let candidate = std::path::Path::new(path);
+        let canonical_candidate = vize_carton::path::canonicalize_non_verbatim(candidate);
+        let canonical_project_root = vize_carton::path::canonicalize_non_verbatim(roots.0);
         if candidate.is_absolute()
-            && let Ok(relative) =
-                vize_carton::path::canonicalize_non_verbatim(candidate).strip_prefix(roots.0)
+            && let Ok(relative) = canonical_candidate
+                .strip_prefix(canonical_project_root.as_path())
+                .or_else(|_| candidate.strip_prefix(roots.0))
             && is_rewritable_project_specifier(relative)
         {
             if !path.ends_with(".vue") && !absolute_import_needs_virtual_rewrite(candidate) {

--- a/crates/vize_canon/src/batch/import_rewriter_virtual.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_virtual.rs
@@ -10,7 +10,8 @@ use vize_carton::{FxHashSet, String, cstr};
 use super::DynamicImportCollector;
 
 const SOURCE_EXTENSIONS: &[&str] = &[
-    ".ts", ".tsx", ".vue", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs",
+    ".ts", ".tsx", ".d.ts", ".d.mts", ".d.cts", ".vue", ".mts", ".cts", ".js", ".jsx", ".mjs",
+    ".cjs",
 ];
 
 pub(super) fn absolute_import_needs_virtual_rewrite(path: &Path) -> bool {
@@ -165,4 +166,60 @@ fn collect_import_specifiers(source: &str) -> Vec<String> {
     }
 
     specifiers
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    use vize_carton::cstr;
+
+    use super::{absolute_import_needs_virtual_rewrite, collect_import_specifiers};
+
+    fn unique_case_dir(name: &str) -> PathBuf {
+        static NEXT_CASE_ID: std::sync::atomic::AtomicUsize =
+            std::sync::atomic::AtomicUsize::new(0);
+        let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        std::env::temp_dir().join(
+            cstr!(
+                "vize-import-rewriter-virtual-helper-{name}-{}-{case_id}",
+                std::process::id()
+            )
+            .as_str(),
+        )
+    }
+
+    fn write(dir: &Path, rel: &str, contents: &str) -> PathBuf {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn absolute_index_module_declaration_detects_vue_import() {
+        let root = unique_case_dir("index-dcts");
+        let _ = fs::remove_dir_all(&root);
+        write(
+            &root,
+            "src/feature/index.d.cts",
+            "import Widget from '../Widget.vue'\nexport type Feature = typeof Widget\n",
+        );
+        write(&root, "src/Widget.vue", "<template />");
+
+        assert_eq!(
+            collect_import_specifiers(
+                "import Widget from '../Widget.vue'\nexport type Feature = typeof Widget\n"
+            ),
+            vec!["../Widget.vue".to_string()]
+        );
+        assert!(absolute_import_needs_virtual_rewrite(
+            &root.join("src/feature")
+        ));
+
+        let _ = fs::remove_dir_all(&root);
+    }
 }

--- a/crates/vize_canon/src/batch/import_rewriter_virtual_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_virtual_tests.rs
@@ -1,0 +1,100 @@
+use super::ImportRewriter;
+use oxc_span::SourceType;
+use std::fs;
+use std::path::{Path, PathBuf};
+use vize_carton::cstr;
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    std::env::temp_dir().join(
+        cstr!(
+            "vize-import-rewriter-virtual-{name}-{}-{case_id}",
+            std::process::id()
+        )
+        .as_str(),
+    )
+}
+
+fn write(dir: &Path, rel: &str, contents: &str) -> PathBuf {
+    let path = dir.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(&path, contents).unwrap();
+    path
+}
+
+#[test]
+fn rewrites_absolute_module_declaration_import_that_needs_vue_virtual_path() {
+    let root = unique_case_dir("declaration-with-vue-import");
+    let _ = fs::remove_dir_all(&root);
+    let feature = write(
+        &root,
+        "src/feature.d.mts",
+        "import Widget from './Widget.vue'\nexport type Feature = typeof Widget\n",
+    );
+    write(
+        &root,
+        "src/Widget.vue",
+        "<script setup lang=\"ts\">const label = 'ok'</script>",
+    );
+
+    let rewriter = ImportRewriter::new();
+    let source = cstr!(
+        "import type {{ Feature }} from '{}';",
+        feature.with_file_name("feature").display()
+    );
+    let virtual_root = root.join("node_modules/.vize/canon");
+    let roots = (root.as_path(), virtual_root.as_path());
+    let result =
+        rewriter.rewrite_for_virtual_project(source.as_str(), SourceType::ts(), roots, None);
+
+    assert_eq!(
+        result.code.as_str(),
+        cstr!(
+            "import type {{ Feature }} from '{}';",
+            virtual_root.join("src/feature").display()
+        )
+        .as_str()
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn rewrites_absolute_index_module_declaration_import_that_needs_vue_virtual_path() {
+    let root = unique_case_dir("index-declaration-with-vue-import");
+    let _ = fs::remove_dir_all(&root);
+    write(
+        &root,
+        "src/feature/index.d.cts",
+        "import Widget from '../Widget.vue'\nexport type Feature = typeof Widget\n",
+    );
+    write(
+        &root,
+        "src/Widget.vue",
+        "<script setup lang=\"ts\">const label = 'ok'</script>",
+    );
+
+    let rewriter = ImportRewriter::new();
+    let source = cstr!(
+        "import type {{ Feature }} from '{}';",
+        root.join("src/feature").display()
+    );
+    let virtual_root = root.join("node_modules/.vize/canon");
+    let roots = (root.as_path(), virtual_root.as_path());
+    let result =
+        rewriter.rewrite_for_virtual_project(source.as_str(), SourceType::ts(), roots, None);
+
+    assert_eq!(
+        result.code.as_str(),
+        cstr!(
+            "import type {{ Feature }} from '{}';",
+            virtual_root.join("src/feature").display()
+        )
+        .as_str()
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
## Summary
- resolve `.d.ts`, `.d.mts`, and `.d.cts` files when checking whether absolute imports need virtual-project rewriting
- handle existing directory imports by comparing canonical project roots before rewriting
- add regression coverage for extensionless and index module declaration imports that reach Vue files

## Validation
- `cargo test -p vize_canon rewrites_absolute_module_declaration_import_that_needs_vue_virtual_path`
- `cargo test -p vize_canon rewrites_absolute_index_module_declaration_import_that_needs_vue_virtual_path`
- `cargo test -p vize_canon absolute_index_module_declaration_detects_vue_import`
- `cargo test -p vize_canon import_rewriter`
- `node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785783890&installation_id=136613492&pr_number=2589&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2589&signature=f987e3ae72323f29596c5893de2ca67387c0d49db188f3675b04ecb37bfab096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling for TypeScript declaration files, including `.d.ts`, `.d.mts`, and `.d.cts`, when resolving source files.
  * Virtual project imports now rewrite more reliably for absolute paths, helping generated imports point to the correct virtual location.

* **Bug Fixes**
  * Fixed cases where imports from declaration files and Vue components could be missed or rewritten incorrectly during virtual project processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->