### PR TITLE
fix(canon): expand generated import type aliases

### DIFF
--- a/crates/vize/src/commands/check.rs
+++ b/crates/vize/src/commands/check.rs
@@ -4,6 +4,8 @@
 //! Can connect to a running check-server via Unix socket for faster repeated checks.
 
 mod dts;
+mod dts_import_aliases;
+mod dts_rewrite;
 mod imports;
 mod imports_aliases;
 mod nuxt;

--- a/crates/vize/src/commands/check/dts.rs
+++ b/crates/vize/src/commands/check/dts.rs
@@ -6,6 +6,12 @@ use std::{fs, path::Path};
 
 use vize_carton::{String, ToCompactString, profile, profiler::global_profiler};
 
+use super::dts_import_aliases::{
+    ImportTypeAliases, collect_import_type_aliases, rewrite_import_type_aliases,
+};
+use super::dts_rewrite::rewrite_relative_import_types;
+pub(super) use super::dts_rewrite::rewrite_relative_specifier;
+
 pub(super) fn parse_interface_members(
     path: &Path,
     interface_name: &str,
@@ -38,12 +44,13 @@ pub(super) fn parse_interface_members_with_rewritten_imports(
         }
     };
     let source_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let import_aliases = collect_import_type_aliases(content.as_str(), source_dir);
     Ok(parse_interface_members_content(&content, interface_name)
         .into_iter()
         .map(|(name, type_annotation)| {
             (
                 name,
-                normalize_rewritten_type(type_annotation.as_str(), source_dir),
+                normalize_rewritten_type(type_annotation.as_str(), source_dir, &import_aliases),
             )
         })
         .collect())
@@ -63,12 +70,13 @@ pub(super) fn parse_global_component_members_with_rewritten_imports(
         }
     };
     let source_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let import_aliases = collect_import_type_aliases(content.as_str(), source_dir);
     Ok(parse_global_component_members_content(&content)
         .into_iter()
         .map(|(name, type_annotation)| {
             (
                 name,
-                normalize_rewritten_type(type_annotation.as_str(), source_dir),
+                normalize_rewritten_type(type_annotation.as_str(), source_dir, &import_aliases),
             )
         })
         .collect())
