### PR TITLE
fix(canon): scan module declaration dependencies

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -257,6 +257,8 @@ fn resolve_relative_script_import(dir: &Path, specifier: &str) -> Option<PathBuf
         "index.mjs",
         "index.cjs",
         "index.d.ts",
+        "index.d.mts",
+        "index.d.cts",
     ] {
         let candidate = base.join(name);
         if candidate.exists() {
@@ -305,4 +307,31 @@ fn normalize_path(path: &Path) -> PathBuf {
         }
     }
     normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_relative_script_import;
+
+    #[test]
+    fn resolves_directory_module_declaration_indices() {
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = project.path().join("src");
+        std::fs::create_dir_all(src.join("esm")).expect("esm dir");
+        std::fs::create_dir_all(src.join("cjs")).expect("cjs dir");
+
+        let esm = src.join("esm").join("index.d.mts");
+        let cjs = src.join("cjs").join("index.d.cts");
+        std::fs::write(&esm, "export type Value = string;\n").expect("esm dts");
+        std::fs::write(&cjs, "export type Value = string;\n").expect("cjs dts");
+
+        assert_eq!(
+            resolve_relative_script_import(&src, "./esm").as_deref(),
+            Some(esm.as_path())
+        );
+        assert_eq!(
+            resolve_relative_script_import(&src, "./cjs").as_deref(),
+            Some(cjs.as_path())
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- include index.d.mts and index.d.cts in Vue virtual dependency directory fallback resolution
- add coverage for module declaration directory imports

## Tests
- cargo test -p vize_canon resolves_directory_module_declaration_indices --lib
- cargo test -p vize_canon corsa_bridge --lib
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785786133&installation_id=136613492&pr_number=2593&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2593&signature=e55dafb5023197edf73cbd32c16a68463060d8df1d2c98337c9a4dd208e00894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module resolution for directory-style imports so TypeScript declaration index files with `.d.mts` and `.d.cts` are recognized, in addition to `.d.ts`.
  * Fixed import handling for both ESM and CommonJS directory paths, making project layouts with declaration index files resolve more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->