### PR TITLE
feat(croquis-cf): summarize provide inject tree shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3657,6 +3657,8 @@ dependencies = [
  "oxc_parser",
  "oxc_span",
  "rustc-hash",
+ "serde",
+ "serde_json",
  "vize_armature",
  "vize_carton",
  "vize_croquis",

--- a/crates/vize_croquis_cf/Cargo.toml
+++ b/crates/vize_croquis_cf/Cargo.toml
@@ -15,11 +15,13 @@ oxc_allocator.workspace = true
 oxc_ast.workspace = true
 oxc_parser.workspace = true
 oxc_span.workspace = true
+serde.workspace = true
 
 [dev-dependencies]
 vize_armature.workspace = true
 insta.workspace = true
 criterion.workspace = true
+serde_json.workspace = true
 
 [[bench]]
 name = "cross_file"

--- a/crates/vize_croquis_cf/src/analyzer/tests_provide_inject/tree.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_provide_inject/tree.rs
@@ -129,10 +129,13 @@ const state = inject('state')"#,
         .expect("tree summary should be built");
     assert_eq!(summary.root_count, 1);
     assert_eq!(summary.node_count, 3);
+    assert_eq!(summary.leaf_component_count, 1);
+    assert_eq!(summary.pass_through_component_count, 1);
     assert_eq!(summary.provider_component_count, 1);
     assert_eq!(summary.injector_component_count, 1);
     assert_eq!(summary.provide_count, 1);
     assert_eq!(summary.inject_count, 1);
+    assert_eq!(summary.defaulted_inject_count, 0);
     assert_eq!(summary.matched_inject_count, 1);
     assert_eq!(summary.unmatched_inject_count, 0);
     assert_eq!(summary.max_depth, 3);

--- a/crates/vize_croquis_cf/src/rules/provide_inject/summary.rs
+++ b/crates/vize_croquis_cf/src/rules/provide_inject/summary.rs
@@ -1,14 +1,19 @@
 use super::types::{ProvideInjectTree, ProvideNode};
+use serde::Serialize;
 
 /// Stable counters for a provide/inject tree.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ProvideInjectTreeSummary {
     pub root_count: usize,
     pub node_count: usize,
+    pub leaf_component_count: usize,
+    pub pass_through_component_count: usize,
     pub provider_component_count: usize,
     pub injector_component_count: usize,
     pub provide_count: usize,
     pub inject_count: usize,
+    pub defaulted_inject_count: usize,
     pub matched_inject_count: usize,
     pub unmatched_inject_count: usize,
     pub max_depth: usize,
@@ -37,6 +42,12 @@ fn summarize_node(node: &ProvideNode, depth: usize, summary: &mut ProvideInjectT
     summary.max_depth = summary.max_depth.max(depth);
     summary.max_child_fanout = summary.max_child_fanout.max(node.children.len());
 
+    if node.children.is_empty() {
+        summary.leaf_component_count += 1;
+    } else if node.provides.is_empty() && node.injects.is_empty() {
+        summary.pass_through_component_count += 1;
+    }
+
     if !node.provides.is_empty() {
         summary.provider_component_count += 1;
     }
@@ -54,6 +65,9 @@ fn summarize_node(node: &ProvideNode, depth: usize, summary: &mut ProvideInjectT
     summary.inject_count += node.injects.len();
 
     for inject in &node.injects {
+        if inject.has_default {
+            summary.defaulted_inject_count += 1;
+        }
         if inject.provider.is_some() {
             summary.matched_inject_count += 1;
         } else {
@@ -128,14 +142,20 @@ mod tests {
 
         assert_eq!(summary.root_count, 1);
         assert_eq!(summary.node_count, 4);
+        assert_eq!(summary.leaf_component_count, 2);
+        assert_eq!(summary.pass_through_component_count, 0);
         assert_eq!(summary.provider_component_count, 1);
         assert_eq!(summary.injector_component_count, 2);
         assert_eq!(summary.provide_count, 1);
         assert_eq!(summary.inject_count, 2);
+        assert_eq!(summary.defaulted_inject_count, 1);
         assert_eq!(summary.matched_inject_count, 1);
         assert_eq!(summary.unmatched_inject_count, 1);
         assert_eq!(summary.max_depth, 3);
         assert_eq!(summary.max_child_fanout, 2);
         assert_eq!(summary.max_provider_consumer_count, 2);
+
+        let json = serde_json::to_string(&summary).unwrap();
+        assert!(json.contains(r#""defaultedInjectCount":1"#));
     }
 }


### PR DESCRIPTION
## Summary

- add serialized provide/inject tree summary counters for leaves, pass-through components, and defaulted injects
- keep pass-through tree coverage tied to the new summary counters
- add direct serde/serde_json dependencies for the public summary contract

## Validation

- `cargo fmt --check`
- `cargo test -p vize_croquis_cf provide_inject --profile ci`
- `cargo test -p vize_croquis_cf --profile ci`

Refs #2747

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786194612&installation_id=136613492&pr_number=2768&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2768&signature=a4f9b90a98718d59a84b6efb2632802f883bf4421c8af0686c6e44d408531f7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON serialization for provide/inject tree summaries, with camelCase field names.
  * Expanded summary output with new counts for leaf components, pass-through components, and defaulted injects.

* **Bug Fixes**
  * Improved tree counting so summary metrics now reflect more component types and injection cases accurately.

* **Tests**
  * Updated coverage to verify the new summary counts and JSON output fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->