### PR TITLE
feat(croquis-cf): add complexity score model

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/core/run.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/run.rs
@@ -110,6 +110,8 @@ impl CrossFileAnalyzer {
             result.diagnostics.extend(diags);
         }
 
+        result.complexity_report = rules::summarize_complexity(&self.registry, &result);
+
         dedupe_diagnostics(&mut result.diagnostics);
         sort_diagnostics(&mut result.diagnostics);
 

--- a/crates/vize_croquis_cf/src/analyzer/types.rs
+++ b/crates/vize_croquis_cf/src/analyzer/types.rs
@@ -231,6 +231,9 @@ pub struct CrossFileResult {
     /// Props validation issues.
     pub props_validation_issues: Vec<rules::PropsValidationIssue>,
 
+    /// Explainable complexity score derived from the enabled cross-file facts.
+    pub complexity_report: rules::ComplexityReport,
+
     /// Statistics.
     pub stats: CrossFileStats,
 }

--- a/crates/vize_croquis_cf/src/lib.rs
+++ b/crates/vize_croquis_cf/src/lib.rs
@@ -65,7 +65,8 @@ pub use suppression::{SuppressionDirective, SuppressionError, SuppressionMap};
 
 // Re-export rule result types
 pub use rules::{
-    BoundaryInfo, BoundaryKind, EmitFlow, EventBubble, FallthroughInfo, FallthroughSummary,
+    BoundaryInfo, BoundaryKind, ComplexityBand, ComplexityDimensionScores, ComplexityInput,
+    ComplexityReport, EmitFlow, EventBubble, FallthroughInfo, FallthroughSummary,
     PropsValidationIssue, PropsValidationIssueKind, ProvideInjectMatch, ProvideInjectTreeSummary,
-    ReactivityIssue, ReactivityIssueKind, UniqueIdIssue,
+    ReactivityIssue, ReactivityIssueKind, UniqueIdIssue, band_for_score,
 };

--- a/crates/vize_croquis_cf/src/rules.rs
+++ b/crates/vize_croquis_cf/src/rules.rs
@@ -11,6 +11,9 @@
 //! ```
 
 mod boundary;
+mod complexity;
+#[cfg(test)]
+mod complexity_tests;
 mod component_resolution;
 pub(crate) mod cross_file_reactivity;
 mod element_id;
@@ -25,6 +28,10 @@ mod setup_context;
 
 // Re-export rule result types
 pub use boundary::{BoundaryInfo, BoundaryKind, analyze_boundaries};
+pub use complexity::{
+    ComplexityBand, ComplexityDimensionScores, ComplexityInput, ComplexityReport, band_for_score,
+    summarize_complexity,
+};
 pub use component_resolution::{ComponentResolutionIssue, analyze_component_resolution};
 pub use element_id::{UniqueIdIssue, analyze_element_ids};
 pub use emit::{EmitFlow, analyze_emits};

