### PR TITLE
feat(croquis-cf): expose fallthrough usage facts

### DIFF
--- a/crates/vize_croquis_cf/src/lib.rs
+++ b/crates/vize_croquis_cf/src/lib.rs
@@ -67,7 +67,8 @@ pub use suppression::{SuppressionDirective, SuppressionError, SuppressionMap};
 pub use rules::{
     BoundaryInfo, BoundaryKind, ComplexityBand, ComplexityDimension, ComplexityDimensionBreakdown,
     ComplexityDimensionScores, ComplexityInput, ComplexityReport, EmitFlow, EventBubble,
-    FallthroughInfo, FallthroughSummary, PropsValidationIssue, PropsValidationIssueKind,
-    ProvideInjectMatch, ProvideInjectTreeSummary, ReactivityIssue, ReactivityIssueKind,
-    UniqueIdIssue, band_for_score,
+    FallthroughInfo, FallthroughSummary, FallthroughUsageAttrFact, FallthroughUsageAttrKind,
+    FallthroughUsageFact, PropsValidationIssue, PropsValidationIssueKind, ProvideInjectMatch,
+    ProvideInjectTreeSummary, ReactivityIssue, ReactivityIssueKind, UniqueIdIssue, band_for_score,
+    collect_fallthrough_usage_facts,
 };

