### PR TITLE
feat(croquis-cf): match provide inject explicit types

### DIFF
--- a/crates/vize_croquis/src/script_parser/extract.rs
+++ b/crates/vize_croquis/src/script_parser/extract.rs
@@ -26,6 +26,7 @@ pub use plain_values::{
     check_ref_value_extraction, detect_call_argument_reactivity_loss,
     record_getter_context_from_call,
 };
+pub(in crate::script_parser) use provide::extract_inject_expected_type_from_init;
 pub use provide::{detect_provide_inject_call, extract_argument_source, extract_provide_key};
 pub use race::detect_race_condition_call;
 pub use reactivity::{detect_reactivity_call, detect_setup_context_violation};

--- a/crates/vize_croquis/src/script_parser/extract/provide.rs
+++ b/crates/vize_croquis/src/script_parser/extract/provide.rs
@@ -1,4 +1,5 @@
-use oxc_ast::ast::{Argument, CallExpression, Expression};
+use oxc_ast::ast::{Argument, CallExpression, Expression, TSType};
+use oxc_span::GetSpan;
 
 use crate::provide::ProvideKey;
 use vize_carton::{CompactString, String};
@@ -31,12 +32,16 @@ pub fn detect_provide_inject_call(
                 .get(1)
                 .map(|arg| extract_argument_source(arg, source))
                 .unwrap_or_default();
+            let value_type = call
+                .arguments
+                .get(1)
+                .and_then(|arg| extract_argument_type_annotation(arg, source));
 
             if let Some(key) = key {
                 result.provide_inject.add_provide(
                     key,
                     CompactString::new(&value),
-                    None, // value_type
+                    value_type,
                     None, // from_composable
                     call.span.start,
                     call.span.end,
@@ -50,6 +55,68 @@ pub fn detect_provide_inject_call(
         // it's handled in process_variable_declarator. This handles bare inject calls
         // like `a('key')` that appear in expression statements.
     }
+}
+
+pub fn extract_inject_expected_type(
+    call: &CallExpression<'_>,
+    source: &str,
+) -> Option<CompactString> {
+    call.type_arguments
+        .as_ref()
+        .and_then(|type_params| type_params.params.first())
+        .and_then(|ty| type_source(ty, source))
+}
+
+pub fn extract_inject_expected_type_from_init(
+    init: Option<&Expression<'_>>,
+    call: &CallExpression<'_>,
+    source: &str,
+) -> Option<CompactString> {
+    init.and_then(|init| extract_expression_type_annotation(init, source))
+        .or_else(|| extract_inject_expected_type(call, source))
+}
+
+pub fn extract_expression_type_annotation(
+    expression: &Expression<'_>,
+    source: &str,
+) -> Option<CompactString> {
+    match expression {
+        Expression::TSAsExpression(ts_as) => type_source(&ts_as.type_annotation, source),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            type_source(&ts_satisfies.type_annotation, source)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            extract_expression_type_annotation(&ts_non_null.expression, source)
+        }
+        Expression::ParenthesizedExpression(parenthesized) => {
+            extract_expression_type_annotation(&parenthesized.expression, source)
+        }
+        _ => None,
+    }
+}
+
+pub fn extract_argument_type_annotation(arg: &Argument<'_>, source: &str) -> Option<CompactString> {
+    match arg {
+        Argument::TSAsExpression(ts_as) => type_source(&ts_as.type_annotation, source),
+        Argument::TSSatisfiesExpression(ts_satisfies) => {
+            type_source(&ts_satisfies.type_annotation, source)
+        }
+        Argument::TSNonNullExpression(ts_non_null) => {
+            extract_expression_type_annotation(&ts_non_null.expression, source)
+        }
+        Argument::ParenthesizedExpression(parenthesized) => {
+            extract_expression_type_annotation(&parenthesized.expression, source)
+        }
+        _ => None,
+    }
+}
+
+fn type_source(ty: &TSType<'_>, source: &str) -> Option<CompactString> {
+    source
+        .get(ty.span().start as usize..ty.span().end as usize)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .map(CompactString::new)
 }
 
 pub fn extract_provide_key(arg: &Argument<'_>, source: &str) -> Option<ProvideKey> {
@@ -87,6 +154,10 @@ pub fn extract_argument_source(arg: &Argument<'_>, source: &str) -> String {
         Argument::FunctionExpression(f) => f.span,
         Argument::ArrowFunctionExpression(a) => a.span,
         Argument::CallExpression(c) => c.span,
+        Argument::TSAsExpression(ts_as) => ts_as.span,
+        Argument::TSSatisfiesExpression(ts_satisfies) => ts_satisfies.span,
+        Argument::TSNonNullExpression(ts_non_null) => ts_non_null.span,
+        Argument::ParenthesizedExpression(parenthesized) => parenthesized.span,
         _ => return String::default(),
     };
     String::from(

--- a/crates/vize_croquis/src/script_parser/process/macros.rs
+++ b/crates/vize_croquis/src/script_parser/process/macros.rs
@@ -22,8 +22,9 @@ use super::super::extract::{
     check_getter_call_extraction, check_reactive_plain_alias_extraction,
     check_reactive_property_extraction, check_ref_value_extraction, detect_reactivity_call,
     detect_setup_context_violation, extract_argument_source, extract_call_expression,
-    extract_provide_key, get_binding_type_from_kind, process_call_expression,
-    record_getter_context_from_call, record_static_runtime_object_literal,
+    extract_inject_expected_type_from_init as inject_type, extract_provide_key,
+    get_binding_type_from_kind, process_call_expression, record_getter_context_from_call,
+    record_static_runtime_object_literal,
 };
 use super::super::walk::{walk_call_arguments, walk_expression};
 use super::super::{ReactiveValueOrigin, ScriptParseResult};
@@ -111,13 +112,12 @@ pub(in crate::script_parser) fn process_variable_declarator(
                             .get(1)
                             .map(|arg| CompactString::new(extract_argument_source(arg, source)));
                         let local_name = CompactString::new(name);
-                        // Track inject variable name for indirect destructure detection
                         result.inject_var_names.insert(local_name.clone());
                         result.provide_inject.add_inject(
                             key,
                             local_name, // local_name is the binding name
                             default_value,
-                            None, // expected_type
+                            inject_type(declarator.init.as_ref(), call, source),
                             InjectPattern::Simple,
                             None, // from_composable
                             call.span.start,
@@ -332,7 +332,7 @@ pub(in crate::script_parser) fn process_variable_declarator(
                         call.arguments
                             .get(1)
                             .map(|arg| CompactString::new(extract_argument_source(arg, source))),
-                        None,
+                        inject_type(declarator.init.as_ref(), call, source),
                         InjectPattern::ObjectDestructure(destructured_props.clone()),
                         None,
                         call.span.start,
@@ -351,7 +351,7 @@ pub(in crate::script_parser) fn process_variable_declarator(
                         call.arguments
                             .get(1)
                             .map(|arg| CompactString::new(extract_argument_source(arg, source))),
-                        None,
+                        inject_type(None, call, source),
                         InjectPattern::Simple,
                         None,
                         call.span.start,
@@ -565,7 +565,7 @@ pub(in crate::script_parser) fn process_variable_declarator(
                         call.arguments
                             .get(1)
                             .map(|arg| CompactString::new(extract_argument_source(arg, source))),
-                        None,
+                        inject_type(declarator.init.as_ref(), call, source),
                         InjectPattern::ArrayDestructure(destructured_items),
                         None,
                         call.span.start,
@@ -584,7 +584,7 @@ pub(in crate::script_parser) fn process_variable_declarator(
                         call.arguments
                             .get(1)
                             .map(|arg| CompactString::new(extract_argument_source(arg, source))),
-                        None,
+                        inject_type(None, call, source),
                         InjectPattern::Simple,
                         None,
                         call.span.start,

--- a/crates/vize_croquis_cf/src/analyzer/tests_provide_inject/basic.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_provide_inject/basic.rs
@@ -100,6 +100,139 @@ provide(ThemeKey, 'dark')"#,
 }
 
 #[test]
+fn test_provide_inject_records_explicit_types() {
+    let mut analyzer =
+        CrossFileAnalyzer::new(CrossFileOptions::default().with_provide_inject(true));
+
+    analyzer.add_file(
+        Path::new("Typed.ts"),
+        r#"import { inject, provide } from 'vue'
+type Theme = { mode: 'dark' | 'light' }
+const ThemeKey = Symbol('theme')
+provide(ThemeKey, ({ mode: 'dark' } as Theme))
+const theme = inject<Theme>(ThemeKey)"#,
+    );
+
+    let _result = analyzer.analyze();
+    let analysis = analyzer
+        .get_analysis(analyzer.registry().iter().next().unwrap().id)
+        .unwrap();
+
+    assert_eq!(
+        analysis.provide_inject.provides()[0].value_type.as_deref(),
+        Some("Theme")
+    );
+    assert_eq!(
+        analysis.provide_inject.injects()[0]
+            .expected_type
+            .as_deref(),
+        Some("Theme")
+    );
+}
+
+#[test]
+fn test_provide_inject_type_match_uses_explicit_types() {
+    let mut analyzer =
+        CrossFileAnalyzer::new(CrossFileOptions::default().with_provide_inject(true));
+
+    analyzer.add_file_with_analysis(
+        Path::new("Parent.vue"),
+        "",
+        script_analysis(
+            r#"import { provide } from 'vue'
+type Theme = { mode: string }
+const ThemeKey = Symbol('theme')
+provide(ThemeKey, ({ mode: 'dark' } as Theme))"#,
+            &["Child"],
+        ),
+    );
+    analyzer.add_file_with_analysis(
+        Path::new("Child.vue"),
+        "",
+        script_analysis(
+            r#"import { inject } from 'vue'
+type Theme = { mode: string }
+const ThemeKey = Symbol('theme')
+const theme = inject<Theme>(ThemeKey)"#,
+            &[],
+        ),
+    );
+    analyzer.rebuild_component_edges();
+
+    let result = analyzer.analyze();
+
+    assert_eq!(result.provide_inject_matches.len(), 1);
+    assert_eq!(result.provide_inject_matches[0].type_match, Some(true));
+    assert!(result.diagnostics.iter().all(|diagnostic| !matches!(
+        diagnostic.kind,
+        crate::diagnostics::CrossFileDiagnosticKind::ProvideInjectTypeMismatch { .. }
+    )));
+}
+
+#[test]
+fn test_provide_inject_type_mismatch_reports_related_provider() {
+    use crate::diagnostics::CrossFileDiagnosticKind;
+
+    let mut analyzer =
+        CrossFileAnalyzer::new(CrossFileOptions::default().with_provide_inject(true));
+
+    let provider = analyzer.add_file_with_analysis(
+        Path::new("Parent.vue"),
+        "",
+        script_analysis(
+            r#"import { provide } from 'vue'
+type Theme = { mode: string }
+const ThemeKey = Symbol('theme')
+provide(ThemeKey, ({ mode: 'dark' } as Theme))"#,
+            &["Child"],
+        ),
+    );
+    analyzer.add_file_with_analysis(
+        Path::new("Child.vue"),
+        "",
+        script_analysis(
+            r#"import { inject } from 'vue'
+type ThemeRef = { mode: string }
+const ThemeKey = Symbol('theme')
+const theme = inject<ThemeRef>(ThemeKey)"#,
+            &[],
+        ),
+    );
+    analyzer.rebuild_component_edges();
+
+    let result = analyzer.analyze();
+
+    assert_eq!(result.provide_inject_matches.len(), 1);
+    assert_eq!(result.provide_inject_matches[0].type_match, Some(false));
+
+    let diagnostic = result
+        .diagnostics
+        .iter()
+        .find(|diagnostic| {
+            matches!(
+                diagnostic.kind,
+                CrossFileDiagnosticKind::ProvideInjectTypeMismatch { .. }
+            )
+        })
+        .expect("type mismatch diagnostic");
+
+    match &diagnostic.kind {
+        CrossFileDiagnosticKind::ProvideInjectTypeMismatch {
+            key,
+            provided_type,
+            injected_type,
+        } => {
+            assert_eq!(key.as_str(), "ThemeKey");
+            assert_eq!(provided_type.as_str(), "Theme");
+            assert_eq!(injected_type.as_str(), "ThemeRef");
+        }
+        other => panic!("unexpected diagnostic: {other:?}"),
+    }
+    assert_eq!(diagnostic.related_files.len(), 1);
+    assert_eq!(diagnostic.related_files[0].0, provider);
+}
+
+#[test]
 fn test_inject_with_default_value() {
     let mut analyzer =
         CrossFileAnalyzer::new(CrossFileOptions::default().with_provide_inject(true));

--- a/crates/vize_croquis_cf/src/rules/provide_inject/analysis.rs
+++ b/crates/vize_croquis_cf/src/rules/provide_inject/analysis.rs
@@ -188,6 +188,44 @@ pub(crate) fn analyze_provide_inject_with_index(
                         provider_match.provider_id,
                         provider_match.provide.id.as_u32(),
                     ));
+                    let type_match = provide_inject_type_match(
+                        provider_match.provide.value_type.as_ref(),
+                        inject.expected_type.as_ref(),
+                    );
+
+                    if let Some(false) = type_match {
+                        let provided_type = provider_match
+                            .provide
+                            .value_type
+                            .clone()
+                            .expect("mismatched type requires provider type");
+                        let injected_type = inject
+                            .expected_type
+                            .clone()
+                            .expect("mismatched type requires inject type");
+                        diagnostics.push(
+                            CrossFileDiagnostic::new(
+                                CrossFileDiagnosticKind::ProvideInjectTypeMismatch {
+                                    key: key_str.clone(),
+                                    provided_type,
+                                    injected_type,
+                                },
+                                DiagnosticSeverity::Warning,
+                                consumer_id,
+                                inject.start,
+                                cstr!(
+                                    "inject('{}') expects a different type than its nearest provide()",
+                                    key_str
+                                ),
+                            )
+                            .with_end_offset(inject.end)
+                            .with_related(
+                                provider_match.provider_id,
+                                provider_match.provide.start,
+                                cstr!("provide('{key_str}') source"),
+                            ),
+                        );
+                    }
 
                     matches.push(ProvideInjectMatch {
                         provider: provider_match.provider_id,
@@ -195,7 +233,7 @@ pub(crate) fn analyze_provide_inject_with_index(
                         key: key_str.clone(),
                         key_identity: provide_key_identity(&inject.key),
                         path: provider_match.path,
-                        type_match: None, // Would need type analysis
+                        type_match,
                         provide_offset: provider_match.provide.start,
                         inject_offset: inject.start,
                     });
@@ -231,6 +269,22 @@ pub(crate) fn analyze_provide_inject_with_index(
     }
 
     (matches, diagnostics)
+}
+
+fn provide_inject_type_match(
+    provided_type: Option<&CompactString>,
+    injected_type: Option<&CompactString>,
+) -> Option<bool> {
+    Some(types_equal_ignoring_ascii_whitespace(
+        provided_type?.as_str(),
+        injected_type?.as_str(),
+    ))
+}
+
+fn types_equal_ignoring_ascii_whitespace(left: &str, right: &str) -> bool {
+    left.chars()
+        .filter(|ch| !ch.is_ascii_whitespace())
+        .eq(right.chars().filter(|ch| !ch.is_ascii_whitespace()))
 }
 
 fn with_provider_relateds(


### PR DESCRIPTION
## Summary

- extract explicit provide value types from TypeScript assertions/satisfies expressions
- extract explicit inject expected types from `inject<T>()` and assertion-wrapped inject calls
- populate `ProvideInjectMatch::type_match` and emit related-provider diagnostics for explicit mismatches
- add analyzer coverage for matched and mismatched typed provide/inject relationships

Part of #2747

## Validation

- cargo fmt --check
- cargo test -p vize_croquis_cf provide_inject --profile ci
- cargo test -p vize_croquis --profile ci
- cargo test -p vize_croquis_cf --profile ci
- cargo clippy -p vize_croquis -p vize_croquis_cf --lib --profile ci -- -D warnings
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786208699&installation_id=136613492&pr_number=2778&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2778&signature=567f6ecec0f91672192ca8ceb4be4d55b5aed46835491ed8fa6c44648b30435f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced provide/inject analysis now records TypeScript types for both provided values and injected expectations.
  * Matched provide/inject pairs are now flagged as type-compatible or type-mismatched (with type comparison tolerant of ASCII whitespace).

* **Bug Fixes**
  * Improved recognition of TypeScript type annotations wrapped in common syntaxes (e.g., assertions/wrappers), leading to more accurate type extraction.

* **Tests**
  * Added new analyzer tests covering type-match and type-mismatch scenarios, including diagnostic validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->