### PR TITLE
fix(canon): rewrite require specifiers

### DIFF
--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -2,8 +2,8 @@
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
-    ExportAllDeclaration, ExportNamedDeclaration, Expression, ImportDeclaration, ImportExpression,
-    TSImportType,
+    CallExpression, ExportAllDeclaration, ExportNamedDeclaration, Expression, ImportDeclaration,
+    ImportExpression, TSExternalModuleReference, TSImportType,
 };
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
@@ -318,6 +318,13 @@ impl<'a> Visit<'a> for ModuleSpecifierCollector {
         walk::walk_import_expression(self, expr);
     }
 
+    fn visit_call_expression(&mut self, expr: &CallExpression<'a>) {
+        if let Some(lit) = expr.common_js_require() {
+            self.push(lit.span.start, lit.span.end, lit.value.as_str());
+        }
+        walk::walk_call_expression(self, expr);
+    }
+
     fn visit_ts_import_type(&mut self, import_type: &TSImportType<'a>) {
         self.push(
             import_type.source.span.start,
@@ -325,5 +332,14 @@ impl<'a> Visit<'a> for ModuleSpecifierCollector {
             import_type.source.value.as_str(),
         );
         walk::walk_ts_import_type(self, import_type);
+    }
+
+    fn visit_ts_external_module_reference(&mut self, reference: &TSExternalModuleReference<'a>) {
+        self.push(
+            reference.expression.span.start,
+            reference.expression.span.end,
+            reference.expression.value.as_str(),
+        );
+        walk::walk_ts_external_module_reference(self, reference);
     }
 }

--- a/crates/vize_canon/src/batch/import_rewriter_type_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_type_tests.rs
@@ -29,3 +29,57 @@ export type AppProps = import("./App.vue.ts").PublicProps;"#;
 export type AppProps = import("./App.vue").PublicProps;"#
     );
 }
+
+#[test]
+fn rewrites_ts_import_equals_external_module_references() {
+    let rewriter = ImportRewriter::new();
+    let source = r#"import App = require("./App.vue");
+export type AppModule = typeof App;"#;
+    let result = rewriter.rewrite(source, SourceType::ts());
+
+    assert_eq!(
+        result.code,
+        r#"import App = require("./App.vue.ts");
+export type AppModule = typeof App;"#
+    );
+}
+
+#[test]
+fn rewrites_common_js_require_specifiers() {
+    let rewriter = ImportRewriter::new();
+    let source = r#"const App = require("./App.vue");
+const util = require("./util");"#;
+    let result = rewriter.rewrite(source, SourceType::ts());
+
+    assert_eq!(
+        result.code,
+        r#"const App = require("./App.vue.ts");
+const util = require("./util");"#
+    );
+}
+
+#[test]
+fn rewrites_declaration_require_specifiers() {
+    let rewriter = ImportRewriter::new();
+    let source = r#"import App = require("./App.vue.ts");
+export { App };"#;
+    let result = rewriter.rewrite_declaration_specifiers(source, SourceType::ts());
+
+    assert_eq!(
+        result.code,
+        r#"import App = require("./App.vue");
+export { App };"#
+    );
+}
+
+#[test]
+fn collects_relative_vue_specifiers_from_require_forms() {
+    let rewriter = ImportRewriter::new();
+    let source = r#"import App = require("./App.vue");
+const Other = require("../Other.vue");"#;
+
+    assert_eq!(
+        rewriter.collect_relative_vue_specifiers(source, SourceType::ts()),
+        vec!["./App.vue", "../Other.vue"]
+    );
+}


### PR DESCRIPTION
## Summary
- rewrite CommonJS require string specifiers through the canon import rewriter
- include TS import-equals external module references in the shared module specifier collector
- cover require forms in virtual rewrite, declaration reverse rewrite, and relative Vue dependency collection tests

## Validation
- cargo fmt --check --all
- cargo test -p vize_canon import_rewriter --lib
- cargo test -p vize --test check_declaration_emit_cli check_declaration_emit_reports_module_declaration_outputs -- --nocapture
- cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785795132&installation_id=136613492&pr_number=2599&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2599&signature=b48f6529c94eab11d4e0fbf4f3ecd9d103f0fffbc195d9a203b2919b1ff30978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Vue and TypeScript import references in CommonJS-style `require(...)` patterns.
  - Fixed detection of additional module specifiers so relative Vue files are rewritten and collected more reliably.
  - Preserved existing rewrite behavior for declaration-style imports while expanding support for type-related import forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->