### PR TITLE
feat(croquis): expose semantic summary

### DIFF
--- a/crates/vize_croquis/src/croquis.rs
+++ b/crates/vize_croquis/src/croquis.rs
@@ -31,6 +31,11 @@
 mod bindings;
 mod model;
 mod options_descriptor;
+mod summary;
+#[cfg(test)]
+mod summary_core_tests;
+#[cfg(test)]
+mod summary_template_tests;
 mod template;
 mod vir;
 
@@ -42,6 +47,7 @@ pub use bindings::{
 };
 pub use model::{AnalysisStats, CroquisStats};
 pub use options_descriptor::{OptionGroup, OptionKey, OptionMember, OptionsDescriptor};
+pub use summary::CroquisSemanticSummary;
 pub use template::{
     ComponentRegistration, ComponentUsage, ElementIdInfo, ElementIdKind, EventListener, PassedProp,
     SlotUsage, TemplateExpression, TemplateExpressionKind, TemplateInfo,

--- a/crates/vize_croquis/src/croquis/summary.rs
+++ b/crates/vize_croquis/src/croquis/summary.rs
@@ -1,0 +1,190 @@
+//! Reusable semantic summary derived from a [`Croquis`].
+//!
+//! This module gives downstream crates one stable place to consume the facts
+//! already collected by croquis without re-counting public fields differently.
+
+use super::Croquis;
+use super::template::TemplateExpressionKind;
+use crate::scope::ScopeKind;
+
+/// Aggregate counts for the semantic facts stored in a [`Croquis`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CroquisSemanticSummary {
+    pub scope_count: usize,
+    pub scope_binding_count: usize,
+    pub template_scope_count: usize,
+    pub v_for_scope_count: usize,
+    pub v_slot_scope_count: usize,
+    pub event_handler_scope_count: usize,
+    pub callback_scope_count: usize,
+    pub symbol_count: usize,
+    pub symbol_reference_count: usize,
+    pub unused_symbol_count: usize,
+    pub script_binding_count: usize,
+    pub prop_alias_count: usize,
+    pub macro_call_count: usize,
+    pub prop_definition_count: usize,
+    pub emit_definition_count: usize,
+    pub emit_call_count: usize,
+    pub model_definition_count: usize,
+    pub exposed_binding_count: usize,
+    pub slot_definition_count: usize,
+    pub top_level_await_count: usize,
+    pub hoist_count: usize,
+    pub reactive_source_count: usize,
+    pub reactivity_loss_count: usize,
+    pub race_condition_count: usize,
+    pub provide_count: usize,
+    pub inject_count: usize,
+    pub destructured_inject_count: usize,
+    pub composable_count: usize,
+    pub setup_context_violation_count: usize,
+    pub used_component_count: usize,
+    pub component_registration_count: usize,
+    pub component_usage_count: usize,
+    pub passed_prop_count: usize,
+    pub event_listener_count: usize,
+    pub slot_usage_count: usize,
+    pub spread_attr_component_count: usize,
+    pub used_directive_count: usize,
+    pub template_expression_count: usize,
+    pub v_if_expression_count: usize,
+    pub v_model_expression_count: usize,
+    pub element_id_count: usize,
+    pub static_element_id_count: usize,
+    pub dynamic_element_id_count: usize,
+    pub id_definition_count: usize,
+    pub id_reference_count: usize,
+    pub undefined_ref_count: usize,
+    pub unused_binding_count: usize,
+    pub type_export_count: usize,
+    pub invalid_export_count: usize,
+    pub import_statement_count: usize,
+    pub re_export_count: usize,
+    pub binding_span_count: usize,
+    pub has_multiple_roots: bool,
+    pub uses_attrs: bool,
+    pub binds_attrs_explicitly: bool,
+    pub inherit_attrs_disabled: bool,
+}
+
+impl CroquisSemanticSummary {
+    /// Build a summary from the current croquis facts.
+    pub fn from_croquis(croquis: &Croquis) -> Self {
+        let mut summary = Self {
+            scope_count: croquis.scopes.len(),
+            symbol_count: croquis.symbols.len(),
+            script_binding_count: croquis.bindings.bindings.len(),
+            prop_alias_count: croquis.bindings.props_aliases.len(),
+            macro_call_count: croquis.macros.all_calls().len(),
+            prop_definition_count: croquis.macros.props().len(),
+            emit_definition_count: croquis.macros.emits().len(),
+            emit_call_count: croquis.macros.emit_calls().len(),
+            model_definition_count: croquis.macros.models().len(),
+            exposed_binding_count: croquis.macros.exposes().len(),
+            slot_definition_count: croquis.macros.slots().len(),
+            top_level_await_count: croquis.macros.top_level_awaits().len(),
+            hoist_count: croquis.hoists.count(),
+            reactive_source_count: croquis.reactivity.count(),
+            reactivity_loss_count: croquis.reactivity.losses().len(),
+            race_condition_count: croquis.race_conditions.risks().len(),
+            provide_count: croquis.provide_inject.provides().len(),
+            inject_count: croquis.provide_inject.injects().len(),
+            destructured_inject_count: croquis.provide_inject.destructured_injects().count(),
+            composable_count: croquis.provide_inject.composables().len(),
+            setup_context_violation_count: croquis.setup_context.count(),
+            used_component_count: croquis.used_components.len(),
+            component_registration_count: croquis.component_registrations.len(),
+            component_usage_count: croquis.component_usages.len(),
+            used_directive_count: croquis.used_directives.len(),
+            template_expression_count: croquis.template_expressions.len(),
+            element_id_count: croquis.element_ids.len(),
+            undefined_ref_count: croquis.undefined_refs.len(),
+            unused_binding_count: croquis.unused_bindings.len(),
+            type_export_count: croquis.type_exports.len(),
+            invalid_export_count: croquis.invalid_exports.len(),
+            import_statement_count: croquis.import_statements.len(),
+            re_export_count: croquis.re_exports.len(),
+            binding_span_count: croquis.binding_spans.len(),
+            has_multiple_roots: croquis.template_info.has_multiple_roots(),
+            uses_attrs: croquis.template_info.uses_attrs,
+            binds_attrs_explicitly: croquis.template_info.binds_attrs_explicitly,
+            inherit_attrs_disabled: croquis.template_info.inherit_attrs_disabled,
+            ..Default::default()
+        };
+
+        for scope in croquis.scopes.iter() {
+            summary.scope_binding_count += scope.binding_count();
+            match scope.kind {
+                ScopeKind::VFor => {
+                    summary.template_scope_count += 1;
+                    summary.v_for_scope_count += 1;
+                }
+                ScopeKind::VSlot => {
+                    summary.template_scope_count += 1;
+                    summary.v_slot_scope_count += 1;
+                }
+                ScopeKind::EventHandler => {
+                    summary.template_scope_count += 1;
+                    summary.event_handler_scope_count += 1;
+                }
+                ScopeKind::Callback => summary.callback_scope_count += 1,
+                _ => {}
+            }
+        }
+
+        for symbol in croquis.symbols.iter() {
+            summary.symbol_reference_count += symbol.references.len();
+            if !symbol.is_used() {
+                summary.unused_symbol_count += 1;
+            }
+        }
+
+        for usage in &croquis.component_usages {
+            summary.passed_prop_count += usage.props.len();
+            summary.event_listener_count += usage.events.len();
+            summary.slot_usage_count += usage.slots.len();
+            if usage.has_spread_attrs {
+                summary.spread_attr_component_count += 1;
+            }
+        }
+
+        for expression in &croquis.template_expressions {
+            match expression.kind {
+                TemplateExpressionKind::VIf => summary.v_if_expression_count += 1,
+                TemplateExpressionKind::VModel => summary.v_model_expression_count += 1,
+                _ => {}
+            }
+        }
+
+        for id in &croquis.element_ids {
+            if id.is_static {
+                summary.static_element_id_count += 1;
+            } else {
+                summary.dynamic_element_id_count += 1;
+            }
+            if id.kind.is_definition() {
+                summary.id_definition_count += 1;
+            } else {
+                summary.id_reference_count += 1;
+            }
+        }
+
+        summary
+    }
+
+    /// Whether fallthrough attributes may be dropped by a fragment root.
+    #[inline]
+    pub const fn may_lose_fallthrough_attrs(self) -> bool {
+        self.has_multiple_roots && !self.binds_attrs_explicitly
+    }
+}
+
+impl Croquis {
+    /// Return a reusable aggregate summary of the semantic facts in this croquis.
+    #[inline]
+    pub fn semantic_summary(&self) -> CroquisSemanticSummary {
+        CroquisSemanticSummary::from_croquis(self)
+    }
+}

