### PR TITLE
test(canon): clean up generic prop harness

### DIFF
--- a/crates/vize/tests/check_canon_generic_props_cli.rs
+++ b/crates/vize/tests/check_canon_generic_props_cli.rs
@@ -85,11 +85,19 @@ fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
     }
 }
 
-fn create_case_with_files(name: &str, files: &[(&str, &str)]) -> PathBuf {
+fn skip_case(name: &str, reason: impl std::fmt::Display) {
+    eprintln!("skipping {name}: {reason}");
+}
+
+fn create_case_with_files(name: &str, files: &[(&str, &str)]) -> Option<PathBuf> {
     let project_root = unique_case_dir(name);
     let _ = std::fs::remove_dir_all(&project_root);
     std::fs::create_dir_all(project_root.join("src")).unwrap();
-    link_workspace_vue(&project_root).unwrap();
+    if let Err(error) = link_workspace_vue(&project_root) {
+        skip_case(name, error);
+        let _ = std::fs::remove_dir_all(&project_root);
+        return None;
+    }
     std::fs::write(
         project_root.join("tsconfig.json"),
         r#"{"compilerOptions":{"strict":true,"target":"ES2022","module":"ESNext","moduleResolution":"bundler","jsx":"preserve","jsxImportSource":"vue","noEmit":true},"include":["src/**/*"]}"#,
@@ -102,7 +110,7 @@ fn create_case_with_files(name: &str, files: &[(&str, &str)]) -> PathBuf {
         }
         std::fs::write(target, source).unwrap();
     }
-    project_root
+    Some(project_root)
 }
 
 fn run_check_json(project_root: &Path, corsa_path: &Path) {
@@ -131,12 +139,24 @@ fn run_check_json(project_root: &Path, corsa_path: &Path) {
     assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
 }
 
-#[test]
-fn generic_model_array_normalization_accepts_empty_arrays() {
+fn run_generic_props_case(name: &str, files: &[(&str, &str)]) {
     let Some(corsa_path) = resolve_test_corsa_path() else {
+        skip_case(name, "tsgo not found");
         return;
     };
-    let project_root = create_case_with_files(
+
+    let Some(project_root) = create_case_with_files(name, files) else {
+        return;
+    };
+
+    run_check_json(&project_root, &corsa_path);
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn generic_model_array_normalization_accepts_empty_arrays() {
+    run_generic_props_case(
         "model-array-normalization",
         &[(
             "src/Foo.vue",
@@ -158,18 +178,11 @@ if (props.multiple && !Array.isArray(modelValue.value)) {
 "#,
         )],
     );
-
-    run_check_json(&project_root, &corsa_path);
-
-    let _ = std::fs::remove_dir_all(&project_root);
 }
 
 #[test]
 fn generic_model_sentinel_comparison_keeps_literal_member() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
-        return;
-    };
-    let project_root = create_case_with_files(
+    run_generic_props_case(
         "model-sentinel-comparison",
         &[(
             "src/Foo.vue",
@@ -188,18 +201,11 @@ const isSpecial = computed(() => modelValue.value === "special");
 "#,
         )],
     );
-
-    run_check_json(&project_root, &corsa_path);
-
-    let _ = std::fs::remove_dir_all(&project_root);
 }
 
 #[test]
 fn imported_generic_props_do_not_pollute_computed_values_with_boolean() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
-        return;
-    };
-    let project_root = create_case_with_files(
+    run_generic_props_case(
         "imported-props-computed-boolean-pollution",
         &[
             (
@@ -233,18 +239,11 @@ const entries = computed(() => {
             ),
         ],
     );
-
-    run_check_json(&project_root, &corsa_path);
-
-    let _ = std::fs::remove_dir_all(&project_root);
 }
 
 #[test]
 fn generic_function_prop_is_callable_after_typeof_guard() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
-        return;
-    };
-    let project_root = create_case_with_files(
+    run_generic_props_case(
         "function-prop-typeof-guard",
         &[(
             "src/Foo.vue",
@@ -270,8 +269,4 @@ if (typeof props.getChildren === "function") {
 "#,
         )],
     );
-
-    run_check_json(&project_root, &corsa_path);
-
-    let _ = std::fs::remove_dir_all(&project_root);
 }


### PR DESCRIPTION
## Summary
- make skipped generic prop CLI coverage visible when tsgo is unavailable
- skip consistently when the workspace Vue package cannot be linked
- extract the repeated setup/run/cleanup flow into a shared helper

## Verification
- cargo test -p vize --test check_canon_generic_props_cli
- cargo fmt --check
- git diff --check origin/main...HEAD
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785910997&installation_id=136613492&pr_number=2635&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2635&signature=ab7e88b0f202391377bbc84e5607b60612c5d2b9e179a82dfebc24f8fcd85504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of the CLI test suite by skipping cases cleanly when required tools or workspace links aren’t available.
  * Test projects are now cleaned up more consistently after each run, reducing leftover temporary files.
* **Tests**
  * Consolidated repeated test setup and execution steps for the generic props CLI checks, making the suite easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->