### PR TITLE
feat(croquis-cf): serialize provide inject tree

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/tests_provide_inject/tree.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_provide_inject/tree.rs
@@ -124,6 +124,23 @@ const state = inject('state')"#,
     assert_eq!(tree.roots[0].children[0].children.len(), 1);
     assert_eq!(tree.roots[0].children[0].children[0].injects.len(), 1);
 
+    let tree_json = serde_json::to_value(tree).expect("tree should serialize");
+    assert_eq!(tree_json["roots"][0]["componentName"], "App");
+    assert_eq!(tree_json["roots"][0]["provides"][0]["key"], "state");
+    assert_eq!(tree_json["roots"][0]["provides"][0]["consumerCount"], 1);
+    assert_eq!(
+        tree_json["roots"][0]["children"][0]["componentName"],
+        "Middle"
+    );
+    assert_eq!(
+        tree_json["roots"][0]["children"][0]["children"][0]["componentName"],
+        "Leaf"
+    );
+    assert_eq!(
+        tree_json["roots"][0]["children"][0]["children"][0]["injects"][0]["key"],
+        "state"
+    );
+
     let summary = result
         .provide_inject_tree_summary
         .expect("tree summary should be built");

--- a/crates/vize_croquis_cf/src/registry.rs
+++ b/crates/vize_croquis_cf/src/registry.rs
@@ -13,14 +13,13 @@
 use crate::rules::cross_file_reactivity::store_detection::{
     StoreFactories, collect_store_factories,
 };
-use serde::Serialize;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use vize_carton::{CompactString, FxHashMap, FxHashSet};
 use vize_croquis::Croquis;
 
 /// Unique identifier for a file in the registry.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
 #[repr(transparent)]
 pub struct FileId(u32);
 

--- a/crates/vize_croquis_cf/src/registry.rs
+++ b/crates/vize_croquis_cf/src/registry.rs
@@ -13,13 +13,14 @@
 use crate::rules::cross_file_reactivity::store_detection::{
     StoreFactories, collect_store_factories,
 };
+use serde::Serialize;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use vize_carton::{CompactString, FxHashMap, FxHashSet};
 use vize_croquis::Croquis;
 
 /// Unique identifier for a file in the registry.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[repr(transparent)]
 pub struct FileId(u32);
 

--- a/crates/vize_croquis_cf/src/rules/provide_inject/types.rs
+++ b/crates/vize_croquis_cf/src/rules/provide_inject/types.rs
@@ -1,7 +1,9 @@
 use crate::registry::FileId;
+use serde::Serialize;
 use vize_carton::CompactString;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ProvideInjectMatch {
     /// Component providing the value.
     pub provider: FileId,
@@ -22,13 +24,15 @@ pub struct ProvideInjectMatch {
 }
 
 /// Tree representation of provide/inject relationships.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ProvideInjectTree {
     /// Root nodes (components that provide but don't inject from ancestors).
     pub roots: Vec<ProvideNode>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ProvideNode {
     /// File ID of this component.
     pub file_id: FileId,
@@ -43,7 +47,8 @@ pub struct ProvideNode {
 }
 
 /// Information about a provide call.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ProvideInfo {
     /// The provide key.
     pub key: CompactString,
@@ -56,7 +61,8 @@ pub struct ProvideInfo {
 }
 
 /// Information about an inject call.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct InjectInfo {
     /// The inject key.
     pub key: CompactString,


### PR DESCRIPTION
## Summary

- make provide/inject tree and match result types serializable with camelCase fields
- serialize `FileId` so report consumers can preserve stable component IDs
- add analyzer-level JSON shape assertions for pass-through tree output

Part of #2747.

## Validation

- cargo fmt --check
- cargo test -p vize_croquis_cf provide_inject --profile ci
- cargo test -p vize_croquis_cf --profile ci

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786198656&installation_id=136613492&pr_number=2774&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2774&signature=cf5c9d5fcb37cb763e879d32b99ee2d99ea3112cce648a0d6dd36638ba71d526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON-serializable output for provide/inject relationships, including support for inspecting provide/inject tree structures.
  * Standardized serialized field naming (camelCase) for consistent, tooling-friendly results.

* **Tests**
  * Expanded assertions to validate the serialized provide/inject tree structure and key/value details, including pass-through and injected data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->