### PR TITLE
feat(croquis-cf): relate fallthrough diagnostics to usage attrs

### DIFF
--- a/crates/vize_croquis_cf/src/rules/fallthrough.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough.rs
@@ -113,6 +113,8 @@ pub fn analyze_fallthrough(
     let usage_facts = collect_fallthrough_usage_facts(registry, graph);
     let mut passed_attrs_map: FxHashMap<FileId, FxHashMap<FileId, FxHashSet<CompactString>>> =
         FxHashMap::default();
+    let mut fallthrough_related_map: FxHashMap<FileId, Vec<FallthroughUsageRelated>> =
+        FxHashMap::default();
     for fact in &usage_facts {
         let attrs = passed_attrs_map
             .entry(fact.child_file_id)
@@ -120,6 +122,21 @@ pub fn analyze_fallthrough(
             .entry(fact.parent_file_id)
             .or_default();
         attrs.extend(fact.attrs.iter().map(|attr| attr.name.clone()));
+
+        let related = fallthrough_related_map
+            .entry(fact.child_file_id)
+            .or_default();
+        related.extend(
+            fact.attrs
+                .iter()
+                .filter(|attr| attr.fallthrough)
+                .map(|attr| FallthroughUsageRelated {
+                    parent_file_id: fact.parent_file_id,
+                    attr_name: attr.name.clone(),
+                    source_start: attr.source_start,
+                    component_name: fact.component_name.clone(),
+                }),
+        );
     }
 
     // Merge passed attrs into infos
@@ -142,7 +159,7 @@ pub fn analyze_fallthrough(
 
             if has_fallthrough {
                 // Use offset 0 to point to <template> tag start (wasm.rs adds tag_start offset)
-                diagnostics.push(
+                diagnostics.push(with_fallthrough_relateds(
                     CrossFileDiagnostic::with_span(
                         CrossFileDiagnosticKind::MultiRootMissingAttrs,
                         DiagnosticSeverity::Warning,
@@ -154,14 +171,18 @@ pub fn analyze_fallthrough(
                     .with_suggestion(
                         "Add v-bind=\"$attrs\" to the intended root element or wrap in single root",
                     ),
-                );
+                    fallthrough_related_map
+                        .get(&info.file_id)
+                        .map(Vec::as_slice),
+                    None,
+                ));
             }
         }
 
         // Check for inheritAttrs: false without $attrs usage
         if info.inherit_attrs_disabled && !info.uses_attrs && !info.binds_attrs {
             // Use offset 0 to point to <template> tag start (wasm.rs adds tag_start offset)
-            diagnostics.push(
+            diagnostics.push(with_fallthrough_relateds(
                 CrossFileDiagnostic::with_span(
                     CrossFileDiagnosticKind::InheritAttrsDisabledUnused,
                     DiagnosticSeverity::Warning,
@@ -171,7 +192,11 @@ pub fn analyze_fallthrough(
                     "inheritAttrs is disabled but $attrs is not used anywhere",
                 )
                 .with_suggestion("Use v-bind=\"$attrs\" or $attrs.class/$attrs.style in template"),
-            );
+                fallthrough_related_map
+                    .get(&info.file_id)
+                    .map(Vec::as_slice),
+                None,
+            ));
         }
 
         // Check for unused fallthrough attributes
@@ -188,7 +213,7 @@ pub fn analyze_fallthrough(
 
         if !unused_attrs.is_empty() && !info.binds_attrs && info.root_element_count > 1 {
             // Use offset 0 to point to <template> tag start (wasm.rs adds tag_start offset)
-            diagnostics.push(
+            diagnostics.push(with_fallthrough_relateds(
                 CrossFileDiagnostic::with_span(
                     CrossFileDiagnosticKind::UnusedFallthroughAttrs {
                         passed_attrs: unused_attrs.clone(),
@@ -203,7 +228,11 @@ pub fn analyze_fallthrough(
                     ),
                 )
                 .with_suggestion("Bind $attrs explicitly or declare as props"),
-            );
+                fallthrough_related_map
+                    .get(&info.file_id)
+                    .map(Vec::as_slice),
+                Some(&unused_attrs),
+            ));
         }
     }
 
@@ -260,6 +289,48 @@ fn is_listener_attr(attr: &str) -> bool {
         .and_then(|suffix| suffix.chars().next())
         .is_some_and(|first| first.is_ascii_uppercase())
 }
+
+struct FallthroughUsageRelated {
+    parent_file_id: FileId,
+    attr_name: CompactString,
+    source_start: u32,
+    component_name: CompactString,
+}
+
+fn with_fallthrough_relateds(
+    mut diagnostic: CrossFileDiagnostic,
+    relateds: Option<&[FallthroughUsageRelated]>,
+    attrs_filter: Option<&[CompactString]>,
+) -> CrossFileDiagnostic {
+    let Some(relateds) = relateds else {
+        return diagnostic;
+    };
+
+    for related in relateds {
+        if attrs_filter.is_some_and(|attrs| {
+            !attrs
+                .iter()
+                .any(|attr| attr.as_str() == related.attr_name.as_str())
+        }) {
+            continue;
+        }
+
+        diagnostic = diagnostic.with_related(
+            related.parent_file_id,
+            related.source_start,
+            cstr!(
+                "{} passed to <{}>",
+                related.attr_name,
+                related.component_name
+            ),
+        );
+    }
+
+    diagnostic
+}
+
+#[cfg(test)]
+mod diagnostics_tests;
 
 #[cfg(test)]
 mod tests;

--- a/crates/vize_croquis_cf/src/rules/fallthrough/diagnostics_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough/diagnostics_tests.rs
@@ -1,0 +1,87 @@
+use super::analyze_fallthrough;
+use crate::diagnostics::CrossFileDiagnosticKind;
+use crate::graph::{DependencyEdge, DependencyGraph, ModuleNode};
+use crate::registry::{FileId, ModuleRegistry};
+use vize_carton::{CompactString, smallvec};
+use vize_croquis::analysis::{ComponentUsage, PassedProp};
+use vize_croquis::{Croquis, ScopeId};
+
+fn passed_prop_at(name: &str, start: u32, end: u32, is_dynamic: bool) -> PassedProp {
+    PassedProp {
+        name: CompactString::new(name),
+        value: None,
+        start,
+        end,
+        is_dynamic,
+    }
+}
+
+fn graph_node(id: FileId, path: &str, component: &str) -> ModuleNode {
+    let mut node = ModuleNode::new(id, path);
+    node.component_name = Some(CompactString::new(component));
+    node
+}
+
+#[test]
+fn diagnostics_include_parent_usage_related_locations() {
+    let mut registry = ModuleRegistry::new();
+
+    let parent_analysis = {
+        let mut analysis = Croquis::new();
+        analysis.component_usages.push(ComponentUsage {
+            name: CompactString::new("Panel"),
+            start: 10,
+            end: 80,
+            props: smallvec![passed_prop_at("trackingId", 34, 58, true)],
+            events: smallvec![],
+            slots: smallvec![],
+            has_spread_attrs: false,
+            scope_id: ScopeId::ROOT,
+            vif_guard: None,
+        });
+        analysis
+    };
+    let mut panel_analysis = Croquis::new();
+    panel_analysis.template_info.root_element_count = 2;
+
+    let (parent_id, _) = registry.register("Parent.vue", "", parent_analysis);
+    let (panel_id, _) = registry.register("Panel.vue", "", panel_analysis);
+
+    let mut graph = DependencyGraph::new();
+    graph.add_node(graph_node(parent_id, "Parent.vue", "Parent"));
+    graph.add_node(graph_node(panel_id, "Panel.vue", "Panel"));
+    graph.add_edge(parent_id, panel_id, DependencyEdge::ComponentUsage);
+
+    let (_infos, diagnostics) = analyze_fallthrough(&registry, &graph);
+    let multi_root = diagnostics
+        .iter()
+        .find(|diagnostic| {
+            matches!(
+                diagnostic.kind,
+                CrossFileDiagnosticKind::MultiRootMissingAttrs
+            )
+        })
+        .expect("multi-root diagnostic should be emitted");
+    assert_eq!(multi_root.primary_file, panel_id);
+    assert_eq!(multi_root.related_files.len(), 1);
+    assert_eq!(multi_root.related_files[0].0, parent_id);
+    assert_eq!(multi_root.related_files[0].1, 34);
+    assert!(
+        multi_root.related_files[0]
+            .2
+            .contains("trackingId passed to <Panel>")
+    );
+
+    let unused = diagnostics
+        .iter()
+        .find(|diagnostic| {
+            matches!(
+                diagnostic.kind,
+                CrossFileDiagnosticKind::UnusedFallthroughAttrs { .. }
+            )
+        })
+        .expect("unused fallthrough diagnostic should be emitted");
+    assert_eq!(unused.related_files.len(), 1);
+    assert_eq!(unused.related_files[0].0, parent_id);
+    assert_eq!(unused.related_files[0].1, 34);
+}


### PR DESCRIPTION
## Summary
- attach parent component usage related locations to fallthrough diagnostics
- reuse per-usage attr facts so multi-root and unused-fallthrough warnings point back to passed attrs
- add coverage for non-zero parent usage offsets

Part of #2749.

## Validation
- cargo fmt --check
- cargo test -p vize_croquis_cf fallthrough --profile ci
- cargo test -p vize_croquis_cf --profile ci
- cargo clippy -p vize_croquis_cf --lib --profile ci -- -D warnings
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786210853&installation_id=136613492&pr_number=2779&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2779&signature=78c9d31de93538177b80f6096ff0f862d65b60ddac90ef77d93412e41e7b3e51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallthrough-related warnings so they now include clearer linked locations across related components/files.
  * Enhanced unused attribute warnings to point to the specific unused items and their source locations.
  * Updated multi-root and disabled-inheritance warnings to surface related context for easier troubleshooting.

* **Tests**
  * Added coverage for cross-file fallthrough diagnostics to verify related location details are included in warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->