### PR TITLE
feat(croquis-cf): summarize fallthrough attributes

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/core/run.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/run.rs
@@ -27,6 +27,7 @@ impl CrossFileAnalyzer {
         // Run enabled rules
         if self.options.fallthrough_attrs {
             let (info, diags) = rules::analyze_fallthrough(&self.registry, &self.graph);
+            result.fallthrough_summary = Some(rules::summarize_fallthrough(&info));
             result.fallthrough_info = info;
             result.diagnostics.extend(diags);
         }

--- a/crates/vize_croquis_cf/src/analyzer/types.rs
+++ b/crates/vize_croquis_cf/src/analyzer/types.rs
@@ -186,6 +186,9 @@ pub struct CrossFileResult {
     /// Fallthrough attribute information per component.
     pub fallthrough_info: Vec<rules::FallthroughInfo>,
 
+    /// Fallthrough attribute summary, populated when fallthrough analysis is enabled.
+    pub fallthrough_summary: Option<rules::FallthroughSummary>,
+
     /// Emit flow information.
     pub emit_flows: Vec<rules::EmitFlow>,
 

--- a/crates/vize_croquis_cf/src/lib.rs
+++ b/crates/vize_croquis_cf/src/lib.rs
@@ -65,7 +65,7 @@ pub use suppression::{SuppressionDirective, SuppressionError, SuppressionMap};
 
 // Re-export rule result types
 pub use rules::{
-    BoundaryInfo, BoundaryKind, EmitFlow, EventBubble, FallthroughInfo, PropsValidationIssue,
-    PropsValidationIssueKind, ProvideInjectMatch, ProvideInjectTreeSummary, ReactivityIssue,
-    ReactivityIssueKind, UniqueIdIssue,
+    BoundaryInfo, BoundaryKind, EmitFlow, EventBubble, FallthroughInfo, FallthroughSummary,
+    PropsValidationIssue, PropsValidationIssueKind, ProvideInjectMatch, ProvideInjectTreeSummary,
+    ReactivityIssue, ReactivityIssueKind, UniqueIdIssue,
 };

--- a/crates/vize_croquis_cf/src/rules.rs
+++ b/crates/vize_croquis_cf/src/rules.rs
@@ -29,7 +29,9 @@ pub use component_resolution::{ComponentResolutionIssue, analyze_component_resol
 pub use element_id::{UniqueIdIssue, analyze_element_ids};
 pub use emit::{EmitFlow, analyze_emits};
 pub use event_bubbling::{EventBubble, analyze_event_bubbling};
-pub use fallthrough::{FallthroughInfo, analyze_fallthrough};
+pub use fallthrough::{
+    FallthroughInfo, FallthroughSummary, analyze_fallthrough, summarize_fallthrough,
+};
 pub use props_validation::{
     PropsValidationIssue, PropsValidationIssueKind, analyze_props_validation,
 };

--- a/crates/vize_croquis_cf/src/rules/fallthrough.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough.rs
@@ -10,6 +10,10 @@ use crate::graph::DependencyGraph;
 use crate::registry::{FileId, ModuleRegistry};
 use vize_carton::{CompactString, FxHashMap, FxHashSet, cstr};
 
+mod summary;
+
+pub use summary::{FallthroughSummary, summarize_fallthrough};
+
 /// Information about fallthrough attributes for a component.
 #[derive(Debug, Clone)]
 pub struct FallthroughInfo {

--- a/crates/vize_croquis_cf/src/rules/fallthrough/summary.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough/summary.rs
@@ -1,0 +1,136 @@
+use super::FallthroughInfo;
+
+/// Stable counters for fallthrough attribute analysis.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct FallthroughSummary {
+    pub component_count: usize,
+    pub components_with_passed_attrs: usize,
+    pub components_with_potential_issues: usize,
+    pub inherit_attrs_disabled_count: usize,
+    pub uses_attrs_count: usize,
+    pub binds_attrs_count: usize,
+    pub multi_root_count: usize,
+    pub multi_root_without_attrs_count: usize,
+    pub passed_attr_count: usize,
+    pub declared_prop_count: usize,
+    pub undeclared_passed_attr_count: usize,
+    pub unconsumed_fallthrough_attr_count: usize,
+    pub max_passed_attrs: usize,
+    pub max_root_element_count: usize,
+}
+
+/// Summarize fallthrough attribute facts for reports and complexity scoring.
+pub fn summarize_fallthrough(infos: &[FallthroughInfo]) -> FallthroughSummary {
+    let mut summary = FallthroughSummary {
+        component_count: infos.len(),
+        ..FallthroughSummary::default()
+    };
+
+    for info in infos {
+        if !info.passed_attrs.is_empty() {
+            summary.components_with_passed_attrs += 1;
+        }
+        if info.has_potential_issues() {
+            summary.components_with_potential_issues += 1;
+        }
+        if info.inherit_attrs_disabled {
+            summary.inherit_attrs_disabled_count += 1;
+        }
+        if info.uses_attrs {
+            summary.uses_attrs_count += 1;
+        }
+        if info.binds_attrs {
+            summary.binds_attrs_count += 1;
+        }
+        if info.root_element_count > 1 {
+            summary.multi_root_count += 1;
+            if !info.binds_attrs {
+                summary.multi_root_without_attrs_count += 1;
+            }
+        }
+
+        summary.passed_attr_count += info.passed_attrs.len();
+        summary.declared_prop_count += info.declared_props.len();
+        summary.max_passed_attrs = summary.max_passed_attrs.max(info.passed_attrs.len());
+        summary.max_root_element_count =
+            summary.max_root_element_count.max(info.root_element_count);
+
+        for attr in &info.passed_attrs {
+            if !info.declared_props.contains(attr) {
+                summary.undeclared_passed_attr_count += 1;
+                if !info.uses_attrs && !info.binds_attrs {
+                    summary.unconsumed_fallthrough_attr_count += 1;
+                }
+            }
+        }
+    }
+
+    summary
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::FileId;
+    use vize_carton::{CompactString, FxHashSet};
+
+    fn set(names: &[&str]) -> FxHashSet<CompactString> {
+        names.iter().map(|name| CompactString::new(*name)).collect()
+    }
+
+    #[test]
+    fn summary_counts_fallthrough_risk_dimensions() {
+        let infos = vec![
+            FallthroughInfo {
+                file_id: FileId::new(1),
+                inherit_attrs_disabled: false,
+                uses_attrs: false,
+                binds_attrs: false,
+                root_element_count: 2,
+                passed_attrs: set(&["title", "kind"]),
+                declared_props: set(&["kind"]),
+                template_start: 0,
+                template_end: 10,
+            },
+            FallthroughInfo {
+                file_id: FileId::new(2),
+                inherit_attrs_disabled: true,
+                uses_attrs: true,
+                binds_attrs: false,
+                root_element_count: 1,
+                passed_attrs: set(&["class"]),
+                declared_props: FxHashSet::default(),
+                template_start: 0,
+                template_end: 10,
+            },
+            FallthroughInfo {
+                file_id: FileId::new(3),
+                inherit_attrs_disabled: false,
+                uses_attrs: false,
+                binds_attrs: true,
+                root_element_count: 3,
+                passed_attrs: FxHashSet::default(),
+                declared_props: FxHashSet::default(),
+                template_start: 0,
+                template_end: 10,
+            },
+        ];
+
+        let summary = summarize_fallthrough(&infos);
+
+        assert_eq!(summary.component_count, 3);
+        assert_eq!(summary.components_with_passed_attrs, 2);
+        assert_eq!(summary.components_with_potential_issues, 1);
+        assert_eq!(summary.inherit_attrs_disabled_count, 1);
+        assert_eq!(summary.uses_attrs_count, 1);
+        assert_eq!(summary.binds_attrs_count, 1);
+        assert_eq!(summary.multi_root_count, 2);
+        assert_eq!(summary.multi_root_without_attrs_count, 1);
+        assert_eq!(summary.passed_attr_count, 3);
+        assert_eq!(summary.declared_prop_count, 1);
+        assert_eq!(summary.undeclared_passed_attr_count, 2);
+        assert_eq!(summary.unconsumed_fallthrough_attr_count, 1);
+        assert_eq!(summary.max_passed_attrs, 2);
+        assert_eq!(summary.max_root_element_count, 3);
+    }
+}

--- a/crates/vize_croquis_cf/src/rules/fallthrough/tests.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough/tests.rs
@@ -1,4 +1,4 @@
-use super::{FallthroughInfo, analyze_fallthrough};
+use super::{FallthroughInfo, analyze_fallthrough, summarize_fallthrough};
 use crate::graph::{DependencyEdge, DependencyGraph, ModuleNode};
 use crate::registry::{FileId, ModuleRegistry};
 use vize_carton::{CompactString, FxHashSet, smallvec};
@@ -77,6 +77,14 @@ fn passed_attrs_are_attributed_per_child() {
     // Each child only sees the prop passed to its own usage site.
     assert_eq!(attrs_for(child_a), vec!["foo"]);
     assert_eq!(attrs_for(child_b), vec!["bar"]);
+
+    let summary = summarize_fallthrough(&infos);
+    assert_eq!(summary.component_count, 3);
+    assert_eq!(summary.components_with_passed_attrs, 2);
+    assert_eq!(summary.passed_attr_count, 2);
+    assert_eq!(summary.undeclared_passed_attr_count, 2);
+    assert_eq!(summary.unconsumed_fallthrough_attr_count, 2);
+    assert_eq!(summary.max_passed_attrs, 1);
 }
 
 /// The same child component used at two sites with different props must not


### PR DESCRIPTION
## Summary

- add a typed `FallthroughSummary` for passed attrs, declared props, multi-root risk, `$attrs` handling, and potential issue counts
- populate `fallthrough_summary` on `CrossFileResult` when fallthrough analysis is enabled
- cover both direct summary aggregation and analyzer-produced fallthrough facts

Refs #2748

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vize_croquis_cf fallthrough`
- `cargo test -p vize_croquis_cf`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786177552&installation_id=136613492&pr_number=2753&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2753&signature=1d140b29aa586d99dc7ef17090d7be4eaf52b192727b439b74d4519e99d4c878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an aggregated fallthrough summary to analyzer results, providing component-level risk indicators and totals (e.g., passed/undeclared/unconsumed attributes and multi-root stats).
  * When fallthrough attribute analysis is enabled, the results now include this additional summary alongside existing fallthrough diagnostics.
* **Tests**
  * Extended fallthrough coverage to validate the new summary metrics and ensure attribute aggregation stays correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->