### PR TITLE
fix(patina): recognize template scope bindings

### DIFF
--- a/crates/vize_croquis/src/drawer/helpers/slots/slot_props.rs
+++ b/crates/vize_croquis/src/drawer/helpers/slots/slot_props.rs
@@ -2,9 +2,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::BindingPattern;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::{CompactString, SmallVec, profile, smallvec};
-
-use crate::drawer::helpers::is_valid_identifier_fast;
+use vize_carton::{CompactString, SmallVec, profile};
 
 /// Extract prop names from v-slot expression pattern
 #[inline]
@@ -14,49 +12,6 @@ pub fn extract_slot_props(pattern: &str) -> SmallVec<[CompactString; 4]> {
         return SmallVec::new();
     }
 
-    let bytes = pattern.as_bytes();
-
-    // Fast path: simple identifier
-    if bytes[0] != b'{' && bytes[0] != b'[' {
-        if is_valid_identifier_fast(bytes) {
-            return smallvec![CompactString::new(pattern)];
-        }
-        return SmallVec::new();
-    }
-
-    // Fast path: simple object destructuring. Stay conservative so default
-    // expressions that can contain commas still fall back to OXC.
-    if bytes[0] == b'{'
-        && pattern.ends_with('}')
-        && can_parse_simple_object_destructure_fast(&pattern[1..pattern.len() - 1])
-    {
-        let inner = &pattern[1..pattern.len() - 1];
-        let mut props = SmallVec::new();
-        let mut valid = true;
-        for part in inner.split(',') {
-            let part = part.trim();
-            if part.is_empty() {
-                continue;
-            }
-            let part = part.strip_prefix("...").unwrap_or(part).trim();
-            let name = if let Some(eq_pos) = part.find('=') {
-                part[..eq_pos].trim()
-            } else {
-                part
-            };
-            if !name.is_empty() && is_valid_identifier_fast(name.as_bytes()) {
-                props.push(CompactString::new(name));
-            } else {
-                valid = false;
-                break;
-            }
-        }
-        if valid && !props.is_empty() {
-            return props;
-        }
-    }
-
-    // Complex case: use OXC parser
     profile!(
         "croquis.helpers.slot_props.oxc",
         extract_slot_props_with_oxc(pattern)
@@ -93,15 +48,6 @@ fn extract_slot_props_with_oxc(pattern: &str) -> SmallVec<[CompactString; 4]> {
     }
 }
 
