### PR TITLE
fix(declarations): emit tsx vue declarations from source

### DIFF
--- a/crates/vize/tests/check_declaration_emit_cli.rs
+++ b/crates/vize/tests/check_declaration_emit_cli.rs
@@ -2,6 +2,9 @@ use std::{path::Path, process::Command};
 
 use vize_carton::{String, ToCompactString, cstr};
 
+#[path = "support/vue_stub.rs"]
+mod vue_stub;
+
 fn workspace_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -99,9 +102,27 @@ defineProps<PublicProps>()
 "#,
             ),
             (
+                "src/TsxWidget.vue",
+                r#"<script setup lang="tsx">
+export interface TsxProps {
+  active: boolean
+}
+
+defineProps<TsxProps>()
+const vnode = null as unknown
+</script>
+
+<template>
+  <div />
+</template>
+"#,
+            ),
+            (
                 "src/modern.mts",
                 r#"export { default as App } from "./App.vue";
 export type AppModule = typeof import("./App.vue");
+export { default as TsxWidget } from "./TsxWidget.vue";
+export type TsxWidgetModule = typeof import("./TsxWidget.vue");
 export const answer = 42;
 "#,
             ),
@@ -112,6 +133,7 @@ export const answer = 42;
             ),
         ],
     );
+    vue_stub::install_vue_jsx_type_stub(&project_root);
 
     let output = Command::new(env!("CARGO_BIN_EXE_vize"))
         .current_dir(&project_root)
@@ -164,8 +186,23 @@ export const answer = 42;
         "declaration import types should point at .vue:\n{modern_declaration}"
     );
     assert!(
+        modern_declaration.contains("./TsxWidget.vue"),
+        "TSX SFC declaration import should point at .vue:\n{modern_declaration}"
+    );
+    assert!(
+        modern_declaration.contains(r#"typeof import("./TsxWidget.vue")"#),
+        "TSX SFC declaration import types should point at .vue:\n{modern_declaration}"
+    );
+    assert!(
         !modern_declaration.contains(".vue.ts"),
-        "declaration import should not leak virtual .vue.ts paths:\n{modern_declaration}"
+        "declaration import should not leak virtual .vue.ts/.vue.tsx paths:\n{modern_declaration}"
+    );
+    let tsx_widget_declaration =
+        std::fs::read_to_string(project_root.join("types/TsxWidget.vue.d.ts"))
+            .expect("TSX widget declaration should be emitted");
+    assert!(
+        tsx_widget_declaration.contains("export interface TsxProps"),
+        "TSX SFC declaration should preserve exported props:\n{tsx_widget_declaration}"
     );
     assert!(project_root.join("types/legacy.d.cts").is_file());
 

--- a/crates/vize/tests/support/vue_stub.rs
+++ b/crates/vize/tests/support/vue_stub.rs
@@ -1,0 +1,79 @@
+use std::path::Path;
+
+pub fn install_vue_jsx_type_stub(project_root: &Path) {
+    let node_modules = project_root.join("node_modules");
+    if let Ok(metadata) = std::fs::symlink_metadata(&node_modules) {
+        if metadata.file_type().is_symlink() || metadata.is_file() {
+            std::fs::remove_file(&node_modules).unwrap();
+        } else {
+            std::fs::remove_dir_all(&node_modules).unwrap();
+        }
+    }
+    let vue_dir = node_modules.join("vue");
+    std::fs::create_dir_all(&vue_dir).unwrap();
+    std::fs::write(
+        vue_dir.join("package.json"),
+        r#"{
+  "name": "vue",
+  "types": "index.d.ts"
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        vue_dir.join("index.d.ts"),
+        r#"export interface ComponentPublicInstance<Props = {}> {
+  $props: Props;
+  $attrs: Record<string, unknown>;
+  $slots: Record<string, unknown>;
+  $refs: Record<string, unknown>;
+  $emit: (...args: any[]) => void;
+}
+
+export type DefineComponent<Props = {}> = {
+  new (): ComponentPublicInstance<Props>;
+};
+
+export type ComponentOptions<Props = {}> = {
+  props?: Props;
+  setup?: any;
+  render?: Function;
+};
+
+export interface FunctionalComponent<P = {}> {
+  (props: P, ctx: any): any;
+}
+
+export type ConcreteComponent<Props = {}> =
+  | ComponentOptions<Props>
+  | FunctionalComponent<Props>;
+
+export interface Ref<T = unknown, _Raw = T> {
+  value: T;
+}
+
+export interface ShallowRef<T = unknown, _Raw = T> extends Ref<T, _Raw> {
+  readonly __v_isShallow?: true;
+}
+
+export type PropType<T> = { new (...args: any[]): T & {} } | { (): T } | null;
+
+export declare const Transition: DefineComponent;
+export declare function defineComponent(options: any): DefineComponent;
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        vue_dir.join("jsx.d.ts"),
+        r#"declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      [name: string]: unknown;
+    }
+  }
+}
+
+export {};
+"#,
+    )
+    .unwrap();
+}

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -26,6 +26,7 @@ use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 
 mod art_usage;
 mod build;