--- a/crates/vize_croquis_cf/src/rules/complexity.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity.rs
@@ -1,0 +1,204 @@
+//! Cross-file complexity scoring.
+//!
+//! The model is intentionally explainable: callers can inspect both raw input
+//! counts and weighted dimension scores before deciding how to surface the
+//! result in reports or diagnostics.
+
+use crate::analyzer::CrossFileResult;
+use crate::registry::ModuleRegistry;
+use crate::rules::cross_file_reactivity::CrossFileReactivityIssueKind;
+use vize_croquis::{ScopeKind, TemplateExpressionKind};
+
+/// Raw cross-file signals used to score Vue component complexity.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ComplexityInput {
+    pub template_if_count: usize,
+    pub template_for_count: usize,
+    pub slot_count: usize,
+    pub prop_drilling_edge_count: usize,
+    pub global_state_reference_count: usize,
+    pub provide_inject_max_depth: usize,
+    pub provide_inject_reference_count: usize,
+    pub fallthrough_risk_count: usize,
+    pub reactive_node_count: usize,
+    pub reactive_edge_count: usize,
+    pub reactive_cycle_count: usize,
+}
+
+/// Per-dimension complexity score.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ComplexityDimensionScores {
+    pub template_control_flow: u32,
+    pub slot_usage: u32,
+    pub prop_drilling: u32,
+    pub global_state: u32,
+    pub provide_inject: u32,
+    pub fallthrough_attrs: u32,
+    pub reactive_graph: u32,
+}
+
+impl ComplexityDimensionScores {
+    pub fn total(self) -> u32 {
+        self.template_control_flow
+            .saturating_add(self.slot_usage)
+            .saturating_add(self.prop_drilling)
+            .saturating_add(self.global_state)
+            .saturating_add(self.provide_inject)
+            .saturating_add(self.fallthrough_attrs)
+            .saturating_add(self.reactive_graph)
+    }
+}
+
+/// Human-facing band for the total complexity score.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum ComplexityBand {
+    #[default]
+    Low,
+    Moderate,
+    High,
+    Extreme,
+}
+
+/// Explainable complexity score for one cross-file graph or component slice.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ComplexityReport {
+    pub input: ComplexityInput,
+    pub dimensions: ComplexityDimensionScores,
+    pub total_score: u32,
+    pub band: ComplexityBand,
+}
+
+impl ComplexityReport {
+    pub fn from_input(input: ComplexityInput) -> Self {
+        let dimensions = ComplexityDimensionScores {
+            template_control_flow: weighted(input.template_if_count, 2)
+                .saturating_add(weighted(input.template_for_count, 3)),
+            slot_usage: weighted(input.slot_count, 2),
+            prop_drilling: weighted(input.prop_drilling_edge_count, 3),
+            global_state: weighted(input.global_state_reference_count, 2),
+            provide_inject: weighted(input.provide_inject_max_depth.saturating_sub(1), 2)
+                .saturating_add(weighted(input.provide_inject_reference_count, 1)),
+            fallthrough_attrs: weighted(input.fallthrough_risk_count, 4),
+            reactive_graph: weighted(input.reactive_node_count, 1)
+                .saturating_add(weighted(input.reactive_edge_count, 2))
+                .saturating_add(weighted(input.reactive_cycle_count, 10)),
+        };
+        let total_score = dimensions.total();
+
+        Self {
+            input,
+            dimensions,
+            total_score,
+            band: band_for_score(total_score),
+        }
+    }
+}
+
+/// Convert a total score to a human-facing complexity band.
+pub fn band_for_score(score: u32) -> ComplexityBand {
+    match score {
+        0..=14 => ComplexityBand::Low,
+        15..=34 => ComplexityBand::Moderate,
+        35..=69 => ComplexityBand::High,
+        _ => ComplexityBand::Extreme,
+    }
+}
+
+/// Summarize complexity from the analyzer's existing cross-file facts.
+pub fn summarize_complexity(
+    registry: &ModuleRegistry,
+    result: &CrossFileResult,
+) -> ComplexityReport {
+    ComplexityReport::from_input(complexity_input(registry, result))
+}
+
+fn complexity_input(registry: &ModuleRegistry, result: &CrossFileResult) -> ComplexityInput {
+    let mut input = ComplexityInput {
+        fallthrough_risk_count: result
+            .fallthrough_info
+            .iter()
+            .filter(|info| info.has_potential_issues())
+            .count(),
+        reactive_edge_count: result
+            .reactivity_issues
+            .len()
+            .saturating_add(result.cross_file_reactivity_issues.len())
+            .saturating_add(result.provide_inject_matches.len()),
+        reactive_cycle_count: result
+            .cross_file_reactivity_issues
+            .iter()
+            .filter(|issue| {
+                matches!(
+                    issue.kind,
+                    CrossFileReactivityIssueKind::CircularReactiveDependency { .. }
+                )
+            })
+            .count(),
+        global_state_reference_count: result
+            .reactivity_issues
+            .iter()
+            .filter(|issue| {
+                matches!(
+                    issue.kind,
+                    super::ReactivityIssueKind::ShouldUseStoreToRefs { .. }
+                )
+            })
+            .count()
+            .saturating_add(
+                result
+                    .cross_file_reactivity_issues
+                    .iter()
+                    .filter(|issue| {
+                        matches!(
+                            issue.kind,
+                            CrossFileReactivityIssueKind::StoreDestructured { .. }
+                        )
+                    })
+                    .count(),
+            ),
+        ..ComplexityInput::default()
+    };
+
+    if let Some(summary) = result.provide_inject_tree_summary {
+        input.provide_inject_max_depth = summary.max_depth;
+        input.provide_inject_reference_count =
+            summary.provide_count.saturating_add(summary.inject_count);
+    } else {
+        input.provide_inject_reference_count = result.provide_inject_matches.len();
+    }
+
+    for entry in registry.vue_components() {
+        let analysis = &entry.analysis;
+
+        input.template_if_count += analysis
+            .template_expressions
+            .iter()
+            .filter(|expr| expr.kind == TemplateExpressionKind::VIf)
+            .count();
+        input.template_for_count += analysis
+            .scopes
+            .iter()
+            .filter(|scope| scope.kind == ScopeKind::VFor)
+            .count();
+        input.slot_count += analysis.macros.slots().len();
+        input.slot_count += analysis
+            .component_usages
+            .iter()
+            .map(|usage| usage.slots.len())
+            .sum::<usize>();
+        input.prop_drilling_edge_count += analysis
+            .component_usages
+            .iter()
+            .map(|usage| usage.props.len())
+            .sum::<usize>();
+        input.reactive_node_count += analysis.reactivity.count();
+    }
+
+    input
+}
+
+fn weighted(count: usize, weight: u32) -> u32 {
+    u32::try_from(count)
+        .unwrap_or(u32::MAX)
+        .saturating_mul(weight)
+}

