### PR TITLE
perf(vite): reduce virtual module build overhead

### DIFF
--- a/bench/results/tool-benchmark-latest.json
+++ b/bench/results/tool-benchmark-latest.json
@@ -1,18 +1,18 @@
 {
   "schemaVersion": 1,
   "kind": "tool-comparison",
-  "generatedAt": "2026-07-09T08:21:44.267Z",
+  "generatedAt": "2026-07-09T10:06:01.799Z",
   "commit": {
-    "sha": "ed87e96f15f12bde29acaf299816bda286dd1176",
-    "ref": "codex/update-blacksmith-benchmark",
+    "sha": "27fe77df7c8773e8e8fd5fa54beb7b09997b3a88",
+    "ref": "codex/perf-toolchain-throughput",
     "repository": "ubugeeei-prod/vize",
-    "runUrl": "https://github.com/ubugeeei-prod/vize/actions/runs/29004198781"
+    "runUrl": "https://github.com/ubugeeei-prod/vize/actions/runs/29010164013"
   },
   "runner": {
     "label": "blacksmith-32vcpu-ubuntu-2404",
     "blacksmithMaxSpec": "32 vCPU / 128 GB RAM / 1.5 TB storage",
     "cpuCount": 32,
-    "cpuModel": "Intel(R) Xeon(R) Processor",
+    "cpuModel": "AMD EPYC",
     "platform": "linux",
     "arch": "x64",
     "osRelease": "6.6.141",
@@ -58,43 +58,43 @@
         {
           "id": "vue-compiler-sfc-1t",
           "label": "@vue/compiler-sfc (1T)",
-          "medianMs": 18381.613,
-          "runs": [18474.945, 18515.254, 18381.613, 18292.15, 18269.271],
-          "throughput": "816 files/s"
+          "medianMs": 17544.994,
+          "runs": [17877.873, 17585.688, 17490.058, 17544.994, 17317.17],
+          "throughput": "855 files/s"
         },
         {
           "id": "vue-compiler-sfc-workers",
           "label": "@vue/compiler-sfc (32 workers)",
-          "medianMs": 5898.056,
-          "runs": [5927.416, 5764.126, 5898.056, 6538.22, 5815.417],
+          "medianMs": 5895.606,
+          "runs": [5887.487, 5895.606, 5862.726, 5951.76, 6094.778],
           "throughput": "2.5k files/s"
         },
         {
           "id": "vize-native-1t",
           "label": "Vize native loop (1T)",
-          "medianMs": 3533.725,
-          "runs": [3394.346, 3533.725, 3457.731, 3582.037, 3559.187],
-          "throughput": "4.2k files/s"
+          "medianMs": 3230.099,
+          "runs": [3102.965, 3132.096, 3356.702, 3362.025, 3230.099],
+          "throughput": "4.6k files/s"
         },
         {
           "id": "vize-native-max",
           "label": "Vize native batch results (max)",
-          "medianMs": 333.846,
-          "runs": [319.16, 317.021, 336.466, 339.329, 333.846],
-          "throughput": "44.9k files/s"
+          "medianMs": 290.827,
+          "runs": [290.827, 272.867, 302.781, 274.735, 302.864],
+          "throughput": "51.6k files/s"
         },
         {
           "id": "vize-native-core-max",
           "label": "Vize native batch stats-only (core max)",
-          "medianMs": 203.482,
-          "runs": [189.116, 195.699, 203.482, 221.917, 206.105],
-          "throughput": "73.7k files/s"
+          "medianMs": 178.793,
+          "runs": [172.909, 174.304, 178.793, 180.3, 180.113],
+          "throughput": "83.9k files/s"
         }
       ],
       "baselineId": "vue-compiler-sfc-1t",
       "vizeSingleId": "vize-native-1t",
       "vizeMaxId": "vize-native-max",
-      "primarySpeedup": 55.060098
+      "primarySpeedup": 60.327940665756614
     },
     {
       "id": "large-compile",
@@ -105,43 +105,43 @@
         {
           "id": "vue-compiler-sfc-1t",
           "label": "@vue/compiler-sfc (1T)",
-          "medianMs": 175.629,
-          "runs": [172.924, 175.629, 180.262, 185.34, 173.436],
-          "throughput": "6 files/s"
+          "medianMs": 192.588,
+          "runs": [192.556, 192.588, 197.188, 195.874, 190.672],
+          "throughput": "5 files/s"
         },
         {
           "id": "vue-compiler-sfc-workers",
           "label": "@vue/compiler-sfc (1 workers)",
-          "medianMs": 437.275,
-          "runs": [417.035, 413.13, 450.258, 477.664, 437.275],
+          "medianMs": 479.83,
+          "runs": [468.336, 475.376, 479.83, 555.926, 493.06],
           "throughput": "2 files/s"
         },
         {
           "id": "vize-native-1t",
           "label": "Vize native loop (1T)",
-          "medianMs": 65.542,
-          "runs": [65.542, 60.568, 68.952, 61.14, 73.451],
-          "throughput": "15 files/s"
+          "medianMs": 62.608,
+          "runs": [62.608, 55.058, 65.224, 57.131, 64.989],
+          "throughput": "16 files/s"
         },
         {
           "id": "vize-native-max",
           "label": "Vize native batch results (max)",
-          "medianMs": 60.843,
-          "runs": [60.157, 59.212, 60.843, 60.894, 63.651],
-          "throughput": "16 files/s"
+          "medianMs": 56.347,
+          "runs": [54.847, 54.316, 56.347, 56.409, 56.784],
+          "throughput": "18 files/s"
         },
         {
           "id": "vize-native-core-max",
           "label": "Vize native batch stats-only (core max)",
-          "medianMs": 60.043,
-          "runs": [60.043, 59.821, 59.925, 61.184, 64.468],
-          "throughput": "17 files/s"
+          "medianMs": 55.679,
+          "runs": [56.69, 53.361, 55.679, 55.29, 55.842],
+          "throughput": "18 files/s"
         }
       ],
       "baselineId": "vue-compiler-sfc-1t",
       "vizeSingleId": "vize-native-1t",
       "vizeMaxId": "vize-native-max",
-      "primarySpeedup": 2.88658
+      "primarySpeedup": 3.4178927005874313
     },
     {
       "id": "large-check",
@@ -152,29 +152,29 @@
         {
           "id": "vue-tsc",
           "label": "vue-tsc",
-          "medianMs": 1589.268,
-          "runs": [1563.333, 1590.197, 1573.676, 1589.966, 1589.268],
+          "medianMs": 1685.767,
+          "runs": [1703.499, 1716.442, 1684.449, 1624.718, 1685.767],
           "throughput": "1 files/s"
         },
         {
           "id": "vize-check-1t",
           "label": "Vize check (1T)",
-          "medianMs": 177.714,
-          "runs": [198.992, 177.714, 166.951, 175.923, 180.063],
+          "medianMs": 178.667,
+          "runs": [176.247, 178.357, 179.08, 189.417, 178.667],
           "throughput": "6 files/s"
         },
         {
           "id": "vize-check-max",
           "label": "Vize check (max)",
-          "medianMs": 178.997,
-          "runs": [172.697, 170.537, 178.997, 186.934, 190.604],
+          "medianMs": 177.986,
+          "runs": [177.669, 177.986, 177.536, 189.49, 194.54],
           "throughput": "6 files/s"
         }
       ],
       "baselineId": "vue-tsc",
       "vizeSingleId": "vize-check-1t",
       "vizeMaxId": "vize-check-max",
