### PR TITLE
refactor(nuxt): parse generated import manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3402,6 +3402,7 @@ dependencies = [
  "mimalloc",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_ast_visit",
  "oxc_codegen",
  "oxc_parser",
  "oxc_semantic",

--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -65,6 +65,7 @@ serde_json = { workspace = true }
 # TypeScript/JSX transpilation
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
+oxc_ast_visit = { workspace = true }
 oxc_parser = { workspace = true }
 oxc_codegen = { workspace = true }
 oxc_semantic = { workspace = true }

--- a/crates/vize/src/commands/check/nuxt.rs
+++ b/crates/vize/src/commands/check/nuxt.rs
@@ -9,6 +9,7 @@ use vize_carton::{FxHashSet, String, ToCompactString, config::VueVersion};
 
 mod fallback;
 mod generated;
+mod generated_ast;
 mod generated_dir;
 mod legacy_template_globals;
 mod parsing;
@@ -18,6 +19,8 @@ mod stubs;
 mod tsconfig_aliases;
 mod virtual_modules;
 
+#[cfg(test)]
+mod generated_ast_tests;
 #[cfg(test)]
 mod generated_tests;
 #[cfg(test)]

--- a/crates/vize/src/commands/check/nuxt/generated.rs
+++ b/crates/vize/src/commands/check/nuxt/generated.rs
@@ -8,14 +8,15 @@ use vize_carton::{FxHashSet, String, ToCompactString, cstr};
 
 use super::super::dts::{
     parse_declared_global_values, parse_interface_members_with_rewritten_imports,
-    rewrite_relative_specifier,
+};
+use super::generated_ast::{
+    collect_import_type_specifiers, parse_import_manifest_exports,
+    rewrite_component_imports_for_virtual_project,
 };
 use super::generated_dir::{
     NuxtGeneratedDir, is_declaration_file, is_imports_declaration, is_nitro_imports_declaration,
 };
-use super::parsing::{
-    normalize_component_binding_name, parse_export_names, parse_module_specifier,
-};
+use super::parsing::normalize_component_binding_name;
 use super::stubs::{push_declared_const, tracked_read_to_string};
 
 pub(super) fn collect_generated_stubs(
@@ -91,42 +92,20 @@ pub(super) fn collect_generated_stubs(
 
     if let Ok(content) = tracked_read_to_string(&imports_path) {
         let base_dir = imports_path.parent().unwrap_or_else(|| Path::new("."));
-        for line in content.lines() {
-            let trimmed = line.trim();
-            if !trimmed.starts_with("export {") {
-                continue;
-            }
-
-            let Some((exports_part, from_part)) = trimmed
-                .strip_prefix("export {")
-                .and_then(|rest| rest.split_once("} from "))
-            else {
-                continue;
-            };
-
-            let module_specifier = parse_module_specifier(from_part);
-            let Some(module_specifier) = module_specifier else {
-                continue;
-            };
-            let module_specifier = rewrite_relative_specifier(module_specifier, base_dir);
-
-            for export_part in exports_part.split(',') {
-                let export_part = export_part.trim();
-                if export_part.is_empty() {
-                    continue;
-                }
-
-                let (local_name, exported_name) = parse_export_names(export_part);
-                let type_annotation = cstr!("typeof import('{module_specifier}')['{local_name}']");
-                push_generated_declared_const(
-                    cwd,
-                    &imports_path,
-                    stubs,
-                    seen_names,
-                    exported_name,
-                    type_annotation.as_str(),
-                );
-            }
+        for manifest_export in parse_import_manifest_exports(content.as_str(), base_dir) {
+            let type_annotation = cstr!(
+                "typeof import('{}')['{}']",
+                manifest_export.module_specifier,
+                manifest_export.local_name
+            );
+            push_generated_declared_const(
+                cwd,
+                &imports_path,
+                stubs,
+                seen_names,
+                manifest_export.exported_name.as_str(),
+                type_annotation.as_str(),
+            );
         }
     }
 
@@ -184,39 +163,9 @@ fn has_missing_project_import_type(
     type_origin: &Path,
     project_root: &Path,
 ) -> bool {
-    let bytes = type_annotation.as_bytes();
-    let mut i = 0usize;
-
-    while i < bytes.len() {
-        let quote = if type_annotation[i..].starts_with("import('") {
-            Some('\'')
-        } else if type_annotation[i..].starts_with("import(\"") {
-            Some('"')
-        } else {
-            None
-        };
-
-        let Some(quote) = quote else {
-            i += 1;
-            continue;
-        };
-
-        i += 8;
-        let start = i;
-        while i < bytes.len() && bytes[i] != quote as u8 {
-            i += 1;
-        }
-
-        if generated_import_specifier_is_missing(
-            &type_annotation[start..i],
-            type_origin,
-            project_root,
-        ) {
+    for specifier in collect_import_type_specifiers(type_annotation) {
+        if generated_import_specifier_is_missing(specifier.as_str(), type_origin, project_root) {
             return true;
-        }
-
-        if i < bytes.len() {
-            i += 1;
         }
     }
 
@@ -382,69 +331,4 @@ fn push_template_global(
             default_value: "undefined as any".into(),
         });
     }
-}
-
-fn rewrite_component_imports_for_virtual_project(
-    type_annotation: &str,
-    project_root: &Path,
-) -> String {
-    let bytes = type_annotation.as_bytes();
-    let mut out = String::with_capacity(type_annotation.len());
-    let mut i = 0usize;
-
-    while i < bytes.len() {
-        let quote = if type_annotation[i..].starts_with("import('") {
-            Some('\'')
-        } else if type_annotation[i..].starts_with("import(\"") {
-            Some('"')
-        } else {
-            None
-        };
-
-        let Some(quote) = quote else {
-            out.push(bytes[i] as char);
-            i += 1;
-            continue;
-        };
-
-        out.push_str("import(");
-        out.push(quote);
-        i += 8;
-
-        let start = i;
-        while i < bytes.len() && bytes[i] != quote as u8 {
-            i += 1;
-        }
-
-        let specifier = &type_annotation[start..i];
-        out.push_str(&virtual_project_specifier(specifier, project_root));
-
-        if i < bytes.len() {
-            out.push(quote);
-            i += 1;
-        }
-    }
-
-    out
-}
-
-fn virtual_project_specifier(specifier: &str, project_root: &Path) -> String {
-    if !specifier.ends_with(".vue") {
-        return specifier.to_compact_string();
-    }
-
-    let specifier_path = Path::new(specifier);
-    let relative = if specifier_path.is_absolute() {
-        specifier_path.strip_prefix(project_root).ok()
-    } else {
-        None
-    };
-
-    if let Some(relative) = relative {
-        let mut rendered = cstr!("./{}", relative.display());
-        rendered.push_str(".ts");
-        return rendered;
-    }
-
-    cstr!("{specifier}.ts")
 }

--- a/crates/vize/src/commands/check/nuxt/generated_ast.rs
+++ b/crates/vize/src/commands/check/nuxt/generated_ast.rs
@@ -1,0 +1,191 @@
+use std::path::Path;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Statement, TSImportType};
+use oxc_ast_visit::{Visit, walk::walk_ts_import_type};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{String, ToCompactString, cstr};
+
+use super::super::dts::rewrite_relative_specifier;
+use super::parsing::module_export_name;
+
+pub(super) struct ImportManifestExport {
+    pub(super) local_name: String,
+    pub(super) exported_name: String,
+    pub(super) module_specifier: String,
+}
+
+pub(super) fn parse_import_manifest_exports(
+    content: &str,
+    base_dir: &Path,
+) -> Vec<ImportManifestExport> {
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, content, SourceType::d_ts()).parse();
+    if ret.panicked {
+        return Vec::new();
+    }
+
+    let mut exports = Vec::new();
+    for statement in &ret.program.body {
+        let Statement::ExportNamedDeclaration(export) = statement else {
+            continue;
+        };
+        if export.export_kind.is_type() {
+            continue;
+        }
+        let Some(source) = &export.source else {
+            continue;
+        };
+        let module_specifier = rewrite_relative_specifier(source.value.as_str(), base_dir);
+
+        for specifier in &export.specifiers {
+            if specifier.export_kind.is_type() {
+                continue;
+            }
+            let Some(local_name) = module_export_name(&specifier.local) else {
+                continue;
+            };
+            let Some(exported_name) = module_export_name(&specifier.exported) else {
+                continue;
+            };
+            exports.push(ImportManifestExport {
+                local_name: local_name.to_compact_string(),
+                exported_name: exported_name.to_compact_string(),
+                module_specifier: module_specifier.clone(),
+            });
+        }
+    }
+
+    exports
+}
+
+pub(super) fn collect_import_type_specifiers(type_annotation: &str) -> Vec<String> {
+    collect_import_types(type_annotation)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|import| import.specifier)
+        .collect()
+}
+
+pub(super) fn rewrite_component_imports_for_virtual_project(
+    type_annotation: &str,
+    project_root: &Path,
+) -> String {
+    rewrite_import_type_specifiers(type_annotation, |specifier| {
+        virtual_project_specifier(specifier, project_root)
+    })
+    .unwrap_or_else(|| type_annotation.to_compact_string())
+}
+
+fn virtual_project_specifier(specifier: &str, project_root: &Path) -> String {
+    if !specifier.ends_with(".vue") {
+        return specifier.to_compact_string();
+    }
+
+    let specifier_path = Path::new(specifier);
+    let relative = if specifier_path.is_absolute() {
+        specifier_path.strip_prefix(project_root).ok()
+    } else {
+        None
+    };
+
+    if let Some(relative) = relative {
+        let mut rendered = cstr!("./{}", relative.display());
+        rendered.push_str(".ts");
+        return rendered;
+    }
+
+    cstr!("{specifier}.ts")
+}
+
+const TYPE_ANNOTATION_PREFIX: &str = "type __VizeGeneratedType = ";
+
+fn rewrite_import_type_specifiers(
+    type_annotation: &str,
+    rewrite: impl Fn(&str) -> String,
+) -> Option<String> {
+    let imports = collect_import_types(type_annotation)?;
+    let prefix_len = TYPE_ANNOTATION_PREFIX.len();
+
+    let mut replacements = imports
+        .into_iter()
+        .filter_map(|import| {
+            let start = import.source_start.checked_sub(prefix_len)?;
+            let end = import.source_end.checked_sub(prefix_len)?;
+            if start > end || end > type_annotation.len() {
+                return None;
+            }
+
+            let quote = import.quote.unwrap_or('\'');
+            let rewritten = rewrite(import.specifier.as_str());
+            Some(ImportTypeReplacement {
+                start,
+                end,
+                replacement: cstr!("{quote}{rewritten}{quote}"),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if replacements.is_empty() {
+        return Some(type_annotation.to_compact_string());
+    }
+
+    replacements.sort_by_key(|replacement| replacement.start);
+    let mut out = type_annotation.to_compact_string();
+    for replacement in replacements.into_iter().rev() {
+        out.replace_range(
+            replacement.start..replacement.end,
+            replacement.replacement.as_str(),
+        );
+    }
+    Some(out)
+}
+
+fn collect_import_types(type_annotation: &str) -> Option<Vec<ImportTypeSource>> {
+    let wrapped = cstr!("{TYPE_ANNOTATION_PREFIX}{type_annotation};");
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, wrapped.as_str(), SourceType::d_ts()).parse();
+    if ret.panicked || !ret.errors.is_empty() {
+        return None;
+    }
+
+    let mut collector = ImportTypeCollector::default();
+    collector.visit_program(&ret.program);
+    Some(collector.imports)
+}
+
+#[derive(Default)]
+struct ImportTypeCollector {
+    imports: Vec<ImportTypeSource>,
+}
+
+struct ImportTypeSource {
+    specifier: String,
+    source_start: usize,
+    source_end: usize,
+    quote: Option<char>,
+}
+
+struct ImportTypeReplacement {
+    start: usize,
+    end: usize,
+    replacement: String,
+}
+
+impl<'a> Visit<'a> for ImportTypeCollector {
+    fn visit_ts_import_type(&mut self, it: &TSImportType<'a>) {
+        self.imports.push(ImportTypeSource {
+            specifier: it.source.value.as_str().to_compact_string(),
+            source_start: it.source.span.start as usize,
+            source_end: it.source.span.end as usize,
+            quote: it
+                .source
+                .raw
+                .as_ref()
+                .and_then(|raw| raw.as_str().chars().next())
+                .filter(|quote| *quote == '\'' || *quote == '"'),
+        });
+        walk_ts_import_type(self, it);
+    }
+}

--- a/crates/vize/src/commands/check/nuxt/generated_ast_tests.rs
+++ b/crates/vize/src/commands/check/nuxt/generated_ast_tests.rs
@@ -1,0 +1,126 @@
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use vize_canon::virtual_ts::VirtualTsOptions;
+use vize_carton::cstr;
+
+use super::detect_nuxt_auto_imports;
+
+#[test]
+fn generated_component_import_rewrite_ignores_string_literal_import_text() {
+    let project_root = unique_case_dir("nuxt-component-string-import-text");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join(".nuxt")).unwrap();
+    std::fs::write(project_root.join("nuxt.config.ts"), "export default {}").unwrap();
+    std::fs::write(
+        project_root.join(".nuxt/components.d.ts"),
+        r#"declare module 'vue' {
+  export interface GlobalComponents {
+    StringImportText: "import('../components/Fake.vue')"
+  }
+}
+export {}
+"#,
+    )
+    .unwrap();
+
+    let mut options = VirtualTsOptions::default();
+    let _ = detect_nuxt_auto_imports(&mut options, &project_root);
+    let stubs = options.auto_import_stubs.join("\n");
+
+    assert!(
+        stubs.contains("declare const StringImportText: \"import("),
+        "expected string-literal import text to remain a string type, got:\n{stubs}"
+    );
+    assert!(
+        !stubs.contains("StringImportText: \"import('./components/Fake.vue.ts')"),
+        "string-literal import text should not be rewritten as a component import type, got:\n{stubs}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn detects_root_generated_manifest_multiline_exports() {
+    let project_root = unique_case_dir("nuxt-root-import-manifest");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join(".nuxt")).unwrap();
+    std::fs::create_dir_all(project_root.join("app/composables")).unwrap();
+    std::fs::write(project_root.join("nuxt.config.ts"), "export default {}").unwrap();
+    std::fs::write(
+        project_root.join("app/composables/use-alpha.ts"),
+        "export const useAlpha = () => true\nexport const useBeta = () => true\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join(".nuxt/imports.d.ts"),
+        r#"export {
+  useAlpha,
+  useBeta as useRenamedBeta,
+} from '../app/composables/use-alpha'
+"#,
+    )
+    .unwrap();
+
+    let mut options = VirtualTsOptions::default();
+    let _ = detect_nuxt_auto_imports(&mut options, &project_root);
+    let stubs = options.auto_import_stubs.join("\n");
+
+    assert!(
+        stubs.contains("declare const useAlpha: typeof import("),
+        "expected multiline manifest export useAlpha stub, got:\n{stubs}"
+    );
+    assert!(
+        stubs.contains("declare const useRenamedBeta: typeof import(")
+            && stubs.contains(")['useBeta'];"),
+        "expected aliased multiline manifest export stub, got:\n{stubs}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn generated_import_missing_check_ignores_string_literal_import_text() {
+    let project_root = unique_case_dir("nuxt-string-import-text");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join(".nuxt/types")).unwrap();
+    std::fs::write(project_root.join("nuxt.config.ts"), "export default {}").unwrap();
+    std::fs::write(
+        project_root.join(".nuxt/types/imports.d.ts"),
+        r#"declare global {
+  const literalImportText: "import('../composables/missing')"
+}
+export {}
+"#,
+    )
+    .unwrap();
+
+    let mut options = VirtualTsOptions::default();
+    let _ = detect_nuxt_auto_imports(&mut options, &project_root);
+    let stubs = options.auto_import_stubs.join("\n");
+
+    assert!(
+        stubs.contains("declare const literalImportText: \"import("),
+        "expected string-literal import text to remain precise, got:\n{stubs}"
+    );
+    assert!(
+        !stubs.contains("declare const literalImportText: any;"),
+        "string-literal import text should not trigger missing import fallback, got:\n{stubs}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn unique_case_dir(name: &str) -> std::path::PathBuf {
+    static NEXT_CASE_ID: AtomicUsize = AtomicUsize::new(0);
+
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist");
+    let case_id = NEXT_CASE_ID.fetch_add(1, Ordering::Relaxed);
+    workspace_root
+        .join("target")
+        .join("vize-tests")
+        .join(cstr!("{name}-{}-{case_id}", std::process::id()).as_str())
+}

--- a/crates/vize/src/commands/check/nuxt/parsing.rs
+++ b/crates/vize/src/commands/check/nuxt/parsing.rs
@@ -51,25 +51,6 @@ pub(super) fn module_export_name<'a>(name: &'a ModuleExportName<'a>) -> Option<&
     }
 }
 
