### PR TITLE
fix(musea): detect musea-like member spreads

### DIFF
--- a/crates/vize/src/commands/musea/migrate/csf/storyfn.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/storyfn.rs
@@ -164,11 +164,11 @@ fn unresolved_spread_may_be_story(export_name: &str, expression: &Expression<'_>
         || match expression {
             Expression::Identifier(ident) => story_like_name(ident.name.as_str()),
             Expression::StaticMemberExpression(member) => {
-                if let Expression::Identifier(object) = unwrap_expression(&member.object) {
-                    story_like_name(object.name.as_str())
-                } else {
-                    false
-                }
+                story_like_name(member.property.name.as_str())
+                    || matches!(
+                        unwrap_expression(&member.object),
+                        Expression::Identifier(object) if story_like_name(object.name.as_str())
+                    )
             }
             _ => false,
         }

--- a/crates/vize/src/commands/musea/migrate/csf/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/csf/tests.rs
@@ -109,6 +109,7 @@ export const Empty = {};
 export const SpreadStory = { ...storyBase };
 export const ImportedSpread = { ...ImportedStory };
 export const NamespaceSpread = { ...Stories.Primary };
+export const base = { ...utils.PrimaryStory };
 "#;
     let allocator = Allocator::default();
     let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
@@ -172,6 +173,12 @@ export const NamespaceSpread = { ...Stories.Primary };
             },
             TestStory {
                 name: "NamespaceSpread",
+                has_render: false,
+                has_args: false,
+                unsupported: true,
+            },
+            TestStory {
+                name: "base",
                 has_render: false,
                 has_args: false,
                 unsupported: true,


### PR DESCRIPTION
## Summary
- detect story-like static member spread properties such as `utils.PrimaryStory`
- keep lower-case composed story exports as unsupported instead of dropping them
- add a CSF extraction regression case for this path

## Validation
- `cargo fmt --check`
- `cargo test -p vize commands::musea::migrate -- --nocapture`
- `cargo test -p vize --test musea_migrate_cli -- --nocapture`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786042933&installation_id=136613492&pr_number=2699&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2699&signature=e3343980a68a7f4b421aaee33af71695f797053a77e056a18608c05a9c33feee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of story-like exports in nested member expressions, making story migration behavior more consistent.
  * Added coverage for exported constants that spread from another story, ensuring they’re recognized and marked as unsupported when appropriate.

* **Tests**
  * Updated automated test fixtures and expectations to reflect the expanded export-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->