### PR TITLE
fix(vite-plugin): support glob string filters

### DIFF
--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -2,6 +2,7 @@ import "./hmr.test.ts";
 import "./compiler.test.ts";
 import "./config.test.ts";
 import "./options-api-events.test.ts";
+import "./utils-filter.test.ts";
 import "./utils.test.ts";
 import "./plugin/compat.test.ts";
 import "./plugin/css-modules.test.ts";

--- a/npm/builder/vite/src/utils-filter.test.ts
+++ b/npm/builder/vite/src/utils-filter.test.ts
@@ -1,0 +1,35 @@
+import { test } from "node:test";
+import { createFilter } from "./utils/filter.ts";
+
+void test("string glob include matches absolute Vue SFC paths", (t) => {
+  const filter = createFilter(["**/*.vue", "../design/**/*.vue"]);
+
+  t.assert.equal(filter("/repo/app/layouts/header-only.vue"), true);
+  t.assert.equal(filter("/repo/design/components/Button.vue"), true);
+  t.assert.equal(filter("/repo/app/routes/home.ts"), false);
+});
+
+void test("string glob exclude matches absolute generated directories", (t) => {
+  const filter = createFilter("**/*.vue", ["../node_modules/**", "../.nuxt/**", "../.output/**"]);
+
+  t.assert.equal(filter("/repo/app/pages/index.vue"), true);
+  t.assert.equal(filter("/repo/node_modules/pkg/Widget.vue"), false);
+  t.assert.equal(filter("/repo/app/.nuxt/components/App.vue"), false);
+  t.assert.equal(filter("/repo/app/.output/server/App.vue"), false);
+});
+
+void test("plain string filters keep substring semantics", (t) => {
+  const filter = createFilter(".custom", ".generated.");
+
+  t.assert.equal(filter("/repo/app/x.custom"), true);
+  t.assert.equal(filter("/repo/app/x.generated.custom"), false);
+});
+
+void test("global regex filters are stable across repeated calls", (t) => {
+  const filter = createFilter(/\.vue$/g, /node_modules/g);
+
+  t.assert.equal(filter("/repo/app/App.vue"), true);
+  t.assert.equal(filter("/repo/app/App.vue"), true);
+  t.assert.equal(filter("/repo/node_modules/pkg/App.vue"), false);
+  t.assert.equal(filter("/repo/node_modules/pkg/App.vue"), false);
+});