--- a/crates/vize_croquis/src/croquis/summary_core_tests.rs
+++ b/crates/vize_croquis/src/croquis/summary_core_tests.rs
@@ -1,0 +1,191 @@
+use super::Croquis;
+use crate::BindingType;
+use crate::hoist::HoistLevel;
+use crate::macros::{
+    EmitDefinition, ExposeDefinition, MacroKind, ModelDefinition, PropDefinition, SlotsDefinition,
+};
+use crate::provide::{InjectPattern, ProvideKey};
+use crate::race::RaceConditionRiskKind;
+use crate::reactivity::{ReactiveKind, ReactivityLoss, ReactivityLossKind};
+use crate::scope::{EventHandlerScopeData, ScopeId, VForScopeData, VSlotScopeData};
+use crate::setup_context::SetupContextViolationKind;
+use vize_carton::{CompactString, ToCompactString, smallvec};
+
+#[test]
+fn semantic_summary_collects_core_croquis_counts() {
+    let mut croquis = Croquis::new();
+    croquis.bindings.add("count", BindingType::SetupRef);
+    croquis
+        .bindings
+        .props_aliases
+        .insert(CompactString::new("message"), CompactString::new("msg"));
+
+    let symbol_id = croquis.symbols.add_symbol(
+        "count".to_compact_string(),
+        BindingType::SetupRef,
+        ScopeId::ROOT,
+        10,
+    );
+    croquis.symbols.add_reference("count", 42);
+    assert!(croquis.symbols.get(symbol_id).is_some());
+
+    croquis.scopes.enter_v_for_scope(
+        VForScopeData {
+            value_alias: CompactString::new("item"),
+            value_bindings: smallvec![CompactString::new("item")],
+            key_alias: None,
+            index_alias: Some(CompactString::new("index")),
+            source: CompactString::new("items"),
+            key_expression: Some(CompactString::new("item.id")),
+        },
+        1,
+        20,
+    );
+    croquis.scopes.exit_scope();
+    croquis.scopes.enter_v_slot_scope(
+        VSlotScopeData {
+            name: CompactString::new("default"),
+            props_pattern: None,
+            prop_names: smallvec![CompactString::new("row")],
+            component: Some(CompactString::new("Child")),
+        },
+        21,
+        40,
+    );
+    croquis.scopes.exit_scope();
+    croquis.scopes.enter_event_handler_scope(
+        EventHandlerScopeData {
+            event_name: CompactString::new("click"),
+            has_implicit_event: true,
+            param_names: smallvec![],
+            handler_expression: Some(CompactString::new("onClick($event)")),
+            target_component: None,
+        },
+        41,
+        50,
+    );
+
+    croquis
+        .macros
+        .add_call("defineProps", MacroKind::DefineProps, 0, 12, None, None);
+    croquis.macros.add_prop(PropDefinition {
+        name: CompactString::new("msg"),
+        prop_type: None,
+        required: true,
+        default_value: None,
+    });
+    croquis.macros.add_emit(EmitDefinition {
+        name: CompactString::new("save"),
+        payload_type: None,
+    });
+    croquis
+        .macros
+        .add_emit_call(CompactString::new("save"), false, 13, 24);
+    croquis.macros.add_model(ModelDefinition {
+        name: CompactString::new("modelValue"),
+        local_name: CompactString::new("model"),
+        model_type: None,
+        required: false,
+        default_value: None,
+    });
+    croquis.macros.add_expose(ExposeDefinition {
+        name: CompactString::new("focus"),
+        expose_type: None,
+    });
+    croquis.macros.add_slot(SlotsDefinition {
+        name: CompactString::new("default"),
+        props_type: None,
+    });
+    croquis
+        .macros
+        .add_top_level_await(CompactString::new("load()"), 25, 31);
+
+    croquis.hoists.add_hoist(
+        HoistLevel::Constant,
+        CompactString::new("_hoisted_1"),
+        0,
+        10,
+    );
+    croquis
+        .reactivity
+        .register(CompactString::new("count"), ReactiveKind::Ref, 10);
+    croquis.reactivity.add_loss(ReactivityLoss {
+        kind: ReactivityLossKind::ReactiveSpread {
+            source_name: CompactString::new("state"),
+        },
+        start: 30,
+        end: 40,
+    });
+    croquis.race_conditions.record(
+        RaceConditionRiskKind::ScheduledMutation {
+            scheduler_name: CompactString::new("setTimeout"),
+            mutated_targets: vec![CompactString::new("count")],
+        },
+        50,
+        70,
+    );
+    croquis.provide_inject.add_provide(
+        ProvideKey::String(CompactString::new("theme")),
+        CompactString::new("theme"),
+        None,
+        None,
+        71,
+        80,
+    );
+    croquis.provide_inject.add_inject(
+        ProvideKey::String(CompactString::new("theme")),
+        CompactString::new("theme"),
+        None,
+        None,
+        InjectPattern::ObjectDestructure(vec![CompactString::new("color")]),
+        None,
+        81,
+        90,
+    );
+    croquis.provide_inject.add_composable(
+        CompactString::new("useTheme"),
+        CompactString::new("./theme"),
+        None,
+        true,
+        true,
+        true,
+        91,
+        100,
+    );
+    croquis.setup_context.record_violation(
+        SetupContextViolationKind::ModuleLevelState,
+        CompactString::new("ref"),
+        101,
+        105,
+    );
+
+    let summary = croquis.semantic_summary();
+
+    assert_eq!(summary.script_binding_count, 1);
+    assert_eq!(summary.prop_alias_count, 1);
+    assert_eq!(summary.symbol_count, 1);
+    assert_eq!(summary.symbol_reference_count, 1);
+    assert_eq!(summary.unused_symbol_count, 0);
+    assert_eq!(summary.v_for_scope_count, 1);
+    assert_eq!(summary.v_slot_scope_count, 1);
+    assert_eq!(summary.event_handler_scope_count, 1);
+    assert_eq!(summary.template_scope_count, 3);
+    assert!(summary.scope_binding_count >= 4);
+    assert_eq!(summary.macro_call_count, 1);
+    assert_eq!(summary.prop_definition_count, 1);
+    assert_eq!(summary.emit_definition_count, 1);
+    assert_eq!(summary.emit_call_count, 1);
+    assert_eq!(summary.model_definition_count, 1);
+    assert_eq!(summary.exposed_binding_count, 1);
+    assert_eq!(summary.slot_definition_count, 1);
+    assert_eq!(summary.top_level_await_count, 1);
+    assert_eq!(summary.hoist_count, 1);
+    assert_eq!(summary.reactive_source_count, 1);
+    assert_eq!(summary.reactivity_loss_count, 1);
+    assert_eq!(summary.race_condition_count, 1);
+    assert_eq!(summary.provide_count, 1);
+    assert_eq!(summary.inject_count, 1);
+    assert_eq!(summary.destructured_inject_count, 1);
+    assert_eq!(summary.composable_count, 1);
+    assert_eq!(summary.setup_context_violation_count, 1);
+}

