### PR TITLE
fix(canon): accept Nuxt 2 page options

### DIFF
--- a/crates/vize/tests/check_legacy_vue2_helpers_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_helpers_cli.rs
@@ -153,6 +153,72 @@ export default {
     let _ = std::fs::remove_dir_all(&project_root);
 }
 
+#[test]
+fn legacy_vue2_accepts_nuxt2_layout_and_head_this_bindings() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project("legacy-vue2-nuxt2-layout-head-this");
+    std::fs::create_dir_all(project_root.join("layouts")).unwrap();
+    std::fs::write(
+        project_root.join("layouts/error.vue"),
+        r#"<script>
+export default {
+  layout: "empty",
+  props: {
+    error: {
+      type: Object,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      pageNotFound: "404 Not Found",
+      otherError: "An error occurred",
+    };
+  },
+  head() {
+    const title = this.error.statusCode === 404 ? this.pageNotFound : this.otherError;
+    return { title };
+  },
+};
+</script>
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--config",
+            "vize.config.json",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+            "layouts/error.vue",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(
+        json["errorCount"], 0,
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
 fn create_project(name: &str) -> std::path::PathBuf {
     let project_root = unique_case_dir(name);
     let _ = std::fs::remove_dir_all(&project_root);

--- a/crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs
@@ -54,11 +54,17 @@ const LEGACY_DEFINE_COMPONENT_HELPER: &str = r#"type __VizeNuxt2Context = {
   isDev?: boolean;
   isHMR?: boolean;
 } & Record<string, any>;
-type __VizeNuxt2PageOptions = {
+type __VizeNuxt2PageOptions = ThisType<any> & {
   validate?: (context: __VizeNuxt2Context) => unknown;
   asyncData?: (context: __VizeNuxt2Context) => any;
   fetch?: (context: __VizeNuxt2Context) => any;
+  head?: any;
+  layout?: any;
+  layoutTransition?: any;
+  loading?: any;
   middleware?: any;
+  scrollToTop?: any;
+  transition?: any;
 };
 declare function __vizeDefineComponent<T>(options: T & __VizeNuxt2PageOptions): T;
 "#;

--- a/crates/vize_canon/src/virtual_ts/tests/legacy_nuxt2_page_context.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/legacy_nuxt2_page_context.rs
@@ -38,6 +38,14 @@ fn test_legacy_nuxt2_page_validate_gets_contextual_type() {
     assert!(
         output
             .code
+            .contains("type __VizeNuxt2PageOptions = ThisType<any> & {")
+            && output.code.contains("layout?: any;"),
+        "legacy Nuxt 2 page options should accept page-only options without narrowing `this`:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
             .contains("const __default__ = __vizeDefineComponent({"),
         "plain object exports should be wrapped by the legacy helper:\n{}",
         output.code


### PR DESCRIPTION
## Summary
- allow legacy Vue 2 virtual TS to accept Nuxt 2 page-only options such as `layout`
- avoid narrowing Options API `this` to the Nuxt helper shape
- add CLI coverage for `layout` plus `head()` accessing props/data bindings

Fixes #2665.

## Tests
- cargo test -p vize_canon --features legacy legacy_nuxt2_page_context
- cargo test -p vize --features legacy --test check_legacy_vue2_helpers_cli legacy_vue2_accepts_nuxt2_layout_and_head_this_bindings
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786025524&installation_id=136613492&pr_number=2682&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2682&signature=9da5aece80104040bf8231e62b5bba8883c8d8a55340d4be6d7005b2d155d8bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for legacy Nuxt 2/Vue 2 pages, including additional page options and better context handling in page-level logic.
  * Expanded compatibility for `layout` and `head()` usage so page metadata can be derived more reliably from page state.

* **Tests**
  * Added coverage for legacy Vue 2/Nuxt 2 projects to verify these behaviors work correctly and report no issues during checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->