### PR TITLE
test(editor): harden VS Code host integration

### DIFF
--- a/editors/vscode/test/fixtures/fake-vize-server.cjs
+++ b/editors/vscode/test/fixtures/fake-vize-server.cjs
@@ -161,6 +161,7 @@ function createCapabilities() {
     },
     definitionProvider: true,
     documentFormattingProvider: true,
+    documentHighlightProvider: true,
     documentLinkProvider: {
       resolveProvider: false,
     },
@@ -238,6 +239,18 @@ function createResponse(message) {
 
     case "textDocument/definition":
       return [definitionLocation(uri)];
+
+    case "textDocument/documentHighlight":
+      return [
+        {
+          kind: 3,
+          range: fixtureRange(),
+        },
+        {
+          kind: 2,
+          range: referenceLocation(uri).range,
+        },
+      ];
 
     case "textDocument/references":
       return [definitionLocation(uri), referenceLocation(uri)];

--- a/editors/vscode/test/suite/editor-capability-smoke.cjs
+++ b/editors/vscode/test/suite/editor-capability-smoke.cjs
@@ -1,0 +1,238 @@
+const assert = require("node:assert/strict");
+const vscode = require("vscode");
+
+async function runEditorCapabilityProviderSmoke({
+  assertLocation,
+  assertTextDocumentRequest,
+  disableVizeAndWaitForShutdown,
+  getFakeServer,
+  methodMessages,
+  openWorkspaceDocument,
+  prepareConfiguredFakeServer,
+  readLogEntries,
+  runProviderCommand,
+  waitForLogEntries,
+  waitForReadyServer,
+}) {
+  const { logPath, serverPath } = getFakeServer();
+
+  await prepareConfiguredFakeServer({ logPath, serverPath });
+  await vscode.commands.executeCommand("vize.enableRecommendedProfile");
+  await waitForReadyServer(logPath, "editor capability provider setup");
+
+  const document = await openWorkspaceDocument("src", "App.vue");
+  await vscode.window.showTextDocument(document);
+
+  const position = new vscode.Position(1, 6);
+  const range = new vscode.Range(position, position.translate(0, 7));
+
+  await runProviderCommand(logPath, {
+    args: [document.uri, position],
+    commandIds: ["vscode.executeCompletionItemProvider"],
+    label: "completion",
+    method: "textDocument/completion",
+    validate(result, request) {
+      const items = Array.isArray(result) ? result : result?.items;
+      const item = items?.find((nextItem) => nextItem.label === "Fake Vize Completion");
+      assert.ok(item, "expected fake completion item");
+      assert.equal(item.detail, "Fake Vize autocomplete property");
+      assert.equal(item.insertText, "fakeCompletion");
+      assert.equal(item.kind, vscode.CompletionItemKind.Property);
+      assert.equal(item.sortText, "0001");
+      assert.equal(item.documentation.value, "Completion supplied by fake-vize.");
+      assertTextDocumentRequest(request, document.uri, position);
+    },
+  });
+
+  await runProviderCommand(logPath, {
+    args: [document.uri, position],
+    commandIds: ["vscode.executeHoverProvider"],
+    label: "hover",
+    method: "textDocument/hover",
+    validate(result) {
+      assert.ok(result?.length >= 1, "expected hover result");
+    },
+  });
+
+  await runProviderCommand(logPath, {
+    args: [document.uri, position],
+    commandIds: ["vscode.executeDefinitionProvider"],
+    label: "definition",
+    method: "textDocument/definition",
+    validate(result, request) {
+      assert.equal(result?.length, 1);
+      assertLocation(result[0], document.uri, new vscode.Range(1, 6, 1, 13));
+      assertTextDocumentRequest(request, document.uri, position);
+    },
+  });
+
+  await runProviderCommand(logPath, {
+    args: [document.uri, position],
+    commandIds: ["vscode.executeReferenceProvider"],
+    label: "references",
+    method: "textDocument/references",
+    validate(result, request) {
+      assert.equal(result?.length, 2);
+      assertLocation(result[0], document.uri, new vscode.Range(1, 6, 1, 13));
+      assertLocation(result[1], document.uri, new vscode.Range(5, 12, 5, 19));
+      assertTextDocumentRequest(request, document.uri, position);
+      assert.equal(request.params.context.includeDeclaration, true);
+    },
+  });
+
+  await runProviderCommand(logPath, {
+    args: [document.uri, position],
+    commandIds: ["vscode.executeDocumentHighlights"],
+    label: "document highlights",
+    method: "textDocument/documentHighlight",
+    validate(result, request) {
+      assert.equal(result?.length, 2);
+      assert.deepEqual(result[0].range, new vscode.Range(1, 6, 1, 13));
+      assert.deepEqual(result[1].range, new vscode.Range(5, 12, 5, 19));
+      assert.equal(result[0].kind, vscode.DocumentHighlightKind.Write);
+      assert.equal(result[1].kind, vscode.DocumentHighlightKind.Read);
+      assertTextDocumentRequest(request, document.uri, position);
+    },
+  });
+
+  await runProviderCommand(logPath, {
+    args: [document.uri],
+    commandIds: ["vscode.executeDocumentSymbolProvider"],
+    label: "document symbols",
+    method: "textDocument/documentSymbol",
+    validate(result) {
+      assertIncludesWhere(
+        result,
+        (symbol) => symbol.name === "FakeComponent",
+        "expected document symbol",
+      );
+    },
+  });
+
+  await runProviderCommand(logPath, {
+    args: ["Fake"],
+    commandIds: ["vscode.executeWorkspaceSymbolProvider"],
+    label: "workspace symbols",
+    method: "workspace/symbol",
+    validate(result) {
+      assertIncludesWhere(
+        result,
+        (symbol) => symbol.name === "FakeWorkspaceSymbol",
+        "expected workspace symbol",
+      );
+    },
+  });
+
+  await runProviderCommand(logPath, {
+    args: [document.uri, range],
+    commandIds: ["vscode.executeCodeActionProvider"],
+    label: "code actions",
+    method: "textDocument/codeAction",
+    validate(result) {
+      assertIncludesWhere(
+        result,
+        (action) => action.title === "Fake Vize Quick Fix",
+        "expected code action",
+      );
+    },
+  });
+
+  await runProviderCommand(logPath, {
+    args: [document.uri],
+    commandIds: ["vscode.executeCodeLensProvider"],
+    label: "code lens",
+    method: "textDocument/codeLens",
+    validate(result) {
+      assertIncludesWhere(
+        result,
+        (lens) => lens.command?.title === "Fake Vize Lens",
+        "expected code lens",
+      );
+    },
+  });
+
+  await runProviderCommand(logPath, {
+    args: [document.uri, { insertSpaces: true, tabSize: 2 }],
+    commandIds: ["vscode.executeFormatDocumentProvider"],
+    label: "formatting",
+    method: "textDocument/formatting",
+    validate(result) {
+      assert.ok(result?.length >= 1, "expected formatting edit");
+    },
+  });
+
+  await runProviderCommand(logPath, {
+    args: [document.uri],
+    commandIds: ["vscode.executeLinkProvider"],
+    label: "document links",
+    method: "textDocument/documentLink",
+    validate(result) {
+      assert.ok(result?.length >= 1, "expected document link");
+    },
+  });
+
+  await runProviderCommand(logPath, {
+    args: [document.uri],
+    commandIds: ["vscode.executeFoldingRangeProvider"],
+    label: "folding ranges",
+    method: "textDocument/foldingRange",
+    validate(result) {
+      assert.ok(result?.length >= 1, "expected folding range");
+    },
+  });
+
+  await runProviderCommand(logPath, {
+    args: [document.uri, new vscode.Range(0, 0, document.lineCount, 0)],
+    commandIds: ["vscode.executeInlayHintProvider"],
+    label: "inlay hints",
+    method: "textDocument/inlayHint",
+    validate(result) {
+      assertIncludesWhere(result, (hint) => hint.label === ": string", "expected inlay hint");
+    },
+  });
+
+  await runProviderCommand(logPath, {
+    args: [document.uri],
+    commandIds: [
+      "vscode.provideDocumentSemanticTokens",
+      "vscode.executeDocumentSemanticTokensProvider",
+    ],
+    label: "semantic tokens",
+    method: "textDocument/semanticTokens/full",
+    validate(result) {
+      assert.deepEqual(Array.from(result?.data ?? []), [1, 6, 7, 0, 1, 4, 2, 4, 1, 0]);
+    },
+  });
+
+  await runProviderCommand(logPath, {
+    args: [document.uri, position, "renamedMessage"],
+    commandIds: ["vscode.executeDocumentRenameProvider"],
+    label: "rename",
+    method: "textDocument/rename",
+    validate(result) {
+      assert.ok(result?.size >= 1, "expected rename workspace edit");
+    },
+  });
+
+  const referenceCount = methodMessages(readLogEntries(logPath), "textDocument/references").length;
+  vscode.window.activeTextEditor.selection = new vscode.Selection(position, position);
+  await vscode.commands.executeCommand("vize.findReferences");
+  const entries = await waitForLogEntries(
+    logPath,
+    (entries) => methodMessages(entries, "textDocument/references").length > referenceCount,
+    "find references command delegation",
+  );
+  assertTextDocumentRequest(
+    methodMessages(entries, "textDocument/references").at(-1),
+    document.uri,
+    position,
+  );
+
+  await disableVizeAndWaitForShutdown(logPath);
+}
+
+function assertIncludesWhere(items, predicate, message) {
+  assert.ok(items?.some(predicate), message);
+}
+
+module.exports = { runEditorCapabilityProviderSmoke };

--- a/editors/vscode/test/suite/extension-host.cjs
+++ b/editors/vscode/test/suite/extension-host.cjs
@@ -2,6 +2,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 const vscode = require("vscode");
+const { runEditorCapabilityProviderSmoke } = require("./editor-capability-smoke.cjs");
 
 const extensionId = "ubugeeei.vize";
 const recommendedInitializationOptions = {
@@ -91,7 +92,19 @@ exports.run = async function run() {
   await runFakeServerLifecycleSmoke();
   await runConfigurationEdgeCaseSmoke();
   await runDiagnosticSmoke();
-  await runEditorCapabilityProviderSmoke();
+  await runEditorCapabilityProviderSmoke({
+    assertLocation,
+    assertTextDocumentRequest,
+    disableVizeAndWaitForShutdown,
+    getFakeServer,
+    methodMessages,
+    openWorkspaceDocument,
+    prepareConfiguredFakeServer,
+    readLogEntries,
+    runProviderCommand,
+    waitForLogEntries,
+    waitForReadyServer,
+  });
   await runDocumentSelectorAndWatcherSmoke();
 };
 
@@ -455,208 +468,6 @@ async function runDiagnosticSmoke() {
   );
 
   await vscode.workspace.fs.delete(lintOnlyUri);
-  await disableVizeAndWaitForShutdown(logPath);
-}
-
-async function runEditorCapabilityProviderSmoke() {
-  const { logPath, serverPath } = getFakeServer();
-
-  await prepareConfiguredFakeServer({ logPath, serverPath });
-  await vscode.commands.executeCommand("vize.enableRecommendedProfile");
-  await waitForReadyServer(logPath, "editor capability provider setup");
-
-  const document = await openWorkspaceDocument("src", "App.vue");
-  await vscode.window.showTextDocument(document);
-
-  const position = new vscode.Position(1, 6);
-  const range = new vscode.Range(position, position.translate(0, 7));
-
-  await runProviderCommand(logPath, {
-    args: [document.uri, position],
-    commandIds: ["vscode.executeCompletionItemProvider"],
-    label: "completion",
-    method: "textDocument/completion",
-    validate(result, request) {
-      const items = Array.isArray(result) ? result : result?.items;
-      const item = items?.find((nextItem) => nextItem.label === "Fake Vize Completion");
-      assert.ok(item, "expected fake completion item");
-      assert.equal(item.detail, "Fake Vize autocomplete property");
-      assert.equal(item.insertText, "fakeCompletion");
-      assert.equal(item.kind, vscode.CompletionItemKind.Property);
-      assert.equal(item.sortText, "0001");
-      assert.equal(item.documentation.value, "Completion supplied by fake-vize.");
-      assertTextDocumentRequest(request, document.uri, position);
-    },
-  });
-
-  await runProviderCommand(logPath, {
-    args: [document.uri, position],
-    commandIds: ["vscode.executeHoverProvider"],
-    label: "hover",
-    method: "textDocument/hover",
-    validate(result) {
-      assert.ok(result?.length >= 1, "expected hover result");
-    },
-  });
-
-  await runProviderCommand(logPath, {
-    args: [document.uri, position],
-    commandIds: ["vscode.executeDefinitionProvider"],
-    label: "definition",
-    method: "textDocument/definition",
-    validate(result, request) {
-      assert.equal(result?.length, 1);
-      assertLocation(result[0], document.uri, new vscode.Range(1, 6, 1, 13));
-      assertTextDocumentRequest(request, document.uri, position);
-    },
-  });
-
-  await runProviderCommand(logPath, {
-    args: [document.uri, position],
-    commandIds: ["vscode.executeReferenceProvider"],
-    label: "references",
-    method: "textDocument/references",
-    validate(result, request) {
-      assert.equal(result?.length, 2);
-      assertLocation(result[0], document.uri, new vscode.Range(1, 6, 1, 13));
-      assertLocation(result[1], document.uri, new vscode.Range(5, 12, 5, 19));
-      assertTextDocumentRequest(request, document.uri, position);
-      assert.equal(request.params.context.includeDeclaration, true);
-    },
-  });
-
-  await runProviderCommand(logPath, {
-    args: [document.uri],
-    commandIds: ["vscode.executeDocumentSymbolProvider"],
-    label: "document symbols",
-    method: "textDocument/documentSymbol",
-    validate(result) {
-      assert.ok(
-        result?.some((symbol) => symbol.name === "FakeComponent"),
-        "expected document symbol",
-      );
-    },
-  });
-
-  await runProviderCommand(logPath, {
-    args: ["Fake"],
-    commandIds: ["vscode.executeWorkspaceSymbolProvider"],
-    label: "workspace symbols",
-    method: "workspace/symbol",
-    validate(result) {
-      assert.ok(
-        result?.some((symbol) => symbol.name === "FakeWorkspaceSymbol"),
-        "expected workspace symbol",
-      );
-    },
-  });
-
-  await runProviderCommand(logPath, {
-    args: [document.uri, range],
-    commandIds: ["vscode.executeCodeActionProvider"],
-    label: "code actions",
-    method: "textDocument/codeAction",
-    validate(result) {
-      assert.ok(
-        result?.some((action) => action.title === "Fake Vize Quick Fix"),
-        "expected code action",
-      );
-    },
-  });
-
-  await runProviderCommand(logPath, {
-    args: [document.uri],
-    commandIds: ["vscode.executeCodeLensProvider"],
-    label: "code lens",
-    method: "textDocument/codeLens",
-    validate(result) {
-      assert.ok(
-        result?.some((lens) => lens.command?.title === "Fake Vize Lens"),
-        "expected code lens",
-      );
-    },
-  });
-
-  await runProviderCommand(logPath, {
-    args: [document.uri, { insertSpaces: true, tabSize: 2 }],
-    commandIds: ["vscode.executeFormatDocumentProvider"],
-    label: "formatting",
-    method: "textDocument/formatting",
-    validate(result) {
-      assert.ok(result?.length >= 1, "expected formatting edit");
-    },
-  });
-
-  await runProviderCommand(logPath, {
-    args: [document.uri],
-    commandIds: ["vscode.executeLinkProvider"],
-    label: "document links",
-    method: "textDocument/documentLink",
-    validate(result) {
-      assert.ok(result?.length >= 1, "expected document link");
-    },
-  });
-
-  await runProviderCommand(logPath, {
-    args: [document.uri],
-    commandIds: ["vscode.executeFoldingRangeProvider"],
-    label: "folding ranges",
-    method: "textDocument/foldingRange",
-    validate(result) {
-      assert.ok(result?.length >= 1, "expected folding range");
-    },
-  });
-
-  await runProviderCommand(logPath, {
-    args: [document.uri, new vscode.Range(0, 0, document.lineCount, 0)],
-    commandIds: ["vscode.executeInlayHintProvider"],
-    label: "inlay hints",
-    method: "textDocument/inlayHint",
-    validate(result) {
-      assert.ok(
-        result?.some((hint) => hint.label === ": string"),
-        "expected inlay hint",
-      );
-    },
-  });
-
-  await runProviderCommand(logPath, {
-    args: [document.uri],
-    commandIds: [
-      "vscode.provideDocumentSemanticTokens",
-      "vscode.executeDocumentSemanticTokensProvider",
-    ],
-    label: "semantic tokens",
-    method: "textDocument/semanticTokens/full",
-    validate(result) {
-      assert.deepEqual(Array.from(result?.data ?? []), [1, 6, 7, 0, 1, 4, 2, 4, 1, 0]);
-    },
-  });
-
-  await runProviderCommand(logPath, {
-    args: [document.uri, position, "renamedMessage"],
-    commandIds: ["vscode.executeDocumentRenameProvider"],
-    label: "rename",
-    method: "textDocument/rename",
-    validate(result) {
-      assert.ok(result?.size >= 1, "expected rename workspace edit");
-    },
-  });
-
-  const referenceCount = methodMessages(readLogEntries(logPath), "textDocument/references").length;
-  vscode.window.activeTextEditor.selection = new vscode.Selection(position, position);
-  await vscode.commands.executeCommand("vize.findReferences");
-  const entries = await waitForLogEntries(
-    logPath,
-    (entries) => methodMessages(entries, "textDocument/references").length > referenceCount,
-    "find references command delegation",
-  );
-  assertTextDocumentRequest(
-    methodMessages(entries, "textDocument/references").at(-1),
-    document.uri,
-    position,
-  );
-
   await disableVizeAndWaitForShutdown(logPath);
 }
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "oxfmt": "catalog:linting",
     "oxlint": "catalog:linting",
     "pkg-pr-new": "catalog:repo-tooling",
+    "shiki": "catalog:content",
     "tsdown": "catalog:vite-stack",
     "vite": "catalog:vite-stack",
     "vite-plus": "catalog:vite-stack"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,9 @@ importers:
       pkg-pr-new:
         specifier: catalog:repo-tooling
         version: 0.0.73
+      shiki:
+        specifier: catalog:content
+        version: 4.0.2
       tsdown:
         specifier: catalog:vite-stack
         version: 0.22.0(@tsdown/css@0.22.0)(@typescript/native-preview@7.0.0-dev.20260602.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(vue-tsc@3.2.9(typescript@6.0.3))

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -3,20 +3,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  onigurumaModulePath,
+  onigurumaWasmPath,
+  textmateModulePath,
+} from "./support/textmate-deps.ts";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-const textmateModulePath = path.join(
-  root,
-  "node_modules/.pnpm/@shikijs+vscode-textmate@10.0.2/node_modules/@shikijs/vscode-textmate/dist/index.js",
-);
-const onigurumaModulePath = path.join(
-  root,
-  "node_modules/.pnpm/@shikijs+engine-oniguruma@4.0.2/node_modules/@shikijs/engine-oniguruma/dist/index.mjs",
-);
-const onigurumaWasmPath = path.join(
-  root,
-  "node_modules/.pnpm/shiki@4.0.2/node_modules/shiki/dist/onig.wasm",
-);
 
 function readJson<T>(relativePath: string): T {
   return JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf-8")) as T;

--- a/tests/tooling/support/textmate-deps.ts
+++ b/tests/tooling/support/textmate-deps.ts
@@ -1,0 +1,16 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const rootRequire = createRequire(path.join(root, "package.json"));
+const shikiPackageJsonPath = rootRequire.resolve("shiki/package.json");
+const shikiRequire = createRequire(shikiPackageJsonPath);
+
+export const textmateModulePath = shikiRequire.resolve("@shikijs/vscode-textmate");
+export const onigurumaModulePath = shikiRequire.resolve("@shikijs/engine-oniguruma");
+export const onigurumaWasmPath = path.join(path.dirname(shikiPackageJsonPath), "dist", "onig.wasm");
+
+export function shikiLanguageModulePath(name: string): string {
+  return shikiRequire.resolve(`@shikijs/langs/${name}`);
+}

--- a/tests/tooling/vscode-vize-template-grammar.test.ts
+++ b/tests/tooling/vscode-vize-template-grammar.test.ts
@@ -3,24 +3,14 @@ import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  onigurumaModulePath,
+  onigurumaWasmPath,
+  shikiLanguageModulePath,
+  textmateModulePath,
+} from "./support/textmate-deps.ts";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-const textmateModulePath = path.join(
-  root,
-  "node_modules/.pnpm/@shikijs+vscode-textmate@10.0.2/node_modules/@shikijs/vscode-textmate/dist/index.js",
-);
-const onigurumaModulePath = path.join(
-  root,
-  "node_modules/.pnpm/@shikijs+engine-oniguruma@4.0.2/node_modules/@shikijs/engine-oniguruma/dist/index.mjs",
-);
-const onigurumaWasmPath = path.join(
-  root,
-  "node_modules/.pnpm/shiki@4.0.2/node_modules/shiki/dist/onig.wasm",
-);
-const shikiLangsPath = path.join(
-  root,
-  "node_modules/.pnpm/@shikijs+langs@4.0.2/node_modules/@shikijs/langs/dist",
-);
 
 type TextMateToken = {
   endIndex: number;
@@ -53,7 +43,7 @@ function createStubGrammar(scopeName: string) {
 }
 
 async function loadBundledLanguageGrammar(name: string) {
-  const module = await import(pathToFileURL(path.join(shikiLangsPath, `${name}.mjs`)).href);
+  const module = await import(pathToFileURL(shikiLanguageModulePath(name)).href);
   return Array.isArray(module.default) ? module.default[0] : module.default;
 }
 


### PR DESCRIPTION
## Summary

- Add VS Code extension-host smoke coverage for `textDocument/documentHighlight`.
- Resolve TextMate/Oniguruma/Shiki test dependencies through the declared `shiki` package instead of hardcoded pnpm store paths.
- Declare the root `shiki` dev dependency so grammar tests work from a clean frozen install.

## Root Cause

The editor grammar tests depended on implementation-specific `node_modules/.pnpm/...` paths, which made them pass only with a stale local install layout. The VS Code host smoke also did not exercise document highlights, leaving one advertised editor provider unverified in the actual extension host.

## Validation

- `vp install --workspace-root --frozen-lockfile --prefer-offline`
- `node --test tests/tooling/lsp-*.test.ts tests/tooling/editor-*.test.ts tests/tooling/vscode-*.test.ts`
- `node --test tests/tooling/editor-integrations.test.ts tests/tooling/vscode-vize-template-grammar.test.ts tests/tooling/vscode-extension-manifest.test.ts tests/tooling/source-file-lengths.test.ts`
- `vp run --workspace-root test:vscode-extension:host`
- `vp run --workspace-root package:editor-extensions`
- `cargo test -p vize_maestro --lib -- --nocapture`
- `vp check package.json tests/tooling/editor-integrations.test.ts tests/tooling/vscode-vize-template-grammar.test.ts tests/tooling/support/textmate-deps.ts`
- `node --check editors/vscode/test/suite/extension-host.cjs && node --check editors/vscode/test/fixtures/fake-vize-server.cjs`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785944542&installation_id=136613492&pr_number=2644&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2644&signature=26edecf798c1e72ebf8ccf6bece85d8914d94fdcafe8b53e93ad9b2cfd68d807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for **document highlights**, enabling the editor to highlight related code references during navigation and inspection.
* **Bug Fixes**
  * Improved editor integrations so **document highlight** results are returned reliably, with correct highlight ranges and consistent ordering for supported documents.
  
* **Tests**
  * Expanded and refactored editor capability smoke coverage to validate highlight behavior end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->