### PR TITLE
fix(vite): recognize tsx vue virtual ids

### DIFF
--- a/crates/vize_atelier_sfc/src/vite_plugin/request.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/request.rs
@@ -18,7 +18,7 @@ pub struct VitePluginRequest {
     pub path: String,
     /// Query suffix including the leading `?`, or an empty string.
     pub query_suffix: String,
-    /// Path normalized for macro virtual modules (`.vue.ts` -> `.vue`).
+    /// Path normalized for macro virtual modules (`.vue.ts[x]` -> `.vue`).
     pub normalized_vue_path: String,
     /// For `\0...` virtual macro IDs, the real path without the virtual prefix.
     pub stripped_virtual_path: Option<String>,
@@ -140,6 +140,7 @@ pub fn normalize_fs_id_for_build(id: &str) -> String {
 
 fn normalize_vue_path(path: &str) -> &str {
     path.strip_suffix(".ts")
+        .or_else(|| path.strip_suffix(".tsx"))
         .filter(|normalized| normalized.ends_with(".vue"))
         .unwrap_or(path)
 }
@@ -152,7 +153,7 @@ fn stripped_virtual_query_path(id: &str) -> Option<String> {
 }
 
 fn is_vize_virtual_vue_module_id(id: &str, path: &str) -> bool {
-    id.starts_with('\0') && path.ends_with(".vue.ts")
+    id.starts_with('\0') && (path.ends_with(".vue.ts") || path.ends_with(".vue.tsx"))
 }
 
 fn vize_virtual_path(id: &str) -> String {

--- a/crates/vize_atelier_sfc/src/vite_plugin/tests.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/tests.rs
@@ -139,6 +139,22 @@ fn classifies_virtual_vue_ts_with_query_consistently() {
 }
 
 #[test]
+fn classifies_virtual_vue_tsx_modules() {
+    let request = classify_vite_plugin_request("\0/src/App.vue.tsx?macro=true");
+
+    assert!(request.is_vize_virtual);
+    assert!(!request.is_vize_ssr_virtual);
+    assert!(request.is_macro_virtual_id);
+    assert!(request.is_vue_sfc_path);
+    assert_eq!(request.normalized_vue_path.as_str(), "\0/src/App.vue");
+    assert_eq!(request.vize_virtual_path.as_deref(), Some("/src/App.vue"));
+    assert_eq!(
+        normalize_virtual_vue_module_id("\0/src/App.vue.tsx?macro=true").as_str(),
+        "/src/App.vue?macro=true"
+    );
+}
+
+#[test]
 fn classifies_fs_prefixed_vue_request() {
     // A /@fs path that is also a .vue request: normalized_fs_id strips the
     // prefix and keeps the query, while the .vue (not .vue.ts) path is not a

--- a/crates/vize_vitrine/src/napi/plugin/request.rs
+++ b/crates/vize_vitrine/src/napi/plugin/request.rs
@@ -9,7 +9,7 @@ pub struct VitePluginRequestNapi {
     pub path: String,
     /// Query suffix including the leading `?`, or an empty string.
     pub query_suffix: String,
-    /// Path normalized for macro virtual modules (`.vue.ts` -> `.vue`).
+    /// Path normalized for macro virtual modules (`.vue.ts[x]` -> `.vue`).
     pub normalized_vue_path: String,
     /// For `\0...` virtual macro IDs, the real path without the virtual prefix.
     pub stripped_virtual_path: Option<String>,

--- a/npm/builder/vite/src/plugin/resolve.ts
+++ b/npm/builder/vite/src/plugin/resolve.ts
@@ -674,7 +674,7 @@ function isPotentialVizeResolveId(id: string): boolean {
     id === VIRTUAL_CSS_MODULE ||
     id.endsWith(".vue") ||
     id.includes(".vue?") ||
-    id.includes(".vue.ts?") ||
+    /\.vue\.tsx?\?/.test(id) ||
     id.includes("?macro=true") ||
     id.includes("?definePage")
   );
@@ -751,7 +751,7 @@ function cleanVueSfcImporter(
     cleanImporter = cleanImporter.slice("__x00__".length);
   }
 
-  return cleanImporter.endsWith(".vue.ts") ? cleanImporter.slice(0, -3) : cleanImporter;
+  return classifyVitePluginRequest(cleanImporter).normalizedVuePath;
 }
 
 async function resolveAliasedVueImport(
@@ -847,7 +847,7 @@ export async function resolveIdHook(
 
   // Skip all virtual module IDs
   if (id.startsWith("\0")) {
-    // This is one of our .vue.ts virtual modules. Return the ID so Rolldown/Rollup
+    // This is one of our .vue.ts[x] virtual modules. Return the ID so Rolldown/Rollup
     // treats imports of Vize virtual modules from other virtual modules as resolved.
     if (request.isVizeVirtual) {
       if (isSsrRequest && !request.isVizeSsrVirtual && request.vizeVirtualPath) {

--- a/npm/builder/vite/src/plugin/unocss.ts
+++ b/npm/builder/vite/src/plugin/unocss.ts
@@ -26,11 +26,11 @@ function stripBridgePrefix(id: string): string {
 }
 
 function isUnoCssBridgeModuleId(id: string): boolean {
-  return /\.vue\.ts(?:\?|$)/.test(stripBridgePrefix(id));
+  return /\.vue\.tsx?(?:\?|$)/.test(stripBridgePrefix(id));
 }
 
 function normalizeUnoCssBridgeModuleId(id: string): string {
-  return stripBridgePrefix(id).replace(/\.ts(?=\?|$)/, "");
+  return stripBridgePrefix(id).replace(/\.tsx?(?=\?|$)/, "");
 }
 
 function appendOriginalVueSourceForUnoCss(code: string, normalizedId: string): string {

--- a/npm/builder/vite/src/virtual.test.ts
+++ b/npm/builder/vite/src/virtual.test.ts
@@ -51,6 +51,7 @@ const visibleSsrVirtualId = toPluginVisibleVirtualId(
   true,
   "?vue&used=true",
 );
+const visibleTsxVirtualId = "/repo/app/components/Foo.vue.tsx?vue&vize";
 
 assert.equal(
   visibleVirtualId,
@@ -66,6 +67,11 @@ assert.equal(
   fromPluginVisibleVirtualId(visibleVirtualId),
   "/repo/app/components/Foo.vue",
   "Plugin-visible virtual IDs should resolve back to the real .vue path",
+);
+assert.equal(
+  fromPluginVisibleVirtualId(visibleTsxVirtualId),
+  "/repo/app/components/Foo.vue",
+  "Plugin-visible TSX virtual IDs should resolve back to the real .vue path",
 );
 assert.equal(
   isPluginVisibleSsrVirtualId(visibleSsrVirtualId),

--- a/npm/builder/vite/src/virtual.ts
+++ b/npm/builder/vite/src/virtual.ts
@@ -58,14 +58,26 @@ export function fromPluginVisibleVirtualId(id: string): string | null {
     return null;
   }
   const request = classifyVitePluginRequest(id);
-  if (!request.path.endsWith(".vue.ts") || !request.querySuffix) {
+  if (!isPluginVisibleVueVirtualPath(request.path) || !request.querySuffix) {
     return null;
   }
   const params = new URLSearchParams(request.querySuffix.slice(1));
   if (!params.has("vue") || (!params.has("vize") && !params.has("vize-ssr"))) {
     return null;
   }
-  return classifyVitePluginRequest(request.normalizedFsId ?? id).normalizedVuePath;
+  const normalizedRequest = classifyVitePluginRequest(request.normalizedFsId ?? id);
+  return stripPluginVisibleVueVirtualSuffix(normalizedRequest.path);
+}
+
+function isPluginVisibleVueVirtualPath(path: string): boolean {
+  return path.endsWith(".vue.ts") || path.endsWith(".vue.tsx");
+}
+
+function stripPluginVisibleVueVirtualSuffix(path: string): string {
+  if (path.endsWith(".vue.tsx")) {
+    return path.slice(0, -4);
+  }
+  return path.endsWith(".vue.ts") ? path.slice(0, -3) : path;
 }
 
 export function isPluginVisibleSsrVirtualId(id: string): boolean {

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -495,7 +495,7 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
         // Only process Vize-compiled component modules. In dev, Vite can call
         // transform hooks with the plugin-visible `.vue.ts?vue&vize` ID
         // rather than Rollup's internal `\0` virtual ID. Raw `.jsx`/`.tsx`
-        // Vue components are compiled in place (no `.vue.ts` virtual id), so
+        // Vue components are compiled in place (no `.vue.ts[x]` virtual id), so
         // they are matched separately and still receive Nuxt's auto-import,
         // component, and i18n bridging.
         if (!isVizeGeneratedVueModuleId(id) && !isVizeJsxModuleId(id)) return;

--- a/npm/framework/nuxt/src/utils-edge.test.ts
+++ b/npm/framework/nuxt/src/utils-edge.test.ts
@@ -87,10 +87,11 @@ void test("isVizeVirtualVueModuleId requires a NUL prefix while generated does n
   assert.equal(isVizeGeneratedVueModuleId("/App.vue.ts"), true);
 });
 
-void test("the .vue.tsx extension is neither virtual nor generated", () => {
-  // The regex anchors ".vue.ts" to "?" or end-of-string, so the trailing "x" excludes it.
-  assert.equal(isVizeVirtualVueModuleId("\0/App.vue.tsx"), false);
-  assert.equal(isVizeGeneratedVueModuleId("/App.vue.tsx"), false);
+void test("the .vue.tsx extension is treated as a generated Vue virtual module", () => {
+  assert.equal(isVizeVirtualVueModuleId("\0/App.vue.tsx"), true);
+  assert.equal(isVizeGeneratedVueModuleId("/App.vue.tsx"), true);
+  assert.equal(normalizeVizeVirtualVueModuleId("\0/App.vue.tsx?vue"), "/App.vue?vue");
+  assert.equal(normalizeVizeGeneratedVueModuleId("/App.vue.tsx?vue&vize"), "/App.vue?vue&vize");
 });
 
 void test("ids without .vue are rejected and a query after .vue.ts is accepted", () => {
@@ -102,7 +103,7 @@ void test("ids without .vue are rejected and a query after .vue.ts is accepted",
 
 void test("isVizeJsxModuleId matches in-place .jsx and .tsx component modules", () => {
   // Raw JSX/TSX Vue components are compiled in place: the underlying Vite
-  // plugin keeps the original id (no `.vue.ts` virtual), so the Nuxt bridge
+  // plugin keeps the original id (no `.vue.ts[x]` virtual), so the Nuxt bridge
   // must recognize them through this predicate to apply auto-imports etc.
   assert.equal(isVizeJsxModuleId("/components/Foo.jsx"), true);
   assert.equal(isVizeJsxModuleId("/components/Foo.tsx"), true);
@@ -115,6 +116,7 @@ void test("isVizeJsxModuleId matches in-place .jsx and .tsx component modules", 
 
 void test("isVizeJsxModuleId rejects non-JSX ids and asset-import queries", () => {
   assert.equal(isVizeJsxModuleId("/App.vue.ts"), false);
+  assert.equal(isVizeJsxModuleId("/App.vue.tsx"), false);
   assert.equal(isVizeJsxModuleId("/App.ts"), false);
   assert.equal(isVizeJsxModuleId("/App.js"), false);
   // `.jsx`/`.tsx` referenced as raw/url/worker assets are not component modules.

--- a/npm/framework/nuxt/src/utils.test.ts
+++ b/npm/framework/nuxt/src/utils.test.ts
@@ -94,6 +94,7 @@ assert.equal(
 
 assert.equal(isVizeGeneratedVueModuleId("\0/repo/app/components/Foo.vue.ts"), true);
 assert.equal(isVizeGeneratedVueModuleId("/repo/app/components/Foo.vue.ts"), true);
+assert.equal(isVizeGeneratedVueModuleId("/repo/app/components/Foo.vue.tsx"), true);
 assert.equal(isVizeGeneratedVueModuleId("/@id/__x00__/repo/app/components/Foo.vue.ts"), true);
 assert.equal(isVizeGeneratedVueModuleId("/repo/app/components/Foo.vue"), false);
 
@@ -119,6 +120,12 @@ assert.equal(
   normalizeVizeGeneratedVueModuleId("/repo/app/components/Foo.vue.ts?vue&vize"),
   "/repo/app/components/Foo.vue?vue&vize",
   "Nuxt bridge normalization should also handle plugin-visible dev ids",
+);
+
+assert.equal(
+  normalizeVizeGeneratedVueModuleId("/repo/app/components/Foo.vue.tsx?vue&vize"),
+  "/repo/app/components/Foo.vue?vue&vize",
+  "Nuxt bridge normalization should also handle TSX Vue virtual dev ids",
 );
 
 {

--- a/npm/framework/nuxt/src/utils.ts
+++ b/npm/framework/nuxt/src/utils.ts
@@ -64,7 +64,7 @@ function mergeNuxtCompilerPatterns(
 }
 
 export function isVizeVirtualVueModuleId(id: string): boolean {
-  return id.startsWith("\0") && /\.vue\.ts(?:\?|$)/.test(id);
+  return id.startsWith("\0") && /\.vue\.tsx?(?:\?|$)/.test(id);
 }
 
 export function isVizeGeneratedVueModuleId(id: string): boolean {
@@ -74,7 +74,7 @@ export function isVizeGeneratedVueModuleId(id: string): boolean {
   } else if (normalized.startsWith("__x00__")) {
     normalized = normalized.slice("__x00__".length);
   }
-  return /\.vue\.ts(?:\?|$)/.test(normalized);
+  return /\.vue\.tsx?(?:\?|$)/.test(normalized);
 }
 
 /**
@@ -82,7 +82,7 @@ export function isVizeGeneratedVueModuleId(id: string): boolean {
  *
  * Unlike `.vue` files, JSX/TSX modules are transformed in place by the
  * underlying Vite plugin (the original `.jsx`/`.tsx` id is preserved, no
- * `\0`-prefixed `.vue.ts` virtual id is created). Nuxt's auto-import,
+ * `\0`-prefixed `.vue.ts[x]` virtual id is created). Nuxt's auto-import,
  * component, and i18n transforms still need to run on these modules, so the
  * Nuxt transform bridge keys off this predicate in addition to
  * `isVizeGeneratedVueModuleId`.
@@ -94,7 +94,7 @@ export function isVizeGeneratedVueModuleId(id: string): boolean {
 export function isVizeJsxModuleId(id: string): boolean {
   const queryIndex = id.indexOf("?");
   const pathPart = queryIndex === -1 ? id : id.slice(0, queryIndex);
-  if (!/\.(?:jsx|tsx)$/.test(pathPart)) {
+  if (/\.vue\.tsx?$/.test(pathPart) || !/\.(?:jsx|tsx)$/.test(pathPart)) {
     return false;
   }
 
@@ -113,7 +113,7 @@ export function isVizeJsxModuleId(id: string): boolean {
 
 export function normalizeVizeVirtualVueModuleId(id: string): string {
   const withoutPrefix = id.startsWith("\0vize-ssr:") ? id.slice("\0vize-ssr:".length) : id.slice(1);
-  return withoutPrefix.replace(/\.ts(?=\?|$)/, "");
+  return withoutPrefix.replace(/\.tsx?(?=\?|$)/, "");
 }
 
 export function normalizeVizeGeneratedVueModuleId(id: string): string {
@@ -124,7 +124,7 @@ export function normalizeVizeGeneratedVueModuleId(id: string): string {
   return id
     .replace(/^\/@id\/__x00__/, "")
     .replace(/^__x00__/, "")
-    .replace(/\.ts(?=\?|$)/, "");
+    .replace(/\.tsx?(?=\?|$)/, "");
 }
 
 const NUXT_INJECTED_MARKER = "/* nuxt-injected */";

--- a/npm/native/index.d.ts
+++ b/npm/native/index.d.ts
@@ -1009,7 +1009,7 @@ export interface VitePluginRequestNapi {
   path: string;
   /** Query suffix including the leading `?`, or an empty string. */
   querySuffix: string;
-  /** Path normalized for macro virtual modules (`.vue.ts` -> `.vue`). */
+  /** Path normalized for macro virtual modules (`.vue.ts[x]` -> `.vue`). */
   normalizedVuePath: string;
   /** For `\0...` virtual macro IDs, the real path without the virtual prefix. */
   strippedVirtualPath?: string;

--- a/npm/native/types/vite.d.ts
+++ b/npm/native/types/vite.d.ts
@@ -38,7 +38,7 @@ export interface VitePluginRequestNapi {
   path: string;
   /** Query suffix including the leading `?`, or an empty string. */
   querySuffix: string;
-  /** Path normalized for macro virtual modules (`.vue.ts` -> `.vue`). */
+  /** Path normalized for macro virtual modules (`.vue.ts[x]` -> `.vue`). */
   normalizedVuePath: string;
   /** For `\0...` virtual macro IDs, the real path without the virtual prefix. */
   strippedVirtualPath?: string;


### PR DESCRIPTION
## Summary
- recognize .vue.tsx virtual Vue module ids in the native Vite request classifier
- normalize .vue.tsx ids back to .vue in Vite and Nuxt bridge utilities
- keep generated .vue.tsx ids out of the plain JSX/TSX in-place module path
- update native type declarations and regression coverage

## Validation
- cargo fmt --check --all
- cargo test -p vize_atelier_sfc vite_plugin --lib
- cargo clippy -p vize_atelier_sfc -p vize_vitrine --lib -- -D warnings -D clippy::wildcard_imports
- node --test npm/builder/vite/src/virtual.test.ts npm/builder/vite/src/plugin/native.test.ts npm/framework/nuxt/src/utils-edge.test.ts npm/framework/nuxt/src/utils.test.ts tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785815893&installation_id=136613492&pr_number=2613&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2613&signature=2016a1b885f19321e0dca3c18a38097967a0192debf6ce191b8d55d0a2e37228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Vue macro virtual module IDs so `.vue.tsx` is recognized and normalized alongside `.vue.ts`.
  * Prevented Vue TSX virtual/generated module IDs from being misclassified as raw JSX/TSX component modules.
  * Updated Vite, Nuxt, and UnoCSS virtual-module resolution/importer cleanup to match the new `.vue.tsx` behavior.

* **Tests**
  * Added and extended test coverage for `.vue.tsx` virtual module detection, normalization, and plugin-visible path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->