### PR TITLE
fix(nuxt): use bridge fast-path runtime helper

### DIFF
--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -666,8 +666,6 @@ const vizeNuxtModule = Object.assign(
 );
 
 export default vizeNuxtModule;
-
-// Re-export types for convenience
 export type { MuseaOptions } from "@vizejs/vite-plugin-musea";
 export type {
   NuxtMuseaOptions,

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -269,7 +269,9 @@ function normalizeNuxtAutoImportTransformResult(
   if (typeof result === "string") {
     const normalized = preserveExplicitVueImportsFromNuxtAutoImports(code, result);
     const restored = preserveExplicitVueImportsFromVizeModuleSource(id, normalized);
-    return rewriteVueRuntimeImports ? rewriteBareVueImportsToClientRuntime(restored) : restored;
+    return rewriteVueRuntimeImports
+      ? bridgeFastPath.rewriteBareVueImportsToClientRuntime(restored)
+      : restored;
   }
   if (typeof result.code !== "string") {
     return result;
@@ -279,7 +281,7 @@ function normalizeNuxtAutoImportTransformResult(
     preserveExplicitVueImportsFromNuxtAutoImports(code, result.code),
   );
   if (rewriteVueRuntimeImports) {
-    normalized = rewriteBareVueImportsToClientRuntime(normalized);
+    normalized = bridgeFastPath.rewriteBareVueImportsToClientRuntime(normalized);
   }
   return normalized === result.code ? result : { ...result, code: normalized };
 }


### PR DESCRIPTION
## Summary

- fixes the Nuxt transform bridge after moving the Vue runtime import rewrite helper behind the bridge fast-path namespace
- unblocks the Tool Benchmark Nuxt build failure seen after #2762 merged

## Verification

- `corepack pnpm exec vp check npm/framework/nuxt/src/index.ts`
- `CI=1 corepack pnpm --dir npm/framework/nuxt build`
- `node npm/framework/nuxt/src/i18n-edge.test.ts`
- `node npm/framework/nuxt/src/components-edge.test.ts`
- `node npm/framework/nuxt/src/utils.test.ts`
- `node npm/framework/nuxt/src/utils-edge.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786187007&installation_id=136613492&pr_number=2764&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2764&signature=29f8ed0b8588ed3f88971e345e4a47fa8640bc47ef03199912d1f71010e2a83c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Vue runtime imports in Nuxt transforms when the related rewrite option is enabled, ensuring consistent output across different transform paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->