### PR TITLE
feat(vitrine): expose complexity hotspots in cross-file payload

### DIFF
--- a/crates/vize_vitrine/src/template_syntax.rs
+++ b/crates/vize_vitrine/src/template_syntax.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
 use vize_atelier_core::TemplateSyntaxMode;
 
 pub(crate) fn resolve_template_syntax(

--- a/crates/vize_vitrine/src/wasm/cross_file.rs
+++ b/crates/vize_vitrine/src/wasm/cross_file.rs
@@ -274,7 +274,6 @@ pub fn analyze_cross_file_wasm(files: JsValue, options: JsValue) -> Result<JsVal
         })
         .collect();
 
-    // Convert circular dependencies
     let circular_deps: Vec<Vec<String>> = result
         .circular_deps
         .iter()
@@ -290,6 +289,7 @@ pub fn analyze_cross_file_wasm(files: JsValue, options: JsValue) -> Result<JsVal
         "diagnostics": diagnostics,
         "circularDependencies": circular_deps,
         "complexityReport": super::cross_file_complexity::complexity_report_json(&result.complexity_report),
+        "complexityHotspots": super::cross_file_complexity::complexity_hotspots_json(&result.complexity_hotspots),
         "stats": {
             "filesAnalyzed": result.stats.files_analyzed,
             "vueComponents": result.stats.vue_components,

--- a/crates/vize_vitrine/src/wasm/cross_file_complexity.rs
+++ b/crates/vize_vitrine/src/wasm/cross_file_complexity.rs
@@ -1,5 +1,93 @@
-use vize_croquis_cf::ComplexityReport;
+use vize_croquis_cf::{ComplexityHotspot, ComplexityReport};
 
 pub(crate) fn complexity_report_json(report: &ComplexityReport) -> serde_json::Value {
     serde_json::to_value(report).expect("complexity report should serialize")
+}
+
+pub(crate) fn complexity_hotspots_json(hotspots: &[ComplexityHotspot]) -> serde_json::Value {
+    serde_json::to_value(hotspots).expect("complexity hotspots should serialize")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use vize_croquis_cf::{
+        ComplexityDimension, ComplexityDimensionBreakdown, ComplexityDimensionScores,
+        ComplexityInput, FileId,
+    };
+
+    #[test]
+    fn complexity_hotspots_json_preserves_js_shape() {
+        let hotspots = vec![ComplexityHotspot {
+            file_id: FileId::new(7),
+            file_name: "App.vue".into(),
+            component_name: Some("App".into()),
+            input: ComplexityInput {
+                component_count: 1,
+                template_if_count: 2,
+                prop_drilling_edge_count: 1,
+                ..ComplexityInput::default()
+            },
+            dimensions: ComplexityDimensionScores {
+                template_control_flow: 3,
+                prop_drilling: 3,
+                ..ComplexityDimensionScores::default()
+            },
+            total_score: 6,
+            dominant_dimension: Some(ComplexityDimensionBreakdown {
+                dimension: ComplexityDimension::TemplateControlFlow,
+                score: 3,
+            }),
+        }];
+
+        assert_eq!(
+            complexity_hotspots_json(&hotspots),
+            json!([
+                {
+                    "fileId": 7,
+                    "fileName": "App.vue",
+                    "componentName": "App",
+                    "input": {
+                        "componentCount": 1,
+                        "templateIfCount": 2,
+                        "templateForCount": 0,
+                        "templateLogicalOperatorCount": 0,
+                        "componentTreeVIfMaxDepth": 0,
+                        "componentTreeVForMaxDepth": 0,
+                        "componentTreeScopedSlotMaxDepth": 0,
+                        "componentTreeTemplateNestingScore": 0,
+                        "slotCount": 0,
+                        "propDrillingEdgeCount": 1,
+                        "globalStateReferenceCount": 0,
+                        "provideInjectMaxDepth": 0,
+                        "provideInjectReferenceCount": 0,
+                        "fallthroughRiskCount": 0,
+                        "reactiveNodeCount": 0,
+                        "reactiveEdgeCount": 0,
+                        "reactiveCycleCount": 0
+                    },
+                    "dimensions": {
+                        "templateControlFlow": 3,
+                        "slotUsage": 0,
+                        "propDrilling": 3,
+                        "globalState": 0,
+                        "provideInject": 0,
+                        "fallthroughAttrs": 0,
+                        "reactiveGraph": 0
+                    },
+                    "totalScore": 6,
+                    "dominantDimension": {
+                        "dimension": "template-control-flow",
+                        "score": 3
+                    }
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn complexity_hotspots_json_serializes_empty_list() {
+        assert_eq!(complexity_hotspots_json(&[]), json!([]));
+    }
 }

--- a/docs/content/guide/cross-file-complexity.md
+++ b/docs/content/guide/cross-file-complexity.md
@@ -50,8 +50,16 @@ This means a shallow-looking component can still produce a high score when it fo
 drills props, or depends on a deep provide/inject path. The Playground's Cross-file mode shows the
 score beside diagnostics so those signals are visible while editing fixtures.
 
+## Hotspots
+
+The report also exposes ranked hotspots so tools can point to the files/components that create the
+score instead of showing only one project-level number. Each hotspot carries the local score input,
+dimension scores, total score, and dominant dimension. Use `dominantDimension` to explain why the
+entry is high, then use `input` to show the raw signal that drove it.
+
 ## Current Surface
 
 The public JSON shape is available from the WASM cross-file binding as
-`CrossFileResult.complexityReport`. The CLI does not fail builds on this score yet. Use the report as
-an exploratory signal, then promote stable thresholds only after project-specific baselines exist.
+`CrossFileResult.complexityReport` and `CrossFileResult.complexityHotspots`. The CLI does not fail
+builds on this score yet. Use the report as an exploratory signal, then promote stable thresholds
+only after project-specific baselines exist.


### PR DESCRIPTION
## Summary
- expose Croquis complexity hotspots in the WASM cross-file JSON payload
- document complexityHotspots alongside complexityReport
- add serialization tests for the JS-facing hotspot shape

Refs #2748

## Verification
- cargo test -p vize_vitrine --features wasm --profile ci
- cargo clippy -p vize_vitrine --features wasm --lib --profile ci -- -D warnings
- cargo fmt --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786214663&installation_id=136613492&pr_number=2781&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2781&signature=b3f931f8fd49e76fe6daf37a1e4ba21de110cfe35c88f3d27dfcb4f018cea409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-file analysis JSON now includes a new `complexityHotspots` field with ranked hotspot details (including scores and dominant dimension).
  * Hotspot data is now emitted alongside the existing complexity report for easier consumption.

* **Documentation**
  * Updated the cross-file complexity guide with a new **Hotspots** section explaining the hotspot fields and the meaning of the ranking.
  * Added `CrossFileResult.complexityHotspots` to the **Current Surface** section.

* **Tests**
  * Added unit coverage to verify hotspot JSON serialization for both non-empty and empty inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->