### PR TITLE
fix(core): preserve looped dynamic slot names

### DIFF
--- a/crates/vize_atelier_core/src/codegen/slots.rs
+++ b/crates/vize_atelier_core/src/codegen/slots.rs
@@ -4,6 +4,7 @@
 
 mod detect;
 mod generate;
+mod name;
 mod outlet;
 mod params;
 

--- a/crates/vize_atelier_core/src/codegen/slots/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/generate.rs
@@ -4,8 +4,7 @@ use crate::steps::v_slot::{collect_slots, get_slot_name, has_v_slot};
 use crate::{
     ElementNode, ExpressionNode, ForNode, IfNode, PropNode, RuntimeHelper, TemplateChildNode,
 };
-use vize_carton::String;
-use vize_carton::ToCompactString;
+use vize_carton::{String, ToCompactString};
 
 use super::super::context::CodegenContext;
 use super::super::expression::generate_expression;
@@ -15,6 +14,7 @@ use super::detect::{
     child_is_slot_template, has_conditional_or_loop_slots, has_forwarded_slot_outlet,
     slot_children_have_meaningful_content,
 };
+use super::name::generate_slot_entry_name;
 use super::params::{extract_slot_params, get_slot_props, prefix_slot_defaults};
 
 /// Generate slots object for component
@@ -446,9 +446,9 @@ fn generate_slot_object_entry(
         ctx.newline();
 
         // name
-        ctx.push("name: \"");
-        ctx.push(&escape_js_string(&slot_name));
-        ctx.push("\",");
+        ctx.push("name: ");
+        generate_slot_entry_name(ctx, dir, &slot_name);
+        ctx.push(",");
         ctx.newline();
 
         // fn

--- a/crates/vize_atelier_core/src/codegen/slots/name.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/name.rs
@@ -1,0 +1,21 @@
+use crate::{DirectiveNode, ExpressionNode};
+
+use super::super::context::CodegenContext;
+use super::super::expression::generate_expression;
+use super::super::helpers::escape_js_string;
+
+pub(super) fn generate_slot_entry_name(
+    ctx: &mut CodegenContext,
+    dir: &DirectiveNode<'_>,
+    slot_name: &str,
+) {
+    match dir.arg.as_ref() {
+        Some(arg @ ExpressionNode::Simple(exp)) if !exp.is_static => generate_expression(ctx, arg),
+        Some(arg @ ExpressionNode::Compound(_)) => generate_expression(ctx, arg),
+        _ => {
+            ctx.push("\"");
+            ctx.push(&escape_js_string(slot_name));
+            ctx.push("\"");
+        }
+    }
+}

--- a/crates/vize_atelier_core/tests/dynamic_slot_forwarding.rs
+++ b/crates/vize_atelier_core/tests/dynamic_slot_forwarding.rs
@@ -1,0 +1,62 @@
+use vize_atelier_core::{
+    CodegenOptions, CodegenResult, TransformOptions, generate, parse, transform,
+};
+
+fn result_output(result: &CodegenResult) -> String {
+    let mut output = String::with_capacity(result.preamble.len() + result.code.len() + 1);
+    output.push_str(&result.preamble);
+    output.push('\n');
+    output.push_str(&result.code);
+    output
+}
+
+fn compile(source: &str) -> String {
+    let allocator = bumpalo::Bump::new();
+    let (mut root, errors) = parse(&allocator, source);
+    assert!(errors.is_empty(), "Parse errors: {:?}", errors);
+
+    transform(
+        &allocator,
+        &mut root,
+        TransformOptions {
+            prefix_identifiers: true,
+            ..Default::default()
+        },
+        None,
+    );
+
+    result_output(&generate(
+        &root,
+        CodegenOptions {
+            prefix_identifiers: true,
+            ..Default::default()
+        },
+    ))
+}
+
+#[test]
+fn looped_dynamic_slot_name_uses_v_for_alias() {
+    let output = compile(
+        r#"<Wrapper>
+  <template v-for="(_, s) of $slots" :key="s" #[s]="scope">
+    <slot :name="s" v-bind="scope" />
+  </template>
+</Wrapper>"#,
+    );
+
+    assert!(
+        output.contains("name: s,"),
+        "looped dynamic slot names should use the v-for alias as an expression:\n{}",
+        output
+    );
+    assert!(
+        output.contains(r#"_renderSlot(_ctx.$slots, s"#),
+        "forwarded slot outlet should render the matching dynamic slot name:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("name: \"s\"") && !output.contains("_ctx.s"),
+        "dynamic slot aliases must not be emitted as literals or outer-scope refs:\n{}",
+        output
+    );
+}


### PR DESCRIPTION
## Summary
- emit dynamic createSlots entry names as expressions instead of string literals
- add a regression for forwarding dynamic slot names from a v-for wrapper

## Tests
- cargo test -p vize_atelier_core test_codegen_looped_dynamic_slot_name_uses_v_for_alias

Closes #2717

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786125979&installation_id=136613492&pr_number=2733&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2733&signature=c35ed29a8ce38d77735a528256c2f8a1ff41d0c70477956dc6808742b6cea8aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic slot forwarding so slot names are now generated correctly from loop aliases and other expressions.
  * Fixed cases where slot names could be treated as plain text instead of using the intended dynamic value.
  * Preserved static slot names as escaped strings for safer output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->