### PR TITLE
refactor(rspack): parse output default exports

### DIFF
--- a/npm/builder/rspack/package.json
+++ b/npm/builder/rspack/package.json
@@ -68,7 +68,8 @@
     "test:update": "pnpm build && node --test --test-update-snapshots src/*.test.ts src/**/*.test.ts"
   },
   "dependencies": {
-    "@vizejs/native": "workspace:*"
+    "@vizejs/native": "workspace:*",
+    "oxc-parser": "catalog:oxc"
   },
   "devDependencies": {
     "@rspack/core": "catalog:bundlers",

--- a/npm/builder/rspack/src/shared/module-output.ts
+++ b/npm/builder/rspack/src/shared/module-output.ts
@@ -1,0 +1,134 @@
+import { parseSync } from "oxc-parser";
+
+const OUTPUT_PARSE_ID = "vize-rspack-output.tsx";
+const SFC_MAIN_NAME = "_sfc_main";
+
+type AstNode = {
+  type?: string;
+  start?: number;
+  end?: number;
+  [key: string]: unknown;
+};
+
+export type ModuleOutputInfo = {
+  hasDefaultExport: boolean;
+  hasSfcMainDefined: boolean;
+};
+
+function isNode(value: unknown): value is AstNode {
+  return value != null && typeof value === "object" && typeof (value as AstNode).type === "string";
+}
+
+function getNodeStart(node: AstNode | null | undefined): number | null {
+  return typeof node?.start === "number" ? node.start : null;
+}
+
+function getNodeName(node: AstNode | null | undefined): string | null {
+  return isNode(node) && typeof node.name === "string" ? node.name : null;
+}
+
+function parseProgram(code: string): AstNode | null {
+  try {
+    const result = parseSync(OUTPUT_PARSE_ID, code) as unknown;
+    if (result != null && typeof result === "object") {
+      const errors = (result as { errors?: unknown }).errors;
+      if (Array.isArray(errors) && errors.length > 0) {
+        return null;
+      }
+
+      const program = (result as { program?: unknown }).program;
+      if (isNode(program)) {
+        return program;
+      }
+    }
+
+    return isNode(result) ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+function getProgramBody(program: AstNode | null): AstNode[] {
+  if (!program || !Array.isArray(program.body)) {
+    return [];
+  }
+
+  return program.body.filter(isNode);
+}
+
+function isIdentifierNamed(node: AstNode | null | undefined, name: string): boolean {
+  return getNodeName(node) === name;
+}
+
+function getVariableDeclarationNames(statement: AstNode): string[] {
+  const declarations = Array.isArray(statement.declarations) ? statement.declarations : [];
+  return declarations
+    .filter(isNode)
+    .map((declaration) => (isNode(declaration.id) ? getNodeName(declaration.id) : null))
+    .filter((name): name is string => name != null);
+}
+
+function findDefaultExport(program: AstNode | null): AstNode | null {
+  return (
+    getProgramBody(program).find((statement) => statement.type === "ExportDefaultDeclaration") ??
+    null
+  );
+}
+
+function getExportDefaultKeywordEnd(code: string, defaultExport: AstNode): number | null {
+  const exportStart = getNodeStart(defaultExport);
+  if (exportStart == null) {
+    return null;
+  }
+
+  const match = /^export\s+default\b/.exec(code.slice(exportStart));
+  return match ? exportStart + match[0].length : null;
+}
+
+export function analyzeModuleOutput(code: string): ModuleOutputInfo {
+  const program = parseProgram(code);
+  const body = getProgramBody(program);
+  const defaultExport = findDefaultExport(program);
+
+  return {
+    hasDefaultExport: defaultExport != null,
+    hasSfcMainDefined: body.some((statement) => {
+      return (
+        statement.type === "VariableDeclaration" &&
+        getVariableDeclarationNames(statement).includes(SFC_MAIN_NAME)
+      );
+    }),
+  };
+}
+
+export function rewriteDefaultExportToSfcMain(code: string): string {
+  const defaultExport = findDefaultExport(parseProgram(code));
+  const exportStart = getNodeStart(defaultExport);
+  const keywordEnd = defaultExport ? getExportDefaultKeywordEnd(code, defaultExport) : null;
+  if (exportStart == null || keywordEnd == null) {
+    return code;
+  }
+
+  return `${code.slice(0, exportStart)}const ${SFC_MAIN_NAME} =${code.slice(keywordEnd)}`;
+}
+
+export function insertBeforeSfcMainDefaultExport(
+  code: string,
+  insertion: string,
+  options: { normalizeSemicolon?: boolean } = {},
+): string {
+  const defaultExport = findDefaultExport(parseProgram(code));
+  const declaration = isNode(defaultExport?.declaration) ? defaultExport.declaration : null;
+  const exportStart = getNodeStart(defaultExport);
+  const exportEnd = typeof defaultExport?.end === "number" ? defaultExport.end : null;
+  if (!isIdentifierNamed(declaration, SFC_MAIN_NAME) || exportStart == null) {
+    return code;
+  }
+
+  if (options.normalizeSemicolon && exportEnd != null) {
+    const suffixStart = code[exportEnd] === ";" ? exportEnd + 1 : exportEnd;
+    return `${code.slice(0, exportStart)}${insertion}\nexport default ${SFC_MAIN_NAME};${code.slice(suffixStart)}`;
+  }
+
+  return `${code.slice(0, exportStart)}${insertion}\n${code.slice(exportStart)}`;
+}

--- a/npm/builder/rspack/src/shared/output.test.ts
+++ b/npm/builder/rspack/src/shared/output.test.ts
@@ -1,9 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import type { CompiledModule } from "../types/index.ts";
+import type { CompiledModule, TemplateAssetUrl } from "../types/index.ts";
 import { generateOutput } from "./output.ts";
 
-function compiledModule(code: string): CompiledModule {
+function compiledModule(
+  code: string,
+  overrides: Partial<Pick<CompiledModule, "templateAssetUrls">> = {},
+): CompiledModule {
   return {
     code,
     errors: [],
@@ -13,8 +16,9 @@ function compiledModule(code: string): CompiledModule {
     styles: [],
     customBlocks: [],
     isCustomElement: false,
-    templateAssetUrls: [{ url: "./logo.png", varName: "_imports_0" }],
+    templateAssetUrls: [{ url: "./logo.png", varName: "_imports_0" }] satisfies TemplateAssetUrl[],
     macroArtifacts: [],
+    ...overrides,
   };
 }
 
@@ -55,4 +59,37 @@ export default _sfc_main;
 
   assert.match(output, /const same = "\.\/logo\.png";/);
   assert.ok(output.includes('_push("<img src=\\"" + _imports_0 + "\\">")'));
+});
+
+void test("output export rewrite ignores export default text inside template literals", () => {
+  const output = generateOutput(
+    compiledModule(
+      ["const message = `", "export default fake", "`;", "export default { name: 'Real' };"].join(
+        "\n",
+      ),
+      { templateAssetUrls: [] },
+    ),
+    { requestPath: "./App.vue" },
+  );
+
+  assert.match(output, /export default fake/);
+  assert.doesNotMatch(output, /const _sfc_main = fake/);
+  assert.match(output, /const _sfc_main = \{ name: 'Real' \};/);
+  assert.match(output, /export default _sfc_main;/);
+});
+
+void test("output export rewrite preserves pure annotations on default exports", () => {
+  const output = generateOutput(
+    compiledModule(
+      [
+        'import { defineComponent } from "vue";',
+        "export default /*#__PURE__*/ defineComponent({ name: 'Annotated' });",
+      ].join("\n"),
+      { templateAssetUrls: [] },
+    ),
+    { requestPath: "./App.vue" },
+  );
+
+  assert.match(output, /const _sfc_main = \/\*#__PURE__\*\/ defineComponent/);
+  assert.match(output, /export default _sfc_main;/);
 });

--- a/npm/builder/rspack/src/shared/output.ts
+++ b/npm/builder/rspack/src/shared/output.ts
@@ -4,6 +4,11 @@ import path from "node:path";
 import { rewriteSfcTemplateAssetReferences } from "@vizejs/native";
 import type { CompiledModule } from "../types/index.ts";
 import { genHotReloadCode, genCSSModuleHotReloadCode } from "./hotReload.ts";
+import {
+  analyzeModuleOutput,
+  insertBeforeSfcMainDefaultExport,
+  rewriteDefaultExportToSfcMain,
+} from "./module-output.ts";
 
 /** Generate JS output with style/custom-block imports and optional HMR code. */
 export function generateOutput(
@@ -29,20 +34,20 @@ export function generateOutput(
     output = rewriteSfcTemplateAssetReferences(output, compiled.templateAssetUrls);
   }
 
-  const exportDefaultRegex = /^export default /m;
-  const hasExportDefault = exportDefaultRegex.test(output);
-  const hasSfcMainDefined = /\bconst\s+_sfc_main\s*=/.test(output);
+  const moduleInfo = analyzeModuleOutput(output);
+  const hasExportDefault = moduleInfo.hasDefaultExport;
+  const hasSfcMainDefined = moduleInfo.hasSfcMainDefined;
 
   if (hasExportDefault && !hasSfcMainDefined) {
-    output = output.replace(exportDefaultRegex, "const _sfc_main = ");
+    output = rewriteDefaultExportToSfcMain(output);
     if (compiled.hasScoped && compiled.scopeId) {
       output += `\n_sfc_main.__scopeId = "data-v-${compiled.scopeId}";`;
     }
     output += "\nexport default _sfc_main;";
   } else if (hasExportDefault && hasSfcMainDefined && compiled.hasScoped && compiled.scopeId) {
-    output = output.replace(
-      /^export default _sfc_main/m,
-      `_sfc_main.__scopeId = "data-v-${compiled.scopeId}";\nexport default _sfc_main`,
+    output = insertBeforeSfcMainDefaultExport(
+      output,
+      `_sfc_main.__scopeId = "data-v-${compiled.scopeId}";`,
     );
   }
 
@@ -102,10 +107,9 @@ export function generateOutput(
 
     if (isCustomElement) {
       const stylesArray = activeStyles.map((style) => `_style_${style.index}`).join(",");
-      output = output.replace(
-        /^export default _sfc_main;/m,
-        `_sfc_main.styles = [${stylesArray}];\nexport default _sfc_main;`,
-      );
+      output = insertBeforeSfcMainDefaultExport(output, `_sfc_main.styles = [${stylesArray}];`, {
+        normalizeSemicolon: true,
+      });
     }
 
     if (!isCustomElement && cssModuleHmrEntries.length > 0) {
@@ -130,10 +134,9 @@ export function generateOutput(
               .join("\n")
           : "";
 
-      output = output.replace(
-        /^export default _sfc_main;/m,
-        `${cssModuleSetup}\n${cssModuleHmr}\nexport default _sfc_main;`,
-      );
+      output = insertBeforeSfcMainDefaultExport(output, `${cssModuleSetup}\n${cssModuleHmr}`, {
+        normalizeSemicolon: true,
+      });
     }
   }
 
@@ -141,17 +144,17 @@ export function generateOutput(
     const relativePath = options.rootContext
       ? path.relative(options.rootContext, options.filePath).replace(/\\/g, "/")
       : path.basename(options.filePath);
-    output = output.replace(
-      /^export default _sfc_main;/m,
-      `_sfc_main.__file = ${JSON.stringify(relativePath)};\nexport default _sfc_main;`,
+    output = insertBeforeSfcMainDefaultExport(
+      output,
+      `_sfc_main.__file = ${JSON.stringify(relativePath)};`,
+      { normalizeSemicolon: true },
     );
   }
 
   if (options.hmr && compiled.scopeId) {
-    output = output.replace(
-      /^export default _sfc_main;/m,
-      `${genHotReloadCode(compiled.scopeId)}\nexport default _sfc_main;`,
-    );
+    output = insertBeforeSfcMainDefaultExport(output, genHotReloadCode(compiled.scopeId), {
+      normalizeSemicolon: true,
+    });
   }
 
   if (compiled.customBlocks.length > 0) {
@@ -180,10 +183,9 @@ export function generateOutput(
       })
       .join("\n");
 
-    output = output.replace(
-      /^export default _sfc_main;/m,
-      `${customBlockImports}\nexport default _sfc_main;`,
-    );
+    output = insertBeforeSfcMainDefaultExport(output, customBlockImports, {
+      normalizeSemicolon: true,
+    });
   }
 
   if (compiled.templateAssetUrls.length > 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,6 +558,9 @@ importers:
       '@vizejs/native':
         specifier: workspace:*
         version: link:../../native
+      oxc-parser:
+        specifier: catalog:oxc
+        version: 0.133.0
     devDependencies:
       '@rspack/core':
         specifier: catalog:bundlers

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -105,6 +105,7 @@ catalogs:
 
   # JS-side OXC transform bridge.
   oxc:
+    oxc-parser: "0.133.0"
     oxc-transform: "0.130.0"
 
   # Published native binary packages that are installed optionally at runtime.


### PR DESCRIPTION
## Summary
- replace Rspack output default-export line rewrites with OXC parser-guided module analysis
- insert scope, CSS module, file, HMR, and custom-block setup before the parsed `_sfc_main` default export
- cover helper-looking `export default` text inside template literals and pure annotations on default exports

Part of #2703.

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --dir npm/builder/rspack run check`
- `corepack pnpm --dir npm/builder/rspack run build`
- `corepack pnpm --dir npm/native run build:debug`
- `corepack pnpm --dir npm/builder/rspack run test`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786110825&installation_id=136613492&pr_number=2708&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2708&signature=ff422ceed1bdc6855c029910b8d4262367b31c894cef8bf06602130c9f52a148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved how compiled output is assembled, making generated code handling more robust.
  * Added support for preserving embedded comments and annotations during output rewriting.

* **Bug Fixes**
  * Fixed cases where text that only looked like a default export was incorrectly processed.
  * Improved handling of styles, custom blocks, and dev-only metadata so they are inserted more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->