### PR TITLE
feat(croquis): summarize effect graph shape

### DIFF
--- a/crates/vize_croquis/src/effect_graph.rs
+++ b/crates/vize_croquis/src/effect_graph.rs
@@ -8,6 +8,7 @@
 //! follow-ups. The intent of landing the model now is so the analyzer and
 //! the lint rule can be developed against a stable shape.
 
+use serde::Serialize;
 use vize_carton::CompactString;
 
 /// A node in the effect graph — usually a reactive binding name.
@@ -28,6 +29,16 @@ pub struct EffectGraph {
     edges: Vec<EffectEdge>,
 }
 
+/// Stable counters for one reactive effect graph.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EffectGraphSummary {
+    pub node_count: usize,
+    pub edge_count: usize,
+    pub cycle_count: usize,
+    pub cycle_node_count: usize,
+}
+
 impl EffectGraph {
     /// Add a `from → to` dependency edge.
     pub fn add_edge(&mut self, from: impl Into<EffectNodeId>, to: impl Into<EffectNodeId>) {
@@ -43,6 +54,31 @@ impl EffectGraph {
     /// Iterate over all dependency edges.
     pub fn edges(&self) -> impl Iterator<Item = &EffectEdge> {
         self.edges.iter()
+    }
+
+    /// Count unique nodes that appear in dependency edges.
+    pub fn node_count(&self) -> usize {
+        let mut nodes = std::collections::BTreeSet::new();
+        for edge in &self.edges {
+            nodes.insert(&edge.from);
+            nodes.insert(&edge.to);
+        }
+        nodes.len()
+    }
+
+    /// Summarize edge and cycle counts for reports and diagnostics.
+    pub fn summary(&self) -> EffectGraphSummary {
+        let cycle = self.find_cycle();
+
+        EffectGraphSummary {
+            node_count: self.node_count(),
+            edge_count: self.edges.len(),
+            cycle_count: usize::from(cycle.is_some()),
+            cycle_node_count: cycle
+                .as_ref()
+                .map(|cycle| cycle.len().saturating_sub(1))
+                .unwrap_or_default(),
+        }
     }
 
     /// Detect the first cycle reachable from any node, returned as the chain
@@ -121,6 +157,18 @@ mod tests {
         assert_eq!(cycle.first(), cycle.last());
         assert!(cycle.contains(&"a".into()));
         assert!(cycle.contains(&"b".into()));
+
+        let summary = g.summary();
+        assert_eq!(summary.node_count, 2);
+        assert_eq!(summary.edge_count, 2);
+        assert_eq!(summary.cycle_count, 1);
+        assert_eq!(summary.cycle_node_count, 2);
+
+        let json = serde_json::to_string(&summary).unwrap();
+        assert_eq!(
+            json,
+            r#"{"nodeCount":2,"edgeCount":2,"cycleCount":1,"cycleNodeCount":2}"#
+        );
     }
 
     #[test]
@@ -130,6 +178,8 @@ mod tests {
         g.add_edge("b", "c");
         g.add_edge("a", "c");
         assert!(g.find_cycle().is_none());
+        assert_eq!(g.summary().node_count, 3);
+        assert_eq!(g.summary().cycle_count, 0);
     }
 
     #[test]

--- a/crates/vize_croquis/src/lib.rs
+++ b/crates/vize_croquis/src/lib.rs
@@ -98,6 +98,7 @@ pub use croquis::{
     UnusedVarContext,
 };
 pub use drawer::{Drawer, DrawerOptions};
+pub use effect_graph::EffectGraphSummary;
 pub use reactivity_overlay::{
     ReactivityEffectEdgeOverlay, ReactivityEffectGraphOverlay, ReactivityLossOverlay,
     ReactivityOverlay, ReactivityOverlaySummary, ReactivitySourceOverlay,


### PR DESCRIPTION
## Summary

- add a serializable `EffectGraphSummary` for node, edge, and cycle counters
- expose `EffectGraph::node_count()` and `EffectGraph::summary()` for downstream reports and diagnostics
- cover the stable camelCase JSON shape in effect graph tests

Part of #2746.

## Validation

- cargo fmt --check
- cargo test -p vize_croquis effect_graph --profile ci
- cargo test -p vize_croquis --profile ci

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786198511&installation_id=136613492&pr_number=2773&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2773&signature=144749ca76acd8be7eca86445752218462253db4bfab0d0cc96224691ac90868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a graph summary view that reports node count, edge count, cycle presence, and the size of the first detected cycle.
  * Exposed the graph summary as part of the public API for easier reporting and integration.

* **Tests**
  * Expanded coverage to verify summary results for both cyclic and acyclic graphs, including exact serialized output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->