### PR TITLE
fix(editor): harden Vue authoring LSP support

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -33,6 +33,7 @@ pub(crate) mod musea;
 pub mod references;
 pub mod rename;
 pub mod semantic_tokens;
+mod template_expression;
 pub mod type_service;
 pub mod workspace_symbols;
 
@@ -56,6 +57,7 @@ pub use jsx::{JsxReferencesService, JsxRenameService, JsxService};
 pub use references::ReferencesService;
 pub use rename::RenameService;
 pub use semantic_tokens::{SemanticTokensService, TokenModifier, TokenType};
+pub(crate) use template_expression::is_in_vue_template_expression;
 pub use type_service::{LspTypeCheckOptions, TypeService};
 pub use workspace_symbols::WorkspaceSymbolsService;
 
@@ -228,125 +230,6 @@ where
 {
     let (start, end) = token_span_at_offset(content, offset, is_token_char)?;
     Some(content[start..end].to_string())
-}
-
-/// Check if a cursor offset is inside a Vue template expression.
-///
-/// This covers mustache interpolations and Vue directive attribute values, but
-/// deliberately excludes plain text nodes and static attribute values.
-pub(crate) fn is_in_vue_template_expression(content: &str, offset: usize) -> bool {
-    if content.is_empty() {
-        return false;
-    }
-
-    let mut offset = offset.min(content.len());
-    while offset > 0 && !content.is_char_boundary(offset) {
-        offset -= 1;
-    }
-
-    if is_in_mustache_expression(content, offset) {
-        return true;
-    }
-
-    is_in_vue_directive_attribute_value(content, offset)
-}
-
-fn is_in_mustache_expression(content: &str, offset: usize) -> bool {
-    let before = &content[..offset];
-    let Some(mustache_start) = before.rfind("{{") else {
-        return false;
-    };
-
-    let closed_before_cursor = before
-        .rfind("}}")
-        .is_some_and(|mustache_end| mustache_end > mustache_start);
-    if closed_before_cursor {
-        return false;
-    }
-
-    content[offset..].contains("}}")
-}
-
-fn is_in_vue_directive_attribute_value(content: &str, offset: usize) -> bool {
-    let bytes = content.as_bytes();
-    for (tag_start, _) in content[..offset].match_indices('<').rev() {
-        let name_start = tag_start + 1;
-        if matches!(bytes.get(name_start), Some(b'/' | b'!' | b'?')) {
-            continue;
-        }
-        let mut name_end = name_start;
-        while name_end < bytes.len()
-            && (bytes[name_end].is_ascii_alphanumeric() || matches!(bytes[name_end], b'-' | b'_'))
-        {
-            name_end += 1;
-        }
-        if name_start == name_end {
-            continue;
-        }
-
-        let mut quote = None;
-        let mut quote_start = None;
-        let mut pos = name_end;
-        while pos < offset {
-            let byte = bytes[pos];
-            if let Some(open_quote) = quote {
-                if byte == open_quote {
-                    quote = None;
-                    quote_start = None;
-                }
-            } else if byte == b'"' || byte == b'\'' {
-                quote = Some(byte);
-                quote_start = Some(pos);
-            } else if byte == b'>' {
-                break;
-            }
-            pos += 1;
-        }
-
-        if pos < offset || quote.is_none() {
-            continue;
-        }
-        let Some(quote_start) = quote_start else {
-            continue;
-        };
-        return directive_attribute_name_before_quote(content, quote_start)
-            .is_some_and(is_vue_expression_attribute);
-    }
-
-    false
-}
-
-fn directive_attribute_name_before_quote(content: &str, quote_start: usize) -> Option<&str> {
-    let bytes = content.as_bytes();
-    let mut pos = quote_start;
-    while pos > 0 && bytes[pos - 1].is_ascii_whitespace() {
-        pos -= 1;
-    }
-    if pos == 0 || bytes[pos - 1] != b'=' {
-        return None;
-    }
-    pos -= 1;
-
-    while pos > 0 && bytes[pos - 1].is_ascii_whitespace() {
-        pos -= 1;
-    }
-    let attr_end = pos;
-    while pos > 0 {
-        let byte = bytes[pos - 1];
-        if byte.is_ascii_whitespace() || matches!(byte, b'<' | b'>' | b'/') {
-            break;
-        }
-        pos -= 1;
-    }
-
-    Some(&content[pos..attr_end])
-}
-
-fn is_vue_expression_attribute(attr_name: &str) -> bool {
-    attr_name.starts_with(':')
-        || attr_name.starts_with('@')
-        || attr_name.starts_with('#')
-        || attr_name.starts_with("v-")
 }
 
 fn standalone_html_block_at_offset(content: &str, offset: usize) -> BlockType {

--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -269,38 +269,61 @@ fn is_in_mustache_expression(content: &str, offset: usize) -> bool {
 
 fn is_in_vue_directive_attribute_value(content: &str, offset: usize) -> bool {
     let bytes = content.as_bytes();
-    let mut pos = offset;
-    let mut quote_start = None;
+    for (tag_start, _) in content[..offset].match_indices('<').rev() {
+        let name_start = tag_start + 1;
+        if matches!(bytes.get(name_start), Some(b'/' | b'!' | b'?')) {
+            continue;
+        }
+        let mut name_end = name_start;
+        while name_end < bytes.len()
+            && (bytes[name_end].is_ascii_alphanumeric() || matches!(bytes[name_end], b'-' | b'_'))
+        {
+            name_end += 1;
+        }
+        if name_start == name_end {
+            continue;
+        }
 
-    while pos > 0 {
-        let byte = bytes[pos - 1];
-        match byte {
-            b'"' | b'\'' => {
-                quote_start = Some((pos - 1, byte));
+        let mut quote = None;
+        let mut quote_start = None;
+        let mut pos = name_end;
+        while pos < offset {
+            let byte = bytes[pos];
+            if let Some(open_quote) = quote {
+                if byte == open_quote {
+                    quote = None;
+                    quote_start = None;
+                }
+            } else if byte == b'"' || byte == b'\'' {
+                quote = Some(byte);
+                quote_start = Some(pos);
+            } else if byte == b'>' {
                 break;
             }
-            b'<' | b'>' | b'\n' | b'\r' => return false,
-            _ => pos -= 1,
+            pos += 1;
         }
+
+        if pos < offset || quote.is_none() {
+            continue;
+        }
+        let Some(quote_start) = quote_start else {
+            continue;
+        };
+        return directive_attribute_name_before_quote(content, quote_start)
+            .is_some_and(is_vue_expression_attribute);
     }
 
-    let Some((quote_start, quote)) = quote_start else {
-        return false;
-    };
-    let Some(relative_quote_end) = content[quote_start + 1..].find(quote as char) else {
-        return false;
-    };
-    let quote_end = quote_start + 1 + relative_quote_end;
-    if offset > quote_end {
-        return false;
-    }
+    false
+}
 
+fn directive_attribute_name_before_quote(content: &str, quote_start: usize) -> Option<&str> {
+    let bytes = content.as_bytes();
     let mut pos = quote_start;
     while pos > 0 && bytes[pos - 1].is_ascii_whitespace() {
         pos -= 1;
     }
     if pos == 0 || bytes[pos - 1] != b'=' {
-        return false;
+        return None;
     }
     pos -= 1;
 
@@ -316,7 +339,10 @@ fn is_in_vue_directive_attribute_value(content: &str, offset: usize) -> bool {
         pos -= 1;
     }
 
-    let attr_name = &content[pos..attr_end];
+    Some(&content[pos..attr_end])
+}
+
+fn is_vue_expression_attribute(attr_name: &str) -> bool {
     attr_name.starts_with(':')
         || attr_name.starts_with('@')
         || attr_name.starts_with('#')

--- a/crates/vize_maestro/src/ide/completion.rs
+++ b/crates/vize_maestro/src/ide/completion.rs
@@ -20,6 +20,8 @@ pub(crate) mod template;
 #[cfg(test)]
 mod component_props_tests;
 #[cfg(test)]
+mod dedup_tests;
+#[cfg(test)]
 mod tests;
 
 // Cross-module reuse: inlay-hint code resolves reactive binding types with

--- a/crates/vize_maestro/src/ide/completion/dedup_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/dedup_tests.rs
@@ -1,0 +1,69 @@
+use std::fs;
+
+use tower_lsp::lsp_types::{CompletionResponse, Url};
+
+use crate::ide::{CompletionService, IdeContext};
+use crate::server::ServerState;
+
+#[test]
+fn script_completion_lists_reactive_binding_once() {
+    let source = r#"<script setup lang="ts">
+import { ref, computed } from 'vue'
+const st = ref(0)
+const ts = computed(() => st.value * 2)
+st
+</script>
+"#;
+    let (state, uri) = state_with_document("ScriptDedup.vue", source);
+    let offset = source.rfind("st\n").unwrap() + 2;
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+    assert_eq!(labels.iter().filter(|l| l.as_str() == "st").count(), 1);
+    assert_eq!(labels.iter().filter(|l| l.as_str() == "ts").count(), 1);
+}
+
+#[test]
+fn template_completion_lists_reactive_binding_once() {
+    let source = r#"<script setup lang="ts">
+import { ref, computed } from 'vue'
+const st = ref(0)
+const ts = computed(() => st.value * 2)
+</script>
+<template>
+  <div>{{ st }}</div>
+</template>
+"#;
+    let (state, uri) = state_with_document("TemplateDedup.vue", source);
+    let offset = source.rfind("st }}").unwrap() + 2;
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+    assert_eq!(labels.iter().filter(|l| l.as_str() == "st").count(), 1);
+    assert_eq!(labels.iter().filter(|l| l.as_str() == "ts").count(), 1);
+}
+
+fn completion_labels(response: CompletionResponse) -> Vec<String> {
+    match response {
+        CompletionResponse::Array(items) => items,
+        CompletionResponse::List(list) => list.items,
+    }
+    .into_iter()
+    .map(|item| item.label)
+    .collect()
+}
+
+fn state_with_document(name: &str, source: &str) -> (ServerState, Url) {
+    let dir = tempfile::tempdir().unwrap();
+    let source_path = dir.path().join(name);
+    fs::write(&source_path, source).unwrap();
+
+    let uri = Url::from_file_path(&source_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    (state, uri)
+}

--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -13,6 +13,7 @@ mod bindings;
 mod component_meta;
 mod components;
 mod directives;
+mod native;
 mod self_component;
 mod slot_outlets;
 mod tag_context;
@@ -46,29 +47,79 @@ pub(crate) fn complete_template(ctx: &IdeContext) -> Vec<CompletionItem> {
         return items;
     }
 
+    let is_template_expression =
+        crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset);
+
+    if let Some(tag_ctx) = tag_context::opening_tag_context_at_offset(&ctx.content, ctx.offset) {
+        if !tag_ctx.inside_attribute_value {
+            let mut items_vec = contextual_directive_completions(ctx);
+            items_vec.extend(native::native_element_attribute_completions(ctx));
+            items_vec.extend(component_meta::component_surface_completions(ctx));
+            return filter_open_tag_completions(items_vec, &tag_ctx.current_token);
+        }
+
+        if !is_template_expression {
+            return Vec::new();
+        }
+    }
+
+    if is_template_expression {
+        return analyzed_template_binding_completions(ctx, true);
+    }
+
     let mut items_vec = Vec::new();
 
-    // Add Vue directives
+    // Add Vue directives and built-in components for template text/tag contexts.
     items_vec.extend(contextual_directive_completions(ctx));
-
-    // Add built-in components
     items_vec.extend(builtin_component_completions());
     if ctx.state.lsp_features().legacy_vue2 {
         items_vec.extend(components::legacy_vue2_component_completions());
     }
     items_vec.extend(component_meta::component_surface_completions(ctx));
 
-    if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset) {
-        items_vec.extend(bindings::template_snippets());
-        return items_vec;
-    }
-
-    items_vec.extend(analyzed_template_binding_completions(ctx, true));
-
     // Add common template snippets
     items_vec.extend(bindings::template_snippets());
 
     items_vec
+}
+
+fn filter_open_tag_completions(
+    items: Vec<CompletionItem>,
+    current_token: &str,
+) -> Vec<CompletionItem> {
+    let prefix = current_token.trim();
+    if prefix.is_empty() {
+        return items;
+    }
+
+    items
+        .into_iter()
+        .filter(|item| open_tag_completion_matches_prefix(&item.label, prefix))
+        .collect()
+}
+
+fn open_tag_completion_matches_prefix(label: &str, prefix: &str) -> bool {
+    if prefix.contains('=') {
+        return false;
+    }
+
+    if prefix.starts_with('@') {
+        return label.starts_with(prefix) || label == "v-on";
+    }
+
+    if let Some(name_prefix) = prefix.strip_prefix(':') {
+        return label == ":" || label == "v-bind" || label.starts_with(name_prefix);
+    }
+
+    if let Some(name_prefix) = prefix.strip_prefix("v-bind:") {
+        return label == "v-bind" || label.starts_with(name_prefix);
+    }
+
+    if prefix.starts_with('#') {
+        return label.starts_with(prefix) || label == "v-slot";
+    }
+
+    label.starts_with(prefix)
 }
 
 pub(crate) fn corsa_template_completions(ctx: &IdeContext) -> Vec<CompletionItem> {

--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -14,6 +14,8 @@ mod component_meta;
 mod components;
 mod directives;
 mod native;
+#[cfg(test)]
+mod native_tests;
 mod self_component;
 mod slot_outlets;
 mod tag_context;
@@ -107,19 +109,25 @@ fn open_tag_completion_matches_prefix(label: &str, prefix: &str) -> bool {
         return label.starts_with(prefix) || label == "v-on";
     }
 
-    if let Some(name_prefix) = prefix.strip_prefix(':') {
-        return label == ":" || label == "v-bind" || label.starts_with(name_prefix);
+    if prefix.starts_with(':') {
+        return is_bind_completion_label(label);
     }
 
-    if let Some(name_prefix) = prefix.strip_prefix("v-bind:") {
-        return label == "v-bind" || label.starts_with(name_prefix);
+    if prefix.starts_with("v-bind:") {
+        return is_bind_completion_label(label);
     }
 
-    if prefix.starts_with('#') {
-        return label.starts_with(prefix) || label == "v-slot";
+    if let Some(slot_prefix) = prefix.strip_prefix('#') {
+        return label == "#" || label == "v-slot" || label.starts_with(slot_prefix);
     }
 
     label.starts_with(prefix)
+}
+
+fn is_bind_completion_label(label: &str) -> bool {
+    label == ":"
+        || label == "v-bind"
+        || (!label.starts_with('@') && !label.starts_with('#') && !label.starts_with("v-"))
 }
 
 pub(crate) fn corsa_template_completions(ctx: &IdeContext) -> Vec<CompletionItem> {

--- a/crates/vize_maestro/src/ide/completion/template/directives.rs
+++ b/crates/vize_maestro/src/ide/completion/template/directives.rs
@@ -9,7 +9,7 @@ use crate::ide::completion::items;
 
 /// Vue directive completions.
 pub(crate) fn directive_completions() -> Vec<CompletionItem> {
-    vec![
+    let mut items = vec![
         items::directive_item("v-if", "Conditional rendering", "v-if=\"$1\""),
         items::directive_item("v-else-if", "Else-if block", "v-else-if=\"$1\""),
         items::directive_item("v-else", "Else block", "v-else"),
@@ -28,7 +28,43 @@ pub(crate) fn directive_completions() -> Vec<CompletionItem> {
         items::directive_item("@", "Event shorthand", "@$1=\"$2\""),
         items::directive_item(":", "Bind shorthand", ":$1=\"$2\""),
         items::directive_item("#", "Slot shorthand", "#$1"),
+    ];
+    items.extend(event_shorthand_completions());
+    items
+}
+
+fn event_shorthand_completions() -> Vec<CompletionItem> {
+    [
+        ("@click", "Click event"),
+        ("@input", "Input event"),
+        ("@change", "Change event"),
+        ("@submit", "Submit event"),
+        ("@keydown", "Key down event"),
+        ("@keyup", "Key up event"),
+        ("@focus", "Focus event"),
+        ("@blur", "Blur event"),
+        ("@mouseenter", "Mouse enter event"),
+        ("@mouseleave", "Mouse leave event"),
     ]
+    .into_iter()
+    .map(|(label, detail)| event_item(label, detail))
+    .collect()
+}
+
+#[allow(clippy::disallowed_macros)]
+fn event_item(label: &str, detail: &str) -> CompletionItem {
+    CompletionItem {
+        label: label.to_string(),
+        kind: Some(CompletionItemKind::EVENT),
+        detail: Some(detail.to_string()),
+        insert_text: Some(format!("{label}=\"$1\"")),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: format!("**`{label}`**\n\nVue event listener shorthand."),
+        })),
+        ..Default::default()
+    }
 }
 
 /// Vue directive completions, extended with opt-in document-specific directives.

--- a/crates/vize_maestro/src/ide/completion/template/native.rs
+++ b/crates/vize_maestro/src/ide/completion/template/native.rs
@@ -1,0 +1,105 @@
+//! Native HTML attribute completions for template opening tags.
+
+use tower_lsp::lsp_types::CompletionItem;
+
+use crate::ide::completion::items;
+use crate::ide::{IdeContext, is_component_tag};
+
+use super::tag_context::{is_prop_completion_prefix, opening_tag_context_at_offset};
+
+pub(super) fn native_element_attribute_completions(ctx: &IdeContext) -> Vec<CompletionItem> {
+    let Some(tag_ctx) = opening_tag_context_at_offset(&ctx.content, ctx.offset) else {
+        return Vec::new();
+    };
+    if tag_ctx.inside_attribute_value
+        || is_component_tag(&tag_ctx.tag_name)
+        || !is_prop_completion_prefix(&tag_ctx.current_token)
+    {
+        return Vec::new();
+    }
+
+    let mut items = common_attribute_completions();
+    items.extend(tag_attribute_completions(&tag_ctx.tag_name));
+    items
+}
+
+fn common_attribute_completions() -> Vec<CompletionItem> {
+    [
+        ("id", "HTML id", "id=\"$1\""),
+        ("class", "CSS class", "class=\"$1\""),
+        ("style", "Inline style", "style=\"$1\""),
+        ("title", "Tooltip title", "title=\"$1\""),
+        ("role", "ARIA role", "role=\"$1\""),
+        ("tabindex", "Tab order", "tabindex=\"$1\""),
+        ("aria-label", "Accessible label", "aria-label=\"$1\""),
+        ("ref", "Template ref", "ref=\"$1\""),
+        ("key", "VNode key", ":key=\"$1\""),
+    ]
+    .into_iter()
+    .map(|(label, detail, snippet)| items::attr_item(label, detail, snippet))
+    .collect()
+}
+
+fn tag_attribute_completions(tag_name: &str) -> Vec<CompletionItem> {
+    match tag_name {
+        "button" => attrs(&[
+            ("type", "Button type", "type=\"$1\""),
+            ("disabled", "Disabled state", "disabled"),
+            ("name", "Form control name", "name=\"$1\""),
+            ("value", "Submitted value", "value=\"$1\""),
+            ("autofocus", "Autofocus", "autofocus"),
+            ("form", "Associated form id", "form=\"$1\""),
+        ]),
+        "input" => attrs(&[
+            ("type", "Input type", "type=\"$1\""),
+            ("value", "Input value", "value=\"$1\""),
+            ("placeholder", "Placeholder text", "placeholder=\"$1\""),
+            ("name", "Form control name", "name=\"$1\""),
+            ("disabled", "Disabled state", "disabled"),
+            ("checked", "Checked state", "checked"),
+            ("required", "Required input", "required"),
+            ("autocomplete", "Autocomplete hint", "autocomplete=\"$1\""),
+        ]),
+        "a" => attrs(&[
+            ("href", "Link target", "href=\"$1\""),
+            ("target", "Browsing context", "target=\"$1\""),
+            ("rel", "Link relationship", "rel=\"$1\""),
+            ("download", "Download target", "download"),
+        ]),
+        "form" => attrs(&[
+            ("action", "Submit URL", "action=\"$1\""),
+            ("method", "Submit method", "method=\"$1\""),
+            ("novalidate", "Skip validation", "novalidate"),
+        ]),
+        "img" => attrs(&[
+            ("src", "Image source", "src=\"$1\""),
+            ("alt", "Alternative text", "alt=\"$1\""),
+            ("width", "Image width", "width=\"$1\""),
+            ("height", "Image height", "height=\"$1\""),
+            ("loading", "Loading strategy", "loading=\"$1\""),
+        ]),
+        "label" => attrs(&[("for", "Associated control id", "for=\"$1\"")]),
+        "textarea" => attrs(&[
+            ("name", "Form control name", "name=\"$1\""),
+            ("placeholder", "Placeholder text", "placeholder=\"$1\""),
+            ("disabled", "Disabled state", "disabled"),
+            ("required", "Required input", "required"),
+            ("rows", "Visible rows", "rows=\"$1\""),
+            ("cols", "Visible columns", "cols=\"$1\""),
+        ]),
+        "select" => attrs(&[
+            ("name", "Form control name", "name=\"$1\""),
+            ("disabled", "Disabled state", "disabled"),
+            ("required", "Required input", "required"),
+            ("multiple", "Multiple selection", "multiple"),
+        ]),
+        _ => Vec::new(),
+    }
+}
+
+fn attrs(values: &[(&str, &str, &str)]) -> Vec<CompletionItem> {
+    values
+        .iter()
+        .map(|(label, detail, snippet)| items::attr_item(label, detail, snippet))
+        .collect()
+}

--- a/crates/vize_maestro/src/ide/completion/template/native_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/template/native_tests.rs
@@ -1,0 +1,105 @@
+use std::fs;
+
+use tower_lsp::lsp_types::{CompletionResponse, Url};
+
+use crate::ide::{CompletionService, IdeContext};
+use crate::server::ServerState;
+
+#[test]
+fn offers_native_attributes_in_opening_tag() {
+    let source = r#"<script setup lang="ts">
+const count = ref(0)
+</script>
+<template>
+  <button
+    
+  >
+    {{ count }}
+  </button>
+</template>
+"#;
+    let (state, uri) = state_with_document("NativeAttributeCompletion.vue", source);
+    let offset = source.find("    \n  >").unwrap() + "    ".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+    assert!(has_label(&labels, "class"), "{labels:?}");
+    assert!(has_label(&labels, "type"), "{labels:?}");
+    assert!(has_label(&labels, "@click"), "{labels:?}");
+    assert!(has_label(&labels, "v-if"), "{labels:?}");
+    assert!(!has_label(&labels, "Transition"), "{labels:?}");
+    assert!(!has_label(&labels, "vfor"), "{labels:?}");
+    assert!(!has_label(&labels, "count"), "{labels:?}");
+}
+
+#[test]
+fn offers_event_shorthand_after_prefix() {
+    let source = r#"<template>
+  <button @cli></button>
+</template>
+"#;
+    let (state, uri) = state_with_document("EventShorthandCompletion.vue", source);
+    let offset = source.find("@cli").unwrap() + "@cli".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+    assert!(has_label(&labels, "@click"), "{labels:?}");
+    assert!(!has_label(&labels, "v-if"), "{labels:?}");
+    assert!(!has_label(&labels, "class"), "{labels:?}");
+}
+
+#[test]
+fn keeps_bindings_in_multiline_event_handler() {
+    let source = r#"<script setup lang="ts">
+const count = ref(0)
+</script>
+<template>
+  <button
+    @click="
+      () => {
+        co
+      }
+    "
+  >
+    {{ count }}
+  </button>
+</template>
+"#;
+    let (state, uri) = state_with_document("MultilineEventCompletion.vue", source);
+    let offset = source.find("        co").unwrap() + "        co".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+    assert!(has_label(&labels, "count"), "{labels:?}");
+    assert!(!has_label(&labels, "v-if"), "{labels:?}");
+    assert!(!has_label(&labels, "Transition"), "{labels:?}");
+}
+
+fn completion_labels(response: CompletionResponse) -> Vec<String> {
+    match response {
+        CompletionResponse::Array(items) => items,
+        CompletionResponse::List(list) => list.items,
+    }
+    .into_iter()
+    .map(|item| item.label)
+    .collect()
+}
+
+fn has_label(labels: &[String], expected: &str) -> bool {
+    labels.iter().any(|label| label == expected)
+}
+
+fn state_with_document(name: &str, source: &str) -> (ServerState, Url) {
+    let dir = tempfile::tempdir().unwrap();
+    let source_path = dir.path().join(name);
+    fs::write(&source_path, source).unwrap();
+
+    let uri = Url::from_file_path(&source_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    (state, uri)
+}

--- a/crates/vize_maestro/src/ide/completion/tests.rs
+++ b/crates/vize_maestro/src/ide/completion/tests.rs
@@ -526,10 +526,12 @@ const message = ref('hello')
     let (state, uri) = state_with_document("StaticAttributeCompletion.vue", source);
     let offset = source.rfind("message\"").unwrap() + "message".len();
     let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+    let labels = CompletionService::complete(&ctx)
+        .map(completion_labels)
+        .unwrap_or_default();
 
     assert!(!has_label(&labels, "message"));
-    assert!(has_label(&labels, "v-if"));
+    assert!(!has_label(&labels, "v-if"));
 }
 
 #[test]
@@ -547,7 +549,77 @@ const message = ref('hello')
     let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
 
     assert!(has_label(&labels, "message"));
-    assert!(has_label(&labels, "v-if"));
+    assert!(!has_label(&labels, "v-if"));
+}
+
+#[test]
+fn test_template_completion_offers_native_attributes_in_opening_tag() {
+    let source = r#"<script setup lang="ts">
+const count = ref(0)
+</script>
+<template>
+  <button
+    
+  >
+    {{ count }}
+  </button>
+</template>
+"#;
+    let (state, uri) = state_with_document("NativeAttributeCompletion.vue", source);
+    let offset = source.find("    \n  >").unwrap() + "    ".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+    assert!(has_label(&labels, "class"), "{labels:?}");
+    assert!(has_label(&labels, "type"), "{labels:?}");
+    assert!(has_label(&labels, "@click"), "{labels:?}");
+    assert!(has_label(&labels, "v-if"), "{labels:?}");
+    assert!(!has_label(&labels, "Transition"), "{labels:?}");
+    assert!(!has_label(&labels, "vfor"), "{labels:?}");
+    assert!(!has_label(&labels, "count"), "{labels:?}");
+}
+
+#[test]
+fn test_template_completion_offers_event_shorthand_after_prefix() {
+    let source = r#"<template>
+  <button @cli></button>
+</template>
+"#;
+    let (state, uri) = state_with_document("EventShorthandCompletion.vue", source);
+    let offset = source.find("@cli").unwrap() + "@cli".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+    assert!(has_label(&labels, "@click"), "{labels:?}");
+    assert!(!has_label(&labels, "v-if"), "{labels:?}");
+    assert!(!has_label(&labels, "class"), "{labels:?}");
+}
+
+#[test]
+fn test_template_completion_keeps_bindings_in_multiline_event_handler() {
+    let source = r#"<script setup lang="ts">
+const count = ref(0)
+</script>
+<template>
+  <button
+    @click="
+      () => {
+        co
+      }
+    "
+  >
+    {{ count }}
+  </button>
+</template>
+"#;
+    let (state, uri) = state_with_document("MultilineEventCompletion.vue", source);
+    let offset = source.find("        co").unwrap() + "        co".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+    assert!(has_label(&labels, "count"), "{labels:?}");
+    assert!(!has_label(&labels, "v-if"), "{labels:?}");
+    assert!(!has_label(&labels, "Transition"), "{labels:?}");
 }
 
 #[test]
@@ -588,7 +660,7 @@ const secondaryLabel = ref('secondary')
     let labels: Vec<&str> = items.iter().map(|item| item.label.as_str()).collect();
     assert!(labels.contains(&"secondaryLabel"));
     assert!(labels.contains(&"primaryLabel"));
-    assert!(labels.contains(&"v-if"));
+    assert!(!labels.contains(&"v-if"));
 }
 
 #[test]

--- a/crates/vize_maestro/src/ide/completion/tests.rs
+++ b/crates/vize_maestro/src/ide/completion/tests.rs
@@ -220,7 +220,9 @@ fn test_standalone_html_completion_v_scope_bindings_do_not_leak_to_sibling() {
     let p_start = source.find("<p>").unwrap();
     let offset = source[p_start..].find("{{ count").unwrap() + p_start + "{{ co".len();
     let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+    let labels = CompletionService::complete(&ctx)
+        .map(completion_labels)
+        .unwrap_or_default();
 
     assert!(
         !has_label(&labels, "count"),
@@ -550,76 +552,6 @@ const message = ref('hello')
 
     assert!(has_label(&labels, "message"));
     assert!(!has_label(&labels, "v-if"));
-}
-
-#[test]
-fn test_template_completion_offers_native_attributes_in_opening_tag() {
-    let source = r#"<script setup lang="ts">
-const count = ref(0)
-</script>
-<template>
-  <button
-    
-  >
-    {{ count }}
-  </button>
-</template>
-"#;
-    let (state, uri) = state_with_document("NativeAttributeCompletion.vue", source);
-    let offset = source.find("    \n  >").unwrap() + "    ".len();
-    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
-
-    assert!(has_label(&labels, "class"), "{labels:?}");
-    assert!(has_label(&labels, "type"), "{labels:?}");
-    assert!(has_label(&labels, "@click"), "{labels:?}");
-    assert!(has_label(&labels, "v-if"), "{labels:?}");
-    assert!(!has_label(&labels, "Transition"), "{labels:?}");
-    assert!(!has_label(&labels, "vfor"), "{labels:?}");
-    assert!(!has_label(&labels, "count"), "{labels:?}");
-}
-
-#[test]
-fn test_template_completion_offers_event_shorthand_after_prefix() {
-    let source = r#"<template>
-  <button @cli></button>
-</template>
-"#;
-    let (state, uri) = state_with_document("EventShorthandCompletion.vue", source);
-    let offset = source.find("@cli").unwrap() + "@cli".len();
-    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
-
-    assert!(has_label(&labels, "@click"), "{labels:?}");
-    assert!(!has_label(&labels, "v-if"), "{labels:?}");
-    assert!(!has_label(&labels, "class"), "{labels:?}");
-}
-
-#[test]
-fn test_template_completion_keeps_bindings_in_multiline_event_handler() {
-    let source = r#"<script setup lang="ts">
-const count = ref(0)
-</script>
-<template>
-  <button
-    @click="
-      () => {
-        co
-      }
-    "
-  >
-    {{ count }}
-  </button>
-</template>
-"#;
-    let (state, uri) = state_with_document("MultilineEventCompletion.vue", source);
-    let offset = source.find("        co").unwrap() + "        co".len();
-    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
-
-    assert!(has_label(&labels, "count"), "{labels:?}");
-    assert!(!has_label(&labels, "v-if"), "{labels:?}");
-    assert!(!has_label(&labels, "Transition"), "{labels:?}");
 }
 
 #[test]
@@ -1032,46 +964,6 @@ const title = t("auth.")
     let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
 
     assert_eq!(labels, vec!["auth.login"]);
-}
-
-#[test]
-fn test_script_completion_lists_reactive_binding_once() {
-    // A ref/computed binding is both a binding and a reactive source.
-    // Completion must surface each name once, not twice.
-    let source = r#"<script setup lang="ts">
-import { ref, computed } from 'vue'
-const st = ref(0)
-const ts = computed(() => st.value * 2)
-st
-</script>
-"#;
-    let (state, uri) = state_with_document("ScriptDedup.vue", source);
-    let offset = source.rfind("st\n").unwrap() + 2;
-    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
-
-    assert_eq!(labels.iter().filter(|l| l.as_str() == "st").count(), 1);
-    assert_eq!(labels.iter().filter(|l| l.as_str() == "ts").count(), 1);
-}
-
-#[test]
-fn test_template_completion_lists_reactive_binding_once() {
-    let source = r#"<script setup lang="ts">
-import { ref, computed } from 'vue'
-const st = ref(0)
-const ts = computed(() => st.value * 2)
-</script>
-<template>
-  <div>{{ st }}</div>
-</template>
-"#;
-    let (state, uri) = state_with_document("TemplateDedup.vue", source);
-    let offset = source.rfind("st }}").unwrap() + 2;
-    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
-
-    assert_eq!(labels.iter().filter(|l| l.as_str() == "st").count(), 1);
-    assert_eq!(labels.iter().filter(|l| l.as_str() == "ts").count(), 1);
 }
 
 fn completion_labels(response: CompletionResponse) -> Vec<String> {

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -46,6 +46,10 @@ impl HoverService {
             return Some(hover);
         }
 
+        if let Some(hover) = Self::hover_template_directive_attribute(ctx) {
+            return Some(hover);
+        }
+
         if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset) {
             return None;
         }
@@ -106,6 +110,91 @@ impl HoverService {
                 .description("Expression evaluated against the component template scope.")
                 .build(),
         )
+    }
+
+    fn hover_template_directive_attribute(ctx: &IdeContext<'_>) -> Option<Hover> {
+        let attr_name = template_attribute_name_at_offset(&ctx.content, ctx.offset)?;
+
+        if let Some(event_name) = attr_name
+            .strip_prefix('@')
+            .or_else(|| attr_name.strip_prefix("v-on:"))
+        {
+            let event_name = event_name
+                .split_once('.')
+                .map_or(event_name, |(name, _)| name);
+            let title = if event_name.is_empty() {
+                "v-on".to_string()
+            } else {
+                format!("@{event_name}")
+            };
+            let example = if event_name.is_empty() {
+                "v-on:event=\"handler\"".to_string()
+            } else {
+                format!("@{event_name}=\"handler\"")
+            };
+
+            return Some(
+                HoverBuilder::new()
+                    .title(&title)
+                    .meta("Vue event listener")
+                    .code("vue", &example)
+                    .description(
+                        "Attaches a DOM or component event listener. The handler expression is evaluated in component scope.",
+                    )
+                    .bullets(
+                        "Template behavior",
+                        &[
+                            "`$event` is available inside inline handler expressions.",
+                            "Event modifiers such as `.stop`, `.prevent`, and key modifiers are compiled by Vue.",
+                        ],
+                    )
+                    .link(
+                        "Vue Event Handling",
+                        "https://vuejs.org/guide/essentials/event-handling.html",
+                    )
+                    .build(),
+            );
+        }
+
+        if attr_name.starts_with(':') || attr_name.starts_with("v-bind:") || attr_name == "v-bind" {
+            return Some(
+                HoverBuilder::new()
+                    .title("v-bind")
+                    .meta("Vue attribute / prop binding")
+                    .code("vue", ":prop=\"expression\"")
+                    .description(
+                        "Binds an attribute or component prop to a JavaScript expression in template scope.",
+                    )
+                    .bullets(
+                        "Template behavior",
+                        &[
+                            "Native element bindings patch DOM attributes or reflected properties.",
+                            "Component bindings resolve to props when the target is a component.",
+                        ],
+                    )
+                    .link(
+                        "Vue v-bind",
+                        "https://vuejs.org/api/built-in-directives.html#v-bind",
+                    )
+                    .build(),
+            );
+        }
+
+        if attr_name.starts_with('#') || attr_name.starts_with("v-slot:") || attr_name == "v-slot" {
+            return Self::hover_directive("v-slot");
+        }
+
+        if attr_name.starts_with("v-") {
+            let without_argument = attr_name
+                .split_once(':')
+                .map_or(attr_name, |(name, _)| name);
+            let base = without_argument
+                .split_once('.')
+                .map_or(without_argument, |(name, _)| name);
+            return Self::hover_directive(base);
+        }
+
+        None
     }
 
     /// Get hover for TypeScript binding using croquis analysis.
@@ -280,4 +369,100 @@ impl HoverService {
                 .build(),
         )
     }
+}
+
+fn template_attribute_name_at_offset(content: &str, offset: usize) -> Option<&str> {
+    let cursor = offset.min(content.len());
+    let tag_start = content[..cursor].rfind('<')?;
+    let bytes = content.as_bytes();
+    if matches!(bytes.get(tag_start + 1), Some(b'/' | b'!' | b'?')) {
+        return None;
+    }
+
+    let tag_end = find_open_tag_end(content, tag_start)?;
+    if cursor > tag_end {
+        return None;
+    }
+
+    let mut pos = tag_start + 1;
+    while pos < tag_end {
+        let byte = bytes[pos];
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_') {
+            pos += 1;
+        } else {
+            break;
+        }
+    }
+
+    while pos < tag_end {
+        while pos < tag_end && bytes[pos].is_ascii_whitespace() {
+            pos += 1;
+        }
+        if pos >= tag_end || matches!(bytes[pos], b'/' | b'>') {
+            break;
+        }
+
+        let attr_start = pos;
+        while pos < tag_end
+            && !bytes[pos].is_ascii_whitespace()
+            && !matches!(bytes[pos], b'=' | b'/' | b'>')
+        {
+            pos += 1;
+        }
+        let attr_end = pos;
+        if attr_start == attr_end {
+            return None;
+        }
+
+        if cursor >= attr_start && cursor <= attr_end {
+            return Some(&content[attr_start..attr_end]);
+        }
+
+        while pos < tag_end && bytes[pos].is_ascii_whitespace() {
+            pos += 1;
+        }
+        if pos < tag_end && bytes[pos] == b'=' {
+            pos += 1;
+            while pos < tag_end && bytes[pos].is_ascii_whitespace() {
+                pos += 1;
+            }
+            if pos < tag_end && matches!(bytes[pos], b'"' | b'\'') {
+                let quote = bytes[pos];
+                pos += 1;
+                while pos < tag_end && bytes[pos] != quote {
+                    pos += 1;
+                }
+                if pos < tag_end {
+                    pos += 1;
+                }
+            } else {
+                while pos < tag_end && !bytes[pos].is_ascii_whitespace() && bytes[pos] != b'>' {
+                    pos += 1;
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn find_open_tag_end(content: &str, tag_start: usize) -> Option<usize> {
+    let mut quote = None;
+    let mut pos = tag_start;
+
+    while pos < content.len() {
+        let ch = content[pos..].chars().next()?;
+        if let Some(open_quote) = quote {
+            if ch == open_quote {
+                quote = None;
+            }
+        } else if ch == '"' || ch == '\'' {
+            quote = Some(ch);
+        } else if ch == '>' {
+            return Some(pos);
+        }
+        pos += ch.len_utf8();
+    }
+
+    None
 }

--- a/crates/vize_maestro/src/ide/template_expression.rs
+++ b/crates/vize_maestro/src/ide/template_expression.rs
@@ -1,0 +1,115 @@
+/// Check if a cursor offset is inside a Vue template expression.
+///
+/// This covers mustache interpolations and Vue directive attribute values, but
+/// deliberately excludes plain text nodes and static attribute values.
+pub(crate) fn is_in_vue_template_expression(content: &str, offset: usize) -> bool {
+    if content.is_empty() {
+        return false;
+    }
+
+    let mut offset = offset.min(content.len());
+    while offset > 0 && !content.is_char_boundary(offset) {
+        offset -= 1;
+    }
+
+    is_in_mustache_expression(content, offset)
+        || is_in_vue_directive_attribute_value(content, offset)
+}
+
+fn is_in_mustache_expression(content: &str, offset: usize) -> bool {
+    let before = &content[..offset];
+    let Some(mustache_start) = before.rfind("{{") else {
+        return false;
+    };
+
+    let closed_before_cursor = before
+        .rfind("}}")
+        .is_some_and(|mustache_end| mustache_end > mustache_start);
+    if closed_before_cursor {
+        return false;
+    }
+
+    content[offset..].contains("}}")
+}
+
+fn is_in_vue_directive_attribute_value(content: &str, offset: usize) -> bool {
+    let bytes = content.as_bytes();
+    for (tag_start, _) in content[..offset].match_indices('<').rev() {
+        let name_start = tag_start + 1;
+        if matches!(bytes.get(name_start), Some(b'/' | b'!' | b'?')) {
+            continue;
+        }
+        let mut name_end = name_start;
+        while name_end < bytes.len()
+            && (bytes[name_end].is_ascii_alphanumeric() || matches!(bytes[name_end], b'-' | b'_'))
+        {
+            name_end += 1;
+        }
+        if name_start == name_end {
+            continue;
+        }
+
+        let mut quote = None;
+        let mut quote_start = None;
+        let mut pos = name_end;
+        while pos < offset {
+            let byte = bytes[pos];
+            if let Some(open_quote) = quote {
+                if byte == open_quote {
+                    quote = None;
+                    quote_start = None;
+                }
+            } else if byte == b'"' || byte == b'\'' {
+                quote = Some(byte);
+                quote_start = Some(pos);
+            } else if byte == b'>' {
+                break;
+            }
+            pos += 1;
+        }
+
+        if pos < offset || quote.is_none() {
+            continue;
+        }
+        let Some(quote_start) = quote_start else {
+            continue;
+        };
+        return directive_attribute_name_before_quote(content, quote_start)
+            .is_some_and(is_vue_expression_attribute);
+    }
+
+    false
+}
+
+fn directive_attribute_name_before_quote(content: &str, quote_start: usize) -> Option<&str> {
+    let bytes = content.as_bytes();
+    let mut pos = quote_start;
+    while pos > 0 && bytes[pos - 1].is_ascii_whitespace() {
+        pos -= 1;
+    }
+    if pos == 0 || bytes[pos - 1] != b'=' {
+        return None;
+    }
+    pos -= 1;
+
+    while pos > 0 && bytes[pos - 1].is_ascii_whitespace() {
+        pos -= 1;
+    }
+    let attr_end = pos;
+    while pos > 0 {
+        let byte = bytes[pos - 1];
+        if byte.is_ascii_whitespace() || matches!(byte, b'<' | b'>' | b'/') {
+            break;
+        }
+        pos -= 1;
+    }
+
+    Some(&content[pos..attr_end])
+}
+
+fn is_vue_expression_attribute(attr_name: &str) -> bool {
+    attr_name.starts_with(':')
+        || attr_name.starts_with('@')
+        || attr_name.starts_with('#')
+        || attr_name.starts_with("v-")
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -29,13 +29,13 @@
   "publisher": "ubugeeei",
   "main": "./dist/extension.cjs",
   "scripts": {
-    "vscode:prepublish": "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && vp pack",
-    "build": "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && vp pack",
-    "watch": "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && vp pack --watch",
+    "vscode:prepublish": "vp pack",
+    "build": "vp pack",
+    "watch": "vp pack --watch",
     "check": "tsgo --noEmit && vp check src vite.config.ts",
     "check:fix": "vp check --fix src vite.config.ts && tsgo --noEmit",
     "fmt": "vp fmt --write src vite.config.ts",
-    "package": "vsce package --no-dependencies --out dist/vize.vsix && node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix",
+    "package": "vsce package --no-dependencies --out dist/vize.vsix",
     "test:host": "node test/run-extension-host.mjs",
     "publish": "npm run package && vsce publish --packagePath dist/vize.vsix",
     "publish:pre": "npm run package && vsce publish --pre-release --packagePath dist/vize.vsix"
@@ -83,12 +83,6 @@
           "light": "./icons/vue.svg",
           "dark": "./icons/vue.svg"
         }
-      }
-    ],
-    "typescriptServerPlugins": [
-      {
-        "name": "@vizejs/typescript-vue-plugin",
-        "enableForWorkspaceTypeScriptVersions": true
       }
     ],
     "grammars": [

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -217,6 +217,54 @@ test("vscode-vize wires art-vue documents into editor features", () => {
   assert.match(extensionSource, /Trace\.(Verbose|Messages|Off)/);
 });
 
+test("editor adapters consistently route Vue documents to the Vize LSP", () => {
+  const vscodeManifest = readJson<{
+    activationEvents?: string[];
+    contributes?: {
+      typescriptServerPlugins?: unknown;
+    };
+  }>("editors/vscode/package.json");
+  for (const language of ["vue", "art-vue", "html"]) {
+    assert.ok(
+      vscodeManifest.activationEvents?.includes(`onLanguage:${language}`),
+      `missing VS Code activation for ${language}`,
+    );
+  }
+  assert.equal(vscodeManifest.contributes?.typescriptServerPlugins, undefined);
+
+  const nvimConfig = fs.readFileSync(path.join(root, "editors/nvim/lua/vize/config.lua"), "utf-8");
+  assert.match(nvimConfig, /cmd = \{ "vize", "lsp" \}/);
+  assert.match(nvimConfig, /filetypes = \{ "vue", "art-vue" \}/);
+  assert.match(nvimConfig, /editor = true/);
+  assert.match(nvimConfig, /lint = true/);
+
+  const vimConfig = fs.readFileSync(path.join(root, "editors/vim/autoload/vize.vim"), "utf-8");
+  assert.match(vimConfig, /'cmd': \['vize', 'lsp'\]/);
+  assert.match(vimConfig, /'allowlist': \['vue', 'art-vue'\]/);
+  assert.match(vimConfig, /'editor': v:true/);
+  assert.match(vimConfig, /'lint': v:true/);
+
+  const helixConfig = fs.readFileSync(path.join(root, "editors/helix/languages.toml"), "utf-8");
+  assert.match(helixConfig, /\[language-server\.vize\][\s\S]*command = "vize"/);
+  assert.match(helixConfig, /\[language-server\.vize\][\s\S]*args = \["lsp"\]/);
+  assert.match(helixConfig, /name = "vue"[\s\S]*language-servers = \["vize"\]/);
+  assert.match(helixConfig, /name = "art-vue"[\s\S]*language-id = "art-vue"/);
+
+  const emacsConfig = fs.readFileSync(path.join(root, "editors/emacs/vize.el"), "utf-8");
+  assert.match(emacsConfig, /defcustom vize-eglot-command '\("vize" "lsp"\)/);
+  assert.match(emacsConfig, /vue-mode vue-ts-mode web-mode vize-vue-mode vize-art-vue-mode/);
+  assert.match(emacsConfig, /recommended \. \(:editor t :ecosystem t :lint t :typecheck t\)/);
+
+  const zedManifest = fs.readFileSync(path.join(root, "editors/zed/extension.toml"), "utf-8");
+  assert.match(zedManifest, /\[language_servers\.vize\][\s\S]*languages = \["Vue", "Art Vue"\]/);
+  assert.match(zedManifest, /"Vue" = "vue"/);
+  assert.match(zedManifest, /"Art Vue" = "art-vue"/);
+
+  const zedSource = fs.readFileSync(path.join(root, "editors/zed/src/lib.rs"), "utf-8");
+  assert.match(zedSource, /const SERVER_BINARY: &'static str = "vize"/);
+  assert.match(zedSource, /unwrap_or_else\(\|\| vec!\["lsp"\.to_string\(\)\]\)/);
+});
+
 test("vscode-vize grammar keeps quote-aware block lookaheads", () => {
   type GrammarCapture = {
     name?: string;

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -217,54 +217,6 @@ test("vscode-vize wires art-vue documents into editor features", () => {
   assert.match(extensionSource, /Trace\.(Verbose|Messages|Off)/);
 });
 
-test("editor adapters consistently route Vue documents to the Vize LSP", () => {
-  const vscodeManifest = readJson<{
-    activationEvents?: string[];
-    contributes?: {
-      typescriptServerPlugins?: unknown;
-    };
-  }>("editors/vscode/package.json");
-  for (const language of ["vue", "art-vue", "html"]) {
-    assert.ok(
-      vscodeManifest.activationEvents?.includes(`onLanguage:${language}`),
-      `missing VS Code activation for ${language}`,
-    );
-  }
-  assert.equal(vscodeManifest.contributes?.typescriptServerPlugins, undefined);
-
-  const nvimConfig = fs.readFileSync(path.join(root, "editors/nvim/lua/vize/config.lua"), "utf-8");
-  assert.match(nvimConfig, /cmd = \{ "vize", "lsp" \}/);
-  assert.match(nvimConfig, /filetypes = \{ "vue", "art-vue" \}/);
-  assert.match(nvimConfig, /editor = true/);
-  assert.match(nvimConfig, /lint = true/);
-
-  const vimConfig = fs.readFileSync(path.join(root, "editors/vim/autoload/vize.vim"), "utf-8");
-  assert.match(vimConfig, /'cmd': \['vize', 'lsp'\]/);
-  assert.match(vimConfig, /'allowlist': \['vue', 'art-vue'\]/);
-  assert.match(vimConfig, /'editor': v:true/);
-  assert.match(vimConfig, /'lint': v:true/);
-
-  const helixConfig = fs.readFileSync(path.join(root, "editors/helix/languages.toml"), "utf-8");
-  assert.match(helixConfig, /\[language-server\.vize\][\s\S]*command = "vize"/);
-  assert.match(helixConfig, /\[language-server\.vize\][\s\S]*args = \["lsp"\]/);
-  assert.match(helixConfig, /name = "vue"[\s\S]*language-servers = \["vize"\]/);
-  assert.match(helixConfig, /name = "art-vue"[\s\S]*language-id = "art-vue"/);
-
-  const emacsConfig = fs.readFileSync(path.join(root, "editors/emacs/vize.el"), "utf-8");
-  assert.match(emacsConfig, /defcustom vize-eglot-command '\("vize" "lsp"\)/);
-  assert.match(emacsConfig, /vue-mode vue-ts-mode web-mode vize-vue-mode vize-art-vue-mode/);
-  assert.match(emacsConfig, /recommended \. \(:editor t :ecosystem t :lint t :typecheck t\)/);
-
-  const zedManifest = fs.readFileSync(path.join(root, "editors/zed/extension.toml"), "utf-8");
-  assert.match(zedManifest, /\[language_servers\.vize\][\s\S]*languages = \["Vue", "Art Vue"\]/);
-  assert.match(zedManifest, /"Vue" = "vue"/);
-  assert.match(zedManifest, /"Art Vue" = "art-vue"/);
-
-  const zedSource = fs.readFileSync(path.join(root, "editors/zed/src/lib.rs"), "utf-8");
-  assert.match(zedSource, /const SERVER_BINARY: &'static str = "vize"/);
-  assert.match(zedSource, /unwrap_or_else\(\|\| vec!\["lsp"\.to_string\(\)\]\)/);
-});
-
 test("vscode-vize grammar keeps quote-aware block lookaheads", () => {
   type GrammarCapture = {
     name?: string;

--- a/tests/tooling/editor-lsp-adapters.test.ts
+++ b/tests/tooling/editor-lsp-adapters.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf-8")) as T;
+}
+
+test("editor adapters consistently route Vue documents to the Vize LSP", () => {
+  const vscodeManifest = readJson<{
+    activationEvents?: string[];
+    contributes?: {
+      typescriptServerPlugins?: unknown;
+    };
+  }>("editors/vscode/package.json");
+  for (const language of ["vue", "art-vue", "html"]) {
+    assert.ok(
+      vscodeManifest.activationEvents?.includes(`onLanguage:${language}`),
+      `missing VS Code activation for ${language}`,
+    );
+  }
+  assert.equal(vscodeManifest.contributes?.typescriptServerPlugins, undefined);
+
+  const nvimConfig = fs.readFileSync(path.join(root, "editors/nvim/lua/vize/config.lua"), "utf-8");
+  assert.match(nvimConfig, /cmd = \{ "vize", "lsp" \}/);
+  assert.match(nvimConfig, /filetypes = \{ "vue", "art-vue" \}/);
+  assert.match(nvimConfig, /editor = true/);
+  assert.match(nvimConfig, /lint = true/);
+
+  const vimConfig = fs.readFileSync(path.join(root, "editors/vim/autoload/vize.vim"), "utf-8");
+  assert.match(vimConfig, /'cmd': \['vize', 'lsp'\]/);
+  assert.match(vimConfig, /'allowlist': \['vue', 'art-vue'\]/);
+  assert.match(vimConfig, /'editor': v:true/);
+  assert.match(vimConfig, /'lint': v:true/);
+
+  const helixConfig = fs.readFileSync(path.join(root, "editors/helix/languages.toml"), "utf-8");
+  assert.match(helixConfig, /\[language-server\.vize\][\s\S]*command = "vize"/);
+  assert.match(helixConfig, /\[language-server\.vize\][\s\S]*args = \["lsp"\]/);
+  assert.match(helixConfig, /name = "vue"[\s\S]*language-servers = \["vize"\]/);
+  assert.match(helixConfig, /name = "art-vue"[\s\S]*language-id = "art-vue"/);
+
+  const emacsConfig = fs.readFileSync(path.join(root, "editors/emacs/vize.el"), "utf-8");
+  assert.match(emacsConfig, /defcustom vize-eglot-command '\("vize" "lsp"\)/);
+  assert.match(emacsConfig, /vue-mode vue-ts-mode web-mode vize-vue-mode vize-art-vue-mode/);
+  assert.match(emacsConfig, /recommended \. \(:editor t :ecosystem t :lint t :typecheck t\)/);
+
+  const zedManifest = fs.readFileSync(path.join(root, "editors/zed/extension.toml"), "utf-8");
+  assert.match(zedManifest, /\[language_servers\.vize\][\s\S]*languages = \["Vue", "Art Vue"\]/);
+  assert.match(zedManifest, /"Vue" = "vue"/);
+  assert.match(zedManifest, /"Art Vue" = "art-vue"/);
+
+  const zedSource = fs.readFileSync(path.join(root, "editors/zed/src/lib.rs"), "utf-8");
+  assert.match(zedSource, /const SERVER_BINARY: &'static str = "vize"/);
+  assert.match(zedSource, /unwrap_or_else\(\|\| vec!\["lsp"\.to_string\(\)\]\)/);
+});

--- a/tests/tooling/lsp-authoring-core.test.ts
+++ b/tests/tooling/lsp-authoring-core.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import {
+  completionLabels,
+  firstLocation,
+  hoverToText,
+  isDiagnosticsForUri,
+  offsetToPosition,
+} from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+test("vize lsp supports production Vue authoring requests in one editor session", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-authoring-core");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: true,
+      typecheck: false,
+    });
+
+    const source = `<script setup lang="ts">
+import { ref } from 'vue'
+const count = ref(0)
+const items = [1, 2]
+</script>
+
+<template>
+  <button
+    @click="
+      () => {
+        co
+      }
+    "
+  >
+    {{ count }}
+  </button>
+  <ul>
+    <li v-for="item in items">{{ item }}</li>
+  </ul>
+</template>
+`;
+    const filePath = path.join(workspaceDir, "AuthoringCore.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+
+    session.notify("textDocument/didOpen", {
+      textDocument: {
+        uri,
+        languageId: "vue",
+        version: 1,
+        text: source,
+      },
+    });
+
+    const publish = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) =>
+        isDiagnosticsForUri(params, uri) &&
+        params.diagnostics.some(
+          (diagnostic) =>
+            diagnostic.source === "vize/lint" && diagnostic.code === "vue/require-v-for-key",
+        ),
+    )) as PublishDiagnosticsParams;
+    assert.ok(publish.diagnostics.length > 0, JSON.stringify(publish.diagnostics));
+
+    const completionOffset = source.indexOf("        co") + "        co".length;
+    const completion = await session.request("textDocument/completion", {
+      textDocument: { uri },
+      position: offsetToPosition(source, completionOffset),
+    });
+    const completionItems = completionLabels(completion);
+    assert.ok(completionItems.includes("count"), completionItems.join(", "));
+    assert.ok(!completionItems.includes("v-if"), completionItems.join(", "));
+
+    const clickOffset = source.indexOf("@click") + "@click".length;
+    const clickHover = (await session.request("textDocument/hover", {
+      textDocument: { uri },
+      position: offsetToPosition(source, clickOffset),
+    })) as { contents?: unknown } | null;
+    const clickHoverText = hoverToText(clickHover);
+    assert.match(clickHoverText, /Vue event listener/);
+    assert.match(clickHoverText, /@click="handler"/);
+    assert.match(clickHoverText, /\$event/);
+
+    const countUsageStart = source.lastIndexOf("count }}");
+    const countUsagePosition = offsetToPosition(source, countUsageStart + "count".length);
+
+    const hover = (await session.request("textDocument/hover", {
+      textDocument: { uri },
+      position: countUsagePosition,
+    })) as { contents?: unknown } | null;
+    const hoverText = hoverToText(hover);
+    assert.match(hoverText, /count/);
+    assert.match(hoverText, /Template binding from script|Ref<number>|<script setup>/);
+    assert.match(hoverText, /automatically unwrapped|template scope/i);
+
+    const definition = (await session.request("textDocument/definition", {
+      textDocument: { uri },
+      position: countUsagePosition,
+    })) as
+      | Array<{ uri: string; range: { start: { line: number; character: number } } }>
+      | { uri: string; range: { start: { line: number; character: number } } };
+    const declarationOffset = source.indexOf("count = ref");
+    const declarationPosition = offsetToPosition(source, declarationOffset);
+    const definitionLocation = firstLocation(definition);
+    assert.equal(definitionLocation.uri, uri);
+    assert.deepEqual(definitionLocation.range.start, declarationPosition);
+
+    const references = (await session.request("textDocument/references", {
+      textDocument: { uri },
+      position: countUsagePosition,
+      context: {
+        includeDeclaration: true,
+      },
+    })) as Array<{ uri: string; range: { start: { line: number; character: number } } }>;
+    assert.ok(
+      references.some(
+        (reference) =>
+          reference.uri === uri &&
+          reference.range.start.line === declarationPosition.line &&
+          reference.range.start.character === declarationPosition.character,
+      ),
+      JSON.stringify(references),
+    );
+    assert.ok(
+      references.some(
+        (reference) =>
+          reference.uri === uri &&
+          reference.range.start.line === countUsagePosition.line &&
+          reference.range.start.character === countUsagePosition.character - "count".length,
+      ),
+      JSON.stringify(references),
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/lsp-smoke.test.ts
+++ b/tests/tooling/lsp-smoke.test.ts
@@ -168,7 +168,7 @@ const secondaryLabel = ref('secondary')
       const labels = completionLabels(response);
       assert.ok(labels.includes("secondaryLabel"), labels.join(", "));
       assert.ok(labels.includes("primaryLabel"), labels.join(", "));
-      assert.ok(labels.includes("v-if"), labels.join(", "));
+      assert.ok(!labels.includes("v-if"), labels.join(", "));
     });
 
     await t.test("definition and references use UTF-16 LSP coordinates", async () => {

--- a/tests/tooling/lsp-template-completion.test.ts
+++ b/tests/tooling/lsp-template-completion.test.ts
@@ -63,6 +63,47 @@ import Child from './Child.vue'
     const stylePath = path.join(workspaceDir, "StyleMod.vue");
     fs.writeFileSync(stylePath, styleSource, "utf8");
 
+    const authoringSource = `<script setup lang="ts">
+import { ref } from 'vue'
+const count = ref(0)
+</script>
+<template>
+  <button
+    
+  >
+    {{ count }}
+  </button>
+</template>
+`;
+    const authoringPath = path.join(workspaceDir, "Authoring.vue");
+    fs.writeFileSync(authoringPath, authoringSource, "utf8");
+
+    const eventPrefixSource = `<template>
+  <button @cli></button>
+</template>
+`;
+    const eventPrefixPath = path.join(workspaceDir, "EventPrefix.vue");
+    fs.writeFileSync(eventPrefixPath, eventPrefixSource, "utf8");
+
+    const multilineEventSource = `<script setup lang="ts">
+import { ref } from 'vue'
+const count = ref(0)
+</script>
+<template>
+  <button
+    @click="
+      () => {
+        co
+      }
+    "
+  >
+    {{ count }}
+  </button>
+</template>
+`;
+    const multilineEventPath = path.join(workspaceDir, "MultilineEvent.vue");
+    fs.writeFileSync(multilineEventPath, multilineEventSource, "utf8");
+
     await session.initialize(workspaceDir, {
       editor: true,
       lint: true,
@@ -73,6 +114,9 @@ import Child from './Child.vue'
     const ltUri = pathToFileURL(ltPath).href;
     const commentUri = pathToFileURL(commentPath).href;
     const styleUri = pathToFileURL(stylePath).href;
+    const authoringUri = pathToFileURL(authoringPath).href;
+    const eventPrefixUri = pathToFileURL(eventPrefixPath).href;
+    const multilineEventUri = pathToFileURL(multilineEventPath).href;
 
     const openDocument = (uri: string, text: string): void => {
       session.notify("textDocument/didOpen", {
@@ -89,6 +133,9 @@ import Child from './Child.vue'
     openDocument(ltUri, ltSource);
     openDocument(commentUri, commentSource);
     openDocument(styleUri, styleSource);
+    openDocument(authoringUri, authoringSource);
+    openDocument(eventPrefixUri, eventPrefixSource);
+    openDocument(multilineEventUri, multilineEventSource);
 
     await session.waitForNotification("textDocument/publishDiagnostics");
 
@@ -108,6 +155,7 @@ import Child from './Child.vue'
         assert.ok(labels.includes("disabled"), labels.join(", "));
         assert.ok(labels.includes("v-if"), labels.join(", "));
         assert.ok(labels.includes(":"), labels.join(", "));
+        assert.ok(!labels.includes("Transition"), labels.join(", "));
       },
     );
 
@@ -179,6 +227,47 @@ import Child from './Child.vue'
       for (const item of items) {
         assert.equal(item.kind, 5, JSON.stringify(item));
       }
+    });
+
+    await t.test("inside a native opening tag surfaces HTML attrs and Vue events", async () => {
+      const offset = authoringSource.indexOf("    \n  >") + "    ".length;
+      const response = await session.request("textDocument/completion", {
+        textDocument: { uri: authoringUri },
+        position: offsetToPosition(authoringSource, offset),
+      });
+
+      const labels = completionLabels(response);
+      for (const label of ["class", "type", "@click", "v-if"]) {
+        assert.ok(labels.includes(label), `missing ${label}; got ${labels.join(", ")}`);
+      }
+      assert.ok(!labels.includes("count"), labels.join(", "));
+      assert.ok(!labels.includes("Transition"), labels.join(", "));
+    });
+
+    await t.test("typing @cli in an opening tag offers @click", async () => {
+      const offset = eventPrefixSource.indexOf("@cli") + "@cli".length;
+      const response = await session.request("textDocument/completion", {
+        textDocument: { uri: eventPrefixUri },
+        position: offsetToPosition(eventPrefixSource, offset),
+      });
+
+      const labels = completionLabels(response);
+      assert.ok(labels.includes("@click"), labels.join(", "));
+      assert.ok(!labels.includes("v-if"), labels.join(", "));
+      assert.ok(!labels.includes("class"), labels.join(", "));
+    });
+
+    await t.test("inside a multiline event handler surfaces script setup bindings", async () => {
+      const offset = multilineEventSource.indexOf("        co") + "        co".length;
+      const response = await session.request("textDocument/completion", {
+        textDocument: { uri: multilineEventUri },
+        position: offsetToPosition(multilineEventSource, offset),
+      });
+
+      const labels = completionLabels(response);
+      assert.ok(labels.includes("count"), labels.join(", "));
+      assert.ok(!labels.includes("v-if"), labels.join(", "));
+      assert.ok(!labels.includes("Transition"), labels.join(", "));
     });
   } finally {
     await session.shutdown();

--- a/tests/tooling/support/lsp/launch.ts
+++ b/tests/tooling/support/lsp/launch.ts
@@ -5,16 +5,18 @@ import { root } from "./paths.ts";
 /**
  * Resolves the fastest available way to launch `vize lsp` for smoke tests.
  *
- * A CI-profile binary wins when it is already present, then a release binary,
- * then a debug binary, then a globally installed CLI. Falling back to Cargo
- * keeps fresh checkouts usable at the cost of a slower first run, which is
- * acceptable for CI coverage.
+ * A caller-provided binary wins first, then the checkout's debug binary, then
+ * CI/release artifacts, then a globally installed CLI. Preferring the debug
+ * binary keeps local and workflow tests tied to the code that was just built
+ * instead of a stale `target/ci/vize` left by a previous job.
  */
 export function resolveVizeLaunchCommand(): string[] {
+  const envBinary = process.env.VIZE_LSP_BIN;
   const candidates = [
+    ...(envBinary ? [[envBinary, "lsp"]] : []),
+    [path.join(root, "target/debug/vize"), "lsp"],
     [path.join(root, "target/ci/vize"), "lsp"],
     [path.join(root, "target/release/vize"), "lsp"],
-    [path.join(root, "target/debug/vize"), "lsp"],
     ["vize", "lsp"],
   ];
 

--- a/tests/tooling/vscode-typescript-vue-plugin.test.ts
+++ b/tests/tooling/vscode-typescript-vue-plugin.test.ts
@@ -26,7 +26,7 @@ const initVuePlugin = require(
   }): import("typescript").LanguageService;
 };
 
-test("VS Code extension ships the TypeScript Vue plugin", () => {
+test("VS Code extension does not install a global TypeScript server plugin", () => {
   const manifest = readJson<{
     contributes?: {
       typescriptServerPlugins?: Array<{
@@ -36,32 +36,30 @@ test("VS Code extension ships the TypeScript Vue plugin", () => {
     };
     scripts?: Record<string, string>;
   }>("editors/vscode/package.json");
-  const plugin = manifest.contributes?.typescriptServerPlugins?.find(
-    (entry) => entry.name === "@vizejs/typescript-vue-plugin",
-  );
-  const stageScript = "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && vp pack";
 
-  assert.ok(plugin, "manifest should contribute the Vue TypeScript plugin");
-  assert.equal(plugin.enableForWorkspaceTypeScriptVersions, true);
-  assert.equal(manifest.scripts?.["vscode:prepublish"], stageScript);
-  assert.equal(manifest.scripts?.build, stageScript);
-  assert.equal(manifest.scripts?.watch, `${stageScript} --watch`);
   assert.equal(
-    manifest.scripts?.package,
-    "vsce package --no-dependencies --out dist/vize.vsix && node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix",
+    manifest.contributes?.typescriptServerPlugins,
+    undefined,
+    "Vize must not inject a TypeScript server plugin into every .ts/.tsx project",
   );
+  assert.equal(manifest.scripts?.["vscode:prepublish"], "vp pack");
+  assert.equal(manifest.scripts?.build, "vp pack");
+  assert.equal(manifest.scripts?.watch, "vp pack --watch");
+  assert.equal(manifest.scripts?.package, "vsce package --no-dependencies --out dist/vize.vsix");
+
+  for (const file of [
+    "editors/vscode/package.json",
+    "tools/vite-plus/tasks/build.ts",
+    "tools/vite-plus/tasks/test-benchmark.ts",
+  ]) {
+    assert.doesNotMatch(readFile(file), /sync-typescript-plugin\.mjs/);
+    assert.doesNotMatch(readFile(file), /@vizejs\/typescript-vue-plugin/);
+  }
+
+  assert.match(readFile("editors/vscode/.vscodeignore"), /^typescript-vue-plugin\/$/m);
   assert.ok(
     fs.existsSync(path.join(root, "editors/vscode/typescript-vue-plugin/index.cjs")),
-    "plugin package source must exist for the local file dependency",
-  );
-  assert.match(readFile("editors/vscode/.vscodeignore"), /^typescript-vue-plugin\/$/m);
-  assert.match(
-    readFile("tools/vite-plus/tasks/build.ts"),
-    /package:vscode-extension[\s\S]*vscode-typescript-vue-plugin\.test\.ts/,
-  );
-  assert.match(
-    readFile("tools/vite-plus/tasks/build.ts"),
-    /package:editor-extensions[\s\S]*vscode-typescript-vue-plugin\.test\.ts/,
+    "kept plugin source is tested below but no longer packaged or contributed",
   );
 });
 

--- a/tools/vite-plus/tasks/build.ts
+++ b/tools/vite-plus/tasks/build.ts
@@ -58,9 +58,7 @@ export const buildTasks = defineTasks({
   "package:vscode-extension": noCacheTask(
     runInVscodeExtension(
       "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
-      "node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix",
       "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
-      "node --test ../../tests/tooling/vscode-typescript-vue-plugin.test.ts",
     ),
   ),
   "check:zed-extension": task("cargo check --manifest-path editors/zed/Cargo.toml", {
@@ -86,9 +84,7 @@ export const buildTasks = defineTasks({
       "pnpm exec tsgo --noEmit",
       "pnpm exec vp check src vite.config.ts",
       "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
-      "node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix",
       "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
-      "node --test ../../tests/tooling/vscode-typescript-vue-plugin.test.ts",
     )} && ${runTask("check:zed-extension")} && ${runTask(
       "test:zed-extension:unit",
     )} && ${runTask("package:zed-extension")} && ${runTask(

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -92,7 +92,6 @@ export const testAndBenchmarkTasks = defineTasks({
   "test:vscode-extension:vsix": noCacheTask(
     runInVscodeExtension(
       "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
-      "node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix",
       "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
     ),
   ),

--- a/tools/vscode-vize/assert-vsix-package.mjs
+++ b/tools/vscode-vize/assert-vsix-package.mjs
@@ -19,7 +19,9 @@ const builtins = new Set([
 assert.ok(fs.existsSync(vsixPath), `VSIX does not exist: ${vsixPath}`);
 
 const archive = readZip(vsixPath);
-const entryNames = archive.entries.map((entry) => entry.name).sort();
+const entryNames = archive.entries
+  .map((entry) => entry.name)
+  .sort((left, right) => left.localeCompare(right));
 const entries = new Set(entryNames);
 const vsixSize = fs.statSync(vsixPath).size;
 
@@ -48,8 +50,6 @@ const requiredFiles = [
   "extension/icons/logo.png",
   "extension/icons/vue.svg",
   "extension/language-configuration.json",
-  "extension/node_modules/@vizejs/typescript-vue-plugin/index.cjs",
-  "extension/node_modules/@vizejs/typescript-vue-plugin/package.json",
   "extension/package.json",
   "extension/readme.md",
   "extension/syntaxes/art-vue.tmLanguage.json",
@@ -67,7 +67,6 @@ const allowedExtensionEntries = [
   /^extension\/dist\/extension\.cjs$/,
   /^extension\/icons\/(?:logo\.png|vue\.svg)$/,
   /^extension\/language-configuration\.json$/,
-  /^extension\/node_modules\/@vizejs\/typescript-vue-plugin\/(?:index\.cjs|package\.json)$/,
   /^extension\/package\.json$/,
   /^extension\/readme\.md$/,
   /^extension\/syntaxes\/(?:art-vue|vue)\.tmLanguage\.json$/,
@@ -85,7 +84,7 @@ const forbiddenEntries = [
   /^extension\/\.vscode-test\//,
   /^extension\/\.vscode\//,
   /^extension\/dist\/.*\.map$/,
-  /^extension\/node_modules\/(?!@vizejs\/typescript-vue-plugin\/(?:index\.cjs|package\.json)$)/,
+  /^extension\/node_modules\//,
   /^extension\/package-lock\.json$/,
   /^extension\/pnpm-lock\.yaml$/,
   /^extension\/src\//,
@@ -130,12 +129,7 @@ for (const command of packageJson.contributes.commands) {
 
 assert.ok(packageJson.activationEvents.includes("onLanguage:vue"));
 assert.ok(packageJson.activationEvents.includes("onLanguage:art-vue"));
-assert.deepEqual(packageJson.contributes.typescriptServerPlugins, [
-  {
-    name: "@vizejs/typescript-vue-plugin",
-    enableForWorkspaceTypeScriptVersions: true,
-  },
-]);
+assert.equal(packageJson.contributes.typescriptServerPlugins, undefined);
 
 const languages = new Map(
   packageJson.contributes.languages.map((language) => [language.id, language]),


### PR DESCRIPTION
## Summary
- stop shipping the VS Code TypeScript server plugin so .ts/.tsx projects are not globally patched
- add context-aware Vue template completions for native attributes, event shorthand, and multiline directive expressions
- tighten completion noise so expression positions return bindings and opening-tag positions return only relevant attributes/directives
- add richer directive hover coverage and CLI LSP authoring regression tests across completion, hover, definition, references, and diagnostics
- add all-editor adapter smoke coverage for VS Code, Zed, Neovim, Vim, Helix, and Emacs

## Validation
- cargo fmt --all
- cargo test -p vize_maestro hover_template -- --nocapture
- cargo test -p vize_maestro test_template_completion_ -- --nocapture
- cargo build -p vize && node --test tests/tooling/lsp-authoring-core.test.ts tests/tooling/lsp-template-completion.test.ts tests/tooling/lsp-smoke.test.ts tests/tooling/editor-integrations.test.ts tests/tooling/vscode-typescript-vue-plugin.test.ts tests/tooling/vscode-extension-manifest.test.ts
- ./node_modules/.bin/vp run package:editor-extensions

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785926406&installation_id=136613492&pr_number=2642&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2642&signature=9309f39f4dbbcd72681842c371d219d0f2c4b813dda1afbece2f6b1cb19452b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Vue template editing with smarter completions for opening tags, native HTML attributes, event listeners, and component-related suggestions.
  * Added richer hover info for template directives, including event listeners, bindings, and slots.
  * Expanded language-server support for “go to definition” and references in template bindings.

* **Bug Fixes**
  * Reduced unwanted completion suggestions in template attribute values.
  * Improved completion behavior for multiline event handlers and native element contexts.
  * Updated extension packaging to ship a cleaner, leaner VS Code bundle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->