### PR TITLE
refactor(vite): parse output default exports

### DIFF
--- a/npm/builder/vite/src/output-ast.test.ts
+++ b/npm/builder/vite/src/output-ast.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { generateOutput } from "./utils/index.ts";
+
+void test("generateOutput ignores export default text inside template literals", () => {
+  const output = generateOutput(
+    {
+      code: [
+        "const message = `",
+        "export default fake",
+        "`;",
+        "export function render() {",
+        "  return message;",
+        "}",
+      ].join("\n"),
+      scopeId: "literalexport",
+      hasScoped: false,
+      styles: [],
+    },
+    {
+      isProduction: true,
+      isDev: false,
+    },
+  );
+
+  assert.match(output, /export default fake/);
+  assert.doesNotMatch(output, /const _sfc_main = fake/);
+  assert.match(output, /const _sfc_main = \{\};/);
+  assert.match(output, /export default _sfc_main;/);
+});
+
+void test("generateOutput preserves pure annotations on default exports", () => {
+  const output = generateOutput(
+    {
+      code: [
+        'import { defineComponent } from "vue";',
+        "export default /*#__PURE__*/ defineComponent({ name: 'Annotated' });",
+      ].join("\n"),
+      scopeId: "annotated",
+      hasScoped: false,
+      styles: [],
+    },
+    {
+      isProduction: true,
+      isDev: false,
+    },
+  );
+
+  assert.match(output, /const _sfc_main = \/\*#__PURE__\*\/ defineComponent/);
+  assert.match(output, /export default _sfc_main;/);
+});

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -2,6 +2,7 @@ import "./hmr.test.ts";
 import "./compiler.test.ts";
 import "./config.test.ts";
 import "./options-api-events.test.ts";
+import "./output-ast.test.ts";
 import "./utils-filter.test.ts";
 import "./utils.test.ts";
 import "./plugin/compat.test.ts";

--- a/npm/builder/vite/src/utils/index.ts
+++ b/npm/builder/vite/src/utils/index.ts
@@ -1,6 +1,11 @@
 import { createHash } from "node:crypto";
 import type { CompiledModule, StyleBlockInfo } from "../types.ts";
 import { type HmrUpdateType, generateHmrCode } from "../hmr.ts";
+import {
+  analyzeModuleOutput,
+  insertBeforeSfcMainDefaultExport,
+  rewriteDefaultExportToSfcMain,
+} from "./module-output.ts";
 
 // Re-export CSS utilities for backward compatibility
 export { resolveCssImports, type CssAliasRule } from "./css.ts";
@@ -103,19 +108,14 @@ export function generateOutput(compiled: CompiledModule, options: GenerateOutput
 
   let output = compiled.code;
 
-  // Rewrite "export default" to named variable for HMR
-  // Use regex to match only line-start "export default" (not inside strings)
-  const exportDefaultRegex = /^export default /m;
-  const hasExportDefault = exportDefaultRegex.test(output);
-  const hasNamedRenderExport = /^export function render\b/m.test(output);
-  const hasNamedSsrRenderExport = /^export function ssrRender\b/m.test(output);
-
-  // Check if _sfc_main is already defined (Case 2: non-script-setup SFCs)
-  // In this case, the compiler already outputs: const _sfc_main = ...; export default _sfc_main
-  const hasSfcMainDefined = /\bconst\s+_sfc_main\s*=/.test(output);
+  const moduleInfo = analyzeModuleOutput(output);
+  const hasExportDefault = moduleInfo.hasDefaultExport;
+  const hasNamedRenderExport = moduleInfo.hasNamedRenderExport;
+  const hasNamedSsrRenderExport = moduleInfo.hasNamedSsrRenderExport;
+  const hasSfcMainDefined = moduleInfo.hasSfcMainDefined;
 
   if (hasExportDefault && !hasSfcMainDefined) {
-    output = output.replace(exportDefaultRegex, "const _sfc_main = ");
+    output = rewriteDefaultExportToSfcMain(output);
     // Add __scopeId for scoped CSS support
     if (compiled.hasScoped && compiled.scopeId) {
       output += `\n_sfc_main.__scopeId = "data-v-${compiled.scopeId}";`;
@@ -124,10 +124,9 @@ export function generateOutput(compiled: CompiledModule, options: GenerateOutput
   } else if (hasExportDefault && hasSfcMainDefined) {
     // _sfc_main already defined, just add scopeId if needed
     if (compiled.hasScoped && compiled.scopeId) {
-      // Insert scopeId assignment before the export default line
-      output = output.replace(
-        /^export default _sfc_main/m,
-        `_sfc_main.__scopeId = "data-v-${compiled.scopeId}";\nexport default _sfc_main`,
+      output = insertBeforeSfcMainDefaultExport(
+        output,
+        `_sfc_main.__scopeId = "data-v-${compiled.scopeId}";`,
       );
     }
   } else if (!hasExportDefault && !hasSfcMainDefined && hasNamedRenderExport) {
@@ -210,12 +209,9 @@ export function generateOutput(compiled: CompiledModule, options: GenerateOutput
             `_sfc_main.__cssModules = _sfc_main.__cssModules || {};\n_sfc_main.__cssModules[${JSON.stringify(m.name)}] = ${m.bindingName};`,
         )
         .join("\n");
-      // Insert before the final export, regardless of whether the compiler
-      // emitted a trailing semicolon.
-      output = output.replace(
-        /^export default _sfc_main;?$/m,
-        `${cssModuleSetup}\nexport default _sfc_main;`,
-      );
+      output = insertBeforeSfcMainDefaultExport(output, cssModuleSetup, {
+        normalizeSemicolon: true,
+      });
     }
   } else if (!ssr && compiled.css && !(isProduction && extractCss)) {
     // --- Inline CSS injection (original behavior for plain CSS) ---

--- a/npm/builder/vite/src/utils/module-output.ts
+++ b/npm/builder/vite/src/utils/module-output.ts
@@ -1,0 +1,169 @@
+import { parseSync } from "vite";
+
+const OUTPUT_PARSE_ID = "vize-output.tsx";
+const SFC_MAIN_NAME = "_sfc_main";
+
+type AstNode = {
+  type?: string;
+  start?: number;
+  end?: number;
+  [key: string]: unknown;
+};
+
+export type ModuleOutputInfo = {
+  hasDefaultExport: boolean;
+  hasSfcMainDefined: boolean;
+  hasNamedRenderExport: boolean;
+  hasNamedSsrRenderExport: boolean;
+};
+
+function isNode(value: unknown): value is AstNode {
+  return value != null && typeof value === "object" && typeof (value as AstNode).type === "string";
+}
+
+function getNodeStart(node: AstNode | null | undefined): number | null {
+  return typeof node?.start === "number" ? node.start : null;
+}
+
+function getNodeName(node: AstNode | null | undefined): string | null {
+  return isNode(node) && typeof node.name === "string" ? node.name : null;
+}
+
+function parseProgram(code: string): AstNode | null {
+  try {
+    const result = parseSync(OUTPUT_PARSE_ID, code) as unknown;
+    if (result != null && typeof result === "object") {
+      const errors = (result as { errors?: unknown }).errors;
+      if (Array.isArray(errors) && errors.length > 0) {
+        return null;
+      }
+
+      const program = (result as { program?: unknown }).program;
+      if (isNode(program)) {
+        return program;
+      }
+    }
+
+    return isNode(result) ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+function getProgramBody(program: AstNode | null): AstNode[] {
+  if (!program || !Array.isArray(program.body)) {
+    return [];
+  }
+
+  return program.body.filter(isNode);
+}
+
+function isIdentifierNamed(node: AstNode | null | undefined, name: string): boolean {
+  return getNodeName(node) === name;
+}
+
+function getVariableDeclarationNames(statement: AstNode): string[] {
+  const declarations = Array.isArray(statement.declarations) ? statement.declarations : [];
+  return declarations
+    .filter(isNode)
+    .map((declaration) => (isNode(declaration.id) ? getNodeName(declaration.id) : null))
+    .filter((name): name is string => name != null);
+}
+
+function getExportedNames(statement: AstNode): string[] {
+  const declaration = isNode(statement.declaration) ? statement.declaration : null;
+  const names: string[] = [];
+
+  if (declaration?.type === "FunctionDeclaration" || declaration?.type === "ClassDeclaration") {
+    const name = isNode(declaration.id) ? getNodeName(declaration.id) : null;
+    if (name) names.push(name);
+  }
+
+  if (declaration?.type === "VariableDeclaration") {
+    names.push(...getVariableDeclarationNames(declaration));
+  }
+
+  const specifiers = Array.isArray(statement.specifiers) ? statement.specifiers : [];
+  for (const specifier of specifiers) {
+    if (!isNode(specifier)) {
+      continue;
+    }
+
+    const exported = isNode(specifier.exported) ? specifier.exported : null;
+    const local = isNode(specifier.local) ? specifier.local : null;
+    const name = getNodeName(exported) ?? getNodeName(local);
+    if (name) names.push(name);
+  }
+
+  return names;
+}
+
+function findDefaultExport(program: AstNode | null): AstNode | null {
+  return (
+    getProgramBody(program).find((statement) => statement.type === "ExportDefaultDeclaration") ??
+    null
+  );
+}
+
+function getExportDefaultKeywordEnd(code: string, defaultExport: AstNode): number | null {
+  const exportStart = getNodeStart(defaultExport);
+  if (exportStart == null) {
+    return null;
+  }
+
+  const match = /^export\s+default\b/.exec(code.slice(exportStart));
+  return match ? exportStart + match[0].length : null;
+}
+
+export function analyzeModuleOutput(code: string): ModuleOutputInfo {
+  const program = parseProgram(code);
+  const body = getProgramBody(program);
+  const defaultExport = findDefaultExport(program);
+  const exportedNames = body
+    .filter((statement) => statement.type === "ExportNamedDeclaration")
+    .flatMap(getExportedNames);
+
+  return {
+    hasDefaultExport: defaultExport != null,
+    hasSfcMainDefined: body.some((statement) => {
+      return (
+        statement.type === "VariableDeclaration" &&
+        getVariableDeclarationNames(statement).includes(SFC_MAIN_NAME)
+      );
+    }),
+    hasNamedRenderExport: exportedNames.includes("render"),
+    hasNamedSsrRenderExport: exportedNames.includes("ssrRender"),
+  };
+}
+
+export function rewriteDefaultExportToSfcMain(code: string): string {
+  const defaultExport = findDefaultExport(parseProgram(code));
+  const exportStart = getNodeStart(defaultExport);
+  const keywordEnd = defaultExport ? getExportDefaultKeywordEnd(code, defaultExport) : null;
+  if (exportStart == null || keywordEnd == null) {
+    return code;
+  }
+
+  return `${code.slice(0, exportStart)}const ${SFC_MAIN_NAME} =${code.slice(keywordEnd)}`;
+}
+
+export function insertBeforeSfcMainDefaultExport(
+  code: string,
+  insertion: string,
+  options: { normalizeSemicolon?: boolean } = {},
+): string {
+  const defaultExport = findDefaultExport(parseProgram(code));
+  const declaration = isNode(defaultExport?.declaration) ? defaultExport.declaration : null;
+  const exportStart = getNodeStart(defaultExport);
+  const exportEnd = typeof defaultExport?.end === "number" ? defaultExport.end : null;
+  if (!isIdentifierNamed(declaration, SFC_MAIN_NAME) || exportStart == null) {
+    return code;
+  }
+
+  if (options.normalizeSemicolon && exportEnd != null) {
+    const suffixStart = code[exportEnd] === ";" ? exportEnd + 1 : exportEnd;
+    return `${code.slice(0, exportStart)}${insertion}\nexport default ${SFC_MAIN_NAME};${code.slice(suffixStart)}`;
+  }
+
+  return `${code.slice(0, exportStart)}${insertion}\n${code.slice(exportStart)}`;
+}


### PR DESCRIPTION
## Summary
- replace Vite output default-export string rewrites with parser-guided module analysis
- insert scope and CSS module setup before the parsed `_sfc_main` default export
- cover helper-looking `export default` text inside template literals and pure annotations on default exports

Part of #2703.

## Validation
- `corepack pnpm --dir npm/builder/vite run check`
- `corepack pnpm --dir npm/builder/vite run build`
- `corepack pnpm --dir npm/builder/vite exec node src/test.ts`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786109673&installation_id=136613492&pr_number=2707&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2707&signature=4291a0696eb863c32ab9a7ca27dfb432d8cc74cd9ef8a8cc4fdd04e36e7ea9fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of compiled component output so default exports are rewritten more reliably, including cases where `export default` appears inside strings or template literals.
  * Preserved tree-shaking annotations during output generation.
* **Tests**
  * Added coverage for default-export rewriting and annotation preservation.
  * Included the new test suite in the Vite builder test run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->