### PR TITLE
fix(lsp): sync type-only dependencies

### DIFF
--- a/crates/vize_canon/src/corsa_bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge.rs
@@ -7,6 +7,7 @@
 mod bridge;
 mod types;
 mod vue_dependencies;
+mod vue_dependency_specifiers;
 mod vue_document;
 
 pub use bridge::{BatchTypeChecker, CorsaBridge};

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -4,9 +4,10 @@ use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 
 use oxc_span::SourceType;
-use vize_carton::{FxHashSet, String, ToCompactString, cstr};
+use vize_carton::{FxHashSet, String, cstr};
 
 use super::bridge::normalize_document_uri;
+use super::vue_dependency_specifiers::collect_relative_ts_specifiers;
 use super::vue_document::{
     CorsaVueVirtualDocumentOptions, GeneratedVueDocument, generate_vue_document,
 };
@@ -181,61 +182,6 @@ fn queue_ts_imports(
             content: content.into(),
         });
     }
-}
-
-fn collect_relative_ts_specifiers(code: &str, source_type: SourceType) -> Vec<String> {
-    use oxc_allocator::Allocator;
-    use oxc_ast::ast::{Expression, Statement};
-    use oxc_ast_visit::Visit;
-    use oxc_parser::Parser;
-
-    let allocator = Allocator::default();
-    let result = Parser::new(&allocator, code, source_type).parse();
-    let mut specifiers = Vec::new();
-    let mut push = |path: &str| {
-        if (path.starts_with("./") || path.starts_with("../"))
-            && !path.ends_with(".vue")
-            && !path.ends_with(".vue.ts")
-            && !specifiers.iter().any(|known| known == path)
-        {
-            specifiers.push(path.to_compact_string());
-        }
-    };
-
-    for stmt in &result.program.body {
-        match stmt {
-            Statement::ImportDeclaration(decl) => push(&decl.source.value),
-            Statement::ExportNamedDeclaration(decl) => {
-                if let Some(source) = &decl.source {
-                    push(&source.value);
-                }
-            }
-            Statement::ExportAllDeclaration(decl) => push(&decl.source.value),
-            _ => {}
-        }
-    }
-
-    struct DynamicImportCollector {
-        imports: Vec<String>,
-    }
-    impl<'a> Visit<'a> for DynamicImportCollector {
-        fn visit_import_expression(&mut self, expr: &oxc_ast::ast::ImportExpression<'a>) {
-            if let Expression::StringLiteral(lit) = &expr.source {
-                self.imports.push(lit.value.as_str().to_compact_string());
-            }
-            oxc_ast_visit::walk::walk_import_expression(self, expr);
-        }
-    }
-
-    let mut collector = DynamicImportCollector {
-        imports: Vec::new(),
-    };
-    collector.visit_program(&result.program);
-    for path in collector.imports {
-        push(&path);
-    }
-
-    specifiers
 }
 
 fn resolve_relative_script_import(dir: &Path, specifier: &str) -> Option<PathBuf> {

--- a/crates/vize_canon/src/corsa_bridge/vue_dependency_specifiers.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependency_specifiers.rs
@@ -1,0 +1,123 @@
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    CallExpression, ExportAllDeclaration, ExportNamedDeclaration, Expression, ImportDeclaration,
+    ImportExpression, StringLiteral, TSExternalModuleReference, TSImportType,
+    TSModuleDeclarationName,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{String, ToCompactString};
+
+pub(super) fn collect_relative_ts_specifiers(code: &str, source_type: SourceType) -> Vec<String> {
+    let allocator = Allocator::default();
+    let result = Parser::new(&allocator, code, source_type).parse();
+    let mut collector = RelativeTsSpecifierCollector::default();
+    collector.visit_program(&result.program);
+    collector.specifiers
+}
+
+#[derive(Default)]
+struct RelativeTsSpecifierCollector {
+    specifiers: Vec<String>,
+}
+
+impl RelativeTsSpecifierCollector {
+    fn push(&mut self, specifier: &str) {
+        if (specifier.starts_with("./") || specifier.starts_with("../"))
+            && !specifier.ends_with(".vue")
+            && !specifier.ends_with(".vue.ts")
+            && !self
+                .specifiers
+                .iter()
+                .any(|known| known.as_str() == specifier)
+        {
+            self.specifiers.push(specifier.to_compact_string());
+        }
+    }
+
+    fn push_literal(&mut self, lit: &StringLiteral<'_>) {
+        self.push(lit.value.as_str());
+    }
+}
+
+impl<'a> Visit<'a> for RelativeTsSpecifierCollector {
+    fn visit_import_declaration(&mut self, decl: &ImportDeclaration<'a>) {
+        self.push_literal(&decl.source);
+        walk::walk_import_declaration(self, decl);
+    }
+
+    fn visit_export_named_declaration(&mut self, decl: &ExportNamedDeclaration<'a>) {
+        if let Some(source) = &decl.source {
+            self.push_literal(source);
+        }
+        walk::walk_export_named_declaration(self, decl);
+    }
+
+    fn visit_export_all_declaration(&mut self, decl: &ExportAllDeclaration<'a>) {
+        self.push_literal(&decl.source);
+        walk::walk_export_all_declaration(self, decl);
+    }
+
+    fn visit_import_expression(&mut self, expr: &ImportExpression<'a>) {
+        if let Expression::StringLiteral(lit) = &expr.source {
+            self.push_literal(lit);
+        }
+        walk::walk_import_expression(self, expr);
+    }
+
+    fn visit_call_expression(&mut self, expr: &CallExpression<'a>) {
+        if let Some(lit) = expr.common_js_require() {
+            self.push(lit.value.as_str());
+        }
+        walk::walk_call_expression(self, expr);
+    }
+
+    fn visit_ts_import_type(&mut self, import_type: &TSImportType<'a>) {
+        self.push_literal(&import_type.source);
+        walk::walk_ts_import_type(self, import_type);
+    }
+
+    fn visit_ts_external_module_reference(&mut self, reference: &TSExternalModuleReference<'a>) {
+        self.push_literal(&reference.expression);
+        walk::walk_ts_external_module_reference(self, reference);
+    }
+
+    fn visit_ts_module_declaration_name(&mut self, name: &TSModuleDeclarationName<'a>) {
+        if let TSModuleDeclarationName::StringLiteral(lit) = name {
+            self.push_literal(lit);
+        }
+        walk::walk_ts_module_declaration_name(self, name);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use oxc_span::SourceType;
+
+    use super::collect_relative_ts_specifiers;
+
+    #[test]
+    fn collects_type_only_and_require_dependency_specifiers() {
+        let source = r#"import type { User } from "./user";
+export type { Model } from "../model";
+export type Lazy = import("./lazy").Lazy;
+import Common = require("./common");
+const runtime = require("./runtime");
+declare module "./augment" {}
+type App = typeof import("./App.vue");
+"#;
+
+        assert_eq!(
+            collect_relative_ts_specifiers(source, SourceType::ts()),
+            vec![
+                "./user",
+                "../model",
+                "./lazy",
+                "./common",
+                "./runtime",
+                "./augment"
+            ]
+        );
+    }
+}

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -156,6 +156,7 @@ mod tests {
         let grand_child_path = src.join("GrandChild.vue");
         let util_path = src.join("util.ts");
         let types_path = src.join("types.ts");
+        let helper_path = src.join("helper.ts");
         let child_util_path = src.join("childUtil.ts");
         std::fs::write(
             &host_path,
@@ -196,10 +197,12 @@ defineProps<{ label?: string }>();
         std::fs::write(
             &types_path,
             r#"export type ChildModule = typeof import("./Child.vue");
+export type HelperModule = import("./helper").Helper;
 export { default as ReexportedChild } from "./Child.vue";
 "#,
         )
         .expect("types");
+        std::fs::write(&helper_path, "export type Helper = { ok: true };\n").expect("helper");
         std::fs::write(&child_util_path, "export const childValue = 2;\n").expect("child util");
 
         let host = std::fs::read_to_string(&host_path).expect("host source");
@@ -231,6 +234,10 @@ export { default as ReexportedChild } from "./Child.vue";
             types_document.contains(r#"import("./Child.vue.ts")"#)
                 && types_document.contains(r#"from "./Child.vue.ts""#),
             "TS dependency Vue specifiers must target virtual Vue modules:\n{types_document}",
+        );
+        assert!(
+            uris.contains(&path_to_file_uri(&helper_path).as_str()),
+            "TS import-type dependencies must be synced too: {uris:?}",
         );
         assert!(
             uris.contains(&path_to_file_uri(&child_util_path).as_str()),


### PR DESCRIPTION
Summary
- Move editor dependency specifier collection into an AST visitor shared by all TS dependency scans.
- Sync type-only import(), import equals, CommonJS require, and module declaration dependency files for editor Corsa sessions.
- Keep Vue virtual imports excluded from TS dependency syncing while preserving the existing Vue dependency path.

Validation
- cargo test -p vize_canon vue_dependency_specifiers --lib
- cargo test -p vize_canon vue_virtual_project_syncs_relative_vue_and_ts_dependencies --lib
- cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports
- cargo fmt --check --all
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785800933&installation_id=136613492&pr_number=2603&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2603&signature=5ba797b13fb3562342d3b902a2664196bc64618de3759028d815863e9e068d5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dependency detection for Vue/TypeScript files, including type-only imports, dynamic imports, `require()` calls, and other relative references.
  * Virtual projects now stay in sync with additional TypeScript type dependencies more reliably.

* **Bug Fixes**
  * Better handling of Vue document generation failures with a fallback path, reducing sync interruptions.

* **Tests**
  * Expanded coverage for syncing type-only dependencies in virtual projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->