### PR TITLE
fix(canon): allow remapped key indexed assignments

### DIFF
--- a/crates/vize/tests/check_canon_remapped_key_cli.rs
+++ b/crates/vize/tests/check_canon_remapped_key_cli.rs
@@ -1,0 +1,106 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("check-canon-remapped-key-{name}-{}", std::process::id()).as_str())
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+#[test]
+fn check_remapped_key_indexed_assignment_matches_typescript() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("indexed-assignment");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/foo.ts"),
+        r#"type WithOptionalBooleans<T> = {
+  [K in keyof T as [T[K]] extends [boolean] ? K : never]?: T[K];
+} & {
+  [K in keyof T as [T[K]] extends [boolean] ? never : K]: T[K];
+};
+
+export function pickDefinedProps<T extends Record<string, unknown>>(
+  source: T,
+  key: string
+): WithOptionalBooleans<T> {
+  const result = {} as WithOptionalBooleans<T>;
+  const value = source[
+    key
+  ] as WithOptionalBooleans<T>[keyof WithOptionalBooleans<T>];
+
+  result[key as keyof WithOptionalBooleans<T>] = value;
+
+  return result;
+}
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "src",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "check failed\nstdout:\n{}\nstderr:\n{}",
+        std::str::from_utf8(&output.stdout).unwrap_or("<non-utf8 stdout>"),
+        std::str::from_utf8(&output.stderr).unwrap_or("<non-utf8 stderr>")
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -562,20 +562,20 @@ fn parse_cli_diagnostic_line(
     }
 
     let virtual_path = normalize_cli_path(path, project.virtual_root());
+    if code == Some(2322) && mapper.is_keyof_indexed_assignment(&virtual_path, line, column) {
+        return None;
+    }
     if let Some(diagnostic) =
         project_diagnostics::config(&virtual_path, project, message, code, severity)
     {
         return Some(diagnostic);
     }
-
     let original = mapper.map_to_original(&virtual_path, line, column)?;
     if should_skip_original_diagnostic(code, &original) {
         return None;
     }
 
-    // Suppress the false `TS2307` raised for a relative import of a sibling that
-    // exists on disk but sits outside an explicit file subset. See the matching
-    // check in `diagnostics::map_lsp_diagnostic`.
+    // Suppress false `TS2307` for existing siblings outside an explicit subset.
     if code == Some(2307) && relative_module_resolves_on_disk(message, &original.path) {
         return None;
     }

--- a/crates/vize_canon/src/batch/executor/diagnostics.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics.rs
@@ -7,8 +7,11 @@ use crate::corsa_client::LspDiagnostic;
 use crate::file_uri::file_uri_to_path;
 use vize_carton::{FxHashMap, FxHashSet, String};
 
+mod keyof_indexed_assignment;
+mod line_index;
 mod module_resolution;
 
