### PR TITLE
refactor(mcp-musea): inspect self tags with ast

### DIFF
--- a/npm/mcp-musea/package.json
+++ b/npm/mcp-musea/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "catalog:integrations",
     "@vizejs/native": "workspace:*",
+    "@vue/compiler-dom": "catalog:vue-stable",
     "typescript": "catalog:typescript"
   },
   "devDependencies": {

--- a/npm/mcp-musea/src/markdown-template.ts
+++ b/npm/mcp-musea/src/markdown-template.ts
@@ -1,0 +1,107 @@
+import { NodeTypes, baseParse, type ElementNode, type TemplateChildNode } from "@vue/compiler-dom";
+
+interface Replacement {
+  start: number;
+  end: number;
+  text: string;
+}
+
+const SELF_TAG_NAME = "Self";
+const TEMPLATE_FENCE_LANGUAGES = new Set(["", "html", "template", "vue"]);
+
+export function formatGeneratedMarkdown(markdown: string, componentName: string): string {
+  return markdown.replace(
+    /```(\w*)\n([\s\S]*?)```/g,
+    (_match: string, lang: string, code: string) => {
+      const normalizedLang = lang.toLowerCase();
+      const rewrittenCode = TEMPLATE_FENCE_LANGUAGES.has(normalizedLang)
+        ? rewriteSelfComponentTags(code, componentName)
+        : code;
+
+      return formatCodeFence(lang, rewrittenCode);
+    },
+  );
+}
+
+function formatCodeFence(lang: string, code: string): string {
+  const lines = code.split("\n");
+  let minIndent = Infinity;
+
+  for (const line of lines) {
+    if (line.trim()) {
+      const indent = line.match(/^(\s*)/)?.[1].length ?? 0;
+      minIndent = Math.min(minIndent, indent);
+    }
+  }
+
+  if (minIndent === Infinity) {
+    minIndent = 0;
+  }
+
+  const normalizedLines = minIndent > 0 ? lines.map((line) => line.slice(minIndent)) : lines;
+  return `\`\`\`${lang}\n${normalizedLines.join("\n")}\`\`\``;
+}
+
+function rewriteSelfComponentTags(code: string, componentName: string): string {
+  const replacements: Replacement[] = [];
+
+  try {
+    const root = baseParse(code, { comments: true });
+    collectSelfTagReplacements(root.children, replacements, componentName);
+  } catch {
+    return code;
+  }
+
+  if (replacements.length === 0) {
+    return code;
+  }
+
+  let rewritten = code;
+  for (const replacement of replacements.sort((left, right) => right.start - left.start)) {
+    rewritten =
+      rewritten.slice(0, replacement.start) + replacement.text + rewritten.slice(replacement.end);
+  }
+  return rewritten;
+}
+
+function collectSelfTagReplacements(
+  nodes: TemplateChildNode[],
+  replacements: Replacement[],
+  componentName: string,
+): void {
+  for (const node of nodes) {
+    if (node.type !== NodeTypes.ELEMENT) continue;
+
+    if (node.tag === SELF_TAG_NAME) {
+      addSelfElementReplacements(node, replacements, componentName);
+    }
+
+    collectSelfTagReplacements(node.children, replacements, componentName);
+  }
+}
+
+function addSelfElementReplacements(
+  node: ElementNode,
+  replacements: Replacement[],
+  componentName: string,
+): void {
+  const openStart = node.loc.start.offset + 1;
+  const openEnd = openStart + SELF_TAG_NAME.length;
+  replacements.push({ start: openStart, end: openEnd, text: componentName });
+
+  if (node.isSelfClosing) {
+    return;
+  }
+
+  const closeTagIndex = node.loc.source.lastIndexOf(`</${SELF_TAG_NAME}>`);
+  if (closeTagIndex < 0) {
+    return;
+  }
+
+  const closeStart = node.loc.start.offset + closeTagIndex + 2;
+  replacements.push({
+    start: closeStart,
+    end: closeStart + SELF_TAG_NAME.length,
+    text: componentName,
+  });
+}

--- a/npm/mcp-musea/src/musea.test.ts
+++ b/npm/mcp-musea/src/musea.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import { buildPalette } from "./musea.ts";
+import { buildDocumentation, buildPalette } from "./musea.ts";
 import type { NativeBinding, ServerContext } from "./types.ts";
 
 test("buildPalette prints fallback TypeScript through the AST printer", async () => {
@@ -97,6 +97,87 @@ test("buildPalette prints fallback TypeScript through the AST printer", async ()
         "",
       ].join("\n"),
     );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("buildDocumentation rewrites Self tags inside template fences", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "musea-mcp-docs-"));
+  try {
+    const artPath = path.join(root, "FancyButton.art.vue");
+    const binding = {
+      parseArt() {
+        throw new Error("parseArt should not be called");
+      },
+      artToCsf() {
+        throw new Error("artToCsf should not be called");
+      },
+      generateArtDoc() {
+        return {
+          markdown: [
+            "Inline <Self /> should stay prose.",
+            "",
+            "```vue",
+            '    <Self tone="brand">',
+            "      <Self />",
+            "      <Selfish />",
+            "    </Self>",
+            "```",
+            "",
+            "```ts",
+            "const tag = '<Self />';",
+            "```",
+            "",
+          ].join("\n"),
+          filename: artPath,
+          title: "FancyButton",
+          variant_count: 1,
+        };
+      },
+      parseDesignTokensFromPath() {
+        return [];
+      },
+      flattenDesignTokenCategories() {
+        return [];
+      },
+      generateDesignTokensMarkdown() {
+        return "";
+      },
+    } satisfies NativeBinding;
+
+    const documentation = await buildDocumentation(
+      binding,
+      {
+        info: {
+          path: artPath,
+          title: "FancyButton",
+          tags: [],
+          status: "ready",
+          variantCount: 0,
+          variantNames: [],
+        },
+        absolutePath: artPath,
+        relativePath: "FancyButton.art.vue",
+        matchedBy: "path",
+        matchValue: "FancyButton.art.vue",
+        score: 1,
+        reasons: [],
+        alternatives: [],
+      },
+      "",
+      { includeTemplates: true },
+    );
+
+    assert.ok(documentation);
+    assert.match(documentation.markdown, /Inline <Self \/> should stay prose\./);
+    assert.match(documentation.markdown, /<FancyButton tone="brand">/);
+    assert.match(documentation.markdown, /<FancyButton \/>/);
+    assert.match(documentation.markdown, /<\/FancyButton>/);
+    assert.match(documentation.markdown, /<Selfish \/>/);
+    assert.match(documentation.markdown, /const tag = '<Self \/>';/);
+    assert.doesNotMatch(documentation.markdown, /<Self tone=/);
+    assert.doesNotMatch(documentation.markdown, /<\/Self>\n```/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/npm/mcp-musea/src/musea.ts
+++ b/npm/mcp-musea/src/musea.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { formatGeneratedMarkdown } from "./markdown-template.js";
 import { buildPaletteTypescript } from "./palette-typescript.js";
 import type { ArtInfo, NativeBinding, ServerContext } from "./types.js";
 
@@ -609,37 +610,6 @@ export async function analyzeResolvedComponent(
       emits: analysis.emits,
     },
   };
-}
-
-function formatGeneratedMarkdown(markdown: string, componentName: string): string {
-  let formatted = markdown
-    .replace(/<Self(\s|>|\/)/g, `<${componentName}$1`)
-    .replace(/<\/Self>/g, `</${componentName}>`);
-
-  formatted = formatted.replace(
-    /```(\w*)\n([\s\S]*?)```/g,
-    (_match: string, lang: string, code: string) => {
-      const lines = code.split("\n");
-      let minIndent = Infinity;
-
-      for (const line of lines) {
-        if (line.trim()) {
-          const indent = line.match(/^(\s*)/)?.[1].length ?? 0;
-          minIndent = Math.min(minIndent, indent);
-        }
-      }
-
-      if (minIndent === Infinity) {
-        minIndent = 0;
-      }
-
-      const normalizedLines = minIndent > 0 ? lines.map((line) => line.slice(minIndent)) : lines;
-
-      return `\`\`\`${lang}\n${normalizedLines.join("\n")}\`\`\``;
-    },
-  );
-
-  return formatted;
 }
 
 export async function buildPalette(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ catalogs:
       specifier: 3.6.0-beta.10
       version: 3.6.0-beta.10
   vue-stable:
+    '@vue/compiler-dom':
+      specifier: 3.5.35
+      version: 3.5.35
     '@vue/runtime-core':
       specifier: 3.5.35
       version: 3.5.35
@@ -422,6 +425,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: catalog:integrations
         version: 1.29.0(zod@3.25.76)
+      '@vue/compiler-dom':
+        specifier: catalog:vue-stable
+        version: 3.5.35
       '@vizejs/native':
         specifier: workspace:*
         version: link:../native

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,6 +49,7 @@ catalogs:
   # Stable Vue ecosystem packages used by shipping examples and integrations.
   vue-stable:
     vue: "3.5.35"
+    "@vue/compiler-dom": "3.5.35"
     "@vue/runtime-core": "3.5.35"
     "@vue/test-utils": "2.4.10"
     vue-router: "4.5.1"


### PR DESCRIPTION
## Summary
- move generated markdown Self tag replacement into a compiler-dom based helper
- rewrite Self tags only inside Vue/HTML/template code fences
- add a regression test for prose and non-template fences

Refs #2703

## Validation
- npm/mcp-musea/node_modules/.bin/vp check npm/mcp-musea/src npm/mcp-musea/vite.config.ts
- npm/mcp-musea/node_modules/.bin/tsx --test npm/mcp-musea/src/**/*.test.ts
- ./node_modules/.bin/vp pack (from npm/mcp-musea)
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786124135&installation_id=136613492&pr_number=2729&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2729&signature=6ee2d5860e487db9b0c22e468f67b1aef256d6913245873417c8903037fb4da3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated documentation formatting for fenced code blocks, including consistent indentation normalization.
  * Template placeholders like `<Self>` inside Vue/template fences are now reliably rewritten to the selected component name, while prose and unrelated code fences remain unchanged.
  * Non-matching tags (e.g., `<Selfish>`) and inline text are preserved as-is.

* **Tests**
  * Added coverage to verify correct `<Self>` rewriting behavior across prose and fenced code blocks, including edge cases.

* **Chores**
  * Added a required Vue compiler dependency for template parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->