### PR TITLE
refactor(patina): inspect reserved identifiers with ast

### DIFF
--- a/crates/vize_patina/src/rules/script/no_reserved_identifiers.rs
+++ b/crates/vize_patina/src/rules/script/no_reserved_identifiers.rs
@@ -32,9 +32,17 @@
 //! const myData = {}
 //! ```
 
-use memchr::memmem;
-
 use crate::diagnostic::{LintDiagnostic, Severity};
+use oxc_ast::ast::{
+    AssignmentExpression, AssignmentTarget, BindingIdentifier, BindingPattern, Function, Program,
+    VariableDeclarator,
+};
+use oxc_ast_visit::{
+    Visit,
+    walk::{walk_assignment_expression, walk_function, walk_variable_declarator},
+};
+use oxc_span::Span;
+use oxc_syntax::scope::ScopeFlags;
 
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 
@@ -74,47 +82,103 @@ impl ScriptRule for NoReservedIdentifiers {
         &META
     }
 
-    fn check(&self, source: &str, offset: usize, result: &mut ScriptLintResult) {
-        let bytes = source.as_bytes();
+    #[inline]
+    fn uses_ast(&self) -> bool {
+        true
+    }
 
-        for reserved in RESERVED_IDENTIFIERS {
-            let finder = memmem::Finder::new(reserved.as_bytes());
-            let mut search_start = 0;
+    #[inline]
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        _source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        let mut visitor = NoReservedIdentifiersVisitor { offset, result };
+        visitor.visit_program(program);
+    }
+}
 
-            while let Some(pos) = finder.find(&bytes[search_start..]) {
-                let abs_pos = search_start + pos;
-                search_start = abs_pos + reserved.len();
+struct NoReservedIdentifiersVisitor<'result> {
+    offset: usize,
+    result: &'result mut ScriptLintResult,
+}
 
-                // Check if this is a variable declaration
-                let before = &source[..abs_pos];
-                let trimmed = before.trim_end();
+impl<'a> Visit<'a> for NoReservedIdentifiersVisitor<'_> {
+    fn visit_variable_declarator(&mut self, it: &VariableDeclarator<'a>) {
+        self.check_binding_pattern(&it.id);
+        walk_variable_declarator(self, it);
+    }
 
-                // Look for const, let, var, or function before the identifier
-                let is_declaration = trimmed.ends_with("const")
-                    || trimmed.ends_with("let")
-                    || trimmed.ends_with("var")
-                    || trimmed.ends_with("function");
+    fn visit_function(&mut self, it: &Function<'a>, flags: ScopeFlags) {
+        if let Some(id) = &it.id {
+            self.check_binding_identifier(id);
+        }
+        walk_function(self, it, flags);
+    }
 
-                // Also check if it's being assigned
-                let after = &source[abs_pos + reserved.len()..];
-                let after_trimmed = after.trim_start();
-                let is_assignment =
-                    after_trimmed.starts_with('=') && !after_trimmed.starts_with("==");
+    fn visit_assignment_expression(&mut self, it: &AssignmentExpression<'a>) {
+        if let AssignmentTarget::AssignmentTargetIdentifier(identifier) = &it.left {
+            self.check_identifier(identifier.name.as_str(), identifier.span);
+        }
+        walk_assignment_expression(self, it);
+    }
+}
 
-                if is_declaration || is_assignment {
-                    result.add_diagnostic(
-                        LintDiagnostic::error(
-                            META.name,
-                            "Vue compiler reserved identifier should not be used",
-                            (offset + abs_pos) as u32,
-                            (offset + abs_pos + reserved.len()) as u32,
-                        )
-                        .with_help("Choose a different variable name to avoid conflicts with Vue internals"),
-                    );
+impl NoReservedIdentifiersVisitor<'_> {
+    fn check_binding_pattern(&mut self, pattern: &BindingPattern<'_>) {
+        match pattern {
+            BindingPattern::BindingIdentifier(identifier) => {
+                self.check_binding_identifier(identifier);
+            }
+            BindingPattern::ObjectPattern(object) => {
+                for property in &object.properties {
+                    self.check_binding_pattern(&property.value);
                 }
+                if let Some(rest) = &object.rest {
+                    self.check_binding_pattern(&rest.argument);
+                }
+            }
+            BindingPattern::ArrayPattern(array) => {
+                for element in array.elements.iter().flatten() {
+                    self.check_binding_pattern(element);
+                }
+                if let Some(rest) = &array.rest {
+                    self.check_binding_pattern(&rest.argument);
+                }
+            }
+            BindingPattern::AssignmentPattern(assignment) => {
+                self.check_binding_pattern(&assignment.left);
             }
         }
     }
+
+    fn check_binding_identifier(&mut self, identifier: &BindingIdentifier<'_>) {
+        self.check_identifier(identifier.name.as_str(), identifier.span);
+    }
+
+    fn check_identifier(&mut self, name: &str, span: Span) {
+        if is_reserved_identifier(name) {
+            let start = self.offset as u32 + span.start;
+            let end = self.offset as u32 + span.end;
+            self.result.add_diagnostic(
+                LintDiagnostic::error(
+                    META.name,
+                    "Vue compiler reserved identifier should not be used",
+                    start,
+                    end,
+                )
+                .with_help(
+                    "Choose a different variable name to avoid conflicts with Vue internals",
+                ),
+            );
+        }
+    }
+}
+
+fn is_reserved_identifier(name: &str) -> bool {
+    RESERVED_IDENTIFIERS.contains(&name) || name.starts_with("_hoisted_")
 }
 
 #[cfg(test)]
@@ -154,5 +218,40 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint("var __sfc__ = {}", 0);
         assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_reserved_hoisted_prefix() {
+        let linter = create_linter();
+        let result = linter.lint("const _hoisted_1 = {}", 0);
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_reserved_function_name() {
+        let linter = create_linter();
+        let result = linter.lint("function _openBlock() {}", 0);
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_reserved_assignment() {
+        let linter = create_linter();
+        let result = linter.lint("__props = {}", 0);
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_reserved_identifier_string_not_matched() {
+        let linter = create_linter();
+        let result = linter.lint(r#"const text = "const __props = {}""#, 0);
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_reserved_member_assignment_not_matched() {
+        let linter = create_linter();
+        let result = linter.lint("state.__props = {}", 0);
+        assert_eq!(result.error_count, 0);
     }
 }


### PR DESCRIPTION
## Summary
- move script/no-reserved-identifiers from substring scans to OXC AST traversal
- report reserved binding identifiers, function names, and direct identifier assignments by span
- avoid string literal and member assignment false positives while preserving generated `_hoisted_` prefix detection

## Validation
- cargo fmt --check
- cargo test -p vize_patina no_reserved_identifiers
- cargo clippy -p vize_patina -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786123420&installation_id=136613492&pr_number=2728&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2728&signature=3506ecf07b87dd48b808e18d8338986249600f66af01d34f5dcad51132f6408a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identifier checking so reserved names are flagged more accurately in scripts.
  * Reduced false positives from text inside strings and property accesses.
  * Added support for detecting more invalid naming patterns, including special hoisted-style identifiers and reserved names in assignments and function definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->