### PR TITLE
feat(vize): render cross-file complexity reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3680,6 +3680,7 @@ dependencies = [
  "vize_atelier_sfc",
  "vize_carton",
  "vize_croquis",
+ "vize_croquis_cf",
 ]
 
 [[package]]

--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -134,7 +134,6 @@ pub fn run(args: LintArgs) {
         profiler.enable();
     }
 
-    // Lint all files in parallel and collect results
     let lint_start = Instant::now();
     let mut results: Vec<_> = files
         .par_iter()
@@ -202,13 +201,18 @@ pub fn run(args: LintArgs) {
         .collect();
     let lint_time = lint_start.elapsed();
 
-    let mut cross_file_tree = None;
-    let cross_file_enabled = args.cross_file || args.cross_file_tree;
+    let mut cross_file_report = None;
+    let cross_file_enabled = args.cross_file || args.cross_file_tree || args.cross_file_complexity;
     let cross_file_start = args.profile.then(Instant::now);
     if cross_file_enabled {
-        cross_file_tree = profile!(
+        cross_file_report = profile!(
             "cli.lint.cross_file.build",
-            apply_sfc_cross_file_lint(&mut results, help_level, args.cross_file_tree)
+            apply_sfc_cross_file_lint(
+                &mut results,
+                help_level,
+                args.cross_file_tree,
+                args.cross_file_complexity
+            )
         );
     }
     let cross_file_time = cross_file_start
@@ -258,7 +262,6 @@ pub fn run(args: LintArgs) {
         (None, None, None)
     };
 
-    // Print summary
     let elapsed = start.elapsed();
     if format == OutputFormat::Text {
         stdout::write_text_summary(
@@ -266,9 +269,7 @@ pub fn run(args: LintArgs) {
             total_warnings,
             files.len(),
             elapsed,
-            args.cross_file_tree
-                .then_some(cross_file_tree.as_deref())
-                .flatten(),
+            cross_file_report.as_deref(),
         );
     }
 
@@ -380,7 +381,6 @@ pub fn run(args: LintArgs) {
     // `process::exit` below bypasses normal stdout teardown, so flush report output first.
     let _ = std::io::stdout().flush();
 
-    // Exit with appropriate code
     if total_errors > 0 {
         std::process::exit(1);
     }

--- a/crates/vize/src/commands/lint/args.rs
+++ b/crates/vize/src/commands/lint/args.rs
@@ -53,6 +53,10 @@ pub struct LintArgs {
     #[arg(long)]
     pub cross_file_tree: bool,
 
+    /// Print cross-file complexity score and top hotspots when cross-file lint is enabled.
+    #[arg(long)]
+    pub cross_file_complexity: bool,
+
     /// Enable native type-aware lint rules from the active lint configuration.
     #[arg(long)]
     pub type_aware: bool,

--- a/crates/vize/src/commands/lint/cross_file.rs
+++ b/crates/vize/src/commands/lint/cross_file.rs
@@ -13,11 +13,13 @@ use vize_croquis_cf::{
     CrossFileAnalyzer, CrossFileDiagnostic, CrossFileDiagnosticKind, CrossFileOptions,
     DiagnosticSeverity, FileId,
 };
+use vize_curator::complexity::render_complexity_markdown;
 use vize_patina::{HelpLevel, LintDiagnostic, LintResult};
 
 pub(super) struct CrossFileLintOutput {
     pub(super) results: Vec<LintResult>,
     pub(super) provide_inject_tree: Option<String>,
+    pub(super) complexity_report: Option<String>,
 }
 
 pub(super) type CliLintFileResult = (PathBuf, String, String, LintResult);
@@ -32,6 +34,7 @@ pub(super) fn apply_sfc_cross_file_lint(
     results: &mut [CliLintFileResult],
     help_level: HelpLevel,
     include_tree: bool,
+    include_complexity: bool,
 ) -> Option<String> {
     let targets: Vec<_> = results
         .iter()
@@ -46,8 +49,16 @@ pub(super) fn apply_sfc_cross_file_lint(
             (path.clone(), source.clone())
         })
         .collect();
-    let output = build_cross_file_lint_output(&inputs, help_level, include_tree);
-    let tree = output.provide_inject_tree;
+    let output = build_cross_file_lint_output_with_report(
+        &inputs,
+        help_level,
+        include_tree,
+        include_complexity,
+    );
+    let report = combine_cross_file_report(
+        output.provide_inject_tree.as_deref(),
+        output.complexity_report.as_deref(),
+    );
 
     for (target_index, cross_result) in targets.into_iter().zip(output.results) {
         if let Some((_, _, _, result)) = results.get_mut(target_index) {
@@ -55,13 +66,23 @@ pub(super) fn apply_sfc_cross_file_lint(
         }
     }
 
-    tree
+    report
 }
 
+#[cfg(test)]
 pub(super) fn build_cross_file_lint_output<S: AsRef<str>>(
     files: &[(PathBuf, S)],
     help_level: HelpLevel,
     include_tree: bool,
+) -> CrossFileLintOutput {
+    build_cross_file_lint_output_with_report(files, help_level, include_tree, false)
+}
+
+pub(super) fn build_cross_file_lint_output_with_report<S: AsRef<str>>(
+    files: &[(PathBuf, S)],
+    help_level: HelpLevel,
+    include_tree: bool,
+    include_complexity: bool,
 ) -> CrossFileLintOutput {
     let root = std::env::current_dir().unwrap_or_default();
     let mut analyzer = CrossFileAnalyzer::with_project_root(patina_cross_file_options(), root);
@@ -127,11 +148,32 @@ pub(super) fn build_cross_file_lint_output<S: AsRef<str>>(
                 .map(|tree| tree.to_markdown(analyzer.registry()))
         })
         .flatten();
+    let complexity_report = include_complexity.then(|| {
+        render_complexity_markdown(
+            &cross_file_result.complexity_report,
+            &cross_file_result.complexity_hotspots,
+        )
+    });
 
     CrossFileLintOutput {
         results,
         provide_inject_tree,
+        complexity_report,
     }
+}
+
+fn combine_cross_file_report(tree: Option<&str>, complexity: Option<&str>) -> Option<String> {
+    let mut report = String::default();
+    if let Some(tree) = tree {
+        report.push_str(tree);
+    }
+    if let Some(complexity) = complexity {
+        if !report.is_empty() {
+            report.push('\n');
+        }
+        report.push_str(complexity);
+    }
+    (!report.is_empty()).then_some(report)
 }
 
 fn patina_cross_file_options() -> CrossFileOptions {
@@ -249,4 +291,60 @@ pub(super) fn merge_lint_result(target: &mut LintResult, mut extra: LintResult) 
     target
         .diagnostics
         .sort_unstable_by_key(|diagnostic| (diagnostic.start, diagnostic.end));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn cross_file_complexity_report_mentions_hotspot_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("App.vue");
+        let child = dir.path().join("Child.vue");
+
+        fs::write(&app, r#"<script setup lang="ts">
+import { reactive } from 'vue'
+import Child from './Child.vue'
+const ready = true
+const enabled = true
+const fallback = false
+const state = reactive({ count: 0 })
+</script>
+<template><Child v-if="ready && enabled" :item="state" /><Child v-if="fallback" :item="state" /></template>
+"#).unwrap();
+        fs::write(
+            &child,
+            r#"<script setup lang="ts">
+defineProps<{ item: { count: number } }>()
+</script>
+"#,
+        )
+        .unwrap();
+
+        let files = [&app, &child]
+            .into_iter()
+            .map(|path| (path.to_path_buf(), fs::read_to_string(path).unwrap()))
+            .collect::<Vec<_>>();
+        let output =
+            build_cross_file_lint_output_with_report(&files, HelpLevel::Short, false, true);
+        let report = output
+            .complexity_report
+            .as_deref()
+            .expect("complexity report should be rendered");
+
+        assert!(report.contains("## Cross-file Complexity"));
+        assert!(report.contains("App.vue"));
+        assert!(report.contains("template-control-flow"));
+        assert!(report.contains("v-if=2"));
+        assert!(report.contains("prop edges=2"));
+    }
+
+    #[test]
+    fn combined_cross_file_report_keeps_tree_before_complexity() {
+        let report = combine_cross_file_report(Some("tree"), Some("complexity")).unwrap();
+
+        assert_eq!(report, "tree\ncomplexity");
+    }
 }

--- a/crates/vize/src/commands/ready.rs
+++ b/crates/vize/src/commands/ready.rs
@@ -106,6 +106,7 @@ pub fn run(args: ReadyArgs) {
         preset: None,
         cross_file: false,
         cross_file_tree: false,
+        cross_file_complexity: false,
         type_aware: false,
         strict_reactivity: false,
         profile: false,

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_lint_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_lint_help.snap
@@ -47,6 +47,9 @@ Options:
       --cross-file-tree
           Print the provide/inject tree when cross-file lint is enabled
 
+      --cross-file-complexity
+          Print cross-file complexity score and top hotspots when cross-file lint is enabled
+
       --type-aware
           Enable native type-aware lint rules from the active lint configuration
 

--- a/crates/vize_curator/Cargo.toml
+++ b/crates/vize_curator/Cargo.toml
@@ -20,6 +20,7 @@ vize_atelier_core = { workspace = true }
 vize_atelier_sfc = { workspace = true }
 vize_carton = { workspace = true }
 vize_croquis = { workspace = true }
+vize_croquis_cf = { workspace = true }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/vize_curator/src/complexity.rs
+++ b/crates/vize_curator/src/complexity.rs
@@ -1,0 +1,196 @@
+//! Cross-file complexity report rendering.
+
+#[cfg(test)]
+mod tests;
+
+use vize_carton::{String, appendln, appends};
+use vize_croquis_cf::{
+    ComplexityBand, ComplexityDimension, ComplexityDimensionBreakdown, ComplexityHotspot,
+    ComplexityInput, ComplexityReport,
+};
+
+pub fn render_complexity_markdown(
+    report: &ComplexityReport,
+    hotspots: &[ComplexityHotspot],
+) -> String {
+    let mut out = String::default();
+
+    appendln!(out, "## Cross-file Complexity");
+    appendln!(out);
+    appendln!(out, "| Metric | Value |");
+    appendln!(out, "| --- | ---: |");
+    appendln!(out, "| Band | ", band_label(report.band), " |");
+    appendln!(out, "| Total score | ", @report.total_score, " |");
+    appendln!(out, "| Cyclomatic score | ", @report.cyclomatic_score, " |");
+    appendln!(out, "| Cognitive score | ", @report.cognitive_score, " |");
+
+    appendln!(out);
+    appendln!(out, "### Dimensions");
+    appendln!(out);
+    appendln!(out, "| Dimension | Score |");
+    appendln!(out, "| --- | ---: |");
+    for dimension in report.dimensions.breakdown() {
+        append_dimension_row(&mut out, dimension);
+    }
+
+    appendln!(out);
+    appendln!(out, "### Top Hotspots");
+    appendln!(out);
+    if hotspots.is_empty() {
+        appendln!(out, "No component hotspots were identified.");
+        return out;
+    }
+
+    appendln!(out, "| Rank | File | Component | Score | Reason |");
+    appendln!(out, "| ---: | --- | --- | ---: | --- |");
+    for (index, hotspot) in hotspots.iter().take(5).enumerate() {
+        append_hotspot_row(&mut out, index + 1, hotspot);
+    }
+
+    out
+}
+
+fn append_dimension_row(out: &mut String, dimension: ComplexityDimensionBreakdown) {
+    appendln!(
+        out,
+        "| ",
+        dimension_label(dimension.dimension),
+        " | ",
+        @dimension.score,
+        " |"
+    );
+}
+
+fn append_hotspot_row(out: &mut String, rank: usize, hotspot: &ComplexityHotspot) {
+    let file_name = escape_table_cell(hotspot.file_name.as_str());
+    let component_name = hotspot
+        .component_name
+        .as_ref()
+        .map(|name| escape_table_cell(name.as_str()))
+        .unwrap_or_else(|| "-".into());
+    let reason = escape_table_cell(hotspot_reason(hotspot).as_str());
+
+    appendln!(
+        out,
+        "| ",
+        @rank,
+        " | ",
+        file_name.as_str(),
+        " | ",
+        component_name.as_str(),
+        " | ",
+        @hotspot.total_score,
+        " | ",
+        reason.as_str(),
+        " |"
+    );
+}
+
+fn hotspot_reason(hotspot: &ComplexityHotspot) -> String {
+    let mut reason = String::default();
+    if let Some(dominant) = hotspot.dominant_dimension {
+        appends!(
+            reason,
+            dimension_label(dominant.dimension),
+            " (",
+            @dominant.score,
+            ")"
+        );
+    } else {
+        reason.push_str("balanced dimensions");
+    }
+
+    let drivers = input_drivers(hotspot.input);
+    if !drivers.is_empty() {
+        appends!(reason, " via ", drivers.as_str());
+    }
+
+    reason
+}
+
+fn input_drivers(input: ComplexityInput) -> String {
+    let mut drivers = String::default();
+    push_driver(&mut drivers, "v-if", input.template_if_count);
+    push_driver(&mut drivers, "v-for", input.template_for_count);
+    push_driver(
+        &mut drivers,
+        "logical ops",
+        input.template_logical_operator_count,
+    );
+    push_driver(
+        &mut drivers,
+        "tree if depth",
+        input.component_tree_v_if_max_depth,
+    );
+    push_driver(
+        &mut drivers,
+        "tree for depth",
+        input.component_tree_v_for_max_depth,
+    );
+    push_driver(
+        &mut drivers,
+        "scoped slot depth",
+        input.component_tree_scoped_slot_max_depth,
+    );
+    push_driver(&mut drivers, "slots", input.slot_count);
+    push_driver(&mut drivers, "prop edges", input.prop_drilling_edge_count);
+    push_driver(
+        &mut drivers,
+        "global refs",
+        input.global_state_reference_count,
+    );
+    push_driver(
+        &mut drivers,
+        "provide depth",
+        input.provide_inject_max_depth,
+    );
+    push_driver(
+        &mut drivers,
+        "provide refs",
+        input.provide_inject_reference_count,
+    );
+    push_driver(
+        &mut drivers,
+        "fallthrough risks",
+        input.fallthrough_risk_count,
+    );
+    push_driver(&mut drivers, "reactive nodes", input.reactive_node_count);
+    push_driver(&mut drivers, "reactive edges", input.reactive_edge_count);
+    push_driver(&mut drivers, "reactive cycles", input.reactive_cycle_count);
+    drivers
+}
+
+fn push_driver(drivers: &mut String, label: &'static str, value: usize) {
+    if value == 0 {
+        return;
+    }
+    if !drivers.is_empty() {
+        drivers.push_str(", ");
+    }
+    appends!(drivers, label, "=", @value);
+}
+
+fn escape_table_cell(value: &str) -> String {
+    let mut escaped = String::default();
+    for ch in value.chars() {
+        match ch {
+            '|' => escaped.push_str("\\|"),
+            '\n' | '\r' => escaped.push(' '),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+fn band_label(band: ComplexityBand) -> &'static str {
+    match band {
+        ComplexityBand::Low => "low",
+        ComplexityBand::Moderate => "moderate",
+        ComplexityBand::High => "high",
+        ComplexityBand::Extreme => "extreme",
+    }
+}
+
+fn dimension_label(dimension: ComplexityDimension) -> &'static str {
+    dimension.as_str()
+}

--- a/crates/vize_curator/src/complexity/tests.rs
+++ b/crates/vize_curator/src/complexity/tests.rs
@@ -1,0 +1,62 @@
+use super::*;
+use vize_croquis_cf::{ComplexityDimensionScores, FileId};
+
+#[test]
+fn complexity_markdown_explains_dimensions_and_hotspots() {
+    let input = ComplexityInput {
+        component_count: 1,
+        template_if_count: 2,
+        prop_drilling_edge_count: 3,
+        reactive_cycle_count: 1,
+        ..ComplexityInput::default()
+    };
+    let report = ComplexityReport::from_input(input);
+    let hotspot = ComplexityHotspot {
+        file_id: FileId::new(2),
+        file_name: "Feature|Panel.vue".into(),
+        component_name: Some("FeaturePanel".into()),
+        input,
+        dimensions: report.dimensions,
+        total_score: report.total_score,
+        dominant_dimension: report.dominant_dimension(),
+    };
+
+    let markdown = render_complexity_markdown(&report, &[hotspot]);
+
+    assert!(markdown.contains("## Cross-file Complexity"));
+    assert!(markdown.contains("| Total score | 22 |"));
+    assert!(markdown.contains("| reactive-graph | 10 |"));
+    assert!(markdown.contains("Feature\\|Panel.vue"));
+    assert!(markdown.contains("reactive-graph (10) via v-if=2, prop edges=3, reactive cycles=1"));
+}
+
+#[test]
+fn complexity_markdown_handles_empty_hotspots() {
+    let report = ComplexityReport::from_input(ComplexityInput::default());
+
+    let markdown = render_complexity_markdown(&report, &[]);
+
+    assert!(markdown.contains("| Band | low |"));
+    assert!(markdown.contains("No component hotspots were identified."));
+}
+
+#[test]
+fn complexity_markdown_uses_report_dimension_scores() {
+    let report = ComplexityReport {
+        input: ComplexityInput::default(),
+        dimensions: ComplexityDimensionScores {
+            slot_usage: 7,
+            provide_inject: 5,
+            ..ComplexityDimensionScores::default()
+        },
+        cyclomatic_score: 0,
+        cognitive_score: 0,
+        total_score: 12,
+        band: ComplexityBand::Low,
+    };
+
+    let markdown = render_complexity_markdown(&report, &[]);
+
+    assert!(markdown.contains("| slot-usage | 7 |"));
+    assert!(markdown.contains("| provide-inject | 5 |"));
+}

--- a/crates/vize_curator/src/lib.rs
+++ b/crates/vize_curator/src/lib.rs
@@ -4,5 +4,6 @@
 //! generated. It is intentionally workspace-local and is not part of the
 //! published crate set.
 
+pub mod complexity;
 pub mod inspector;
 pub mod profile;


### PR DESCRIPTION
## Summary
- add a Curator renderer for cross-file complexity Markdown reports
- add `vize lint --cross-file-complexity` to print scores, dimensions, and top hotspots
- preserve provide/inject tree output ordering when both reports are requested

Refs #2748

## Verification
- cargo fmt --check
- cargo clippy -p vize_curator --lib --profile ci -- -D warnings
- cargo clippy -p vize --lib --profile ci -- -D warnings
- cargo test -p vize_curator --profile ci
- cargo test -p vize --lib --profile ci
- cargo test -p vize lint_help_snapshot --profile ci
- cargo test -p vize cross_file_complexity_report_mentions_hotspot_reason --profile ci
- cargo test -p vize combined_cross_file_report_keeps_tree_before_complexity --profile ci
- git diff --check

Note: local source-file-lengths.test.ts could not run because the local MoonBit binary rejects the workspace `moon.mod` `source` key; GitHub Actions test-scripts uses setup-moonbit and remains the source-length gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786217206&installation_id=136613492&pr_number=2782&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2782&signature=af5cc82907e14686b6b109528fd144e3e9a1727432f32b00bc5894dae3fb89c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional cross-file complexity view to lint output, including a score summary and top hotspots.
  * The ready command now includes the updated lint settings so this information can be surfaced consistently.
* **Bug Fixes**
  * Improved the combined cross-file report so tree and complexity results display together in a cleaner, more consistent format.
* **Tests**
  * Added coverage for complexity report formatting, hotspot handling, and output escaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->