### PR TITLE
fix(canon): prefer module source imports

### DIFF
--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -219,7 +219,7 @@ pub(super) fn resolve_import_base(
         return Some(canonical_paths.canonicalize(base));
     }
 
-    // 2. A `.js`/`.mjs`/`.cjs` specifier resolving to its `.ts`/`.tsx` sibling.
+    // 2. A `.js`/`.mjs`/`.cjs` specifier resolving to its TS sibling.
     if let Some(rewritten) = rewrite_js_to_ts(base, canonical_paths) {
         return Some(rewritten);
     }
@@ -245,11 +245,16 @@ pub(super) fn resolve_import_base(
 
 fn rewrite_js_to_ts(base: &Path, canonical_paths: &mut CanonicalPathCache) -> Option<PathBuf> {
     let name = base.file_name()?.to_str()?;
-    let stem = name
-        .strip_suffix(".js")
-        .or_else(|| name.strip_suffix(".mjs"))
-        .or_else(|| name.strip_suffix(".cjs"))?;
-    for ext in [".ts", ".tsx", ".mts", ".cts"] {
+    let (stem, extensions): (&str, &[&str]) = if let Some(stem) = name.strip_suffix(".mjs") {
+        (stem, &[".mts"])
+    } else if let Some(stem) = name.strip_suffix(".cjs") {
+        (stem, &[".cts"])
+    } else if let Some(stem) = name.strip_suffix(".js") {
+        (stem, &[".ts", ".tsx"])
+    } else {
+        return None;
+    };
+    for ext in extensions {
         let candidate = base.with_file_name(cstr!("{stem}{ext}"));
         if candidate.is_file() {
             return Some(canonical_paths.canonicalize(&candidate));

--- a/crates/vize/src/commands/check/imports_tests.rs
+++ b/crates/vize/src/commands/check/imports_tests.rs
@@ -138,6 +138,41 @@ fn jsx_imports_are_resolved_only_when_jsx_typecheck_is_enabled() {
 }
 
 #[test]
+fn module_js_specifiers_prefer_module_source_extensions() {
+    let root = std::env::temp_dir().join(cstr!("vize-imports-module-js-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+
+    let entry = write(
+        &root,
+        "src/entry.ts",
+        "import { esm } from './esm.mjs'\nimport { common } from './common.cjs'\nvoid esm\nvoid common\n",
+    );
+    let esm_mts = write(&root, "src/esm.mts", "export const esm = 'mts'\n");
+    write(&root, "src/esm.ts", "export const esm = 'ts'\n");
+    let common_cts = write(&root, "src/common.cts", "export const common = 'cts'\n");
+    write(&root, "src/common.ts", "export const common = 'ts'\n");
+
+    let discovered = collect_transitive_local_imports(
+        &[entry],
+        &root,
+        &mut CanonicalPathCache::default(),
+        false,
+        None,
+    );
+
+    assert_eq!(
+        discovered,
+        vec![
+            canonicalize_non_verbatim(&esm_mts),
+            canonicalize_non_verbatim(&common_cts),
+        ]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
 fn collects_only_non_relative_imports_that_need_virtual_rewrites() {
     let root = std::env::temp_dir().join(cstr!("vize-imports-matrix-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&root);


### PR DESCRIPTION
## Summary
- resolve `.mjs` specifiers to `.mts` sources instead of unrelated `.ts` files
- resolve `.cjs` specifiers to `.cts` sources instead of unrelated `.ts` files
- add transitive import coverage for module JS specifier substitution

## Validation
- `cargo test -p vize module_js_specifiers_prefer_module_source_extensions --lib`
- `cargo test -p vize imports --lib`
- `node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785784837&installation_id=136613492&pr_number=2591&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2591&signature=c060dae410d2ea702404a098c5f4846ccfc6018aea275517bd8f1e5411230796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import resolution for JavaScript-like module specifiers, handling `.js`, `.mjs`, and `.cjs` more accurately.
  * Module file lookups now prefer matching TypeScript source extensions where appropriate, reducing incorrect import matches.
  * Added coverage for `.mjs` and `.cjs` resolution to ensure imports are discovered from the expected source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->