### PR TITLE
ci: include MoonBit project root in title policy checkout

### DIFF
--- a/.github/workflows/title-policy.yml
+++ b/.github/workflows/title-policy.yml
@@ -30,6 +30,9 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: |
             .github/actions/setup-moonbit
+            tools/moon/moon.mod
+            tools/moon/moon.pkg
+            tools/moon/lib
             tools/moon/cmd/github/issue_pr_title_policy
           sparse-checkout-cone-mode: false
 


### PR DESCRIPTION
## Summary
- include the MoonBit project root and shared lib package in the title-policy sparse checkout
- keep the pull_request_target job running trusted default-branch MoonBit code after the .mbtx to package migration

## Verification
- MOON_HOME="/Users/nishimura/Code/github.com/ubugeeei/vize/.cache/moonbit" MOON_BIN="/Users/nishimura/Code/github.com/ubugeeei/vize/.cache/moonbit/bin/moon" node --test tests/tooling/github-workflows.test.ts tests/tooling/moonbit-warnings.test.ts
- MOON_HOME="/Users/nishimura/Code/github.com/ubugeeei/vize/.cache/moonbit" /Users/nishimura/Code/github.com/ubugeeei/vize/.cache/moonbit/bin/moon check --target native --deny-warn

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786176274&installation_id=136613492&pr_number=2744&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2744&signature=686cf53111969fb13df07cfe7888c871081f3ccb5156ac681baeeec9a3ecfd89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an automated validation workflow to fetch additional repository content, helping ensure title checks run more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->