### PR TITLE
fix(curator): resolve modern module imports in inspector graph

### DIFF
--- a/crates/vize_curator/src/inspector/graph.rs
+++ b/crates/vize_curator/src/inspector/graph.rs
@@ -68,8 +68,8 @@ pub fn build_graph(files: &[InspectorSourceFile]) -> InspectorGraph {
                     },
                 );
 
-                if to.ends_with(".vue")
-                    && import.kind == "import"
+                if import.kind == "import"
+                    && is_component_module_path(to.as_str())
                     && component_is_used(&analysis.template_used_ids, &import.locals)
                 {
                     push_graph_edge(
@@ -135,13 +135,25 @@ fn import_candidates(from: &str, specifier: &str) -> Vec<String> {
     let mut candidates = vec![base.clone()];
 
     if !has_known_extension(base.as_str()) {
-        for extension in [".vue", ".ts", ".tsx", ".js", ".jsx"] {
+        for extension in [
+            ".vue", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs",
+        ] {
             let mut candidate = base.clone();
             candidate.push_str(extension);
             candidates.push(candidate);
         }
 
-        for extension in ["/index.vue", "/index.ts", "/index.js"] {
+        for extension in [
+            "/index.vue",
+            "/index.ts",
+            "/index.tsx",
+            "/index.mts",
+            "/index.cts",
+            "/index.js",
+            "/index.jsx",
+            "/index.mjs",
+            "/index.cjs",
+        ] {
             let mut candidate = base.clone();
             candidate.push_str(extension);
             candidates.push(candidate);
@@ -183,15 +195,24 @@ fn normalize_path(path: &str) -> String {
 }
 
 fn has_known_extension(path: &str) -> bool {
+    path.rsplit_once('.').is_some_and(|(_, extension)| {
+        matches!(
+            extension,
+            "vue" | "ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs"
+        )
+    })
+}
+
+fn is_component_module_path(path: &str) -> bool {
     path.rsplit_once('.')
-        .is_some_and(|(_, extension)| matches!(extension, "vue" | "ts" | "tsx" | "js" | "jsx"))
+        .is_some_and(|(_, extension)| matches!(extension, "vue" | "tsx" | "jsx"))
 }
 
 fn file_kind(path: &str) -> &'static str {
     match path.rsplit_once('.').map(|(_, extension)| extension) {
         Some("vue") => "vue",
-        Some("ts") | Some("tsx") => "typescript",
-        Some("js") | Some("jsx") => "javascript",
+        Some("ts") | Some("tsx") | Some("mts") | Some("cts") => "typescript",
+        Some("js") | Some("jsx") | Some("mjs") | Some("cjs") => "javascript",
         _ => "other",
     }
 }

--- a/crates/vize_curator/src/inspector/tests.rs
+++ b/crates/vize_curator/src/inspector/tests.rs
@@ -186,6 +186,48 @@ const Lazy = () => import('./Lazy.vue');
 }
 
 #[test]
+fn graph_resolves_modern_script_module_extensions() {
+    let files = vec![
+        InspectorSourceFile {
+            path: cstr!("src/App.vue"),
+            source: cstr!(
+                r#"<script setup>
+import EntryPanel from './entry';
+import config from './config.cts';
+const loadServer = () => import('./server');
+</script>
+<template><EntryPanel /></template>"#
+            ),
+        },
+        InspectorSourceFile {
+            path: cstr!("src/entry/index.tsx"),
+            source: cstr!("export default null;\n"),
+        },
+        InspectorSourceFile {
+            path: cstr!("src/config.cts"),
+            source: cstr!("export default true;\n"),
+        },
+        InspectorSourceFile {
+            path: cstr!("src/server/index.mjs"),
+            source: cstr!("export default true;\n"),
+        },
+    ];
+
+    let graph = build_graph(&files);
+    let mut edges: Vec<_> = graph
+        .edges
+        .iter()
+        .map(|edge| (edge.kind, edge.to.as_str()))
+        .collect();
+    edges.sort_unstable();
+
+    assert!(edges.contains(&("component", "src/entry/index.tsx")));
+    assert!(edges.contains(&("dynamic-import", "src/server/index.mjs")));
+    assert!(edges.contains(&("import", "src/config.cts")));
+    assert!(edges.contains(&("import", "src/entry/index.tsx")));
+}
+
+#[test]
 fn builds_line_diff_and_stats() {
     let diff = build_diff("one\ntwo\nthree", "one\nTWO\nthree\nfour");
 


### PR DESCRIPTION
## Summary
- resolve inspector graph imports through .mts/.cts/.mjs/.cjs and index TSX/JSX module candidates
- classify modern script module extensions in graph nodes
- mark local TSX/JSX modules used from templates as component edges

## Verification
- cargo test -p vize_curator

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786177428&installation_id=136613492&pr_number=2752&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2752&signature=dd1164b7f6670c96c7293fbf28151b3cc114adae7a2e32b20bea450f2858bf58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Graph inspection now recognizes more component and script module formats, including modern `.tsx`, `.jsx`, `.mts`, `.cts`, `.mjs`, and `.cjs` files.
  * Extensionless imports are now resolved across a broader set of common module patterns, improving graph accuracy.
* **Bug Fixes**
  * Fixed graph edge detection so component links and import relationships are identified more consistently for newer JavaScript and TypeScript module styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->