### PR TITLE
refactor(mcp-musea): print palette types with ast

### DIFF
--- a/npm/mcp-musea/package.json
+++ b/npm/mcp-musea/package.json
@@ -51,14 +51,14 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "catalog:integrations",
-    "@vizejs/native": "workspace:*"
+    "@vizejs/native": "workspace:*",
+    "typescript": "catalog:typescript"
   },
   "devDependencies": {
     "@tsdown/css": "catalog:content",
     "@types/node": "catalog:typescript",
     "tsdown": "catalog:vite-stack",
     "tsx": "catalog:typescript",
-    "typescript": "catalog:typescript",
     "vite": "catalog:vite-stack",
     "vite-plus": "catalog:vite-stack"
   },

--- a/npm/mcp-musea/src/musea.test.ts
+++ b/npm/mcp-musea/src/musea.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { buildPalette } from "./musea.ts";
+import type { NativeBinding, ServerContext } from "./types.ts";
+
+test("buildPalette prints fallback TypeScript through the AST printer", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "musea-mcp-palette-"));
+  try {
+    const artPath = path.join(root, "FancyButton.art.vue");
+    const componentPath = path.join(root, "FancyButton.vue");
+    fs.writeFileSync(componentPath, "<template><button /></template>\n");
+
+    const ctx: ServerContext = {
+      projectRoot: root,
+      loadNative() {
+        throw new Error("native binding should be provided by the test");
+      },
+      scanArtFiles: async () => new Map(),
+      resolveTokensPath: async () => null,
+    };
+    const binding = {
+      parseArt() {
+        throw new Error("parseArt should not be called");
+      },
+      artToCsf() {
+        throw new Error("artToCsf should not be called");
+      },
+      parseDesignTokensFromPath() {
+        return [];
+      },
+      flattenDesignTokenCategories() {
+        return [];
+      },
+      generateDesignTokensMarkdown() {
+        return "";
+      },
+      analyzeSfc() {
+        return {
+          props: [
+            {
+              name: "tone",
+              type: '"brand" | "neutral"',
+              required: false,
+            },
+            {
+              name: "disabled",
+              type: "boolean",
+              required: true,
+            },
+            {
+              name: "model-value",
+              type: "string",
+              required: false,
+            },
+          ],
+          emits: [],
+        };
+      },
+    } satisfies NativeBinding;
+
+    const palette = await buildPalette(
+      ctx,
+      binding,
+      {
+        info: {
+          path: artPath,
+          title: "Fancy Button",
+          component: "./FancyButton.vue",
+          tags: [],
+          status: "ready",
+          variantCount: 0,
+          variantNames: [],
+        },
+        absolutePath: artPath,
+        relativePath: "FancyButton.art.vue",
+        matchedBy: "path",
+        matchValue: "FancyButton.art.vue",
+        score: 1,
+        reasons: [],
+        alternatives: [],
+      },
+      "",
+    );
+
+    assert.equal(
+      palette?.typescript,
+      [
+        "export interface FancyButtonProps {",
+        '    tone?: "brand" | "neutral";',
+        "    disabled: boolean;",
+        '    "model-value"?: string;',
+        "}",
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/npm/mcp-musea/src/musea.ts
+++ b/npm/mcp-musea/src/musea.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { buildPaletteTypescript } from "./palette-typescript.js";
 import type { ArtInfo, NativeBinding, ServerContext } from "./types.js";
 
 type PaletteControl = {
@@ -569,19 +570,7 @@ function buildPaletteFromAnalysis(title: string, analysis: ComponentAnalysisResu
     controls,
     groups: [],
     json: JSON.stringify({ title, controls }, null, 2),
-    typescript: `export interface ${title.replace(/\s+/g, "")}Props {\n${controls
-      .map((control) => {
-        const type =
-          control.control === "boolean"
-            ? "boolean"
-            : control.control === "number"
-              ? "number"
-              : control.control === "select" && control.options.length > 0
-                ? control.options.map((option) => `"${String(option.value)}"`).join(" | ")
-                : "string";
-        return `  ${control.name}${control.required ? "" : "?"}: ${type};`;
-      })
-      .join("\n")}\n}\n`,
+    typescript: buildPaletteTypescript(title, controls),
   };
 }
 

--- a/npm/mcp-musea/src/palette-typescript.ts
+++ b/npm/mcp-musea/src/palette-typescript.ts
@@ -1,0 +1,64 @@
+import ts from "typescript";
+
+export interface PaletteTypeControl {
+  name: string;
+  control: string;
+  required: boolean;
+  options: Array<{ value: unknown }>;
+}
+
+export function buildPaletteTypescript(title: string, controls: PaletteTypeControl[]): string {
+  const members = controls.map((control) =>
+    ts.factory.createPropertySignature(
+      undefined,
+      propertyNameNode(control.name),
+      control.required ? undefined : ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+      controlTypeNode(control),
+    ),
+  );
+  const declaration = ts.factory.createInterfaceDeclaration(
+    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+    interfaceNameFromTitle(title),
+    undefined,
+    undefined,
+    members,
+  );
+  const sourceFile = ts.createSourceFile(
+    "palette.ts",
+    "",
+    ts.ScriptTarget.Latest,
+    false,
+    ts.ScriptKind.TS,
+  );
+  const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+  return `${printer.printNode(ts.EmitHint.Unspecified, declaration, sourceFile)}\n`;
+}
+
+function interfaceNameFromTitle(title: string): string {
+  const compact = title.replace(/\s+/g, "");
+  const candidate = `${compact || "Component"}Props`.replace(/[^A-Za-z0-9_$]/g, "_");
+  return /^[A-Za-z_$]/.test(candidate) ? candidate : `_${candidate}`;
+}
+
+function propertyNameNode(name: string): ts.PropertyName {
+  return /^[$A-Z_a-z][$\w]*$/.test(name)
+    ? ts.factory.createIdentifier(name)
+    : ts.factory.createStringLiteral(name);
+}
+
+function controlTypeNode(control: PaletteTypeControl): ts.TypeNode {
+  if (control.control === "boolean") {
+    return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword);
+  }
+  if (control.control === "number") {
+    return ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
+  }
+  if (control.control === "select" && control.options.length > 0) {
+    return ts.factory.createUnionTypeNode(
+      control.options.map((option) =>
+        ts.factory.createLiteralTypeNode(ts.factory.createStringLiteral(String(option.value))),
+      ),
+    );
+  }
+  return ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,6 +425,9 @@ importers:
       '@vizejs/native':
         specifier: workspace:*
         version: link:../native
+      typescript:
+        specifier: catalog:typescript
+        version: 6.0.3
     devDependencies:
       '@tsdown/css':
         specifier: catalog:content
@@ -438,9 +441,6 @@ importers:
       tsx:
         specifier: catalog:typescript
         version: 4.22.4
-      typescript:
-        specifier: catalog:typescript
-        version: 6.0.3
       vite:
         specifier: catalog:vite-stack
         version: '@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)'


### PR DESCRIPTION
## Summary
- Generate fallback palette TypeScript with the TypeScript AST factory/printer instead of assembling an interface string by hand.
- Move `typescript` to runtime dependencies because the MCP server now uses the printer at runtime.
- Add a regression covering select unions and non-identifier prop names.

## Validation
- `./node_modules/.bin/vp fmt --write src vite.config.ts` (from `npm/mcp-musea`)
- `./node_modules/.bin/vp check src vite.config.ts` (from `npm/mcp-musea`)
- `./node_modules/.bin/tsx --test src/**/*.test.ts` (from `npm/mcp-musea`)
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786120659&installation_id=136613492&pr_number=2718&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2718&signature=69cd705d407564f47f9acd145afb95d4cdb21920e1d54cb223cf67716c937f44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated TypeScript output for palettes is now more reliable and consistent, including cleaner names and better handling of control types and select options.
  * Added coverage to verify the generated TypeScript matches expected component props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->