### PR TITLE
feat(croquis-cf): score component template nesting

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/core/run.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/run.rs
@@ -110,7 +110,8 @@ impl CrossFileAnalyzer {
             result.diagnostics.extend(diags);
         }
 
-        result.complexity_report = rules::summarize_complexity(&self.registry, &result);
+        result.complexity_report =
+            rules::summarize_complexity_with_graph(&self.registry, &self.graph, &result);
 
         dedupe_diagnostics(&mut result.diagnostics);
         sort_diagnostics(&mut result.diagnostics);

--- a/crates/vize_croquis_cf/src/rules.rs
+++ b/crates/vize_croquis_cf/src/rules.rs
@@ -30,7 +30,7 @@ mod setup_context;
 pub use boundary::{BoundaryInfo, BoundaryKind, analyze_boundaries};
 pub use complexity::{
     ComplexityBand, ComplexityDimensionScores, ComplexityInput, ComplexityReport, band_for_score,
-    summarize_complexity,
+    summarize_complexity_with_graph,
 };
 pub use component_resolution::{ComponentResolutionIssue, analyze_component_resolution};
 pub use element_id::{UniqueIdIssue, analyze_element_ids};

--- a/crates/vize_croquis_cf/src/rules/complexity.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity.rs
@@ -4,7 +4,10 @@
 //! counts and weighted dimension scores before deciding how to surface the
 //! result in reports or diagnostics.
 
+mod nesting;
+
 use crate::analyzer::CrossFileResult;
+use crate::graph::DependencyGraph;
 use crate::registry::ModuleRegistry;
 use crate::rules::cross_file_reactivity::CrossFileReactivityIssueKind;
 use vize_croquis::{ScopeKind, TemplateExpressionKind};
