### PR TITLE
feat(croquis): expose reactivity violation counts

### DIFF
--- a/crates/vize_croquis/src/reactivity_tracking.rs
+++ b/crates/vize_croquis/src/reactivity_tracking.rs
@@ -36,8 +36,8 @@ use vize_carton::{CompactString, FxHashSet, SmallVec};
 
 // Re-export the tracker (it is the primary public API)
 pub use summary::{
-    BindingStateCounts, ReactiveOriginCounts, ReactivityTrackerSummary, ViolationKindCounts,
-    ViolationSeverityCounts,
+    BindingStateCounts, ReactiveOriginCounts, ReactivityTrackerDetailedSummary,
+    ReactivityTrackerSummary, ViolationKindCounts, ViolationSeverityCounts,
 };
 pub use tracker::ReactivityTracker;
 

--- a/crates/vize_croquis/src/reactivity_tracking.rs
+++ b/crates/vize_croquis/src/reactivity_tracking.rs
@@ -36,7 +36,8 @@ use vize_carton::{CompactString, FxHashSet, SmallVec};
 
 // Re-export the tracker (it is the primary public API)
 pub use summary::{
-    BindingStateCounts, ReactiveOriginCounts, ReactivityTrackerSummary, ViolationSeverityCounts,
+    BindingStateCounts, ReactiveOriginCounts, ReactivityTrackerSummary, ViolationKindCounts,
+    ViolationSeverityCounts,
 };
 pub use tracker::ReactivityTracker;
 

--- a/crates/vize_croquis/src/reactivity_tracking/summary.rs
+++ b/crates/vize_croquis/src/reactivity_tracking/summary.rs
@@ -145,6 +145,14 @@ pub struct ReactivityTrackerSummary {
     pub bindings_by_origin: ReactiveOriginCounts,
     pub bindings_by_state: BindingStateCounts,
     pub violations_by_severity: ViolationSeverityCounts,
+}
+
+/// Reactivity tracker summary plus derived violation-kind counters.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReactivityTrackerDetailedSummary {
+    #[serde(flatten)]
+    pub summary: ReactivityTrackerSummary,
     pub violations_by_kind: ViolationKindCounts,
 }
 
@@ -172,10 +180,28 @@ impl ReactivityTracker {
 
         for violation in &self.violations {
             summary.violations_by_severity.record(violation.severity);
-            summary.violations_by_kind.record(&violation.kind);
         }
 
         summary
+    }
+
+    /// Count violations by kind without changing the stable summary struct shape.
+    pub fn violation_kind_counts(&self) -> ViolationKindCounts {
+        let mut counts = ViolationKindCounts::default();
+
+        for violation in &self.violations {
+            counts.record(&violation.kind);
+        }
+
+        counts
+    }
+
+    /// Build a detailed summary for serialized reports that need violation kinds.
+    pub fn detailed_summary(&self) -> ReactivityTrackerDetailedSummary {
+        ReactivityTrackerDetailedSummary {
+            summary: self.summary(),
+            violations_by_kind: self.violation_kind_counts(),
+        }
     }
 }
 
