### PR TITLE
fix(lsp): ignore virtual tsx vue specifiers

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/vue_dependency_specifiers.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependency_specifiers.rs
@@ -27,6 +27,7 @@ impl RelativeTsSpecifierCollector {
         if (specifier.starts_with("./") || specifier.starts_with("../"))
             && !specifier.ends_with(".vue")
             && !specifier.ends_with(".vue.ts")
+            && !specifier.ends_with(".vue.tsx")
             && !self
                 .specifiers
                 .iter()
@@ -104,6 +105,8 @@ export type { Model } from "../model";
 export type Lazy = import("./lazy").Lazy;
 import Common = require("./common");
 const runtime = require("./runtime");
+type VirtualTs = typeof import("./App.vue.ts");
+type VirtualTsx = typeof import("./App.vue.tsx");
 declare module "./augment" {}
 type App = typeof import("./App.vue");
 "#;


### PR DESCRIPTION
## Summary
- keep `.vue.tsx` virtual Vue specifiers out of regular TS dependency collection
- cover the collector alongside the existing `.vue` and `.vue.ts` behavior

## Verification
- cargo test -p vize_canon collects_type_only_and_require_dependency_specifiers --lib
- cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports
- cargo fmt --check --all
- git diff --check
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785809168&installation_id=136613492&pr_number=2609&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2609&signature=a38deac73dced07a75efb419cc7916afad6d2cf8e09b0ca14cac0898329d6083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved specifier filtering so Vue-related TypeScript and TSX virtual imports are no longer included in collected results.
  * Expanded test coverage to verify that `*.vue.ts` and `*.vue.tsx` imports are excluded as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->