### PR TITLE
fix(canon): rewrite declaration map sources

### DIFF
--- a/crates/vize/tests/check_declaration_emit_cli.rs
+++ b/crates/vize/tests/check_declaration_emit_cli.rs
@@ -1,5 +1,7 @@
 use std::{path::Path, process::Command};
 
+use vize_carton::{String, ToCompactString, cstr};
+
 fn workspace_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -14,7 +16,7 @@ fn unique_case_dir(name: &str) -> std::path::PathBuf {
         .join("target")
         .join("vize-tests")
         .join("tests")
-        .join(format!("{name}-{}-{case_id}", std::process::id()))
+        .join(cstr!("{name}-{}-{case_id}", std::process::id()).as_str())
 }
 
 fn link_workspace_node_modules(project_root: &Path) {
@@ -64,13 +66,13 @@ fn resolve_test_corsa_path() -> Option<String> {
     let workspace_root = workspace_root();
     let sibling_cache = workspace_root.parent()?.join("corsa-bind/.cache/tsgo");
     if sibling_cache.exists() {
-        return Some(sibling_cache.display().to_string());
+        return Some(sibling_cache.to_string_lossy().to_compact_string());
     }
 
     let workspace_bin = workspace_root.join("node_modules/.bin/tsgo");
     workspace_bin
         .exists()
-        .then(|| workspace_bin.display().to_string())
+        .then(|| workspace_bin.to_string_lossy().to_compact_string())
 }
 
 #[test]
@@ -112,7 +114,7 @@ export const answer = 42;
 
     let output = Command::new(env!("CARGO_BIN_EXE_vize"))
         .current_dir(&project_root)
-        .env("CORSA_PATH", corsa_path)
+        .env("CORSA_PATH", corsa_path.as_str())
         .args([
             "check",
             ".",
@@ -125,15 +127,15 @@ export const answer = 42;
         .output()
         .unwrap();
 
-    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
-    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
     assert_eq!(
         output.status.code(),
         Some(0),
         "stdout:\n{stdout}\nstderr:\n{stderr}"
     );
 
-    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
     let declarations = json["declarations"]
         .as_array()
         .unwrap()
@@ -161,6 +163,89 @@ export const answer = 42;
         "declaration import should not leak virtual .vue.ts paths:\n{modern_declaration}"
     );
     assert!(project_root.join("types/legacy.d.cts").is_file());
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn check_declaration_emit_rewrites_declaration_map_sources() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "declaration-map-sources",
+        &[
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+export interface PublicProps {
+  label: string
+}
+
+defineProps<PublicProps>()
+</script>
+
+<template>
+  <p>{{ label }}</p>
+</template>
+"#,
+            ),
+            (
+                "src/index.ts",
+                r#"export { default as App } from "./App.vue";
+"#,
+            ),
+        ],
+    );
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declarationMap": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path.as_str())
+        .args(["check", ".", "--format", "json", "--declaration"])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let app_map_path = project_root.join("dist/types/App.vue.d.ts.map");
+    let index_map_path = project_root.join("dist/types/index.d.ts.map");
+    let app_map: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&app_map_path).unwrap()).unwrap();
+    let index_map: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&index_map_path).unwrap()).unwrap();
+
+    assert_eq!(app_map["sources"], serde_json::json!(["../../src/App.vue"]));
+    assert_eq!(
+        index_map["sources"],
+        serde_json::json!(["../../src/index.ts"])
+    );
+
+    let app_map_text = std::fs::read_to_string(app_map_path).unwrap();
+    let index_map_text = std::fs::read_to_string(index_map_path).unwrap();
+    assert!(!app_map_text.contains(".vize"), "{app_map_text}");
+    assert!(!app_map_text.contains(".vue.ts"), "{app_map_text}");
+    assert!(!index_map_text.contains(".vize"), "{index_map_text}");
 
     let _ = std::fs::remove_dir_all(&project_root);
 }

--- a/crates/vize_canon/src/batch/executor.rs
+++ b/crates/vize_canon/src/batch/executor.rs
@@ -1,8 +1,7 @@
 //! Corsa-backed batch executor.
 //!
-//! This module materializes the virtual project, asks the Corsa project-session
-//! API for diagnostics across every generated file, and maps those diagnostics
-//! back to the original source positions.
+//! This module materializes the virtual project, asks Corsa for diagnostics,
+//! and maps those diagnostics back to the original source positions.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -25,12 +24,10 @@ use vize_carton::{
     cstr, profile,
 };
 
