### PR TITLE
fix(canon): normalize optional boolean template props

### DIFF
--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_reserved_prop_and_hyphenated_slot_names.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_reserved_prop_and_hyphenated_slot_names.snap
@@ -97,7 +97,7 @@ function __setup() {
 
   // Props are available in template as variables
   // Access via `propName` or `props.propName`
-  const props: Props = {} as Props;
+  const props: __DefineProps<Props> = {} as __DefineProps<Props>;
   void props; // Mark as used to avoid TS6133
   const _class = props["class"];
   void _class;

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
@@ -287,3 +287,55 @@ watchEffect(() => {
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn issue_2719_normalizes_optional_boolean_props_in_template() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "issue-2719-optional-boolean-template-prop",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts">
+defineProps<{ present: boolean }>();
+</script>
+
+<template>
+  <span />
+</template>
+"#,
+            ),
+            (
+                "src/Foo.vue",
+                r#"<script setup lang="ts">
+import Child from "./Child.vue";
+
+defineProps<{ loading?: boolean }>();
+</script>
+
+<template>
+  <Child :present="loading" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !(file == "src/Foo.vue"
+                && *code == Some(2322)
+                && message.contains("boolean | undefined"))
+        }),
+        "optional boolean props should be normalized in templates, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/virtual_project/snapshots/vize_canon__batch__virtual_project__tests__reexported_vue_interface_props_virtual_ts.snap
+++ b/crates/vize_canon/src/batch/virtual_project/snapshots/vize_canon__batch__virtual_project__tests__reexported_vue_interface_props_virtual_ts.snap
@@ -57,7 +57,7 @@ function __setup() {
 
   // Props are available in template as variables
   // Access via `propName` or `props.propName`
-  const props: Props = {} as Props;
+  const props: __DefineProps<Props> = {} as __DefineProps<Props>;
   void props; // Mark as used to avoid TS6133
   const _as = props["as"];
   void _as;

--- a/crates/vize_canon/src/batch/virtual_project/snapshots/vize_canon__batch__virtual_project__tests__template_as_assertion_prop_virtual_ts.snap
+++ b/crates/vize_canon/src/batch/virtual_project/snapshots/vize_canon__batch__virtual_project__tests__template_as_assertion_prop_virtual_ts.snap
@@ -57,7 +57,7 @@ function __setup() {
 
   // Props are available in template as variables
   // Access via `propName` or `props.propName`
-  const props: Props = {} as Props;
+  const props: __DefineProps<Props> = {} as __DefineProps<Props>;
   void props; // Mark as used to avoid TS6133
   const _as = props["as"];
   void _as;

--- a/crates/vize_canon/src/batch/virtual_project/tests/setup_props.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/setup_props.rs
@@ -104,7 +104,7 @@ void props
 
     assert!(
         virtual_ts.contains(
-            r#"const targetStudent = props["targetStudent"] as Exclude<__WithDefaultsResult<Props, Pick<Props, "targetStudent">>["targetStudent"], undefined>;"#
+            r#"const targetStudent = props["targetStudent"] as Exclude<__WithDefaultsResult<__DefineProps<Props>, Pick<__DefineProps<Props>, "targetStudent">>["targetStudent"], undefined>;"#
         ),
         "legacy Vue2 template scope must expose inline defineProps keys:\n{virtual_ts}"
     );

--- a/crates/vize_canon/src/batch/virtual_project/tests/snapshots/vize_canon__batch__virtual_project__tests__ref_arity__dialect_default_v3.snap
+++ b/crates/vize_canon/src/batch/virtual_project/tests/snapshots/vize_canon__batch__virtual_project__tests__ref_arity__dialect_default_v3.snap
@@ -63,7 +63,7 @@ function __setup() {
 
   // Props are available in template as variables
   // Access via `propName` or `props.propName`
-  const props: Props = {} as Props;
+  const props: __DefineProps<Props> = {} as __DefineProps<Props>;
   void props; // Mark as used to avoid TS6133
   const test = props["test"];
   void test;

--- a/crates/vize_canon/src/batch/virtual_project/tests/snapshots/vize_canon__batch__virtual_project__tests__ref_arity__dialect_v2.snap
+++ b/crates/vize_canon/src/batch/virtual_project/tests/snapshots/vize_canon__batch__virtual_project__tests__ref_arity__dialect_v2.snap
@@ -118,7 +118,7 @@ function __setup() {
 
   // Props are available in template as variables
   // Access via `propName` or `props.propName`
-  const props: Props = {} as Props;
+  const props: __DefineProps<Props> = {} as __DefineProps<Props>;
   void props; // Mark as used to avoid TS6133
   const test = props["test"];
   void test;

--- a/crates/vize_canon/src/sfc_typecheck/snapshots/vize_canon__sfc_typecheck__tests__type_check_component_with_props_and_events.snap
+++ b/crates/vize_canon/src/sfc_typecheck/snapshots/vize_canon__sfc_typecheck__tests__type_check_component_with_props_and_events.snap
@@ -101,7 +101,7 @@ function __setup() {
 
   // Props are available in template as variables
   // Access via `propName` or `props.propName`
-  const props: Props = {} as Props;
+  const props: __DefineProps<Props> = {} as __DefineProps<Props>;
   void props; // Mark as used to avoid TS6133
   const title = props["title"];
   void title;

--- a/crates/vize_canon/src/sfc_typecheck/snapshots/vize_canon__sfc_typecheck__tests__type_check_virtual_ts_generation.snap
+++ b/crates/vize_canon/src/sfc_typecheck/snapshots/vize_canon__sfc_typecheck__tests__type_check_virtual_ts_generation.snap
@@ -101,7 +101,7 @@ function __setup() {
 
   // Props are available in template as variables
   // Access via `propName` or `props.propName`
-  const props: Props = {} as Props;
+  const props: __DefineProps<Props> = {} as __DefineProps<Props>;
   void props; // Mark as used to avoid TS6133
   const count = props["count"];
   void count;

--- a/crates/vize_canon/src/sfc_typecheck/tests.rs
+++ b/crates/vize_canon/src/sfc_typecheck/tests.rs
@@ -156,7 +156,7 @@ const { thickness, label } = props;
         );
     assert!(
         virtual_ts.contains(
-            r#"const props: __WithDefaultsResult<Props, Pick<Props, "label" | "thickness">>"#
+            r#"const props: __WithDefaultsResult<__DefineProps<Props>, Pick<__DefineProps<Props>, "label" | "thickness">>"#
         ),
         "{virtual_ts}"
     );
@@ -260,7 +260,7 @@ void props;
 
     assert!(
             virtual_ts.contains(
-                r#"const count = props["count"] as Exclude<__WithDefaultsResult<Props, Pick<Props, "count">>["count"], undefined>;"#
+                r#"const count = props["count"] as Exclude<__WithDefaultsResult<__DefineProps<Props>, Pick<__DefineProps<Props>, "count">>["count"], undefined>;"#
             ),
             "{virtual_ts}"
         );

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_complex_component.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_complex_component.snap
@@ -128,9 +128,9 @@ function __setup() {
 
   // Props are available in template as variables
   // Access via `propName` or `props.propName`
-  const props: __WithDefaultsResult<Props, Pick<Props, "initialCount">> = {} as __WithDefaultsResult<Props, Pick<Props, "initialCount">>;
+  const props: __WithDefaultsResult<__DefineProps<Props>, Pick<__DefineProps<Props>, "initialCount">> = {} as __WithDefaultsResult<__DefineProps<Props>, Pick<__DefineProps<Props>, "initialCount">>;
   void props; // Mark as used to avoid TS6133
-  const initialCount = props["initialCount"] as Exclude<__WithDefaultsResult<Props, Pick<Props, "initialCount">>["initialCount"], undefined>;
+  const initialCount = props["initialCount"] as Exclude<__WithDefaultsResult<__DefineProps<Props>, Pick<__DefineProps<Props>, "initialCount">>["initialCount"], undefined>;
   void initialCount;
   const title = props["title"];
   void title;

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_generic_component.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_generic_component.snap
@@ -113,7 +113,7 @@ function __setup<T extends string | number>() {
 
   // Props are available in template as variables
   // Access via `propName` or `props.propName`
-  const props: Props<T> = {} as Props<T>;
+  const props: __DefineProps<Props<T>> = {} as __DefineProps<Props<T>>;
   void props; // Mark as used to avoid TS6133
   const items = props["items"];
   void items;

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_with_props.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_with_props.snap
@@ -97,7 +97,7 @@ function __setup() {
 
   // Props are available in template as variables
   // Access via `propName` or `props.propName`
-  const props: Props = {} as Props;
+  const props: __DefineProps<Props> = {} as __DefineProps<Props>;
   void props; // Mark as used to avoid TS6133
   const title = props["title"];
   void title;

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -32,6 +32,7 @@ fn emit_template_prop_binding(
 fn emit_keyed_template_prop_binding(
     ts: &mut String,
     props_type_ref: &str,
+    key_type_ref: &str,
     prop_name: &str,
     has_default: bool,
 ) {
@@ -39,12 +40,12 @@ fn emit_keyed_template_prop_binding(
     if has_default {
         append!(
             *ts,
-            "  const {binding_name} = props[(\"{prop_name}\" satisfies keyof {props_type_ref})] as Exclude<{props_type_ref}[\"{prop_name}\"], undefined>;\n"
+            "  const {binding_name} = props[(\"{prop_name}\" satisfies keyof {key_type_ref})] as Exclude<{props_type_ref}[\"{prop_name}\"], undefined>;\n"
         );
     } else {
         append!(
             *ts,
-            "  const {binding_name} = props[(\"{prop_name}\" satisfies keyof {props_type_ref})];\n"
+            "  const {binding_name} = props[(\"{prop_name}\" satisfies keyof {key_type_ref})];\n"
         );
     }
     append!(*ts, "  void {binding_name};\n");
@@ -334,8 +335,6 @@ fn emit_options_api_props_type(
     }
 }
 
-/// Generate props variables inside template closure.
-/// When `generic_param` is present, uses `Props<T, P>` instead of `Props`.
 pub(crate) fn generate_props_variables(
     ts: &mut String,
     summary: &Croquis,
@@ -359,8 +358,13 @@ pub(crate) fn generate_props_variables(
             defaulted_prop_names.insert(model.name.as_str().into());
         }
     }
+    let template_base_props_type_ref = if define_props_type_args.is_some() {
+        cstr!("__DefineProps<{props_type_ref}>")
+    } else {
+        props_type_ref.clone()
+    };
     let template_props_type_ref =
-        template_props_type_ref(props_type_ref.as_str(), &defaulted_prop_names);
+        template_props_type_ref(template_base_props_type_ref.as_str(), &defaulted_prop_names);
 
     if has_props || define_props_type_args.is_some() || has_models {
         ts.push_str("  // Props are available in template as variables\n");
@@ -373,15 +377,8 @@ pub(crate) fn generate_props_variables(
 
         let mut emitted_names = FxHashSet::default();
         if let Some(type_args) = define_props_type_args {
-            // Type-only defineProps<TypeName>(): extract fields
-            // type_args may include angle brackets (e.g., "<Props>", "<Foo<T>>"), strip outer pair
             let type_name = strip_outer_angle_brackets(type_args.trim());
 
-            // Resolve the named type's fields through the croquis TypeResolver,
-            // which the script analysis populates from the OXC AST (local
-            // interfaces/type literals included). This handles inline object
-            // types, registered local types, nested braces, generics, and
-            // comments — no raw-text scanning.
             let type_properties = summary
                 .types
                 .extract_properties(type_reference_lookup_key(type_name));
@@ -414,6 +411,7 @@ pub(crate) fn generate_props_variables(
                         emit_keyed_template_prop_binding(
                             ts,
                             template_props_type_ref.as_str(),
+                            props_type_ref.as_str(),
                             name.as_str(),
                             defaulted_prop_names.contains(&name),
                         );


### PR DESCRIPTION
## Summary
- expose type-based defineProps in templates through the normalized defineProps result
- add a regression for forwarding an optional boolean prop into a required boolean child prop

## Tests
- cargo test -p vize_canon issue_2719_normalizes_optional_boolean_props_in_template

Closes #2719

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786125727&installation_id=136613492&pr_number=2731&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2731&signature=839453f97c8741da16ca80bbb481ec99e0f66190de7992eea909d2a2cb4420b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template prop typing to normalize optional boolean props more reliably.
  * Reduced false-positive type diagnostics for boolean assignments across component boundaries.
* **Tests**
  * Added snapshot-based coverage for a recent optional boolean prop normalization issue to prevent regressions.
* **Documentation**
  * Updated existing type-check test expectations for `withDefaults(defineProps(...))` output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->