### PR TITLE
perf(patina): prefilter prop destructure scan

### DIFF
--- a/crates/vize_patina/src/rules/script/no_deep_destructure_in_props.rs
+++ b/crates/vize_patina/src/rules/script/no_deep_destructure_in_props.rs
@@ -70,10 +70,14 @@ impl ScriptRule for NoDeepDestructureInProps {
     fn check_program<'a>(
         &self,
         program: &'a Program<'a>,
-        _source: &str,
+        source: &str,
         offset: usize,
         result: &mut ScriptLintResult,
     ) {
+        if !may_contain_define_props_object_binding(source) {
+            return;
+        }
+
         let mut visitor = NoDeepDestructureInPropsVisitor {
             max_depth: self.max_depth,
             offset,
@@ -178,6 +182,81 @@ fn call_is_named(call: &CallExpression<'_>, name: &str) -> bool {
     )
 }
 
+fn may_contain_define_props_object_binding(source: &str) -> bool {
+    source.contains("defineProps") && contains_object_binding_declaration(source)
+}
+
+fn contains_object_binding_declaration(source: &str) -> bool {
+    let bytes = source.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        let Some(keyword) = declaration_keyword_at(source, index) else {
+            index += 1;
+            continue;
+        };
+
+        let cursor = skip_javascript_trivia(bytes, index + keyword.len());
+
+        if bytes.get(cursor) == Some(&b'{') {
+            return true;
+        }
+
+        index = cursor;
+    }
+
+    false
+}
+
+fn declaration_keyword_at(source: &str, index: usize) -> Option<&'static str> {
+    ["const", "let", "var"].into_iter().find(|keyword| {
+        source[index..].starts_with(keyword) && has_keyword_boundaries(source, index, keyword)
+    })
+}
+
+fn skip_javascript_trivia(bytes: &[u8], mut cursor: usize) -> usize {
+    loop {
+        while matches!(bytes.get(cursor), Some(b' ' | b'\t' | b'\n' | b'\r')) {
+            cursor += 1;
+        }
+
+        match (bytes.get(cursor), bytes.get(cursor + 1)) {
+            (Some(b'/'), Some(b'/')) => {
+                cursor += 2;
+                while !matches!(bytes.get(cursor), None | Some(b'\n' | b'\r')) {
+                    cursor += 1;
+                }
+            }
+            (Some(b'/'), Some(b'*')) => {
+                cursor += 2;
+                while !matches!(
+                    (bytes.get(cursor), bytes.get(cursor + 1)),
+                    (None, _) | (Some(b'*'), Some(b'/'))
+                ) {
+                    cursor += 1;
+                }
+                if bytes.get(cursor).is_some() {
+                    cursor += 2;
+                }
+            }
+            _ => return cursor,
+        }
+    }
+}
+
+fn has_keyword_boundaries(source: &str, index: usize, keyword: &str) -> bool {
+    let bytes = source.as_bytes();
+    let before = index.checked_sub(1).and_then(|before| bytes.get(before));
+    let after = bytes.get(index + keyword.len());
+
+    before.is_none_or(|byte| !is_identifier_byte(*byte))
+        && after.is_none_or(|byte| !is_identifier_byte(*byte))
+}
+
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+}
+
 #[cfg(test)]
 mod tests {
     use super::NoDeepDestructureInProps;
@@ -221,7 +300,7 @@ mod tests {
     fn test_invalid_very_deep_destructure() {
         let linter = create_linter();
         let result = linter.lint(
-            "const { config: { settings: { theme } } } = defineProps()",
+            "const /* props */ { config: { settings: { theme } } } = defineProps()",
             0,
         );
         assert_eq!(result.warning_count, 1);


### PR DESCRIPTION
## Summary
- skip no-deep-destructure traversal when source has no defineProps object binding
- keep AST-based detection for actual defineProps destructuring
- cover comment trivia before the object binding in an invalid case

Refs #2703

## Validation
- cargo fmt --check
- cargo test -p vize_patina no_deep_destructure_in_props
- cargo clippy -p vize_patina -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786124568&installation_id=136613492&pr_number=2730&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2730&signature=c4b273d69c165b0d84f469a397f847cbc6b4356ef41d711ea01e51510d6f3d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved rule scanning so files without relevant prop-destructuring patterns are skipped sooner.
  * Reduced unnecessary analysis work, which should make checks faster in many cases.

* **Bug Fixes**
  * Preserved existing warning behavior for deeply nested destructuring, including cases with comments inside the pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->