### PR TITLE
fix(patina): honor builtin rule severity overrides

### DIFF
--- a/crates/vize/tests/lint_rule_severity_cli.rs
+++ b/crates/vize/tests/lint_rule_severity_cli.rs
@@ -1,0 +1,76 @@
+use std::{fs, path::Path, process::Command};
+
+fn write_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(file_path, content).unwrap();
+}
+
+fn output_details(output: &std::process::Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn lint_config_rule_severity_override_applies_to_builtin_script_rules() {
+    let project_root = tempfile::tempdir().unwrap();
+    write_file(
+        project_root.path(),
+        "vize.config.json",
+        r#"{
+  "linter": {
+    "preset": "ecosystem",
+    "rules": {
+      "script/custom-event-name-casing": "warn"
+    }
+  }
+}"#,
+    );
+    write_file(
+        project_root.path(),
+        "src/AfsStepperDialog.vue",
+        r#"<script setup lang="ts">
+const emit = defineEmits(["update:current-step-index"])
+
+const handleStepClick = (stepIndex: number) => {
+  emit("update:current-step-index", stepIndex)
+}
+</script>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root.path())
+        .args([
+            "lint",
+            "--config",
+            "vize.config.json",
+            "--format",
+            "json",
+            "src/AfsStepperDialog.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_details(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let file = json.as_array().unwrap().first().unwrap();
+    assert_eq!(file["errorCount"], serde_json::json!(0), "{stdout}");
+    assert_eq!(file["warningCount"], serde_json::json!(1), "{stdout}");
+    assert_eq!(
+        file["messages"][0]["ruleId"],
+        serde_json::json!("script/custom-event-name-casing"),
+        "{stdout}"
+    );
+    assert_eq!(
+        file["messages"][0]["severity"],
+        serde_json::json!(1),
+        "{stdout}"
+    );
+}

--- a/crates/vize_patina/src/linter.rs
+++ b/crates/vize_patina/src/linter.rs
@@ -16,6 +16,7 @@ mod engine;
 mod native_type_aware;
 mod restricted_rules;
 pub(crate) mod script_rules;
+mod severity;
 
 pub use config::{LintResult, Linter};
 

--- a/crates/vize_patina/src/linter/css_rules.rs
+++ b/crates/vize_patina/src/linter/css_rules.rs
@@ -117,8 +117,10 @@ pub(crate) fn append_builtin_css_diagnostics(
             "patina.css_rule.lint_style_block",
             css_linter.lint(source, style.loc.start)
         );
-        result.error_count += css_result.error_count;
-        result.warning_count += css_result.warning_count;
-        result.diagnostics.extend(css_result.diagnostics);
+        super::severity::append_with_rule_overrides(
+            result,
+            css_result.diagnostics,
+            &linter.severity_overrides,
+        );
     }
 }

--- a/crates/vize_patina/src/linter/script_rules.rs
+++ b/crates/vize_patina/src/linter/script_rules.rs
@@ -1,4 +1,4 @@
-use super::{LintResult, Linter};
+use super::{LintResult, Linter, severity::append_with_rule_overrides};
 use crate::rules::script::{ScriptLintResult, script_source_type};
 use memchr::memmem;
 use oxc_allocator::Allocator;
@@ -235,7 +235,7 @@ fn run_builtin_script_rule(
     } else {
         profile!(entry.profile_name, rule.check(source, offset, &mut lint));
     }
-    merge_script_result(result, lint);
+    merge_script_result(linter, result, lint);
 }
 
 pub(crate) fn append_builtin_script_diagnostics_from_html(
@@ -252,10 +252,9 @@ pub(crate) fn append_builtin_script_diagnostics_from_html(
     }
 }
 