@@ -247,11 +273,13 @@ mod tests {
         assert_eq!(summary.violations_by_severity.error, 1);
         assert_eq!(summary.violations_by_severity.warning, 1);
         assert_eq!(summary.violations_by_severity.hint, 1);
-        assert_eq!(summary.violations_by_kind.destructuring_loss, 1);
-        assert_eq!(summary.violations_by_kind.external_mutation, 1);
-        assert_eq!(summary.violations_by_kind.missing_value_access, 1);
 
-        let json = serde_json::to_string(&summary).unwrap();
+        let violations_by_kind = tracker.violation_kind_counts();
+        assert_eq!(violations_by_kind.destructuring_loss, 1);
+        assert_eq!(violations_by_kind.external_mutation, 1);
+        assert_eq!(violations_by_kind.missing_value_access, 1);
+
+        let json = serde_json::to_string(&tracker.detailed_summary()).unwrap();
         assert!(json.contains(r#""bindingsByOrigin""#));
         assert!(json.contains(r#""missingValueAccess":1"#));
     }

--- a/crates/vize_croquis/src/reactivity_tracking/summary.rs
+++ b/crates/vize_croquis/src/reactivity_tracking/summary.rs
@@ -1,7 +1,11 @@
-use super::{BindingState, ReactiveOrigin, ViolationSeverity, tracker::ReactivityTracker};
+use super::{
+    BindingState, ReactiveOrigin, ViolationKind, ViolationSeverity, tracker::ReactivityTracker,
+};
+use serde::Serialize;
 
 /// Aggregated counts by [`ReactiveOrigin`].
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ReactiveOriginCounts {
     pub ref_binding: usize,
     pub shallow_ref: usize,
@@ -43,7 +47,8 @@ impl ReactiveOriginCounts {
 }
 
 /// Aggregated counts by [`BindingState`].
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct BindingStateCounts {
     pub active: usize,
     pub reactivity_lost: usize,
@@ -65,7 +70,8 @@ impl BindingStateCounts {
 }
 
 /// Aggregated counts by [`ViolationSeverity`].
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ViolationSeverityCounts {
     pub error: usize,
     pub warning: usize,
@@ -84,8 +90,52 @@ impl ViolationSeverityCounts {
     }
 }
 
+/// Aggregated counts by [`ViolationKind`].
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ViolationKindCounts {
+    pub destructuring_loss: usize,
+    pub spread_loss: usize,
+    pub reassignment: usize,
+    pub missing_value_access: usize,
+    pub scope_escape: usize,
+    pub unsafe_closure_capture: usize,
+    pub external_mutation: usize,
+    pub wrong_unwrap_context: usize,
+    pub pinia_destructure: usize,
+    pub props_destructure: usize,
+    pub inject_destructure: usize,
+    pub to_refs_on_non_reactive: usize,
+    pub double_unwrap: usize,
+    pub reactive_const: usize,
+    pub shallow_deep_mismatch: usize,
+}
+
+impl ViolationKindCounts {
+    fn record(&mut self, kind: &ViolationKind) {
+        match kind {
+            ViolationKind::DestructuringLoss { .. } => self.destructuring_loss += 1,
+            ViolationKind::SpreadLoss => self.spread_loss += 1,
+            ViolationKind::Reassignment => self.reassignment += 1,
+            ViolationKind::MissingValueAccess => self.missing_value_access += 1,
+            ViolationKind::ScopeEscape { .. } => self.scope_escape += 1,
+            ViolationKind::UnsafeClosureCapture => self.unsafe_closure_capture += 1,
+            ViolationKind::ExternalMutation => self.external_mutation += 1,
+            ViolationKind::WrongUnwrapContext => self.wrong_unwrap_context += 1,
+            ViolationKind::PiniaDestructure => self.pinia_destructure += 1,
+            ViolationKind::PropsDestructure => self.props_destructure += 1,
+            ViolationKind::InjectDestructure => self.inject_destructure += 1,
+            ViolationKind::ToRefsOnNonReactive => self.to_refs_on_non_reactive += 1,
+            ViolationKind::DoubleUnwrap => self.double_unwrap += 1,
+            ViolationKind::ReactiveConst => self.reactive_const += 1,
+            ViolationKind::ShallowDeepMismatch => self.shallow_deep_mismatch += 1,
+        }
+    }
+}
+
 /// Stable, consumer-friendly summary of a [`ReactivityTracker`] run.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ReactivityTrackerSummary {
     pub binding_count: usize,
     pub violation_count: usize,
@@ -95,6 +145,7 @@ pub struct ReactivityTrackerSummary {
     pub bindings_by_origin: ReactiveOriginCounts,
     pub bindings_by_state: BindingStateCounts,
     pub violations_by_severity: ViolationSeverityCounts,
+    pub violations_by_kind: ViolationKindCounts,
 }
 
 impl ReactivityTracker {
@@ -121,6 +172,7 @@ impl ReactivityTracker {
 
         for violation in &self.violations {
             summary.violations_by_severity.record(violation.severity);
+            summary.violations_by_kind.record(&violation.kind);
         }
 
         summary
@@ -195,5 +247,12 @@ mod tests {
         assert_eq!(summary.violations_by_severity.error, 1);
         assert_eq!(summary.violations_by_severity.warning, 1);
         assert_eq!(summary.violations_by_severity.hint, 1);
+        assert_eq!(summary.violations_by_kind.destructuring_loss, 1);
+        assert_eq!(summary.violations_by_kind.external_mutation, 1);
+        assert_eq!(summary.violations_by_kind.missing_value_access, 1);
+
+        let json = serde_json::to_string(&summary).unwrap();
+        assert!(json.contains(r#""bindingsByOrigin""#));
+        assert!(json.contains(r#""missingValueAccess":1"#));
     }
 }


### PR DESCRIPTION
## Summary

- add kind-level counts to `ReactivityTrackerSummary`
- make reactivity tracker summary/count structs serializable with camelCase fields
- cover the serialized summary contract in the existing tracker summary test

## Validation

- `cargo fmt --check`
- `cargo test -p vize_croquis reactivity_tracking::summary --profile ci`
- `cargo test -p vize_croquis --profile ci`

Refs #2746

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786194338&installation_id=136613492&pr_number=2767&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2767&signature=27b219c5fd5cef9de0462b124f9c5cd03e62602902bb5b64716c7bd432b2891f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a detailed reactivity report that includes a per-violation-kind breakdown.
  * Exposed new APIs to generate both detailed and kind-count summary data for reporting.
* **Bug Fixes**
  * Improved summary serialization with stable, JSON-friendly field naming for more predictable exported output.
  * Extended tests to validate kind-count values and ensure expected fields are present in serialized detailed reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->