### PR TITLE
fix(musea): guard nested static args bindings

### DIFF
--- a/crates/vize/src/commands/musea/migrate/csf.rs
+++ b/crates/vize/src/commands/musea/migrate/csf.rs
@@ -10,8 +10,8 @@ mod render;
 mod storyfn;
 
 use oxc_ast::ast::{
-    ExportDefaultDeclarationKind, Expression, ImportDeclarationSpecifier, ObjectExpression,
-    ObjectPropertyKind, Program, PropertyKey, Statement, VariableDeclarationKind,
+    Declaration, ExportDefaultDeclarationKind, Expression, ImportDeclarationSpecifier,
+    ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement, VariableDeclarationKind,
     VariableDeclarator,
 };
 use vize_carton::String;
@@ -77,8 +77,16 @@ pub(super) fn extract_csf<'a>(program: &'a Program<'a>) -> CsfModule<'a> {
 fn collect_module_bindings<'a>(program: &'a Program<'a>) -> Vec<(&'a str, &'a Expression<'a>)> {
     let mut bindings = Vec::new();
     for stmt in &program.body {
-        let Statement::VariableDeclaration(decl) = stmt else {
-            continue;
+        let decl = match stmt {
+            Statement::VariableDeclaration(decl) => decl,
+            Statement::ExportNamedDeclaration(export) => {
+                let Some(Declaration::VariableDeclaration(decl)) = export.declaration.as_ref()
+                else {
+                    continue;
+                };
+                decl
+            }
+            _ => continue,
         };
         if decl.kind != VariableDeclarationKind::Const {
             continue;

--- a/crates/vize/src/commands/musea/migrate/csf/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/tests.rs
@@ -96,6 +96,25 @@ export const Only = { args: {} };
 }
 
 #[test]
+fn extracts_exported_const_module_bindings() {
+    let source = r#"import Card from "../components/Card.vue";
+export default { component: Card, title: "Card" } satisfies Meta<typeof Card>;
+export const fixture = { tone: "neutral" };
+"#;
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+    assert!(!parsed.panicked);
+    let module = extract_csf(&parsed.program);
+
+    assert!(
+        module
+            .module_bindings
+            .iter()
+            .any(|(name, _)| *name == "fixture")
+    );
+}
+
+#[test]
 fn extracts_as_meta_and_name_override() {
     let source = r#"import Box from "./Box.vue";
 export default { component: Box, title: "Box" } as Meta;

--- a/crates/vize/src/commands/musea/migrate/emit/static_args.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/static_args.rs
@@ -38,35 +38,33 @@ fn args_object_contains_unmigrated_bindings(
         if overrides.is_some_and(|object| args_has_static_property(object, name)) {
             return false;
         }
-        expression_needs_module_binding(&prop.value, module_bindings)
+        if static_binding_value(&prop.value, module_bindings).is_some() {
+            return false;
+        }
+        expression_needs_module_binding(&prop.value)
     })
 }
 
-fn expression_needs_module_binding(
-    expression: &Expression<'_>,
-    module_bindings: &ModuleBindings<'_>,
-) -> bool {
+fn expression_needs_module_binding(expression: &Expression<'_>) -> bool {
     match unwrap_expression(expression) {
         Expression::StringLiteral(_)
         | Expression::NumericLiteral(_)
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_) => false,
         Expression::TemplateLiteral(template) => !template.expressions.is_empty(),
-        Expression::UnaryExpression(unary) => {
-            expression_needs_module_binding(&unary.argument, module_bindings)
-        }
+        Expression::UnaryExpression(unary) => expression_needs_module_binding(&unary.argument),
         Expression::ArrayExpression(array) => array.elements.iter().any(|element| match element {
             ArrayExpressionElement::Elision(_) => false,
             ArrayExpressionElement::SpreadElement(_) => true,
-            _ => element.as_expression().is_none_or(|expression| {
-                expression_needs_module_binding(expression, module_bindings)
-            }),
+            _ => element
+                .as_expression()
+                .is_none_or(expression_needs_module_binding),
         }),
         Expression::ObjectExpression(object) => {
-            args_object_contains_unmigrated_bindings(object, None, module_bindings)
+            args_object_contains_unmigrated_bindings(object, None, &[])
         }
-        Expression::Identifier(_) => static_binding_value(expression, module_bindings).is_none(),
-        Expression::StaticMemberExpression(_)
+        Expression::Identifier(_)
+        | Expression::StaticMemberExpression(_)
         | Expression::ComputedMemberExpression(_)
         | Expression::CallExpression(_) => true,
         _ => true,
@@ -84,7 +82,7 @@ pub(super) fn static_binding_value<'a>(
         .iter()
         .rev()
         .find_map(|(name, value)| (*name == ident.name.as_str()).then_some(*value))?;
-    (!expression_needs_module_binding(value, &[])).then_some(value)
+    (!expression_needs_module_binding(value)).then_some(value)
 }
 
 pub(super) fn args_has_static_property(args: &ObjectExpression<'_>, name: &str) -> bool {

--- a/crates/vize/src/commands/musea/migrate/emit/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/tests.rs
@@ -261,6 +261,23 @@ export const Primary = { args: {} };
 }
 
 #[test]
+fn emits_todo_for_static_args_with_nested_module_bindings() {
+    let source = r#"import AfButton from "./AfButton.vue";
+const base = { label: "Hi" };
+const fixture = { data: base };
+export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;
+export const Primary = { args: { data: fixture } };
+"#;
+    let (content, variants, todos) = emit(source);
+
+    assert!(content.contains("<AfButton />"));
+    assert!(content.contains("TODO(vize musea migrate)"));
+    assert!(!content.contains(":data"));
+    assert_eq!(variants, 1);
+    assert_eq!(todos, 1);
+}
+
+#[test]
 fn emits_todo_for_nested_story_args_module_bindings() {
     let source = r#"import AfButton from "./AfButton.vue";
 const base = createFixture();


### PR DESCRIPTION
## Summary
- collect exported const fixtures as static module bindings
- avoid inlining static args that hide unresolved module references inside arrays or objects
- add regression coverage for nested static binding TODOs

## Tests
- cargo fmt --check
- node --test tests/tooling/source-file-lengths.test.ts
- cargo test -p vize commands::musea::migrate -- --nocapture
- cargo test -p vize --test musea_migrate_cli -- --nocapture
- cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786039650&installation_id=136613492&pr_number=2694&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2694&signature=8dd613ec46a25f343ba13ab229bfc075b0cd4ac42bf3663b6e8b2a4b6268dc1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of exported constants, so module bindings are now detected in more cases.
  * Fixed generated output for static arguments with nested module references, avoiding incorrect prop emission and adding a clear TODO marker when manual review is needed.

* **Tests**
  * Added coverage for exported constants and nested module-binding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->