### PR TITLE
fix: enable Vue JSX typing for experimental TSX

### DIFF
--- a/crates/vize/tests/check_tsx_intrinsic_elements_cli.rs
+++ b/crates/vize/tests/check_tsx_intrinsic_elements_cli.rs
@@ -1,0 +1,162 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(cstr!("check-tsx-intrinsic-{name}-{}", std::process::id()).as_str())
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn workspace_vue_package() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.join("node_modules/vue"),
+        root.join("tests/node_modules/vue"),
+        root.join("playground/node_modules/vue"),
+        root.join("examples/vite-musea/node_modules/vue"),
+        root.join("examples/jsx-tsx/node_modules/vue"),
+        root.join("npm/framework/nuxt/node_modules/vue"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn link_workspace_vue(project_root: &Path) -> std::io::Result<()> {
+    let vue_package = workspace_vue_package().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace Vue package missing",
+        )
+    })?;
+    let workspace_node_modules = vue_package.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace Vue package has no node_modules parent",
+        )
+    })?;
+    let target = project_root.join("node_modules");
+    std::fs::create_dir_all(&target)?;
+    symlink_path(&vue_package, &target.join("vue"))?;
+    let vue_namespace = workspace_node_modules.join("@vue");
+    if vue_namespace.exists() {
+        symlink_path(&vue_namespace, &target.join("@vue"))?;
+    }
+    Ok(())
+}
+
+fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
+    if target.is_symlink() || target.is_file() {
+        std::fs::remove_file(target)?;
+    } else if target.exists() {
+        std::fs::remove_dir_all(target)?;
+    }
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(source, target)
+    }
+}
+
+#[test]
+fn check_tsx_intrinsic_elements_with_experimental_jsx_vapor() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("jsx-vapor");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    link_workspace_vue(&project_root).unwrap();
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        r#"{ "experimentals": { "jsxVapor": {} } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/Standalone.tsx"),
+        r#"export const Example = () => <div class="story-shell">Preview</div>;
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "src/Standalone.tsx",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        std::str::from_utf8(&output.stderr).unwrap_or("<non-utf8 stderr>")
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    assert!(
+        project_root
+            .join("node_modules/.vize/canon/src/Standalone.tsx.ts")
+            .exists()
+    );
+    let helpers =
+        std::fs::read_to_string(project_root.join("node_modules/.vize/canon/__vize_helpers.d.ts"))
+            .unwrap();
+    assert!(helpers.contains("/// <reference types=\"vue/jsx\" />"));
+    let generated_tsconfig =
+        std::fs::read_to_string(project_root.join("node_modules/.vize/canon/tsconfig.json"))
+            .unwrap();
+    assert!(generated_tsconfig.contains(r#""jsxImportSource": "vue""#));
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/virtual_project/tests/tsconfig_native_options.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/tsconfig_native_options.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use super::{VirtualProject, unique_case_dir};
+use super::{SHARED_HELPERS_FILE, VirtualProject, unique_case_dir};
 
 #[test]
 fn materialized_tsconfig_normalizes_native_removed_options() {
@@ -50,6 +50,63 @@ fn materialized_tsconfig_normalizes_native_removed_options() {
         serde_json::json!(false)
     );
     assert!(!compiler_options.contains_key("downlevelIteration"));
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn materialized_tsconfig_adds_vue_jsx_defaults_for_lowered_tsx() {
+    let case_dir = unique_case_dir("tsconfig-lowered-tsx-jsx");
+    let _ = fs::remove_dir_all(&case_dir);
+    let src_dir = case_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    let tsx_path = src_dir.join("Comp.tsx");
+    fs::write(
+        &tsx_path,
+        "export const Comp = () => <button class=\"primary\">Save</button>;\n",
+    )
+    .unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.set_tsconfig_path(Some(case_dir.join("tsconfig.json")));
+    project.set_jsx_typecheck(true);
+    project.register_path(&tsx_path).unwrap();
+    project.materialize().unwrap();
+
+    let tsconfig_path = project.virtual_root().join("tsconfig.json");
+    let value: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
+    let compiler_options = value["compilerOptions"].as_object().unwrap();
+
+    assert_eq!(
+        compiler_options["jsx"],
+        serde_json::json!("preserve"),
+        "{value:#}"
+    );
+    assert_eq!(
+        compiler_options["jsxImportSource"],
+        serde_json::json!("vue"),
+        "{value:#}"
+    );
+    let helpers = fs::read_to_string(project.virtual_root().join(SHARED_HELPERS_FILE)).unwrap();
+    assert!(
+        helpers.contains("/// <reference types=\"vue/jsx\" />"),
+        "{helpers}"
+    );
 
     let _ = fs::remove_dir_all(&case_dir);
 }

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
@@ -123,13 +123,9 @@ impl VirtualProject {
         let mut config = Map::new();
         let original_tsconfig = self.resolved_tsconfig_path();
 
-        // The effective compiler options are flattened into the generated
-        // config instead of `extends`-ing the user's tsconfig. Corsa would
-        // otherwise re-parse the whole original chain and fail the entire CLI
-        // run on config-file diagnostics vize already compensates for (e.g.
-        // TS5102 for the removed `baseUrl` the mirror strips and re-anchors),
-        // and the real tree's `files`/`include` lists must not leak into the
-        // virtual program anyway.
+        // Flatten the effective compiler options instead of `extends`-ing the
+        // user's tsconfig, so Corsa does not re-parse the source chain or inherit
+        // real-tree `files`/`include` entries into the virtual program.
         let mut compiler_options = self.load_compiler_options(original_tsconfig.as_deref())?;
 
         // Capture the original path-alias map and type roots before stripping
@@ -229,7 +225,11 @@ impl VirtualProject {
             file.virtual_path
                 .file_name()
                 .and_then(|name| name.to_str())
-                .is_some_and(|name| name.ends_with(".vue.tsx"))
+                .is_some_and(|name| {
+                    name.ends_with(".vue.tsx")
+                        || name.ends_with(".tsx.ts")
+                        || name.ends_with(".jsx.ts")
+                })
         })
     }
 

--- a/crates/vize_carton/src/config/loader/experimental_tests.rs
+++ b/crates/vize_carton/src/config/loader/experimental_tests.rs
@@ -25,6 +25,7 @@ fn load_config_reads_experimentals() {
     assert!(loaded.features.experimental_in_tag_comments);
     assert!(loaded.features.experimental_patterned_template);
     assert!(loaded.features.experimental_server_script);
+    assert!(loaded.features.type_checker_jsx_typecheck);
     assert_eq!(loaded.features.jsx_mode, Some(JsxMode::Vapor));
     assert_eq!(load_compiler_vapor(Some(&config_path)), Some(true));
 }
@@ -52,6 +53,7 @@ fn load_config_accepts_experimental_aliases_and_false_switches() {
     assert!(loaded.features.experimental_in_tag_comments);
     assert!(!loaded.features.experimental_patterned_template);
     assert!(!loaded.features.experimental_server_script);
+    assert!(loaded.features.type_checker_jsx_typecheck);
     assert_eq!(loaded.features.jsx_mode, Some(JsxMode::Vdom));
     assert_eq!(load_compiler_vapor(Some(&config_path)), Some(false));
 }

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -83,9 +83,9 @@ pub struct ConfigFeatureFlags {
     pub type_checker_legacy_vue2: bool,
     /// Opt-in type-checking of `.jsx`/`.tsx` Vue components (#1497). Default-off
     /// so mixed Vue/React repositories do not accidentally route React `.tsx`
-    /// through the Vue JSX checker. Set `typeChecker.jsxTypecheck: true` to route
-    /// `.jsx`/`.tsx` through the Vize JSX virtual-TS path instead of the verbatim
-    /// passthrough.
+    /// through the Vue JSX checker. Set `typeChecker.jsxTypecheck: true` or
+    /// opt into `experimentals.jsxVapor` to route `.jsx`/`.tsx` through the
+    /// Vize JSX virtual-TS path instead of the verbatim passthrough.
     pub type_checker_jsx_typecheck: bool,
     pub language_server_legacy_vue2: Option<bool>,
     /// Dialect selected by `vue.version`; `None` when the key is absent
@@ -264,7 +264,8 @@ impl RawVizeConfig {
         // Default-on (matches vue-tsc); explicit `false` opts out.
         let type_checker_options_api = raw_type_checker.options_api.unwrap_or(true);
         let type_checker_legacy_vue2 = raw_type_checker.legacy_vue2;
-        let type_checker_jsx_typecheck = raw_type_checker.jsx_typecheck;
+        let experimental_jsx_vapor = experimentals.jsx_vapor_enabled();
+        let type_checker_jsx_typecheck = raw_type_checker.jsx_typecheck || experimental_jsx_vapor;
         let mut type_checker = raw_type_checker.config;
         if let Some(legacy_check) = legacy_check {
             if type_checker.globals_file.is_none() {
@@ -295,9 +296,9 @@ impl RawVizeConfig {
             vue_version: vue.version.or(compiler.compatibility.vue_version),
             jsx_mode: compiler
                 .jsx_mode
-                .or_else(|| experimentals.jsx_vapor_enabled().then_some(JsxMode::Vapor)),
+                .or_else(|| experimental_jsx_vapor.then_some(JsxMode::Vapor)),
             experimental_vapor: experimentals.vapor_enabled(),
-            experimental_jsx_vapor: experimentals.jsx_vapor_enabled(),
+            experimental_jsx_vapor,
             experimental_in_tag_comments: experimentals.in_tag_comments_enabled(),
             experimental_patterned_template: experimentals.patterned_template_enabled(),
             experimental_server_script: experimentals.server_script_enabled(),


### PR DESCRIPTION
## Summary

- Make `experimentals.jsxVapor` opt into the Vue JSX/TSX type-checking path.
- Add Vue JSX compiler defaults and the `vue/jsx` helper reference for lowered standalone `.tsx` / `.jsx` virtual files.
- Cover the TS7026-prone standalone TSX case with a CLI regression test.

## Validation

- `cargo test -p vize_carton load_config_`
- `cargo test -p vize_canon materialized_tsconfig_adds_vue_jsx_defaults_for_lowered_tsx`
- `cargo test -p vize_canon tsconfig_native_options`
- `cargo test -p vize --test check_tsx_intrinsic_elements_cli check_tsx_intrinsic_elements_with_experimental_jsx_vapor`
- `cargo test -p vize --test check_tsx_sfc_attrs_cli`
- `cargo test -p vize_maestro jsx_typecheck_`
- `cargo fmt --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786137606&installation_id=136613492&pr_number=2740&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2740&signature=51be2fc30f3d15d44de5da6c9095282fa930466f9bf6c90fab9dc40f95577669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled JSX/TSX type-checking when the experimental `jsxVapor` option is turned on.
  * Generated projects now include Vue JSX settings and helper type references when needed.

* **Bug Fixes**
  * Improved detection for additional TSX/JSX file patterns so Vue JSX options are applied more consistently.
  * Added test coverage for CLI and virtual project output to verify the generated configuration and helper files are correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->