### PR TITLE
feat(croquis-cf): expose complexity dominant dimension

### DIFF
--- a/crates/vize_croquis_cf/src/lib.rs
+++ b/crates/vize_croquis_cf/src/lib.rs
@@ -65,8 +65,9 @@ pub use suppression::{SuppressionDirective, SuppressionError, SuppressionMap};
 
 // Re-export rule result types
 pub use rules::{
-    BoundaryInfo, BoundaryKind, ComplexityBand, ComplexityDimensionScores, ComplexityInput,
-    ComplexityReport, EmitFlow, EventBubble, FallthroughInfo, FallthroughSummary,
-    PropsValidationIssue, PropsValidationIssueKind, ProvideInjectMatch, ProvideInjectTreeSummary,
-    ReactivityIssue, ReactivityIssueKind, UniqueIdIssue, band_for_score,
+    BoundaryInfo, BoundaryKind, ComplexityBand, ComplexityDimension, ComplexityDimensionBreakdown,
+    ComplexityDimensionScores, ComplexityInput, ComplexityReport, EmitFlow, EventBubble,
+    FallthroughInfo, FallthroughSummary, PropsValidationIssue, PropsValidationIssueKind,
+    ProvideInjectMatch, ProvideInjectTreeSummary, ReactivityIssue, ReactivityIssueKind,
+    UniqueIdIssue, band_for_score,
 };

--- a/crates/vize_croquis_cf/src/rules.rs
+++ b/crates/vize_croquis_cf/src/rules.rs
@@ -29,8 +29,8 @@ mod setup_context;
 // Re-export rule result types
 pub use boundary::{BoundaryInfo, BoundaryKind, analyze_boundaries};
 pub use complexity::{
-    ComplexityBand, ComplexityDimensionScores, ComplexityInput, ComplexityReport, band_for_score,
-    summarize_complexity_with_graph,
+    ComplexityBand, ComplexityDimension, ComplexityDimensionBreakdown, ComplexityDimensionScores,
+    ComplexityInput, ComplexityReport, band_for_score, summarize_complexity_with_graph,
 };
 pub use component_resolution::{ComponentResolutionIssue, analyze_component_resolution};
 pub use element_id::{UniqueIdIssue, analyze_element_ids};

--- a/crates/vize_croquis_cf/src/rules/complexity.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity.rs
@@ -46,6 +46,39 @@ pub struct ComplexityDimensionScores {
     pub reactive_graph: u32,
 }
 
