### PR TITLE
test: expand typechecker and LSP edge coverage

### DIFF
--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -220,7 +220,7 @@ pub(super) fn resolve_import_base(
     }
 
     // 2. A `.js`/`.mjs`/`.cjs` specifier resolving to its TS sibling.
-    if let Some(rewritten) = rewrite_js_to_ts(base, canonical_paths) {
+    if let Some(rewritten) = rewrite_js_to_ts(base, canonical_paths, include_jsx) {
         return Some(rewritten);
     }
 
@@ -243,14 +243,25 @@ pub(super) fn resolve_import_base(
     None
 }
 
-fn rewrite_js_to_ts(base: &Path, canonical_paths: &mut CanonicalPathCache) -> Option<PathBuf> {
+fn rewrite_js_to_ts(
+    base: &Path,
+    canonical_paths: &mut CanonicalPathCache,
+    include_jsx: bool,
+) -> Option<PathBuf> {
     let name = base.file_name()?.to_str()?;
     let (stem, extensions): (&str, &[&str]) = if let Some(stem) = name.strip_suffix(".mjs") {
         (stem, &[".mts"])
     } else if let Some(stem) = name.strip_suffix(".cjs") {
         (stem, &[".cts"])
     } else if let Some(stem) = name.strip_suffix(".js") {
-        (stem, &[".ts", ".tsx"])
+        (
+            stem,
+            if include_jsx {
+                &[".ts", ".tsx"]
+            } else {
+                &[".ts"]
+            },
+        )
     } else {
         return None;
     };

--- a/crates/vize/src/commands/check/imports_tests.rs
+++ b/crates/vize/src/commands/check/imports_tests.rs
@@ -173,6 +173,44 @@ fn module_js_specifiers_prefer_module_source_extensions() {
 }
 
 #[test]
+fn js_specifiers_can_follow_tsx_when_jsx_typecheck_is_enabled() {
+    let root = std::env::temp_dir().join(cstr!("vize-imports-js-to-tsx-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+
+    let entry = write(
+        &root,
+        "src/entry.ts",
+        "import { Panel } from './Panel.js'\nvoid Panel\n",
+    );
+    let panel = write(
+        &root,
+        "src/Panel.tsx",
+        "export const Panel = () => <section />\n",
+    );
+
+    let disabled = collect_transitive_local_imports(
+        std::slice::from_ref(&entry),
+        &root,
+        &mut CanonicalPathCache::default(),
+        false,
+        None,
+    );
+    let enabled = collect_transitive_local_imports(
+        &[entry],
+        &root,
+        &mut CanonicalPathCache::default(),
+        true,
+        None,
+    );
+
+    assert_eq!(disabled, Vec::<PathBuf>::new());
+    assert_eq!(enabled, vec![canonicalize_non_verbatim(&panel)]);
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
 fn collects_only_non_relative_imports_that_need_virtual_rewrites() {
     let root = std::env::temp_dir().join(cstr!("vize-imports-matrix-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&root);

--- a/crates/vize/src/commands/check/tsconfig_inputs/ambient/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/ambient/tests.rs
@@ -225,6 +225,59 @@ fn ambient_collection_loads_compiler_options_module_declaration_packages() {
 }
 
 #[test]
+fn ambient_collection_keeps_vue_plugin_globals_from_exported_type_package() {
+    let root = unique_case_dir("compiler-options-vue-plugin-types");
+    let _ = std::fs::remove_dir_all(&root);
+    write(&root, "src/App.vue", "<template><VpButton /></template>\n");
+    write(
+        &root,
+        "node_modules/vue-plugin/package.json",
+        r#"{
+  "exports": {
+    "./components": {
+      "types": "./components.d.ts",
+      "import": "./components.mjs"
+    }
+  }
+}"#,
+    );
+    write(
+        &root,
+        "node_modules/vue-plugin/components.d.ts",
+        "export {};\ndeclare module \"vue\" { export interface GlobalComponents { VpButton: unknown } }\n",
+    );
+    write(
+        &root,
+        "node_modules/vue-plugin/components.mjs",
+        "export {}\n",
+    );
+    write(
+        &root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "types": ["vue-plugin/components"]
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+
+    let project_root = root.canonicalize().unwrap();
+    let files = collect_ambient_declaration_files(
+        &project_root,
+        Some(&project_root.join("tsconfig.json")),
+        &mut TsconfigInputCache::default(),
+    );
+
+    assert!(
+        relative_paths(&project_root, &files)
+            .contains(&"node_modules/vue-plugin/components.d.ts".to_string()),
+        "{files:?}"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
 fn ambient_collection_resolves_compiler_options_types_from_tsconfig_dir() {
     let root = unique_case_dir("compiler-options-types-nested");
     let _ = std::fs::remove_dir_all(&root);

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
@@ -7,12 +7,12 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use vize_carton::{cstr, path::canonicalize_non_verbatim};
 mod codegen;
+mod tsx_owner;
 // Each call uses a fresh run-scoped cache, mirroring how an actual `vize
 // check` run constructs one `TsconfigInputCache` per invocation.
 fn collect_default_check_files(project_root: &Path, tsconfig_path: Option<&Path>) -> Vec<PathBuf> {
     collect_default_check_files_with_jsx(project_root, tsconfig_path, false)
 }
-
 fn collect_default_check_files_with_jsx(
     project_root: &Path,
     tsconfig_path: Option<&Path>,

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests/tsx_owner.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests/tsx_owner.rs
@@ -1,0 +1,42 @@
+use super::unique_case_dir;
+use std::fs;
+
+#[test]
+fn tsconfig_for_files_can_use_referenced_tsx_owner_when_jsx_is_enabled() {
+    let case_dir = unique_case_dir("tsconfig-reference-tsx-owner");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("packages/ui/src")).unwrap();
+    let widget = case_dir.join("packages/ui/src/Widget.tsx");
+    fs::write(&widget, "export const Widget = () => <button />").unwrap();
+    let root = case_dir.join("tsconfig.json");
+    fs::write(
+        &root,
+        r#"{
+  "files": [],
+  "references": [{ "path": "./packages/ui/tsconfig.json" }]
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("packages/ui/tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "vue"
+  },
+  "include": ["src/**/*.tsx"]
+}"#,
+    )
+    .unwrap();
+
+    let owner = super::super::resolve_tsconfig_for_files(
+        Some(&root),
+        &[widget],
+        true,
+        &mut super::TsconfigInputCache::default(),
+    );
+
+    assert_eq!(owner, Some(case_dir.join("packages/ui/tsconfig.json")));
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize/src/commands/check/tsconfig_inputs/type_references/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/type_references/tests.rs
@@ -92,6 +92,56 @@ fn type_reference_resolution_supports_subpaths_exports_and_graphs() {
 }
 
 #[test]
+fn type_reference_resolution_prefers_nested_exports_types_conditions() {
+    let root = unique_case_dir("nested-exports-types");
+    let _ = std::fs::remove_dir_all(&root);
+    write(
+        &root,
+        "node_modules/vue-plugin/package.json",
+        r#"{
+  "exports": {
+    "./global-components": {
+      "vue": {
+        "types": "./types/vue-components.d.ts",
+        "default": "./dist/vue-components.js"
+      },
+      "import": "./dist/global-components.mjs",
+      "default": "./dist/global-components.js"
+    }
+  }
+}"#,
+    );
+    write(
+        &root,
+        "node_modules/vue-plugin/types/vue-components.d.ts",
+        "/// <reference path=\"./shared.d.ts\" />\nexport {};\ndeclare module 'vue' { export interface GlobalComponents { VpButton: unknown } }\n",
+    );
+    write(
+        &root,
+        "node_modules/vue-plugin/types/shared.d.ts",
+        "export {};\ndeclare global { interface Window { __vp: true } }\n",
+    );
+    write(
+        &root,
+        "node_modules/vue-plugin/dist/global-components.mjs",
+        "export default {}\n",
+    );
+
+    let root = root.canonicalize().unwrap();
+    let files = resolve_type_reference_declaration_files(&root, "vue-plugin/global-components");
+
+    assert_eq!(
+        relative_paths(&root, &files),
+        vec![
+            "node_modules/vue-plugin/types/vue-components.d.ts",
+            "node_modules/vue-plugin/types/shared.d.ts",
+        ]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
 fn type_reference_resolution_supports_module_declaration_suffixes() {
     let root = unique_case_dir("module-suffixes");
     let _ = std::fs::remove_dir_all(&root);

--- a/crates/vize/tests/check_tsx_intrinsic_elements_cli.rs
+++ b/crates/vize/tests/check_tsx_intrinsic_elements_cli.rs
@@ -160,3 +160,88 @@ fn check_tsx_intrinsic_elements_with_experimental_jsx_vapor() {
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn check_tsx_vapor_keeps_script_type_errors() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("jsx-vapor-type-error");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    if link_workspace_vue(&project_root).is_err() {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    }
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        r#"{ "experimentals": { "jsxVapor": {} } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/Standalone.tsx"),
+        r#"export const Example = () => {
+  const count: number = "bad";
+  return <div>{count}</div>;
+};
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "src/Standalone.tsx",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap_or("<non-utf8 stderr>");
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap_or_else(|error| {
+        panic!("failed to parse JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    let diagnostics = json["files"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .flat_map(|file| file["diagnostics"].as_array().cloned().unwrap_or_default())
+        .map(|diagnostic| diagnostic.as_str().unwrap_or_default().to_string())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(json["errorCount"], serde_json::json!(1), "{diagnostics:#?}");
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.contains("[TS2322]")),
+        "JSX Vapor typecheck should keep TSX script errors: {diagnostics:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -18,6 +18,7 @@ mod options_api_required_props;
 mod package_exports_types;
 mod recent_issues;
 mod scan;
+mod template_block;
 mod tsx_sfc;
 #[test]
 fn batch_type_checker_snapshots_vue_diagnostics() {
@@ -67,7 +68,6 @@ const count: string = 0;
         insta::assert_debug_snapshot!("batch_type_checker_script_setup_type_error", relevant);
     });
 }
-
 #[test]
 fn corsa_bridge_completion_returns_inner_members_for_chained_ref_value() {
     // Guards the wired Corsa completion path (see #751): when the bridge is

--- a/crates/vize_canon/src/batch/type_checker/tests/template_block.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/template_block.rs
@@ -1,0 +1,233 @@
+use super::{BatchTypeChecker, create_project_case, relative_path, resolve_test_tsgo_binary};
+use crate::batch::{SfcBlockType, TypeChecker};
+
+const PLUGIN_GLOBALS: &str = r#"import type { DefineComponent } from "vue";
+export {};
+
+declare module "vue" {
+  export interface ComponentCustomProperties {
+    $portal: {
+      open(el: HTMLElement): void;
+    };
+  }
+
+  export interface GlobalComponents {
+    PluginCard: DefineComponent<{ tone: "info" | "danger" }>;
+  }
+}
+"#;
+
+#[test]
+fn template_expression_diagnostics_are_mapped_to_the_template_block() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case(
+        "template-block-diagnostic-mapping",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const count = 1
+</script>
+
+<template>
+  <button>{{ count.toUpperCase() }}</button>
+</template>
+"#,
+        )],
+    );
+
+    let mut checker = match BatchTypeChecker::new(&project_root) {
+        Ok(checker) => checker,
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        }
+    };
+    checker.scan_project().unwrap();
+    let result = match checker.check_project() {
+        Ok(result) => result,
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        }
+    };
+
+    let relevant = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            relative_path(&project_root, &diagnostic.file) == "src/App.vue"
+                && diagnostic.code == Some(2339)
+                && diagnostic.message.contains("toUpperCase")
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        relevant.iter().any(|diagnostic| {
+            diagnostic.block_type == Some(SfcBlockType::Template) && diagnostic.line >= 5
+        }),
+        "template expression diagnostics should point at <template>, got: {relevant:#?}"
+    );
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|diagnostic| relative_path(&project_root, &diagnostic.file) == "src/App.vue"),
+        "diagnostics should be remapped away from generated .vue.ts files: {:#?}",
+        result.diagnostics
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn template_typecheck_uses_dom_libs_and_vue_plugin_augmentations() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case(
+        "template-dom-vue-plugin-augmentations",
+        &[
+            ("src/plugin-globals.d.ts", PLUGIN_GLOBALS),
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+const tone: "info" = "info"
+const target = document.createElement("button")
+</script>
+
+<template>
+  <PluginCard :tone="tone" @click="$portal.open(target)" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let mut checker = match BatchTypeChecker::new(&project_root) {
+        Ok(checker) => checker,
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        }
+    };
+    checker.scan_project().unwrap();
+    let result = match checker.check_project() {
+        Ok(result) => result,
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        }
+    };
+
+    let unexpected = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            relative_path(&project_root, &diagnostic.file) == "src/App.vue"
+                && matches!(diagnostic.code, Some(2304 | 2322 | 2339 | 2345))
+        })
+        .map(|diagnostic| {
+            (
+                diagnostic.code,
+                diagnostic.line,
+                diagnostic.column,
+                diagnostic.message.clone(),
+                diagnostic.block_type,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        unexpected.is_empty(),
+        "DOM globals and Vue plugin augmentations should typecheck in template: {unexpected:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn options_api_template_keeps_plugin_globals_and_dom_typed() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case(
+        "options-api-template-dom-plugin",
+        &[
+            ("src/plugin-globals.d.ts", PLUGIN_GLOBALS),
+            (
+                "src/App.vue",
+                r#"<script lang="ts">
+export default {
+  data() {
+    return {
+      tone: "info" as const,
+      target: document.createElement("button"),
+    }
+  },
+  methods: {
+    open() {
+      this.$portal.open(this.target)
+    },
+  },
+}
+</script>
+
+<template>
+  <PluginCard :tone="tone" @click="open">{{ tone.toUpperCase() }}</PluginCard>
+</template>
+"#,
+            ),
+        ],
+    );
+
+    if !project_root.join("node_modules/vue/dist").exists() {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    }
+
+    let mut checker = match BatchTypeChecker::new(&project_root) {
+        Ok(checker) => checker,
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        }
+    };
+    checker.scan_project().unwrap();
+    let result = match checker.check_project() {
+        Ok(result) => result,
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        }
+    };
+
+    let unexpected = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            relative_path(&project_root, &diagnostic.file) == "src/App.vue"
+                && matches!(diagnostic.code, Some(2304 | 2322 | 2339 | 2345 | 7006))
+        })
+        .map(|diagnostic| {
+            (
+                diagnostic.code,
+                diagnostic.line,
+                diagnostic.column,
+                diagnostic.message.clone(),
+                diagnostic.block_type,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        unexpected.is_empty(),
+        "Options API template bindings should keep plugin globals and DOM types: {unexpected:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/tests/tooling/lsp-typecheck-template.test.ts
+++ b/tests/tooling/lsp-typecheck-template.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { hoverToText, isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+test("vize lsp typecheck keeps DOM libs and template diagnostics", async (t) => {
+  const corsaPath = resolveTsgoBinary();
+  if (corsaPath == null) {
+    t.skip("tsgo binary not found; skipping LSP typecheck test");
+    return;
+  }
+
+  const testRootDir = path.join(testOutputRoot, "lsp-typecheck-template");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    fs.mkdirSync(path.join(workspaceDir, "src"), { recursive: true });
+    const vuePackage = resolveVuePackage();
+    if (vuePackage == null) {
+      writeVueShim(workspaceDir);
+    } else {
+      linkVuePackage(workspaceDir, vuePackage);
+    }
+    fs.writeFileSync(
+      path.join(workspaceDir, "vize.config.json"),
+      JSON.stringify(
+        {
+          lsp: {
+            hover: true,
+            lint: false,
+            typecheck: true,
+          },
+          typeChecker: {
+            corsaPath,
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "tsconfig.json"),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            module: "ESNext",
+            moduleResolution: "bundler",
+            noEmit: true,
+            strict: true,
+            target: "ES2022",
+          },
+          include: ["src/**/*"],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    await session.initialize(workspaceDir, {
+      editor: true,
+      hover: true,
+      lint: false,
+      typecheck: true,
+    });
+
+    const source = `<script setup lang="ts">
+const count: number = "oops"
+const button = document.createElement("button")
+</script>
+
+<template>
+  <button @click="button.focus()">{{ count.toFixed(1) }}</button>
+</template>
+`;
+    const filePath = path.join(workspaceDir, "src/App.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: source },
+    });
+
+    const publish = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) =>
+        isDiagnosticsForUri(params, uri) &&
+        params.diagnostics.some((diagnostic) =>
+          diagnostic.message?.includes("Type 'string' is not assignable to type 'number'"),
+        ),
+    )) as PublishDiagnosticsParams;
+    const messages = publish.diagnostics.map((diagnostic) => diagnostic.message ?? "");
+
+    assert.ok(
+      messages.some((message) =>
+        message.includes("Type 'string' is not assignable to type 'number'"),
+      ),
+      messages.join("\n"),
+    );
+    assert.equal(
+      messages.some(
+        (message) =>
+          message.includes("Cannot find name 'document'") ||
+          message.includes("Cannot find name 'HTMLElement'"),
+      ),
+      false,
+      messages.join("\n"),
+    );
+
+    const hover = (await session.request("textDocument/hover", {
+      textDocument: { uri },
+      position: offsetToPosition(source, source.lastIndexOf("count.toFixed") + "count".length),
+    })) as { contents?: unknown } | null;
+    assert.match(hoverToText(hover), /count/);
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+function resolveTsgoBinary(): string | undefined {
+  const candidates = [
+    path.join(root, "../corsa-bind/.cache/tsgo"),
+    path.join(root, "node_modules/.bin/tsgo"),
+    path.join(root, "tests/node_modules/.bin/tsgo"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function resolveVuePackage(): string | undefined {
+  const candidates = [
+    path.join(root, "node_modules/vue"),
+    path.join(root, "tests/node_modules/vue"),
+    path.join(root, "playground/node_modules/vue"),
+    path.join(root, "examples/jsx-tsx/node_modules/vue"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function linkVuePackage(workspaceDir: string, vuePackage: string): void {
+  const nodeModules = path.join(workspaceDir, "node_modules");
+  fs.mkdirSync(nodeModules, { recursive: true });
+  symlink(vuePackage, path.join(nodeModules, "vue"));
+
+  const vueNamespace = path.join(path.dirname(vuePackage), "@vue");
+  if (fs.existsSync(vueNamespace)) {
+    symlink(vueNamespace, path.join(nodeModules, "@vue"));
+  }
+}
+
+function symlink(source: string, target: string): void {
+  fs.rmSync(target, { force: true, recursive: true });
+  fs.symlinkSync(source, target, process.platform === "win32" ? "junction" : "dir");
+}
+
+function writeVueShim(workspaceDir: string): void {
+  fs.writeFileSync(
+    path.join(workspaceDir, "src/vue-shim.d.ts"),
+    `declare module "vue" {
+  export interface Ref<T = any> {
+    value: T;
+  }
+
+  export interface ShallowRef<T = any> {
+    value: T;
+  }
+
+  export interface ComponentPublicInstance {
+    $attrs: Record<string, unknown>;
+    $slots: Record<string, unknown>;
+    $refs: Record<string, unknown>;
+    $emit: (...args: any[]) => void;
+  }
+
+  export interface GlobalComponents {}
+}
+`,
+    "utf8",
+  );
+}

--- a/tests/tooling/vscode-typescript-vue-plugin-module-resolution.test.ts
+++ b/tests/tooling/vscode-typescript-vue-plugin-module-resolution.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const require = createRequire(import.meta.url);
+const ts = require(
+  require.resolve("typescript", {
+    paths: [path.join(root, "editors/vscode"), path.join(root, "tests")],
+  }),
+) as typeof import("typescript");
+const initVuePlugin = require(
+  path.join(root, "editors/vscode/typescript-vue-plugin/index.cjs"),
+) as (modules: { typescript: typeof ts }) => {
+  create(info: {
+    languageService: import("typescript").LanguageService;
+    languageServiceHost: import("typescript").LanguageServiceHost;
+    serverHost: typeof ts.sys;
+  }): import("typescript").LanguageService;
+};
+
+test("TypeScript Vue plugin resolves relative .vue imports from TSX under NodeNext", () => {
+  const project = createVueProject(
+    'import Card from "./Card.vue";\nconst render = () => <Card label="ok" />;\nrender;\n',
+    {
+      "Card.vue":
+        '<script setup lang="ts">\ndefineProps<{ label: string }>();\n</script>\n<template />\n',
+    },
+    {
+      jsx: ts.JsxEmit.Preserve,
+      jsxImportSource: "vue",
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    },
+    "main.tsx",
+  );
+  try {
+    const withoutPlugin = collectDiagnostics(project.mainTs, false, project.compilerOptions);
+    assert.ok(
+      hasCannotFindVueModule(withoutPlugin, "./Card.vue"),
+      formatDiagnostics(withoutPlugin),
+    );
+
+    const withPlugin = collectDiagnostics(project.mainTs, true, project.compilerOptions);
+    assert.equal(
+      hasCannotFindVueModule(withPlugin, "./Card.vue"),
+      false,
+      formatDiagnostics(withPlugin),
+    );
+
+    const service = createLanguageService(project.mainTs, true, project.compilerOptions);
+    const source = fs.readFileSync(project.mainTs, "utf8");
+    const definition = service.getDefinitionAtPosition(
+      project.mainTs,
+      source.indexOf("./Card.vue") + 2,
+    );
+    assert.equal(definition?.[0]?.fileName, path.join(path.dirname(project.mainTs), "Card.vue"));
+  } finally {
+    fs.rmSync(project.root, { force: true, recursive: true });
+  }
+});
+
+test("TypeScript Vue plugin does not hide unresolved bare .vue subpath imports", () => {
+  const project = createVueProject('import Remote from "design-system/Card.vue";\nRemote;\n', {});
+  try {
+    const diagnostics = collectDiagnostics(project.mainTs, true, project.compilerOptions);
+    assert.ok(
+      hasCannotFindVueModule(diagnostics, "design-system/Card.vue"),
+      formatDiagnostics(diagnostics),
+    );
+  } finally {
+    fs.rmSync(project.root, { force: true, recursive: true });
+  }
+});
+
+function createVueProject(
+  mainSource: string,
+  vueFiles: Record<string, string>,
+  compilerOptions: import("typescript").CompilerOptions = {},
+  entryFileName = "main.ts",
+) {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-vscode-vue-plugin-"));
+  const srcDir = path.join(rootDir, "src");
+  fs.mkdirSync(srcDir, { recursive: true });
+  const mainTs = path.join(srcDir, entryFileName);
+  fs.writeFileSync(mainTs, mainSource);
+  for (const [fileName, content] of Object.entries(vueFiles)) {
+    fs.writeFileSync(path.join(srcDir, fileName), content);
+  }
+  return { compilerOptions, root: rootDir, mainTs };
+}
+
+function collectDiagnostics(
+  mainTs: string,
+  enablePlugin: boolean,
+  compilerOptions: import("typescript").CompilerOptions,
+) {
+  return createLanguageService(mainTs, enablePlugin, compilerOptions).getSemanticDiagnostics(
+    mainTs,
+  );
+}
+
+function createLanguageService(
+  mainTs: string,
+  enablePlugin: boolean,
+  compilerOptions: import("typescript").CompilerOptions,
+) {
+  const host = createHost(path.dirname(path.dirname(mainTs)), mainTs, compilerOptions);
+  const service = ts.createLanguageService(host);
+  return enablePlugin
+    ? initVuePlugin({ typescript: ts }).create({
+        languageService: service,
+        languageServiceHost: host,
+        serverHost: ts.sys,
+      })
+    : service;
+}
+
+function createHost(
+  rootDir: string,
+  mainTs: string,
+  compilerOptions: import("typescript").CompilerOptions,
+): import("typescript").LanguageServiceHost {
+  const options: import("typescript").CompilerOptions = {
+    allowSyntheticDefaultImports: true,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2022,
+    ...compilerOptions,
+  };
+
+  return {
+    directoryExists: (directoryName) => ts.sys.directoryExists(directoryName),
+    fileExists: (fileName) => ts.sys.fileExists(fileName),
+    getCompilationSettings: () => options,
+    getCurrentDirectory: () => rootDir,
+    getDefaultLibFileName: (compilerOptions) => ts.getDefaultLibFilePath(compilerOptions),
+    getDirectories: (directoryName) => ts.sys.getDirectories(directoryName),
+    getScriptFileNames: () => [mainTs],
+    getScriptSnapshot(fileName) {
+      if (!fs.existsSync(fileName)) return undefined;
+      return ts.ScriptSnapshot.fromString(fs.readFileSync(fileName, "utf8"));
+    },
+    getScriptVersion: () => "0",
+    readDirectory: (rootDir, extensions, excludes, includes, depth) =>
+      ts.sys.readDirectory(rootDir, extensions, excludes, includes, depth),
+    readFile: (fileName, encoding) => ts.sys.readFile(fileName, encoding),
+    useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
+  };
+}
+
+function hasCannotFindVueModule(
+  diagnostics: readonly import("typescript").Diagnostic[],
+  specifier: string,
+) {
+  return diagnostics.some((diagnostic) => {
+    const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+    return message.includes(`Cannot find module '${specifier}'`);
+  });
+}
+
+function formatDiagnostics(diagnostics: readonly import("typescript").Diagnostic[]) {
+  return diagnostics
+    .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))
+    .join("\n");
+}


### PR DESCRIPTION
## Summary
- add stricter typechecker template-block coverage for remapped template diagnostics, DOM globals, Vue plugin augmentations, and Options API template bindings
- add tsconfig/module-resolution edge tests for TSX project ownership, package exports type references, ambient Vue plugin globals, and JSX-gated .js to .tsx import discovery
- harden VS Code TypeScript Vue plugin and LSP smoke coverage for TSX/NodeNext .vue imports, unresolved bare .vue imports, and typecheck-backed template diagnostics
- add JSX Vapor CLI coverage proving TSX script type errors still surface under experimental Vapor mode

## Validation
- cargo test -p vize js_specifiers_can_follow_tsx_when_jsx_typecheck_is_enabled
- cargo test -p vize --lib tsconfig_for_files_can_use_referenced_tsx_owner_when_jsx_is_enabled
- cargo test -p vize --lib type_reference_resolution_prefers_nested_exports_types_conditions
- cargo test -p vize --lib ambient_collection_keeps_vue_plugin_globals_from_exported_type_package
- cargo test -p vize_canon --lib template_block
- cargo test -p vize --test check_tsx_intrinsic_elements_cli check_tsx_vapor_keeps_script_type_errors
- node --test tests/tooling/vscode-typescript-vue-plugin.test.ts
- VIZE_LSP_BIN=target/debug/vize node --test tests/tooling/lsp-typecheck-template.test.ts
- git diff --check
- cargo fmt --all -- --check
- node --check tests/tooling/vscode-typescript-vue-plugin.test.ts && node --check tests/tooling/lsp-typecheck-template.test.ts

Note: corepack pnpm exec vp check --fix ... was attempted but the local root vite.config.ts could not resolve vite-plus in this checkout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786166375&installation_id=136613492&pr_number=2742&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2742&signature=8962fa5f88c267681ee6e6c5a968301e4c80b995cd69b761a8bace6d2a14a80c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved JSX/TSX-aware import and tsconfig resolution, including correct handling of `.js` specifiers and referenced TSX owner configs.
  * Enhanced Vue template typechecking and LSP behavior, including DOM typings preservation and accurate hover results.

* **Bug Fixes**
  * Fixed Vue `.vue` module resolution behavior in TypeScript projects.
  * Preserved package-exported ambient type declarations (including nested export conditions) during ambient collection.
  * Kept relevant script and template diagnostics (without false “cannot find” DOM-lib errors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->