@@ -228,6 +236,7 @@ pub(super) fn parse_declared_global_values_content(
     content: &str,
     source_dir: &Path,
 ) -> Vec<(String, String)> {
+    let import_aliases = collect_import_type_aliases(content, source_dir);
     let mut values = Vec::new();
     let mut in_global = false;
     let mut brace_depth = 0i32;
@@ -252,6 +261,7 @@ pub(super) fn parse_declared_global_values_content(
                 &mut current_name,
                 &mut current_type,
                 source_dir,
+                &import_aliases,
             );
             in_global = false;
             continue;
@@ -267,6 +277,7 @@ pub(super) fn parse_declared_global_values_content(
             &mut current_type,
             trimmed,
             source_dir,
+            &import_aliases,
         ) {
             continue;
         }
@@ -283,7 +294,7 @@ pub(super) fn parse_declared_global_values_content(
             } else if is_type_complete(type_ann.as_str()) {
                 values.push((
                     name,
-                    normalize_rewritten_type(type_ann.as_str(), source_dir),
+                    normalize_rewritten_type(type_ann.as_str(), source_dir, &import_aliases),
                 ));
             } else {
                 current_name = Some(name);
@@ -297,6 +308,7 @@ pub(super) fn parse_declared_global_values_content(
         &mut current_name,
         &mut current_type,
         source_dir,
+        &import_aliases,
     );
     values
 }
@@ -330,6 +342,7 @@ fn append_pending_global(
     current_type: &mut String,
     trimmed: &str,
     source_dir: &Path,
+    import_aliases: &ImportTypeAliases,
 ) -> bool {
     if current_name.is_none() {
         return false;
@@ -343,7 +356,7 @@ fn append_pending_global(
     {
         values.push((
             name,
-            normalize_rewritten_type(current_type.as_str(), source_dir),
+            normalize_rewritten_type(current_type.as_str(), source_dir, import_aliases),
         ));
         current_type.clear();
     }
@@ -367,11 +380,12 @@ fn flush_pending_global(
     current_name: &mut Option<String>,
     current_type: &mut String,
     source_dir: &Path,
+    import_aliases: &ImportTypeAliases,
 ) {
     if let Some(name) = current_name.take() {
         values.push((
             name,
-            normalize_rewritten_type(current_type.as_str(), source_dir),
+            normalize_rewritten_type(current_type.as_str(), source_dir, import_aliases),
         ));
         current_type.clear();
     }
@@ -405,8 +419,16 @@ fn normalize_type(type_annotation: &str) -> String {
         .to_compact_string()
 }
 
-fn normalize_rewritten_type(type_annotation: &str, source_dir: &Path) -> String {
-    normalize_type(&rewrite_relative_import_types(type_annotation, source_dir))
+fn normalize_rewritten_type(
+    type_annotation: &str,
+    source_dir: &Path,
+    import_aliases: &ImportTypeAliases,
+) -> String {
+    let type_annotation = rewrite_import_type_aliases(type_annotation, import_aliases);
+    normalize_type(&rewrite_relative_import_types(
+        type_annotation.as_str(),
+        source_dir,
+    ))
 }
 
 fn brace_delta(line: &str) -> i32 {
@@ -437,69 +459,6 @@ fn is_type_complete(s: &str) -> bool {
         }
     }
     paren <= 0 && angle <= 0 && brace <= 0
-}
-
-fn rewrite_relative_import_types(type_annotation: &str, source_dir: &Path) -> String {
-    let bytes = type_annotation.as_bytes();
-    let mut out = String::with_capacity(type_annotation.len());
-    let mut i = 0usize;
-
-    while i < bytes.len() {
-        let import_prefix = if type_annotation[i..].starts_with("import('") {
-            Some('\'')
-        } else if type_annotation[i..].starts_with("import(\"") {
-            Some('"')
-        } else {
-            None
-        };
-
-        let Some(quote) = import_prefix else {
-            out.push(bytes[i] as char);
-            i += 1;
-            continue;
-        };
-
-        out.push_str("import(");
-        out.push(quote);
-        i += 8;
-
-        let start = i;
-        while i < bytes.len() && bytes[i] != quote as u8 {
-            i += 1;
-        }
-
-        let specifier = &type_annotation[start..i];
-        out.push_str(&rewrite_relative_specifier(specifier, source_dir));
-
-        if i < bytes.len() {
-            out.push(quote);
-            i += 1;
-        }
-    }
-
-    out
-}
-
-pub(super) fn rewrite_relative_specifier(specifier: &str, source_dir: &Path) -> String {
-    if !specifier.starts_with("./") && !specifier.starts_with("../") {
-        return specifier.to_compact_string();
-    }
-
-    normalize_path(&source_dir.join(specifier))
-}
-
-fn normalize_path(path: &Path) -> String {
-    let mut normalized = std::path::PathBuf::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                normalized.pop();
-            }
-            _ => normalized.push(component.as_os_str()),
-        }
-    }
-    normalized.to_string_lossy().to_compact_string()
 }
 
 #[cfg(test)]

--- a/crates/vize/src/commands/check/dts_import_aliases.rs
+++ b/crates/vize/src/commands/check/dts_import_aliases.rs
@@ -1,0 +1,324 @@
+use std::path::Path;
+
+use vize_carton::{FxHashMap, String, ToCompactString, cstr};
+
+use super::dts_rewrite::rewrite_relative_specifier;
+
+#[derive(Default)]
+pub(super) struct ImportTypeAliases {
+    aliases: FxHashMap<String, ImportTypeAlias>,
+}
+
+enum ImportTypeAlias {
+    Default { module: String },
+    Named { module: String, imported: String },
+    Namespace { module: String },
+}
+
+pub(super) fn collect_import_type_aliases(content: &str, source_dir: &Path) -> ImportTypeAliases {
+    let mut aliases = ImportTypeAliases::default();
+    let mut current = String::default();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if current.is_empty() {
+            if !trimmed.starts_with("import ") {
+                continue;
+            }
+            current.push_str(trimmed);
+        } else {
+            current.push(' ');
+            current.push_str(trimmed);
+        }
+
+        if import_statement_complete(current.as_str()) {
+            collect_import_statement(current.as_str(), source_dir, &mut aliases);
+            current.clear();
+        }
+    }
+
+    if !current.is_empty() {
+        collect_import_statement(current.as_str(), source_dir, &mut aliases);
+    }
+
+    aliases
+}
+
+pub(super) fn rewrite_import_type_aliases(
+    type_annotation: &str,
+    aliases: &ImportTypeAliases,
+) -> String {
+    if aliases.aliases.is_empty() {
+        return type_annotation.to_compact_string();
+    }
+
+    let mut out = String::with_capacity(type_annotation.len());
+    let mut i = 0usize;
+    while i < type_annotation.len() {
+        let ch = type_annotation[i..].chars().next().unwrap();
+        if ch == '\'' || ch == '"' || ch == '`' {
+            i = copy_quoted(type_annotation, i, &mut out);
+            continue;
+        }
+        if !is_identifier_start(ch) {
+            out.push(ch);
+            i += ch.len_utf8();
+            continue;
+        }
+
+        let start = i;
+        i += ch.len_utf8();
+        while i < type_annotation.len() {
+            let ch = type_annotation[i..].chars().next().unwrap();
+            if !is_identifier_char(ch) {
+                break;
+            }
+            i += ch.len_utf8();
+        }
+
+        let ident = &type_annotation[start..i];
+        let next = type_annotation[i..].chars().next();
+        if let Some(alias) = aliases.aliases.get(ident) {
+            match alias {
+                ImportTypeAlias::Namespace { module } if next == Some('.') => {
+                    out.push_str(&render_namespace_reference(module.as_str()));
+                    continue;
+                }
+                ImportTypeAlias::Named { module, imported }
+                    if previous_non_whitespace(type_annotation, start) != Some('.') =>
+                {
+                    out.push_str(&render_named_reference(module.as_str(), imported.as_str()));
+                    continue;
+                }
+                ImportTypeAlias::Default { module }
+                    if previous_non_whitespace(type_annotation, start) != Some('.') =>
+                {
+                    out.push_str(&render_named_reference(module.as_str(), "default"));
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        out.push_str(ident);
+    }
+
+    out
+}
+
+fn collect_import_statement(statement: &str, source_dir: &Path, aliases: &mut ImportTypeAliases) {
+    let statement = statement.trim().trim_end_matches(';').trim();
+    let Some(rest) = statement.strip_prefix("import ") else {
+        return;
+    };
+    let Some((imports, from_part)) = rest.rsplit_once(" from ") else {
+        return;
+    };
+    let Some(specifier) = parse_module_specifier(from_part) else {
+        return;
+    };
+    let module = rewrite_relative_specifier(specifier, source_dir);
+    let imports = imports.trim();
+
+    if let Some(type_imports) = imports.strip_prefix("type ") {
+        collect_type_only_imports(type_imports.trim(), module.as_str(), aliases);
+    } else {
+        collect_inline_type_imports(imports, module.as_str(), aliases);
+    }
+}
+
+fn collect_type_only_imports(imports: &str, module: &str, aliases: &mut ImportTypeAliases) {
+    if imports.starts_with('{') {
+        collect_named_imports(imports, module, aliases, false);
+        return;
+    }
+    if let Some(namespace) = imports.strip_prefix("* as ") {
+        push_namespace_alias(namespace.trim(), module, aliases);
+        return;
+    }
+    if let Some((default_import, rest)) = imports.split_once(',') {
+        push_default_alias(default_import.trim(), module, aliases);
+        collect_type_only_imports(rest.trim(), module, aliases);
+        return;
+    }
+    push_default_alias(imports.trim(), module, aliases);
+}
+
+fn collect_inline_type_imports(imports: &str, module: &str, aliases: &mut ImportTypeAliases) {
+    if imports.starts_with('{') {
+        collect_named_imports(imports, module, aliases, true);
+    }
+}
+
+fn collect_named_imports(
+    imports: &str,
+    module: &str,
+    aliases: &mut ImportTypeAliases,
+    require_type_prefix: bool,
+) {
+    let Some(inner) = imports
+        .trim()
+        .strip_prefix('{')
+        .and_then(|value| value.strip_suffix('}'))
+    else {
+        return;
+    };
+
+    for raw in inner.split(',') {
+        let mut item = raw.trim();
+        if item.is_empty() {
+            continue;
+        }
+        if require_type_prefix {
+            let Some(rest) = item.strip_prefix("type ") else {
+                continue;
+            };
+            item = rest.trim();
+        }
+        let (imported, local) = parse_import_binding(item);
+        if is_identifier(imported) && is_identifier(local) {
+            aliases.aliases.insert(
+                local.to_compact_string(),
+                ImportTypeAlias::Named {
+                    module: module.into(),
+                    imported: imported.into(),
+                },
+            );
+        }
+    }
+}
+
+fn parse_import_binding(item: &str) -> (&str, &str) {
+    let mut parts = item.split_whitespace();
+    let imported = parts.next().unwrap_or_default();
+    match (parts.next(), parts.next()) {
+        (Some("as"), Some(local)) => (imported, local),
+        _ => (imported, imported),
+    }
+}
+
+fn push_default_alias(local: &str, module: &str, aliases: &mut ImportTypeAliases) {
+    if is_identifier(local) {
+        aliases.aliases.insert(
+            local.to_compact_string(),
+            ImportTypeAlias::Default {
+                module: module.into(),
+            },
+        );
+    }
+}
+
+fn push_namespace_alias(local: &str, module: &str, aliases: &mut ImportTypeAliases) {
+    if is_identifier(local) {
+        aliases.aliases.insert(
+            local.to_compact_string(),
+            ImportTypeAlias::Namespace {
+                module: module.into(),
+            },
+        );
+    }
+}
+
+fn import_statement_complete(statement: &str) -> bool {
+    statement.ends_with(';')
+        || statement
+            .rsplit_once(" from ")
+            .and_then(|(_, from_part)| parse_module_specifier(from_part))
+            .is_some()
+}
+
+fn parse_module_specifier(from_part: &str) -> Option<&str> {
+    let from_part = from_part.trim();
+    let quote = from_part
+        .chars()
+        .next()
+        .filter(|ch| *ch == '\'' || *ch == '"')?;
+    let rest = &from_part[quote.len_utf8()..];
+    let end = rest.find(quote)?;
+    Some(&rest[..end])
+}
+
+fn copy_quoted(input: &str, start: usize, out: &mut String) -> usize {
+    let quote = input[start..].chars().next().unwrap();
+    let mut i = start;
+    while i < input.len() {
+        let ch = input[i..].chars().next().unwrap();
+        out.push(ch);
+        i += ch.len_utf8();
+        if ch == '\\' && i < input.len() {
+            let escaped = input[i..].chars().next().unwrap();
+            out.push(escaped);
+            i += escaped.len_utf8();
+            continue;
+        }
+        if ch == quote && i > start + quote.len_utf8() {
+            break;
+        }
+    }
+    i
+}
+
+fn render_named_reference(module: &str, imported: &str) -> String {
+    cstr!("import('{module}').{imported}")
+}
+
+fn render_namespace_reference(module: &str) -> String {
+    cstr!("import('{module}')")
+}
+
+fn previous_non_whitespace(input: &str, index: usize) -> Option<char> {
+    input[..index].chars().rev().find(|ch| !ch.is_whitespace())
+}
+
+fn is_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    is_identifier_start(first) && chars.all(is_identifier_char)
+}
+
+fn is_identifier_start(ch: char) -> bool {
+    ch == '_' || ch == '$' || ch.is_ascii_alphabetic()
+}
+
+fn is_identifier_char(ch: char) -> bool {
+    is_identifier_start(ch) || ch.is_ascii_digit()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{collect_import_type_aliases, rewrite_import_type_aliases};
+
+    #[test]
+    fn rewrites_import_type_aliases() {
+        let content = r#"
+import type { User, Wrapped as AliasedWrapped } from '../../app/types/user'
+import type DefaultThing from '../../app/types/default'
+import type * as Shared from '../../app/types/shared'
+"#;
+        let aliases = collect_import_type_aliases(content, Path::new("/workspace/.nuxt/types"));
+        let rewritten = rewrite_import_type_aliases(
+            "() => User | AliasedWrapped | DefaultThing | Shared.Thing",
+            &aliases,
+        );
+
+        assert_eq!(
+            rewritten.as_str(),
+            "() => import('/workspace/app/types/user').User | import('/workspace/app/types/user').Wrapped | import('/workspace/app/types/default').default | import('/workspace/app/types/shared').Thing"
+        );
+    }
+
+    #[test]
+    fn ignores_value_imports_and_quoted_literals() {
+        let content = r#"import { type User, value } from './types'"#;
+        let aliases = collect_import_type_aliases(content, Path::new("/workspace/.nuxt/types"));
+        let rewritten = rewrite_import_type_aliases("Record<'User', User> | value", &aliases);
+
+        assert_eq!(
+            rewritten.as_str(),
+            "Record<'User', import('/workspace/.nuxt/types/types').User> | value"
+        );
+    }
+}

--- a/crates/vize/src/commands/check/dts_rewrite.rs
+++ b/crates/vize/src/commands/check/dts_rewrite.rs
@@ -1,0 +1,66 @@
+use std::path::Path;
+
+use vize_carton::{String, ToCompactString};
+
+pub(super) fn rewrite_relative_import_types(type_annotation: &str, source_dir: &Path) -> String {
+    let bytes = type_annotation.as_bytes();
+    let mut out = String::with_capacity(type_annotation.len());
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        let import_prefix = if type_annotation[i..].starts_with("import('") {
+            Some('\'')
+        } else if type_annotation[i..].starts_with("import(\"") {
+            Some('"')
+        } else {
+            None
+        };
+
+        let Some(quote) = import_prefix else {
+            out.push(bytes[i] as char);
+            i += 1;
+            continue;
+        };
+
+        out.push_str("import(");
+        out.push(quote);
+        i += 8;
+
+        let start = i;
+        while i < bytes.len() && bytes[i] != quote as u8 {
+            i += 1;
+        }
+
+        let specifier = &type_annotation[start..i];
+        out.push_str(&rewrite_relative_specifier(specifier, source_dir));
+
+        if i < bytes.len() {
+            out.push(quote);
+            i += 1;
+        }
+    }
+
+    out
+}
+
+pub(super) fn rewrite_relative_specifier(specifier: &str, source_dir: &Path) -> String {
+    if !specifier.starts_with("./") && !specifier.starts_with("../") {
+        return specifier.to_compact_string();
+    }
+
+    normalize_path(&source_dir.join(specifier))
+}
+
+fn normalize_path(path: &Path) -> String {
+    let mut normalized = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized.to_string_lossy().to_compact_string()
+}

--- a/crates/vize/src/commands/check/nuxt/generated_tests.rs
+++ b/crates/vize/src/commands/check/nuxt/generated_tests.rs
@@ -96,6 +96,88 @@ export {}
 }
 
 #[test]
+fn expands_generated_import_type_aliases() {
+    let project_root = unique_case_dir("import-type-aliases");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join(".nuxt/types")).unwrap();
+    std::fs::create_dir_all(project_root.join("app/types")).unwrap();
+    std::fs::write(project_root.join("nuxt.config.ts"), "export default {}").unwrap();
+    std::fs::write(
+        project_root.join("app/types/user.ts"),
+        "export type User = { id: string };\nexport type Wrapped = { ok: true };\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("app/types/default.ts"),
+        "export default interface DefaultThing { id: string }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("app/types/shared.ts"),
+        "export interface Thing { name: string }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join(".nuxt/types/imports.d.ts"),
+        r#"import type { User, Wrapped as AliasedWrapped } from '../../app/types/user'
+import type DefaultThing from '../../app/types/default'
+import type * as Shared from '../../app/types/shared'
+declare global {
+  const useTypedUser: () => User
+  const useWrapped: () => AliasedWrapped
+  const useDefaultThing: () => DefaultThing
+  const useSharedThing: () => Shared.Thing
+}
+export {}
+"#,
+    )
+    .unwrap();
+
+    let mut options = VirtualTsOptions::default();
+    let _ = detect_nuxt_auto_imports(&mut options, &project_root);
+    let stubs = options.auto_import_stubs.join("\n");
+    let user = project_root
+        .join("app/types/user")
+        .to_string_lossy()
+        .replace('\\', "/");
+    let default = project_root
+        .join("app/types/default")
+        .to_string_lossy()
+        .replace('\\', "/");
+    let shared = project_root
+        .join("app/types/shared")
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    assert!(
+        stubs.contains(&format!(
+            "declare const useTypedUser: () => import('{user}').User;"
+        )),
+        "expected named import type alias expansion, got:\n{stubs}"
+    );
+    assert!(
+        stubs.contains(&format!(
+            "declare const useWrapped: () => import('{user}').Wrapped;"
+        )),
+        "expected aliased import type expansion, got:\n{stubs}"
+    );
+    assert!(
+        stubs.contains(&format!(
+            "declare const useDefaultThing: () => import('{default}').default;"
+        )),
+        "expected default import type expansion, got:\n{stubs}"
+    );
+    assert!(
+        stubs.contains(&format!(
+            "declare const useSharedThing: () => import('{shared}').Thing;"
+        )),
+        "expected namespace import type expansion, got:\n{stubs}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn detects_root_module_declaration_import_manifest() {
     let project_root = unique_case_dir("root-module-declaration-imports");
     let _ = std::fs::remove_dir_all(&project_root);


### PR DESCRIPTION
Summary
- Expand type-only imports found in generated declaration files into inline import() type references.
- Preserve existing relative import() rewriting by moving it into a small helper module.
- Cover named, aliased, default, and namespace type imports in generated Nuxt stubs.

Validation
- cargo test -p vize dts_import_aliases --lib
- cargo test -p vize generated_tests --lib
- cargo test -p vize dts --lib
- cargo clippy -p vize --lib -- -D warnings -D clippy::wildcard_imports
- cargo fmt --check --all
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785798203&installation_id=136613492&pr_number=2601&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2601&signature=2d475818dac52c087f41652fc63b0b2ea26be0ec20018f14f94d9abf5fd8c576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of TypeScript type imports, including aliases, default exports, namespace imports, and relative paths.
  * Generated Nuxt auto-import stubs now expand more import type patterns correctly.

* **Bug Fixes**
  * Fixed cases where type annotations could keep unresolved or incorrectly rewritten import paths.
  * Better preserves quoted strings while rewriting type references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->