### PR TITLE
feat(croquis-cf): expose complexity hotspots

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/core/run.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/run.rs
@@ -112,6 +112,7 @@ impl CrossFileAnalyzer {
 
         result.complexity_report =
             rules::summarize_complexity_with_graph(&self.registry, &self.graph, &result);
+        result.complexity_hotspots = rules::summarize_complexity_hotspots(&self.registry, &result);
 
         dedupe_diagnostics(&mut result.diagnostics);
         sort_diagnostics(&mut result.diagnostics);

--- a/crates/vize_croquis_cf/src/analyzer/types.rs
+++ b/crates/vize_croquis_cf/src/analyzer/types.rs
@@ -234,6 +234,9 @@ pub struct CrossFileResult {
     /// Explainable complexity score derived from the enabled cross-file facts.
     pub complexity_report: rules::ComplexityReport,
 
+    /// Top per-file complexity contributors derived from the same cross-file facts.
+    pub complexity_hotspots: Vec<rules::ComplexityHotspot>,
+
     /// Statistics.
     pub stats: CrossFileStats,
 }

--- a/crates/vize_croquis_cf/src/lib.rs
+++ b/crates/vize_croquis_cf/src/lib.rs
@@ -66,9 +66,9 @@ pub use suppression::{SuppressionDirective, SuppressionError, SuppressionMap};
 // Re-export rule result types
 pub use rules::{
     BoundaryInfo, BoundaryKind, ComplexityBand, ComplexityDimension, ComplexityDimensionBreakdown,
-    ComplexityDimensionScores, ComplexityInput, ComplexityReport, EmitFlow, EventBubble,
-    FallthroughInfo, FallthroughSummary, FallthroughUsageAttrFact, FallthroughUsageAttrKind,
-    FallthroughUsageFact, PropsValidationIssue, PropsValidationIssueKind, ProvideInjectMatch,
-    ProvideInjectTreeSummary, ReactivityIssue, ReactivityIssueKind, UniqueIdIssue, band_for_score,
-    collect_fallthrough_usage_facts,
+    ComplexityDimensionScores, ComplexityHotspot, ComplexityInput, ComplexityReport, EmitFlow,
+    EventBubble, FallthroughInfo, FallthroughSummary, FallthroughUsageAttrFact,
+    FallthroughUsageAttrKind, FallthroughUsageFact, PropsValidationIssue, PropsValidationIssueKind,
+    ProvideInjectMatch, ProvideInjectTreeSummary, ReactivityIssue, ReactivityIssueKind,
+    UniqueIdIssue, band_for_score, collect_fallthrough_usage_facts,
 };

--- a/crates/vize_croquis_cf/src/rules.rs
+++ b/crates/vize_croquis_cf/src/rules.rs
@@ -13,6 +13,8 @@
 mod boundary;
 mod complexity;
 #[cfg(test)]
+mod complexity_hotspots_tests;
+#[cfg(test)]
 mod complexity_tests;
 mod component_resolution;
 pub(crate) mod cross_file_reactivity;
@@ -30,7 +32,8 @@ mod setup_context;
 pub use boundary::{BoundaryInfo, BoundaryKind, analyze_boundaries};
 pub use complexity::{
     ComplexityBand, ComplexityDimension, ComplexityDimensionBreakdown, ComplexityDimensionScores,
-    ComplexityInput, ComplexityReport, band_for_score, summarize_complexity_with_graph,
+    ComplexityHotspot, ComplexityInput, ComplexityReport, band_for_score,
+    summarize_complexity_hotspots, summarize_complexity_with_graph,
 };
 pub use component_resolution::{ComponentResolutionIssue, analyze_component_resolution};
 pub use element_id::{UniqueIdIssue, analyze_element_ids};

--- a/crates/vize_croquis_cf/src/rules/complexity.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity.rs
@@ -1,5 +1,6 @@
 //! Cross-file complexity scoring.
 
+mod hotspots;
 mod nesting;
 
 use crate::analyzer::CrossFileResult;
@@ -7,6 +8,8 @@ use crate::graph::DependencyGraph;
 use crate::registry::ModuleRegistry;
 use crate::rules::cross_file_reactivity::CrossFileReactivityIssueKind;
 use vize_croquis::{ScopeKind, TemplateExpressionKind};
+
+pub use hotspots::{ComplexityHotspot, summarize_complexity_hotspots};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/vize_croquis_cf/src/rules/complexity/hotspots.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity/hotspots.rs
@@ -1,0 +1,167 @@
+use super::{ComplexityDimensionBreakdown, ComplexityDimensionScores, ComplexityInput};
+use super::{ComplexityReport, CrossFileReactivityIssueKind};
+use crate::analyzer::CrossFileResult;
+use crate::registry::{FileId, ModuleEntry, ModuleRegistry};
+use crate::rules::ReactivityIssueKind;
+use vize_carton::{CompactString, FxHashMap};
+use vize_croquis::{ScopeKind, TemplateExpressionKind};
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplexityHotspot {
+    pub file_id: FileId,
+    pub file_name: CompactString,
+    pub component_name: Option<CompactString>,
+    pub input: ComplexityInput,
+    pub dimensions: ComplexityDimensionScores,
+    pub total_score: u32,
+    pub dominant_dimension: Option<ComplexityDimensionBreakdown>,
+}
+
+/// Rank Vue files by their local contribution to the cross-file complexity score.
+pub fn summarize_complexity_hotspots(
+    registry: &ModuleRegistry,
+    result: &CrossFileResult,
+) -> Vec<ComplexityHotspot> {
+    let mut inputs = local_inputs(registry);
+    add_fallthrough_inputs(&mut inputs, result);
+    add_reactivity_inputs(&mut inputs, result);
+    add_provide_inject_inputs(&mut inputs, result);
+
+    let mut hotspots: Vec<_> = registry
+        .vue_components()
+        .filter_map(|entry| hotspot_for_entry(entry, inputs.remove(&entry.id).unwrap_or_default()))
+        .collect();
+    hotspots.sort_by(|a, b| {
+        b.total_score
+            .cmp(&a.total_score)
+            .then_with(|| a.file_name.cmp(&b.file_name))
+    });
+    hotspots
+}
+
+fn local_inputs(registry: &ModuleRegistry) -> FxHashMap<FileId, ComplexityInput> {
+    registry
+        .vue_components()
+        .map(|entry| (entry.id, local_input(entry)))
+        .collect()
+}
+
+fn local_input(entry: &ModuleEntry) -> ComplexityInput {
+    let analysis = &entry.analysis;
+
+    ComplexityInput {
+        component_count: 1,
+        template_if_count: analysis
+            .template_expressions
+            .iter()
+            .filter(|expr| expr.kind == TemplateExpressionKind::VIf)
+            .count(),
+        template_for_count: analysis
+            .scopes
+            .iter()
+            .filter(|scope| scope.kind == ScopeKind::VFor)
+            .count(),
+        template_logical_operator_count: analysis
+            .template_expressions
+            .iter()
+            .filter(|expr| expr.kind == TemplateExpressionKind::VIf)
+            .map(|expr| logical_operator_count(expr.content.as_str()))
+            .sum(),
+        slot_count: analysis.macros.slots().len()
+            + analysis
+                .component_usages
+                .iter()
+                .map(|usage| usage.slots.len())
+                .sum::<usize>(),
+        prop_drilling_edge_count: analysis
+            .component_usages
+            .iter()
+            .map(|usage| usage.props.len())
+            .sum(),
+        reactive_node_count: analysis.reactivity.count(),
+        ..ComplexityInput::default()
+    }
+}
+
+fn add_fallthrough_inputs(
+    inputs: &mut FxHashMap<FileId, ComplexityInput>,
+    result: &CrossFileResult,
+) {
+    for info in &result.fallthrough_info {
+        inputs
+            .entry(info.file_id)
+            .or_default()
+            .fallthrough_risk_count += usize::from(info.has_potential_issues())
+            .saturating_add(info.risky_unconsumed_fallthrough_attr_count());
+    }
+}
+
+fn add_reactivity_inputs(
+    inputs: &mut FxHashMap<FileId, ComplexityInput>,
+    result: &CrossFileResult,
+) {
+    for issue in &result.reactivity_issues {
+        let input = inputs.entry(issue.file_id).or_default();
+        input.reactive_edge_count += 1;
+        if matches!(issue.kind, ReactivityIssueKind::ShouldUseStoreToRefs { .. }) {
+            input.global_state_reference_count += 1;
+        }
+    }
+
+    for issue in &result.cross_file_reactivity_issues {
+        let input = inputs.entry(issue.file_id).or_default();
+        input.reactive_edge_count += 1;
+        match issue.kind {
+            CrossFileReactivityIssueKind::StoreDestructured { .. } => {
+                input.global_state_reference_count += 1;
+            }
+            CrossFileReactivityIssueKind::CircularReactiveDependency { .. } => {
+                input.reactive_cycle_count += 1;
+            }
+            _ => {}
+        }
+    }
+}
+
+fn add_provide_inject_inputs(
+    inputs: &mut FxHashMap<FileId, ComplexityInput>,
+    result: &CrossFileResult,
+) {
+    for matched in &result.provide_inject_matches {
+        inputs
+            .entry(matched.provider)
+            .or_default()
+            .provide_inject_reference_count += 1;
+
+        let consumer = inputs.entry(matched.consumer).or_default();
+        consumer.provide_inject_reference_count += 1;
+        consumer.reactive_edge_count += 1;
+
+        let depth = matched.path.len();
+        for file_id in &matched.path {
+            let input = inputs.entry(*file_id).or_default();
+            input.provide_inject_max_depth = input.provide_inject_max_depth.max(depth);
+        }
+    }
+}
+
+fn hotspot_for_entry(entry: &ModuleEntry, input: ComplexityInput) -> Option<ComplexityHotspot> {
+    let report = ComplexityReport::from_input(input);
+    (report.total_score > 0).then(|| ComplexityHotspot {
+        file_id: entry.id,
+        file_name: entry.filename.clone(),
+        component_name: entry.component_name.clone(),
+        input,
+        dimensions: report.dimensions,
+        total_score: report.total_score,
+        dominant_dimension: report.dominant_dimension(),
+    })
+}
+
+fn logical_operator_count(content: &str) -> usize {
+    content
+        .matches("&&")
+        .count()
+        .saturating_add(content.matches("||").count())
+}

--- a/crates/vize_croquis_cf/src/rules/complexity_hotspots_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity_hotspots_tests.rs
@@ -1,0 +1,197 @@
+use super::{
+    ComplexityDimension, CrossFileReactivityIssue, CrossFileReactivityIssueKind, FallthroughInfo,
+    ProvideInjectMatch, ReactivityIssue, ReactivityIssueKind, summarize_complexity_hotspots,
+};
+use crate::analyzer::CrossFileResult;
+use crate::diagnostics::DiagnosticSeverity;
+use crate::registry::ModuleRegistry;
+use vize_carton::{CompactString, FxHashSet, smallvec};
+use vize_croquis::analysis::{ComponentUsage, PassedProp, SlotUsage, TemplateExpression};
+use vize_croquis::reactivity::ReactiveKind;
+use vize_croquis::{Croquis, ScopeId, TemplateExpressionKind, VForScopeData};
+
+#[test]
+fn ranks_hotspots_with_dimension_inputs_and_json_shape() {
+    let mut parent = Croquis::new();
+    parent.template_expressions.push(TemplateExpression {
+        content: CompactString::new("ready && active"),
+        kind: TemplateExpressionKind::VIf,
+        start: 0,
+        end: 15,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    });
+    parent.scopes.enter_v_for_scope(v_for_data(), 16, 40);
+    parent.component_usages.push(ComponentUsage {
+        name: CompactString::new("Child"),
+        start: 41,
+        end: 90,
+        props: smallvec![PassedProp {
+            name: CompactString::new("model"),
+            value: Some(CompactString::new("state")),
+            start: 45,
+            end: 60,
+            is_dynamic: true,
+        }],
+        events: smallvec![],
+        slots: smallvec![SlotUsage {
+            name: CompactString::new("default"),
+            scope_vars: smallvec![CompactString::new("slotProps")],
+            start: 61,
+            end: 89,
+            has_scope: true,
+        }],
+        has_spread_attrs: false,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    });
+    parent
+        .reactivity
+        .register(CompactString::new("state"), ReactiveKind::Reactive, 10);
+
+    let child = Croquis::new();
+    let mut registry = ModuleRegistry::new();
+    let (parent_id, _) = registry.register("Parent.vue", "", parent);
+    let (child_id, _) = registry.register("Child.vue", "", child);
+
+    let result = CrossFileResult {
+        fallthrough_info: vec![FallthroughInfo {
+            file_id: child_id,
+            inherit_attrs_disabled: false,
+            uses_attrs: false,
+            binds_attrs: false,
+            root_element_count: 2,
+            passed_attrs: FxHashSet::from_iter([CompactString::new("trackingId")]),
+            declared_props: FxHashSet::default(),
+            template_start: 0,
+            template_end: 10,
+        }],
+        provide_inject_matches: vec![ProvideInjectMatch {
+            provider: parent_id,
+            consumer: child_id,
+            key: CompactString::new("theme"),
+            key_identity: CompactString::new("string:theme"),
+            path: vec![parent_id, child_id],
+            type_match: Some(true),
+            provide_offset: 20,
+            inject_offset: 5,
+        }],
+        reactivity_issues: vec![ReactivityIssue {
+            file_id: parent_id,
+            kind: ReactivityIssueKind::ShouldUseStoreToRefs {
+                store_name: CompactString::new("useUserStore"),
+            },
+            offset: 1,
+            source: None,
+        }],
+        cross_file_reactivity_issues: vec![
+            CrossFileReactivityIssue {
+                file_id: child_id,
+                kind: CrossFileReactivityIssueKind::StoreDestructured {
+                    store_name: CompactString::new("useCartStore"),
+                    destructured_props: vec![CompactString::new("items")],
+                },
+                offset: 2,
+                related_file: Some(parent_id),
+                severity: DiagnosticSeverity::Warning,
+            },
+            CrossFileReactivityIssue {
+                file_id: child_id,
+                kind: CrossFileReactivityIssueKind::CircularReactiveDependency {
+                    cycle: vec![CompactString::new("left"), CompactString::new("right")],
+                },
+                offset: 3,
+                related_file: None,
+                severity: DiagnosticSeverity::Error,
+            },
+        ],
+        ..CrossFileResult::default()
+    };
+
+    let hotspots = summarize_complexity_hotspots(&registry, &result);
+
+    assert_eq!(hotspots.len(), 2);
+    assert_eq!(hotspots[0].file_id, child_id);
+    assert_eq!(hotspots[0].file_name, "Child.vue");
+    assert_eq!(hotspots[0].component_name.as_deref(), Some("Child"));
+    assert_eq!(hotspots[0].input.fallthrough_risk_count, 2);
+    assert_eq!(hotspots[0].input.reactive_edge_count, 3);
+    assert_eq!(hotspots[0].input.reactive_cycle_count, 1);
+    assert_eq!(hotspots[0].input.provide_inject_max_depth, 2);
+    assert_eq!(hotspots[0].dimensions.fallthrough_attrs, 8);
+    assert_eq!(hotspots[0].dimensions.reactive_graph, 16);
+    assert_eq!(hotspots[0].total_score, 30);
+    assert_eq!(
+        hotspots[0].dominant_dimension.unwrap().dimension,
+        ComplexityDimension::ReactiveGraph
+    );
+
+    assert_eq!(hotspots[1].file_id, parent_id);
+    assert_eq!(hotspots[1].input.template_if_count, 1);
+    assert_eq!(hotspots[1].input.template_for_count, 1);
+    assert_eq!(hotspots[1].input.template_logical_operator_count, 1);
+    assert_eq!(hotspots[1].input.slot_count, 1);
+    assert_eq!(hotspots[1].input.prop_drilling_edge_count, 1);
+    assert_eq!(hotspots[1].dimensions.template_control_flow, 4);
+    assert_eq!(hotspots[1].total_score, 17);
+
+    let json = serde_json::to_value(&hotspots[0]).unwrap();
+    assert_eq!(json["fileName"], "Child.vue");
+    assert_eq!(json["componentName"], "Child");
+    assert_eq!(json["input"]["fallthroughRiskCount"], 2);
+    assert_eq!(json["dominantDimension"]["dimension"], "reactive-graph");
+}
+
+#[test]
+fn analyzer_result_stores_complexity_hotspots() {
+    let mut analyzer = crate::CrossFileAnalyzer::new(
+        crate::CrossFileOptions::default()
+            .with_fallthrough_attrs(true)
+            .with_reactivity_tracking(true),
+    );
+
+    let mut parent = Croquis::new();
+    parent.used_components.insert(CompactString::new("Child"));
+    parent.component_usages.push(ComponentUsage {
+        name: CompactString::new("Child"),
+        start: 0,
+        end: 30,
+        props: smallvec![PassedProp {
+            name: CompactString::new("trackingId"),
+            value: Some(CompactString::new("id")),
+            start: 8,
+            end: 24,
+            is_dynamic: true,
+        }],
+        events: smallvec![],
+        slots: smallvec![],
+        has_spread_attrs: false,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    });
+
+    let mut child = Croquis::new();
+    child.template_info.root_element_count = 2;
+
+    analyzer.add_file_with_analysis("Parent.vue", "const id = 'abc'", parent);
+    analyzer.add_file_with_analysis("Child.vue", "", child);
+    analyzer.rebuild_component_edges();
+
+    let result = analyzer.analyze();
+
+    assert!(!result.complexity_hotspots.is_empty());
+    assert!(result.complexity_hotspots.iter().any(
+        |hotspot| hotspot.file_name == "Child.vue" && hotspot.input.fallthrough_risk_count >= 1
+    ));
+}
+
+fn v_for_data() -> VForScopeData {
+    VForScopeData {
+        value_alias: CompactString::new("item"),
+        value_bindings: smallvec![CompactString::new("item")],
+        key_alias: None,
+        index_alias: None,
+        source: CompactString::new("items"),
+        key_expression: None,
+    }
+}


### PR DESCRIPTION
## Summary
- add per-file complexity hotspots with dimension inputs, scores, and dominant dimension
- populate hotspots on CrossFileResult alongside the aggregate complexity report
- cover hotspot ranking, serialization, and analyzer result storage

## Validation
- cargo fmt --check
- cargo test -p vize_croquis_cf complexity --profile ci
- cargo test -p vize_croquis_cf --profile ci
- cargo clippy -p vize_croquis_cf --lib --profile ci -- -D warnings
- git diff --check

Refs #2748

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786213115&installation_id=136613492&pr_number=2780&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2780&signature=c9b6dbee0a8270dec895c9a2e800f179fbc5f6aaf0093888ba2a7cc1e781c69e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complexity hotspots summary to cross-file analysis, highlighting the files and components contributing most to complexity.
  * Results now include per-file hotspot details alongside existing analysis output.

* **Tests**
  * Added coverage for hotspot ranking, output formatting, and end-to-end analyzer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->