--- a/crates/vize_croquis_cf/src/rules.rs
+++ b/crates/vize_croquis_cf/src/rules.rs
@@ -37,7 +37,9 @@ pub use element_id::{UniqueIdIssue, analyze_element_ids};
 pub use emit::{EmitFlow, analyze_emits};
 pub use event_bubbling::{EventBubble, analyze_event_bubbling};
 pub use fallthrough::{
-    FallthroughInfo, FallthroughSummary, analyze_fallthrough, summarize_fallthrough,
+    FallthroughInfo, FallthroughSummary, FallthroughUsageAttrFact, FallthroughUsageAttrKind,
+    FallthroughUsageFact, analyze_fallthrough, collect_fallthrough_usage_facts,
+    summarize_fallthrough,
 };
 pub use props_validation::{
     PropsValidationIssue, PropsValidationIssueKind, analyze_props_validation,

--- a/crates/vize_croquis_cf/src/rules/fallthrough.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough.rs
@@ -12,8 +12,10 @@ use vize_carton::{CompactString, FxHashMap, FxHashSet, cstr};
 
 mod info;
 mod summary;
+mod usage;
 
 pub use summary::{FallthroughSummary, summarize_fallthrough};
+pub use usage::*;
 
 /// Information about fallthrough attributes for a component.
 #[derive(Debug, Clone)]
@@ -74,10 +76,6 @@ pub fn analyze_fallthrough(
     let mut infos = Vec::new();
     let mut diagnostics = Vec::new();
 
-    // Build a map of what attributes each component passes to its children
-    let mut passed_attrs_map: FxHashMap<FileId, FxHashMap<FileId, FxHashSet<CompactString>>> =
-        FxHashMap::default();
-
     // First pass: collect information from each component
     for entry in registry.vue_components() {
         let analysis = &entry.analysis;
@@ -111,29 +109,17 @@ pub fn analyze_fallthrough(
         infos.push(info);
     }
 
-    // Second pass: track attribute passing through component usage
-    for node in graph.nodes() {
-        // Look at component usage edges
-        for (child_id, edge_type) in &node.imports {
-            if *edge_type != crate::graph::DependencyEdge::ComponentUsage {
-                continue;
-            }
-
-            // Get the parent's analysis to find what attrs are passed
-            if let Some(parent_entry) = registry.get(node.file_id) {
-                // Only collect the attributes from the usages that actually
-                // target this specific child component, so two distinct usage
-                // sites of different children are not conflated.
-                let attrs = extract_passed_attrs(&parent_entry.analysis, *child_id, graph);
-
-                passed_attrs_map
-                    .entry(*child_id)
-                    .or_default()
-                    .entry(node.file_id)
-                    .or_default()
-                    .extend(attrs);
-            }
-        }
+    // Second pass: track attribute passing through each component usage.
+    let usage_facts = collect_fallthrough_usage_facts(registry, graph);
+    let mut passed_attrs_map: FxHashMap<FileId, FxHashMap<FileId, FxHashSet<CompactString>>> =
+        FxHashMap::default();
+    for fact in &usage_facts {
+        let attrs = passed_attrs_map
+            .entry(fact.child_file_id)
+            .or_default()
+            .entry(fact.parent_file_id)
+            .or_default();
+        attrs.extend(fact.attrs.iter().map(|attr| attr.name.clone()));
     }
 
     // Merge passed attrs into infos
@@ -240,34 +226,12 @@ fn check_inherit_attrs_disabled(analysis: &vize_croquis::Croquis) -> bool {
     })
 }
 
-/// Extract attributes passed to a specific child component.
-///
-/// Uses `component_usages` for precise static analysis. Each usage carries the
-/// component name as written in the template; we resolve that name to a
-/// `FileId` through the dependency graph and only keep the props from usages
-/// that target `child_id`. This ensures distinct usage sites of different
-/// children are attributed independently, rather than merging every prop the
-/// parent passes to any child onto a single component.
-fn extract_passed_attrs(
-    analysis: &vize_croquis::Croquis,
-    child_id: FileId,
+/// Collect durable per-usage fallthrough facts with parent-side source ranges.
+pub fn collect_fallthrough_usage_facts(
+    registry: &ModuleRegistry,
     graph: &DependencyGraph,
-) -> FxHashSet<CompactString> {
-    let mut attrs = FxHashSet::default();
-
-    for usage in &analysis.component_usages {
-        // Resolve the usage's component name to the file it refers to and skip
-        // usages that target a different child component.
-        if graph.find_by_component(usage.name.as_str()) != Some(child_id) {
-            continue;
-        }
-
-        for prop in &usage.props {
-            attrs.insert(prop.name.clone());
-        }
-    }
-
-    attrs
+) -> Vec<FallthroughUsageFact> {
+    usage::collect_fallthrough_usage_facts(registry, graph)
 }
 
 /// Check if an attribute is a standard HTML attribute.

--- a/crates/vize_croquis_cf/src/rules/fallthrough/tests.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough/tests.rs
@@ -1,17 +1,25 @@
-use super::{FallthroughInfo, analyze_fallthrough, summarize_fallthrough};
+use super::{
+    FallthroughInfo, FallthroughUsageAttrKind, analyze_fallthrough,
+    collect_fallthrough_usage_facts, summarize_fallthrough,
+};
 use crate::graph::{DependencyEdge, DependencyGraph, ModuleNode};
 use crate::registry::{FileId, ModuleRegistry};
 use vize_carton::{CompactString, FxHashSet, smallvec};
-use vize_croquis::analysis::{ComponentUsage, PassedProp};
+use vize_croquis::analysis::{ComponentUsage, EventListener, PassedProp};
+use vize_croquis::macros::PropDefinition;
 use vize_croquis::{Croquis, ScopeId};
 
 fn passed_prop(name: &str) -> PassedProp {
+    passed_prop_at(name, 0, 0, false)
+}
+
+fn passed_prop_at(name: &str, start: u32, end: u32, is_dynamic: bool) -> PassedProp {
     PassedProp {
         name: CompactString::new(name),
         value: None,
-        start: 0,
-        end: 0,
-        is_dynamic: false,
+        start,
+        end,
+        is_dynamic,
     }
 }
 
@@ -29,10 +37,156 @@ fn usage_with_prop(name: &str, prop: &str) -> ComponentUsage {
     }
 }
 
+fn event_listener_at(name: &str, start: u32, end: u32) -> EventListener {
+    EventListener {
+        name: CompactString::new(name),
+        handler: None,
+        modifiers: smallvec![],
+        start,
+        end,
+    }
+}
+
+fn declare_prop(analysis: &mut Croquis, name: &str) {
+    analysis.macros.add_prop(PropDefinition {
+        name: CompactString::new(name),
+        prop_type: None,
+        required: false,
+        default_value: None,
+    });
+}
+
 fn graph_node(id: FileId, path: &str, component: &str) -> ModuleNode {
     let mut node = ModuleNode::new(id, path);
     node.component_name = Some(CompactString::new(component));
     node
+}
+
+#[test]
+fn usage_facts_keep_parent_source_ranges_and_attr_classification() {
+    let mut registry = ModuleRegistry::new();
+
+    let parent_analysis = {
+        let mut analysis = Croquis::new();
+        analysis.component_usages.push(ComponentUsage {
+            name: CompactString::new("Child"),
+            start: 10,
+            end: 90,
+            props: smallvec![
+                passed_prop_at("kind", 18, 29, false),
+                passed_prop_at("trackingId", 34, 58, true)
+            ],
+            events: smallvec![event_listener_at("click", 60, 76)],
+            slots: smallvec![],
+            has_spread_attrs: true,
+            scope_id: ScopeId::ROOT,
+            vif_guard: None,
+        });
+        analysis
+    };
+    let mut child_analysis = Croquis::new();
+    declare_prop(&mut child_analysis, "kind");
+
+    let (parent_id, _) = registry.register("Parent.vue", "", parent_analysis);
+    let (child_id, _) = registry.register("Child.vue", "", child_analysis);
+
+    let mut graph = DependencyGraph::new();
+    graph.add_node(graph_node(parent_id, "Parent.vue", "Parent"));
+    graph.add_node(graph_node(child_id, "Child.vue", "Child"));
+    graph.add_edge(parent_id, child_id, DependencyEdge::ComponentUsage);
+
+    let facts = collect_fallthrough_usage_facts(&registry, &graph);
+    assert_eq!(facts.len(), 1);
+
+    let fact = &facts[0];
+    assert_eq!(fact.parent_file_id, parent_id);
+    assert_eq!(fact.child_file_id, child_id);
+    assert_eq!(fact.component_name, "Child");
+    assert_eq!(fact.usage_start, 10);
+    assert_eq!(fact.usage_end, 90);
+    assert!(fact.has_spread_attrs);
+    assert_eq!(fact.attrs.len(), 3);
+
+    let kind = fact.attrs.iter().find(|attr| attr.name == "kind").unwrap();
+    assert_eq!(kind.kind, FallthroughUsageAttrKind::Prop);
+    assert_eq!((kind.source_start, kind.source_end), (18, 29));
+    assert!(kind.declared_prop);
+    assert!(!kind.fallthrough);
+
+    let tracking = fact
+        .attrs
+        .iter()
+        .find(|attr| attr.name == "trackingId")
+        .unwrap();
+    assert!(tracking.dynamic);
+    assert!(tracking.fallthrough);
+    assert!(!tracking.standard_html_attr);
+
+    let listener = fact
+        .attrs
+        .iter()
+        .find(|attr| attr.name == "onClick")
+        .unwrap();
+    assert_eq!(listener.kind, FallthroughUsageAttrKind::Listener);
+    assert_eq!((listener.source_start, listener.source_end), (60, 76));
+    assert!(listener.dynamic);
+    assert!(listener.fallthrough);
+    assert!(listener.standard_html_attr);
+
+    let json = serde_json::to_value(fact).unwrap();
+    assert_eq!(json["componentName"], "Child");
+    assert_eq!(json["attrs"][0]["sourceStart"], 18);
+    assert_eq!(json["attrs"][2]["kind"], "listener");
+}
+
+#[test]
+fn usage_facts_feed_listener_attrs_into_component_aggregates() {
+    let mut registry = ModuleRegistry::new();
+
+    let parent_analysis = {
+        let mut analysis = Croquis::new();
+        analysis.component_usages.push(ComponentUsage {
+            name: CompactString::new("Dialog"),
+            start: 5,
+            end: 40,
+            props: smallvec![],
+            events: smallvec![event_listener_at("close", 12, 28)],
+            slots: smallvec![],
+            has_spread_attrs: false,
+            scope_id: ScopeId::ROOT,
+            vif_guard: None,
+        });
+        analysis
+    };
+    let mut child_analysis = Croquis::new();
+    child_analysis.template_info.root_element_count = 2;
+
+    let (parent_id, _) = registry.register("Parent.vue", "", parent_analysis);
+    let (dialog_id, _) = registry.register("Dialog.vue", "", child_analysis);
+
+    let mut graph = DependencyGraph::new();
+    graph.add_node(graph_node(parent_id, "Parent.vue", "Parent"));
+    graph.add_node(graph_node(dialog_id, "Dialog.vue", "Dialog"));
+    graph.add_edge(parent_id, dialog_id, DependencyEdge::ComponentUsage);
+
+    let (infos, diagnostics) = analyze_fallthrough(&registry, &graph);
+    let dialog = infos.iter().find(|info| info.file_id == dialog_id).unwrap();
+    assert!(dialog.passed_attrs.contains("onClose"));
+    assert_eq!(dialog.fallthrough_attr_count(), 1);
+    assert_eq!(dialog.safe_standard_fallthrough_attr_count(), 1);
+    assert_eq!(dialog.risky_unconsumed_fallthrough_attr_count(), 0);
+
+    let summary = summarize_fallthrough(&infos);
+    assert_eq!(summary.passed_attr_count, 1);
+    assert_eq!(summary.safe_standard_fallthrough_attr_count, 1);
+    assert_eq!(summary.risky_unconsumed_fallthrough_attr_count, 0);
+
+    assert!(diagnostics.iter().any(|diagnostic| {
+        matches!(
+            diagnostic.kind,
+            crate::diagnostics::CrossFileDiagnosticKind::MultiRootMissingAttrs
+        )
+    }));
 }
 
 /// A parent that uses two distinct child components, each receiving a

--- a/crates/vize_croquis_cf/src/rules/fallthrough/usage.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough/usage.rs
@@ -1,0 +1,153 @@
+use crate::graph::{DependencyEdge, DependencyGraph};
+use crate::registry::{FileId, ModuleRegistry};
+use serde::Serialize;
+use vize_carton::{CompactString, FxHashSet, cstr};
+
+use super::is_standard_html_attr;
+
+/// One parent template usage of a child component and the attrs it passes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FallthroughUsageFact {
+    pub parent_file_id: FileId,
+    pub child_file_id: FileId,
+    pub component_name: CompactString,
+    pub usage_start: u32,
+    pub usage_end: u32,
+    pub has_spread_attrs: bool,
+    pub attrs: Vec<FallthroughUsageAttrFact>,
+}
+
+/// One passed attr/listener on a component usage.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FallthroughUsageAttrFact {
+    pub name: CompactString,
+    pub kind: FallthroughUsageAttrKind,
+    pub source_start: u32,
+    pub source_end: u32,
+    pub dynamic: bool,
+    pub declared_prop: bool,
+    pub standard_html_attr: bool,
+    pub fallthrough: bool,
+}
+
+/// Source category of a usage attr.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum FallthroughUsageAttrKind {
+    Prop,
+    Listener,
+}
+
+pub(super) fn collect_fallthrough_usage_facts(
+    registry: &ModuleRegistry,
+    graph: &DependencyGraph,
+) -> Vec<FallthroughUsageFact> {
+    let mut facts = Vec::new();
+
+    for node in graph.nodes() {
+        for (child_id, edge_type) in &node.imports {
+            if *edge_type != DependencyEdge::ComponentUsage {
+                continue;
+            }
+            let Some(parent_entry) = registry.get(node.file_id) else {
+                continue;
+            };
+            let declared_props = declared_props_for(registry, *child_id);
+
+            for usage in &parent_entry.analysis.component_usages {
+                if graph.find_by_component(usage.name.as_str()) != Some(*child_id) {
+                    continue;
+                }
+
+                let mut attrs = Vec::with_capacity(usage.props.len() + usage.events.len());
+                attrs.extend(usage.props.iter().map(|prop| {
+                    let name = prop.name.clone();
+                    usage_attr_fact(
+                        name,
+                        FallthroughUsageAttrKind::Prop,
+                        prop.start,
+                        prop.end,
+                        prop.is_dynamic,
+                        &declared_props,
+                    )
+                }));
+                attrs.extend(usage.events.iter().map(|event| {
+                    usage_attr_fact(
+                        listener_attr_name(event.name.as_str()),
+                        FallthroughUsageAttrKind::Listener,
+                        event.start,
+                        event.end,
+                        true,
+                        &declared_props,
+                    )
+                }));
+
+                facts.push(FallthroughUsageFact {
+                    parent_file_id: node.file_id,
+                    child_file_id: *child_id,
+                    component_name: usage.name.clone(),
+                    usage_start: usage.start,
+                    usage_end: usage.end,
+                    has_spread_attrs: usage.has_spread_attrs,
+                    attrs,
+                });
+            }
+        }
+    }
+
+    facts.sort_by_key(|fact| {
+        (
+            fact.child_file_id.as_u32(),
+            fact.parent_file_id.as_u32(),
+            fact.usage_start,
+            fact.usage_end,
+        )
+    });
+    facts
+}
+
+fn usage_attr_fact(
+    name: CompactString,
+    kind: FallthroughUsageAttrKind,
+    source_start: u32,
+    source_end: u32,
+    dynamic: bool,
+    declared_props: &FxHashSet<CompactString>,
+) -> FallthroughUsageAttrFact {
+    let declared_prop = declared_props.contains(&name);
+    FallthroughUsageAttrFact {
+        standard_html_attr: is_standard_html_attr(name.as_str()),
+        fallthrough: !declared_prop,
+        name,
+        kind,
+        source_start,
+        source_end,
+        dynamic,
+        declared_prop,
+    }
+}
+
+fn declared_props_for(registry: &ModuleRegistry, child_id: FileId) -> FxHashSet<CompactString> {
+    registry
+        .get(child_id)
+        .map(|entry| {
+            entry
+                .analysis
+                .macros
+                .props()
+                .iter()
+                .map(|prop| prop.name.clone())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn listener_attr_name(event_name: &str) -> CompactString {
+    let mut chars = event_name.chars();
+    let Some(first) = chars.next() else {
+        return cstr!("on");
+    };
+    cstr!("on{}{}", first.to_ascii_uppercase(), chars.as_str())
+}


### PR DESCRIPTION
## Summary

- add durable per-usage fallthrough facts with parent/child file IDs and source ranges
- classify passed props and listeners as declared props, standard attrs, or fallthrough attrs
- feed usage facts back into component aggregates so listener fallthrough is counted
- re-export the usage fact API for downstream diagnostics and reports

Part of #2749.
Part of #2748.
Part of #2745.

## Validation

- cargo fmt --check
- git diff --check
- cargo test -p vize_croquis_cf fallthrough --profile ci
- cargo test -p vize_croquis_cf --profile ci
- cargo clippy -p vize_croquis_cf --profile ci --lib -- -D warnings
- cargo test -p vize_vitrine --profile ci

Note: cargo clippy -p vize_croquis_cf --profile ci --all-targets -- -D warnings currently fails on pre-existing snapshot-test uses of disallowed macros/types outside this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786206764&installation_id=136613492&pr_number=2777&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2777&signature=907d85758ce1789008a6d97542debcf2004aa5536992a6f8e396f6aad959ee0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer fallthrough usage reporting for component imports, including passed props and event listeners.
  * Exposed additional fallthrough-related facts through the public API for broader analysis support.

* **Bug Fixes**
  * Improved component attribute classification so declared props, standard HTML attributes, and fallthrough attributes are handled more accurately.
  * Better preserves source ranges and ordering for analyzed usage data, improving diagnostic consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->