### PR TITLE
fix(canon): parse Nuxt template tuple modules

### DIFF
--- a/crates/vize/src/commands/check/nuxt/fallback.rs
+++ b/crates/vize/src/commands/check/nuxt/fallback.rs
@@ -244,11 +244,7 @@ fn collect_nuxt_config_module_list(value: &Expression<'_>, resolved: &mut NuxtCo
             ArrayExpressionElement::Elision(_) => {}
             ArrayExpressionElement::SpreadElement(_) => resolved.has_unresolved_entries = true,
             _ => match element.as_expression().and_then(extract_expression) {
-                Some(Expression::StringLiteral(literal)) => resolved.insert(&literal.value),
-                Some(Expression::TemplateLiteral(template)) => match template.single_quasi() {
-                    Some(name) => resolved.insert(&name),
-                    None => resolved.has_unresolved_entries = true,
-                },
+                Some(expression) if static_module_name(expression, resolved) => {}
                 // `['module-name', { ...options }]` tuple form.
                 Some(Expression::ArrayExpression(tuple)) => {
                     match tuple
@@ -257,13 +253,30 @@ fn collect_nuxt_config_module_list(value: &Expression<'_>, resolved: &mut NuxtCo
                         .and_then(ArrayExpressionElement::as_expression)
                         .and_then(extract_expression)
                     {
-                        Some(Expression::StringLiteral(literal)) => resolved.insert(&literal.value),
+                        Some(expression) if static_module_name(expression, resolved) => {}
                         _ => resolved.has_unresolved_entries = true,
                     }
                 }
                 _ => resolved.has_unresolved_entries = true,
             },
         }
+    }
+}
+
+fn static_module_name(expression: &Expression<'_>, resolved: &mut NuxtConfigModules) -> bool {
+    match expression {
+        Expression::StringLiteral(literal) => {
+            resolved.insert(&literal.value);
+            true
+        }
+        Expression::TemplateLiteral(template) => match template.single_quasi() {
+            Some(name) => {
+                resolved.insert(&name);
+                true
+            }
+            None => false,
+        },
+        _ => false,
     }
 }
 

--- a/crates/vize/src/commands/check/nuxt/tests/config_modules.rs
+++ b/crates/vize/src/commands/check/nuxt/tests/config_modules.rs
@@ -33,6 +33,7 @@ fn parses_tuple_entries_and_plain_object_export() {
 export default {
   modules: [
     ['@nuxtjs/i18n', { locales: ['en'] }],
+    [`@vueuse/nuxt`, { ssrHandlers: true }],
     'nuxt-og-image',
   ],
 }
@@ -40,8 +41,9 @@ export default {
     );
 
     assert!(modules.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]));
+    assert!(modules.might_include(&["@vueuse/nuxt"]));
     assert!(modules.might_include(&["nuxt-og-image"]));
-    assert!(!modules.might_include(&["@vueuse/nuxt"]));
+    assert!(!modules.might_include(&["@nuxtjs/color-mode"]));
 
     let empty = parse_nuxt_config_modules("export default defineNuxtConfig({})");
     assert!(!empty.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]));


### PR DESCRIPTION
## Summary
- parse static template literals as Nuxt module names inside tuple module entries
- reuse the same static module-name extraction for plain and tuple module entries
- add regression coverage for a plain object config using a template-literal tuple head

## Root cause
The Nuxt config module parser already accepted no-substitution template literals for plain module entries, but tuple entries only recognized string literals as the module name. A config such as [`@vueuse/nuxt`, options] was treated as unresolved instead of being parsed as a static module.

## Validation
- cargo fmt --check
- cargo test -p vize parses_tuple_entries_and_plain_object_export -- --nocapture
- cargo test -p vize commands::check::nuxt -- --nocapture
- cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786035840&installation_id=136613492&pr_number=2691&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2691&signature=8b3ddf8c45cfb610a1c6826539e552b30a1ece9dd9fb954b11708f715d43270a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Nuxt config module detection so tuple-style entries are recognized more reliably, including cases with additional options.
  * Better handles static module names in config arrays, reducing missed module entries during checks.

* **Tests**
  * Updated coverage to reflect the new tuple-entry behavior and expected module detection results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->