### PR TITLE
fix(maestro): enrich template component intellisense

### DIFF
--- a/crates/vize_maestro/src/ide/completion.rs
+++ b/crates/vize_maestro/src/ide/completion.rs
@@ -22,6 +22,8 @@ mod component_props_tests;
 #[cfg(test)]
 mod dedup_tests;
 #[cfg(test)]
+mod template_event_tests;
+#[cfg(test)]
 mod tests;
 
 // Cross-module reuse: inlay-hint code resolves reactive binding types with

--- a/crates/vize_maestro/src/ide/completion/component_props_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/component_props_tests.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use tower_lsp::lsp_types::{CompletionResponse, Url};
+use tower_lsp::lsp_types::{CompletionResponse, CompletionTextEdit, Url};
 
 use super::CompletionService;
 use crate::{ide::IdeContext, server::ServerState};
@@ -45,6 +45,58 @@ import Child from './Child.vue'
 
     assert!(has_label(&labels, "some-message"), "{labels:?}");
     assert!(has_label(&labels, "disabled"), "{labels:?}");
+}
+
+#[test]
+fn template_component_prop_completion_replaces_dynamic_prefix() {
+    let dir = tempfile::tempdir().unwrap();
+    let child_path = dir.path().join("Child.vue");
+    fs::write(
+        &child_path,
+        r#"<script setup lang="ts">
+defineProps<{
+  someMessage: string
+}>()
+</script>
+"#,
+    )
+    .unwrap();
+
+    let source = r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template>
+  <Child :so />
+</template>
+"#;
+    let parent_path = dir.path().join("Parent.vue");
+    fs::write(&parent_path, source).unwrap();
+
+    let uri = Url::from_file_path(&parent_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    let offset = source.find(":so").unwrap() + ":so".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let items = completion_items(CompletionService::complete(&ctx).unwrap());
+    let prop = items
+        .iter()
+        .find(|item| item.label == "someMessage")
+        .expect("dynamic prop completion should use the camelCase label");
+
+    let edit = match prop
+        .text_edit
+        .as_ref()
+        .expect("dynamic prop completion should replace the typed prefix")
+    {
+        CompletionTextEdit::Edit(edit) => edit,
+        CompletionTextEdit::InsertAndReplace(_) => panic!("expected a simple text edit"),
+    };
+    assert_eq!(edit.new_text, ":someMessage=\"$1\"");
 }
 
 #[cfg(feature = "native")]
@@ -138,13 +190,17 @@ import Child from './Child.vue'
 }
 
 fn completion_labels(response: CompletionResponse) -> Vec<String> {
+    completion_items(response)
+        .into_iter()
+        .map(|item| item.label)
+        .collect()
+}
+
+fn completion_items(response: CompletionResponse) -> Vec<tower_lsp::lsp_types::CompletionItem> {
     match response {
         CompletionResponse::Array(items) => items,
         CompletionResponse::List(list) => list.items,
     }
-    .into_iter()
-    .map(|item| item.label)
-    .collect()
 }
 
 fn has_label(labels: &[String], expected: &str) -> bool {

--- a/crates/vize_maestro/src/ide/completion/items.rs
+++ b/crates/vize_maestro/src/ide/completion/items.rs
@@ -9,7 +9,8 @@
 )]
 
 use tower_lsp::lsp_types::{
-    CompletionItem, CompletionItemKind, Documentation, InsertTextFormat, MarkupContent, MarkupKind,
+    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, Documentation,
+    InsertTextFormat, MarkupContent, MarkupKind,
 };
 use vize_relief::BindingType;
 
