### PR TITLE
refactor(nuxt): parse i18n helper injection

### DIFF
--- a/npm/framework/nuxt/src/i18n-edge.test.ts
+++ b/npm/framework/nuxt/src/i18n-edge.test.ts
@@ -116,9 +116,7 @@ export default {
   assert.equal(out.match(/useI18n\(\)/g)?.length, 2);
 });
 
-// SURPRISING (text-based regex): a "$t(" that lives only inside a string literal still
-// matches and triggers injection, because the transform never parses JS.
-void test("matches helper-looking text inside a string literal (no JS parsing)", () => {
+void test("ignores helper-looking text inside a string literal", () => {
   const out = injectNuxtI18nHelpers(`
 export default {
   setup(__props) {
@@ -126,11 +124,10 @@ export default {
   }
 }
 `);
-  assert.match(out, /const \{ t: \$t \} = useI18n\(\);/);
+  assert.equal(out.includes("useI18n()"), false);
 });
 
-// SURPRISING (text-based regex): a "$d(" inside a line comment also triggers injection.
-void test("matches helper-looking text inside a comment (no JS parsing)", () => {
+void test("ignores helper-looking text inside a comment", () => {
   const out = injectNuxtI18nHelpers(`
 export default {
   setup(__props) {
@@ -139,5 +136,20 @@ export default {
   }
 }
 `);
-  assert.match(out, /const \{ d: \$d \} = useI18n\(\);/);
+  assert.equal(out.includes("useI18n()"), false);
+});
+
+void test("parses TypeScript syntax while collecting runtime helper calls", () => {
+  const out = injectNuxtI18nHelpers(
+    `
+export default {
+  setup(__props: { msg: string }) {
+    const title: string = $t("settings.title");
+    return { title };
+  }
+}
+`,
+    "Component.vue.ts",
+  );
+  assert.match(out, /const \{ t: \$t \} = useI18n\(\);/);
 });

--- a/npm/framework/nuxt/src/i18n.ts
+++ b/npm/framework/nuxt/src/i18n.ts
@@ -1,3 +1,5 @@
+import { parseSync } from "vite";
+
 const I18N_FN_MAP: Record<string, string> = {
   $t: "t: $t",
   $rt: "rt: $rt",
@@ -7,98 +9,298 @@ const I18N_FN_MAP: Record<string, string> = {
   $te: "te: $te",
 };
 
-const I18N_FN_RE = /(?<![.\w])\$([tdn]|rt|tm|te)\s*\(/g;
-const SETUP_FN_RE = /setup\s*\(__props[\s\S]*?\)\s*\{/;
-const USE_I18N_DESTRUCTURE_RE = /const\s*\{([^}]*)\}\s*=\s*useI18n\s*\(\s*\)\s*;?/;
+const I18N_HELPER_LOCALS = new Set(Object.keys(I18N_FN_MAP));
+const DEFAULT_PARSE_ID = "vize-nuxt-i18n-bridge.tsx";
+
+type AstNode = {
+  type?: string;
+  start?: number;
+  end?: number;
+  [key: string]: unknown;
+};
+
+type ExistingUseI18nDestructure = {
+  declaration: AstNode;
+  pattern: AstNode;
+  locals: Set<string>;
+};
 
 function getLocalAlias(specifier: string): string {
   const colon = specifier.indexOf(":");
   return (colon === -1 ? specifier : specifier.slice(colon + 1)).trim();
 }
 
-function collectUsedI18nSpecifiers(code: string): { firstUseIndex: number; specifiers: string[] } {
-  const used = new Set<string>();
-  let firstUseIndex = Number.POSITIVE_INFINITY;
+function isNode(value: unknown): value is AstNode {
+  return value != null && typeof value === "object" && typeof (value as AstNode).type === "string";
+}
 
-  for (const match of code.matchAll(I18N_FN_RE)) {
-    const fnName = `$${match[1]}`;
-    const specifier = I18N_FN_MAP[fnName];
-    if (specifier) {
-      used.add(specifier);
-      firstUseIndex = Math.min(firstUseIndex, match.index ?? firstUseIndex);
+function getNodeStart(node: AstNode): number | null {
+  return typeof node.start === "number" ? node.start : null;
+}
+
+function getNodeEnd(node: AstNode): number | null {
+  return typeof node.end === "number" ? node.end : null;
+}
+
+function getNodeName(node: AstNode | null | undefined): string | null {
+  return isNode(node) && typeof node.name === "string" ? node.name : null;
+}
+
+function getChildNodes(node: AstNode): AstNode[] {
+  const children: AstNode[] = [];
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "parent") {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (isNode(item)) {
+          children.push(item);
+        }
+      }
+      continue;
+    }
+
+    if (isNode(value)) {
+      children.push(value);
     }
   }
 
-  return { firstUseIndex, specifiers: Array.from(used) };
+  return children;
 }
 
-function collectDestructuredLocalNames(destructure: string): Set<string> {
-  const locals = new Set<string>();
+function walkNode(node: AstNode, visit: (node: AstNode) => void): void {
+  visit(node);
 
-  for (const rawPart of destructure.split(",")) {
-    const part = rawPart.trim();
-    if (!part) continue;
+  for (const child of getChildNodes(node)) {
+    walkNode(child, visit);
+  }
+}
 
-    const withoutDefault = (part.split("=")[0] ?? part).trim();
-    const aliasMatch = withoutDefault.match(/^(?:\.\.\.)?[^:]+:\s*(.+)$/);
-    const localName = (aliasMatch ? aliasMatch[1] : withoutDefault).trim();
+function parseProgram(code: string, id: string): AstNode | null {
+  try {
+    const result = parseSync(normalizeParseId(id), code) as unknown;
+    if (isNode(result)) {
+      return result;
+    }
 
-    if (localName) {
-      locals.add(localName);
+    if (result != null && typeof result === "object") {
+      const program = (result as { program?: unknown }).program;
+      if (isNode(program)) {
+        return program;
+      }
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeParseId(id: string): string {
+  const withoutNullPrefix = id.startsWith("\0") ? id.slice(1) : id;
+  const withoutQuery = withoutNullPrefix.split(/[?#]/, 1)[0];
+  return withoutQuery || DEFAULT_PARSE_ID;
+}
+
+function isSetupFunction(node: AstNode): boolean {
+  if (node.type !== "Property") {
+    return false;
+  }
+
+  const key = isNode(node.key) ? node.key : null;
+  const value = isNode(node.value) ? node.value : null;
+  if (getNodeName(key) !== "setup" || !value) {
+    return false;
+  }
+
+  if (value.type !== "FunctionExpression" && value.type !== "ArrowFunctionExpression") {
+    return false;
+  }
+
+  const params = Array.isArray(value.params) ? value.params : [];
+  return getNodeName(params[0] as AstNode | undefined) === "__props";
+}
+
+function findSetupFunctionBody(program: AstNode): AstNode | null {
+  let setupBody: AstNode | null = null;
+
+  walkNode(program, (node) => {
+    if (setupBody || !isSetupFunction(node)) {
+      return;
+    }
+
+    const value = isNode(node.value) ? node.value : null;
+    const body = value && isNode(value.body) ? value.body : null;
+    if (body?.type === "BlockStatement") {
+      setupBody = body;
+    }
+  });
+
+  return setupBody;
+}
+
+function isUseI18nCall(node: AstNode | null | undefined): boolean {
+  if (!isNode(node) || node.type !== "CallExpression") {
+    return false;
+  }
+
+  return getNodeName(isNode(node.callee) ? node.callee : null) === "useI18n";
+}
+
+function collectPatternBindingNames(pattern: AstNode, locals: Set<string>): void {
+  if (pattern.type === "Identifier" && typeof pattern.name === "string") {
+    locals.add(pattern.name);
+    return;
+  }
+
+  if (pattern.type === "AssignmentPattern" && isNode(pattern.left)) {
+    collectPatternBindingNames(pattern.left, locals);
+    return;
+  }
+
+  if (pattern.type === "RestElement" && isNode(pattern.argument)) {
+    collectPatternBindingNames(pattern.argument, locals);
+    return;
+  }
+
+  if (pattern.type === "Property" && isNode(pattern.value)) {
+    collectPatternBindingNames(pattern.value, locals);
+    return;
+  }
+
+  for (const child of getChildNodes(pattern)) {
+    collectPatternBindingNames(child, locals);
+  }
+}
+
+function findExistingUseI18nDestructure(setupBody: AstNode): ExistingUseI18nDestructure | null {
+  const statements = Array.isArray(setupBody.body) ? setupBody.body : [];
+
+  for (const statement of statements) {
+    if (!isNode(statement) || statement.type !== "VariableDeclaration") {
+      continue;
+    }
+
+    const declarations = Array.isArray(statement.declarations) ? statement.declarations : [];
+    for (const declaration of declarations) {
+      if (
+        !isNode(declaration) ||
+        !isNode(declaration.id) ||
+        declaration.id.type !== "ObjectPattern"
+      ) {
+        continue;
+      }
+      if (!isUseI18nCall(isNode(declaration.init) ? declaration.init : null)) {
+        continue;
+      }
+
+      const locals = new Set<string>();
+      collectPatternBindingNames(declaration.id, locals);
+      return { declaration: statement, pattern: declaration.id, locals };
     }
   }
 
-  return locals;
+  return null;
 }
 
-export function injectNuxtI18nHelpers(code: string): string {
-  const setupMatch = code.match(SETUP_FN_RE);
-  if (!setupMatch || setupMatch.index === undefined) {
+function collectUsedI18nSpecifiers(setupBody: AstNode): {
+  firstUseIndex: number;
+  specifiers: string[];
+} {
+  const used = new Map<string, number>();
+
+  walkNode(setupBody, (node) => {
+    if (node.type !== "CallExpression") {
+      return;
+    }
+
+    const callee = isNode(node.callee) ? node.callee : null;
+    const fnName = getNodeName(callee);
+    const callStart = getNodeStart(node);
+    if (!fnName || callStart == null || !I18N_HELPER_LOCALS.has(fnName)) {
+      return;
+    }
+
+    if (!used.has(fnName)) {
+      used.set(fnName, callStart);
+    }
+  });
+
+  const helpers = Array.from(used.entries()).sort((a, b) => a[1] - b[1]);
+  return {
+    firstUseIndex: helpers[0]?.[1] ?? Number.POSITIVE_INFINITY,
+    specifiers: helpers.map(([name]) => I18N_FN_MAP[name]).filter((value) => value != null),
+  };
+}
+
+export function injectNuxtI18nHelpers(code: string, id = DEFAULT_PARSE_ID): string {
+  const program = parseProgram(code, id);
+  if (!program) {
     return code;
   }
 
-  const setupBodyStart = setupMatch.index + setupMatch[0].length;
-  const setupBody = code.slice(setupBodyStart);
+  const setupBody = findSetupFunctionBody(program);
+  const setupBodyStart = setupBody ? getNodeStart(setupBody) : null;
+  if (!setupBody || setupBodyStart == null) {
+    return code;
+  }
+
+  const insertAt = setupBodyStart + 1;
   const { firstUseIndex, specifiers: usedSpecifiers } = collectUsedI18nSpecifiers(setupBody);
   if (usedSpecifiers.length === 0) {
     return code;
   }
 
-  const existingMatch = setupBody.match(USE_I18N_DESTRUCTURE_RE);
+  const existing = findExistingUseI18nDestructure(setupBody);
 
-  if (existingMatch && existingMatch.index !== undefined) {
-    const existingLocals = collectDestructuredLocalNames(existingMatch[1]);
+  if (existing) {
     const missingSpecifiers = usedSpecifiers.filter((specifier) => {
-      return !existingLocals.has(getLocalAlias(specifier));
+      return !existing.locals.has(getLocalAlias(specifier));
     });
 
     if (missingSpecifiers.length === 0) {
       return code;
     }
 
-    if (existingMatch.index > firstUseIndex) {
+    const declarationStart = getNodeStart(existing.declaration);
+    const declarationEnd = getNodeEnd(existing.declaration);
+    const patternStart = getNodeStart(existing.pattern);
+    const patternEnd = getNodeEnd(existing.pattern);
+    if (
+      declarationStart == null ||
+      declarationEnd == null ||
+      patternStart == null ||
+      patternEnd == null
+    ) {
+      return code;
+    }
+
+    if (declarationStart > firstUseIndex) {
       return (
-        code.slice(0, setupBodyStart) +
+        code.slice(0, insertAt) +
         `\nconst { ${missingSpecifiers.join(", ")} } = useI18n();\n` +
-        code.slice(setupBodyStart)
+        code.slice(insertAt)
       );
     }
 
-    const merged = existingMatch[1].trim();
+    const merged = code.slice(patternStart + 1, patternEnd - 1).trim();
     const nextDestructure = merged
       ? `${merged}, ${missingSpecifiers.join(", ")}`
       : missingSpecifiers.join(", ");
-    const matchStart = setupBodyStart + existingMatch.index;
-    const matchEnd = matchStart + existingMatch[0].length;
 
     return (
-      code.slice(0, matchStart) + `const { ${nextDestructure} } = useI18n();` + code.slice(matchEnd)
+      code.slice(0, declarationStart) +
+      `const { ${nextDestructure} } = useI18n();` +
+      code.slice(declarationEnd)
     );
   }
 
   return (
-    code.slice(0, setupBodyStart) +
+    code.slice(0, insertAt) +
     `\nconst { ${usedSpecifiers.join(", ")} } = useI18n();\n` +
-    code.slice(setupBodyStart)
+    code.slice(insertAt)
   );
 }

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -518,10 +518,10 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
         // 2. i18n function injection: inject useI18n() for $t, $rt, $d, $n, $tm, $te
         // @nuxtjs/i18n's TransformI18nFunctionPlugin skips \0-prefixed IDs.
         // Must inject inside the setup() function body, not at module top level.
-        // Use negative lookbehind to exclude `_ctx.$t(` and `this.$t(` (property access),
-        // which are Vue template globals and don't need useI18n injection.
+        // Parse the virtual module so string literals, comments, and Vue template
+        // globals do not look like setup-scope runtime helper calls.
         if (bridgeOptions.i18n) {
-          const nextResult = injectNuxtI18nHelpers(result);
+          const nextResult = injectNuxtI18nHelpers(result, id);
           if (nextResult !== result) {
             result = nextResult;
             changed = true;


### PR DESCRIPTION
## Summary

- replace Nuxt i18n helper detection regexes with Vite/Rolldown AST traversal
- keep injection scoped to `setup(__props)` and use AST spans for the minimal source edits
- flip the string/comment false-positive regressions so helper-looking text no longer injects `useI18n()`

Part of #2703.

## Validation

- `corepack pnpm --dir npm/framework/nuxt run check`
- `corepack pnpm --dir npm/framework/nuxt run build`
- `corepack pnpm --dir npm/framework/nuxt exec node --test 'src/*.test.ts' 'src/**/*.test.ts'`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786078777&installation_id=136613492&pr_number=2704&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2704&signature=c2ba93df64a38246c946cc65667be8643fa8169192cc145d1de66f7f7787be4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved i18n helper detection so only real helper calls trigger automatic imports.
  * Prevented accidental helper insertion when helper-like text appears in comments or strings.
  * Better handled typed setup code, reducing incorrect or missing i18n helper injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->