### PR TITLE
feat(croquis): build effect graphs from scripts

### DIFF
--- a/crates/vize_croquis/src/drawer/helpers/slots/slot_props.rs
+++ b/crates/vize_croquis/src/drawer/helpers/slots/slot_props.rs
@@ -104,29 +104,33 @@ fn extract_slot_binding_names(
 #[cfg(test)]
 mod tests {
     use super::extract_slot_props;
+    use vize_carton::{CompactString, SmallVec, cstr};
 
-    fn names(pattern: &str) -> Vec<String> {
+    fn names(pattern: &str) -> SmallVec<[CompactString; 4]> {
         extract_slot_props(pattern)
-            .iter()
-            .map(|name| name.to_string())
-            .collect()
     }
 
     #[test]
     fn extracts_simple_object_rest_with_default() {
-        assert_eq!(names("{ open = false, ...rest }"), vec!["open", "rest"]);
+        assert_eq!(
+            names("{ open = false, ...rest }"),
+            [cstr!("open"), cstr!("rest")].into()
+        );
     }
 
     #[test]
     fn falls_back_for_nested_object_patterns() {
-        assert_eq!(names("{ item: { id }, ...rest }"), vec!["id", "rest"]);
+        assert_eq!(
+            names("{ item: { id }, ...rest }"),
+            [cstr!("id"), cstr!("rest")].into()
+        );
     }
 
     #[test]
     fn falls_back_for_default_calls_with_commas() {
         assert_eq!(
             names("{ value = getDefault(a, b), rest }"),
-            vec!["value", "rest"]
+            [cstr!("value"), cstr!("rest")].into()
         );
     }
 }

--- a/crates/vize_croquis/src/effect_graph.rs
+++ b/crates/vize_croquis/src/effect_graph.rs
@@ -8,6 +8,10 @@
 //! follow-ups. The intent of landing the model now is so the analyzer and
 //! the lint rule can be developed against a stable shape.
 
+mod builder;
+
+pub use builder::{build_effect_graph_from_script, build_effect_graph_from_script_setup};
+
 use serde::Serialize;
 use vize_carton::CompactString;
 

--- a/crates/vize_croquis/src/effect_graph/builder.rs
+++ b/crates/vize_croquis/src/effect_graph/builder.rs
@@ -1,0 +1,243 @@
+//! Parser-driven effect graph construction.
+
+mod deps;
+
+use deps::collect_argument_deps;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    BindingPattern, CallExpression, Expression, Program, Statement, VariableDeclaration,
+};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{CompactString, FxHashMap, FxHashSet, cstr};
+
+use super::EffectGraph;
+
+pub fn build_effect_graph_from_script_setup(source: &str) -> EffectGraph {
+    build_effect_graph_from_source(source, "script.ts")
+}
+
+pub fn build_effect_graph_from_script(source: &str) -> EffectGraph {
+    build_effect_graph_from_source(source, "script.ts")
+}
+
+fn build_effect_graph_from_source(source: &str, path: &str) -> EffectGraph {
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(path).unwrap_or_default();
+    let ret = Parser::new(&allocator, source, source_type).parse();
+    if ret.panicked {
+        return EffectGraph::default();
+    }
+    build_effect_graph_from_program(&ret.program)
+}
+
+pub(crate) fn build_effect_graph_from_program(program: &Program<'_>) -> EffectGraph {
+    let mut api_aliases = FxHashMap::default();
+    let mut reactive_sources = FxHashSet::default();
+
+    for statement in program.body.iter() {
+        collect_vue_api_aliases(statement, &mut api_aliases);
+    }
+    for statement in program.body.iter() {
+        collect_reactive_sources(statement, &api_aliases, &mut reactive_sources);
+    }
+
+    let mut graph = EffectGraph::default();
+    for statement in program.body.iter() {
+        collect_effect_edges(statement, &api_aliases, &reactive_sources, &mut graph);
+    }
+    graph
+}
+
+fn collect_vue_api_aliases(
+    statement: &Statement<'_>,
+    api_aliases: &mut FxHashMap<CompactString, CompactString>,
+) {
+    let Statement::ImportDeclaration(import) = statement else {
+        return;
+    };
+    if import.source.value.as_str() != "vue" {
+        return;
+    }
+    let Some(specifiers) = &import.specifiers else {
+        return;
+    };
+
+    for specifier in specifiers.iter() {
+        if let oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier {
+            let imported = specifier.imported.name().as_str();
+            let local = specifier.local.name.as_str();
+            if (is_reactive_api(imported) || is_effect_api(imported)) && imported != local {
+                api_aliases.insert(CompactString::new(local), CompactString::new(imported));
+            }
+        }
+    }
+}
+
+fn collect_reactive_sources(
+    statement: &Statement<'_>,
+    api_aliases: &FxHashMap<CompactString, CompactString>,
+    reactive_sources: &mut FxHashSet<CompactString>,
+) {
+    let Statement::VariableDeclaration(declaration) = statement else {
+        return;
+    };
+
+    for declarator in declaration.declarations.iter() {
+        let BindingPattern::BindingIdentifier(identifier) = &declarator.id else {
+            continue;
+        };
+        let Some(call) = declarator.init.as_ref().and_then(call_from_expression) else {
+            continue;
+        };
+        if call_api_name(call, api_aliases).is_some_and(|name| is_reactive_api(name.as_str())) {
+            reactive_sources.insert(CompactString::new(identifier.name.as_str()));
+        }
+    }
+}
+
+fn collect_effect_edges(
+    statement: &Statement<'_>,
+    api_aliases: &FxHashMap<CompactString, CompactString>,
+    reactive_sources: &FxHashSet<CompactString>,
+    graph: &mut EffectGraph,
+) {
+    match statement {
+        Statement::VariableDeclaration(declaration) => {
+            collect_variable_effect_edges(declaration, api_aliases, reactive_sources, graph);
+        }
+        Statement::ExpressionStatement(statement) => {
+            collect_call_effect_edges(&statement.expression, api_aliases, reactive_sources, graph);
+        }
+        _ => {}
+    }
+}
+
+fn collect_variable_effect_edges(
+    declaration: &VariableDeclaration<'_>,
+    api_aliases: &FxHashMap<CompactString, CompactString>,
+    reactive_sources: &FxHashSet<CompactString>,
+    graph: &mut EffectGraph,
+) {
+    for declarator in declaration.declarations.iter() {
+        let Some(init) = &declarator.init else {
+            continue;
+        };
+        let Some(call) = call_from_expression(init) else {
+            collect_call_effect_edges(init, api_aliases, reactive_sources, graph);
+            continue;
+        };
+
+        let Some(api_name) = call_api_name(call, api_aliases) else {
+            collect_call_effect_edges(init, api_aliases, reactive_sources, graph);
+            continue;
+        };
+
+        if api_name == "computed" {
+            if let BindingPattern::BindingIdentifier(identifier) = &declarator.id {
+                let from = CompactString::new(identifier.name.as_str());
+                add_edges_from_first_arg(&from, call, reactive_sources, graph);
+            }
+        } else if is_effect_api(api_name.as_str()) {
+            let from = effect_node_name(api_name.as_str(), call.span.start);
+            add_edges_from_first_arg(&from, call, reactive_sources, graph);
+        }
+    }
+}
+
+fn collect_call_effect_edges(
+    expression: &Expression<'_>,
+    api_aliases: &FxHashMap<CompactString, CompactString>,
+    reactive_sources: &FxHashSet<CompactString>,
+    graph: &mut EffectGraph,
+) {
+    let Some(call) = call_from_expression(expression) else {
+        return;
+    };
+    let Some(api_name) = call_api_name(call, api_aliases) else {
+        return;
+    };
+    if is_effect_api(api_name.as_str()) {
+        let from = effect_node_name(api_name.as_str(), call.span.start);
+        add_edges_from_first_arg(&from, call, reactive_sources, graph);
+    }
+}
+
+fn add_edges_from_first_arg(
+    from: &CompactString,
+    call: &CallExpression<'_>,
+    reactive_sources: &FxHashSet<CompactString>,
+    graph: &mut EffectGraph,
+) {
+    let Some(arg) = call.arguments.first() else {
+        return;
+    };
+
+    let mut deps = std::collections::BTreeSet::new();
+    let excluded = FxHashSet::default();
+    collect_argument_deps(arg, reactive_sources, &excluded, &mut deps);
+    for dep in deps {
+        if dep != *from {
+            graph.add_edge(from.clone(), dep);
+        }
+    }
+}
+
+fn call_from_expression<'a>(expression: &'a Expression<'a>) -> Option<&'a CallExpression<'a>> {
+    match expression {
+        Expression::CallExpression(call) => Some(call),
+        Expression::ParenthesizedExpression(expression) => {
+            call_from_expression(&expression.expression)
+        }
+        Expression::TSAsExpression(expression) => call_from_expression(&expression.expression),
+        Expression::TSSatisfiesExpression(expression) => {
+            call_from_expression(&expression.expression)
+        }
+        Expression::TSNonNullExpression(expression) => call_from_expression(&expression.expression),
+        _ => None,
+    }
+}
+
+fn call_api_name(
+    call: &CallExpression<'_>,
+    api_aliases: &FxHashMap<CompactString, CompactString>,
+) -> Option<CompactString> {
+    let Expression::Identifier(identifier) = &call.callee else {
+        return None;
+    };
+    let raw = identifier.name.as_str();
+    Some(
+        api_aliases
+            .get(raw)
+            .cloned()
+            .unwrap_or_else(|| CompactString::new(raw)),
+    )
+}
+
+fn effect_node_name(api_name: &str, start: u32) -> CompactString {
+    cstr!("{api_name}@{start}")
+}
+
+fn is_reactive_api(name: &str) -> bool {
+    matches!(
+        name,
+        "ref"
+            | "shallowRef"
+            | "reactive"
+            | "shallowReactive"
+            | "computed"
+            | "readonly"
+            | "shallowReadonly"
+            | "toRef"
+            | "toRefs"
+            | "customRef"
+            | "useTemplateRef"
+    )
+}
+
+fn is_effect_api(name: &str) -> bool {
+    matches!(
+        name,
+        "watch" | "watchEffect" | "watchPostEffect" | "watchSyncEffect"
+    )
+}