@@ -93,18 +94,31 @@ pub(crate) fn binding_type_to_completion_info(
 pub(crate) fn directive_item(label: &str, description: &str, snippet: &str) -> CompletionItem {
     CompletionItem {
         label: label.to_string(),
-        kind: Some(CompletionItemKind::KEYWORD),
+        kind: Some(directive_completion_kind(label)),
         detail: Some(description.to_string()),
+        label_details: Some(CompletionItemLabelDetails {
+            detail: None,
+            description: Some("Vue directive".to_string()),
+        }),
         insert_text: Some(snippet.to_string()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
         documentation: Some(Documentation::MarkupContent(MarkupContent {
             kind: MarkupKind::Markdown,
             value: format!(
-                "**{}**\n\n{}\n\n[Vue Documentation](https://vuejs.org/api/built-in-directives.html)",
-                label, description
+                "**`{}`**\n\n{}\n\n```vue\n<template>\n  <div {}></div>\n</template>\n```\n\n[Vue built-in directives](https://vuejs.org/api/built-in-directives.html)",
+                label, description, snippet
             ),
         })),
         ..Default::default()
+    }
+}
+
+fn directive_completion_kind(label: &str) -> CompletionItemKind {
+    match label {
+        "@" | "v-on" => CompletionItemKind::EVENT,
+        ":" | "v-bind" | "v-model" => CompletionItemKind::PROPERTY,
+        "#" | "v-slot" => CompletionItemKind::FIELD,
+        _ => CompletionItemKind::KEYWORD,
     }
 }
 

--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -20,7 +20,7 @@ mod self_component;
 mod slot_outlets;
 mod tag_context;
 
-use tower_lsp::lsp_types::CompletionItem;
+use tower_lsp::lsp_types::{CompletionItem, CompletionTextEdit, Position, Range, TextEdit};
 
 use super::is_inside_html_comment;
 use crate::ide::IdeContext;
@@ -57,7 +57,7 @@ pub(crate) fn complete_template(ctx: &IdeContext) -> Vec<CompletionItem> {
             let mut items_vec = contextual_directive_completions(ctx);
             items_vec.extend(native::native_element_attribute_completions(ctx));
             items_vec.extend(component_meta::component_surface_completions(ctx));
-            return filter_open_tag_completions(items_vec, &tag_ctx.current_token);
+            return prepare_open_tag_completions(ctx, &tag_ctx, items_vec);
         }
 
         if !is_template_expression {
@@ -100,6 +100,89 @@ fn filter_open_tag_completions(
         .collect()
 }
 
+fn prepare_open_tag_completions(
+    ctx: &IdeContext,
+    tag_ctx: &tag_context::OpenTagContext,
+    items: Vec<CompletionItem>,
+) -> Vec<CompletionItem> {
+    let items = filter_open_tag_completions(items, &tag_ctx.current_token);
+    with_open_tag_text_edits(ctx, tag_ctx, items)
+}
+
+fn with_open_tag_text_edits(
+    ctx: &IdeContext,
+    tag_ctx: &tag_context::OpenTagContext,
+    mut items: Vec<CompletionItem>,
+) -> Vec<CompletionItem> {
+    if tag_ctx.current_token.is_empty() {
+        return items;
+    }
+
+    let range = range_from_offsets(&ctx.content, tag_ctx.current_token_start, ctx.offset);
+    for item in &mut items {
+        let insert_text = item
+            .insert_text
+            .take()
+            .unwrap_or_else(|| item.label.clone());
+        item.text_edit = Some(CompletionTextEdit::Edit(TextEdit {
+            range,
+            new_text: replacement_text_for_open_tag_completion(
+                &tag_ctx.current_token,
+                &insert_text,
+            ),
+        }));
+    }
+
+    items
+}
+
+fn replacement_text_for_open_tag_completion(prefix: &str, insert_text: &str) -> String {
+    if prefix.starts_with("v-bind:")
+        && !insert_text.starts_with("v-bind:")
+        && !insert_text.starts_with(':')
+    {
+        return format!("v-bind:{insert_text}");
+    }
+
+    if prefix.starts_with(':')
+        && !insert_text.starts_with(':')
+        && !insert_text.starts_with("v-bind:")
+    {
+        return format!(":{insert_text}");
+    }
+
+    if prefix.starts_with("v-slot:")
+        && !insert_text.starts_with("v-slot:")
+        && !insert_text.starts_with('#')
+    {
+        return format!("v-slot:{insert_text}");
+    }
+
+    if prefix.starts_with('#')
+        && !insert_text.starts_with('#')
+        && !insert_text.starts_with("v-slot:")
+    {
+        return format!("#{insert_text}");
+    }
+
+    insert_text.to_string()
+}
+
+fn range_from_offsets(content: &str, start: usize, end: usize) -> Range {
+    let (start_line, start_character) = crate::ide::offset_to_position(content, start);
+    let (end_line, end_character) = crate::ide::offset_to_position(content, end);
+    Range {
+        start: Position {
+            line: start_line,
+            character: start_character,
+        },
+        end: Position {
+            line: end_line,
+            character: end_character,
+        },
+    }
+}
+
 fn open_tag_completion_matches_prefix(label: &str, prefix: &str) -> bool {
     if prefix.contains('=') {
         return false;
@@ -134,6 +217,11 @@ pub(crate) fn corsa_template_completions(ctx: &IdeContext) -> Vec<CompletionItem
     let mut items = contextual_directive_completions(ctx);
     items.extend(component_meta::component_surface_completions(ctx));
     items.extend(legacy_vue2_template_completions(ctx));
+    if let Some(tag_ctx) = tag_context::opening_tag_context_at_offset(&ctx.content, ctx.offset)
+        && !tag_ctx.inside_attribute_value
+    {
+        return prepare_open_tag_completions(ctx, &tag_ctx, items);
+    }
     items
 }
 

--- a/crates/vize_maestro/src/ide/completion/template/directives.rs
+++ b/crates/vize_maestro/src/ide/completion/template/directives.rs
@@ -1,7 +1,8 @@
 //! Vue / petite-vue / Vize directive completions.
 
 use tower_lsp::lsp_types::{
-    CompletionItem, CompletionItemKind, Documentation, InsertTextFormat, MarkupContent, MarkupKind,
+    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, Documentation,
+    InsertTextFormat, MarkupContent, MarkupKind,
 };
 
 use crate::ide::IdeContext;
@@ -57,11 +58,17 @@ fn event_item(label: &str, detail: &str) -> CompletionItem {
         label: label.to_string(),
         kind: Some(CompletionItemKind::EVENT),
         detail: Some(detail.to_string()),
+        label_details: Some(CompletionItemLabelDetails {
+            detail: None,
+            description: Some("Vue event".to_string()),
+        }),
         insert_text: Some(format!("{label}=\"$1\"")),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
         documentation: Some(Documentation::MarkupContent(MarkupContent {
             kind: MarkupKind::Markdown,
-            value: format!("**`{label}`**\n\nVue event listener shorthand."),
+            value: format!(
+                "**`{label}`**\n\nVue event listener shorthand.\n\n```vue\n<template>\n  <button {label}=\"handler\"></button>\n</template>\n```\n\n[Vue event handling](https://vuejs.org/guide/essentials/event-handling.html)"
+            ),
         })),
         ..Default::default()
     }

--- a/crates/vize_maestro/src/ide/completion/template/tag_context.rs
+++ b/crates/vize_maestro/src/ide/completion/template/tag_context.rs
@@ -8,6 +8,7 @@ pub(super) struct OpenTagContext {
     pub tag_name: String,
     pub tag_start: usize,
     pub current_token: String,
+    pub current_token_start: usize,
     pub inside_attribute_value: bool,
 }
 
@@ -43,12 +44,13 @@ pub(super) fn opening_tag_context_at_offset(
 
     let tag_name = content[name_start..name_end].to_string();
     let inside_attribute_value = is_inside_open_tag_attribute_value(content, tag_start, cursor);
-    let current_token = current_open_tag_token(content, tag_start, cursor);
+    let (current_token_start, current_token) = current_open_tag_token(content, tag_start, cursor);
 
     Some(OpenTagContext {
         tag_name,
         tag_start,
         current_token,
+        current_token_start,
         inside_attribute_value,
     })
 }
@@ -74,7 +76,7 @@ fn is_inside_open_tag_attribute_value(content: &str, tag_start: usize, cursor: u
     quote.is_some()
 }
 
-fn current_open_tag_token(content: &str, tag_start: usize, cursor: usize) -> String {
+fn current_open_tag_token(content: &str, tag_start: usize, cursor: usize) -> (usize, String) {
     let slice = &content[tag_start..cursor];
     let mut token_start = tag_start;
 
@@ -84,7 +86,10 @@ fn current_open_tag_token(content: &str, tag_start: usize, cursor: usize) -> Str
         }
     }
 
-    content[token_start..cursor].trim_start().to_string()
+    (
+        token_start,
+        content[token_start..cursor].trim_start().to_string(),
+    )
 }
 
 pub(super) fn is_prop_completion_prefix(prefix: &str) -> bool {

--- a/crates/vize_maestro/src/ide/completion/template_event_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/template_event_tests.rs
@@ -1,0 +1,76 @@
+#![allow(
+    clippy::disallowed_methods,
+    clippy::disallowed_macros,
+    clippy::disallowed_types
+)]
+
+use super::CompletionService;
+use crate::{ide::IdeContext, server::ServerState};
+use tower_lsp::lsp_types::{CompletionItemKind, CompletionResponse, CompletionTextEdit, Url};
+
+#[test]
+fn event_completion_replaces_typed_shorthand_prefix() {
+    let source = r#"<template>
+  <button @c />
+  <button @cli />
+</template>
+"#;
+    let (state, uri) = state_with_document("EventCompletion.vue", source);
+
+    let first_offset = source.find("@c").unwrap() + "@c".len();
+    let ctx = IdeContext::new(&state, &uri, first_offset).unwrap();
+    let items = completion_items(CompletionService::complete(&ctx).unwrap());
+    let click = items
+        .iter()
+        .find(|item| item.label == "@click")
+        .expect("@click completion should be present for @c");
+    assert_eq!(click.kind, Some(CompletionItemKind::EVENT));
+    assert_eq!(click.insert_text, None);
+
+    let edit = match click
+        .text_edit
+        .as_ref()
+        .expect("@click completion should replace the typed token")
+    {
+        CompletionTextEdit::Edit(edit) => edit,
+        CompletionTextEdit::InsertAndReplace(_) => panic!("expected a simple text edit"),
+    };
+    assert_eq!(edit.new_text, "@click=\"$1\"");
+    assert_eq!(edit.range.start.line, 1);
+    assert_eq!(edit.range.start.character, 10);
+    assert_eq!(edit.range.end.line, 1);
+    assert_eq!(edit.range.end.character, 12);
+
+    let second_offset = source.find("@cli").unwrap() + "@cli".len();
+    let ctx = IdeContext::new(&state, &uri, second_offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+    assert!(has_label(&labels, "@click"), "{labels:?}");
+}
+
+fn state_with_document(name: &str, source: &str) -> (ServerState, Url) {
+    let uri = Url::parse(&format!("file:///{name}")).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, source);
+    (state, uri)
+}
+
+fn completion_labels(response: CompletionResponse) -> Vec<String> {
+    completion_items(response)
+        .into_iter()
+        .map(|item| item.label)
+        .collect()
+}
+
+fn completion_items(response: CompletionResponse) -> Vec<tower_lsp::lsp_types::CompletionItem> {
+    match response {
+        CompletionResponse::Array(items) => items,
+        CompletionResponse::List(list) => list.items,
+    }
+}
+
+fn has_label(labels: &[String], expected: &str) -> bool {
+    labels.iter().any(|label| label == expected)
+}

--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -9,6 +9,9 @@
 
 mod builder;
 mod collectors;
+mod component_props;
+#[cfg(test)]
+mod component_props_tests;
 #[cfg(feature = "native")]
 pub(in crate::ide) mod corsa;
 #[cfg(all(test, feature = "native"))]
@@ -40,5 +43,6 @@ pub mod sources {
     pub const JSX_COMPILER: &str = "vize/jsx";
     pub const LINTER: &str = "vize/lint";
     pub const TYPE_CHECKER: &str = "vize/types";
+    pub const COMPONENTS: &str = "vize/components";
     pub const MUSEA: &str = "vize/musea";
 }

--- a/crates/vize_maestro/src/ide/diagnostics/component_props.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/component_props.rs
@@ -1,0 +1,146 @@
+//! Component-surface diagnostics that need template usage plus imported metadata.
+#![allow(clippy::disallowed_methods, clippy::disallowed_macros)]
+
+use tower_lsp::lsp_types::{
+    CodeDescription, Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url,
+};
+use vize_atelier_sfc::SfcDescriptor;
+use vize_croquis::{Drawer, DrawerOptions};
+
+use super::{DiagnosticService, LineIndex, sources};
+use crate::ide::IdeContext;
+use crate::ide::completion::template::component_metadata;
+use crate::ide::definition::helpers;
+use crate::server::ServerState;
+
+impl DiagnosticService {
+    pub(super) fn extend_component_required_prop_diagnostics(
+        state: &ServerState,
+        uri: &Url,
+        content: &str,
+        descriptor: &SfcDescriptor<'_>,
+        line_index: &LineIndex<'_>,
+        enabled: bool,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        if !enabled {
+            return;
+        }
+
+        let component_diags = Self::collect_component_required_prop_diagnostics(
+            state, uri, content, descriptor, line_index,
+        );
+        tracing::info!(
+            "collect: component required prop diagnostics: {}",
+            component_diags.len()
+        );
+        diagnostics.extend(component_diags);
+    }
+
+    fn collect_component_required_prop_diagnostics(
+        state: &ServerState,
+        uri: &Url,
+        content: &str,
+        descriptor: &SfcDescriptor<'_>,
+        line_index: &LineIndex<'_>,
+    ) -> Vec<Diagnostic> {
+        let Some(template) = descriptor.template.as_ref() else {
+            return Vec::new();
+        };
+        let Some(template_content) = content.get(template.loc.start..template.loc.end) else {
+            return Vec::new();
+        };
+
+        let allocator = vize_carton::Bump::new();
+        let (root, _) = vize_armature::parse(&allocator, template_content);
+        let mut drawer = Drawer::with_options(DrawerOptions {
+            analyze_template_scopes: true,
+            track_usage: true,
+            ..Default::default()
+        });
+        drawer.draw_template(&root);
+        let croquis = drawer.finish();
+        if croquis.component_usages.is_empty() {
+            return Vec::new();
+        }
+
+        let metadata_ctx =
+            IdeContext::with_content(state, uri, template.loc.start, content.to_string());
+        let mut diagnostics = Vec::new();
+
+        for usage in croquis.component_usages {
+            if usage.has_spread_attrs {
+                continue;
+            }
+
+            let Some(metadata) = component_metadata(&metadata_ctx, usage.name.as_str()) else {
+                continue;
+            };
+            let missing = metadata
+                .props
+                .iter()
+                .filter(|prop| prop.required)
+                .filter(|prop| {
+                    !usage
+                        .props
+                        .iter()
+                        .any(|passed| prop_names_match(passed.name.as_str(), prop.name.as_str()))
+                })
+                .map(|prop| prop.name.clone())
+                .collect::<Vec<_>>();
+            if missing.is_empty() {
+                continue;
+            }
+
+            let tag_name_start = template.loc.start + usage.start as usize + 1;
+            let tag_name_end = tag_name_start + usage.name.len();
+            let (start_line, start_col) = line_index.line_col(tag_name_start.min(content.len()));
+            let (end_line, end_col) = line_index.line_col(tag_name_end.min(content.len()));
+
+            diagnostics.push(Diagnostic {
+                range: Range {
+                    start: Position {
+                        line: start_line,
+                        character: start_col,
+                    },
+                    end: Position {
+                        line: end_line,
+                        character: end_col,
+                    },
+                },
+                severity: Some(DiagnosticSeverity::ERROR),
+                code: Some(NumberOrString::String(
+                    "component-required-props".to_string(),
+                )),
+                code_description: vue_props_code_description(),
+                source: Some(sources::COMPONENTS.to_string()),
+                message: required_props_message(usage.name.as_str(), &missing),
+                ..Default::default()
+            });
+        }
+
+        diagnostics
+    }
+}
+
+fn prop_names_match(passed_name: &str, declared_name: &str) -> bool {
+    passed_name == declared_name || helpers::kebab_to_camel(passed_name) == declared_name
+}
+
+fn required_props_message(component_name: &str, missing: &[String]) -> String {
+    let props = missing
+        .iter()
+        .map(|name| format!("`{name}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let noun = if missing.len() == 1 { "prop" } else { "props" };
+    format!(
+        "<{component_name}> is missing required {noun}: {props}\n\nPass the prop in this template usage, or make it optional/provide a default in the child component."
+    )
+}
+
+fn vue_props_code_description() -> Option<CodeDescription> {
+    Url::parse("https://vuejs.org/guide/components/props.html#prop-validation")
+        .ok()
+        .map(|href| CodeDescription { href })
+}

--- a/crates/vize_maestro/src/ide/diagnostics/component_props_tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/component_props_tests.rs
@@ -1,0 +1,125 @@
+#![allow(
+    clippy::disallowed_methods,
+    clippy::disallowed_macros,
+    clippy::disallowed_types
+)]
+
+use std::fs;
+
+use super::{DiagnosticService, offset_to_line_col, sources};
+use crate::server::ServerState;
+use tower_lsp::lsp_types::{DiagnosticSeverity, NumberOrString, Url};
+
+fn state_with_lsp_diagnostics(lint: bool, typecheck: bool) -> ServerState {
+    let state = ServerState::new();
+    state.apply_lsp_initialization_options(Some(&serde_json::json!({
+        "lint": lint,
+        "typecheck": typecheck
+    })));
+    state
+}
+
+#[test]
+fn reports_missing_required_component_props_on_template_tag() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("Child.vue"),
+        r#"<script setup lang="ts">
+defineProps<{
+  someMessage: string
+  count?: number
+}>()
+</script>
+"#,
+    )
+    .unwrap();
+
+    let source = r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template>
+  <Child />
+</template>
+"#;
+    let parent_path = dir.path().join("Parent.vue");
+    fs::write(&parent_path, source).unwrap();
+
+    let state = state_with_lsp_diagnostics(false, true);
+    let uri = Url::from_file_path(&parent_path).unwrap();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    let diagnostics = DiagnosticService::collect(&state, &uri);
+    let diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.source.as_deref() == Some(sources::COMPONENTS))
+        .expect("expected a component required-props diagnostic");
+
+    assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::ERROR));
+    assert_eq!(
+        diagnostic.code,
+        Some(NumberOrString::String(
+            "component-required-props".to_string()
+        ))
+    );
+    assert!(diagnostic.message.contains("<Child>"), "{diagnostic:?}");
+    assert!(
+        diagnostic.message.contains("`someMessage`"),
+        "{diagnostic:?}"
+    );
+    assert!(
+        diagnostic
+            .code_description
+            .as_ref()
+            .is_some_and(|description| description.href.as_str().contains("components/props")),
+        "{diagnostic:?}"
+    );
+
+    let tag_name_start = source.find("<Child").unwrap() + 1;
+    let (line, character) = offset_to_line_col(source, tag_name_start);
+    assert_eq!(diagnostic.range.start.line, line);
+    assert_eq!(diagnostic.range.start.character, character);
+}
+
+#[test]
+fn skips_required_component_prop_diagnostic_when_spread_attrs_are_present() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("Child.vue"),
+        r#"<script setup lang="ts">
+defineProps<{ someMessage: string }>()
+</script>
+"#,
+    )
+    .unwrap();
+
+    let source = r#"<script setup lang="ts">
+import Child from './Child.vue'
+const attrs = {}
+</script>
+
+<template>
+  <Child v-bind="attrs" />
+</template>
+"#;
+    let parent_path = dir.path().join("Parent.vue");
+    fs::write(&parent_path, source).unwrap();
+
+    let state = state_with_lsp_diagnostics(false, true);
+    let uri = Url::from_file_path(&parent_path).unwrap();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    let diagnostics = DiagnosticService::collect(&state, &uri);
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.source.as_deref() != Some(sources::COMPONENTS)),
+        "spread attrs may satisfy required props at runtime; got {diagnostics:#?}"
+    );
+}

