### PR TITLE
refactor(sfc): derive defineModel metadata from ast

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -8,7 +8,7 @@ use vize_carton::{Bump, FxHashSet, String, ToCompactString};
 use vize_croquis::macros::runtime_erased_macro_names;
 
 use crate::script::{
-    PropsDestructuredBindings, ScriptCompileContext, TemplateUsedIdentifiers,
+    PropsDestructuredBindings, ScriptCompileContext, TemplateUsedIdentifiers, define_model_name,
     model_modifiers_binding_name, resolve_template_used_identifiers, resolve_type_args,
     transform_destructured_props,
 };
@@ -503,23 +503,7 @@ fn collect_model_names(ctx: &ScriptCompileContext) -> Vec<String> {
     ctx.macros
         .define_models
         .iter()
-        .map(|m| {
-            if m.args.is_empty() {
-                "modelValue".to_compact_string()
-            } else {
-                let args_trimmed = m.args.trim();
-                if args_trimmed.starts_with('\'') || args_trimmed.starts_with('"') {
-                    let quote_char = args_trimmed.as_bytes()[0] as char;
-                    if let Some(end_pos) = args_trimmed[1..].find(quote_char) {
-                        String::from(&args_trimmed[1..end_pos + 1])
-                    } else {
-                        "modelValue".to_compact_string()
-                    }
-                } else {
-                    "modelValue".to_compact_string()
-                }
-            }
-        })
+        .map(|m| define_model_name(ctx.source.as_str(), m))
         .collect()
 }
 
