### PR TITLE
fix(canon): detect Nuxt buildModules fallbacks

### DIFF
--- a/crates/vize/src/commands/check/nuxt/fallback.rs
+++ b/crates/vize/src/commands/check/nuxt/fallback.rs
@@ -197,7 +197,7 @@ impl NuxtConfigModules {
     }
 }
 
-/// Parses `nuxt.config` source and extracts the `modules` array from the
+/// Parses `nuxt.config` source and extracts module arrays from the
 /// default-exported config object, handling both
 /// `export default defineNuxtConfig({ ... })` and `export default { ... }`.
 pub(super) fn parse_nuxt_config_modules(config_source: &str) -> NuxtConfigModules {
@@ -214,17 +214,31 @@ pub(super) fn parse_nuxt_config_modules(config_source: &str) -> NuxtConfigModule
         return NuxtConfigModules::unresolved();
     };
 
-    let Some(modules_value) = find_object_property(config_object, "modules") else {
-        // A statically-visible config without a `modules` key registers no
+    let mut resolved = NuxtConfigModules::default();
+    let mut found_module_list = false;
+    for key in ["modules", "buildModules"] {
+        let Some(modules_value) = find_object_property(config_object, key) else {
+            continue;
+        };
+        found_module_list = true;
+        collect_nuxt_config_module_list(modules_value, &mut resolved);
+    }
+
+    if !found_module_list {
+        // A statically-visible config without module list keys registers no
         // modules, so nothing needs stubbing.
         return NuxtConfigModules::default();
+    }
+
+    resolved
+}
+
+fn collect_nuxt_config_module_list(value: &Expression<'_>, resolved: &mut NuxtConfigModules) {
+    let Some(Expression::ArrayExpression(modules)) = extract_expression(value) else {
+        resolved.has_unresolved_entries = true;
+        return;
     };
 
-    let Some(Expression::ArrayExpression(modules)) = extract_expression(modules_value) else {
-        return NuxtConfigModules::unresolved();
-    };
-
-    let mut resolved = NuxtConfigModules::default();
     for element in &modules.elements {
         match element {
             ArrayExpressionElement::Elision(_) => {}
@@ -251,7 +265,6 @@ pub(super) fn parse_nuxt_config_modules(config_source: &str) -> NuxtConfigModule
             },
         }
     }
-    resolved
 }
 
 #[cfg(test)]

--- a/crates/vize/src/commands/check/nuxt/tests.rs
+++ b/crates/vize/src/commands/check/nuxt/tests.rs
@@ -9,12 +9,13 @@ use vize_carton::cstr;
 
 use super::super::dts::rewrite_relative_specifier;
 use super::detect_nuxt_auto_imports;
-use super::fallback::{fallback_stub_strings, parse_nuxt_config_modules};
+use super::fallback::fallback_stub_strings;
 use super::parsing::{parse_export_names, parse_module_specifier};
 use super::plugins::extract_plugin_provide_keys_from_source;
 use super::stubs::declared_name;
 
 mod build_dir;
+mod config_modules;
 
 #[test]
 fn parses_module_export_lines() {
@@ -555,75 +556,6 @@ export default defineNuxtConfig({
     );
 
     let _ = std::fs::remove_dir_all(&project_root);
-}
-
-#[test]
-fn nuxt_config_modules_ignores_comments_and_unrelated_strings() {
-    let modules = parse_nuxt_config_modules(
-        r#"
-export default defineNuxtConfig({
-  // modules: ['@nuxtjs/i18n'],
-  /* '@vueuse/nuxt' would be nice */
-  modules: [
-    // '@nuxtjs/color-mode',
-    '@nuxtjs/i18n',
-  ],
-  runtimeConfig: { public: { hint: "enable nuxt-og-image later" } },
-})
-"#,
-    );
-
-    assert!(modules.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]));
-    assert!(!modules.might_include(&["@vueuse/nuxt"]));
-    assert!(!modules.might_include(&["@nuxtjs/color-mode"]));
-    assert!(!modules.might_include(&["nuxt-og-image"]));
-}
-
-#[test]
-fn nuxt_config_modules_parses_tuple_entries_and_plain_object_export() {
-    let modules = parse_nuxt_config_modules(
-        r#"
-export default {
-  modules: [
-    ['@nuxtjs/i18n', { locales: ['en'] }],
-    'nuxt-og-image',
-  ],
-}
-"#,
-    );
-
-    assert!(modules.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]));
-    assert!(modules.might_include(&["nuxt-og-image"]));
-    assert!(!modules.might_include(&["@vueuse/nuxt"]));
-
-    let empty = parse_nuxt_config_modules("export default defineNuxtConfig({})");
-    assert!(!empty.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]));
-}
-
-#[test]
-fn nuxt_config_modules_falls_back_conservatively_for_dynamic_entries() {
-    // A spread may contribute any module name, so unmatched candidates stay
-    // conservatively "maybe present" while static entries still resolve.
-    let spread = parse_nuxt_config_modules(
-        r#"
-const extras = ['@vueuse/nuxt']
-export default defineNuxtConfig({
-  modules: ['@nuxtjs/color-mode', ...extras],
-})
-"#,
-    );
-    assert!(spread.might_include(&["@nuxtjs/color-mode"]));
-    assert!(spread.might_include(&["@vueuse/nuxt"]));
-    assert!(spread.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]));
-
-    // Computed entries and opaque default exports are equally unresolved.
-    let computed =
-        parse_nuxt_config_modules("export default { modules: [resolveModule('nuxt-og-image')] }");
-    assert!(computed.might_include(&["nuxt-og-image"]));
-    assert!(computed.might_include(&["@vueuse/nuxt"]));
-
-    let opaque = parse_nuxt_config_modules("export default buildConfig()");
-    assert!(opaque.might_include(&["nuxt-og-image"]));
 }
 
 #[test]

