### PR TITLE
fix(canon): infer dynamic component kebab events

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload.rs
@@ -155,6 +155,58 @@ function handleMathKey(key: string) {
 }
 
 #[test]
+fn batch_type_checker_infers_dynamic_component_kebab_listener_payload() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "dynamic-component-kebab-listener-payload",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts">
+defineEmits<{ escapeKeyDown: [event: KeyboardEvent] }>();
+</script>
+
+<template>
+  <button type="button" @keydown.escape="$emit('escapeKeyDown', $event)">
+    Close
+  </button>
+</template>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from "./Child.vue";
+
+function handleEscape(event: KeyboardEvent) {
+  event.preventDefault();
+}
+</script>
+
+<template>
+  <component :is="Child" @escape-key-down="handleEscape" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.is_empty(),
+        "dynamic component kebab-case listener should infer child emit payload, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn batch_type_checker_infers_event_name_from_define_emits_helper_argument() {
     if resolve_test_tsgo_binary().is_none() {
         return;

--- a/crates/vize_croquis/src/drawer/template/tests.rs
+++ b/crates/vize_croquis/src/drawer/template/tests.rs
@@ -144,6 +144,33 @@ fn component_usage_records_slots() {
 }
 
 #[test]
+fn dynamic_component_v_on_uses_is_binding_as_target_component() {
+    use crate::scope::ScopeData;
+    use vize_armature::parse;
+    use vize_carton::Bump;
+
+    let template = r#"<component :is="Child" @escape-key-down="handleEscape"></component>"#;
+
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, template);
+    assert!(errors.is_empty(), "Template should parse without errors");
+
+    let mut drawer = Drawer::with_options(DrawerOptions::full());
+    drawer.draw_template(&root);
+    let summary = drawer.finish();
+    let event = summary
+        .scopes
+        .iter()
+        .find_map(|scope| match scope.data() {
+            ScopeData::EventHandler(data) => Some(data),
+            _ => None,
+        })
+        .expect("dynamic component listener should create an event scope");
+
+    assert_eq!(event.target_component.as_deref(), Some("Child"));
+}
+
+#[test]
 fn nested_v_scope_shadows_outer() {
     use vize_armature::parse;
     use vize_carton::Bump;

--- a/crates/vize_croquis/src/drawer/template/visit_element/second_pass.rs
+++ b/crates/vize_croquis/src/drawer/template/visit_element/second_pass.rs
@@ -1,7 +1,11 @@
 use crate::croquis::{TemplateExpression, TemplateExpressionKind};
 use crate::drawer::Drawer;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Expression;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
 use vize_carton::{CompactString, profile};
-use vize_relief::{ElementNode, ExpressionNode, PropNode};
+use vize_relief::{DirectiveNode, ElementNode, ExpressionNode, PropNode};
 
 impl Drawer {
     pub(super) fn process_element_directives(
@@ -11,6 +15,7 @@ impl Drawer {
         is_component: bool,
         tag: &str,
     ) {
+        let event_target_component = event_target_component(el, is_component, tag);
         profile!("croquis.template.element.second_pass", {
             for prop in &el.props {
                 let PropNode::Directive(dir) = prop else {
@@ -38,10 +43,9 @@ impl Drawer {
                         TemplateExpressionKind::VModel,
                     );
                 } else if dir.name == "on" && self.options.analyze_template_scopes {
-                    let target_component = is_component.then(|| CompactString::new(tag));
                     profile!(
                         "croquis.template.directive.v_on",
-                        self.handle_v_on_directive(dir, scope_vars, target_component)
+                        self.handle_v_on_directive(dir, scope_vars, event_target_component.clone())
                     );
                 }
             }
@@ -95,6 +99,62 @@ impl Drawer {
             scope_id,
             vif_guard: self.current_vif_guard(),
         });
+    }
+}
+
+fn event_target_component(
+    el: &ElementNode<'_>,
+    is_component: bool,
+    tag: &str,
+) -> Option<CompactString> {
+    if is_component {
+        return Some(CompactString::new(tag));
+    }
+
+    dynamic_component_target(el, tag)
+}
+
+fn dynamic_component_target(el: &ElementNode<'_>, tag: &str) -> Option<CompactString> {
+    if tag != "component" {
+        return None;
+    }
+
+    el.props.iter().find_map(|prop| {
+        let PropNode::Directive(dir) = prop else {
+            return None;
+        };
+        if !is_bind_is_directive(dir) {
+            return None;
+        }
+        expression_identifier(dir.exp.as_ref()?)
+    })
+}
+
+fn is_bind_is_directive(dir: &DirectiveNode<'_>) -> bool {
+    dir.name == "bind"
+        && matches!(
+            dir.arg.as_ref(),
+            Some(ExpressionNode::Simple(arg)) if arg.content == "is"
+        )
+}
+
+fn expression_identifier(exp: &ExpressionNode<'_>) -> Option<CompactString> {
+    let source = match exp {
+        ExpressionNode::Simple(simple) => simple.content.as_str(),
+        ExpressionNode::Compound(compound) => compound.loc.source.as_str(),
+    };
+    parse_identifier_expression(source)
+}
+
+fn parse_identifier_expression(source: &str) -> Option<CompactString> {
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path("expr.ts").unwrap_or_default();
+    let expression = Parser::new(&allocator, source, source_type)
+        .parse_expression()
+        .ok()?;
+    match expression {
+        Expression::Identifier(identifier) => Some(CompactString::new(identifier.name.as_str())),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
## Summary
- Resolve `<component :is="Child">` event handlers against the bound component when `:is` is a single identifier parsed as an expression.
- Preserve the existing dynamic component prop and slot behavior.
- Add regressions for the kebab-case listener payload case from #2616.

Fixes #2616

## Validation
- `cargo test -p vize_croquis dynamic_component_v_on_uses_is_binding_as_target_component`
- `cargo test -p vize_canon generic_component_listener_payload`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`
- `cargo clippy -p vize_croquis -p vize_canon -- -D warnings`
- `vize check` on the #2616 CLI reproduction

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785905698&installation_id=136613492&pr_number=2630&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2630&signature=8cdab6deb7f16ac9926096007d78649f28dd5674a16f7601c1bb4941f9f3ba41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved event handling for dynamic components, including better support for listeners on components rendered through a dynamic component tag.

* **Bug Fixes**
  * Fixed event payload inference so kebab-cased listeners work correctly with dynamically selected components.
  * Improved component target detection for event listeners, reducing false type-checking errors in these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->