### PR TITLE
feat(croquis-cf): summarize fallthrough attr consumption

### DIFF
--- a/crates/vize_croquis_cf/src/rules/fallthrough.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough.rs
@@ -38,6 +38,64 @@ pub struct FallthroughInfo {
 }
 
 impl FallthroughInfo {
+    /// Count passed attributes that are not declared props.
+    pub fn fallthrough_attr_count(&self) -> usize {
+        self.passed_attrs
+            .iter()
+            .filter(|attr| !self.declared_props.contains(*attr))
+            .count()
+    }
+
+    /// Single-root components inherit fallthrough attrs automatically unless disabled.
+    pub fn automatically_inherits_attrs(&self) -> bool {
+        self.root_element_count == 1 && !self.inherit_attrs_disabled
+    }
+
+    /// Whether this component has a path that consumes fallthrough attrs.
+    pub fn consumes_fallthrough_attrs(&self) -> bool {
+        self.automatically_inherits_attrs() || self.uses_attrs || self.binds_attrs
+    }
+
+    /// Count undeclared passed attrs that have a consumption path.
+    pub fn consumed_fallthrough_attr_count(&self) -> usize {
+        if self.consumes_fallthrough_attrs() {
+            self.fallthrough_attr_count()
+        } else {
+            0
+        }
+    }
+
+    /// Count undeclared passed attrs that are not consumed.
+    pub fn unconsumed_fallthrough_attr_count(&self) -> usize {
+        if self.consumes_fallthrough_attrs() {
+            0
+        } else {
+            self.fallthrough_attr_count()
+        }
+    }
+
+    /// Count undeclared passed attrs that Vue commonly forwards safely.
+    pub fn safe_standard_fallthrough_attr_count(&self) -> usize {
+        self.passed_attrs
+            .iter()
+            .filter(|attr| !self.declared_props.contains(*attr))
+            .filter(|attr| is_standard_html_attr(attr))
+            .count()
+    }
+
+    /// Count undeclared, unconsumed attrs that are not known safe HTML/listener attrs.
+    pub fn risky_unconsumed_fallthrough_attr_count(&self) -> usize {
+        if self.consumes_fallthrough_attrs() {
+            return 0;
+        }
+
+        self.passed_attrs
+            .iter()
+            .filter(|attr| !self.declared_props.contains(*attr))
+            .filter(|attr| !is_standard_html_attr(attr))
+            .count()
+    }
+
     /// Check if fallthrough may cause issues.
     pub fn has_potential_issues(&self) -> bool {
         // Multiple roots without explicit $attrs
@@ -271,6 +329,10 @@ fn extract_passed_attrs(
 
 /// Check if an attribute is a standard HTML attribute.
 fn is_standard_html_attr(attr: &str) -> bool {
+    if attr.starts_with("data-") || attr.starts_with("aria-") || is_listener_attr(attr) {
+        return true;
+    }
+
     matches!(
         attr,
         "class"
@@ -278,14 +340,18 @@ fn is_standard_html_attr(attr: &str) -> bool {
             | "id"
             | "key"
             | "ref"
-            | "data-*"
-            | "aria-*"
             | "role"
             | "tabindex"
             | "title"
             | "disabled"
             | "hidden"
     )
+}
+
+fn is_listener_attr(attr: &str) -> bool {
+    attr.strip_prefix("on")
+        .and_then(|suffix| suffix.chars().next())
+        .is_some_and(|first| first.is_ascii_uppercase())
 }
 
 #[cfg(test)]

--- a/crates/vize_croquis_cf/src/rules/fallthrough.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough.rs
@@ -10,6 +10,7 @@ use crate::graph::DependencyGraph;
 use crate::registry::{FileId, ModuleRegistry};
 use vize_carton::{CompactString, FxHashMap, FxHashSet, cstr};
 
+mod info;
 mod summary;
 
 pub use summary::{FallthroughSummary, summarize_fallthrough};
@@ -38,64 +39,6 @@ pub struct FallthroughInfo {
 }
 
 impl FallthroughInfo {
-    /// Count passed attributes that are not declared props.
-    pub fn fallthrough_attr_count(&self) -> usize {
-        self.passed_attrs
-            .iter()
-            .filter(|attr| !self.declared_props.contains(*attr))
-            .count()
-    }
-
-    /// Single-root components inherit fallthrough attrs automatically unless disabled.
-    pub fn automatically_inherits_attrs(&self) -> bool {
-        self.root_element_count == 1 && !self.inherit_attrs_disabled
-    }
-
-    /// Whether this component has a path that consumes fallthrough attrs.
-    pub fn consumes_fallthrough_attrs(&self) -> bool {
-        self.automatically_inherits_attrs() || self.uses_attrs || self.binds_attrs
-    }
-
-    /// Count undeclared passed attrs that have a consumption path.
-    pub fn consumed_fallthrough_attr_count(&self) -> usize {
-        if self.consumes_fallthrough_attrs() {
-            self.fallthrough_attr_count()
-        } else {
-            0
-        }
-    }
-
-    /// Count undeclared passed attrs that are not consumed.
-    pub fn unconsumed_fallthrough_attr_count(&self) -> usize {
-        if self.consumes_fallthrough_attrs() {
-            0
-        } else {
-            self.fallthrough_attr_count()
-        }
-    }
-
-    /// Count undeclared passed attrs that Vue commonly forwards safely.
-    pub fn safe_standard_fallthrough_attr_count(&self) -> usize {
-        self.passed_attrs
-            .iter()
-            .filter(|attr| !self.declared_props.contains(*attr))
-            .filter(|attr| is_standard_html_attr(attr))
-            .count()
-    }
-
-    /// Count undeclared, unconsumed attrs that are not known safe HTML/listener attrs.
-    pub fn risky_unconsumed_fallthrough_attr_count(&self) -> usize {
-        if self.consumes_fallthrough_attrs() {
-            return 0;
-        }
-
-        self.passed_attrs
-            .iter()
-            .filter(|attr| !self.declared_props.contains(*attr))
-            .filter(|attr| !is_standard_html_attr(attr))
-            .count()
-    }
-
     /// Check if fallthrough may cause issues.
     pub fn has_potential_issues(&self) -> bool {
         // Multiple roots without explicit $attrs

--- a/crates/vize_croquis_cf/src/rules/fallthrough/info.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough/info.rs
@@ -1,0 +1,61 @@
+use super::{FallthroughInfo, is_standard_html_attr};
+
+impl FallthroughInfo {
+    /// Count passed attributes that are not declared props.
+    pub fn fallthrough_attr_count(&self) -> usize {
+        self.passed_attrs
+            .iter()
+            .filter(|attr| !self.declared_props.contains(*attr))
+            .count()
+    }
+
+    /// Single-root components inherit fallthrough attrs automatically unless disabled.
+    pub fn automatically_inherits_attrs(&self) -> bool {
+        self.root_element_count == 1 && !self.inherit_attrs_disabled
+    }
+
+    /// Whether this component has a path that consumes fallthrough attrs.
+    pub fn consumes_fallthrough_attrs(&self) -> bool {
+        self.automatically_inherits_attrs() || self.uses_attrs || self.binds_attrs
+    }
+
+    /// Count undeclared passed attrs that have a consumption path.
+    pub fn consumed_fallthrough_attr_count(&self) -> usize {
+        if self.consumes_fallthrough_attrs() {
+            self.fallthrough_attr_count()
+        } else {
+            0
+        }
+    }
+
+    /// Count undeclared passed attrs that are not consumed.
+    pub fn unconsumed_fallthrough_attr_count(&self) -> usize {
+        if self.consumes_fallthrough_attrs() {
+            0
+        } else {
+            self.fallthrough_attr_count()
+        }
+    }
+
+    /// Count undeclared passed attrs that Vue commonly forwards safely.
+    pub fn safe_standard_fallthrough_attr_count(&self) -> usize {
+        self.passed_attrs
+            .iter()
+            .filter(|attr| !self.declared_props.contains(*attr))
+            .filter(|attr| is_standard_html_attr(attr))
+            .count()
+    }
+
+    /// Count undeclared, unconsumed attrs that are not known safe HTML/listener attrs.
+    pub fn risky_unconsumed_fallthrough_attr_count(&self) -> usize {
+        if self.consumes_fallthrough_attrs() {
+            return 0;
+        }
+
+        self.passed_attrs
+            .iter()
+            .filter(|attr| !self.declared_props.contains(*attr))
+            .filter(|attr| !is_standard_html_attr(attr))
+            .count()
+    }
+}

--- a/crates/vize_croquis_cf/src/rules/fallthrough/summary.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough/summary.rs
@@ -5,6 +5,7 @@ use super::FallthroughInfo;
 pub struct FallthroughSummary {
     pub component_count: usize,
     pub components_with_passed_attrs: usize,
+    pub components_consuming_fallthrough_attrs: usize,
     pub components_with_potential_issues: usize,
     pub inherit_attrs_disabled_count: usize,
     pub uses_attrs_count: usize,
@@ -14,7 +15,10 @@ pub struct FallthroughSummary {
     pub passed_attr_count: usize,
     pub declared_prop_count: usize,
     pub undeclared_passed_attr_count: usize,
+    pub consumed_fallthrough_attr_count: usize,
     pub unconsumed_fallthrough_attr_count: usize,
+    pub safe_standard_fallthrough_attr_count: usize,
+    pub risky_unconsumed_fallthrough_attr_count: usize,
     pub max_passed_attrs: usize,
     pub max_root_element_count: usize,
 }
@@ -29,6 +33,9 @@ pub fn summarize_fallthrough(infos: &[FallthroughInfo]) -> FallthroughSummary {
     for info in infos {
         if !info.passed_attrs.is_empty() {
             summary.components_with_passed_attrs += 1;
+        }
+        if info.consumed_fallthrough_attr_count() > 0 {
+            summary.components_consuming_fallthrough_attrs += 1;
         }
         if info.has_potential_issues() {
             summary.components_with_potential_issues += 1;
@@ -51,18 +58,15 @@ pub fn summarize_fallthrough(infos: &[FallthroughInfo]) -> FallthroughSummary {
 
         summary.passed_attr_count += info.passed_attrs.len();
         summary.declared_prop_count += info.declared_props.len();
+        summary.undeclared_passed_attr_count += info.fallthrough_attr_count();
+        summary.consumed_fallthrough_attr_count += info.consumed_fallthrough_attr_count();
+        summary.unconsumed_fallthrough_attr_count += info.unconsumed_fallthrough_attr_count();
+        summary.safe_standard_fallthrough_attr_count += info.safe_standard_fallthrough_attr_count();
+        summary.risky_unconsumed_fallthrough_attr_count +=
+            info.risky_unconsumed_fallthrough_attr_count();
         summary.max_passed_attrs = summary.max_passed_attrs.max(info.passed_attrs.len());
         summary.max_root_element_count =
             summary.max_root_element_count.max(info.root_element_count);
-
-        for attr in &info.passed_attrs {
-            if !info.declared_props.contains(attr) {
-                summary.undeclared_passed_attr_count += 1;
-                if !info.uses_attrs && !info.binds_attrs {
-                    summary.unconsumed_fallthrough_attr_count += 1;
-                }
-            }
-        }
     }
 
     summary
@@ -120,6 +124,7 @@ mod tests {
 
         assert_eq!(summary.component_count, 3);
         assert_eq!(summary.components_with_passed_attrs, 2);
+        assert_eq!(summary.components_consuming_fallthrough_attrs, 1);
         assert_eq!(summary.components_with_potential_issues, 1);
         assert_eq!(summary.inherit_attrs_disabled_count, 1);
         assert_eq!(summary.uses_attrs_count, 1);
@@ -129,8 +134,48 @@ mod tests {
         assert_eq!(summary.passed_attr_count, 3);
         assert_eq!(summary.declared_prop_count, 1);
         assert_eq!(summary.undeclared_passed_attr_count, 2);
+        assert_eq!(summary.consumed_fallthrough_attr_count, 1);
         assert_eq!(summary.unconsumed_fallthrough_attr_count, 1);
+        assert_eq!(summary.safe_standard_fallthrough_attr_count, 2);
+        assert_eq!(summary.risky_unconsumed_fallthrough_attr_count, 0);
         assert_eq!(summary.max_passed_attrs, 2);
         assert_eq!(summary.max_root_element_count, 3);
+    }
+
+    #[test]
+    fn summary_distinguishes_consumed_safe_and_risky_attrs() {
+        let infos = vec![
+            FallthroughInfo {
+                file_id: FileId::new(1),
+                inherit_attrs_disabled: false,
+                uses_attrs: false,
+                binds_attrs: false,
+                root_element_count: 1,
+                passed_attrs: set(&["class", "data-testid", "onClick"]),
+                declared_props: FxHashSet::default(),
+                template_start: 0,
+                template_end: 10,
+            },
+            FallthroughInfo {
+                file_id: FileId::new(2),
+                inherit_attrs_disabled: false,
+                uses_attrs: false,
+                binds_attrs: false,
+                root_element_count: 2,
+                passed_attrs: set(&["aria-label", "trackingId"]),
+                declared_props: FxHashSet::default(),
+                template_start: 0,
+                template_end: 10,
+            },
+        ];
+
+        let summary = summarize_fallthrough(&infos);
+
+        assert_eq!(summary.components_consuming_fallthrough_attrs, 1);
+        assert_eq!(summary.undeclared_passed_attr_count, 5);
+        assert_eq!(summary.consumed_fallthrough_attr_count, 3);
+        assert_eq!(summary.unconsumed_fallthrough_attr_count, 2);
+        assert_eq!(summary.safe_standard_fallthrough_attr_count, 4);
+        assert_eq!(summary.risky_unconsumed_fallthrough_attr_count, 1);
     }
 }


### PR DESCRIPTION
## Summary
- add per-component helpers for fallthrough consumed/unconsumed attr counts
- expose aggregate consumed, safe standard, and risky unconsumed attr counters
- treat single-root inheritance, data/aria attrs, and listener attrs as safe fallthrough paths

## Verification
- cargo fmt --check
- cargo test -p vize_croquis_cf fallthrough --profile ci
- cargo test -p vize_croquis_cf --profile ci

Refs #2749

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786194975&installation_id=136613492&pr_number=2770&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2770&signature=2108807839197323a976a7f3f8bdfda10b4d1045b5044237a375ded447d15bcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced fallthrough attribute reporting with new component-level and breakdown metrics (consumed vs unconsumed, and safe-standard vs risky).
  * Improved recognition of standard attributes, including consistent handling of `data-*` / `aria-*` and listener-like attributes.
* **Bug Fixes**
  * Corrected the underlying fallthrough count logic to better reflect undeclared attributes and consumption behavior.
* **Tests**
  * Expanded assertions to validate the updated totals and safe vs risky fallthrough attribute breakdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->