### PR TITLE
fix(release): bypass local hooks for release commits

### DIFF
--- a/tests/tooling/moonbit-release.test.ts
+++ b/tests/tooling/moonbit-release.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import { repoRoot, runMoonScript } from "./_helpers/moonbit.ts";
+import { moonScriptPath, repoRoot, runMoonScript } from "./_helpers/moonbit.ts";
 
 function writeTempFile(contents: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-release-test-"));
@@ -184,4 +184,17 @@ test("release script includes nested release packages in extra synced manifests"
       `${manifestPath} version must be bumped with release commits`,
     );
   }
+});
+
+test("release script bypasses local git hooks when committing", () => {
+  const script = fs.readFileSync(moonScriptPath("release"), "utf8");
+
+  assert.ok(
+    script.includes('["commit", "--allow-empty", "--no-verify", "-m", "chore: release \\{tag}"]'),
+    "force-tag release commits must bypass local hooks",
+  );
+  assert.ok(
+    script.includes('["commit", "--no-verify", "-m", "chore: release \\{tag}"]'),
+    "normal release commits must bypass local hooks",
+  );
 });

--- a/tools/moon/scripts/release.mbtx
+++ b/tools/moon/scripts/release.mbtx
@@ -888,9 +888,9 @@ async fn run_app() -> Int {
     return 1
   }
   let commit_args = if staged_output.text().trim() == "" && force_tag {
-    ["commit", "--allow-empty", "-m", "chore: release \{tag}"]
+    ["commit", "--allow-empty", "--no-verify", "-m", "chore: release \{tag}"]
   } else {
-    ["commit", "-m", "chore: release \{tag}"]
+    ["commit", "--no-verify", "-m", "chore: release \{tag}"]
   }
   if @process.run("git", commit_args) != 0 {
     @stdio.stderr.write("Failed to create the release commit\n")


### PR DESCRIPTION
## Summary

- add `--no-verify` to release-script commits
- cover the release commit arguments in the MoonBit release tooling test

## Validation

- `node --test tests/tooling/moonbit-release.test.ts`
- `node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786029741&installation_id=136613492&pr_number=2687&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2687&signature=5e0770b50c5274ba9c9c963b6869e2254729762d41481ef945855d7a14ea5208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release commits now consistently bypass local commit hooks.
  * Force-tag releases now create empty commits with the correct options, improving reliability when no files are staged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->