### PR TITLE
test(canon): cover generic SFC mount props inference

### DIFF
--- a/crates/vize/tests/check_canon_generic_sfc_mount_cli.rs
+++ b/crates/vize/tests/check_canon_generic_sfc_mount_cli.rs
@@ -1,0 +1,228 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("check-canon-mount-{name}-{}", std::process::id()).as_str())
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn link_workspace_vue(project_root: &Path) -> std::io::Result<()> {
+    let Some(vue_package) = workspace_vue_package() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace Vue package missing",
+        ));
+    };
+    let workspace_node_modules = vue_package.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace Vue package has no node_modules parent",
+        )
+    })?;
+    let target = project_root.join("node_modules");
+    std::fs::create_dir_all(&target)?;
+    symlink_path(&vue_package, &target.join("vue"))?;
+    let vue_namespace = workspace_node_modules.join("@vue");
+    if vue_namespace.exists() {
+        symlink_path(&vue_namespace, &target.join("@vue"))?;
+    }
+    Ok(())
+}
+
+fn workspace_vue_package() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.join("node_modules/vue"),
+        root.join("tests/node_modules/vue"),
+        root.join("playground/node_modules/vue"),
+        root.join("examples/vite-musea/node_modules/vue"),
+        root.join("examples/jsx-tsx/node_modules/vue"),
+        root.join("npm/framework/nuxt/node_modules/vue"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
+    if target.is_symlink() || target.is_file() {
+        std::fs::remove_file(target)?;
+    } else if target.exists() {
+        std::fs::remove_dir_all(target)?;
+    }
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(source, target)
+    }
+}
+
+fn write_tsconfig(project_root: &Path) {
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+}
+
+fn create_case_with_files(name: &str, files: &[(&str, &str)]) -> PathBuf {
+    let project_root = unique_case_dir(name);
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    link_workspace_vue(&project_root).unwrap();
+    write_tsconfig(&project_root);
+    for (path, source) in files {
+        let target = project_root.join(path);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(target, source).unwrap();
+    }
+    project_root
+}
+
+fn run_check_json(project_root: &Path, corsa_path: &Path, target: &str) {
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            target,
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        std::str::from_utf8(&output.stderr).unwrap_or("<non-utf8 stderr>")
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+}
+
+#[test]
+fn check_generic_sfc_props_infer_from_typescript_mount_options() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_case_with_files(
+        "generic-sfc-mount-props",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script lang="ts">
+type ItemKey<T> = Extract<keyof T, string> | (string & {});
+
+export interface ChildProps<
+  TItems extends object[] = object[],
+  TValueKey extends ItemKey<TItems[number]> | undefined = undefined
+> {
+  items: TItems;
+  valueKey?: TValueKey;
+}
+</script>
+
+<script setup lang="ts" generic="
+  TItems extends object[] = object[],
+  TValueKey extends ItemKey<TItems[number]> | undefined = undefined
+">
+defineProps<ChildProps<TItems, TValueKey>>();
+</script>
+
+<template><div /></template>
+"#,
+            ),
+            (
+                "src/usage.ts",
+                r#"import { mount } from "@vue/test-utils";
+import Child from "./Child.vue";
+
+const items = [{ label: "One", value: "one" }];
+
+mount(Child, {
+  props: {
+    items,
+    valueKey: "value",
+  },
+});
+"#,
+            ),
+            (
+                "node_modules/vue-component-type-helpers/index.d.ts",
+                r#"export type ComponentProps<T> = T extends new (...args: any) => {
+  $props: infer P;
+} ? NonNullable<P> : T extends (props: infer P, ...args: any) => any ? P : {};
+"#,
+            ),
+            (
+                "node_modules/@vue/test-utils/index.d.ts",
+                r#"import type { ComponentProps } from "vue-component-type-helpers";
+
+type RawProps = Record<string, any>;
+interface MountingOptions<Props> {
+  props?: RawProps & Props;
+}
+export type ComponentMountingOptions<
+  T,
+  P extends ComponentProps<T> = ComponentProps<T>,
+> = MountingOptions<P> & Record<string, unknown>;
+export declare function mount<
+  T,
+  C = T extends ((...args: any) => any) | (new (...args: any) => any) ? T : any,
+  P extends ComponentProps<C> = ComponentProps<C>,
+>(originalComponent: T, options?: ComponentMountingOptions<C, P>): void;
+"#,
+            ),
+        ],
+    );
+
+    run_check_json(&project_root, &corsa_path, "src");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
## Summary\n- Add a regression test for TypeScript-side mounting of generic SFC props.\n- Model the relevant @vue/test-utils and vue-component-type-helpers prop extraction types in the fixture.\n\nFixes #2675\n\n## Tests\n- cargo test -p vize --test check_canon_recent_type_regressions_cli check_generic_sfc_props_infer_from_typescript_mount_options\n- cargo test -p vize --test check_canon_generic_inference_cli\n- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786026484&installation_id=136613492&pr_number=2684&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2684&signature=f39e8b6bd57bd9d726ae60c07193a48fa045b9a5728c0924ab65956ed9c25b45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for checking Vue single-file components with generic props in a mounted usage scenario.
  * Improved validation of CLI behavior in an isolated workspace with strict TypeScript settings.
  * Ensures the check command reports zero errors for this supported case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->