### PR TITLE
fix(musea): tighten musea object detection

### DIFF
--- a/crates/vize/src/commands/musea/migrate/csf/storyfn.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/storyfn.rs
@@ -12,6 +12,7 @@ use super::{
 pub(super) fn collect_stories<'a>(program: &'a Program<'a>) -> Vec<CsfStory<'a>> {
     let templates = collect_template_renders(program);
     let story_args = collect_story_args(program);
+    let object_bindings = collect_object_bindings(program);
     let mut stories = Vec::new();
 
     for stmt in &program.body {
@@ -30,7 +31,7 @@ pub(super) fn collect_stories<'a>(program: &'a Program<'a>) -> Vec<CsfStory<'a>>
             };
             let assigned_args = find_object_by_name(&story_args, export_name);
             let story = if let Some(object) = unwrap_object(init) {
-                if !is_story_object(object) {
+                if !is_story_object(object, &object_bindings) {
                     continue;
                 }
                 let mut story = story_from_object(export_name, object);
@@ -49,14 +50,73 @@ pub(super) fn collect_stories<'a>(program: &'a Program<'a>) -> Vec<CsfStory<'a>>
     stories
 }
 
-fn is_story_object(object: &ObjectExpression<'_>) -> bool {
+fn collect_object_bindings<'a>(
+    program: &'a Program<'a>,
+) -> Vec<(&'a str, &'a ObjectExpression<'a>)> {
+    let mut bindings = Vec::new();
+    for stmt in &program.body {
+        let decl = match stmt {
+            Statement::VariableDeclaration(decl) => decl,
+            Statement::ExportNamedDeclaration(export) => {
+                let Some(Declaration::VariableDeclaration(decl)) = export.declaration.as_ref()
+                else {
+                    continue;
+                };
+                decl
+            }
+            _ => continue,
+        };
+        for declarator in &decl.declarations {
+            let Some(name) = binding_name(declarator) else {
+                continue;
+            };
+            let Some(object) = declarator.init.as_ref().and_then(unwrap_object) else {
+                continue;
+            };
+            bindings.push((name, object));
+        }
+    }
+    bindings
+}
+
+fn is_story_object<'a>(
+    object: &'a ObjectExpression<'a>,
+    object_bindings: &[(&'a str, &'a ObjectExpression<'a>)],
+) -> bool {
+    is_story_object_at_depth(object, object_bindings, 0)
+}
+
+fn is_story_object_at_depth<'a>(
+    object: &'a ObjectExpression<'a>,
+    object_bindings: &[(&'a str, &'a ObjectExpression<'a>)],
+    depth: usize,
+) -> bool {
+    const MAX_SPREAD_DEPTH: usize = 8;
+    if depth > MAX_SPREAD_DEPTH {
+        return false;
+    }
+
     object.properties.is_empty()
         || object.properties.iter().any(|property| match property {
-            ObjectPropertyKind::SpreadProperty(_) => true,
+            ObjectPropertyKind::SpreadProperty(spread) => {
+                spread_story_object(&spread.argument, object_bindings, depth + 1)
+            }
             ObjectPropertyKind::ObjectProperty(prop) => {
                 !prop.computed && property_key_name(&prop.key).is_some_and(is_story_annotation_key)
             }
         })
+}
+
+fn spread_story_object<'a>(
+    expression: &'a Expression<'a>,
+    object_bindings: &[(&'a str, &'a ObjectExpression<'a>)],
+    depth: usize,
+) -> bool {
+    let Expression::Identifier(ident) = unwrap_expression(expression) else {
+        return false;
+    };
+    find_object_by_name(object_bindings, ident.name.as_str())
+        .is_some_and(|object| is_story_object_at_depth(object, object_bindings, depth))
 }
 
 fn is_story_annotation_key(key: &str) -> bool {
@@ -69,7 +129,6 @@ fn is_story_annotation_key(key: &str) -> bool {
             | "experimental_afterEach"
             | "globals"
             | "loaders"
-            | "name"
             | "parameters"
             | "play"
             | "render"

--- a/crates/vize/src/commands/musea/migrate/csf/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/tests.rs
@@ -99,8 +99,12 @@ export const Only = { args: {} };
 fn extracts_exported_const_module_bindings() {
     let source = r#"import Card from "../components/Card.vue";
 export default { component: Card, title: "Card" } satisfies Meta<typeof Card>;
+const storyBase = { args: { tone: "neutral" } };
 export const fixture = { tone: "neutral" };
+export const currentUser = { name: "Jane" };
+export const mergedFixture = { ...fixture, label: "Hi" };
 export const Empty = {};
+export const SpreadStory = { ...storyBase };
 "#;
     let allocator = Allocator::default();
     let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
@@ -112,6 +116,18 @@ export const Empty = {};
             .module_bindings
             .iter()
             .any(|(name, _)| *name == "fixture")
+    );
+    assert!(
+        module
+            .module_bindings
+            .iter()
+            .any(|(name, _)| *name == "currentUser")
+    );
+    assert!(
+        module
+            .module_bindings
+            .iter()
+            .any(|(name, _)| *name == "mergedFixture")
     );
     let stories: Vec<TestStory> = module
         .stories
@@ -125,12 +141,20 @@ export const Empty = {};
         .collect();
     assert_eq!(
         stories,
-        vec![TestStory {
-            name: "Empty",
-            has_render: false,
-            has_args: false,
-            unsupported: false,
-        }]
+        vec![
+            TestStory {
+                name: "Empty",
+                has_render: false,
+                has_args: false,
+                unsupported: false,
+            },
+            TestStory {
+                name: "SpreadStory",
+                has_render: false,
+                has_args: false,
+                unsupported: false,
+            }
+        ]
     );
 }
 


### PR DESCRIPTION
## Summary
- remove generic name-only object exports from story detection
- resolve spread object exports only when their spread source is story-like
- add regression coverage for name fixtures, spread fixtures, and spread story bases

## Tests
- cargo fmt --check
- cargo test -p vize commands::musea::migrate -- --nocapture
- cargo test -p vize --test musea_migrate_cli -- --nocapture
- node --test tests/tooling/source-file-lengths.test.ts
- cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786041288&installation_id=136613492&pr_number=2697&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2697&signature=05d4612da92a0af7964e37491f43630d4465ba173ade5ce87ca3dbf5bf51a1cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved story detection for exported objects that use spread properties, so more valid stories are recognized correctly.
  * Story matching now follows referenced object spreads with a safe recursion limit, reducing false positives and missed stories.
  * Adjusted annotation handling so the `name` key is no longer treated as a story marker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->