### PR TITLE
feat(croquis-cf): score fallthrough summary risk

### DIFF
--- a/crates/vize_croquis_cf/src/rules/complexity.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity.rs
@@ -220,11 +220,7 @@ pub fn summarize_complexity_with_graph(
 
 fn complexity_input(registry: &ModuleRegistry, result: &CrossFileResult) -> ComplexityInput {
     let mut input = ComplexityInput {
-        fallthrough_risk_count: result
-            .fallthrough_info
-            .iter()
-            .filter(|info| info.has_potential_issues())
-            .count(),
+        fallthrough_risk_count: fallthrough_risk_count(result),
         reactive_edge_count: result
             .reactivity_issues
             .len()
@@ -308,6 +304,20 @@ fn complexity_input(registry: &ModuleRegistry, result: &CrossFileResult) -> Comp
     }
 
     input
+}
+
+fn fallthrough_risk_count(result: &CrossFileResult) -> usize {
+    if let Some(summary) = result.fallthrough_summary {
+        return summary
+            .components_with_potential_issues
+            .saturating_add(summary.risky_unconsumed_fallthrough_attr_count);
+    }
+
+    result
+        .fallthrough_info
+        .iter()
+        .filter(|info| info.has_potential_issues())
+        .count()
 }
 
 fn weighted(count: usize, weight: u32) -> u32 {

--- a/crates/vize_croquis_cf/src/rules/complexity_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity_tests.rs
@@ -1,7 +1,7 @@
 use super::complexity::summarize_complexity;
 use super::{
     ComplexityBand, ComplexityDimension, ComplexityInput, ComplexityReport, FallthroughInfo,
-    ProvideInjectTreeSummary, ReactivityIssue, ReactivityIssueKind,
+    FallthroughSummary, ProvideInjectTreeSummary, ReactivityIssue, ReactivityIssueKind,
     summarize_complexity_with_graph,
 };
 use crate::analyzer::CrossFileResult;
@@ -135,6 +135,11 @@ fn summarizes_complexity_from_registry_and_result() {
             template_start: 0,
             template_end: 10,
         }],
+        fallthrough_summary: Some(FallthroughSummary {
+            components_with_potential_issues: 1,
+            risky_unconsumed_fallthrough_attr_count: 0,
+            ..FallthroughSummary::default()
+        }),
         provide_inject_tree_summary: Some(ProvideInjectTreeSummary {
             max_depth: 3,
             provide_count: 1,
@@ -169,6 +174,48 @@ fn summarizes_complexity_from_registry_and_result() {
     assert_eq!(report.input.reactive_edge_count, 1);
     assert_eq!(report.total_score, 25);
     assert_eq!(report.band, ComplexityBand::Moderate);
+}
+
+#[test]
+fn summarizes_fallthrough_risk_from_detailed_summary() {
+    let registry = ModuleRegistry::new();
+    let result = CrossFileResult {
+        fallthrough_summary: Some(FallthroughSummary {
+            components_with_potential_issues: 2,
+            risky_unconsumed_fallthrough_attr_count: 3,
+            ..FallthroughSummary::default()
+        }),
+        ..CrossFileResult::default()
+    };
+
+    let report = summarize_complexity(&registry, &result);
+
+    assert_eq!(report.input.fallthrough_risk_count, 5);
+    assert_eq!(report.dimensions.fallthrough_attrs, 20);
+}
+
+#[test]
+fn summarizes_fallthrough_risk_from_infos_when_summary_is_absent() {
+    let registry = ModuleRegistry::new();
+    let result = CrossFileResult {
+        fallthrough_info: vec![FallthroughInfo {
+            file_id: crate::FileId::new(1),
+            inherit_attrs_disabled: false,
+            uses_attrs: false,
+            binds_attrs: false,
+            root_element_count: 2,
+            passed_attrs: FxHashSet::from_iter([CompactString::new("tracking-id")]),
+            declared_props: FxHashSet::default(),
+            template_start: 0,
+            template_end: 10,
+        }],
+        ..CrossFileResult::default()
+    };
+
+    let report = summarize_complexity(&registry, &result);
+
+    assert_eq!(report.input.fallthrough_risk_count, 1);
+    assert_eq!(report.dimensions.fallthrough_attrs, 4);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- use the richer fallthrough summary when computing complexity fallthrough risk
- include risky unconsumed attrs in the fallthrough complexity dimension
- keep the previous per-component fallback when a summary is unavailable

Part of #2748.
Part of #2749.

## Validation

- cargo fmt --check
- cargo test -p vize_croquis_cf complexity --profile ci
- cargo test -p vize_croquis_cf --profile ci

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786198215&installation_id=136613492&pr_number=2771&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2771&signature=1ba3fab65283ca49ffe4e61bfc00bd36bcc66c1ee854185da74b2a08a6986f25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how complexity metrics are calculated when fallthrough details are available, making the reported risk count more accurate.
  * Preserved the previous behavior as a fallback when the newer fallthrough summary data is not present.

* **Tests**
  * Added coverage for complexity reporting with and without summarized fallthrough data.
  * Updated existing test data to reflect the newer fallthrough information format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->