### PR TITLE
fix(patina): honor script rule severity overrides

### DIFF
--- a/crates/vize/tests/lint_config_cli.rs
+++ b/crates/vize/tests/lint_config_cli.rs
@@ -328,3 +328,67 @@ await nextTick()
 
     let _ = fs::remove_dir_all(project_root);
 }
+
+#[test]
+fn lint_config_rule_severity_override_applies_to_script_rules() {
+    let project_root = temp_project_dir("script-rule-severity-override");
+    write_project_file(
+        &project_root,
+        "vize.config.json",
+        r#"{
+  "linter": {
+    "preset": "nuxt",
+    "rules": {
+      "script/custom-event-name-casing": "warn"
+    }
+  }
+}"#,
+    );
+    write_project_file(
+        &project_root,
+        "src/AfsStepperDialog.vue",
+        r#"<script setup lang="ts">
+defineOptions({ name: "AfsStepperDialog" })
+
+const emit = defineEmits<{
+  "update:current-step-index": [number]
+}>()
+
+const handleStepClick = () => {
+  emit("update:current-step-index", 1)
+}
+</script>
+
+<template>
+  <button type="button" @click="handleStepClick">Step</button>
+</template>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args([
+            "lint",
+            "--config",
+            "vize.config.json",
+            "--format",
+            "json",
+            "src/AfsStepperDialog.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_details(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let file = &json[0];
+    assert_eq!(file["errorCount"], 0, "{stdout}");
+    assert_eq!(file["warningCount"], 1, "{stdout}");
+    assert_eq!(
+        file["messages"][0]["ruleId"], "script/custom-event-name-casing",
+        "{stdout}"
+    );
+    assert_eq!(file["messages"][0]["severity"], 1, "{stdout}");
+
+    let _ = fs::remove_dir_all(project_root);
+}

--- a/crates/vize_patina/src/linter/config.rs
+++ b/crates/vize_patina/src/linter/config.rs
@@ -45,6 +45,28 @@ impl LintResult {
     pub fn has_diagnostics(&self) -> bool {
         !self.diagnostics.is_empty()
     }
+
+    #[inline]
+    pub(crate) fn add_diagnostic(&mut self, diagnostic: LintDiagnostic) {
+        match diagnostic.severity {
+            Severity::Error => self.error_count += 1,
+            Severity::Warning => self.warning_count += 1,
+        }
+        self.diagnostics.push(diagnostic);
+    }
+
+    pub(crate) fn extend_diagnostics_with_severity_overrides(
+        &mut self,
+        diagnostics: impl IntoIterator<Item = LintDiagnostic>,
+        severity_overrides: &FxHashMap<String, Severity>,
+    ) {
+        for mut diagnostic in diagnostics {
+            if let Some(severity) = severity_overrides.get(diagnostic.rule_name) {
+                diagnostic.severity = *severity;
+            }
+            self.add_diagnostic(diagnostic);
+        }
+    }
 }
 
 /// Main linter struct.

--- a/crates/vize_patina/src/linter/css_rules.rs
+++ b/crates/vize_patina/src/linter/css_rules.rs
@@ -117,8 +117,9 @@ pub(crate) fn append_builtin_css_diagnostics(
             "patina.css_rule.lint_style_block",
             css_linter.lint(source, style.loc.start)
         );
-        result.error_count += css_result.error_count;
-        result.warning_count += css_result.warning_count;
-        result.diagnostics.extend(css_result.diagnostics);
+        result.extend_diagnostics_with_severity_overrides(
+            css_result.diagnostics,
+            &linter.severity_overrides,
+        );
     }
 }

--- a/crates/vize_patina/src/linter/script_rules.rs
+++ b/crates/vize_patina/src/linter/script_rules.rs
@@ -235,7 +235,7 @@ fn run_builtin_script_rule(
     } else {
         profile!(entry.profile_name, rule.check(source, offset, &mut lint));
     }
-    merge_script_result(result, lint);
+    merge_script_result(linter, result, lint);
 }
 
 pub(crate) fn append_builtin_script_diagnostics_from_html(
@@ -252,10 +252,11 @@ pub(crate) fn append_builtin_script_diagnostics_from_html(
     }
 }
 
-fn merge_script_result(result: &mut LintResult, script_result: ScriptLintResult) {
-    result.error_count += script_result.error_count;
-    result.warning_count += script_result.warning_count;
-    result.diagnostics.extend(script_result.diagnostics);
+fn merge_script_result(linter: &Linter, result: &mut LintResult, script_result: ScriptLintResult) {
+    result.extend_diagnostics_with_severity_overrides(
+        script_result.diagnostics,
+        &linter.severity_overrides,
+    );
 }
 
 /// Run every enabled built-in script rule against a single script block.


### PR DESCRIPTION
## Summary

- apply configured rule severity overrides when merging built-in script lint diagnostics
- apply the same merge path to built-in CSS lint diagnostics so counts stay consistent
- add a CLI regression test for `script/custom-event-name-casing` configured as `warn`

## Validation

- `cargo test -p vize --test lint_config_cli`
- `cargo test -p vize_patina linter::tests::basic`

Fixes #2671.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786024359&installation_id=136613492&pr_number=2681&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2681&signature=6d1b755e6421d7afa48e62d719979b9e9183977692a07fa7d670269e7ffb87cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->