### PR TITLE
refactor(oxint): resolve scriptless bridge via blocks

### DIFF
--- a/npm/oxint/src/workaround.ts
+++ b/npm/oxint/src/workaround.ts
@@ -1,8 +1,16 @@
 import { extractSfcBlocks } from "./sfc-blocks.js";
+import type { LineColumn } from "./model.js";
 
 const SCRIPTLESS_WORKAROUND_MARKER = "oxlint-plugin-vize-scriptless";
 const SCRIPTLESS_WORKAROUND_OPEN_TAG_PREFIX = `<script setup lang="ts" data-${SCRIPTLESS_WORKAROUND_MARKER}="`;
 const SCRIPTLESS_WORKAROUND_CLOSE_TAG = "</script>";
+const SCRIPTLESS_WORKAROUND_FILENAME_ATTR = `data-${SCRIPTLESS_WORKAROUND_MARKER}="`;
+
+export const SCRIPTLESS_WORKAROUND_TRACKING = {
+  strategy: "synthetic-script-setup-bridge",
+  removeWhen:
+    "Oxlint JS plugins can pass scriptless Vue/HTML files to native structured input with original Vue positions.",
+} as const;
 
 export interface ResolvedWorkaroundSource {
   filename: string;
@@ -24,7 +32,8 @@ export function resolveWorkaroundSource(
   source: string,
   fallbackFilename: string,
 ): ResolvedWorkaroundSource {
-  if (!source.startsWith(SCRIPTLESS_WORKAROUND_OPEN_TAG_PREFIX)) {
+  const workaroundBlock = getPrependedWorkaroundBlock(source);
+  if (workaroundBlock == null) {
     return {
       filename: fallbackFilename,
       source,
@@ -32,26 +41,7 @@ export function resolveWorkaroundSource(
     };
   }
 
-  const encodedFilenameStart = SCRIPTLESS_WORKAROUND_OPEN_TAG_PREFIX.length;
-  const encodedFilenameEnd = source.indexOf(`">`, encodedFilenameStart);
-  if (encodedFilenameEnd === -1) {
-    return {
-      filename: fallbackFilename,
-      source,
-      usesOriginalLocations: false,
-    };
-  }
-
-  const closeTagStart = source.indexOf(SCRIPTLESS_WORKAROUND_CLOSE_TAG, encodedFilenameEnd + 2);
-  if (closeTagStart === -1) {
-    return {
-      filename: fallbackFilename,
-      source,
-      usesOriginalLocations: false,
-    };
-  }
-
-  let strippedSourceStart = closeTagStart + SCRIPTLESS_WORKAROUND_CLOSE_TAG.length;
+  let strippedSourceStart = workaroundBlock.closeTagEnd;
   if (source.charCodeAt(strippedSourceStart) === 13) {
     strippedSourceStart += 1;
   }
@@ -60,8 +50,7 @@ export function resolveWorkaroundSource(
   }
 
   const decodedFilename =
-    decodeWorkaroundFilename(source.slice(encodedFilenameStart, encodedFilenameEnd)) ??
-    fallbackFilename;
+    decodeWorkaroundFilename(workaroundBlock.encodedFilename) ?? fallbackFilename;
   const strippedSource = source.slice(strippedSourceStart);
 
   return {
@@ -69,6 +58,50 @@ export function resolveWorkaroundSource(
     source: strippedSource,
     usesOriginalLocations: true,
   };
+}
+
+function getPrependedWorkaroundBlock(
+  source: string,
+): { closeTagEnd: number; encodedFilename: string } | null {
+  const [firstBlock] = extractSfcBlocks(source);
+  if (!firstBlock || firstBlock.kind !== "script-setup") {
+    return null;
+  }
+  if (!isWhitespaceOnly(firstBlock.content)) {
+    return null;
+  }
+
+  const contentStart = offsetFromLineColumn(source, firstBlock.contentStart);
+  const contentEnd = offsetFromLineColumn(source, firstBlock.contentEnd);
+  const openTag = source.slice(0, contentStart);
+  const encodedFilename = encodedFilenameFromWorkaroundOpenTag(openTag);
+  if (encodedFilename == null) {
+    return null;
+  }
+
+  return {
+    closeTagEnd: contentEnd + SCRIPTLESS_WORKAROUND_CLOSE_TAG.length,
+    encodedFilename,
+  };
+}
+
+function encodedFilenameFromWorkaroundOpenTag(openTag: string): string | null {
+  if (!openTag.startsWith(SCRIPTLESS_WORKAROUND_OPEN_TAG_PREFIX)) {
+    return null;
+  }
+
+  const encodedFilenameStart =
+    openTag.indexOf(SCRIPTLESS_WORKAROUND_FILENAME_ATTR) +
+    SCRIPTLESS_WORKAROUND_FILENAME_ATTR.length;
+  const encodedFilenameEnd = openTag.indexOf('"', encodedFilenameStart);
+  if (
+    encodedFilenameStart < SCRIPTLESS_WORKAROUND_FILENAME_ATTR.length ||
+    encodedFilenameEnd === -1
+  ) {
+    return null;
+  }
+
+  return openTag.slice(encodedFilenameStart, encodedFilenameEnd);
 }
 
 function createWorkaroundScript(source: string, filename: string): string {
@@ -89,6 +122,24 @@ function decodeWorkaroundFilename(encoded: string): string | null {
   } catch {
     return null;
   }
+}
+
+function isWhitespaceOnly(value: string): boolean {
+  return /^\s*$/u.test(value);
+}
+
+function offsetFromLineColumn(source: string, loc: LineColumn): number {
+  let line = 1;
+  let lineStart = 0;
+
+  for (let index = 0; index < source.length && line < loc.line; index += 1) {
+    if (source.charCodeAt(index) === 10) {
+      line += 1;
+      lineStart = index + 1;
+    }
+  }
+
+  return lineStart + loc.column - 1;
 }
 
 if (import.meta.vitest) {
@@ -112,6 +163,17 @@ if (import.meta.vitest) {
         filename,
         source,
         usesOriginalLocations: true,
+      });
+    });
+
+    it("does not strip real script setup blocks that mimic the marker", () => {
+      const fallbackFilename = "/Users/example/fallback.vue";
+      const source = `${SCRIPTLESS_WORKAROUND_OPEN_TAG_PREFIX}${encodeWorkaroundFilename("/Users/example/Real.vue")}">const userCode = true;</script>\n<template />`;
+
+      expect(resolveWorkaroundSource(source, fallbackFilename)).toEqual({
+        filename: fallbackFilename,
+        source,
+        usesOriginalLocations: false,
       });
     });
   });


### PR DESCRIPTION
## Summary
- resolve the scriptless SFC bridge from extracted SFC block metadata instead of direct prefix/index scans
- document the temporary bridge removal condition in exported tracking metadata
- add a regression for real script setup blocks that mimic the marker

Refs #2703

## Validation
- `vp fmt --write src vite.config.ts`
- `vp check src vite.config.ts`
- `vp pack`
- `node src/test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786121226&installation_id=136613492&pr_number=2721&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2721&signature=a0740481254375b8bd540d389e7c006f1514dcfe11dd2f2eff836527f27dca84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Vue single-file components so genuine `script setup` content is no longer mistaken for a special workaround case.
  * Source location resolution is now more reliable, especially when files include prepended wrapper content, helping errors and diagnostics point to the correct file locations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->