### PR TITLE
feat(maestro): enrich lsp markdown docs

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -29,6 +29,7 @@ pub mod file_rename;
 pub mod hover;
 pub mod inlay_hint;
 pub mod jsx;
+pub(crate) mod markup;
 pub(crate) mod musea;
 pub mod references;
 pub mod rename;
@@ -69,7 +70,6 @@ use crate::virtual_code::{
     ArtCursorPosition, BlockType, VirtualDocuments, find_art_block_at_offset, find_block_at_offset,
 };
 
-// =============================================================================
 // Position conversion utilities
 // =============================================================================
 

--- a/crates/vize_maestro/src/ide/completion/component_props_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/component_props_tests.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use tower_lsp::lsp_types::{CompletionResponse, CompletionTextEdit, Url};
+use tower_lsp::lsp_types::{CompletionResponse, CompletionTextEdit, Documentation, Url};
 
 use super::CompletionService;
 use crate::{ide::IdeContext, server::ServerState};
@@ -41,10 +41,22 @@ import Child from './Child.vue'
 
     let offset = source.find("<Child  />").unwrap() + "<Child ".len();
     let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+    let items = completion_items(CompletionService::complete(&ctx).unwrap());
+    let labels = items
+        .iter()
+        .map(|item| item.label.clone())
+        .collect::<Vec<_>>();
 
     assert!(has_label(&labels, "some-message"), "{labels:?}");
     assert!(has_label(&labels, "disabled"), "{labels:?}");
+    let prop = items
+        .iter()
+        .find(|item| item.label == "some-message")
+        .expect("some-message prop completion should be present");
+    let doc = markdown_doc(&prop.documentation);
+    assert!(doc.contains("```typescript"), "got {doc:?}");
+    assert!(doc.contains("```vue"), "got {doc:?}");
+    assert!(doc.contains("Vue Component Props"), "got {doc:?}");
 }
 
 #[test]
@@ -200,6 +212,13 @@ fn completion_items(response: CompletionResponse) -> Vec<tower_lsp::lsp_types::C
     match response {
         CompletionResponse::Array(items) => items,
         CompletionResponse::List(list) => list.items,
+    }
+}
+
+fn markdown_doc(doc: &Option<Documentation>) -> &str {
+    match doc.as_ref().expect("completion should include docs") {
+        Documentation::MarkupContent(content) => &content.value,
+        Documentation::String(value) => value,
     }
 }
 

--- a/crates/vize_maestro/src/ide/completion/items.rs
+++ b/crates/vize_maestro/src/ide/completion/items.rs
@@ -9,10 +9,11 @@
 )]
 
 use tower_lsp::lsp_types::{
-    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, Documentation,
-    InsertTextFormat, MarkupContent, MarkupKind,
+    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, InsertTextFormat,
 };
 use vize_relief::BindingType;
