### PR TITLE
feat(musea): migrate storyfn bind variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3406,6 +3406,7 @@ dependencies = [
  "oxc_parser",
  "oxc_semantic",
  "oxc_span",
+ "oxc_syntax",
  "oxc_transformer",
  "rayon",
  "serde",

--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -69,6 +69,7 @@ oxc_parser = { workspace = true }
 oxc_codegen = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
+oxc_syntax = { workspace = true }
 oxc_transformer = { workspace = true }
 
 # Home/config directory detection

--- a/crates/vize/src/commands/musea/migrate/csf.rs
+++ b/crates/vize/src/commands/musea/migrate/csf.rs
@@ -6,11 +6,15 @@
 //! as borrowed AST references so the JSX/template emitter can slice the original
 //! source by span.
 
+mod storyfn;
+
 use oxc_ast::ast::{
-    Declaration, ExportDefaultDeclarationKind, Expression, ImportDeclarationSpecifier,
-    ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement, VariableDeclarator,
+    ExportDefaultDeclarationKind, Expression, ImportDeclarationSpecifier, ObjectExpression,
+    ObjectPropertyKind, Program, PropertyKey, Statement, VariableDeclarator,
 };
 use vize_carton::String;
+
+use self::storyfn::collect_stories;
 
 /// A single CSF story (named export) ready for template emission.
 pub(super) struct CsfStory<'a> {
@@ -174,34 +178,6 @@ fn find_import_source(program: &Program<'_>, local: &str) -> Option<String> {
         }
     }
     None
-}
-
-/// Collect `export const NAME = {...}` stories in source order.
-fn collect_stories<'a>(program: &'a Program<'a>) -> Vec<CsfStory<'a>> {
-    let mut stories = Vec::new();
-
-    for stmt in &program.body {
-        let Statement::ExportNamedDeclaration(decl) = stmt else {
-            continue;
-        };
-        let Some(Declaration::VariableDeclaration(var)) = decl.declaration.as_ref() else {
-            continue;
-        };
-        for declarator in &var.declarations {
-            let Some(export_name) = binding_name(declarator) else {
-                continue;
-            };
-            let Some(init) = declarator.init.as_ref() else {
-                continue;
-            };
-            let story = unwrap_object(init)
-                .map(|object| story_from_object(export_name, object))
-                .unwrap_or_else(|| unsupported_story(export_name));
-            stories.push(story);
-        }
-    }
-
-    stories
 }
 
 /// Build a [`CsfStory`] from a story object literal.

