### PR TITLE
fix(lsp): resolve extensionless declaration dependencies

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -190,7 +190,9 @@ fn resolve_relative_script_import(dir: &Path, specifier: &str) -> Option<PathBuf
         return known_script_path(&base).then(|| normalize_path(&base));
     }
 
-    for ext in ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"] {
+    for ext in [
+        "ts", "tsx", "mts", "cts", "d.ts", "d.mts", "d.cts", "js", "jsx", "mjs", "cjs",
+    ] {
         let candidate = base.with_extension(ext);
         if candidate.exists() {
             return Some(normalize_path(&candidate));
@@ -271,8 +273,10 @@ mod tests {
 
         let esm = src.join("esm").join("index.d.mts");
         let cjs = src.join("cjs").join("index.d.cts");
+        let schema = src.join("schema.d.ts");
         std::fs::write(&esm, "export type Value = string;\n").expect("esm dts");
         std::fs::write(&cjs, "export type Value = string;\n").expect("cjs dts");
+        std::fs::write(&schema, "export type Schema = { id: string };\n").expect("schema dts");
 
         assert_eq!(
             resolve_relative_script_import(&src, "./esm").as_deref(),
@@ -281,6 +285,10 @@ mod tests {
         assert_eq!(
             resolve_relative_script_import(&src, "./cjs").as_deref(),
             Some(cjs.as_path())
+        );
+        assert_eq!(
+            resolve_relative_script_import(&src, "./schema").as_deref(),
+            Some(schema.as_path())
         );
     }
 }

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -157,6 +157,7 @@ mod tests {
         let util_path = src.join("util.ts");
         let types_path = src.join("types.ts");
         let helper_path = src.join("helper.ts");
+        let schema_path = src.join("schema.d.ts");
         let child_util_path = src.join("childUtil.ts");
         std::fs::write(
             &host_path,
@@ -198,11 +199,13 @@ defineProps<{ label?: string }>();
             &types_path,
             r#"export type ChildModule = typeof import("./Child.vue");
 export type HelperModule = import("./helper").Helper;
+export type SchemaModule = import("./schema").Schema;
 export { default as ReexportedChild } from "./Child.vue";
 "#,
         )
         .expect("types");
         std::fs::write(&helper_path, "export type Helper = { ok: true };\n").expect("helper");
+        std::fs::write(&schema_path, "export type Schema = { id: string };\n").expect("schema");
         std::fs::write(&child_util_path, "export const childValue = 2;\n").expect("child util");
 
         let host = std::fs::read_to_string(&host_path).expect("host source");
@@ -238,6 +241,10 @@ export { default as ReexportedChild } from "./Child.vue";
         assert!(
             uris.contains(&path_to_file_uri(&helper_path).as_str()),
             "TS import-type dependencies must be synced too: {uris:?}",
+        );
+        assert!(
+            uris.contains(&path_to_file_uri(&schema_path).as_str()),
+            "extensionless TS import-type dependencies must resolve generated d.ts files too: {uris:?}",
         );
         assert!(
             uris.contains(&path_to_file_uri(&child_util_path).as_str()),


### PR DESCRIPTION
## Summary
- resolve extensionless relative TS imports to sibling `.d.ts`, `.d.mts`, and `.d.cts` files during Vue editor dependency sync
- cover generated declaration-only dependencies in the Vue virtual project regression test

## Validation
- cargo test -p vize_canon resolves_directory_module_declaration_indices --lib
- cargo test -p vize_canon vue_virtual_project_syncs_relative_vue_and_ts_dependencies --lib
- cargo fmt --all
- cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports
- cargo fmt --check --all
- git diff --check
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785802368&installation_id=136613492&pr_number=2604&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2604&signature=51d92a63b089a01374e02f7f7e641edeb1a89bd1e33fd9ec50d73b74be2bf17f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module resolution so extension-less imports can now resolve additional TypeScript declaration files.
  * Virtual project syncing now includes declaration-file dependencies more consistently, helping related documents stay up to date.
  * Expanded coverage for import and dependency resolution scenarios involving declaration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->