### PR TITLE
fix(canon): loosen component fallthrough listener events

### DIFF
--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_kebab_case_component_names.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_kebab_case_component_names.snap
@@ -106,7 +106,7 @@ function __setup() {
     ? __EP extends { "onUpdate:modelValue"?: (...args: infer __A) => any } ? __A : unknown[]
     : unknown[];
   type __my_widget_7_update_model_value_args = unknown[] extends __my_widget_7_update_model_value_prop_args ? __my_widget_7_update_model_value_emit_args : __my_widget_7_update_model_value_prop_args;
-  type __my_widget_7_update_model_value_event = __my_widget_7_update_model_value_args extends [] ? any : unknown[] extends __my_widget_7_update_model_value_args ? Event : __my_widget_7_update_model_value_args[0];
+  type __my_widget_7_update_model_value_event = __my_widget_7_update_model_value_args extends [] ? any : unknown[] extends __my_widget_7_update_model_value_args ? any : __my_widget_7_update_model_value_args[0];
   type __my_widget_7_update_model_value_listener = unknown[] extends __my_widget_7_update_model_value_args ? (($event: __my_widget_7_update_model_value_event) => unknown) : ((...args: __my_widget_7_update_model_value_args) => unknown);
   ((...__vize_args: Parameters<__my_widget_7_update_model_value_listener>) => {
     const $event = __vize_args[0] as __my_widget_7_update_model_value_event; void $event;

--- a/crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload.rs
@@ -1,6 +1,47 @@
 use super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
 
 #[test]
+fn batch_type_checker_accepts_component_fallthrough_touch_listener() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "component-fallthrough-touch-listener",
+        &[(
+            "src/Foo.vue",
+            r#"<script setup lang="ts">
+import { defineComponent, h } from "vue";
+
+const Child = defineComponent(() => () => h("button"));
+
+function onPress(event: MouseEvent) {
+  event.preventDefault();
+}
+</script>
+
+<template>
+  <Child @touchstart="onPress" />
+</template>
+"#,
+        )],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !(file == "src/Foo.vue" && *code == Some(2345) && message.contains("TouchEvent"))
+        }),
+        "component fallthrough listeners should not be checked as native DOM listeners, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn batch_type_checker_infers_generic_component_listener_payload_from_props() {
     if resolve_test_tsgo_binary().is_none() {
         return;

--- a/crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs
@@ -77,8 +77,8 @@ function updateDate(newDate: string) {
 
     let standard = standard_virtual_ts(script, template, &VirtualTsOptions::default());
     assert!(
-        standard.contains("? InputEvent :"),
-        "standard component event fallback should stay DOM-typed:\n{standard}"
+        standard.contains("? any :") && !standard.contains("? InputEvent :"),
+        "standard component event fallback should stay permissive:\n{standard}"
     );
 
     let legacy = legacy_virtual_ts(script, template, &VirtualTsOptions::default());

--- a/crates/vize_canon/src/virtual_ts/scope/component_events.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events.rs
@@ -9,7 +9,7 @@ use vize_croquis::{
 
 use crate::virtual_ts::{
     expressions::rewrite_reserved_template_prop,
-    helpers::{get_dom_event_type, to_camel_case, to_safe_identifier, to_safe_identifier_fragment},
+    helpers::{to_camel_case, to_safe_identifier, to_safe_identifier_fragment},
 };
 
 pub(super) struct ComponentEventTypes {
@@ -130,10 +130,9 @@ pub(super) fn generate_component_event_types(
         );
         legacy_args_type
     } else {
-        let fallback_event = get_dom_event_type(data.event_name.as_str());
         append!(
             *ts,
-            "{indent}type {event_type} = {args_type} extends [] ? any : unknown[] extends {args_type} ? {fallback_event} : {args_type}[0];\n",
+            "{indent}type {event_type} = {args_type} extends [] ? any : unknown[] extends {args_type} ? any : {args_type}[0];\n",
         );
         args_type.clone()
     };

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -1583,7 +1583,7 @@ const arr = [(event: PointerEvent) => event.preventDefault()]
 }
 
 #[test]
-fn test_component_event_fallback_uses_dom_event_type_when_args_stay_unknown() {
+fn test_component_event_fallback_uses_any_when_args_stay_unknown() {
     use vize_croquis::{Analyzer, AnalyzerOptions};
 
     let script = r#"import Child from './Child.vue'
@@ -1611,8 +1611,8 @@ function eventHandler(event: Event) {
     );
     assert!(
         standard_output.code.contains("unknown[] extends __Child_")
-            && standard_output.code.contains("? KeyboardEvent : __Child_"),
-        "standard component event fallback should use the DOM event type when args stay unknown:\n{}",
+            && standard_output.code.contains("? any : __Child_"),
+        "standard component event fallback should stay loose when args stay unknown:\n{}",
         standard_output.code
     );
 
@@ -1630,8 +1630,8 @@ function eventHandler(event: Event) {
     );
     assert!(
         quirks_output.code.contains("unknown[] extends __Child_")
-            && quirks_output.code.contains("? KeyboardEvent : __Child_"),
-        "quirks component event fallback should use the DOM event type when args stay unknown:\n{}",
+            && quirks_output.code.contains("? any : __Child_"),
+        "quirks component event fallback should stay loose when args stay unknown:\n{}",
         quirks_output.code
     );
 }


### PR DESCRIPTION
## Summary
- keep component listener fallback args loose when no emit/listener type is declared
- add a vize check regression for @touchstart fallthrough on a local component

## Tests
- cargo test -p vize_canon batch_type_checker_accepts_component_fallthrough_touch_listener
- cargo test -p vize_canon test_component_event_fallback_uses_any_when_args_stay_unknown

Closes #2720

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786125858&installation_id=136613492&pr_number=2732&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2732&signature=91c7ddfe9ff1131cd902d22d49db6942f6c207ee18d7d3209c81316c7ad3f4e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component event type fallback behavior so unknown listener arguments are handled more permissively.
  * Reduced false TypeScript errors for component listeners, including touch-related events on child components.
  * Kept Vue 2 event typing behavior unchanged while updating the standard generation path to use a safer fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->