### PR TITLE
feat(croquis-cf): summarize provide inject trees

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/core/run.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/run.rs
@@ -47,11 +47,9 @@ impl CrossFileAnalyzer {
             && let Some(index) = provide_inject_index.as_ref()
         {
             let (matches, diags) = rules::analyze_provide_inject_with_index(index);
-            result.provide_inject_tree = Some(rules::build_provide_inject_tree_with_index(
-                &self.registry,
-                index,
-                &matches,
-            ));
+            let tree = rules::build_provide_inject_tree_with_index(&self.registry, index, &matches);
+            result.provide_inject_tree_summary = Some(tree.summary());
+            result.provide_inject_tree = Some(tree);
             result.provide_inject_matches = matches;
             result.diagnostics.extend(diags);
         }

--- a/crates/vize_croquis_cf/src/analyzer/tests_provide_inject/tree.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_provide_inject/tree.rs
@@ -123,6 +123,21 @@ const state = inject('state')"#,
     assert_eq!(tree.roots[0].children.len(), 1);
     assert_eq!(tree.roots[0].children[0].children.len(), 1);
     assert_eq!(tree.roots[0].children[0].children[0].injects.len(), 1);
+
+    let summary = result
+        .provide_inject_tree_summary
+        .expect("tree summary should be built");
+    assert_eq!(summary.root_count, 1);
+    assert_eq!(summary.node_count, 3);
+    assert_eq!(summary.provider_component_count, 1);
+    assert_eq!(summary.injector_component_count, 1);
+    assert_eq!(summary.provide_count, 1);
+    assert_eq!(summary.inject_count, 1);
+    assert_eq!(summary.matched_inject_count, 1);
+    assert_eq!(summary.unmatched_inject_count, 0);
+    assert_eq!(summary.max_depth, 3);
+    assert_eq!(summary.max_child_fanout, 1);
+    assert_eq!(summary.max_provider_consumer_count, 1);
 }
 
 #[test]