--- a/crates/vize_croquis/src/effect_graph/builder/deps.rs
+++ b/crates/vize_croquis/src/effect_graph/builder/deps.rs
@@ -1,0 +1,287 @@
+//! Reactive dependency extraction for effect graph builders.
+
+use oxc_ast::ast::{Argument, BindingPattern, Expression, FunctionBody, Statement};
+use vize_carton::{CompactString, FxHashSet};
+
+pub(super) fn collect_argument_deps(
+    argument: &Argument<'_>,
+    reactive_sources: &FxHashSet<CompactString>,
+    excluded: &FxHashSet<CompactString>,
+    deps: &mut std::collections::BTreeSet<CompactString>,
+) {
+    match argument {
+        Argument::ArrowFunctionExpression(arrow) => {
+            let mut inner_excluded = excluded.clone();
+            collect_binding_pattern_names_from_params(&arrow.params, &mut inner_excluded);
+            collect_body_deps(&arrow.body, reactive_sources, &inner_excluded, deps);
+        }
+        Argument::FunctionExpression(function) => {
+            let mut inner_excluded = excluded.clone();
+            collect_binding_pattern_names_from_params(&function.params, &mut inner_excluded);
+            if let Some(body) = &function.body {
+                collect_body_deps(body, reactive_sources, &inner_excluded, deps);
+            }
+        }
+        _ => {
+            if let Some(expression) = argument.as_expression() {
+                collect_expression_deps(expression, reactive_sources, excluded, deps);
+            }
+        }
+    }
+}
+
+fn collect_body_deps(
+    body: &FunctionBody<'_>,
+    reactive_sources: &FxHashSet<CompactString>,
+    excluded: &FxHashSet<CompactString>,
+    deps: &mut std::collections::BTreeSet<CompactString>,
+) {
+    for statement in body.statements.iter() {
+        collect_statement_deps(statement, reactive_sources, &mut excluded.clone(), deps);
+    }
+}
+
+fn collect_statement_deps(
+    statement: &Statement<'_>,
+    reactive_sources: &FxHashSet<CompactString>,
+    excluded: &mut FxHashSet<CompactString>,
+    deps: &mut std::collections::BTreeSet<CompactString>,
+) {
+    match statement {
+        Statement::ExpressionStatement(statement) => {
+            collect_expression_deps(&statement.expression, reactive_sources, excluded, deps);
+        }
+        Statement::ReturnStatement(statement) => {
+            if let Some(argument) = &statement.argument {
+                collect_expression_deps(argument, reactive_sources, excluded, deps);
+            }
+        }
+        Statement::VariableDeclaration(declaration) => {
+            for declarator in declaration.declarations.iter() {
+                if let Some(init) = &declarator.init {
+                    collect_expression_deps(init, reactive_sources, excluded, deps);
+                }
+                collect_binding_pattern_names(&declarator.id, excluded);
+            }
+        }
+        Statement::BlockStatement(block) => {
+            let mut local_excluded = excluded.clone();
+            for statement in block.body.iter() {
+                collect_statement_deps(statement, reactive_sources, &mut local_excluded, deps);
+            }
+        }
+        Statement::IfStatement(statement) => {
+            collect_expression_deps(&statement.test, reactive_sources, excluded, deps);
+            collect_statement_deps(&statement.consequent, reactive_sources, excluded, deps);
+            if let Some(alternate) = &statement.alternate {
+                collect_statement_deps(alternate, reactive_sources, excluded, deps);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_expression_deps(
+    expression: &Expression<'_>,
+    reactive_sources: &FxHashSet<CompactString>,
+    excluded: &FxHashSet<CompactString>,
+    deps: &mut std::collections::BTreeSet<CompactString>,
+) {
+    match expression {
+        Expression::Identifier(identifier) => {
+            let name = CompactString::new(identifier.name.as_str());
+            if reactive_sources.contains(&name) && !excluded.contains(&name) {
+                deps.insert(name);
+            }
+        }
+        Expression::StaticMemberExpression(member) => {
+            collect_expression_deps(&member.object, reactive_sources, excluded, deps);
+        }
+        Expression::ComputedMemberExpression(member) => {
+            collect_expression_deps(&member.object, reactive_sources, excluded, deps);
+            collect_expression_deps(&member.expression, reactive_sources, excluded, deps);
+        }
+        Expression::ChainExpression(chain) => match &chain.expression {
+            oxc_ast::ast::ChainElement::CallExpression(call) => {
+                for argument in call.arguments.iter() {
+                    collect_argument_deps(argument, reactive_sources, excluded, deps);
+                }
+            }
+            oxc_ast::ast::ChainElement::StaticMemberExpression(member) => {
+                collect_expression_deps(&member.object, reactive_sources, excluded, deps);
+            }
+            oxc_ast::ast::ChainElement::ComputedMemberExpression(member) => {
+                collect_expression_deps(&member.object, reactive_sources, excluded, deps);
+                collect_expression_deps(&member.expression, reactive_sources, excluded, deps);
+            }
+            oxc_ast::ast::ChainElement::TSNonNullExpression(expression) => {
+                collect_expression_deps(&expression.expression, reactive_sources, excluded, deps);
+            }
+            oxc_ast::ast::ChainElement::PrivateFieldExpression(expression) => {
+                collect_expression_deps(&expression.object, reactive_sources, excluded, deps);
+            }
+        },
+        Expression::CallExpression(call) => {
+            for argument in call.arguments.iter() {
+                collect_argument_deps(argument, reactive_sources, excluded, deps);
+            }
+        }
+        Expression::ArrowFunctionExpression(arrow) => {
+            let mut inner_excluded = excluded.clone();
+            collect_binding_pattern_names_from_params(&arrow.params, &mut inner_excluded);
+            collect_body_deps(&arrow.body, reactive_sources, &inner_excluded, deps);
+        }
+        Expression::FunctionExpression(function) => {
+            let mut inner_excluded = excluded.clone();
+            collect_binding_pattern_names_from_params(&function.params, &mut inner_excluded);
+            if let Some(body) = &function.body {
+                collect_body_deps(body, reactive_sources, &inner_excluded, deps);
+            }
+        }
+        Expression::LogicalExpression(expression) => {
+            collect_expression_deps(&expression.left, reactive_sources, excluded, deps);
+            collect_expression_deps(&expression.right, reactive_sources, excluded, deps);
+        }
+        Expression::BinaryExpression(expression) => {
+            collect_expression_deps(&expression.left, reactive_sources, excluded, deps);
+            collect_expression_deps(&expression.right, reactive_sources, excluded, deps);
+        }
+        Expression::ConditionalExpression(expression) => {
+            collect_expression_deps(&expression.test, reactive_sources, excluded, deps);
+            collect_expression_deps(&expression.consequent, reactive_sources, excluded, deps);
+            collect_expression_deps(&expression.alternate, reactive_sources, excluded, deps);
+        }
+        Expression::ArrayExpression(array) => {
+            for element in array.elements.iter() {
+                if let Some(expression) = element.as_expression() {
+                    collect_expression_deps(expression, reactive_sources, excluded, deps);
+                }
+            }
+        }
+        Expression::ObjectExpression(object) => {
+            for property in object.properties.iter() {
+                match property {
+                    oxc_ast::ast::ObjectPropertyKind::ObjectProperty(property) => {
+                        if let Some(key) = property.key.as_expression() {
+                            collect_expression_deps(key, reactive_sources, excluded, deps);
+                        }
+                        collect_expression_deps(&property.value, reactive_sources, excluded, deps);
+                    }
+                    oxc_ast::ast::ObjectPropertyKind::SpreadProperty(spread) => {
+                        collect_expression_deps(&spread.argument, reactive_sources, excluded, deps);
+                    }
+                }
+            }
+        }
+        Expression::AssignmentExpression(expression) => {
+            collect_expression_deps(&expression.right, reactive_sources, excluded, deps);
+        }
+        Expression::UpdateExpression(expression) => {
+            collect_simple_assignment_target_deps(
+                &expression.argument,
+                reactive_sources,
+                excluded,
+                deps,
+            );
+        }
+        Expression::AwaitExpression(expression) => {
+            collect_expression_deps(&expression.argument, reactive_sources, excluded, deps);
+        }
+        Expression::UnaryExpression(expression) => {
+            collect_expression_deps(&expression.argument, reactive_sources, excluded, deps);
+        }
+        Expression::SequenceExpression(expression) => {
+            for expression in expression.expressions.iter() {
+                collect_expression_deps(expression, reactive_sources, excluded, deps);
+            }
+        }
+        Expression::ParenthesizedExpression(expression) => {
+            collect_expression_deps(&expression.expression, reactive_sources, excluded, deps);
+        }
+        Expression::TSAsExpression(expression) => {
+            collect_expression_deps(&expression.expression, reactive_sources, excluded, deps);
+        }
+        Expression::TSSatisfiesExpression(expression) => {
+            collect_expression_deps(&expression.expression, reactive_sources, excluded, deps);
+        }
+        Expression::TSNonNullExpression(expression) => {
+            collect_expression_deps(&expression.expression, reactive_sources, excluded, deps);
+        }
+        _ => {}
+    }
+}
+
+fn collect_simple_assignment_target_deps(
+    target: &oxc_ast::ast::SimpleAssignmentTarget<'_>,
+    reactive_sources: &FxHashSet<CompactString>,
+    excluded: &FxHashSet<CompactString>,
+    deps: &mut std::collections::BTreeSet<CompactString>,
+) {
+    match target {
+        oxc_ast::ast::SimpleAssignmentTarget::AssignmentTargetIdentifier(identifier) => {
+            let name = CompactString::new(identifier.name.as_str());
+            if reactive_sources.contains(&name) && !excluded.contains(&name) {
+                deps.insert(name);
+            }
+        }
+        oxc_ast::ast::SimpleAssignmentTarget::StaticMemberExpression(member) => {
+            collect_expression_deps(&member.object, reactive_sources, excluded, deps);
+        }
+        oxc_ast::ast::SimpleAssignmentTarget::ComputedMemberExpression(member) => {
+            collect_expression_deps(&member.object, reactive_sources, excluded, deps);
+            collect_expression_deps(&member.expression, reactive_sources, excluded, deps);
+        }
+        oxc_ast::ast::SimpleAssignmentTarget::TSAsExpression(expression) => {
+            collect_expression_deps(&expression.expression, reactive_sources, excluded, deps);
+        }
+        oxc_ast::ast::SimpleAssignmentTarget::TSSatisfiesExpression(expression) => {
+            collect_expression_deps(&expression.expression, reactive_sources, excluded, deps);
+        }
+        oxc_ast::ast::SimpleAssignmentTarget::TSNonNullExpression(expression) => {
+            collect_expression_deps(&expression.expression, reactive_sources, excluded, deps);
+        }
+        _ => {}
+    }
+}
+
+fn collect_binding_pattern_names_from_params(
+    params: &oxc_ast::ast::FormalParameters<'_>,
+    names: &mut FxHashSet<CompactString>,
+) {
+    for param in params.items.iter() {
+        collect_binding_pattern_names(&param.pattern, names);
+    }
+    if let Some(rest) = &params.rest {
+        collect_binding_pattern_names(&rest.rest.argument, names);
+    }
+}
+
+fn collect_binding_pattern_names(
+    pattern: &BindingPattern<'_>,
+    names: &mut FxHashSet<CompactString>,
+) {
+    match pattern {
+        BindingPattern::BindingIdentifier(identifier) => {
+            names.insert(CompactString::new(identifier.name.as_str()));
+        }
+        BindingPattern::ObjectPattern(object) => {
+            for property in object.properties.iter() {
+                collect_binding_pattern_names(&property.value, names);
+            }
+            if let Some(rest) = &object.rest {
+                collect_binding_pattern_names(&rest.argument, names);
+            }
+        }
+        BindingPattern::ArrayPattern(array) => {
+            for element in array.elements.iter().flatten() {
+                collect_binding_pattern_names(element, names);
+            }
+            if let Some(rest) = &array.rest {
+                collect_binding_pattern_names(&rest.argument, names);
+            }
+        }
+        BindingPattern::AssignmentPattern(assign) => {
+            collect_binding_pattern_names(&assign.left, names);
+        }
+    }
+}

--- a/crates/vize_croquis/src/effect_graph_builder_tests.rs
+++ b/crates/vize_croquis/src/effect_graph_builder_tests.rs
@@ -1,0 +1,118 @@
+use crate::effect_graph::{EffectGraph, build_effect_graph_from_script_setup};
+use crate::script_parser::parse_script_setup;
+use vize_carton::{CompactString, cstr};
+
+fn edge_pairs(graph: &EffectGraph) -> Vec<(CompactString, CompactString)> {
+    let mut pairs: Vec<_> = graph
+        .edges()
+        .map(|edge| (edge.from.clone(), edge.to.clone()))
+        .collect();
+    pairs.sort();
+    pairs
+}
+
+#[test]
+fn builds_computed_dependency_edges_from_script_setup() {
+    let graph = build_effect_graph_from_script_setup(
+        r#"
+import { ref, computed } from 'vue'
+const count = ref(0)
+const doubled = computed(() => count.value * 2)
+const tripled = computed(() => doubled.value + count.value)
+"#,
+    );
+
+    assert_eq!(
+        edge_pairs(&graph),
+        [
+            (cstr!("doubled"), cstr!("count")),
+            (cstr!("tripled"), cstr!("count")),
+            (cstr!("tripled"), cstr!("doubled")),
+        ]
+    );
+    assert_eq!(graph.summary().node_count, 3);
+    assert_eq!(graph.summary().edge_count, 3);
+    assert_eq!(graph.summary().cycle_count, 0);
+}
+
+#[test]
+fn builds_watch_and_watcheffect_edges_with_vue_import_aliases() {
+    let graph = build_effect_graph_from_script_setup(
+        r#"
+import { ref as r, computed as c, watch as observe, watchEffect as fx } from 'vue'
+const count = r(0)
+const total = c(() => count.value + 1)
+observe([count, () => total.value], () => {})
+fx(() => {
+  console.log(total.value)
+})
+"#,
+    );
+    let pairs = edge_pairs(&graph);
+
+    assert!(pairs.contains(&(cstr!("total"), cstr!("count"))));
+    assert!(
+        pairs
+            .iter()
+            .any(|(from, to)| from.starts_with("watch@") && to.as_str() == "count")
+    );
+    assert!(
+        pairs
+            .iter()
+            .any(|(from, to)| from.starts_with("watch@") && to.as_str() == "total")
+    );
+    assert!(
+        pairs
+            .iter()
+            .any(|(from, to)| from.starts_with("watchEffect@") && to.as_str() == "total")
+    );
+    assert_eq!(graph.summary().edge_count, 4);
+}
+
+#[test]
+fn detects_cycles_in_parser_built_computed_chains() {
+    let graph = build_effect_graph_from_script_setup(
+        r#"
+import { computed } from 'vue'
+const left = computed(() => right.value)
+const right = computed(() => left.value)
+"#,
+    );
+
+    let cycle = graph.find_cycle().expect("computed chain should cycle");
+    assert_eq!(graph.summary().cycle_count, 1);
+    assert!(cycle.contains(&"left".into()));
+    assert!(cycle.contains(&"right".into()));
+}
+
+#[test]
+fn ignores_shadowed_callback_parameters_when_collecting_deps() {
+    let graph = build_effect_graph_from_script_setup(
+        r#"
+import { ref, computed } from 'vue'
+const count = ref(0)
+const source = ref(1)
+const doubled = computed((count) => count + source.value)
+"#,
+    );
+
+    assert_eq!(edge_pairs(&graph), [(cstr!("doubled"), cstr!("source"))]);
+}
+
+#[test]
+fn overlay_snapshot_includes_parser_built_effect_graph() {
+    let source = r#"
+import { ref, computed, watchEffect } from 'vue'
+const count = ref(0)
+const doubled = computed(() => count.value * 2)
+watchEffect(() => {
+  console.log(doubled.value)
+})
+"#;
+    let parsed = parse_script_setup(source);
+    let graph = build_effect_graph_from_script_setup(source);
+    let json =
+        serde_json::to_string_pretty(&parsed.reactivity.overlay_with_effect_graph(&graph)).unwrap();
+
+    insta::assert_snapshot!(json);
+}

--- a/crates/vize_croquis/src/lib.rs
+++ b/crates/vize_croquis/src/lib.rs
@@ -65,6 +65,9 @@ pub mod types;
 pub mod virtual_ts;
 
 #[cfg(test)]
+mod effect_graph_builder_tests;
+
+#[cfg(test)]
 mod reactivity_overlay_tests;
 
 // Re-export commonly used utilities from vize_carton for convenience
@@ -98,7 +101,10 @@ pub use croquis::{
     UnusedVarContext,
 };
 pub use drawer::{Drawer, DrawerOptions};
-pub use effect_graph::EffectGraphSummary;
+pub use effect_graph::{
+    EffectGraph, EffectGraphSummary, build_effect_graph_from_script,
+    build_effect_graph_from_script_setup,
+};
 pub use reactivity_overlay::{
     ReactivityEffectEdgeOverlay, ReactivityEffectGraphOverlay, ReactivityLossOverlay,
     ReactivityOverlay, ReactivityOverlaySummary, ReactivitySourceOverlay,

--- a/crates/vize_croquis/src/snapshots/vize_croquis__effect_graph_builder_tests__overlay_snapshot_includes_parser_built_effect_graph.snap
+++ b/crates/vize_croquis/src/snapshots/vize_croquis__effect_graph_builder_tests__overlay_snapshot_includes_parser_built_effect_graph.snap
@@ -1,0 +1,51 @@
+---
+source: crates/vize_croquis/src/effect_graph_builder_tests.rs
+expression: json
+---
+{
+  "summary": {
+    "sourceCount": 2,
+    "refSourceCount": 1,
+    "reactiveSourceCount": 0,
+    "computedSourceCount": 1,
+    "readonlySourceCount": 0,
+    "needsValueAccessCount": 2,
+    "lossCount": 0,
+    "effectEdgeCount": 2,
+    "effectCycleCount": 0
+  },
+  "sources": [
+    {
+      "id": 0,
+      "name": "count",
+      "kind": "ref",
+      "category": "ref",
+      "needsValueAccess": true,
+      "declarationOffset": 0
+    },
+    {
+      "id": 1,
+      "name": "doubled",
+      "kind": "computed",
+      "category": "computed",
+      "needsValueAccess": true,
+      "declarationOffset": 0
+    }
+  ],
+  "losses": [],
+  "effectGraph": {
+    "edges": [
+      {
+        "from": "doubled",
+        "to": "count",
+        "category": "effectEdge"
+      },
+      {
+        "from": "watchEffect@119",
+        "to": "doubled",
+        "category": "effectEdge"
+      }
+    ],
+    "cycle": null
+  }
+}


### PR DESCRIPTION
## Summary

- add a parser-driven effect graph builder for computed/watch/watchEffect dependencies
- expose the script effect graph builders from vize_croquis
- add focused graph, cycle, alias, shadowing, and overlay snapshot coverage
- clean up one test helper so strict clippy all-targets stays green

Part of #2746.
Part of #2748.
Part of #2745.

## Validation

- cargo fmt --check
- git diff --check
- cargo test -p vize_croquis effect_graph_builder --profile ci
- cargo test -p vize_croquis --profile ci
- cargo test -p vize_croquis_cf --profile ci
- cargo clippy -p vize_croquis --profile ci --all-targets -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786204873&installation_id=136613492&pr_number=2776&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2776&signature=6cc7fd5514442fea810faf0df2ed9e18b2a768ae17945cb7e4e186347b84dd21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating effect graphs from scripts, including Vue Composition API patterns such as `computed`, `watch`, and `watchEffect`.
  * Improved dependency detection so reactive relationships are captured more accurately, including nested and aliased usage.
  * Expanded the crate’s public API to make effect-graph building available to callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->