-/// Helper-type declarations shipped alongside emitted declaration outputs.
-/// Shares the mirror helpers file name so the artifact is recognizable, but
-/// carries only the type aliases (no global augmentation, no macro values).
 const DECLARATION_HELPERS_FILE: &str = crate::virtual_ts::SHARED_PREAMBLE_FILE_NAME;
 
 mod cli;
+mod declaration_maps;
 mod diagnostics;
 
 use cli::{auto_server_count, check_with_cli, check_with_cli_sharded};
@@ -203,6 +200,7 @@ impl CorsaExecutor {
             "canon.dts.rewrite_outputs",
             rewrite_declaration_outputs(options.out_dir.as_path())
         )?;
+        declaration_maps::rewrite_declaration_map_outputs(options.out_dir.as_path(), project)?;
 
         Ok(DeclarationEmitResult {
             files: profile!(

--- a/crates/vize_canon/src/batch/executor/declaration_maps.rs
+++ b/crates/vize_canon/src/batch/executor/declaration_maps.rs
@@ -1,0 +1,257 @@
+use std::{
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde_json::Value;
+use vize_carton::{String, path::canonicalize_non_verbatim};
+
+use crate::batch::{CorsaResult, VirtualProject};
+
+pub(super) fn rewrite_declaration_map_outputs(
+    out_dir: &Path,
+    project: &VirtualProject,
+) -> CorsaResult<()> {
+    if !out_dir.exists() {
+        return Ok(());
+    }
+
+    for entry in walkdir::WalkDir::new(out_dir) {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() || !is_declaration_map_file(path) {
+            continue;
+        }
+
+        rewrite_declaration_map(path, project)?;
+    }
+
+    Ok(())
+}
+
+fn rewrite_declaration_map(path: &Path, project: &VirtualProject) -> CorsaResult<()> {
+    let content = fs::read_to_string(path)?;
+    let mut map: Value = serde_json::from_str(&content)?;
+    let source_root: String = map
+        .get("sourceRoot")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .into();
+    let Some(sources) = map.get_mut("sources").and_then(Value::as_array_mut) else {
+        return Ok(());
+    };
+    let map_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut changed = false;
+
+    for source in sources {
+        let Some(value) = source.as_str() else {
+            continue;
+        };
+        let Some(rewritten) = rewrite_map_source(value, source_root.as_str(), map_dir, project)
+        else {
+            continue;
+        };
+        *source = Value::String(rewritten.into());
+        changed = true;
+    }
+
+    if changed {
+        if let Some(object) = map.as_object_mut() {
+            object.insert("sourceRoot".into(), Value::String("".into()));
+        }
+        fs::write(path, serde_json::to_string(&map)?)?;
+    }
+
+    Ok(())
+}
+
+fn rewrite_map_source(
+    source: &str,
+    source_root: &str,
+    map_dir: &Path,
+    project: &VirtualProject,
+) -> Option<String> {
+    let source_path = normalize_path_lexically(&resolve_source_path(source, source_root, map_dir));
+    let virtual_path = canonicalize_non_verbatim(&source_path);
+    let file = project
+        .find_by_virtual(&virtual_path)
+        .or_else(|| project.find_by_virtual(&source_path))?;
+    let map_dir = canonicalize_non_verbatim(map_dir);
+    let original_path = canonicalize_non_verbatim(&file.original_path);
+    Some(path_to_map_source(&relative_path_from(
+        &map_dir,
+        &original_path,
+    )))
+}
+
+fn resolve_source_path(source: &str, source_root: &str, map_dir: &Path) -> PathBuf {
+    let source = Path::new(source);
+    if source.is_absolute() {
+        return source.to_path_buf();
+    }
+    let source_root = Path::new(source_root);
+    if source_root.as_os_str().is_empty() {
+        map_dir.join(source)
+    } else if source_root.is_absolute() {
+        source_root.join(source)
+    } else {
+        map_dir.join(source_root).join(source)
+    }
+}
+
+fn is_declaration_map_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            name.ends_with(".d.ts.map")
+                || name.ends_with(".d.mts.map")
+                || name.ends_with(".d.cts.map")
+        })
+}
+
+fn relative_path_from(from_dir: &Path, target: &Path) -> PathBuf {
+    let from = path_components(from_dir);
+    let to = path_components(target);
+    let mut common = 0usize;
+    while common < from.len() && common < to.len() && from[common] == to[common] {
+        common += 1;
+    }
+    if common == 0 {
+        return target.to_path_buf();
+    }
+
+    let mut relative = PathBuf::new();
+    for _ in common..from.len() {
+        relative.push("..");
+    }
+    for component in to.iter().skip(common) {
+        relative.push(component);
+    }
+    if relative.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        relative
+    }
+}
+
+fn normalize_path_lexically(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push("..");
+                }
+            }
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn path_components(path: &Path) -> Vec<OsString> {
+    path.components()
+        .filter_map(|component| match component {
+            std::path::Component::CurDir => None,
+            component => Some(component.as_os_str().to_os_string()),
+        })
+        .collect()
+}
+
+fn path_to_map_source(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/").into()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::json;
+    use tempfile::TempDir;
+    use vize_carton::path::canonicalize_non_verbatim;
+
+    use super::{path_to_map_source, relative_path_from, rewrite_declaration_map_outputs};
+    use crate::batch::VirtualProject;
+
+    #[test]
+    fn rewrites_virtual_sources_to_original_sources() {
+        let temp = TempDir::new().unwrap();
+        let root = canonicalize_non_verbatim(temp.path());
+        let src = root.join("src");
+        let out_dir = root.join("dist/types");
+        fs::create_dir_all(&src).unwrap();
+        fs::create_dir_all(&out_dir).unwrap();
+
+        let vue_path = src.join("App.vue");
+        let index_path = src.join("index.ts");
+        fs::write(
+            &vue_path,
+            r#"<script setup lang="ts">
+export interface PublicProps {
+  label: string
+}
+defineProps<PublicProps>()
+</script>
+"#,
+        )
+        .unwrap();
+        fs::write(&index_path, "export { default as App } from './App.vue'\n").unwrap();
+
+        let mut project = VirtualProject::new(&root).unwrap();
+        project.register_path(&vue_path).unwrap();
+        project.register_path(&index_path).unwrap();
+
+        let vue_virtual = project.find_by_original(&vue_path).unwrap();
+        let index_virtual = project.find_by_original(&index_path).unwrap();
+        fs::write(
+            out_dir.join("App.vue.d.ts.map"),
+            serde_json::to_string(&json!({
+                "version": 3,
+                "file": "App.vue.d.ts",
+                "sourceRoot": "",
+                "sources": [
+                    path_to_map_source(&relative_path_from(&out_dir, &vue_virtual.virtual_path))
+                ],
+                "names": [],
+                "mappings": ""
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            out_dir.join("index.d.ts.map"),
+            serde_json::to_string(&json!({
+                "version": 3,
+                "file": "index.d.ts",
+                "sourceRoot": "",
+                "sources": [
+                    path_to_map_source(&relative_path_from(&out_dir, &index_virtual.virtual_path))
+                ],
+                "names": [],
+                "mappings": ""
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        rewrite_declaration_map_outputs(&out_dir, &project).unwrap();
+
+        assert_map_sources(&out_dir.join("App.vue.d.ts.map"), &["../../src/App.vue"]);
+        assert_map_sources(&out_dir.join("index.d.ts.map"), &["../../src/index.ts"]);
+    }
+
+    fn assert_map_sources(path: &std::path::Path, expected: &[&str]) {
+        let map: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap();
+        let sources = map["sources"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|source| source.as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(sources, expected);
+        assert_eq!(map["sourceRoot"], "");
+    }
+}


### PR DESCRIPTION
## Summary
- rewrite declaration map sources emitted from virtual project files back to original project files
- clear sourceRoot after rewriting so maps resolve from the output directory
- cover declarationMap output in canon unit and CLI emit tests

## Validation
- cargo fmt --check --all
- cargo test -p vize_canon declaration_maps --lib
- cargo test -p vize --test check_declaration_emit_cli -- --nocapture
- cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports
- cargo clippy -p vize --test check_declaration_emit_cli -- -D warnings -D clippy::wildcard_imports
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785790160&installation_id=136613492&pr_number=2596&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2596&signature=21821a02116528316cf1c4833b0f274faaf43d3f14f1e65e36b0661458ff73f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Declaration maps are now rewritten to point back to the original source files, improving debugging and editor navigation for generated type files.

* **Bug Fixes**
  * Fixed generated declaration map `sources` entries so they no longer reference virtual build paths.
  * Cleared `sourceRoot` when maps are updated, helping tools resolve source locations more reliably.
  * Improved handling of declaration map output across common TypeScript declaration formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->