### PR TITLE
fix(musea): inline renamed render arg spreads

### DIFF
--- a/crates/vize/src/commands/musea/migrate/csf.rs
+++ b/crates/vize/src/commands/musea/migrate/csf.rs
@@ -6,6 +6,7 @@
 //! as borrowed AST references so the JSX/template emitter can slice the original
 //! source by span.
 
+mod render;
 mod storyfn;
 
 use oxc_ast::ast::{
@@ -14,14 +15,22 @@ use oxc_ast::ast::{
 };
 use vize_carton::String;
 
+use self::render::render_body;
 use self::storyfn::collect_stories;
+
+/// JSX render expression plus the story args binding name visible to it.
+#[derive(Clone, Copy)]
+pub(super) struct CsfRender<'a> {
+    pub expression: &'a Expression<'a>,
+    pub args_name: Option<&'a str>,
+}
 
 /// A single CSF story (named export) ready for template emission.
 pub(super) struct CsfStory<'a> {
     /// Variant name (the `name:` override if present, else the export name).
     pub name: String,
     /// `render` arrow/function body expression (a JSX element/fragment), if any.
-    pub render: Option<&'a Expression<'a>>,
+    pub render: Option<CsfRender<'a>>,
     /// `args` object literal, if present.
     pub args: Option<&'a ObjectExpression<'a>>,
     /// Story shape was recognized as CSF but cannot be migrated safely.
@@ -210,49 +219,6 @@ fn unsupported_story(export_name: &str) -> CsfStory<'_> {
         render: None,
         args: None,
         unsupported: true,
-    }
-}
-
-/// Reach the single JSX-returning expression of a `render` arrow/function.
-fn render_body<'a>(value: &'a Expression<'a>) -> Option<&'a Expression<'a>> {
-    match unwrap_expression(value) {
-        Expression::ArrowFunctionExpression(arrow) => {
-            let body = if arrow.expression {
-                first_expression_statement(&arrow.body.statements)
-            } else {
-                first_return_argument(&arrow.body.statements)
-            }?;
-            render_expression(body)
-        }
-        Expression::FunctionExpression(func) => render_expression(
-            func.body
-                .as_ref()
-                .and_then(|body| first_return_argument(&body.statements))?,
-        ),
-        _ => None,
-    }
-}
-
-fn render_expression<'a>(expr: &'a Expression<'a>) -> Option<&'a Expression<'a>> {
-    match unwrap_expression(expr) {
-        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => {
-            render_body(expr)
-        }
-        other => Some(other),
-    }
-}
-
-fn first_expression_statement<'a>(statements: &'a [Statement<'a>]) -> Option<&'a Expression<'a>> {
-    match statements.first()? {
-        Statement::ExpressionStatement(stmt) => Some(&stmt.expression),
-        _ => None,
-    }
-}
-
-fn first_return_argument<'a>(statements: &'a [Statement<'a>]) -> Option<&'a Expression<'a>> {
-    match statements.first()? {
-        Statement::ReturnStatement(stmt) => stmt.argument.as_ref(),
-        _ => None,
     }
 }
 

--- a/crates/vize/src/commands/musea/migrate/csf/render.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/render.rs
@@ -1,0 +1,73 @@
+use oxc_ast::ast::{BindingPattern, Expression, FormalParameters, Statement};
+
+use super::{CsfRender, unwrap_expression};
+
+/// Reach the single JSX-returning expression of a `render` arrow/function.
+pub(super) fn render_body<'a>(value: &'a Expression<'a>) -> Option<CsfRender<'a>> {
+    match unwrap_expression(value) {
+        Expression::ArrowFunctionExpression(arrow) => {
+            let args_name = first_param_name(&arrow.params);
+            let body = if arrow.expression {
+                first_expression_statement(&arrow.body.statements)
+            } else {
+                first_return_argument(&arrow.body.statements)
+            }?;
+            render_expression(body, args_name)
+        }
+        Expression::FunctionExpression(func) => {
+            let args_name = first_param_name(&func.params);
+            render_expression(
+                func.body
+                    .as_ref()
+                    .and_then(|body| first_return_argument(&body.statements))?,
+                args_name,
+            )
+        }
+        _ => None,
+    }
+}
+
+fn render_expression<'a>(
+    expr: &'a Expression<'a>,
+    args_name: Option<&'a str>,
+) -> Option<CsfRender<'a>> {
+    match unwrap_expression(expr) {
+        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => {
+            let mut render = render_body(expr)?;
+            if render.args_name.is_none() {
+                render.args_name = args_name;
+            }
+            Some(render)
+        }
+        other => Some(CsfRender {
+            expression: other,
+            args_name,
+        }),
+    }
+}
+
+fn first_param_name<'a>(params: &'a FormalParameters<'a>) -> Option<&'a str> {
+    let param = params.items.first()?;
+    binding_identifier_name(&param.pattern)
+}
+
+fn binding_identifier_name<'a>(pattern: &'a BindingPattern<'a>) -> Option<&'a str> {
+    match pattern {
+        BindingPattern::BindingIdentifier(identifier) => Some(identifier.name.as_str()),
+        _ => None,
+    }
+}
+
+fn first_expression_statement<'a>(statements: &'a [Statement<'a>]) -> Option<&'a Expression<'a>> {
+    match statements.first()? {
+        Statement::ExpressionStatement(stmt) => Some(&stmt.expression),
+        _ => None,
+    }
+}
+
+fn first_return_argument<'a>(statements: &'a [Statement<'a>]) -> Option<&'a Expression<'a>> {
+    match statements.first()? {
+        Statement::ReturnStatement(stmt) => stmt.argument.as_ref(),
+        _ => None,
+    }
+}