+/// Named complexity dimension for explainable report output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComplexityDimension {
+    TemplateControlFlow,
+    SlotUsage,
+    PropDrilling,
+    GlobalState,
+    ProvideInject,
+    FallthroughAttrs,
+    ReactiveGraph,
+}
+
+impl ComplexityDimension {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::TemplateControlFlow => "template-control-flow",
+            Self::SlotUsage => "slot-usage",
+            Self::PropDrilling => "prop-drilling",
+            Self::GlobalState => "global-state",
+            Self::ProvideInject => "provide-inject",
+            Self::FallthroughAttrs => "fallthrough-attrs",
+            Self::ReactiveGraph => "reactive-graph",
+        }
+    }
+}
+
+/// One scored dimension in a complexity report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ComplexityDimensionBreakdown {
+    pub dimension: ComplexityDimension,
+    pub score: u32,
+}
+
 impl ComplexityDimensionScores {
     pub fn total(self) -> u32 {
         self.template_control_flow
@@ -55,6 +88,46 @@ impl ComplexityDimensionScores {
             .saturating_add(self.provide_inject)
             .saturating_add(self.fallthrough_attrs)
             .saturating_add(self.reactive_graph)
+    }
+
+    pub fn breakdown(self) -> [ComplexityDimensionBreakdown; 7] {
+        [
+            ComplexityDimensionBreakdown {
+                dimension: ComplexityDimension::TemplateControlFlow,
+                score: self.template_control_flow,
+            },
+            ComplexityDimensionBreakdown {
+                dimension: ComplexityDimension::SlotUsage,
+                score: self.slot_usage,
+            },
+            ComplexityDimensionBreakdown {
+                dimension: ComplexityDimension::PropDrilling,
+                score: self.prop_drilling,
+            },
+            ComplexityDimensionBreakdown {
+                dimension: ComplexityDimension::GlobalState,
+                score: self.global_state,
+            },
+            ComplexityDimensionBreakdown {
+                dimension: ComplexityDimension::ProvideInject,
+                score: self.provide_inject,
+            },
+            ComplexityDimensionBreakdown {
+                dimension: ComplexityDimension::FallthroughAttrs,
+                score: self.fallthrough_attrs,
+            },
+            ComplexityDimensionBreakdown {
+                dimension: ComplexityDimension::ReactiveGraph,
+                score: self.reactive_graph,
+            },
+        ]
+    }
+
+    pub fn dominant_dimension(self) -> Option<ComplexityDimensionBreakdown> {
+        self.breakdown()
+            .into_iter()
+            .filter(|breakdown| breakdown.score > 0)
+            .max_by_key(|breakdown| breakdown.score)
     }
 }
 
@@ -108,6 +181,10 @@ impl ComplexityReport {
             total_score,
             band: band_for_score(total_score),
         }
+    }
+
+    pub fn dominant_dimension(self) -> Option<ComplexityDimensionBreakdown> {
+        self.dimensions.dominant_dimension()
     }
 }
 

--- a/crates/vize_croquis_cf/src/rules/complexity_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity_tests.rs
@@ -1,7 +1,8 @@
 use super::complexity::summarize_complexity;
 use super::{
-    ComplexityBand, ComplexityInput, ComplexityReport, FallthroughInfo, ProvideInjectTreeSummary,
-    ReactivityIssue, ReactivityIssueKind, summarize_complexity_with_graph,
+    ComplexityBand, ComplexityDimension, ComplexityInput, ComplexityReport, FallthroughInfo,
+    ProvideInjectTreeSummary, ReactivityIssue, ReactivityIssueKind,
+    summarize_complexity_with_graph,
 };
 use crate::analyzer::CrossFileResult;
 use crate::graph::{DependencyEdge, DependencyGraph, ModuleNode};
@@ -46,6 +47,20 @@ fn scores_each_complexity_dimension() {
     assert_eq!(report.dimensions.reactive_graph, 30);
     assert_eq!(report.total_score, 90);
     assert_eq!(report.band, ComplexityBand::Extreme);
+
+    let dominant = report
+        .dominant_dimension()
+        .expect("non-zero report should expose a dominant dimension");
+    assert_eq!(dominant.dimension, ComplexityDimension::ReactiveGraph);
+    assert_eq!(dominant.dimension.as_str(), "reactive-graph");
+    assert_eq!(dominant.score, 30);
+}
+
+#[test]
+fn dominant_dimension_is_none_for_zero_score() {
+    let report = ComplexityReport::from_input(ComplexityInput::default());
+
+    assert!(report.dominant_dimension().is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add named complexity dimensions and per-dimension breakdown entries
- expose a dominant_dimension helper for complexity reports
- cover non-zero and zero-score dominant-dimension behavior

## Verification
- cargo fmt --check
- cargo test -p vize_croquis_cf complexity --profile ci
- cargo test -p vize_croquis_cf --profile ci

Refs #2748

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786194778&installation_id=136613492&pr_number=2769&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2769&signature=859471b7efc6556aad0fba4ca380a120c4ee2a5ee635a5ce0e0df483e0ea0665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more detailed complexity reporting, including per-dimension score breakdowns.
  * Introduced a “dominant dimension” view to highlight the strongest complexity area when a report has non-zero scores.
  * Exposed the new complexity dimension types through the public API for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->