### PR TITLE
chore(deps): update corsa-bind crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "corsa"
-version = "0.36.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cae3e14a400484c06b0578e63cb14f60de01fd33f4e0a143e64c4d96ad2924"
+checksum = "adc9fca16c2d57cc07470efad6ffb1d95df8c56676cb826d17926326ab22dba1"
 dependencies = [
  "base64",
  "corsa_client",
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "corsa_client"
-version = "0.36.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acf8c65e85211669765894f4253700de59e8e1e2b6264b1faf6a3aafba901b0"
+checksum = "82d60a7340233d2b1055be3acf4b5ce369e40a522fe1c35d7b07bac715415f2d"
 dependencies = [
  "base64",
  "corsa_core",
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "corsa_core"
-version = "0.36.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31da616b7b3ee544694fa852a66e92a1656fdcaa99562020f1d3670662c2a1e6"
+checksum = "c1592080fe4254c02f3857f6df89d57689c568cb7fc3ea3d1cc5df9ebeaced1e"
 dependencies = [
  "base64",
  "bumpalo",
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "corsa_jsonrpc"
-version = "0.36.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9400f1602c4fc0c3b5a66efe30a951f1030cd2c6e0e3cf4984785e4a3b46159"
+checksum = "71b4546e14180a3b9e9298daaca8609a069c2a39390d62aa69a649e523525340"
 dependencies = [
  "corsa_core",
  "corsa_runtime",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "corsa_lsp"
-version = "0.36.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd75a7c6341921b87108af76c298e2ef0e83312282e78927c5e95387c0730e5"
+checksum = "37b8d52b25f29c2b3660b28589f897f25a15c882ccf85e5dfbd3a49da0b1929e"
 dependencies = [
  "corsa_core",
  "corsa_jsonrpc",
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "corsa_orchestrator"
-version = "0.36.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb47caeb0f4a355d43e71de4df4a84ba6c2d2ff70ea7420a967c4588f088270c"
+checksum = "0d451fc73c829c839b75b21c83f43bf87747af7bcaa96c00e8aa19647e1a3e78"
 dependencies = [
  "corsa_client",
  "corsa_core",
@@ -571,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "corsa_runtime"
-version = "0.36.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c88dc8c86f67beee84e4ff5b3ba2398f63db78213a8631d1ed7c3a5f0a96e407"
+checksum = "3f71bfacd4eaafe2f1175d9cfcacb91abc97f31d042a08ea7c777d2f16316a8f"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,9 +141,9 @@ insta = { version = "=1.47.2", features = ["toml"] }
 criterion = "=0.8.2"
 
 # Published corsa crates
-corsa = { package = "corsa", version = "=0.36.0" }
-corsa_lsp = { package = "corsa_lsp", version = "=0.36.0" }
-corsa_runtime = { package = "corsa_runtime", version = "=0.36.0" }
+corsa = { package = "corsa", version = "=0.52.0" }
+corsa_lsp = { package = "corsa_lsp", version = "=0.52.0" }
+corsa_runtime = { package = "corsa_runtime", version = "=0.52.0" }
 
 [profile.release]
 # Release artifacts are benchmarked and shipped from this profile. Fat LTO plus


### PR DESCRIPTION
## Summary
- update published corsa-bind crates from 0.36.0 to 0.52.0
- refresh Cargo.lock for the corsa dependency family

## Verification
- cargo check -p vize_canon --features native -p vize_patina -p vize
- cargo test -p vize_canon --features native -p vize_patina

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786188173&installation_id=136613492&pr_number=2765&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2765&signature=ddb65887781612a5eaaf03fa4846f41cc53375e2cde19eb9afcf21fc8689fd5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the published `corsa` workspace packages to version `0.52.0` across the release configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->