### PR TITLE
fix(vite): preserve component override resolution

### DIFF
--- a/npm/builder/vite/src/plugin/resolve-relative-vue.test.ts
+++ b/npm/builder/vite/src/plugin/resolve-relative-vue.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { VizePluginState } from "./state.ts";
+import { resolveIdHook } from "./resolve.ts";
+import { toPluginVisibleVirtualId } from "../virtual.ts";
+
+const testRoot = fs.mkdtempSync(
+  path.join(fs.realpathSync(os.tmpdir()), "vize-vite-plugin-relative-vue-"),
+);
+
+function writeFixtureFile(filePath: string, content = ""): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function createState(root: string): VizePluginState {
+  return {
+    cache: new Map(),
+    ssrCache: new Map(),
+    collectedCss: new Map(),
+    precompileMetadata: new Map(),
+    pendingHmrUpdateTypes: new Map(),
+    isProduction: false,
+    root,
+    clientViteBase: "/",
+    serverViteBase: "/",
+    server: null,
+    filter: () => true,
+    scanPatterns: ["**/*.vue"],
+    precompileBatchSize: 128,
+    ignorePatterns: [],
+    mergedOptions: {},
+    initialized: true,
+    dynamicImportAliasRules: [],
+    cssAliasRules: [],
+    extractCss: false,
+    componentsCssFileName: "assets/vize-components.css",
+    clientViteDefine: {},
+    serverViteDefine: {},
+    logger: {
+      log() {},
+      info() {},
+      warn() {},
+      error() {},
+    } as never,
+  };
+}
+
+function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): string {
+  assert.notEqual(resolved, null);
+  assert.notEqual(resolved, undefined);
+  return typeof resolved === "string" ? resolved : resolved.id;
+}
+
+{
+  const projectRoot = fs.mkdtempSync(path.join(testRoot, "nuxt-ui-override-"));
+  const runtimeDir = path.join(projectRoot, "node_modules", "@nuxt", "ui", "dist", "runtime");
+  const source = path.join(runtimeDir, "components", "Button.vue");
+  const override = path.join(runtimeDir, "vue", "components", "Icon.vue");
+  writeFixtureFile(source, '<script setup>import UIcon from "./Icon.vue"</script>');
+  writeFixtureFile(override, "<template><span /></template>");
+
+  let resolverImporter: string | undefined;
+  const resolved = await resolveIdHook(
+    {
+      resolve: async (id, importer) => {
+        resolverImporter = importer;
+        return id === "./Icon.vue" && importer === source ? { id: override } : null;
+      },
+    },
+    createState(projectRoot),
+    "./Icon.vue",
+    toPluginVisibleVirtualId(source),
+    undefined,
+  );
+
+  assert.equal(
+    resolverImporter,
+    source,
+    "Relative Vue imports from virtual modules should reach Vite resolvers with the real importer path",
+  );
+  assert.equal(
+    expectResolvedId(resolved),
+    toPluginVisibleVirtualId(override),
+    "Relative Vue imports from virtual modules should preserve upstream component override resolvers",
+  );
+}
+
+console.log("vite-plugin-vize relative Vue resolve tests passed!");

--- a/npm/builder/vite/src/plugin/resolve-relative-vue.ts
+++ b/npm/builder/vite/src/plugin/resolve-relative-vue.ts
@@ -1,0 +1,73 @@
+import { classifyVitePluginRequest, splitViteIdQuery } from "@vizejs/native";
+
+import type { VizePluginState } from "./state.ts";
+import { toPluginVisibleVirtualId, toVirtualId } from "../virtual.ts";
+
+type ViteResolveResult = { id: string; external?: boolean } | null;
+
+interface ResolveContext {
+  environment?: { name?: string };
+  resolve(
+    id: string,
+    importer?: string,
+    options?: { skipSelf: boolean },
+  ): Promise<ViteResolveResult>;
+}
+
+type ResolveWithVite = (
+  ctx: ResolveContext,
+  state: VizePluginState,
+  id: string,
+  importer?: string,
+  options?: { skipSelf: boolean },
+) => Promise<ViteResolveResult>;
+
+export function cleanVueSfcImporter(
+  importer: string,
+  request: ReturnType<typeof classifyVitePluginRequest> | null,
+): string {
+  let cleanImporter = request?.normalizedFsId ?? request?.normalizedVuePath ?? importer;
+
+  if (cleanImporter.startsWith("/@id/__x00__")) {
+    cleanImporter = cleanImporter.slice("/@id/__x00__".length);
+  } else if (cleanImporter.startsWith("__x00__")) {
+    cleanImporter = cleanImporter.slice("__x00__".length);
+  }
+
+  return classifyVitePluginRequest(cleanImporter).normalizedVuePath;
+}
+
+export async function resolveRelativeVueSfcImport(
+  ctx: ResolveContext,
+  state: VizePluginState,
+  id: string,
+  cleanImporter: string,
+  isSsrRequest: boolean,
+  isDependencyScan: boolean,
+  resolveWithVite: ResolveWithVite,
+): Promise<string | { id: string; external?: boolean } | null> {
+  if (!id.startsWith("./") && !id.startsWith("../")) {
+    return null;
+  }
+
+  const { request, querySuffix } = splitViteIdQuery(id);
+  if (!request.endsWith(".vue")) {
+    return null;
+  }
+
+  const resolved = await resolveWithVite(ctx, state, id, cleanImporter, { skipSelf: true });
+  if (!resolved) {
+    return null;
+  }
+
+  const resolvedRequest = classifyVitePluginRequest(resolved.id);
+  const resolvedPath = resolvedRequest.normalizedFsId ?? resolvedRequest.normalizedVuePath;
+  if (!resolvedPath || !resolvedPath.endsWith(".vue")) {
+    return resolved;
+  }
+
+  const effectiveQuery = resolvedRequest.querySuffix || querySuffix;
+  return isDependencyScan
+    ? toVirtualId(resolvedPath, isSsrRequest)
+    : toPluginVisibleVirtualId(resolvedPath, isSsrRequest, effectiveQuery);
+}

