### PR TITLE
feat(croquis): add semantic snapshot query helpers

### DIFF
--- a/crates/vize_croquis/src/croquis/snapshot.rs
+++ b/crates/vize_croquis/src/croquis/snapshot.rs
@@ -28,6 +28,68 @@ impl CroquisSemanticSnapshot {
             reactivity_losses: losses::reactivity_loss_snapshots(croquis),
         }
     }
+
+    /// Find a binding by its declared or macro-exposed name.
+    #[inline]
+    pub fn binding_by_name(&self, name: &str) -> Option<&SemanticBindingSnapshot> {
+        self.bindings.iter().find(|binding| binding.name == name)
+    }
+
+    /// Find a scope by its stable numeric ID.
+    #[inline]
+    pub fn scope_by_id(&self, id: u32) -> Option<&SemanticScopeSnapshot> {
+        self.scopes.iter().find(|scope| scope.id == id)
+    }
+
+    /// Iterate component usages with the exact template component name.
+    #[inline]
+    pub fn component_usages_by_name<'a>(
+        &'a self,
+        name: &'a str,
+    ) -> impl Iterator<Item = &'a SemanticComponentUsageSnapshot> + 'a {
+        self.component_usages
+            .iter()
+            .filter(move |usage| usage.name == name)
+    }
+
+    /// Iterate template expressions that were analyzed in one scope.
+    #[inline]
+    pub fn template_expressions_in_scope(
+        &self,
+        scope_id: u32,
+    ) -> impl Iterator<Item = &SemanticTemplateExpressionSnapshot> {
+        self.template_expressions
+            .iter()
+            .filter(move |expression| expression.scope_id == scope_id)
+    }
+
+    /// Iterate provides with the given normalized key text.
+    #[inline]
+    pub fn provides_by_key<'a>(
+        &'a self,
+        key: &'a str,
+    ) -> impl Iterator<Item = &'a SemanticProvideSnapshot> + 'a {
+        self.provides
+            .iter()
+            .filter(move |provide| provide.key == key)
+    }
+
+    /// Iterate injects with the given normalized key text.
+    #[inline]
+    pub fn injects_by_key<'a>(
+        &'a self,
+        key: &'a str,
+    ) -> impl Iterator<Item = &'a SemanticInjectSnapshot> + 'a {
+        self.injects.iter().filter(move |inject| inject.key == key)
+    }
+
+    /// Find a reactive source by binding name.
+    #[inline]
+    pub fn reactive_source_by_name(&self, name: &str) -> Option<&SemanticReactiveSourceSnapshot> {
+        self.reactive_sources
+            .iter()
+            .find(|source| source.name == name)
+    }
 }
 
 impl Croquis {

--- a/crates/vize_croquis/src/croquis/snapshot_tests.rs
+++ b/crates/vize_croquis/src/croquis/snapshot_tests.rs
@@ -197,4 +197,34 @@ fn semantic_snapshot_is_deterministic_for_manual_croquis_facts() {
     assert_eq!(snapshot.injects[0].destructured_names, ["color"]);
     assert_eq!(snapshot.reactive_sources[0].id, "reactive:alpha@20");
     assert_eq!(snapshot.reactivity_losses[0].kind, "refValueExtract");
+
+    let alpha = snapshot
+        .binding_by_name("alpha")
+        .expect("binding helper should find alpha");
+    assert_eq!(alpha.id, "binding:alpha@20");
+    assert!(snapshot.binding_by_name("missing").is_none());
+    assert!(snapshot.scope_by_id(ScopeId::ROOT.as_u32()).is_some());
+
+    let panel_usages: Vec<_> = snapshot.component_usages_by_name("Panel").collect();
+    assert_eq!(panel_usages.len(), 1);
+    assert_eq!(panel_usages[0].props[0].name, "title");
+
+    let root_expressions: Vec<_> = snapshot
+        .template_expressions_in_scope(ScopeId::ROOT.as_u32())
+        .collect();
+    assert_eq!(root_expressions.len(), 1);
+    assert_eq!(root_expressions[0].content, "alpha");
+
+    let theme_provides: Vec<_> = snapshot.provides_by_key("theme").collect();
+    assert_eq!(theme_provides.len(), 1);
+    assert_eq!(theme_provides[0].value, "alpha");
+
+    let theme_injects: Vec<_> = snapshot.injects_by_key("theme").collect();
+    assert_eq!(theme_injects.len(), 1);
+    assert_eq!(theme_injects[0].destructured_names, ["color"]);
+
+    let reactive_alpha = snapshot
+        .reactive_source_by_name("alpha")
+        .expect("reactive helper should find alpha");
+    assert_eq!(reactive_alpha.kind, "ref");
 }


### PR DESCRIPTION
## Summary

- add query helpers on `CroquisSemanticSnapshot` for bindings, scopes, component usages, template expressions, provide/inject keys, and reactive sources
- keep the serialized snapshot schema unchanged
- cover the helpers in the existing semantic snapshot contract test

Part of #2745.

## Validation

- cargo fmt --check
- cargo test -p vize_croquis semantic_snapshot --profile ci
- cargo test -p vize_croquis --profile ci

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786198387&installation_id=136613492&pr_number=2772&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2772&signature=4da494ead1850f543b3b2f1381d55d0cc6cd9e45e61ee5134c56130e85c73f48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new snapshot lookup and filtering options for bindings, scopes, component usage, template expressions, provides/injects, and reactive sources.
  * Improved access to semantic snapshot data by name, key, and ID for easier downstream use.

* **Bug Fixes**
  * Added coverage to ensure snapshot lookups return the expected single match, multiple matches, or no result when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->