### PR TITLE
fix(musea): inline static args bindings

### DIFF
--- a/crates/vize/src/commands/musea/migrate/csf.rs
+++ b/crates/vize/src/commands/musea/migrate/csf.rs
@@ -11,7 +11,8 @@ mod storyfn;
 
 use oxc_ast::ast::{
     ExportDefaultDeclarationKind, Expression, ImportDeclarationSpecifier, ObjectExpression,
-    ObjectPropertyKind, Program, PropertyKey, Statement, VariableDeclarator,
+    ObjectPropertyKind, Program, PropertyKey, Statement, VariableDeclarationKind,
+    VariableDeclarator,
 };
 use vize_carton::String;
 
@@ -45,6 +46,8 @@ pub(super) struct CsfModule<'a> {
     pub title: Option<String>,
     /// Default CSF `args` object from the module meta, if present.
     pub meta_args: Option<&'a ObjectExpression<'a>>,
+    /// Top-level `const` initializers available for static args inlining.
+    pub module_bindings: Vec<(&'a str, &'a Expression<'a>)>,
     /// Ordered stories.
     pub stories: Vec<CsfStory<'a>>,
 }
@@ -55,6 +58,7 @@ pub(super) fn extract_csf<'a>(program: &'a Program<'a>) -> CsfModule<'a> {
     let component_local = meta.and_then(meta_component_local);
     let title = meta.and_then(meta_title);
     let meta_args = meta.and_then(meta_args);
+    let module_bindings = collect_module_bindings(program);
     let component_path = component_local
         .as_deref()
         .and_then(|local| find_import_source(program, local));
@@ -65,8 +69,31 @@ pub(super) fn extract_csf<'a>(program: &'a Program<'a>) -> CsfModule<'a> {
         component_path,
         title,
         meta_args,
+        module_bindings,
         stories,
     }
+}
+
+fn collect_module_bindings<'a>(program: &'a Program<'a>) -> Vec<(&'a str, &'a Expression<'a>)> {
+    let mut bindings = Vec::new();
+    for stmt in &program.body {
+        let Statement::VariableDeclaration(decl) = stmt else {
+            continue;
+        };
+        if decl.kind != VariableDeclarationKind::Const {
+            continue;
+        }
+        for declarator in &decl.declarations {
+            let Some(name) = binding_name(declarator) else {
+                continue;
+            };
+            let Some(init) = declarator.init.as_ref() else {
+                continue;
+            };
+            bindings.push((name, init));
+        }
+    }
+    bindings
 }
 
 /// Find the meta object literal: either the `export default {...}` expression or

--- a/crates/vize/src/commands/musea/migrate/emit.rs
+++ b/crates/vize/src/commands/musea/migrate/emit.rs
@@ -1,15 +1,18 @@
 //! Generate `.art.vue` text from extracted CSF metadata.
 
-use oxc_ast::ast::{
-    ArrayExpressionElement, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey,
-};
+use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, PropertyKey};
 use oxc_span::GetSpan;
 use vize_carton::{String, append};
 
+use self::static_args::{
+    ModuleBindings, args_contain_unmigrated_bindings, args_has_static_property,
+    static_binding_value,
+};
 use super::csf::{CsfModule, CsfStory, unwrap_expression};
 use super::jsx::convert_render;
 use super::text::{escape_attr, escape_js_string, quote_directive_expression};
 
+mod static_args;
 const TODO_COMMENT: &str = "<!-- TODO(vize musea migrate): unsupported story; port manually -->";
 
 /// Outcome of generating one `.art.vue` file.