@@ -14,6 +17,9 @@ use vize_croquis::{ScopeKind, TemplateExpressionKind};
 pub struct ComplexityInput {
     pub template_if_count: usize,
     pub template_for_count: usize,
+    pub component_tree_v_if_max_depth: usize,
+    pub component_tree_v_for_max_depth: usize,
+    pub component_tree_scoped_slot_max_depth: usize,
     pub slot_count: usize,
     pub prop_drilling_edge_count: usize,
     pub global_state_reference_count: usize,
@@ -72,8 +78,19 @@ impl ComplexityReport {
     pub fn from_input(input: ComplexityInput) -> Self {
         let dimensions = ComplexityDimensionScores {
             template_control_flow: weighted(input.template_if_count, 2)
-                .saturating_add(weighted(input.template_for_count, 3)),
-            slot_usage: weighted(input.slot_count, 2),
+                .saturating_add(weighted(input.template_for_count, 3))
+                .saturating_add(weighted(
+                    input.component_tree_v_if_max_depth.saturating_sub(1),
+                    4,
+                ))
+                .saturating_add(weighted(
+                    input.component_tree_v_for_max_depth.saturating_sub(1),
+                    5,
+                )),
+            slot_usage: weighted(input.slot_count, 2).saturating_add(weighted(
+                input.component_tree_scoped_slot_max_depth.saturating_sub(1),
+                4,
+            )),
             prop_drilling: weighted(input.prop_drilling_edge_count, 3),
             global_state: weighted(input.global_state_reference_count, 2),
             provide_inject: weighted(input.provide_inject_max_depth.saturating_sub(1), 2)
@@ -105,11 +122,23 @@ pub fn band_for_score(score: u32) -> ComplexityBand {
 }
 
 /// Summarize complexity from the analyzer's existing cross-file facts.
-pub fn summarize_complexity(
+#[cfg(test)]
+pub(super) fn summarize_complexity(
     registry: &ModuleRegistry,
     result: &CrossFileResult,
 ) -> ComplexityReport {
     ComplexityReport::from_input(complexity_input(registry, result))
+}
+
+/// Summarize complexity with component-tree template nesting signals.
+pub fn summarize_complexity_with_graph(
+    registry: &ModuleRegistry,
+    graph: &DependencyGraph,
+    result: &CrossFileResult,
+) -> ComplexityReport {
+    let mut input = complexity_input(registry, result);
+    nesting::add_component_tree_template_nesting(&mut input, registry, graph);
+    ComplexityReport::from_input(input)
 }
 
 fn complexity_input(registry: &ModuleRegistry, result: &CrossFileResult) -> ComplexityInput {

--- a/crates/vize_croquis_cf/src/rules/complexity/nesting.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity/nesting.rs
@@ -1,0 +1,222 @@
+use super::ComplexityInput;
+use crate::graph::{DependencyEdge, DependencyGraph};
+use crate::registry::{FileId, ModuleRegistry};
+use vize_carton::{FxHashMap, FxHashSet};
+use vize_croquis::croquis::ComponentUsage;
+use vize_croquis::{Croquis, ScopeId, ScopeKind, TemplateExpressionKind};
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct TemplateNesting {
+    v_if: usize,
+    v_for: usize,
+    scoped_slot: usize,
+}
+
+impl TemplateNesting {
+    fn add(self, other: Self) -> Self {
+        Self {
+            v_if: self.v_if.saturating_add(other.v_if),
+            v_for: self.v_for.saturating_add(other.v_for),
+            scoped_slot: self.scoped_slot.saturating_add(other.scoped_slot),
+        }
+    }
+
+    fn max_assign(&mut self, other: Self) {
+        self.v_if = self.v_if.max(other.v_if);
+        self.v_for = self.v_for.max(other.v_for);
+        self.scoped_slot = self.scoped_slot.max(other.scoped_slot);
+    }
+}
+
+struct ComponentProfile {
+    local: TemplateNesting,
+    usages: Vec<UsageTemplateNesting>,
+}
+
+struct UsageTemplateNesting {
+    child: FileId,
+    nesting: TemplateNesting,
+}
+
+pub(super) fn add_component_tree_template_nesting(
+    input: &mut ComplexityInput,
+    registry: &ModuleRegistry,
+    graph: &DependencyGraph,
+) {
+    let profiles = component_profiles(registry, graph);
+    let mut cache = FxHashMap::default();
+    let mut best = TemplateNesting::default();
+
+    for entry in registry.vue_components() {
+        let mut visiting = FxHashSet::default();
+        best.max_assign(component_tree_nesting(
+            entry.id,
+            &profiles,
+            &mut visiting,
+            &mut cache,
+        ));
+    }
+
+    input.component_tree_v_if_max_depth = best.v_if;
+    input.component_tree_v_for_max_depth = best.v_for;
+    input.component_tree_scoped_slot_max_depth = best.scoped_slot;
+}
+
+fn component_profiles(
+    registry: &ModuleRegistry,
+    graph: &DependencyGraph,
+) -> FxHashMap<FileId, ComponentProfile> {
+    let mut profiles = FxHashMap::default();
+
+    for entry in registry.vue_components() {
+        let mut profile = ComponentProfile {
+            local: local_template_nesting(&entry.analysis),
+            usages: Vec::new(),
+        };
+
+        for usage in &entry.analysis.component_usages {
+            let Some(child) = graph.find_by_component(usage.name.as_str()) else {
+                continue;
+            };
+            if !has_component_usage_edge(graph, entry.id, child) {
+                continue;
+            }
+
+            profile.usages.push(UsageTemplateNesting {
+                child,
+                nesting: component_usage_nesting(&entry.analysis, usage),
+            });
+        }
+
+        profiles.insert(entry.id, profile);
+    }
+
+    profiles
+}
+
+fn component_tree_nesting(
+    id: FileId,
+    profiles: &FxHashMap<FileId, ComponentProfile>,
+    visiting: &mut FxHashSet<FileId>,
+    cache: &mut FxHashMap<FileId, TemplateNesting>,
+) -> TemplateNesting {
+    if let Some(cached) = cache.get(&id) {
+        return *cached;
+    }
+
+    let Some(profile) = profiles.get(&id) else {
+        return TemplateNesting::default();
+    };
+
+    if !visiting.insert(id) {
+        return TemplateNesting::default();
+    }
+
+    let mut best = profile.local;
+    for usage in &profile.usages {
+        let child = component_tree_nesting(usage.child, profiles, visiting, cache);
+        best.max_assign(usage.nesting.add(child));
+    }
+
+    visiting.remove(&id);
+    cache.insert(id, best);
+    best
+}
+
+fn local_template_nesting(analysis: &Croquis) -> TemplateNesting {
+    let mut nesting = TemplateNesting::default();
+
+    for expr in analysis
+        .template_expressions
+        .iter()
+        .filter(|expr| expr.kind == TemplateExpressionKind::VIf)
+    {
+        nesting.v_if = nesting
+            .v_if
+            .max(v_if_guard_depth(analysis, expr.vif_guard.as_deref()).saturating_add(1));
+    }
+
+    for scope in analysis.scopes.iter() {
+        match scope.kind {
+            ScopeKind::VFor => {
+                nesting.v_for =
+                    nesting
+                        .v_for
+                        .max(scope_kind_depth(analysis, scope.id, ScopeKind::VFor));
+            }
+            ScopeKind::VSlot => {
+                nesting.scoped_slot =
+                    nesting
+                        .scoped_slot
+                        .max(scope_kind_depth(analysis, scope.id, ScopeKind::VSlot));
+            }
+            _ => {}
+        }
+    }
+
+    for usage in &analysis.component_usages {
+        nesting.v_if = nesting
+            .v_if
+            .max(v_if_guard_depth(analysis, usage.vif_guard.as_deref()));
+        if usage.slots.iter().any(|slot| slot.has_scope) {
+            let scoped_depth =
+                scope_kind_depth(analysis, usage.scope_id, ScopeKind::VSlot).saturating_add(1);
+            nesting.scoped_slot = nesting.scoped_slot.max(scoped_depth);
+        }
+    }
+
+    nesting
+}
+
+fn component_usage_nesting(analysis: &Croquis, usage: &ComponentUsage) -> TemplateNesting {
+    let scoped_slot_depth = scope_kind_depth(analysis, usage.scope_id, ScopeKind::VSlot);
+    let own_scoped_slot_depth = usize::from(usage.slots.iter().any(|slot| slot.has_scope));
+
+    TemplateNesting {
+        v_if: v_if_guard_depth(analysis, usage.vif_guard.as_deref()),
+        v_for: scope_kind_depth(analysis, usage.scope_id, ScopeKind::VFor),
+        scoped_slot: scoped_slot_depth.saturating_add(own_scoped_slot_depth),
+    }
+}
+
+fn scope_kind_depth(analysis: &Croquis, start: ScopeId, kind: ScopeKind) -> usize {
+    let mut depth = 0usize;
+    let mut current = Some(start);
+    let mut seen = FxHashSet::default();
+
+    while let Some(id) = current {
+        if !seen.insert(id) {
+            break;
+        }
+
+        let Some(scope) = analysis.scopes.get_scope(id) else {
+            break;
+        };
+        if scope.kind == kind {
+            depth = depth.saturating_add(1);
+        }
+        current = scope.parent();
+    }
+
+    depth
+}
+
+fn v_if_guard_depth(analysis: &Croquis, guard: Option<&str>) -> usize {
+    let Some(guard) = guard else {
+        return 0;
+    };
+
+    analysis
+        .template_expressions
+        .iter()
+        .filter(|expr| expr.kind == TemplateExpressionKind::VIf)
+        .filter(|expr| !expr.content.is_empty() && guard.contains(expr.content.as_str()))
+        .count()
+        .max(1)
+}
+
+fn has_component_usage_edge(graph: &DependencyGraph, parent: FileId, child: FileId) -> bool {
+    graph
+        .dependencies(parent)
+        .any(|(id, edge)| id == child && edge == DependencyEdge::ComponentUsage)
+}

--- a/crates/vize_croquis_cf/src/rules/complexity_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity_tests.rs
@@ -1,21 +1,26 @@
+use super::complexity::summarize_complexity;
 use super::{
     ComplexityBand, ComplexityInput, ComplexityReport, FallthroughInfo, ProvideInjectTreeSummary,
-    ReactivityIssue, ReactivityIssueKind, summarize_complexity,
+    ReactivityIssue, ReactivityIssueKind, summarize_complexity_with_graph,
 };
 use crate::analyzer::CrossFileResult;
+use crate::graph::{DependencyEdge, DependencyGraph, ModuleNode};
 use crate::registry::ModuleRegistry;
 use vize_carton::{CompactString, FxHashSet, smallvec};
 use vize_croquis::croquis::{
     ComponentUsage, EventListener, PassedProp, SlotUsage, TemplateExpression,
     TemplateExpressionKind,
 };
-use vize_croquis::{Croquis, ScopeId};
+use vize_croquis::{Croquis, ScopeId, VForScopeData, VSlotScopeData};
 
 #[test]
 fn scores_each_complexity_dimension() {
     let report = ComplexityReport::from_input(ComplexityInput {
         template_if_count: 2,
         template_for_count: 1,
+        component_tree_v_if_max_depth: 3,
+        component_tree_v_for_max_depth: 2,
+        component_tree_scoped_slot_max_depth: 3,
         slot_count: 3,
         prop_drilling_edge_count: 2,
         global_state_reference_count: 4,
@@ -27,14 +32,14 @@ fn scores_each_complexity_dimension() {
         reactive_cycle_count: 1,
     });
 
-    assert_eq!(report.dimensions.template_control_flow, 7);
-    assert_eq!(report.dimensions.slot_usage, 6);
+    assert_eq!(report.dimensions.template_control_flow, 20);
+    assert_eq!(report.dimensions.slot_usage, 14);
     assert_eq!(report.dimensions.prop_drilling, 6);
     assert_eq!(report.dimensions.global_state, 8);
     assert_eq!(report.dimensions.provide_inject, 9);
     assert_eq!(report.dimensions.fallthrough_attrs, 8);
     assert_eq!(report.dimensions.reactive_graph, 30);
-    assert_eq!(report.total_score, 74);
+    assert_eq!(report.total_score, 95);
     assert_eq!(report.band, ComplexityBand::Extreme);
 }
 
@@ -144,6 +149,74 @@ fn summarizes_complexity_from_registry_and_result() {
 }
 
 #[test]
+fn summarizes_component_tree_template_nesting() {
+    let mut parent = Croquis::new();
+    let parent_loop = parent
+        .scopes
+        .enter_v_for_scope(v_for_data("row", "rows"), 0, 20);
+    parent.component_usages.push(ComponentUsage {
+        name: CompactString::new("Child"),
+        start: 21,
+        end: 60,
+        props: smallvec![],
+        events: smallvec![],
+        slots: smallvec![SlotUsage {
+            name: CompactString::new("default"),
+            scope_vars: smallvec![CompactString::new("slotProps")],
+            start: 35,
+            end: 55,
+            has_scope: true,
+        }],
+        has_spread_attrs: false,
+        scope_id: parent_loop,
+        vif_guard: Some(CompactString::new("ready")),
+    });
+
+    let mut child = Croquis::new();
+    child.template_expressions.push(TemplateExpression {
+        content: CompactString::new("expanded"),
+        kind: TemplateExpressionKind::VIf,
+        start: 0,
+        end: 8,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    });
+    child
+        .scopes
+        .enter_v_for_scope(v_for_data("item", "items"), 9, 30);
+    child.scopes.exit_scope();
+    child.scopes.enter_v_slot_scope(
+        VSlotScopeData {
+            name: CompactString::new("default"),
+            props_pattern: None,
+            prop_names: smallvec![CompactString::new("item")],
+            component: Some(CompactString::new("GrandChild")),
+        },
+        31,
+        50,
+    );
+
+    let mut registry = ModuleRegistry::new();
+    let (parent_id, _) = registry.register("Parent.vue", "", parent);
+    let (child_id, _) = registry.register("Child.vue", "", child);
+    let mut graph = DependencyGraph::new();
+    graph.add_node(component_node(parent_id, "Parent.vue", "Parent"));
+    graph.add_node(component_node(child_id, "Child.vue", "Child"));
+    graph.add_edge(parent_id, child_id, DependencyEdge::ComponentUsage);
+
+    let report = summarize_complexity_with_graph(&registry, &graph, &CrossFileResult::default());
+
+    assert_eq!(report.input.template_if_count, 1);
+    assert_eq!(report.input.template_for_count, 2);
+    assert_eq!(report.input.slot_count, 1);
+    assert_eq!(report.input.component_tree_v_if_max_depth, 2);
+    assert_eq!(report.input.component_tree_v_for_max_depth, 2);
+    assert_eq!(report.input.component_tree_scoped_slot_max_depth, 2);
+    assert_eq!(report.dimensions.template_control_flow, 17);
+    assert_eq!(report.dimensions.slot_usage, 6);
+}
+
+#[test]
 fn score_saturates_instead_of_overflowing() {
     let report = ComplexityReport::from_input(ComplexityInput {
         reactive_cycle_count: usize::MAX,
@@ -153,4 +226,21 @@ fn score_saturates_instead_of_overflowing() {
     assert_eq!(report.dimensions.reactive_graph, u32::MAX);
     assert_eq!(report.total_score, u32::MAX);
     assert_eq!(report.band, ComplexityBand::Extreme);
+}
+
+fn v_for_data(value_alias: &str, source: &str) -> VForScopeData {
+    VForScopeData {
+        value_alias: CompactString::new(value_alias),
+        value_bindings: smallvec![CompactString::new(value_alias)],
+        key_alias: None,
+        index_alias: None,
+        source: CompactString::new(source),
+        key_expression: None,
+    }
+}
+
+fn component_node(id: crate::FileId, path: &str, name: &str) -> ModuleNode {
+    let mut node = ModuleNode::new(id, path);
+    node.component_name = Some(CompactString::new(name));
+    node
 }


### PR DESCRIPTION
## Summary
- add component-tree max-depth signals for v-if, v-for, and scoped slot complexity
- compute template nesting through DependencyGraph component usage edges instead of only per-file counts
- cover Parent -> Child nesting across guarded usage, v-for scope, and scoped slot usage

Refs #2749

## Tests
- cargo fmt --all -- --check
- cargo test -p vize_croquis_cf
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786180397&installation_id=136613492&pr_number=2759&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2759&signature=a3a6b8e7588b9c6e61664d07ab87f38122b70e741a35582e424ba109ee9053fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->