### PR TITLE
fix(canon): detect Nuxt mjs config fallbacks

### DIFF
--- a/crates/vize/src/commands/check/nuxt.rs
+++ b/crates/vize/src/commands/check/nuxt.rs
@@ -63,7 +63,7 @@ pub(in crate::commands::check) fn detect(
     legacy_vue2: bool,
     dialect: VueVersion,
 ) -> Vec<NuxtPathAlias> {
-    if !is_nuxt_project(cwd) {
+    if !is_nuxt_project_root(cwd) {
         return Vec::new();
     }
 
@@ -133,10 +133,11 @@ pub(in crate::commands::check) fn detect(
     path_aliases
 }
 
-fn is_nuxt_project(cwd: &Path) -> bool {
+pub(in crate::commands::check) fn is_nuxt_project_root(cwd: &Path) -> bool {
     cwd.join("nuxt.config.ts").exists()
         || cwd.join("nuxt.config.js").exists()
         || cwd.join("nuxt.config.mts").exists()
+        || cwd.join("nuxt.config.mjs").exists()
 }
 
 /// Warning shown once per `vize check` run for a Nuxt project that has no

--- a/crates/vize/src/commands/check/nuxt/parsing.rs
+++ b/crates/vize/src/commands/check/nuxt/parsing.rs
@@ -206,7 +206,12 @@ pub(super) fn default_export_config_object<'a>(
 }
 
 pub(super) fn nuxt_config_source(cwd: &Path) -> String {
-    for file_name in ["nuxt.config.ts", "nuxt.config.js", "nuxt.config.mts"] {
+    for file_name in [
+        "nuxt.config.ts",
+        "nuxt.config.js",
+        "nuxt.config.mts",
+        "nuxt.config.mjs",
+    ] {
         let path = cwd.join(file_name);
         if let Ok(source) = tracked_read_to_string(path.as_path()) {
             return source.into();

--- a/crates/vize/src/commands/check/nuxt/tests/config_modules.rs
+++ b/crates/vize/src/commands/check/nuxt/tests/config_modules.rs
@@ -100,6 +100,36 @@ export default defineNuxtConfig({
 }
 
 #[test]
+fn detects_module_fallbacks_from_mjs_nuxt_config() {
+    let project_root = unique_case_dir("nuxt-mjs-module-fallbacks");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    std::fs::write(
+        project_root.join("nuxt.config.mjs"),
+        r#"
+export default defineNuxtConfig({
+  modules: ['@vueuse/nuxt'],
+})
+"#,
+    )
+    .unwrap();
+
+    let mut options = VirtualTsOptions::default();
+    let _ = detect_nuxt_auto_imports(&mut options, &project_root);
+
+    assert!(
+        options
+            .auto_import_stubs
+            .iter()
+            .any(|stub| stub.starts_with("declare function useClipboard<T = any")),
+        "expected @vueuse/nuxt fallback stub from nuxt.config.mjs, got: {:#?}",
+        options.auto_import_stubs
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn falls_back_conservatively_for_dynamic_entries() {
     // A spread may contribute any module name, so unmatched candidates stay
     // conservatively "maybe present" while static entries still resolve.

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -701,22 +701,16 @@ fn resolve_nuxt_project_root(
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(|| fallback.to_path_buf());
-    if is_nuxt_project_root(&tsconfig_dir) {
+    if super::nuxt::is_nuxt_project_root(&tsconfig_dir) {
         return tsconfig_dir;
     }
     if tsconfig_dir.join("package.json").exists() {
         return tsconfig_dir;
     }
     if let Some(parent) = tsconfig_dir.parent()
-        && is_nuxt_project_root(parent)
+        && super::nuxt::is_nuxt_project_root(parent)
     {
         return parent.to_path_buf();
     }
     tsconfig_dir
-}
-
-fn is_nuxt_project_root(path: &Path) -> bool {
-    ["nuxt.config.ts", "nuxt.config.js", "nuxt.config.mts"]
-        .iter()
-        .any(|file| path.join(file).exists())
 }

--- a/crates/vize/src/commands/check/runner/tests.rs
+++ b/crates/vize/src/commands/check/runner/tests.rs
@@ -13,7 +13,6 @@ use std::{
 
 fn unique_case_dir(name: &str) -> PathBuf {
     static NEXT_CASE_ID: AtomicUsize = AtomicUsize::new(0);
-
     let case_id = NEXT_CASE_ID.fetch_add(1, Ordering::Relaxed);
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("target")
@@ -24,6 +23,7 @@ fn unique_case_dir(name: &str) -> PathBuf {
         ))
 }
 
+mod nuxt_root;
 #[test]
 fn suppresses_nuxt_nitro_import_meta_conflict_false_positive() {
     let diagnostic = vize_canon::BatchDiagnostic {

--- a/crates/vize/src/commands/check/runner/tests/nuxt_root.rs
+++ b/crates/vize/src/commands/check/runner/tests/nuxt_root.rs
@@ -1,0 +1,19 @@
+use super::super::resolve_nuxt_project_root;
+use super::unique_case_dir;
+
+#[test]
+fn resolves_parent_nuxt_mjs_root_for_explicit_tsconfig() {
+    let project_root = unique_case_dir("nuxt-mjs-root");
+    let _ = std::fs::remove_dir_all(&project_root);
+    let config_dir = project_root.join("config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let tsconfig = config_dir.join("tsconfig.json");
+    std::fs::write(project_root.join("nuxt.config.mjs"), "export default {}").unwrap();
+    std::fs::write(&tsconfig, "{}").unwrap();
+
+    let resolved = resolve_nuxt_project_root(Some(&tsconfig), &project_root, &config_dir);
+
+    assert_eq!(resolved, project_root);
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
## Summary
- treat nuxt.config.mjs as a Nuxt project marker
- read nuxt.config.mjs for module-driven fallback stubs
- resolve parent Nuxt roots from explicit tsconfig paths when the root config is .mjs

## Root cause
Several Nuxt config helpers only checked nuxt.config.ts/js/mts. Projects using an ESM nuxt.config.mjs were skipped before fallback module parsing and root resolution could run.

## Validation
- cargo fmt --check
- cargo test -p vize mjs -- --nocapture
- cargo test -p vize commands::check::nuxt -- --nocapture
- cargo test -p vize commands::check::runner -- --nocapture
- cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786036821&installation_id=136613492&pr_number=2692&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2692&signature=5ea0055355aba2f15896bdf7c59c13d42e5877fdb963890dcaddfa1f08821bfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Nuxt auto-detection and project-root resolution to support `nuxt.config.mjs`, including when configuration files are found via nested-directory `tsconfig` paths.
* **Tests**
  * Added unit tests covering Nuxt module fallback detection from `nuxt.config.mjs` and resolving the correct Nuxt project root when `tsconfig.json` is explicitly provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->