### PR TITLE
fix: update SFC resource paths on file rename

### DIFF
--- a/crates/vize_maestro/src/ide/file_rename.rs
+++ b/crates/vize_maestro/src/ide/file_rename.rs
@@ -4,6 +4,11 @@
 #[cfg(all(test, feature = "native"))]
 mod declaration_index_tests;
 mod manual;
+#[cfg(all(test, feature = "native"))]
+mod manual_tests;
+#[cfg(test)]
+mod merge_tests;
+mod resources;
 
 use tower_lsp::lsp_types::{
     DocumentChangeOperation, DocumentChanges, OneOf, OptionalVersionedTextDocumentIdentifier,
@@ -89,7 +94,7 @@ impl FileRenameService {
     }
 }
 
-fn merge_workspace_edits(
+pub(super) fn merge_workspace_edits(
     base: Option<WorkspaceEdit>,
     overlay: Option<WorkspaceEdit>,
 ) -> Option<WorkspaceEdit> {
@@ -217,145 +222,4 @@ fn changes_to_document_edits(
             edits: edits.into_iter().map(OneOf::Left).collect(),
         })
         .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use tower_lsp::lsp_types::{
-        DocumentChangeOperation, DocumentChanges, OneOf, OptionalVersionedTextDocumentIdentifier,
-        RenameFile, ResourceOp, TextDocumentEdit, TextEdit, Url, WorkspaceEdit,
-    };
-
-    use super::merge_workspace_edits;
-
-    fn text_edit(new_text: &str) -> TextEdit {
-        TextEdit {
-            range: Default::default(),
-            new_text: new_text.to_string(),
-        }
-    }
-
-    #[test]
-    fn merges_changes_into_document_changes() {
-        let base_uri = Url::parse("file:///base.vue").unwrap();
-        let overlay_uri = Url::parse("file:///overlay.vue").unwrap();
-        let merged = merge_workspace_edits(
-            Some(WorkspaceEdit {
-                changes: None,
-                document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
-                    text_document: OptionalVersionedTextDocumentIdentifier {
-                        uri: base_uri.clone(),
-                        version: None,
-                    },
-                    edits: vec![OneOf::Left(text_edit("from-corsa"))],
-                }])),
-                change_annotations: None,
-            }),
-            Some(WorkspaceEdit {
-                changes: Some(std::collections::HashMap::from([(
-                    overlay_uri.clone(),
-                    vec![text_edit("from-manual")],
-                )])),
-                document_changes: None,
-                change_annotations: None,
-            }),
-        )
-        .unwrap();
-
-        assert!(merged.changes.is_none());
-
-        let DocumentChanges::Edits(edits) = merged.document_changes.unwrap() else {
-            panic!("expected document edits");
-        };
-
-        assert_eq!(edits.len(), 2);
-        assert!(edits.iter().any(|edit| edit.text_document.uri == base_uri));
-        assert!(
-            edits
-                .iter()
-                .any(|edit| edit.text_document.uri == overlay_uri)
-        );
-    }
-
-    #[test]
-    fn prefers_overlay_document_changes_over_base_changes() {
-        let base_uri = Url::parse("file:///base.vue").unwrap();
-        let overlay_uri = Url::parse("file:///overlay.vue").unwrap();
-        let merged = merge_workspace_edits(
-            Some(WorkspaceEdit {
-                changes: Some(std::collections::HashMap::from([(
-                    base_uri.clone(),
-                    vec![text_edit("from-base")],
-                )])),
-                document_changes: None,
-                change_annotations: None,
-            }),
-            Some(WorkspaceEdit {
-                changes: None,
-                document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
-                    text_document: OptionalVersionedTextDocumentIdentifier {
-                        uri: overlay_uri.clone(),
-                        version: None,
-                    },
-                    edits: vec![OneOf::Left(text_edit("from-overlay"))],
-                }])),
-                change_annotations: None,
-            }),
-        )
-        .unwrap();
-
-        assert!(merged.changes.is_none());
-
-        let DocumentChanges::Edits(edits) = merged.document_changes.unwrap() else {
-            panic!("expected document edits");
-        };
-
-        assert_eq!(edits.len(), 2);
-        assert!(edits.iter().any(|edit| edit.text_document.uri == base_uri));
-        assert!(
-            edits
-                .iter()
-                .any(|edit| edit.text_document.uri == overlay_uri)
-        );
-    }
-
-    #[test]
-    fn inserts_manual_edits_before_resource_operations() {
-        let manual_uri = Url::parse("file:///manual.vue").unwrap();
-        let merged = merge_workspace_edits(
-            Some(WorkspaceEdit {
-                changes: None,
-                document_changes: Some(DocumentChanges::Operations(vec![
-                    DocumentChangeOperation::Op(ResourceOp::Rename(RenameFile {
-                        old_uri: Url::parse("file:///old.vue").unwrap(),
-                        new_uri: Url::parse("file:///new.vue").unwrap(),
-                        options: None,
-                        annotation_id: None,
-                    })),
-                ])),
-                change_annotations: None,
-            }),
-            Some(WorkspaceEdit {
-                changes: Some(std::collections::HashMap::from([(
-                    manual_uri.clone(),
-                    vec![text_edit("from-manual")],
-                )])),
-                document_changes: None,
-                change_annotations: None,
-            }),
-        )
-        .unwrap();
-
-        let DocumentChanges::Operations(operations) = merged.document_changes.unwrap() else {
-            panic!("expected document operations");
-        };
-
-        assert!(
-            matches!(operations.first(), Some(DocumentChangeOperation::Edit(edit)) if edit.text_document.uri == manual_uri)
-        );
-        assert!(matches!(
-            operations.get(1),
-            Some(DocumentChangeOperation::Op(ResourceOp::Rename(_)))
-        ));
-    }
 }

