### PR TITLE
fix(inspector): build graph edges from AST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3665,8 +3665,15 @@ name = "vize_curator"
 version = "0.277.0"
 dependencies = [
  "insta",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
+ "oxc_parser",
+ "oxc_span",
  "serde",
  "serde_json",
+ "vize_atelier_core",
+ "vize_atelier_sfc",
  "vize_carton",
 ]
 

--- a/crates/vize_curator/Cargo.toml
+++ b/crates/vize_curator/Cargo.toml
@@ -9,8 +9,15 @@ description = "Curator - local inspection and reporting utilities for Vize"
 publish = false
 
 [dependencies]
+oxc_allocator = { workspace = true }
+oxc_ast = { workspace = true }
+oxc_ast_visit = { workspace = true }
+oxc_parser = { workspace = true }
+oxc_span = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+vize_atelier_core = { workspace = true }
+vize_atelier_sfc = { workspace = true }
 vize_carton = { workspace = true }
 
 [dev-dependencies]

--- a/crates/vize_curator/src/inspector/graph.rs
+++ b/crates/vize_curator/src/inspector/graph.rs
@@ -2,7 +2,7 @@
 
 use vize_carton::{String, ToCompactString};
 
-use super::imports::{extract_imports, skip_whitespace};
+use super::imports::analyze_file;
 use super::payload::InspectorSourceFile;
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -34,12 +34,16 @@ pub struct InspectorGraphEdge {
 pub fn build_graph(files: &[InspectorSourceFile]) -> InspectorGraph {
     let normalized_files: Vec<_> = files
         .iter()
-        .map(|file| (normalize_path(file.path.as_str()), file.source.as_str()))
+        .map(|file| {
+            let path = normalize_path(file.path.as_str());
+            let analysis = analyze_file(path.as_str(), file.source.as_str());
+            (path, file.source.as_str(), analysis)
+        })
         .collect();
 
     let nodes = normalized_files
         .iter()
-        .map(|(path, source)| InspectorGraphNode {
+        .map(|(path, source, _)| InspectorGraphNode {
             path: path.clone(),
             kind: file_kind(path.as_str()),
             is_entry: is_entry_path(path.as_str()),
@@ -49,8 +53,8 @@ pub fn build_graph(files: &[InspectorSourceFile]) -> InspectorGraph {
         .collect();
 
     let mut edges = Vec::new();
-    for (path, source) in &normalized_files {
-        for import in extract_imports(source) {
+    for (path, _, analysis) in &normalized_files {
+        for import in &analysis.imports {
             if let Some(to) =
                 resolve_import(&normalized_files, path.as_str(), import.specifier.as_str())
             {
@@ -66,7 +70,7 @@ pub fn build_graph(files: &[InspectorSourceFile]) -> InspectorGraph {
 
                 if to.ends_with(".vue")
                     && import.kind == "import"
-                    && component_is_used(source, &import.locals)
+                    && component_is_used(&analysis.template_used_ids, &import.locals)
                 {
                     push_graph_edge(
                         &mut edges,
@@ -74,7 +78,7 @@ pub fn build_graph(files: &[InspectorSourceFile]) -> InspectorGraph {
                             from: path.clone(),
                             to,
                             kind: "component",
-                            specifier: import.specifier,
+                            specifier: import.specifier.clone(),
                         },
                     );
                 }
@@ -93,54 +97,13 @@ pub fn build_graph(files: &[InspectorSourceFile]) -> InspectorGraph {
     InspectorGraph { nodes, edges }
 }
 
-fn component_is_used(source: &str, locals: &[String]) -> bool {
-    locals.iter().any(|local| {
-        tag_is_used(source, local.as_str())
-            || tag_is_used(source, to_kebab_case(local.as_str()).as_str())
-    })
-}
-
-fn tag_is_used(source: &str, tag: &str) -> bool {
-    if tag.is_empty() {
-        return false;
-    }
-
-    let bytes = source.as_bytes();
-    let tag_bytes = tag.as_bytes();
-    let mut offset = 0;
-    while let Some(index) = source[offset..].find('<') {
-        let mut cursor = offset + index + 1;
-        cursor = skip_whitespace(source, cursor);
-        if bytes
-            .get(cursor..cursor + tag_bytes.len())
-            .is_some_and(|candidate| candidate == tag_bytes)
-            && bytes
-                .get(cursor + tag_bytes.len())
-                .is_some_and(|byte| byte.is_ascii_whitespace() || matches!(*byte, b'/' | b'>'))
-        {
-            return true;
-        }
-        offset = cursor.saturating_add(1);
-    }
-
-    false
-}
-
-fn to_kebab_case(value: &str) -> String {
-    let mut output = String::default();
-    for (index, char) in value.chars().enumerate() {
-        if char == '_' {
-            output.push('-');
-        } else if char.is_ascii_uppercase() {
-            if index > 0 {
-                output.push('-');
-            }
-            output.extend(char.to_lowercase());
-        } else {
-            output.push(char);
-        }
-    }
-    output
+fn component_is_used(
+    template_used_ids: &vize_carton::FxHashSet<String>,
+    locals: &[String],
+) -> bool {
+    locals
+        .iter()
+        .any(|local| template_used_ids.contains(local.as_str()))
 }
 
 fn push_graph_edge(edges: &mut Vec<InspectorGraphEdge>, edge: InspectorGraphEdge) {
@@ -149,7 +112,11 @@ fn push_graph_edge(edges: &mut Vec<InspectorGraphEdge>, edge: InspectorGraphEdge
     }
 }
 
-fn resolve_import(files: &[(String, &str)], from: &str, specifier: &str) -> Option<String> {
+fn resolve_import(
+    files: &[(String, &str, super::imports::FileAnalysis)],
+    from: &str,
+    specifier: &str,
+) -> Option<String> {
     if !specifier.starts_with('.') {
         return None;
     }
@@ -159,7 +126,7 @@ fn resolve_import(files: &[(String, &str)], from: &str, specifier: &str) -> Opti
         .find(|candidate| {
             files
                 .iter()
-                .any(|(path, _)| path.as_str() == candidate.as_str())
+                .any(|(path, _, _)| path.as_str() == candidate.as_str())
         })
 }
 

--- a/crates/vize_curator/src/inspector/imports.rs
+++ b/crates/vize_curator/src/inspector/imports.rs
@@ -1,6 +1,15 @@
-//! Lightweight scanner for static and dynamic import statements in source text.
+//! AST-backed import extraction for inspector graphs.
 
-use vize_carton::{String, ToCompactString};
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Expression, ImportDeclaration, ImportDeclarationSpecifier, ImportExpression};
+use oxc_ast_visit::{Visit, walk};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_atelier_core::parser::parse;
+use vize_atelier_sfc::{
+    SfcParseOptions, SfcScriptBlock, parse_sfc, script::resolve_template_used_identifiers,
+};
+use vize_carton::{Bump, FxHashSet, String, ToCompactString};
 
 #[derive(Debug)]
 pub(super) struct ImportEdge {
@@ -9,190 +18,171 @@ pub(super) struct ImportEdge {
     pub locals: Vec<String>,
 }
 
-pub(super) fn extract_imports(source: &str) -> Vec<ImportEdge> {
-    let mut imports = Vec::new();
-    collect_static_imports(source, &mut imports);
-    collect_dynamic_imports(source, &mut imports);
-    imports
+#[derive(Debug, Default)]
+pub(super) struct FileAnalysis {
+    pub imports: Vec<ImportEdge>,
+    pub template_used_ids: FxHashSet<String>,
 }
 
-fn collect_static_imports(source: &str, imports: &mut Vec<ImportEdge>) {
-    let mut offset = 0;
-    while let Some(index) = source[offset..].find("import") {
-        let import_start = offset + index;
-        let clause_start = import_start + "import".len();
-        if !is_word_boundary(source, import_start, clause_start) {
-            offset = clause_start;
-            continue;
-        }
+pub(super) fn analyze_file(path: &str, source: &str) -> FileAnalysis {
+    if path.ends_with(".vue") {
+        return analyze_sfc_file(path, source);
+    }
 
-        let start = skip_whitespace(source, clause_start);
-        if source[start..].starts_with('(') {
-            offset = start + 1;
-            continue;
-        }
-        if source[start..].starts_with('.') {
-            offset = start + 1;
-            continue;
-        }
-
-        if let Some((specifier, end)) = read_quoted(source, start) {
-            imports.push(ImportEdge {
-                specifier,
-                kind: "import",
-                locals: Vec::new(),
-            });
-            offset = end;
-            continue;
-        }
-
-        let Some(from_index) = find_import_from(source, start) else {
-            offset = clause_start;
-            continue;
-        };
-
-        if let Some((specifier, end)) = read_quoted(source, from_index + "from".len()) {
-            let clause = &source[start..from_index];
-            imports.push(ImportEdge {
-                specifier,
-                kind: "import",
-                locals: extract_import_locals(clause),
-            });
-            offset = end;
-        } else {
-            offset = from_index + "from".len();
-        }
+    FileAnalysis {
+        imports: extract_script_imports(source, source_type_for_path(path)),
+        template_used_ids: FxHashSet::default(),
     }
 }
 
-fn collect_dynamic_imports(source: &str, imports: &mut Vec<ImportEdge>) {
-    let mut offset = 0;
-    while let Some(index) = source[offset..].find("import") {
-        let import_start = offset + index;
-        let import_end = import_start + "import".len();
-        if !is_word_boundary(source, import_start, import_end) {
-            offset = import_end;
-            continue;
-        }
+fn analyze_sfc_file(path: &str, source: &str) -> FileAnalysis {
+    let Ok(descriptor) = parse_sfc(
+        source,
+        SfcParseOptions {
+            filename: path.into(),
+            ..Default::default()
+        },
+    ) else {
+        return FileAnalysis::default();
+    };
 
-        let start = skip_whitespace(source, import_end);
-        if !source[start..].starts_with('(') {
-            offset = import_end;
-            continue;
-        }
+    let mut imports = Vec::new();
+    if let Some(script) = descriptor.script.as_ref() {
+        imports.extend(extract_script_block_imports(script));
+    }
+    if let Some(script_setup) = descriptor.script_setup.as_ref() {
+        imports.extend(extract_script_block_imports(script_setup));
+    }
 
-        if let Some((specifier, end)) = read_quoted(source, start + 1) {
-            imports.push(ImportEdge {
-                specifier,
+    let template_used_ids = descriptor
+        .template
+        .as_ref()
+        .map(|template| {
+            let allocator = Bump::new();
+            let (root, _) = parse(&allocator, template.content.as_ref());
+            resolve_template_used_identifiers(&root).used_ids
+        })
+        .unwrap_or_default();
+
+    FileAnalysis {
+        imports,
+        template_used_ids,
+    }
+}
+
+fn extract_script_block_imports(script: &SfcScriptBlock<'_>) -> Vec<ImportEdge> {
+    extract_script_imports(
+        script.content.as_ref(),
+        source_type_for_script_lang(script.lang.as_deref()),
+    )
+}
+
+fn extract_script_imports(source: &str, source_type: SourceType) -> Vec<ImportEdge> {
+    let allocator = Allocator::default();
+    let result = Parser::new(&allocator, source, source_type).parse();
+    if result.panicked {
+        return Vec::new();
+    }
+
+    let mut collector = ImportCollector::default();
+    collector.visit_program(&result.program);
+    collector.imports
+}
+
+#[derive(Default)]
+struct ImportCollector {
+    imports: Vec<ImportEdge>,
+}
+
+impl ImportCollector {
+    fn collect_static_import(&mut self, import: &ImportDeclaration<'_>) {
+        let Some(locals) = runtime_import_locals(import) else {
+            return;
+        };
+
+        self.imports.push(ImportEdge {
+            specifier: import.source.value.as_str().to_compact_string(),
+            kind: "import",
+            locals,
+        });
+    }
+}
+
+impl<'a> Visit<'a> for ImportCollector {
+    fn visit_import_declaration(&mut self, import: &ImportDeclaration<'a>) {
+        self.collect_static_import(import);
+        walk::walk_import_declaration(self, import);
+    }
+
+    fn visit_import_expression(&mut self, import: &ImportExpression<'a>) {
+        if let Expression::StringLiteral(literal) = &import.source {
+            self.imports.push(ImportEdge {
+                specifier: literal.value.as_str().to_compact_string(),
                 kind: "dynamic-import",
                 locals: Vec::new(),
             });
-            offset = end;
-        } else {
-            offset = start + 1;
         }
+
+        walk::walk_import_expression(self, import);
     }
 }
 
-pub(super) fn skip_whitespace(source: &str, mut index: usize) -> usize {
-    let bytes = source.as_bytes();
-    while index < bytes.len() && bytes[index].is_ascii_whitespace() {
-        index += 1;
-    }
-    index
-}
-
-fn is_word_boundary(source: &str, start: usize, end: usize) -> bool {
-    let bytes = source.as_bytes();
-    let before = start
-        .checked_sub(1)
-        .and_then(|index| bytes.get(index))
-        .is_none_or(|byte| !is_identifier_byte(*byte));
-    let after = bytes.get(end).is_none_or(|byte| !is_identifier_byte(*byte));
-    before && after
-}
-
-fn is_identifier_byte(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
-}
-
-fn find_import_from(source: &str, start: usize) -> Option<usize> {
-    let mut offset = start;
-    while let Some(index) = source[offset..].find("from") {
-        let from_index = offset + index;
-        let from_end = from_index + "from".len();
-        if is_word_boundary(source, from_index, from_end) {
-            return Some(from_index);
-        }
-        offset = from_end;
-    }
-    None
-}
-
-fn read_quoted(source: &str, start: usize) -> Option<(String, usize)> {
-    let bytes = source.as_bytes();
-    let mut index = skip_whitespace(source, start);
-    let quote = *bytes.get(index)?;
-    if quote != b'\'' && quote != b'"' {
+fn runtime_import_locals(import: &ImportDeclaration<'_>) -> Option<Vec<String>> {
+    if import.import_kind.is_type() {
         return None;
     }
-    index += 1;
-    let value_start = index;
-    while index < bytes.len() && bytes[index] != quote {
-        index += 1;
-    }
-    if index >= bytes.len() {
-        return None;
-    }
-    Some((String::from(&source[value_start..index]), index + 1))
-}
 
-fn extract_import_locals(clause: &str) -> Vec<String> {
-    let mut locals = Vec::new();
-    let trimmed = clause.trim();
-    if trimmed.starts_with("type ") {
-        return locals;
-    }
-
-    if let Some(default_name) = trimmed.split(',').next().map(str::trim)
-        && is_identifier(default_name)
-    {
-        locals.push(default_name.to_compact_string());
-    }
-
-    if let Some(namespace_name) = trimmed.strip_prefix("* as ").map(str::trim)
-        && is_identifier(namespace_name)
-    {
-        locals.push(namespace_name.to_compact_string());
-    }
-
-    if let Some(named_start) = trimmed.find('{')
-        && let Some(named_end) = trimmed[named_start + 1..].find('}')
-    {
-        let named = &trimmed[named_start + 1..named_start + 1 + named_end];
-        for part in named.split(',') {
-            let part = part.trim();
-            if part.starts_with("type ") {
-                continue;
-            }
-            let local = part
-                .rsplit_once(" as ")
-                .map(|(_, local)| local)
-                .unwrap_or(part);
-            if is_identifier(local.trim()) {
-                locals.push(local.trim().to_compact_string());
-            }
-        }
-    }
-
-    locals
-}
-
-fn is_identifier(value: &str) -> bool {
-    let mut chars = value.chars();
-    let Some(first) = chars.next() else {
-        return false;
+    let Some(specifiers) = import.specifiers.as_ref() else {
+        return Some(Vec::new());
     };
-    (first == '_' || first == '$' || first.is_ascii_alphabetic())
-        && chars.all(|char| char == '_' || char == '$' || char.is_ascii_alphanumeric())
+
+    let mut locals = Vec::new();
+    let mut saw_type_only_specifier = false;
+    for specifier in specifiers {
+        match specifier {
+            ImportDeclarationSpecifier::ImportSpecifier(specifier) => {
+                if specifier.import_kind.is_type() {
+                    saw_type_only_specifier = true;
+                } else {
+                    locals.push(specifier.local.name.as_str().to_compact_string());
+                }
+            }
+            ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => {
+                locals.push(specifier.local.name.as_str().to_compact_string());
+            }
+            ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => {
+                locals.push(specifier.local.name.as_str().to_compact_string());
+            }
+        }
+    }
+
+    if specifiers.is_empty() || !locals.is_empty() || !saw_type_only_specifier {
+        Some(locals)
+    } else {
+        None
+    }
+}
+
+fn source_type_for_path(path: &str) -> SourceType {
+    let path_without_query = path.split(['?', '#']).next().unwrap_or(path);
+    match path_without_query
+        .rsplit_once('.')
+        .map(|(_, extension)| extension)
+    {
+        Some("tsx" | "jsx") => SourceType::tsx().with_module(true),
+        Some("js" | "mjs" | "cjs") => SourceType::from_path("module.js")
+            .unwrap_or_else(|_| SourceType::default())
+            .with_module(true),
+        _ => SourceType::ts().with_module(true),
+    }
+}
+
+fn source_type_for_script_lang(lang: Option<&str>) -> SourceType {
+    match lang {
+        Some("tsx" | "jsx") => SourceType::tsx().with_module(true),
+        Some("js" | "mjs" | "cjs") => SourceType::from_path("module.js")
+            .unwrap_or_else(|_| SourceType::default())
+            .with_module(true),
+        _ => SourceType::ts().with_module(true),
+    }
 }

--- a/crates/vize_curator/src/inspector/tests.rs
+++ b/crates/vize_curator/src/inspector/tests.rs
@@ -53,7 +53,7 @@ fn builds_graph_edges_for_relative_imports() {
     let files = vec![
         InspectorSourceFile {
             path: cstr!("src/App.vue"),
-            source: cstr!("import Child from './Child.vue'\n"),
+            source: cstr!("<script setup>import Child from './Child.vue'</script>\n"),
         },
         InspectorSourceFile {
             path: cstr!("src/Child.vue"),
@@ -129,6 +129,63 @@ import RuntimeOnly from './RuntimeOnly.vue';
 }
 
 #[test]
+fn graph_uses_ast_for_imports_and_template_component_usage() {
+    let files = vec![
+        InspectorSourceFile {
+            path: cstr!("src/App.vue"),
+            source: cstr!(
+                r#"<script setup>
+// import Ghost from './Ghost.vue'
+const example = "import Phantom from './Phantom.vue'; <Hidden />";
+import RuntimeOnly from './RuntimeOnly.vue';
+import Hidden from './Hidden.vue';
+const Lazy = () => import('./Lazy.vue');
+</script>
+<template>
+  <RuntimeOnly />
+</template>"#
+            ),
+        },
+        InspectorSourceFile {
+            path: cstr!("src/RuntimeOnly.vue"),
+            source: cstr!("<template><span /></template>\n"),
+        },
+        InspectorSourceFile {
+            path: cstr!("src/Hidden.vue"),
+            source: cstr!("<template><span /></template>\n"),
+        },
+        InspectorSourceFile {
+            path: cstr!("src/Lazy.vue"),
+            source: cstr!("<template><span /></template>\n"),
+        },
+        InspectorSourceFile {
+            path: cstr!("src/Ghost.vue"),
+            source: cstr!("<template><span /></template>\n"),
+        },
+        InspectorSourceFile {
+            path: cstr!("src/Phantom.vue"),
+            source: cstr!("<template><span /></template>\n"),
+        },
+    ];
+
+    let graph = build_graph(&files);
+    let mut edges: Vec<_> = graph
+        .edges
+        .iter()
+        .map(|edge| (edge.kind, edge.to.as_str()))
+        .collect();
+    edges.sort_unstable();
+
+    assert!(edges.contains(&("component", "src/RuntimeOnly.vue")));
+    assert!(edges.contains(&("dynamic-import", "src/Lazy.vue")));
+    assert!(edges.contains(&("import", "src/Hidden.vue")));
+    assert!(edges.contains(&("import", "src/RuntimeOnly.vue")));
+    assert!(!edges.contains(&("component", "src/Hidden.vue")));
+    assert!(!edges.iter().any(|(_, to)| *to == "src/Ghost.vue"));
+    assert!(!edges.iter().any(|(_, to)| *to == "src/Phantom.vue"));
+}
+
+#[test]
 fn builds_line_diff_and_stats() {
     let diff = build_diff("one\ntwo\nthree", "one\nTWO\nthree\nfour");
 
@@ -179,7 +236,7 @@ fn builds_agent_report_with_payload_url_and_graph() {
     let files = vec![
         InspectorSourceFile {
             path: cstr!("src/App.vue"),
-            source: cstr!("import Child from './Child'\n"),
+            source: cstr!("<script setup>import Child from './Child'</script>\n"),
         },
         InspectorSourceFile {
             path: cstr!("src/Child.vue"),


### PR DESCRIPTION
## Summary
- replace inspector graph import scanning with OXC-backed script import extraction
- derive component edges from parsed SFC template identifiers instead of raw string tag scanning
- add regressions for comments, string literals, dynamic imports, and type-only component imports

## Verification
- cargo fmt
- cargo test -p vize_curator --no-fail-fast
- cargo test -p vize --test inspector_cli --no-fail-fast
- cargo clippy -p vize_curator -- -D warnings -D clippy::wildcard_imports
- cargo fmt --check
- git diff --check
- cargo check -p vize_vitrine --no-default-features --features wasm
- cargo check -p vize_vitrine --features napi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785900887&installation_id=136613492&pr_number=2628&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2628&signature=ab11bc82db3e4f91c9753ce991337e9ba107b27dd502726ce5231774daf0aee0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved file analysis for code and Vue components, including support for script blocks, template usage, and dynamic imports.
  * Graph relationships now reflect actual imports and component usage more accurately.

* **Bug Fixes**
  * Reduced false positives from commented, unused, and type-only imports.
  * Better handling of Vue single-file components when building dependency graphs.

* **Tests**
  * Added coverage for import detection and template-based graph edges.
  * Updated existing test inputs to match Vue component script structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->