### PR TITLE
fix(canon): rewrite component-derived reserved props

### DIFF
--- a/crates/vize/tests/check_canon_component_derived_props_cli.rs
+++ b/crates/vize/tests/check_canon_component_derived_props_cli.rs
@@ -1,0 +1,203 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(
+            cstr!(
+                "check-canon-component-derived-{name}-{}",
+                std::process::id()
+            )
+            .as_str(),
+        )
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn workspace_vue_package() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.join("node_modules/vue"),
+        root.join("tests/node_modules/vue"),
+        root.join("playground/node_modules/vue"),
+        root.join("examples/vite-musea/node_modules/vue"),
+        root.join("examples/jsx-tsx/node_modules/vue"),
+        root.join("npm/framework/nuxt/node_modules/vue"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
+    if target.is_symlink() || target.is_file() {
+        std::fs::remove_file(target)?;
+    } else if target.exists() {
+        std::fs::remove_dir_all(target)?;
+    }
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(source, target)
+    }
+}
+
+fn link_workspace_vue(project_root: &Path) -> std::io::Result<()> {
+    let Some(vue_package) = workspace_vue_package() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace Vue package missing",
+        ));
+    };
+    let workspace_node_modules = vue_package.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace Vue package has no node_modules parent",
+        )
+    })?;
+    let target = project_root.join("node_modules");
+    std::fs::create_dir_all(&target)?;
+    symlink_path(&vue_package, &target.join("vue"))?;
+    let vue_namespace = workspace_node_modules.join("@vue");
+    if vue_namespace.exists() {
+        symlink_path(&vue_namespace, &target.join("@vue"))?;
+    }
+    Ok(())
+}
+
+fn write_tsconfig(project_root: &Path) {
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "noEmit": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.vue"]
+}"#,
+    )
+    .unwrap();
+}
+
+fn create_case(name: &str, files: &[(&str, &str)]) -> PathBuf {
+    let project_root = unique_case_dir(name);
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    link_workspace_vue(&project_root).unwrap();
+    write_tsconfig(&project_root);
+    for (path, source) in files {
+        std::fs::write(project_root.join("src").join(path), source).unwrap();
+    }
+    project_root
+}
+
+fn run_check_json(project_root: &Path, corsa_path: &Path) {
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "src",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        std::str::from_utf8(&output.stderr).unwrap_or("<non-utf8 stderr>")
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+}
+
+#[test]
+fn check_component_derived_reserved_prop_shorthand_in_template_scope() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_case(
+        "reserved-shorthand",
+        &[
+            (
+                "Base.vue",
+                r#"<script setup lang="ts">
+defineProps<{ as?: string }>()
+</script>
+
+<template>
+  <component :is="as ?? 'div'" />
+</template>
+"#,
+            ),
+            (
+                "Foo.vue",
+                r#"<script lang="ts">
+import type BaseComponent from "./Base.vue"
+
+type ComponentProps<T> = T extends new (...args: never[]) => {
+  $props: infer Props
+}
+  ? Props
+  : never
+
+export interface FooProps extends ComponentProps<typeof BaseComponent> {}
+</script>
+
+<script setup lang="ts">
+import Base from "./Base.vue"
+
+defineProps<FooProps>()
+</script>
+
+<template>
+  <Base :as />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    run_check_json(&project_root, &corsa_path);
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/virtual_ts/props/template_names.rs
+++ b/crates/vize_canon/src/virtual_ts/props/template_names.rs
@@ -33,6 +33,19 @@ pub(crate) fn collect_template_prop_names(summary: &Croquis) -> FxHashSet<String
         insert_reserved_prop_name(summary, &mut names, model.name.as_str());
     }
 
+    for usage in &summary.component_usages {
+        for prop in &usage.props {
+            if prop.is_dynamic
+                && prop
+                    .value
+                    .as_ref()
+                    .is_some_and(|value| value.as_str() == prop.name.as_str())
+            {
+                insert_reserved_prop_name(summary, &mut names, prop.name.as_str());
+            }
+        }
+    }
+
     names
 }
 


### PR DESCRIPTION
## Summary
- Treat same-name dynamic component props such as `:as` as reserved template prop references when collecting template prop names.
- This lets component-derived props from `defineProps<FooProps>()` be rewritten to `props["as"]` instead of emitting invalid `as` expressions.
- Add an end-to-end CLI regression covering component-derived `$props` through `ComponentProps<typeof BaseComponent>`.

Fixes #2619

## Tests
- `cargo fmt --check`
- `cargo test -p vize_canon`
- `cargo test -p vize --test check_canon_component_derived_props_cli`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785913078&installation_id=136613492&pr_number=2637&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2637&signature=a717d5e6b31163166011cc541284f0587dd53aeb079c808d56b6d7c0c4a0b11b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of reserved prop shorthand in Vue templates, reducing false-positive errors in valid component usage.

* **Tests**
  * Added end-to-end coverage for the CLI to verify a real-world template case completes with zero errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->