--- a/crates/vize_croquis/src/croquis/summary_template_tests.rs
+++ b/crates/vize_croquis/src/croquis/summary_template_tests.rs
@@ -1,0 +1,144 @@
+use super::{
+    ComponentRegistration, ComponentUsage, Croquis, CroquisSemanticSummary, ElementIdInfo,
+    ElementIdKind, EventListener, ImportStatementInfo, InvalidExport, InvalidExportKind,
+    PassedProp, ReExportInfo, SlotUsage, TemplateExpression, TemplateExpressionKind, TypeExport,
+    TypeExportKind, UndefinedRef,
+};
+use crate::scope::ScopeId;
+use vize_carton::{CompactString, smallvec};
+
+#[test]
+fn semantic_summary_collects_template_and_export_counts() {
+    let mut croquis = Croquis::new();
+    croquis.template_info.root_element_count = 2;
+    croquis.template_info.uses_attrs = true;
+    croquis.template_info.inherit_attrs_disabled = true;
+    croquis.used_components.insert(CompactString::new("Child"));
+    croquis.used_directives.insert(CompactString::new("focus"));
+    croquis
+        .unused_bindings
+        .push(CompactString::new("unusedBinding"));
+    croquis.undefined_refs.push(UndefinedRef {
+        name: CompactString::new("missing"),
+        offset: 12,
+        context: CompactString::new("interpolation"),
+    });
+    croquis.component_registrations.push(ComponentRegistration {
+        name: CompactString::new("Child"),
+        local_name: CompactString::new("Child"),
+    });
+    croquis.component_usages.push(ComponentUsage {
+        name: CompactString::new("Child"),
+        start: 0,
+        end: 20,
+        props: smallvec![PassedProp {
+            name: CompactString::new("title"),
+            value: Some(CompactString::new("message")),
+            start: 1,
+            end: 8,
+            is_dynamic: true,
+        }],
+        events: smallvec![EventListener {
+            name: CompactString::new("save"),
+            handler: Some(CompactString::new("save")),
+            modifiers: smallvec![],
+            start: 9,
+            end: 14,
+        }],
+        slots: smallvec![SlotUsage {
+            name: CompactString::new("default"),
+            scope_vars: smallvec![CompactString::new("row")],
+            start: 15,
+            end: 20,
+            has_scope: true,
+        }],
+        has_spread_attrs: true,
+        scope_id: ScopeId::ROOT,
+        vif_guard: Some(CompactString::new("visible")),
+    });
+    croquis.template_expressions.push(TemplateExpression {
+        content: CompactString::new("visible"),
+        kind: TemplateExpressionKind::VIf,
+        start: 0,
+        end: 7,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    });
+    croquis.template_expressions.push(TemplateExpression {
+        content: CompactString::new("model"),
+        kind: TemplateExpressionKind::VModel,
+        start: 8,
+        end: 13,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    });
+    croquis.element_ids.push(ElementIdInfo {
+        value: CompactString::new("field"),
+        start: 21,
+        end: 26,
+        is_static: true,
+        in_loop: false,
+        scope_id: ScopeId::ROOT,
+        kind: ElementIdKind::Id,
+    });
+    croquis.element_ids.push(ElementIdInfo {
+        value: CompactString::new("field"),
+        start: 27,
+        end: 32,
+        is_static: false,
+        in_loop: false,
+        scope_id: ScopeId::ROOT,
+        kind: ElementIdKind::AriaReference,
+    });
+    croquis.type_exports.push(TypeExport {
+        name: CompactString::new("Props"),
+        kind: TypeExportKind::Interface,
+        start: 33,
+        end: 40,
+        hoisted: true,
+    });
+    croquis.invalid_exports.push(InvalidExport {
+        name: CompactString::new("value"),
+        kind: InvalidExportKind::Const,
+        start: 41,
+        end: 50,
+    });
+    croquis
+        .import_statements
+        .push(ImportStatementInfo { start: 51, end: 60 });
+    croquis.re_exports.push(ReExportInfo { start: 61, end: 70 });
+    croquis
+        .binding_spans
+        .insert(CompactString::new("model"), (71, 76));
+
+    let summary = CroquisSemanticSummary::from_croquis(&croquis);
+
+    assert_eq!(summary.used_component_count, 1);
+    assert_eq!(summary.component_registration_count, 1);
+    assert_eq!(summary.component_usage_count, 1);
+    assert_eq!(summary.passed_prop_count, 1);
+    assert_eq!(summary.event_listener_count, 1);
+    assert_eq!(summary.slot_usage_count, 1);
+    assert_eq!(summary.spread_attr_component_count, 1);
+    assert_eq!(summary.used_directive_count, 1);
+    assert_eq!(summary.template_expression_count, 2);
+    assert_eq!(summary.v_if_expression_count, 1);
+    assert_eq!(summary.v_model_expression_count, 1);
+    assert_eq!(summary.element_id_count, 2);
+    assert_eq!(summary.static_element_id_count, 1);
+    assert_eq!(summary.dynamic_element_id_count, 1);
+    assert_eq!(summary.id_definition_count, 1);
+    assert_eq!(summary.id_reference_count, 1);
+    assert_eq!(summary.undefined_ref_count, 1);
+    assert_eq!(summary.unused_binding_count, 1);
+    assert_eq!(summary.type_export_count, 1);
+    assert_eq!(summary.invalid_export_count, 1);
+    assert_eq!(summary.import_statement_count, 1);
+    assert_eq!(summary.re_export_count, 1);
+    assert_eq!(summary.binding_span_count, 1);
+    assert!(summary.has_multiple_roots);
+    assert!(summary.uses_attrs);
+    assert!(!summary.binds_attrs_explicitly);
+    assert!(summary.inherit_attrs_disabled);
+    assert!(summary.may_lose_fallthrough_attrs());
+}

