### PR TITLE
refactor(patina): inspect template refs with ast

### DIFF
--- a/crates/vize_patina/src/rules/script/prefer_use_template_ref.rs
+++ b/crates/vize_patina/src/rules/script/prefer_use_template_ref.rs
@@ -29,9 +29,9 @@
 //! const name = ref('hello')
 //! ```
 
-use memchr::memmem;
-
 use crate::diagnostic::{LintDiagnostic, Severity};
+use oxc_ast::ast::{CallExpression, Expression, Program};
+use oxc_ast_visit::{Visit, walk::walk_call_expression};
 
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 
@@ -49,116 +49,103 @@ impl ScriptRule for PreferUseTemplateRef {
         &META
     }
 
-    fn check(&self, source: &str, offset: usize, result: &mut ScriptLintResult) {
-        let bytes = source.as_bytes();
-
-        // Fast bailout: check if ref is used
-        if memmem::find(bytes, b"ref(").is_none() && memmem::find(bytes, b"ref<").is_none() {
-            return;
-        }
-
-        // Look for patterns that suggest template refs:
-        // 1. ref(null)
-        // 2. ref<HTMLElement>(null)
-        // 3. ref<SomeElement | null>(null)
-
-        // Pattern 1: ref(null)
-        let finder_null = memmem::Finder::new(b"ref(null)");
-        let mut search_start = 0;
-
-        while let Some(pos) = finder_null.find(&bytes[search_start..]) {
-            let abs_pos = search_start + pos;
-            search_start = abs_pos + 9;
-
-            // Make sure it's not part of another identifier like "toRef"
-            if abs_pos > 0 {
-                let prev_char = source.as_bytes()[abs_pos - 1];
-                if prev_char.is_ascii_alphanumeric() || prev_char == b'_' {
-                    continue;
-                }
-            }
-
-            result.add_diagnostic(
-                LintDiagnostic::warn(
-                    META.name,
-                    "Consider using useTemplateRef() for template references (Vue 3.5+)",
-                    (offset + abs_pos) as u32,
-                    (offset + abs_pos + 9) as u32,
-                )
-                .with_help(
-                    "If this is a template ref, use: `const el = useTemplateRef<ElementType>('refName')`. \
-                     If this is a regular ref that starts as null, you can ignore this warning.",
-                ),
-            );
-        }
-
-        // Pattern 2: ref<...Element...>(null) - suggests DOM element ref
-        // Look for ref< followed by Element or HTML
-        let finder_typed = memmem::Finder::new(b"ref<");
-        search_start = 0;
-
-        while let Some(pos) = finder_typed.find(&bytes[search_start..]) {
-            let abs_pos = search_start + pos;
-            search_start = abs_pos + 4;
-
-            // Make sure it's not part of another identifier
-            if abs_pos > 0 {
-                let prev_char = source.as_bytes()[abs_pos - 1];
-                if prev_char.is_ascii_alphanumeric() || prev_char == b'_' {
-                    continue;
-                }
-            }
-
-            // Get the type parameter content
-            let rest = &source[abs_pos + 4..];
-
-            // Find closing > (accounting for nested generics)
-            let mut depth = 1;
-            let mut close_pos = None;
-            for (i, c) in rest.char_indices() {
-                match c {
-                    '<' => depth += 1,
-                    '>' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            close_pos = Some(i);
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-
-            if let Some(cp) = close_pos {
-                let type_content = &rest[..cp];
-                let after_type = &rest[cp + 1..];
-
-                // Check if type suggests DOM element
-                let is_element_type = type_content.contains("Element")
-                    || type_content.contains("HTML")
-                    || type_content.contains("SVG");
-
-                // Check if initialized with null
-                let starts_with_null = after_type.trim_start().starts_with("(null)");
-
-                if is_element_type && starts_with_null {
-                    let end_pos = abs_pos + 4 + cp + 1 + after_type.find(')').unwrap_or(5) + 1;
-
-                    result.add_diagnostic(
-                        LintDiagnostic::warn(
-                            META.name,
-                            "Use useTemplateRef() for DOM element references (Vue 3.5+)",
-                            (offset + abs_pos) as u32,
-                            (offset + end_pos) as u32,
-                        )
-                        .with_help(
-                            "Replace with: `const el = useTemplateRef<ElementType>('refName')`",
-                        ),
-                    );
-                }
-            }
-        }
+    #[inline]
+    fn uses_ast(&self) -> bool {
+        true
     }
+
+    #[inline]
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        let mut visitor = PreferUseTemplateRefVisitor {
+            source,
+            offset,
+            result,
+        };
+        visitor.visit_program(program);
+    }
+}
+
+struct PreferUseTemplateRefVisitor<'source, 'result> {
+    source: &'source str,
+    offset: usize,
+    result: &'result mut ScriptLintResult,
+}
+
+impl<'a> Visit<'a> for PreferUseTemplateRefVisitor<'_, '_> {
+    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+        if is_ref_call(it) && initialized_with_null(it) {
+            let start = self.offset as u32 + it.span.start;
+            let end = self.offset as u32 + it.span.end;
+
+            if element_type_argument(it, self.source) {
+                self.result.add_diagnostic(
+                    LintDiagnostic::warn(
+                        META.name,
+                        "Use useTemplateRef() for DOM element references (Vue 3.5+)",
+                        start,
+                        end,
+                    )
+                    .with_help("Replace with: `const el = useTemplateRef<ElementType>('refName')`"),
+                );
+            } else if it.type_arguments.is_none() {
+                self.result.add_diagnostic(
+                    LintDiagnostic::warn(
+                        META.name,
+                        "Consider using useTemplateRef() for template references (Vue 3.5+)",
+                        start,
+                        end,
+                    )
+                    .with_help(
+                        "If this is a template ref, use: `const el = useTemplateRef<ElementType>('refName')`. \
+                         If this is a regular ref that starts as null, you can ignore this warning.",
+                    ),
+                );
+            }
+        }
+
+        walk_call_expression(self, it);
+    }
+}
+
+fn is_ref_call(call: &CallExpression<'_>) -> bool {
+    matches!(
+        &call.callee,
+        Expression::Identifier(identifier) if identifier.name.as_str() == "ref"
+    )
+}
+
+fn initialized_with_null(call: &CallExpression<'_>) -> bool {
+    call.arguments
+        .first()
+        .and_then(|argument| argument.as_expression())
+        .is_some_and(is_null)
+}
+
+fn is_null(expression: &Expression<'_>) -> bool {
+    match expression {
+        Expression::NullLiteral(_) => true,
+        Expression::ParenthesizedExpression(parenthesized) => is_null(&parenthesized.expression),
+        _ => false,
+    }
+}
+
+fn element_type_argument(call: &CallExpression<'_>, source: &str) -> bool {
+    call.type_arguments.as_ref().is_some_and(|type_arguments| {
+        let span = type_arguments.span;
+        let start = span.start as usize;
+        let end = span.end as usize;
+        source.get(start..end).is_some_and(|type_source| {
+            type_source.contains("Element")
+                || type_source.contains("HTML")
+                || type_source.contains("SVG")
+        })
+    })
 }
 
 #[cfg(test)]
@@ -212,6 +199,20 @@ mod tests {
     fn test_toref_not_matched() {
         let linter = create_linter();
         let result = linter.lint("const x = toRef(state, 'count')", 0);
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_ref_null_string_not_matched() {
+        let linter = create_linter();
+        let result = linter.lint(r#"const text = "ref(null)""#, 0);
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_typed_ref_null_string_not_matched() {
+        let linter = create_linter();
+        let result = linter.lint(r#"const text = "ref<HTMLInputElement | null>(null)""#, 0);
         assert_eq!(result.warning_count, 0);
     }
 }


### PR DESCRIPTION
## Summary
- move script/prefer-use-template-ref from raw string searches to OXC call-expression traversal
- keep the existing ref(null) and DOM element ref diagnostics while avoiding string literal false positives

## Validation
- cargo fmt --check
- cargo test -p vize_patina prefer_use_template_ref
- cargo clippy -p vize_patina -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786122743&installation_id=136613492&pr_number=2726&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2726&signature=a03a0c0773a51e85b6c50da8a6a29d87c39f2d727bce931ba896056c672baecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->