### PR TITLE
fix(nix): refresh moonbit artifact hashes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,20 +41,22 @@
         nixCargoLockContents = builtins.replaceStrings [ cratesIoIndex ] [ cratesIoNixIndex ] (
           builtins.readFile ./Cargo.lock
         );
+        moonbitVersion = "0.10.3+16975d007";
+        moonbitUrlVersion = builtins.replaceStrings [ "+" ] [ "%2B" ] moonbitVersion;
         moonbitArtifacts = {
           aarch64-darwin = {
-            version = "0.1.20260703-2026-07-03";
-            url = "https://cli.moonbitlang.com/binaries/latest/moonbit-darwin-aarch64.tar.gz";
+            version = moonbitVersion;
+            url = "https://cli.moonbitlang.com/binaries/${moonbitUrlVersion}/moonbit-darwin-aarch64.tar.gz";
             hash = "sha256-WDV4V3lmdDNeYL4KJ8/8SbzJ+KJJfgZo7BVNw6LcJOU=";
           };
           x86_64-linux = {
-            version = "0.1.20260703-2026-07-03";
-            url = "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-x86_64.tar.gz";
+            version = moonbitVersion;
+            url = "https://cli.moonbitlang.com/binaries/${moonbitUrlVersion}/moonbit-linux-x86_64.tar.gz";
             hash = "sha256-1F49AgHPOxNhIG6pxybNShx7jN+DLbKuCzX1zfKxwTY=";
           };
           aarch64-linux = {
-            version = "0.1.20260703-2026-07-03";
-            url = "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-aarch64.tar.gz";
+            version = moonbitVersion;
+            url = "https://cli.moonbitlang.com/binaries/${moonbitUrlVersion}/moonbit-linux-aarch64.tar.gz";
             hash = "sha256-Vf0CZCXEVcLVa160aKZ5cEoxTyBoQ4uslLocPw83Ix4=";
           };
         };
@@ -70,7 +72,8 @@
                 inherit (artifact) url hash;
               };
               coreSrc = pkgs.fetchurl {
-                url = "https://cli.moonbitlang.com/cores/core-latest.tar.gz";
+                name = "core-${moonbitVersion}.tar.gz";
+                url = "https://cli.moonbitlang.com/cores/core-${moonbitUrlVersion}.tar.gz";
                 hash = "sha256-PHPWerElUb0jNNM4nq99AzbxmsCKucOW8R4SfjdbPQY=";
               };
               nativeBuildInputs = lib.optionals pkgs.stdenv.isLinux [ pkgs.patchelf ];

--- a/flake.nix
+++ b/flake.nix
@@ -43,19 +43,19 @@
         );
         moonbitArtifacts = {
           aarch64-darwin = {
-            version = "0.1.20260608-2026-06-08";
+            version = "0.1.20260703-2026-07-03";
             url = "https://cli.moonbitlang.com/binaries/latest/moonbit-darwin-aarch64.tar.gz";
-            hash = "sha256-YAgKPu+uA4e2Z/UXJJpwt2ezdMANIjLuczet2ff3JIc=";
+            hash = "sha256-WDV4V3lmdDNeYL4KJ8/8SbzJ+KJJfgZo7BVNw6LcJOU=";
           };
           x86_64-linux = {
-            version = "0.1.20260608-2026-06-08";
+            version = "0.1.20260703-2026-07-03";
             url = "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-x86_64.tar.gz";
-            hash = "sha256-ug6+47tfi5RiOb/4DITkEQHSsRSo07QwjnOibTY+GEg=";
+            hash = "sha256-1F49AgHPOxNhIG6pxybNShx7jN+DLbKuCzX1zfKxwTY=";
           };
           aarch64-linux = {
-            version = "0.1.20260608-2026-06-08";
+            version = "0.1.20260703-2026-07-03";
             url = "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-aarch64.tar.gz";
-            hash = "sha256-fw4LyzobPWKaDV/9sattbQzjs2GXdRJ+wLhr/4dtVo4=";
+            hash = "sha256-Vf0CZCXEVcLVa160aKZ5cEoxTyBoQ4uslLocPw83Ix4=";
           };
         };
         moonbit =


### PR DESCRIPTION
## Summary
- update pinned MoonBit artifact hashes for all supported Nix platforms
- pin MoonBit binary and core downloads to the `0.10.3+16975d007` versioned endpoints instead of mutable `latest` endpoints

## Root cause
The upstream latest MoonBit binary artifacts changed, so the fixed-output Nix hashes on main no longer matched the downloaded tarballs.

## Verification
- git diff --check
- nix store prefetch-file --json https://cli.moonbitlang.com/binaries/0.10.3%2B16975d007/moonbit-darwin-aarch64.tar.gz
- nix store prefetch-file --json https://cli.moonbitlang.com/binaries/0.10.3%2B16975d007/moonbit-linux-x86_64.tar.gz
- nix store prefetch-file --json https://cli.moonbitlang.com/binaries/0.10.3%2B16975d007/moonbit-linux-aarch64.tar.gz
- nix store prefetch-file --name core-0.10.3+16975d007.tar.gz --json https://cli.moonbitlang.com/cores/core-0.10.3%2B16975d007.tar.gz
- nix build .#moonbit --no-link
- nix flake check --all-systems --no-build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned MoonBit artifacts version used by the build for supported platforms.
  * Refreshed platform-specific download URLs and updated the associated checksums to match the new artifact sources.
  * Updated the fetched MoonBit core tarball to use the versioned core artifact naming scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->