+use line_index::LineIndex;
 pub(super) use module_resolution::relative_module_resolves_on_disk;
 
 pub(super) fn map_batch_diagnostics(
@@ -102,6 +105,15 @@ impl<'a> DiagnosticMapper<'a> {
         if code == Some(6133) && !self.preserve_unused_diagnostics {
             return None;
         }
+        if code == Some(2322)
+            && self.is_keyof_indexed_assignment(
+                virtual_path,
+                diagnostic.range.start.line,
+                diagnostic.range.start.character,
+            )
+        {
+            return None;
+        }
 
         let original = self.map_to_original(
             virtual_path,
@@ -191,93 +203,26 @@ impl<'a> DiagnosticMapper<'a> {
 
         self.original_sources.get(path)
     }
+
+    pub(super) fn is_keyof_indexed_assignment(
+        &mut self,
+        virtual_path: &Path,
+        line: u32,
+        column: u32,
+    ) -> bool {
+        let Some(file) = self.project.find_by_virtual(virtual_path) else {
+            return false;
+        };
+        let Some(offset) = self.virtual_offset(file, line, column) else {
+            return false;
+        };
+        keyof_indexed_assignment::matches_at(&file.content, &file.virtual_path, offset)
+    }
 }
 
 struct CachedSource {
     content: String,
     line_index: LineIndex,
-}
-
-struct LineIndex {
-    starts: Vec<usize>,
-    len: usize,
-}
-
-impl LineIndex {
-    fn new(content: &str) -> Self {
-        let mut starts = vec![0];
-        for (index, byte) in content.bytes().enumerate() {
-            if byte == b'\n' {
-                starts.push(index + 1);
-            }
-        }
-
-        Self {
-            starts,
-            len: content.len(),
-        }
-    }
-
-    /// Convert an LSP (line, character) — where character is in UTF-16 code
-    /// units — back to a byte offset into `content`. (#965)
-    fn line_col_to_offset(&self, content: &str, line: u32, col: u32) -> Option<u32> {
-        let line = usize::try_from(line).ok()?;
-        let start = *self.starts.get(line)?;
-        let end = self.line_end(line);
-        let mut current_col = 0u32;
-        let mut offset = start;
-
-        if col == 0 {
-            return u32::try_from(offset).ok();
-        }
-
-        for ch in content[start..end].chars() {
-            offset += ch.len_utf8();
-            current_col += ch.len_utf16() as u32;
-            if current_col >= col {
-                return u32::try_from(offset).ok();
-            }
-        }
-
-        if current_col == col {
-            u32::try_from(offset).ok()
-        } else {
-            None
-        }
-    }
-
-    /// Convert a byte offset to LSP (line, character). `character` is in
-    /// UTF-16 code units — astral characters (`len_utf16() == 2`) count as
-    /// two so the column matches what `vue-tsc` / `@vue/language-tools`
-    /// report. (#965)
-    fn offset_to_line_col(&self, content: &str, offset: u32) -> Option<(u32, u32)> {
-        let offset = usize::try_from(offset).ok()?;
-        if offset > self.len {
-            return None;
-        }
-
-        let line = self.starts.partition_point(|start| *start <= offset);
-        let line = line.saturating_sub(1);
-        let start = *self.starts.get(line)?;
-        let end = self.line_end(line);
-        let mut col = 0u32;
-        let mut cursor = start;
-        for ch in content[start..end].chars() {
-            if cursor >= offset {
-                break;
-            }
-            col += ch.len_utf16() as u32;
-            cursor += ch.len_utf8();
-        }
-        Some((u32::try_from(line).ok()?, col))
-    }
-
-    fn line_end(&self, line: usize) -> usize {
-        self.starts
-            .get(line + 1)
-            .map(|next_start| next_start.saturating_sub(1))
-            .unwrap_or(self.len)
-    }
 }
 
 fn uri_to_path(uri: &str) -> PathBuf {
@@ -497,39 +442,6 @@ mod tests {
             uri_to_path("file:///workspace/pages/%5Bname%5D%20%231.vue.ts"),
             PathBuf::from("/workspace/pages/[name] #1.vue.ts")
         );
-    }
-
-    #[test]
-    fn line_index_matches_source_map_boundaries() {
-        let content = "a\nbeta\n";
-        let index = LineIndex::new(content);
-
-        assert_eq!(index.line_col_to_offset(content, 0, 1), Some(1));
-        assert_eq!(index.line_col_to_offset(content, 1, 4), Some(6));
-        assert_eq!(index.line_col_to_offset(content, 2, 0), Some(7));
-        assert_eq!(index.line_col_to_offset(content, 1, 5), None);
-        assert_eq!(index.offset_to_line_col(content, 7), Some((2, 0)));
-
-        let content = "é\n";
-        let index = LineIndex::new(content);
-        assert_eq!(index.offset_to_line_col(content, 1), Some((0, 1)));
-    }
-
-    #[test]
-    fn line_index_counts_astral_chars_as_two_utf16_units() {
-        // Regression for #965: LSP `Position.character` is in UTF-16 code
-        // units. An emoji (`U+1F600`) is one Unicode scalar but TWO UTF-16
-        // units (encoded as a surrogate pair) — `vue-tsc` /
-        // `@vue/language-tools` report the post-emoji column as `+2`, so
-        // vize must too.
-        let content = "\u{1F600}x\n";
-        let index = LineIndex::new(content);
-
-        // Byte offset 4 is right after the emoji + `x`. The emoji is 4
-        // UTF-8 bytes and counts as 2 UTF-16 units; `x` is 1 of each.
-        assert_eq!(index.offset_to_line_col(content, 5), Some((0, 3)));
-        // The reverse direction must round-trip.
-        assert_eq!(index.line_col_to_offset(content, 0, 3), Some(5));
     }
 
     #[test]

--- a/crates/vize_canon/src/batch/executor/diagnostics/keyof_indexed_assignment.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics/keyof_indexed_assignment.rs
@@ -1,0 +1,225 @@
+use std::path::Path;
+
+use oxc_ast::ast::{
+    AssignmentExpression, AssignmentTarget, BindingPattern, Expression, TSIndexedAccessType,
+    TSType, TSTypeOperatorOperator, VariableDeclarator,
+};
+use oxc_ast_visit::{
+    Visit,
+    walk::{walk_assignment_expression, walk_variable_declarator},
+};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType, Span};
+use vize_carton::{FxHashMap, String};
+
+pub(super) fn matches_at(source: &str, path: &Path, offset: u32) -> bool {
+    let allocator = oxc_allocator::Allocator::default();
+    let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::ts());
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+    if !parsed.errors.is_empty() {
+        return false;
+    }
+
+    let mut visitor = Visitor {
+        source,
+        offset,
+        value_casts: FxHashMap::default(),
+        found: false,
+    };
+    visitor.visit_program(&parsed.program);
+    visitor.found
+}
+
+struct Visitor<'source> {
+    source: &'source str,
+    offset: u32,
+    value_casts: FxHashMap<String, Span>,
+    found: bool,
+}
+
+impl<'a> Visit<'a> for Visitor<'_> {
+    fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'a>) {
+        if let BindingPattern::BindingIdentifier(id) = &declarator.id
+            && let Some(init) = &declarator.init
+            && let Some(object) = keyof_indexed_object_from_cast(init, self.source)
+        {
+            self.value_casts
+                .insert(String::from(id.name.as_str()), object);
+        }
+        walk_variable_declarator(self, declarator);
+    }
+
+    fn visit_assignment_expression(&mut self, assignment: &AssignmentExpression<'a>) {
+        if self.found {
+            return;
+        }
+        if span_contains(assignment.span, self.offset)
+            && assignment.operator.is_assign()
+            && is_explicit_keyof_indexed_assignment(assignment, self.source, &self.value_casts)
+        {
+            self.found = true;
+            return;
+        }
+        walk_assignment_expression(self, assignment);
+    }
+}
+
+fn is_explicit_keyof_indexed_assignment(
+    assignment: &AssignmentExpression<'_>,
+    source: &str,
+    value_casts: &FxHashMap<String, Span>,
+) -> bool {
+    let AssignmentTarget::ComputedMemberExpression(member) = &assignment.left else {
+        return false;
+    };
+    let Some(target_keyof_object) = keyof_operand_from_cast(&member.expression) else {
+        return false;
+    };
+    let Some(value_indexed_object) =
+        indexed_assignment_value_object(&assignment.right, source, value_casts)
+    else {
+        return false;
+    };
+    same_type_text(source, target_keyof_object, value_indexed_object)
+}
+
+fn indexed_assignment_value_object(
+    expression: &Expression<'_>,
+    source: &str,
+    value_casts: &FxHashMap<String, Span>,
+) -> Option<Span> {
+    if let Some(object) = keyof_indexed_object_from_cast(expression, source) {
+        return Some(object);
+    }
+    let Expression::Identifier(identifier) = peel_expression(expression) else {
+        return None;
+    };
+    value_casts.get(identifier.name.as_str()).copied()
+}
+
+fn keyof_operand_from_cast(expression: &Expression<'_>) -> Option<Span> {
+    let Expression::TSAsExpression(ts_as) = peel_expression(expression) else {
+        return None;
+    };
+    keyof_operand(&ts_as.type_annotation)
+}
+
+fn keyof_indexed_object_from_cast(expression: &Expression<'_>, source: &str) -> Option<Span> {
+    let Expression::TSAsExpression(ts_as) = peel_expression(expression) else {
+        return None;
+    };
+    let TSType::TSIndexedAccessType(indexed) = peel_type(&ts_as.type_annotation) else {
+        return None;
+    };
+    keyof_indexed_object(indexed, source)
+}
+
+fn keyof_indexed_object(indexed: &TSIndexedAccessType<'_>, source: &str) -> Option<Span> {
+    let object = peel_type(&indexed.object_type);
+    let keyof = keyof_operand(&indexed.index_type)?;
+    let object = object_span(object);
+    same_type_text(source, object, keyof).then_some(object)
+}
+
+fn keyof_operand(ty: &TSType<'_>) -> Option<Span> {
+    let TSType::TSTypeOperatorType(operator) = peel_type(ty) else {
+        return None;
+    };
+    (operator.operator == TSTypeOperatorOperator::Keyof)
+        .then(|| object_span(peel_type(&operator.type_annotation)))
+}
+
+fn object_span(ty: &TSType<'_>) -> Span {
+    match ty {
+        TSType::TSParenthesizedType(parenthesized) => {
+            object_span(peel_type(&parenthesized.type_annotation))
+        }
+        _ => ty.span(),
+    }
+}
+
+fn peel_expression<'expr, 'ast>(expression: &'expr Expression<'ast>) -> &'expr Expression<'ast> {
+    match expression {
+        Expression::ParenthesizedExpression(parenthesized) => {
+            peel_expression(&parenthesized.expression)
+        }
+        _ => expression,
+    }
+}
+
+fn peel_type<'ty, 'ast>(ty: &'ty TSType<'ast>) -> &'ty TSType<'ast> {
+    match ty {
+        TSType::TSParenthesizedType(parenthesized) => peel_type(&parenthesized.type_annotation),
+        _ => ty,
+    }
+}
+
+fn same_type_text(source: &str, left: Span, right: Span) -> bool {
+    span_text(source, left).is_some_and(|left| {
+        span_text(source, right).is_some_and(|right| left.trim() == right.trim())
+    })
+}
+
+fn span_text(source: &str, span: Span) -> Option<&str> {
+    source.get(span.start as usize..span.end as usize)
+}
+
+fn span_contains(span: Span, offset: u32) -> bool {
+    span.start <= offset && offset < span.end
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::matches_at;
+
+    #[test]
+    fn detects_false_positive_shape() {
+        let source = r#"type WithOptionalBooleans<T> = {
+  [K in keyof T as [T[K]] extends [boolean] ? K : never]?: T[K];
+} & {
+  [K in keyof T as [T[K]] extends [boolean] ? never : K]: T[K];
+};
+
+export function pickDefinedProps<T extends Record<string, unknown>>(
+  source: T,
+  key: string
+): WithOptionalBooleans<T> {
+  const result = {} as WithOptionalBooleans<T>;
+  const value = source[
+    key
+  ] as WithOptionalBooleans<T>[keyof WithOptionalBooleans<T>];
+
+  result[key as keyof WithOptionalBooleans<T>] = value;
+
+  return result;
+}
+"#;
+        let offset = source.find("result[key").unwrap() as u32;
+
+        assert!(matches_at(
+            source,
+            PathBuf::from("foo.ts").as_path(),
+            offset
+        ));
+    }
+
+    #[test]
+    fn requires_matching_types() {
+        let source = r#"type A = { one: string };
+type B = { two: number };
+declare const target: A;
+declare const key: string;
+declare const value: B[keyof B];
+target[key as keyof A] = value as B[keyof B];
+"#;
+        let offset = source.find("target[key").unwrap() as u32;
+
+        assert!(!matches_at(
+            source,
+            PathBuf::from("foo.ts").as_path(),
+            offset
+        ));
+    }
+}

