### PR TITLE
fix(musea): skip exported fixture objects

### DIFF
--- a/crates/vize/src/commands/musea/migrate/csf/storyfn.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/storyfn.rs
@@ -1,11 +1,12 @@
 use oxc_ast::ast::{
-    AssignmentTarget, Declaration, Expression, ObjectExpression, Program, Statement,
+    AssignmentTarget, Declaration, Expression, ObjectExpression, ObjectPropertyKind, Program,
+    Statement,
 };
 use oxc_syntax::operator::AssignmentOperator;
 
 use super::{
-    CsfRender, CsfStory, binding_name, render_body, story_from_object, unsupported_story,
-    unwrap_expression, unwrap_object,
+    CsfRender, CsfStory, binding_name, property_key_name, render_body, story_from_object,
+    unsupported_story, unwrap_expression, unwrap_object,
 };
 
 pub(super) fn collect_stories<'a>(program: &'a Program<'a>) -> Vec<CsfStory<'a>> {
@@ -29,6 +30,9 @@ pub(super) fn collect_stories<'a>(program: &'a Program<'a>) -> Vec<CsfStory<'a>>
             };
             let assigned_args = find_object_by_name(&story_args, export_name);
             let story = if let Some(object) = unwrap_object(init) {
+                if !is_story_object(object) {
+                    continue;
+                }
                 let mut story = story_from_object(export_name, object);
                 if story.args.is_none() {
                     story.args = assigned_args;
@@ -43,6 +47,35 @@ pub(super) fn collect_stories<'a>(program: &'a Program<'a>) -> Vec<CsfStory<'a>>
     }
 
     stories
+}
+
+fn is_story_object(object: &ObjectExpression<'_>) -> bool {
+    object.properties.is_empty()
+        || object.properties.iter().any(|property| match property {
+            ObjectPropertyKind::SpreadProperty(_) => true,
+            ObjectPropertyKind::ObjectProperty(prop) => {
+                !prop.computed && property_key_name(&prop.key).is_some_and(is_story_annotation_key)
+            }
+        })
+}
+
+fn is_story_annotation_key(key: &str) -> bool {
+    matches!(
+        key,
+        "args"
+            | "argTypes"
+            | "beforeEach"
+            | "decorators"
+            | "experimental_afterEach"
+            | "globals"
+            | "loaders"
+            | "name"
+            | "parameters"
+            | "play"
+            | "render"
+            | "storyName"
+            | "tags"
+    )
 }
 
 fn collect_template_renders<'a>(program: &'a Program<'a>) -> Vec<(&'a str, CsfRender<'a>)> {

--- a/crates/vize/src/commands/musea/migrate/csf/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/tests.rs
@@ -100,6 +100,7 @@ fn extracts_exported_const_module_bindings() {
     let source = r#"import Card from "../components/Card.vue";
 export default { component: Card, title: "Card" } satisfies Meta<typeof Card>;
 export const fixture = { tone: "neutral" };
+export const Empty = {};
 "#;
     let allocator = Allocator::default();
     let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
@@ -111,6 +112,25 @@ export const fixture = { tone: "neutral" };
             .module_bindings
             .iter()
             .any(|(name, _)| *name == "fixture")
+    );
+    let stories: Vec<TestStory> = module
+        .stories
+        .iter()
+        .map(|story| TestStory {
+            name: story.name.as_str(),
+            has_render: story.render.is_some(),
+            has_args: story.args.is_some(),
+            unsupported: story.unsupported,
+        })
+        .collect();
+    assert_eq!(
+        stories,
+        vec![TestStory {
+            name: "Empty",
+            has_render: false,
+            has_args: false,
+            unsupported: false,
+        }]
     );
 }
 

--- a/crates/vize/src/commands/musea/migrate/emit/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/tests.rs
@@ -180,6 +180,22 @@ export const Big = { args: { data: fixture } };
 }
 
 #[test]
+fn skips_exported_fixture_object_variants() {
+    let source = r#"import AfButton from "./AfButton.vue";
+export const fixture = { label: "Hi" };
+export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;
+export const Primary = { args: { data: fixture } };
+"#;
+    let (content, variants, todos) = emit(source);
+
+    assert!(content.contains(r#"<variant name="Primary" default>"#));
+    assert!(!content.contains(r#"<variant name="fixture""#));
+    assert!(content.contains(r#"<AfButton :data='{ label: "Hi" }' />"#));
+    assert_eq!(variants, 1);
+    assert_eq!(todos, 0);
+}
+
+#[test]
 fn emits_meta_args_and_lets_story_args_override() {
     let source = r#"import AfButton from "./AfButton.vue";
 export default { component: AfButton, title: "AfButton", args: { color: "primary", disabled: true, count: 1 } } satisfies Meta<typeof AfButton>;


### PR DESCRIPTION
## Summary
- skip exported object literals that do not look like Storybook stories
- keep empty story objects and known story annotations
- add regression coverage so exported fixtures can inline args without producing extra variants

## Tests
- cargo fmt --check
- cargo test -p vize commands::musea::migrate -- --nocapture
- cargo test -p vize --test musea_migrate_cli -- --nocapture
- node --test tests/tooling/source-file-lengths.test.ts
- cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786040631&installation_id=136613492&pr_number=2696&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2696&signature=3026527a07a9f4d720954754b6d44bbf949c46b3d2ba3759b49b7d0ea7e86578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty exported objects are now recognized as valid stories.
  * Non-story exported objects are no longer treated as stories or extra variants.
  * Story outputs now avoid generating duplicate entries for shared object values, producing cleaner results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->