### PR TITLE
test: broaden lsp editor protocol coverage

### DIFF
--- a/editors/emacs/test/vize-test.el
+++ b/editors/emacs/test/vize-test.el
@@ -57,6 +57,18 @@
     (setcar program "changed")
     (should (equal vize-eglot-command '("/tmp/vize" "lsp")))))
 
+(ert-deftest vize-eglot-server-program-does-not-mutate-command-for-profile-options ()
+  (let* ((vize-eglot-command '("/tmp/vize" "lsp"))
+         (program (vize-eglot-server-program 'lint)))
+    (setcar program "changed")
+    (should (equal vize-eglot-command '("/tmp/vize" "lsp")))))
+
+(ert-deftest vize-profile-options-recommended-copy-is-independent ()
+  (let ((first-copy (vize-profile-options 'recommended))
+        (second-copy (vize-profile-options 'recommended)))
+    (plist-put first-copy :editor nil)
+    (should (equal second-copy '(:editor t :ecosystem t :lint t :typecheck t)))))
+
 (ert-deftest vize-eglot-major-modes-cover-common-and-fallback-modes ()
   (dolist (mode '(vue-mode vue-ts-mode web-mode vize-vue-mode vize-art-vue-mode))
     (should (memq mode vize-eglot-major-modes))))
@@ -64,3 +76,19 @@
 (ert-deftest vize-auto-mode-alist-registers-vue-patterns ()
   (should (equal (cdr (assoc "\\.vue\\'" auto-mode-alist)) 'vize-vue-mode))
   (should (equal (cdr (assoc "\\.art\\.vue\\'" auto-mode-alist)) 'vize-art-vue-mode)))
+
+(ert-deftest vize-setup-eglot-registers-each-configured-major-mode ()
+  (let ((eglot-server-programs nil)
+        (vize-eglot-major-modes '(vize-vue-mode vize-art-vue-mode)))
+    (vize-setup-eglot 'lint)
+    (provide 'eglot)
+    (should
+     (equal eglot-server-programs
+            '((vize-art-vue-mode "vize" "lsp" :initializationOptions (:lint t))
+              (vize-vue-mode "vize" "lsp" :initializationOptions (:lint t)))))))
+
+(ert-deftest vize-setup-eglot-off-profile-registers-command-only ()
+  (let ((eglot-server-programs nil)
+        (vize-eglot-major-modes '(vize-vue-mode)))
+    (vize-setup-eglot 'off)
+    (should (equal eglot-server-programs '((vize-vue-mode "vize" "lsp"))))))

--- a/editors/nvim/test/vize_spec.lua
+++ b/editors/nvim/test/vize_spec.lua
@@ -57,10 +57,29 @@ assert_eq(custom.init_options, { hover = true, references = true }, "custom init
 assert_eq(custom.root_markers, { "deno.json", ".git" }, "custom root markers")
 assert(custom.autostart == false, "custom autostart")
 
+local init_options_override_profile = config.normalize({
+  profile = "lint",
+  init_options = { hover = true, references = true },
+})
+assert_eq(
+  init_options_override_profile.init_options,
+  { hover = true, references = true },
+  "explicit init_options override profile"
+)
+
 local mutable_opts = { init_options = { hover = true } }
 local mutable_config = config.normalize(mutable_opts)
 mutable_opts.init_options.hover = false
 assert_eq(mutable_config.init_options, { hover = true }, "normalization copies init options")
+
+local mutable_nested_opts = { init_options = { nested = { hover = true } } }
+local mutable_nested_config = config.normalize(mutable_nested_opts)
+mutable_nested_opts.init_options.nested.hover = false
+assert_eq(
+  mutable_nested_config.init_options,
+  { nested = { hover = true } },
+  "normalization copies nested init options"
+)
 
 local mutable_settings_opts = { settings = { vize = { trace = "messages" } } }
 local mutable_settings_config = config.normalize(mutable_settings_opts)
@@ -75,6 +94,20 @@ local mutable_cmd_opts = { cmd = { "vize", "lsp" } }
 local mutable_cmd_config = config.normalize(mutable_cmd_opts)
 mutable_cmd_opts.cmd[1] = "changed"
 assert_eq(mutable_cmd_config.cmd, { "vize", "lsp" }, "normalization copies cmd")
+
+local mutable_filetypes_opts = { filetypes = { "vue", "art-vue" } }
+local mutable_filetypes_config = config.normalize(mutable_filetypes_opts)
+mutable_filetypes_opts.filetypes[1] = "changed"
+assert_eq(mutable_filetypes_config.filetypes, { "vue", "art-vue" }, "normalization copies filetypes")
+
+local mutable_root_opts = { root_markers = { "vize.config.pkl", ".git" } }
+local mutable_root_config = config.normalize(mutable_root_opts)
+mutable_root_opts.root_markers[1] = "changed"
+assert_eq(
+  mutable_root_config.root_markers,
+  { "vize.config.pkl", ".git" },
+  "normalization copies root markers"
+)
 
 assert_fails("rejects unknown profile", function()
   config.profile("missing")
@@ -111,6 +144,21 @@ local setup_config = require("vize").setup({ autostart = false, profile = "off" 
 assert_eq(setup_config.init_options, {}, "setup returns normalized config")
 assert_eq(vim.lsp.config.vize.cmd, { "vize", "lsp" }, "registered LSP cmd")
 assert_eq(vim.lsp.config.vize.filetypes, { "vue", "art-vue" }, "registered LSP filetypes")
+
+local original_enable = vim.lsp.enable
+local enable_calls = {}
+vim.lsp.enable = function(name)
+  table.insert(enable_calls, name)
+end
+
+local autostart_config = require("vize").setup({ profile = "lint" })
+assert_eq(autostart_config.init_options, { lint = true }, "setup returns lint profile")
+assert_eq(enable_calls, { "vize" }, "setup autostarts vize")
+assert_eq(vim.lsp.config.vize.init_options, { lint = true }, "setup registers normalized init options")
+
+require("vize").setup({ autostart = false, profile = "off" })
+assert_eq(enable_calls, { "vize" }, "autostart false does not enable vize")
+vim.lsp.enable = original_enable
 
 vim.cmd("runtime! ftdetect/vize.lua")
 vim.cmd("edit " .. vim.fn.fnameescape(vim.fn.tempname() .. ".vue"))

--- a/editors/vim/test/vize_spec.vim
+++ b/editors/vim/test/vize_spec.vim
@@ -39,6 +39,12 @@ call assert_equal(['/tmp/vize', 'lsp', '--debug'], s:custom.cmd)
 call assert_equal(['vue'], s:custom.allowlist)
 call assert_equal({'hover': v:true, 'references': v:true}, s:custom.initialization_options)
 
+let s:override_profile = vize#normalize({
+      \ 'profile': 'lint',
+      \ 'initialization_options': {'hover': v:true, 'references': v:true},
+      \ })
+call assert_equal({'hover': v:true, 'references': v:true}, s:override_profile.initialization_options)
+
 let s:mutable_opts = {'initialization_options': {'hover': v:true}}
 let s:mutable_config = vize#normalize(s:mutable_opts)
 let s:mutable_opts.initialization_options.hover = v:false
@@ -54,10 +60,27 @@ let s:mutable_cmd_config = vize#normalize(s:mutable_cmd_opts)
 let s:mutable_cmd_opts.cmd[0] = 'changed'
 call assert_equal(['vize', 'lsp'], s:mutable_cmd_config.cmd)
 
+let s:mutable_allowlist_opts = {'allowlist': ['vue', 'art-vue']}
+let s:mutable_allowlist_config = vize#normalize(s:mutable_allowlist_opts)
+let s:mutable_allowlist_opts.allowlist[0] = 'changed'
+call assert_equal(['vue', 'art-vue'], s:mutable_allowlist_config.allowlist)
+
+let s:default_config_nested_copy = vize#default_config()
+let s:default_config_nested_copy.initialization_options.editor = v:false
+call assert_equal({
+      \ 'editor': v:true,
+      \ 'ecosystem': v:true,
+      \ 'lint': v:true,
+      \ 'typecheck': v:true,
+      \ }, vize#default_config().initialization_options)
+
 let s:lsp_config = vize#vim_lsp_config({'profile': 'off'})
 call assert_equal('vize', s:lsp_config.name)
 call assert_equal(['vue', 'art-vue'], s:lsp_config.allowlist)
 call assert_equal({}, s:lsp_config.initialization_options)
+call assert_equal(['vize', 'lsp'], s:lsp_config.cmd({}))
+let s:lsp_cmd_copy = s:lsp_config.cmd({})
+let s:lsp_cmd_copy[0] = 'changed'
 call assert_equal(['vize', 'lsp'], s:lsp_config.cmd({}))
 
 let s:custom_lsp_config = vize#vim_lsp_config({

--- a/tests/tooling/lsp-protocol-resilience.test.ts
+++ b/tests/tooling/lsp-protocol-resilience.test.ts
@@ -1,0 +1,348 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import {
+  completionLabels,
+  firstLocation,
+  hoverToText,
+  isDiagnosticsForUri,
+  offsetToPosition,
+} from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspRequestError, LspSession } from "./support/lsp/session.ts";
+
+type ProtocolContext = {
+  session: LspSession;
+  source: string;
+  uri: string;
+  workspaceDir: string;
+};
+
+async function withProtocolDocument(
+  label: string,
+  run: (ctx: ProtocolContext) => Promise<void>,
+): Promise<void> {
+  const testRootDir = path.join(testOutputRoot, `lsp-protocol-resilience-${label}`);
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: true,
+      typecheck: false,
+    });
+
+    fs.writeFileSync(
+      path.join(workspaceDir, "Dep.vue"),
+      `<script setup lang="ts">
+defineProps<{ label: string }>()
+</script>
+<template><button /></template>
+`,
+      "utf8",
+    );
+
+    const source = `<script setup lang="ts">
+import Dep from './Dep.vue'
+import { ref } from 'vue'
+
+const message = ref('hello')
+const enabled = ref(false)
+</script>
+
+<template>
+  <Dep :label="message" />
+  <button :disabled="enabled" @click="message = 'clicked'">{{ message }}</button>
+</template>
+`;
+    const filePath = path.join(workspaceDir, "Protocol.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: source },
+    });
+
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, uri),
+    );
+
+    await run({ session, source, uri, workspaceDir });
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+}
+
+test("vize lsp reports unsupported requests without poisoning the session", async () => {
+  await withProtocolDocument("unknown-request", async ({ session, source, uri }) => {
+    await assert.rejects(
+      session.request("vize/definitelyMissing", { reason: "coverage" }),
+      (error) =>
+        error instanceof LspRequestError &&
+        error.method === "vize/definitelyMissing" &&
+        error.code === -32601,
+    );
+
+    const hover = (await session.request("textDocument/hover", {
+      textDocument: { uri },
+      position: offsetToPosition(source, source.lastIndexOf("message }}</button>") + 3),
+    })) as { contents?: unknown } | null;
+    assert.match(hoverToText(hover), /message/);
+  });
+});
+
+test("vize lsp ignores cancellation and workspace notifications it does not consume", async () => {
+  await withProtocolDocument(
+    "no-op-notifications",
+    async ({ session, source, uri, workspaceDir }) => {
+      session.notify("$/cancelRequest", { id: 999_999 });
+      session.notify("workspace/didChangeConfiguration", {
+        settings: { vize: { trace: "messages" } },
+      });
+      session.notify("workspace/didChangeWatchedFiles", {
+        changes: [
+          {
+            uri: pathToFileURL(path.join(workspaceDir, "Ghost.vue")).href,
+            type: 1,
+          },
+        ],
+      });
+      session.notify("textDocument/didSave", {
+        textDocument: { uri },
+        text: source,
+      });
+
+      const symbols = (await session.request("textDocument/documentSymbol", {
+        textDocument: { uri },
+      })) as Array<{ name: string }> | null;
+      assert.ok(Array.isArray(symbols), JSON.stringify(symbols));
+      assert.ok(
+        symbols.some((symbol) => symbol.name === "template"),
+        JSON.stringify(symbols),
+      );
+
+      const tokens = (await session.request("textDocument/semanticTokens/full", {
+        textDocument: { uri },
+      })) as { data?: number[] } | null;
+      assert.ok((tokens?.data?.length ?? 0) > 0, JSON.stringify(tokens));
+    },
+  );
+});
+
+test("vize lsp resolves concurrent editor requests to their matching responses", async () => {
+  await withProtocolDocument("concurrent-requests", async ({ session, source, uri }) => {
+    const templateMessage = offsetToPosition(
+      source,
+      source.lastIndexOf("message }}</button>") + "message".length,
+    );
+    const enabledValue = offsetToPosition(source, source.indexOf('"enabled"') + '"en'.length);
+
+    const [
+      hover,
+      definition,
+      references,
+      completion,
+      documentSymbols,
+      foldingRanges,
+      documentLinks,
+      semanticTokens,
+      workspaceSymbols,
+    ] = await Promise.all([
+      session.request("textDocument/hover", {
+        textDocument: { uri },
+        position: templateMessage,
+      }),
+      session.request("textDocument/definition", {
+        textDocument: { uri },
+        position: templateMessage,
+      }),
+      session.request("textDocument/references", {
+        textDocument: { uri },
+        position: templateMessage,
+        context: { includeDeclaration: true },
+      }),
+      session.request("textDocument/completion", {
+        textDocument: { uri },
+        position: enabledValue,
+      }),
+      session.request("textDocument/documentSymbol", {
+        textDocument: { uri },
+      }),
+      session.request("textDocument/foldingRange", {
+        textDocument: { uri },
+      }),
+      session.request("textDocument/documentLink", {
+        textDocument: { uri },
+      }),
+      session.request("textDocument/semanticTokens/full", {
+        textDocument: { uri },
+      }),
+      session.request("workspace/symbol", {
+        query: "message",
+      }),
+    ]);
+
+    assert.match(hoverToText(hover as { contents?: unknown } | null), /message/);
+
+    const location = firstLocation(
+      definition as
+        | Array<{ uri: string; range: { start: { line: number; character: number } } }>
+        | { uri: string; range: { start: { line: number; character: number } } },
+    );
+    assert.equal(location.uri, uri);
+    assert.deepEqual(location.range.start, offsetToPosition(source, source.indexOf("message =")));
+
+    assert.ok(
+      Array.isArray(references) &&
+        references.some(
+          (reference) =>
+            reference.uri === uri &&
+            reference.range.start.line === templateMessage.line &&
+            reference.range.start.character === templateMessage.character - "message".length,
+        ),
+      JSON.stringify(references),
+    );
+
+    assert.ok(completionLabels(completion).includes("enabled"), JSON.stringify(completion));
+    assert.ok(
+      Array.isArray(documentSymbols) &&
+        documentSymbols.some((symbol: { name?: string }) => symbol.name === "script setup"),
+      JSON.stringify(documentSymbols),
+    );
+    assert.ok(
+      Array.isArray(foldingRanges) && foldingRanges.length > 0,
+      JSON.stringify(foldingRanges),
+    );
+    assert.ok(
+      Array.isArray(documentLinks) &&
+        documentLinks.some((link: { target?: string }) => link.target?.endsWith("/Dep.vue")),
+      JSON.stringify(documentLinks),
+    );
+    assert.ok(
+      Array.isArray((semanticTokens as { data?: unknown[] } | null)?.data) &&
+        ((semanticTokens as { data?: unknown[] }).data?.length ?? 0) > 0,
+      JSON.stringify(semanticTokens),
+    );
+    assert.ok(
+      Array.isArray(workspaceSymbols) &&
+        workspaceSymbols.some((symbol: { name?: string }) => symbol.name === "message"),
+      JSON.stringify(workspaceSymbols),
+    );
+  });
+});
+
+test("vize lsp applies multiple range changes in one didChange notification", async () => {
+  await withProtocolDocument("multi-range-change", async ({ session, source, uri }) => {
+    const declarationStart = source.indexOf("message =");
+    const templateStart = source.lastIndexOf("{{ message }}") + "{{ ".length;
+
+    session.notify("textDocument/didChange", {
+      textDocument: { uri, version: 2 },
+      contentChanges: [
+        {
+          range: {
+            start: offsetToPosition(source, declarationStart),
+            end: offsetToPosition(source, declarationStart + "message".length),
+          },
+          text: "counter",
+        },
+        {
+          range: {
+            start: offsetToPosition(source, templateStart),
+            end: offsetToPosition(source, templateStart + "message".length),
+          },
+          text: "counter",
+        },
+      ],
+    });
+
+    const publish = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri) && params.version === 2,
+    )) as PublishDiagnosticsParams;
+    assert.equal(publish.version, 2);
+
+    const updatedSource =
+      source.slice(0, declarationStart) +
+      "counter" +
+      source.slice(declarationStart + "message".length, templateStart) +
+      "counter" +
+      source.slice(templateStart + "message".length);
+    const counterUsage = offsetToPosition(
+      updatedSource,
+      updatedSource.lastIndexOf("counter }}") + 3,
+    );
+
+    const hover = (await session.request("textDocument/hover", {
+      textDocument: { uri },
+      position: counterUsage,
+    })) as { contents?: unknown } | null;
+    assert.match(hoverToText(hover), /counter/);
+
+    const definition = (await session.request("textDocument/definition", {
+      textDocument: { uri },
+      position: counterUsage,
+    })) as
+      | Array<{ uri: string; range: { start: { line: number; character: number } } }>
+      | { uri: string; range: { start: { line: number; character: number } } };
+    assert.deepEqual(
+      firstLocation(definition).range.start,
+      offsetToPosition(updatedSource, declarationStart),
+    );
+  });
+});
+
+test("vize lsp full-text changes replace stale virtual document contents", async () => {
+  await withProtocolDocument("full-text-change", async ({ session, uri }) => {
+    const nextSource = `<script setup lang="ts">
+import { ref } from 'vue'
+
+const status = ref('ready')
+</script>
+
+<template>
+  <p>{{ status }}</p>
+</template>
+`;
+
+    session.notify("textDocument/didChange", {
+      textDocument: { uri, version: 3 },
+      contentChanges: [{ text: nextSource }],
+    });
+
+    await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri) && params.version === 3,
+    );
+
+    const statusUsage = offsetToPosition(nextSource, nextSource.lastIndexOf("status }}</p>") + 3);
+    const definition = (await session.request("textDocument/definition", {
+      textDocument: { uri },
+      position: statusUsage,
+    })) as
+      | Array<{ uri: string; range: { start: { line: number; character: number } } }>
+      | { uri: string; range: { start: { line: number; character: number } } };
+    assert.deepEqual(
+      firstLocation(definition).range.start,
+      offsetToPosition(nextSource, nextSource.indexOf("status =")),
+    );
+
+    const staleSymbols = (await session.request("workspace/symbol", {
+      query: "message",
+    })) as Array<{ name?: string; location?: { uri?: string } }> | null;
+    assert.equal(
+      (staleSymbols ?? []).some(
+        (symbol) => symbol.name === "message" && symbol.location?.uri === uri,
+      ),
+      false,
+      JSON.stringify(staleSymbols),
+    );
+  });
+});

--- a/tests/tooling/support/lsp/protocol.ts
+++ b/tests/tooling/support/lsp/protocol.ts
@@ -6,7 +6,7 @@ export type JsonRpcMessage = {
   method?: string;
   params?: unknown;
   result?: unknown;
-  error?: { code: number; message: string };
+  error?: { code: number; message: string; data?: unknown };
 };
 
 export type LspInitializationOptions = {

--- a/tests/tooling/support/lsp/session.ts
+++ b/tests/tooling/support/lsp/session.ts
@@ -6,6 +6,20 @@ import { resolveVizeLaunchCommand } from "./launch.ts";
 import { root } from "./paths.ts";
 import type { JsonRpcId, JsonRpcMessage, LspInitializationOptions } from "./protocol.ts";
 
+export class LspRequestError extends Error {
+  readonly code: number;
+  readonly data: unknown;
+  readonly method: string;
+
+  constructor(method: string, error: { code: number; message: string; data?: unknown }) {
+    super(`${method}: ${error.message}`);
+    this.name = "LspRequestError";
+    this.code = error.code;
+    this.data = error.data;
+    this.method = method;
+  }
+}
+
 /**
  * Minimal JSON-RPC client for production LSP smoke tests.
  *
@@ -222,7 +236,7 @@ export class LspSession {
       this.pending.delete(message.id);
 
       if (message.error) {
-        pending.reject(new Error(`${pending.method}: ${message.error.message}`));
+        pending.reject(new LspRequestError(pending.method, message.error));
         return;
       }
 

--- a/tests/tooling/vscode-extension-core-behavior.test.ts
+++ b/tests/tooling/vscode-extension-core-behavior.test.ts
@@ -9,6 +9,7 @@ import {
   describeCapabilities,
   getInitializationOptions,
   hasAnyEnabledCapability,
+  hasAnyExplicitCapabilityValue,
   shouldStartFromConfiguration,
   type ConfigurationInspection,
   type VizeConfigurationLike,
@@ -41,22 +42,43 @@ const FEATURE_TO_OPTION = {
   "fileRename.enable": "fileRename",
 } as const satisfies Record<(typeof FEATURE_SETTING_KEYS)[number], string>;
 
-class FakeConfig implements VizeConfigurationLike {
-  readonly values: Record<string, unknown>;
+type Scope = "global" | "workspace" | "workspaceFolder";
+type ConfigValue = {
+  scope: Scope;
+  value: unknown;
+};
 
-  constructor(values: Record<string, unknown>) {
-    this.values = values;
+class FakeConfig implements VizeConfigurationLike {
+  readonly values: Record<string, ConfigValue>;
+
+  constructor(values: Record<string, unknown>, scopes: Record<string, Scope> = {}) {
+    this.values = Object.fromEntries(
+      Object.entries(values).map(([key, value]) => [
+        key,
+        {
+          scope: scopes[key] ?? "workspace",
+          value,
+        },
+      ]),
+    );
   }
 
   get<T>(key: string, defaultValue: T): T {
-    return Object.hasOwn(this.values, key) ? (this.values[key] as T) : defaultValue;
+    return Object.hasOwn(this.values, key) ? (this.values[key].value as T) : defaultValue;
   }
 
   inspect<T>(key: string): ConfigurationInspection<T> | undefined {
-    if (!Object.hasOwn(this.values, key)) {
+    const entry = this.values[key];
+    if (!entry) {
       return undefined;
     }
-    return { workspaceValue: this.values[key] as T };
+    if (entry.scope === "global") {
+      return { globalValue: entry.value as T };
+    }
+    if (entry.scope === "workspaceFolder") {
+      return { workspaceFolderValue: entry.value as T };
+    }
+    return { workspaceValue: entry.value as T };
   }
 }
 
@@ -78,6 +100,21 @@ for (const key of FEATURE_SETTING_KEYS) {
       [option]: true,
     });
   });
+}
+
+for (const key of FEATURE_SETTING_KEYS) {
+  const option = FEATURE_TO_OPTION[key];
+
+  for (const scope of ["global", "workspace", "workspaceFolder"] as const) {
+    for (const value of [false, true] as const) {
+      test(`vscode ${scope} ${key}:${value} is explicit and maps to ${option}`, () => {
+        const config = new FakeConfig({ enable: true, [key]: value }, { [key]: scope });
+
+        assert.deepEqual(getInitializationOptions(config), { [option]: value });
+        assert.equal(hasAnyExplicitCapabilityValue(config), true);
+      });
+    }
+  }
 }
 
 test("vscode lint.enable takes precedence over deprecated diagnostics.enable", () => {
@@ -143,6 +180,23 @@ test("vscode start and enabled-capability checks handle false-only configs", () 
 
   assert.equal(shouldStartFromConfiguration(config), true);
   assert.equal(hasAnyEnabledCapability(config), false);
+  assert.equal(hasAnyExplicitCapabilityValue(config), true);
+});
+
+test("vscode explicit capability detection ignores unrelated settings", () => {
+  const config = new FakeConfig({
+    enable: true,
+    serverPath: "/tmp/vize",
+    "trace.server": "verbose",
+  });
+
+  assert.equal(hasAnyExplicitCapabilityValue(config), false);
+  assert.deepEqual(getInitializationOptions(config), {
+    editor: true,
+    ecosystem: true,
+    lint: true,
+    typecheck: true,
+  });
 });
 
 test("vscode document selector does not duplicate language and scheme pairs", () => {


### PR DESCRIPTION
## Summary
- add live LSP protocol resilience coverage for unsupported requests, cancellation/workspace notifications, concurrent requests, and didChange replacement paths
- extend VS Code initialization tests across global/workspace/workspaceFolder scopes for every feature switch
- deepen Vim, Neovim, and Emacs adapter tests around profile overrides, copy isolation, and setup registration

## Verification
- cargo build -p vize
- node --test --test-concurrency=1 tests/tooling/lsp-protocol-resilience.test.ts
- node --test tests/tooling/vscode-extension-core-behavior.test.ts
- nvim --headless -u NONE -c 'luafile editors/nvim/test/vize_spec.lua' -c qa
- vim -Nu NONE -n -es -S editors/vim/test/vize_spec.vim
- node --test --test-concurrency=1 tests/tooling/lsp-protocol-resilience.test.ts tests/tooling/lsp-editor-feature-isolation.test.ts tests/tooling/lsp-editor-feature-routing.test.ts tests/tooling/lsp-capabilities.test.ts tests/tooling/lsp-diagnostics-lifecycle.test.ts tests/tooling/lsp-document-features.test.ts
- node --test --test-reporter=dot --test-concurrency=1 tests/tooling/vscode-extension-core-behavior.test.ts tests/tooling/lsp-editor-feature-matrix.test.ts tests/tooling/editor-lsp-adapters.test.ts tests/tooling/lsp-protocol-resilience.test.ts tests/tooling/lsp-editor-feature-isolation.test.ts tests/tooling/lsp-editor-feature-routing.test.ts tests/tooling/lsp-capabilities.test.ts tests/tooling/lsp-diagnostics-lifecycle.test.ts tests/tooling/lsp-document-features.test.ts tests/tooling/editor-integrations.test.ts tests/tooling/editor-integrations-vim.test.ts tests/tooling/editor-integrations-neovim.test.ts tests/tooling/editor-integrations-emacs.test.ts tests/tooling/editor-integrations-zed.test.ts tests/tooling/editor-integrations-vscode-art.test.ts tests/tooling/editor-integrations-consistency.test.ts tests/tooling/editor-language-configuration.test.ts tests/tooling/editor-profiles-consistency.test.ts tests/tooling/vscode-extension-manifest.test.ts tests/tooling/vscode-vize-template-grammar.test.ts
- vp check tests/tooling/lsp-protocol-resilience.test.ts tests/tooling/vscode-extension-core-behavior.test.ts tests/tooling/support/lsp/protocol.ts tests/tooling/support/lsp/session.ts
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Emacs ERT was not run locally because the emacs binary is not installed in this environment; editor-extensions CI covers it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786011313&installation_id=136613492&pr_number=2662&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2662&signature=5039e0423b92e69c350f6398751c54107807e76fbf66a5bb05c0f71bad97694e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LSP request handling so unsupported requests return clearer errors without disrupting later editor actions.
  * Fixed configuration handling to avoid shared mutable state, preventing one profile or option change from affecting another.
  * Improved setup behavior for editor integrations, including more reliable autostart and better handling of initialization options and command updates.

* **Tests**
  * Expanded automated coverage for LSP resilience, configuration normalization, and copy/immutability behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->