### PR TITLE
fix(canon): handle recent type regressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_reserved_prop_and_hyphenated_slot_names.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_reserved_prop_and_hyphenated_slot_names.snap
@@ -106,7 +106,7 @@ function __setup() {
   // @vize-map: expr -> 20:25
 
   // v-slot scope: #area-gradient
-  void function _slot_area_gradient_7({ id }: typeof TrendChart extends { new (): { $slots: infer __S } } ? (__S extends { "area-gradient"?: (props: infer __P, ...args: any[]) => any } ? __P : any) : any) {
+  void function _slot_area_gradient_7({ id }: typeof TrendChart extends { new (): { $slots: infer __S } } ? ("area-gradient" extends keyof __S ? (NonNullable<__S["area-gradient"]> extends (props: infer __P, ...args: any[]) => any ? __P : any) : any) : any) {
     void id;
     void (id); // Interpolation
     // @vize-map: expr -> 72:74
@@ -137,7 +137,7 @@ function __setup() {
   });
 
   // Component props in v-slot scope: #area-gradient
-  void function _slot_props_area_gradient_7({ id }: typeof TrendChart extends { new (): { $slots: infer __S } } ? (__S extends { "area-gradient"?: (props: infer __P, ...args: any[]) => any } ? __P : any) : any) {
+  void function _slot_props_area_gradient_7({ id }: typeof TrendChart extends { new (): { $slots: infer __S } } ? ("area-gradient" extends keyof __S ? (NonNullable<__S["area-gradient"]> extends (props: infer __P, ...args: any[]) => any ? __P : any) : any) : any) {
     void id;
   };
 

--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_scoped_slot_expressions.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_scoped_slot_expressions.snap
@@ -95,7 +95,7 @@ function __setup() {
   // @vize-map: expr -> 16:21
 
   // v-slot scope: #default
-  void function _slot_default_7({ item }: typeof MyList extends { new (): { $slots: infer __S } } ? (__S extends { "default"?: (props: infer __P, ...args: any[]) => any } ? __P : any) : any) {
+  void function _slot_default_7({ item }: typeof MyList extends { new (): { $slots: infer __S } } ? ("default" extends keyof __S ? (NonNullable<__S["default"]> extends (props: infer __P, ...args: any[]) => any ? __P : any) : any) : any) {
     void item;
     void (item); // Interpolation
     // @vize-map: expr -> 64:68
@@ -126,7 +126,7 @@ function __setup() {
   });
 
   // Component props in v-slot scope: #default
-  void function _slot_props_default_7({ item }: typeof MyList extends { new (): { $slots: infer __S } } ? (__S extends { "default"?: (props: infer __P, ...args: any[]) => any } ? __P : any) : any) {
+  void function _slot_props_default_7({ item }: typeof MyList extends { new (): { $slots: infer __S } } ? ("default" extends keyof __S ? (NonNullable<__S["default"]> extends (props: infer __P, ...args: any[]) => any ? __P : any) : any) : any) {
     void item;
   };
 

--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -16,6 +16,7 @@ mod no_check_props;
 mod no_unused;
 mod options_api_required_props;
 mod package_exports_types;
+mod recent_issues;
 mod scan;
 mod tsx_sfc;
 #[test]
@@ -40,7 +41,6 @@ const count: number = 'oops'
         insta::assert_debug_snapshot!("batch_type_checker_vue_diagnostics", snapshot);
     });
 }
-
 #[test]
 fn batch_type_checker_snapshots_script_setup_type_error() {
     if resolve_test_tsgo_binary().is_none() {

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
@@ -1,0 +1,289 @@
+use super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
+
+#[test]
+fn issue_2645_infers_generic_sfc_props_in_tsx() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "issue-2645-generic-sfc-tsx",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts" generic="T = string">
+defineProps<{ value: T }>();
+</script>
+"#,
+            ),
+            (
+                "src/usage.tsx",
+                r#"import Child from "./Child.vue";
+
+export default () => <Child value={123} />;
+"#,
+            ),
+        ],
+    );
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !(file == "src/usage.tsx" && *code == Some(2322) && message.contains("never"))
+        }),
+        "generic SFC props should infer from TSX usage, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn issue_2646_does_not_widen_generic_template_refs() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "issue-2646-generic-template-ref",
+        &[(
+            "src/Foo.vue",
+            r#"<script setup lang="ts" generic="T">
+import { ref } from "vue";
+
+const value = ref<T>();
+
+function update(value: T | undefined) {}
+</script>
+
+<template>
+  <button @click="update(value)" />
+</template>
+"#,
+        )],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !(file == "src/Foo.vue"
+                && *code == Some(2345)
+                && message.contains("__VizeWidenTemplateRef"))
+        }),
+        "generic refs should keep T | undefined in templates, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn issue_2647_keeps_setup_type_imports_and_local_aliases_separate() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "issue-2647-setup-type-import-scope",
+        &[
+            (
+                "src/types.ts",
+                "export type MaybeElement = Element | null;\n",
+            ),
+            (
+                "src/Foo.vue",
+                r#"<script lang="ts">
+export type FooContext = MaybeElement;
+</script>
+
+<script setup lang="ts">
+import type { MaybeElement } from "./types";
+
+type MaybeElement = HTMLElement | null;
+</script>
+"#,
+            ),
+        ],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !(file == "src/Foo.vue" && *code == Some(2440) && message.contains("MaybeElement"))
+        }),
+        "setup type imports and local aliases should not collide, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn issue_2648_exposes_props_inherited_from_imported_interfaces() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "issue-2648-imported-interface-props",
+        &[
+            (
+                "src/Base.vue",
+                r#"<script lang="ts">
+export interface BaseProps {
+  decorative?: boolean;
+}
+</script>
+"#,
+            ),
+            (
+                "src/Foo.vue",
+                r#"<script setup lang="ts">
+import type { BaseProps as ImportedProps } from "./Base.vue";
+
+interface Props extends ImportedProps {}
+defineProps<Props>();
+</script>
+
+<template>
+  {{ decorative }}
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !(file == "src/Foo.vue" && *code == Some(2304) && message.contains("decorative"))
+        }),
+        "imported interface props should be template bindings, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn issue_2649_keeps_v_slot_scope_spread_object_compatible() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "issue-2649-v-slot-spread",
+        &[
+            (
+                "src/Base.vue",
+                r#"<template>
+  <slot value="one" />
+</template>
+"#,
+            ),
+            (
+                "src/Foo.vue",
+                r#"<script setup lang="ts">
+import Base from "./Base.vue";
+</script>
+
+<template>
+  <Base v-slot="slotData">
+    <slot v-bind="{ ...slotData }" />
+  </Base>
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !(file == "src/Foo.vue" && *code == Some(2698) && message.contains("Spread types"))
+        }),
+        "v-slot scope should be spread-compatible, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn issue_2650_preserves_exposed_component_instance_casts() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "issue-2650-exposed-instance-cast",
+        &[
+            (
+                "src/Base.vue",
+                r#"<script setup lang="ts">
+function syncModelValue() {}
+defineExpose({ syncModelValue });
+</script>
+"#,
+            ),
+            (
+                "src/Foo.vue",
+                r#"<script setup lang="ts">
+import { ref, watchEffect } from "vue";
+import type { ComponentPublicInstance } from "vue";
+import Base from "./Base.vue";
+
+type MaybeElement = ComponentPublicInstance | null;
+
+const current = ref<MaybeElement>(null);
+
+watchEffect(() => {
+  if (current.value) {
+    (current.value as InstanceType<typeof Base>).syncModelValue();
+  }
+});
+</script>
+"#,
+            ),
+        ],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !(file == "src/Foo.vue" && *code == Some(2352) && message.contains("syncModelValue"))
+        }),
+        "exposed component instance casts should stay accepted, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_generic_component.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_generic_component.snap
@@ -100,9 +100,7 @@ function __setup<T extends string | number>() {
   type __R_activeItem = typeof activeItem;
   ;(function __template() {
     // Auto-unwrap Vue refs in template scope
-    type __VizeIsUnion<T, __U = T> = T extends unknown ? ([__U] extends [T] ? false : true) : false;
-    type __VizeWidenTemplateRef<T> = __VizeIsUnion<T> extends true ? T : T extends string ? string : T extends number ? number : T extends boolean ? boolean : T;
-    type __U<T> = T extends import('vue').Ref ? __VizeWidenTemplateRef<T['value']> : T;
+    type __U<T> = T extends import('vue').Ref ? T['value'] : T;
     var activeItem: __U<__R_activeItem> = undefined as any;
     // Vue template context (delegates to ComponentPublicInstance)
     type __Ctx = import('vue').ComponentPublicInstance;

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_scoped_slots.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_scoped_slots.snap
@@ -105,7 +105,7 @@ function __setup() {
   // @vize-map: expr -> 161:166
 
   // v-slot scope: #default
-  void function _slot_default_8({ item, index }: typeof MyList extends { new (): { $slots: infer __S } } ? (__S extends { "default"?: (props: infer __P, ...args: any[]) => any } ? __P : any) : any) {
+  void function _slot_default_8({ item, index }: typeof MyList extends { new (): { $slots: infer __S } } ? ("default" extends keyof __S ? (NonNullable<__S["default"]> extends (props: infer __P, ...args: any[]) => any ? __P : any) : any) : any) {
     void item;
     void index;
     void (index); // Interpolation
@@ -115,7 +115,7 @@ function __setup() {
   };
 
   // v-slot scope: #header
-  void function _slot_header_9({ title }: typeof MyList extends { new (): { $slots: infer __S } } ? (__S extends { "header"?: (props: infer __P, ...args: any[]) => any } ? __P : any) : any) {
+  void function _slot_header_9({ title }: typeof MyList extends { new (): { $slots: infer __S } } ? ("header" extends keyof __S ? (NonNullable<__S["header"]> extends (props: infer __P, ...args: any[]) => any ? __P : any) : any) : any) {
     void title;
     void (title); // Interpolation
     // @vize-map: expr -> 318:323
@@ -146,13 +146,13 @@ function __setup() {
   });
 
   // Component props in v-slot scope: #default
-  void function _slot_props_default_8({ item, index }: typeof MyList extends { new (): { $slots: infer __S } } ? (__S extends { "default"?: (props: infer __P, ...args: any[]) => any } ? __P : any) : any) {
+  void function _slot_props_default_8({ item, index }: typeof MyList extends { new (): { $slots: infer __S } } ? ("default" extends keyof __S ? (NonNullable<__S["default"]> extends (props: infer __P, ...args: any[]) => any ? __P : any) : any) : any) {
     void item;
     void index;
   };
 
   // Component props in v-slot scope: #header
-  void function _slot_props_header_9({ title }: typeof MyList extends { new (): { $slots: infer __S } } ? (__S extends { "header"?: (props: infer __P, ...args: any[]) => any } ? __P : any) : any) {
+  void function _slot_props_header_9({ title }: typeof MyList extends { new (): { $slots: infer __S } } ? ("header" extends keyof __S ? (NonNullable<__S["header"]> extends (props: infer __P, ...args: any[]) => any ? __P : any) : any) : any) {
     void title;
   };
 

--- a/crates/vize_canon/src/tests.rs
+++ b/crates/vize_canon/src/tests.rs
@@ -262,7 +262,7 @@ const items = ref(['a', 'b', 'c'])
         assert!(
             virtual_ts.contains(r#"void function _slot_default_"#)
                 && virtual_ts.contains(
-                    r#"({ item, index }: typeof MyList extends { new (): { $slots: infer __S } } ? (__S extends { "default"?: (props: infer __P"#
+                    r#"({ item, index }: typeof MyList extends { new (): { $slots: infer __S } } ? ("default" extends keyof __S ? (NonNullable<__S["default"]> extends (props: infer __P"#
                 ),
             "<template #default> slot props should be typed from the owning component:\n{virtual_ts}"
         );

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -749,7 +749,12 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
 
             // Shadow ref bindings with unwrapped types.
             // `var` allows reassignment (Vue templates can assign to refs).
-            template_ref_unwraps.emit_template_variables(&mut ts, legacy_vue2, dialect);
+            template_ref_unwraps.emit_template_variables(
+                &mut ts,
+                legacy_vue2,
+                dialect,
+                generic_param.is_some(),
+            );
 
             // Vue template context (available in template expressions)
             let template_context = profile!(

--- a/crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs
@@ -37,6 +37,8 @@ const MODERN_REF_UNWRAP_HELPER: &str = r#"    type __VizeIsUnion<T, __U = T> = T
     type __VizeWidenTemplateRef<T> = __VizeIsUnion<T> extends true ? T : T extends string ? string : T extends number ? number : T extends boolean ? boolean : T;
     type __U<T> = T extends import('vue').Ref ? __VizeWidenTemplateRef<T['value']> : T;
 "#;
+const MODERN_GENERIC_REF_UNWRAP_HELPER: &str =
+    "    type __U<T> = T extends import('vue').Ref ? T['value'] : T;\n";
 const MODERN_EXPOSED_UNWRAP_HELPER: &str = "type __VizeShallowUnwrapRef<T> = { [K in keyof T]: T[K] extends import('vue').Ref<infer __V> ? __V : T[K] };\n";
 const LEGACY_DEFINE_COMPONENT_HELPER: &str = r#"type __VizeNuxt2Context = {
   app: any;
@@ -105,6 +107,18 @@ pub(super) fn ref_unwrap_helper(legacy_vue2: bool, dialect: VueVersion) -> &'sta
     }
 }
 
+pub(super) fn ref_unwrap_helper_for_template(
+    legacy_vue2: bool,
+    dialect: VueVersion,
+    has_generic_param: bool,
+) -> &'static str {
+    if has_generic_param && !needs_legacy_vue2_helpers(legacy_vue2, dialect) {
+        MODERN_GENERIC_REF_UNWRAP_HELPER
+    } else {
+        ref_unwrap_helper(legacy_vue2, dialect)
+    }
+}
+
 pub(super) fn exposed_unwrap_helper(legacy_vue2: bool, dialect: VueVersion) -> &'static str {
     if needs_legacy_vue2_helpers(legacy_vue2, dialect) {
         LEGACY_EXPOSED_UNWRAP_HELPER
@@ -140,7 +154,9 @@ pub(super) fn instance_suffix(
     ) {
         (true, true) => "} & __VizeVue2ComponentInstance & __VizeShallowUnwrapRef<Exposed>;\n",
         (true, false) => "} & __VizeVue2ComponentInstance;\n",
-        (false, true) => "} & __VizeShallowUnwrapRef<Exposed>;\n",
+        (false, true) => {
+            "} & import('vue').ComponentPublicInstance & __VizeShallowUnwrapRef<Exposed>;\n"
+        }
         (false, false) => "};\n",
     }
 }

--- a/crates/vize_canon/src/virtual_ts/generator/template_refs.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/template_refs.rs
@@ -2,7 +2,7 @@ use vize_carton::config::VueVersion;
 use vize_carton::{FxHashSet, String, append};
 use vize_croquis::{BindingType, Croquis};
 
-use super::legacy_vue2::ref_unwrap_helper;
+use super::legacy_vue2::ref_unwrap_helper_for_template;
 use super::spans::is_local_setup_binding;
 
 pub(super) struct TemplateRefUnwraps {
@@ -81,13 +81,18 @@ impl TemplateRefUnwraps {
         mut ts: &mut String,
         legacy_vue2: bool,
         dialect: VueVersion,
+        has_generic_param: bool,
     ) {
         if self.setup_bindings.is_empty() && self.options_api_setup_bindings.is_empty() {
             return;
         }
 
         ts.push_str("    // Auto-unwrap Vue refs in template scope\n");
-        ts.push_str(ref_unwrap_helper(legacy_vue2, dialect));
+        ts.push_str(ref_unwrap_helper_for_template(
+            legacy_vue2,
+            dialect,
+            has_generic_param,
+        ));
         for name in &self.setup_bindings {
             append!(ts, "    var {name}: __U<__R_{name}> = undefined as any;\n");
         }

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -7,10 +7,7 @@ use setup_scoped::props_type_ref;
 pub(crate) use setup_scoped::{PropsTypeEmission, generate_setup_scoped_props_artifact};
 use template_bindings::{emit_macro_template_prop_bindings, should_skip_template_prop_binding};
 pub(crate) use template_names::collect_template_prop_names;
-use vize_carton::FxHashSet;
-use vize_carton::String;
-use vize_carton::append;
-use vize_carton::cstr;
+use vize_carton::{FxHashSet, String, append, cstr};
 use vize_croquis::Croquis;
 use vize_croquis::macros::{MacroKind, ModelDefinition};
 use with_defaults::collect_with_defaults_default_names_from_source;
@@ -102,6 +99,9 @@ fn should_emit_keyed_template_prop_bindings(
         return false;
     }
     let base_name = strip_generic_params(type_name).trim();
+    if summary.types.definitions().has_interface_extends(base_name) {
+        return true;
+    }
     if let Some(body) = summary.types.definitions().resolve(base_name) {
         return has_top_level_type_operator(body.as_str())
             || !is_plain_inline_type_literal(body.as_str());

--- a/crates/vize_canon/src/virtual_ts/scope/emit.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/emit.rs
@@ -24,7 +24,7 @@ pub(super) fn slot_props_type(
             let component_ref = to_safe_identifier(component);
             if slot_name_is_static {
                 cstr!(
-                    "typeof {component_ref} extends {{ new (): {{ $slots: infer __S }} }} ? (__S extends {{ \"{slot_name}\"?: (props: infer __P, ...args: any[]) => any }} ? __P : any) : any"
+                    "typeof {component_ref} extends {{ new (): {{ $slots: infer __S }} }} ? (\"{slot_name}\" extends keyof __S ? (NonNullable<__S[\"{slot_name}\"]> extends (props: infer __P, ...args: any[]) => any ? __P : any) : any) : any"
                 )
             } else {
                 cstr!(

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -960,7 +960,7 @@ fn test_define_expose_is_part_of_component_instance() {
         output.code
     );
     assert!(
-        output.code.contains("type __VizeComponentInstance = {\n  $props: __VizeComponentProps<Props>;\n  $emit: __EmitFn<Emits>;\n  $slots: Slots;\n} & __VizeShallowUnwrapRef<Exposed>;"),
+        output.code.contains("type __VizeComponentInstance = {\n  $props: __VizeComponentProps<Props>;\n  $emit: __EmitFn<Emits>;\n  $slots: Slots;\n} & import('vue').ComponentPublicInstance & __VizeShallowUnwrapRef<Exposed>;"),
         "component instance should include exposed bindings:\n{}",
         output.code
     );

--- a/crates/vize_croquis/src/script_parser/result.rs
+++ b/crates/vize_croquis/src/script_parser/result.rs
@@ -211,6 +211,23 @@ impl ScriptParseResult {
             return;
         }
 
+        let imported_names: FxHashSet<&str> = self
+            .binding_spans
+            .iter()
+            .filter_map(|(name, (start, end))| {
+                self.import_statements
+                    .iter()
+                    .any(|import| *start >= import.start && *end <= import.end)
+                    .then_some(name.as_str())
+            })
+            .collect();
+
+        for type_export in &mut self.type_exports {
+            if imported_names.contains(type_export.name.as_str()) {
+                type_export.hoisted = false;
+            }
+        }
+
         // A `typeof name` ref keeps a type hoisted only when `name` is visible
         // at module scope. Rather than materialize all imported binding names
         // up front (O(imports × bindings)), test each referenced name's

--- a/crates/vize_croquis/src/types.rs
+++ b/crates/vize_croquis/src/types.rs
@@ -118,6 +118,12 @@ impl TypeDefinitions {
         self.imported_types.contains_key(type_name)
     }
 
+    /// Check whether a local interface declaration has heritage clauses.
+    #[inline]
+    pub fn has_interface_extends(&self, name: &str) -> bool {
+        !self.interface_extends(name).is_empty()
+    }
+
     /// Merge another set of definitions in, keeping existing entries on a name
     /// clash. Used to fold a plain `<script>`'s local types into a
     /// `<script setup>` summary, which keeps precedence for setup-local data.


### PR DESCRIPTION
## Summary

- Add batch type-check regressions for issues #2645 through #2650.
- Keep generic SFC template ref unwrapping from widening unresolved type parameters.
- Preserve setup type-import scope, imported interface prop bindings, object-compatible slot spreads, and exposed instance casts.

## Validation

- `cargo test -p vize_canon recent_issues -- --nocapture`
- `cargo test -p vize_canon --test nuxt_false_positives -- --nocapture`
- `cargo test -p vize_canon ref_arity -- --nocapture`
- `cargo test -p vize_canon define_props_scope -- --nocapture`
- `cargo test -p vize_canon interface_extends_tests -- --nocapture`
- `cargo test -p vize_canon test_define_expose_is_part_of_component_instance -- --nocapture`

Fixes #2645
Fixes #2646
Fixes #2647
Fixes #2648
Fixes #2649
Fixes #2650

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785987112&installation_id=136613492&pr_number=2651&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2651&signature=07a5ca98197ecf907049e956d76ddff9751798959df4099430201b0dee226b64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated TypeScript typings for template ref unwrapping (including generic setup cases) and legacy Vue 2 behavior.
  * Refined scoped slot prop typing and generated component instance intersections to better match Vue’s `ComponentPublicInstance`.
  * Corrected type-hoisting behavior by demoting certain `type` exports when they conflict with locally imported bindings, and improved keyed template prop emission for inherited interfaces.

* **Tests**
  * Added regression snapshot coverage for recent TypeScript type-checking issues and updated affected scoped-slots expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->