### PR TITLE
fix(musea): fallback unsupported render output

### DIFF
--- a/crates/vize/src/commands/musea/migrate/emit/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/tests.rs
@@ -116,6 +116,29 @@ export const Stateful = {
 }
 
 #[test]
+fn emits_todo_for_render_output_requiring_story_bindings() {
+    let source = r#"import AfButton from "./AfButton.vue";
+const schema = createSchema();
+export default { component: AfButton, title: "Base/AfButton" } satisfies Meta<typeof AfButton>;
+export const LocalBinding = { render: () => <AfButton data={schema} /> };
+export const ArgsMember = { render: args => <AfButton value={args.value} /> };
+export const SlotObject = {
+  render: () => <AfButton>{{ default: () => <span>Primary</span> }}</AfButton>,
+};
+"#;
+    let (content, variants, todos) = emit(source);
+
+    assert!(content.contains(r#"<variant name="LocalBinding" default>"#));
+    assert!(content.contains(r#"<variant name="ArgsMember">"#));
+    assert!(content.contains(r#"<variant name="SlotObject">"#));
+    assert!(!content.contains(":data=\"schema\""));
+    assert!(!content.contains(":value=\"args.value\""));
+    assert!(!content.contains("=> <span>"));
+    assert_eq!(variants, 3);
+    assert_eq!(todos, 3);
+}
+
+#[test]
 fn emits_plain_title_without_category() {
     let source = r#"import AfButton from "./AfButton.vue";
 export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;

--- a/crates/vize/src/commands/musea/migrate/jsx.rs
+++ b/crates/vize/src/commands/musea/migrate/jsx.rs
@@ -63,7 +63,13 @@ fn convert_children(children: &[JSXChild<'_>], source: &str) -> Option<String> {
             JSXChild::ExpressionContainer(container) => match &container.expression {
                 JSXExpression::EmptyExpression(_) => {}
                 expression => {
+                    if child_expression_requires_binding(expression) {
+                        return None;
+                    }
                     let text = jsx_expression_source(expression, source)?;
+                    if references_render_args(text.as_str()) {
+                        return None;
+                    }
                     append!(out, "{{{{ {text} }}}}");
                 }
             },
@@ -90,6 +96,11 @@ fn convert_attribute(item: &JSXAttributeItem<'_>, source: &str) -> Option<String
                         JSXExpression::EmptyExpression(_) => None,
                         expression => {
                             let text = jsx_expression_source(expression, source)?;
+                            if references_render_args(text.as_str())
+                                || attribute_expression_requires_binding(expression)
+                            {
+                                return None;
+                            }
                             let mut out = String::default();
                             append!(out, ":{name}=\"{}\"", escape_attr(text.as_str()));
                             Some(out)
@@ -136,6 +147,100 @@ fn attribute_name<'a>(name: &'a JSXAttributeName<'a>) -> Option<&'a str> {
         // Namespaced attribute names (`foo:bar`) have no clean Vue mapping.
         JSXAttributeName::NamespacedName(_) => None,
     }
+}
+
+fn child_expression_requires_binding(expression: &JSXExpression<'_>) -> bool {
+    match expression {
+        JSXExpression::ObjectExpression(_)
+        | JSXExpression::ArrowFunctionExpression(_)
+        | JSXExpression::FunctionExpression(_)
+        | JSXExpression::JSXElement(_)
+        | JSXExpression::JSXFragment(_) => true,
+        JSXExpression::ParenthesizedExpression(inner) => {
+            child_value_requires_binding(&inner.expression)
+        }
+        JSXExpression::TSAsExpression(inner) => child_value_requires_binding(&inner.expression),
+        JSXExpression::TSSatisfiesExpression(inner) => {
+            child_value_requires_binding(&inner.expression)
+        }
+        JSXExpression::TSNonNullExpression(inner) => {
+            child_value_requires_binding(&inner.expression)
+        }
+        _ => false,
+    }
+}
+
+fn child_value_requires_binding(expression: &Expression<'_>) -> bool {
+    match expression {
+        Expression::ObjectExpression(_)
+        | Expression::ArrowFunctionExpression(_)
+        | Expression::FunctionExpression(_)
+        | Expression::JSXElement(_)
+        | Expression::JSXFragment(_) => true,
+        Expression::ParenthesizedExpression(inner) => {
+            child_value_requires_binding(&inner.expression)
+        }
+        Expression::TSAsExpression(inner) => child_value_requires_binding(&inner.expression),
+        Expression::TSSatisfiesExpression(inner) => child_value_requires_binding(&inner.expression),
+        Expression::TSNonNullExpression(inner) => child_value_requires_binding(&inner.expression),
+        _ => false,
+    }
+}
+
+fn attribute_expression_requires_binding(expression: &JSXExpression<'_>) -> bool {
+    match expression {
+        JSXExpression::Identifier(_)
+        | JSXExpression::StaticMemberExpression(_)
+        | JSXExpression::ComputedMemberExpression(_)
+        | JSXExpression::PrivateFieldExpression(_)
+        | JSXExpression::CallExpression(_)
+        | JSXExpression::ChainExpression(_)
+        | JSXExpression::NewExpression(_)
+        | JSXExpression::ThisExpression(_) => true,
+        JSXExpression::ParenthesizedExpression(inner) => {
+            attribute_value_requires_binding(&inner.expression)
+        }
+        JSXExpression::TSAsExpression(inner) => attribute_value_requires_binding(&inner.expression),
+        JSXExpression::TSSatisfiesExpression(inner) => {
+            attribute_value_requires_binding(&inner.expression)
+        }
+        JSXExpression::TSNonNullExpression(inner) => {
+            attribute_value_requires_binding(&inner.expression)
+        }
+        _ => false,
+    }
+}
+
+fn attribute_value_requires_binding(expression: &Expression<'_>) -> bool {
+    match expression {
+        Expression::Identifier(_)
+        | Expression::StaticMemberExpression(_)
+        | Expression::ComputedMemberExpression(_)
+        | Expression::PrivateFieldExpression(_)
+        | Expression::CallExpression(_)
+        | Expression::ChainExpression(_)
+        | Expression::NewExpression(_)
+        | Expression::ThisExpression(_) => true,
+        Expression::ParenthesizedExpression(inner) => {
+            attribute_value_requires_binding(&inner.expression)
+        }
+        Expression::TSAsExpression(inner) => attribute_value_requires_binding(&inner.expression),
+        Expression::TSSatisfiesExpression(inner) => {
+            attribute_value_requires_binding(&inner.expression)
+        }
+        Expression::TSNonNullExpression(inner) => {
+            attribute_value_requires_binding(&inner.expression)
+        }
+        _ => false,
+    }
+}
+
+fn references_render_args(text: &str) -> bool {
+    let text = text.trim();
+    text == "args"
+        || text.starts_with("args.")
+        || text.starts_with("args?.")
+        || text.starts_with("args[")
 }
 
 /// Source text of a `JSXExpression` (the expression inside `{...}`).

--- a/crates/vize/src/commands/musea/migrate/jsx/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/jsx/tests.rs
@@ -94,6 +94,25 @@ fn escapes_quotes_in_expression_attr() {
 }
 
 #[test]
+fn rejects_identifier_attribute_without_script_binding() {
+    assert_eq!(convert("<AfButton data={schema} />").as_deref(), None);
+}
+
+#[test]
+fn rejects_render_args_member_attribute() {
+    assert_eq!(convert("<AfButton value={args.value} />").as_deref(), None);
+}
+
+#[test]
+fn rejects_tsx_slot_object_children() {
+    assert_eq!(
+        convert("<AfTooltip>{{ activator: () => <AfButton>Hover</AfButton> }}</AfTooltip>")
+            .as_deref(),
+        None
+    );
+}
+
+#[test]
 fn non_jsx_render_returns_none() {
     assert_eq!(convert("42").as_deref(), None);
 }

--- a/crates/vize/tests/musea_migrate_cli.rs
+++ b/crates/vize/tests/musea_migrate_cli.rs
@@ -161,6 +161,42 @@ Checked.args = { checked: true };
 }
 
 #[test]
+fn migrates_unsupported_render_output_as_todo_variants() {
+    let dir = tempfile::tempdir().unwrap();
+    let story = dir.path().join("AfsForm.stories.tsx");
+    fs::write(
+        &story,
+        r#"import AfsForm from "./AfsForm.vue";
+const loginSchema = createSchema();
+export default { component: AfsForm, title: "Forms/AfsForm" } satisfies Meta<typeof AfsForm>;
+export const UsesLocalBinding = { render: () => <AfsForm schema={loginSchema} /> };
+export const UsesRenderArgs = { render: args => <AfsForm value={args.value} /> };
+export const UsesSlotObject = {
+  render: () => <AfsForm>{{ default: () => <div>body</div> }}</AfsForm>,
+};
+"#,
+    )
+    .unwrap();
+
+    let output = run_migrate(dir.path(), &["AfsForm.stories.tsx"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        std::string::String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = std::string::String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("3 variant(s) generated, 3 TODO fallback(s)"));
+    let generated = fs::read_to_string(dir.path().join("AfsForm.art.vue")).unwrap();
+    assert!(generated.contains(r#"<variant name="UsesLocalBinding" default>"#));
+    assert!(generated.contains(r#"<variant name="UsesRenderArgs">"#));
+    assert!(generated.contains(r#"<variant name="UsesSlotObject">"#));
+    assert!(!generated.contains(":schema=\"loginSchema\""));
+    assert!(!generated.contains(":value=\"args.value\""));
+    assert!(!generated.contains("=> <div>"));
+}
+
+#[test]
 fn dry_run_prints_without_writing() {
     let dir = tempfile::tempdir().unwrap();
     let story = dir.path().join("Box.stories.tsx");


### PR DESCRIPTION
## Summary\n- Reject CSF render JSX that would emit undefined story-local bindings or render args references.\n- Fall back to explicit TODO variants for unsupported slot-object JSX output instead of generating invalid art.\n- Add unit and CLI coverage for the #2673 repro shapes.\n\nFixes #2673\n\n## Tests\n- cargo test -p vize musea::migrate\n- cargo test -p vize --test musea_migrate_cli\n- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786026175&installation_id=136613492&pr_number=2683&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2683&signature=cfb83837188e71bc4711b57c8a41c4ab988eeb2583c570428a8e1e91e8cad6d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration output for story content that can’t be safely converted, now using clear TODO fallbacks instead of generating incorrect template code.
  * Preserved multiple story variants during migration, including cases with dynamic values and complex slot content.
  * Reduced the chance of unsupported expressions being inlined into the generated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->