### PR TITLE
fix(release): stabilize Open VSX publishing

### DIFF
--- a/tests/tooling/moonbit-publish-open-vsx.test.ts
+++ b/tests/tooling/moonbit-publish-open-vsx.test.ts
@@ -44,6 +44,9 @@ test("publish_open_vsx_extension publishes a packaged VSIX with ovsx", () => {
         "  }",
         "  process.exit(1);",
         "}",
+        "if (args[0] === 'dlx' && args[2] === 'ovsx@^1.0.0' && args[3] === 'ovsx' && args[4] === 'create-namespace') {",
+        "  process.exit(0);",
+        "}",
         "if (args[0] === 'dlx' && args[2] === 'ovsx@^1.0.0' && args[3] === 'ovsx' && args[4] === 'publish') {",
         "  state.published = true;",
         "  fs.writeFileSync(process.env.STATE_PATH, JSON.stringify(state));",
@@ -63,6 +66,14 @@ test("publish_open_vsx_extension publishes a packaged VSIX with ovsx", () => {
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
 
     const calls = JSON.parse(fs.readFileSync(callsPath, "utf8")) as string[][];
+    assert.deepEqual(calls.at(-2), [
+      "dlx",
+      "-p",
+      "ovsx@^1.0.0",
+      "ovsx",
+      "create-namespace",
+      "ubugeeei",
+    ]);
     assert.deepEqual(calls.at(-1), ["dlx", "-p", "ovsx@^1.0.0", "ovsx", "publish", vsixPath]);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });

--- a/tools/moon/scripts/publish_open_vsx_extension.mbtx
+++ b/tools/moon/scripts/publish_open_vsx_extension.mbtx
@@ -20,6 +20,7 @@ import {
 ///|
 struct ExtensionInfo {
   extension_id : String
+  publisher : String
   version : String
 }
 
@@ -80,7 +81,7 @@ fn extension_info_from_package_json(value : Json) -> ExtensionInfo? {
   guard obj.get("name") is Some(String(name)) else { return None }
   guard obj.get("version") is Some(String(version)) else { return None }
   guard publisher != "" && name != "" && version != "" else { return None }
-  Some(ExtensionInfo::{ extension_id: publisher + "." + name, version })
+  Some(ExtensionInfo::{ extension_id: publisher + "." + name, publisher, version })
 }
 
 ///|
@@ -157,6 +158,17 @@ async fn wait_for_extension_visibility(
 }
 
 ///|
+async fn ensure_namespace(vp_bin : String, publisher : String) -> Unit {
+  let exit_code = @process.run(
+    vp_bin,
+    ["dlx", "-p", "ovsx@^1.0.0", "ovsx", "create-namespace", publisher],
+  )
+  if exit_code != 0 {
+    println("Open VSX namespace \{publisher} may already exist; continuing to publish.")
+  }
+}
+
+///|
 async fn run_app() -> Int {
   let args = cli_args()
   if args.is_empty() || args.length() > 2 {
@@ -200,6 +212,7 @@ async fn run_app() -> Int {
     )
     return 0
   }
+  ensure_namespace(vp_bin, extension_info.publisher)
 
   let exit_code = @process.run(
     vp_bin,

--- a/tools/vscode-vize/assert-vsix-package.mjs
+++ b/tools/vscode-vize/assert-vsix-package.mjs
@@ -7,10 +7,8 @@ import { fileURLToPath } from "node:url";
 import zlib from "node:zlib";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-const vsixPath = path.resolve(
-  process.cwd(),
-  process.argv[2] ?? path.join(root, "editors/vscode/dist/vize.vsix"),
-);
+const defaultVsixPath = path.join(root, "editors/vscode/dist/vize.vsix");
+const vsixPath = path.resolve(process.cwd(), process.argv[2] ?? defaultVsixPath);
 const builtins = new Set([
   ...builtinModules,
   ...builtinModules.map((moduleName) => `node:${moduleName}`),
@@ -19,7 +17,9 @@ const builtins = new Set([
 assert.ok(fs.existsSync(vsixPath), `VSIX does not exist: ${vsixPath}`);
 
 const archive = readZip(vsixPath);
-const entryNames = archive.entries.map((entry) => entry.name).sort();
+const topLevelEntry = /^(?:extension\/|extension\.vsixmanifest$|\[Content_Types\]\.xml$)/;
+const entryNames = archive.entries.map((entry) => entry.name);
+entryNames.sort((left, right) => left.localeCompare(right));
 const entries = new Set(entryNames);
 const vsixSize = fs.statSync(vsixPath).size;
 
@@ -32,11 +32,7 @@ for (const name of entryNames) {
   assert.ok(!name.includes("\0"), `VSIX entry contains a NUL byte: ${name}`);
   assert.ok(!name.startsWith("/"), `VSIX entry must be relative: ${name}`);
   assert.ok(!name.split("/").includes(".."), `VSIX entry must not traverse: ${name}`);
-  assert.match(
-    name,
-    /^(?:extension\/|extension\.vsixmanifest$|\[Content_Types\]\.xml$)/,
-    `VSIX entry has an unexpected top-level path: ${name}`,
-  );
+  assert.match(name, topLevelEntry, `VSIX entry has an unexpected top-level path: ${name}`);
 }
 
 const requiredFiles = [
@@ -316,6 +312,11 @@ function readZip(filePath) {
     const commentLength = buffer.readUInt16LE(offset + 32);
     const localHeaderOffset = buffer.readUInt32LE(offset + 42);
     const name = buffer.subarray(offset + 46, offset + 46 + fileNameLength).toString("utf-8");
+    const localExtraLength = buffer.readUInt16LE(localHeaderOffset + 28);
+
+    assert.equal(buffer.readUInt32LE(localHeaderOffset), 0x04034b50);
+    assert.equal(extraLength, 0, `VSIX entry has central ZIP extra fields: ${name}`);
+    assert.equal(localExtraLength, 0, `VSIX entry has local ZIP extra fields: ${name}`);
 
     entries.push({
       compressedSize,

--- a/tools/vscode-vize/sync-typescript-plugin.mjs
+++ b/tools/vscode-vize/sync-typescript-plugin.mjs
@@ -41,7 +41,7 @@ function injectPlugin(vsixPath) {
     const targetDir = path.join(tempDir, "extension", packagePath);
     stagePlugin(targetDir);
     const entries = pluginFiles.map((file) => path.posix.join("extension", packagePath, file));
-    const result = spawnSync("zip", ["-q", vsixPath, ...entries], {
+    const result = spawnSync("zip", ["-X", "-q", vsixPath, ...entries], {
       cwd: tempDir,
       encoding: "utf8",
     });


### PR DESCRIPTION
## Summary

- inject the bundled TypeScript Vue plugin into VSIX files with `zip -X` so Open VSX does not reject ZIP extra fields
- extend the VSIX package smoke assertion to reject central and local ZIP extra fields
- ensure the Open VSX publisher namespace exists before publishing

## Root cause

The release VSIX was produced by `vsce`, then `sync-typescript-plugin.mjs` appended two runtime plugin files with plain `zip -q`. Those appended entries included 24-byte ZIP extra fields, which Open VSX blocks as potentially harmful. After replacing the release asset with a normalized VSIX, the next Open VSX failure was `Unknown publisher: ubugeeei`, so the publish script now creates the namespace before publishing and still tolerates the namespace already existing.

## Verification

- `node tools/vscode-vize/assert-vsix-package.mjs /tmp/vize-v0.278.0-assets/vize.vsix` fails on the original released bad VSIX as expected
- regenerated the two plugin entries with the updated injector and verified `node tools/vscode-vize/assert-vsix-package.mjs /tmp/vize-v0.278.0-assets/vize-fixed.vsix`
- `./node_modules/.bin/vp check --fix tools/vscode-vize/sync-typescript-plugin.mjs tools/vscode-vize/assert-vsix-package.mjs tests/tooling/moonbit-publish-open-vsx.test.ts`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `node --test tests/tooling/moonbit-publish-open-vsx.test.ts tests/tooling/github-workflows-release-publish.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VSIX package validation by tightening ZIP structure checks and local header verification to catch malformed entries earlier.
  * Improved extension packaging consistency by adjusting ZIP creation to exclude extra metadata for cleaner archives.
  * Improved Open VSX publishing flow by retaining publisher metadata and ensuring the publisher namespace exists before publishing.
* **Tests**
  * Updated tooling tests to reflect the added Open VSX namespace creation step during publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->