-fn can_parse_simple_object_destructure_fast(inner: &str) -> bool {
-    !inner.as_bytes().iter().any(|byte| {
-        matches!(
-            byte,
-            b':' | b'{' | b'}' | b'[' | b']' | b'(' | b')' | b'"' | b'\'' | b'`'
-        )
-    })
-}
-
 /// Parse slot pattern using OXC
 fn parse_slot_pattern(pattern_str: &str) -> SmallVec<[CompactString; 4]> {
     let allocator = Allocator::default();
@@ -110,6 +56,9 @@ fn parse_slot_pattern(pattern_str: &str) -> SmallVec<[CompactString; 4]> {
         "croquis.helpers.slot_props.oxc_parse",
         Parser::new(&allocator, pattern_str, source_type).parse()
     );
+    if !ret.errors.is_empty() {
+        return SmallVec::new();
+    }
 
     let mut props = SmallVec::new();
 

--- a/crates/vize_croquis/src/drawer/helpers/slots/slot_props.rs
+++ b/crates/vize_croquis/src/drawer/helpers/slots/slot_props.rs
@@ -24,12 +24,21 @@ pub fn extract_slot_props(pattern: &str) -> SmallVec<[CompactString; 4]> {
         return SmallVec::new();
     }
 
-    // Fast path: simple object destructuring
-    if bytes[0] == b'{' && !pattern.contains(':') && !pattern.contains('{') {
-        let inner = &pattern[1..pattern.len().saturating_sub(1)];
+    // Fast path: simple object destructuring. Stay conservative so default
+    // expressions that can contain commas still fall back to OXC.
+    if bytes[0] == b'{'
+        && pattern.ends_with('}')
+        && can_parse_simple_object_destructure_fast(&pattern[1..pattern.len() - 1])
+    {
+        let inner = &pattern[1..pattern.len() - 1];
         let mut props = SmallVec::new();
+        let mut valid = true;
         for part in inner.split(',') {
             let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
+            let part = part.strip_prefix("...").unwrap_or(part).trim();
             let name = if let Some(eq_pos) = part.find('=') {
                 part[..eq_pos].trim()
             } else {
@@ -37,9 +46,12 @@ pub fn extract_slot_props(pattern: &str) -> SmallVec<[CompactString; 4]> {
             };
             if !name.is_empty() && is_valid_identifier_fast(name.as_bytes()) {
                 props.push(CompactString::new(name));
+            } else {
+                valid = false;
+                break;
             }
         }
-        if !props.is_empty() {
+        if valid && !props.is_empty() {
             return props;
         }
     }
@@ -79,6 +91,15 @@ fn extract_slot_props_with_oxc(pattern: &str) -> SmallVec<[CompactString; 4]> {
         ),
         Err(_) => SmallVec::new(),
     }
+}
+
+fn can_parse_simple_object_destructure_fast(inner: &str) -> bool {
+    !inner.as_bytes().iter().any(|byte| {
+        matches!(
+            byte,
+            b':' | b'{' | b'}' | b'[' | b']' | b'(' | b')' | b'"' | b'\'' | b'`'
+        )
+    })
 }
 
 /// Parse slot pattern using OXC
@@ -129,5 +150,35 @@ fn extract_slot_binding_names(
         BindingPattern::AssignmentPattern(assign) => {
             extract_slot_binding_names(&assign.left, names);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_slot_props;
+
+    fn names(pattern: &str) -> Vec<String> {
+        extract_slot_props(pattern)
+            .iter()
+            .map(|name| name.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn extracts_simple_object_rest_with_default() {
+        assert_eq!(names("{ open = false, ...rest }"), vec!["open", "rest"]);
+    }
+
+    #[test]
+    fn falls_back_for_nested_object_patterns() {
+        assert_eq!(names("{ item: { id }, ...rest }"), vec!["id", "rest"]);
+    }
+
+    #[test]
+    fn falls_back_for_default_calls_with_commas() {
+        assert_eq!(
+            names("{ value = getDefault(a, b), rest }"),
+            vec!["value", "rest"]
+        );
     }
 }

--- a/crates/vize_croquis/src/drawer/helpers/slots/slot_props.rs
+++ b/crates/vize_croquis/src/drawer/helpers/slots/slot_props.rs
@@ -19,7 +19,6 @@ pub fn extract_slot_props(pattern: &str) -> SmallVec<[CompactString; 4]> {
 }
 
 /// Parse complex slot props using OXC
-#[cold]
 fn extract_slot_props_with_oxc(pattern: &str) -> SmallVec<[CompactString; 4]> {
     let mut buffer = [0u8; 256];
     let prefix = b"let ";

--- a/crates/vize_croquis/src/drawer/helpers/v_for.rs
+++ b/crates/vize_croquis/src/drawer/helpers/v_for.rs
@@ -9,6 +9,8 @@
 
 use vize_carton::{CompactString, SmallVec, profile, smallvec};
 
+use super::is_valid_identifier_fast;
+
 /// Parsed aliases for a v-for scope.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VForScopeAliases {
@@ -29,6 +31,10 @@ pub struct VForScopeAliases {
 pub fn parse_v_for_expression(expr: &str) -> (SmallVec<[CompactString; 3]>, CompactString) {
     let expr = expr.trim();
     parse_first_v_for_candidate(expr, |alias_part, source_part| {
+        if let Some(bindings) = parse_simple_v_for_bindings(alias_part) {
+            return Some((bindings, CompactString::new(source_part)));
+        }
+
         let source = CompactString::new(source_part);
         let (bindings, source) = profile!(
             "croquis.helpers.v_for.oxc",
@@ -44,6 +50,10 @@ pub fn parse_v_for_expression(expr: &str) -> (SmallVec<[CompactString; 3]>, Comp
 #[inline]
 pub fn parse_v_for_scope_expression(expr: &str) -> Option<VForScopeAliases> {
     parse_first_v_for_candidate(expr.trim(), |alias_part, source_part| {
+        if let Some(aliases) = parse_simple_v_for_scope_aliases(alias_part, source_part) {
+            return Some(aliases);
+        }
+
         let source = CompactString::new(source_part);
 
         profile!(
@@ -97,6 +107,79 @@ fn parse_first_v_for_candidate<T>(
     }
 
     None
+}
+
+fn parse_simple_v_for_bindings(alias: &str) -> Option<SmallVec<[CompactString; 3]>> {
+    let alias = alias.trim_start_matches("const ").trim();
+    if is_valid_identifier_fast(alias.as_bytes()) {
+        return Some(smallvec![CompactString::new(alias)]);
+    }
+
+    let inner = simple_tuple_inner(alias)?;
+    let mut bindings = SmallVec::new();
+    for part in inner.split(',') {
+        let part = part.trim();
+        if !is_valid_identifier_fast(part.as_bytes()) {
+            return None;
+        }
+        bindings.push(CompactString::new(part));
+    }
+
+    (!bindings.is_empty()).then_some(bindings)
+}
+
+fn parse_simple_v_for_scope_aliases(alias: &str, source: &str) -> Option<VForScopeAliases> {
+    let alias = alias.trim_start_matches("const ").trim();
+    if is_valid_identifier_fast(alias.as_bytes()) {
+        return Some(VForScopeAliases {
+            value_pattern: CompactString::new(alias),
+            value_bindings: smallvec![CompactString::new(alias)],
+            key_alias: None,
+            index_alias: None,
+            source: CompactString::new(source),
+        });
+    }
+
+    let inner = simple_tuple_inner(alias)?;
+    let mut parts = inner.split(',');
+    let value_pattern = parts.next()?.trim();
+    if !is_valid_identifier_fast(value_pattern.as_bytes()) {
+        return None;
+    }
+
+    let key_alias = simple_tuple_part(parts.next())?;
+    let index_alias = simple_tuple_part(parts.next())?;
+    if parts.any(|part| !part.trim().is_empty()) {
+        return None;
+    }
+
+    Some(VForScopeAliases {
+        value_pattern: CompactString::new(value_pattern),
+        value_bindings: smallvec![CompactString::new(value_pattern)],
+        key_alias,
+        index_alias,
+        source: CompactString::new(source),
+    })
+}
+
+fn simple_tuple_part(part: Option<&str>) -> Option<Option<CompactString>> {
+    let Some(part) = part else {
+        return Some(None);
+    };
+    let part = part.trim();
+    if part.is_empty() {
+        return Some(None);
+    }
+    is_valid_identifier_fast(part.as_bytes()).then(|| Some(CompactString::new(part)))
+}
+
+fn simple_tuple_inner(alias: &str) -> Option<&str> {
+    let alias = alias.trim();
+    if alias.starts_with('(') && alias.ends_with(')') {
+        Some(alias[1..alias.len() - 1].trim())
+    } else {
+        None
+    }
 }
 
 mod oxc;

--- a/crates/vize_croquis/src/drawer/helpers/v_for.rs
+++ b/crates/vize_croquis/src/drawer/helpers/v_for.rs
@@ -4,12 +4,10 @@
 //! `"(item, index) in items"` into separate variable bindings
 //! and the iterable source expression.
 //!
-//! Uses fast-path string scanning for simple patterns and falls
-//! back to OXC parsing for destructured bindings.
+//! Splits the Vue-specific `in`/`of` boundary, then normalizes aliases into
+//! JavaScript binding patterns and walks the OXC AST for binding names.
 
 use vize_carton::{CompactString, SmallVec, profile, smallvec};
-
-use super::is_valid_identifier_fast;
 
 /// Parsed aliases for a v-for scope.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -34,34 +32,6 @@ pub fn parse_v_for_expression(expr: &str) -> (SmallVec<[CompactString; 3]>, Comp
     };
     let source = CompactString::new(source_part);
 
-    // Fast path: simple identifier
-    if !alias_part.starts_with('(')
-        && !alias_part.contains('{')
-        && is_valid_identifier_fast(alias_part.as_bytes())
-    {
-        return (smallvec![CompactString::new(alias_part)], source);
-    }
-
-    // Fast path: simple tuple (item, index)
-    if alias_part.starts_with('(')
-        && alias_part.ends_with(')')
-        && !alias_part.contains('{')
-        && !alias_part.contains('[')
-    {
-        let inner = &alias_part[1..alias_part.len() - 1];
-        let mut vars = SmallVec::new();
-        for part in inner.split(',') {
-            let part = part.trim();
-            if !part.is_empty() && is_valid_identifier_fast(part.as_bytes()) {
-                vars.push(CompactString::new(part));
-            }
-        }
-        if !vars.is_empty() {
-            return (vars, source);
-        }
-    }
-
-    // Complex case: use OXC parser
     profile!(
         "croquis.helpers.v_for.oxc",
         oxc::parse_v_for_with_oxc(alias_part, source)
@@ -74,138 +44,48 @@ pub fn parse_v_for_scope_expression(expr: &str) -> Option<VForScopeAliases> {
     let (alias_part, source_part) = split_v_for_expression(expr)?;
     let source = CompactString::new(source_part);
 
-    let (value_pattern, key_alias, index_alias) =
-        split_v_for_aliases(alias_part.trim_start_matches("const ").trim());
-    let value_pattern = value_pattern.trim();
-    let value_bindings = oxc::extract_binding_names_from_pattern(value_pattern);
-    if value_bindings.is_empty() {
-        return None;
-    }
-
-    Some(VForScopeAliases {
-        value_pattern: CompactString::new(value_pattern),
-        value_bindings,
-        key_alias,
-        index_alias,
-        source,
-    })
+    profile!(
+        "croquis.helpers.v_for.scope_oxc",
+        oxc::parse_v_for_scope_aliases(alias_part.trim_start_matches("const ").trim(), source)
+    )
 }
 
 fn split_v_for_expression(expr: &str) -> Option<(&str, &str)> {
     let expr = expr.trim();
-    let bytes = expr.as_bytes();
-    let len = bytes.len();
+    let chars: Vec<_> = expr.char_indices().collect();
 
-    // Find " in " or " of " separator
-    let mut split_pos = None;
-    let mut i = 0;
-    while i + 4 <= len {
-        if bytes[i] == b' '
-            && ((bytes[i + 1] == b'i' && bytes[i + 2] == b'n')
-                || (bytes[i + 1] == b'o' && bytes[i + 2] == b'f'))
-            && bytes[i + 3] == b' '
-        {
-            split_pos = Some(i);
-            break;
+    for keyword_idx in 0..chars.len().saturating_sub(1) {
+        match (chars[keyword_idx].1, chars[keyword_idx + 1].1) {
+            ('i', 'n') | ('o', 'f') => {}
+            _ => continue,
         }
-        i += 1;
-    }
 
-    let pos = split_pos?;
-
-    let alias_part = expr[..pos].trim();
-    let source_part = expr[pos + 4..].trim();
-    Some((alias_part, source_part))
-}
-
-fn split_v_for_aliases(alias: &str) -> (&str, Option<CompactString>, Option<CompactString>) {
-    let Some(inner) = enclosing_parens_inner(alias) else {
-        return (alias, None, None);
-    };
-    let parts = split_top_level_commas(inner);
-    if parts.len() <= 1 {
-        return (parts.first().copied().unwrap_or(inner), None, None);
-    }
-
-    let key_alias = parts.get(1).and_then(|part| simple_alias(part));
-    let index_alias = parts.get(2).and_then(|part| simple_alias(part));
-    (parts[0], key_alias, index_alias)
-}
-
-fn simple_alias(part: &str) -> Option<CompactString> {
-    let alias = part.trim();
-    is_valid_identifier_fast(alias.as_bytes()).then(|| CompactString::new(alias))
-}
-
-fn enclosing_parens_inner(text: &str) -> Option<&str> {
-    let text = text.trim();
-    if !text.starts_with('(') || !text.ends_with(')') {
-        return None;
-    }
-
-    let mut depth = 0usize;
-    let last = text.len() - 1;
-    for (index, ch) in text.char_indices() {
-        match ch {
-            '(' => depth += 1,
-            ')' => {
-                depth = depth.checked_sub(1)?;
-                if depth == 0 && index != last {
-                    return None;
-                }
-            }
-            _ => {}
-        }
-    }
-
-    (depth == 0).then_some(text[1..last].trim())
-}
-
-fn split_top_level_commas(text: &str) -> Vec<&str> {
-    let mut parts = Vec::new();
-    let mut start = 0;
-    let mut paren_depth = 0usize;
-    let mut brace_depth = 0usize;
-    let mut bracket_depth = 0usize;
-    let mut quote = None;
-    let mut escaped = false;
-
-    for (index, ch) in text.char_indices() {
-        if let Some(quote_char) = quote {
-            if escaped {
-                escaped = false;
-            } else if ch == '\\' {
-                escaped = true;
-            } else if ch == quote_char {
-                quote = None;
-            }
+        let has_space_before = keyword_idx > 0 && chars[keyword_idx - 1].1.is_whitespace();
+        let after_keyword_idx = keyword_idx + 2;
+        let has_space_after = chars
+            .get(after_keyword_idx)
+            .is_some_and(|(_, ch)| ch.is_whitespace());
+        if !has_space_before || !has_space_after {
             continue;
         }
 
-        match ch {
-            '"' | '\'' | '`' => quote = Some(ch),
-            '(' => paren_depth += 1,
-            ')' => paren_depth = paren_depth.saturating_sub(1),
-            '{' => brace_depth += 1,
-            '}' => brace_depth = brace_depth.saturating_sub(1),
-            '[' => bracket_depth += 1,
-            ']' => bracket_depth = bracket_depth.saturating_sub(1),
-            ',' if paren_depth == 0 && brace_depth == 0 && bracket_depth == 0 => {
-                let part = text[start..index].trim();
-                if !part.is_empty() {
-                    parts.push(part);
-                }
-                start = index + ch.len_utf8();
-            }
-            _ => {}
+        let keyword_start = chars[keyword_idx].0;
+        let keyword_end = chars
+            .get(after_keyword_idx)
+            .map_or(expr.len(), |(byte_idx, _)| *byte_idx);
+        let alias_part = expr[..keyword_start].trim();
+        let source_part = expr[keyword_end..].trim();
+
+        if !alias_part.is_empty()
+            && !source_part.is_empty()
+            && oxc::is_valid_v_for_alias(alias_part)
+            && oxc::is_valid_expression(source_part)
+        {
+            return Some((alias_part, source_part));
         }
     }
 
-    let part = text[start..].trim();
-    if !part.is_empty() {
-        parts.push(part);
-    }
-    parts
+    None
 }
 
 mod oxc;

--- a/crates/vize_croquis/src/drawer/helpers/v_for.rs
+++ b/crates/vize_croquis/src/drawer/helpers/v_for.rs
@@ -27,62 +27,73 @@ pub struct VForScopeAliases {
 /// Parse v-for expression into variables and source
 #[inline]
 pub fn parse_v_for_expression(expr: &str) -> (SmallVec<[CompactString; 3]>, CompactString) {
-    let Some((alias_part, source_part)) = split_v_for_expression(expr) else {
-        return (smallvec![], CompactString::new(expr.trim()));
-    };
-    let source = CompactString::new(source_part);
+    let expr = expr.trim();
+    parse_first_v_for_candidate(expr, |alias_part, source_part| {
+        let source = CompactString::new(source_part);
+        let (bindings, source) = profile!(
+            "croquis.helpers.v_for.oxc",
+            oxc::parse_v_for_with_oxc(alias_part, source)
+        );
 
-    profile!(
-        "croquis.helpers.v_for.oxc",
-        oxc::parse_v_for_with_oxc(alias_part, source)
-    )
+        (!bindings.is_empty()).then_some((bindings, source))
+    })
+    .unwrap_or_else(|| (smallvec![], CompactString::new(expr)))
 }
 
 /// Parse v-for expression into structured scope aliases.
 #[inline]
 pub fn parse_v_for_scope_expression(expr: &str) -> Option<VForScopeAliases> {
-    let (alias_part, source_part) = split_v_for_expression(expr)?;
-    let source = CompactString::new(source_part);
+    parse_first_v_for_candidate(expr.trim(), |alias_part, source_part| {
+        let source = CompactString::new(source_part);
 
-    profile!(
-        "croquis.helpers.v_for.scope_oxc",
-        oxc::parse_v_for_scope_aliases(alias_part.trim_start_matches("const ").trim(), source)
-    )
+        profile!(
+            "croquis.helpers.v_for.scope_oxc",
+            oxc::parse_v_for_scope_aliases(alias_part.trim_start_matches("const ").trim(), source)
+        )
+    })
 }
 
-fn split_v_for_expression(expr: &str) -> Option<(&str, &str)> {
-    let expr = expr.trim();
-    let chars: Vec<_> = expr.char_indices().collect();
+fn parse_first_v_for_candidate<T>(
+    expr: &str,
+    mut parse: impl FnMut(&str, &str) -> Option<T>,
+) -> Option<T> {
+    let mut previous_char = None;
 
-    for keyword_idx in 0..chars.len().saturating_sub(1) {
-        match (chars[keyword_idx].1, chars[keyword_idx + 1].1) {
-            ('i', 'n') | ('o', 'f') => {}
-            _ => continue,
-        }
+    for (keyword_start, ch) in expr.char_indices() {
+        let keyword_len = match ch {
+            'i' if expr[keyword_start..].starts_with("in") => 2,
+            'o' if expr[keyword_start..].starts_with("of") => 2,
+            _ => {
+                previous_char = Some(ch);
+                continue;
+            }
+        };
 
-        let has_space_before = keyword_idx > 0 && chars[keyword_idx - 1].1.is_whitespace();
-        let after_keyword_idx = keyword_idx + 2;
-        let has_space_after = chars
-            .get(after_keyword_idx)
-            .is_some_and(|(_, ch)| ch.is_whitespace());
-        if !has_space_before || !has_space_after {
+        if !previous_char.is_some_and(char::is_whitespace) {
+            previous_char = Some(ch);
             continue;
         }
 
-        let keyword_start = chars[keyword_idx].0;
-        let keyword_end = chars
-            .get(after_keyword_idx)
-            .map_or(expr.len(), |(byte_idx, _)| *byte_idx);
+        let keyword_end = keyword_start + keyword_len;
+        if !expr[keyword_end..]
+            .chars()
+            .next()
+            .is_some_and(char::is_whitespace)
+        {
+            previous_char = Some(ch);
+            continue;
+        }
+
         let alias_part = expr[..keyword_start].trim();
         let source_part = expr[keyword_end..].trim();
-
         if !alias_part.is_empty()
             && !source_part.is_empty()
-            && oxc::is_valid_v_for_alias(alias_part)
-            && oxc::is_valid_expression(source_part)
+            && let Some(parsed) = parse(alias_part, source_part)
         {
-            return Some((alias_part, source_part));
+            return Some(parsed);
         }
+
+        previous_char = Some(ch);
     }
 
     None

--- a/crates/vize_croquis/src/drawer/helpers/v_for.rs
+++ b/crates/vize_croquis/src/drawer/helpers/v_for.rs
@@ -43,7 +43,11 @@ pub fn parse_v_for_expression(expr: &str) -> (SmallVec<[CompactString; 3]>, Comp
     }
 
     // Fast path: simple tuple (item, index)
-    if alias_part.starts_with('(') && alias_part.ends_with(')') && !alias_part.contains('{') {
+    if alias_part.starts_with('(')
+        && alias_part.ends_with(')')
+        && !alias_part.contains('{')
+        && !alias_part.contains('[')
+    {
         let inner = &alias_part[1..alias_part.len() - 1];
         let mut vars = SmallVec::new();
         for part in inner.split(',') {

--- a/crates/vize_croquis/src/drawer/helpers/v_for/oxc.rs
+++ b/crates/vize_croquis/src/drawer/helpers/v_for/oxc.rs
@@ -1,10 +1,40 @@
 use oxc_allocator::Allocator;
 use oxc_ast::ast::BindingPattern;
 use oxc_parser::Parser;
-use oxc_span::SourceType;
-use vize_carton::{CompactString, SmallVec, String, profile, smallvec};
+use oxc_span::{GetSpan, SourceType};
+use vize_carton::{CompactString, SmallVec, String, profile};
 
-use crate::drawer::helpers::is_valid_identifier_fast;
+use super::VForScopeAliases;
+
+pub(super) fn is_valid_v_for_alias(alias: &str) -> bool {
+    let inner = tuple_alias_inner(alias.trim_start_matches("const ").trim());
+    let pattern_str = format_binding_pattern(inner);
+    let allocator = Allocator::default();
+    let source_type = SourceType::default().with_typescript(true);
+    let ret = Parser::new(&allocator, &pattern_str, source_type).parse();
+    if !ret.errors.is_empty() {
+        return false;
+    }
+
+    ret.program.body.first().is_some_and(|statement| {
+        if let oxc_ast::ast::Statement::VariableDeclaration(var_decl) = statement
+            && let Some(declarator) = var_decl.declarations.first()
+            && let BindingPattern::ArrayPattern(root) = &declarator.id
+        {
+            root.elements.first().and_then(Option::as_ref).is_some()
+        } else {
+            false
+        }
+    })
+}
+
+pub(super) fn is_valid_expression(source: &str) -> bool {
+    let allocator = Allocator::default();
+    let source_type = SourceType::default().with_typescript(true);
+    Parser::new(&allocator, source, source_type)
+        .parse_expression()
+        .is_ok()
+}
 
 /// Parse complex v-for alias using OXC
 #[cold]
@@ -16,11 +46,7 @@ pub(super) fn parse_v_for_with_oxc(
     let prefix = b"let [";
     let suffix = b"] = x";
 
-    let inner = if alias.starts_with('(') && alias.ends_with(')') {
-        &alias[1..alias.len() - 1]
-    } else {
-        alias
-    };
+    let inner = tuple_alias_inner(alias);
 
     let total_len = prefix.len() + inner.len() + suffix.len();
     if total_len > buffer.len() {
@@ -45,6 +71,80 @@ pub(super) fn parse_v_for_with_oxc(
     }
 }
 
+pub(super) fn parse_v_for_scope_aliases(
+    alias: &str,
+    source: CompactString,
+) -> Option<VForScopeAliases> {
+    let inner = tuple_alias_inner(alias);
+    let pattern_str = format_binding_pattern(inner);
+    let allocator = Allocator::default();
+    let source_type = SourceType::default().with_typescript(true);
+    let ret = profile!(
+        "croquis.helpers.v_for.scope_alias_parse",
+        Parser::new(&allocator, &pattern_str, source_type).parse()
+    );
+    if !ret.errors.is_empty() {
+        return None;
+    }
+
+    let declarator = ret.program.body.first().and_then(|statement| {
+        if let oxc_ast::ast::Statement::VariableDeclaration(var_decl) = statement {
+            var_decl.declarations.first()
+        } else {
+            None
+        }
+    })?;
+
+    let BindingPattern::ArrayPattern(root) = &declarator.id else {
+        return None;
+    };
+
+    let value_pattern = root.elements.first().and_then(Option::as_ref)?;
+    let mut value_bindings = SmallVec::new();
+    extract_binding_names4(value_pattern, &mut value_bindings);
+    if value_bindings.is_empty() {
+        return None;
+    }
+
+    Some(VForScopeAliases {
+        value_pattern: binding_pattern_source(value_pattern, &pattern_str),
+        value_bindings,
+        key_alias: root
+            .elements
+            .get(1)
+            .and_then(Option::as_ref)
+            .and_then(binding_identifier_name),
+        index_alias: root
+            .elements
+            .get(2)
+            .and_then(Option::as_ref)
+            .and_then(binding_identifier_name),
+        source,
+    })
+}
+
+fn binding_pattern_source(pattern: &BindingPattern<'_>, source: &str) -> CompactString {
+    let span = pattern.span();
+    CompactString::new(&source[span.start as usize..span.end as usize])
+}
+
+fn binding_identifier_name(pattern: &BindingPattern<'_>) -> Option<CompactString> {
+    if let BindingPattern::BindingIdentifier(id) = pattern {
+        Some(CompactString::new(id.name.as_str()))
+    } else {
+        None
+    }
+}
+
+fn tuple_alias_inner(alias: &str) -> &str {
+    let alias = alias.trim();
+    if alias.starts_with('(') && alias.ends_with(')') {
+        alias[1..alias.len() - 1].trim()
+    } else {
+        alias
+    }
+}
+
 /// Parse v-for pattern using OXC
 fn parse_v_for_pattern(
     pattern_str: &str,
@@ -56,6 +156,9 @@ fn parse_v_for_pattern(
         "croquis.helpers.v_for.oxc_parse",
         Parser::new(&allocator, pattern_str, source_type).parse()
     );
+    if !ret.errors.is_empty() {
+        return (SmallVec::new(), source);
+    }
 
     let mut vars = SmallVec::new();
 
@@ -66,28 +169,6 @@ fn parse_v_for_pattern(
     }
 
     (vars, source)
-}
-
-pub(super) fn extract_binding_names_from_pattern(pattern: &str) -> SmallVec<[CompactString; 4]> {
-    if is_valid_identifier_fast(pattern.as_bytes()) {
-        return smallvec![CompactString::new(pattern)];
-    }
-
-    let pattern_str = format_binding_pattern(pattern);
-    let allocator = Allocator::default();
-    let source_type = SourceType::default().with_typescript(true);
-    let ret = profile!(
-        "croquis.helpers.v_for.oxc_scope_parse",
-        Parser::new(&allocator, &pattern_str, source_type).parse()
-    );
-
-    let mut vars = SmallVec::new();
-    if let Some(oxc_ast::ast::Statement::VariableDeclaration(var_decl)) = ret.program.body.first()
-        && let Some(declarator) = var_decl.declarations.first()
-    {
-        extract_binding_names4(&declarator.id, &mut vars);
-    }
-    vars
 }
 
 fn format_binding_pattern(pattern: &str) -> String {

--- a/crates/vize_croquis/src/drawer/helpers/v_for/oxc.rs
+++ b/crates/vize_croquis/src/drawer/helpers/v_for/oxc.rs
@@ -6,38 +6,7 @@ use vize_carton::{CompactString, SmallVec, String, profile};
 
 use super::VForScopeAliases;
 
-pub(super) fn is_valid_v_for_alias(alias: &str) -> bool {
-    let inner = tuple_alias_inner(alias.trim_start_matches("const ").trim());
-    let pattern_str = format_binding_pattern(inner);
-    let allocator = Allocator::default();
-    let source_type = SourceType::default().with_typescript(true);
-    let ret = Parser::new(&allocator, &pattern_str, source_type).parse();
-    if !ret.errors.is_empty() {
-        return false;
-    }
-
-    ret.program.body.first().is_some_and(|statement| {
-        if let oxc_ast::ast::Statement::VariableDeclaration(var_decl) = statement
-            && let Some(declarator) = var_decl.declarations.first()
-            && let BindingPattern::ArrayPattern(root) = &declarator.id
-        {
-            root.elements.first().and_then(Option::as_ref).is_some()
-        } else {
-            false
-        }
-    })
-}
-
-pub(super) fn is_valid_expression(source: &str) -> bool {
-    let allocator = Allocator::default();
-    let source_type = SourceType::default().with_typescript(true);
-    Parser::new(&allocator, source, source_type)
-        .parse_expression()
-        .is_ok()
-}
-
 /// Parse complex v-for alias using OXC
-#[cold]
 pub(super) fn parse_v_for_with_oxc(
     alias: &str,
     source: CompactString,

--- a/crates/vize_croquis/src/drawer/helpers/v_for/oxc.rs
+++ b/crates/vize_croquis/src/drawer/helpers/v_for/oxc.rs
@@ -15,7 +15,7 @@ pub(super) fn parse_v_for_with_oxc(
     let prefix = b"let [";
     let suffix = b"] = x";
 
-    let inner = tuple_alias_inner(alias);
+    let inner = tuple_alias_inner(alias.trim_start_matches("const ").trim());
 
     let total_len = prefix.len() + inner.len() + suffix.len();
     if total_len > buffer.len() {

--- a/crates/vize_croquis/src/drawer/helpers/v_for/tests.rs
+++ b/crates/vize_croquis/src/drawer/helpers/v_for/tests.rs
@@ -47,3 +47,33 @@ fn parse_expression_collects_array_destructured_tuple_value() {
         vec!["name", "count", "index"]
     );
 }
+
+#[test]
+fn parse_expression_uses_parser_validated_separator() {
+    let (bindings, source) =
+        super::parse_v_for_expression(r#"({ label = " in " }, index) in items"#);
+
+    assert_eq!(source.as_str(), "items");
+    assert_eq!(
+        bindings
+            .iter()
+            .map(|name| name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["label", "index"]
+    );
+
+    let (bindings, source) =
+        super::parse_v_for_expression("item in items.filter(entry => entry.kind in allowed)");
+
+    assert_eq!(
+        source.as_str(),
+        "items.filter(entry => entry.kind in allowed)"
+    );
+    assert_eq!(
+        bindings
+            .iter()
+            .map(|name| name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["item"]
+    );
+}

--- a/crates/vize_croquis/src/drawer/helpers/v_for/tests.rs
+++ b/crates/vize_croquis/src/drawer/helpers/v_for/tests.rs
@@ -33,3 +33,17 @@ fn parse_scope_expression_splits_tuple_around_destructured_value() {
     assert_eq!(aliases.key_alias.as_deref(), Some("index"));
     assert!(aliases.index_alias.is_none());
 }
+
+#[test]
+fn parse_expression_collects_array_destructured_tuple_value() {
+    let (bindings, source) = super::parse_v_for_expression("([name, count], index) of entries");
+
+    assert_eq!(source.as_str(), "entries");
+    assert_eq!(
+        bindings
+            .iter()
+            .map(|name| name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["name", "count", "index"]
+    );
+}

--- a/crates/vize_patina/src/rules/vue/valid_v_for/key_tests.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_for/key_tests.rs
@@ -29,6 +29,19 @@ fn valid_v_for_key_uses_second_alias() {
 }
 
 #[test]
+fn valid_v_for_key_uses_destructured_tuple_alias() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<ul>
+            <li v-for="({ color }, index) of colors" :key="color">{{ index }}</li>
+            <li v-for="([name, count], index) of entries" :key="name">{{ count }}</li>
+        </ul>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
 fn valid_v_for_static_key_is_ignored() {
     let linter = create_linter();
     let result = linter.lint_template(

--- a/crates/vize_patina/src/rules/vue/valid_v_slot.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_slot.rs
@@ -21,8 +21,10 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::{FxHashSet, String, ToCompactString};
-use vize_relief::{DirectiveNode, ElementNode, ExpressionNode, PropNode, TemplateChildNode};
+use vize_carton::{FxHashSet, String, ToCompactString, is_native_tag};
+use vize_relief::{
+    DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode, TemplateChildNode,
+};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/valid-v-slot",
@@ -37,12 +39,22 @@ static META: RuleMeta = RuleMeta {
 pub struct ValidVSlot;
 
 impl ValidVSlot {
-    fn is_custom_component(tag: &str) -> bool {
-        // Custom components: PascalCase, kebab-case with hyphen, or Vue's
-        // built-in dynamic component element.
-        tag == "component"
-            || tag.chars().next().is_some_and(|c| c.is_uppercase())
-            || tag.contains('-')
+    fn is_custom_component(element: &ElementNode) -> bool {
+        Self::is_custom_component_tag(element.tag.as_str(), Some(element.tag_type))
+    }
+
+    fn is_custom_component_tag(tag: &str, tag_type: Option<ElementType>) -> bool {
+        if matches!(tag_type, Some(ElementType::Slot | ElementType::Template))
+            || matches!(tag, "slot" | "template")
+        {
+            return false;
+        }
+
+        // Vue treats unknown non-native tags as components, including
+        // lowercase single-word registered components such as <draggable>.
+        matches!(tag_type, Some(ElementType::Component))
+            || tag == "component"
+            || !is_native_tag(tag)
     }
 
     fn count_slot_directives(element: &ElementNode) -> (usize, usize) {
@@ -79,7 +91,7 @@ impl Rule for ValidVSlot {
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if Self::is_custom_component(element.tag.as_str()) {
+        if Self::is_custom_component(element) {
             check_child_slot_templates(ctx, element);
         }
     }
@@ -97,7 +109,7 @@ impl Rule for ValidVSlot {
         let tag = element.tag.as_str();
 
         // v-slot can only be used on components or <template>
-        if tag != "template" && !Self::is_custom_component(tag) {
+        if tag != "template" && !Self::is_custom_component(element) {
             ctx.error_with_help(
                 ctx.t("vue/valid-v-slot.invalid_location"),
                 &directive.loc,
@@ -246,7 +258,7 @@ fn has_directive(element: &ElementNode, name: &str) -> bool {
 
 fn has_component_parent(ctx: &LintContext) -> bool {
     ctx.parent_element()
-        .is_some_and(|parent| ValidVSlot::is_custom_component(parent.tag.as_str()))
+        .is_some_and(|parent| ValidVSlot::is_custom_component_tag(parent.tag.as_str(), None))
 }
 
 fn static_slot_name(directive: &DirectiveNode) -> Option<String> {

--- a/crates/vize_patina/src/rules/vue/valid_v_slot.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_slot.rs
@@ -18,7 +18,7 @@
 //! <MyComponent><template v-slot:header>Header</template></MyComponent>
 //! ```
 
-use crate::context::LintContext;
+use crate::context::{ElementContext, LintContext};
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_carton::{FxHashSet, String, ToCompactString, is_native_tag};
@@ -258,7 +258,12 @@ fn has_directive(element: &ElementNode, name: &str) -> bool {
 
 fn has_component_parent(ctx: &LintContext) -> bool {
     ctx.parent_element()
-        .is_some_and(|parent| ValidVSlot::is_custom_component_tag(parent.tag.as_str(), None))
+        .is_some_and(is_component_parent_context)
+}
+
+fn is_component_parent_context(parent: &ElementContext) -> bool {
+    let tag = parent.tag.as_str();
+    !matches!(tag, "slot" | "template") && (tag == "component" || !is_native_tag(tag))
 }
 
 fn static_slot_name(directive: &DirectiveNode) -> Option<String> {

--- a/crates/vize_patina/src/rules/vue/valid_v_slot/tests.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_slot/tests.rs
@@ -29,6 +29,20 @@ fn test_valid_named_slot_template() {
 }
 
 #[test]
+fn test_valid_named_slot_template_on_lowercase_component() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<draggable :list="items">
+            <template #item="{ element }">
+                <span>{{ element }}</span>
+            </template>
+        </draggable>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
 fn test_valid_default_slot_argument_on_component() {
     let linter = create_linter();
     let result = linter.lint_template(

--- a/crates/vize_patina/src/visitor_scope.rs
+++ b/crates/vize_patina/src/visitor_scope.rs
@@ -5,6 +5,7 @@
 //! template-local bindings from unresolved identifiers.
 
 use vize_carton::CompactString;
+use vize_croquis::drawer::{extract_slot_props, parse_v_for_expression};
 use vize_relief::ExpressionNode;
 
 /// Parse v-for expression to extract variable names.
@@ -22,19 +23,10 @@ pub fn parse_v_for_variables(exp: &ExpressionNode) -> Vec<CompactString> {
         ExpressionNode::Compound(_) => return Vec::new(),
     };
 
-    // Split on " in " or " of " - use byte search for speed
-    let bytes = content.as_bytes();
-    let (alias_part, _) = if let Some(idx) = find_pattern(bytes, b" in ") {
-        (&content[..idx], &content[idx + 4..])
-    } else if let Some(idx) = find_pattern(bytes, b" of ") {
-        (&content[..idx], &content[idx + 4..])
-    } else {
-        return Vec::new();
-    };
-
-    let alias_str = alias_part.trim();
-
-    parse_binding_variables(alias_str)
+    parse_v_for_expression(content)
+        .0
+        .into_iter()
+        .collect::<Vec<_>>()
 }
 
 /// Parse a scoped slot expression to extract variable names.
@@ -45,77 +37,7 @@ pub fn parse_slot_scope_variables(exp: &ExpressionNode) -> Vec<CompactString> {
         ExpressionNode::Compound(_) => return Vec::new(),
     };
 
-    parse_binding_variables(content.trim())
-}
-
-fn parse_binding_variables(alias_str: &str) -> Vec<CompactString> {
-    if alias_str.is_empty() {
-        return Vec::new();
-    }
-
-    // Handle destructuring: (item, index), { id, name }, or [first, second]
-    let is_tuple = alias_str.starts_with('(') && alias_str.ends_with(')');
-    let is_object = alias_str.starts_with('{') && alias_str.ends_with('}');
-    let is_array = alias_str.starts_with('[') && alias_str.ends_with(']');
-
-    if is_tuple || is_object || is_array {
-        let inner = &alias_str[1..alias_str.len() - 1];
-        // Pre-allocate with estimated capacity
-        let mut vars = Vec::with_capacity(3);
-        for s in inner.split(',') {
-            let trimmed = s.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            // Handle object shorthand: { id } -> id, { id: itemId } -> itemId
-            if is_object {
-                if let Some(colon_idx) = trimmed.find(':') {
-                    // { id: itemId } -> itemId
-                    let value_part = trimmed[colon_idx + 1..].trim();
-                    if let Some(name) = normalize_binding_name(value_part) {
-                        vars.push(CompactString::from(name));
-                    }
-                } else {
-                    // { id } -> id (shorthand)
-                    if let Some(name) = normalize_binding_name(trimmed) {
-                        vars.push(CompactString::from(name));
-                    }
-                }
-            } else {
-                if let Some(name) = normalize_binding_name(trimmed) {
-                    vars.push(CompactString::from(name));
-                }
-            }
-        }
-        vars
-    } else {
-        // Single variable - avoid allocation if possible
-        normalize_binding_name(alias_str)
-            .map(|name| vec![CompactString::from(name)])
-            .unwrap_or_default()
-    }
-}
-
-fn normalize_binding_name(binding: &str) -> Option<&str> {
-    let binding = binding.trim().trim_start_matches("...").trim();
-    let binding = binding
-        .split_once('=')
-        .map(|(name, _)| name.trim())
-        .unwrap_or(binding);
-
-    (!binding.is_empty()).then_some(binding)
-}
-
-/// Fast byte pattern search
-#[inline]
-fn find_pattern(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    if needle.is_empty() || haystack.len() < needle.len() {
-        return None;
-    }
-
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
+    extract_slot_props(content.trim()).into_iter().collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- reuse Croquis binding extraction for Patina template scope variables
- route array-destructured v-for tuple aliases through the OXC parser
- treat unknown non-native tags as component-like for vue/valid-v-slot

Fixes #2625
Fixes #2626
Refs #1634

## Verification
- cargo fmt --check
- git diff --check
- cargo test -p vize_croquis drawer::helpers::v_for
- cargo test -p vize_patina visitor_scope
- cargo test -p vize_patina valid_v_for
- cargo test -p vize_patina valid_v_slot
- cargo clippy -p vize_croquis -p vize_patina -- -D warnings -D clippy::wildcard_imports

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785894949&installation_id=136613492&pr_number=2627&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2627&signature=5b86660ea696cc3ef3f5d5c8d1cd85e4300a55f8113ab82b209395e38693e80d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `v-for` parsing for `in`/`of` splitting and tuple/destructured aliases (including array destructuring with index bindings), and improved scope variable extraction.
  * Updated `v-for` `:key` validation to accept destructured tuple aliases.
  * Refined `v-slot` target detection to use element metadata, fixing named slots with lowercase component tags.
  * Made slot prop extraction more conservative, with safer OXC fallbacks for complex patterns/defaults.
* **Tests**
  * Added unit tests covering the new `v-for`/`v-slot`/slot-prop scenarios, plus `:key` validation for destructured tuple aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->