--- a/crates/vize_croquis/src/lib.rs
+++ b/crates/vize_croquis/src/lib.rs
@@ -82,10 +82,11 @@ pub use symbol::{Symbol, SymbolFlags, SymbolId, SymbolTable};
 // Re-export analysis types
 pub use analyzer::{Analyzer, AnalyzerOptions};
 pub use croquis::{
-    AnalysisStats, BindingMetadata, COMPILER_MACRO_NAMES, ComponentShape, Croquis, CroquisStats,
-    ImportStatementInfo, InvalidExport, InvalidExportKind, OptionGroup, OptionKey, OptionMember,
-    OptionsDescriptor, ReExportInfo, TemplateExpression, TemplateExpressionKind, TypeExport,
-    TypeExportKind, UndefinedRef, UnusedTemplateVar, UnusedVarContext,
+    AnalysisStats, BindingMetadata, COMPILER_MACRO_NAMES, ComponentShape, Croquis,
+    CroquisSemanticSummary, CroquisStats, ImportStatementInfo, InvalidExport, InvalidExportKind,
+    OptionGroup, OptionKey, OptionMember, OptionsDescriptor, ReExportInfo, TemplateExpression,
+    TemplateExpressionKind, TypeExport, TypeExportKind, UndefinedRef, UnusedTemplateVar,
+    UnusedVarContext,
 };
 pub use drawer::{Drawer, DrawerOptions};
 


### PR DESCRIPTION
## Summary
- add CroquisSemanticSummary as a reusable aggregate over existing croquis facts
- expose Croquis::semantic_summary() and re-export the summary type
- cover core tracker, template, and export count aggregation

Refs #2745

## Verification
- cargo fmt --all -- --check
- cargo test -p vize_croquis semantic_summary
- cargo test -p vize_croquis
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786178080&installation_id=136613492&pr_number=2755&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2755&signature=6104485f2b4bfa139a3be4493deec6b63e4dc0ac2606e012c42c6ff89895e664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a semantic summary for Croquis that surfaces high-level counts and flags from analysis data.
  * Exposed a new summary API so apps can retrieve these aggregated insights directly.

* **Tests**
  * Added coverage for core analysis metrics and template-related summary details to validate the new summary output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->