--- a/crates/vize_croquis_cf/src/analyzer/types.rs
+++ b/crates/vize_croquis_cf/src/analyzer/types.rs
@@ -198,6 +198,9 @@ pub struct CrossFileResult {
     /// Provide/inject tree, populated when provide/inject analysis is enabled.
     pub provide_inject_tree: Option<rules::ProvideInjectTree>,
 
+    /// Provide/inject tree summary, populated when provide/inject analysis is enabled.
+    pub provide_inject_tree_summary: Option<rules::ProvideInjectTreeSummary>,
+
     /// Unique ID issues.
     pub unique_id_issues: Vec<rules::UniqueIdIssue>,
 

--- a/crates/vize_croquis_cf/src/lib.rs
+++ b/crates/vize_croquis_cf/src/lib.rs
@@ -66,6 +66,6 @@ pub use suppression::{SuppressionDirective, SuppressionError, SuppressionMap};
 // Re-export rule result types
 pub use rules::{
     BoundaryInfo, BoundaryKind, EmitFlow, EventBubble, FallthroughInfo, PropsValidationIssue,
-    PropsValidationIssueKind, ProvideInjectMatch, ReactivityIssue, ReactivityIssueKind,
-    UniqueIdIssue,
+    PropsValidationIssueKind, ProvideInjectMatch, ProvideInjectTreeSummary, ReactivityIssue,
+    ReactivityIssueKind, UniqueIdIssue,
 };

--- a/crates/vize_croquis_cf/src/rules.rs
+++ b/crates/vize_croquis_cf/src/rules.rs
@@ -36,7 +36,7 @@ pub use props_validation::{
 pub(crate) use provide_inject::{
     ProvideInjectIndex, analyze_provide_inject_with_index, build_provide_inject_tree_with_index,
 };
-pub use provide_inject::{ProvideInjectMatch, ProvideInjectTree};
+pub use provide_inject::{ProvideInjectMatch, ProvideInjectTree, ProvideInjectTreeSummary};
 pub use race_conditions::RaceConditionIssue;
 pub(crate) use race_conditions::analyze_race_conditions_with_index;
 pub use reactivity::{ReactivityIssue, ReactivityIssueKind, analyze_reactivity};

--- a/crates/vize_croquis_cf/src/rules/provide_inject.rs
+++ b/crates/vize_croquis_cf/src/rules/provide_inject.rs
@@ -6,11 +6,13 @@ mod analysis;
 mod index;
 mod keys;
 mod markdown;
+mod summary;
 mod tree;
 mod types;
 
 pub(crate) use analysis::analyze_provide_inject_with_index;
 pub(crate) use index::ProvideInjectIndex;
+pub use summary::ProvideInjectTreeSummary;
 pub(crate) use tree::build_provide_inject_tree_with_index;
 pub use types::{ProvideInjectMatch, ProvideInjectTree};
 

--- a/crates/vize_croquis_cf/src/rules/provide_inject/summary.rs
+++ b/crates/vize_croquis_cf/src/rules/provide_inject/summary.rs
@@ -1,0 +1,141 @@
+use super::types::{ProvideInjectTree, ProvideNode};
+
+/// Stable counters for a provide/inject tree.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ProvideInjectTreeSummary {
+    pub root_count: usize,
+    pub node_count: usize,
+    pub provider_component_count: usize,
+    pub injector_component_count: usize,
+    pub provide_count: usize,
+    pub inject_count: usize,
+    pub matched_inject_count: usize,
+    pub unmatched_inject_count: usize,
+    pub max_depth: usize,
+    pub max_child_fanout: usize,
+    pub max_provider_consumer_count: usize,
+}
+
+impl ProvideInjectTree {
+    /// Summarize the tree for reports and cross-file complexity scoring.
+    pub fn summary(&self) -> ProvideInjectTreeSummary {
+        let mut summary = ProvideInjectTreeSummary {
+            root_count: self.roots.len(),
+            ..ProvideInjectTreeSummary::default()
+        };
+
+        for root in &self.roots {
+            summarize_node(root, 1, &mut summary);
+        }
+
+        summary
+    }
+}
+
+fn summarize_node(node: &ProvideNode, depth: usize, summary: &mut ProvideInjectTreeSummary) {
+    summary.node_count += 1;
+    summary.max_depth = summary.max_depth.max(depth);
+    summary.max_child_fanout = summary.max_child_fanout.max(node.children.len());
+
+    if !node.provides.is_empty() {
+        summary.provider_component_count += 1;
+    }
+    summary.provide_count += node.provides.len();
+
+    for provide in &node.provides {
+        summary.max_provider_consumer_count = summary
+            .max_provider_consumer_count
+            .max(provide.consumer_count);
+    }
+
+    if !node.injects.is_empty() {
+        summary.injector_component_count += 1;
+    }
+    summary.inject_count += node.injects.len();
+
+    for inject in &node.injects {
+        if inject.provider.is_some() {
+            summary.matched_inject_count += 1;
+        } else {
+            summary.unmatched_inject_count += 1;
+        }
+    }
+
+    for child in &node.children {
+        summarize_node(child, depth + 1, summary);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::FileId;
+    use vize_carton::CompactString;
+
+    fn file_id(id: u32) -> FileId {
+        FileId::new(id)
+    }
+
+    #[test]
+    fn summary_counts_tree_depth_fanout_and_match_state() {
+        let tree = ProvideInjectTree {
+            roots: vec![ProvideNode {
+                file_id: file_id(1),
+                component_name: Some(CompactString::new("Root")),
+                provides: vec![super::super::types::ProvideInfo {
+                    key: CompactString::new("theme"),
+                    value_type: None,
+                    offset: 10,
+                    consumer_count: 2,
+                }],
+                injects: Vec::new(),
+                children: vec![
+                    ProvideNode {
+                        file_id: file_id(2),
+                        component_name: Some(CompactString::new("Panel")),
+                        provides: Vec::new(),
+                        injects: vec![super::super::types::InjectInfo {
+                            key: CompactString::new("theme"),
+                            has_default: false,
+                            provider: Some(file_id(1)),
+                            offset: 20,
+                        }],
+                        children: vec![ProvideNode {
+                            file_id: file_id(3),
+                            component_name: Some(CompactString::new("Leaf")),
+                            provides: Vec::new(),
+                            injects: vec![super::super::types::InjectInfo {
+                                key: CompactString::new("locale"),
+                                has_default: true,
+                                provider: None,
+                                offset: 30,
+                            }],
+                            children: Vec::new(),
+                        }],
+                    },
+                    ProvideNode {
+                        file_id: file_id(4),
+                        component_name: Some(CompactString::new("Sidebar")),
+                        provides: Vec::new(),
+                        injects: Vec::new(),
+                        children: Vec::new(),
+                    },
+                ],
+            }],
+        };
+
+        let summary = tree.summary();
+
+        assert_eq!(summary.root_count, 1);
+        assert_eq!(summary.node_count, 4);
+        assert_eq!(summary.provider_component_count, 1);
+        assert_eq!(summary.injector_component_count, 2);
+        assert_eq!(summary.provide_count, 1);
+        assert_eq!(summary.inject_count, 2);
+        assert_eq!(summary.matched_inject_count, 1);
+        assert_eq!(summary.unmatched_inject_count, 1);
+        assert_eq!(summary.max_depth, 3);
+        assert_eq!(summary.max_child_fanout, 2);
+        assert_eq!(summary.max_provider_consumer_count, 2);
+    }
+}


### PR DESCRIPTION
## Summary

- add a typed `ProvideInjectTreeSummary` for provider/injector counts, matched/unmatched injects, max depth, and fan-out
- populate the summary beside `provide_inject_tree` in `CrossFileResult`
- cover both manual tree aggregation and analyzer-produced pass-through tree summaries

Refs #2747

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vize_croquis_cf provide_inject`
- `cargo test -p vize_croquis_cf`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786177395&installation_id=136613492&pr_number=2751&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2751&signature=b939b987f35777b8c9de4f2efe2d76af385b9df2d0e98ca1705470d27b2c50d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new summary view for provide/inject analysis results, including counts and depth/fanout metrics.
  * Analysis outputs now include both the detailed tree and a compact tree summary when provide/inject analysis is enabled.

* **Tests**
  * Expanded coverage to verify the new summary values alongside the existing tree structure checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->