### PR TITLE
fix(canon): isolate virtual project package scope

### DIFF
--- a/crates/vize/tests/check_ambient_export_assignment_cli.rs
+++ b/crates/vize/tests/check_ambient_export_assignment_cli.rs
@@ -1,0 +1,111 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("check-ambient-export-{name}-{}", std::process::id()).as_str())
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("CORSA_PATH") {
+        return Some(PathBuf::from(path));
+    }
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn write(root: &Path, rel: &str, content: &str) {
+    let path = root.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, content).unwrap();
+}
+
+#[test]
+fn check_allows_export_assignment_inside_ambient_module_declaration() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("cjs-module");
+    let _ = std::fs::remove_dir_all(&project_root);
+
+    write(
+        &project_root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "noEmit": true
+  },
+  "include": ["src/**/*.d.ts"]
+}"#,
+    );
+    write(
+        &project_root,
+        "src/ambients/buffer-from.d.ts",
+        r#"declare interface Buffer {}
+
+declare module "buffer-from" {
+  function bufferFrom(arrayBuffer: ArrayBuffer): Buffer;
+  export = bufferFrom;
+}
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+            "src/ambients/buffer-from.d.ts",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "ambient CommonJS declaration should type-check\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    assert!(
+        !stdout.contains("TS1203"),
+        "ambient export assignment must not be rejected as an ES module export:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -50,6 +50,7 @@ mod tests;
 pub(super) const AUTO_IMPORT_STUBS_FILE: &str = "__vize_auto_imports.d.ts";
 pub(super) const MODULE_AUGMENTATION_STUBS_FILE: &str = "__vize_module_augmentations.d.ts";
 pub(super) const MODULE_AUGMENTATION_STUB_PREFIX: &str = "// @vize-module-augmentation\n";
+pub(super) const PACKAGE_BOUNDARY_FILE: &str = "package.json";
 pub(super) const VUE_MODULE_STUBS_FILE: &str = "__vize_vue_modules.d.ts";
 /// Shared ambient helpers materialized once per program; generated `.vue.ts`
 /// modules are emitted with their preamble hoisted into this file.

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -38,6 +38,7 @@ mod jsx_codegen;
 mod mapping;
 mod materialize;
 mod passthrough;
+mod paths;
 mod project;
 mod setup_props;
 mod tsconfig_gen;

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -203,7 +203,7 @@ pub(super) fn build_script_registered_file(
         "canon.import.rewrite.script",
         rewriter.rewrite_for_virtual_project(content, source_type, roots, path.parent())
     );
-    let virtual_path = mirrored_virtual_path(roots.0, roots.1, path)?;
+    let virtual_path = super::paths::script_virtual_path(roots.0, roots.1, path)?;
 
     Ok(RegisteredFile {
         file: VirtualFile {

--- a/crates/vize_canon/src/batch/virtual_project/materialize.rs
+++ b/crates/vize_canon/src/batch/virtual_project/materialize.rs
@@ -16,7 +16,7 @@ use crate::batch::runtime_deps::materialize_runtime_dependencies;
 
 use super::{
     AUTO_IMPORT_STUBS_FILE, MODULE_AUGMENTATION_STUB_PREFIX, MODULE_AUGMENTATION_STUBS_FILE,
-    SHARED_HELPERS_FILE, VUE_MODULE_STUBS_FILE, VirtualProject,
+    PACKAGE_BOUNDARY_FILE, SHARED_HELPERS_FILE, VUE_MODULE_STUBS_FILE, VirtualProject,
 };
 
 impl VirtualProject {
@@ -48,6 +48,11 @@ impl VirtualProject {
         profile!(
             "canon.project.runtime_deps",
             materialize_runtime_dependencies(&self.project_root, &self.virtual_root)
+        )?;
+
+        profile!(
+            "canon.project.write_package_boundary",
+            self.write_package_boundary()
         )?;
 
         profile!(
@@ -120,6 +125,12 @@ impl VirtualProject {
             "canon.project.write_tsconfig",
             self.write_tsconfig_file(&self.virtual_root.join("tsconfig.json"), None, false)
         )?;
+        Ok(())
+    }
+
+    fn write_package_boundary(&self) -> CorsaResult<()> {
+        let content = b"{\n  \"type\": \"commonjs\"\n}\n";
+        write_if_changed(&self.virtual_root.join(PACKAGE_BOUNDARY_FILE), content)?;
         Ok(())
     }
 
@@ -265,6 +276,7 @@ impl VirtualProject {
         if self.uses_shared_helpers() {
             files.insert(self.virtual_root.join(SHARED_HELPERS_FILE));
         }
+        files.insert(self.virtual_root.join(PACKAGE_BOUNDARY_FILE));
         files.insert(self.virtual_root.join("tsconfig.json"));
         files
     }

--- a/crates/vize_canon/src/batch/virtual_project/materialize.rs
+++ b/crates/vize_canon/src/batch/virtual_project/materialize.rs
@@ -129,7 +129,7 @@ impl VirtualProject {
     }
 
     fn write_package_boundary(&self) -> CorsaResult<()> {
-        let content = b"{\n  \"type\": \"commonjs\"\n}\n";
+        let content = b"{\n  \"type\": \"module\"\n}\n";
         write_if_changed(&self.virtual_root.join(PACKAGE_BOUNDARY_FILE), content)?;
         Ok(())
     }

--- a/crates/vize_canon/src/batch/virtual_project/paths.rs
+++ b/crates/vize_canon/src/batch/virtual_project/paths.rs
@@ -1,0 +1,23 @@
+use std::path::{Path, PathBuf};
+
+use vize_carton::cstr;
+
+use crate::batch::error::{CorsaError, CorsaResult};
+
+pub(super) fn script_virtual_path(
+    project_root: &Path,
+    virtual_root: &Path,
+    path: &Path,
+) -> CorsaResult<PathBuf> {
+    let relative = path.strip_prefix(project_root)?;
+    let mut virtual_path = virtual_root.join(relative);
+    let Some(file_name) = virtual_path.file_name().and_then(|name| name.to_str()) else {
+        return Err(CorsaError::PathError {
+            path: path.to_path_buf(),
+        });
+    };
+    if let Some(stem) = file_name.strip_suffix(".d.ts") {
+        virtual_path.set_file_name(cstr!("{stem}.d.cts").as_str());
+    }
+    Ok(virtual_path)
+}


### PR DESCRIPTION
## Summary
- add a package boundary to the materialized Canon virtual project
- prevent parent `type: module` package scopes from reclassifying mirrored `.d.ts` files
- add CLI regression coverage for `export =` inside an ambient module declaration

Fixes #2674.

## Tests
- cargo fmt --check -p vize -p vize_canon
- CORSA_PATH="$PWD/../vize-issue-2664/node_modules/.bin/tsgo" cargo test -p vize --test check_ambient_export_assignment_cli
- cargo test -p vize_canon virtual_project::tests::materialize_prunes_stale_virtual_project_entries
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786019580&installation_id=136613492&pr_number=2679&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2679&signature=4f1efddbcfba25cca7faf96b8bf567ea26e11a9b59c1911f54130178d4547ad3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved project handling for generated output, including better support for package-boundary files and script path mapping.
* **Bug Fixes**
  * Fixed a regression that could incorrectly report ambient CommonJS `export =` declarations as invalid ES module exports.
  * Improved validation so check results now correctly return success with no errors in supported cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->