### PR TITLE
fix(musea): keep unresolved musea spreads

### DIFF
--- a/crates/vize/src/commands/musea/migrate/csf/storyfn.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/storyfn.rs
@@ -31,10 +31,12 @@ pub(super) fn collect_stories<'a>(program: &'a Program<'a>) -> Vec<CsfStory<'a>>
             };
             let assigned_args = find_object_by_name(&story_args, export_name);
             let story = if let Some(object) = unwrap_object(init) {
-                if !is_story_object(object, &object_bindings) {
+                let story_kind = classify_story_object(export_name, object, &object_bindings);
+                if story_kind == StoryObjectKind::Fixture {
                     continue;
                 }
                 let mut story = story_from_object(export_name, object);
+                story.unsupported |= story_kind == StoryObjectKind::Unsupported;
                 if story.args.is_none() {
                     story.args = assigned_args;
                 }
@@ -79,44 +81,101 @@ fn collect_object_bindings<'a>(
     bindings
 }
 
-fn is_story_object<'a>(
-    object: &'a ObjectExpression<'a>,
-    object_bindings: &[(&'a str, &'a ObjectExpression<'a>)],
-) -> bool {
-    is_story_object_at_depth(object, object_bindings, 0)
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StoryObjectKind {
+    Fixture,
+    Story,
+    Unsupported,
 }
 
-fn is_story_object_at_depth<'a>(
+fn classify_story_object<'a>(
+    export_name: &str,
+    object: &'a ObjectExpression<'a>,
+    object_bindings: &[(&'a str, &'a ObjectExpression<'a>)],
+) -> StoryObjectKind {
+    classify_story_object_at_depth(export_name, object, object_bindings, 0)
+}
+
+fn classify_story_object_at_depth<'a>(
+    export_name: &str,
     object: &'a ObjectExpression<'a>,
     object_bindings: &[(&'a str, &'a ObjectExpression<'a>)],
     depth: usize,
-) -> bool {
+) -> StoryObjectKind {
     const MAX_SPREAD_DEPTH: usize = 8;
     if depth > MAX_SPREAD_DEPTH {
-        return false;
+        return StoryObjectKind::Unsupported;
     }
 
-    object.properties.is_empty()
-        || object.properties.iter().any(|property| match property {
+    let mut has_story_shape = object.properties.is_empty();
+    let mut has_unsupported_spread = false;
+
+    for property in &object.properties {
+        match property {
             ObjectPropertyKind::SpreadProperty(spread) => {
-                spread_story_object(&spread.argument, object_bindings, depth + 1)
+                match spread_story_object(export_name, &spread.argument, object_bindings, depth + 1)
+                {
+                    StoryObjectKind::Fixture => {}
+                    StoryObjectKind::Story => has_story_shape = true,
+                    StoryObjectKind::Unsupported => has_unsupported_spread = true,
+                }
             }
             ObjectPropertyKind::ObjectProperty(prop) => {
-                !prop.computed && property_key_name(&prop.key).is_some_and(is_story_annotation_key)
+                if !prop.computed
+                    && property_key_name(&prop.key).is_some_and(is_story_annotation_key)
+                {
+                    has_story_shape = true;
+                }
             }
-        })
+        }
+    }
+
+    if has_unsupported_spread {
+        StoryObjectKind::Unsupported
+    } else if has_story_shape {
+        StoryObjectKind::Story
+    } else {
+        StoryObjectKind::Fixture
+    }
 }
 
 fn spread_story_object<'a>(
+    export_name: &str,
     expression: &'a Expression<'a>,
     object_bindings: &[(&'a str, &'a ObjectExpression<'a>)],
     depth: usize,
-) -> bool {
-    let Expression::Identifier(ident) = unwrap_expression(expression) else {
-        return false;
-    };
-    find_object_by_name(object_bindings, ident.name.as_str())
-        .is_some_and(|object| is_story_object_at_depth(object, object_bindings, depth))
+) -> StoryObjectKind {
+    let expression = unwrap_expression(expression);
+    if let Expression::Identifier(ident) = expression
+        && let Some(object) = find_object_by_name(object_bindings, ident.name.as_str())
+    {
+        return classify_story_object_at_depth(export_name, object, object_bindings, depth);
+    }
+
+    if unresolved_spread_may_be_story(export_name, expression) {
+        StoryObjectKind::Unsupported
+    } else {
+        StoryObjectKind::Fixture
+    }
+}
+
+fn unresolved_spread_may_be_story(export_name: &str, expression: &Expression<'_>) -> bool {
+    story_like_name(export_name)
+        || match expression {
+            Expression::Identifier(ident) => story_like_name(ident.name.as_str()),
+            Expression::StaticMemberExpression(member) => {
+                if let Expression::Identifier(object) = unwrap_expression(&member.object) {
+                    story_like_name(object.name.as_str())
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+}
+
+fn story_like_name(name: &str) -> bool {
+    name.contains("Story") || name.chars().next().is_some_and(|ch| ch.is_uppercase())
 }
 
 fn is_story_annotation_key(key: &str) -> bool {

--- a/crates/vize/src/commands/musea/migrate/csf/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/tests.rs
@@ -98,13 +98,17 @@ export const Only = { args: {} };
 #[test]
 fn extracts_exported_const_module_bindings() {
     let source = r#"import Card from "../components/Card.vue";
+import { Primary as ImportedStory } from "./Card.stories";
 export default { component: Card, title: "Card" } satisfies Meta<typeof Card>;
 const storyBase = { args: { tone: "neutral" } };
 export const fixture = { tone: "neutral" };
 export const currentUser = { name: "Jane" };
 export const mergedFixture = { ...fixture, label: "Hi" };
+export const externalFixture = { ...defaults, label: "Hi" };
 export const Empty = {};
 export const SpreadStory = { ...storyBase };
+export const ImportedSpread = { ...ImportedStory };
+export const NamespaceSpread = { ...Stories.Primary };
 "#;
     let allocator = Allocator::default();
     let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
@@ -128,6 +132,12 @@ export const SpreadStory = { ...storyBase };
             .module_bindings
             .iter()
             .any(|(name, _)| *name == "mergedFixture")
+    );
+    assert!(
+        module
+            .module_bindings
+            .iter()
+            .any(|(name, _)| *name == "externalFixture")
     );
     let stories: Vec<TestStory> = module
         .stories
@@ -153,6 +163,18 @@ export const SpreadStory = { ...storyBase };
                 has_render: false,
                 has_args: false,
                 unsupported: false,
+            },
+            TestStory {
+                name: "ImportedSpread",
+                has_render: false,
+                has_args: false,
+                unsupported: true,
+            },
+            TestStory {
+                name: "NamespaceSpread",
+                has_render: false,
+                has_args: false,
+                unsupported: true,
             }
         ]
     );

--- a/crates/vize/src/commands/musea/migrate/emit/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/tests.rs
@@ -310,6 +310,21 @@ export const Primary = { args: { data: { ...base, status: Status.Ready } } };
 }
 
 #[test]
+fn emits_todo_for_unresolved_story_spread() {
+    let source = r#"import AfButton from "./AfButton.vue";
+import { Primary as BaseStory } from "./Base.stories";
+export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;
+export const Imported = { ...BaseStory };
+"#;
+    let (content, variants, todos) = emit(source);
+
+    assert!(content.contains(r#"<variant name="Imported" default>"#));
+    assert!(content.contains("TODO(vize musea migrate)"));
+    assert_eq!(variants, 1);
+    assert_eq!(todos, 1);
+}
+
+#[test]
 fn emits_directive_expressions_without_quot_entities() {
     let source = r#"import AfButton from "./AfButton.vue";
 export default { component: AfButton, title: "AfButton" } satisfies Meta<typeof AfButton>;


### PR DESCRIPTION
## Summary
- preserve likely external/composed CSF story object spreads instead of dropping them as fixtures
- mark unresolved story spreads unsupported so Musea migration emits a manual TODO variant
- keep lower-confidence fixture-like spreads out of the story list

## Validation
- `cargo fmt --check`
- `cargo test -p vize commands::musea::migrate -- --nocapture`
- `cargo test -p vize --test musea_migrate_cli -- --nocapture`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786042296&installation_id=136613492&pr_number=2698&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2698&signature=2cdfdb08cb0c3e69c5005426a8fc9e7e863d7fb4d9a43c206da82545d6c45ce2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved story migration handling for spread-based stories, including cases that reference imported or namespaced stories.
  * Stories with unresolved spreads are now still included, with a clear unsupported status when needed.

* **Bug Fixes**
  * Fixed story extraction so fixture-like exports are skipped more reliably.
  * Better distinguishes between valid stories, fixtures, and unsupported patterns during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->