### PR TITLE
test: expand lsp and editor integration coverage

### DIFF
--- a/crates/vize/src/commands/ide/editor_files.rs
+++ b/crates/vize/src/commands/ide/editor_files.rs
@@ -54,7 +54,7 @@ pub(super) fn find_zed_extension_source_in_locations(
 ) -> Option<PathBuf> {
     locations
         .into_iter()
-        .find(|path| path.join("extension.toml").exists())
+        .find(|path| path.join("extension.toml").is_file())
 }
 
 pub(super) fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
@@ -147,6 +147,61 @@ mod tests {
     }
 
     #[test]
+    fn zed_source_lookup_rejects_directory_named_extension_manifest() {
+        let fake_source = tempfile::tempdir().unwrap();
+        let source = tempfile::tempdir().unwrap();
+        std::fs::create_dir(fake_source.path().join("extension.toml")).unwrap();
+        std::fs::write(source.path().join("extension.toml"), "id = \"vize\"").unwrap();
+
+        let found = find_zed_extension_source_in_locations([
+            fake_source.path().to_path_buf(),
+            source.path().to_path_buf(),
+        ]);
+
+        assert_eq!(found.as_deref(), Some(source.path()));
+    }
+
+    #[test]
+    fn zed_source_lookup_prefers_first_real_manifest() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        std::fs::write(first.path().join("extension.toml"), "id = \"first\"").unwrap();
+        std::fs::write(second.path().join("extension.toml"), "id = \"second\"").unwrap();
+
+        let found = find_zed_extension_source_in_locations([
+            first.path().to_path_buf(),
+            second.path().to_path_buf(),
+        ]);
+
+        assert_eq!(found.as_deref(), Some(first.path()));
+    }
+
+    #[test]
+    fn vscode_vsix_lookup_rejects_nested_or_suffix_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(nested.join("vize.vsix"), "nested").unwrap();
+        std::fs::write(dir.path().join("vize.vsix.bak"), "backup").unwrap();
+
+        let found = find_vscode_vsix_in_locations([dir.path().to_path_buf()]);
+
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn vsix_file_detection_rejects_missing_and_suffix_extensions() {
+        let dir = tempfile::tempdir().unwrap();
+        let no_extension = dir.path().join("vize");
+        let suffix = dir.path().join("vize.vsix.bak");
+        std::fs::write(&no_extension, "package").unwrap();
+        std::fs::write(&suffix, "package").unwrap();
+
+        assert!(!is_vsix_file(&no_extension));
+        assert!(!is_vsix_file(&suffix));
+    }
+
+    #[test]
     fn copy_dir_all_copies_nested_files_without_touching_source() {
         let source = tempfile::tempdir().unwrap();
         let nested = source.path().join("grammars");
@@ -167,5 +222,39 @@ mod tests {
             "(source_file)"
         );
         assert!(source.path().join("extension.toml").exists());
+    }
+
+    #[test]
+    fn copy_dir_all_overwrites_files_and_keeps_unrelated_targets() {
+        let source = tempfile::tempdir().unwrap();
+        std::fs::write(source.path().join("extension.toml"), "id = \"new\"").unwrap();
+
+        let target = tempfile::tempdir().unwrap();
+        let install_dir = target.path().join("vize");
+        std::fs::create_dir(&install_dir).unwrap();
+        std::fs::write(install_dir.join("extension.toml"), "id = \"old\"").unwrap();
+        std::fs::write(install_dir.join("local-only.txt"), "keep").unwrap();
+
+        copy_dir_all(source.path(), &install_dir).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(install_dir.join("extension.toml")).unwrap(),
+            "id = \"new\""
+        );
+        assert_eq!(
+            std::fs::read_to_string(install_dir.join("local-only.txt")).unwrap(),
+            "keep"
+        );
+    }
+
+    #[test]
+    fn copy_dir_all_returns_error_for_missing_source() {
+        let target = tempfile::tempdir().unwrap();
+        let missing = target.path().join("missing-source");
+        let install_dir = target.path().join("vize");
+
+        let error = copy_dir_all(&missing, &install_dir).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
     }
 }

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -98,7 +98,6 @@ impl LanguageServer for MaestroServer {
             .documents
             .open(uri.clone(), content.clone(), version, language_id);
 
-        // Generate virtual documents for the SFC
         self.state.update_virtual_docs(&uri, &content);
 
         self.publish_diagnostics(&uri).await;
@@ -112,7 +111,6 @@ impl LanguageServer for MaestroServer {
             .documents
             .apply_changes(&uri, params.content_changes, version);
 
-        // Regenerate virtual documents with updated content
         if let Some(doc) = self.state.documents.get(&uri) {
             let content = doc.text();
             self.state.update_virtual_docs(&uri, &content);
@@ -987,6 +985,13 @@ impl LanguageServer for MaestroServer {
         };
 
         let _content = doc.text();
+        let valid_position =
+            |position: Position| position_to_offset(&_content, position.line, position.character);
+        if valid_position(params.range.start).is_none()
+            || valid_position(params.range.end).is_none()
+        {
+            return Ok(None);
+        }
         #[cfg(feature = "glyph")]
         {
             let options = self.state.get_format_options();
@@ -1064,13 +1069,8 @@ mod tests {
         }
     }
 
-    // ----------------------------------------------------------------------
-    // JSX/TSX LSP routing (#1498). These exercise the request handlers
-    // end-to-end for a standalone `.tsx` document: the structural features
-    // (document symbols, semantic tokens, code actions, embedded CSS) answer
-    // without a Corsa bridge, and the type-aware features (references, rename)
-    // stay gated on `typeChecker.jsxTypecheck`.
-    // ----------------------------------------------------------------------
+    mod lifecycle;
+    mod requests;
 
     use tower_lsp::lsp_types::{
         CodeActionContext, CodeActionParams, DocumentSymbolParams, PartialResultParams,

--- a/crates/vize_maestro/src/server/handlers/tests/lifecycle.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/lifecycle.rs
@@ -1,0 +1,193 @@
+use super::*;
+use tower_lsp::{
+    LspService,
+    lsp_types::{
+        DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+        DidSaveTextDocumentParams, TextDocumentContentChangeEvent, TextDocumentIdentifier,
+        TextDocumentItem, VersionedTextDocumentIdentifier,
+    },
+};
+
+fn quiet_service() -> tower_lsp::LspService<MaestroServer> {
+    let (service, _socket) = LspService::new(MaestroServer::new);
+    service
+        .inner()
+        .state
+        .apply_lsp_initialization_options(Some(&serde_json::json!({
+            "lint": false,
+            "typecheck": false,
+            "ecosystem": false
+        })));
+    service
+}
+
+fn uri(path: &str) -> Url {
+    Url::parse(&format!("file:///{path}")).unwrap()
+}
+
+fn open_vue(server: &MaestroServer, uri: Url, text: &str, version: i32) {
+    futures::executor::block_on(server.did_open(DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri,
+            language_id: "vue".to_string(),
+            version,
+            text: text.to_string(),
+        },
+    }));
+}
+
+fn full_change(uri: Url, version: i32, text: &str) -> DidChangeTextDocumentParams {
+    DidChangeTextDocumentParams {
+        text_document: VersionedTextDocumentIdentifier { uri, version },
+        content_changes: vec![TextDocumentContentChangeEvent {
+            range: None,
+            range_length: None,
+            text: text.to_string(),
+        }],
+    }
+}
+
+fn replace_text_change(
+    uri: Url,
+    version: i32,
+    source: &str,
+    needle: &str,
+    replacement: &str,
+) -> DidChangeTextDocumentParams {
+    let offset = source.find(needle).unwrap();
+    let (line, character) = crate::ide::offset_to_position(source, offset);
+    DidChangeTextDocumentParams {
+        text_document: VersionedTextDocumentIdentifier { uri, version },
+        content_changes: vec![TextDocumentContentChangeEvent {
+            range: Some(Range::new(
+                Position::new(line, character),
+                Position::new(line, character + needle.len() as u32),
+            )),
+            range_length: None,
+            text: replacement.to_string(),
+        }],
+    }
+}
+
+#[test]
+fn did_open_stores_document_and_generates_virtual_docs() {
+    let service = quiet_service();
+    let server = service.inner();
+    let uri = uri("Open.vue");
+    let source = "<script setup lang=\"ts\">\nconst message = 'hi'\n</script>\n\
+                  <template>\n  <div>{{ message }}</div>\n</template>\n";
+
+    open_vue(server, uri.clone(), source, 7);
+
+    let doc = server.state.documents.get(&uri).unwrap();
+    assert_eq!(doc.version, 7);
+    assert_eq!(doc.language_id, "vue");
+    assert_eq!(doc.text(), source);
+
+    let virtual_docs = server.state.get_virtual_docs(&uri).unwrap();
+    assert!(virtual_docs.template.is_some());
+    assert!(virtual_docs.script_setup.is_some());
+}
+
+#[test]
+fn did_change_full_content_replaces_document_and_rebuilds_virtual_docs() {
+    let service = quiet_service();
+    let server = service.inner();
+    let uri = uri("Changed.vue");
+    let before = "<template>{{ beforeMessage }}</template>\n";
+    let after = "<template>{{ afterMessage }}</template>\n";
+
+    open_vue(server, uri.clone(), before, 1);
+    futures::executor::block_on(server.did_change(full_change(uri.clone(), 2, after)));
+
+    let doc = server.state.documents.get(&uri).unwrap();
+    assert_eq!(doc.version, 2);
+    assert_eq!(doc.text(), after);
+
+    let template = server
+        .state
+        .get_virtual_docs(&uri)
+        .and_then(|docs| docs.template.clone())
+        .expect("template virtual doc should be regenerated");
+    assert!(template.content.contains("afterMessage"));
+    assert!(!template.content.contains("beforeMessage"));
+}
+
+#[test]
+fn did_change_incremental_content_updates_document_and_virtual_docs() {
+    let service = quiet_service();
+    let server = service.inner();
+    let uri = uri("Incremental.vue");
+    let before = "<script setup lang=\"ts\">\nconst count = 1\n</script>\n\
+                  <template>{{ count }}</template>\n";
+
+    open_vue(server, uri.clone(), before, 1);
+    futures::executor::block_on(server.did_change(replace_text_change(
+        uri.clone(),
+        2,
+        before,
+        "1",
+        "2",
+    )));
+
+    let doc = server.state.documents.get(&uri).unwrap();
+    assert_eq!(doc.version, 2);
+    assert!(doc.text().contains("count = 2"));
+
+    let script_setup = server
+        .state
+        .get_virtual_docs(&uri)
+        .and_then(|docs| docs.script_setup.clone())
+        .expect("script setup virtual doc should be regenerated");
+    assert!(script_setup.content.contains("count = 2"));
+}
+
+#[test]
+fn did_change_unopened_document_does_not_create_document_or_virtual_docs() {
+    let service = quiet_service();
+    let server = service.inner();
+    let uri = uri("Missing.vue");
+
+    futures::executor::block_on(server.did_change(full_change(
+        uri.clone(),
+        2,
+        "<template>ignored</template>",
+    )));
+
+    assert!(!server.state.documents.contains(&uri));
+    assert!(server.state.get_virtual_docs(&uri).is_none());
+}
+
+#[test]
+fn did_close_removes_document_and_virtual_docs() {
+    let service = quiet_service();
+    let server = service.inner();
+    let uri = uri("Close.vue");
+    let source = "<template>{{ message }}</template>\n";
+
+    open_vue(server, uri.clone(), source, 1);
+    assert!(server.state.documents.contains(&uri));
+    assert!(server.state.get_virtual_docs(&uri).is_some());
+
+    futures::executor::block_on(server.did_close(DidCloseTextDocumentParams {
+        text_document: TextDocumentIdentifier { uri: uri.clone() },
+    }));
+
+    assert!(!server.state.documents.contains(&uri));
+    assert!(server.state.get_virtual_docs(&uri).is_none());
+}
+
+#[test]
+fn did_save_unopened_document_does_not_create_document() {
+    let service = quiet_service();
+    let server = service.inner();
+    let uri = uri("SaveOnly.vue");
+
+    futures::executor::block_on(server.did_save(DidSaveTextDocumentParams {
+        text_document: TextDocumentIdentifier { uri: uri.clone() },
+        text: Some("<template>ignored</template>".to_string()),
+    }));
+
+    assert!(!server.state.documents.contains(&uri));
+    assert!(server.state.get_virtual_docs(&uri).is_none());
+}

--- a/crates/vize_maestro/src/server/handlers/tests/requests.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/requests.rs
@@ -1,0 +1,350 @@
+use super::*;
+use tower_lsp::{
+    LspService,
+    lsp_types::{
+        CodeLensParams, DocumentLinkParams, FileRename, FoldingRangeParams, HoverParams,
+        InlayHintParams, SemanticTokensRangeParams, WorkspaceSymbolParams,
+    },
+};
+
+mod guards_extra;
+mod responses;
+
+const SAMPLE: &str = "<template>\n  <div>{{ message }}</div>\n</template>\n\
+                      <script setup lang=\"ts\">\nconst message = 'hi'\n</script>\n\
+                      <style scoped>\n.box { color: red; }\n</style>\n";
+
+fn service_with_options(options: serde_json::Value) -> tower_lsp::LspService<MaestroServer> {
+    let (service, _socket) = LspService::new(MaestroServer::new);
+    service
+        .inner()
+        .state
+        .apply_lsp_initialization_options(Some(&options));
+    service
+}
+
+fn quiet_options(mut overrides: serde_json::Map<String, serde_json::Value>) -> serde_json::Value {
+    overrides.insert("lint".to_string(), false.into());
+    overrides.insert("typecheck".to_string(), false.into());
+    overrides.insert("ecosystem".to_string(), false.into());
+    serde_json::Value::Object(overrides)
+}
+
+fn options(pairs: &[(&str, bool)]) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    for (key, value) in pairs {
+        map.insert((*key).to_string(), (*value).into());
+    }
+    quiet_options(map)
+}
+
+fn uri(path: &str) -> Url {
+    Url::parse(&format!("file:///{path}")).unwrap()
+}
+
+fn open_vue(server: &MaestroServer, uri: &Url, source: &str) {
+    server
+        .state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    server.state.update_virtual_docs(uri, source);
+}
+
+fn text_doc(uri: &Url) -> TextDocumentIdentifier {
+    TextDocumentIdentifier { uri: uri.clone() }
+}
+
+fn text_pos(uri: &Url) -> TextDocumentPositionParams {
+    TextDocumentPositionParams {
+        text_document: text_doc(uri),
+        position: Position::new(0, 0),
+    }
+}
+
+fn range() -> Range {
+    Range::new(Position::new(0, 0), Position::new(0, 1))
+}
+
+fn hover_params(uri: &Url) -> HoverParams {
+    HoverParams {
+        text_document_position_params: text_pos(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+    }
+}
+
+fn completion_params(uri: &Url) -> CompletionParams {
+    CompletionParams {
+        text_document_position: text_pos(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+        context: None,
+    }
+}
+
+fn definition_params(uri: &Url) -> GotoDefinitionParams {
+    GotoDefinitionParams {
+        text_document_position_params: text_pos(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn references_params(uri: &Url) -> ReferenceParams {
+    ReferenceParams {
+        text_document_position: text_pos(uri),
+        context: ReferenceContext {
+            include_declaration: true,
+        },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn document_symbol_params(uri: &Url) -> DocumentSymbolParams {
+    DocumentSymbolParams {
+        text_document: text_doc(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn code_action_params(uri: &Url) -> CodeActionParams {
+    CodeActionParams {
+        text_document: text_doc(uri),
+        range: range(),
+        context: CodeActionContext::default(),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn rename_params(uri: &Url) -> RenameParams {
+    RenameParams {
+        text_document_position: text_pos(uri),
+        new_name: "renamed".to_string(),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+    }
+}
+
+fn semantic_tokens_params(uri: &Url) -> SemanticTokensParams {
+    SemanticTokensParams {
+        text_document: text_doc(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn semantic_tokens_range_params(uri: &Url) -> SemanticTokensRangeParams {
+    SemanticTokensRangeParams {
+        text_document: text_doc(uri),
+        range: range(),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn code_lens_params(uri: &Url) -> CodeLensParams {
+    CodeLensParams {
+        text_document: text_doc(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn document_link_params(uri: &Url) -> DocumentLinkParams {
+    DocumentLinkParams {
+        text_document: text_doc(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn inlay_hint_params(uri: &Url) -> InlayHintParams {
+    InlayHintParams {
+        text_document: text_doc(uri),
+        range: range(),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+    }
+}
+
+fn folding_range_params(uri: &Url) -> FoldingRangeParams {
+    FoldingRangeParams {
+        text_document: text_doc(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+macro_rules! disabled_open_doc_request_returns_none {
+    ($name:ident, $opts:expr, |$server:ident, $uri:ident| $call:expr) => {
+        #[test]
+        fn $name() {
+            let service = service_with_options(options($opts));
+            let $server = service.inner();
+            let $uri = uri("Guard.vue");
+            open_vue($server, &$uri, SAMPLE);
+            let response = futures::executor::block_on($call).unwrap();
+            assert!(response.is_none());
+        }
+    };
+}
+
+macro_rules! enabled_missing_doc_request_returns_none {
+    ($name:ident, $opts:expr, |$server:ident, $uri:ident| $call:expr) => {
+        #[test]
+        fn $name() {
+            let service = service_with_options(options($opts));
+            let $server = service.inner();
+            let $uri = uri("Missing.vue");
+            let response = futures::executor::block_on($call).unwrap();
+            assert!(response.is_none());
+        }
+    };
+}
+
+disabled_open_doc_request_returns_none!(
+    hover_disabled_returns_none,
+    &[("hover", false)],
+    |server, uri| server.hover(hover_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    hover_missing_document_returns_none,
+    &[("hover", true)],
+    |server, uri| server.hover(hover_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    completion_disabled_returns_none,
+    &[("completion", false)],
+    |server, uri| server.completion(completion_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    completion_missing_document_returns_none,
+    &[("completion", true)],
+    |server, uri| server.completion(completion_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    definition_disabled_returns_none,
+    &[("definition", false)],
+    |server, uri| server.goto_definition(definition_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    definition_missing_document_returns_none,
+    &[("definition", true)],
+    |server, uri| server.goto_definition(definition_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    references_disabled_returns_none,
+    &[("references", false)],
+    |server, uri| server.references(references_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    document_highlight_disabled_returns_none,
+    &[("references", false)],
+    |server, uri| {
+        server.document_highlight(DocumentHighlightParams {
+            text_document_position_params: text_pos(&uri),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        })
+    }
+);
+disabled_open_doc_request_returns_none!(
+    document_symbol_disabled_returns_none,
+    &[("documentSymbols", false)],
+    |server, uri| server.document_symbol(document_symbol_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    code_action_disabled_when_lint_is_off,
+    &[("lint", false), ("codeActions", true)],
+    |server, uri| server.code_action(code_action_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    code_action_disabled_when_code_actions_are_off,
+    &[("lint", true), ("codeActions", false)],
+    |server, uri| server.code_action(code_action_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    prepare_rename_disabled_returns_none,
+    &[("rename", false)],
+    |server, uri| server.prepare_rename(text_pos(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    rename_disabled_returns_none,
+    &[("rename", false)],
+    |server, uri| server.rename(rename_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    semantic_tokens_full_disabled_returns_none,
+    &[("semanticTokens", false)],
+    |server, uri| server.semantic_tokens_full(semantic_tokens_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    semantic_tokens_range_disabled_returns_none,
+    &[("semanticTokens", false)],
+    |server, uri| server.semantic_tokens_range(semantic_tokens_range_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    code_lens_disabled_returns_none,
+    &[("codeLens", false)],
+    |server, uri| server.code_lens(code_lens_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    document_link_disabled_returns_none,
+    &[("documentLinks", false)],
+    |server, uri| server.document_link(document_link_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    inlay_hint_disabled_returns_none,
+    &[("inlayHints", false)],
+    |server, uri| server.inlay_hint(inlay_hint_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    folding_range_disabled_returns_none,
+    &[("foldingRanges", false)],
+    |server, uri| server.folding_range(folding_range_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    formatting_disabled_returns_none,
+    &[("formatting", false)],
+    |server, uri| server.formatting(formatting_params(uri))
+);
+disabled_open_doc_request_returns_none!(
+    range_formatting_disabled_returns_none,
+    &[("formatting", false)],
+    |server, uri| {
+        server.range_formatting(DocumentRangeFormattingParams {
+            text_document: text_doc(&uri),
+            range: range(),
+            options: FormattingOptions::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        })
+    }
+);
+
+#[test]
+fn workspace_symbols_disabled_returns_none() {
+    let service = service_with_options(options(&[("workspaceSymbols", false)]));
+    let response = futures::executor::block_on(service.inner().symbol(WorkspaceSymbolParams {
+        query: "message".to_string(),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }))
+    .unwrap();
+    assert!(response.is_none());
+}
+
+#[test]
+fn file_rename_disabled_returns_none() {
+    let service = service_with_options(options(&[("fileRename", false)]));
+    let old_uri = uri("Old.vue");
+    let new_uri = uri("New.vue");
+    let response =
+        futures::executor::block_on(service.inner().will_rename_files(RenameFilesParams {
+            files: vec![FileRename {
+                old_uri: old_uri.to_string(),
+                new_uri: new_uri.to_string(),
+            }],
+        }))
+        .unwrap();
+    assert!(response.is_none());
+}

--- a/crates/vize_maestro/src/server/handlers/tests/requests/guards_extra.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/requests/guards_extra.rs
@@ -1,0 +1,231 @@
+use super::*;
+
+fn out_of_range_pos(uri: &Url) -> TextDocumentPositionParams {
+    TextDocumentPositionParams {
+        text_document: text_doc(uri),
+        position: Position::new(999, 0),
+    }
+}
+
+fn out_of_range_range() -> Range {
+    Range::new(Position::new(999, 0), Position::new(999, 1))
+}
+
+fn out_of_range_code_action_params(uri: &Url) -> CodeActionParams {
+    CodeActionParams {
+        text_document: text_doc(uri),
+        range: out_of_range_range(),
+        context: CodeActionContext::default(),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn out_of_range_rename_params(uri: &Url) -> RenameParams {
+    RenameParams {
+        text_document_position: out_of_range_pos(uri),
+        new_name: "renamed".to_string(),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+    }
+}
+
+fn out_of_range_document_highlight_params(uri: &Url) -> DocumentHighlightParams {
+    DocumentHighlightParams {
+        text_document_position_params: out_of_range_pos(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn out_of_range_reference_params(uri: &Url) -> ReferenceParams {
+    ReferenceParams {
+        text_document_position: out_of_range_pos(uri),
+        context: ReferenceContext {
+            include_declaration: true,
+        },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn range_formatting_params_with_range(uri: &Url, range: Range) -> DocumentRangeFormattingParams {
+    DocumentRangeFormattingParams {
+        text_document: text_doc(uri),
+        range,
+        options: FormattingOptions::default(),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+    }
+}
+
+macro_rules! enabled_missing_doc_request_returns_none {
+    ($name:ident, $opts:expr, |$server:ident, $uri:ident| $call:expr) => {
+        #[test]
+        fn $name() {
+            let service = service_with_options(options($opts));
+            let $server = service.inner();
+            let $uri = uri("MissingExtra.vue");
+            let response = futures::executor::block_on($call).unwrap();
+            assert!(response.is_none());
+        }
+    };
+}
+
+macro_rules! enabled_out_of_range_request_returns_none {
+    ($name:ident, $opts:expr, |$server:ident, $uri:ident| $call:expr) => {
+        #[test]
+        fn $name() {
+            let service = service_with_options(options($opts));
+            let $server = service.inner();
+            let $uri = uri("OutOfRange.vue");
+            open_vue($server, &$uri, SAMPLE);
+            let response = futures::executor::block_on($call).unwrap();
+            assert!(response.is_none());
+        }
+    };
+}
+
+enabled_missing_doc_request_returns_none!(
+    references_missing_document_returns_none,
+    &[("references", true)],
+    |server, uri| server.references(references_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    document_highlight_missing_document_returns_none,
+    &[("references", true)],
+    |server, uri| {
+        server.document_highlight(DocumentHighlightParams {
+            text_document_position_params: text_pos(&uri),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        })
+    }
+);
+enabled_missing_doc_request_returns_none!(
+    document_symbol_missing_document_returns_none,
+    &[("documentSymbols", true)],
+    |server, uri| server.document_symbol(document_symbol_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    code_action_missing_document_returns_none,
+    &[("lint", true), ("codeActions", true)],
+    |server, uri| server.code_action(code_action_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    prepare_rename_missing_document_returns_none,
+    &[("rename", true)],
+    |server, uri| server.prepare_rename(text_pos(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    rename_missing_document_returns_none,
+    &[("rename", true)],
+    |server, uri| server.rename(rename_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    semantic_tokens_full_missing_document_returns_none,
+    &[("semanticTokens", true)],
+    |server, uri| server.semantic_tokens_full(semantic_tokens_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    semantic_tokens_range_missing_document_returns_none,
+    &[("semanticTokens", true)],
+    |server, uri| server.semantic_tokens_range(semantic_tokens_range_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    code_lens_missing_document_returns_none,
+    &[("codeLens", true)],
+    |server, uri| server.code_lens(code_lens_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    document_link_missing_document_returns_none,
+    &[("documentLinks", true)],
+    |server, uri| server.document_link(document_link_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    inlay_hint_missing_document_returns_none,
+    &[("inlayHints", true)],
+    |server, uri| server.inlay_hint(inlay_hint_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    folding_range_missing_document_returns_none,
+    &[("foldingRanges", true)],
+    |server, uri| server.folding_range(folding_range_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    formatting_missing_document_returns_none,
+    &[("formatting", true)],
+    |server, uri| server.formatting(formatting_params(uri))
+);
+enabled_missing_doc_request_returns_none!(
+    range_formatting_missing_document_returns_none,
+    &[("formatting", true)],
+    |server, uri| server.range_formatting(range_formatting_params_with_range(&uri, range()))
+);
+
+enabled_out_of_range_request_returns_none!(
+    hover_out_of_range_returns_none,
+    &[("hover", true)],
+    |server, uri| {
+        server.hover(HoverParams {
+            text_document_position_params: out_of_range_pos(&uri),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        })
+    }
+);
+enabled_out_of_range_request_returns_none!(
+    completion_out_of_range_returns_none,
+    &[("completion", true)],
+    |server, uri| {
+        server.completion(CompletionParams {
+            text_document_position: out_of_range_pos(&uri),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+            context: None,
+        })
+    }
+);
+enabled_out_of_range_request_returns_none!(
+    definition_out_of_range_returns_none,
+    &[("definition", true)],
+    |server, uri| {
+        server.goto_definition(GotoDefinitionParams {
+            text_document_position_params: out_of_range_pos(&uri),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        })
+    }
+);
+enabled_out_of_range_request_returns_none!(
+    references_out_of_range_returns_none,
+    &[("references", true)],
+    |server, uri| server.references(out_of_range_reference_params(&uri))
+);
+enabled_out_of_range_request_returns_none!(
+    document_highlight_out_of_range_returns_none,
+    &[("references", true)],
+    |server, uri| server.document_highlight(out_of_range_document_highlight_params(&uri))
+);
+enabled_out_of_range_request_returns_none!(
+    code_action_out_of_range_returns_none,
+    &[("lint", true), ("codeActions", true)],
+    |server, uri| server.code_action(out_of_range_code_action_params(&uri))
+);
+enabled_out_of_range_request_returns_none!(
+    prepare_rename_out_of_range_returns_none,
+    &[("rename", true)],
+    |server, uri| server.prepare_rename(out_of_range_pos(&uri))
+);
+enabled_out_of_range_request_returns_none!(
+    rename_out_of_range_returns_none,
+    &[("rename", true)],
+    |server, uri| server.rename(out_of_range_rename_params(&uri))
+);
+enabled_out_of_range_request_returns_none!(
+    range_formatting_out_of_range_returns_none,
+    &[("formatting", true)],
+    |server, uri| {
+        server.range_formatting(range_formatting_params_with_range(
+            &uri,
+            out_of_range_range(),
+        ))
+    }
+);

--- a/crates/vize_maestro/src/server/handlers/tests/requests/responses.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/requests/responses.rs
@@ -1,0 +1,73 @@
+use super::*;
+use tower_lsp::lsp_types::CompletionList;
+
+#[test]
+fn root_completion_returns_block_snippet_labels() {
+    let service = service_with_options(options(&[("completion", true)]));
+    let server = service.inner();
+    let uri = uri("Empty.vue");
+    open_vue(server, &uri, "\n");
+
+    let response = futures::executor::block_on(server.completion(completion_params(&uri)))
+        .unwrap()
+        .expect("root completion should return block snippets");
+    let labels: Vec<_> = match response {
+        CompletionResponse::Array(items) => items.into_iter().map(|item| item.label).collect(),
+        CompletionResponse::List(CompletionList { items, .. }) => {
+            items.into_iter().map(|item| item.label).collect()
+        }
+    };
+
+    for label in [
+        "template",
+        "script setup",
+        "script",
+        "style scoped",
+        "style",
+    ] {
+        assert!(
+            labels.iter().any(|item| item == label),
+            "missing {label}: {labels:?}"
+        );
+    }
+}
+
+#[test]
+fn document_symbols_list_sfc_blocks_with_editor_labels() {
+    let service = service_with_options(options(&[("documentSymbols", true)]));
+    let server = service.inner();
+    let uri = uri("Symbols.vue");
+    open_vue(server, &uri, SAMPLE);
+
+    let response =
+        futures::executor::block_on(server.document_symbol(document_symbol_params(&uri)))
+            .unwrap()
+            .expect("document symbols should be available");
+    let DocumentSymbolResponse::Nested(symbols) = response else {
+        panic!("expected nested document symbols");
+    };
+    let names: Vec<_> = symbols.into_iter().map(|symbol| symbol.name).collect();
+    assert!(names.contains(&"template".to_string()));
+    assert!(names.contains(&"script setup".to_string()));
+    assert!(names.contains(&"style scoped".to_string()));
+}
+
+#[test]
+fn folding_ranges_cover_multiline_sfc_blocks() {
+    let service = service_with_options(options(&[("foldingRanges", true)]));
+    let server = service.inner();
+    let uri = uri("Folds.vue");
+    open_vue(server, &uri, SAMPLE);
+
+    let ranges = futures::executor::block_on(server.folding_range(folding_range_params(&uri)))
+        .unwrap()
+        .expect("folding ranges should be available");
+    let labels: Vec<_> = ranges
+        .into_iter()
+        .filter_map(|range| range.collapsed_text)
+        .collect();
+
+    assert!(labels.contains(&"template".to_string()));
+    assert!(labels.contains(&"script setup".to_string()));
+    assert!(labels.contains(&"style".to_string()));
+}


### PR DESCRIPTION
## Summary
- add handler-level lifecycle tests for open/change/save/close document and virtual document updates
- add request guard coverage for disabled, missing-document, and out-of-range LSP paths
- harden editor install helper coverage for VSIX/Zed lookup and recursive copy edge cases
- reject invalid rangeFormatting ranges before falling back to full-document formatting

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p vize_maestro --lib
- cargo test -p vize --lib
- cargo build --profile ci -p vize
- PATH="$PWD/target/ci:$PATH" vp run --workspace-root test:scripts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786000650&installation_id=136613492&pr_number=2657&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2657&signature=080f3f9f581b3240350af6f26b0b73bdc147905ae734c7239a8d7674ec108253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of editor extension files and package files so invalid matches are ignored.
  * Range formatting now safely stops when the selected range is outside the document, preventing invalid formatting attempts.
  * Open, change, save, and close events now keep document state and virtual content in sync more reliably.

* **New Features**
  * Editor completion, symbols, and folding now surface clearer labels for Vue single-file component sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->