### PR TITLE
test: extend lsp editor workspace coverage

### DIFF
--- a/crates/vize_maestro/src/ide/document_link.rs
+++ b/crates/vize_maestro/src/ide/document_link.rs
@@ -34,7 +34,7 @@ impl DocumentLinkService {
         if let Some(ref script_setup) = descriptor.script_setup {
             if let Some(ref src) = script_setup.src
                 && let Some((start, end)) =
-                    Self::find_src_attr_range(content, script_setup.loc.start)
+                    Self::find_src_attr_range(content, script_setup.loc.tag_start)
                 && let Some(target) = Self::resolve_path(src, base_path.as_deref())
             {
                 links.push(Self::create_link(content, start, end, target));
@@ -52,7 +52,7 @@ impl DocumentLinkService {
 
         if let Some(ref script) = descriptor.script {
             if let Some(ref src) = script.src
-                && let Some((start, end)) = Self::find_src_attr_range(content, script.loc.start)
+                && let Some((start, end)) = Self::find_src_attr_range(content, script.loc.tag_start)
                 && let Some(target) = Self::resolve_path(src, base_path.as_deref())
             {
                 links.push(Self::create_link(content, start, end, target));
@@ -69,7 +69,7 @@ impl DocumentLinkService {
 
         if let Some(ref template) = descriptor.template
             && let Some(ref src) = template.src
-            && let Some((start, end)) = Self::find_src_attr_range(content, template.loc.start)
+            && let Some((start, end)) = Self::find_src_attr_range(content, template.loc.tag_start)
             && let Some(target) = Self::resolve_path(src, base_path.as_deref())
         {
             links.push(Self::create_link(content, start, end, target));
@@ -77,7 +77,7 @@ impl DocumentLinkService {
 
         for style in &descriptor.styles {
             if let Some(ref src) = style.src
-                && let Some((start, end)) = Self::find_src_attr_range(content, style.loc.start)
+                && let Some((start, end)) = Self::find_src_attr_range(content, style.loc.tag_start)
                 && let Some(target) = Self::resolve_path(src, base_path.as_deref())
             {
                 links.push(Self::create_link(content, start, end, target));
@@ -270,10 +270,7 @@ impl DocumentLinkService {
 
     /// Find src attribute range in the opening tag.
     fn find_src_attr_range(content: &str, tag_start: usize) -> Option<(usize, usize)> {
-        // Find the end of opening tag (>)
-        let tag_content = &content[tag_start..];
-        let tag_end = tag_content.find('>')?;
-        let tag = &tag_content[..tag_end];
+        let tag = content.get(tag_start..)?.split_once('>')?.0;
 
         // Find src="..." or src='...'
         let src_pos = tag.find("src=")?;
@@ -285,7 +282,7 @@ impl DocumentLinkService {
         }
 
         let value_start = src_pos + 5; // src=" plus quote
-        let value_end = after_src[1..].find(quote)? + 1; // content length
+        let value_end = after_src[1..].find(quote)?;
 
         Some((tag_start + value_start, tag_start + value_start + value_end))
     }

--- a/tests/tooling/lsp-document-link.test.ts
+++ b/tests/tooling/lsp-document-link.test.ts
@@ -15,6 +15,28 @@ type DocumentLink = {
   target?: string;
 };
 
+function offsetForPosition(source: string, position: { line: number; character: number }): number {
+  let offset = 0;
+  for (let line = 0; line < position.line; line += 1) {
+    const nextLine = source.indexOf("\n", offset);
+    assert.notEqual(nextLine, -1, `line ${position.line} is outside source`);
+    offset = nextLine + 1;
+  }
+  return offset + position.character;
+}
+
+function textAtLinkRange(source: string, link: DocumentLink): string {
+  return source.slice(
+    offsetForPosition(source, link.range.start),
+    offsetForPosition(source, link.range.end),
+  );
+}
+
+function basenameForTarget(link: DocumentLink): string {
+  assert.ok(link.target, JSON.stringify(link));
+  return path.basename(decodeURIComponent(new URL(link.target).pathname));
+}
+
 test("vize lsp documentLink resolves relative imports and ranges", async (t) => {
   const testRootDir = path.join(testOutputRoot, "lsp-document-link");
   fs.mkdirSync(testRootDir, { recursive: true });
@@ -114,6 +136,110 @@ const _x = ref(0)
 
       assert.deepEqual(componentLink.range.start, expectedStart);
       assert.deepEqual(componentLink.range.end, expectedEnd);
+    });
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+test("vize lsp documentLink resolves SFC block src attributes and CSS imports", async (t) => {
+  const testRootDir = path.join(testOutputRoot, "lsp-document-link-src-css");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: false,
+    });
+
+    fs.mkdirSync(path.join(workspaceDir, "partials"), { recursive: true });
+    fs.mkdirSync(path.join(workspaceDir, "styles"), { recursive: true });
+    fs.writeFileSync(path.join(workspaceDir, "partials", "card.html"), "<section />\n", "utf8");
+    fs.writeFileSync(path.join(workspaceDir, "entry.ts"), "export const value = 1\n", "utf8");
+    fs.writeFileSync(path.join(workspaceDir, "styles", "card.css"), ".card {}\n", "utf8");
+    fs.writeFileSync(
+      path.join(workspaceDir, "styles", "reset.css"),
+      "* { box-sizing: border-box }\n",
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "styles", "theme.css"),
+      ":root { color: black }\n",
+      "utf8",
+    );
+
+    const source = `<template src="./partials/card.html"></template>
+<script src="./entry.ts"></script>
+<style src="./styles/card.css"></style>
+<style>
+@import "./styles/reset.css";
+@import url("./styles/theme.css");
+@import "https://cdn.example.test/remote.css";
+</style>
+`;
+    const filePath = path.join(workspaceDir, "LinkedBlocks.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+
+    session.notify("textDocument/didOpen", {
+      textDocument: {
+        uri,
+        languageId: "vue",
+        version: 1,
+        text: source,
+      },
+    });
+
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, uri),
+    );
+
+    const links = (await session.request("textDocument/documentLink", {
+      textDocument: { uri },
+    })) as DocumentLink[] | null;
+    assert.ok(Array.isArray(links), JSON.stringify(links));
+
+    await t.test("links only local block and CSS targets", async () => {
+      assert.deepEqual(links.map(basenameForTarget).sort(), [
+        "card.css",
+        "card.html",
+        "entry.ts",
+        "reset.css",
+        "theme.css",
+      ]);
+      assert.equal(
+        links.some((link) => link.target?.includes("cdn.example.test")),
+        false,
+        JSON.stringify(links),
+      );
+    });
+
+    await t.test("block src ranges cover only the attribute value", async () => {
+      const templateLink = links.find((link) => basenameForTarget(link) === "card.html");
+      const scriptLink = links.find((link) => basenameForTarget(link) === "entry.ts");
+      const styleLink = links.find((link) => basenameForTarget(link) === "card.css");
+
+      assert.ok(templateLink, JSON.stringify(links));
+      assert.ok(scriptLink, JSON.stringify(links));
+      assert.ok(styleLink, JSON.stringify(links));
+      assert.equal(textAtLinkRange(source, templateLink), "./partials/card.html");
+      assert.equal(textAtLinkRange(source, scriptLink), "./entry.ts");
+      assert.equal(textAtLinkRange(source, styleLink), "./styles/card.css");
+    });
+
+    await t.test("CSS import ranges keep the quoted specifier selected", async () => {
+      const resetLink = links.find((link) => basenameForTarget(link) === "reset.css");
+      const themeLink = links.find((link) => basenameForTarget(link) === "theme.css");
+
+      assert.ok(resetLink, JSON.stringify(links));
+      assert.ok(themeLink, JSON.stringify(links));
+      assert.equal(textAtLinkRange(source, resetLink), '"./styles/reset.css"');
+      assert.equal(textAtLinkRange(source, themeLink), '"./styles/theme.css"');
     });
   } finally {
     await session.shutdown();

--- a/tests/tooling/lsp-file-rename-workspace.test.ts
+++ b/tests/tooling/lsp-file-rename-workspace.test.ts
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { isDiagnosticsForUri } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+type Position = { line: number; character: number };
+type Range = { start: Position; end: Position };
+type TextEdit = { range: Range; newText: string };
+type WorkspaceEdit = {
+  changes?: Record<string, TextEdit[]>;
+  documentChanges?: Array<{
+    textDocument?: { uri?: string };
+    edits?: TextEdit[];
+  }>;
+} | null;
+type SymbolInformation = {
+  name: string;
+  location: { uri: string };
+};
+
+function editsForUri(edit: WorkspaceEdit, uri: string): TextEdit[] {
+  if (!edit) {
+    return [];
+  }
+
+  const edits = edit.changes?.[uri] ?? [];
+  for (const documentChange of edit.documentChanges ?? []) {
+    if (documentChange.textDocument?.uri === uri) {
+      edits.push(...(documentChange.edits ?? []));
+    }
+  }
+
+  return edits.sort(
+    (left, right) =>
+      left.range.start.line - right.range.start.line ||
+      left.range.start.character - right.range.start.character,
+  );
+}
+
+function offsetForPosition(source: string, position: Position): number {
+  let offset = 0;
+  for (let line = 0; line < position.line; line += 1) {
+    const nextLine = source.indexOf("\n", offset);
+    assert.notEqual(nextLine, -1, `line ${position.line} is outside source`);
+    offset = nextLine + 1;
+  }
+  return offset + position.character;
+}
+
+function textAtRange(source: string, range: Range): string {
+  return source.slice(offsetForPosition(source, range.start), offsetForPosition(source, range.end));
+}
+
+async function workspaceSymbolUris(session: LspSession, query: string): Promise<string[]> {
+  const symbols = (await session.request("workspace/symbol", { query })) as
+    | SymbolInformation[]
+    | null;
+  return (symbols ?? []).map((symbol) => symbol.location.uri).sort();
+}
+
+test("vize lsp willRenameFiles rewrites Vue importer specifiers and preserves query suffixes", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-file-rename-workspace");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      fileRename: true,
+      lint: false,
+      typecheck: false,
+    });
+
+    const componentsDir = path.join(workspaceDir, "src", "components");
+    fs.mkdirSync(componentsDir, { recursive: true });
+
+    const oldComponentPath = path.join(componentsDir, "Foo.vue");
+    const newComponentPath = path.join(componentsDir, "Bar.vue");
+    fs.writeFileSync(oldComponentPath, "<template><div>foo</div></template>\n", "utf8");
+
+    const source = `<script setup lang="ts">
+import Foo from "./components/Foo.vue";
+const Lazy = () => import("./components/Foo.vue?raw");
+type FooModule = typeof import("./components/Foo.vue");
+</script>
+
+<template>
+  <Foo />
+</template>
+`;
+    const appPath = path.join(workspaceDir, "src", "App.vue");
+    const appUri = pathToFileURL(appPath).href;
+    fs.writeFileSync(appPath, source, "utf8");
+
+    const edit = (await session.request("workspace/willRenameFiles", {
+      files: [
+        {
+          oldUri: pathToFileURL(oldComponentPath).href,
+          newUri: pathToFileURL(newComponentPath).href,
+        },
+      ],
+    })) as WorkspaceEdit;
+
+    const appEdits = editsForUri(edit, appUri);
+    assert.equal(appEdits.length, 3, JSON.stringify(edit));
+    assert.deepEqual(
+      appEdits.map((textEdit) => textEdit.newText),
+      ["./components/Bar.vue", "./components/Bar.vue?raw", "./components/Bar.vue"],
+    );
+    assert.deepEqual(
+      appEdits.map((textEdit) => textAtRange(source, textEdit.range)),
+      ["./components/Foo.vue", "./components/Foo.vue?raw", "./components/Foo.vue"],
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+test("vize lsp didRenameFiles moves open document state to the new URI", async (t) => {
+  const testRootDir = path.join(testOutputRoot, "lsp-did-rename-workspace");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      fileRename: true,
+      lint: false,
+      typecheck: false,
+    });
+
+    const source = `<script setup lang="ts">
+const movedLabel = "ready"
+</script>
+
+<template>
+  <span>{{ movedLabel }}</span>
+</template>
+`;
+    const oldPath = path.join(workspaceDir, "OldCard.vue");
+    const newPath = path.join(workspaceDir, "NewCard.vue");
+    const oldUri = pathToFileURL(oldPath).href;
+    const newUri = pathToFileURL(newPath).href;
+    fs.writeFileSync(oldPath, source, "utf8");
+
+    session.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: oldUri,
+        languageId: "vue",
+        version: 1,
+        text: source,
+      },
+    });
+
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, oldUri),
+    );
+
+    await t.test("workspace symbols initially point at the old URI", async () => {
+      assert.deepEqual(await workspaceSymbolUris(session, "movedLabel"), [oldUri]);
+    });
+
+    session.notify("workspace/didRenameFiles", {
+      files: [
+        {
+          oldUri,
+          newUri,
+        },
+      ],
+    });
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, newUri),
+    );
+
+    await t.test("workspace symbols move to the new URI", async () => {
+      assert.deepEqual(await workspaceSymbolUris(session, "movedLabel"), [newUri]);
+    });
+
+    await t.test("the stale old URI no longer serves document features", async () => {
+      const oldSymbols = await session.request("textDocument/documentSymbol", {
+        textDocument: { uri: oldUri },
+      });
+      assert.equal(oldSymbols, null);
+    });
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/lsp-workspace-semantic.test.ts
+++ b/tests/tooling/lsp-workspace-semantic.test.ts
@@ -14,6 +14,13 @@ type SymbolInformation = {
   location: { uri: string; range: { start: { line: number; character: number } } };
 };
 
+async function queryWorkspaceSymbols(
+  session: LspSession,
+  query: string,
+): Promise<SymbolInformation[] | null> {
+  return (await session.request("workspace/symbol", { query })) as SymbolInformation[] | null;
+}
+
 /**
  * workspaceSymbol only indexes documents that are currently open in the
  * editor (the server iterates `state.documents`), and classifies script-setup
@@ -136,6 +143,94 @@ const internalState = ref(1)
       query: "zzzNoSuchSymbol",
     });
     assert.equal(unmatched, null);
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+test("vize lsp workspaceSymbol follows didChange and didClose document lifecycle", async (t) => {
+  const testRootDir = path.join(testOutputRoot, "lsp-workspace-symbol-lifecycle");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: false,
+    });
+
+    const initialSource = `<script setup lang="ts">
+const staleName = 1
+</script>
+
+<template>
+  <span>{{ staleName }}</span>
+</template>
+`;
+    const changedSource = `<script setup lang="ts">
+const freshName = 2
+</script>
+
+<template>
+  <span>{{ freshName }}</span>
+</template>
+`;
+    const filePath = path.join(workspaceDir, "Lifecycle.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, initialSource, "utf8");
+
+    session.notify("textDocument/didOpen", {
+      textDocument: {
+        uri,
+        languageId: "vue",
+        version: 1,
+        text: initialSource,
+      },
+    });
+
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, uri),
+    );
+
+    await t.test("opened document contributes its current script bindings", async () => {
+      const symbols = await queryWorkspaceSymbols(session, "staleName");
+      assert.equal(symbols?.length, 1, JSON.stringify(symbols));
+      assert.equal(symbols?.[0]?.location.uri, uri);
+      assert.equal(await queryWorkspaceSymbols(session, "freshName"), null);
+    });
+
+    session.notify("textDocument/didChange", {
+      textDocument: {
+        uri,
+        version: 2,
+      },
+      contentChanges: [{ text: changedSource }],
+    });
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, uri),
+    );
+
+    await t.test("full document changes replace stale workspace symbols", async () => {
+      const symbols = await queryWorkspaceSymbols(session, "freshName");
+      assert.equal(symbols?.length, 1, JSON.stringify(symbols));
+      assert.equal(symbols?.[0]?.location.uri, uri);
+      assert.equal(await queryWorkspaceSymbols(session, "staleName"), null);
+    });
+
+    session.notify("textDocument/didClose", {
+      textDocument: { uri },
+    });
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, uri),
+    );
+
+    await t.test("closed documents are removed from the workspace symbol index", async () => {
+      assert.equal(await queryWorkspaceSymbols(session, "freshName"), null);
+    });
   } finally {
     await session.shutdown();
     fs.rmSync(workspaceDir, { recursive: true, force: true });

--- a/tests/tooling/vscode-extension-core-behavior.test.ts
+++ b/tests/tooling/vscode-extension-core-behavior.test.ts
@@ -5,6 +5,7 @@ import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   FEATURE_SETTING_KEYS,
+  LINT_ONLY_CONFIGURATION_UPDATES,
   createDocumentSelector,
   describeCapabilities,
   getInitializationOptions,
@@ -41,6 +42,31 @@ const FEATURE_TO_OPTION = {
   "inlayHints.enable": "inlayHints",
   "fileRename.enable": "fileRename",
 } as const satisfies Record<(typeof FEATURE_SETTING_KEYS)[number], string>;
+
+const FEATURE_MANIFEST_DEFAULTS = {
+  "lint.enable": true,
+  "diagnostics.enable": false,
+  "typecheck.enable": true,
+  "editor.enable": true,
+  "ecosystem.enable": true,
+  "optionsApi.enable": false,
+  "legacyVue2.enable": false,
+  "completion.enable": true,
+  "hover.enable": true,
+  "definition.enable": true,
+  "references.enable": true,
+  "documentSymbols.enable": true,
+  "workspaceSymbols.enable": true,
+  "codeActions.enable": true,
+  "rename.enable": true,
+  "codeLens.enable": true,
+  "formatting.enable": false,
+  "semanticTokens.enable": true,
+  "documentLinks.enable": true,
+  "foldingRanges.enable": true,
+  "inlayHints.enable": true,
+  "fileRename.enable": true,
+} as const satisfies Record<(typeof FEATURE_SETTING_KEYS)[number], boolean>;
 
 type Scope = "global" | "workspace" | "workspaceFolder";
 type ConfigValue = {
@@ -117,6 +143,20 @@ for (const key of FEATURE_SETTING_KEYS) {
   }
 }
 
+for (const key of FEATURE_SETTING_KEYS) {
+  test(`vscode manifest default for ${key} matches extension-core fallback`, () => {
+    const manifest = readJson<{
+      contributes?: {
+        configuration?: { properties?: Record<string, { default?: unknown; type?: string }> };
+      };
+    }>("editors/vscode/package.json");
+    const property = manifest.contributes?.configuration?.properties?.[`vize.${key}`];
+
+    assert.equal(property?.type, "boolean", `vize.${key}`);
+    assert.equal(property?.default, FEATURE_MANIFEST_DEFAULTS[key], `vize.${key}`);
+  });
+}
+
 test("vscode lint.enable takes precedence over deprecated diagnostics.enable", () => {
   assert.deepEqual(
     getInitializationOptions(
@@ -161,6 +201,38 @@ test("vscode feature keys are complete boolean manifest properties", () => {
   for (const key of FEATURE_SETTING_KEYS) {
     assert.equal(properties[`vize.${key}`]?.type, "boolean", `vize.${key}`);
   }
+});
+
+test("vscode lint-only profile updates every feature switch exactly once", () => {
+  const keys = LINT_ONLY_CONFIGURATION_UPDATES.map(([key]) => key);
+
+  assert.equal(new Set(keys).size, keys.length);
+  assert.deepEqual(keys.sort(), ["enable", ...FEATURE_SETTING_KEYS].sort());
+  assert.deepEqual(Object.fromEntries(LINT_ONLY_CONFIGURATION_UPDATES), {
+    enable: true,
+    "lint.enable": true,
+    "diagnostics.enable": false,
+    "typecheck.enable": false,
+    "editor.enable": false,
+    "ecosystem.enable": false,
+    "optionsApi.enable": false,
+    "legacyVue2.enable": false,
+    "completion.enable": false,
+    "hover.enable": false,
+    "definition.enable": false,
+    "references.enable": false,
+    "documentSymbols.enable": false,
+    "workspaceSymbols.enable": false,
+    "codeActions.enable": false,
+    "rename.enable": false,
+    "codeLens.enable": false,
+    "formatting.enable": false,
+    "semanticTokens.enable": false,
+    "documentLinks.enable": false,
+    "foldingRanges.enable": false,
+    "inlayHints.enable": false,
+    "fileRename.enable": false,
+  });
 });
 
 test("vscode explicit feature switches suppress synthesized recommended defaults", () => {


### PR DESCRIPTION
## Summary
- Add live LSP coverage for file rename workspace edits, didRenameFiles state moves, documentLink src/CSS ranges, and workspaceSymbol didChange/didClose lifecycle.
- Add VS Code extension checks for manifest defaults and lint-only profile completeness across every feature switch.
- Fix document links for external SFC block `src` attributes so empty external blocks resolve targets and select only the attribute value.

## Validation
- `cargo test -p vize_maestro document_link --features native`
- `cargo build -p vize`
- `NODE_PATH=/Users/ubugeeei/Source/github.com/ubugeeei/vuejs-language-specification/node_modules node --test --test-concurrency=1 tests/tooling/lsp*.test.ts tests/tooling/editor*.test.ts tests/tooling/vscode*.test.ts` (2429 tests)
- `node --test tests/tooling/source-file-lengths.test.ts`
- `vp check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document link targeting for Vue files, so links on `src`/`href` attributes and CSS imports now resolve with more accurate ranges.
  * File rename handling now updates component imports more reliably and keeps query suffixes like `?raw` intact.
  * Workspace symbols and diagnostics now stay in sync after file edits, closes, and renames.

* **Style**
  * Updated extension settings behavior to keep feature defaults and lint-only profiles consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->