### PR TITLE
feat(croquis-cf): serialize complexity reports

### DIFF
--- a/crates/vize_croquis_cf/src/rules/complexity.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity.rs
@@ -1,8 +1,4 @@
 //! Cross-file complexity scoring.
-//!
-//! The model is intentionally explainable: callers can inspect both raw input
-//! counts and weighted dimension scores before deciding how to surface the
-//! result in reports or diagnostics.
 
 mod nesting;
 
@@ -12,8 +8,8 @@ use crate::registry::ModuleRegistry;
 use crate::rules::cross_file_reactivity::CrossFileReactivityIssueKind;
 use vize_croquis::{ScopeKind, TemplateExpressionKind};
 
-/// Raw cross-file signals used to score Vue component complexity.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ComplexityInput {
     pub component_count: usize,
     pub template_if_count: usize,
@@ -34,8 +30,8 @@ pub struct ComplexityInput {
     pub reactive_cycle_count: usize,
 }
 
-/// Per-dimension complexity score.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ComplexityDimensionScores {
     pub template_control_flow: u32,
     pub slot_usage: u32,
@@ -46,8 +42,8 @@ pub struct ComplexityDimensionScores {
     pub reactive_graph: u32,
 }
 
-/// Named complexity dimension for explainable report output.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum ComplexityDimension {
     TemplateControlFlow,
     SlotUsage,
@@ -72,8 +68,8 @@ impl ComplexityDimension {
     }
 }
 
-/// One scored dimension in a complexity report.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ComplexityDimensionBreakdown {
     pub dimension: ComplexityDimension,
     pub score: u32,
@@ -131,8 +127,8 @@ impl ComplexityDimensionScores {
     }
 }
 
-/// Human-facing band for the total complexity score.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 pub enum ComplexityBand {
     #[default]
     Low,
@@ -142,7 +138,8 @@ pub enum ComplexityBand {
 }
 
 /// Explainable complexity score for one cross-file graph or component slice.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ComplexityReport {
     pub input: ComplexityInput,
     pub dimensions: ComplexityDimensionScores,

--- a/crates/vize_croquis_cf/src/rules/complexity_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity_tests.rs
@@ -48,12 +48,23 @@ fn scores_each_complexity_dimension() {
     assert_eq!(report.total_score, 90);
     assert_eq!(report.band, ComplexityBand::Extreme);
 
+    let json = serde_json::to_value(report).expect("complexity report should serialize");
+    assert_eq!(json["input"]["templateIfCount"], 2);
+    assert_eq!(json["input"]["fallthroughRiskCount"], 2);
+    assert_eq!(json["dimensions"]["reactiveGraph"], 30);
+    assert_eq!(json["cyclomaticScore"], 6);
+    assert_eq!(json["band"], "extreme");
+
     let dominant = report
         .dominant_dimension()
         .expect("non-zero report should expose a dominant dimension");
     assert_eq!(dominant.dimension, ComplexityDimension::ReactiveGraph);
     assert_eq!(dominant.dimension.as_str(), "reactive-graph");
     assert_eq!(dominant.score, 30);
+
+    let dominant_json = serde_json::to_value(dominant).unwrap();
+    assert_eq!(dominant_json["dimension"], "reactive-graph");
+    assert_eq!(dominant_json["score"], 30);
 }
 
 #[test]

--- a/crates/vize_croquis_cf/src/rules/fallthrough/summary.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough/summary.rs
@@ -1,7 +1,9 @@
 use super::FallthroughInfo;
+use serde::Serialize;
 
 /// Stable counters for fallthrough attribute analysis.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FallthroughSummary {
     pub component_count: usize,
     pub components_with_passed_attrs: usize,
@@ -140,6 +142,11 @@ mod tests {
         assert_eq!(summary.risky_unconsumed_fallthrough_attr_count, 0);
         assert_eq!(summary.max_passed_attrs, 2);
         assert_eq!(summary.max_root_element_count, 3);
+
+        let json = serde_json::to_value(summary).unwrap();
+        assert_eq!(json["componentCount"], 3);
+        assert_eq!(json["componentsWithPotentialIssues"], 1);
+        assert_eq!(json["safeStandardFallthroughAttrCount"], 2);
     }
 
     #[test]

