### PR TITLE
test: harden lsp editor feature isolation

### DIFF
--- a/editors/emacs/test/vize-test.el
+++ b/editors/emacs/test/vize-test.el
@@ -20,6 +20,10 @@
 (ert-deftest vize-profile-options-lint ()
   (should (equal (vize-profile-options 'lint) '(:lint t))))
 
+(ert-deftest vize-profile-options-uses-default-profile-variable ()
+  (let ((vize-eglot-profile 'lint))
+    (should (equal (vize-profile-options) '(:lint t)))))
+
 (ert-deftest vize-profile-options-off ()
   (should (equal (vize-profile-options 'off) nil)))
 
@@ -39,8 +43,24 @@
      (equal (vize-eglot-server-program 'lint)
             '("/tmp/vize" "lsp" "--debug" :initializationOptions (:lint t))))))
 
+(ert-deftest vize-eglot-server-program-copies-initialization-options ()
+  (let* ((program (vize-eglot-server-program 'recommended))
+         (options (cadr (memq :initializationOptions program))))
+    (plist-put options :lint nil)
+    (should
+     (equal (vize-profile-options 'recommended)
+            '(:editor t :ecosystem t :lint t :typecheck t)))))
+
 (ert-deftest vize-eglot-server-program-copies-command ()
   (let* ((vize-eglot-command '("/tmp/vize" "lsp"))
          (program (vize-eglot-server-program 'off)))
     (setcar program "changed")
     (should (equal vize-eglot-command '("/tmp/vize" "lsp")))))
+
+(ert-deftest vize-eglot-major-modes-cover-common-and-fallback-modes ()
+  (dolist (mode '(vue-mode vue-ts-mode web-mode vize-vue-mode vize-art-vue-mode))
+    (should (memq mode vize-eglot-major-modes))))
+
+(ert-deftest vize-auto-mode-alist-registers-vue-patterns ()
+  (should (equal (cdr (assoc "\\.vue\\'" auto-mode-alist)) 'vize-vue-mode))
+  (should (equal (cdr (assoc "\\.art\\.vue\\'" auto-mode-alist)) 'vize-art-vue-mode)))

--- a/editors/nvim/test/vize_spec.lua
+++ b/editors/nvim/test/vize_spec.lua
@@ -7,6 +7,11 @@ local function assert_eq(actual, expected, label)
   assert(vim.deep_equal(actual, expected), label .. "\nactual: " .. vim.inspect(actual))
 end
 
+local function assert_fails(label, fn, pattern)
+  local ok, err = pcall(fn)
+  assert(not ok and err:match(pattern), label .. "\nerror: " .. tostring(err))
+end
+
 local defaults = config.normalize()
 assert_eq(defaults.cmd, { "vize", "lsp" }, "default cmd")
 assert_eq(defaults.filetypes, { "vue", "art-vue" }, "default filetypes")
@@ -57,14 +62,50 @@ local mutable_config = config.normalize(mutable_opts)
 mutable_opts.init_options.hover = false
 assert_eq(mutable_config.init_options, { hover = true }, "normalization copies init options")
 
-local profile_ok, profile_err = pcall(config.profile, "missing")
-assert(not profile_ok and profile_err:match("unknown vize profile"), "rejects unknown profile")
+local mutable_settings_opts = { settings = { vize = { trace = "messages" } } }
+local mutable_settings_config = config.normalize(mutable_settings_opts)
+mutable_settings_opts.settings.vize.trace = "off"
+assert_eq(
+  mutable_settings_config.settings,
+  { vize = { trace = "messages" } },
+  "normalization copies nested settings"
+)
 
-local ok, err = pcall(config.normalize, { cmd = {} })
-assert(not ok and err:match("cmd"), "rejects empty cmd")
+local mutable_cmd_opts = { cmd = { "vize", "lsp" } }
+local mutable_cmd_config = config.normalize(mutable_cmd_opts)
+mutable_cmd_opts.cmd[1] = "changed"
+assert_eq(mutable_cmd_config.cmd, { "vize", "lsp" }, "normalization copies cmd")
 
-local filetype_ok, filetype_err = pcall(config.normalize, { filetypes = { "" } })
-assert(not filetype_ok and filetype_err:match("filetypes"), "rejects empty filetype")
+assert_fails("rejects unknown profile", function()
+  config.profile("missing")
+end, "unknown vize profile")
+assert_fails("rejects non-table setup options", function()
+  config.normalize("invalid")
+end, "options")
+assert_fails("rejects empty cmd", function()
+  config.normalize({ cmd = {} })
+end, "cmd")
+assert_fails("rejects non-list cmd", function()
+  config.normalize({ cmd = "vize" })
+end, "cmd")
+assert_fails("rejects non-string cmd item", function()
+  config.normalize({ cmd = { "vize", 42 } })
+end, "cmd")
+assert_fails("rejects empty filetype", function()
+  config.normalize({ filetypes = { "" } })
+end, "filetypes")
+assert_fails("rejects empty root marker", function()
+  config.normalize({ root_markers = { "" } })
+end, "root_markers")
+assert_fails("rejects non-table init options", function()
+  config.normalize({ init_options = false })
+end, "init_options")
+assert_fails("rejects non-table settings", function()
+  config.normalize({ settings = "trace" })
+end, "settings")
+assert_fails("rejects non-boolean autostart", function()
+  config.normalize({ autostart = "yes" })
+end, "autostart")
 
 local setup_config = require("vize").setup({ autostart = false, profile = "off" })
 assert_eq(setup_config.init_options, {}, "setup returns normalized config")

--- a/editors/vim/test/vize_spec.vim
+++ b/editors/vim/test/vize_spec.vim
@@ -44,16 +44,41 @@ let s:mutable_config = vize#normalize(s:mutable_opts)
 let s:mutable_opts.initialization_options.hover = v:false
 call assert_equal({'hover': v:true}, s:mutable_config.initialization_options)
 
+let s:mutable_nested_opts = {'initialization_options': {'nested': {'hover': v:true}}}
+let s:mutable_nested_config = vize#normalize(s:mutable_nested_opts)
+let s:mutable_nested_opts.initialization_options.nested.hover = v:false
+call assert_equal({'nested': {'hover': v:true}}, s:mutable_nested_config.initialization_options)
+
+let s:mutable_cmd_opts = {'cmd': ['vize', 'lsp']}
+let s:mutable_cmd_config = vize#normalize(s:mutable_cmd_opts)
+let s:mutable_cmd_opts.cmd[0] = 'changed'
+call assert_equal(['vize', 'lsp'], s:mutable_cmd_config.cmd)
+
 let s:lsp_config = vize#vim_lsp_config({'profile': 'off'})
 call assert_equal('vize', s:lsp_config.name)
 call assert_equal(['vue', 'art-vue'], s:lsp_config.allowlist)
 call assert_equal({}, s:lsp_config.initialization_options)
 call assert_equal(['vize', 'lsp'], s:lsp_config.cmd({}))
 
+let s:custom_lsp_config = vize#vim_lsp_config({
+      \ 'cmd': ['/tmp/vize', 'lsp'],
+      \ 'allowlist': ['art-vue'],
+      \ 'initialization_options': {'hover': v:true},
+      \ })
+call assert_equal(['/tmp/vize', 'lsp'], s:custom_lsp_config.cmd({}))
+call assert_equal(['art-vue'], s:custom_lsp_config.allowlist)
+call assert_equal({'hover': v:true}, s:custom_lsp_config.initialization_options)
+
 try
   call vize#profile('missing')
   call assert_report('expected unknown profile to fail')
 catch /unknown vize profile/
+endtry
+
+try
+  call vize#normalize([])
+  call assert_report('expected non-dictionary options to fail')
+catch /dictionary/
 endtry
 
 try
@@ -63,9 +88,27 @@ catch /cmd/
 endtry
 
 try
+  call vize#normalize({'cmd': ['vize', 1]})
+  call assert_report('expected non-string cmd item to fail')
+catch /cmd/
+endtry
+
+try
   call vize#normalize({'allowlist': ['']})
   call assert_report('expected empty allowlist item to fail')
 catch /allowlist/
+endtry
+
+try
+  call vize#normalize({'allowlist': 'vue'})
+  call assert_report('expected non-list allowlist to fail')
+catch /allowlist/
+endtry
+
+try
+  call vize#normalize({'initialization_options': []})
+  call assert_report('expected non-dictionary initialization options to fail')
+catch /initialization_options/
 endtry
 
 runtime ftdetect/vize.vim

--- a/tests/tooling/lsp-editor-feature-isolation.test.ts
+++ b/tests/tooling/lsp-editor-feature-isolation.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import {
+  FULL_RANGE,
+  assertCodeLensWorks,
+  assertDefinitionWorks,
+  assertDocumentLinksWork,
+  assertDocumentSymbolsWork,
+  assertFoldingRangesWork,
+  assertHoverWorks,
+  assertInlayHintsWork,
+  assertReferencesWork,
+  assertSemanticTokensWork,
+  assertWorkspaceSymbolsWork,
+  completionStylePosition,
+  expectNull,
+  templateMessagePosition,
+  withFeatureDocument,
+} from "./support/lsp/feature-isolation.ts";
+
+test("granular hover disable does not shut down structural and index features", async () => {
+  await withFeatureDocument("hover-off", { hover: false }, async (ctx) => {
+    await expectNull(ctx, "textDocument/hover", {
+      textDocument: { uri: ctx.uri },
+      position: templateMessagePosition(ctx.source),
+    });
+    await assertDocumentSymbolsWork(ctx);
+    await assertWorkspaceSymbolsWork(ctx);
+    await assertSemanticTokensWork(ctx);
+    await assertDocumentLinksWork(ctx);
+  });
+});
+
+test("granular documentSymbols disable leaves hover workspace symbols and folding alive", async () => {
+  await withFeatureDocument("document-symbols-off", { documentSymbols: false }, async (ctx) => {
+    await expectNull(ctx, "textDocument/documentSymbol", { textDocument: { uri: ctx.uri } });
+    await assertHoverWorks(ctx);
+    await assertWorkspaceSymbolsWork(ctx);
+    await assertFoldingRangesWork(ctx);
+  });
+});
+
+test("granular workspaceSymbols disable leaves document-local authoring alive", async () => {
+  await withFeatureDocument("workspace-symbols-off", { workspaceSymbols: false }, async (ctx) => {
+    await expectNull(ctx, "workspace/symbol", { query: "submitMessage" });
+    await assertHoverWorks(ctx);
+    await assertDocumentSymbolsWork(ctx);
+    await assertCodeLensWorks(ctx);
+  });
+});
+
+test("granular semanticTokens disable leaves parser-backed ranges alive", async () => {
+  await withFeatureDocument("semantic-tokens-off", { semanticTokens: false }, async (ctx) => {
+    await expectNull(ctx, "textDocument/semanticTokens/full", { textDocument: { uri: ctx.uri } });
+    await expectNull(ctx, "textDocument/semanticTokens/range", {
+      textDocument: { uri: ctx.uri },
+      range: FULL_RANGE,
+    });
+    await assertDocumentSymbolsWork(ctx);
+    await assertFoldingRangesWork(ctx);
+  });
+});
+
+test("granular foldingRanges disable leaves semantic tokens and symbols alive", async () => {
+  await withFeatureDocument("folding-ranges-off", { foldingRanges: false }, async (ctx) => {
+    await expectNull(ctx, "textDocument/foldingRange", { textDocument: { uri: ctx.uri } });
+    await assertSemanticTokensWork(ctx);
+    await assertDocumentSymbolsWork(ctx);
+  });
+});
+
+test("granular inlayHints disable leaves code lenses and hover alive", async () => {
+  await withFeatureDocument("inlay-hints-off", { inlayHints: false }, async (ctx) => {
+    await expectNull(ctx, "textDocument/inlayHint", {
+      textDocument: { uri: ctx.uri },
+      range: FULL_RANGE,
+    });
+    await assertCodeLensWorks(ctx);
+    await assertHoverWorks(ctx);
+  });
+});
+
+test("granular codeLens disable leaves inlay hints and hover alive", async () => {
+  await withFeatureDocument("code-lens-off", { codeLens: false }, async (ctx) => {
+    await expectNull(ctx, "textDocument/codeLens", { textDocument: { uri: ctx.uri } });
+    await assertInlayHintsWork(ctx);
+    await assertHoverWorks(ctx);
+  });
+});
+
+test("granular documentLinks disable leaves symbols and hover alive", async () => {
+  await withFeatureDocument("document-links-off", { documentLinks: false }, async (ctx) => {
+    await expectNull(ctx, "textDocument/documentLink", { textDocument: { uri: ctx.uri } });
+    await assertDocumentSymbolsWork(ctx);
+    await assertHoverWorks(ctx);
+  });
+});
+
+test("granular definition disable leaves hover and references alive", async () => {
+  await withFeatureDocument("definition-off", { definition: false }, async (ctx) => {
+    await expectNull(ctx, "textDocument/definition", {
+      textDocument: { uri: ctx.uri },
+      position: templateMessagePosition(ctx.source),
+    });
+    await assertHoverWorks(ctx);
+    await assertReferencesWork(ctx);
+  });
+});
+
+test("granular references disable leaves hover and definition alive", async () => {
+  await withFeatureDocument("references-off", { references: false }, async (ctx) => {
+    await expectNull(ctx, "textDocument/references", {
+      textDocument: { uri: ctx.uri },
+      position: templateMessagePosition(ctx.source),
+      context: { includeDeclaration: true },
+    });
+    await expectNull(ctx, "textDocument/documentHighlight", {
+      textDocument: { uri: ctx.uri },
+      position: templateMessagePosition(ctx.source),
+    });
+    await assertHoverWorks(ctx);
+    await assertDefinitionWorks(ctx);
+  });
+});
+
+test("granular completion disable leaves hover and symbols alive", async () => {
+  await withFeatureDocument("completion-off", { completion: false }, async (ctx) => {
+    await expectNull(ctx, "textDocument/completion", {
+      textDocument: { uri: ctx.uri },
+      position: completionStylePosition(ctx.source),
+    });
+    await assertHoverWorks(ctx);
+    await assertDocumentSymbolsWork(ctx);
+  });
+});
+
+test("granular rename disable leaves hover and definition alive", async () => {
+  await withFeatureDocument("rename-off", { rename: false }, async (ctx) => {
+    await expectNull(ctx, "textDocument/prepareRename", {
+      textDocument: { uri: ctx.uri },
+      position: templateMessagePosition(ctx.source),
+    });
+    await expectNull(ctx, "textDocument/rename", {
+      textDocument: { uri: ctx.uri },
+      position: templateMessagePosition(ctx.source),
+      newName: "renamedMessage",
+    });
+    await assertHoverWorks(ctx);
+    await assertDefinitionWorks(ctx);
+  });
+});
+
+test("granular formatting disable leaves parser-backed symbols alive", async () => {
+  await withFeatureDocument("formatting-off", { formatting: false }, async (ctx) => {
+    await expectNull(ctx, "textDocument/formatting", {
+      textDocument: { uri: ctx.uri },
+      options: { tabSize: 2, insertSpaces: true },
+    });
+    await expectNull(ctx, "textDocument/rangeFormatting", {
+      textDocument: { uri: ctx.uri },
+      range: FULL_RANGE,
+      options: { tabSize: 2, insertSpaces: true },
+    });
+    await assertDocumentSymbolsWork(ctx);
+  });
+});
+
+test("granular codeActions disable does not suppress lint diagnostics", async () => {
+  await withFeatureDocument("code-actions-off", { codeActions: false, lint: true }, async (ctx) => {
+    await expectNull(ctx, "textDocument/codeAction", {
+      textDocument: { uri: ctx.uri },
+      range: FULL_RANGE,
+      context: { diagnostics: ctx.publish.diagnostics },
+    });
+    assert.ok(
+      ctx.publish.diagnostics.some(
+        (diagnostic) =>
+          diagnostic.source === "vize/lint" && diagnostic.code === "vue/require-v-for-key",
+      ),
+      JSON.stringify(ctx.publish.diagnostics),
+    );
+    await assertHoverWorks(ctx);
+  });
+});
+
+test("granular fileRename disable leaves document links alive", async () => {
+  await withFeatureDocument("file-rename-off", { fileRename: false }, async (ctx) => {
+    await expectNull(ctx, "workspace/willRenameFiles", {
+      files: [
+        {
+          oldUri: pathToFileURL(path.join(ctx.workspaceDir, "Dep.vue")).href,
+          newUri: pathToFileURL(path.join(ctx.workspaceDir, "RenamedDep.vue")).href,
+        },
+      ],
+    });
+    await assertDocumentLinksWork(ctx);
+  });
+});

--- a/tests/tooling/support/lsp/feature-isolation.ts
+++ b/tests/tooling/support/lsp/feature-isolation.ts
@@ -1,0 +1,256 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { firstLocation, hoverToText, isDiagnosticsForUri, offsetToPosition } from "./assertions.ts";
+import { testOutputRoot } from "./paths.ts";
+import type { LspInitializationOptions, PublishDiagnosticsParams } from "./protocol.ts";
+import { LspSession } from "./session.ts";
+
+export type FeatureContext = {
+  publish: PublishDiagnosticsParams;
+  session: LspSession;
+  source: string;
+  uri: string;
+  workspaceDir: string;
+};
+
+type DocumentSymbol = {
+  name: string;
+};
+
+type SymbolInformation = {
+  name: string;
+  location: { uri: string };
+};
+
+type CodeLens = {
+  command?: { command?: string; title?: string };
+};
+
+type DocumentLink = {
+  target?: string;
+};
+
+type InlayHint = {
+  label: string | Array<{ value: string }>;
+};
+
+export const FULL_RANGE = {
+  start: { line: 0, character: 0 },
+  end: { line: 1000, character: 0 },
+};
+
+export async function withFeatureDocument(
+  label: string,
+  options: LspInitializationOptions,
+  run: (ctx: FeatureContext) => Promise<void>,
+): Promise<void> {
+  const testRootDir = path.join(testOutputRoot, `lsp-editor-feature-isolation-${label}`);
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: false,
+      ...options,
+    });
+
+    fs.writeFileSync(
+      path.join(workspaceDir, "Dep.vue"),
+      `<script setup lang="ts">
+defineProps<{ label: string }>()
+</script>
+<template><button /></template>
+`,
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "useServer.mjs"),
+      "export const useServer = () => 1\n",
+    );
+
+    const source = `<script setup lang="ts">
+import Dep from './Dep.vue'
+import { useServer } from './useServer'
+import { computed, ref } from 'vue'
+
+const message = ref('hello')
+const doubled = computed(() => message.value.length * 2)
+const items = [1, 2]
+
+function submitMessage() {
+  return useServer() + message.value.length
+}
+</script>
+
+<template>
+  <Dep :label="message" @click="submitMessage" />
+  <button :class="$style.primary" @click="submitMessage">{{ message }}</button>
+  <ul>
+    <li v-for="item in items">{{ item }}</li>
+  </ul>
+</template>
+
+<style module>
+.primary {}
+</style>
+`;
+    const filePath = path.join(workspaceDir, "FeatureIsolation.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: source },
+    });
+
+    const publish = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri),
+    )) as PublishDiagnosticsParams;
+
+    await run({ publish, session, source, uri, workspaceDir });
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+}
+
+export function templateMessagePosition(source: string): { line: number; character: number } {
+  return offsetToPosition(source, source.lastIndexOf("message }}</button>") + "message".length);
+}
+
+export function completionStylePosition(source: string): { line: number; character: number } {
+  return offsetToPosition(source, source.indexOf("$style.pr") + "$style.pr".length);
+}
+
+function declarationPosition(source: string): { line: number; character: number } {
+  return offsetToPosition(source, source.indexOf("message = ref"));
+}
+
+function inlayLabel(hint: InlayHint): string {
+  return typeof hint.label === "string"
+    ? hint.label
+    : hint.label.map((part) => part.value).join("");
+}
+
+export async function assertHoverWorks(ctx: FeatureContext): Promise<void> {
+  const hover = (await ctx.session.request("textDocument/hover", {
+    textDocument: { uri: ctx.uri },
+    position: templateMessagePosition(ctx.source),
+  })) as { contents?: unknown } | null;
+  const text = hoverToText(hover);
+  assert.match(text, /message/);
+  assert.match(text, /Ref<string>|Template binding from script/);
+}
+
+export async function assertDocumentSymbolsWork(ctx: FeatureContext): Promise<void> {
+  const symbols = (await ctx.session.request("textDocument/documentSymbol", {
+    textDocument: { uri: ctx.uri },
+  })) as DocumentSymbol[] | null;
+  assert.ok(Array.isArray(symbols), JSON.stringify(symbols));
+  const names = symbols.map((symbol) => symbol.name);
+  assert.ok(names.includes("template"), names.join(", "));
+  assert.ok(names.includes("script setup"), names.join(", "));
+  assert.ok(
+    names.some((name) => name.startsWith("style")),
+    names.join(", "),
+  );
+}
+
+export async function assertWorkspaceSymbolsWork(ctx: FeatureContext): Promise<void> {
+  const symbols = (await ctx.session.request("workspace/symbol", {
+    query: "submitMessage",
+  })) as SymbolInformation[] | null;
+  assert.ok(Array.isArray(symbols), JSON.stringify(symbols));
+  assert.ok(
+    symbols.some((symbol) => symbol.name === "submitMessage" && symbol.location.uri === ctx.uri),
+  );
+}
+
+export async function assertSemanticTokensWork(ctx: FeatureContext): Promise<void> {
+  const tokens = (await ctx.session.request("textDocument/semanticTokens/full", {
+    textDocument: { uri: ctx.uri },
+  })) as { data?: number[] } | null;
+  assert.ok(Array.isArray(tokens?.data), JSON.stringify(tokens));
+  assert.ok(tokens.data.length > 0, JSON.stringify(tokens));
+}
+
+export async function assertFoldingRangesWork(ctx: FeatureContext): Promise<void> {
+  const ranges = (await ctx.session.request("textDocument/foldingRange", {
+    textDocument: { uri: ctx.uri },
+  })) as unknown[] | null;
+  assert.ok(Array.isArray(ranges), JSON.stringify(ranges));
+  assert.ok(ranges.length > 0, JSON.stringify(ranges));
+}
+
+export async function assertInlayHintsWork(ctx: FeatureContext): Promise<void> {
+  const hints = (await ctx.session.request("textDocument/inlayHint", {
+    textDocument: { uri: ctx.uri },
+    range: FULL_RANGE,
+  })) as InlayHint[] | null;
+  assert.ok(Array.isArray(hints), JSON.stringify(hints));
+  const labels = hints.map(inlayLabel);
+  assert.ok(labels.includes(": Ref<string>"), labels.join(", "));
+  assert.ok(labels.includes(": ComputedRef<number>"), labels.join(", "));
+}
+
+export async function assertCodeLensWorks(ctx: FeatureContext): Promise<void> {
+  const lenses = (await ctx.session.request("textDocument/codeLens", {
+    textDocument: { uri: ctx.uri },
+  })) as CodeLens[] | null;
+  assert.ok(Array.isArray(lenses), JSON.stringify(lenses));
+  assert.ok(lenses.some((lens) => lens.command?.command === "vize.findReferences"));
+}
+
+export async function assertDocumentLinksWork(ctx: FeatureContext): Promise<void> {
+  const links = (await ctx.session.request("textDocument/documentLink", {
+    textDocument: { uri: ctx.uri },
+  })) as DocumentLink[] | null;
+  assert.ok(Array.isArray(links), JSON.stringify(links));
+  const basenames = links.map((link) =>
+    path.basename(decodeURIComponent(new URL(link.target ?? "").pathname)),
+  );
+  assert.ok(basenames.includes("Dep.vue"), basenames.join(", "));
+  assert.ok(basenames.includes("useServer.mjs"), basenames.join(", "));
+}
+
+export async function assertDefinitionWorks(ctx: FeatureContext): Promise<void> {
+  const definition = (await ctx.session.request("textDocument/definition", {
+    textDocument: { uri: ctx.uri },
+    position: templateMessagePosition(ctx.source),
+  })) as Parameters<typeof firstLocation>[0];
+  const location = firstLocation(definition);
+  assert.equal(location.uri, ctx.uri);
+  assert.deepEqual(location.range.start, declarationPosition(ctx.source));
+}
+
+export async function assertReferencesWork(ctx: FeatureContext): Promise<void> {
+  const references = (await ctx.session.request("textDocument/references", {
+    textDocument: { uri: ctx.uri },
+    position: templateMessagePosition(ctx.source),
+    context: { includeDeclaration: true },
+  })) as Array<{ uri: string; range: { start: { line: number; character: number } } }> | null;
+  assert.ok(Array.isArray(references), JSON.stringify(references));
+  assert.ok(
+    references.some(
+      (reference) =>
+        reference.uri === ctx.uri &&
+        reference.range.start.line === declarationPosition(ctx.source).line,
+    ),
+    JSON.stringify(references),
+  );
+}
+
+export async function expectNull(
+  ctx: FeatureContext,
+  method: string,
+  params: unknown,
+): Promise<void> {
+  const response = await ctx.session.request(method, params);
+  assert.equal(response, null, `${method} should be inert`);
+}


### PR DESCRIPTION
## Summary
- add live LSP feature-isolation coverage for granular editor flags, checking disabled requests and unaffected sibling features
- add shared LSP fixture/assertion helpers for the isolation suite
- expand Neovim, Vim, and Emacs adapter tests around input validation, copy semantics, profiles, and mode registration

## Verification
- cargo build -p vize
- node --test --test-concurrency=1 tests/tooling/vscode-extension-core-behavior.test.ts tests/tooling/lsp-editor-feature-matrix.test.ts tests/tooling/editor-lsp-adapters.test.ts tests/tooling/lsp-editor-feature-isolation.test.ts tests/tooling/lsp-editor-feature-routing.test.ts tests/tooling/lsp-capabilities.test.ts
- node --test tests/tooling/source-file-lengths.test.ts
- vp check tests/tooling/lsp-editor-feature-isolation.test.ts tests/tooling/support/lsp/feature-isolation.ts
- nvim --headless -u NONE -c "luafile editors/nvim/test/vize_spec.lua" -c qa
- vim -Nu NONE -n -es -S editors/vim/test/vize_spec.vim

Emacs ERT was not run locally because emacs is not installed in this environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786009942&installation_id=136613492&pr_number=2661&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2661&signature=5df20dd379447553169429143c7035dfc643f86f6a15e8caee3faa070b73fa80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded editor integration coverage across Emacs, Neovim, and Vim.
  * Added checks for safer configuration handling, including copying behavior and validation of invalid settings.
  * Broadened LSP feature isolation coverage to ensure disabling one capability doesn’t affect others.
  * Improved coverage for file pattern registration, mode detection, and common language-server interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->