--- a/crates/vize/src/commands/musea/migrate/csf/storyfn.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/storyfn.rs
@@ -1,0 +1,158 @@
+use oxc_ast::ast::{
+    AssignmentTarget, Declaration, Expression, ObjectExpression, Program, Statement,
+};
+use oxc_syntax::operator::AssignmentOperator;
+
+use super::{
+    CsfStory, binding_name, render_body, story_from_object, unsupported_story, unwrap_expression,
+    unwrap_object,
+};
+
+pub(super) fn collect_stories<'a>(program: &'a Program<'a>) -> Vec<CsfStory<'a>> {
+    let templates = collect_template_renders(program);
+    let story_args = collect_story_args(program);
+    let mut stories = Vec::new();
+
+    for stmt in &program.body {
+        let Statement::ExportNamedDeclaration(decl) = stmt else {
+            continue;
+        };
+        let Some(Declaration::VariableDeclaration(var)) = decl.declaration.as_ref() else {
+            continue;
+        };
+        for declarator in &var.declarations {
+            let Some(export_name) = binding_name(declarator) else {
+                continue;
+            };
+            let Some(init) = declarator.init.as_ref() else {
+                continue;
+            };
+            let assigned_args = find_object_by_name(&story_args, export_name);
+            let story = if let Some(object) = unwrap_object(init) {
+                let mut story = story_from_object(export_name, object);
+                if story.args.is_none() {
+                    story.args = assigned_args;
+                }
+                story
+            } else {
+                story_from_template_bind(export_name, init, &templates, assigned_args)
+                    .unwrap_or_else(|| unsupported_story(export_name))
+            };
+            stories.push(story);
+        }
+    }
+
+    stories
+}
+
+fn collect_template_renders<'a>(program: &'a Program<'a>) -> Vec<(&'a str, &'a Expression<'a>)> {
+    let mut templates = Vec::new();
+    for stmt in &program.body {
+        let Statement::VariableDeclaration(decl) = stmt else {
+            continue;
+        };
+        for declarator in &decl.declarations {
+            if let Some(name) = binding_name(declarator)
+                && let Some(render) = declarator.init.as_ref().and_then(render_body)
+            {
+                templates.push((name, render));
+            }
+        }
+    }
+    templates
+}
+
+fn collect_story_args<'a>(program: &'a Program<'a>) -> Vec<(&'a str, &'a ObjectExpression<'a>)> {
+    program
+        .body
+        .iter()
+        .filter_map(story_args_assignment)
+        .collect()
+}
+
+fn story_args_assignment<'a>(
+    stmt: &'a Statement<'a>,
+) -> Option<(&'a str, &'a ObjectExpression<'a>)> {
+    let Statement::ExpressionStatement(stmt) = stmt else {
+        return None;
+    };
+    let Expression::AssignmentExpression(assignment) = unwrap_expression(&stmt.expression) else {
+        return None;
+    };
+    if assignment.operator != AssignmentOperator::Assign {
+        return None;
+    }
+    let story_name = static_member_target_name(&assignment.left, "args")?;
+    let args = unwrap_object(&assignment.right)?;
+    Some((story_name, args))
+}
+
+fn story_from_template_bind<'a>(
+    export_name: &str,
+    init: &'a Expression<'a>,
+    templates: &[(&'a str, &'a Expression<'a>)],
+    args: Option<&'a ObjectExpression<'a>>,
+) -> Option<CsfStory<'a>> {
+    let template_name = template_bind_name(init)?;
+    let render = find_expression_by_name(templates, template_name);
+    Some(CsfStory {
+        name: export_name.into(),
+        render,
+        args,
+        unsupported: render.is_none(),
+    })
+}
+
+fn template_bind_name<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
+    let Expression::CallExpression(call) = unwrap_expression(expr) else {
+        return None;
+    };
+    let Expression::StaticMemberExpression(member) = &call.callee else {
+        return None;
+    };
+    if member.property.name != "bind" {
+        return None;
+    }
+    if let Expression::Identifier(ident) = unwrap_expression(&member.object) {
+        Some(ident.name.as_str())
+    } else {
+        None
+    }
+}
+
+fn static_member_target_name<'a>(
+    target: &'a AssignmentTarget<'a>,
+    property: &str,
+) -> Option<&'a str> {
+    let AssignmentTarget::StaticMemberExpression(member) = target else {
+        return None;
+    };
+    if member.property.name != property {
+        return None;
+    }
+    if let Expression::Identifier(ident) = unwrap_expression(&member.object) {
+        Some(ident.name.as_str())
+    } else {
+        None
+    }
+}
+
+fn find_expression_by_name<'a>(
+    items: &[(&'a str, &'a Expression<'a>)],
+    name: &str,
+) -> Option<&'a Expression<'a>> {
+    items
+        .iter()
+        .rev()
+        .find_map(|(item_name, value)| (*item_name == name).then_some(*value))
+}
+
+fn find_object_by_name<'a>(
+    items: &[(&'a str, &'a ObjectExpression<'a>)],
+    name: &str,
+) -> Option<&'a ObjectExpression<'a>> {
+    items
+        .iter()
+        .rev()
+        .find_map(|(item_name, value)| (*item_name == name).then_some(*value))
+}

--- a/crates/vize/src/commands/musea/migrate/csf/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/tests.rs
@@ -130,7 +130,7 @@ export const First = { name: "Custom Name", render: () => <Box /> };
 }
 
 #[test]
-fn extracts_template_bind_exports_as_unsupported_stories() {
+fn extracts_template_bind_exports_with_assigned_args() {
     let source = r#"import Toggle from "./Toggle.vue";
 export default { component: Toggle, title: "Toggle" } satisfies Meta<typeof Toggle>;
 const Template: StoryFn = (args) => <Toggle {...args} />;
@@ -156,9 +156,9 @@ Checked.args = { checked: true };
         stories,
         vec![TestStory {
             name: "Checked",
-            has_render: false,
-            has_args: false,
-            unsupported: true,
+            has_render: true,
+            has_args: true,
+            unsupported: false,
         }]
     );
 }

--- a/crates/vize/src/commands/musea/migrate/emit/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/tests.rs
@@ -76,7 +76,7 @@ export const Primary = {
 }
 
 #[test]
-fn emits_todo_for_template_bind_storyfn_exports() {
+fn emits_template_bind_storyfn_exports_with_assigned_args() {
     let source = r#"import AfButton from "./AfButton.vue";
 export default { component: AfButton, title: "Base/AfButton" } satisfies Meta<typeof AfButton>;
 const Template: StoryFn = (args) => <AfButton {...args} />;
@@ -86,9 +86,10 @@ Primary.args = { color: "primary" };
     let (content, variants, todos) = emit(source);
 
     assert!(content.contains(r#"<variant name="Primary" default>"#));
-    assert!(content.contains("TODO(vize musea migrate)"));
+    assert!(content.contains(r#"<AfButton color="primary" />"#));
+    assert!(!content.contains("TODO(vize musea migrate)"));
     assert_eq!(variants, 1);
-    assert_eq!(todos, 1);
+    assert_eq!(todos, 0);
 }
 
 #[test]

--- a/crates/vize/tests/musea_migrate_cli.rs
+++ b/crates/vize/tests/musea_migrate_cli.rs
@@ -133,7 +133,7 @@ export const Primary = { args: {} };
 }
 
 #[test]
-fn migrates_unsupported_tsx_storyfn_as_todo_variant() {
+fn migrates_tsx_storyfn_template_bind_variant() {
     let dir = tempfile::tempdir().unwrap();
     let story = dir.path().join("Toggle.stories.tsx");
     fs::write(
@@ -141,7 +141,7 @@ fn migrates_unsupported_tsx_storyfn_as_todo_variant() {
         r#"import type { Meta, StoryFn } from "@storybook/vue3";
 import Toggle from "./Toggle.vue";
 export default { component: Toggle, title: "Controls/Toggle" } satisfies Meta<typeof Toggle>;
-const Template: StoryFn = (args) => <Toggle {...args} />;
+const Template: StoryFn = (args) => <Toggle {...args}>Enabled</Toggle>;
 export const Checked = Template.bind({});
 Checked.args = { checked: true };
 "#,
@@ -157,7 +157,8 @@ Checked.args = { checked: true };
 
     let generated = fs::read_to_string(dir.path().join("Toggle.art.vue")).unwrap();
     assert!(generated.contains(r#"<variant name="Checked" default>"#));
-    assert!(generated.contains("TODO(vize musea migrate)"));
+    assert!(generated.contains(r#"<Toggle :checked="true">Enabled</Toggle>"#));
+    assert!(!generated.contains("TODO(vize musea migrate)"));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #2667.

## Summary
- resolve `export const Story = Template.bind({})` to the source StoryFn template render body
- collect `Story.args = { ... }` assignments and inline them through the existing `args` spread handling
- keep unsupported fallback behavior for bind calls whose template cannot be resolved

## Tests
- cargo test -p vize musea::migrate -- --nocapture
- cargo test -p vize --test musea_migrate_cli -- --nocapture
- node --test tests/tooling/source-file-lengths.test.ts
- cargo fmt --check
- cargo build --profile ci -p vize

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786027605&installation_id=136613492&pr_number=2686&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2686&signature=bc05e24097c8b36e5c2e2aaeae24b279904025d6dfb7fe3122d5d386ad7f89b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for migrating template-bound stories, including stories with assigned args, so more cases now convert cleanly.
  * Generated output now better preserves rendered variants from supported story patterns.

* **Bug Fixes**
  * Reduced false “unsupported” results for stories that use bound templates with args.
  * Removed unnecessary migration TODO markers for supported cases.

* **Tests**
  * Updated migration coverage to reflect the new supported story behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->