--- a/crates/vize_croquis_cf/src/rules/complexity_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity_tests.rs
@@ -1,0 +1,156 @@
+use super::{
+    ComplexityBand, ComplexityInput, ComplexityReport, FallthroughInfo, ProvideInjectTreeSummary,
+    ReactivityIssue, ReactivityIssueKind, summarize_complexity,
+};
+use crate::analyzer::CrossFileResult;
+use crate::registry::ModuleRegistry;
+use vize_carton::{CompactString, FxHashSet, smallvec};
+use vize_croquis::croquis::{
+    ComponentUsage, EventListener, PassedProp, SlotUsage, TemplateExpression,
+    TemplateExpressionKind,
+};
+use vize_croquis::{Croquis, ScopeId};
+
+#[test]
+fn scores_each_complexity_dimension() {
+    let report = ComplexityReport::from_input(ComplexityInput {
+        template_if_count: 2,
+        template_for_count: 1,
+        slot_count: 3,
+        prop_drilling_edge_count: 2,
+        global_state_reference_count: 4,
+        provide_inject_max_depth: 3,
+        provide_inject_reference_count: 5,
+        fallthrough_risk_count: 2,
+        reactive_node_count: 6,
+        reactive_edge_count: 7,
+        reactive_cycle_count: 1,
+    });
+
+    assert_eq!(report.dimensions.template_control_flow, 7);
+    assert_eq!(report.dimensions.slot_usage, 6);
+    assert_eq!(report.dimensions.prop_drilling, 6);
+    assert_eq!(report.dimensions.global_state, 8);
+    assert_eq!(report.dimensions.provide_inject, 9);
+    assert_eq!(report.dimensions.fallthrough_attrs, 8);
+    assert_eq!(report.dimensions.reactive_graph, 30);
+    assert_eq!(report.total_score, 74);
+    assert_eq!(report.band, ComplexityBand::Extreme);
+}
+
+#[test]
+fn summarizes_complexity_from_registry_and_result() {
+    let mut analysis = Croquis::new();
+    analysis.template_expressions.push(TemplateExpression {
+        content: CompactString::new("ready"),
+        kind: TemplateExpressionKind::VIf,
+        start: 0,
+        end: 5,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    });
+    analysis.scopes.enter_v_for_scope(
+        vize_croquis::VForScopeData {
+            value_alias: CompactString::new("item"),
+            value_bindings: smallvec![CompactString::new("item")],
+            key_alias: None,
+            index_alias: None,
+            source: CompactString::new("items"),
+            key_expression: None,
+        },
+        6,
+        20,
+    );
+    analysis.component_usages.push(ComponentUsage {
+        name: CompactString::new("Child"),
+        start: 21,
+        end: 40,
+        props: smallvec![PassedProp {
+            name: CompactString::new("value"),
+            value: Some(CompactString::new("item")),
+            start: 22,
+            end: 30,
+            is_dynamic: true,
+        }],
+        events: smallvec![EventListener {
+            name: CompactString::new("save"),
+            handler: None,
+            modifiers: smallvec![],
+            start: 31,
+            end: 35,
+        }],
+        slots: smallvec![SlotUsage {
+            name: CompactString::new("default"),
+            scope_vars: smallvec![CompactString::new("row")],
+            start: 36,
+            end: 40,
+            has_scope: true,
+        }],
+        has_spread_attrs: false,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    });
+    analysis.reactivity.register(
+        CompactString::new("state"),
+        vize_croquis::reactivity::ReactiveKind::Ref,
+        0,
+    );
+
+    let mut registry = ModuleRegistry::new();
+    let (file_id, _) = registry.register("Parent.vue", "", analysis);
+    let result = CrossFileResult {
+        fallthrough_info: vec![FallthroughInfo {
+            file_id,
+            inherit_attrs_disabled: false,
+            uses_attrs: false,
+            binds_attrs: false,
+            root_element_count: 2,
+            passed_attrs: FxHashSet::from_iter([CompactString::new("class")]),
+            declared_props: FxHashSet::default(),
+            template_start: 0,
+            template_end: 10,
+        }],
+        provide_inject_tree_summary: Some(ProvideInjectTreeSummary {
+            max_depth: 3,
+            provide_count: 1,
+            inject_count: 2,
+            ..ProvideInjectTreeSummary::default()
+        }),
+        reactivity_issues: vec![ReactivityIssue {
+            file_id,
+            kind: ReactivityIssueKind::ShouldUseStoreToRefs {
+                store_name: CompactString::new("useUserStore"),
+            },
+            offset: 1,
+            source: None,
+        }],
+        ..CrossFileResult::default()
+    };
+
+    let report = summarize_complexity(&registry, &result);
+
+    assert_eq!(report.input.template_if_count, 1);
+    assert_eq!(report.input.template_for_count, 1);
+    assert_eq!(report.input.slot_count, 1);
+    assert_eq!(report.input.prop_drilling_edge_count, 1);
+    assert_eq!(report.input.global_state_reference_count, 1);
+    assert_eq!(report.input.provide_inject_max_depth, 3);
+    assert_eq!(report.input.provide_inject_reference_count, 3);
+    assert_eq!(report.input.fallthrough_risk_count, 1);
+    assert_eq!(report.input.reactive_node_count, 1);
+    assert_eq!(report.input.reactive_edge_count, 1);
+    assert_eq!(report.total_score, 26);
+    assert_eq!(report.band, ComplexityBand::Moderate);
+}
+
+#[test]
+fn score_saturates_instead_of_overflowing() {
+    let report = ComplexityReport::from_input(ComplexityInput {
+        reactive_cycle_count: usize::MAX,
+        ..ComplexityInput::default()
+    });
+
+    assert_eq!(report.dimensions.reactive_graph, u32::MAX);
+    assert_eq!(report.total_score, u32::MAX);
+    assert_eq!(report.band, ComplexityBand::Extreme);
+}


### PR DESCRIPTION
## Summary
- add an explainable cross-file complexity score model to vize_croquis_cf
- compute ComplexityReport from existing CrossFileResult and croquis registry facts
- expose complexity types through the croquis-cf public API

Refs #2749
Replaces closed #2754

## Verification
- cargo fmt --all -- --check
- cargo test -p vize_croquis_cf complexity
- cargo test -p vize_croquis_cf
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786178631&installation_id=136613492&pr_number=2756&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2756&signature=e20be308ecbc33f3a1eef63f75c22278925cf64c6542b94c5e03aea940dad42a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->