--- a/crates/vize_maestro/src/ide/file_rename/manual.rs
+++ b/crates/vize_maestro/src/ide/file_rename/manual.rs
@@ -23,7 +23,7 @@ const RESOLVABLE_SCRIPT_EXTENSIONS: &[&str] = &[
     "ts", "tsx", "d.ts", "d.mts", "d.cts", "js", "jsx", "mts", "cts", "mjs", "cjs", "vue",
 ];
 #[derive(Clone)]
-struct RenameTarget {
+pub(super) struct RenameTarget {
     old_path: PathBuf,
     new_path: PathBuf,
 }
@@ -358,6 +358,13 @@ fn collect_vue_edits(
             script_setup.loc.start,
         ));
     }
+    edits.extend(super::resources::collect_vue_resource_edits(
+        state,
+        path,
+        future_path,
+        source,
+        rename_targets,
+    ));
 
     edits
 }
@@ -428,7 +435,7 @@ fn collect_script_content_edits(
         .collect()
 }
 
-fn rewrite_relative_specifier(
+pub(super) fn rewrite_relative_specifier(
     state: &ServerState,
     current_importer_dir: &Path,
     future_importer_dir: &Path,
@@ -669,7 +676,7 @@ fn split_specifier_suffix(specifier: &str) -> (&str, &str) {
     (&specifier[..split_at], &specifier[split_at..])
 }
 
-fn offset_range(source: &str, start: usize, end: usize) -> Option<Range> {
+pub(super) fn offset_range(source: &str, start: usize, end: usize) -> Option<Range> {
     let (start_line, start_character) = offset_to_position(source, start);
     let (end_line, end_character) = offset_to_position(source, end);
 
@@ -738,250 +745,4 @@ fn workspace_root(state: &ServerState) -> PathBuf {
 #[cfg(not(feature = "native"))]
 fn workspace_root(_state: &ServerState) -> PathBuf {
     std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
-}
-
-#[cfg(all(test, feature = "native"))]
-#[allow(clippy::disallowed_macros)]
-mod tests {
-    use super::{collect_import_rename_edits, rename_open_documents};
-    use crate::server::ServerState;
-    use insta::assert_snapshot;
-    use std::collections::BTreeMap;
-    use std::fs;
-    use std::path::{Path, PathBuf};
-    use tower_lsp::lsp_types::{FileRename, Url, WorkspaceEdit};
-
-    fn test_dir() -> tempfile::TempDir {
-        let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("target")
-            .join("vize-tests");
-        fs::create_dir_all(&base).unwrap();
-        tempfile::tempdir_in(base).unwrap()
-    }
-
-    fn file_uri(path: &Path) -> std::string::String {
-        Url::from_file_path(path).unwrap().to_string()
-    }
-
-    fn normalize_edit(root: &Path, edit: &WorkspaceEdit) -> serde_json::Value {
-        let mut files = BTreeMap::<std::string::String, Vec<serde_json::Value>>::new();
-
-        for (uri, edits) in edit.changes.as_ref().unwrap() {
-            let path = uri.to_file_path().unwrap();
-            let label = path
-                .strip_prefix(root)
-                .unwrap()
-                .to_string_lossy()
-                .replace('\\', "/");
-
-            let items = edits
-                .iter()
-                .map(|edit| {
-                    serde_json::json!({
-                        "range": {
-                            "start": {
-                                "line": edit.range.start.line,
-                                "character": edit.range.start.character,
-                            },
-                            "end": {
-                                "line": edit.range.end.line,
-                                "character": edit.range.end.character,
-                            }
-                        },
-                        "newText": edit.new_text
-                    })
-                })
-                .collect::<Vec<_>>();
-
-            files.insert(label, items);
-        }
-
-        serde_json::json!(files)
-    }
-
-    #[test]
-    fn rewrites_vue_imports_for_component_rename() {
-        let dir = test_dir();
-        let root = dir.path();
-        let src_dir = root.join("src");
-        let components_dir = src_dir.join("components");
-        fs::create_dir_all(&components_dir).unwrap();
-
-        let app_path = src_dir.join("App.vue");
-        let old_component = components_dir.join("Foo.vue");
-        let new_component = components_dir.join("Bar.vue");
-
-        fs::write(
-            &app_path,
-            r#"<script setup lang="ts">
-import Foo from "./components/Foo.vue";
-const Lazy = () => import("./components/Foo.vue");
-type FooModule = typeof import("./components/Foo.vue");
-</script>
-"#,
-        )
-        .unwrap();
-        fs::write(&old_component, "<template><div>foo</div></template>").unwrap();
-
-        let state = ServerState::new();
-        state.set_workspace_root(root.to_path_buf());
-
-        let edit = collect_import_rename_edits(
-            &state,
-            &[FileRename {
-                old_uri: file_uri(&old_component),
-                new_uri: file_uri(&new_component),
-            }],
-            true,
-        )
-        .unwrap();
-
-        assert_snapshot!(serde_json::to_string_pretty(&normalize_edit(root, &edit)).unwrap(), @r###"
-        {
-          "src/App.vue": [
-            {
-              "newText": "./components/Bar.vue",
-              "range": {
-                "end": {
-                  "character": 37,
-                  "line": 1
-                },
-                "start": {
-                  "character": 17,
-                  "line": 1
-                }
-              }
-            },
-            {
-              "newText": "./components/Bar.vue",
-              "range": {
-                "end": {
-                  "character": 47,
-                  "line": 2
-                },
-                "start": {
-                  "character": 27,
-                  "line": 2
-                }
-              }
-            },
-            {
-              "newText": "./components/Bar.vue",
-              "range": {
-                "end": {
-                  "character": 52,
-                  "line": 3
-                },
-                "start": {
-                  "character": 32,
-                  "line": 3
-                }
-              }
-            }
-          ]
-        }
-        "###);
-    }
-
-    #[test]
-    fn rewrites_extensionless_ts_imports_without_corsa() {
-        let dir = test_dir();
-        let root = dir.path();
-        let src_dir = root.join("src");
-        let util_dir = src_dir.join("util");
-        fs::create_dir_all(&util_dir).unwrap();
-
-        let entry_path = src_dir.join("entry.ts");
-        let old_module = util_dir.join("foo.ts");
-        let new_module = util_dir.join("bar.ts");
-
-        fs::write(
-            &entry_path,
-            "import { value } from \"./util/foo\";\nconst lazy = require(\"./util/foo\");\n",
-        )
-        .unwrap();
-        fs::write(&old_module, "export const value = 1;\n").unwrap();
-
-        let state = ServerState::new();
-        state.set_workspace_root(root.to_path_buf());
-
-        let edit = collect_import_rename_edits(
-            &state,
-            &[FileRename {
-                old_uri: file_uri(&old_module),
-                new_uri: file_uri(&new_module),
-            }],
-            false,
-        )
-        .unwrap();
-
-        assert_snapshot!(serde_json::to_string_pretty(&normalize_edit(root, &edit)).unwrap(), @r###"
-        {
-          "src/entry.ts": [
-            {
-              "newText": "./util/bar",
-              "range": {
-                "end": {
-                  "character": 33,
-                  "line": 0
-                },
-                "start": {
-                  "character": 23,
-                  "line": 0
-                }
-              }
-            },
-            {
-              "newText": "./util/bar",
-              "range": {
-                "end": {
-                  "character": 32,
-                  "line": 1
-                },
-                "start": {
-                  "character": 22,
-                  "line": 1
-                }
-              }
-            }
-          ]
-        }
-        "###);
-    }
-
-    #[test]
-    fn renames_open_documents_inside_renamed_folder() {
-        let dir = test_dir();
-        let root = dir.path();
-        let old_dir = root.join("src/pages");
-        let new_dir = root.join("src/views");
-        let file_path = old_dir.join("Home.vue");
-        fs::create_dir_all(&old_dir).unwrap();
-        fs::write(&file_path, "<template><div>home</div></template>").unwrap();
-
-        let state = ServerState::new();
-        state.documents.open(
-            Url::from_file_path(&file_path).unwrap(),
-            "<template><div>home</div></template>".to_string(),
-            1,
-            "vue".to_string(),
-        );
-        state.update_virtual_docs(
-            &Url::from_file_path(&file_path).unwrap(),
-            "<template><div>home</div></template>",
-        );
-
-        let renamed = rename_open_documents(
-            &state,
-            &[FileRename {
-                old_uri: file_uri(&old_dir),
-                new_uri: file_uri(&new_dir),
-            }],
-        );
-
-        assert_eq!(renamed.len(), 1);
-        let new_uri = Url::from_file_path(new_dir.join("Home.vue")).unwrap();
-        assert!(state.documents.contains(&new_uri));
-        assert!(state.get_virtual_docs(&new_uri).is_some());
-    }
 }

--- a/crates/vize_maestro/src/ide/file_rename/manual_tests.rs
+++ b/crates/vize_maestro/src/ide/file_rename/manual_tests.rs
@@ -1,0 +1,243 @@
+#![allow(clippy::disallowed_macros, clippy::disallowed_methods)]
+
+use super::manual::{collect_import_rename_edits, rename_open_documents};
+use crate::server::ServerState;
+use insta::assert_snapshot;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tower_lsp::lsp_types::{FileRename, Url, WorkspaceEdit};
+
+fn test_dir() -> tempfile::TempDir {
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("vize-tests");
+    fs::create_dir_all(&base).unwrap();
+    tempfile::tempdir_in(base).unwrap()
+}
+
+fn file_uri(path: &Path) -> std::string::String {
+    Url::from_file_path(path).unwrap().to_string()
+}
+
+fn normalize_edit(root: &Path, edit: &WorkspaceEdit) -> serde_json::Value {
+    let mut files = BTreeMap::<std::string::String, Vec<serde_json::Value>>::new();
+
+    for (uri, edits) in edit.changes.as_ref().unwrap() {
+        let path = uri.to_file_path().unwrap();
+        let label = path
+            .strip_prefix(root)
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        let items = edits
+            .iter()
+            .map(|edit| {
+                serde_json::json!({
+                    "range": {
+                        "start": {
+                            "line": edit.range.start.line,
+                            "character": edit.range.start.character,
+                        },
+                        "end": {
+                            "line": edit.range.end.line,
+                            "character": edit.range.end.character,
+                        }
+                    },
+                    "newText": edit.new_text
+                })
+            })
+            .collect::<Vec<_>>();
+
+        files.insert(label, items);
+    }
+
+    serde_json::json!(files)
+}
+
+#[test]
+fn rewrites_vue_imports_for_component_rename() {
+    let dir = test_dir();
+    let root = dir.path();
+    let src_dir = root.join("src");
+    let components_dir = src_dir.join("components");
+    fs::create_dir_all(&components_dir).unwrap();
+
+    let app_path = src_dir.join("App.vue");
+    let old_component = components_dir.join("Foo.vue");
+    let new_component = components_dir.join("Bar.vue");
+
+    fs::write(
+        &app_path,
+        r#"<script setup lang="ts">
+import Foo from "./components/Foo.vue";
+const Lazy = () => import("./components/Foo.vue");
+type FooModule = typeof import("./components/Foo.vue");
+</script>
+"#,
+    )
+    .unwrap();
+    fs::write(&old_component, "<template><div>foo</div></template>").unwrap();
+
+    let state = ServerState::new();
+    state.set_workspace_root(root.to_path_buf());
+
+    let edit = collect_import_rename_edits(
+        &state,
+        &[FileRename {
+            old_uri: file_uri(&old_component),
+            new_uri: file_uri(&new_component),
+        }],
+        true,
+    )
+    .unwrap();
+
+    assert_snapshot!(serde_json::to_string_pretty(&normalize_edit(root, &edit)).unwrap(), @r###"
+    {
+      "src/App.vue": [
+        {
+          "newText": "./components/Bar.vue",
+          "range": {
+            "end": {
+              "character": 37,
+              "line": 1
+            },
+            "start": {
+              "character": 17,
+              "line": 1
+            }
+          }
+        },
+        {
+          "newText": "./components/Bar.vue",
+          "range": {
+            "end": {
+              "character": 47,
+              "line": 2
+            },
+            "start": {
+              "character": 27,
+              "line": 2
+            }
+          }
+        },
+        {
+          "newText": "./components/Bar.vue",
+          "range": {
+            "end": {
+              "character": 52,
+              "line": 3
+            },
+            "start": {
+              "character": 32,
+              "line": 3
+            }
+          }
+        }
+      ]
+    }
+    "###);
+}
+
+#[test]
+fn rewrites_extensionless_ts_imports_without_corsa() {
+    let dir = test_dir();
+    let root = dir.path();
+    let src_dir = root.join("src");
+    let util_dir = src_dir.join("util");
+    fs::create_dir_all(&util_dir).unwrap();
+
+    let entry_path = src_dir.join("entry.ts");
+    let old_module = util_dir.join("foo.ts");
+    let new_module = util_dir.join("bar.ts");
+
+    fs::write(
+        &entry_path,
+        "import { value } from \"./util/foo\";\nconst lazy = require(\"./util/foo\");\n",
+    )
+    .unwrap();
+    fs::write(&old_module, "export const value = 1;\n").unwrap();
+
+    let state = ServerState::new();
+    state.set_workspace_root(root.to_path_buf());
+
+    let edit = collect_import_rename_edits(
+        &state,
+        &[FileRename {
+            old_uri: file_uri(&old_module),
+            new_uri: file_uri(&new_module),
+        }],
+        false,
+    )
+    .unwrap();
+
+    assert_snapshot!(serde_json::to_string_pretty(&normalize_edit(root, &edit)).unwrap(), @r###"
+    {
+      "src/entry.ts": [
+        {
+          "newText": "./util/bar",
+          "range": {
+            "end": {
+              "character": 33,
+              "line": 0
+            },
+            "start": {
+              "character": 23,
+              "line": 0
+            }
+          }
+        },
+        {
+          "newText": "./util/bar",
+          "range": {
+            "end": {
+              "character": 32,
+              "line": 1
+            },
+            "start": {
+              "character": 22,
+              "line": 1
+            }
+          }
+        }
+      ]
+    }
+    "###);
+}
+
+#[test]
+fn renames_open_documents_inside_renamed_folder() {
+    let dir = test_dir();
+    let root = dir.path();
+    let old_dir = root.join("src/pages");
+    let new_dir = root.join("src/views");
+    let file_path = old_dir.join("Home.vue");
+    fs::create_dir_all(&old_dir).unwrap();
+    fs::write(&file_path, "<template><div>home</div></template>").unwrap();
+
+    let state = ServerState::new();
+    state.documents.open(
+        Url::from_file_path(&file_path).unwrap(),
+        "<template><div>home</div></template>".to_string(),
+        1,
+        "vue".to_string(),
+    );
+    state.update_virtual_docs(
+        &Url::from_file_path(&file_path).unwrap(),
+        "<template><div>home</div></template>",
+    );
+
+    let renamed = rename_open_documents(
+        &state,
+        &[FileRename {
+            old_uri: file_uri(&old_dir),
+            new_uri: file_uri(&new_dir),
+        }],
+    );
+
+    assert_eq!(renamed.len(), 1);
+    let new_uri = Url::from_file_path(new_dir.join("Home.vue")).unwrap();
+    assert!(state.documents.contains(&new_uri));
+    assert!(state.get_virtual_docs(&new_uri).is_some());
+}

--- a/crates/vize_maestro/src/ide/file_rename/merge_tests.rs
+++ b/crates/vize_maestro/src/ide/file_rename/merge_tests.rs
@@ -1,0 +1,139 @@
+#![allow(clippy::disallowed_macros, clippy::disallowed_methods)]
+
+use tower_lsp::lsp_types::{
+    DocumentChangeOperation, DocumentChanges, OneOf, OptionalVersionedTextDocumentIdentifier,
+    RenameFile, ResourceOp, TextDocumentEdit, TextEdit, Url, WorkspaceEdit,
+};
+
+use super::merge_workspace_edits;
+
+fn text_edit(new_text: &str) -> TextEdit {
+    TextEdit {
+        range: Default::default(),
+        new_text: new_text.to_string(),
+    }
+}
+
+#[test]
+fn merges_changes_into_document_changes() {
+    let base_uri = Url::parse("file:///base.vue").unwrap();
+    let overlay_uri = Url::parse("file:///overlay.vue").unwrap();
+    let merged = merge_workspace_edits(
+        Some(WorkspaceEdit {
+            changes: None,
+            document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
+                text_document: OptionalVersionedTextDocumentIdentifier {
+                    uri: base_uri.clone(),
+                    version: None,
+                },
+                edits: vec![OneOf::Left(text_edit("from-corsa"))],
+            }])),
+            change_annotations: None,
+        }),
+        Some(WorkspaceEdit {
+            changes: Some(std::collections::HashMap::from([(
+                overlay_uri.clone(),
+                vec![text_edit("from-manual")],
+            )])),
+            document_changes: None,
+            change_annotations: None,
+        }),
+    )
+    .unwrap();
+
+    assert!(merged.changes.is_none());
+
+    let DocumentChanges::Edits(edits) = merged.document_changes.unwrap() else {
+        panic!("expected document edits");
+    };
+
+    assert_eq!(edits.len(), 2);
+    assert!(edits.iter().any(|edit| edit.text_document.uri == base_uri));
+    assert!(
+        edits
+            .iter()
+            .any(|edit| edit.text_document.uri == overlay_uri)
+    );
+}
+
+#[test]
+fn prefers_overlay_document_changes_over_base_changes() {
+    let base_uri = Url::parse("file:///base.vue").unwrap();
+    let overlay_uri = Url::parse("file:///overlay.vue").unwrap();
+    let merged = merge_workspace_edits(
+        Some(WorkspaceEdit {
+            changes: Some(std::collections::HashMap::from([(
+                base_uri.clone(),
+                vec![text_edit("from-base")],
+            )])),
+            document_changes: None,
+            change_annotations: None,
+        }),
+        Some(WorkspaceEdit {
+            changes: None,
+            document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
+                text_document: OptionalVersionedTextDocumentIdentifier {
+                    uri: overlay_uri.clone(),
+                    version: None,
+                },
+                edits: vec![OneOf::Left(text_edit("from-overlay"))],
+            }])),
+            change_annotations: None,
+        }),
+    )
+    .unwrap();
+
+    assert!(merged.changes.is_none());
+
+    let DocumentChanges::Edits(edits) = merged.document_changes.unwrap() else {
+        panic!("expected document edits");
+    };
+
+    assert_eq!(edits.len(), 2);
+    assert!(edits.iter().any(|edit| edit.text_document.uri == base_uri));
+    assert!(
+        edits
+            .iter()
+            .any(|edit| edit.text_document.uri == overlay_uri)
+    );
+}
+
+#[test]
+fn inserts_manual_edits_before_resource_operations() {
+    let manual_uri = Url::parse("file:///manual.vue").unwrap();
+    let merged = merge_workspace_edits(
+        Some(WorkspaceEdit {
+            changes: None,
+            document_changes: Some(DocumentChanges::Operations(vec![
+                DocumentChangeOperation::Op(ResourceOp::Rename(RenameFile {
+                    old_uri: Url::parse("file:///old.vue").unwrap(),
+                    new_uri: Url::parse("file:///new.vue").unwrap(),
+                    options: None,
+                    annotation_id: None,
+                })),
+            ])),
+            change_annotations: None,
+        }),
+        Some(WorkspaceEdit {
+            changes: Some(std::collections::HashMap::from([(
+                manual_uri.clone(),
+                vec![text_edit("from-manual")],
+            )])),
+            document_changes: None,
+            change_annotations: None,
+        }),
+    )
+    .unwrap();
+
+    let DocumentChanges::Operations(operations) = merged.document_changes.unwrap() else {
+        panic!("expected document operations");
+    };
+
+    assert!(
+        matches!(operations.first(), Some(DocumentChangeOperation::Edit(edit)) if edit.text_document.uri == manual_uri)
+    );
+    assert!(matches!(
+        operations.get(1),
+        Some(DocumentChangeOperation::Op(ResourceOp::Rename(_)))
+    ));
+}

--- a/crates/vize_maestro/src/ide/file_rename/resources.rs
+++ b/crates/vize_maestro/src/ide/file_rename/resources.rs
@@ -1,0 +1,179 @@
+//! SFC resource-path rewriting for file renames.
+
+use std::path::Path;
+
+use tower_lsp::lsp_types::TextEdit;
+
+use super::manual::{RenameTarget, offset_range, rewrite_relative_specifier};
+use crate::server::ServerState;
+
+pub(super) fn collect_vue_resource_edits(
+    state: &ServerState,
+    path: &Path,
+    future_path: &Path,
+    source: &str,
+    rename_targets: &[RenameTarget],
+) -> Vec<TextEdit> {
+    let options = vize_atelier_sfc::SfcParseOptions {
+        filename: path.to_string_lossy().to_string().into(),
+        ..Default::default()
+    };
+    let Ok(descriptor) = vize_atelier_sfc::parse_sfc(source, options) else {
+        return Vec::new();
+    };
+    let Some(current_dir) = path.parent() else {
+        return Vec::new();
+    };
+    let Some(future_dir) = future_path.parent() else {
+        return Vec::new();
+    };
+
+    let mut edits = Vec::new();
+    let mut push_edit = |specifier: &str, start: usize, end: usize| {
+        let Some(new_text) =
+            rewrite_relative_specifier(state, current_dir, future_dir, specifier, rename_targets)
+        else {
+            return;
+        };
+        if new_text == specifier {
+            return;
+        }
+        if let Some(range) = offset_range(source, start, end) {
+            edits.push(TextEdit { range, new_text });
+        }
+    };
+
+    if let Some(template) = descriptor.template.as_ref()
+        && let Some(src) = template.src.as_deref()
+        && let Some((start, end)) = find_src_attr_range(source, template.loc.tag_start)
+    {
+        push_edit(src, start, end);
+    }
+    if let Some(script) = descriptor.script.as_ref()
+        && let Some(src) = script.src.as_deref()
+        && let Some((start, end)) = find_src_attr_range(source, script.loc.tag_start)
+    {
+        push_edit(src, start, end);
+    }
+    if let Some(script_setup) = descriptor.script_setup.as_ref()
+        && let Some(src) = script_setup.src.as_deref()
+        && let Some((start, end)) = find_src_attr_range(source, script_setup.loc.tag_start)
+    {
+        push_edit(src, start, end);
+    }
+    for style in &descriptor.styles {
+        if let Some(src) = style.src.as_deref()
+            && let Some((start, end)) = find_src_attr_range(source, style.loc.tag_start)
+        {
+            push_edit(src, start, end);
+        }
+        collect_css_imports(style.content.as_ref(), style.loc.start, &mut push_edit);
+    }
+
+    edits
+}
+
+fn collect_css_imports(
+    css: &str,
+    base_offset: usize,
+    push_edit: &mut impl FnMut(&str, usize, usize),
+) {
+    let mut pos = 0;
+    while let Some(import_pos) = css[pos..].find("@import") {
+        let start = pos + import_pos;
+        let after_import = &css[start + 7..];
+        let trimmed = after_import.trim_start();
+        let ws_len = after_import.len() - trimmed.len();
+
+        if let Some(url_content) = trimmed.strip_prefix("url(") {
+            let inner = url_content.trim_start();
+            let inner_ws = url_content.len() - inner.len();
+            if let Some((specifier, rel_start, rel_end)) = extract_css_specifier(inner) {
+                let abs_start = base_offset + start + 7 + ws_len + 4 + inner_ws + rel_start;
+                let abs_end = base_offset + start + 7 + ws_len + 4 + inner_ws + rel_end;
+                push_edit(specifier, abs_start, abs_end);
+            }
+        } else if let Some((specifier, rel_start, rel_end)) = extract_css_specifier(trimmed) {
+            let abs_start = base_offset + start + 7 + ws_len + rel_start;
+            let abs_end = base_offset + start + 7 + ws_len + rel_end;
+            push_edit(specifier, abs_start, abs_end);
+        }
+
+        pos = start + 8;
+    }
+}
+
+fn extract_css_specifier(text: &str) -> Option<(&str, usize, usize)> {
+    let bytes = text.as_bytes();
+    let first = *bytes.first()?;
+    if first == b'"' || first == b'\'' {
+        let quote = first as char;
+        let end = text[1..].find(quote)? + 1;
+        return Some((&text[1..end], 1, end));
+    }
+
+    let end = text.find([')', ';', '\n']).unwrap_or(text.len());
+    let specifier = text[..end].trim_end();
+    if specifier.is_empty() {
+        None
+    } else {
+        Some((specifier, 0, specifier.len()))
+    }
+}
+
+fn find_src_attr_range(content: &str, tag_start: usize) -> Option<(usize, usize)> {
+    let tag = content.get(tag_start..)?.split_once('>')?.0;
+    let src_pos = tag.find("src=")?;
+    let after_src = &tag[src_pos + 4..];
+    let quote = after_src.chars().next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+    let value_start = src_pos + 5;
+    let value_end = after_src[1..].find(quote)?;
+    Some((tag_start + value_start, tag_start + value_start + value_end))
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_macros)]
+mod tests {
+    use super::{collect_css_imports, find_src_attr_range};
+
+    #[test]
+    fn css_import_ranges_cover_only_the_specifier_text() {
+        let css =
+            "@import \"./base.css\";\n@import url('./theme.css');\n@import url(../reset.css);\n";
+        let base_offset = 11;
+        let mut imports = Vec::new();
+
+        collect_css_imports(css, base_offset, &mut |specifier, start, end| {
+            imports.push((
+                specifier.to_string(),
+                css[start - base_offset..end - base_offset].to_string(),
+            ));
+        });
+
+        assert_eq!(
+            imports,
+            [
+                ("./base.css".to_string(), "./base.css".to_string()),
+                ("./theme.css".to_string(), "./theme.css".to_string()),
+                ("../reset.css".to_string(), "../reset.css".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn src_attribute_ranges_cover_quoted_values_only() {
+        let source = "<template lang=\"pug\" src='./partial.pug'></template>\n<script setup src=\"./entry.ts\"></script>";
+        let template_range = find_src_attr_range(source, 0).unwrap();
+        let script_range = find_src_attr_range(source, source.find("<script").unwrap()).unwrap();
+
+        assert_eq!(&source[template_range.0..template_range.1], "./partial.pug");
+        assert_eq!(&source[script_range.0..script_range.1], "./entry.ts");
+        assert_eq!(
+            find_src_attr_range("<style src=./style.css></style>", 0),
+            None
+        );
+    }
+}

--- a/tests/tooling/lsp-file-rename-workspace.test.ts
+++ b/tests/tooling/lsp-file-rename-workspace.test.ts
@@ -123,6 +123,155 @@ type FooModule = typeof import("./components/Foo.vue");
   }
 });
 
+test("vize lsp willRenameFiles rewrites SFC block src attributes and CSS imports", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-file-rename-sfc-resources");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      fileRename: true,
+      lint: false,
+      typecheck: false,
+    });
+
+    fs.mkdirSync(path.join(workspaceDir, "partials"), { recursive: true });
+    fs.mkdirSync(path.join(workspaceDir, "styles"), { recursive: true });
+
+    const oldTemplatePath = path.join(workspaceDir, "partials", "card.html");
+    const newTemplatePath = path.join(workspaceDir, "partials", "panel.html");
+    const oldScriptPath = path.join(workspaceDir, "entry.ts");
+    const newScriptPath = path.join(workspaceDir, "boot.ts");
+    const oldStylePath = path.join(workspaceDir, "styles", "card.css");
+    const newStylePath = path.join(workspaceDir, "styles", "panel.css");
+    const oldResetPath = path.join(workspaceDir, "styles", "reset.css");
+    const newResetPath = path.join(workspaceDir, "styles", "modern-reset.css");
+    const oldThemePath = path.join(workspaceDir, "styles", "theme.css");
+    const newThemePath = path.join(workspaceDir, "styles", "brand.css");
+
+    fs.writeFileSync(oldTemplatePath, "<section />\n", "utf8");
+    fs.writeFileSync(oldScriptPath, "export const value = 1\n", "utf8");
+    fs.writeFileSync(oldStylePath, ".card {}\n", "utf8");
+    fs.writeFileSync(oldResetPath, "* { box-sizing: border-box }\n", "utf8");
+    fs.writeFileSync(oldThemePath, ":root { color: black }\n", "utf8");
+
+    const source = `<template src="./partials/card.html"></template>
+<script src="./entry.ts"></script>
+<style src="./styles/card.css"></style>
+<style>
+@import "./styles/reset.css";
+@import url('./styles/theme.css');
+@import "https://cdn.example.test/remote.css";
+</style>
+`;
+    const componentPath = path.join(workspaceDir, "LinkedBlocks.vue");
+    const componentUri = pathToFileURL(componentPath).href;
+    fs.writeFileSync(componentPath, source, "utf8");
+
+    const edit = (await session.request("workspace/willRenameFiles", {
+      files: [
+        {
+          oldUri: pathToFileURL(oldTemplatePath).href,
+          newUri: pathToFileURL(newTemplatePath).href,
+        },
+        { oldUri: pathToFileURL(oldScriptPath).href, newUri: pathToFileURL(newScriptPath).href },
+        { oldUri: pathToFileURL(oldStylePath).href, newUri: pathToFileURL(newStylePath).href },
+        { oldUri: pathToFileURL(oldResetPath).href, newUri: pathToFileURL(newResetPath).href },
+        { oldUri: pathToFileURL(oldThemePath).href, newUri: pathToFileURL(newThemePath).href },
+      ],
+    })) as WorkspaceEdit;
+
+    const componentEdits = editsForUri(edit, componentUri);
+    assert.equal(componentEdits.length, 5, JSON.stringify(edit));
+    assert.deepEqual(
+      componentEdits.map((textEdit) => textEdit.newText),
+      [
+        "./partials/panel.html",
+        "./boot.ts",
+        "./styles/panel.css",
+        "./styles/modern-reset.css",
+        "./styles/brand.css",
+      ],
+    );
+    assert.deepEqual(
+      componentEdits.map((textEdit) => textAtRange(source, textEdit.range)),
+      [
+        "./partials/card.html",
+        "./entry.ts",
+        "./styles/card.css",
+        "./styles/reset.css",
+        "./styles/theme.css",
+      ],
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+test("vize lsp willRenameFiles rewrites SFC resource paths when the importer moves", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-file-rename-sfc-importer-move");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      fileRename: true,
+      lint: false,
+      typecheck: false,
+    });
+
+    fs.mkdirSync(path.join(workspaceDir, "views"), { recursive: true });
+    fs.mkdirSync(path.join(workspaceDir, "partials"), { recursive: true });
+    fs.mkdirSync(path.join(workspaceDir, "styles"), { recursive: true });
+    fs.writeFileSync(path.join(workspaceDir, "partials", "card.html"), "<section />\n", "utf8");
+    fs.writeFileSync(path.join(workspaceDir, "entry.ts"), "export const value = 1\n", "utf8");
+    fs.writeFileSync(path.join(workspaceDir, "styles", "card.css"), ".card {}\n", "utf8");
+    fs.writeFileSync(path.join(workspaceDir, "styles", "reset.css"), "* {}\n", "utf8");
+
+    const source = `<template src="../partials/card.html"></template>
+<script src="../entry.ts"></script>
+<style src="../styles/card.css"></style>
+<style>
+@import url(../styles/reset.css);
+</style>
+`;
+    const componentPath = path.join(workspaceDir, "views", "Card.vue");
+    const newComponentPath = path.join(workspaceDir, "features", "cards", "Card.vue");
+    const componentUri = pathToFileURL(componentPath).href;
+    fs.writeFileSync(componentPath, source, "utf8");
+
+    const edit = (await session.request("workspace/willRenameFiles", {
+      files: [{ oldUri: componentUri, newUri: pathToFileURL(newComponentPath).href }],
+    })) as WorkspaceEdit;
+
+    const componentEdits = editsForUri(edit, componentUri);
+    assert.equal(componentEdits.length, 4, JSON.stringify(edit));
+    assert.deepEqual(
+      componentEdits.map((textEdit) => textEdit.newText),
+      [
+        "../../partials/card.html",
+        "../../entry.ts",
+        "../../styles/card.css",
+        "../../styles/reset.css",
+      ],
+    );
+    assert.deepEqual(
+      componentEdits.map((textEdit) => textAtRange(source, textEdit.range)),
+      ["../partials/card.html", "../entry.ts", "../styles/card.css", "../styles/reset.css"],
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
 test("vize lsp didRenameFiles moves open document state to the new URI", async (t) => {
   const testRootDir = path.join(testOutputRoot, "lsp-did-rename-workspace");
   fs.mkdirSync(testRootDir, { recursive: true });

--- a/tests/tooling/vscode-extension-core-behavior.test.ts
+++ b/tests/tooling/vscode-extension-core-behavior.test.ts
@@ -255,6 +255,21 @@ test("vscode start and enabled-capability checks handle false-only configs", () 
   assert.equal(hasAnyExplicitCapabilityValue(config), true);
 });
 
+test("vscode file rename can be enabled without the editor bundle", () => {
+  const config = new FakeConfig({
+    enable: true,
+    "editor.enable": false,
+    "fileRename.enable": true,
+  });
+
+  assert.deepEqual(getInitializationOptions(config), {
+    editor: false,
+    fileRename: true,
+  });
+  assert.equal(hasAnyEnabledCapability(config), true);
+  assert.equal(hasAnyExplicitCapabilityValue(config), true);
+});
+
 test("vscode explicit capability detection ignores unrelated settings", () => {
   const config = new FakeConfig({
     enable: true,
@@ -295,5 +310,16 @@ test("vscode capability description only includes true options in stable order",
       unknownFutureFeature: true,
     }),
     "completion, editor bundle, unknownFutureFeature",
+  );
+});
+
+test("vscode capability description names file rename explicitly", () => {
+  assert.equal(
+    describeCapabilities({
+      documentLinks: true,
+      fileRename: true,
+      rename: false,
+    }),
+    "document links, file rename",
   );
 });


### PR DESCRIPTION
## Summary
- Rewrite SFC block `src` attributes and CSS `@import` resource paths during `workspace/willRenameFiles`.
- Split existing manual file-rename unit tests out of the long implementation file.
- Add focused LSP file-rename coverage plus VS Code `fileRename` initialization coverage.

## Validation
- `cargo build -p vize`
- `cargo test -p vize_maestro file_rename --features native`
- `node --test --test-concurrency=1 tests/tooling/lsp-file-rename-workspace.test.ts tests/tooling/vscode-extension-core-behavior.test.ts tests/tooling/source-file-lengths.test.ts`
- `NODE_PATH=/Users/ubugeeei/Source/github.com/ubugeeei/vuejs-language-specification/node_modules node --test --test-concurrency=1 tests/tooling/lsp*.test.ts tests/tooling/editor*.test.ts tests/tooling/vscode*.test.ts`
- `git diff --check`
- `vp check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786016286&installation_id=136613492&pr_number=2670&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2670&signature=b4489d92b62749b2d2194c8b2b5513c18a355275eecf16bb69c74ef7c17f6234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File renames now update more Vue-related references, including `src` paths in templates, scripts, styles, and matching CSS imports.
  * Renaming a Vue file now keeps related imports in sync when the file moves to a new folder.
  * Improved capability reporting and configuration support for file rename behavior in the editor.

* **Bug Fixes**
  * Renaming open files and folders now updates active documents more reliably.
  * Extensionless TypeScript imports are rewritten correctly during file renames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->