--- a/crates/vize/src/commands/musea/migrate/csf/storyfn.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/storyfn.rs
@@ -4,8 +4,8 @@ use oxc_ast::ast::{
 use oxc_syntax::operator::AssignmentOperator;
 
 use super::{
-    CsfStory, binding_name, render_body, story_from_object, unsupported_story, unwrap_expression,
-    unwrap_object,
+    CsfRender, CsfStory, binding_name, render_body, story_from_object, unsupported_story,
+    unwrap_expression, unwrap_object,
 };
 
 pub(super) fn collect_stories<'a>(program: &'a Program<'a>) -> Vec<CsfStory<'a>> {
@@ -45,7 +45,7 @@ pub(super) fn collect_stories<'a>(program: &'a Program<'a>) -> Vec<CsfStory<'a>>
     stories
 }
 
-fn collect_template_renders<'a>(program: &'a Program<'a>) -> Vec<(&'a str, &'a Expression<'a>)> {
+fn collect_template_renders<'a>(program: &'a Program<'a>) -> Vec<(&'a str, CsfRender<'a>)> {
     let mut templates = Vec::new();
     for stmt in &program.body {
         let Statement::VariableDeclaration(decl) = stmt else {
@@ -90,7 +90,7 @@ fn story_args_assignment<'a>(
 fn story_from_template_bind<'a>(
     export_name: &str,
     init: &'a Expression<'a>,
-    templates: &[(&'a str, &'a Expression<'a>)],
+    templates: &[(&'a str, CsfRender<'a>)],
     args: Option<&'a ObjectExpression<'a>>,
 ) -> Option<CsfStory<'a>> {
     let template_name = template_bind_name(init)?;
@@ -138,9 +138,9 @@ fn static_member_target_name<'a>(
 }
 
 fn find_expression_by_name<'a>(
-    items: &[(&'a str, &'a Expression<'a>)],
+    items: &[(&'a str, CsfRender<'a>)],
     name: &str,
-) -> Option<&'a Expression<'a>> {
+) -> Option<CsfRender<'a>> {
     items
         .iter()
         .rev()

--- a/crates/vize/src/commands/musea/migrate/emit.rs
+++ b/crates/vize/src/commands/musea/migrate/emit.rs
@@ -96,10 +96,16 @@ fn emit_variant_inner(
     }
 
     if let Some(render) = story.render {
-        let Some(markup) = convert_render(render, source) else {
+        let Some(markup) = convert_render(render.expression, source, render.args_name) else {
             return (emit_todo_element(component_tag), true);
         };
-        return match inline_story_args_spread(markup, meta_args, story.args, source) {
+        return match inline_story_args_spread(
+            markup,
+            render.args_name,
+            meta_args,
+            story.args,
+            source,
+        ) {
             Some(markup) => (markup, false),
             None => (emit_todo_element(component_tag), true),
         };
@@ -180,11 +186,20 @@ fn emit_args_object_attributes(
 
 fn inline_story_args_spread(
     markup: String,
+    render_args_name: Option<&str>,
     meta_args: Option<&ObjectExpression<'_>>,
     story_args: Option<&ObjectExpression<'_>>,
     source: &str,
 ) -> Option<String> {
-    let marker = " v-bind=\"args\"";
+    let marker = render_args_name.map(|name| {
+        let mut marker = String::from(" v-bind=\"");
+        marker.push_str(name);
+        marker.push('"');
+        marker
+    });
+    let Some(marker) = marker.as_deref() else {
+        return Some(markup);
+    };
     if !markup.contains(marker) {
         return Some(markup);
     }

--- a/crates/vize/src/commands/musea/migrate/emit/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/tests.rs
@@ -1,11 +1,12 @@
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
+use vize_carton::String;
 
 use super::super::csf::extract_csf;
 use super::emit_art;
 
-fn emit(source: &str) -> (std::string::String, usize, usize) {
+fn emit(source: &str) -> (String, usize, usize) {
     let allocator = Allocator::default();
     let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
     assert!(!parsed.panicked, "fixture should parse");
@@ -15,11 +16,7 @@ fn emit(source: &str) -> (std::string::String, usize, usize) {
         .clone()
         .unwrap_or_else(|| "./Component.vue".into());
     let result = emit_art(&module, "AfButton", component_path.as_str(), source);
-    (
-        result.content.as_str().to_owned(),
-        result.variants,
-        result.todos,
-    )
+    (result.content, result.variants, result.todos)
 }
 
 #[test]
@@ -213,6 +210,22 @@ export const Primary = {
     let (content, _variants, todos) = emit(source);
 
     assert!(content.contains(r#"<AfButton :disabled="true" color="secondary">Primary</AfButton>"#));
+    assert_eq!(todos, 0);
+}
+
+#[test]
+fn emits_story_args_inside_renamed_render_param_spread() {
+    let source = r#"import AfButton from "./AfButton.vue";
+export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;
+export const Primary = {
+  args: { color: "primary", disabled: true },
+  render: props => <AfButton {...props}>Primary</AfButton>,
+};
+"#;
+    let (content, _variants, todos) = emit(source);
+
+    assert!(content.contains(r#"<AfButton color="primary" :disabled="true">Primary</AfButton>"#));
+    assert!(!content.contains("v-bind=\"props\""));
     assert_eq!(todos, 0);
 }
 

--- a/crates/vize/src/commands/musea/migrate/jsx.rs
+++ b/crates/vize/src/commands/musea/migrate/jsx.rs
@@ -15,29 +15,41 @@ use vize_carton::{String, append};
 /// Convert a JSX expression (element or fragment) to Vue template markup.
 ///
 /// `source` is the full original file text; spans index into it.
-pub(super) fn convert_render(expr: &Expression<'_>, source: &str) -> Option<String> {
+pub(super) fn convert_render(
+    expr: &Expression<'_>,
+    source: &str,
+    render_args_name: Option<&str>,
+) -> Option<String> {
     match expr {
-        Expression::JSXElement(element) => convert_element(element, source),
-        Expression::JSXFragment(fragment) => convert_fragment(fragment, source),
+        Expression::JSXElement(element) => convert_element(element, source, render_args_name),
+        Expression::JSXFragment(fragment) => convert_fragment(fragment, source, render_args_name),
         _ => None,
     }
 }
 
 /// A fragment `<>...</>` emits only its children (no wrapper element).
-fn convert_fragment(fragment: &JSXFragment<'_>, source: &str) -> Option<String> {
-    convert_children(&fragment.children, source)
+fn convert_fragment(
+    fragment: &JSXFragment<'_>,
+    source: &str,
+    render_args_name: Option<&str>,
+) -> Option<String> {
+    convert_children(&fragment.children, source, render_args_name)
 }
 
-fn convert_element(element: &JSXElement<'_>, source: &str) -> Option<String> {
+fn convert_element(
+    element: &JSXElement<'_>,
+    source: &str,
+    render_args_name: Option<&str>,
+) -> Option<String> {
     let tag = element_name(&element.opening_element.name)?;
 
     let mut attributes = String::default();
     for item in &element.opening_element.attributes {
         attributes.push(' ');
-        attributes.push_str(&convert_attribute(item, source)?);
+        attributes.push_str(&convert_attribute(item, source, render_args_name)?);
     }
 
-    let children = convert_children(&element.children, source)?;
+    let children = convert_children(&element.children, source, render_args_name)?;
 
     let mut out = String::default();
     if children.is_empty() {
@@ -48,7 +60,11 @@ fn convert_element(element: &JSXElement<'_>, source: &str) -> Option<String> {
     Some(out)
 }
 
-fn convert_children(children: &[JSXChild<'_>], source: &str) -> Option<String> {
+fn convert_children(
+    children: &[JSXChild<'_>],
+    source: &str,
+    render_args_name: Option<&str>,
+) -> Option<String> {
     let mut out = String::default();
     for child in children {
         match child {
@@ -58,8 +74,12 @@ fn convert_children(children: &[JSXChild<'_>], source: &str) -> Option<String> {
                     out.push_str(trimmed);
                 }
             }
-            JSXChild::Element(element) => out.push_str(&convert_element(element, source)?),
-            JSXChild::Fragment(fragment) => out.push_str(&convert_fragment(fragment, source)?),
+            JSXChild::Element(element) => {
+                out.push_str(&convert_element(element, source, render_args_name)?);
+            }
+            JSXChild::Fragment(fragment) => {
+                out.push_str(&convert_fragment(fragment, source, render_args_name)?);
+            }
             JSXChild::ExpressionContainer(container) => match &container.expression {
                 JSXExpression::EmptyExpression(_) => {}
                 expression => {
@@ -67,7 +87,7 @@ fn convert_children(children: &[JSXChild<'_>], source: &str) -> Option<String> {
                         return None;
                     }
                     let text = jsx_expression_source(expression, source)?;
-                    if references_render_args(text.as_str()) {
+                    if references_render_args(text.as_str(), render_args_name) {
                         return None;
                     }
                     append!(out, "{{{{ {text} }}}}");
@@ -80,7 +100,11 @@ fn convert_children(children: &[JSXChild<'_>], source: &str) -> Option<String> {
     Some(out)
 }
 
-fn convert_attribute(item: &JSXAttributeItem<'_>, source: &str) -> Option<String> {
+fn convert_attribute(
+    item: &JSXAttributeItem<'_>,
+    source: &str,
+    render_args_name: Option<&str>,
+) -> Option<String> {
     match item {
         JSXAttributeItem::Attribute(attribute) => {
             let name = attribute_name(&attribute.name)?;
@@ -96,7 +120,7 @@ fn convert_attribute(item: &JSXAttributeItem<'_>, source: &str) -> Option<String
                         JSXExpression::EmptyExpression(_) => None,
                         expression => {
                             let text = jsx_expression_source(expression, source)?;
-                            if references_render_args(text.as_str())
+                            if references_render_args(text.as_str(), render_args_name)
                                 || attribute_expression_requires_binding(expression)
                             {
                                 return None;
@@ -113,6 +137,9 @@ fn convert_attribute(item: &JSXAttributeItem<'_>, source: &str) -> Option<String
         }
         JSXAttributeItem::SpreadAttribute(spread) => {
             let text = expression_source(&spread.argument, source)?;
+            if !is_render_args_spread(text.as_str(), render_args_name) {
+                return None;
+            }
             let mut out = String::default();
             append!(out, "v-bind=\"{}\"", escape_attr(text.as_str()));
             Some(out)
@@ -235,12 +262,22 @@ fn attribute_value_requires_binding(expression: &Expression<'_>) -> bool {
     }
 }
 
-fn references_render_args(text: &str) -> bool {
+fn references_render_args(text: &str, render_args_name: Option<&str>) -> bool {
+    let Some(args_name) = render_args_name else {
+        return false;
+    };
     let text = text.trim();
-    text == "args"
-        || text.starts_with("args.")
-        || text.starts_with("args?.")
-        || text.starts_with("args[")
+    text == args_name
+        || text.strip_prefix(args_name).is_some_and(|rest| {
+            rest.starts_with('.') || rest.starts_with("?.") || rest.starts_with('[')
+        })
+}
+
+fn is_render_args_spread(text: &str, render_args_name: Option<&str>) -> bool {
+    let Some(args_name) = render_args_name else {
+        return false;
+    };
+    text.trim() == args_name
 }
 
 /// Source text of a `JSXExpression` (the expression inside `{...}`).

--- a/crates/vize/src/commands/musea/migrate/jsx/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/jsx/tests.rs
@@ -8,7 +8,11 @@ use super::convert_render;
 
 /// Wrap a JSX expression in `const x = (<JSX>);` and convert it to template.
 fn convert(jsx: &str) -> Option<String> {
-    let mut source = std::string::String::from("const x = (");
+    convert_with_args(jsx, Some("args"))
+}
+
+fn convert_with_args(jsx: &str, render_args_name: Option<&str>) -> Option<String> {
+    let mut source = String::from("const x = (");
     source.push_str(jsx);
     source.push_str(");\n");
 
@@ -27,7 +31,7 @@ fn convert(jsx: &str) -> Option<String> {
         Expression::ParenthesizedExpression(inner) => &inner.expression,
         other => other,
     };
-    convert_render(expr, &source)
+    convert_render(expr, &source, render_args_name)
 }
 
 #[test]
@@ -54,9 +58,18 @@ fn converts_expression_attr_and_bare_attr() {
 #[test]
 fn converts_spread_attr_to_v_bind() {
     assert_eq!(
-        convert("<AfButton {...props} />").as_deref(),
+        convert("<AfButton {...args} />").as_deref(),
+        Some(r#"<AfButton v-bind="args" />"#)
+    );
+    assert_eq!(
+        convert_with_args("<AfButton {...props} />", Some("props")).as_deref(),
         Some(r#"<AfButton v-bind="props" />"#)
     );
+}
+
+#[test]
+fn rejects_non_render_args_spread_attr() {
+    assert_eq!(convert("<AfButton {...props} />").as_deref(), None);
 }
 
 #[test]
@@ -101,6 +114,10 @@ fn rejects_identifier_attribute_without_script_binding() {
 #[test]
 fn rejects_render_args_member_attribute() {
     assert_eq!(convert("<AfButton value={args.value} />").as_deref(), None);
+    assert_eq!(
+        convert_with_args("<AfButton value={props.value} />", Some("props")).as_deref(),
+        None
+    );
 }
 
 #[test]

--- a/crates/vize/tests/musea_migrate_cli.rs
+++ b/crates/vize/tests/musea_migrate_cli.rs
@@ -162,6 +162,38 @@ Checked.args = { checked: true };
 }
 
 #[test]
+fn migrates_render_spread_with_renamed_args_param() {
+    let dir = tempfile::tempdir().unwrap();
+    let story = dir.path().join("AfButton.stories.tsx");
+    fs::write(
+        &story,
+        r#"import type { Meta, StoryObj } from "@storybook/vue3";
+import AfButton from "./AfButton.vue";
+const meta = { component: AfButton, title: "Base/AfButton" } satisfies Meta<typeof AfButton>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const Primary: Story = {
+  args: { color: "primary", disabled: true },
+  render: props => <AfButton {...props}>Primary</AfButton>,
+};
+"#,
+    )
+    .unwrap();
+
+    let output = run_migrate(dir.path(), &["AfButton.stories.tsx"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        std::string::String::from_utf8_lossy(&output.stderr)
+    );
+
+    let generated = fs::read_to_string(dir.path().join("AfButton.art.vue")).unwrap();
+    assert!(generated.contains(r#"<AfButton color="primary" :disabled="true">Primary</AfButton>"#));
+    assert!(!generated.contains("v-bind=\"props\""));
+    assert!(!generated.contains("TODO(vize musea migrate)"));
+}
+
+#[test]
 fn migrates_unsupported_render_output_as_todo_variants() {
     let dir = tempfile::tempdir().unwrap();
     let story = dir.path().join("AfsForm.stories.tsx");


### PR DESCRIPTION
## Summary

- track the actual first render parameter name while extracting CSF render functions
- inline Storybook args when render uses names like `props` instead of only `args`
- reject non-render-arg JSX spreads so migration keeps falling back instead of emitting missing bindings

## Validation

- `cargo fmt --check`
- `cargo test -p vize musea::migrate -- --nocapture`
- `cargo test -p vize --test musea_migrate_cli -- --nocapture`
- `node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786032683&installation_id=136613492&pr_number=2688&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2688&signature=6ee9b5392aa4836d7f06baee8bcb93d37e05af652dfb84667cd96a7dc4749720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved story migration to correctly detect CSF `render` argument names and generate Vue templates with explicit prop bindings.
  * JSX-to-Vue conversion now supports configurable render-argument identifiers and better handling of nested JSX children.
* **Bug Fixes**
  * Fixed output where renamed render parameter spreads could fall back to generic `v-bind` bindings instead of expanding to concrete props.
* **Tests**
  * Added integration and conversion tests to verify renamed render params and render spreads are migrated correctly without placeholder TODOs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->