### PR TITLE
fix(typecheck): suppress tsx vue resolution diagnostics

### DIFF
--- a/crates/vize_canon/src/batch/executor/diagnostics/module_resolution.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics/module_resolution.rs
@@ -52,7 +52,9 @@ fn relative_specifier_resolves(dir: &Path, specifier: &str) -> bool {
     if specifier_has_source_extension(specifier) && dir.join(specifier).is_file() {
         return true;
     }
-    if let Some(stem) = specifier.strip_suffix(".vue.ts")
+    if let Some(stem) = specifier
+        .strip_suffix(".vue.ts")
+        .or_else(|| specifier.strip_suffix(".vue.tsx"))
         && dir.join(cstr!("{stem}.vue").as_str()).is_file()
     {
         return true;
@@ -114,6 +116,8 @@ mod tests {
         let resolvable_ts = "Cannot find module './types' or its corresponding type declarations.";
         let resolvable_vue_ts =
             "Cannot find module './Panel.vue.ts' or its corresponding type declarations.";
+        let resolvable_vue_tsx =
+            "Cannot find module './Panel.vue.tsx' or its corresponding type declarations.";
         let resolvable_index =
             "Cannot find module './util' or its corresponding type declarations.";
         let resolvable_dmts =
@@ -129,6 +133,10 @@ mod tests {
         assert!(relative_module_resolves_on_disk(resolvable_ts, &importer));
         assert!(relative_module_resolves_on_disk(
             resolvable_vue_ts,
+            &importer
+        ));
+        assert!(relative_module_resolves_on_disk(
+            resolvable_vue_tsx,
             &importer
         ));
         assert!(relative_module_resolves_on_disk(


### PR DESCRIPTION
## Summary
- suppress TS2307 false positives for virtual `.vue.tsx` specifiers when the real `.vue` sibling exists
- add coverage beside the existing `.vue.ts` resolution suppression

## Verification
- cargo test -p vize_canon ts2307_for_resolvable_relative_siblings_is_suppressed --lib
- cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports
- cargo fmt --check --all
- git diff --check
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785807967&installation_id=136613492&pr_number=2608&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2608&signature=2f097358ec6f743dd93a8626fef1e3b55c81e94b270539f3c125d1301e57bb39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module resolution for Vue-to-TypeScript rewritten imports, so missing-module warnings are now correctly handled for both `.vue.ts` and `.vue.tsx` paths.
  * Reduced false “cannot find module” diagnostics when the matching `.vue` file exists on disk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->