### PR TITLE
fix(canon): rewrite tsx vue declaration specifiers

### DIFF
--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -120,7 +120,7 @@ impl ImportRewriter {
         source: &str,
         source_type: SourceType,
     ) -> RewriteResult {
-        if !source.contains(".vue.ts") {
+        if !source.contains(".vue.ts") && !source.contains(".vue.tsx") {
             return RewriteResult {
                 code: source.to_compact_string(),
                 source_map: ImportSourceMap::empty(),
@@ -252,6 +252,11 @@ impl ImportRewriter {
     }
 
     fn rewrite_declaration_specifier(&self, path: &str) -> Option<String> {
+        if path.ends_with(".vue.tsx") {
+            return path
+                .strip_suffix(".tsx")
+                .map(|value| value.to_compact_string());
+        }
         if path.ends_with(".vue.ts") {
             return path
                 .strip_suffix(".ts")

--- a/crates/vize_canon/src/batch/import_rewriter_type_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_type_tests.rs
@@ -31,6 +31,20 @@ export type AppProps = import("./App.vue").PublicProps;"#
 }
 
 #[test]
+fn rewrites_declaration_tsx_vue_specifiers() {
+    let rewriter = ImportRewriter::new();
+    let source = r#"export { default as App } from "./App.vue.tsx";
+export type AppProps = import("./App.vue.tsx").PublicProps;"#;
+    let result = rewriter.rewrite_declaration_specifiers(source, SourceType::ts());
+
+    assert_eq!(
+        result.code,
+        r#"export { default as App } from "./App.vue";
+export type AppProps = import("./App.vue").PublicProps;"#
+    );
+}
+
+#[test]
 fn rewrites_ts_import_equals_external_module_references() {
     let rewriter = ImportRewriter::new();
     let source = r#"import App = require("./App.vue");


### PR DESCRIPTION
## Summary
- rewrite `.vue.tsx` virtual specifiers back to `.vue` in declaration outputs
- cover TSX Vue specifiers in declaration import/export rewrite tests

## Validation
- cargo test -p vize_canon rewrites_declaration_tsx_vue_specifiers --lib
- cargo fmt --all
- cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports
- cargo fmt --check --all
- git diff --check
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785806754&installation_id=136613492&pr_number=2607&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2607&signature=461cd7ab693c71f4d6587adb326d0580def688f596374ad6253fcccb0c3c53f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of TypeScript declaration specifiers so paths ending in `.vue.tsx` are rewritten correctly and left unchanged when no matching Vue declaration path is present.
  * Preserved existing `.vue.ts` behavior while extending support to additional Vue declaration formats.

* **Tests**
  * Added coverage for `.vue.tsx` declaration rewriting, including re-exports and type imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->