### PR TITLE
fix(lsp): resolve module document links

### DIFF
--- a/crates/vize_maestro/src/ide/document_link.rs
+++ b/crates/vize_maestro/src/ide/document_link.rs
@@ -31,9 +31,7 @@ impl DocumentLinkService {
 
         let base_path = uri.to_file_path().ok();
 
-        // Collect links from script setup
         if let Some(ref script_setup) = descriptor.script_setup {
-            // src attribute
             if let Some(ref src) = script_setup.src
                 && let Some((start, end)) =
                     Self::find_src_attr_range(content, script_setup.loc.start)
@@ -42,7 +40,6 @@ impl DocumentLinkService {
                 links.push(Self::create_link(content, start, end, target));
             }
 
-            // Import statements
             Self::collect_import_links(
                 &script_setup.content,
                 script_setup.loc.start,
@@ -53,9 +50,7 @@ impl DocumentLinkService {
             Self::collect_define_art_source_links(content, uri, &mut links);
         }
 
-        // Collect links from script
         if let Some(ref script) = descriptor.script {
-            // src attribute
             if let Some(ref src) = script.src
                 && let Some((start, end)) = Self::find_src_attr_range(content, script.loc.start)
                 && let Some(target) = Self::resolve_path(src, base_path.as_deref())
@@ -63,7 +58,6 @@ impl DocumentLinkService {
                 links.push(Self::create_link(content, start, end, target));
             }
 
-            // Import statements
             Self::collect_import_links(
                 &script.content,
                 script.loc.start,
@@ -73,7 +67,6 @@ impl DocumentLinkService {
             );
         }
 
-        // Collect links from template src
         if let Some(ref template) = descriptor.template
             && let Some(ref src) = template.src
             && let Some((start, end)) = Self::find_src_attr_range(content, template.loc.start)
@@ -82,9 +75,7 @@ impl DocumentLinkService {
             links.push(Self::create_link(content, start, end, target));
         }
 
-        // Collect links from styles
         for style in &descriptor.styles {
-            // src attribute
             if let Some(ref src) = style.src
                 && let Some((start, end)) = Self::find_src_attr_range(content, style.loc.start)
                 && let Some(target) = Self::resolve_path(src, base_path.as_deref())
@@ -92,7 +83,6 @@ impl DocumentLinkService {
                 links.push(Self::create_link(content, start, end, target));
             }
 
-            // @import statements
             Self::collect_css_import_links(
                 &style.content,
                 style.loc.start,
@@ -324,9 +314,17 @@ impl DocumentLinkService {
             resolved.with_extension("vue"),
             resolved.with_extension("tsx"),
             resolved.with_extension("jsx"),
+            resolved.with_extension("mts"),
+            resolved.with_extension("cts"),
+            resolved.with_extension("mjs"),
+            resolved.with_extension("cjs"),
             resolved.join("index.ts"),
             resolved.join("index.js"),
             resolved.join("index.vue"),
+            resolved.join("index.mts"),
+            resolved.join("index.cts"),
+            resolved.join("index.mjs"),
+            resolved.join("index.cjs"),
         ];
 
         for candidate in &candidates {

--- a/tests/tooling/lsp-document-link.test.ts
+++ b/tests/tooling/lsp-document-link.test.ts
@@ -38,12 +38,14 @@ test("vize lsp documentLink resolves relative imports and ranges", async (t) => 
 `,
       "utf8",
     );
+    const modulePath = path.join(workspaceDir, "useServer.mjs");
+    fs.writeFileSync(modulePath, "export const useServer = () => 1\n", "utf8");
 
-    // Line 0: <script setup ...>; line 1: the two import statements.
-    // Keep both imports on a single known line so column math is unambiguous.
-    const importLine = `import Dep from './Dep.vue'`;
+    const componentImportLine = `import Dep from './Dep.vue'`;
+    const moduleImportLine = `import { useServer } from './useServer'`;
     const source = `<script setup lang="ts">
-${importLine}
+${componentImportLine}
+${moduleImportLine}
 import { ref } from 'vue'
 const _x = ref(0)
 </script>
@@ -77,17 +79,17 @@ const _x = ref(0)
         })) as DocumentLink[] | null;
 
         assert.ok(Array.isArray(links), JSON.stringify(links));
-        // Only the relative './Dep.vue' import produces a link; the bare
-        // 'vue' package import is skipped.
-        assert.equal(links.length, 1, JSON.stringify(links));
+        assert.equal(links.length, 2, JSON.stringify(links));
 
-        const link = links[0];
-        assert.ok(link.target, JSON.stringify(link));
-        const targetPath = new URL(link.target).pathname;
-        assert.equal(path.basename(decodeURIComponent(targetPath)), "Dep.vue");
-        // The bare 'vue' import contributes no link, so there is nothing on
-        // line 2 (the 'vue' import line).
-        assert.equal(link.range.start.line, 1);
+        const targets = links.map((link) => {
+          assert.ok(link.target, JSON.stringify(link));
+          return path.basename(decodeURIComponent(new URL(link.target).pathname));
+        });
+        assert.deepEqual(targets.sort(), ["Dep.vue", "useServer.mjs"]);
+        assert.ok(
+          links.every((link) => link.range.start.line !== 3),
+          JSON.stringify(links),
+        );
       },
     );
 
@@ -97,19 +99,21 @@ const _x = ref(0)
       })) as DocumentLink[] | null;
 
       assert.ok(Array.isArray(links), JSON.stringify(links));
-      assert.equal(links.length, 1, JSON.stringify(links));
+      assert.equal(links.length, 2, JSON.stringify(links));
 
       // Compute expected columns from the source rather than hardcoding: the
       // range spans the opening quote through the closing quote inclusive.
-      const lineStartOffset = source.indexOf(importLine);
+      const lineStartOffset = source.indexOf(componentImportLine);
       const quoteStartOffset = source.indexOf("'", lineStartOffset);
       const quoteEndOffset = source.indexOf("'", quoteStartOffset + 1) + 1;
 
       const expectedStart = offsetToPosition(source, quoteStartOffset);
       const expectedEnd = offsetToPosition(source, quoteEndOffset);
+      const componentLink = links.find((link) => link.target?.endsWith("/Dep.vue"));
+      assert.ok(componentLink, JSON.stringify(links));
 
-      assert.deepEqual(links[0].range.start, expectedStart);
-      assert.deepEqual(links[0].range.end, expectedEnd);
+      assert.deepEqual(componentLink.range.start, expectedStart);
+      assert.deepEqual(componentLink.range.end, expectedEnd);
     });
   } finally {
     await session.shutdown();


### PR DESCRIPTION
## Summary
- resolve .mts/.cts/.mjs/.cjs files and directory indices for LSP document links
- cover extensionless module imports in the documentLink smoke test

## Tests
- cargo test -p vize_maestro document_link --lib
- cargo build -p vize --profile ci
- node --test tests/tooling/lsp-document-link.test.ts
- cargo fmt --check --all
- cargo clippy -p vize_maestro -- -D warnings -D clippy::wildcard_imports
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785787855&installation_id=136613492&pr_number=2595&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2595&signature=c4a3449954f8732c760765370503fe52d2ac434450048ee5c0f12fa70168119b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved document link resolution for script/module imports by supporting additional JavaScript/TypeScript module variants and corresponding `index.*` files.
  - Stopped generating document links for `template src="..."`, preventing incorrect targets from template declarations.
  - Enhanced import-link detection to align link ranges with the quoted source text for linked files.

- **Tests**
  - Extended LSP document link tests to validate multiple resolved import targets and verify correct quoted-range matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->