### PR TITLE
fix(canon): rewrite type import specifiers

### DIFF
--- a/crates/vize/tests/check_declaration_emit_cli.rs
+++ b/crates/vize/tests/check_declaration_emit_cli.rs
@@ -101,6 +101,7 @@ defineProps<PublicProps>()
             (
                 "src/modern.mts",
                 r#"export { default as App } from "./App.vue";
+export type AppModule = typeof import("./App.vue");
 export const answer = 42;
 "#,
             ),
@@ -157,6 +158,10 @@ export const answer = 42;
     assert!(
         modern_declaration.contains("./App.vue"),
         "declaration import should point at .vue:\n{modern_declaration}"
+    );
+    assert!(
+        modern_declaration.contains(r#"typeof import("./App.vue")"#),
+        "declaration import types should point at .vue:\n{modern_declaration}"
     );
     assert!(
         !modern_declaration.contains(".vue.ts"),

--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -12,6 +12,8 @@ mod import_rewriter;
 #[cfg(test)]
 mod import_rewriter_tests;
 #[cfg(test)]
+mod import_rewriter_type_tests;
+#[cfg(test)]
 mod import_rewriter_virtual_tests;
 mod materialize_fs;
 mod materialize_lock;

--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -1,7 +1,10 @@
 //! Import rewriter for transforming .vue imports to .vue.ts.
 
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{Expression, Statement};
+use oxc_ast::ast::{
+    ExportAllDeclaration, ExportNamedDeclaration, Expression, ImportDeclaration, ImportExpression,
+    TSImportType,
+};
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
 use oxc_parser::Parser;
@@ -145,41 +148,9 @@ impl ImportRewriter {
         let result = parser.parse();
 
         let mut rewrites: Vec<(u32, u32, String)> = Vec::new();
-
-        for stmt in &result.program.body {
-            match stmt {
-                Statement::ImportDeclaration(decl) => {
-                    if let Some(rewrite) = rewrite_specifier(&decl.source.value) {
-                        rewrites.push((
-                            decl.source.span.start + 1, // +1 to skip opening quote
-                            decl.source.span.end - 1,   // -1 to skip closing quote
-                            rewrite,
-                        ));
-                    }
-                }
-                Statement::ExportNamedDeclaration(decl) => {
-                    if let Some(source) = &decl.source
-                        && let Some(rewrite) = rewrite_specifier(&source.value)
-                    {
-                        rewrites.push((source.span.start + 1, source.span.end - 1, rewrite));
-                    }
-                }
-                Statement::ExportAllDeclaration(decl) => {
-                    if let Some(rewrite) = rewrite_specifier(&decl.source.value) {
-                        rewrites.push((
-                            decl.source.span.start + 1,
-                            decl.source.span.end - 1,
-                            rewrite,
-                        ));
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        let mut collector = DynamicImportCollector::new();
+        let mut collector = ModuleSpecifierCollector::new();
         collector.visit_program(&result.program);
-        for (start, end, path) in collector.imports {
+        for (start, end, path) in collector.specifiers {
             if let Some(rewrite) = rewrite_specifier(&path) {
                 rewrites.push((start, end, rewrite));
             }
@@ -224,32 +195,15 @@ impl ImportRewriter {
         let result = parser.parse();
 
         let mut specifiers: Vec<String> = Vec::new();
-        let mut push = |path: &str| {
+        let mut collector = ModuleSpecifierCollector::new();
+        collector.visit_program(&result.program);
+        for (_, _, path) in collector.specifiers {
             if path.ends_with(".vue") && (path.starts_with("./") || path.starts_with("../")) {
                 let candidate = path.to_compact_string();
                 if !specifiers.iter().any(|s| s.as_str() == candidate.as_str()) {
                     specifiers.push(candidate);
                 }
             }
-        };
-
-        for stmt in &result.program.body {
-            match stmt {
-                Statement::ImportDeclaration(decl) => push(&decl.source.value),
-                Statement::ExportNamedDeclaration(decl) => {
-                    if let Some(source) = &decl.source {
-                        push(&source.value);
-                    }
-                }
-                Statement::ExportAllDeclaration(decl) => push(&decl.source.value),
-                _ => {}
-            }
-        }
-
-        let mut collector = DynamicImportCollector::new();
-        collector.visit_program(&result.program);
-        for (_, _, path) in collector.imports {
-            push(&path);
         }
 
         specifiers
@@ -315,27 +269,61 @@ impl Default for ImportRewriter {
     }
 }
 
-struct DynamicImportCollector {
-    imports: Vec<(u32, u32, String)>,
+struct ModuleSpecifierCollector {
+    specifiers: Vec<(u32, u32, String)>,
 }
 
-impl DynamicImportCollector {
+impl ModuleSpecifierCollector {
     fn new() -> Self {
         Self {
-            imports: Vec::new(),
+            specifiers: Vec::new(),
         }
+    }
+
+    fn push(&mut self, start: u32, end: u32, specifier: &str) {
+        self.specifiers.push((start + 1, end - 1, specifier.into()));
     }
 }
 
-impl<'a> Visit<'a> for DynamicImportCollector {
-    fn visit_import_expression(&mut self, expr: &oxc_ast::ast::ImportExpression<'a>) {
+impl<'a> Visit<'a> for ModuleSpecifierCollector {
+    fn visit_import_declaration(&mut self, decl: &ImportDeclaration<'a>) {
+        self.push(
+            decl.source.span.start,
+            decl.source.span.end,
+            decl.source.value.as_str(),
+        );
+        walk::walk_import_declaration(self, decl);
+    }
+
+    fn visit_export_named_declaration(&mut self, decl: &ExportNamedDeclaration<'a>) {
+        if let Some(source) = &decl.source {
+            self.push(source.span.start, source.span.end, source.value.as_str());
+        }
+        walk::walk_export_named_declaration(self, decl);
+    }
+
+    fn visit_export_all_declaration(&mut self, decl: &ExportAllDeclaration<'a>) {
+        self.push(
+            decl.source.span.start,
+            decl.source.span.end,
+            decl.source.value.as_str(),
+        );
+        walk::walk_export_all_declaration(self, decl);
+    }
+
+    fn visit_import_expression(&mut self, expr: &ImportExpression<'a>) {
         if let Expression::StringLiteral(lit) = &expr.source {
-            self.imports.push((
-                lit.span.start + 1,
-                lit.span.end - 1,
-                lit.value.as_str().into(),
-            ));
+            self.push(lit.span.start, lit.span.end, lit.value.as_str());
         }
         walk::walk_import_expression(self, expr);
+    }
+
+    fn visit_ts_import_type(&mut self, import_type: &TSImportType<'a>) {
+        self.push(
+            import_type.source.span.start,
+            import_type.source.span.end,
+            import_type.source.value.as_str(),
+        );
+        walk::walk_ts_import_type(self, import_type);
     }
 }

--- a/crates/vize_canon/src/batch/import_rewriter_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_tests.rs
@@ -315,6 +315,7 @@ import Aliased from '@/Aliased.vue';
 import { ref } from 'vue';
 import Lazy from './App.vue';
 const Lazy2 = () => import('./Lazy.vue');
+type AppModule = typeof import('./Typed.vue');
 export { default as Re } from './Re.vue';
 "#;
     let mut found = rewriter.collect_relative_vue_specifiers(source, SourceType::ts());
@@ -325,7 +326,8 @@ export { default as Re } from './Re.vue';
             "../shared/Sibling.vue",
             "./App.vue",
             "./Lazy.vue",
-            "./Re.vue"
+            "./Re.vue",
+            "./Typed.vue"
         ]
     );
 }

--- a/crates/vize_canon/src/batch/import_rewriter_type_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_type_tests.rs
@@ -1,0 +1,31 @@
+use oxc_span::SourceType;
+
+use super::ImportRewriter;
+
+#[test]
+fn rewrites_ts_import_type_specifiers() {
+    let rewriter = ImportRewriter::new();
+    let source = r#"type AppModule = typeof import('./App.vue');
+type AppProps = import("./App.vue").PublicProps;"#;
+    let result = rewriter.rewrite(source, SourceType::ts());
+
+    assert_eq!(
+        result.code,
+        r#"type AppModule = typeof import('./App.vue.ts');
+type AppProps = import("./App.vue.ts").PublicProps;"#
+    );
+}
+
+#[test]
+fn rewrites_declaration_ts_import_type_specifiers() {
+    let rewriter = ImportRewriter::new();
+    let source = r#"export type AppModule = typeof import('./App.vue.ts');
+export type AppProps = import("./App.vue.ts").PublicProps;"#;
+    let result = rewriter.rewrite_declaration_specifiers(source, SourceType::ts());
+
+    assert_eq!(
+        result.code,
+        r#"export type AppModule = typeof import('./App.vue');
+export type AppProps = import("./App.vue").PublicProps;"#
+    );
+}

--- a/crates/vize_canon/src/batch/import_rewriter_virtual.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_virtual.rs
@@ -1,13 +1,12 @@
 use std::path::{Path, PathBuf};
 
 use oxc_allocator::Allocator;
-use oxc_ast::ast::Statement;
 use oxc_ast_visit::Visit;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_carton::{FxHashSet, String, cstr};
 
-use super::DynamicImportCollector;
+use super::ModuleSpecifierCollector;
 
 const SOURCE_EXTENSIONS: &[&str] = &[
     ".ts", ".tsx", ".d.ts", ".d.mts", ".d.cts", ".vue", ".mts", ".cts", ".js", ".jsx", ".mjs",
@@ -140,32 +139,13 @@ fn collect_import_specifiers(source: &str) -> Vec<String> {
     let allocator = Allocator::default();
     let parser = Parser::new(&allocator, source, SourceType::tsx());
     let result = parser.parse();
-    let mut specifiers: Vec<String> = Vec::new();
-
-    for stmt in &result.program.body {
-        match stmt {
-            Statement::ImportDeclaration(decl) => {
-                specifiers.push(decl.source.value.as_str().into())
-            }
-            Statement::ExportNamedDeclaration(decl) => {
-                if let Some(source) = &decl.source {
-                    specifiers.push(source.value.as_str().into());
-                }
-            }
-            Statement::ExportAllDeclaration(decl) => {
-                specifiers.push(decl.source.value.as_str().into());
-            }
-            _ => {}
-        }
-    }
-
-    let mut collector = DynamicImportCollector::new();
+    let mut collector = ModuleSpecifierCollector::new();
     collector.visit_program(&result.program);
-    for (_, _, path) in collector.imports {
-        specifiers.push(path);
-    }
-
-    specifiers
+    collector
+        .specifiers
+        .into_iter()
+        .map(|(_, _, path)| path)
+        .collect()
 }
 
 #[cfg(test)]
@@ -206,14 +186,12 @@ mod tests {
         write(
             &root,
             "src/feature/index.d.cts",
-            "import Widget from '../Widget.vue'\nexport type Feature = typeof Widget\n",
+            "export type Feature = typeof import('../Widget.vue')\n",
         );
         write(&root, "src/Widget.vue", "<template />");
 
         assert_eq!(
-            collect_import_specifiers(
-                "import Widget from '../Widget.vue'\nexport type Feature = typeof Widget\n"
-            ),
+            collect_import_specifiers("export type Feature = typeof import('../Widget.vue')\n"),
             vec!["../Widget.vue".to_string()]
         );
         assert!(absolute_import_needs_virtual_rewrite(


### PR DESCRIPTION
## Summary
- collect TypeScript import type specifiers in the shared import rewriter
- rewrite `import("*.vue")` to virtual `*.vue.ts` for type checking and back to `*.vue` for declaration output
- cover transitive declaration dependency scanning and CLI declaration emit output

## Tests
- cargo fmt --check --all
- cargo test -p vize_canon import_rewriter --lib
- cargo test -p vize --test check_declaration_emit_cli check_declaration_emit_reports_module_declaration_outputs -- --nocapture
- cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports
- cargo clippy -p vize --test check_declaration_emit_cli -- -D warnings -D clippy::wildcard_imports
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785793325&installation_id=136613492&pr_number=2598&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2598&signature=b4829365e3165765b6d9443d3593d4e8eb08ca44fb2f408b378c07535ef25f34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rewriting of Vue-related TypeScript type imports, including `typeof import(...)` and derived type forms (such as `.PublicProps`), so generated declarations reference the correct `.vue` targets.
  * Enhanced detection and rewriting of module specifiers used in both type aliases and `export type` declarations.
* **Tests**
  * Updated and expanded import rewriter test coverage and fixtures for `typeof import(...)` scenarios, including stricter assertion matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->