### PR TITLE
refactor(canon): collect import rewrite candidates structurally

### DIFF
--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -10,6 +10,8 @@ mod error;
 mod executor;
 mod import_rewriter;
 #[cfg(test)]
+mod import_rewriter_dts_tests;
+#[cfg(test)]
 mod import_rewriter_tests;
 #[cfg(test)]
 mod import_rewriter_type_tests;

--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -20,7 +20,7 @@ use virtual_rewrite::{
 
 #[path = "import_rewriter_dts.rs"]
 mod dts_rewrite;
-use dts_rewrite::{rewrite_relative_dts_specifier, source_contains_relative_specifier};
+use dts_rewrite::rewrite_relative_dts_specifier;
 
 #[derive(Debug, Clone)]
 pub struct OffsetAdjustment {
@@ -80,13 +80,6 @@ impl ImportRewriter {
     }
 
     pub fn rewrite(&self, source: &str, source_type: SourceType) -> RewriteResult {
-        if !source.contains(".vue") {
-            return RewriteResult {
-                code: source.to_compact_string(),
-                source_map: ImportSourceMap::empty(),
-            };
-        }
-
         self.rewrite_with(source, source_type, |path| {
             self.rewrite_module_specifier(path)
         })
@@ -101,15 +94,6 @@ impl ImportRewriter {
         roots: (&std::path::Path, &std::path::Path),
         source_dir: Option<&std::path::Path>,
     ) -> RewriteResult {
-        let project_root = roots.0.to_string_lossy();
-        let dts_candidate = source_dir.is_some() && source_contains_relative_specifier(source);
-        if !source.contains(".vue") && !source.contains(project_root.as_ref()) && !dts_candidate {
-            return RewriteResult {
-                code: source.to_compact_string(),
-                source_map: ImportSourceMap::empty(),
-            };
-        }
-
         self.rewrite_with(source, source_type, |path| {
             self.rewrite_virtual_project_specifier(path, roots, source_dir)
         })
@@ -120,13 +104,6 @@ impl ImportRewriter {
         source: &str,
         source_type: SourceType,
     ) -> RewriteResult {
-        if !source.contains(".vue.ts") && !source.contains(".vue.tsx") {
-            return RewriteResult {
-                code: source.to_compact_string(),
-                source_map: ImportSourceMap::empty(),
-            };
-        }
-
         self.rewrite_with(source, source_type, |path| {
             self.rewrite_declaration_specifier(path)
         })
@@ -145,9 +122,10 @@ impl ImportRewriter {
         let parser = Parser::new(&allocator, source, source_type);
         let result = parser.parse();
 
-        let mut rewrites: Vec<(u32, u32, String)> = Vec::new();
         let mut collector = ModuleSpecifierCollector::new();
         collector.visit_program(&result.program);
+
+        let mut rewrites: Vec<(u32, u32, String)> = Vec::new();
         for (start, end, path) in collector.specifiers {
             if let Some(rewrite) = rewrite_specifier(&path) {
                 rewrites.push((start, end, rewrite));
@@ -184,10 +162,6 @@ impl ImportRewriter {
         source: &str,
         source_type: SourceType,
     ) -> Vec<String> {
-        if !source.contains(".vue") {
-            return Vec::new();
-        }
-
         let allocator = Allocator::default();
         let parser = Parser::new(&allocator, source, source_type);
         let result = parser.parse();

--- a/crates/vize_canon/src/batch/import_rewriter_dts.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_dts.rs
@@ -14,16 +14,6 @@ use vize_carton::{String, cstr};
 
 use super::virtual_rewrite::append_extension;
 
-/// Cheap text gate: whether `source` has any relative module specifier worth
-/// resolving for the relative-`.d.ts` rewrite. Avoids parsing files that only
-/// import bare packages or aliases.
-pub(super) fn source_contains_relative_specifier(source: &str) -> bool {
-    source.contains("'./")
-        || source.contains("\"./")
-        || source.contains("'../")
-        || source.contains("\"../")
-}
-
 /// Rewrite a relative specifier that resolves to a generated `.d.ts` kept on its
 /// real path to that real (extensionless) path, so the re-exported identity is
 /// preserved inside the mirror.

--- a/crates/vize_canon/src/batch/import_rewriter_dts_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_dts_tests.rs
@@ -1,0 +1,86 @@
+use super::ImportRewriter;
+use oxc_span::SourceType;
+use std::fs;
+use std::path::{Path, PathBuf};
+use vize_carton::cstr;
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    std::env::temp_dir().join(
+        cstr!(
+            "vize-import-rewriter-dts-{name}-{}-{case_id}",
+            std::process::id()
+        )
+        .as_str(),
+    )
+}
+
+fn write(dir: &Path, rel: &str, contents: &str) -> PathBuf {
+    let path = dir.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(&path, contents).unwrap();
+    path
+}
+
+#[test]
+fn rewrite_relative_generated_dts_import_type_to_real_path_for_virtual_project() {
+    let raw_root = unique_case_dir("relative-generated-dts-import-type");
+    let _ = fs::remove_dir_all(&raw_root);
+    let schema = write(
+        &raw_root,
+        "types/codegen/schema.d.ts",
+        "export type Schema = { __typename: 'Schema' }\n",
+    );
+    let barrel = write(
+        &raw_root,
+        "types/index.ts",
+        "export type Schema = import('./codegen/schema').Schema\n",
+    );
+    let root = vize_carton::path::canonicalize_non_verbatim(&raw_root);
+    let schema = vize_carton::path::canonicalize_non_verbatim(&schema);
+    let rewriter = ImportRewriter::new();
+    let source = "export type Schema = import('./codegen/schema').Schema";
+    let virtual_root = root.join("node_modules/.vize/canon");
+    let roots = (root.as_path(), virtual_root.as_path());
+    let result =
+        rewriter.rewrite_for_virtual_project(source, SourceType::ts(), roots, barrel.parent());
+    assert_eq!(
+        result.code.as_str(),
+        cstr!(
+            "export type Schema = import('{}').Schema",
+            schema.with_file_name("schema").display()
+        )
+        .as_str()
+    );
+
+    let _ = fs::remove_dir_all(&raw_root);
+}
+
+#[test]
+fn ignores_relative_dts_text_outside_module_specifiers_for_virtual_project() {
+    let raw_root = unique_case_dir("relative-generated-dts-text");
+    let _ = fs::remove_dir_all(&raw_root);
+    write(
+        &raw_root,
+        "types/codegen/schema.d.ts",
+        "export type Schema = { __typename: 'Schema' }\n",
+    );
+    let barrel = write(
+        &raw_root,
+        "types/index.ts",
+        "const note = './codegen/schema'\n// export * from './codegen/schema'\n",
+    );
+    let root = vize_carton::path::canonicalize_non_verbatim(&raw_root);
+    let rewriter = ImportRewriter::new();
+    let source = "const note = './codegen/schema'\n// export * from './codegen/schema'\n";
+    let virtual_root = root.join("node_modules/.vize/canon");
+    let roots = (root.as_path(), virtual_root.as_path());
+    let result =
+        rewriter.rewrite_for_virtual_project(source, SourceType::ts(), roots, barrel.parent());
+    assert_eq!(result.code.as_str(), source);
+
+    let _ = fs::remove_dir_all(&raw_root);
+}


### PR DESCRIPTION
## Summary
- remove raw source substring gates from canon import rewriting
- let the existing OXC module specifier collector decide which import/export/require/import-type strings are rewrite candidates
- add d.ts redirect regressions for TS import types and non-specifier relative text

Refs #2703

## Validation
- cargo fmt
- cargo test -p vize_canon import_rewriter
- cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786116484&installation_id=136613492&pr_number=2711&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2711&signature=4441b6ba2397ffce64bfc159a28eca91a2ef3c0c130d8eee7b833efbe63670d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript import rewriting so valid relative type imports are handled more reliably in virtual projects.
  * Reduced the chance of missing rewrites by no longer skipping files based on a quick text check.
  * Ensured non-import text containing similar patterns is left unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->