### PR TITLE
fix(vite): bridge tsx vue virtual hooks

### DIFF
--- a/crates/vize_atelier_sfc/src/vite_plugin/middleware.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/middleware.rs
@@ -29,7 +29,7 @@ pub fn normalize_dev_middleware_url(req_url: &str) -> Option<ViteDevMiddlewareRe
     }
 
     let fs_path = &cleaned_path[4..];
-    if !fs_path.starts_with('/') || fs_path.ends_with(".vue.ts") {
+    if !fs_path.starts_with('/') || is_vue_virtual_ts_path(fs_path) {
         return None;
     }
 
@@ -40,6 +40,10 @@ pub fn normalize_dev_middleware_url(req_url: &str) -> Option<ViteDevMiddlewareRe
         cleaned_url,
         fs_path: String::from(fs_path),
     })
+}
+
+fn is_vue_virtual_ts_path(path: &str) -> bool {
+    path.ends_with(".vue.ts") || path.ends_with(".vue.tsx")
 }
 
 fn strip_style_virtual_suffix(path: &str) -> &str {

--- a/crates/vize_atelier_sfc/src/vite_plugin/tests/middleware.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/tests/middleware.rs
@@ -24,4 +24,5 @@ fn normalizes_dev_middleware_x00_urls() {
     );
     assert_eq!(rewrite.fs_path.as_str(), "/Users/app/src/icon.svg");
     assert!(normalize_dev_middleware_url("/@id/__x00__/Users/app/src/App.vue.ts").is_none());
+    assert!(normalize_dev_middleware_url("/@id/__x00__/Users/app/src/App.vue.tsx").is_none());
 }

--- a/npm/builder/vite/src/plugin/compat.test.ts
+++ b/npm/builder/vite/src/plugin/compat.test.ts
@@ -141,6 +141,22 @@ const msg = 'hello'
 }
 
 {
+  const state = createState({
+    filter: () => true,
+  });
+  const plugin = createPostTransformPlugin(state);
+  const result = await plugin.transform?.(
+    virtualSfcSource,
+    path.join("/src", "Card.vue.tsx?vue&vize"),
+    {
+      ssr: false,
+    },
+  );
+
+  assert.equal(result, null, "Post-transform should ignore generated TSX Vue virtual modules");
+}
+
+{
   const transformed = transformScopedPreprocessorCss(
     ".rrevdjwu > .group + .group { color: red; }",
     "\0/src/MkSuperMenu.vue?vue=&type=style&index=0&scoped=data-v-menu&lang=scss.scss",

--- a/npm/builder/vite/src/plugin/compat.ts
+++ b/npm/builder/vite/src/plugin/compat.ts
@@ -91,6 +91,7 @@ function shouldPostTransformSfcLikeModule(state: VizePluginState, id: string): b
   if (
     filename.endsWith(".vue") ||
     filename.endsWith(".vue.ts") ||
+    filename.endsWith(".vue.tsx") ||
     filename.includes("node_modules")
   ) {
     return false;

--- a/npm/builder/vite/src/plugin/quasar.test.ts
+++ b/npm/builder/vite/src/plugin/quasar.test.ts
@@ -6,6 +6,7 @@ import { patchQuasarBridge } from "./quasar.ts";
 const sourcePath = path.resolve(process.cwd(), "target", "vize-tests", "quasar", "App.vue");
 const virtualId = `\0${sourcePath}.ts`;
 const queriedClientVirtualId = `${sourcePath}.ts?vue&vize`;
+const queriedTsxClientVirtualId = `${sourcePath}.tsx?vue&vize`;
 const queriedSsrVirtualId = `\0vize-ssr:${sourcePath}.ts?vue&type=template`;
 const legacyVirtualId = `\0vize:${sourcePath}.ts`;
 
@@ -54,10 +55,12 @@ const legacyVirtualId = `\0vize:${sourcePath}.ts`;
 
   patchQuasarBridge(plugins);
   plugins[0]!.transform!("export default {}", queriedClientVirtualId);
+  plugins[0]!.transform!("export default {}", queriedTsxClientVirtualId);
   plugins[0]!.transform!("export default {}", queriedSsrVirtualId);
   plugins[0]!.transform!("export default {}", legacyVirtualId);
 
   assert.deepEqual(receivedIds, [
+    `${sourcePath}?vue&vize`,
     `${sourcePath}?vue&vize`,
     `${sourcePath}?vue&type=template`,
     sourcePath,

--- a/npm/builder/vite/src/plugin/quasar.ts
+++ b/npm/builder/vite/src/plugin/quasar.ts
@@ -31,11 +31,11 @@ function stripBridgePrefix(id: string): string {
 }
 
 function isQuasarBridgeModuleId(id: string): boolean {
-  return /\.vue\.ts(?:[?#]|$)/.test(stripBridgePrefix(id));
+  return /\.vue\.tsx?(?:[?#]|$)/.test(stripBridgePrefix(id));
 }
 
 function normalizeQuasarBridgeModuleId(id: string): string {
-  return stripBridgePrefix(id).replace(/\.vue\.ts(?=[?#]|$)/, ".vue");
+  return stripBridgePrefix(id).replace(/\.vue\.tsx?(?=[?#]|$)/, ".vue");
 }
 
 export function patchQuasarBridge(plugins: QuasarLikePlugin[]): void {


### PR DESCRIPTION
Summary
- recognize .vue.tsx virtual IDs in the Quasar bridge
- skip generated TSX Vue virtual modules in compat post-transform
- keep dev middleware from rewriting .vue.tsx virtual paths

Tests
- cargo fmt --check --all
- cargo test -p vize_atelier_sfc vite_plugin --lib
- node --test npm/builder/vite/src/plugin/quasar.test.ts npm/builder/vite/src/plugin/compat.test.ts tests/tooling/source-file-lengths.test.ts
- vp check npm/builder/vite/src/plugin/quasar.ts npm/builder/vite/src/plugin/quasar.test.ts npm/builder/vite/src/plugin/compat.ts npm/builder/vite/src/plugin/compat.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785817746&installation_id=136613492&pr_number=2614&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2614&signature=be1c7c400bc5795e5dc649c59bc8e03d64dee7d545a4f192308faeb006f7c737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Vue-related virtual module URLs so `.tsx` variants are no longer incorrectly accepted or rewritten.
  * Updated module normalization to recognize and process `.vue.tsx` paths consistently with existing Vue module formats.
  * Added coverage to ensure TSX-based virtual module IDs are ignored or normalized as expected during transforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->