-pub(super) fn parse_module_specifier(from_part: &str) -> Option<&str> {
-    let from_part = from_part.trim().trim_end_matches(';').trim();
-    let quote = from_part.chars().next()?;
-    if quote != '\'' && quote != '"' {
-        return None;
-    }
-    let rest = &from_part[1..];
-    let end = rest.find(quote)?;
-    Some(&rest[..end])
-}
-
-pub(super) fn parse_export_names(export_part: &str) -> (&str, &str) {
-    if let Some((local_name, exported_name)) = export_part.split_once(" as ") {
-        (local_name.trim(), exported_name.trim())
-    } else {
-        (export_part, export_part)
-    }
-}
-
 pub(super) fn normalize_component_binding_name(name: &str) -> Option<String> {
     let name = name.trim().trim_matches('"').trim_matches('\'');
     if name.is_empty() {

--- a/crates/vize/src/commands/check/nuxt/tests.rs
+++ b/crates/vize/src/commands/check/nuxt/tests.rs
@@ -10,23 +10,12 @@ use vize_carton::cstr;
 use super::super::dts::rewrite_relative_specifier;
 use super::detect_nuxt_auto_imports;
 use super::fallback::fallback_stub_strings;
-use super::parsing::{parse_export_names, parse_module_specifier};
 use super::plugins::extract_plugin_provide_keys_from_source;
 use super::stubs::declared_name;
 
 mod build_dir;
 mod config_modules;
 mod path_aliases;
-
-#[test]
-fn parses_module_export_lines() {
-    assert_eq!(
-        parse_module_specifier("'../../app/composables/users';"),
-        Some("../../app/composables/users")
-    );
-    assert_eq!(parse_export_names("foo as bar"), ("foo", "bar"));
-    assert_eq!(parse_export_names("foo"), ("foo", "foo"));
-}
 
 #[test]
 fn extracts_plugin_provide_keys_from_callback_plugin() {


### PR DESCRIPTION
## Summary
- parse root Nuxt generated import manifests with OXC instead of line splitting
- collect and rewrite generated type import specifiers from TS AST import-type nodes
- add regressions for multiline manifests and import text inside string literal types

## Validation
- cargo check -p vize
- cargo test -p vize commands::check::nuxt
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

Part of #2703

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786112498&installation_id=136613492&pr_number=2709&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2709&signature=1b71719111a575237f86c0e7a6e3553c1bbd6ef8d3c8e7257ba6d2c67481642b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Nuxt auto-import detection and stub generation for generated type manifests and component imports.
* **Bug Fixes**
  * Preserved string-based component entries instead of rewriting them incorrectly.
  * Better handling of multiline export declarations and aliased exports.
  * Avoided false `any` fallbacks when import text appears inside string literals.
* **Tests**
  * Added regression coverage for Nuxt generated manifest parsing and import rewriting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->