### PR TITLE
fix(canon): rewrite module declaration specifiers

### DIFF
--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -3,15 +3,13 @@
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     CallExpression, ExportAllDeclaration, ExportNamedDeclaration, Expression, ImportDeclaration,
-    ImportExpression, TSExternalModuleReference, TSImportType,
+    ImportExpression, StringLiteral, TSExternalModuleReference, TSImportType,
+    TSModuleDeclarationName,
 };
-use oxc_ast_visit::Visit;
-use oxc_ast_visit::walk;
+use oxc_ast_visit::{Visit, walk};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::String;
-use vize_carton::ToCompactString;
-use vize_carton::cstr;
+use vize_carton::{String, ToCompactString, cstr};
 
 #[path = "import_rewriter_virtual.rs"]
 mod virtual_rewrite;
@@ -283,37 +281,33 @@ impl ModuleSpecifierCollector {
     fn push(&mut self, start: u32, end: u32, specifier: &str) {
         self.specifiers.push((start + 1, end - 1, specifier.into()));
     }
+
+    fn push_literal(&mut self, lit: &StringLiteral<'_>) {
+        self.push(lit.span.start, lit.span.end, lit.value.as_str());
+    }
 }
 
 impl<'a> Visit<'a> for ModuleSpecifierCollector {
     fn visit_import_declaration(&mut self, decl: &ImportDeclaration<'a>) {
-        self.push(
-            decl.source.span.start,
-            decl.source.span.end,
-            decl.source.value.as_str(),
-        );
+        self.push_literal(&decl.source);
         walk::walk_import_declaration(self, decl);
     }
 
     fn visit_export_named_declaration(&mut self, decl: &ExportNamedDeclaration<'a>) {
         if let Some(source) = &decl.source {
-            self.push(source.span.start, source.span.end, source.value.as_str());
+            self.push_literal(source);
         }
         walk::walk_export_named_declaration(self, decl);
     }
 
     fn visit_export_all_declaration(&mut self, decl: &ExportAllDeclaration<'a>) {
-        self.push(
-            decl.source.span.start,
-            decl.source.span.end,
-            decl.source.value.as_str(),
-        );
+        self.push_literal(&decl.source);
         walk::walk_export_all_declaration(self, decl);
     }
 
     fn visit_import_expression(&mut self, expr: &ImportExpression<'a>) {
         if let Expression::StringLiteral(lit) = &expr.source {
-            self.push(lit.span.start, lit.span.end, lit.value.as_str());
+            self.push_literal(lit);
         }
         walk::walk_import_expression(self, expr);
     }
@@ -326,20 +320,19 @@ impl<'a> Visit<'a> for ModuleSpecifierCollector {
     }
 
     fn visit_ts_import_type(&mut self, import_type: &TSImportType<'a>) {
-        self.push(
-            import_type.source.span.start,
-            import_type.source.span.end,
-            import_type.source.value.as_str(),
-        );
+        self.push_literal(&import_type.source);
         walk::walk_ts_import_type(self, import_type);
     }
 
     fn visit_ts_external_module_reference(&mut self, reference: &TSExternalModuleReference<'a>) {
-        self.push(
-            reference.expression.span.start,
-            reference.expression.span.end,
-            reference.expression.value.as_str(),
-        );
+        self.push_literal(&reference.expression);
         walk::walk_ts_external_module_reference(self, reference);
+    }
+
+    fn visit_ts_module_declaration_name(&mut self, name: &TSModuleDeclarationName<'a>) {
+        if let TSModuleDeclarationName::StringLiteral(lit) = name {
+            self.push_literal(lit);
+        }
+        walk::walk_ts_module_declaration_name(self, name);
     }
 }

--- a/crates/vize_canon/src/batch/import_rewriter_type_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_type_tests.rs
@@ -83,3 +83,55 @@ const Other = require("../Other.vue");"#;
         vec!["./App.vue", "../Other.vue"]
     );
 }
+
+#[test]
+fn rewrites_module_declaration_specifiers() {
+    let rewriter = ImportRewriter::new();
+    let source = r#"declare module "./App.vue" {
+  export const marker: true;
+}
+declare module "*.vue" {
+  const component: unknown;
+  export default component;
+}"#;
+    let result = rewriter.rewrite(source, SourceType::ts());
+
+    assert_eq!(
+        result.code,
+        r#"declare module "./App.vue.ts" {
+  export const marker: true;
+}
+declare module "*.vue" {
+  const component: unknown;
+  export default component;
+}"#
+    );
+}
+
+#[test]
+fn rewrites_declaration_module_declaration_specifiers() {
+    let rewriter = ImportRewriter::new();
+    let source = r#"declare module "./App.vue.ts" {
+  export const marker: true;
+}"#;
+    let result = rewriter.rewrite_declaration_specifiers(source, SourceType::ts());
+
+    assert_eq!(
+        result.code,
+        r#"declare module "./App.vue" {
+  export const marker: true;
+}"#
+    );
+}
+
+#[test]
+fn collects_relative_vue_specifiers_from_module_declarations() {
+    let rewriter = ImportRewriter::new();
+    let source = r#"declare module "./App.vue" {}
+declare module "*.vue" {}"#;
+
+    assert_eq!(
+        rewriter.collect_relative_vue_specifiers(source, SourceType::ts()),
+        vec!["./App.vue"]
+    );
+}

--- a/crates/vize_canon/src/batch/virtual_project/tests/module_augmentations.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/module_augmentations.rs
@@ -59,3 +59,45 @@ const message = 'Hello'
 
     let _ = fs::remove_dir_all(&case_dir);
 }
+
+#[test]
+fn materialize_rewrites_relative_vue_module_declaration_names() {
+    let case_dir = unique_case_dir("materialize-module-declaration-name");
+    let _ = fs::remove_dir_all(&case_dir);
+    let src_dir = case_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+
+    let vue_path = src_dir.join("App.vue");
+    fs::write(&vue_path, "<template />\n").unwrap();
+
+    let augment_path = src_dir.join("augment.ts");
+    fs::write(
+        &augment_path,
+        r#"declare module "./App.vue" {
+  export const marker: true;
+}
+declare module "*.vue" {
+  const component: unknown;
+  export default component;
+}
+"#,
+    )
+    .unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.register_path(&vue_path).unwrap();
+    project.register_path(&augment_path).unwrap();
+    project.materialize().unwrap();
+
+    let materialized = fs::read_to_string(project.virtual_root().join("src/augment.ts")).unwrap();
+    assert!(
+        materialized.contains(r#"declare module "./App.vue.ts""#),
+        "{materialized}"
+    );
+    assert!(
+        materialized.contains(r#"declare module "*.vue""#),
+        "{materialized}"
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}


### PR DESCRIPTION
Summary
- Rewrite string-literal TS module declarations through the shared import specifier rewriter.
- Preserve wildcard module declarations while collecting relative .vue declaration names.
- Cover virtual project materialization so registered TS augmentations point at generated .vue.ts modules.

Validation
- cargo test -p vize_canon import_rewriter --lib
- cargo test -p vize_canon module_augmentations --lib
- cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports
- cargo fmt --check --all
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785796588&installation_id=136613492&pr_number=2600&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2600&signature=7a76d390c54b6204dae9224b54a550a1a9caa8abd0c59ef04279d1f17ffb0b37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rewriting of Vue-related module specifiers in TypeScript declarations, including `declare module` blocks.
  * Relative `.vue` module paths are now updated consistently, while wildcard patterns like `*.vue` remain unchanged.

* **Tests**
  * Added coverage for module declaration rewriting and specifier collection to ensure the expected Vue import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->