--- a/npm/builder/vite/src/plugin/resolve.ts
+++ b/npm/builder/vite/src/plugin/resolve.ts
@@ -16,6 +16,7 @@ import {
 
 import type { VizePluginState } from "./state.ts";
 import { isInsidePath, isProjectSourceImporter, normalizeImporterFilePath } from "./importer.ts";
+import { cleanVueSfcImporter, resolveRelativeVueSfcImport } from "./resolve-relative-vue.ts";
 import {
   LEGACY_VIZE_PREFIX,
   VIRTUAL_CSS_MODULE,
@@ -739,21 +740,6 @@ function hasNuxtComponentQuery(request: ReturnType<typeof classifyVitePluginRequ
   return new URLSearchParams(request.querySuffix.slice(1)).has("nuxt_component");
 }
 
-function cleanVueSfcImporter(
-  importer: string,
-  request: ReturnType<typeof classifyVitePluginRequest> | null,
-): string {
-  let cleanImporter = request?.normalizedFsId ?? request?.normalizedVuePath ?? importer;
-
-  if (cleanImporter.startsWith("/@id/__x00__")) {
-    cleanImporter = cleanImporter.slice("/@id/__x00__".length);
-  } else if (cleanImporter.startsWith("__x00__")) {
-    cleanImporter = cleanImporter.slice("__x00__".length);
-  }
-
-  return classifyVitePluginRequest(cleanImporter).normalizedVuePath;
-}
-
 async function resolveAliasedVueImport(
   ctx: ResolveContext,
   state: VizePluginState,
@@ -945,6 +931,19 @@ export async function resolveIdHook(
         : cleanVueSfcImporter(importer, importerRequest);
 
     state.logger.log(`resolveId from virtual: id=${id}, cleanImporter=${cleanImporter}`);
+
+    const relativeVueResolved = await resolveRelativeVueSfcImport(
+      ctx,
+      state,
+      id,
+      cleanImporter,
+      isSsrRequest,
+      isDependencyScan,
+      resolveWithVite,
+    );
+    if (relativeVueResolved) {
+      return relativeVueResolved;
+    }
 
     // Subpath imports (e.g., #imports/entry from Nuxt)
     if (id.startsWith("#")) {

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -18,6 +18,7 @@ import "./plugin/quasar.test.ts";
 import "./plugin/resolve-peer-runtime.test.ts";
 import "./plugin/resolve-vue-runtime.test.ts";
 import "./plugin/resolve-dependency-style.test.ts";
+import "./plugin/resolve-relative-vue.test.ts";
 import "./plugin/resolve.test.ts";
 import "./plugin/precompile.test.ts";
 import "./plugin/state.test.ts";


### PR DESCRIPTION
## Summary
- delegate relative Vue imports from virtual SFC modules through Vite before falling back to direct resolution
- preserve upstream component override resolvers such as Nuxt UI's Vue-compatible Icon override
- add a focused resolver regression test

Fixes #2631

## Verification
- node npm/builder/vite/src/test.ts
- CI=true corepack pnpm --dir npm/builder/vite check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check
- CI=true corepack pnpm --dir npm/builder/vite build
- pnpm --dir /tmp/vize-nuxtui-repro-2631 run build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785914429&installation_id=136613492&pr_number=2638&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2638&signature=5d5e8d4468ab04f1c1dedba88a35ab50a5f41b64f4f32aa6de88f8da933f3570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of relative Vue component imports so they resolve more reliably in virtual module scenarios.
  * Added coverage for this import behavior to help prevent regressions.

* **Bug Fixes**
  * Relative `.vue` imports now preserve the correct originating file during resolution, helping imports point to the expected component in more cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->