### PR TITLE
feat(croquis-cf): expose fallthrough component facts

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer.rs
+++ b/crates/vize_croquis_cf/src/analyzer.rs
@@ -14,6 +14,10 @@ pub use types::{CrossFileOptions, CrossFileResult, CrossFileStats};
 mod tests_basic;
 
 #[cfg(test)]
+#[path = "analyzer/tests_fallthrough.rs"]
+mod tests_fallthrough;
+
+#[cfg(test)]
 #[path = "analyzer/tests_element_id.rs"]
 mod tests_element_id;
 

--- a/crates/vize_croquis_cf/src/analyzer/core/run.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/run.rs
@@ -27,6 +27,9 @@ impl CrossFileAnalyzer {
         // Run enabled rules
         if self.options.fallthrough_attrs {
             let (info, diags) = rules::analyze_fallthrough(&self.registry, &self.graph);
+            let usage_facts = rules::collect_fallthrough_usage_facts(&self.registry, &self.graph);
+            result.fallthrough_component_facts =
+                rules::collect_fallthrough_component_facts(&info, &usage_facts);
             result.fallthrough_summary = Some(rules::summarize_fallthrough(&info));
             result.fallthrough_info = info;
             result.diagnostics.extend(diags);

--- a/crates/vize_croquis_cf/src/analyzer/tests_fallthrough.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_fallthrough.rs
@@ -1,0 +1,73 @@
+use super::{CrossFileAnalyzer, CrossFileOptions};
+use std::path::Path;
+use vize_carton::{CompactString, smallvec};
+use vize_croquis::analysis::{ComponentUsage, EventListener, PassedProp};
+use vize_croquis::macros::PropDefinition;
+use vize_croquis::{Croquis, ScopeId};
+
+#[test]
+fn fallthrough_component_facts_are_populated_from_analyzer() {
+    let mut analyzer =
+        CrossFileAnalyzer::new(CrossFileOptions::default().with_fallthrough_attrs(true));
+    let mut child = Croquis::new();
+    child.template_info.root_element_count = 2;
+    child.macros.add_prop(PropDefinition {
+        name: CompactString::new("kind"),
+        prop_type: None,
+        required: false,
+        default_value: None,
+    });
+    let child_id = analyzer.add_file_with_analysis(Path::new("Child.vue"), "", child);
+
+    let mut parent = Croquis::new();
+    parent.used_components.insert(CompactString::new("Child"));
+    parent.component_usages.push(ComponentUsage {
+        name: CompactString::new("Child"),
+        start: 0,
+        end: 80,
+        props: smallvec![
+            PassedProp {
+                name: CompactString::new("kind"),
+                value: None,
+                start: 8,
+                end: 20,
+                is_dynamic: false,
+            },
+            PassedProp {
+                name: CompactString::new("trackingId"),
+                value: None,
+                start: 21,
+                end: 40,
+                is_dynamic: true,
+            }
+        ],
+        events: smallvec![EventListener {
+            name: CompactString::new("close"),
+            handler: None,
+            modifiers: smallvec![],
+            start: 41,
+            end: 55,
+        }],
+        slots: smallvec![],
+        has_spread_attrs: false,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    });
+    analyzer.add_file_with_analysis(Path::new("Parent.vue"), "", parent);
+
+    let result = analyzer.analyze();
+    let fact = result
+        .fallthrough_component_facts
+        .iter()
+        .find(|fact| fact.file_id == child_id)
+        .expect("child component fact should be present");
+
+    assert_eq!(fact.usage_count, 1);
+    assert_eq!(fact.parent_count, 1);
+    assert_eq!(fact.prop_attr_count, 2);
+    assert_eq!(fact.listener_attr_count, 1);
+    assert_eq!(fact.declared_prop_attr_count, 1);
+    assert_eq!(fact.fallthrough_attr_count, 2);
+    assert_eq!(fact.risky_unconsumed_fallthrough_attr_count, 1);
+    assert!(fact.has_potential_issues);
+}

--- a/crates/vize_croquis_cf/src/analyzer/types.rs
+++ b/crates/vize_croquis_cf/src/analyzer/types.rs
@@ -189,6 +189,9 @@ pub struct CrossFileResult {
     /// Fallthrough attribute summary, populated when fallthrough analysis is enabled.
     pub fallthrough_summary: Option<rules::FallthroughSummary>,
 
+    /// Per-component fallthrough aggregate facts, populated when fallthrough analysis is enabled.
+    pub fallthrough_component_facts: Vec<rules::FallthroughComponentFact>,
+
     /// Emit flow information.
     pub emit_flows: Vec<rules::EmitFlow>,
 

--- a/crates/vize_croquis_cf/src/lib.rs
+++ b/crates/vize_croquis_cf/src/lib.rs
@@ -67,8 +67,9 @@ pub use suppression::{SuppressionDirective, SuppressionError, SuppressionMap};
 pub use rules::{
     BoundaryInfo, BoundaryKind, ComplexityBand, ComplexityDimension, ComplexityDimensionBreakdown,
     ComplexityDimensionScores, ComplexityHotspot, ComplexityInput, ComplexityReport, EmitFlow,
-    EventBubble, FallthroughInfo, FallthroughSummary, FallthroughUsageAttrFact,
-    FallthroughUsageAttrKind, FallthroughUsageFact, PropsValidationIssue, PropsValidationIssueKind,
-    ProvideInjectMatch, ProvideInjectTreeSummary, ReactivityIssue, ReactivityIssueKind,
-    UniqueIdIssue, band_for_score, collect_fallthrough_usage_facts,
+    EventBubble, FallthroughComponentFact, FallthroughInfo, FallthroughSummary,
+    FallthroughUsageAttrFact, FallthroughUsageAttrKind, FallthroughUsageFact, PropsValidationIssue,
+    PropsValidationIssueKind, ProvideInjectMatch, ProvideInjectTreeSummary, ReactivityIssue,
+    ReactivityIssueKind, UniqueIdIssue, band_for_score, collect_fallthrough_component_facts,
+    collect_fallthrough_usage_facts,
 };

--- a/crates/vize_croquis_cf/src/rules.rs
+++ b/crates/vize_croquis_cf/src/rules.rs
@@ -40,9 +40,9 @@ pub use element_id::{UniqueIdIssue, analyze_element_ids};
 pub use emit::{EmitFlow, analyze_emits};
 pub use event_bubbling::{EventBubble, analyze_event_bubbling};
 pub use fallthrough::{
-    FallthroughInfo, FallthroughSummary, FallthroughUsageAttrFact, FallthroughUsageAttrKind,
-    FallthroughUsageFact, analyze_fallthrough, collect_fallthrough_usage_facts,
-    summarize_fallthrough,
+    FallthroughComponentFact, FallthroughInfo, FallthroughSummary, FallthroughUsageAttrFact,
+    FallthroughUsageAttrKind, FallthroughUsageFact, analyze_fallthrough,
+    collect_fallthrough_component_facts, collect_fallthrough_usage_facts, summarize_fallthrough,
 };
 pub use props_validation::{
     PropsValidationIssue, PropsValidationIssueKind, analyze_props_validation,

--- a/crates/vize_croquis_cf/src/rules/fallthrough.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough.rs
@@ -10,10 +10,12 @@ use crate::graph::DependencyGraph;
 use crate::registry::{FileId, ModuleRegistry};
 use vize_carton::{CompactString, FxHashMap, FxHashSet, cstr};
 
+mod component;
 mod info;
 mod summary;
 mod usage;
 
+pub use component::{FallthroughComponentFact, collect_fallthrough_component_facts};
 pub use summary::{FallthroughSummary, summarize_fallthrough};
 pub use usage::*;
 

--- a/crates/vize_croquis_cf/src/rules/fallthrough/component.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough/component.rs
@@ -1,0 +1,247 @@
+use super::{FallthroughInfo, FallthroughUsageAttrKind, FallthroughUsageFact};
+use crate::registry::FileId;
+use serde::Serialize;
+use vize_carton::{FxHashMap, FxHashSet};
+
+/// Stable per-component aggregate for fallthrough attribute analysis.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FallthroughComponentFact {
+    pub file_id: FileId,
+    pub usage_count: usize,
+    pub parent_count: usize,
+    pub spread_usage_count: usize,
+    pub passed_attr_count: usize,
+    pub usage_attr_count: usize,
+    pub prop_attr_count: usize,
+    pub listener_attr_count: usize,
+    pub dynamic_attr_count: usize,
+    pub declared_prop_attr_count: usize,
+    pub fallthrough_attr_count: usize,
+    pub consumed_fallthrough_attr_count: usize,
+    pub unconsumed_fallthrough_attr_count: usize,
+    pub safe_standard_fallthrough_attr_count: usize,
+    pub risky_unconsumed_fallthrough_attr_count: usize,
+    pub declared_prop_count: usize,
+    pub root_element_count: usize,
+    pub inherit_attrs_disabled: bool,
+    pub uses_attrs: bool,
+    pub binds_attrs: bool,
+    pub has_potential_issues: bool,
+}
+
+impl Default for FallthroughComponentFact {
+    fn default() -> Self {
+        Self {
+            file_id: FileId::INVALID,
+            usage_count: 0,
+            parent_count: 0,
+            spread_usage_count: 0,
+            passed_attr_count: 0,
+            usage_attr_count: 0,
+            prop_attr_count: 0,
+            listener_attr_count: 0,
+            dynamic_attr_count: 0,
+            declared_prop_attr_count: 0,
+            fallthrough_attr_count: 0,
+            consumed_fallthrough_attr_count: 0,
+            unconsumed_fallthrough_attr_count: 0,
+            safe_standard_fallthrough_attr_count: 0,
+            risky_unconsumed_fallthrough_attr_count: 0,
+            declared_prop_count: 0,
+            root_element_count: 0,
+            inherit_attrs_disabled: false,
+            uses_attrs: false,
+            binds_attrs: false,
+            has_potential_issues: false,
+        }
+    }
+}
+
+pub fn collect_fallthrough_component_facts(
+    infos: &[FallthroughInfo],
+    usage_facts: &[FallthroughUsageFact],
+) -> Vec<FallthroughComponentFact> {
+    let mut facts = infos
+        .iter()
+        .map(FallthroughComponentFact::from_info)
+        .collect::<Vec<_>>();
+    let indexes = facts
+        .iter()
+        .enumerate()
+        .map(|(index, fact)| (fact.file_id, index))
+        .collect::<FxHashMap<_, _>>();
+    let mut parent_sets = vec![FxHashSet::default(); facts.len()];
+
+    for usage in usage_facts {
+        let Some(&index) = indexes.get(&usage.child_file_id) else {
+            continue;
+        };
+        let fact = &mut facts[index];
+        fact.usage_count += 1;
+        fact.spread_usage_count += usize::from(usage.has_spread_attrs);
+        parent_sets[index].insert(usage.parent_file_id);
+
+        for attr in &usage.attrs {
+            fact.usage_attr_count += 1;
+            fact.dynamic_attr_count += usize::from(attr.dynamic);
+            fact.declared_prop_attr_count += usize::from(attr.declared_prop);
+            match attr.kind {
+                FallthroughUsageAttrKind::Prop => fact.prop_attr_count += 1,
+                FallthroughUsageAttrKind::Listener => fact.listener_attr_count += 1,
+            }
+        }
+    }
+
+    for (fact, parents) in facts.iter_mut().zip(parent_sets) {
+        fact.parent_count = parents.len();
+    }
+    facts.sort_unstable_by_key(|fact| fact.file_id.as_u32());
+    facts
+}
+
+impl FallthroughComponentFact {
+    fn from_info(info: &FallthroughInfo) -> Self {
+        Self {
+            file_id: info.file_id,
+            passed_attr_count: info.passed_attrs.len(),
+            fallthrough_attr_count: info.fallthrough_attr_count(),
+            consumed_fallthrough_attr_count: info.consumed_fallthrough_attr_count(),
+            unconsumed_fallthrough_attr_count: info.unconsumed_fallthrough_attr_count(),
+            safe_standard_fallthrough_attr_count: info.safe_standard_fallthrough_attr_count(),
+            risky_unconsumed_fallthrough_attr_count: info.risky_unconsumed_fallthrough_attr_count(),
+            declared_prop_count: info.declared_props.len(),
+            root_element_count: info.root_element_count,
+            inherit_attrs_disabled: info.inherit_attrs_disabled,
+            uses_attrs: info.uses_attrs,
+            binds_attrs: info.binds_attrs,
+            has_potential_issues: info.has_potential_issues(),
+            ..Self::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rules::fallthrough::FallthroughUsageAttrFact;
+    use vize_carton::CompactString;
+
+    fn set(names: &[&str]) -> FxHashSet<CompactString> {
+        names.iter().map(|name| CompactString::new(*name)).collect()
+    }
+
+    fn attr(
+        name: &str,
+        kind: FallthroughUsageAttrKind,
+        dynamic: bool,
+        declared_prop: bool,
+        standard_html_attr: bool,
+    ) -> FallthroughUsageAttrFact {
+        FallthroughUsageAttrFact {
+            name: CompactString::new(name),
+            kind,
+            source_start: 0,
+            source_end: 0,
+            dynamic,
+            declared_prop,
+            standard_html_attr,
+            fallthrough: !declared_prop,
+        }
+    }
+
+    #[test]
+    fn component_facts_preserve_usage_and_component_counts() {
+        let child = FileId::new(2);
+        let infos = vec![FallthroughInfo {
+            file_id: child,
+            inherit_attrs_disabled: false,
+            uses_attrs: false,
+            binds_attrs: false,
+            root_element_count: 2,
+            passed_attrs: set(&["kind", "trackingId", "onClose"]),
+            declared_props: set(&["kind"]),
+            template_start: 0,
+            template_end: 10,
+        }];
+        let usage_facts = vec![
+            FallthroughUsageFact {
+                parent_file_id: FileId::new(1),
+                child_file_id: child,
+                component_name: CompactString::new("Child"),
+                usage_start: 0,
+                usage_end: 0,
+                has_spread_attrs: true,
+                attrs: vec![
+                    attr("kind", FallthroughUsageAttrKind::Prop, false, true, false),
+                    attr(
+                        "trackingId",
+                        FallthroughUsageAttrKind::Prop,
+                        true,
+                        false,
+                        false,
+                    ),
+                ],
+            },
+            FallthroughUsageFact {
+                parent_file_id: FileId::new(3),
+                child_file_id: child,
+                component_name: CompactString::new("Child"),
+                usage_start: 0,
+                usage_end: 0,
+                has_spread_attrs: false,
+                attrs: vec![attr(
+                    "onClose",
+                    FallthroughUsageAttrKind::Listener,
+                    true,
+                    false,
+                    true,
+                )],
+            },
+        ];
+
+        let facts = collect_fallthrough_component_facts(&infos, &usage_facts);
+        let fact = &facts[0];
+
+        assert_eq!(fact.usage_count, 2);
+        assert_eq!(fact.parent_count, 2);
+        assert_eq!(fact.spread_usage_count, 1);
+        assert_eq!(fact.passed_attr_count, 3);
+        assert_eq!(fact.usage_attr_count, 3);
+        assert_eq!(fact.prop_attr_count, 2);
+        assert_eq!(fact.listener_attr_count, 1);
+        assert_eq!(fact.dynamic_attr_count, 2);
+        assert_eq!(fact.declared_prop_attr_count, 1);
+        assert_eq!(fact.fallthrough_attr_count, 2);
+        assert_eq!(fact.safe_standard_fallthrough_attr_count, 1);
+        assert_eq!(fact.risky_unconsumed_fallthrough_attr_count, 1);
+        assert!(fact.has_potential_issues);
+
+        let json = serde_json::to_value(fact).unwrap();
+        assert_eq!(json["spreadUsageCount"], 1);
+        assert_eq!(json["listenerAttrCount"], 1);
+    }
+
+    #[test]
+    fn component_facts_keep_zero_usage_components() {
+        let infos = vec![FallthroughInfo {
+            file_id: FileId::new(5),
+            inherit_attrs_disabled: true,
+            uses_attrs: false,
+            binds_attrs: false,
+            root_element_count: 1,
+            passed_attrs: FxHashSet::default(),
+            declared_props: set(&["kind"]),
+            template_start: 0,
+            template_end: 10,
+        }];
+
+        let facts = collect_fallthrough_component_facts(&infos, &[]);
+
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].usage_count, 0);
+        assert_eq!(facts[0].declared_prop_count, 1);
+        assert!(facts[0].inherit_attrs_disabled);
+        assert!(facts[0].has_potential_issues);
+    }
+}


### PR DESCRIPTION
Refs #2749

## Summary
- add per-component fallthrough aggregate facts to the cross-file result
- include usage, parent, attr kind, declared prop, and component-level risk counts
- cover the collector and analyzer population with focused tests

## Verification
- cargo fmt --check
- cargo test -p vize_croquis_cf --profile ci
- cargo clippy -p vize_croquis_cf --lib --profile ci -- -D warnings
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786219057&installation_id=136613492&pr_number=2783&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2783&signature=560bdddd0bb0b639ba1474a7b9bc787a64536357e250be54d6e6517977ab0154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-component fallthrough analysis results, including usage, parent relationship, attribute counts, and potential issue indicators.
  * Expanded analyzer output to include these component-level facts when fallthrough analysis is enabled.
* **Tests**
  * Added coverage for component fact aggregation and analyzer behavior with fallthrough attributes enabled.
* **Documentation**
  * No user-facing documentation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->