### PR TITLE
test: deepen lsp editor coverage

### DIFF
--- a/crates/vize/src/commands/ide/tests.rs
+++ b/crates/vize/src/commands/ide/tests.rs
@@ -25,10 +25,24 @@ fn vscode_status_trims_lines_and_ignores_case() {
 }
 
 #[test]
+fn vscode_status_accepts_extension_id_among_crlf_lines() {
+    assert!(vscode_extension_is_installed(
+        "foo.bar\r\n  ubugeeei.vize  \r\nbaz.qux\r\n"
+    ));
+}
+
+#[test]
 fn vscode_status_rejects_empty_and_partial_lines() {
     assert!(!vscode_extension_is_installed(""));
     assert!(!vscode_extension_is_installed("ubugeeei.vize-extra\n"));
     assert!(!vscode_extension_is_installed("prefix ubugeeei.vize\n"));
+}
+
+#[test]
+fn vscode_status_rejects_comments_suffixes_and_other_publishers() {
+    assert!(!vscode_extension_is_installed("ubugeeei.vize # comment\n"));
+    assert!(!vscode_extension_is_installed("publisher.ubugeeei.vize\n"));
+    assert!(!vscode_extension_is_installed("ubugeeei.vize.preview\n"));
 }
 
 #[test]
@@ -56,9 +70,33 @@ fn editor_operation_prefers_uninstall_over_status_and_install() {
 }
 
 #[test]
+fn editor_operation_prefers_uninstall_when_install_is_false() {
+    assert_eq!(
+        editor_operation(&editor_args(false, true, false)),
+        EditorOperation::Uninstall
+    );
+}
+
+#[test]
+fn editor_operation_prefers_uninstall_over_status() {
+    assert_eq!(
+        editor_operation(&editor_args(false, true, true)),
+        EditorOperation::Uninstall
+    );
+}
+
+#[test]
 fn editor_operation_prefers_status_over_install() {
     assert_eq!(
         editor_operation(&editor_args(true, false, true)),
+        EditorOperation::Status
+    );
+}
+
+#[test]
+fn editor_operation_accepts_status_without_install() {
+    assert_eq!(
+        editor_operation(&editor_args(false, false, true)),
         EditorOperation::Status
     );
 }

