### PR TITLE
fix(vite-plugin): scope trailing universal selectors

### DIFF
--- a/crates/vize_atelier_sfc/src/css.rs
+++ b/crates/vize_atelier_sfc/src/css.rs
@@ -15,7 +15,7 @@ use vize_carton::{FxHashMap, String};
 #[cfg(feature = "native")]
 mod parser;
 mod scoped;
-mod scoped_selector;
+pub(crate) mod scoped_selector;
 #[cfg(test)]
 mod tests;
 mod transform;

--- a/crates/vize_atelier_sfc/src/css/scoped_selector.rs
+++ b/crates/vize_atelier_sfc/src/css/scoped_selector.rs
@@ -2,7 +2,7 @@
 
 use super::transform::find_matching_paren;
 
-pub(super) fn split_before_trailing_universal_or_pseudo(
+pub(crate) fn split_before_trailing_universal_or_pseudo(
     selector: &str,
 ) -> Option<(&str, &str, &str)> {
     let (prefix_end, suffix_start) = trailing_compound_boundary(selector)?;

--- a/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
@@ -1,3 +1,4 @@
+use crate::css::scoped_selector::split_before_trailing_universal_or_pseudo;
 use vize_carton::{SmallVec, String};
 
 /// Scope CSS with the Vite plugin pipeline's selector model.
@@ -454,6 +455,13 @@ fn add_scope_before_trailing_combinator(selector: &str, scope_id: &str) -> Strin
 }
 
 fn add_scope_to_selector_end(selector: &str, scope_id: &str) -> String {
+    if let Some((prefix, boundary, suffix)) = split_before_trailing_universal_or_pseudo(selector) {
+        let mut output = add_scope_to_selector_end(prefix.trim_end(), scope_id);
+        output.push_str(boundary);
+        output.push_str(suffix.trim_start());
+        return output;
+    }
+
     let target_start = find_last_compound_start(selector);
     let before_target = &selector[..target_start];
     let target = &selector[target_start..];
@@ -708,23 +716,15 @@ mod tests {
     }
 
     #[test]
-    fn scopes_slotted_selector_with_slotted_scope_id() {
+    fn scopes_slotted_selectors_with_slotted_scope_id() {
         assert_eq!(
             scope_css_for_pipeline(":slotted(.foo) { color: red; }", "data-v-x").as_str(),
             ".foo[data-v-x-s]{color: red;}"
         );
-    }
-
-    #[test]
-    fn scopes_legacy_v_slotted_selector_with_slotted_scope_id() {
         assert_eq!(
             scope_css_for_pipeline("::v-slotted(.foo) { color: red; }", "data-v-x").as_str(),
             ".foo[data-v-x-s]{color: red;}"
         );
-    }
-
-    #[test]
-    fn scopes_slotted_selector_with_pseudo_suffix() {
         assert_eq!(
             scope_css_for_pipeline(":slotted(.foo):hover { color: red; }", "data-v-x").as_str(),
             ".foo[data-v-x-s]:hover{color: red;}"

--- a/crates/vize_atelier_sfc/tests/vite_css_scope.rs
+++ b/crates/vize_atelier_sfc/tests/vite_css_scope.rs
@@ -1,0 +1,13 @@
+use vize_atelier_sfc::vite_plugin::scope_css_for_pipeline;
+
+#[test]
+fn vite_pipeline_scopes_parent_before_trailing_universal_selectors() {
+    assert_eq!(
+        scope_css_for_pipeline(".dialog__action-buttons > * { flex: 1; }", "data-v-x").as_str(),
+        ".dialog__action-buttons[data-v-x] > *{flex: 1;}"
+    );
+    assert_eq!(
+        scope_css_for_pipeline(".dialog__action-buttons>*:hover { flex: 1; }", "data-v-x").as_str(),
+        ".dialog__action-buttons[data-v-x]>*:hover{flex: 1;}"
+    );
+}


### PR DESCRIPTION
Fixes #2680.

## Summary
- reuse the scoped CSS universal/pseudo boundary helper in the Vite CSS pipeline
- scope the parent compound before trailing universal selectors like `.dialog__action-buttons > *`
- add a Vite pipeline regression test for direct slotted-child selector coverage

## Tests
- cargo test -p vize_atelier_sfc vite_plugin::css_scope -- --nocapture
- cargo test -p vize_atelier_sfc --test vite_css_scope -- --nocapture
- cargo test -p vize_atelier_sfc --lib css::tests::scoped_regressions -- --nocapture
- node --test tests/tooling/source-file-lengths.test.ts
- cargo build --profile ci -p vize_atelier_sfc

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786027152&installation_id=136613492&pr_number=2685&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2685&signature=b303307f5c83e884d6996ab3ffd7a4a3e84a3429e1ad9c671823d71e0c7fe346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS selector scoping so rules with trailing universal selectors or pseudo-classes are handled more consistently.
  * Fixed selector placement for slotted content so scoped styles apply more reliably.

* **Tests**
  * Added coverage for scoped selector behavior, including trailing universal selectors and `:hover` cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->