--- a/crates/vize/src/commands/check/nuxt/tests/config_modules.rs
+++ b/crates/vize/src/commands/check/nuxt/tests/config_modules.rs
@@ -1,0 +1,124 @@
+use vize_canon::virtual_ts::VirtualTsOptions;
+
+use super::super::detect_nuxt_auto_imports;
+use super::super::fallback::parse_nuxt_config_modules;
+use super::unique_case_dir;
+
+#[test]
+fn ignores_comments_and_unrelated_strings() {
+    let modules = parse_nuxt_config_modules(
+        r#"
+export default defineNuxtConfig({
+  // modules: ['@nuxtjs/i18n'],
+  /* '@vueuse/nuxt' would be nice */
+  modules: [
+    // '@nuxtjs/color-mode',
+    '@nuxtjs/i18n',
+  ],
+  runtimeConfig: { public: { hint: "enable nuxt-og-image later" } },
+})
+"#,
+    );
+
+    assert!(modules.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]));
+    assert!(!modules.might_include(&["@vueuse/nuxt"]));
+    assert!(!modules.might_include(&["@nuxtjs/color-mode"]));
+    assert!(!modules.might_include(&["nuxt-og-image"]));
+}
+
+#[test]
+fn parses_tuple_entries_and_plain_object_export() {
+    let modules = parse_nuxt_config_modules(
+        r#"
+export default {
+  modules: [
+    ['@nuxtjs/i18n', { locales: ['en'] }],
+    'nuxt-og-image',
+  ],
+}
+"#,
+    );
+
+    assert!(modules.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]));
+    assert!(modules.might_include(&["nuxt-og-image"]));
+    assert!(!modules.might_include(&["@vueuse/nuxt"]));
+
+    let empty = parse_nuxt_config_modules("export default defineNuxtConfig({})");
+    assert!(!empty.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]));
+}
+
+#[test]
+fn parses_build_modules() {
+    let modules = parse_nuxt_config_modules(
+        r#"
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n'],
+  buildModules: [
+    '@vueuse/nuxt',
+    ['@nuxtjs/color-mode', { preference: 'dark' }],
+  ],
+})
+"#,
+    );
+
+    assert!(modules.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]));
+    assert!(modules.might_include(&["@vueuse/nuxt"]));
+    assert!(modules.might_include(&["@nuxtjs/color-mode"]));
+    assert!(!modules.might_include(&["nuxt-og-image"]));
+}
+
+#[test]
+fn detects_module_fallbacks_from_build_modules() {
+    let project_root = unique_case_dir("nuxt-build-module-fallbacks");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    std::fs::write(
+        project_root.join("nuxt.config.ts"),
+        r#"
+export default defineNuxtConfig({
+  buildModules: ['@vueuse/nuxt'],
+})
+"#,
+    )
+    .unwrap();
+
+    let mut options = VirtualTsOptions::default();
+    let _ = detect_nuxt_auto_imports(&mut options, &project_root);
+
+    assert!(
+        options
+            .auto_import_stubs
+            .iter()
+            .any(|stub| stub.starts_with("declare function useClipboard<T = any")),
+        "expected @vueuse/nuxt buildModule fallback stub, got: {:#?}",
+        options.auto_import_stubs
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn falls_back_conservatively_for_dynamic_entries() {
+    // A spread may contribute any module name, so unmatched candidates stay
+    // conservatively "maybe present" while static entries still resolve.
+    let spread = parse_nuxt_config_modules(
+        r#"
+const extras = ['@vueuse/nuxt']
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/color-mode', ...extras],
+})
+"#,
+    );
+    assert!(spread.might_include(&["@nuxtjs/color-mode"]));
+    assert!(spread.might_include(&["@vueuse/nuxt"]));
+    assert!(spread.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]));
+
+    // Computed entries and opaque default exports are equally unresolved.
+    let computed =
+        parse_nuxt_config_modules("export default { modules: [resolveModule('nuxt-og-image')] }");
+    assert!(computed.might_include(&["nuxt-og-image"]));
+    assert!(computed.might_include(&["@vueuse/nuxt"]));
+
+    let opaque = parse_nuxt_config_modules("export default buildConfig()");
+    assert!(opaque.might_include(&["nuxt-og-image"]));
+}


### PR DESCRIPTION
## Summary
- parse Nuxt `buildModules` alongside `modules` for module-driven fallback stubs
- move Nuxt config module parser tests into a smaller focused test module
- add behavior coverage for `buildModules: ["@vueuse/nuxt"]` fallback stubs

## Tests
- cargo fmt --check
- cargo test -p vize commands::check::nuxt -- --nocapture
- cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786034143&installation_id=136613492&pr_number=2689&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2689&signature=1d1cc0ce3869bc4adeb0ea011d14e208bbd9aa1b5f85ed711383c5726db53a25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Nuxt module detection to recognize modules declared in both `modules` and `buildModules`.
  * Added more conservative handling when configuration cannot be fully resolved, reducing false positives.
  * Better support for dynamic or partially visible config entries while still extracting safely detectable module names.

* **Tests**
  * Expanded coverage for Nuxt config parsing and fallback detection, including comments, tuple-style entries, plain objects, and dynamic cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->