### PR TITLE
fix(musea): respect base in static gallery assets

### DIFF
--- a/npm/builder/vite-musea/src/static-base.ts
+++ b/npm/builder/vite-musea/src/static-base.ts
@@ -1,0 +1,22 @@
+import { joinUrlPath } from "./static-data.js";
+
+const TEXT_GALLERY_ASSET_EXT = /\.(?:css|html|js|map|mjs)$/u;
+
+export function rewriteGalleryBase(source: string, basePath: string): string {
+  return source.replaceAll("/__musea__/", `${basePath.replace(/\/?$/, "/")}`);
+}
+
+export function rewriteGalleryTextAssetBase(
+  source: Uint8Array,
+  relativePath: string,
+  basePath: string,
+): string | Uint8Array {
+  if (!TEXT_GALLERY_ASSET_EXT.test(relativePath)) return source;
+  return rewriteGalleryBase(Buffer.from(source).toString("utf-8"), basePath);
+}
+
+export function publicBasePathFromViteBase(viteBase: string | undefined, basePath: string): string {
+  return viteBase && viteBase !== "/" && viteBase !== "./"
+    ? joinUrlPath(viteBase, basePath)
+    : basePath;
+}

--- a/npm/builder/vite-musea/src/static-export.test.ts
+++ b/npm/builder/vite-musea/src/static-export.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 import vm from "node:vm";
 import type { ResolvedConfig } from "vite";
 
+import { rewriteGalleryTextAssetBase } from "./static-base.js";
 import { joinUrlPath, staticPreviewId } from "./static-data.js";
 import {
   emitStaticGallery,
@@ -229,6 +230,22 @@ void test("emitStaticGallery prefixes browser URLs with Vite base without nestin
   } finally {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   }
+});
+
+void test("static gallery text assets rewrite Monaco worker URLs with Vite base", () => {
+  const source = Buffer.from(
+    "new Worker(new URL(`/__musea__/assets/css.worker.js`, import.meta.url));",
+  );
+  const rewritten = rewriteGalleryTextAssetBase(
+    source,
+    "assets/MonacoEditorMode.js",
+    "/app/aim/aim-front/design-system/__musea__",
+  );
+  const expected =
+    "new Worker(new URL(`/app/aim/aim-front/design-system/__musea__/assets/css.worker.js`, import.meta.url));";
+
+  assert.equal(rewritten, expected);
+  assert.equal(rewriteGalleryTextAssetBase(source, "assets/logo.png", "/base"), source);
 });
 
 void test("static gallery runtime reports static-mode mutation and missing detail errors", async () => {

--- a/npm/builder/vite-musea/src/static-export.ts
+++ b/npm/builder/vite-musea/src/static-export.ts
@@ -7,6 +7,11 @@ import { generateGalleryBody, generateGalleryScript } from "./gallery/template.j
 import { generateGalleryGlobalsScript } from "./gallery/globals.js";
 import { serializeScriptValue } from "./security.js";
 import {
+  publicBasePathFromViteBase,
+  rewriteGalleryBase,
+  rewriteGalleryTextAssetBase,
+} from "./static-base.js";
+import {
   createStaticGalleryPayload,
   joinUrlPath,
   staticPreviewId,
@@ -180,7 +185,8 @@ async function emitGalleryShell(
       const html = injectStaticGlobals(content.toString("utf-8"), ctx, payload);
       emitFile({ type: "asset", fileName: target, source: rewriteGalleryBase(html, ctx.basePath) });
     } else {
-      emitFile({ type: "asset", fileName: target, source: content });
+      const source = rewriteGalleryTextAssetBase(content, relative, ctx.basePath);
+      emitFile({ type: "asset", fileName: target, source });
     }
   }
 }
@@ -272,16 +278,6 @@ function injectStaticGlobals(
   return html.includes("</head>")
     ? html.replace("</head>", `${script}</head>`)
     : `${script}${html}`;
-}
-
-function rewriteGalleryBase(html: string, basePath: string): string {
-  return html.replaceAll("/__musea__/", `${basePath.replace(/\/?$/, "/")}`);
-}
-
-function publicBasePathFromViteBase(viteBase: string | undefined, basePath: string): string {
-  return viteBase && viteBase !== "/" && viteBase !== "./"
-    ? joinUrlPath(viteBase, basePath)
-    : basePath;
 }
 
 function emitRootRedirect(


### PR DESCRIPTION
## Summary
- rewrite static gallery text assets with the public Musea base, not only index.html
- keep binary gallery assets untouched
- add coverage for Monaco worker URLs emitted under `/__musea__/assets`

Fixes #2664.

## Tests
- ./node_modules/.bin/vp exec tsx --test npm/builder/vite-musea/src/static-export.test.ts
- ./node_modules/.bin/vp fmt --check npm/builder/vite-musea/src/static-export.ts npm/builder/vite-musea/src/static-base.ts npm/builder/vite-musea/src/static-export.test.ts
- ./node_modules/.bin/vp check npm/builder/vite-musea/src npm/builder/vite-musea/vite.config.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786019113&installation_id=136613492&pr_number=2678&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2678&signature=3eff70db1736f57421e5945d4d1822717aac14ee308ab9818096d3f57a336584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->