--- a/crates/vize_canon/src/batch/executor/diagnostics/line_index.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics/line_index.rs
@@ -1,0 +1,111 @@
+pub(super) struct LineIndex {
+    starts: Vec<usize>,
+    len: usize,
+}
+
+impl LineIndex {
+    pub(super) fn new(content: &str) -> Self {
+        let mut starts = vec![0];
+        for (index, byte) in content.bytes().enumerate() {
+            if byte == b'\n' {
+                starts.push(index + 1);
+            }
+        }
+
+        Self {
+            starts,
+            len: content.len(),
+        }
+    }
+
+    /// Convert an LSP (line, character) — where character is in UTF-16 code
+    /// units — back to a byte offset into `content`. (#965)
+    pub(super) fn line_col_to_offset(&self, content: &str, line: u32, col: u32) -> Option<u32> {
+        let line = usize::try_from(line).ok()?;
+        let start = *self.starts.get(line)?;
+        let end = self.line_end(line);
+        let mut current_col = 0u32;
+        let mut offset = start;
+
+        if col == 0 {
+            return u32::try_from(offset).ok();
+        }
+
+        for ch in content[start..end].chars() {
+            offset += ch.len_utf8();
+            current_col += ch.len_utf16() as u32;
+            if current_col >= col {
+                return u32::try_from(offset).ok();
+            }
+        }
+
+        if current_col == col {
+            u32::try_from(offset).ok()
+        } else {
+            None
+        }
+    }
+
+    /// Convert a byte offset to LSP (line, character). `character` is in
+    /// UTF-16 code units — astral characters (`len_utf16() == 2`) count as
+    /// two so the column matches what `vue-tsc` / `@vue/language-tools`
+    /// report. (#965)
+    pub(super) fn offset_to_line_col(&self, content: &str, offset: u32) -> Option<(u32, u32)> {
+        let offset = usize::try_from(offset).ok()?;
+        if offset > self.len {
+            return None;
+        }
+
+        let line = self.starts.partition_point(|start| *start <= offset);
+        let line = line.saturating_sub(1);
+        let start = *self.starts.get(line)?;
+        let end = self.line_end(line);
+        let mut col = 0u32;
+        let mut cursor = start;
+        for ch in content[start..end].chars() {
+            if cursor >= offset {
+                break;
+            }
+            col += ch.len_utf16() as u32;
+            cursor += ch.len_utf8();
+        }
+        Some((u32::try_from(line).ok()?, col))
+    }
+
+    fn line_end(&self, line: usize) -> usize {
+        self.starts
+            .get(line + 1)
+            .map(|next_start| next_start.saturating_sub(1))
+            .unwrap_or(self.len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LineIndex;
+
+    #[test]
+    fn matches_source_map_boundaries() {
+        let content = "a\nbeta\n";
+        let index = LineIndex::new(content);
+
+        assert_eq!(index.line_col_to_offset(content, 0, 1), Some(1));
+        assert_eq!(index.line_col_to_offset(content, 1, 4), Some(6));
+        assert_eq!(index.line_col_to_offset(content, 2, 0), Some(7));
+        assert_eq!(index.line_col_to_offset(content, 1, 5), None);
+        assert_eq!(index.offset_to_line_col(content, 7), Some((2, 0)));
+
+        let content = "é\n";
+        let index = LineIndex::new(content);
+        assert_eq!(index.offset_to_line_col(content, 1), Some((0, 1)));
+    }
+
+    #[test]
+    fn counts_astral_chars_as_two_utf16_units() {
+        let content = "\u{1F600}x\n";
+        let index = LineIndex::new(content);
+
+        assert_eq!(index.offset_to_line_col(content, 5), Some((0, 3)));
+        assert_eq!(index.line_col_to_offset(content, 0, 3), Some(5));
+    }
+}


### PR DESCRIPTION
## Summary
- suppress Corsa TS2322 false positives for explicit keyof indexed assignments using OXC AST shape checks
- share the suppression across CLI and project-session diagnostic mapping
- add a CLI regression for remapped-key indexed assignment parity

Fixes #2623

## Verification
- cargo fmt --check
- git diff --check
- cargo test -p vize_canon batch::executor::diagnostics
- cargo test -p vize_canon keyof_indexed_assignment
- cargo test -p vize_canon line_index
- cargo test -p vize --test check_canon_remapped_key_cli
- cargo test -p vize --test check_canon_recent_type_regressions_cli
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785915931&installation_id=136613492&pr_number=2639&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2639&signature=2981fc5b6a187f440abd74b2ca253c36ac12da05d165380d71d917160434936d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false-positive type errors during checks, including a specific `TS2322` case involving `keyof`-based indexed assignments.
  * Improved diagnostic location handling so results are more accurate across source positions and Unicode text.
  * Added broader CLI coverage to help ensure checks run successfully on temporary projects and clean up afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->