@@ -600,24 +584,7 @@ fn emit_model_bindings(
     let mut model_binding_names: Vec<String> = Vec::new();
     for model_call in &ctx.macros.define_models {
         if let Some(ref binding_name) = model_call.binding_name {
-            // Extract model name from args (first string argument) or default to "modelValue"
-            let model_name = if model_call.args.is_empty() {
-                "modelValue".to_compact_string()
-            } else {
-                // Try to extract the first string argument (e.g., 'title' from defineModel('title'))
-                let args_trimmed = model_call.args.trim();
-                if args_trimmed.starts_with('\'') || args_trimmed.starts_with('"') {
-                    // Extract string content
-                    let quote_char = args_trimmed.as_bytes()[0] as char;
-                    if let Some(end_pos) = args_trimmed[1..].find(quote_char) {
-                        String::from(&args_trimmed[1..end_pos + 1])
-                    } else {
-                        "modelValue".to_compact_string()
-                    }
-                } else {
-                    "modelValue".to_compact_string()
-                }
-            };
+            let model_name = define_model_name(ctx.source.as_str(), model_call);
 
             output.extend_from_slice(b"  const ");
             if let Some(ref modifiers_binding_name) =

--- a/crates/vize_atelier_sfc/src/compile_script/inline.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline.rs
@@ -4,6 +4,8 @@
 //! where the render function is inlined into the setup function.
 
 mod compiler;
+#[cfg(test)]
+mod define_model_tests;
 pub(crate) mod helpers;
 #[cfg(test)]
 mod tests;

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/model.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/model.rs
@@ -1,6 +1,6 @@
 use vize_carton::{String, ToCompactString, cstr};
 
-use crate::script::{ScriptCompileContext, model_modifiers_binding_name};
+use crate::script::{ScriptCompileContext, define_model_metadata, model_modifiers_binding_name};
 
 use super::super::super::props::{
     extract_emit_names_from_type, resolve_prop_js_type, ts_type_to_js_type,
@@ -44,160 +44,6 @@ pub(super) fn model_value_prop(
         (None, Some(options)) => options.trim().to_compact_string(),
         (None, None) => "{}".to_compact_string(),
     }
-}
-
-/// Find the matching `}` for the first `{` in `opts`, returning `(open, close)`
-/// byte indices.
-fn find_object_close(opts: &str) -> Option<(usize, usize)> {
-    let bytes = opts.as_bytes();
-    let open = opts.find('{')?;
-    let mut depth = 0i32;
-    let mut i = open;
-    let mut in_str: Option<u8> = None;
-    while i < bytes.len() {
-        let c = bytes[i];
-        if let Some(q) = in_str {
-            if c == b'\\' {
-                i += 2;
-                continue;
-            }
-            if c == q {
-                in_str = None;
-            }
-            i += 1;
-            continue;
-        }
-        match c {
-            b'"' | b'\'' | b'`' => in_str = Some(c),
-            b'{' | b'[' | b'(' => depth += 1,
-            b'}' | b']' | b')' => {
-                depth -= 1;
-                if depth == 0 {
-                    return Some((open, i));
-                }
-            }
-            _ => {}
-        }
-        i += 1;
-    }
-    None
-}
-
-/// A parsed top-level property of a defineModel options object.
-struct OptionProp {
-    /// byte offset of the property start within the options string
-    start: usize,
-    /// property key (e.g. `set`, `default`, `type`)
-    key: String,
-}
-
-/// Parse the top-level members of an object-literal options string `{ ... }`.
-/// Returns `None` if it contains a spread/computed key (Vue keeps such options
-/// verbatim).
-fn parse_option_props(opts: &str, open: usize, close: usize) -> Option<Vec<OptionProp>> {
-    let bytes = opts.as_bytes();
-    let mut props: Vec<OptionProp> = Vec::new();
-    let mut j = open + 1;
-    let mut depth = 0i32;
-    let mut in_str: Option<u8> = None;
-    let mut member_start: Option<usize> = None;
-    let mut key_buf = String::default();
-    let mut key_done = false;
-    while j < close {
-        let c = bytes[j];
-        if let Some(q) = in_str {
-            if c == b'\\' {
-                j += 2;
-                continue;
-            }
-            // collect quoted key characters while still reading the key
-            if member_start.is_some() && !key_done && depth == 0 && c != q {
-                key_buf.push(c as char);
-            }
-            if c == q {
-                in_str = None;
-            }
-            j += 1;
-            continue;
-        }
-        match c {
-            b'.' if depth == 0 && member_start.is_none() => {
-                // spread element (`...x`) -> bail
-                return None;
-            }
-            b'"' | b'\'' | b'`' => {
-                if member_start.is_none() {
-                    member_start = Some(j);
-                }
-                in_str = Some(c);
-            }
-            b'[' if depth == 0 && member_start.is_none() => {
-                // computed key -> bail
-                return None;
-            }
-            b'{' | b'[' | b'(' => {
-                if member_start.is_none() {
-                    member_start = Some(j);
-                }
-                depth += 1;
-            }
-            b'}' | b']' | b')' => depth -= 1,
-            b',' if depth == 0 => {
-                if let Some(ms) = member_start.take() {
-                    props.push(OptionProp {
-                        start: ms,
-                        key: clean_key(&key_buf),
-                    });
-                }
-                key_buf.clear();
-                key_done = false;
-            }
-            b':' if depth == 0 && !key_done && member_start.is_some() => {
-                key_done = true;
-            }
-            _ => {
-                if member_start.is_none() && !c.is_ascii_whitespace() {
-                    member_start = Some(j);
-                }
-                if member_start.is_some() && !key_done && depth == 0 && !c.is_ascii_whitespace() {
-                    key_buf.push(c as char);
-                }
-            }
-        }
-        j += 1;
-    }
-    if let Some(ms) = member_start.take() {
-        props.push(OptionProp {
-            start: ms,
-            key: clean_key(&key_buf),
-        });
-    }
-    Some(props)
-}
-
-fn clean_key(raw: &str) -> String {
-    raw.trim()
-        .trim_matches(['\'', '"', '`'])
-        .to_compact_string()
-}
-
-/// Produce the prop-options string for a single defineModel, stripping the
-/// runtime-only `get`/`set` accessors (which belong only on the `useModel`
-/// runtime argument), matching `@vue/compiler-sfc`'s `genModelProps`.
-fn strip_runtime_accessors(opts: &str) -> Option<String> {
-    let (open, close) = find_object_close(opts)?;
-    let props = parse_option_props(opts, open, close)?;
-    // Build result by removing get/set spans from last to first, mirroring Vue's
-    // `slice(0, start) + slice(end)` where `end = next ? next.start : close`.
-    let mut result = opts.to_compact_string();
-    for idx in (0..props.len()).rev() {
-        let p = &props[idx];
-        if p.key == "get" || p.key == "set" {
-            let end = props.get(idx + 1).map(|n| n.start).unwrap_or(close);
-            result.replace_range(p.start..end, "");
-        }
-    }
-    Some(result)
 }
 
 /// Build model props (and combine props/emits) when defineModel is used.
@@ -341,46 +187,19 @@ pub(super) fn collect_model_infos(
         .define_models
         .iter()
         .map(|m| {
-            let args = m.args.trim();
-            let has_name = args.starts_with(['\'', '"', '`']);
-            let model_name = if has_name {
-                args.trim_start_matches(['\'', '"', '`'])
-                    .split(['\'', '"', '`'])
-                    .next()
-                    .unwrap_or("modelValue")
-                    .to_compact_string()
-            } else {
-                "modelValue".to_compact_string()
-            };
+            let metadata = define_model_metadata(ctx.source.as_str(), m);
+            let model_name = metadata.name;
             let binding_name = m
                 .binding_name
                 .as_deref()
                 .map(String::from)
                 .unwrap_or_else(|| model_name.clone());
             let modifiers_binding_name = model_modifiers_binding_name(ctx.source.as_str(), m);
-
-            // Locate the options argument (second arg if named, first arg otherwise).
-            let raw_options: Option<&str> = if args.is_empty() {
-                None
-            } else if has_name {
-                // skip the string literal, then the comma
-                args.split_once(',').map(|(_, rest)| rest.trim())
-            } else {
-                Some(args)
-            };
-            let options = raw_options.and_then(|opts| {
-                if opts.starts_with('{') {
-                    // strip runtime-only get/set accessors for the prop options
-                    Some(strip_runtime_accessors(opts).unwrap_or_else(|| opts.to_compact_string()))
-                } else {
-                    None
-                }
-            });
             (
                 model_name,
                 binding_name,
                 modifiers_binding_name,
-                options,
+                metadata.options,
                 m.type_args.clone(),
             )
         })

--- a/crates/vize_atelier_sfc/src/compile_script/inline/define_model_tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/define_model_tests.rs
@@ -1,0 +1,71 @@
+use super::compile_script_setup_inline;
+use crate::compile_script::TemplateParts;
+use vize_carton::String;
+
+fn compile_setup(script_content: &str) -> String {
+    let result = compile_script_setup_inline(
+        script_content,
+        "TestComponent",
+        false,
+        true,
+        false,
+        TemplateParts {
+            imports: "",
+            hoisted: "",
+            render_fn: "",
+            render_fn_name: "",
+            preamble: "",
+            render_body: "null",
+            render_is_block: false,
+        },
+        None,
+        &[],
+        "",
+        None,
+    )
+    .expect("compilation should succeed");
+    result.code
+}
+
+#[test]
+fn define_model_uses_ast_argument_metadata() {
+    let content = r#"
+const model = defineModel(('label') as const, {
+  default: 'Untitled',
+  get(value) {
+    return value
+  },
+  set(value) {
+    return value.trim()
+  },
+})
+"#;
+
+    let output = compile_setup(content);
+    let normalized: String = output
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .into();
+
+    assert!(
+        normalized.contains(r#""label": { default: "Untitled" }"#),
+        "expected the AST string argument to drive the model prop name:\n{output}"
+    );
+    assert!(
+        normalized.contains(r#"emits: ["update:label"]"#),
+        "expected model emits to use the AST string argument:\n{output}"
+    );
+    assert!(
+        normalized.contains(r#"const model = _useModel(__props, "label");"#),
+        "expected useModel to use the AST string argument:\n{output}"
+    );
+    assert!(
+        !normalized.contains("modelValue"),
+        "parenthesized/as string argument should not fall back to modelValue:\n{output}"
+    );
+    assert!(
+        !normalized.contains("get(value)") && !normalized.contains("set(value)"),
+        "runtime-only model accessors should not be copied into props options:\n{output}"
+    );
+}

--- a/crates/vize_atelier_sfc/src/script.rs
+++ b/crates/vize_atelier_sfc/src/script.rs
@@ -11,6 +11,7 @@ mod context;
 mod define_emits;
 mod define_expose;
 mod define_model;
+mod define_model_metadata;
 mod define_options;
 mod define_props;
 mod define_props_destructure;
@@ -25,6 +26,7 @@ pub use context::{ScriptCompileContext, begin_type_resolution_batch};
 pub use define_emits::{
     DefineEmitsResult, extract_runtime_emits, gen_runtime_emits, process_define_emits,
 };
+pub(crate) use define_model_metadata::{define_model_metadata, define_model_name};
 pub use define_props_destructure::{
     PropsDestructureBinding, PropsDestructuredBindings, gen_props_access_exp,
     process_props_destructure, transform_destructured_props,

--- a/crates/vize_atelier_sfc/src/script/context.rs
+++ b/crates/vize_atelier_sfc/src/script/context.rs
@@ -167,18 +167,9 @@ impl ScriptCompileContext {
         // Convert models
         for model_call in &self.macros.define_models {
             if let Some(ref binding_name) = model_call.binding_name {
-                // Extract model name from args if present
-                let args = model_call.args.trim();
-                let name = if args.starts_with('\'') || args.starts_with('"') {
-                    let quote = args.as_bytes()[0];
-                    if let Some(end) = args[1..].find(|c: char| c as u8 == quote) {
-                        CompactString::new(&args[1..=end])
-                    } else {
-                        CompactString::new("modelValue")
-                    }
-                } else {
-                    CompactString::new("modelValue")
-                };
+                let name = CompactString::new(
+                    super::define_model_name(self.source.as_str(), model_call).as_str(),
+                );
 
                 summary.macros.add_model(ModelDefinition {
                     name: name.clone(),

--- a/crates/vize_atelier_sfc/src/script/context/helpers.rs
+++ b/crates/vize_atelier_sfc/src/script/context/helpers.rs
@@ -27,13 +27,13 @@ pub(super) fn extract_macro_from_expr(
 
             return Some((
                 callee_name,
-                MacroCall {
-                    start: call.span.start as usize,
-                    end: call.span.end as usize,
+                MacroCall::new(
+                    call.span.start as usize,
+                    call.span.end as usize,
                     args,
                     type_args,
-                    binding_name: None, // Will be set by caller if applicable
-                },
+                    None,
+                ),
             ));
         }
     }

--- a/crates/vize_atelier_sfc/src/script/context/parse.rs
+++ b/crates/vize_atelier_sfc/src/script/context/parse.rs
@@ -234,14 +234,13 @@ impl ScriptCompileContext {
                         if let Expression::CallExpression(call) = init
                             && is_call_of(call, "withDefaults")
                         {
-                            self.macros.with_defaults = Some(MacroCall {
-                                start: call.span.start as usize,
-                                end: call.span.end as usize,
-                                args: source[call.span.start as usize..call.span.end as usize]
-                                    .into(),
-                                type_args: None,
-                                binding_name: binding_name.as_deref().map(Into::into),
-                            });
+                            self.macros.with_defaults = Some(MacroCall::new(
+                                call.span.start as usize,
+                                call.span.end as usize,
+                                source[call.span.start as usize..call.span.end as usize].into(),
+                                None,
+                                binding_name.as_deref().map(Into::into),
+                            ));
 
                             // Also extract the inner defineProps
                             if let Some(Argument::CallExpression(inner_call)) =
@@ -249,13 +248,13 @@ impl ScriptCompileContext {
                                 && is_call_of(inner_call, "defineProps")
                             {
                                 let type_args = extract_type_args_from_call(inner_call, source);
-                                let props_call = MacroCall {
-                                    start: inner_call.span.start as usize,
-                                    end: inner_call.span.end as usize,
-                                    args: extract_args_from_call(inner_call, source),
+                                let props_call = MacroCall::new(
+                                    inner_call.span.start as usize,
+                                    inner_call.span.end as usize,
+                                    extract_args_from_call(inner_call, source),
                                     type_args,
-                                    binding_name: binding_name.as_deref().map(String::from),
-                                };
+                                    binding_name.as_deref().map(String::from),
+                                );
                                 self.extract_props_bindings(&props_call);
                                 self.macros.define_props = Some(props_call);
                                 self.has_define_props_call = true;
@@ -410,26 +409,26 @@ impl ScriptCompileContext {
                 if let Expression::CallExpression(call) = &expr_stmt.expression
                     && is_call_of(call, "withDefaults")
                 {
-                    self.macros.with_defaults = Some(MacroCall {
-                        start: call.span.start as usize,
-                        end: call.span.end as usize,
-                        args: source[call.span.start as usize..call.span.end as usize].into(),
-                        type_args: None,
-                        binding_name: None,
-                    });
+                    self.macros.with_defaults = Some(MacroCall::new(
+                        call.span.start as usize,
+                        call.span.end as usize,
+                        source[call.span.start as usize..call.span.end as usize].into(),
+                        None,
+                        None,
+                    ));
 
                     // Also extract the inner defineProps
                     if let Some(Argument::CallExpression(inner_call)) = call.arguments.first()
                         && is_call_of(inner_call, "defineProps")
                     {
                         let type_args = extract_type_args_from_call(inner_call, source);
-                        let props_call = MacroCall {
-                            start: inner_call.span.start as usize,
-                            end: inner_call.span.end as usize,
-                            args: extract_args_from_call(inner_call, source),
+                        let props_call = MacroCall::new(
+                            inner_call.span.start as usize,
+                            inner_call.span.end as usize,
+                            extract_args_from_call(inner_call, source),
                             type_args,
-                            binding_name: None,
-                        };
+                            None,
+                        );
                         self.extract_props_bindings(&props_call);
                         self.macros.define_props = Some(props_call);
                         self.has_define_props_call = true;

--- a/crates/vize_atelier_sfc/src/script/define_expose.rs
+++ b/crates/vize_atelier_sfc/src/script/define_expose.rs
@@ -22,13 +22,13 @@ pub fn extract_define_expose(content: &str) -> Option<MacroCall> {
         {
             let args = String::from(&after[paren_start + 1..paren_start + paren_end]);
             let type_args = extract_type_args(&after[..paren_start]);
-            return Some(MacroCall {
+            return Some(MacroCall::new(
                 start,
-                end: start + paren_start + paren_end + 1,
+                start + paren_start + paren_end + 1,
                 args,
                 type_args,
-                binding_name: None,
-            });
+                None,
+            ));
         }
     }
     None

--- a/crates/vize_atelier_sfc/src/script/define_model.rs
+++ b/crates/vize_atelier_sfc/src/script/define_model.rs
@@ -26,13 +26,13 @@ pub fn extract_define_model(content: &str) -> Vec<MacroCall> {
             if let Some(paren_end) = find_matching_paren(&after[paren_start..]) {
                 let args = String::from(&after[paren_start + 1..paren_start + paren_end]);
                 let type_args = extract_type_args(&after[..paren_start]);
-                calls.push(MacroCall {
+                calls.push(MacroCall::new(
                     start,
-                    end: start + paren_start + paren_end + 1,
+                    start + paren_start + paren_end + 1,
                     args,
                     type_args,
-                    binding_name: None,
-                });
+                    None,
+                ));
                 search_from = start + paren_start + paren_end + 1;
             } else {
                 break;

--- a/crates/vize_atelier_sfc/src/script/define_model_metadata.rs
+++ b/crates/vize_atelier_sfc/src/script/define_model_metadata.rs
@@ -1,0 +1,152 @@
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    Argument, CallExpression, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey,
+    Statement,
+};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{String, ToCompactString};
+
+use super::MacroCall;
+
+pub(crate) struct DefineModelMetadata {
+    pub(crate) name: String,
+    pub(crate) options: Option<String>,
+}
+
+pub(crate) fn define_model_name(source: &str, call: &MacroCall) -> String {
+    define_model_metadata(source, call).name
+}
+
+pub(crate) fn define_model_metadata(source: &str, call: &MacroCall) -> DefineModelMetadata {
+    let Some(source) = source.get(call.start..call.end) else {
+        return default_metadata();
+    };
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source, SourceType::ts()).parse();
+    if parsed.panicked || !parsed.errors.is_empty() {
+        return default_metadata();
+    }
+    let Some(Statement::ExpressionStatement(statement)) = parsed.program.body.first() else {
+        return default_metadata();
+    };
+    let Expression::CallExpression(call) = &statement.expression else {
+        return default_metadata();
+    };
+
+    extract_metadata_from_call(call, source)
+}
+
+fn extract_metadata_from_call(call: &CallExpression<'_>, source: &str) -> DefineModelMetadata {
+    let name_arg = call.arguments.first().and_then(argument_string_literal);
+    let name = name_arg
+        .map(|name| name.to_compact_string())
+        .unwrap_or_else(|| "modelValue".to_compact_string());
+    let options_index = if name_arg.is_some() { 1 } else { 0 };
+    let options = call
+        .arguments
+        .get(options_index)
+        .and_then(argument_object)
+        .and_then(|object| strip_model_runtime_accessors(object, source));
+
+    DefineModelMetadata { name, options }
+}
+
+fn default_metadata() -> DefineModelMetadata {
+    DefineModelMetadata {
+        name: "modelValue".into(),
+        options: None,
+    }
+}
+
+fn argument_string_literal<'a>(argument: &'a Argument<'a>) -> Option<&'a str> {
+    match argument {
+        Argument::StringLiteral(literal) => Some(literal.value.as_str()),
+        Argument::ParenthesizedExpression(expr) => expression_string_literal(&expr.expression),
+        Argument::TSAsExpression(expr) => expression_string_literal(&expr.expression),
+        Argument::TSSatisfiesExpression(expr) => expression_string_literal(&expr.expression),
+        Argument::TSNonNullExpression(expr) => expression_string_literal(&expr.expression),
+        _ => None,
+    }
+}
+
+fn argument_object<'a>(argument: &'a Argument<'a>) -> Option<&'a ObjectExpression<'a>> {
+    match argument {
+        Argument::ObjectExpression(object) => Some(object),
+        Argument::ParenthesizedExpression(expr) => expression_object(&expr.expression),
+        Argument::TSAsExpression(expr) => expression_object(&expr.expression),
+        Argument::TSSatisfiesExpression(expr) => expression_object(&expr.expression),
+        Argument::TSNonNullExpression(expr) => expression_object(&expr.expression),
+        _ => None,
+    }
+}
+
+fn expression_string_literal<'a>(expression: &'a Expression<'a>) -> Option<&'a str> {
+    match expression {
+        Expression::StringLiteral(literal) => Some(literal.value.as_str()),
+        Expression::ParenthesizedExpression(expr) => expression_string_literal(&expr.expression),
+        Expression::TSAsExpression(expr) => expression_string_literal(&expr.expression),
+        Expression::TSSatisfiesExpression(expr) => expression_string_literal(&expr.expression),
+        Expression::TSNonNullExpression(expr) => expression_string_literal(&expr.expression),
+        _ => None,
+    }
+}
+
+fn expression_object<'a>(expression: &'a Expression<'a>) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object),
+        Expression::ParenthesizedExpression(expr) => expression_object(&expr.expression),
+        Expression::TSAsExpression(expr) => expression_object(&expr.expression),
+        Expression::TSSatisfiesExpression(expr) => expression_object(&expr.expression),
+        Expression::TSNonNullExpression(expr) => expression_object(&expr.expression),
+        _ => None,
+    }
+}
+
+fn strip_model_runtime_accessors(object: &ObjectExpression<'_>, source: &str) -> Option<String> {
+    if object.properties.iter().any(|property| match property {
+        ObjectPropertyKind::ObjectProperty(property) => property.computed,
+        ObjectPropertyKind::SpreadProperty(_) => true,
+    }) {
+        return source
+            .get(object.span.start as usize..object.span.end as usize)
+            .map(String::from);
+    }
+
+    let object_start = object.span.start as usize;
+    let object_end = object.span.end as usize;
+    let object_close = object_end.checked_sub(1)?;
+    let mut result = source.get(object_start..object_end)?.to_compact_string();
+    let properties: Vec<_> = object
+        .properties
+        .iter()
+        .filter_map(|property| {
+            let ObjectPropertyKind::ObjectProperty(property) = property else {
+                return None;
+            };
+            Some((
+                property.span.start as usize,
+                static_property_name(&property.key),
+            ))
+        })
+        .collect();
+
+    for (index, (start, key)) in properties.iter().enumerate().rev() {
+        if matches!(key, Some("get" | "set")) {
+            let end = properties
+                .get(index + 1)
+                .map(|(next_start, _)| *next_start)
+                .unwrap_or(object_close);
+            result.replace_range(start - object_start..end - object_start, "");
+        }
+    }
+    Some(result)
+}
+
+fn static_property_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
+        PropertyKey::StringLiteral(literal) => Some(literal.value.as_str()),
+        _ => None,
+    }
+}

--- a/crates/vize_atelier_sfc/src/script/define_options.rs
+++ b/crates/vize_atelier_sfc/src/script/define_options.rs
@@ -22,13 +22,13 @@ pub fn extract_define_options(content: &str) -> Option<MacroCall> {
         {
             let args = String::from(&after[paren_start + 1..paren_start + paren_end]);
             let type_args = extract_type_args(&after[..paren_start]);
-            return Some(MacroCall {
+            return Some(MacroCall::new(
                 start,
-                end: start + paren_start + paren_end + 1,
+                start + paren_start + paren_end + 1,
                 args,
                 type_args,
-                binding_name: None,
-            });
+                None,
+            ));
         }
     }
     None

--- a/crates/vize_atelier_sfc/src/script/define_props.rs
+++ b/crates/vize_atelier_sfc/src/script/define_props.rs
@@ -34,13 +34,13 @@ fn extract_macro_call(content: &str, macro_name: &str) -> Option<MacroCall> {
         {
             let args = String::from(&after[paren_start + 1..paren_start + paren_end]);
             let type_args = extract_type_args(&after[..paren_start]);
-            return Some(MacroCall {
+            return Some(MacroCall::new(
                 start,
-                end: start + paren_start + paren_end + 1,
+                start + paren_start + paren_end + 1,
                 args,
                 type_args,
-                binding_name: None,
-            });
+                None,
+            ));
         }
     }
     None

--- a/crates/vize_atelier_sfc/src/script/define_slots.rs
+++ b/crates/vize_atelier_sfc/src/script/define_slots.rs
@@ -22,13 +22,13 @@ pub fn extract_define_slots(content: &str) -> Option<MacroCall> {
         {
             let args = String::from(&after[paren_start + 1..paren_start + paren_end]);
             let type_args = extract_type_args(&after[..paren_start]);
-            return Some(MacroCall {
+            return Some(MacroCall::new(
                 start,
-                end: start + paren_start + paren_end + 1,
+                start + paren_start + paren_end + 1,
                 args,
                 type_args,
-                binding_name: None,
-            });
+                None,
+            ));
         }
     }
     None

--- a/crates/vize_atelier_sfc/src/script/utils.rs
+++ b/crates/vize_atelier_sfc/src/script/utils.rs
@@ -29,7 +29,6 @@ pub struct ScriptSetupMacros {
     pub props_destructure: Option<super::PropsDestructuredBindings>,
 }
 
-/// Information about a macro call
 #[derive(Debug, Clone)]
 pub struct MacroCall {
     /// Start offset
@@ -42,6 +41,24 @@ pub struct MacroCall {
     pub type_args: Option<String>,
     /// Variable name this macro is assigned to (e.g., "emit" for "const emit = defineEmits(...)")
     pub binding_name: Option<String>,
+}
+
+impl MacroCall {
+    pub(crate) fn new(
+        start: usize,
+        end: usize,
+        args: String,
+        type_args: Option<String>,
+        binding_name: Option<String>,
+    ) -> Self {
+        Self {
+            start,
+            end,
+            args,
+            type_args,
+            binding_name,
+        }
+    }
 }
 
 pub(crate) fn model_modifiers_binding_name(source: &str, call: &MacroCall) -> Option<String> {


### PR DESCRIPTION
## Summary
- capture defineModel name/options metadata from the OXC call expression
- remove string delimiter parsing for inline/function-mode model names and prop options
- add regression coverage for parenthesized/as string model names and accessor stripping

## Verification
- cargo test -p vize_atelier_sfc compile_script::inline
- cargo test -p vize_atelier_sfc define_model
- cargo clippy -p vize_atelier_sfc -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786118924&installation_id=136613492&pr_number=2713&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2713&signature=1163098383868e6f00d80bca440d38d69f775ce8c3b4029b38b9e90ba62e966e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `defineModel` name detection so emitted `update:<name>` events and generated bindings consistently use the AST-derived model name (including wrapped string forms), avoiding incorrect defaults.
  * Ensured runtime-only `get`/`set` accessors are no longer carried into generated `defineModel` options.
* **Tests**
  * Added coverage to verify AST-based model naming and output structure for `defineModel`, including correct `_useModel` usage and absence of `modelValue` fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->