### PR TITLE
fix(lsp): rewrite dependency vue imports

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -101,7 +101,7 @@ fn queue_imports(
     source_type: SourceType,
 ) {
     queue_vue_imports(&mut imports, options, rewriter, dir, code, source_type);
-    queue_ts_imports(&mut imports, dir, code, source_type);
+    queue_ts_imports(&mut imports, rewriter, dir, code, source_type);
 }
 
 fn queue_vue_imports(
@@ -155,6 +155,7 @@ fn fallback_vue_virtual_uri(path: &Path) -> String {
 
 fn queue_ts_imports(
     imports: &mut ImportQueue<'_>,
+    rewriter: &ImportRewriter,
     dir: &Path,
     code: &str,
     source_type: SourceType,
@@ -170,11 +171,13 @@ fn queue_ts_imports(
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };
+        let dependency_source_type = source_type_for_path(&path);
+        let rewritten = rewriter.rewrite(&content, dependency_source_type).code;
         let uri = normalize_document_uri(path_to_file_uri(&path).as_str());
-        imports.documents.push((uri, content.to_compact_string()));
+        imports.documents.push((uri, rewritten));
         imports.queue.push_back(DependencyScan::Script {
             path: path.clone(),
-            source_type: source_type_for_path(&path),
+            source_type: dependency_source_type,
             content: content.into(),
         });
     }

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -155,13 +155,16 @@ mod tests {
         let child_path = src.join("Child.vue");
         let grand_child_path = src.join("GrandChild.vue");
         let util_path = src.join("util.ts");
+        let types_path = src.join("types.ts");
         let child_util_path = src.join("childUtil.ts");
         std::fs::write(
             &host_path,
             r#"<script setup lang="ts">
 import Child from "./Child.vue";
 import { value } from "./util";
+import type { ChildModule } from "./types";
 const current = value;
+type _ChildModule = ChildModule;
 </script>
 <template><Child :value="current" /></template>
 "#,
@@ -190,6 +193,13 @@ defineProps<{ label?: string }>();
         )
         .expect("grand child");
         std::fs::write(&util_path, "export const value = 1;\n").expect("util");
+        std::fs::write(
+            &types_path,
+            r#"export type ChildModule = typeof import("./Child.vue");
+export { default as ReexportedChild } from "./Child.vue";
+"#,
+        )
+        .expect("types");
         std::fs::write(&child_util_path, "export const childValue = 2;\n").expect("child util");
 
         let host = std::fs::read_to_string(&host_path).expect("host source");
@@ -210,6 +220,17 @@ defineProps<{ label?: string }>();
             uris.contains(&path_to_file_uri(&util_path).as_str()),
             "uris: {uris:?}\n{}",
             virtual_project.host.pre_rewrite_code,
+        );
+        let types_document = virtual_project
+            .documents
+            .iter()
+            .find(|(uri, _)| uri == path_to_file_uri(&types_path).as_str())
+            .map(|(_, content)| content.as_str())
+            .expect("TS dependency document should be synced");
+        assert!(
+            types_document.contains(r#"import("./Child.vue.ts")"#)
+                && types_document.contains(r#"from "./Child.vue.ts""#),
+            "TS dependency Vue specifiers must target virtual Vue modules:\n{types_document}",
         );
         assert!(
             uris.contains(&path_to_file_uri(&child_util_path).as_str()),


### PR DESCRIPTION
Summary
- Rewrite .vue specifiers inside TS dependency documents before syncing them into editor Corsa sessions.
- Keep dependency discovery based on the original source while opening the rewritten in-memory document.
- Cover import type and re-export specifiers in a Vue virtual project dependency test.

Validation
- cargo test -p vize_canon vue_virtual_project_syncs_relative_vue_and_ts_dependencies --lib
- cargo test -p vize_canon vue_dependencies --lib
- cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports
- cargo fmt --check --all
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785799592&installation_id=136613492&pr_number=2602&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2602&signature=e5365c61d24167066cfa285cb26fdafbb8ce26ccf6ab4e381debc3c70f214eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of Vue and TypeScript dependencies in virtual projects.
  * Ensured TypeScript type-only imports are rewritten consistently so generated modules point to the correct virtual Vue paths.
  * Preserved existing dependency handling while avoiding mismatched import targets in generated in-memory documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->