-fn merge_script_result(result: &mut LintResult, script_result: ScriptLintResult) {
-    result.error_count += script_result.error_count;
-    result.warning_count += script_result.warning_count;
-    result.diagnostics.extend(script_result.diagnostics);
+fn merge_script_result(linter: &Linter, result: &mut LintResult, script_result: ScriptLintResult) {
+    let overrides = &linter.severity_overrides;
+    append_with_rule_overrides(result, script_result.diagnostics, overrides);
 }
 
 /// Run every enabled built-in script rule against a single script block.

--- a/crates/vize_patina/src/linter/severity.rs
+++ b/crates/vize_patina/src/linter/severity.rs
@@ -1,0 +1,34 @@
+use super::LintResult;
+use crate::diagnostic::Severity;
+use vize_carton::{FxHashMap, String};
+
+pub(crate) fn append_with_rule_overrides(
+    result: &mut LintResult,
+    mut diagnostics: Vec<crate::diagnostic::LintDiagnostic>,
+    overrides: &FxHashMap<String, Severity>,
+) {
+    if diagnostics.is_empty() {
+        return;
+    }
+
+    for diagnostic in &mut diagnostics {
+        if let Some(severity) = overrides.get(diagnostic.rule_name) {
+            diagnostic.severity = *severity;
+        }
+    }
+    result.diagnostics.extend(diagnostics);
+    recount(result);
+}
+
+fn recount(result: &mut LintResult) {
+    result.error_count = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.severity == Severity::Error)
+        .count();
+    result.warning_count = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.severity == Severity::Warning)
+        .count();
+}

--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -10,5 +10,6 @@ mod jsx_fallback;
 mod no_top_level_ref;
 mod nuxt;
 mod script;
+mod severity_overrides;
 mod sfc;
 mod v_for_unused_vars;

--- a/crates/vize_patina/src/linter/tests/severity_overrides.rs
+++ b/crates/vize_patina/src/linter/tests/severity_overrides.rs
@@ -1,0 +1,38 @@
+use super::Linter;
+use crate::{LintPreset, Severity};
+
+#[test]
+fn script_rule_severity_override_recounts_sfc_result() {
+    let source = r#"<script setup lang="ts">
+const emit = defineEmits(["update:current-step-index"])
+emit("update:current-step-index")
+</script>
+"#;
+    let result = Linter::with_preset(LintPreset::Ecosystem)
+        .with_enabled_rules(Some(vec!["script/custom-event-name-casing".into()]))
+        .with_rule_severity_overrides(vec![(
+            "script/custom-event-name-casing".into(),
+            Severity::Warning,
+        )])
+        .lint_sfc(source, "Stepper.vue");
+
+    assert_eq!(result.error_count, 0, "{:?}", result.diagnostics);
+    assert_eq!(result.warning_count, 1, "{:?}", result.diagnostics);
+    assert_eq!(result.diagnostics[0].severity, Severity::Warning);
+}
+
+#[test]
+fn css_rule_severity_override_recounts_sfc_result() {
+    let source = r#"<style>
+.button { color: red !important; }
+</style>
+"#;
+    let result = Linter::with_preset(LintPreset::Ecosystem)
+        .with_enabled_rules(Some(vec!["css/no-important".into()]))
+        .with_rule_severity_overrides(vec![("css/no-important".into(), Severity::Error)])
+        .lint_sfc(source, "Button.vue");
+
+    assert_eq!(result.error_count, 1, "{:?}", result.diagnostics);
+    assert_eq!(result.warning_count, 0, "{:?}", result.diagnostics);
+    assert_eq!(result.diagnostics[0].severity, Severity::Error);
+}


### PR DESCRIPTION
## Summary
- apply configured rule severity overrides when built-in script and CSS rules are merged into SFC lint results
- keep error and warning counts in sync after overrides
- add unit and CLI coverage for script/custom-event-name-casing configured as warn

Fixes #2671.

## Tests
- cargo test -p vize_patina severity_overrides
- cargo test -p vize --test lint_rule_severity_cli
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786018327&installation_id=136613492&pr_number=2676&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2676&signature=fac84eafb12c1b4167e15d7b72934a2a27de1da766854c6e7fe7012df1f0fd73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lint severity overrides from configuration are now reflected in reported results.
  * Script and CSS lint messages can now be shown as errors or warnings based on your configured rule settings.

* **Bug Fixes**
  * Lint summaries now count errors and warnings consistently after severity overrides are applied.
  * JSON lint output now matches the configured severity for affected rules.

* **Tests**
  * Added coverage for overridden severities in both script and CSS linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->