+
+use crate::ide::markup::{self, Markdown};
 
 /// Convert BindingType to completion item information.
 pub(crate) fn binding_type_to_completion_info(
@@ -92,6 +93,7 @@ pub(crate) fn binding_type_to_completion_info(
 /// Create a directive completion item.
 #[allow(clippy::disallowed_macros)]
 pub(crate) fn directive_item(label: &str, description: &str, snippet: &str) -> CompletionItem {
+    let example = markup::snippet_for_docs(snippet);
     CompletionItem {
         label: label.to_string(),
         kind: Some(directive_completion_kind(label)),
@@ -102,13 +104,21 @@ pub(crate) fn directive_item(label: &str, description: &str, snippet: &str) -> C
         }),
         insert_text: Some(snippet.to_string()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
-        documentation: Some(Documentation::MarkupContent(MarkupContent {
-            kind: MarkupKind::Markdown,
-            value: format!(
-                "**`{}`**\n\n{}\n\n```vue\n<template>\n  <div {}></div>\n</template>\n```\n\n[Vue built-in directives](https://vuejs.org/api/built-in-directives.html)",
-                label, description, snippet
-            ),
-        })),
+        documentation: Some(
+            Markdown::new()
+                .title(&format!("`{label}`"))
+                .meta("Vue directive")
+                .paragraph(description)
+                .example(
+                    "vue",
+                    &format!("<template>\n  <div {example}></div>\n</template>"),
+                )
+                .docs(
+                    "Vue built-in directives",
+                    "https://vuejs.org/api/built-in-directives.html",
+                )
+                .into_documentation(),
+        ),
         ..Default::default()
     }
 }
@@ -125,6 +135,7 @@ fn directive_completion_kind(label: &str) -> CompletionItemKind {
 /// Create a @vize: directive completion item.
 #[allow(clippy::disallowed_macros)]
 pub(crate) fn vize_directive_item(label: &str, snippet: &str, description: &str) -> CompletionItem {
+    let example = markup::snippet_for_docs(snippet);
     CompletionItem {
         label: label.to_string(),
         kind: Some(CompletionItemKind::KEYWORD),
@@ -132,13 +143,18 @@ pub(crate) fn vize_directive_item(label: &str, snippet: &str, description: &str)
         insert_text: Some(snippet.to_string()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
         sort_text: Some(format!("!{}", label)),
-        documentation: Some(Documentation::MarkupContent(MarkupContent {
-            kind: MarkupKind::Markdown,
-            value: format!(
-                "**`{}`**\n\n{}\n\nUsage: `<!-- {} -->`",
-                label, description, label
-            ),
-        })),
+        documentation: Some(
+            Markdown::new()
+                .title(&format!("`{label}`"))
+                .meta("Vize comment directive")
+                .paragraph(description)
+                .example("html", &format!("<!-- {example} -->"))
+                .docs(
+                    "Vize comment annotations",
+                    "https://github.com/ubugeeei-prod/vize/blob/main/docs/content/guide/comment-annotations.md",
+                )
+                .into_documentation(),
+        ),
         ..Default::default()
     }
 }
@@ -146,19 +162,25 @@ pub(crate) fn vize_directive_item(label: &str, snippet: &str, description: &str)
 /// Create a component completion item.
 #[allow(clippy::disallowed_macros)]
 pub(crate) fn component_item(label: &str, description: &str, snippet: &str) -> CompletionItem {
+    let example = markup::snippet_for_docs(snippet);
     CompletionItem {
         label: label.to_string(),
         kind: Some(CompletionItemKind::CLASS),
         detail: Some(format!("Vue built-in: {}", description)),
         insert_text: Some(snippet.to_string()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
-        documentation: Some(Documentation::MarkupContent(MarkupContent {
-            kind: MarkupKind::Markdown,
-            value: format!(
-                "**<{}>**\n\n{}\n\n[Vue Documentation](https://vuejs.org/api/built-in-components.html)",
-                label, description
-            ),
-        })),
+        documentation: Some(
+            Markdown::new()
+                .title(&format!("<{label}>"))
+                .meta("Vue built-in component")
+                .paragraph(description)
+                .example("vue", &example)
+                .docs(
+                    "Vue built-in components",
+                    "https://vuejs.org/api/built-in-components.html",
+                )
+                .into_documentation(),
+        ),
         ..Default::default()
     }
 }
@@ -182,13 +204,15 @@ pub(crate) fn api_item(label: &str, signature: &str, description: &str) -> Compl
         label: label.to_string(),
         kind: Some(CompletionItemKind::FUNCTION),
         detail: Some(signature.to_string()),
-        documentation: Some(Documentation::MarkupContent(MarkupContent {
-            kind: MarkupKind::Markdown,
-            value: format!(
-                "```typescript\n{}\n```\n\n{}\n\n[Vue Documentation](https://vuejs.org/api/)",
-                signature, description
-            ),
-        })),
+        documentation: Some(
+            Markdown::new()
+                .title(label)
+                .meta("Vue API")
+                .code("typescript", signature)
+                .paragraph(description)
+                .docs("Vue API", "https://vuejs.org/api/")
+                .into_documentation(),
+        ),
         ..Default::default()
     }
 }
@@ -207,13 +231,15 @@ pub(crate) fn macro_item(
         detail: Some(format!("Macro: {}", signature)),
         insert_text: Some(snippet.to_string()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
-        documentation: Some(Documentation::MarkupContent(MarkupContent {
-            kind: MarkupKind::Markdown,
-            value: format!(
-                "```typescript\n{}\n```\n\n{}\n\n*Compiler macro - only usable in `<script setup>`*",
-                signature, description
-            ),
-        })),
+        documentation: Some(
+            Markdown::new()
+                .title(label)
+                .meta("Vue compiler macro")
+                .code("typescript", signature)
+                .paragraph(description)
+                .section("Scope", "Only usable inside `<script setup>`.")
+                .into_documentation(),
+        ),
         ..Default::default()
     }
 }
@@ -232,12 +258,28 @@ pub(crate) fn import_item(label: &str, description: &str, snippet: &str) -> Comp
 
 /// Create an attribute completion item.
 pub(crate) fn attr_item(label: &str, description: &str, snippet: &str) -> CompletionItem {
+    let example = markup::snippet_for_docs(snippet);
     CompletionItem {
         label: label.to_string(),
         kind: Some(CompletionItemKind::PROPERTY),
         detail: Some(description.to_string()),
         insert_text: Some(snippet.to_string()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
+        documentation: Some(
+            Markdown::new()
+                .title(label)
+                .meta("Template attribute")
+                .paragraph(description)
+                .example(
+                    "vue",
+                    &format!("<template>\n  <div {example}></div>\n</template>"),
+                )
+                .docs(
+                    "Vue template syntax",
+                    "https://vuejs.org/guide/essentials/template-syntax.html",
+                )
+                .into_documentation(),
+        ),
         ..Default::default()
     }
 }
@@ -256,13 +298,51 @@ pub(crate) fn css_item(
         detail: Some(format!("Vue CSS: {}", signature)),
         insert_text: Some(snippet.to_string()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
-        documentation: Some(Documentation::MarkupContent(MarkupContent {
-            kind: MarkupKind::Markdown,
-            value: format!(
-                "**{}**\n\n{}\n\n[Vue SFC CSS Features](https://vuejs.org/api/sfc-css-features.html)",
-                signature, description
-            ),
-        })),
+        documentation: Some(
+            Markdown::new()
+                .title(signature)
+                .meta("Vue SFC CSS feature")
+                .code("css", snippet)
+                .paragraph(description)
+                .docs(
+                    "Vue SFC CSS features",
+                    "https://vuejs.org/api/sfc-css-features.html",
+                )
+                .into_documentation(),
+        ),
         ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{attr_item, directive_item};
+    use tower_lsp::lsp_types::Documentation;
+
+    #[test]
+    fn directive_completion_docs_include_highlightable_example() {
+        let item = directive_item("v-if", "Conditional rendering", "v-if=\"$1\"");
+        let doc = markdown_doc(&item.documentation);
+
+        assert!(doc.contains("**Example**"), "got {doc:?}");
+        assert!(doc.contains("```vue"), "got {doc:?}");
+        assert!(doc.contains("Vue built-in directives"), "got {doc:?}");
+    }
+
+    #[test]
+    fn attribute_completion_docs_include_template_syntax_link() {
+        let item = attr_item("class", "CSS classes", "class=\"$1\"");
+        let doc = markdown_doc(&item.documentation);
+
+        assert!(doc.contains("Template attribute"), "got {doc:?}");
+        assert!(doc.contains("```vue"), "got {doc:?}");
+        assert!(doc.contains("Vue template syntax"), "got {doc:?}");
+    }
+
+    fn markdown_doc(doc: &Option<Documentation>) -> &str {
+        match doc.as_ref().expect("completion should include docs") {
+            Documentation::MarkupContent(content) => &content.value,
+            Documentation::String(value) => value,
+        }
     }
 }

--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -10,6 +10,7 @@
 
 mod art;
 mod bindings;
+mod component_docs;
 mod component_meta;
 mod components;
 mod directives;

--- a/crates/vize_maestro/src/ide/completion/template/component_docs.rs
+++ b/crates/vize_maestro/src/ide/completion/template/component_docs.rs
@@ -1,0 +1,91 @@
+//! Markdown docs for component prop and slot completions.
+#![allow(clippy::disallowed_macros)]
+
+use tower_lsp::lsp_types::Documentation;
+
+use crate::ide::markup::Markdown;
+
+pub(super) fn prop_documentation(
+    name: &str,
+    type_detail: &str,
+    required: bool,
+    default_value: Option<&str>,
+    insert_name: &str,
+    dynamic: bool,
+) -> Documentation {
+    let requirement = if required { "Required" } else { "Optional" };
+    let mut doc = Markdown::new()
+        .title(&format!("Prop `{name}`"))
+        .meta(&format!("{requirement} component prop"))
+        .code(
+            "typescript",
+            &format!("interface Props {{\n  {name}: {type_detail}\n}}"),
+        )
+        .section("Requirement", requirement)
+        .example(
+            "vue",
+            &prop_example(name, type_detail, insert_name, dynamic),
+        )
+        .docs(
+            "Vue Component Props",
+            "https://vuejs.org/guide/components/props.html",
+        );
+
+    if let Some(default) = default_value {
+        doc = doc.section("Default", &format!("`{default}`"));
+    }
+
+    doc.into_documentation()
+}
+
+pub(super) fn slot_documentation(
+    name: &str,
+    props_type: &str,
+    prop_names: Option<&[String]>,
+) -> Documentation {
+    let destructure = prop_names
+        .filter(|names| !names.is_empty())
+        .map(|names| names.join(", "))
+        .unwrap_or_else(|| "slotProps".to_string());
+
+    Markdown::new()
+        .title(&format!("Slot `{name}`"))
+        .meta("Component slot")
+        .code("typescript", props_type)
+        .example(
+            "vue",
+            &format!(
+                "<template #{name}=\"{{ {destructure} }}\">\n  <!-- slot content -->\n</template>"
+            ),
+        )
+        .docs("Vue Slots", "https://vuejs.org/guide/components/slots.html")
+        .into_documentation()
+}
+
+fn prop_example(name: &str, type_detail: &str, insert_name: &str, dynamic: bool) -> String {
+    if dynamic {
+        return format!("<Component :{name}=\"value\" />");
+    }
+    if type_detail == "boolean" {
+        return format!("<Component {insert_name} />\n<Component :{name}=\"value\" />");
+    }
+    format!("<Component {insert_name}=\"...\" />\n<Component :{name}=\"value\" />")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::prop_documentation;
+    use tower_lsp::lsp_types::Documentation;
+
+    #[test]
+    fn prop_docs_are_markdown_with_vue_examples() {
+        let doc = prop_documentation("modelValue", "string", true, None, "model-value", false);
+        let Documentation::MarkupContent(content) = doc else {
+            panic!("expected markdown docs");
+        };
+
+        assert!(content.value.contains("```typescript"));
+        assert!(content.value.contains("```vue"));
+        assert!(content.value.contains("Vue Component Props"));
+    }
+}

--- a/crates/vize_maestro/src/ide/completion/template/component_meta.rs
+++ b/crates/vize_maestro/src/ide/completion/template/component_meta.rs
@@ -4,8 +4,7 @@ use std::{collections::BTreeSet, sync::Arc};
 
 use oxc_ast::ast::{PropertyKey, Statement, TSSignature, TSType};
 use tower_lsp::lsp_types::{
-    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, Documentation,
-    InsertTextFormat, MarkupContent, MarkupKind,
+    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, InsertTextFormat,
 };
 use vize_croquis::{Drawer, DrawerOptions};
 use vize_relief::BindingType;
@@ -13,6 +12,7 @@ use vize_relief::BindingType;
 use crate::ide::definition::helpers as definition_helpers;
 use crate::ide::{IdeContext, is_component_tag, kebab_to_pascal, pascal_to_kebab};
 
+use super::component_docs;
 use super::tag_context::{
     is_dynamic_prop_prefix, is_prop_completion_prefix, is_slot_completion_prefix,
     nearest_open_component_before, opening_tag_context_at_offset,
@@ -316,7 +316,7 @@ fn prop_completion_item(prop: &ComponentProp, dynamic: bool) -> CompletionItem {
     };
     let insert_name = label.clone();
     let insert_text = if !dynamic && prop.type_detail.as_deref() == Some("boolean") {
-        insert_name
+        insert_name.clone()
     } else {
         format!("{insert_name}=\"$1\"")
     };
@@ -327,15 +327,14 @@ fn prop_completion_item(prop: &ComponentProp, dynamic: bool) -> CompletionItem {
     };
     let type_detail = prop.type_detail.as_deref().unwrap_or("unknown");
 
-    let mut doc_body = format!(
-        "**Prop** `{}`\n\n```typescript\n{}: {}\n```",
-        prop.name, prop.name, type_detail
+    let documentation = component_docs::prop_documentation(
+        &prop.name,
+        type_detail,
+        prop.required,
+        prop.default_value.as_deref(),
+        &insert_name,
+        dynamic,
     );
-    if let Some(ref default) = prop.default_value {
-        doc_body.push_str("\n\nDefault: `");
-        doc_body.push_str(default);
-        doc_body.push('`');
-    }
 
     CompletionItem {
         label,
@@ -347,10 +346,7 @@ fn prop_completion_item(prop: &ComponentProp, dynamic: bool) -> CompletionItem {
         }),
         insert_text: Some(insert_text),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
-        documentation: Some(Documentation::MarkupContent(MarkupContent {
-            kind: MarkupKind::Markdown,
-            value: doc_body,
-        })),
+        documentation: Some(documentation),
         sort_text: Some(format!("00-prop-{kebab_name}")),
         ..Default::default()
     }
@@ -368,7 +364,7 @@ fn slot_completion_item(slot: &ComponentSlot, prefix: &str) -> CompletionItem {
         .props_type
         .as_ref()
         .and_then(|ty| extract_slot_prop_names(ty));
-    let value_snippet = match destructure {
+    let value_snippet = match destructure.as_ref() {
         Some(names) if !names.is_empty() => {
             // Pre-populate the destructure with the resolved slot prop names
             // so the user gets `{ row, col }` rather than just `="$1"`.
@@ -401,10 +397,7 @@ fn slot_completion_item(slot: &ComponentSlot, prefix: &str) -> CompletionItem {
         insert_text: Some(insert_text),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
         documentation: slot.props_type.as_ref().map(|props| {
-            Documentation::MarkupContent(MarkupContent {
-                kind: MarkupKind::Markdown,
-                value: format!("**Slot** `{}`\n\n```typescript\n{}\n```", slot.name, props),
-            })
+            component_docs::slot_documentation(&slot.name, props, destructure.as_deref())
         }),
         sort_text: Some(format!("00-slot-{}", slot.name)),
         ..Default::default()

--- a/crates/vize_maestro/src/ide/completion/template/directives.rs
+++ b/crates/vize_maestro/src/ide/completion/template/directives.rs
@@ -1,12 +1,12 @@
 //! Vue / petite-vue / Vize directive completions.
 
 use tower_lsp::lsp_types::{
-    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, Documentation,
-    InsertTextFormat, MarkupContent, MarkupKind,
+    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, InsertTextFormat,
 };
 
 use crate::ide::IdeContext;
 use crate::ide::completion::items;
+use crate::ide::markup::{self, Markdown};
 
 /// Vue directive completions.
 pub(crate) fn directive_completions() -> Vec<CompletionItem> {
@@ -64,12 +64,21 @@ fn event_item(label: &str, detail: &str) -> CompletionItem {
         }),
         insert_text: Some(format!("{label}=\"$1\"")),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
-        documentation: Some(Documentation::MarkupContent(MarkupContent {
-            kind: MarkupKind::Markdown,
-            value: format!(
-                "**`{label}`**\n\nVue event listener shorthand.\n\n```vue\n<template>\n  <button {label}=\"handler\"></button>\n</template>\n```\n\n[Vue event handling](https://vuejs.org/guide/essentials/event-handling.html)"
-            ),
-        })),
+        documentation: Some(
+            Markdown::new()
+                .title(&format!("`{label}`"))
+                .meta("Vue event listener")
+                .paragraph("Shorthand for `v-on:event`. The handler runs in component scope.")
+                .example(
+                    "vue",
+                    &format!("<template>\n  <button {label}=\"handler\"></button>\n</template>"),
+                )
+                .docs(
+                    "Vue event handling",
+                    "https://vuejs.org/guide/essentials/event-handling.html",
+                )
+                .into_documentation(),
+        ),
         ..Default::default()
     }
 }
@@ -120,19 +129,22 @@ fn petite_vue_item(
     snippet: &str,
     documentation: &str,
 ) -> CompletionItem {
+    let example = markup::snippet_for_docs(snippet);
     CompletionItem {
         label: label.to_string(),
         kind: Some(CompletionItemKind::KEYWORD),
         detail: Some(detail.to_string()),
         insert_text: Some(snippet.to_string()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
-        documentation: Some(Documentation::MarkupContent(MarkupContent {
-            kind: MarkupKind::Markdown,
-            value: format!(
-                "**{}**\n\n{}\n\n[petite-vue](https://github.com/vuejs/petite-vue)",
-                label, documentation
-            ),
-        })),
+        documentation: Some(
+            Markdown::new()
+                .title(label)
+                .meta("petite-vue directive")
+                .paragraph(documentation)
+                .example("html", &format!("<div {example}></div>"))
+                .docs("petite-vue", "https://github.com/vuejs/petite-vue")
+                .into_documentation(),
+        ),
         ..Default::default()
     }
 }

--- a/crates/vize_maestro/src/ide/completion/template/native_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/template/native_tests.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use tower_lsp::lsp_types::{CompletionResponse, Url};
+use tower_lsp::lsp_types::{CompletionResponse, Documentation, Url};
 
 use crate::ide::{CompletionService, IdeContext};
 use crate::server::ServerState;
@@ -21,7 +21,11 @@ const count = ref(0)
     let (state, uri) = state_with_document("NativeAttributeCompletion.vue", source);
     let offset = source.find("    \n  >").unwrap() + "    ".len();
     let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+    let items = completion_items(CompletionService::complete(&ctx).unwrap());
+    let labels = items
+        .iter()
+        .map(|item| item.label.clone())
+        .collect::<Vec<_>>();
 
     assert!(has_label(&labels, "class"), "{labels:?}");
     assert!(has_label(&labels, "type"), "{labels:?}");
@@ -30,6 +34,18 @@ const count = ref(0)
     assert!(!has_label(&labels, "Transition"), "{labels:?}");
     assert!(!has_label(&labels, "vfor"), "{labels:?}");
     assert!(!has_label(&labels, "count"), "{labels:?}");
+    let class_doc = markdown_doc(
+        &items
+            .iter()
+            .find(|item| item.label == "class")
+            .unwrap()
+            .documentation,
+    );
+    assert!(class_doc.contains("```vue"), "got {class_doc:?}");
+    assert!(
+        class_doc.contains("Vue template syntax"),
+        "got {class_doc:?}"
+    );
 }
 
 #[test]
@@ -76,17 +92,28 @@ const count = ref(0)
 }
 
 fn completion_labels(response: CompletionResponse) -> Vec<String> {
+    completion_items(response)
+        .into_iter()
+        .map(|item| item.label)
+        .collect()
+}
+
+fn completion_items(response: CompletionResponse) -> Vec<tower_lsp::lsp_types::CompletionItem> {
     match response {
         CompletionResponse::Array(items) => items,
         CompletionResponse::List(list) => list.items,
     }
-    .into_iter()
-    .map(|item| item.label)
-    .collect()
 }
 
 fn has_label(labels: &[String], expected: &str) -> bool {
     labels.iter().any(|label| label == expected)
+}
+
+fn markdown_doc(doc: &Option<Documentation>) -> &str {
+    match doc.as_ref().expect("completion should include docs") {
+        Documentation::MarkupContent(content) => &content.value,
+        Documentation::String(value) => value,
+    }
 }
 
 fn state_with_document(name: &str, source: &str) -> (ServerState, Url) {

--- a/crates/vize_maestro/src/ide/completion/template_event_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/template_event_tests.rs
@@ -6,7 +6,9 @@
 
 use super::CompletionService;
 use crate::{ide::IdeContext, server::ServerState};
-use tower_lsp::lsp_types::{CompletionItemKind, CompletionResponse, CompletionTextEdit, Url};
+use tower_lsp::lsp_types::{
+    CompletionItemKind, CompletionResponse, CompletionTextEdit, Documentation, Url,
+};
 
 #[test]
 fn event_completion_replaces_typed_shorthand_prefix() {
@@ -25,6 +27,9 @@ fn event_completion_replaces_typed_shorthand_prefix() {
         .find(|item| item.label == "@click")
         .expect("@click completion should be present for @c");
     assert_eq!(click.kind, Some(CompletionItemKind::EVENT));
+    let doc = markdown_doc(&click.documentation);
+    assert!(doc.contains("```vue"), "got {doc:?}");
+    assert!(doc.contains("Vue event handling"), "got {doc:?}");
     assert_eq!(click.insert_text, None);
 
     let edit = match click
@@ -73,4 +78,11 @@ fn completion_items(response: CompletionResponse) -> Vec<tower_lsp::lsp_types::C
 
 fn has_label(labels: &[String], expected: &str) -> bool {
     labels.iter().any(|label| label == expected)
+}
+
+fn markdown_doc(doc: &Option<Documentation>) -> &str {
+    match doc.as_ref().expect("completion should include docs") {
+        Documentation::MarkupContent(content) => &content.value,
+        Documentation::String(value) => value,
+    }
 }

--- a/crates/vize_maestro/src/ide/hover/builder.rs
+++ b/crates/vize_maestro/src/ide/hover/builder.rs
@@ -1,4 +1,6 @@
-use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Range};
+use tower_lsp::lsp_types::{Hover, HoverContents, Range};
+
+use crate::ide::markup;
 
 /// Hover content builder for creating rich hover information.
 pub struct HoverBuilder {
@@ -30,8 +32,17 @@ impl HoverBuilder {
     /// Add a code block.
     #[allow(clippy::disallowed_macros)]
     pub fn code(mut self, language: &str, code: &str) -> Self {
-        self.sections
-            .push(format!("```{}\n{}\n```", language, code));
+        self.sections.push(markup::code_block(language, code));
+        self
+    }
+
+    /// Add a syntax-highlightable example block.
+    #[allow(clippy::disallowed_macros)]
+    pub fn example(mut self, language: &str, code: &str) -> Self {
+        self.sections.push(format!(
+            "**Example**\n\n{}",
+            markup::code_block(language, code)
+        ));
         self
     }
 
@@ -67,17 +78,22 @@ impl HoverBuilder {
     /// Add a documentation link.
     #[allow(clippy::disallowed_macros)]
     pub fn link(mut self, text: &str, url: &str) -> Self {
-        self.sections.push(format!("[{}]({})", text, url));
+        self.sections.push(markup::link(text, url));
+        self
+    }
+
+    /// Add a named documentation link section.
+    #[allow(clippy::disallowed_macros)]
+    pub fn docs(mut self, text: &str, url: &str) -> Self {
+        self.sections
+            .push(format!("**Docs**\n\n{}", markup::link(text, url)));
         self
     }
 
     /// Build the hover.
     pub fn build(self) -> Hover {
         Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                value: self.sections.join("\n\n"),
-            }),
+            contents: HoverContents::Markup(markup::markdown_content(self.sections.join("\n\n"))),
             range: None,
         }
     }
@@ -85,10 +101,7 @@ impl HoverBuilder {
     /// Build the hover with a range.
     pub fn build_with_range(self, range: Range) -> Hover {
         Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                value: self.sections.join("\n\n"),
-            }),
+            contents: HoverContents::Markup(markup::markdown_content(self.sections.join("\n\n"))),
             range: Some(range),
         }
     }

--- a/crates/vize_maestro/src/ide/hover/component_prop.rs
+++ b/crates/vize_maestro/src/ide/hover/component_prop.rs
@@ -28,13 +28,13 @@ pub(super) fn hover_attribute(ctx: &IdeContext<'_>) -> Option<Hover> {
             .meta("Component prop")
             .code("typescript", &signature)
             .section("Requirement", requirement)
-            .code(
+            .example(
                 "vue",
                 &format!(
                     "<{component_name} {attr_name}=\"...\" />\n<{component_name} :{attr_name}=\"value\" />"
                 ),
             )
-            .link(
+            .docs(
                 "Vue Component Props",
                 "https://vuejs.org/guide/components/props.html",
             );
@@ -71,6 +71,11 @@ pub(super) fn hover_attribute(ctx: &IdeContext<'_>) -> Option<Hover> {
             .title(&prop_name)
             .meta("Component prop")
             .code("typescript", &signature)
+            .example("vue", &format!("<{component_name} {attr_name}=\"...\" />"))
+            .docs(
+                "Vue Component Props",
+                "https://vuejs.org/guide/components/props.html",
+            )
             .build(),
     )
 }
@@ -146,6 +151,8 @@ import Child from './Child.vue'
             "got {value:?}"
         );
         assert!(value.contains("Vue Component Props"), "got {value:?}");
+        assert!(value.contains("**Example**"), "got {value:?}");
+        assert!(value.contains("```vue"), "got {value:?}");
     }
 
     fn hover_markdown(hover: tower_lsp::lsp_types::Hover) -> String {

--- a/crates/vize_maestro/src/ide/hover/html.rs
+++ b/crates/vize_maestro/src/ide/hover/html.rs
@@ -23,6 +23,7 @@ impl HoverService {
         } else {
             "DOM reflected attribute"
         };
+        let example = native_attribute_example(&tag_name, &attr_name, info.is_boolean);
 
         Some(
             HoverBuilder::new()
@@ -40,7 +41,8 @@ impl HoverService {
                         "Component prop lookup is skipped because the enclosing tag is a native element.",
                     ],
                 )
-                .link("MDN reference", &info.documentation_url)
+                .example("vue", &example)
+                .docs("MDN reference", &info.documentation_url)
                 .build(),
         )
     }
@@ -70,7 +72,8 @@ impl HoverService {
                         "Component resolution is skipped for this tag because it is part of the platform DOM surface.",
                     ],
                 )
-                .link("MDN reference", &info.documentation_url)
+                .example("vue", &native_tag_example(&tag_name))
+                .docs("MDN reference", &info.documentation_url)
                 .build(),
         )
     }
@@ -131,6 +134,18 @@ impl HoverService {
     }
 }
 
+fn native_attribute_example(tag_name: &str, attr_name: &str, is_boolean: bool) -> String {
+    if is_boolean {
+        format!("<template>\n  <{tag_name} {attr_name}>...</{tag_name}>\n</template>")
+    } else {
+        format!("<template>\n  <{tag_name} {attr_name}=\"...\">...</{tag_name}>\n</template>")
+    }
+}
+
+fn native_tag_example(tag_name: &str) -> String {
+    format!("<template>\n  <{tag_name}>...</{tag_name}>\n</template>")
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -159,6 +174,8 @@ mod tests {
             "got {value:?}"
         );
         assert!(value.contains("MDN reference"), "got {value:?}");
+        assert!(value.contains("**Example**"), "got {value:?}");
+        assert!(value.contains("```vue"), "got {value:?}");
     }
 
     #[test]
@@ -181,6 +198,8 @@ mod tests {
             "got {value:?}"
         );
         assert!(value.contains("Boolean HTML attribute"), "got {value:?}");
+        assert!(value.contains("**Example**"), "got {value:?}");
+        assert!(value.contains("```vue"), "got {value:?}");
     }
 
     #[test]

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -137,7 +137,7 @@ impl HoverService {
                 HoverBuilder::new()
                     .title(&title)
                     .meta("Vue event listener")
-                    .code("vue", &example)
+                    .example("vue", &example)
                     .description(
                         "Attaches a DOM or component event listener. The handler expression is evaluated in component scope.",
                     )
@@ -148,7 +148,7 @@ impl HoverService {
                             "Event modifiers such as `.stop`, `.prevent`, and key modifiers are compiled by Vue.",
                         ],
                     )
-                    .link(
+                    .docs(
                         "Vue Event Handling",
                         "https://vuejs.org/guide/essentials/event-handling.html",
                     )
@@ -161,7 +161,7 @@ impl HoverService {
                 HoverBuilder::new()
                     .title("v-bind")
                     .meta("Vue attribute / prop binding")
-                    .code("vue", ":prop=\"expression\"")
+                    .example("vue", ":prop=\"expression\"")
                     .description(
                         "Binds an attribute or component prop to a JavaScript expression in template scope.",
                     )
@@ -172,7 +172,7 @@ impl HoverService {
                             "Component bindings resolve to props when the target is a component.",
                         ],
                     )
-                    .link(
+                    .docs(
                         "Vue v-bind",
                         "https://vuejs.org/api/built-in-directives.html#v-bind",
                     )
@@ -362,7 +362,7 @@ impl HoverService {
                         "Directive expressions are evaluated in component scope.",
                     ],
                 )
-                .link(
+                .docs(
                     "Vue Built-in Directives",
                     "https://vuejs.org/api/built-in-directives.html",
                 )

--- a/crates/vize_maestro/src/ide/markup.rs
+++ b/crates/vize_maestro/src/ide/markup.rs
@@ -1,0 +1,150 @@
+//! Markdown helpers for LSP hover and completion documentation.
+
+use tower_lsp::lsp_types::{Documentation, MarkupContent, MarkupKind};
+
+#[derive(Default)]
+pub(crate) struct Markdown {
+    sections: Vec<String>,
+}
+
+impl Markdown {
+    pub(crate) fn new() -> Self {
+        Self {
+            sections: Vec::new(),
+        }
+    }
+
+    #[allow(clippy::disallowed_macros)]
+    pub(crate) fn title(mut self, title: &str) -> Self {
+        self.sections.push(format!("**{}**", title));
+        self
+    }
+
+    #[allow(clippy::disallowed_macros)]
+    pub(crate) fn meta(mut self, text: &str) -> Self {
+        self.sections.push(format!("_{}_", text));
+        self
+    }
+
+    pub(crate) fn paragraph(mut self, text: &str) -> Self {
+        self.sections.push(text.to_string());
+        self
+    }
+
+    pub(crate) fn code(mut self, language: &str, source: &str) -> Self {
+        self.sections.push(code_block(language, source));
+        self
+    }
+
+    #[allow(clippy::disallowed_macros)]
+    pub(crate) fn section(mut self, heading: &str, body: &str) -> Self {
+        self.sections.push(format!("**{}**\n\n{}", heading, body));
+        self
+    }
+
+    pub(crate) fn example(self, language: &str, source: &str) -> Self {
+        self.section("Example", &code_block(language, source))
+    }
+
+    pub(crate) fn docs(self, label: &str, url: &str) -> Self {
+        self.section("Docs", &link(label, url))
+    }
+
+    pub(crate) fn build(self) -> String {
+        self.sections.join("\n\n")
+    }
+
+    pub(crate) fn into_documentation(self) -> Documentation {
+        markdown_documentation(self.build())
+    }
+}
+
+#[allow(clippy::disallowed_macros)]
+pub(crate) fn code_block(language: &str, source: &str) -> String {
+    format!("```{}\n{}\n```", language, source.trim_end())
+}
+
+#[allow(clippy::disallowed_macros)]
+pub(crate) fn link(label: &str, url: &str) -> String {
+    format!("[{}]({})", label, url)
+}
+
+pub(crate) fn markdown_content(value: String) -> MarkupContent {
+    MarkupContent {
+        kind: MarkupKind::Markdown,
+        value,
+    }
+}
+
+pub(crate) fn markdown_documentation(value: String) -> Documentation {
+    Documentation::MarkupContent(markdown_content(value))
+}
+
+pub(crate) fn snippet_for_docs(snippet: &str) -> String {
+    let mut output = String::with_capacity(snippet.len());
+    let mut cursor = 0;
+
+    while cursor < snippet.len() {
+        let rest = &snippet[cursor..];
+        if let Some(stripped) = rest.strip_prefix('$')
+            && let Some(ch) = stripped.chars().next()
+        {
+            if ch.is_ascii_digit() {
+                if ch != '0' {
+                    output.push_str("...");
+                }
+                cursor += 1 + ch.len_utf8();
+                continue;
+            }
+            if ch == '{'
+                && let Some(end) = stripped.find('}')
+            {
+                let placeholder = &stripped[1..end];
+                if let Some((_, default)) = placeholder.split_once(':') {
+                    output.push_str(default);
+                } else if !placeholder.starts_with('0') {
+                    output.push_str("...");
+                }
+                cursor += 1 + end + 1;
+                continue;
+            }
+        }
+
+        let ch = rest.chars().next().expect("cursor is inside snippet");
+        output.push(ch);
+        cursor += ch.len_utf8();
+    }
+
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        "...".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Markdown, snippet_for_docs};
+
+    #[test]
+    fn snippet_for_docs_keeps_examples_readable() {
+        assert_eq!(
+            snippet_for_docs(r#"v-for="$1 in $2" :key="${3:item.id}""#),
+            r#"v-for="... in ..." :key="item.id""#
+        );
+    }
+
+    #[test]
+    fn markdown_builder_emits_fenced_examples_and_docs() {
+        let doc = Markdown::new()
+            .title("v-if")
+            .example("vue", "<div v-if=\"ready\" />")
+            .docs("Vue built-in directives", "https://vuejs.org/api/")
+            .build();
+
+        assert!(doc.contains("**Example**"));
+        assert!(doc.contains("```vue"));
+        assert!(doc.contains("**Docs**"));
+    }
+}

--- a/tests/tooling/lsp-authoring-core.test.ts
+++ b/tests/tooling/lsp-authoring-core.test.ts
@@ -90,6 +90,9 @@ const items = [1, 2]
     assert.match(clickHoverText, /Vue event listener/);
     assert.match(clickHoverText, /@click="handler"/);
     assert.match(clickHoverText, /\$event/);
+    assert.match(clickHoverText, /\*\*Example\*\*/);
+    assert.match(clickHoverText, /```vue/);
+    assert.match(clickHoverText, /Vue Event Handling/);
 
     const countUsageStart = source.lastIndexOf("count }}");
     const countUsagePosition = offsetToPosition(source, countUsageStart + "count".length);

--- a/tests/tooling/lsp-editor-production-gates.test.ts
+++ b/tests/tooling/lsp-editor-production-gates.test.ts
@@ -162,6 +162,8 @@ const isReady = ref(false)
       assert.match(disabledText, /disabled on <button>/);
       assert.match(disabledText, /HTML attribute/);
       assert.match(disabledText, /MDN reference/);
+      assert.match(disabledText, /\*\*Example\*\*/);
+      assert.match(disabledText, /```vue/);
 
       const clickOffset = source.indexOf("@click") + "@click".length;
       const clickHover = (await session.request("textDocument/hover", {
@@ -171,6 +173,8 @@ const isReady = ref(false)
       const clickText = hoverToText(clickHover);
       assert.match(clickText, /Vue event listener/);
       assert.match(clickText, /\$event/);
+      assert.match(clickText, /\*\*Example\*\*/);
+      assert.match(clickText, /```vue/);
 
       const interpolationOffset = source.lastIndexOf("count }}") + "count".length;
       const bindingHover = (await session.request("textDocument/hover", {


### PR DESCRIPTION
## Summary
- Add shared Markdown helpers for LSP hover and completion documentation.
- Enrich Vue/template/completion docs with fenced examples, docs sections, and syntax-highlightable code blocks.
- Add coverage for richer hover and completion Markdown in Rust and LSP smoke tests.

## Validation
- cargo fmt --check
- git diff --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo test -p vize_maestro
- cargo clippy -p vize_maestro -- -D warnings
- cargo build -p vize
- node --test tests/tooling/lsp-authoring-core.test.ts tests/tooling/lsp-editor-production-gates.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786137114&installation_id=136613492&pr_number=2739&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2739&signature=1d0bcbe020aad65df2069fc0ade3e13eb49138659e0671b8ac9e176d6c532a36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced hover and completion details with richer Markdown formatting, including clearer examples, code blocks, and documentation links.
  * Added more informative Vue component prop and slot descriptions in autocomplete results.

* **Bug Fixes**
  * Improved the consistency and readability of hover and completion content across Vue templates, directives, HTML attributes, and events.
  * Expanded validation to ensure documentation appears correctly in editor suggestions and hover tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->