### PR TITLE
refactor(rspack): rewrite template assets from AST

### DIFF
--- a/crates/vize_atelier_sfc/src/bundler.rs
+++ b/crates/vize_atelier_sfc/src/bundler.rs
@@ -1,3 +1,4 @@
+mod asset_rewrite;
 mod assets;
 mod blocks;
 mod css;
@@ -6,6 +7,7 @@ mod scope;
 #[cfg(test)]
 mod tests;
 
+pub use asset_rewrite::rewrite_template_asset_references;
 pub use assets::{
     TemplateAssetTagRule, TemplateAssetUrl, collect_template_asset_urls, is_importable_asset_url,
 };

--- a/crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs
+++ b/crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs
@@ -1,0 +1,341 @@
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    BindingPattern, Expression, Function, ObjectProperty, PropertyKey, ReturnStatement,
+    StringLiteral, TemplateLiteral, VariableDeclarator,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
+use oxc_syntax::scope::ScopeFlags;
+use vize_carton::{SmallVec, String};
+
+use super::assets::TemplateAssetUrl;
+use crate::vite_plugin::js_string::push_js_string_literal;
+
+/// Rewrite compiled template asset references into import identifiers.
+///
+/// The Rspack builder compiles the SFC first, then assembles the final module
+/// output. Template asset references can appear either in render functions, in
+/// compiler hoists, or inside SSR HTML template literals. Restricting edits to
+/// those AST-owned regions keeps same-valued strings from `<script>` intact.
+pub fn rewrite_template_asset_references(code: &str, assets: &[TemplateAssetUrl]) -> String {
+    if assets.is_empty() {
+        return String::from(code);
+    }
+
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, code, SourceType::tsx().with_module(true)).parse();
+    if !parsed.errors.is_empty() {
+        return String::from(code);
+    }
+
+    let mut collector = TemplateAssetReferenceCollector {
+        code,
+        assets,
+        replacements: Vec::new(),
+        render_depth: 0,
+        setup_depth: 0,
+    };
+    collector.visit_program(&parsed.program);
+    apply_asset_replacements(code, collector.replacements)
+}
+
+struct AssetReferenceReplacement {
+    start: usize,
+    end: usize,
+    value: String,
+}
+
+struct TemplateAssetReferenceCollector<'a> {
+    code: &'a str,
+    assets: &'a [TemplateAssetUrl],
+    replacements: Vec<AssetReferenceReplacement>,
+    render_depth: usize,
+    setup_depth: usize,
+}
+
+impl<'a> TemplateAssetReferenceCollector<'a> {
+    fn with_render_scope(&mut self, visit: impl FnOnce(&mut Self)) {
+        self.render_depth += 1;
+        visit(self);
+        self.render_depth -= 1;
+    }
+
+    fn with_setup_scope(&mut self, visit: impl FnOnce(&mut Self)) {
+        self.setup_depth += 1;
+        visit(self);
+        self.setup_depth -= 1;
+    }
+
+    fn asset_for_value(&self, value: &str) -> Option<&'a TemplateAssetUrl> {
+        self.assets.iter().find(|asset| asset.url.as_str() == value)
+    }
+
+    fn collect_string_literal(&mut self, literal: &StringLiteral<'_>) {
+        if self.render_depth == 0 {
+            return;
+        }
+
+        let Some(asset) = self.asset_for_value(literal.value.as_str()) else {
+            return;
+        };
+
+        self.replacements.push(AssetReferenceReplacement {
+            start: literal.span.start as usize,
+            end: literal.span.end as usize,
+            value: asset_expression(asset),
+        });
+    }
+
+    fn collect_template_literal(&mut self, template: &TemplateLiteral<'_>) -> bool {
+        if self.render_depth == 0 {
+            return false;
+        }
+
+        let Some(value) = self.template_literal_expression(template) else {
+            return false;
+        };
+
+        self.replacements.push(AssetReferenceReplacement {
+            start: template.span.start as usize,
+            end: template.span.end as usize,
+            value,
+        });
+        true
+    }
+
+    fn template_literal_expression(&self, template: &TemplateLiteral<'_>) -> Option<String> {
+        let mut parts: SmallVec<[String; 8]> = SmallVec::new();
+        let mut changed = false;
+
+        for (index, quasi) in template.quasis.iter().enumerate() {
+            let text = quasi
+                .value
+                .cooked
+                .as_ref()
+                .map_or_else(|| quasi.value.raw.as_str(), |value| value.as_str());
+            self.push_template_text_parts(text, &mut parts, &mut changed);
+
+            if let Some(expression) = template.expressions.get(index) {
+                let span = expression.span();
+                let start = span.start as usize;
+                let end = span.end as usize;
+                if start <= end && end <= self.code.len() {
+                    let mut source = String::from("(");
+                    source.push_str(&self.code[start..end]);
+                    source.push(')');
+                    parts.push(source);
+                }
+            }
+        }
+
+        if !changed {
+            return None;
+        }
+
+        Some(join_expression_parts(parts))
+    }
+
+    fn push_template_text_parts(
+        &self,
+        text: &str,
+        parts: &mut SmallVec<[String; 8]>,
+        changed: &mut bool,
+    ) {
+        let mut cursor = 0usize;
+        while cursor < text.len() {
+            let Some((relative_start, asset)) = self.find_next_asset(&text[cursor..]) else {
+                push_string_part(parts, &text[cursor..]);
+                return;
+            };
+
+            let start = cursor + relative_start;
+            push_string_part(parts, &text[cursor..start]);
+            parts.push(asset_expression(asset));
+            *changed = true;
+            cursor = start + asset.url.len();
+        }
+
+        push_string_part(parts, "");
+    }
+
+    fn find_next_asset<'b>(&'a self, text: &'b str) -> Option<(usize, &'a TemplateAssetUrl)> {
+        self.assets
+            .iter()
+            .filter_map(|asset| text.find(asset.url.as_str()).map(|index| (index, asset)))
+            .min_by_key(|(index, _)| *index)
+    }
+}
+
+impl<'a> Visit<'a> for TemplateAssetReferenceCollector<'_> {
+    fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'a>) {
+        if is_template_hoist_declarator(declarator) {
+            self.with_render_scope(|this| {
+                if let Some(init) = &declarator.init {
+                    this.visit_expression(init);
+                }
+            });
+            return;
+        }
+
+        walk::walk_variable_declarator(self, declarator);
+    }
+
+    fn visit_function(&mut self, function: &Function<'a>, flags: ScopeFlags) {
+        if function
+            .id
+            .as_ref()
+            .is_some_and(|id| is_render_function_name(id.name.as_str()))
+        {
+            self.with_render_scope(|this| walk::walk_function(this, function, flags));
+            return;
+        }
+
+        walk::walk_function(self, function, flags);
+    }
+
+    fn visit_object_property(&mut self, property: &ObjectProperty<'a>) {
+        match property_key_name(&property.key) {
+            Some("setup") => {
+                self.with_setup_scope(|this| walk::walk_object_property(this, property));
+            }
+            Some("render" | "ssrRender") => {
+                if self.visit_render_expression(&property.value) {
+                    return;
+                }
+                walk::walk_object_property(self, property);
+            }
+            _ => walk::walk_object_property(self, property),
+        }
+    }
+
+    fn visit_return_statement(&mut self, statement: &ReturnStatement<'a>) {
+        if self.setup_depth > 0
+            && let Some(argument) = &statement.argument
+            && self.visit_render_expression(argument)
+        {
+            return;
+        }
+
+        walk::walk_return_statement(self, statement);
+    }
+
+    fn visit_string_literal(&mut self, literal: &StringLiteral<'a>) {
+        self.collect_string_literal(literal);
+        walk::walk_string_literal(self, literal);
+    }
+
+    fn visit_template_literal(&mut self, template: &TemplateLiteral<'a>) {
+        if self.collect_template_literal(template) {
+            return;
+        }
+
+        walk::walk_template_literal(self, template);
+    }
+}
+
+impl TemplateAssetReferenceCollector<'_> {
+    fn visit_render_expression<'a>(&mut self, expression: &Expression<'a>) -> bool {
+        match expression {
+            Expression::ArrowFunctionExpression(arrow) => {
+                self.with_render_scope(|this| walk::walk_arrow_function_expression(this, arrow));
+                true
+            }
+            Expression::FunctionExpression(function) => {
+                self.with_render_scope(|this| {
+                    walk::walk_function(this, function, ScopeFlags::Function)
+                });
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+fn is_template_hoist_declarator(declarator: &VariableDeclarator<'_>) -> bool {
+    let BindingPattern::BindingIdentifier(id) = &declarator.id else {
+        return false;
+    };
+
+    let name = id.name.as_str();
+    name.starts_with("_hoisted_")
+        && name["_hoisted_".len()..]
+            .bytes()
+            .all(|byte| byte.is_ascii_digit())
+}
+
+fn is_render_function_name(name: &str) -> bool {
+    matches!(name, "render" | "_sfc_render" | "ssrRender")
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
+        PropertyKey::StringLiteral(literal) => Some(literal.value.as_str()),
+        _ => None,
+    }
+}
+
+fn asset_expression(asset: &TemplateAssetUrl) -> String {
+    let Some(hash_index) = asset.url.find('#') else {
+        return asset.var_name.clone();
+    };
+
+    let mut output = String::from(asset.var_name.as_str());
+    output.push_str(" + ");
+    push_js_string_literal(&mut output, &asset.url[hash_index..]);
+    output
+}
+
+fn push_string_part(parts: &mut SmallVec<[String; 8]>, value: &str) {
+    let mut output = String::default();
+    push_js_string_literal(&mut output, value);
+    parts.push(output);
+}
+
+fn join_expression_parts(parts: SmallVec<[String; 8]>) -> String {
+    let mut output = String::default();
+    let mut first = true;
+
+    for part in parts {
+        if !first {
+            output.push_str(" + ");
+        }
+        first = false;
+        output.push_str(part.as_str());
+    }
+
+    output
+}
+
+fn apply_asset_replacements(
+    code: &str,
+    mut replacements: Vec<AssetReferenceReplacement>,
+) -> String {
+    if replacements.is_empty() {
+        return String::from(code);
+    }
+
+    replacements.sort_by_key(|replacement| replacement.start);
+    let mut output = String::with_capacity(code.len());
+    let mut last = 0usize;
+    let mut changed = false;
+
+    for replacement in replacements {
+        if replacement.start < last || replacement.end > code.len() {
+            continue;
+        }
+
+        output.push_str(&code[last..replacement.start]);
+        output.push_str(replacement.value.as_str());
+        last = replacement.end;
+        changed = true;
+    }
+
+    if !changed {
+        return String::from(code);
+    }
+
+    output.push_str(&code[last..]);
+    output
+}

--- a/crates/vize_atelier_sfc/src/bundler/tests.rs
+++ b/crates/vize_atelier_sfc/src/bundler/tests.rs
@@ -137,6 +137,54 @@ fn collects_template_asset_urls() {
 }
 
 #[test]
+fn rewrites_template_asset_references_without_touching_script_literals() {
+    let code = r#"
+const same = "./logo.png";
+const _hoisted_1 = { src: "./logo.png" };
+function _sfc_render() {
+  return _createElementVNode("img", { src: "./logo.png" });
+}
+"#;
+    let assets = vec![TemplateAssetUrl {
+        url: "./logo.png".into(),
+        var_name: "_imports_0".into(),
+    }];
+
+    let output = rewrite_template_asset_references(code, &assets);
+
+    assert!(output.contains(r#"const same = "./logo.png";"#));
+    assert!(output.contains("const _hoisted_1 = { src: _imports_0 };"));
+    assert!(output.contains(r#"_createElementVNode("img", { src: _imports_0 })"#));
+}
+
+#[test]
+fn rewrites_ssr_template_literals_as_asset_concatenations() {
+    let code = r#"
+const same = "./logo.png";
+function ssrRender(_ctx, _push) {
+  _push(`<img src="./logo.png"><use href="./icons.svg#home"></use>`);
+}
+"#;
+    let assets = vec![
+        TemplateAssetUrl {
+            url: "./logo.png".into(),
+            var_name: "_imports_0".into(),
+        },
+        TemplateAssetUrl {
+            url: "./icons.svg#home".into(),
+            var_name: "_imports_1".into(),
+        },
+    ];
+
+    let output = rewrite_template_asset_references(code, &assets);
+
+    assert!(output.contains(r#"const same = "./logo.png";"#));
+    assert!(output.contains(
+        r##"_push("<img src=\"" + _imports_0 + "\"><use href=\"" + _imports_1 + "#home" + "\"></use>")"##
+    ));
+}
+
+#[test]
 fn strips_css_comments_without_touching_strings() {
     let input = ".a { color: red; }\n/* :deep(.x) */\n.b::before { content: \"/* kept */\"; }";
     let output = strip_css_comments_for_scoped(input);

--- a/crates/vize_atelier_sfc/src/vite_plugin.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin.rs
@@ -9,7 +9,7 @@ mod boundary;
 mod css;
 mod css_scope;
 mod hmr;
-mod js_string;
+pub(crate) mod js_string;
 mod middleware;
 mod precompile;
 mod query;

--- a/crates/vize_atelier_sfc/src/vite_plugin/js_string.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/js_string.rs
@@ -1,6 +1,6 @@
 use vize_carton::String;
 
-pub(super) fn push_js_string_literal(output: &mut String, value: &str) {
+pub(crate) fn push_js_string_literal(output: &mut String, value: &str) {
     output.push('"');
 
     let mut segment_start = 0usize;

--- a/crates/vize_vitrine/src/napi/sfc/bundler.rs
+++ b/crates/vize_vitrine/src/napi/sfc/bundler.rs
@@ -58,6 +58,15 @@ impl From<vize_atelier_sfc::TemplateAssetUrl> for TemplateAssetUrlNapi {
     }
 }
 
+impl From<TemplateAssetUrlNapi> for vize_atelier_sfc::TemplateAssetUrl {
+    fn from(url: TemplateAssetUrlNapi) -> Self {
+        Self {
+            url: url.url.into(),
+            var_name: url.var_name.into(),
+        }
+    }
+}
+
 impl From<TemplateAssetTagRuleNapi> for vize_atelier_sfc::TemplateAssetTagRule {
     fn from(rule: TemplateAssetTagRuleNapi) -> Self {
         Self {
@@ -125,6 +134,15 @@ pub fn collect_sfc_template_asset_urls(
         .into_iter()
         .map(Into::into)
         .collect()
+}
+
+#[napi(js_name = "rewriteSfcTemplateAssetReferences")]
+pub fn rewrite_sfc_template_asset_references(
+    code: String,
+    assets: Vec<TemplateAssetUrlNapi>,
+) -> String {
+    let assets = assets.into_iter().map(Into::into).collect::<Vec<_>>();
+    vize_atelier_sfc::bundler::rewrite_template_asset_references(&code, &assets).into()
 }
 
 #[napi(js_name = "stripSfcScopedCssComments")]

--- a/npm/builder/rspack/src/shared/output.test.ts
+++ b/npm/builder/rspack/src/shared/output.test.ts
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { CompiledModule } from "../types/index.ts";
+import { generateOutput } from "./output.ts";
+
+function compiledModule(code: string): CompiledModule {
+  return {
+    code,
+    errors: [],
+    warnings: [],
+    scopeId: "test1234",
+    hasScoped: false,
+    styles: [],
+    customBlocks: [],
+    isCustomElement: false,
+    templateAssetUrls: [{ url: "./logo.png", varName: "_imports_0" }],
+    macroArtifacts: [],
+  };
+}
+
+void test("template asset rewrite leaves same-valued script strings intact", () => {
+  const output = generateOutput(
+    compiledModule(`
+const same = "./logo.png";
+const _sfc_main = {};
+const _hoisted_1 = { src: "./logo.png" };
+function _sfc_render() {
+  return _createElementVNode("img", { src: "./logo.png" });
+}
+_sfc_main.render = _sfc_render;
+export default _sfc_main;
+`),
+    { requestPath: "./App.vue" },
+  );
+
+  assert.match(output, /import _imports_0 from "\.\/logo\.png";/);
+  assert.match(output, /const same = "\.\/logo\.png";/);
+  assert.match(output, /const _hoisted_1 = \{ src: _imports_0 \};/);
+  assert.match(output, /_createElementVNode\("img", \{ src: _imports_0 \}\)/);
+});
+
+void test("template asset rewrite converts SSR template literals to concatenations", () => {
+  const output = generateOutput(
+    compiledModule(`
+const same = "./logo.png";
+const _sfc_main = {};
+function ssrRender(_ctx, _push) {
+  _push(\`<img src="./logo.png">\`);
+}
+_sfc_main.ssrRender = ssrRender;
+export default _sfc_main;
+`),
+    { requestPath: "./App.vue" },
+  );
+
+  assert.match(output, /const same = "\.\/logo\.png";/);
+  assert.ok(output.includes('_push("<img src=\\"" + _imports_0 + "\\">")'));
+});

--- a/npm/builder/rspack/src/shared/output.ts
+++ b/npm/builder/rspack/src/shared/output.ts
@@ -1,6 +1,7 @@
 /** JS module output assembly for compiled SFCs. */
 
 import path from "node:path";
+import { rewriteSfcTemplateAssetReferences } from "@vizejs/native";
 import type { CompiledModule } from "../types/index.ts";
 import { genHotReloadCode, genCSSModuleHotReloadCode } from "./hotReload.ts";
 
@@ -24,19 +25,8 @@ export function generateOutput(
   let output = compiled.code;
   const isCustomElement = compiled.isCustomElement;
 
-  // Template static-asset URL rewrite: replace URL string literals in compiled
-  // output with import bindings so Rspack can bundle them as assets.
-  // Caveat: string-based replacement may also match identical literals in <script>.
   if (compiled.templateAssetUrls.length > 0) {
-    for (const { url, varName } of compiled.templateAssetUrls) {
-      const hashIdx = url.indexOf("#");
-      const fragment = hashIdx >= 0 ? url.slice(hashIdx) : "";
-      const replacement = fragment ? `${varName} + ${JSON.stringify(fragment)}` : varName;
-
-      const escaped = url.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      output = output.replace(new RegExp(`"${escaped}"`, "g"), replacement);
-      output = output.replace(new RegExp(`'${escaped}'`, "g"), replacement);
-    }
+    output = rewriteSfcTemplateAssetReferences(output, compiled.templateAssetUrls);
   }
 
   const exportDefaultRegex = /^export default /m;

--- a/npm/native/index.d.ts
+++ b/npm/native/index.d.ts
@@ -849,6 +849,11 @@ export declare function resolveViteVuePath(
   importer?: string | undefined | null,
 ): string;
 
+export declare function rewriteSfcTemplateAssetReferences(
+  code: string,
+  assets: Array<TemplateAssetUrlNapi>,
+): string;
+
 export declare function rewriteViteDynamicTemplateImports(
   code: string,
   aliasRules: Array<DynamicImportAliasRuleNapi>,

--- a/npm/native/index.js
+++ b/npm/native/index.js
@@ -766,6 +766,7 @@ module.exports.buildInspectorGraph = nativeBinding.buildInspectorGraph;
 module.exports.chunkVitePrecompileFiles = nativeBinding.chunkVitePrecompileFiles;
 module.exports.classifyVitePluginRequest = nativeBinding.classifyVitePluginRequest;
 module.exports.collectSfcTemplateAssetUrls = nativeBinding.collectSfcTemplateAssetUrls;
+module.exports.rewriteSfcTemplateAssetReferences = nativeBinding.rewriteSfcTemplateAssetReferences;
 module.exports.compile = nativeBinding.compile;
 module.exports.compileCss = nativeBinding.compileCss;
 module.exports.compileJsx = nativeBinding.compileJsx;

--- a/npm/native/types/sfc.d.ts
+++ b/npm/native/types/sfc.d.ts
@@ -192,6 +192,11 @@ export declare function collectSfcTemplateAssetUrls(
   filename?: string | undefined | null,
 ): Array<TemplateAssetUrlNapi>;
 
+export declare function rewriteSfcTemplateAssetReferences(
+  code: string,
+  assets: Array<TemplateAssetUrlNapi>,
+): string;
+
 export declare function extractSfcCustomBlocks(
   source: string,
   filename?: string | undefined | null,


### PR DESCRIPTION
## Summary
- replace the Rspack template asset whole-output regex replacement with an OXC-backed native rewrite helper
- limit asset edits to compiler render scopes, hoists, and SSR template literals so same-valued script strings stay intact
- expose the helper through @vizejs/native and cover the Rspack output path with regressions

Refs #2703

## Validation
- cargo fmt --all
- cargo test -p vize_atelier_sfc rewrites_
- cargo check -p vize_vitrine --features napi,legacy
- corepack pnpm --dir npm/builder/rspack run check
- corepack pnpm --dir npm/builder/rspack run build
- corepack pnpm --dir npm/builder/rspack exec node --test 'src/*.test.ts' 'src/**/*.test.ts'

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786080452&installation_id=136613492&pr_number=2705&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2705&signature=9e1600dd0fc382c10a99d871a3a2b30fb65fa757d164eb38d8fd5f604f05618e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for rewriting template asset references in generated output, so asset URLs now resolve consistently to the correct imported assets.
  * Exposed the same rewriting capability through the native API for JavaScript/TypeScript consumers.

* **Bug Fixes**
  * Improved handling of asset references in rendered templates, including SSR output, while leaving unrelated script strings unchanged.

* **Tests**
  * Added coverage for standard and SSR template asset rewriting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->