--- a/npm/builder/vite/src/utils/filter.ts
+++ b/npm/builder/vite/src/utils/filter.ts
@@ -1,0 +1,103 @@
+export function createFilter(
+  include?: string | RegExp | (string | RegExp)[],
+  exclude?: string | RegExp | (string | RegExp)[],
+): (id: string) => boolean {
+  const includePatterns = include ? (Array.isArray(include) ? include : [include]) : [/\.vue$/];
+  const excludePatterns = exclude
+    ? Array.isArray(exclude)
+      ? exclude
+      : [exclude]
+    : [/node_modules/];
+
+  return (id: string) => {
+    const matchInclude = includePatterns.some((pattern) => matchesFilterPattern(pattern, id));
+    const matchExclude = excludePatterns.some((pattern) => matchesFilterPattern(pattern, id));
+    return matchInclude && !matchExclude;
+  };
+}
+
+const GLOB_META = /[*?]/;
+
+function matchesFilterPattern(pattern: string | RegExp, id: string): boolean {
+  if (typeof pattern === "string") {
+    return matchesStringFilter(pattern, id);
+  }
+
+  pattern.lastIndex = 0;
+  const matched = pattern.test(id);
+  pattern.lastIndex = 0;
+  return matched;
+}
+
+function matchesStringFilter(pattern: string, id: string): boolean {
+  const normalizedId = normalizeFilterPath(id);
+  const normalizedPattern = normalizeFilterPath(pattern);
+  if (!GLOB_META.test(normalizedPattern)) {
+    return normalizedId.includes(normalizedPattern);
+  }
+  return stringGlobToRegExp(normalizedPattern).test(normalizedId);
+}
+
+function normalizeFilterPath(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+function stringGlobToRegExp(pattern: string): RegExp {
+  const absolute = pattern.startsWith("/");
+  let body = absolute ? pattern : stripRelativePrefix(pattern);
+  let descendantSuffix = false;
+
+  if (body.endsWith("/**")) {
+    body = body.slice(0, -3);
+    descendantSuffix = true;
+  }
+
+  const prefix = absolute ? "^" : "(?:^|/)";
+  const suffix = descendantSuffix ? "(?:/.*)?$" : "$";
+  return new RegExp(`${prefix}${globBodyToRegExp(body)}${suffix}`);
+}
+
+function stripRelativePrefix(pattern: string): string {
+  let rest = pattern;
+  while (rest.startsWith("../")) {
+    rest = rest.slice(3);
+  }
+  while (rest.startsWith("./")) {
+    rest = rest.slice(2);
+  }
+  return rest;
+}
+
+function globBodyToRegExp(pattern: string): string {
+  let source = "";
+  for (let i = 0; i < pattern.length; ) {
+    const char = pattern[i];
+    if (char === "*") {
+      if (pattern[i + 1] === "*") {
+        if (pattern[i + 2] === "/") {
+          source += "(?:.*\\/)?";
+          i += 3;
+        } else {
+          source += ".*";
+          i += 2;
+        }
+      } else {
+        source += "[^/]*";
+        i += 1;
+      }
+      continue;
+    }
+    if (char === "?") {
+      source += "[^/]";
+      i += 1;
+      continue;
+    }
+    source += escapeRegExp(char);
+    i += 1;
+  }
+  return source;
+}
+
+function escapeRegExp(char: string): string {
+  return "\\^$+?.()|[]{}".includes(char) ? `\\${char}` : char;
+}

--- a/npm/builder/vite/src/utils/index.ts
+++ b/npm/builder/vite/src/utils/index.ts
@@ -4,6 +4,7 @@ import { type HmrUpdateType, generateHmrCode } from "../hmr.ts";
 
 // Re-export CSS utilities for backward compatibility
 export { resolveCssImports, type CssAliasRule } from "./css.ts";
+export { createFilter } from "./filter.ts";
 
 /** Known CSS preprocessor languages that must be delegated to Vite */
 const PREPROCESSOR_LANGS = new Set(["scss", "sass", "less", "stylus", "styl"]);
@@ -82,28 +83,6 @@ function insertAfterStaticImports(output: string, imports: string): string {
 export function generateScopeId(filename: string): string {
   const hash = createHash("sha256").update(filename).digest("hex");
   return hash.slice(0, 8);
-}
-
-export function createFilter(
-  include?: string | RegExp | (string | RegExp)[],
-  exclude?: string | RegExp | (string | RegExp)[],
-): (id: string) => boolean {
-  const includePatterns = include ? (Array.isArray(include) ? include : [include]) : [/\.vue$/];
-  const excludePatterns = exclude
-    ? Array.isArray(exclude)
-      ? exclude
-      : [exclude]
-    : [/node_modules/];
-
-  return (id: string) => {
-    const matchInclude = includePatterns.some((pattern) =>
-      typeof pattern === "string" ? id.includes(pattern) : pattern.test(id),
-    );
-    const matchExclude = excludePatterns.some((pattern) =>
-      typeof pattern === "string" ? id.includes(pattern) : pattern.test(id),
-    );
-    return matchInclude && !matchExclude;
-  };
 }
 
 export interface GenerateOutputOptions {


### PR DESCRIPTION
## Summary
- treat string include/exclude entries with glob metacharacters as path globs
- keep plain string filters as substring matches for compatibility
- add coverage for Nuxt-style **/*.vue and ../node_modules/** filters

Fixes #2669.

## Tests
- node --test npm/builder/vite/src/utils-filter.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786018648&installation_id=136613492&pr_number=2677&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2677&signature=b4dfa308ceb77b60115d7cec4cee2e814ef364e3c32ece29b1d63a2e7e6df43a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new filtering utility for matching files with include/exclude patterns, including glob and regular expression support.
  * Filter matching now handles common path formats more consistently, including Windows-style separators.

* **Tests**
  * Expanded automated coverage for file filtering behavior, including glob matching, exclusions, substring matching, and repeated regex use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->