--- a/crates/vize_vitrine/src/wasm/cross_file_complexity.rs
+++ b/crates/vize_vitrine/src/wasm/cross_file_complexity.rs
@@ -1,57 +1,5 @@
-use vize_croquis_cf::{
-    ComplexityBand, ComplexityDimensionScores, ComplexityInput, ComplexityReport,
-};
+use vize_croquis_cf::ComplexityReport;
 
 pub(crate) fn complexity_report_json(report: &ComplexityReport) -> serde_json::Value {
-    serde_json::json!({
-        "input": complexity_input_json(report.input),
-        "dimensions": complexity_dimensions_json(report.dimensions),
-        "cyclomaticScore": report.cyclomatic_score,
-        "cognitiveScore": report.cognitive_score,
-        "totalScore": report.total_score,
-        "band": complexity_band_name(report.band),
-    })
-}
-
-fn complexity_input_json(input: ComplexityInput) -> serde_json::Value {
-    serde_json::json!({
-        "componentCount": input.component_count,
-        "templateIfCount": input.template_if_count,
-        "templateForCount": input.template_for_count,
-        "templateLogicalOperatorCount": input.template_logical_operator_count,
-        "componentTreeVIfMaxDepth": input.component_tree_v_if_max_depth,
-        "componentTreeVForMaxDepth": input.component_tree_v_for_max_depth,
-        "componentTreeScopedSlotMaxDepth": input.component_tree_scoped_slot_max_depth,
-        "componentTreeTemplateNestingScore": input.component_tree_template_nesting_score,
-        "slotCount": input.slot_count,
-        "propDrillingEdgeCount": input.prop_drilling_edge_count,
-        "globalStateReferenceCount": input.global_state_reference_count,
-        "provideInjectMaxDepth": input.provide_inject_max_depth,
-        "provideInjectReferenceCount": input.provide_inject_reference_count,
-        "fallthroughRiskCount": input.fallthrough_risk_count,
-        "reactiveNodeCount": input.reactive_node_count,
-        "reactiveEdgeCount": input.reactive_edge_count,
-        "reactiveCycleCount": input.reactive_cycle_count,
-    })
-}
-
-fn complexity_dimensions_json(dimensions: ComplexityDimensionScores) -> serde_json::Value {
-    serde_json::json!({
-        "templateControlFlow": dimensions.template_control_flow,
-        "slotUsage": dimensions.slot_usage,
-        "propDrilling": dimensions.prop_drilling,
-        "globalState": dimensions.global_state,
-        "provideInject": dimensions.provide_inject,
-        "fallthroughAttrs": dimensions.fallthrough_attrs,
-        "reactiveGraph": dimensions.reactive_graph,
-    })
-}
-
-fn complexity_band_name(band: ComplexityBand) -> &'static str {
-    match band {
-        ComplexityBand::Low => "low",
-        ComplexityBand::Moderate => "moderate",
-        ComplexityBand::High => "high",
-        ComplexityBand::Extreme => "extreme",
-    }
+    serde_json::to_value(report).expect("complexity report should serialize")
 }


### PR DESCRIPTION
## Summary

- make complexity report, dimension, and band types serialize with stable camelCase/kebab-case JSON
- make fallthrough summary serialize with camelCase counters
- replace the manual Vitrine complexity JSON builder with the shared report shape

Part of #2748.
Part of #2749.
Part of #2745.

## Validation

- cargo fmt --check
- cargo test -p vize_croquis_cf --profile ci
- cargo test -p vize_vitrine cross_file_complexity --profile ci
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786202395&installation_id=136613492&pr_number=2775&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2775&signature=154002f711f8a201a4c300759c4368c54f6a89ebf83247b0296568189fc933e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Complexity and fallthrough reporting data can now be exported as JSON with consistent, readable field names.
  * Cross-file complexity output now uses the same structured report format end-to-end.

* **Bug Fixes**
  * Improved JSON output consistency for complexity reports, including band and dimension values.

* **Tests**
  * Expanded coverage to verify serialized JSON fields and report contents for complexity and fallthrough summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->