### PR TITLE
ci: add Miri transform checks

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,48 @@
+name: Miri
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: miri-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  MIRIFLAGS: "-Zmiri-ignore-leaks"
+
+jobs:
+  miri:
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # nightly
+        with:
+          toolchain: nightly
+          components: miri,rust-src
+
+      - uses: ./.github/actions/setup-rust-sticky-cache
+        with:
+          key: miri
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
+          target-path: target/miri
+
+      - name: Setup Miri
+        run: cargo +nightly miri setup
+
+      - name: Test VDOM transform with Miri
+        run: cargo +nightly miri test -p vize_atelier_core --test scoped_slot_shadowing
+
+      - name: Test DOM transform with Miri
+        run: cargo +nightly miri test -p vize_atelier_dom --test setup_component_unref
+
+      - name: Test SFC transform with Miri
+        run: cargo +nightly miri test -p vize_atelier_sfc --test setup_component_unref --no-default-features

--- a/crates/vize_atelier_core/src/transform/context.rs
+++ b/crates/vize_atelier_core/src/transform/context.rs
@@ -447,41 +447,36 @@ impl<'a> TransformContext<'a> {
 
     /// Replace current node with a new node
     pub fn replace_node(&mut self, new_node: TemplateChildNode<'a>) {
-        if let Some(parent) = &self.parent {
-            let children = parent.children_mut();
-            if self.child_index < children.len() {
-                children[self.child_index] = new_node;
-                self.current_node = Some(&mut children[self.child_index] as *mut _);
+        if let Some(current) = self.current_node {
+            // SAFETY: `current_node` is created from the active child slot that
+            // traversal is visiting. Replacing through that pointer avoids
+            // borrowing the parent children vector a second time while the
+            // current slot is already mutably borrowed.
+            unsafe {
+                *current = new_node;
             }
         }
     }
 
     /// Take the current node, replacing it with a placeholder
     pub fn take_current_node(&mut self) -> Option<TemplateChildNode<'a>> {
-        if let Some(parent) = &self.parent {
-            let children = parent.children_mut();
-            if self.child_index < children.len() {
-                let placeholder = TemplateChildNode::Comment(Box::new_in(
-                    CommentNode::new("", SourceLocation::STUB),
-                    self.allocator,
-                ));
-                let taken = std::mem::replace(&mut children[self.child_index], placeholder);
-                return Some(taken);
-            }
+        if let Some(current) = self.current_node {
+            let placeholder = TemplateChildNode::Comment(Box::new_in(
+                CommentNode::new("", SourceLocation::STUB),
+                self.allocator,
+            ));
+            // SAFETY: see `replace_node`. The pointer is derived from the
+            // active traversal slot, so this replacement does not create an
+            // independent mutable borrow of the parent children vector.
+            return Some(unsafe { std::mem::replace(&mut *current, placeholder) });
         }
         None
     }
 
     /// Remove current node
     pub fn remove_node(&mut self) {
-        if let Some(parent) = &self.parent {
-            let children = parent.children_mut();
-            if self.child_index < children.len() {
-                children.remove(self.child_index);
-                self.current_node = None;
-                self.node_removed = true;
-            }
-        }
+        self.current_node = None;
+        self.node_removed = true;
     }
 
     /// Remove a specific node

--- a/crates/vize_atelier_core/src/transform/traverse.rs
+++ b/crates/vize_atelier_core/src/transform/traverse.rs
@@ -50,19 +50,27 @@ fn enter_v_slot_scope_if_needed<'a>(ctx: &mut TransformContext<'a>, el: &Element
 
 /// Traverse children of a parent node
 pub fn traverse_children<'a>(ctx: &mut TransformContext<'a>, parent: ParentNode<'a>) {
-    let children = parent.children_mut();
     let mut i = 0;
 
-    while i < children.len() {
+    while i < parent.children_mut().len() {
         ctx.grandparent = ctx.parent;
         ctx.parent = Some(parent);
         ctx.child_index = i;
         ctx.reset_node_removed();
 
-        traverse_node(ctx, &mut children[i]);
+        {
+            let children = parent.children_mut();
+            traverse_node(ctx, &mut children[i]);
+        }
 
-        if ctx.was_node_removed() {
-            // Node was removed, don't increment i
+        let node_removed = ctx.was_node_removed();
+        ctx.reset_node_removed();
+
+        if node_removed {
+            let children = parent.children_mut();
+            if i < children.len() {
+                children.remove(i);
+            }
         } else {
             i += 1;
         }
@@ -71,225 +79,225 @@ pub fn traverse_children<'a>(ctx: &mut TransformContext<'a>, parent: ParentNode<
 
 /// Traverse a single node
 pub fn traverse_node<'a>(ctx: &mut TransformContext<'a>, node: &mut TemplateChildNode<'a>) {
-    ctx.current_node = Some(node as *mut _);
-
     // Collect exit functions from transforms
     let mut exit_fns = ExitFns::new();
 
-    // Apply node transforms based on node type
-    match node {
-        TemplateChildNode::Element(el) => {
-            // Check for structural directives first
-            let structural_result = profile!(
-                "atelier.transform.check_structural",
-                take_structural_directive(el)
-            );
+    // Check structural directives before storing the current-node pointer so
+    // the `Element` borrow ends before structural transforms replace the slot.
+    let structural_result = if let TemplateChildNode::Element(el) = node {
+        profile!(
+            "atelier.transform.check_structural",
+            take_structural_directive(el)
+        )
+    } else {
+        None
+    };
 
-            if let Some((directive_kind, exp, directive_loc)) = structural_result {
-                // Handle the structural directive
-                match directive_kind {
-                    StructuralDirectiveKind::If => {
-                        if let Some(exits) = profile!(
-                            "atelier.transform.v_if",
-                            transform_v_if_with_directive(
-                                ctx,
-                                directive_kind,
-                                exp.as_ref(),
-                                &directive_loc,
-                                true
-                            )
-                        ) {
-                            exit_fns.extend(exits);
-                        }
-                    }
-                    StructuralDirectiveKind::ElseIf | StructuralDirectiveKind::Else => {
-                        if let Some(exits) = profile!(
-                            "atelier.transform.v_if",
-                            transform_v_if_with_directive(
-                                ctx,
-                                directive_kind,
-                                exp.as_ref(),
-                                &directive_loc,
-                                false
-                            )
-                        ) {
-                            exit_fns.extend(exits);
-                        }
-                    }
-                    StructuralDirectiveKind::For => {
-                        if let Some(exits) = profile!(
-                            "atelier.transform.v_for",
-                            transform_v_for(ctx, exp.as_ref())
-                        ) {
-                            exit_fns.extend(exits);
-                        }
-                    }
+    ctx.current_node = Some(node as *mut _);
+
+    if let Some((directive_kind, exp, directive_loc)) = structural_result {
+        // Handle the structural directive
+        match directive_kind {
+            StructuralDirectiveKind::If => {
+                if let Some(exits) = profile!(
+                    "atelier.transform.v_if",
+                    transform_v_if_with_directive(
+                        ctx,
+                        directive_kind,
+                        exp.as_ref(),
+                        &directive_loc,
+                        true
+                    )
+                ) {
+                    exit_fns.extend(exits);
                 }
+            }
+            StructuralDirectiveKind::ElseIf | StructuralDirectiveKind::Else => {
+                if let Some(exits) = profile!(
+                    "atelier.transform.v_if",
+                    transform_v_if_with_directive(
+                        ctx,
+                        directive_kind,
+                        exp.as_ref(),
+                        &directive_loc,
+                        false
+                    )
+                ) {
+                    exit_fns.extend(exits);
+                }
+            }
+            StructuralDirectiveKind::For => {
+                if let Some(exits) = profile!(
+                    "atelier.transform.v_for",
+                    transform_v_for(ctx, exp.as_ref())
+                ) {
+                    exit_fns.extend(exits);
+                }
+            }
+        }
 
-                // If node was replaced (e.g., by v-if transform), we need to traverse the new node
-                if let Some(current_ptr) = ctx.current_node {
-                    // SAFETY: `ctx.current_node` is written immediately before
-                    // transforms run and points at the child slot currently owned
-                    // by the traversal loop. Structural transforms may replace
-                    // that slot, but they do not free the bump-allocated storage
-                    // or retain another mutable reference to it. We reborrow here
-                    // only after the transform call returns so we can inspect the
-                    // replacement without cloning the AST node.
-                    let current = unsafe { &mut *current_ptr };
-                    match current {
-                        TemplateChildNode::If(if_node) => {
-                            // Traverse if branches that were just created
-                            for i in 0..if_node.branches.len() {
-                                let branch_ptr = &mut if_node.branches[i] as *mut IfBranchNode<'a>;
-                                profile!(
-                                    "atelier.transform.traverse_v_if_branch",
-                                    traverse_children(ctx, ParentNode::IfBranch(branch_ptr))
-                                );
-                            }
-                            // Run exit functions and return early
-                            for exit_fn in exit_fns.into_iter().rev() {
-                                profile!("atelier.transform.exit_fn", exit_fn(ctx));
-                            }
-                            return;
-                        }
-                        TemplateChildNode::For(for_node) => {
-                            // Enter v-for scope with aliases
-                            let value = for_node.value_alias.as_ref().and_then(|e| {
-                                if let ExpressionNode::Simple(exp) = e {
-                                    Some(exp.content.as_str())
-                                } else {
-                                    None
-                                }
-                            });
-                            let key = for_node.key_alias.as_ref().and_then(|e| {
-                                if let ExpressionNode::Simple(exp) = e {
-                                    Some(exp.content.as_str())
-                                } else {
-                                    None
-                                }
-                            });
-                            let index = for_node.object_index_alias.as_ref().and_then(|e| {
-                                if let ExpressionNode::Simple(exp) = e {
-                                    Some(exp.content.as_str())
-                                } else {
-                                    None
-                                }
-                            });
-                            let source = match &for_node.source {
-                                ExpressionNode::Simple(exp) => exp.content.as_str(),
-                                ExpressionNode::Compound(c) => c.loc.source.as_str(),
-                            };
-                            ctx.enter_v_for_scope(value, key, index, source);
-
-                            // Traverse for children
-                            let for_ptr = for_node.as_mut() as *mut ForNode<'a>;
-                            profile!(
-                                "atelier.transform.traverse_v_for_children",
-                                traverse_children(ctx, ParentNode::For(for_ptr))
-                            );
-
-                            // Exit v-for scope
-                            ctx.exit_scope();
-
-                            // Add helpers
-                            ctx.helper(RuntimeHelper::RenderList);
-                            ctx.helper(RuntimeHelper::Fragment);
-
-                            // Run exit functions and return early
-                            for exit_fn in exit_fns.into_iter().rev() {
-                                profile!("atelier.transform.exit_fn", exit_fn(ctx));
-                            }
-                            return;
-                        }
-                        TemplateChildNode::Element(el) => {
-                            // Still an element, process it
-                            if let Some(exits) =
-                                profile!("atelier.transform.element", transform_element(ctx, el))
-                            {
-                                exit_fns.extend(exits);
-                            }
-                        }
-                        _ => {}
+        // If node was replaced (e.g., by v-if transform), we need to traverse the new node
+        if let Some(current_ptr) = ctx.current_node {
+            // SAFETY: `ctx.current_node` points at the child slot currently owned
+            // by the traversal loop. Structural transforms may replace that slot,
+            // but they do not retain another mutable reference to it.
+            let current = unsafe { &mut *current_ptr };
+            match current {
+                TemplateChildNode::If(if_node) => {
+                    // Traverse if branches that were just created
+                    for i in 0..if_node.branches.len() {
+                        let branch_ptr = &mut if_node.branches[i] as *mut IfBranchNode<'a>;
+                        profile!(
+                            "atelier.transform.traverse_v_if_branch",
+                            traverse_children(ctx, ParentNode::IfBranch(branch_ptr))
+                        );
                     }
-                } else {
-                    // Node was removed, return early
+                    // Run exit functions and return early
+                    for exit_fn in exit_fns.into_iter().rev() {
+                        profile!("atelier.transform.exit_fn", exit_fn(ctx));
+                    }
                     return;
                 }
-            } else {
-                // No structural directive, process element normally
+                TemplateChildNode::For(for_node) => {
+                    // Enter v-for scope with aliases
+                    let value = for_node.value_alias.as_ref().and_then(|e| {
+                        if let ExpressionNode::Simple(exp) = e {
+                            Some(exp.content.as_str())
+                        } else {
+                            None
+                        }
+                    });
+                    let key = for_node.key_alias.as_ref().and_then(|e| {
+                        if let ExpressionNode::Simple(exp) = e {
+                            Some(exp.content.as_str())
+                        } else {
+                            None
+                        }
+                    });
+                    let index = for_node.object_index_alias.as_ref().and_then(|e| {
+                        if let ExpressionNode::Simple(exp) = e {
+                            Some(exp.content.as_str())
+                        } else {
+                            None
+                        }
+                    });
+                    let source = match &for_node.source {
+                        ExpressionNode::Simple(exp) => exp.content.as_str(),
+                        ExpressionNode::Compound(c) => c.loc.source.as_str(),
+                    };
+                    ctx.enter_v_for_scope(value, key, index, source);
+
+                    // Traverse for children
+                    let for_ptr = for_node.as_mut() as *mut ForNode<'a>;
+                    profile!(
+                        "atelier.transform.traverse_v_for_children",
+                        traverse_children(ctx, ParentNode::For(for_ptr))
+                    );
+
+                    // Exit v-for scope
+                    ctx.exit_scope();
+
+                    // Add helpers
+                    ctx.helper(RuntimeHelper::RenderList);
+                    ctx.helper(RuntimeHelper::Fragment);
+
+                    // Run exit functions and return early
+                    for exit_fn in exit_fns.into_iter().rev() {
+                        profile!("atelier.transform.exit_fn", exit_fn(ctx));
+                    }
+                    return;
+                }
+                TemplateChildNode::Element(el) => {
+                    // Still an element, process it
+                    if let Some(exits) =
+                        profile!("atelier.transform.element", transform_element(ctx, el))
+                    {
+                        exit_fns.extend(exits);
+                    }
+                }
+                _ => {}
+            }
+        } else {
+            // Node was removed, return early
+            return;
+        }
+    } else {
+        // Apply node transforms based on node type
+        match node {
+            TemplateChildNode::Element(el) => {
                 if let Some(exits) =
                     profile!("atelier.transform.element", transform_element(ctx, el))
                 {
                     exit_fns.extend(exits);
                 }
             }
-        }
-        TemplateChildNode::Interpolation(interp) => {
-            profile!(
-                "atelier.transform.interpolation",
-                transform_interpolation(ctx, interp)
-            );
-        }
-        TemplateChildNode::Text(_) => {
-            ctx.helper(RuntimeHelper::CreateText);
-        }
-        TemplateChildNode::Comment(_) => {
-            ctx.helper(RuntimeHelper::CreateComment);
-        }
-        TemplateChildNode::If(if_node) => {
-            // Traverse if branches
-            for i in 0..if_node.branches.len() {
-                let branch_ptr = &mut if_node.branches[i] as *mut IfBranchNode<'a>;
+            TemplateChildNode::Interpolation(interp) => {
                 profile!(
-                    "atelier.transform.traverse_v_if_branch",
-                    traverse_children(ctx, ParentNode::IfBranch(branch_ptr))
+                    "atelier.transform.interpolation",
+                    transform_interpolation(ctx, interp)
                 );
             }
+            TemplateChildNode::Text(_) => {
+                ctx.helper(RuntimeHelper::CreateText);
+            }
+            TemplateChildNode::Comment(_) => {
+                ctx.helper(RuntimeHelper::CreateComment);
+            }
+            TemplateChildNode::If(if_node) => {
+                // Traverse if branches
+                for i in 0..if_node.branches.len() {
+                    let branch_ptr = &mut if_node.branches[i] as *mut IfBranchNode<'a>;
+                    profile!(
+                        "atelier.transform.traverse_v_if_branch",
+                        traverse_children(ctx, ParentNode::IfBranch(branch_ptr))
+                    );
+                }
+            }
+            TemplateChildNode::For(for_node) => {
+                // Enter v-for scope with aliases
+                let value = for_node.value_alias.as_ref().and_then(|e| {
+                    if let ExpressionNode::Simple(exp) = e {
+                        Some(exp.content.as_str())
+                    } else {
+                        None
+                    }
+                });
+                let key = for_node.key_alias.as_ref().and_then(|e| {
+                    if let ExpressionNode::Simple(exp) = e {
+                        Some(exp.content.as_str())
+                    } else {
+                        None
+                    }
+                });
+                let index = for_node.object_index_alias.as_ref().and_then(|e| {
+                    if let ExpressionNode::Simple(exp) = e {
+                        Some(exp.content.as_str())
+                    } else {
+                        None
+                    }
+                });
+                let source = match &for_node.source {
+                    ExpressionNode::Simple(exp) => exp.content.as_str(),
+                    ExpressionNode::Compound(c) => c.loc.source.as_str(),
+                };
+                ctx.enter_v_for_scope(value, key, index, source);
+
+                // Traverse for children
+                let for_ptr = for_node.as_mut() as *mut ForNode<'a>;
+                profile!(
+                    "atelier.transform.traverse_v_for_children",
+                    traverse_children(ctx, ParentNode::For(for_ptr))
+                );
+
+                // Exit v-for scope
+                ctx.exit_scope();
+
+                // Add helpers
+                ctx.helper(RuntimeHelper::RenderList);
+                ctx.helper(RuntimeHelper::Fragment);
+            }
+            _ => {}
         }
-        TemplateChildNode::For(for_node) => {
-            // Enter v-for scope with aliases
-            let value = for_node.value_alias.as_ref().and_then(|e| {
-                if let ExpressionNode::Simple(exp) = e {
-                    Some(exp.content.as_str())
-                } else {
-                    None
-                }
-            });
-            let key = for_node.key_alias.as_ref().and_then(|e| {
-                if let ExpressionNode::Simple(exp) = e {
-                    Some(exp.content.as_str())
-                } else {
-                    None
-                }
-            });
-            let index = for_node.object_index_alias.as_ref().and_then(|e| {
-                if let ExpressionNode::Simple(exp) = e {
-                    Some(exp.content.as_str())
-                } else {
-                    None
-                }
-            });
-            let source = match &for_node.source {
-                ExpressionNode::Simple(exp) => exp.content.as_str(),
-                ExpressionNode::Compound(c) => c.loc.source.as_str(),
-            };
-            ctx.enter_v_for_scope(value, key, index, source);
-
-            // Traverse for children
-            let for_ptr = for_node.as_mut() as *mut ForNode<'a>;
-            profile!(
-                "atelier.transform.traverse_v_for_children",
-                traverse_children(ctx, ParentNode::For(for_ptr))
-            );
-
-            // Exit v-for scope
-            ctx.exit_scope();
-
-            // Add helpers
-            ctx.helper(RuntimeHelper::RenderList);
-            ctx.helper(RuntimeHelper::Fragment);
-        }
-        _ => {}
     }
 
     // Traverse children for element nodes

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -19,6 +19,7 @@ test("GitHub workflows opt JavaScript actions into Node 24", () => {
   for (const workflowName of [
     "check.yml",
     "deploy-docs.yml",
+    "miri.yml",
     "native-smoke.yml",
     "pkg-pr-new.yml",
     "release.yml",
@@ -38,6 +39,7 @@ test("GitHub workflows use the current cache action", () => {
     ".github/workflows/check.yml",
     ".github/workflows/deploy-docs.yml",
     ".github/workflows/e2e.yml",
+    ".github/workflows/miri.yml",
     ".github/workflows/native-smoke.yml",
     ".github/workflows/release.yml",
     ".github/workflows/tool-benchmark.yml",
@@ -204,6 +206,7 @@ test("Blacksmith Rust CI uses sticky disks for Cargo and target caches", () => {
     "deploy-docs.yml",
     "e2e.yml",
     "fuzz.yml",
+    "miri.yml",
     "tool-benchmark.yml",
   ]) {
     const workflow = readRepoFile(".github", "workflows", workflowName);


### PR DESCRIPTION
## Summary

- Add a dedicated Miri workflow for transform-focused Rust tests on nightly.
- Route structural transform node replacement through the active traversal slot so Miri does not flag aliased parent-child mutation.
- Cover the new workflow in the GitHub workflow policy tests.

## Validation

- `MIRIFLAGS=-Zmiri-ignore-leaks cargo +nightly miri setup`
- `MIRIFLAGS=-Zmiri-ignore-leaks cargo +nightly miri test -p vize_atelier_core --test scoped_slot_shadowing`
- `MIRIFLAGS=-Zmiri-ignore-leaks cargo +nightly miri test -p vize_atelier_dom --test setup_component_unref`
- `MIRIFLAGS=-Zmiri-ignore-leaks cargo +nightly miri test -p vize_atelier_sfc --test setup_component_unref --no-default-features`
- `cargo test -p vize_atelier_core -p vize_atelier_dom -p vize_atelier_sfc --tests`
- `cargo clippy -p vize_atelier_core -p vize_atelier_dom -p vize_atelier_sfc -- -D warnings -D clippy::wildcard_imports`
- `node --test tests/tooling/github-workflows-check.test.ts tests/tooling/github-workflows.test.ts tests/tooling/github-workflows-setup.test.ts`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786182386&installation_id=136613492&pr_number=2761&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2761&signature=ca3fe17d2ef822bee4b0fcd9b4b78455eac936eb2d5813509173b43f59b5891c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust node traversal handling to make template updates and structural changes more reliable.
  * Adjusted node removal and replacement behavior to reduce traversal issues during rendering.

* **Chores**
  * Added Miri checks to CI for Rust code on pushes and pull requests to help catch memory-safety regressions earlier.

* **Tests**
  * Expanded workflow validation coverage to include the new Miri pipeline and cache-related settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->