### PR TITLE
fix(editor): harden LSP production gates

### DIFF
--- a/crates/vize_maestro/src/ide/definition/helpers.rs
+++ b/crates/vize_maestro/src/ide/definition/helpers.rs
@@ -160,21 +160,42 @@ fn find_tag_name_span(content: &str, offset: usize) -> Option<(usize, usize, usi
         cursor -= 1;
     }
 
-    let mut tag_start = None;
-    let mut i = cursor + 1;
-    while i > 0 {
-        i -= 1;
-        match bytes[i] {
-            b'<' => {
-                tag_start = Some(i);
+    let mut search_end = cursor.saturating_add(1).min(content.len());
+    while search_end > 0 {
+        let tag_start = content[..search_end].rfind('<')?;
+        let tag_end = find_tag_end_from(content, tag_start)?;
+
+        if cursor > tag_end {
+            return None;
+        }
+
+        let mut name_start = tag_start + 1;
+        if name_start < tag_end && bytes[name_start] == b'/' {
+            name_start += 1;
+        }
+
+        let mut name_end = name_start;
+        while name_end < tag_end {
+            let byte = bytes[name_end];
+            if byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_' {
+                name_end += 1;
+            } else {
                 break;
             }
-            b'>' | b'\n' => return None,
-            _ => {}
         }
+
+        if name_start != name_end {
+            return Some((tag_start, tag_end, name_start, name_end));
+        }
+
+        search_end = tag_start;
     }
 
-    let tag_start = tag_start?;
+    None
+}
+
+fn find_tag_end_from(content: &str, tag_start: usize) -> Option<usize> {
+    let bytes = content.as_bytes();
     let mut tag_end = tag_start;
     let mut quote = None;
 
@@ -187,37 +208,12 @@ fn find_tag_name_span(content: &str, offset: usize) -> Option<(usize, usize, usi
         } else if byte == b'"' || byte == b'\'' {
             quote = Some(byte);
         } else if byte == b'>' {
-            break;
-        } else if byte == b'\n' {
-            return None;
+            return Some(tag_end);
         }
         tag_end += 1;
     }
 
-    if tag_end >= bytes.len() || bytes[tag_end] != b'>' {
-        return None;
-    }
-
-    let mut name_start = tag_start + 1;
-    if name_start < tag_end && bytes[name_start] == b'/' {
-        name_start += 1;
-    }
-
-    let mut name_end = name_start;
-    while name_end < tag_end {
-        let byte = bytes[name_end];
-        if byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_' {
-            name_end += 1;
-        } else {
-            break;
-        }
-    }
-
-    if name_start == name_end {
-        return None;
-    }
-
-    Some((tag_start, tag_end, name_start, name_end))
+    None
 }
 
 /// Convert kebab-case to camelCase.

--- a/crates/vize_maestro/src/ide/definition/html_tests.rs
+++ b/crates/vize_maestro/src/ide/definition/html_tests.rs
@@ -29,6 +29,67 @@ fn static_boolean_attribute_is_detected_at_identifier_end_boundary() {
 }
 
 #[test]