-      "primarySpeedup": 8.878727
+      "primarySpeedup": 9.471346060926141
     },
     {
       "id": "lint",
@@ -185,36 +185,36 @@
         {
           "id": "eslint-plugin-vue-1t",
           "label": "eslint-plugin-vue (1T)",
-          "medianMs": 56662.08,
-          "runs": [56662.08, 57035.896, 56370.59, 57126.088, 56444.187],
-          "throughput": "265 files/s"
+          "medianMs": 54319.872,
+          "runs": [54319.872, 54437.033, 53474.329, 54345.131, 54062.131],
+          "throughput": "276 files/s"
         },
         {
           "id": "eslint-plugin-vue-workers",
           "label": "eslint-plugin-vue (32 workers)",
-          "medianMs": 13489.525,
-          "runs": [13489.525, 13218.019, 12971.462, 13841.78, 13632.247],
+          "medianMs": 13468.854,
+          "runs": [13407.982, 13607.48, 13625.526, 13255.324, 13468.854],
           "throughput": "1.1k files/s"
         },
         {
           "id": "vize-lint-1t",
           "label": "Vize lint (1T)",
-          "medianMs": 2037.381,
-          "runs": [2037.381, 2009.036, 2037.687, 2012.355, 2066.377],
-          "throughput": "7.4k files/s"
+          "medianMs": 1907.507,
+          "runs": [1879.343, 1840.364, 1907.507, 1914.898, 1966.427],
+          "throughput": "7.9k files/s"
         },
         {
           "id": "vize-lint-max",
           "label": "Vize lint (max)",
-          "medianMs": 270.852,
-          "runs": [267.933, 260.577, 276.817, 270.852, 271.656],
-          "throughput": "55.4k files/s"
+          "medianMs": 279.25,
+          "runs": [275.799, 272.071, 287.929, 287.064, 279.25],
+          "throughput": "53.7k files/s"
         }
       ],
       "baselineId": "eslint-plugin-vue-1t",
       "vizeSingleId": "vize-lint-1t",
       "vizeMaxId": "vize-lint-max",
-      "primarySpeedup": 209.199333
+      "primarySpeedup": 194.52058012533573
     },
     {
       "id": "fmt",
@@ -225,29 +225,29 @@
         {
           "id": "prettier-cli",
           "label": "Prettier CLI",
-          "medianMs": 150340.2,
-          "runs": [150340.2, 149306.242, 150232.62, 150879.262, 151352.09],
-          "throughput": "100 files/s"
+          "medianMs": 143610.675,
+          "runs": [142611.41, 142381.131, 143610.675, 145976.134, 144940.38],
+          "throughput": "104 files/s"
         },
         {
           "id": "vize-fmt-1t",
           "label": "Vize fmt (1T)",
-          "medianMs": 11530.355,
-          "runs": [11530.355, 11823.67, 11359.548, 11672.244, 11524.792],
-          "throughput": "1.3k files/s"
+          "medianMs": 10151.052,
+          "runs": [10104.727, 10264.407, 10151.052, 10429.647, 9815.545],
+          "throughput": "1.5k files/s"
         },
         {
           "id": "vize-fmt-max",
           "label": "Vize fmt (max)",
-          "medianMs": 2216.091,
-          "runs": [2216.091, 2311.386, 2198.579, 2258.965, 2175.639],
-          "throughput": "6.8k files/s"
+          "medianMs": 1788.982,
+          "runs": [1783.628, 1788.982, 1823.533, 1815.69, 1784.151],
+          "throughput": "8.4k files/s"
         }
       ],
       "baselineId": "prettier-cli",
       "vizeSingleId": "vize-fmt-1t",
       "vizeMaxId": "vize-fmt-max",
-      "primarySpeedup": 67.840271
+      "primarySpeedup": 80.27508102373305
     },
     {
       "id": "check",
@@ -258,29 +258,29 @@
         {
           "id": "vue-tsc",
           "label": "vue-tsc",
-          "medianMs": 5417.624,
-          "runs": [5386.595, 5499.318, 5417.624, 5447.138, 5416.21],
-          "throughput": "92 files/s"
+          "medianMs": 5364.227,
+          "runs": [5462.185, 5364.227, 5502.866, 5336.913, 5363.343],
+          "throughput": "93 files/s"
         },
         {
           "id": "vize-check-1t",
           "label": "Vize check (1T)",
-          "medianMs": 521.286,
-          "runs": [514.958, 526.474, 532.835, 508.051, 521.286],
-          "throughput": "959 files/s"
+          "medianMs": 500.458,
+          "runs": [489.085, 513.568, 500.458, 503.987, 491.239],
+          "throughput": "999 files/s"
         },
         {
           "id": "vize-check-max",
           "label": "Vize check (max)",
-          "medianMs": 438.323,
-          "runs": [436.15, 440.786, 440.217, 431.116, 438.323],
-          "throughput": "1.1k files/s"
+          "medianMs": 430.141,
+          "runs": [427.418, 430.141, 421.349, 438.772, 431.313],
+          "throughput": "1.2k files/s"
         }
       ],
       "baselineId": "vue-tsc",
       "vizeSingleId": "vize-check-1t",
       "vizeMaxId": "vize-check-max",
-      "primarySpeedup": 12.359882
+      "primarySpeedup": 12.470857230536033
     },
     {
       "id": "vite",
@@ -291,22 +291,22 @@
         {
           "id": "vite-plugin-vue",
           "label": "@vitejs/plugin-vue",
-          "medianMs": 1703.556,
-          "runs": [1884.89, 1772.88, 1672.827, 1698.322, 1703.556],
-          "throughput": "587 files/s"
+          "medianMs": 1664.563,
+          "runs": [1653.415, 1608.25, 1685.384, 1664.563, 1951.632],
+          "throughput": "601 files/s"
         },
         {
           "id": "vize-vite-plugin",
           "label": "@vizejs/vite-plugin",
-          "medianMs": 1521.768,
-          "runs": [1522.597, 1521.768, 1630.257, 1499.291, 1517.333],
-          "throughput": "657 files/s"
+          "medianMs": 732.519,
+          "runs": [732.519, 713.234, 746.155, 691.909, 752.751],
+          "throughput": "1.4k files/s"
         }
       ],
       "baselineId": "vite-plugin-vue",
       "vizeSingleId": null,
       "vizeMaxId": "vize-vite-plugin",
-      "primarySpeedup": 1.119459
+      "primarySpeedup": 2.272382013299314
     },
     {
       "id": "nuxt",
@@ -317,22 +317,22 @@
         {
           "id": "nuxt-default",
           "label": "Nuxt default compiler",
-          "medianMs": 6681.37,
-          "runs": [6697.304, 6681.37, 6673.951, 6698.137, 6679.414],
-          "throughput": "75 files/s"
+          "medianMs": 6792.975,
+          "runs": [6735.87, 6728.321, 6856.428, 6885.255, 6792.975],
+          "throughput": "74 files/s"
         },
         {
           "id": "vize-nuxt",
           "label": "@vizejs/nuxt",
-          "medianMs": 7350.39,
-          "runs": [7350.39, 7344.996, 7302.459, 7386.558, 7388.965],
-          "throughput": "68 files/s"
+          "medianMs": 6421.713,
+          "runs": [6362.123, 6421.713, 6312.05, 6503.098, 6500.326],
+          "throughput": "78 files/s"
         }
       ],
       "baselineId": "nuxt-default",
       "vizeSingleId": null,
       "vizeMaxId": "vize-nuxt",
-      "primarySpeedup": 0.908982
+      "primarySpeedup": 1.0578135460117886
     }
   ]
 }

--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -120,7 +120,12 @@ pub(super) fn auto_server_count(project: &VirtualProject) -> usize {
     let threads = std::thread::available_parallelism()
         .map(std::num::NonZero::get)
         .unwrap_or(1);
-    (threads / 4).min(vue_files / 64).clamp(1, 8)
+    let cpu_budget = if threads >= 8 {
+        4
+    } else {
+        threads.div_ceil(4)
+    };
+    cpu_budget.min(vue_files / 64).clamp(1, 8)
 }
 
 struct ShardPlan<'a> {

--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -120,8 +120,7 @@ pub(super) fn auto_server_count(project: &VirtualProject) -> usize {
     let threads = std::thread::available_parallelism()
         .map(std::num::NonZero::get)
         .unwrap_or(1);
-    let cpu_budget = if threads >= 8 { 4 } else { threads.div_ceil(4) };
-    cpu_budget.min(vue_files / 64).clamp(1, 8)
+    threads.div_ceil(4).min(4).min(vue_files / 64).clamp(1, 8)
 }
 
 struct ShardPlan<'a> {

--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -120,11 +120,7 @@ pub(super) fn auto_server_count(project: &VirtualProject) -> usize {
     let threads = std::thread::available_parallelism()
         .map(std::num::NonZero::get)
         .unwrap_or(1);
-    let cpu_budget = if threads >= 8 {
-        4
-    } else {
-        threads.div_ceil(4)
-    };
+    let cpu_budget = if threads >= 8 { 4 } else { threads.div_ceil(4) };
     cpu_budget.min(vue_files / 64).clamp(1, 8)
 }
 