--- a/editors/emacs/test/vize-test.el
+++ b/editors/emacs/test/vize-test.el
@@ -17,8 +17,30 @@
 (ert-deftest vize-eglot-off-program ()
   (should (equal (vize-eglot-server-program 'off) '("vize" "lsp"))))
 
+(ert-deftest vize-profile-options-lint ()
+  (should (equal (vize-profile-options 'lint) '(:lint t))))
+
+(ert-deftest vize-profile-options-off ()
+  (should (equal (vize-profile-options 'off) nil)))
+
+(ert-deftest vize-profile-options-rejects-unknown-profile ()
+  (should-error (vize-profile-options 'missing) :type 'error))
+
+(ert-deftest vize-profile-options-returns-copy ()
+  (let ((options (vize-profile-options 'recommended)))
+    (setf (plist-get options :lint) nil)
+    (should
+     (equal (vize-profile-options 'recommended)
+            '(:editor t :ecosystem t :lint t :typecheck t)))))
+
 (ert-deftest vize-eglot-custom-command ()
   (let ((vize-eglot-command '("/tmp/vize" "lsp" "--debug")))
     (should
      (equal (vize-eglot-server-program 'lint)
             '("/tmp/vize" "lsp" "--debug" :initializationOptions (:lint t))))))
+
+(ert-deftest vize-eglot-server-program-copies-command ()
+  (let* ((vize-eglot-command '("/tmp/vize" "lsp"))
+         (program (vize-eglot-server-program 'off)))
+    (setcar program "changed")
+    (should (equal vize-eglot-command '("/tmp/vize" "lsp")))))

--- a/editors/nvim/test/vize_spec.lua
+++ b/editors/nvim/test/vize_spec.lua
@@ -26,6 +26,17 @@ assert_eq(recommended.init_options, {
   typecheck = true,
 }, "recommended profile")
 
+assert_eq(config.profile("lint"), { lint = true }, "lint profile")
+assert_eq(config.profile("off"), {}, "off profile")
+
+local lint_profile = config.profile("lint")
+lint_profile.lint = false
+assert_eq(config.profile("lint"), { lint = true }, "profile returns copy")
+
+local default_copy = config.default_config()
+default_copy.cmd[1] = "changed"
+assert_eq(config.default_config().cmd, { "vize", "lsp" }, "default config returns copy")
+
 local custom = config.normalize({
   autostart = false,
   cmd = { "/tmp/vize", "lsp", "--debug" },
@@ -41,8 +52,19 @@ assert_eq(custom.init_options, { hover = true, references = true }, "custom init
 assert_eq(custom.root_markers, { "deno.json", ".git" }, "custom root markers")
 assert(custom.autostart == false, "custom autostart")
 
+local mutable_opts = { init_options = { hover = true } }
+local mutable_config = config.normalize(mutable_opts)
+mutable_opts.init_options.hover = false
+assert_eq(mutable_config.init_options, { hover = true }, "normalization copies init options")
+
+local profile_ok, profile_err = pcall(config.profile, "missing")
+assert(not profile_ok and profile_err:match("unknown vize profile"), "rejects unknown profile")
+
 local ok, err = pcall(config.normalize, { cmd = {} })
 assert(not ok and err:match("cmd"), "rejects empty cmd")
+
+local filetype_ok, filetype_err = pcall(config.normalize, { filetypes = { "" } })
+assert(not filetype_ok and filetype_err:match("filetypes"), "rejects empty filetype")
 
 local setup_config = require("vize").setup({ autostart = false, profile = "off" })
 assert_eq(setup_config.init_options, {}, "setup returns normalized config")

--- a/editors/vim/test/vize_spec.vim
+++ b/editors/vim/test/vize_spec.vim
@@ -19,6 +19,17 @@ call assert_equal({
       \ 'typecheck': v:true,
       \ }, s:recommended.initialization_options)
 
+call assert_equal({'lint': v:true}, vize#profile('lint'))
+call assert_equal({}, vize#profile('off'))
+
+let s:lint_profile = vize#profile('lint')
+let s:lint_profile.lint = v:false
+call assert_equal({'lint': v:true}, vize#profile('lint'))
+
+let s:default_copy = vize#default_config()
+let s:default_copy.cmd[0] = 'changed'
+call assert_equal(['vize', 'lsp'], vize#default_config().cmd)
+
 let s:custom = vize#normalize({
       \ 'cmd': ['/tmp/vize', 'lsp', '--debug'],
       \ 'allowlist': ['vue'],
@@ -28,6 +39,11 @@ call assert_equal(['/tmp/vize', 'lsp', '--debug'], s:custom.cmd)
 call assert_equal(['vue'], s:custom.allowlist)
 call assert_equal({'hover': v:true, 'references': v:true}, s:custom.initialization_options)
 
+let s:mutable_opts = {'initialization_options': {'hover': v:true}}
+let s:mutable_config = vize#normalize(s:mutable_opts)
+let s:mutable_opts.initialization_options.hover = v:false
+call assert_equal({'hover': v:true}, s:mutable_config.initialization_options)
+
 let s:lsp_config = vize#vim_lsp_config({'profile': 'off'})
 call assert_equal('vize', s:lsp_config.name)
 call assert_equal(['vue', 'art-vue'], s:lsp_config.allowlist)
@@ -35,9 +51,21 @@ call assert_equal({}, s:lsp_config.initialization_options)
 call assert_equal(['vize', 'lsp'], s:lsp_config.cmd({}))
 
 try
+  call vize#profile('missing')
+  call assert_report('expected unknown profile to fail')
+catch /unknown vize profile/
+endtry
+
+try
   call vize#normalize({'cmd': []})
   call assert_report('expected empty cmd to fail')
 catch /cmd/
+endtry
+
+try
+  call vize#normalize({'allowlist': ['']})
+  call assert_report('expected empty allowlist item to fail')
+catch /allowlist/
 endtry
 
 runtime ftdetect/vize.vim

--- a/editors/vscode/src/extension-core.ts
+++ b/editors/vscode/src/extension-core.ts
@@ -196,15 +196,16 @@ function setDiagnosticsAliasOption(
   options: LspInitializationOptions,
   config: VizeConfigurationLike,
 ): void {
+  if (hasExplicitConfigurationValue(config, "lint.enable")) {
+    return;
+  }
+
   const enabled = config.get<boolean>("diagnostics.enable", false);
   if (enabled === true) {
     options.lint = true;
     return;
   }
-  if (
-    hasExplicitConfigurationValue(config, "diagnostics.enable") &&
-    !hasExplicitConfigurationValue(config, "lint.enable")
-  ) {
+  if (hasExplicitConfigurationValue(config, "diagnostics.enable")) {
     options.lint = false;
   }
 }

--- a/tests/tooling/editor-lsp-adapters.test.ts
+++ b/tests/tooling/editor-lsp-adapters.test.ts
@@ -29,6 +29,8 @@ test("editor adapters consistently route Vue documents to the Vize LSP", () => {
   assert.match(nvimConfig, /cmd = \{ "vize", "lsp" \}/);
   assert.match(nvimConfig, /filetypes = \{ "vue", "art-vue" \}/);
   assert.match(nvimConfig, /init_options = profiles\.recommended/);
+  assert.match(nvimConfig, /lint = \{\s*lint = true,\s*\}/);
+  assert.match(nvimConfig, /off = \{\}/);
   assert.match(nvimConfig, /editor = true/);
   assert.match(nvimConfig, /ecosystem = true/);
   assert.match(nvimConfig, /lint = true/);
@@ -38,6 +40,8 @@ test("editor adapters consistently route Vue documents to the Vize LSP", () => {
   assert.match(vimConfig, /'cmd': \['vize', 'lsp'\]/);
   assert.match(vimConfig, /'allowlist': \['vue', 'art-vue'\]/);
   assert.match(vimConfig, /'initialization_options': s:profiles\.recommended/);
+  assert.match(vimConfig, /'lint': \{'lint': v:true\}/);
+  assert.match(vimConfig, /'off': \{\}/);
   assert.match(vimConfig, /'editor': v:true/);
   assert.match(vimConfig, /'ecosystem': v:true/);
   assert.match(vimConfig, /'lint': v:true/);
@@ -57,6 +61,8 @@ test("editor adapters consistently route Vue documents to the Vize LSP", () => {
   assert.match(emacsConfig, /defcustom vize-eglot-command '\("vize" "lsp"\)/);
   assert.match(emacsConfig, /defcustom vize-eglot-profile 'recommended/);
   assert.match(emacsConfig, /vue-mode vue-ts-mode web-mode vize-vue-mode vize-art-vue-mode/);
+  assert.match(emacsConfig, /\(lint \. \(:lint t\)\)/);
+  assert.match(emacsConfig, /\(off \. nil\)/);
   assert.match(emacsConfig, /recommended \. \(:editor t :ecosystem t :lint t :typecheck t\)/);
 
   const zedManifest = fs.readFileSync(path.join(root, "editors/zed/extension.toml"), "utf-8");

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { testOutputRoot } from "./support/lsp/paths.ts";
-import type { LspInitializationOptions } from "./support/lsp/protocol.ts";
+import type { LspInitializationOptions, ServerCapabilities } from "./support/lsp/protocol.ts";
 import { LspSession } from "./support/lsp/session.ts";
 
 // Capability-advertisement suite for `vize lsp`.
@@ -16,56 +16,9 @@ import { LspSession } from "./support/lsp/session.ts";
 // "."); here we pin the full provider set and the per-feature gating shapes for
 // distinct option bundles, which the smoke suite does not cover.
 
-/**
- * Granular initialization options accepted by the server's camelCase config
- * section. The shared `LspInitializationOptions` type only models the common
- * bundle flags, so this test widens it with the per-feature toggles it needs.
- */
-type GranularInitOptions = LspInitializationOptions & {
-  completion?: boolean;
-  hover?: boolean;
-  definition?: boolean;
-  references?: boolean;
-  inlayHints?: boolean;
-  foldingRanges?: boolean;
-  documentSymbols?: boolean;
-  codeLens?: boolean;
-};
-
-type ServerCapabilities = {
-  documentSymbolProvider?: unknown;
-  foldingRangeProvider?: unknown;
-  inlayHintProvider?: unknown;
-  documentHighlightProvider?: unknown;
-  workspaceSymbolProvider?: unknown;
-  semanticTokensProvider?: unknown;
-  completionProvider?: {
-    triggerCharacters?: string[];
-    resolveProvider?: boolean;
-  };
-  codeLensProvider?: { resolveProvider?: boolean };
-  documentLinkProvider?: { resolveProvider?: boolean };
-  renameProvider?: { prepareProvider?: boolean };
-  codeActionProvider?: {
-    codeActionKinds?: string[];
-    resolveProvider?: boolean;
-  };
-  hoverProvider?: unknown;
-  definitionProvider?: unknown;
-  referencesProvider?: unknown;
-  textDocumentSync?: {
-    change?: number;
-    openClose?: boolean;
-    save?: { includeText?: boolean };
-  };
-  signatureHelpProvider?: unknown;
-  selectionRangeProvider?: unknown;
-  documentRangeFormattingProvider?: unknown;
-};
-
 async function withCapabilities(
   label: string,
-  initializationOptions: GranularInitOptions,
+  initializationOptions: LspInitializationOptions,
   run: (capabilities: ServerCapabilities) => void,
 ): Promise<void> {
   const testRootDir = path.join(testOutputRoot, `lsp-capabilities-${label}`);
@@ -74,10 +27,9 @@ async function withCapabilities(
   const session = new LspSession();
 
   try {
-    const init = (await session.initialize(
-      workspaceDir,
-      initializationOptions as LspInitializationOptions,
-    )) as { capabilities?: ServerCapabilities };
+    const init = (await session.initialize(workspaceDir, initializationOptions)) as {
+      capabilities?: ServerCapabilities;
+    };
     assert.ok(init.capabilities, "initialize result should advertise capabilities");
     run(init.capabilities);
   } finally {

--- a/tests/tooling/lsp-editor-feature-routing.test.ts
+++ b/tests/tooling/lsp-editor-feature-routing.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { LspInitializationOptions } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+const ALL_EDITOR_FEATURES_OFF: LspInitializationOptions = {
+  codeActions: false,
+  codeLens: false,
+  completion: false,
+  definition: false,
+  documentLinks: false,
+  documentSymbols: false,
+  editor: true,
+  fileRename: false,
+  foldingRanges: false,
+  formatting: false,
+  hover: false,
+  inlayHints: false,
+  lint: false,
+  references: false,
+  rename: false,
+  semanticTokens: false,
+  typecheck: false,
+  workspaceSymbols: false,
+};
+
+type RequestCase = {
+  method: string;
+  params: (uri: string, workspaceDir: string) => unknown;
+  expected?: unknown;
+};
+
+const position = { line: 1, character: 7 };
+const range = { start: position, end: position };
+
+const DISABLED_REQUESTS: RequestCase[] = [
+  {
+    method: "textDocument/hover",
+    params: (uri) => ({ textDocument: { uri }, position }),
+  },
+  {
+    method: "textDocument/definition",
+    params: (uri) => ({ textDocument: { uri }, position }),
+  },
+  {
+    method: "textDocument/references",
+    params: (uri) => ({ textDocument: { uri }, position, context: { includeDeclaration: true } }),
+  },
+  {
+    method: "textDocument/completion",
+    params: (uri) => ({ textDocument: { uri }, position }),
+  },
+  {
+    method: "textDocument/documentSymbol",
+    params: (uri) => ({ textDocument: { uri } }),
+  },
+  {
+    method: "textDocument/documentLink",
+    params: (uri) => ({ textDocument: { uri } }),
+  },
+  {
+    method: "textDocument/semanticTokens/full",
+    params: (uri) => ({ textDocument: { uri } }),
+  },
+  {
+    method: "textDocument/semanticTokens/range",
+    params: (uri) => ({ textDocument: { uri }, range }),
+  },
+  {
+    method: "textDocument/codeLens",
+    params: (uri) => ({ textDocument: { uri } }),
+  },
+  {
+    method: "textDocument/inlayHint",
+    params: (uri) => ({ textDocument: { uri }, range }),
+  },
+  {
+    method: "textDocument/foldingRange",
+    params: (uri) => ({ textDocument: { uri } }),
+  },
+  {
+    method: "textDocument/codeAction",
+    params: (uri) => ({ textDocument: { uri }, range, context: { diagnostics: [] } }),
+  },
+  {
+    method: "textDocument/prepareRename",
+    params: (uri) => ({ textDocument: { uri }, position }),
+  },
+  {
+    method: "textDocument/rename",
+    params: (uri) => ({ textDocument: { uri }, position, newName: "renamedMessage" }),
+  },
+  {
+    method: "textDocument/formatting",
+    params: (uri) => ({ textDocument: { uri }, options: { tabSize: 2, insertSpaces: true } }),
+  },
+  {
+    method: "textDocument/rangeFormatting",
+    params: (uri) => ({
+      textDocument: { uri },
+      range,
+      options: { tabSize: 2, insertSpaces: true },
+    }),
+  },
+  {
+    method: "workspace/symbol",
+    params: () => ({ query: "message" }),
+  },
+  {
+    method: "workspace/willRenameFiles",
+    params: (_uri, workspaceDir) => ({
+      files: [
+        {
+          oldUri: pathToFileURL(path.join(workspaceDir, "Widget.vue")).href,
+          newUri: pathToFileURL(path.join(workspaceDir, "RenamedWidget.vue")).href,
+        },
+      ],
+    }),
+  },
+];
+
+test("vize lsp honors explicit editor feature disables for live requests", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-editor-feature-routing");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, ALL_EDITOR_FEATURES_OFF);
+
+    const source = `<script setup lang="ts">
+const message = "hello"
+</script>
+
+<template>
+  <span>{{ message }}</span>
+</template>
+`;
+    const filePath = path.join(workspaceDir, "Widget.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+    session.notify("textDocument/didOpen", {
+      textDocument: {
+        uri,
+        languageId: "vue",
+        version: 1,
+        text: source,
+      },
+    });
+
+    for (const request of DISABLED_REQUESTS) {
+      const response = await session.request(request.method, request.params(uri, workspaceDir));
+      assert.deepEqual(response, request.expected ?? null, `${request.method} should be inert`);
+    }
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/support/lsp/protocol.ts
+++ b/tests/tooling/support/lsp/protocol.ts
@@ -10,11 +10,88 @@ export type JsonRpcMessage = {
 };
 
 export type LspInitializationOptions = {
-  semanticTokens?: boolean;
-  editor?: boolean;
-  lint?: boolean;
-  typecheck?: boolean;
   codeActions?: boolean;
+  codeLens?: boolean;
+  completion?: boolean;
+  definition?: boolean;
+  documentLinks?: boolean;
+  documentSymbols?: boolean;
+  ecosystem?: boolean;
+  editor?: boolean;
+  fileRename?: boolean;
+  foldingRanges?: boolean;
+  formatting?: boolean;
+  hover?: boolean;
+  inlayHints?: boolean;
+  legacyVue2?: boolean;
+  lint?: boolean;
+  optionsApi?: boolean;
+  references?: boolean;
+  rename?: boolean;
+  semanticTokens?: boolean;
+  typecheck?: boolean;
+  workspaceSymbols?: boolean;
+};
+
+export type LspPosition = {
+  line: number;
+  character: number;
+};
+
+export type LspRange = {
+  start: LspPosition;
+  end: LspPosition;
+};
+
+export type TextDocumentIdentifier = {
+  uri: string;
+};
+
+export type TextDocumentPositionParams = {
+  textDocument: TextDocumentIdentifier;
+  position: LspPosition;
+};
+
+export type TextDocumentRangeParams = {
+  textDocument: TextDocumentIdentifier;
+  range: LspRange;
+};
+
+export type WorkspaceEdit = {
+  changes?: Record<string, Array<{ range: LspRange; newText: string }>>;
+  documentChanges?: unknown[];
+};
+
+export type ServerCapabilities = {
+  codeActionProvider?: {
+    codeActionKinds?: string[];
+    resolveProvider?: boolean;
+  };
+  codeLensProvider?: { resolveProvider?: boolean };
+  completionProvider?: {
+    triggerCharacters?: string[];
+    resolveProvider?: boolean;
+  };
+  definitionProvider?: unknown;
+  documentHighlightProvider?: unknown;
+  documentLinkProvider?: { resolveProvider?: boolean };
+  documentRangeFormattingProvider?: unknown;
+  documentSymbolProvider?: unknown;
+  foldingRangeProvider?: unknown;
+  hoverProvider?: unknown;
+  inlayHintProvider?: unknown;
+  referencesProvider?: unknown;
+  renameProvider?: { prepareProvider?: boolean };
+  selectionRangeProvider?: unknown;
+  semanticTokensProvider?: unknown;
+  signatureHelpProvider?: unknown;
+  textDocumentSync?: {
+    change?: number;
+    openClose?: boolean;
+    save?: { includeText?: boolean };
+  };
+  workspace?: unknown;
+  workspaceSymbolProvider?: unknown;
 };
 
 export type LspDiagnostic = {

--- a/tests/tooling/vscode-extension-core-behavior.test.ts
+++ b/tests/tooling/vscode-extension-core-behavior.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  FEATURE_SETTING_KEYS,
+  createDocumentSelector,
+  describeCapabilities,
+  getInitializationOptions,
+  hasAnyEnabledCapability,
+  shouldStartFromConfiguration,
+  type ConfigurationInspection,
+  type VizeConfigurationLike,
+} from "../../editors/vscode/src/extension-core.ts";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+const FEATURE_TO_OPTION = {
+  "lint.enable": "lint",
+  "diagnostics.enable": "lint",
+  "typecheck.enable": "typecheck",
+  "editor.enable": "editor",
+  "ecosystem.enable": "ecosystem",
+  "optionsApi.enable": "optionsApi",
+  "legacyVue2.enable": "legacyVue2",
+  "completion.enable": "completion",
+  "hover.enable": "hover",
+  "definition.enable": "definition",
+  "references.enable": "references",
+  "documentSymbols.enable": "documentSymbols",
+  "workspaceSymbols.enable": "workspaceSymbols",
+  "codeActions.enable": "codeActions",
+  "rename.enable": "rename",
+  "codeLens.enable": "codeLens",
+  "formatting.enable": "formatting",
+  "semanticTokens.enable": "semanticTokens",
+  "documentLinks.enable": "documentLinks",
+  "foldingRanges.enable": "foldingRanges",
+  "inlayHints.enable": "inlayHints",
+  "fileRename.enable": "fileRename",
+} as const satisfies Record<(typeof FEATURE_SETTING_KEYS)[number], string>;
+
+class FakeConfig implements VizeConfigurationLike {
+  readonly values: Record<string, unknown>;
+
+  constructor(values: Record<string, unknown>) {
+    this.values = values;
+  }
+
+  get<T>(key: string, defaultValue: T): T {
+    return Object.hasOwn(this.values, key) ? (this.values[key] as T) : defaultValue;
+  }
+
+  inspect<T>(key: string): ConfigurationInspection<T> | undefined {
+    if (!Object.hasOwn(this.values, key)) {
+      return undefined;
+    }
+    return { workspaceValue: this.values[key] as T };
+  }
+}
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf-8")) as T;
+}
+
+for (const key of FEATURE_SETTING_KEYS) {
+  const option = FEATURE_TO_OPTION[key];
+
+  test(`vscode explicit false for ${key} maps to ${option}:false`, () => {
+    assert.deepEqual(getInitializationOptions(new FakeConfig({ enable: true, [key]: false })), {
+      [option]: false,
+    });
+  });
+
+  test(`vscode explicit true for ${key} maps to ${option}:true`, () => {
+    assert.deepEqual(getInitializationOptions(new FakeConfig({ enable: true, [key]: true })), {
+      [option]: true,
+    });
+  });
+}
+
+test("vscode lint.enable takes precedence over deprecated diagnostics.enable", () => {
+  assert.deepEqual(
+    getInitializationOptions(
+      new FakeConfig({
+        enable: true,
+        "diagnostics.enable": true,
+        "lint.enable": false,
+      }),
+    ),
+    { lint: false },
+  );
+  assert.deepEqual(
+    getInitializationOptions(
+      new FakeConfig({
+        enable: true,
+        "diagnostics.enable": false,
+        "lint.enable": true,
+      }),
+    ),
+    { lint: true },
+  );
+});
+
+test("vscode deprecated diagnostics.enable still configures lint when lint is absent", () => {
+  assert.deepEqual(
+    getInitializationOptions(new FakeConfig({ enable: true, "diagnostics.enable": true })),
+    { lint: true },
+  );
+  assert.deepEqual(
+    getInitializationOptions(new FakeConfig({ enable: true, "diagnostics.enable": false })),
+    { lint: false },
+  );
+});
+
+test("vscode feature keys are complete boolean manifest properties", () => {
+  const manifest = readJson<{
+    contributes?: { configuration?: { properties?: Record<string, { type?: string }> } };
+  }>("editors/vscode/package.json");
+  const properties = manifest.contributes?.configuration?.properties ?? {};
+
+  assert.deepEqual(Object.keys(FEATURE_TO_OPTION).sort(), [...FEATURE_SETTING_KEYS].sort());
+  for (const key of FEATURE_SETTING_KEYS) {
+    assert.equal(properties[`vize.${key}`]?.type, "boolean", `vize.${key}`);
+  }
+});
+
+test("vscode explicit feature switches suppress synthesized recommended defaults", () => {
+  for (const key of FEATURE_SETTING_KEYS) {
+    const options = getInitializationOptions(new FakeConfig({ enable: true, [key]: false }));
+    assert.deepEqual(Object.keys(options), [FEATURE_TO_OPTION[key]]);
+  }
+});
+
+test("vscode start and enabled-capability checks handle false-only configs", () => {
+  const config = new FakeConfig({
+    enable: true,
+    "completion.enable": false,
+    "editor.enable": false,
+    "lint.enable": false,
+  });
+
+  assert.equal(shouldStartFromConfiguration(config), true);
+  assert.equal(hasAnyEnabledCapability(config), false);
+});
+
+test("vscode document selector does not duplicate language and scheme pairs", () => {
+  const selector = createDocumentSelector();
+  const pairs = selector.map(({ language, scheme }) => `${language}:${scheme}`);
+
+  assert.equal(new Set(pairs).size, pairs.length);
+  assert.deepEqual(pairs.sort(), [
+    "art-vue:file",
+    "art-vue:untitled",
+    "html:file",
+    "html:untitled",
+    "vue:file",
+    "vue:untitled",
+  ]);
+});
+
+test("vscode capability description only includes true options in stable order", () => {
+  assert.equal(
+    describeCapabilities({
+      codeActions: false,
+      completion: true,
+      editor: true,
+      unknownFutureFeature: true,
+    }),
+    "completion, editor bundle, unknownFutureFeature",
+  );
+});


### PR DESCRIPTION
## Summary

- Add VS Code extension-core behavior tests covering every feature setting key, explicit true/false mapping, deprecated diagnostics alias precedence, document selector uniqueness, and capability descriptions.
- Add live LSP request-routing coverage that verifies explicitly disabled editor features return inert responses across hover, completion, symbols, links, rename, formatting, semantic tokens, code actions, workspace symbols, and file rename.
- Strengthen Neovim, Vim, Emacs, and CLI editor integration tests for profile values, copy isolation, unknown profile rejection, VS Code extension id matching, and editor operation precedence.
- Move shared LSP test protocol types to the common support module so granular editor capability tests use the same option/capability contract.

## Validation

- `env VIZE_LSP_BIN=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target/debug/vize node --test --test-concurrency=1 tests/tooling/vscode-extension-core-behavior.test.ts tests/tooling/lsp-editor-feature-matrix.test.ts tests/tooling/editor-lsp-adapters.test.ts tests/tooling/lsp-capabilities.test.ts tests/tooling/lsp-editor-feature-routing.test.ts` (2114 tests)
- `env CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo test -p vize commands::ide`
- `env CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo test -p vize commands::lsp`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.bin/vp check tests/tooling/vscode-extension-core-behavior.test.ts tests/tooling/lsp-editor-feature-routing.test.ts tests/tooling/lsp-capabilities.test.ts tests/tooling/editor-lsp-adapters.test.ts tests/tooling/support/lsp/protocol.ts`
- `/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.bin/tsgo --noEmit` in `editors/vscode`
- `/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.bin/vp check src vite.config.ts` in `editors/vscode`
- `nvim --headless -u NONE --noplugin +set\ runtimepath^=editors/nvim +luafile\ editors/nvim/test/vize_spec.lua +qa`
- `vim -Nu NONE -n -es -S editors/vim/test/vize_spec.vim`
- `cargo fmt --all -- --check`

Note: #2659 was already merged, so this is a follow-up PR with only the additional hardening changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786007903&installation_id=136613492&pr_number=2660&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2660&signature=930e0eb3f5a548c56a858e1f8ae9def72d4377b7e62896c32f70bf544b1a6c68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor configuration handling so explicit settings are respected, profile defaults are copied safely, and invalid or unknown profiles are rejected more consistently.
  * Fixed VS Code behavior for feature toggles and diagnostics/lint settings, including better handling of disabled capabilities and explicit “off” configurations.

* **Tests**
  * Expanded coverage across supported editors and LSP behavior to verify configuration copies, normalization, and live request routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->