+fn multiline_bound_attribute_is_detected_at_identifier_end_boundary() {
+    let dir = tempfile::tempdir().unwrap();
+    let source_path = dir.path().join("MultilineBound.vue");
+    let source = r#"<template>
+  <button
+    :disabled="isDisabled"
+  >
+    Save
+  </button>
+</template>
+"#;
+    fs::write(&source_path, source).unwrap();
+
+    let uri = Url::from_file_path(&source_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    let offset = source.find(":disabled").unwrap() + ":disabled".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+
+    assert_eq!(
+        helpers::get_attribute_and_component_at_offset(&ctx),
+        Some(("disabled".to_string(), "button".to_string()))
+    );
+}
+
+#[test]
+fn multiline_bound_attribute_ignores_gt_inside_previous_attribute_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let source_path = dir.path().join("MultilineWithEvent.vue");
+    let source = r#"<template>
+  <button
+    @click="() => { count }"
+    :disabled="isDisabled"
+  >
+    Save
+  </button>
+</template>
+"#;
+    fs::write(&source_path, source).unwrap();
+
+    let uri = Url::from_file_path(&source_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    let offset = source.find(":disabled").unwrap() + ":disabled".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+
+    assert_eq!(
+        helpers::get_attribute_and_component_at_offset(&ctx),
+        Some(("disabled".to_string(), "button".to_string()))
+    );
+}
+
+#[test]
 fn definition_resolves_native_html_tag_to_mdn_reference() {
     let (state, uri, source) = open_source(
         "NativeTag.vue",
@@ -59,6 +120,30 @@ fn definition_resolves_native_html_attribute_to_mdn_reference() {
     );
 
     let offset = source.find("disabled").unwrap() + "disabled".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let location = scalar_location(DefinitionService::definition(&ctx).unwrap());
+
+    assert_eq!(
+        location.uri.as_str(),
+        "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/disabled"
+    );
+}
+
+#[test]
+fn definition_resolves_multiline_native_html_attribute_to_mdn_reference() {
+    let (state, uri, source) = open_source(
+        "MultilineNativeAttribute.vue",
+        r#"<template>
+  <button
+    :disabled="isDisabled"
+  >
+    Save
+  </button>
+</template>
+"#,
+    );
+
+    let offset = source.find(":disabled").unwrap() + ":disabled".len();
     let ctx = IdeContext::new(&state, &uri, offset).unwrap();
     let location = scalar_location(DefinitionService::definition(&ctx).unwrap());
 

--- a/crates/vize_maestro/src/ide/hover/html.rs
+++ b/crates/vize_maestro/src/ide/hover/html.rs
@@ -207,6 +207,33 @@ const disabled = true
     }
 
     #[test]
+    fn test_hover_template_describes_multiline_native_html_bound_attribute_name() {
+        let source = r#"<script setup>
+const disabled = true
+</script>
+<template>
+  <button
+    :disabled="disabled"
+  >
+    Save
+  </button>
+</template>
+"#;
+        let (state, uri) = state_with_document("MultilineNativeBoundAttributeHover.vue", source);
+
+        let offset = source.find(":disabled").unwrap() + ":disabled".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let hover = HoverService::hover(&ctx).unwrap();
+        let value = hover_markdown(hover);
+
+        assert!(value.contains("disabled on <button>"), "got {value:?}");
+        assert!(
+            value.contains("HTMLElementTagNameMap[\"button\"][\"disabled\"]"),
+            "got {value:?}"
+        );
+    }
+
+    #[test]
     fn test_hover_template_does_not_describe_custom_element_as_native_dom() {
         let source = r#"<template>
   <my-widget />

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -235,6 +235,10 @@ impl LanguageServer for MaestroServer {
                     return Ok(Some(response));
                 }
             }
+
+            if ctx.block_type.is_some() {
+                return Ok(None);
+            }
         }
 
         let items = self.get_block_snippets();

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -218,27 +218,22 @@ impl LanguageServer for MaestroServer {
             return Ok(None);
         }
 
+        #[cfg(feature = "native")]
         {
-            #[cfg(feature = "native")]
+            let corsa_bridge = self.state.get_corsa_bridge().await;
+            if let Some(response) = CompletionService::complete_with_corsa(&ctx, corsa_bridge).await
             {
-                let corsa_bridge = self.state.get_corsa_bridge().await;
-                if let Some(response) =
-                    CompletionService::complete_with_corsa(&ctx, corsa_bridge).await
-                {
-                    return Ok(Some(response));
-                }
+                return Ok(Some(response));
             }
+        }
 
-            #[cfg(not(feature = "native"))]
-            {
-                if let Some(response) = CompletionService::complete(&ctx) {
-                    return Ok(Some(response));
-                }
-            }
+        #[cfg(not(feature = "native"))]
+        if let Some(response) = CompletionService::complete(&ctx) {
+            return Ok(Some(response));
+        }
 
-            if ctx.block_type.is_some() {
-                return Ok(None);
-            }
+        if ctx.block_type.is_some() {
+            return Ok(None);
         }
 
         let items = self.get_block_snippets();

--- a/editors/emacs/README.md
+++ b/editors/emacs/README.md
@@ -5,8 +5,11 @@ Emacs Eglot integration for the Vize language server.
 ```elisp
 (add-to-list 'load-path "/path/to/emacs-vize")
 (require 'vize)
-(vize-setup-eglot 'lint)
+(vize-setup-eglot 'recommended)
 ```
+
+The default profile is `recommended`, so Eglot starts Vize with diagnostics,
+hover, completion, definition, references, symbols, and ecosystem helpers enabled.
 
 Profiles:
 

--- a/editors/emacs/test/vize-test.el
+++ b/editors/emacs/test/vize-test.el
@@ -5,7 +5,8 @@
 (ert-deftest vize-eglot-default-program ()
   (should
    (equal (vize-eglot-server-program)
-          '("vize" "lsp" :initializationOptions (:lint t)))))
+          '("vize" "lsp" :initializationOptions
+            (:editor t :ecosystem t :lint t :typecheck t)))))
 
 (ert-deftest vize-eglot-recommended-program ()
   (should

--- a/editors/emacs/vize.el
+++ b/editors/emacs/vize.el
@@ -19,7 +19,7 @@
   :type '(repeat string)
   :group 'vize)
 
-(defcustom vize-eglot-profile 'lint
+(defcustom vize-eglot-profile 'recommended
   "Default Vize feature profile for Eglot."
   :type '(choice (const :tag "Lint only" lint)
                  (const :tag "Recommended" recommended)

--- a/editors/helix/README.md
+++ b/editors/helix/README.md
@@ -8,7 +8,7 @@ Copy or merge `languages.toml` into:
 ~/.config/helix/languages.toml
 ```
 
-The default profile is lint-only:
+The default profile is recommended:
 
 ```toml
 [language-server.vize]
@@ -16,7 +16,10 @@ command = "vize"
 args = ["lsp"]
 
 [language-server.vize.config]
+editor = true
+ecosystem = true
 lint = true
+typecheck = true
 ```
 
 The package registers Vize for `vue` and `art-vue`. The `art-vue` language uses a glob so

--- a/editors/helix/languages.toml
+++ b/editors/helix/languages.toml
@@ -3,7 +3,10 @@ command = "vize"
 args = ["lsp"]
 
 [language-server.vize.config]
+editor = true
+ecosystem = true
 lint = true
+typecheck = true
 
 [[language]]
 name = "vue"

--- a/editors/nvim/README.md
+++ b/editors/nvim/README.md
@@ -4,12 +4,13 @@ Neovim integration for the Vize language server.
 
 ```lua
 require("vize").setup({
-  profile = "lint",
+  profile = "recommended",
 })
 ```
 
 The plugin configures `vim.lsp.config("vize", ...)` with `cmd = { "vize", "lsp" }` and filetypes
-for `vue` and `art-vue`. Features are opt-in through initialization options.
+for `vue` and `art-vue`. The default profile enables diagnostics, hover, completion,
+definition, references, symbols, and ecosystem helpers.
 
 Profiles:
 

--- a/editors/nvim/lua/vize/config.lua
+++ b/editors/nvim/lua/vize/config.lua
@@ -17,7 +17,7 @@ local default_config = {
   autostart = true,
   cmd = { "vize", "lsp" },
   filetypes = { "vue", "art-vue" },
-  init_options = profiles.lint,
+  init_options = profiles.recommended,
   root_markers = { "vize.config.pkl", "vize.config.json", "package.json", ".git" },
   settings = {},
 }

--- a/editors/nvim/test/vize_spec.lua
+++ b/editors/nvim/test/vize_spec.lua
@@ -10,7 +10,12 @@ end
 local defaults = config.normalize()
 assert_eq(defaults.cmd, { "vize", "lsp" }, "default cmd")
 assert_eq(defaults.filetypes, { "vue", "art-vue" }, "default filetypes")
-assert_eq(defaults.init_options, { lint = true }, "default lint profile")
+assert_eq(defaults.init_options, {
+  editor = true,
+  ecosystem = true,
+  lint = true,
+  typecheck = true,
+}, "default recommended profile")
 assert(defaults.root_markers[1] == "vize.config.pkl", "prefers vize config root marker")
 
 local recommended = config.normalize({ profile = "recommended" })

--- a/editors/vim/README.md
+++ b/editors/vim/README.md
@@ -9,8 +9,11 @@ Vim does not include a built-in LSP client. This package provides filetype detec
 Plug 'prabirshrestha/vim-lsp'
 Plug 'ubugeeei-prod/vize', { 'rtp': 'editors/vim' }
 
-call vize#setup({'profile': 'lint'})
+call vize#setup({'profile': 'recommended'})
 ```
+
+The default profile is `recommended`, so Vim starts Vize with diagnostics, hover,
+completion, definition, references, symbols, and ecosystem helpers enabled.
 
 Profiles:
 

--- a/editors/vim/autoload/vize.vim
+++ b/editors/vim/autoload/vize.vim
@@ -12,7 +12,7 @@ let s:profiles = {
 let s:default_config = {
       \ 'allowlist': ['vue', 'art-vue'],
       \ 'cmd': ['vize', 'lsp'],
-      \ 'initialization_options': s:profiles.lint,
+      \ 'initialization_options': s:profiles.recommended,
       \ }
 
 function! vize#profile(name) abort

--- a/editors/vim/test/vize_spec.vim
+++ b/editors/vim/test/vize_spec.vim
@@ -4,7 +4,12 @@ runtime autoload/vize.vim
 let s:defaults = vize#normalize({})
 call assert_equal(['vize', 'lsp'], s:defaults.cmd)
 call assert_equal(['vue', 'art-vue'], s:defaults.allowlist)
-call assert_equal({'lint': v:true}, s:defaults.initialization_options)
+call assert_equal({
+      \ 'editor': v:true,
+      \ 'ecosystem': v:true,
+      \ 'lint': v:true,
+      \ 'typecheck': v:true,
+      \ }, s:defaults.initialization_options)
 
 let s:recommended = vize#normalize({'profile': 'recommended'})
 call assert_equal({

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -1,13 +1,16 @@
 # Vize for Zed
 
-Opt-in Vue diagnostics and language support powered by Vize.
+Vue diagnostics and language support powered by Vize.
 
 This extension expects the `vize` CLI to be available on `PATH`, or configured through Zed settings.
 
 The extension also registers an `Art Vue` language for `*.art.vue`, so Vize can power hover,
 completion, go-to-definition, and references there without relying on a separate Zed extension.
 
-## Enable Lint First
+By default, the extension starts Vize with the recommended profile: lint, typecheck, editor
+features, and ecosystem helpers. Override `initialization_options` if you need a narrower profile.
+
+## Recommended Profile
 
 ```json
 {
@@ -22,20 +25,8 @@ completion, go-to-definition, and references there without relying on a separate
   "lsp": {
     "vize": {
       "initialization_options": {
-        "lint": true
-      }
-    }
-  }
-}
-```
-
-## Add Type Checking
-
-```json
-{
-  "lsp": {
-    "vize": {
-      "initialization_options": {
+        "editor": true,
+        "ecosystem": true,
         "lint": true,
         "typecheck": true
       }
@@ -44,9 +35,24 @@ completion, go-to-definition, and references there without relying on a separate
 }
 ```
 
-## Evaluate Editor Features
+## Lint Only
 
-Use this only when you are ready to let Vize overlap with the existing Vue language server.
+```json
+{
+  "lsp": {
+    "vize": {
+      "initialization_options": {
+        "lint": true,
+        "typecheck": false,
+        "editor": false,
+        "ecosystem": false
+      }
+    }
+  }
+}
+```
+
+## Narrow Editor Profile
 
 ```json
 {

--- a/editors/zed/src/lib.rs
+++ b/editors/zed/src/lib.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use zed_extension_api::{
-    self as zed, Result,
+    self as zed,
     settings::{CommandSettings, LspSettings},
+    Result,
 };
 
 struct VizeExtension;
@@ -65,7 +66,9 @@ impl zed::Extension for VizeExtension {
         worktree: &zed::Worktree,
     ) -> Result<Option<zed::serde_json::Value>> {
         let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
-        Ok(settings.initialization_options)
+        Ok(settings
+            .initialization_options
+            .or_else(|| Some(recommended_initialization_options())))
     }
 
     fn language_server_workspace_configuration(
@@ -104,9 +107,20 @@ fn merge_env(shell_env: zed::EnvVars, custom_env: Option<HashMap<String, String>
     env
 }
 
+fn recommended_initialization_options() -> zed::serde_json::Value {
+    zed::serde_json::json!({
+        "editor": true,
+        "ecosystem": true,
+        "lint": true,
+        "typecheck": true,
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{CommandSettings, LspSettings, VizeExtension, zed};
+    use super::{
+        recommended_initialization_options, zed, CommandSettings, LspSettings, VizeExtension,
+    };
 
     #[test]
     fn discovered_binary_defaults_to_lsp() {
@@ -196,6 +210,19 @@ mod tests {
 
         assert!(error.contains("Install the Vize CLI"));
         assert!(error.contains("lsp.vize.binary.path"));
+    }
+
+    #[test]
+    fn default_initialization_options_are_recommended_profile() {
+        assert_eq!(
+            recommended_initialization_options(),
+            zed::serde_json::json!({
+                "editor": true,
+                "ecosystem": true,
+                "lint": true,
+                "typecheck": true,
+            })
+        );
     }
 
     fn settings_with_binary(binary: CommandSettings) -> LspSettings {

--- a/tests/tooling/editor-integrations-emacs.test.ts
+++ b/tests/tooling/editor-integrations-emacs.test.ts
@@ -16,8 +16,8 @@ test("emacs vize.el defines the eglot command default and customizable profile",
   // The LSP launch command defaults to running the `vize lsp` subcommand.
   assert.match(el, /\(defcustom\s+vize-eglot-command\s+'\("vize"\s+"lsp"\)/);
 
-  // The default feature profile is `lint`.
-  assert.match(el, /\(defcustom\s+vize-eglot-profile\s+'lint\b/);
+  // The default feature profile is `recommended`.
+  assert.match(el, /\(defcustom\s+vize-eglot-profile\s+'recommended\b/);
 
   // The profile is a customizable choice exposing lint / recommended / off.
   assert.match(

--- a/tests/tooling/editor-integrations-helix.test.ts
+++ b/tests/tooling/editor-integrations-helix.test.ts
@@ -18,9 +18,12 @@ test("helix languages.toml registers the vize language server with the lsp comma
   assert.match(config, /^command = "vize"$/m);
   assert.match(config, /^args = \["lsp"\]$/m);
 
-  // Server-level config enables linting.
+  // Server-level config enables the recommended editor profile.
   assert.match(config, /^\[language-server\.vize\.config\]$/m);
+  assert.match(config, /^editor = true$/m);
+  assert.match(config, /^ecosystem = true$/m);
   assert.match(config, /^lint = true$/m);
+  assert.match(config, /^typecheck = true$/m);
 });
 
 test("helix languages.toml declares the vue language wired to the vize server", () => {

--- a/tests/tooling/editor-integrations-neovim.test.ts
+++ b/tests/tooling/editor-integrations-neovim.test.ts
@@ -44,7 +44,7 @@ test("nvim config default cmd, filetypes and root_markers declare the canonical 
   );
 });
 
-test("nvim config defines the lint, recommended and off profiles, defaulting init_options to lint", () => {
+test("nvim config defines profiles and defaults init_options to recommended", () => {
   const config = readRepoFile("editors/nvim/lua/vize/config.lua");
 
   // All three named profiles are defined inside the profiles table.
@@ -52,8 +52,8 @@ test("nvim config defines the lint, recommended and off profiles, defaulting ini
   assert.match(config, /\brecommended\s*=\s*\{/);
   assert.match(config, /\boff\s*=\s*\{\s*\}/);
 
-  // Default init_options points at the lint profile.
-  assert.match(config, /init_options\s*=\s*profiles\.lint/);
+  // Default init_options points at the full editor profile.
+  assert.match(config, /init_options\s*=\s*profiles\.recommended/);
 });
 
 test("nvim plugin entrypoint wires the plugin via guard + setup command", () => {

--- a/tests/tooling/editor-integrations-zed.test.ts
+++ b/tests/tooling/editor-integrations-zed.test.ts
@@ -46,6 +46,16 @@ test("zed extension.toml declares vize server, language ids, grammar pin and ver
   assert.equal(declaredVersion, workspaceVersion());
 });
 
+test("zed extension source falls back to the recommended initialization profile", () => {
+  const source = readRepoFile("editors/zed/src/lib.rs");
+
+  assert.match(source, /recommended_initialization_options/);
+  assert.match(source, /"editor": true/);
+  assert.match(source, /"ecosystem": true/);
+  assert.match(source, /"lint": true/);
+  assert.match(source, /"typecheck": true/);
+});
+
 test("zed art-vue config.toml declares comments, brackets, autoclose and tailwind opt-in", () => {
   const config = readRepoFile("editors/zed/languages/art-vue/config.toml");
 

--- a/tests/tooling/editor-lsp-adapters.test.ts
+++ b/tests/tooling/editor-lsp-adapters.test.ts
@@ -28,23 +28,34 @@ test("editor adapters consistently route Vue documents to the Vize LSP", () => {
   const nvimConfig = fs.readFileSync(path.join(root, "editors/nvim/lua/vize/config.lua"), "utf-8");
   assert.match(nvimConfig, /cmd = \{ "vize", "lsp" \}/);
   assert.match(nvimConfig, /filetypes = \{ "vue", "art-vue" \}/);
+  assert.match(nvimConfig, /init_options = profiles\.recommended/);
   assert.match(nvimConfig, /editor = true/);
+  assert.match(nvimConfig, /ecosystem = true/);
   assert.match(nvimConfig, /lint = true/);
+  assert.match(nvimConfig, /typecheck = true/);
 
   const vimConfig = fs.readFileSync(path.join(root, "editors/vim/autoload/vize.vim"), "utf-8");
   assert.match(vimConfig, /'cmd': \['vize', 'lsp'\]/);
   assert.match(vimConfig, /'allowlist': \['vue', 'art-vue'\]/);
+  assert.match(vimConfig, /'initialization_options': s:profiles\.recommended/);
   assert.match(vimConfig, /'editor': v:true/);
+  assert.match(vimConfig, /'ecosystem': v:true/);
   assert.match(vimConfig, /'lint': v:true/);
+  assert.match(vimConfig, /'typecheck': v:true/);
 
   const helixConfig = fs.readFileSync(path.join(root, "editors/helix/languages.toml"), "utf-8");
   assert.match(helixConfig, /\[language-server\.vize\][\s\S]*command = "vize"/);
   assert.match(helixConfig, /\[language-server\.vize\][\s\S]*args = \["lsp"\]/);
+  assert.match(helixConfig, /\[language-server\.vize\.config\][\s\S]*editor = true/);
+  assert.match(helixConfig, /\[language-server\.vize\.config\][\s\S]*ecosystem = true/);
+  assert.match(helixConfig, /\[language-server\.vize\.config\][\s\S]*lint = true/);
+  assert.match(helixConfig, /\[language-server\.vize\.config\][\s\S]*typecheck = true/);
   assert.match(helixConfig, /name = "vue"[\s\S]*language-servers = \["vize"\]/);
   assert.match(helixConfig, /name = "art-vue"[\s\S]*language-id = "art-vue"/);
 
   const emacsConfig = fs.readFileSync(path.join(root, "editors/emacs/vize.el"), "utf-8");
   assert.match(emacsConfig, /defcustom vize-eglot-command '\("vize" "lsp"\)/);
+  assert.match(emacsConfig, /defcustom vize-eglot-profile 'recommended/);
   assert.match(emacsConfig, /vue-mode vue-ts-mode web-mode vize-vue-mode vize-art-vue-mode/);
   assert.match(emacsConfig, /recommended \. \(:editor t :ecosystem t :lint t :typecheck t\)/);
 
@@ -56,4 +67,9 @@ test("editor adapters consistently route Vue documents to the Vize LSP", () => {
   const zedSource = fs.readFileSync(path.join(root, "editors/zed/src/lib.rs"), "utf-8");
   assert.match(zedSource, /const SERVER_BINARY: &'static str = "vize"/);
   assert.match(zedSource, /unwrap_or_else\(\|\| vec!\["lsp"\.to_string\(\)\]\)/);
+  assert.match(zedSource, /recommended_initialization_options/);
+  assert.match(zedSource, /"editor": true/);
+  assert.match(zedSource, /"ecosystem": true/);
+  assert.match(zedSource, /"lint": true/);
+  assert.match(zedSource, /"typecheck": true/);
 });

--- a/tests/tooling/editor-profiles-consistency.test.ts
+++ b/tests/tooling/editor-profiles-consistency.test.ts
@@ -153,8 +153,8 @@ PROFILE_DECLARATIONS.push({
 
 // Editors that legitimately declare NO profile table: VS Code (it exposes
 // per-feature `*.enable` settings plus Recommended/Lint-only *commands*, not a
-// canonical profile table), Zed and Helix (single `lint = true` config, no
-// named profiles).
+// canonical profile table), Zed and Helix (single recommended config, no named
+// profiles).
 const PROFILE_LESS_EDITORS = new Set(["vscode", "zed", "helix"]);
 
 test("every editor that declares Vue languages references both canonical ids", () => {

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -22,6 +22,10 @@ import { LspSession } from "./support/lsp/session.ts";
  * bundle flags, so this test widens it with the per-feature toggles it needs.
  */
 type GranularInitOptions = LspInitializationOptions & {
+  completion?: boolean;
+  hover?: boolean;
+  definition?: boolean;
+  references?: boolean;
   inlayHints?: boolean;
   foldingRanges?: boolean;
   documentSymbols?: boolean;
@@ -47,6 +51,8 @@ type ServerCapabilities = {
     resolveProvider?: boolean;
   };
   hoverProvider?: unknown;
+  definitionProvider?: unknown;
+  referencesProvider?: unknown;
   textDocumentSync?: {
     change?: number;
     openClose?: boolean;
@@ -89,6 +95,9 @@ test("vize lsp advertises the full editor-feature provider set with exact shapes
     assert.equal(capabilities.inlayHintProvider, true);
     assert.equal(capabilities.documentHighlightProvider, true);
     assert.equal(capabilities.workspaceSymbolProvider, true);
+    assert.equal(capabilities.hoverProvider, true);
+    assert.equal(capabilities.definitionProvider, true);
+    assert.equal(capabilities.referencesProvider, true);
 
     // Resolve-provider shapes.
     assert.equal(capabilities.codeLensProvider?.resolveProvider, false);
@@ -145,6 +154,9 @@ test("vize lsp editor:false strips editor providers but keeps lint-driven codeAc
       assert.equal(capabilities.documentLinkProvider, undefined);
       assert.equal(capabilities.workspaceSymbolProvider, undefined);
       assert.equal(capabilities.hoverProvider, undefined);
+      assert.equal(capabilities.definitionProvider, undefined);
+      assert.equal(capabilities.referencesProvider, undefined);
+      assert.equal(capabilities.documentHighlightProvider, undefined);
 
       // Lint code actions survive without the editor bundle.
       assert.ok(capabilities.codeActionProvider, "codeActionProvider should remain present");
@@ -174,6 +186,26 @@ test("vize lsp per-feature init flags toggle individual providers independently"
       assert.equal(capabilities.semanticTokensProvider, undefined);
       // A sibling editor provider is untouched.
       assert.equal(capabilities.hoverProvider, true);
+    },
+  );
+
+  await withCapabilities(
+    "granular-authoring-off",
+    {
+      editor: true,
+      completion: false,
+      hover: false,
+      definition: false,
+      references: false,
+    },
+    (capabilities) => {
+      assert.equal(capabilities.completionProvider, undefined);
+      assert.equal(capabilities.hoverProvider, undefined);
+      assert.equal(capabilities.definitionProvider, undefined);
+      assert.equal(capabilities.referencesProvider, undefined);
+      assert.equal(capabilities.documentHighlightProvider, undefined);
+      // A sibling editor provider is untouched.
+      assert.equal(capabilities.documentSymbolProvider, true);
     },
   );
 

--- a/tests/tooling/lsp-editor-production-gates.test.ts
+++ b/tests/tooling/lsp-editor-production-gates.test.ts
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import {
+  completionLabels,
+  firstLocation,
+  hoverToText,
+  isDiagnosticsForUri,
+  offsetToPosition,
+} from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+type Location = {
+  uri: string;
+  range: {
+    start: { line: number; character: number };
+    end: { line: number; character: number };
+  };
+};
+
+type DefinitionResponse = Location | Location[] | null;
+
+test("vize lsp gates production Vue authoring boundaries", async (t) => {
+  const testRootDir = path.join(testOutputRoot, "lsp-editor-production-gates");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: true,
+      typecheck: false,
+    });
+
+    const source = `<script setup lang="ts">
+import { ref } from 'vue'
+
+const count = ref(0)
+const isReady = ref(false)
+</script>
+
+<template>
+  <button
+    
+    class="co"
+    @click="
+      () => {
+        count
+      }
+    "
+    :disabled="isReady"
+  >
+    {{ count }}
+  </button>
+</template>
+`;
+    const filePath = path.join(workspaceDir, "ProductionGates.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+
+    session.notify("textDocument/didOpen", {
+      textDocument: {
+        uri,
+        languageId: "vue",
+        version: 1,
+        text: source,
+      },
+    });
+
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, uri),
+    );
+
+    await t.test("opening tag completion offers attributes and directives only", async () => {
+      const offset = source.indexOf("    \n    class") + "    ".length;
+      const response = await session.request("textDocument/completion", {
+        textDocument: { uri },
+        position: offsetToPosition(source, offset),
+      });
+
+      const labels = completionLabels(response);
+      for (const label of ["class", "type", "@click", "v-if"]) {
+        assert.ok(labels.includes(label), `missing ${label}; got ${labels.join(", ")}`);
+      }
+      assert.ok(!labels.includes("count"), labels.join(", "));
+      assert.ok(!labels.includes("isReady"), labels.join(", "));
+      assert.ok(!labels.includes("Transition"), labels.join(", "));
+    });
+
+    await t.test(
+      "static attribute values do not leak script or directive completions",
+      async () => {
+        const offset = source.indexOf('class="co') + 'class="co'.length;
+        const response = await session.request("textDocument/completion", {
+          textDocument: { uri },
+          position: offsetToPosition(source, offset),
+        });
+
+        assert.deepEqual(completionLabels(response), []);
+      },
+    );
+
+    await t.test(
+      "event handler expressions offer bindings but not authoring directives",
+      async () => {
+        const offset = source.indexOf("        count") + "        cou".length;
+        const response = await session.request("textDocument/completion", {
+          textDocument: { uri },
+          position: offsetToPosition(source, offset),
+        });
+
+        const labels = completionLabels(response);
+        assert.ok(labels.includes("count"), labels.join(", "));
+        assert.ok(labels.includes("isReady"), labels.join(", "));
+        assert.ok(!labels.includes("v-if"), labels.join(", "));
+        assert.ok(!labels.includes("@click"), labels.join(", "));
+        assert.ok(!labels.includes("class"), labels.join(", "));
+      },
+    );
+
+    await t.test("directive prefix completion stays on the event/directive surface", async () => {
+      const prefixSource = `<template><button @></button></template>`;
+      const prefixPath = path.join(workspaceDir, "DirectivePrefix.vue");
+      const prefixUri = pathToFileURL(prefixPath).href;
+      fs.writeFileSync(prefixPath, prefixSource, "utf8");
+      session.notify("textDocument/didOpen", {
+        textDocument: {
+          uri: prefixUri,
+          languageId: "vue",
+          version: 1,
+          text: prefixSource,
+        },
+      });
+      await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+        isDiagnosticsForUri(params, prefixUri),
+      );
+
+      const offset = prefixSource.indexOf("@") + 1;
+      const response = await session.request("textDocument/completion", {
+        textDocument: { uri: prefixUri },
+        position: offsetToPosition(prefixSource, offset),
+      });
+
+      const labels = completionLabels(response);
+      assert.ok(labels.includes("@click"), labels.join(", "));
+      assert.ok(!labels.includes("class"), labels.join(", "));
+      assert.ok(!labels.includes("v-if"), labels.join(", "));
+      assert.ok(!labels.includes("Transition"), labels.join(", "));
+    });
+
+    await t.test("rich hover covers native attrs, events, and template bindings", async () => {
+      const disabledAttrOffset = source.indexOf(":disabled") + ":disabled".length;
+      const disabledHover = (await session.request("textDocument/hover", {
+        textDocument: { uri },
+        position: offsetToPosition(source, disabledAttrOffset),
+      })) as { contents?: unknown } | null;
+      const disabledText = hoverToText(disabledHover);
+      assert.match(disabledText, /disabled on <button>/);
+      assert.match(disabledText, /HTML attribute/);
+      assert.match(disabledText, /MDN reference/);
+
+      const clickOffset = source.indexOf("@click") + "@click".length;
+      const clickHover = (await session.request("textDocument/hover", {
+        textDocument: { uri },
+        position: offsetToPosition(source, clickOffset),
+      })) as { contents?: unknown } | null;
+      const clickText = hoverToText(clickHover);
+      assert.match(clickText, /Vue event listener/);
+      assert.match(clickText, /\$event/);
+
+      const interpolationOffset = source.lastIndexOf("count }}") + "count".length;
+      const bindingHover = (await session.request("textDocument/hover", {
+        textDocument: { uri },
+        position: offsetToPosition(source, interpolationOffset),
+      })) as { contents?: unknown } | null;
+      const bindingText = hoverToText(bindingHover);
+      assert.match(bindingText, /count/);
+      assert.match(bindingText, /Template binding from script/);
+      assert.match(bindingText, /automatically unwrapped|template scope/i);
+    });
+
+    await t.test(
+      "definition and references include event handlers and interpolations",
+      async () => {
+        const eventUseOffset = source.indexOf("        count") + "        count".length;
+        const eventUsePosition = offsetToPosition(source, eventUseOffset);
+        const declarationOffset = source.indexOf("count = ref");
+        const declarationPosition = offsetToPosition(source, declarationOffset);
+
+        const definition = (await session.request("textDocument/definition", {
+          textDocument: { uri },
+          position: eventUsePosition,
+        })) as DefinitionResponse;
+
+        assert.ok(definition, "definition should resolve from an inline event handler");
+        const location = firstLocation(definition);
+        assert.equal(location.uri, uri);
+        assert.deepEqual(location.range.start, declarationPosition);
+
+        const references = (await session.request("textDocument/references", {
+          textDocument: { uri },
+          position: eventUsePosition,
+          context: { includeDeclaration: true },
+        })) as Location[];
+
+        const starts = references.map((reference) => reference.range.start);
+        assert.ok(
+          starts.some(
+            (start) =>
+              start.line === declarationPosition.line &&
+              start.character === declarationPosition.character,
+          ),
+          JSON.stringify(references),
+        );
+        assert.ok(
+          starts.some(
+            (start) =>
+              start.line === eventUsePosition.line &&
+              start.character === eventUsePosition.character - "count".length,
+          ),
+          JSON.stringify(references),
+        );
+
+        const interpolationStart = offsetToPosition(source, source.lastIndexOf("{{ count }}") + 3);
+        assert.ok(
+          starts.some(
+            (start) =>
+              start.line === interpolationStart.line &&
+              start.character === interpolationStart.character,
+          ),
+          JSON.stringify(references),
+        );
+      },
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});

--- a/tools/emacs-vize/assert-emacs-package.mjs
+++ b/tools/emacs-vize/assert-emacs-package.mjs
@@ -81,7 +81,7 @@ const testEl = readTextEntry(entryMap, "emacs/test/vize-test.el");
 
 assert.match(vizeEl, /lexical-binding: t/);
 assert.match(vizeEl, /defcustom vize-eglot-command '\("vize" "lsp"\)/);
-assert.match(vizeEl, /defcustom vize-eglot-profile 'lint/);
+assert.match(vizeEl, /defcustom vize-eglot-profile 'recommended/);
 assert.match(vizeEl, /recommended \. \(:editor t :ecosystem t :lint t :typecheck t\)/);
 assert.match(vizeEl, /define-derived-mode vize-vue-mode/);
 assert.match(vizeEl, /define-derived-mode vize-art-vue-mode/);
@@ -95,7 +95,7 @@ assert.match(vizeEl, /:initializationOptions options/);
 assert.match(vizeEl, /eglot-server-programs/);
 assert.match(vizeEl, /provide 'vize/);
 assert.match(testEl, /ert-deftest vize-eglot-default-program/);
-assert.match(testEl, /:initializationOptions \(:lint t\)/);
+assert.match(testEl, /:initializationOptions\s*\(:editor t :ecosystem t :lint t :typecheck t\)/);
 assert.match(testEl, /ert-deftest vize-eglot-off-program/);
 
 console.log(

--- a/tools/helix-vize/assert-helix-package.mjs
+++ b/tools/helix-vize/assert-helix-package.mjs
@@ -74,7 +74,12 @@ const parsed = toml.parse(languagesToml);
 
 assert.equal(parsed["language-server"].vize.command, "vize");
 assert.deepEqual(parsed["language-server"].vize.args, ["lsp"]);
-assert.deepEqual(parsed["language-server"].vize.config, { lint: true });
+assert.deepEqual(parsed["language-server"].vize.config, {
+  editor: true,
+  ecosystem: true,
+  lint: true,
+  typecheck: true,
+});
 
 const languages = new Map(parsed.language.map((language) => [language.name, language]));
 assertLanguage(languages.get("vue"), {
@@ -92,7 +97,10 @@ assert.match(languagesToml, /^\[language-server\.vize\]$/m);
 assert.match(languagesToml, /^command = "vize"$/m);
 assert.match(languagesToml, /^args = \["lsp"\]$/m);
 assert.match(languagesToml, /^\[language-server\.vize\.config\]$/m);
+assert.match(languagesToml, /^editor = true$/m);
+assert.match(languagesToml, /^ecosystem = true$/m);
 assert.match(languagesToml, /^lint = true$/m);
+assert.match(languagesToml, /^typecheck = true$/m);
 assert.match(languagesToml, /^file-types = \[\{ glob = "\*\.art\.vue" \}\]$/m);
 
 console.log(

--- a/tools/nvim-vize/assert-nvim-package.mjs
+++ b/tools/nvim-vize/assert-nvim-package.mjs
@@ -97,6 +97,7 @@ assert.match(
 );
 assert.match(configLua, /lint = true/);
 assert.match(configLua, /recommended = \{/);
+assert.match(configLua, /init_options = profiles\.recommended/);
 assert.match(configLua, /assert_list\("cmd"/);
 assert.match(initLua, /vim\.lsp\.config\("vize", resolved\)/);
 assert.match(initLua, /vim\.lsp\.enable\("vize"\)/);

--- a/tools/vim-vize/assert-vim-package.mjs
+++ b/tools/vim-vize/assert-vim-package.mjs
@@ -88,7 +88,7 @@ const spec = readTextEntry(entryMap, "vim/test/vize_spec.vim");
 
 assert.match(autoload, /'cmd': \['vize', 'lsp'\]/);
 assert.match(autoload, /'allowlist': \['vue', 'art-vue'\]/);
-assert.match(autoload, /'initialization_options': s:profiles\.lint/);
+assert.match(autoload, /'initialization_options': s:profiles\.recommended/);
 assert.match(autoload, /function! vize#vim_lsp_config/);
 assert.match(autoload, /lsp#register_server/);
 assert.match(ftdetect, /\*\.vue setlocal filetype=vue/);

--- a/tools/zed-vize/assert-zed-package.mjs
+++ b/tools/zed-vize/assert-zed-package.mjs
@@ -130,6 +130,11 @@ assert.match(libRs, /const SERVER_BINARY: &'static str = "vize";/);
 assert.match(libRs, /worktree\.which\(Self::SERVER_BINARY\)/);
 assert.match(libRs, /unwrap_or_else\(\|\| vec!\["lsp"\.to_string\(\)\]\)/);
 assert.match(libRs, /language_server_initialization_options/);
+assert.match(libRs, /recommended_initialization_options/);
+assert.match(libRs, /"editor": true/);
+assert.match(libRs, /"ecosystem": true/);
+assert.match(libRs, /"lint": true/);
+assert.match(libRs, /"typecheck": true/);
 assert.match(libRs, /language_server_workspace_configuration/);
 assert.match(libRs, /zed::register_extension!\(VizeExtension\);/);
 


### PR DESCRIPTION
## Summary
- default Neovim, Vim, Emacs, Helix, and Zed adapters to the recommended LSP profile so completion, hover, definitions, references, diagnostics, and ecosystem helpers are enabled out of the box
- fix Vue template completion fallback so static attribute values do not receive block snippets
- make native attribute hover/definition work in multiline tags even when earlier attribute values contain arrow functions
- add CLI LSP production gates for opening-tag completion, unwanted completion suppression, rich hover, definition, and references

## Verification
- cargo test -p vize_maestro --lib -- --nocapture
- cargo build -p vize
- node --test tests/tooling/lsp-capabilities.test.ts tests/tooling/lsp-editor-production-gates.test.ts tests/tooling/lsp-template-completion.test.ts tests/tooling/lsp-authoring-core.test.ts
- node --test tests/tooling/editor-lsp-adapters.test.ts tests/tooling/editor-integrations-neovim.test.ts tests/tooling/editor-integrations-vim.test.ts tests/tooling/editor-integrations-emacs.test.ts tests/tooling/editor-integrations-helix.test.ts tests/tooling/editor-integrations-zed.test.ts tests/tooling/editor-profiles-consistency.test.ts
- cargo test (in editors/zed)
- nvim --headless -u NONE -i NONE -n -S editors/nvim/test/vize_spec.lua +qa
- vim -Nu NONE -n -es -S editors/vim/test/vize_spec.vim
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/editor-integrations.test.ts tests/tooling/editor-integrations-consistency.test.ts tests/tooling/vscode-typescript-vue-plugin.test.ts

Local note: Emacs package test was not run locally because emacs is not installed on this machine; GitHub Actions will verify it if configured.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785936707&installation_id=136613492&pr_number=2643&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2643&signature=83dae9f01ff24c6ad9bdf48b5d1107fcb3c9f8838f105236299e3fec0faef519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default editor setup now enables the broader “recommended” experience (diagnostics, hover, completion, definition, references, symbols, and ecosystem helpers) across supported integrations.
* **Bug Fixes**
  * Improved Vue/HTML tag and attribute detection for multiline templates.
  * Hover, definition, and reference resolution now behave more reliably with multiline bound attributes.
  * Completion in block contexts no longer falls back to snippet-based results.
* **Documentation**
  * Updated Emacs/Helix/Neovim/Vim/Zed setup docs and examples to reflect the new default “recommended” profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->