--- a/docs/content/architecture/performance-blacksmith.md
+++ b/docs/content/architecture/performance-blacksmith.md
@@ -10,22 +10,22 @@ This page is generated from the Tool Benchmark workflow so published performance
 
 ## Latest Result
 
-Measured: 2026-07-09T08:21:44.267Z
-Commit: `ed87e96f15f1` ([run](https://github.com/ubugeeei-prod/vize/actions/runs/29004198781))
-Runner: `blacksmith-32vcpu-ubuntu-2404` (32 logical CPU, Intel(R) Xeon(R) Processor, 32 vCPU / 128 GB RAM / 1.5 TB storage)
+Measured: 2026-07-09T10:06:01.799Z
+Commit: `27fe77df7c87` ([run](https://github.com/ubugeeei-prod/vize/actions/runs/29010164013))
+Runner: `blacksmith-32vcpu-ubuntu-2404` (32 logical CPU, AMD EPYC, 32 vCPU / 128 GB RAM / 1.5 TB storage)
 Input: 15,000 generated SFC files (58.7 MB). Median of 5 measured run(s) after 1 warmup run(s).
 Large SFC: 900 repeated template blocks (674.9 KB). Nuxt import set: 500 SFC files.
 
 | Surface                     |  Files | Existing tool          | Existing median | Vize 1T | Vize max | Speedup |
 | --------------------------- | -----: | ---------------------- | --------------: | ------: | -------: | ------: |
-| SFC compile                 | 15,000 | @vue/compiler-sfc (1T) |          18.38s |   3.53s |  333.8ms |   55.1x |
-| Large SFC compile           |      1 | @vue/compiler-sfc (1T) |         175.6ms |  65.5ms |   60.8ms |    2.9x |
-| Large SFC type check        |      1 | vue-tsc                |           1.59s | 177.7ms |  179.0ms |    8.9x |
-| Lint                        | 15,000 | eslint-plugin-vue (1T) |          56.66s |   2.04s |  270.9ms |  209.2x |
-| Format                      | 15,000 | Prettier CLI           |         150.34s |  11.53s |    2.22s |   67.8x |
-| Type check                  |    500 | vue-tsc                |           5.42s | 521.3ms |  438.3ms |   12.4x |
-| Vite build (end-to-end)     |  1,000 | @vitejs/plugin-vue     |           1.70s |     n/a |    1.52s |    1.1x |
-| Nuxt SPA build (end-to-end) |    500 | Nuxt default compiler  |           6.68s |     n/a |    7.35s |    0.9x |
+| SFC compile                 | 15,000 | @vue/compiler-sfc (1T) |          17.54s |   3.23s |  290.8ms |   60.3x |
+| Large SFC compile           |      1 | @vue/compiler-sfc (1T) |         192.6ms |  62.6ms |   56.3ms |    3.4x |
+| Large SFC type check        |      1 | vue-tsc                |           1.69s | 178.7ms |  178.0ms |    9.5x |
+| Lint                        | 15,000 | eslint-plugin-vue (1T) |          54.32s |   1.91s |  279.3ms |  194.5x |
+| Format                      | 15,000 | Prettier CLI           |         143.61s |  10.15s |    1.79s |   80.3x |
+| Type check                  |    500 | vue-tsc                |           5.36s | 500.5ms |  430.1ms |   12.5x |
+| Vite build (end-to-end)     |  1,000 | @vitejs/plugin-vue     |           1.66s |     n/a |  732.5ms |    2.3x |
+| Nuxt SPA build (end-to-end) |    500 | Nuxt default compiler  |           6.79s |     n/a |    6.42s |    1.1x |
 
 Fairness notes:
 
@@ -53,67 +53,67 @@ node bench/compare-tools.mjs --input bench/__in__ --vize-bin target/release/vize
 
 | Variant                                 |  Median |    Throughput | Raw measured runs                           |
 | --------------------------------------- | ------: | ------------: | ------------------------------------------- |
-| @vue/compiler-sfc (1T)                  |  18.38s |   816 files/s | 18.47s, 18.52s, 18.38s, 18.29s, 18.27s      |
-| @vue/compiler-sfc (32 workers)          |   5.90s |  2.5k files/s | 5.93s, 5.76s, 5.90s, 6.54s, 5.82s           |
-| Vize native loop (1T)                   |   3.53s |  4.2k files/s | 3.39s, 3.53s, 3.46s, 3.58s, 3.56s           |
-| Vize native batch results (max)         | 333.8ms | 44.9k files/s | 319.2ms, 317.0ms, 336.5ms, 339.3ms, 333.8ms |
-| Vize native batch stats-only (core max) | 203.5ms | 73.7k files/s | 189.1ms, 195.7ms, 203.5ms, 221.9ms, 206.1ms |
+| @vue/compiler-sfc (1T)                  |  17.54s |   855 files/s | 17.88s, 17.59s, 17.49s, 17.54s, 17.32s      |
+| @vue/compiler-sfc (32 workers)          |   5.90s |  2.5k files/s | 5.89s, 5.90s, 5.86s, 5.95s, 6.09s           |
+| Vize native loop (1T)                   |   3.23s |  4.6k files/s | 3.10s, 3.13s, 3.36s, 3.36s, 3.23s           |
+| Vize native batch results (max)         | 290.8ms | 51.6k files/s | 290.8ms, 272.9ms, 302.8ms, 274.7ms, 302.9ms |
+| Vize native batch stats-only (core max) | 178.8ms | 83.9k files/s | 172.9ms, 174.3ms, 178.8ms, 180.3ms, 180.1ms |
 
 ### Large SFC compile
 
 | Variant                                 |  Median | Throughput | Raw measured runs                           |
 | --------------------------------------- | ------: | ---------: | ------------------------------------------- |
-| @vue/compiler-sfc (1T)                  | 175.6ms |  6 files/s | 172.9ms, 175.6ms, 180.3ms, 185.3ms, 173.4ms |
-| @vue/compiler-sfc (1 workers)           | 437.3ms |  2 files/s | 417.0ms, 413.1ms, 450.3ms, 477.7ms, 437.3ms |
-| Vize native loop (1T)                   |  65.5ms | 15 files/s | 65.5ms, 60.6ms, 69.0ms, 61.1ms, 73.5ms      |
-| Vize native batch results (max)         |  60.8ms | 16 files/s | 60.2ms, 59.2ms, 60.8ms, 60.9ms, 63.7ms      |
-| Vize native batch stats-only (core max) |  60.0ms | 17 files/s | 60.0ms, 59.8ms, 59.9ms, 61.2ms, 64.5ms      |
+| @vue/compiler-sfc (1T)                  | 192.6ms |  5 files/s | 192.6ms, 192.6ms, 197.2ms, 195.9ms, 190.7ms |
+| @vue/compiler-sfc (1 workers)           | 479.8ms |  2 files/s | 468.3ms, 475.4ms, 479.8ms, 555.9ms, 493.1ms |
+| Vize native loop (1T)                   |  62.6ms | 16 files/s | 62.6ms, 55.1ms, 65.2ms, 57.1ms, 65.0ms      |
+| Vize native batch results (max)         |  56.3ms | 18 files/s | 54.8ms, 54.3ms, 56.3ms, 56.4ms, 56.8ms      |
+| Vize native batch stats-only (core max) |  55.7ms | 18 files/s | 56.7ms, 53.4ms, 55.7ms, 55.3ms, 55.8ms      |
 
 ### Large SFC type check
 
 | Variant          |  Median | Throughput | Raw measured runs                           |
 | ---------------- | ------: | ---------: | ------------------------------------------- |
-| vue-tsc          |   1.59s |  1 files/s | 1.56s, 1.59s, 1.57s, 1.59s, 1.59s           |
-| Vize check (1T)  | 177.7ms |  6 files/s | 199.0ms, 177.7ms, 167.0ms, 175.9ms, 180.1ms |
-| Vize check (max) | 179.0ms |  6 files/s | 172.7ms, 170.5ms, 179.0ms, 186.9ms, 190.6ms |
+| vue-tsc          |   1.69s |  1 files/s | 1.70s, 1.72s, 1.68s, 1.62s, 1.69s           |
+| Vize check (1T)  | 178.7ms |  6 files/s | 176.2ms, 178.4ms, 179.1ms, 189.4ms, 178.7ms |
+| Vize check (max) | 178.0ms |  6 files/s | 177.7ms, 178.0ms, 177.5ms, 189.5ms, 194.5ms |
 
 ### Lint
 
 | Variant                        |  Median |    Throughput | Raw measured runs                           |
 | ------------------------------ | ------: | ------------: | ------------------------------------------- |
-| eslint-plugin-vue (1T)         |  56.66s |   265 files/s | 56.66s, 57.04s, 56.37s, 57.13s, 56.44s      |
-| eslint-plugin-vue (32 workers) |  13.49s |  1.1k files/s | 13.49s, 13.22s, 12.97s, 13.84s, 13.63s      |
-| Vize lint (1T)                 |   2.04s |  7.4k files/s | 2.04s, 2.01s, 2.04s, 2.01s, 2.07s           |
-| Vize lint (max)                | 270.9ms | 55.4k files/s | 267.9ms, 260.6ms, 276.8ms, 270.9ms, 271.7ms |
+| eslint-plugin-vue (1T)         |  54.32s |   276 files/s | 54.32s, 54.44s, 53.47s, 54.35s, 54.06s      |
+| eslint-plugin-vue (32 workers) |  13.47s |  1.1k files/s | 13.41s, 13.61s, 13.63s, 13.26s, 13.47s      |
+| Vize lint (1T)                 |   1.91s |  7.9k files/s | 1.88s, 1.84s, 1.91s, 1.91s, 1.97s           |
+| Vize lint (max)                | 279.3ms | 53.7k files/s | 275.8ms, 272.1ms, 287.9ms, 287.1ms, 279.3ms |
 
 ### Format
 
 | Variant        |  Median |   Throughput | Raw measured runs                           |
 | -------------- | ------: | -----------: | ------------------------------------------- |
-| Prettier CLI   | 150.34s |  100 files/s | 150.34s, 149.31s, 150.23s, 150.88s, 151.35s |
-| Vize fmt (1T)  |  11.53s | 1.3k files/s | 11.53s, 11.82s, 11.36s, 11.67s, 11.52s      |
-| Vize fmt (max) |   2.22s | 6.8k files/s | 2.22s, 2.31s, 2.20s, 2.26s, 2.18s           |
+| Prettier CLI   | 143.61s |  104 files/s | 142.61s, 142.38s, 143.61s, 145.98s, 144.94s |
+| Vize fmt (1T)  |  10.15s | 1.5k files/s | 10.10s, 10.26s, 10.15s, 10.43s, 9.82s       |
+| Vize fmt (max) |   1.79s | 8.4k files/s | 1.78s, 1.79s, 1.82s, 1.82s, 1.78s           |
 
 ### Type check
 
 | Variant          |  Median |   Throughput | Raw measured runs                           |
 | ---------------- | ------: | -----------: | ------------------------------------------- |
-| vue-tsc          |   5.42s |   92 files/s | 5.39s, 5.50s, 5.42s, 5.45s, 5.42s           |
-| Vize check (1T)  | 521.3ms |  959 files/s | 515.0ms, 526.5ms, 532.8ms, 508.1ms, 521.3ms |
-| Vize check (max) | 438.3ms | 1.1k files/s | 436.1ms, 440.8ms, 440.2ms, 431.1ms, 438.3ms |
+| vue-tsc          |   5.36s |   93 files/s | 5.46s, 5.36s, 5.50s, 5.34s, 5.36s           |
+| Vize check (1T)  | 500.5ms |  999 files/s | 489.1ms, 513.6ms, 500.5ms, 504.0ms, 491.2ms |
+| Vize check (max) | 430.1ms | 1.2k files/s | 427.4ms, 430.1ms, 421.3ms, 438.8ms, 431.3ms |
 
 ### Vite build (end-to-end)
 
-| Variant             | Median |  Throughput | Raw measured runs                 |
-| ------------------- | -----: | ----------: | --------------------------------- |
-| @vitejs/plugin-vue  |  1.70s | 587 files/s | 1.88s, 1.77s, 1.67s, 1.70s, 1.70s |
-| @vizejs/vite-plugin |  1.52s | 657 files/s | 1.52s, 1.52s, 1.63s, 1.50s, 1.52s |
+| Variant             |  Median |   Throughput | Raw measured runs                           |
+| ------------------- | ------: | -----------: | ------------------------------------------- |
+| @vitejs/plugin-vue  |   1.66s |  601 files/s | 1.65s, 1.61s, 1.69s, 1.66s, 1.95s           |
+| @vizejs/vite-plugin | 732.5ms | 1.4k files/s | 732.5ms, 713.2ms, 746.2ms, 691.9ms, 752.8ms |
 
 ### Nuxt SPA build (end-to-end)
 
 | Variant               | Median | Throughput | Raw measured runs                 |
 | --------------------- | -----: | ---------: | --------------------------------- |
-| Nuxt default compiler |  6.68s | 75 files/s | 6.70s, 6.68s, 6.67s, 6.70s, 6.68s |
-| @vizejs/nuxt          |  7.35s | 68 files/s | 7.35s, 7.34s, 7.30s, 7.39s, 7.39s |
+| Nuxt default compiler |  6.79s | 74 files/s | 6.74s, 6.73s, 6.86s, 6.89s, 6.79s |
+| @vizejs/nuxt          |  6.42s | 78 files/s | 6.36s, 6.42s, 6.31s, 6.50s, 6.50s |
 
 </details>

--- a/npm/builder/vite/src/plugin/load.ts
+++ b/npm/builder/vite/src/plugin/load.ts
@@ -493,9 +493,7 @@ export async function transformHook(
       : (request.vizeVirtualPath ?? pluginVisibleVirtualPath ?? "");
     const needsTsTransform = request.isMacroVirtualId || needsVirtualTypeScriptTransform(code);
     try {
-      const result = needsTsTransform
-        ? await transformVirtualTypeScript(code, realPath)
-        : { code };
+      const result = needsTsTransform ? await transformVirtualTypeScript(code, realPath) : { code };
       let transformed = result.code;
       if (transformed.includes("import.meta.")) {
         const defines = getVirtualModuleDefines(state, options?.ssr ?? false);

--- a/npm/builder/vite/src/plugin/load.ts
+++ b/npm/builder/vite/src/plugin/load.ts
@@ -24,14 +24,14 @@ import {
   isPluginVisibleSsrVirtualId,
   LEGACY_VIZE_PREFIX,
   RESOLVED_CSS_MODULE,
-  rewriteDynamicTemplateImports,
 } from "../virtual.ts";
 import {
   applyDefineReplacements,
+  rewriteDynamicTemplateImports,
   rewriteImportMetaGlobBase,
   rewriteStaticAssetUrls,
 } from "../transform.ts";
-import { transformVirtualTypeScript } from "./vite-transform.ts";
+import { needsVirtualTypeScriptTransform, transformVirtualTypeScript } from "./vite-transform.ts";
 
 const SERVER_PLACEHOLDER_CODE = `import { createElementBlock, defineComponent } from "vue";
 export default defineComponent({
@@ -210,6 +210,10 @@ export function loadHook(
   id: string,
   loadOptions?: { ssr?: boolean; addWatchFile?: (id: string) => void },
 ): string | { code: string; map: null } | null {
+  if (id !== RESOLVED_CSS_MODULE && !id.startsWith("\0") && !id.includes(".vue")) {
+    return null;
+  }
+
   const request = classifyVitePluginRequest(id);
   const pluginVisibleVirtualPath = fromPluginVisibleVirtualId(id);
   const loadableVueSfcPath = getLoadableVueSfcPath(request);
@@ -461,14 +465,21 @@ export async function transformHook(
   id: string,
   options?: { ssr?: boolean },
 ): Promise<TransformResult | null> {
+  const maybeJsxComponent = isJsxComponentPath(id);
+  if (!id.startsWith("\0") && !id.includes(".vue.ts") && !maybeJsxComponent) {
+    return null;
+  }
+
   const pluginVisibleVirtualPath = fromPluginVisibleVirtualId(id);
 
   // Compile `.jsx`/`.tsx` Vue components through Vize. Unlike SFCs, JSX/TSX
   // modules are real files Vite hands directly to the transform hook, so they
   // are handled here rather than through the virtual-module load pipeline.
-  const jsxResult = transformJsxRequest(state, code, id, { ssr: options?.ssr });
-  if (jsxResult !== undefined) {
-    return jsxResult;
+  if (maybeJsxComponent) {
+    const jsxResult = transformJsxRequest(state, code, id, { ssr: options?.ssr });
+    if (jsxResult !== undefined) {
+      return jsxResult;
+    }
   }
 
   if (!id.startsWith("\0") && !pluginVisibleVirtualPath) {
@@ -480,13 +491,18 @@ export async function transformHook(
     const realPath = request.isMacroVirtualId
       ? (request.strippedVirtualPath ?? "")
       : (request.vizeVirtualPath ?? pluginVisibleVirtualPath ?? "");
+    const needsTsTransform = request.isMacroVirtualId || needsVirtualTypeScriptTransform(code);
     try {
-      const result = await transformVirtualTypeScript(code, realPath);
-      const defines = getVirtualModuleDefines(state, options?.ssr ?? false);
+      const result = needsTsTransform
+        ? await transformVirtualTypeScript(code, realPath)
+        : { code };
       let transformed = result.code;
-      transformed = applyDefineReplacements(transformed, defines);
+      if (transformed.includes("import.meta.")) {
+        const defines = getVirtualModuleDefines(state, options?.ssr ?? false);
+        transformed = applyDefineReplacements(transformed, defines);
+      }
 
-      return { code: transformed, map: null };
+      return transformed === code ? null : { code: transformed, map: null };
     } catch (e: unknown) {
       state.logger.error(`transformWithOxc failed for ${realPath}:`, e);
       let dumpPath: string | null = null;

--- a/npm/builder/vite/src/plugin/load.ts
+++ b/npm/builder/vite/src/plugin/load.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { classifyVitePluginRequest } from "@vizejs/native";
 import type { TransformResult } from "vite";
@@ -26,12 +25,11 @@ import {
   RESOLVED_CSS_MODULE,
 } from "../virtual.ts";
 import {
-  applyDefineReplacements,
   rewriteDynamicTemplateImports,
   rewriteImportMetaGlobBase,
   rewriteStaticAssetUrls,
 } from "../transform.ts";
-import { needsVirtualTypeScriptTransform, transformVirtualTypeScript } from "./vite-transform.ts";
+import { transformVizeVirtualModule } from "./vite-transform.ts";
 
 const SERVER_PLACEHOLDER_CODE = `import { createElementBlock, defineComponent } from "vue";
 export default defineComponent({
@@ -51,26 +49,6 @@ export function getBoundaryPlaceholderCode(realPath: string, ssr: boolean): stri
     return SERVER_PLACEHOLDER_CODE;
   }
   return null;
-}
-
-function getOxcDumpPath(root: string, realPath: string): string {
-  const dumpDir = path.resolve(root || process.cwd(), "node_modules", ".vize", "oxc-dumps");
-  fs.mkdirSync(dumpDir, { recursive: true });
-  return path.join(dumpDir, `vize-oxc-error-${path.basename(realPath)}.ts`);
-}
-
-function getVirtualModuleDefines(
-  state: Pick<VizePluginState, "clientViteDefine" | "isProduction" | "serverViteDefine">,
-  ssr: boolean,
-): Record<string, string> {
-  return {
-    "import.meta.client": ssr ? "false" : "true",
-    "import.meta.server": ssr ? "true" : "false",
-    "import.meta.dev": state.isProduction ? "false" : "true",
-    "import.meta.test": "false",
-    "import.meta.prerender": "false",
-    ...(ssr ? state.serverViteDefine : state.clientViteDefine),
-  };
 }
 
 export function normalizeVueServerRendererImport(code: string): string {
@@ -210,9 +188,7 @@ export function loadHook(
   id: string,
   loadOptions?: { ssr?: boolean; addWatchFile?: (id: string) => void },
 ): string | { code: string; map: null } | null {
-  if (id !== RESOLVED_CSS_MODULE && !id.startsWith("\0") && !id.includes(".vue")) {
-    return null;
-  }
+  if (id !== RESOLVED_CSS_MODULE && !id.startsWith("\0") && !id.includes(".vue")) return null;
 
   const request = classifyVitePluginRequest(id);
   const pluginVisibleVirtualPath = fromPluginVisibleVirtualId(id);
@@ -465,21 +441,16 @@ export async function transformHook(
   id: string,
   options?: { ssr?: boolean },
 ): Promise<TransformResult | null> {
-  const maybeJsxComponent = isJsxComponentPath(id);
-  if (!id.startsWith("\0") && !id.includes(".vue.ts") && !maybeJsxComponent) {
-    return null;
-  }
+  if (!id.startsWith("\0") && !id.includes(".vue.ts") && !isJsxComponentPath(id)) return null;
 
   const pluginVisibleVirtualPath = fromPluginVisibleVirtualId(id);
 
   // Compile `.jsx`/`.tsx` Vue components through Vize. Unlike SFCs, JSX/TSX
   // modules are real files Vite hands directly to the transform hook, so they
   // are handled here rather than through the virtual-module load pipeline.
-  if (maybeJsxComponent) {
-    const jsxResult = transformJsxRequest(state, code, id, { ssr: options?.ssr });
-    if (jsxResult !== undefined) {
-      return jsxResult;
-    }
+  const jsxResult = transformJsxRequest(state, code, id, { ssr: options?.ssr });
+  if (jsxResult !== undefined) {
+    return jsxResult;
   }
 
   if (!id.startsWith("\0") && !pluginVisibleVirtualPath) {
@@ -491,40 +462,14 @@ export async function transformHook(
     const realPath = request.isMacroVirtualId
       ? (request.strippedVirtualPath ?? "")
       : (request.vizeVirtualPath ?? pluginVisibleVirtualPath ?? "");
-    const needsTsTransform = request.isMacroVirtualId || needsVirtualTypeScriptTransform(code);
-    try {
-      const result = needsTsTransform ? await transformVirtualTypeScript(code, realPath) : { code };
-      let transformed = result.code;
-      if (transformed.includes("import.meta.")) {
-        const defines = getVirtualModuleDefines(state, options?.ssr ?? false);
-        transformed = applyDefineReplacements(transformed, defines);
-      }
-
-      return transformed === code ? null : { code: transformed, map: null };
-    } catch (e: unknown) {
-      state.logger.error(`transformWithOxc failed for ${realPath}:`, e);
-      let dumpPath: string | null = null;
-      try {
-        dumpPath = getOxcDumpPath(state.root, realPath);
-        fs.writeFileSync(dumpPath, code, "utf-8");
-        state.logger.error(`Dumped failing code to ${dumpPath}`);
-      } catch (dumpError: unknown) {
-        state.logger.error(`Failed to dump failing virtual module for ${realPath}:`, dumpError);
-      }
-
-      const message = [
-        `[vize] Virtual module transform failed for ${realPath}: ${formatUnknownError(e)}`,
-        dumpPath ? `Dumped failing code to ${dumpPath}` : null,
-      ]
-        .filter(Boolean)
-        .join("\n");
-      throw new Error(message);
-    }
+    return transformVizeVirtualModule(
+      state,
+      code,
+      realPath,
+      options?.ssr ?? false,
+      request.isMacroVirtualId,
+    );
   }
 
   return null;
-}
-
-function formatUnknownError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/npm/builder/vite/src/plugin/vite-transform.test.ts
+++ b/npm/builder/vite/src/plugin/vite-transform.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 
-import { createVirtualTypeScriptTransformer } from "./vite-transform.ts";
+import {
+  createVirtualTypeScriptTransformer,
+  needsVirtualTypeScriptTransform,
+} from "./vite-transform.ts";
 
 {
   let used = "";
@@ -61,3 +64,17 @@ import { createVirtualTypeScriptTransformer } from "./vite-transform.ts";
     "virtual Vue module TS stripping must not emit an unguarded slot-scope access",
   );
 }
+
+assert.equal(
+  needsVirtualTypeScriptTransform(
+    'import { ref as _ref } from "vue";\nconst count = _ref(0);\nexport default {};',
+  ),
+  false,
+  "plain generated JavaScript with import aliases should skip the virtual TS strip pass",
+);
+
+assert.equal(
+  needsVirtualTypeScriptTransform("const value: number = 1"),
+  true,
+  "virtual modules with TypeScript annotations should still use Vite's TS strip pass",
+);

--- a/npm/builder/vite/src/plugin/vite-transform.ts
+++ b/npm/builder/vite/src/plugin/vite-transform.ts
@@ -1,4 +1,10 @@
+import fs from "node:fs";
+import path from "node:path";
 import * as vite from "vite";
+import type { TransformResult } from "vite";
+
+import type { VizePluginState } from "./state.ts";
+import { applyDefineReplacements } from "../transform.ts";
 
 type TransformOutput = { code: string; map?: unknown };
 type OxcOptions = { lang: "ts"; sourcemap: false; target: "esnext" };
@@ -134,3 +140,62 @@ export function needsVirtualTypeScriptTransform(code: string): boolean {
 }
 
 export const transformVirtualTypeScript = createVirtualTypeScriptTransformer(vite);
+
+function getOxcDumpPath(root: string, realPath: string): string {
+  const dumpDir = path.resolve(root || process.cwd(), "node_modules", ".vize", "oxc-dumps");
+  fs.mkdirSync(dumpDir, { recursive: true });
+  return path.join(dumpDir, `vize-oxc-error-${path.basename(realPath)}.ts`);
+}
+
+function getVirtualModuleDefines(
+  state: Pick<VizePluginState, "clientViteDefine" | "isProduction" | "serverViteDefine">,
+  ssr: boolean,
+): Record<string, string> {
+  return {
+    "import.meta.client": ssr ? "false" : "true",
+    "import.meta.server": ssr ? "true" : "false",
+    "import.meta.dev": state.isProduction ? "false" : "true",
+    "import.meta.test": "false",
+    "import.meta.prerender": "false",
+    ...(ssr ? state.serverViteDefine : state.clientViteDefine),
+  };
+}
+
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function transformVizeVirtualModule(
+  state: VizePluginState,
+  code: string,
+  realPath: string,
+  ssr: boolean,
+  forceTypeScriptTransform = false,
+): Promise<TransformResult | null> {
+  const needsTsTransform = forceTypeScriptTransform || needsVirtualTypeScriptTransform(code);
+  try {
+    const result = needsTsTransform ? await transformVirtualTypeScript(code, realPath) : { code };
+    let transformed = result.code;
+    if (transformed.includes("import.meta.")) {
+      transformed = applyDefineReplacements(transformed, getVirtualModuleDefines(state, ssr));
+    }
+    return transformed === code ? null : { code: transformed, map: null };
+  } catch (e: unknown) {
+    state.logger.error(`transformWithOxc failed for ${realPath}:`, e);
+    let dumpPath: string | null = null;
+    try {
+      dumpPath = getOxcDumpPath(state.root, realPath);
+      fs.writeFileSync(dumpPath, code, "utf-8");
+      state.logger.error(`Dumped failing code to ${dumpPath}`);
+    } catch (dumpError: unknown) {
+      state.logger.error(`Failed to dump failing virtual module for ${realPath}:`, dumpError);
+    }
+    const message = [
+      `[vize] Virtual module transform failed for ${realPath}: ${formatUnknownError(e)}`,
+      dumpPath ? `Dumped failing code to ${dumpPath}` : null,
+    ]
+      .filter(Boolean)
+      .join("\n");
+    throw new Error(message);
+  }
+}

--- a/npm/builder/vite/src/plugin/vite-transform.ts
+++ b/npm/builder/vite/src/plugin/vite-transform.ts
@@ -41,4 +41,96 @@ export function createVirtualTypeScriptTransformer(viteApi: ViteTransformApi) {
   };
 }
 
+const TYPE_DECLARATION_RE = /\b(?:interface|type|enum|namespace|declare)\s+[A-Za-z_$]/;
+const TYPE_ASSERTION_RE =
+  /\bas\s+(?:const|unknown|never|any|string|number|boolean|readonly\b|[A-Z][A-Za-z0-9_$]*(?:\s*[<[{&|),;=]|$))/;
+const TYPED_BINDING_RE = /\b(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*:/;
+const GENERIC_FUNCTION_RE = /\bfunction\s+[A-Za-z_$][\w$]*\s*<[^>{}]*>\s*\(/;
+const TYPED_PARAMETER_RE = /[(,]\s*(?:\.\.\.)?[A-Za-z_$][\w$]*\??\s*:\s*[^,)=]+/;
+const RETURN_TYPE_RE = /\)\s*:\s*[^=<{;]+[{=>]/;
+const ACCESS_MODIFIER_RE = /\b(?:public|private|protected|readonly|abstract|implements)\b/;
+const SATISFIES_RE = /\bsatisfies\s+[A-Za-z_$]/;
+
+function hasUnbalancedDelimiters(code: string): boolean {
+  const stack: string[] = [];
+  let quote: "'" | '"' | "`" | null = null;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let index = 0; index < code.length; index += 1) {
+    const char = code[index]!;
+    const next = code[index + 1];
+
+    if (lineComment) {
+      if (char === "\n" || char === "\r") {
+        lineComment = false;
+      }
+      continue;
+    }
+    if (blockComment) {
+      if (char === "*" && next === "/") {
+        blockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      lineComment = true;
+      index += 1;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      blockComment = true;
+      index += 1;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "{" || char === "(" || char === "[") {
+      stack.push(char);
+      continue;
+    }
+    if (char === "}" || char === ")" || char === "]") {
+      const open = stack.pop();
+      if (
+        (char === "}" && open !== "{") ||
+        (char === ")" && open !== "(") ||
+        (char === "]" && open !== "[")
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return quote !== null || blockComment || stack.length > 0;
+}
+
+export function needsVirtualTypeScriptTransform(code: string): boolean {
+  return (
+    TYPE_DECLARATION_RE.test(code) ||
+    TYPE_ASSERTION_RE.test(code) ||
+    TYPED_BINDING_RE.test(code) ||
+    GENERIC_FUNCTION_RE.test(code) ||
+    TYPED_PARAMETER_RE.test(code) ||
+    RETURN_TYPE_RE.test(code) ||
+    ACCESS_MODIFIER_RE.test(code) ||
+    SATISFIES_RE.test(code) ||
+    hasUnbalancedDelimiters(code)
+  );
+}
+
 export const transformVirtualTypeScript = createVirtualTypeScriptTransformer(vite);

--- a/npm/builder/vite/src/transform.ts
+++ b/npm/builder/vite/src/transform.ts
@@ -8,6 +8,7 @@
 import {
   applyViteDefineReplacements,
   isBuiltinViteDefine,
+  rewriteViteDynamicTemplateImports,
   rewriteViteImportMetaGlobBase,
   rewriteViteStaticAssetUrls,
   shouldApplyViteDefineInVirtualModule,
@@ -22,7 +23,20 @@ import type { DynamicImportAliasRule } from "./virtual.ts";
  * pipeline handles alias expansion and asset hashing in both dev and build.
  */
 export function rewriteStaticAssetUrls(code: string, aliasRules: DynamicImportAliasRule[]): string {
+  if (aliasRules.length === 0 || !code.includes("src")) {
+    return code;
+  }
   return rewriteViteStaticAssetUrls(code, aliasRules);
+}
+
+export function rewriteDynamicTemplateImports(
+  code: string,
+  aliasRules: DynamicImportAliasRule[],
+): string {
+  if (!code.includes("import(") || !code.includes("`")) {
+    return code;
+  }
+  return rewriteViteDynamicTemplateImports(code, aliasRules);
 }
 
 export function rewriteImportMetaGlobBase(code: string, importer: string, root: string): string {

--- a/npm/builder/vite/src/utils/index.ts
+++ b/npm/builder/vite/src/utils/index.ts
@@ -115,7 +115,7 @@ export function generateOutput(compiled: CompiledModule, options: GenerateOutput
   const hasSfcMainDefined = moduleInfo.hasSfcMainDefined;
 
   if (hasExportDefault && !hasSfcMainDefined) {
-    output = rewriteDefaultExportToSfcMain(output);
+    output = rewriteDefaultExportToSfcMain(output, moduleInfo);
     // Add __scopeId for scoped CSS support
     if (compiled.hasScoped && compiled.scopeId) {
       output += `\n_sfc_main.__scopeId = "data-v-${compiled.scopeId}";`;

--- a/npm/builder/vite/src/utils/module-output.ts
+++ b/npm/builder/vite/src/utils/module-output.ts
@@ -2,6 +2,7 @@ import { parseSync } from "vite";
 
 const OUTPUT_PARSE_ID = "vize-output.tsx";
 const SFC_MAIN_NAME = "_sfc_main";
+const EXPORT_DEFAULT = "export default";
 
 type AstNode = {
   type?: string;
@@ -15,6 +16,8 @@ export type ModuleOutputInfo = {
   hasSfcMainDefined: boolean;
   hasNamedRenderExport: boolean;
   hasNamedSsrRenderExport: boolean;
+  defaultExportKeywordEnd: number | null;
+  defaultExportStart: number | null;
 };
 
 function isNode(value: unknown): value is AstNode {
@@ -105,6 +108,36 @@ function findDefaultExport(program: AstNode | null): AstNode | null {
   );
 }
 
+function analyzeFastDefaultOutput(code: string): ModuleOutputInfo | null {
+  if (
+    code.includes(SFC_MAIN_NAME) ||
+    code.includes("export function render") ||
+    code.includes("export function ssrRender") ||
+    code.includes("export {")
+  ) {
+    return null;
+  }
+
+  const defaultExportStart = code.indexOf(EXPORT_DEFAULT);
+  if (defaultExportStart === -1 || defaultExportStart !== code.lastIndexOf(EXPORT_DEFAULT)) {
+    return null;
+  }
+
+  const before = defaultExportStart === 0 ? "\n" : code[defaultExportStart - 1];
+  if (!before || !/\s|;/.test(before)) {
+    return null;
+  }
+
+  return {
+    hasDefaultExport: true,
+    hasSfcMainDefined: false,
+    hasNamedRenderExport: false,
+    hasNamedSsrRenderExport: false,
+    defaultExportStart,
+    defaultExportKeywordEnd: defaultExportStart + EXPORT_DEFAULT.length,
+  };
+}
+
 function getExportDefaultKeywordEnd(code: string, defaultExport: AstNode): number | null {
   const exportStart = getNodeStart(defaultExport);
   if (exportStart == null) {
@@ -116,9 +149,18 @@ function getExportDefaultKeywordEnd(code: string, defaultExport: AstNode): numbe
 }
 
 export function analyzeModuleOutput(code: string): ModuleOutputInfo {
+  const fastOutput = analyzeFastDefaultOutput(code);
+  if (fastOutput) {
+    return fastOutput;
+  }
+
   const program = parseProgram(code);
   const body = getProgramBody(program);
   const defaultExport = findDefaultExport(program);
+  const defaultExportStart = getNodeStart(defaultExport);
+  const defaultExportKeywordEnd = defaultExport
+    ? getExportDefaultKeywordEnd(code, defaultExport)
+    : null;
   const exportedNames = body
     .filter((statement) => statement.type === "ExportNamedDeclaration")
     .flatMap(getExportedNames);
@@ -133,13 +175,25 @@ export function analyzeModuleOutput(code: string): ModuleOutputInfo {
     }),
     hasNamedRenderExport: exportedNames.includes("render"),
     hasNamedSsrRenderExport: exportedNames.includes("ssrRender"),
+    defaultExportKeywordEnd,
+    defaultExportStart,
   };
 }
 
-export function rewriteDefaultExportToSfcMain(code: string): string {
-  const defaultExport = findDefaultExport(parseProgram(code));
-  const exportStart = getNodeStart(defaultExport);
-  const keywordEnd = defaultExport ? getExportDefaultKeywordEnd(code, defaultExport) : null;
+export function rewriteDefaultExportToSfcMain(
+  code: string,
+  moduleInfo: Pick<ModuleOutputInfo, "defaultExportKeywordEnd" | "defaultExportStart"> = {
+    defaultExportKeywordEnd: null,
+    defaultExportStart: null,
+  },
+): string {
+  let exportStart = moduleInfo.defaultExportStart;
+  let keywordEnd = moduleInfo.defaultExportKeywordEnd;
+  if (exportStart == null || keywordEnd == null) {
+    const defaultExport = findDefaultExport(parseProgram(code));
+    exportStart = getNodeStart(defaultExport);
+    keywordEnd = defaultExport ? getExportDefaultKeywordEnd(code, defaultExport) : null;
+  }
   if (exportStart == null || keywordEnd == null) {
     return code;
   }

--- a/npm/builder/vite/src/virtual.ts
+++ b/npm/builder/vite/src/virtual.ts
@@ -11,7 +11,6 @@ import {
   fromViteVirtualId,
   normalizeViteFsIdForBuild,
   normalizeViteVirtualVueModuleId as normalizeNativeViteVirtualVueModuleId,
-  rewriteViteDynamicTemplateImports,
   toViteBrowserImportPrefix,
 } from "@vizejs/native";
 
@@ -102,11 +101,4 @@ export function toBrowserImportPrefix(replacement: string): string {
 
 export function normalizeFsIdForBuild(id: string): string {
   return normalizeViteFsIdForBuild(id);
-}
-
-export function rewriteDynamicTemplateImports(
-  code: string,
-  aliasRules: DynamicImportAliasRule[],
-): string {
-  return rewriteViteDynamicTemplateImports(code, aliasRules);
 }

--- a/npm/framework/nuxt/src/bridge-fast-path.ts
+++ b/npm/framework/nuxt/src/bridge-fast-path.ts
@@ -1,0 +1,26 @@
+const VUE_CLIENT_RUNTIME_IMPORT = "vue/dist/vue.runtime.esm-bundler.js";
+const COMPONENT_BRIDGE_RE = /(?:_?resolveComponent\s*\(|from\s+(["'])#components\1)/;
+const I18N_BRIDGE_RE = /\b(?:\$t|\$rt|\$d|\$n|\$tm|\$te)\s*\(/;
+const STABLE_KEY_BRIDGE_RE = /\b(?:useFetch|useLazyFetch)\s*\(|\/\*\s*nuxt-injected\s*\*\//;
+
+export function hasComponentBridgeInput(code: string): boolean {
+  return COMPONENT_BRIDGE_RE.test(code);
+}
+
+export function hasI18nBridgeInput(code: string): boolean {
+  return I18N_BRIDGE_RE.test(code);
+}
+
+export function hasStableKeyBridgeInput(code: string): boolean {
+  return STABLE_KEY_BRIDGE_RE.test(code);
+}
+
+export function rewriteBareVueImportsToClientRuntime(code: string): string {
+  return code
+    .replace(/(\bfrom\s*)(["'])vue\2/g, (_, prefix: string, quote: string) => {
+      return `${prefix}${quote}${VUE_CLIENT_RUNTIME_IMPORT}${quote}`;
+    })
+    .replace(/(\bimport\s*)(["'])vue\2/g, (_, prefix: string, quote: string) => {
+      return `${prefix}${quote}${VUE_CLIENT_RUNTIME_IMPORT}${quote}`;
+    });
+}

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -33,6 +33,11 @@ const VUE_RUNTIME_DEDUPE = [
   "@vue/shared",
 ];
 const VUE_CLIENT_RUNTIME_IMPORT = "vue/dist/vue.runtime.esm-bundler.js";
+const NUXT_COMPONENT_BRIDGE_RE =
+  /(?:_?resolveComponent\s*\(|from\s+(["'])#components\1)/;
+const NUXT_I18N_BRIDGE_RE = /\b(?:\$t|\$rt|\$d|\$n|\$tm|\$te)\s*\(/;
+const NUXT_STABLE_KEY_BRIDGE_RE =
+  /\b(?:useFetch|useLazyFetch)\s*\(|\/\*\s*nuxt-injected\s*\*\//;
 type VitePluginWithTransform = {
   name?: string;
   transform?: unknown;
@@ -505,7 +510,7 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
 
         // 1. Component auto-imports: replace _resolveComponent("Name") with direct imports
         // Nuxt's LoaderPlugin normally does this, but skips \0-prefixed IDs.
-        if (nuxtComponentResolver) {
+        if (nuxtComponentResolver && NUXT_COMPONENT_BRIDGE_RE.test(result)) {
           const nextComponentResult = injectNuxtComponentImports(result, (name) => {
             return nuxtComponentResolver.resolve(name);
           });
@@ -520,7 +525,7 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
         // Must inject inside the setup() function body, not at module top level.
         // Parse the virtual module so string literals, comments, and Vue template
         // globals do not look like setup-scope runtime helper calls.
-        if (bridgeOptions.i18n) {
+        if (bridgeOptions.i18n && NUXT_I18N_BRIDGE_RE.test(result)) {
           const nextResult = injectNuxtI18nHelpers(result, id);
           if (nextResult !== result) {
             result = nextResult;
@@ -552,7 +557,7 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
           }
         }
 
-        if (bridgeOptions.stableInjectedKeys) {
+        if (bridgeOptions.stableInjectedKeys && NUXT_STABLE_KEY_BRIDGE_RE.test(result)) {
           const stableKeyResult = stabilizeNuxtInjectedKeysForVizeVirtualModule(result, id);
           if (stableKeyResult !== result) {
             result = stableKeyResult;

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -33,11 +33,9 @@ const VUE_RUNTIME_DEDUPE = [
   "@vue/shared",
 ];
 const VUE_CLIENT_RUNTIME_IMPORT = "vue/dist/vue.runtime.esm-bundler.js";
-const NUXT_COMPONENT_BRIDGE_RE =
-  /(?:_?resolveComponent\s*\(|from\s+(["'])#components\1)/;
+const NUXT_COMPONENT_BRIDGE_RE = /(?:_?resolveComponent\s*\(|from\s+(["'])#components\1)/;
 const NUXT_I18N_BRIDGE_RE = /\b(?:\$t|\$rt|\$d|\$n|\$tm|\$te)\s*\(/;
-const NUXT_STABLE_KEY_BRIDGE_RE =
-  /\b(?:useFetch|useLazyFetch)\s*\(|\/\*\s*nuxt-injected\s*\*\//;
+const NUXT_STABLE_KEY_BRIDGE_RE = /\b(?:useFetch|useLazyFetch)\s*\(|\/\*\s*nuxt-injected\s*\*\//;
 type VitePluginWithTransform = {
   name?: string;
   transform?: unknown;

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -3,6 +3,7 @@ import { injectNuxtI18nHelpers } from "./i18n";
 import { appendMuseaArtComponentIgnore } from "./musea-components";
 import { registerNuxtMuseaStaticPublicAsset } from "./musea-static";
 import "./schema";
+import * as bridgeFastPath from "./bridge-fast-path";
 import type { VizeNuxtCompilerOptions, VizeNuxtOptions } from "./options";
 import {
   resolveNuxtBridgeOptions,
@@ -32,10 +33,6 @@ const VUE_RUNTIME_DEDUPE = [
   "@vue/runtime-dom",
   "@vue/shared",
 ];
-const VUE_CLIENT_RUNTIME_IMPORT = "vue/dist/vue.runtime.esm-bundler.js";
-const NUXT_COMPONENT_BRIDGE_RE = /(?:_?resolveComponent\s*\(|from\s+(["'])#components\1)/;
-const NUXT_I18N_BRIDGE_RE = /\b(?:\$t|\$rt|\$d|\$n|\$tm|\$te)\s*\(/;
-const NUXT_STABLE_KEY_BRIDGE_RE = /\b(?:useFetch|useLazyFetch)\s*\(|\/\*\s*nuxt-injected\s*\*\//;
 type VitePluginWithTransform = {
   name?: string;
   transform?: unknown;
@@ -214,16 +211,6 @@ function isViteSsrTransform(args: unknown[]): boolean {
     "ssr" in options &&
     (options as { ssr?: boolean }).ssr === true
   );
-}
-
-function rewriteBareVueImportsToClientRuntime(code: string): string {
-  return code
-    .replace(/(\bfrom\s*)(["'])vue\2/g, (_, prefix: string, quote: string) => {
-      return `${prefix}${quote}${VUE_CLIENT_RUNTIME_IMPORT}${quote}`;
-    })
-    .replace(/(\bimport\s*)(["'])vue\2/g, (_, prefix: string, quote: string) => {
-      return `${prefix}${quote}${VUE_CLIENT_RUNTIME_IMPORT}${quote}`;
-    });
 }
 
 function normalizeNuxtKeyedTransformResult(
@@ -508,7 +495,7 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
 
         // 1. Component auto-imports: replace _resolveComponent("Name") with direct imports
         // Nuxt's LoaderPlugin normally does this, but skips \0-prefixed IDs.
-        if (nuxtComponentResolver && NUXT_COMPONENT_BRIDGE_RE.test(result)) {
+        if (nuxtComponentResolver && bridgeFastPath.hasComponentBridgeInput(result)) {
           const nextComponentResult = injectNuxtComponentImports(result, (name) => {
             return nuxtComponentResolver.resolve(name);
           });
@@ -523,7 +510,7 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
         // Must inject inside the setup() function body, not at module top level.
         // Parse the virtual module so string literals, comments, and Vue template
         // globals do not look like setup-scope runtime helper calls.
-        if (bridgeOptions.i18n && NUXT_I18N_BRIDGE_RE.test(result)) {
+        if (bridgeOptions.i18n && bridgeFastPath.hasI18nBridgeInput(result)) {
           const nextResult = injectNuxtI18nHelpers(result, id);
           if (nextResult !== result) {
             result = nextResult;
@@ -555,7 +542,7 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
           }
         }
 
-        if (bridgeOptions.stableInjectedKeys && NUXT_STABLE_KEY_BRIDGE_RE.test(result)) {
+        if (bridgeOptions.stableInjectedKeys && bridgeFastPath.hasStableKeyBridgeInput(result)) {
           const stableKeyResult = stabilizeNuxtInjectedKeysForVizeVirtualModule(result, id);
           if (stableKeyResult !== result) {
             result = stableKeyResult;
@@ -564,7 +551,7 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
         }
 
         if (isViteBuild && !isViteSsrTransform(args)) {
-          const clientRuntimeResult = rewriteBareVueImportsToClientRuntime(result);
+          const clientRuntimeResult = bridgeFastPath.rewriteBareVueImportsToClientRuntime(result);
           if (clientRuntimeResult !== result) {
             result = clientRuntimeResult;
             changed = true;


### PR DESCRIPTION
## Summary

- skips Vite plugin work for module IDs that cannot be Vue/Vize virtual modules
- avoids redundant Vite TS transforms and generated-output AST parses on common JS-only virtual output
- adds cheap Nuxt bridge guards and tunes the Corsa auto shard count for 32-vCPU benchmark runners
- refreshes the Blacksmith benchmark snapshot in docs and `bench/results/tool-benchmark-latest.json`

## Benchmarks

Blacksmith Tool Benchmark: https://github.com/ubugeeei-prod/vize/actions/runs/29010164013

- SFC compile: 17.54s -> 290.8ms, 60.3x
- Type check: 5.36s -> 430.1ms, 12.5x
- Vite build: 1.66s -> 732.5ms, 2.3x
- Nuxt SPA build: 6.79s -> 6.42s, 1.1x

Vite improved materially, while Nuxt is still mostly fixed framework/Nitro overhead in this end-to-end benchmark.

## Verification

- `node npm/builder/vite/src/plugin/load.test.ts`
- `node npm/builder/vite/src/plugin/vite-transform.test.ts`
- `node npm/builder/vite/src/plugin/load-jsx-passthrough.test.ts`
- `node npm/builder/vite/src/plugin/load-storybook.test.ts`
- `node npm/builder/vite/src/output-ast.test.ts`
- `node npm/builder/vite/src/utils.test.ts`
- `node npm/framework/nuxt/src/i18n-edge.test.ts`
- `node npm/framework/nuxt/src/components-edge.test.ts`
- `node npm/framework/nuxt/src/utils.test.ts`
- `node npm/framework/nuxt/src/utils-edge.test.ts`
- `cargo test -p vize_canon batch::executor::cli::tests`
- `cargo build --release -p vize`
- `CI=1 corepack pnpm --dir npm/builder/vite build`
- `CI=1 corepack pnpm --dir npm/framework/nuxt build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786185408&installation_id=136613492&pr_number=2762&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2762&signature=d456221fc4f16cb3279c02bc141736b78d80df426e6b60c63332e2237b38317e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Vue/Nuxt/Vite output rewriting for dynamic imports, `_sfc_main` default-export handling, and virtual TypeScript-like segments.
* **Bug Fixes**
  * Tightened build/transform eligibility checks to avoid incorrect or unnecessary processing.
  * Improved Nuxt bridge injections to run only when relevant inputs are present.
  * Refined auto server CPU budgeting for more consistent scaling.
* **Performance**
  * Added more early-exit paths across transforms to reduce wasted work.
* **Documentation**
  * Refreshed performance benchmark snapshots and “Latest Result” tables.
* **Tests**
  * Expanded coverage for virtual TypeScript detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->