### PR TITLE
fix(lsp): index module composable imports

### DIFF
--- a/crates/vize_maestro/src/ide/auto_import.rs
+++ b/crates/vize_maestro/src/ide/auto_import.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 pub enum AutoImportKind {
     /// Default export from a `.vue` file.
     VueComponent,
-    /// Named export from a `.ts` / `.js` file matching `use*` convention.
+    /// Named export from a script file matching the `use*` convention.
     Composable,
 }
 
@@ -44,7 +44,7 @@ pub struct AutoImportIndex {
 
 impl AutoImportIndex {
     /// Build the index by scanning `root` for `.vue` files (treated as
-    /// default exports of components) and `use*.ts` / `use*.js` files
+    /// default exports of components) and `use*` script files
     /// (treated as composable exports).
     ///
     /// The scan is shallow on purpose so the foundation costs ~milliseconds
@@ -66,19 +66,12 @@ impl AutoImportIndex {
                     source: path,
                     kind: AutoImportKind::VueComponent,
                 });
-            } else if file_name.starts_with("use") {
-                let lowered = file_name.to_ascii_lowercase();
-                if lowered.ends_with(".ts") || lowered.ends_with(".js") {
-                    let stem = path
-                        .file_stem()
-                        .and_then(|n| n.to_str())
-                        .unwrap_or(file_name);
-                    entries.push(AutoImportEntry {
-                        name: stem.to_string(),
-                        source: path,
-                        kind: AutoImportKind::Composable,
-                    });
-                }
+            } else if let Some(stem) = composable_file_stem(file_name) {
+                entries.push(AutoImportEntry {
+                    name: stem.to_string(),
+                    source: path,
+                    kind: AutoImportKind::Composable,
+                });
             }
         }
         Self { entries }
@@ -114,17 +107,14 @@ impl AutoImportIndex {
                         kind: AutoImportKind::VueComponent,
                     });
                 }
-            } else if file_name.starts_with("use") {
-                let lowered = file_name.to_ascii_lowercase();
-                if (lowered.ends_with(".ts") || lowered.ends_with(".js"))
-                    && path.file_stem().and_then(|n| n.to_str()) == Some(name)
-                {
-                    return Some(AutoImportEntry {
-                        name: name.to_string(),
-                        source: path,
-                        kind: AutoImportKind::Composable,
-                    });
-                }
+            } else if let Some(stem) = composable_file_stem(file_name)
+                && stem == name
+            {
+                return Some(AutoImportEntry {
+                    name: name.to_string(),
+                    source: path,
+                    kind: AutoImportKind::Composable,
+                });
             }
         }
         None
@@ -139,6 +129,19 @@ impl AutoImportIndex {
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
+}
+
+const COMPOSABLE_EXTENSIONS: &[&str] = &[".ts", ".js", ".mts", ".cts", ".mjs", ".cjs"];
+
+fn composable_file_stem(file_name: &str) -> Option<&str> {
+    if !file_name.starts_with("use") {
+        return None;
+    }
+    let lowered = file_name.to_ascii_lowercase();
+    COMPOSABLE_EXTENSIONS
+        .iter()
+        .find(|extension| lowered.ends_with(*extension))
+        .and_then(|extension| file_name.get(..file_name.len() - extension.len()))
 }
 
 fn pascal_case(s: &str) -> String {
@@ -168,15 +171,21 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("MyButton.vue"), "").unwrap();
         std::fs::write(dir.path().join("useCounter.ts"), "").unwrap();
+        std::fs::write(dir.path().join("useServer.mts"), "").unwrap();
+        std::fs::write(dir.path().join("useLegacy.cjs"), "").unwrap();
         std::fs::write(dir.path().join("random.txt"), "").unwrap();
 
         let index = AutoImportIndex::from_directory(dir.path());
-        assert_eq!(index.len(), 2, "expected 2 entries, got {:?}", index);
+        assert_eq!(index.len(), 4, "expected 4 entries, got {:?}", index);
 
         let button = index.lookup("MyButton").next().unwrap();
         assert_eq!(button.kind, AutoImportKind::VueComponent);
         let counter = index.lookup("useCounter").next().unwrap();
         assert_eq!(counter.kind, AutoImportKind::Composable);
+        let server = index.lookup("useServer").next().unwrap();
+        assert_eq!(server.kind, AutoImportKind::Composable);
+        let legacy = index.lookup("useLegacy").next().unwrap();
+        assert_eq!(legacy.kind, AutoImportKind::Composable);
     }
 
     #[test]
@@ -190,7 +199,7 @@ mod tests {
     fn find_in_directory_matches_lookup_first() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("MyButton.vue"), "").unwrap();
-        std::fs::write(dir.path().join("useCounter.ts"), "").unwrap();
+        std::fs::write(dir.path().join("useCounter.mjs"), "").unwrap();
         std::fs::write(dir.path().join("random.txt"), "").unwrap();
 
         let index = AutoImportIndex::from_directory(dir.path());

--- a/crates/vize_maestro/src/ide/code_action.rs
+++ b/crates/vize_maestro/src/ide/code_action.rs
@@ -645,16 +645,16 @@ fn relative_specifier(from_dir: &std::path::Path, target: &std::path::Path) -> O
     if !s.starts_with('.') && !s.starts_with('/') {
         s.insert_str(0, "./");
     }
-    if s.ends_with(".ts") || s.ends_with(".js") {
-        // Strip trailing .ts/.js for the import specifier so the bundler /
-        // tsconfig resolution picks the right file.
-        s.truncate(s.len() - 3);
+    if let Some(suffix) = [".mts", ".cts", ".mjs", ".cjs", ".ts", ".js"]
+        .into_iter()
+        .find(|suffix| s.ends_with(suffix))
+    {
+        s.truncate(s.len() - suffix.len());
     }
     Some(s)
 }
 
-/// Compute `target` relative to `base`. Mirrors `pathdiff::diff_paths` —
-/// inlined here to avoid pulling a new dependency for one function.
+/// Compute `target` relative to `base`; inlined to avoid a dependency.
 fn diff_paths(target: &std::path::Path, base: &std::path::Path) -> Option<std::path::PathBuf> {
     use std::path::{Component, PathBuf};
     if target.is_absolute() != base.is_absolute() {


### PR DESCRIPTION
## Summary
- include use*.mts/use*.cts/use*.mjs/use*.cjs files in the LSP auto-import index
- strip module script extensions when rendering auto-import specifiers

## Tests
- cargo test -p vize_maestro auto_import --lib
- cargo test -p vize_maestro test_diff_paths_relative_specifier --lib
- cargo test -p vize_maestro code_action --lib
- cargo fmt --check --all
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785786649&installation_id=136613492&pr_number=2594&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2594&signature=bb1daa3ce0e2922614cbf95c8068c1f9b76f3ef93549e555b99c91b4b5379174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded auto-import discovery to recognize additional `use*` composable files, including `.mts`, `.cts`, `.mjs`, and `.cjs`.

* **Bug Fixes**
  * Improved relative import path generation to strip a broader set of script-module extensions (e.g., `.mts`, `.cts`, `.mjs`, `.cjs`, `.ts`, `.js`) when computing specifiers.
  * Ensured composable detection behaves consistently across directory scanning and lookup to avoid mismatched results.

* **Documentation / Tests**
  * Updated composable documentation and refreshed tests to cover the new supported extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->