@@ -54,7 +57,13 @@ pub(super) fn emit_art(
     let mut todos = 0usize;
     for (index, story) in module.stories.iter().enumerate() {
         let is_default = index == 0;
-        let (inner, is_todo) = emit_variant_inner(story, module.meta_args, component_tag, source);
+        let (inner, is_todo) = emit_variant_inner(
+            story,
+            module.meta_args,
+            &module.module_bindings,
+            component_tag,
+            source,
+        );
         if is_todo {
             todos += 1;
         }
@@ -88,6 +97,7 @@ pub(super) fn emit_art(
 fn emit_variant_inner(
     story: &CsfStory<'_>,
     meta_args: Option<&ObjectExpression<'_>>,
+    module_bindings: &ModuleBindings<'_>,
     component_tag: &str,
     source: &str,
 ) -> (String, bool) {
@@ -104,6 +114,7 @@ fn emit_variant_inner(
             render.args_name,
             meta_args,
             story.args,
+            module_bindings,
             source,
         ) {
             Some(markup) => (markup, false),
@@ -112,10 +123,16 @@ fn emit_variant_inner(
     }
 
     if meta_args.is_some() || story.args.is_some() {
-        if args_contain_unmigrated_bindings(meta_args, story.args) {
+        if args_contain_unmigrated_bindings(meta_args, story.args, module_bindings) {
             return (emit_todo_element(component_tag), true);
         }
-        if let Some(element) = emit_args_element(meta_args, story.args, component_tag, source) {
+        if let Some(element) = emit_args_element(
+            meta_args,
+            story.args,
+            module_bindings,
+            component_tag,
+            source,
+        ) {
             return (element, false);
         }
         return (emit_todo_element(component_tag), true);
@@ -134,12 +151,18 @@ fn emit_todo_element(component_tag: &str) -> String {
 fn emit_args_element(
     meta_args: Option<&ObjectExpression<'_>>,
     story_args: Option<&ObjectExpression<'_>>,
+    module_bindings: &ModuleBindings<'_>,
     component_tag: &str,
     source: &str,
 ) -> Option<String> {
     let mut out = String::default();
     append!(out, "<{component_tag}");
-    out.push_str(&emit_args_attributes(meta_args, story_args, source)?);
+    out.push_str(&emit_args_attributes(
+        meta_args,
+        story_args,
+        module_bindings,
+        source,
+    )?);
     out.push_str(" />");
     Some(out)
 }
@@ -147,14 +170,15 @@ fn emit_args_element(
 fn emit_args_attributes(
     meta_args: Option<&ObjectExpression<'_>>,
     story_args: Option<&ObjectExpression<'_>>,
+    module_bindings: &ModuleBindings<'_>,
     source: &str,
 ) -> Option<String> {
     let mut out = String::default();
     if let Some(args) = meta_args {
-        emit_args_object_attributes(args, story_args, source, &mut out)?;
+        emit_args_object_attributes(args, story_args, module_bindings, source, &mut out)?;
     }
     if let Some(args) = story_args {
-        emit_args_object_attributes(args, None, source, &mut out)?;
+        emit_args_object_attributes(args, None, module_bindings, source, &mut out)?;
     }
     Some(out)
 }
@@ -162,6 +186,7 @@ fn emit_args_attributes(
 fn emit_args_object_attributes(
     args: &ObjectExpression<'_>,
     overrides: Option<&ObjectExpression<'_>>,
+    module_bindings: &ModuleBindings<'_>,
     source: &str,
     out: &mut String,
 ) -> Option<()> {
@@ -179,7 +204,12 @@ fn emit_args_object_attributes(
             continue;
         }
         out.push(' ');
-        out.push_str(&attribute_from_value(name, &prop.value, source)?);
+        out.push_str(&attribute_from_value(
+            name,
+            &prop.value,
+            module_bindings,
+            source,
+        )?);
     }
     Some(())
 }
@@ -189,6 +219,7 @@ fn inline_story_args_spread(
     render_args_name: Option<&str>,
     meta_args: Option<&ObjectExpression<'_>>,
     story_args: Option<&ObjectExpression<'_>>,
+    module_bindings: &ModuleBindings<'_>,
     source: &str,
 ) -> Option<String> {
     let marker = render_args_name.map(|name| {
@@ -204,16 +235,22 @@ fn inline_story_args_spread(
         return Some(markup);
     }
     meta_args.or(story_args)?;
-    if args_contain_unmigrated_bindings(meta_args, story_args) {
+    if args_contain_unmigrated_bindings(meta_args, story_args, module_bindings) {
         return None;
     }
-    let attributes = emit_args_attributes(meta_args, story_args, source)?;
+    let attributes = emit_args_attributes(meta_args, story_args, module_bindings, source)?;
     Some(markup.replace(marker, attributes.as_str()).into())
 }
 
 /// Map one `args` entry to an attribute: string literal -> `name="value"`,
 /// everything else -> `:name="<expr source>"`.
-fn attribute_from_value(name: &str, value: &Expression<'_>, source: &str) -> Option<String> {
+fn attribute_from_value(
+    name: &str,
+    value: &Expression<'_>,
+    module_bindings: &ModuleBindings<'_>,
+    source: &str,
+) -> Option<String> {
+    let value = static_binding_value(value, module_bindings).unwrap_or(value);
     let mut out = String::default();
     if let Expression::StringLiteral(literal) = unwrap_expression(value) {
         append!(out, "{name}=\"{}\"", escape_attr(literal.value.as_str()));
@@ -223,74 +260,6 @@ fn attribute_from_value(name: &str, value: &Expression<'_>, source: &str) -> Opt
         append!(out, ":{name}={}", quoted.as_str());
     }
     Some(out)
-}
-
-fn args_contain_unmigrated_bindings(
-    meta_args: Option<&ObjectExpression<'_>>,
-    story_args: Option<&ObjectExpression<'_>>,
-) -> bool {
-    if let Some(args) = meta_args
-        && args_object_contains_unmigrated_bindings(args, story_args)
-    {
-        return true;
-    }
-    story_args.is_some_and(|args| args_object_contains_unmigrated_bindings(args, None))
-}
-
-fn args_object_contains_unmigrated_bindings(
-    args: &ObjectExpression<'_>,
-    overrides: Option<&ObjectExpression<'_>>,
-) -> bool {
-    args.properties.iter().any(|property| {
-        let ObjectPropertyKind::ObjectProperty(prop) = property else {
-            return true;
-        };
-        if prop.computed {
-            return true;
-        }
-        let Some(name) = property_key_name(&prop.key) else {
-            return true;
-        };
-        if overrides.is_some_and(|object| args_has_static_property(object, name)) {
-            return false;
-        }
-        expression_needs_module_binding(&prop.value)
-    })
-}
-
-fn expression_needs_module_binding(expression: &Expression<'_>) -> bool {
-    match unwrap_expression(expression) {
-        Expression::StringLiteral(_)
-        | Expression::NumericLiteral(_)
-        | Expression::BooleanLiteral(_)
-        | Expression::NullLiteral(_) => false,
-        Expression::TemplateLiteral(template) => !template.expressions.is_empty(),
-        Expression::UnaryExpression(unary) => expression_needs_module_binding(&unary.argument),
-        Expression::ArrayExpression(array) => array.elements.iter().any(|element| match element {
-            ArrayExpressionElement::Elision(_) => false,
-            ArrayExpressionElement::SpreadElement(_) => true,
-            _ => element
-                .as_expression()
-                .is_none_or(expression_needs_module_binding),
-        }),
-        Expression::ObjectExpression(object) => {
-            args_object_contains_unmigrated_bindings(object, None)
-        }
-        Expression::Identifier(_)
-        | Expression::StaticMemberExpression(_)
-        | Expression::ComputedMemberExpression(_)
-        | Expression::CallExpression(_) => true,
-        _ => true,
-    }
-}
-
-fn args_has_static_property(args: &ObjectExpression<'_>, name: &str) -> bool {
-    args.properties.iter().any(|property| {
-        let ObjectPropertyKind::ObjectProperty(prop) = property else {
-            return false;
-        };
-        !prop.computed && property_key_name(&prop.key) == Some(name)
-    })
 }
 
 fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {

--- a/crates/vize/src/commands/musea/migrate/emit/static_args.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/static_args.rs
@@ -1,0 +1,105 @@
+use oxc_ast::ast::{
+    ArrayExpressionElement, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey,
+};
+
+use super::super::csf::unwrap_expression;
+
+pub(super) type ModuleBindings<'a> = [(&'a str, &'a Expression<'a>)];
+
+pub(super) fn args_contain_unmigrated_bindings(
+    meta_args: Option<&ObjectExpression<'_>>,
+    story_args: Option<&ObjectExpression<'_>>,
+    module_bindings: &ModuleBindings<'_>,
+) -> bool {
+    if let Some(args) = meta_args
+        && args_object_contains_unmigrated_bindings(args, story_args, module_bindings)
+    {
+        return true;
+    }
+    story_args
+        .is_some_and(|args| args_object_contains_unmigrated_bindings(args, None, module_bindings))
+}
+
+fn args_object_contains_unmigrated_bindings(
+    args: &ObjectExpression<'_>,
+    overrides: Option<&ObjectExpression<'_>>,
+    module_bindings: &ModuleBindings<'_>,
+) -> bool {
+    args.properties.iter().any(|property| {
+        let ObjectPropertyKind::ObjectProperty(prop) = property else {
+            return true;
+        };
+        if prop.computed {
+            return true;
+        }
+        let Some(name) = property_key_name(&prop.key) else {
+            return true;
+        };
+        if overrides.is_some_and(|object| args_has_static_property(object, name)) {
+            return false;
+        }
+        expression_needs_module_binding(&prop.value, module_bindings)
+    })
+}
+
+fn expression_needs_module_binding(
+    expression: &Expression<'_>,
+    module_bindings: &ModuleBindings<'_>,
+) -> bool {
+    match unwrap_expression(expression) {
+        Expression::StringLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_) => false,
+        Expression::TemplateLiteral(template) => !template.expressions.is_empty(),
+        Expression::UnaryExpression(unary) => {
+            expression_needs_module_binding(&unary.argument, module_bindings)
+        }
+        Expression::ArrayExpression(array) => array.elements.iter().any(|element| match element {
+            ArrayExpressionElement::Elision(_) => false,
+            ArrayExpressionElement::SpreadElement(_) => true,
+            _ => element.as_expression().is_none_or(|expression| {
+                expression_needs_module_binding(expression, module_bindings)
+            }),
+        }),
+        Expression::ObjectExpression(object) => {
+            args_object_contains_unmigrated_bindings(object, None, module_bindings)
+        }
+        Expression::Identifier(_) => static_binding_value(expression, module_bindings).is_none(),
+        Expression::StaticMemberExpression(_)
+        | Expression::ComputedMemberExpression(_)
+        | Expression::CallExpression(_) => true,
+        _ => true,
+    }
+}
+
+pub(super) fn static_binding_value<'a>(
+    expression: &'a Expression<'a>,
+    module_bindings: &ModuleBindings<'a>,
+) -> Option<&'a Expression<'a>> {
+    let Expression::Identifier(ident) = unwrap_expression(expression) else {
+        return None;
+    };
+    let value = module_bindings
+        .iter()
+        .rev()
+        .find_map(|(name, value)| (*name == ident.name.as_str()).then_some(*value))?;
+    (!expression_needs_module_binding(value, &[])).then_some(value)
+}
+
+pub(super) fn args_has_static_property(args: &ObjectExpression<'_>, name: &str) -> bool {
+    args.properties.iter().any(|property| {
+        let ObjectPropertyKind::ObjectProperty(prop) = property else {
+            return false;
+        };
+        !prop.computed && property_key_name(&prop.key) == Some(name)
+    })
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(ident) => Some(ident.name.as_str()),
+        PropertyKey::StringLiteral(literal) => Some(literal.value.as_str()),
+        _ => None,
+    }
+}

--- a/crates/vize/src/commands/musea/migrate/emit/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/tests.rs
@@ -164,7 +164,7 @@ defineArt("./AfButton.vue", {
 }
 
 #[test]
-fn emits_todo_for_args_referencing_local_fixture_identifiers() {
+fn inlines_static_local_fixture_args() {
     let source = r#"import AfButton from "./AfButton.vue";
 const fixture = { label: "Hi" };
 export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;
@@ -172,11 +172,11 @@ export const Big = { args: { data: fixture } };
 "#;
     let (content, variants, todos) = emit(source);
 
-    assert!(content.contains("<AfButton />"));
-    assert!(content.contains("TODO(vize musea migrate)"));
+    assert!(content.contains(r#"<AfButton :data='{ label: "Hi" }' />"#));
+    assert!(!content.contains("TODO(vize musea migrate)"));
     assert!(!content.contains(":data=\"fixture\""));
     assert_eq!(variants, 1);
-    assert_eq!(todos, 1);
+    assert_eq!(todos, 0);
 }
 
 #[test]
@@ -243,6 +243,21 @@ export const Primary = { args: {} };
     assert!(!content.contains(":data"));
     assert_eq!(variants, 1);
     assert_eq!(todos, 1);
+}
+
+#[test]
+fn inlines_static_meta_args_module_bindings() {
+    let source = r#"import AfButton from "./AfButton.vue";
+const base = { label: "Hi" } as const;
+export default { component: AfButton, title: "AfButton", args: { data: base } } satisfies Meta<typeof AfButton>;
+export const Primary = { args: {} };
+"#;
+    let (content, variants, todos) = emit(source);
+
+    assert!(content.contains(r#"<AfButton :data='{ label: "Hi" } as const' />"#));
+    assert!(!content.contains("TODO(vize musea migrate)"));
+    assert_eq!(variants, 1);
+    assert_eq!(todos, 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- collect top-level const initializers during Musea CSF extraction
- inline only statically-safe const args bindings instead of emitting manual TODO fallbacks
- keep dynamic/call/member/spread bindings on the conservative TODO path

## Tests
- cargo fmt --check
- cargo test -p vize commands::musea::migrate -- --nocapture
- cargo test -p vize --test musea_migrate_cli -- --nocapture
- cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786038384&installation_id=136613492&pr_number=2693&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2693&signature=abe58b782d65b15f154870ecc94caca723b27a2721b4d97e5d93f1ac87da16fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Musea→Vue migration output now resolves more `args` values by inlining static constants and fixture values directly into generated markup.
* **Bug Fixes**
  * Reduced fallback to manual TODO placeholders for argument values that can be determined automatically.
  * More reliably emits literal/object expressions for resolved `args`, avoiding leftover unresolved references.
* **Tests**
  * Updated migration/emit expectations to match the new inlining behavior and ensured TODO markers are no longer produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->