+mod declaration_emit;
 mod document;
 pub use document::{
     VueDocumentVirtualTs, VueDocumentVirtualTsOptions, generate_vue_document_virtual_ts,

--- a/crates/vize_canon/src/batch/virtual_project/declaration_emit.rs
+++ b/crates/vize_canon/src/batch/virtual_project/declaration_emit.rs
@@ -1,0 +1,178 @@
+use std::path::Path;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    CallExpression, ExportAllDeclaration, ExportNamedDeclaration, Expression, ImportDeclaration,
+    ImportExpression, StringLiteral, TSExternalModuleReference, TSImportType,
+    TSModuleDeclarationName,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{String, ToCompactString, cstr};
+
+use crate::batch::CorsaResult;
+
+use super::{VirtualFile, VirtualProject};
+
+impl VirtualProject {
+    pub(super) fn rewrite_tsx_vue_declaration_inputs(&self) -> CorsaResult<()> {
+        for file in self.virtual_files_sorted() {
+            let path = file.virtual_path.as_path();
+            if !is_script_path(path) {
+                continue;
+            }
+            let content = std::fs::read_to_string(path)?;
+            let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::ts());
+            let source_dir = path.parent().unwrap_or_else(|| Path::new("."));
+            let Some(rewritten) =
+                rewrite_tsx_vue_shim_specifiers(&content, source_type, source_dir)
+            else {
+                continue;
+            };
+            std::fs::write(path, rewritten.as_str())?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn declaration_emit_include_paths(&self) -> Vec<&Path> {
+        self.virtual_files
+            .values()
+            .filter(|file| !self.is_tsx_vue_import_shim(file))
+            .map(|file| file.virtual_path.as_path())
+            .collect()
+    }
+
+    fn is_tsx_vue_import_shim(&self, file: &VirtualFile) -> bool {
+        if file.original_path != file.virtual_path {
+            return false;
+        }
+        let Some(file_name) = file.virtual_path.file_name().and_then(|name| name.to_str()) else {
+            return false;
+        };
+        if !file_name.ends_with(".vue.ts") {
+            return false;
+        }
+        let tsx_path = file
+            .virtual_path
+            .with_file_name(cstr!("{file_name}x").as_str());
+        self.virtual_files.contains_key(&tsx_path)
+    }
+}
+
+fn is_script_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| matches!(extension, "ts" | "tsx" | "mts" | "cts"))
+}
+
+fn rewrite_tsx_vue_shim_specifiers(
+    source: &str,
+    source_type: SourceType,
+    source_dir: &Path,
+) -> Option<String> {
+    if !source.contains(".vue.ts") {
+        return None;
+    }
+
+    let allocator = Allocator::default();
+    let parser = Parser::new(&allocator, source, source_type);
+    let result = parser.parse();
+    let mut collector = ModuleSpecifierCollector::default();
+    collector.visit_program(&result.program);
+
+    let mut rewrites = collector
+        .specifiers
+        .into_iter()
+        .filter_map(|(start, end, path)| {
+            rewrite_tsx_vue_shim_specifier(path.as_str(), source_dir)
+                .map(|rewrite| (start, end, rewrite))
+        })
+        .collect::<Vec<_>>();
+    if rewrites.is_empty() {
+        return None;
+    }
+
+    rewrites.sort_by_key(|rewrite| std::cmp::Reverse(rewrite.0));
+    let mut output = source.to_compact_string();
+    for (start, end, new_path) in rewrites {
+        output.replace_range(start as usize..end as usize, new_path.as_str());
+    }
+    Some(output)
+}
+
+fn rewrite_tsx_vue_shim_specifier(path: &str, source_dir: &Path) -> Option<String> {
+    if !(path.starts_with("./") || path.starts_with("../")) {
+        return None;
+    }
+    let _ = path.strip_suffix(".vue.ts")?;
+    let shim_path = source_dir.join(path);
+    let shim_name = shim_path.file_name()?.to_str()?;
+    let tsx_path = shim_path.with_file_name(cstr!("{shim_name}x").as_str());
+    tsx_path.is_file().then(|| cstr!("{path}x"))
+}
+
+#[derive(Default)]
+struct ModuleSpecifierCollector {
+    specifiers: Vec<(u32, u32, String)>,
+}
+
+impl ModuleSpecifierCollector {
+    fn push(&mut self, lit: &StringLiteral<'_>) {
+        self.specifiers.push((
+            lit.span.start + 1,
+            lit.span.end - 1,
+            lit.value.as_str().into(),
+        ));
+    }
+}
+
+impl<'a> Visit<'a> for ModuleSpecifierCollector {
+    fn visit_import_declaration(&mut self, decl: &ImportDeclaration<'a>) {
+        self.push(&decl.source);
+        walk::walk_import_declaration(self, decl);
+    }
+
+    fn visit_export_named_declaration(&mut self, decl: &ExportNamedDeclaration<'a>) {
+        if let Some(source) = &decl.source {
+            self.push(source);
+        }
+        walk::walk_export_named_declaration(self, decl);
+    }
+
+    fn visit_export_all_declaration(&mut self, decl: &ExportAllDeclaration<'a>) {
+        self.push(&decl.source);
+        walk::walk_export_all_declaration(self, decl);
+    }
+
+    fn visit_import_expression(&mut self, expr: &ImportExpression<'a>) {
+        if let Expression::StringLiteral(lit) = &expr.source {
+            self.push(lit);
+        }
+        walk::walk_import_expression(self, expr);
+    }
+
+    fn visit_call_expression(&mut self, expr: &CallExpression<'a>) {
+        if let Some(lit) = expr.common_js_require() {
+            self.push(lit);
+        }
+        walk::walk_call_expression(self, expr);
+    }
+
+    fn visit_ts_import_type(&mut self, import_type: &TSImportType<'a>) {
+        self.push(&import_type.source);
+        walk::walk_ts_import_type(self, import_type);
+    }
+
+    fn visit_ts_external_module_reference(&mut self, reference: &TSExternalModuleReference<'a>) {
+        self.push(&reference.expression);
+        walk::walk_ts_external_module_reference(self, reference);
+    }
+
+    fn visit_ts_module_declaration_name(&mut self, name: &TSModuleDeclarationName<'a>) {
+        if let TSModuleDeclarationName::StringLiteral(lit) = name {
+            self.push(lit);
+        }
+        walk::walk_ts_module_declaration_name(self, name);
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/materialize.rs
+++ b/crates/vize_canon/src/batch/virtual_project/materialize.rs
@@ -130,12 +130,20 @@ impl VirtualProject {
         declaration_map: bool,
     ) -> CorsaResult<PathBuf> {
         let config_path = self.virtual_root.join("tsconfig.declaration.json");
+        self.rewrite_tsx_vue_declaration_inputs()?;
+        let include_paths = self.declaration_emit_include_paths();
         profile!(
             "canon.project.write_dts_tsconfig",
-            self.write_tsconfig_file(&config_path, Some(out_dir), declaration_map)
+            self.write_tsconfig_file_with_includes(
+                &config_path,
+                Some(out_dir),
+                declaration_map,
+                Some(&include_paths),
+            )
         )?;
         Ok(config_path)
     }
+
     fn write_auto_import_stubs(&self) -> CorsaResult<()> {
         if !self.has_global_auto_import_stubs() {
             return Ok(());

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
@@ -100,7 +100,7 @@ impl VirtualProject {
         Ok(config_path)
     }
 
-    fn write_tsconfig_file_with_includes(
+    pub(super) fn write_tsconfig_file_with_includes(
         &self,
         path: &Path,
         out_dir: Option<&Path>,


### PR DESCRIPTION
## Summary
- exclude TSX Vue import shims from declaration emit roots
- rewrite declaration-input `.vue.ts` shim specifiers to the `.vue.tsx` source when that source exists
- add a CLI regression that verifies TSX SFC declaration output keeps exported props and public `.vue` specifiers

## Verification
- cargo test -p vize check_declaration_emit_reports_module_declaration_outputs --test check_declaration_emit_cli -- --exact
- cargo clippy -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports
- cargo clippy -p vize --test check_declaration_emit_cli -- -D warnings -D clippy::wildcard_imports
- cargo fmt --check --all
- git diff --check
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785810848&installation_id=136613492&pr_number=2610&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2610&signature=3827c68497df5b8136c3c0c6c82dc56839e9401f3c48b748dea914b2afe541c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved declaration generation for Vue components using TSX, so emitted type files now reference the correct component paths.
  * Fixed an issue where declaration output could include incorrect `.vue.ts` references.
  * Ensured type stubs are emitted for Vue JSX/TSX components, including props definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->