### PR TITLE
refactor(patina): inspect slots access with ast

### DIFF
--- a/crates/vize_patina/src/rules/script/prefer_use_slots.rs
+++ b/crates/vize_patina/src/rules/script/prefer_use_slots.rs
@@ -28,9 +28,16 @@
 //! return () => h('div', slots.default?.())
 //! ```
 
-use memchr::memmem;
-
 use crate::diagnostic::{LintDiagnostic, Severity};
+use oxc_ast::ast::{
+    BindingPattern, Expression, FormalParameters, ObjectProperty, Program, PropertyKey,
+    StaticMemberExpression,
+};
+use oxc_ast_visit::{
+    Visit,
+    walk::{walk_object_property, walk_static_member_expression},
+};
+use oxc_span::Span;
 
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 
@@ -48,49 +55,94 @@ impl ScriptRule for PreferUseSlots {
         &META
     }
 
-    fn check(&self, source: &str, offset: usize, result: &mut ScriptLintResult) {
-        let bytes = source.as_bytes();
+    #[inline]
+    fn uses_ast(&self) -> bool {
+        true
+    }
 
-        // Check for destructuring { slots } from setup context
-        let finder = memmem::Finder::new(b"{ slots }");
-        let mut search_start = 0;
+    #[inline]
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        _source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        let mut visitor = PreferUseSlotsVisitor { offset, result };
+        visitor.visit_program(program);
+    }
+}
 
-        while let Some(pos) = finder.find(&bytes[search_start..]) {
-            let abs_pos = search_start + pos;
-            search_start = abs_pos + 9;
+struct PreferUseSlotsVisitor<'result> {
+    offset: usize,
+    result: &'result mut ScriptLintResult,
+}
 
-            let before = &source[..abs_pos];
-            if before.contains("setup(") {
-                result.add_diagnostic(
-                    LintDiagnostic::warn(
-                        META.name,
-                        "Prefer useSlots() over destructuring slots from setup context",
-                        (offset + abs_pos) as u32,
-                        (offset + abs_pos + 9) as u32,
-                    )
-                    .with_help("Use `const slots = useSlots()` instead"),
-                );
-            }
-        }
-
-        // Check for context.slots usage
-        let finder2 = memmem::Finder::new(b"context.slots");
-        search_start = 0;
-
-        while let Some(pos) = finder2.find(&bytes[search_start..]) {
-            let abs_pos = search_start + pos;
-            search_start = abs_pos + 13;
-
-            result.add_diagnostic(
-                LintDiagnostic::warn(
-                    META.name,
-                    "Prefer useSlots() over context.slots",
-                    (offset + abs_pos) as u32,
-                    (offset + abs_pos + 13) as u32,
-                )
-                .with_help("Use `const slots = useSlots()` instead"),
+impl<'a> Visit<'a> for PreferUseSlotsVisitor<'_> {
+    fn visit_object_property(&mut self, it: &ObjectProperty<'a>) {
+        if !it.computed
+            && property_key_name(&it.key) == Some("setup")
+            && let Some(params) = setup_parameters(&it.value)
+            && let Some(span) = setup_context_property_span(params, "slots")
+        {
+            self.add_diagnostic(
+                "Prefer useSlots() over destructuring slots from setup context",
+                span,
             );
         }
+
+        walk_object_property(self, it);
+    }
+
+    fn visit_static_member_expression(&mut self, it: &StaticMemberExpression<'a>) {
+        if it.property.name.as_str() == "slots"
+            && matches!(&it.object, Expression::Identifier(identifier) if identifier.name.as_str() == "context")
+        {
+            self.add_diagnostic("Prefer useSlots() over context.slots", it.span);
+        }
+
+        walk_static_member_expression(self, it);
+    }
+}
+
+impl PreferUseSlotsVisitor<'_> {
+    fn add_diagnostic(&mut self, message: &'static str, span: Span) {
+        let start = self.offset as u32 + span.start;
+        let end = self.offset as u32 + span.end;
+        self.result.add_diagnostic(
+            LintDiagnostic::warn(META.name, message, start, end)
+                .with_help("Use `const slots = useSlots()` instead"),
+        );
+    }
+}
+
+fn setup_parameters<'a>(value: &'a Expression<'a>) -> Option<&'a FormalParameters<'a>> {
+    match value {
+        Expression::FunctionExpression(function) => Some(&function.params),
+        Expression::ArrowFunctionExpression(arrow) => Some(&arrow.params),
+        _ => None,
+    }
+}
+
+fn setup_context_property_span(params: &FormalParameters<'_>, name: &str) -> Option<Span> {
+    let context = params.items.get(1)?;
+    let BindingPattern::ObjectPattern(object) = &context.pattern else {
+        return None;
+    };
+
+    for property in &object.properties {
+        if !property.computed && property_key_name(&property.key) == Some(name) {
+            return Some(property.span);
+        }
+    }
+    None
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
+        _ => None,
     }
 }
 
@@ -115,7 +167,35 @@ mod tests {
     #[test]
     fn test_invalid_context_slots() {
         let linter = create_linter();
-        let result = linter.lint("return context.slots.default?.()", 0);
+        let result = linter.lint("const slot = context.slots.default?.()", 0);
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_destructure_slots() {
+        let linter = create_linter();
+        let result = linter.lint("export default { setup(props, { slots }) {} }", 0);
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_arrow_setup_destructure_slots() {
+        let linter = create_linter();
+        let result = linter.lint("export default { setup: (props, { slots }) => {} }", 0);
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_no_warning_for_string_or_unrelated_destructure() {
+        let linter = create_linter();
+        let result = linter.lint(
+            r#"
+const text = "context.slots"
+const { slots } = context
+export default { mounted() { console.log(context.slots) } }
+"#,
+            0,
+        );
         assert_eq!(result.warning_count, 1);
     }
 }


### PR DESCRIPTION
## Summary
- replace raw source scans in script/prefer-use-slots with OXC AST traversal
- detect setup context slots destructuring and context.slots member access structurally
- add regressions for arrow setup and string/unrelated destructuring false positives

Refs #2703

## Validation
- `cargo test -p vize_patina prefer_use_slots`
- `cargo clippy -p vize_patina -- -D warnings -D clippy::wildcard_imports`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786121669&installation_id=136613492&pr_number=2723&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2723&signature=10f130d8d10ba48d04468aaa5ec42816d0d106e227f5b38882266f610e82b9c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slot-related linting to catch more real-world patterns, including destructured `slots` usage in setup parameters and direct `context.slots` access.
  * Reduced false negatives by analyzing code structure more accurately, including multi-line and arrow-function cases.
* **Tests**
  * Expanded coverage for slot usage patterns and added checks to avoid warnings on unrelated destructuring or string content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->