--- a/crates/vize_maestro/src/ide/diagnostics/service.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/service.rs
@@ -62,19 +62,13 @@ impl DiagnosticService {
             return diagnostics;
         }
 
-        // Build the line index once for this document. Every collector below
-        // maps byte offsets in `content` to (line, utf16_col) against it, so
-        // sharing one index avoids re-scanning the whole document per offset.
         let line_index = LineIndex::new(&content);
 
-        // Check if this is an Art file (*.art.vue)
         let path = uri.path();
         if path.ends_with(".art.vue") {
-            // Musea-specific diagnostics for Art files
             if features.lint {
                 diagnostics.extend(Self::collect_musea_diagnostics(uri, &content, &line_index));
             }
-            // Don't return early here; async collection still adds Corsa diagnostics.
             return diagnostics;
         }
 
@@ -96,10 +90,6 @@ impl DiagnosticService {
             return diagnostics;
         }
 
-        // JSX/TSX files (*.jsx, *.tsx): surface JSX compiler/lowering
-        // diagnostics (parse errors, lowering warnings) as LSP squiggles. This
-        // is diagnostics-only — no virtual TypeScript document is generated for
-        // JSX/TSX (type-aware features are deferred to #1497).
         if is_jsx_path(path) {
             let jsx_diags = Self::collect_jsx_diagnostics(uri, &content, &line_index);
             tracing::info!("collect: jsx compiler diagnostics: {}", jsx_diags.len());
@@ -107,8 +97,6 @@ impl DiagnosticService {
             return diagnostics;
         }
 
-        // Standard SFC processing — parse once and share the descriptor with
-        // every block-level collector below.
         let descriptor = match Self::parse_sfc_for_collect(uri, &content) {
             Ok(descriptor) => descriptor,
             Err(parse_diagnostic) => {
@@ -151,6 +139,15 @@ impl DiagnosticService {
         );
         diagnostics.extend(sfc_compile_diags);
 
+        Self::extend_component_required_prop_diagnostics(
+            state,
+            uri,
+            &content,
+            &descriptor,
+            &line_index,
+            features.typecheck,
+            &mut diagnostics,
+        );
         if features.lint {
             // Collect linter diagnostics (vize_patina)
             let lint_diags = Self::collect_lint_diagnostics(

--- a/crates/vize_maestro/src/ide/hover/component_prop.rs
+++ b/crates/vize_maestro/src/ide/hover/component_prop.rs
@@ -27,7 +27,17 @@ pub(super) fn hover_attribute(ctx: &IdeContext<'_>) -> Option<Hover> {
             .title(&prop.name)
             .meta("Component prop")
             .code("typescript", &signature)
-            .section("Requirement", requirement);
+            .section("Requirement", requirement)
+            .code(
+                "vue",
+                &format!(
+                    "<{component_name} {attr_name}=\"...\" />\n<{component_name} :{attr_name}=\"value\" />"
+                ),
+            )
+            .link(
+                "Vue Component Props",
+                "https://vuejs.org/guide/components/props.html",
+            );
 
         if let Some(default) = prop.default_value.as_deref() {
             builder = builder.section("Default", &format!("`{default}`"));
@@ -131,6 +141,11 @@ import Child from './Child.vue'
 
         assert!(value.contains("modelValue: string"), "got {value:?}");
         assert!(value.contains("Required"), "got {value:?}");
+        assert!(
+            value.contains("<Child model-value=\"...\" />"),
+            "got {value:?}"
+        );
+        assert!(value.contains("Vue Component Props"), "got {value:?}");
     }
 
     fn hover_markdown(hover: tower_lsp::lsp_types::Hover) -> String {

--- a/crates/vize_maestro/src/ide/hover/component_tag.rs
+++ b/crates/vize_maestro/src/ide/hover/component_tag.rs
@@ -66,7 +66,18 @@ impl HoverService {
                     "Required props not passed"
                 };
                 builder = section_from_items(builder, heading, &missing_required);
+                if !usage.has_spread_attrs {
+                    builder = builder.code(
+                        "vue",
+                        &missing_required_example(tag_name.as_str(), &missing_required),
+                    );
+                }
             }
+
+            builder = builder.link(
+                "Vue Component Props",
+                "https://vuejs.org/guide/components/props.html",
+            );
         }
 
         Some(builder.build())
@@ -202,6 +213,14 @@ fn section_from_items(builder: HoverBuilder, heading: &str, items: &[String]) ->
 
 fn prop_names_match(passed: &PassedProp, declared_name: &str) -> bool {
     passed.name == declared_name || helpers::kebab_to_camel(passed.name.as_str()) == declared_name
+}
+
+fn missing_required_example(tag_name: &str, missing_required: &[String]) -> String {
+    let attrs = missing_required
+        .iter()
+        .map(|name| format!(" :{}=\"...\"", crate::ide::pascal_to_kebab(name)))
+        .collect::<String>();
+    format!("<{tag_name}{attrs} />")
 }
 
 fn starts_with_uppercase(tag_name: &str) -> bool {


### PR DESCRIPTION
## Summary
- add editor diagnostics for missing required props on component tags when no spread attrs are present
- make template directive/event/prop completions replace the typed open-tag token so @c/@cli and :prop prefixes do not duplicate text
- enrich component prop/tag hover markdown with usage examples and Vue docs links

## Validation
- cargo test -p vize_maestro
- cargo clippy -p vize_maestro --lib -- -D warnings
- git diff --check

Note: cargo clippy -p vize_maestro --all-targets -- -D warnings still fails on existing test-target disallowed macro/type lints outside this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786131357&installation_id=136613492&pr_number=2736&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2736&signature=7998993c40df918a1222ccbf756aa2dc4cf0225155656032f59e4052304d5ec7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added diagnostics for Vue components with missing required props in templates.
  * Improved hover details for component tags and props with example usage and helpful documentation links.
  * Completion suggestions for Vue directives and open tags now include better text replacements and richer metadata.

* **Bug Fixes**
  * Fixed completion behavior so typed prefixes are replaced correctly for component props and event suggestions.
  * Suppressed missing-prop diagnostics when spread attributes are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->