### PR TITLE
fix(vscode): restore vue import resolution in tsserver

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -35,8 +35,8 @@
     "check": "tsgo --noEmit && vp check src vite.config.ts",
     "check:fix": "vp check --fix src vite.config.ts && tsgo --noEmit",
     "fmt": "vp fmt --write src vite.config.ts",
-    "package": "vsce package --no-dependencies --out dist/vize.vsix",
-    "test:host": "node test/run-extension-host.mjs",
+    "package": "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && vsce package --no-dependencies --out dist/vize.vsix && node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix",
+    "test:host": "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && node test/run-extension-host.mjs",
     "publish": "npm run package && vsce publish --packagePath dist/vize.vsix",
     "publish:pre": "npm run package && vsce publish --pre-release --packagePath dist/vize.vsix"
   },
@@ -53,6 +53,12 @@
     "vite-plus": "0.1.19"
   },
   "contributes": {
+    "typescriptServerPlugins": [
+      {
+        "name": "@vizejs/typescript-vue-plugin",
+        "enableForWorkspaceTypeScriptVersions": true
+      }
+    ],
     "languages": [
       {
         "id": "art-vue",

--- a/editors/vscode/test-fixtures/extension-host/basic-vue/src/main.ts
+++ b/editors/vscode/test-fixtures/extension-host/basic-vue/src/main.ts
@@ -1,0 +1,3 @@
+import App from "./App.vue";
+
+App;

--- a/editors/vscode/test/suite/editor-capability-smoke.cjs
+++ b/editors/vscode/test/suite/editor-capability-smoke.cjs
@@ -1,5 +1,8 @@
 const assert = require("node:assert/strict");
+const path = require("node:path");
 const vscode = require("vscode");
+
+const extensionId = "ubugeeei.vize";
 
 async function runEditorCapabilityProviderSmoke({
   assertLocation,
@@ -14,6 +17,8 @@ async function runEditorCapabilityProviderSmoke({
   waitForLogEntries,
   waitForReadyServer,
 }) {
+  await runTypeScriptVueImportSmoke(openWorkspaceDocument);
+
   const { logPath, serverPath } = getFakeServer();
 
   await prepareConfiguredFakeServer({ logPath, serverPath });
@@ -231,8 +236,61 @@ async function runEditorCapabilityProviderSmoke({
   await disableVizeAndWaitForShutdown(logPath);
 }
 
+async function runTypeScriptVueImportSmoke(openWorkspaceDocument) {
+  const extension = vscode.extensions.getExtension(extensionId);
+  assert.ok(extension, `missing extension: ${extensionId}`);
+  assert.deepEqual(extension.packageJSON.contributes?.typescriptServerPlugins, [
+    {
+      enableForWorkspaceTypeScriptVersions: true,
+      name: "@vizejs/typescript-vue-plugin",
+    },
+  ]);
+
+  const document = await openWorkspaceDocument("src", "main.ts");
+  assert.equal(document.languageId, "typescript");
+  await vscode.window.showTextDocument(document);
+
+  const source = document.getText();
+  const specifierOffset = source.indexOf("./App.vue");
+  assert.notEqual(specifierOffset, -1, "main.ts must import App.vue");
+
+  const definitions = await vscode.commands.executeCommand(
+    "vscode.executeDefinitionProvider",
+    document.uri,
+    document.positionAt(specifierOffset + 3),
+  );
+  const appVueUri = vscode.Uri.file(path.join(getWorkspaceFolder().uri.fsPath, "src", "App.vue"));
+
+  assert.ok(
+    Array.isArray(definitions) &&
+      definitions.some(
+        (definition) => definitionUri(definition)?.toString() === appVueUri.toString(),
+      ),
+    `expected TypeScript Vue plugin to resolve ./App.vue, got ${JSON.stringify(definitions)}`,
+  );
+
+  const diagnostics = vscode.languages.getDiagnostics(document.uri);
+  assert.equal(
+    diagnostics.some((diagnostic) =>
+      /Cannot find module ['"]\.\/App\.vue['"]/.test(diagnostic.message),
+    ),
+    false,
+    `main.ts should not report TS2307 for App.vue. Diagnostics: ${JSON.stringify(diagnostics)}`,
+  );
+}
+
 function assertIncludesWhere(items, predicate, message) {
   assert.ok(items?.some(predicate), message);
+}
+
+function definitionUri(definition) {
+  return definition?.uri ?? definition?.targetUri;
+}
+
+function getWorkspaceFolder() {
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  assert.ok(workspaceFolder, "expected a workspace folder");
+  return workspaceFolder;
 }
 
 module.exports = { runEditorCapabilityProviderSmoke };

--- a/editors/vscode/typescript-vue-plugin/index.cjs
+++ b/editors/vscode/typescript-vue-plugin/index.cjs
@@ -3,8 +3,6 @@
 const path = require("node:path");
 
 const vueExtension = ".vue";
-const virtualDtsSuffix = ".d.ts";
-const installedHosts = new WeakSet();
 
 function init({ typescript: ts }) {
   return {
@@ -13,8 +11,9 @@ function init({ typescript: ts }) {
         return info?.languageService;
       }
       try {
-        return installVueImportResolver(ts, info)
-          ? createLanguageServiceProxy(ts, info.languageService)
+        const support = createVueImportSupport(ts, info);
+        return support
+          ? createLanguageServiceProxy(ts, info.languageService, support)
           : info.languageService;
       } catch (error) {
         logPluginError(info, "create", error);
@@ -24,228 +23,89 @@ function init({ typescript: ts }) {
   };
 }
 
-function installVueImportResolver(ts, info) {
+function createVueImportSupport(ts, info) {
   const host = info.languageServiceHost;
   if (!host) {
-    return false;
-  }
-  if (installedHosts.has(host)) {
-    return true;
+    return undefined;
   }
 
   const serverHost = info.serverHost || ts.sys;
   const originalFileExists = bind(host.fileExists, host) || bind(serverHost.fileExists, serverHost);
   const originalReadFile = bind(host.readFile, host) || bind(serverHost.readFile, serverHost);
-  const originalGetScriptSnapshot = bind(host.getScriptSnapshot, host);
-  const originalGetScriptKind = bind(host.getScriptKind, host);
-  const originalResolveModuleNameLiterals = bind(host.resolveModuleNameLiterals, host);
-  const originalResolveModuleNames = bind(host.resolveModuleNames, host);
 
-  if (!originalFileExists || !originalReadFile || !originalGetScriptSnapshot) {
-    return false;
-  }
-
-  const replacements = {
-    fileExists(fileName) {
-      const vuePath = realVuePathFromVirtual(fileName);
-      if (vuePath) {
-        return originalFileExists(vuePath);
-      }
-      return originalFileExists(fileName);
-    },
-    readFile(fileName) {
-      const vuePath = realVuePathFromVirtual(fileName);
-      if (vuePath && originalFileExists(vuePath)) {
-        return virtualVueDts();
-      }
-      return originalReadFile(fileName);
-    },
-    getScriptSnapshot(fileName) {
-      const vuePath = realVuePathFromVirtual(fileName);
-      if (vuePath && originalFileExists(vuePath)) {
-        return ts.ScriptSnapshot.fromString(virtualVueDts());
-      }
-      return originalGetScriptSnapshot(fileName);
-    },
-    getScriptKind(fileName) {
-      if (realVuePathFromVirtual(fileName)) {
-        return ts.ScriptKind.TS;
-      }
-      return originalGetScriptKind ? originalGetScriptKind(fileName) : ts.ScriptKind.Unknown;
-    },
-    resolveModuleNameLiterals(...args) {
-      const [moduleLiterals, containingFile] = args;
-      const previous = toArray(originalResolveModuleNameLiterals?.(...args));
-
-      if (!Array.isArray(moduleLiterals)) {
-        return previous;
-      }
-
-      return moduleLiterals.map((literal, index) => {
-        if (previous[index] && previous[index].resolvedModule) {
-          return previous[index];
-        }
-
-        const resolvedModule = resolveVueModule(
-          ts,
-          literal?.text,
-          containingFile,
-          originalFileExists,
-        );
-        return resolvedModule
-          ? { resolvedModule }
-          : previous[index] || { resolvedModule: undefined };
-      });
-    },
-    resolveModuleNames(...args) {
-      const [moduleNames, containingFile] = args;
-      const previous = toArray(originalResolveModuleNames?.(...args));
-
-      if (!Array.isArray(moduleNames)) {
-        return previous;
-      }
-
-      return moduleNames.map((moduleName, index) => {
-        if (previous[index]) {
-          return previous[index];
-        }
-        return resolveVueModule(ts, moduleName, containingFile, originalFileExists);
-      });
-    },
-  };
-
-  const replacementEntries = Object.entries(replacements);
-  if (!replacementEntries.every(([name]) => canAssignProperty(host, name))) {
-    return false;
-  }
-
-  const originals = new Map(replacementEntries.map(([name]) => [name, host[name]]));
-  try {
-    for (const [name, replacement] of replacementEntries) {
-      host[name] = replacement;
-    }
-  } catch (error) {
-    for (const [name, original] of originals) {
-      try {
-        host[name] = original;
-      } catch {
-        // Best effort rollback only; create() will return the unproxied service.
-      }
-    }
-    logPluginError(info, "install", error);
-    return false;
-  }
-
-  installedHosts.add(host);
-  return true;
-}
-
-function resolveVueModule(ts, specifier, containingFile, fileExists) {
-  if (!isRelativeVueSpecifier(specifier) || typeof containingFile !== "string") {
-    return undefined;
-  }
-
-  const vuePath = path.resolve(path.dirname(containingFile), specifier);
-  if (!fileExists(vuePath)) {
+  if (!originalFileExists || !originalReadFile) {
     return undefined;
   }
 
   return {
-    extension: ts.Extension.Dts,
-    isExternalLibraryImport: false,
-    resolvedFileName: virtualVueDtsPath(vuePath),
+    fileExists: originalFileExists,
+    readFile: originalReadFile,
   };
 }
 
-function createLanguageServiceProxy(ts, languageService) {
+function createLanguageServiceProxy(ts, languageService, support) {
   const proxy = Object.create(null);
   for (const key of Object.keys(languageService)) {
     const value = languageService[key];
     proxy[key] = typeof value === "function" ? value.bind(languageService) : value;
   }
 
-  proxy.getDefinitionAtPosition = (fileName, position) =>
-    remapVueVirtualDefinitions(ts, languageService.getDefinitionAtPosition(fileName, position));
+  proxy.getSemanticDiagnostics = (fileName) =>
+    filterVueImportDiagnostics(ts, languageService.getSemanticDiagnostics(fileName), {
+      fileExists: support.fileExists,
+      fileName,
+    });
 
-  proxy.getDefinitionAndBoundSpan = (fileName, position) => {
-    const result = languageService.getDefinitionAndBoundSpan(fileName, position);
-    if (!result || !result.definitions) {
-      return result;
-    }
-    return {
-      ...result,
-      definitions: remapVueVirtualDefinitions(ts, result.definitions),
-    };
+  proxy.getDefinitionAtPosition = (fileName, position) => {
+    const vueDefinition = resolveVueImportDefinition(ts, support, fileName, position);
+    return vueDefinition
+      ? [vueDefinition.definition]
+      : languageService.getDefinitionAtPosition(fileName, position);
   };
 
-  proxy.getTypeDefinitionAtPosition = (fileName, position) =>
-    remapVueVirtualDefinitions(ts, languageService.getTypeDefinitionAtPosition(fileName, position));
-
-  proxy.getQuickInfoAtPosition = (fileName, position) => {
-    const quickInfo = languageService.getQuickInfoAtPosition(fileName, position);
-    if (!quickInfo) {
-      return quickInfo;
+  proxy.getDefinitionAndBoundSpan = (fileName, position) => {
+    const vueDefinition = resolveVueImportDefinition(ts, support, fileName, position);
+    if (vueDefinition) {
+      return {
+        definitions: [vueDefinition.definition],
+        textSpan: vueDefinition.textSpan,
+      };
     }
 
-    const vuePaths = vuePathsFromDefinitions(
-      safeCall(() => languageService.getDefinitionAtPosition(fileName, position), undefined),
-    );
-    if (vuePaths.length === 0) {
+    const result = languageService.getDefinitionAndBoundSpan(fileName, position);
+    return result;
+  };
+
+  proxy.getTypeDefinitionAtPosition = (fileName, position) => {
+    const vueDefinition = resolveVueImportDefinition(ts, support, fileName, position);
+    return vueDefinition
+      ? [vueDefinition.definition]
+      : languageService.getTypeDefinitionAtPosition(fileName, position);
+  };
+
+  proxy.getQuickInfoAtPosition = (fileName, position) => {
+    const vueDefinition = resolveVueImportDefinition(ts, support, fileName, position);
+    const quickInfo = languageService.getQuickInfoAtPosition(fileName, position);
+    if (!vueDefinition) {
       return quickInfo;
     }
 
     return {
-      ...quickInfo,
+      kind: ts.ScriptElementKind.alias,
+      kindModifiers: "",
+      textSpan: vueDefinition.textSpan,
+      ...(quickInfo || {}),
       documentation: [
-        ...(quickInfo.documentation || []),
+        ...(quickInfo?.documentation || []),
         {
           kind: "text",
-          text: `Vue component: ${path.basename(vuePaths[0])}`,
+          text: `Vue component: ${path.basename(vueDefinition.definition.fileName)}`,
         },
       ],
     };
   };
 
   return proxy;
-}
-
-function canAssignProperty(target, key) {
-  const descriptor = findPropertyDescriptor(target, key);
-  if (!descriptor) {
-    return isExtensible(target);
-  }
-  if ("writable" in descriptor) {
-    return descriptor.writable;
-  }
-  return typeof descriptor.set === "function";
-}
-
-function findPropertyDescriptor(target, key) {
-  let current = target;
-  while (current) {
-    const descriptor = Object.getOwnPropertyDescriptor(current, key);
-    if (descriptor) {
-      return descriptor;
-    }
-    current = Object.getPrototypeOf(current);
-  }
-  return undefined;
-}
-
-function isExtensible(target) {
-  try {
-    return Object.isExtensible(target);
-  } catch {
-    return false;
-  }
-}
-
-function safeCall(fn, fallback) {
-  try {
-    return fn();
-  } catch {
-    return fallback;
-  }
 }
 
 function logPluginError(info, phase, error) {
@@ -259,40 +119,159 @@ function logPluginError(info, phase, error) {
   }
 }
 
-function remapVueVirtualDefinitions(ts, definitions) {
-  return definitions?.map((definition) => remapVueVirtualDefinition(ts, definition));
+function filterVueImportDiagnostics(ts, diagnostics, { fileExists, fileName }) {
+  return diagnostics.filter((diagnostic) => {
+    if (diagnostic.code !== 2307) {
+      return true;
+    }
+
+    const specifier = diagnosticVueSpecifier(ts, diagnostic);
+    const containingFile = diagnostic.file?.fileName || fileName;
+    return !resolveExistingVueSpecifier(containingFile, specifier, fileExists);
+  });
 }
 
-function vuePathsFromDefinitions(definitions) {
-  return (
-    definitions
-      ?.map((definition) => realVuePathFromVirtual(definition.fileName))
-      .filter((vuePath) => vuePath) || []
-  );
+function diagnosticVueSpecifier(ts, diagnostic) {
+  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+  return message.match(/Cannot find module ['"]([^'"]+\.vue)['"]/)?.[1];
 }
 
-function remapVueVirtualDefinition(ts, definition) {
-  const vuePath = realVuePathFromVirtual(definition.fileName);
-  if (!vuePath) {
-    return definition;
+function resolveVueImportDefinition(ts, support, fileName, position) {
+  if (typeof fileName !== "string") {
+    return undefined;
+  }
+
+  const sourceText = support.readFile(fileName);
+  if (typeof sourceText !== "string") {
+    return undefined;
+  }
+
+  const vueImport = findVueImportAtPosition(ts, sourceText, position);
+  const vuePath = resolveExistingVueSpecifier(fileName, vueImport?.specifier, support.fileExists);
+  if (!vueImport || !vuePath) {
+    return undefined;
   }
 
   return {
-    ...definition,
-    fileName: vuePath,
-    textSpan: { start: 0, length: 0 },
-    contextSpan: undefined,
-    kind: ts.ScriptElementKind.scriptElement,
-    name: path.basename(vuePath),
+    definition: {
+      fileName: vuePath,
+      kind: ts.ScriptElementKind.scriptElement,
+      name: path.basename(vuePath),
+      textSpan: { start: 0, length: 0 },
+    },
+    textSpan: vueImport.textSpan,
   };
 }
 
-function bind(fn, thisArg) {
-  return typeof fn === "function" ? fn.bind(thisArg) : undefined;
+function findVueImportAtPosition(ts, sourceText, position) {
+  const sourceFile = ts.createSourceFile(
+    "vize-vue-import.ts",
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const imports = [];
+
+  visit(sourceFile, (node) => {
+    if (!ts.isImportDeclaration(node) || !isStringLiteralLike(ts, node.moduleSpecifier)) {
+      return;
+    }
+
+    const specifier = node.moduleSpecifier.text;
+    if (!isRelativeVueSpecifier(specifier)) {
+      return;
+    }
+
+    const localNames = new Set();
+    const importClause = node.importClause;
+    if (importClause?.name) {
+      localNames.add(importClause.name.text);
+    }
+    const namedBindings = importClause?.namedBindings;
+    if (namedBindings && ts.isNamespaceImport(namedBindings)) {
+      localNames.add(namedBindings.name.text);
+    } else if (namedBindings && ts.isNamedImports(namedBindings)) {
+      for (const element of namedBindings.elements) {
+        localNames.add(element.name.text);
+      }
+    }
+
+    imports.push({
+      localNames,
+      specifier,
+      specifierSpan: {
+        length: specifier.length,
+        start: node.moduleSpecifier.getStart(sourceFile) + 1,
+      },
+    });
+  });
+
+  for (const vueImport of imports) {
+    if (containsPosition(vueImport.specifierSpan, position)) {
+      return {
+        specifier: vueImport.specifier,
+        textSpan: vueImport.specifierSpan,
+      };
+    }
+  }
+
+  const identifier = identifierAtPosition(ts, sourceFile, position);
+  if (!identifier) {
+    return undefined;
+  }
+
+  const identifierText = identifier.text;
+  const vueImport = imports.find((entry) => entry.localNames.has(identifierText));
+  if (!vueImport) {
+    return undefined;
+  }
+
+  return {
+    specifier: vueImport.specifier,
+    textSpan: {
+      length: identifier.getEnd() - identifier.getStart(sourceFile),
+      start: identifier.getStart(sourceFile),
+    },
+  };
 }
 
-function toArray(value) {
-  return Array.isArray(value) ? value : [];
+function identifierAtPosition(ts, sourceFile, position) {
+  let result;
+  visit(sourceFile, (node) => {
+    if (
+      result ||
+      !ts.isIdentifier(node) ||
+      position < node.getStart(sourceFile) ||
+      position > node.getEnd()
+    ) {
+      return;
+    }
+    result = node;
+  });
+  return result;
+}
+
+function visit(node, callback) {
+  callback(node);
+  node.forEachChild((child) => visit(child, callback));
+}
+
+function isStringLiteralLike(ts, node) {
+  return ts.isStringLiteral(node) || node.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral;
+}
+
+function containsPosition(span, position) {
+  return position >= span.start && position <= span.start + span.length;
+}
+
+function resolveExistingVueSpecifier(containingFile, specifier, fileExists) {
+  if (!isRelativeVueSpecifier(specifier) || typeof containingFile !== "string") {
+    return undefined;
+  }
+
+  const vuePath = path.resolve(path.dirname(containingFile), specifier);
+  return fileExists(vuePath) ? vuePath : undefined;
 }
 
 function isRelativeVueSpecifier(specifier) {
@@ -303,18 +282,8 @@ function isRelativeVueSpecifier(specifier) {
   );
 }
 
-function realVuePathFromVirtual(fileName) {
-  return typeof fileName === "string" && fileName.endsWith(`${vueExtension}${virtualDtsSuffix}`)
-    ? fileName.slice(0, -virtualDtsSuffix.length)
-    : undefined;
-}
-
-function virtualVueDtsPath(vuePath) {
-  return `${vuePath}${virtualDtsSuffix}`;
-}
-
-function virtualVueDts() {
-  return "declare const component: any;\nexport default component;\n";
+function bind(fn, thisArg) {
+  return typeof fn === "function" ? fn.bind(thisArg) : undefined;
 }
 
 module.exports = init;

--- a/tests/tooling/editor-lsp-adapters.test.ts
+++ b/tests/tooling/editor-lsp-adapters.test.ts
@@ -14,7 +14,10 @@ test("editor adapters consistently route Vue documents to the Vize LSP", () => {
   const vscodeManifest = readJson<{
     activationEvents?: string[];
     contributes?: {
-      typescriptServerPlugins?: unknown;
+      typescriptServerPlugins?: Array<{
+        enableForWorkspaceTypeScriptVersions?: boolean;
+        name?: string;
+      }>;
     };
   }>("editors/vscode/package.json");
   for (const language of ["vue", "art-vue", "html"]) {
@@ -23,7 +26,12 @@ test("editor adapters consistently route Vue documents to the Vize LSP", () => {
       `missing VS Code activation for ${language}`,
     );
   }
-  assert.equal(vscodeManifest.contributes?.typescriptServerPlugins, undefined);
+  assert.deepEqual(vscodeManifest.contributes?.typescriptServerPlugins, [
+    {
+      enableForWorkspaceTypeScriptVersions: true,
+      name: "@vizejs/typescript-vue-plugin",
+    },
+  ]);
 
   const nvimConfig = fs.readFileSync(path.join(root, "editors/nvim/lua/vize/config.lua"), "utf-8");
   assert.match(nvimConfig, /cmd = \{ "vize", "lsp" \}/);

--- a/tests/tooling/vscode-typescript-vue-plugin.test.ts
+++ b/tests/tooling/vscode-typescript-vue-plugin.test.ts
@@ -26,7 +26,7 @@ const initVuePlugin = require(
   }): import("typescript").LanguageService;
 };
 
-test("VS Code extension does not install a global TypeScript server plugin", () => {
+test("VS Code extension installs the guarded TypeScript Vue plugin", () => {
   const manifest = readJson<{
     contributes?: {
       typescriptServerPlugins?: Array<{
@@ -37,29 +37,39 @@ test("VS Code extension does not install a global TypeScript server plugin", () 
     scripts?: Record<string, string>;
   }>("editors/vscode/package.json");
 
-  assert.equal(
-    manifest.contributes?.typescriptServerPlugins,
-    undefined,
-    "Vize must not inject a TypeScript server plugin into every .ts/.tsx project",
-  );
+  assert.deepEqual(manifest.contributes?.typescriptServerPlugins, [
+    {
+      enableForWorkspaceTypeScriptVersions: true,
+      name: "@vizejs/typescript-vue-plugin",
+    },
+  ]);
   assert.equal(manifest.scripts?.["vscode:prepublish"], "vp pack");
   assert.equal(manifest.scripts?.build, "vp pack");
   assert.equal(manifest.scripts?.watch, "vp pack --watch");
-  assert.equal(manifest.scripts?.package, "vsce package --no-dependencies --out dist/vize.vsix");
+  assert.equal(
+    manifest.scripts?.package,
+    "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && vsce package --no-dependencies --out dist/vize.vsix && node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix",
+  );
+  assert.equal(
+    manifest.scripts?.["test:host"],
+    "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && node test/run-extension-host.mjs",
+  );
 
-  for (const file of [
-    "editors/vscode/package.json",
-    "tools/vite-plus/tasks/build.ts",
-    "tools/vite-plus/tasks/test-benchmark.ts",
-  ]) {
-    assert.doesNotMatch(readFile(file), /sync-typescript-plugin\.mjs/);
-    assert.doesNotMatch(readFile(file), /@vizejs\/typescript-vue-plugin/);
-  }
+  assert.match(readFile("tools/vite-plus/tasks/build.ts"), /sync-typescript-plugin\.mjs stage/);
+  assert.match(readFile("tools/vite-plus/tasks/build.ts"), /sync-typescript-plugin\.mjs inject/);
+  assert.match(
+    readFile("tools/vite-plus/tasks/test-benchmark.ts"),
+    /sync-typescript-plugin\.mjs stage/,
+  );
+  assert.match(
+    readFile("tools/vite-plus/tasks/test-benchmark.ts"),
+    /sync-typescript-plugin\.mjs inject/,
+  );
 
   assert.match(readFile("editors/vscode/.vscodeignore"), /^typescript-vue-plugin\/$/m);
   assert.ok(
     fs.existsSync(path.join(root, "editors/vscode/typescript-vue-plugin/index.cjs")),
-    "kept plugin source is tested below but no longer packaged or contributed",
+    "plugin source is synchronized into node_modules/@vizejs/typescript-vue-plugin for VS Code",
   );
 });
 
@@ -109,6 +119,34 @@ test("TypeScript Vue plugin maps .ts definition results back to real .vue files"
   }
 });
 
+test("TypeScript Vue plugin filters existing .vue import diagnostics without patching host resolution", () => {
+  const project = createVueProject('import App from "./app.vue";\nApp;\n', {
+    "app.vue": "<template />\n",
+  });
+  try {
+    const host = createHost(path.dirname(path.dirname(project.mainTs)), project.mainTs);
+    const service = ts.createLanguageService(host);
+    const plugin = initVuePlugin({ typescript: ts });
+    const wrapped = plugin.create({
+      languageService: service,
+      languageServiceHost: host,
+      serverHost: ts.sys,
+    });
+
+    assert.equal(Reflect.get(host, "resolveModuleNameLiterals"), undefined);
+    assert.equal(Reflect.get(host, "resolveModuleNames"), undefined);
+
+    const diagnostics = wrapped.getSemanticDiagnostics(project.mainTs);
+    assert.equal(
+      hasCannotFindVueModule(diagnostics, "./app.vue"),
+      false,
+      formatDiagnostics(diagnostics),
+    );
+  } finally {
+    fs.rmSync(project.root, { force: true, recursive: true });
+  }
+});
+
 test("TypeScript Vue plugin annotates .ts hover info for .vue imports", () => {
   const project = createVueProject('import App from "./app.vue";\nApp;\n', {
     "app.vue": "<template />\n",
@@ -136,13 +174,10 @@ test("TypeScript Vue plugin keeps missing .vue imports diagnostic", () => {
   }
 });
 
-test("TypeScript Vue plugin keeps plain .ts projects crash-free with unresolved host fallbacks", () => {
+test("TypeScript Vue plugin keeps plain .ts projects crash-free without host resolver patches", () => {
   const project = createVueProject('import value from "./missing";\nvalue;\n', {});
   try {
-    const service = createLanguageService(project.mainTs, true, (host) => {
-      host.resolveModuleNameLiterals = () => undefined as never;
-      host.resolveModuleNames = () => undefined as never;
-    });
+    const service = createLanguageService(project.mainTs, true);
 
     assert.doesNotThrow(() => service.getSemanticDiagnostics(project.mainTs));
   } finally {
@@ -150,7 +185,7 @@ test("TypeScript Vue plugin keeps plain .ts projects crash-free with unresolved 
   }
 });
 
-test("TypeScript Vue plugin falls back when the tsserver host cannot be patched", () => {
+test("TypeScript Vue plugin does not require a patchable tsserver host", () => {
   const project = createVueProject("const value = 1;\nvalue;\n", {});
   try {
     const host = createHost(path.dirname(path.dirname(project.mainTs)), project.mainTs);
@@ -166,14 +201,14 @@ test("TypeScript Vue plugin falls back when the tsserver host cannot be patched"
         serverHost: ts.sys,
       });
     });
-    assert.equal(wrapped, service);
+    assert.notEqual(wrapped, service);
     assert.doesNotThrow(() => wrapped?.getSemanticDiagnostics(project.mainTs));
   } finally {
     fs.rmSync(project.root, { force: true, recursive: true });
   }
 });
 
-test("TypeScript Vue plugin tolerates resolver calls without a containing file", () => {
+test("TypeScript Vue plugin leaves host resolver calls untouched", () => {
   const project = createVueProject('import App from "./app.vue";\nApp;\n', {
     "app.vue": "<template />\n",
   });
@@ -189,11 +224,8 @@ test("TypeScript Vue plugin tolerates resolver calls without a containing file",
     });
 
     assert.doesNotThrow(() => {
-      const result = (host.resolveModuleNameLiterals as unknown as (...args: unknown[]) => unknown)(
-        [{ text: "./app.vue" }],
-        undefined,
-      );
-      assert.deepEqual(result, [{ resolvedModule: undefined }]);
+      assert.equal(Reflect.get(host, "resolveModuleNameLiterals"), undefined);
+      assert.equal(Reflect.get(host, "resolveModuleNames"), undefined);
     });
   } finally {
     fs.rmSync(project.root, { force: true, recursive: true });

--- a/tools/vite-plus/tasks/build.ts
+++ b/tools/vite-plus/tasks/build.ts
@@ -12,6 +12,15 @@ import {
 } from "../task-helpers.ts";
 import { inTestbox } from "./testbox.ts";
 
+const stageVscodeTypeScriptPlugin = "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage";
+const injectVscodeTypeScriptPlugin =
+  "node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix";
+const packageVscodeExtension = [
+  stageVscodeTypeScriptPlugin,
+  "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
+  injectVscodeTypeScriptPlugin,
+].join(" && ");
+
 /**
  * Build and packaging tasks for the repository's compiled artifacts.
  *
@@ -53,11 +62,13 @@ export const buildTasks = defineTasks({
   ),
   "build:plugin": noCacheTask(runTask("build:vite-plugin")),
   "build:cli": task("cargo build --release -p vize"),
-  "build:vscode-extension": noCacheTask(runInVscodeExtension("pnpm exec vp pack")),
+  "build:vscode-extension": noCacheTask(
+    runInVscodeExtension(stageVscodeTypeScriptPlugin, "pnpm exec vp pack"),
+  ),
   "build:editor-extensions": noCacheTask(runTasks("build:vscode-extension", "check:zed-extension")),
   "package:vscode-extension": noCacheTask(
     runInVscodeExtension(
-      "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
+      packageVscodeExtension,
       "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
     ),
   ),
@@ -83,7 +94,7 @@ export const buildTasks = defineTasks({
     `${runInVscodeExtension(
       "pnpm exec tsgo --noEmit",
       "pnpm exec vp check src vite.config.ts",
-      "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
+      packageVscodeExtension,
       "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
     )} && ${runTask("check:zed-extension")} && ${runTask(
       "test:zed-extension:unit",

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -11,6 +11,15 @@ import {
 } from "../task-helpers.ts";
 import { inTestbox } from "./testbox.ts";
 
+const stageVscodeTypeScriptPlugin = "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage";
+const injectVscodeTypeScriptPlugin =
+  "node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix";
+const packageVscodeExtension = [
+  stageVscodeTypeScriptPlugin,
+  "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
+  injectVscodeTypeScriptPlugin,
+].join(" && ");
+
 const jsPackageTestCommand = runInPackages("test", testedPackages, {
   concurrencyLimit: 1,
 });
@@ -91,12 +100,12 @@ export const testAndBenchmarkTasks = defineTasks({
   ),
   "test:vscode-extension:vsix": noCacheTask(
     runInVscodeExtension(
-      "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
+      packageVscodeExtension,
       "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
     ),
   ),
   "test:vscode-extension:host": noCacheTask(
-    runInVscodeExtension("pnpm exec vp pack", "pnpm run test:host"),
+    runInVscodeExtension(stageVscodeTypeScriptPlugin, "pnpm exec vp pack", "pnpm run test:host"),
   ),
   "test:zed-extension:package": noCacheTask("vp run --workspace-root package:zed-extension"),
   "test:zed-extension:unit": task("cargo test --manifest-path editors/zed/Cargo.toml", {

--- a/tools/vscode-vize/assert-vsix-package.mjs
+++ b/tools/vscode-vize/assert-vsix-package.mjs
@@ -5,6 +5,7 @@ import { builtinModules } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import zlib from "node:zlib";
+import * as tsVueVsix from "./typescript-vue-plugin-vsix-policy.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const defaultVsixPath = path.join(root, "editors/vscode/dist/vize.vsix");
@@ -44,6 +45,7 @@ const requiredFiles = [
   "extension/icons/logo.png",
   "extension/icons/vue.svg",
   "extension/language-configuration.json",
+  ...tsVueVsix.typescriptVuePluginRequiredFiles,
   "extension/package.json",
   "extension/readme.md",
   "extension/syntaxes/art-vue.tmLanguage.json",
@@ -61,6 +63,7 @@ const allowedExtensionEntries = [
   /^extension\/dist\/extension\.cjs$/,
   /^extension\/icons\/(?:logo\.png|vue\.svg)$/,
   /^extension\/language-configuration\.json$/,
+  tsVueVsix.typescriptVuePluginAllowedEntry,
   /^extension\/package\.json$/,
   /^extension\/readme\.md$/,
   /^extension\/syntaxes\/(?:art-vue|vue)\.tmLanguage\.json$/,
@@ -78,7 +81,7 @@ const forbiddenEntries = [
   /^extension\/\.vscode-test\//,
   /^extension\/\.vscode\//,
   /^extension\/dist\/.*\.map$/,
-  /^extension\/node_modules\//,
+  tsVueVsix.forbiddenNonPluginNodeModules,
   /^extension\/package-lock\.json$/,
   /^extension\/pnpm-lock\.yaml$/,
   /^extension\/src\//,
@@ -123,7 +126,11 @@ for (const command of packageJson.contributes.commands) {
 
 assert.ok(packageJson.activationEvents.includes("onLanguage:vue"));
 assert.ok(packageJson.activationEvents.includes("onLanguage:art-vue"));
-assert.equal(packageJson.contributes.typescriptServerPlugins, undefined);
+tsVueVsix.assertTypeScriptVuePluginPackage({
+  packageJson,
+  readJsonEntry: (name) => readJsonEntry(archive, name),
+  readTextEntry: (name) => readTextEntry(archive, name),
+});
 
 const languages = new Map(
   packageJson.contributes.languages.map((language) => [language.id, language]),

--- a/tools/vscode-vize/typescript-vue-plugin-vsix-policy.mjs
+++ b/tools/vscode-vize/typescript-vue-plugin-vsix-policy.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+
+const packageName = "@vizejs/typescript-vue-plugin";
+const entryRoot = `extension/node_modules/${packageName}`;
+
+export const typescriptVuePluginRequiredFiles = [
+  `${entryRoot}/index.cjs`,
+  `${entryRoot}/package.json`,
+];
+
+export const typescriptVuePluginAllowedEntry =
+  /^extension\/node_modules\/@vizejs\/typescript-vue-plugin\/(?:index\.cjs|package\.json)$/;
+
+export const forbiddenNonPluginNodeModules =
+  /^extension\/node_modules\/(?!@vizejs\/typescript-vue-plugin\/(?:index\.cjs|package\.json)$)/;
+
+export function assertTypeScriptVuePluginPackage({ packageJson, readJsonEntry, readTextEntry }) {
+  assert.deepEqual(packageJson.contributes?.typescriptServerPlugins, [
+    {
+      enableForWorkspaceTypeScriptVersions: true,
+      name: packageName,
+    },
+  ]);
+
+  const pluginPackage = readJsonEntry(`${entryRoot}/package.json`);
+  assert.equal(pluginPackage.name, packageName);
+  assert.equal(pluginPackage.main, "index.cjs");
+  assert.match(readTextEntry(`${entryRoot}/index.cjs`), /function init\(\{ typescript: ts \}\)/);
+}


### PR DESCRIPTION
## Summary

Restores the VS Code TypeScript server plugin path so TypeScript no longer reports TS2307 for existing relative `.vue` imports such as `import App from "./App.vue"`.

## Root Cause

The TypeScript Vue plugin source still existed, but the VS Code manifest and VSIX packaging path no longer contributed or shipped it. That left VS Code's TypeScript server without a project-local way to recognize existing `.vue` imports.

## Changes

- Re-add `@vizejs/typescript-vue-plugin` to the VS Code extension manifest.
- Package the plugin into the VSIX and assert the packaged files are present.
- Change the plugin to avoid patching tsserver module resolution directly; it filters TS2307 only for existing relative `.vue` imports and provides definition/hover support from import syntax.
- Add real VS Code host smoke coverage for `main.ts -> App.vue`.

## Validation

- `node --test tests/tooling/vscode-typescript-vue-plugin.test.ts tests/tooling/editor-lsp-adapters.test.ts`
- `corepack pnpm exec vp run --workspace-root test:vscode-extension:vsix`
- `corepack pnpm exec vp run --workspace-root test:vscode-extension:host`
- `corepack pnpm --dir editors/vscode run check`
- `git diff --check`

Note: Directly adding `tests/tooling/editor-integrations.test.ts` to the local node test invocation failed before running its assertions because this checkout is missing `shiki/package.json` from the root install tree.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786073490&installation_id=136613492&pr_number=2702&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2702&signature=3ec52de11b3bc63d85f928dfddfbcc86996083118ec521fd785e95bcccc551e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VS Code now includes TypeScript Vue plugin support for better `.vue` import awareness.
  * Vue imports can resolve directly to the source component and show clearer hover info.

* **Bug Fixes**
  * Reduced false “Cannot find module” diagnostics for existing Vue files.
  * Improved editor navigation and type lookup for Vue imports.

* **Tests**
  * Expanded VS Code extension checks to verify packaging, plugin inclusion, and Vue import behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->