### PR TITLE
feat(croquis-cf): score provide inject fanout

### DIFF
--- a/crates/vize_croquis_cf/src/rules/complexity.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity.rs
@@ -27,6 +27,7 @@ pub struct ComplexityInput {
     pub global_state_reference_count: usize,
     pub provide_inject_max_depth: usize,
     pub provide_inject_reference_count: usize,
+    pub provide_inject_fanout_count: usize,
     pub fallthrough_risk_count: usize,
     pub reactive_node_count: usize,
     pub reactive_edge_count: usize,
@@ -91,35 +92,21 @@ impl ComplexityDimensionScores {
 
     pub fn breakdown(self) -> [ComplexityDimensionBreakdown; 7] {
         [
-            ComplexityDimensionBreakdown {
-                dimension: ComplexityDimension::TemplateControlFlow,
-                score: self.template_control_flow,
-            },
-            ComplexityDimensionBreakdown {
-                dimension: ComplexityDimension::SlotUsage,
-                score: self.slot_usage,
-            },
-            ComplexityDimensionBreakdown {
-                dimension: ComplexityDimension::PropDrilling,
-                score: self.prop_drilling,
-            },
-            ComplexityDimensionBreakdown {
-                dimension: ComplexityDimension::GlobalState,
-                score: self.global_state,
-            },
-            ComplexityDimensionBreakdown {
-                dimension: ComplexityDimension::ProvideInject,
-                score: self.provide_inject,
-            },
-            ComplexityDimensionBreakdown {
-                dimension: ComplexityDimension::FallthroughAttrs,
-                score: self.fallthrough_attrs,
-            },
-            ComplexityDimensionBreakdown {
-                dimension: ComplexityDimension::ReactiveGraph,
-                score: self.reactive_graph,
-            },
+            (
+                ComplexityDimension::TemplateControlFlow,
+                self.template_control_flow,
+            ),
+            (ComplexityDimension::SlotUsage, self.slot_usage),
+            (ComplexityDimension::PropDrilling, self.prop_drilling),
+            (ComplexityDimension::GlobalState, self.global_state),
+            (ComplexityDimension::ProvideInject, self.provide_inject),
+            (
+                ComplexityDimension::FallthroughAttrs,
+                self.fallthrough_attrs,
+            ),
+            (ComplexityDimension::ReactiveGraph, self.reactive_graph),
         ]
+        .map(|(dimension, score)| ComplexityDimensionBreakdown { dimension, score })
     }
 
     pub fn dominant_dimension(self) -> Option<ComplexityDimensionBreakdown> {
@@ -165,7 +152,10 @@ impl ComplexityReport {
             prop_drilling: weighted(input.prop_drilling_edge_count, 3),
             global_state: weighted(input.global_state_reference_count, 2),
             provide_inject: weighted(input.provide_inject_max_depth.saturating_sub(1), 2)
-                .saturating_add(weighted(input.provide_inject_reference_count, 1)),
+                .saturating_add(weighted(input.provide_inject_reference_count, 1))
+                .saturating_add(provide_inject_fanout_score(
+                    input.provide_inject_fanout_count,
+                )),
             fallthrough_attrs: weighted(input.fallthrough_risk_count, 4),
             reactive_graph: weighted(input.reactive_node_count, 1)
                 .saturating_add(weighted(input.reactive_edge_count, 2))
@@ -265,6 +255,10 @@ fn complexity_input(registry: &ModuleRegistry, result: &CrossFileResult) -> Comp
         input.provide_inject_max_depth = summary.max_depth;
         input.provide_inject_reference_count =
             summary.provide_count.saturating_add(summary.inject_count);
+        let fanout = summary
+            .max_child_fanout
+            .max(summary.max_provider_consumer_count);
+        input.provide_inject_fanout_count = fanout;
     } else {
         input.provide_inject_reference_count = result.provide_inject_matches.len();
     }
@@ -324,6 +318,10 @@ fn weighted(count: usize, weight: u32) -> u32 {
     u32::try_from(count)
         .unwrap_or(u32::MAX)
         .saturating_mul(weight)
+}
+
+fn provide_inject_fanout_score(count: usize) -> u32 {
+    weighted(count.saturating_sub(1), 2)
 }
 
 fn cyclomatic_score(input: ComplexityInput) -> u32 {

--- a/crates/vize_croquis_cf/src/rules/complexity/hotspots.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity/hotspots.rs
@@ -129,10 +129,9 @@ fn add_provide_inject_inputs(
     result: &CrossFileResult,
 ) {
     for matched in &result.provide_inject_matches {
-        inputs
-            .entry(matched.provider)
-            .or_default()
-            .provide_inject_reference_count += 1;
+        let provider = inputs.entry(matched.provider).or_default();
+        provider.provide_inject_reference_count += 1;
+        provider.provide_inject_fanout_count += 1;
 
         let consumer = inputs.entry(matched.consumer).or_default();
         consumer.provide_inject_reference_count += 1;

--- a/crates/vize_croquis_cf/src/rules/complexity_hotspots_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity_hotspots_tests.rs
@@ -132,6 +132,7 @@ fn ranks_hotspots_with_dimension_inputs_and_json_shape() {
     assert_eq!(hotspots[1].input.template_logical_operator_count, 1);
     assert_eq!(hotspots[1].input.slot_count, 1);
     assert_eq!(hotspots[1].input.prop_drilling_edge_count, 1);
+    assert_eq!(hotspots[1].input.provide_inject_fanout_count, 1);
     assert_eq!(hotspots[1].dimensions.template_control_flow, 4);
     assert_eq!(hotspots[1].total_score, 17);
 

--- a/crates/vize_croquis_cf/src/rules/complexity_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity_tests.rs
@@ -30,6 +30,7 @@ fn scores_each_complexity_dimension() {
         global_state_reference_count: 4,
         provide_inject_max_depth: 3,
         provide_inject_reference_count: 5,
+        provide_inject_fanout_count: 4,
         fallthrough_risk_count: 2,
         reactive_node_count: 6,
         reactive_edge_count: 7,
@@ -42,14 +43,15 @@ fn scores_each_complexity_dimension() {
     assert_eq!(report.dimensions.slot_usage, 14);
     assert_eq!(report.dimensions.prop_drilling, 6);
     assert_eq!(report.dimensions.global_state, 8);
-    assert_eq!(report.dimensions.provide_inject, 9);
+    assert_eq!(report.dimensions.provide_inject, 15);
     assert_eq!(report.dimensions.fallthrough_attrs, 8);
     assert_eq!(report.dimensions.reactive_graph, 30);
-    assert_eq!(report.total_score, 90);
+    assert_eq!(report.total_score, 96);
     assert_eq!(report.band, ComplexityBand::Extreme);
 
     let json = serde_json::to_value(report).expect("complexity report should serialize");
     assert_eq!(json["input"]["templateIfCount"], 2);
+    assert_eq!(json["input"]["provideInjectFanoutCount"], 4);
     assert_eq!(json["input"]["fallthroughRiskCount"], 2);
     assert_eq!(json["dimensions"]["reactiveGraph"], 30);
     assert_eq!(json["cyclomaticScore"], 6);
@@ -153,6 +155,7 @@ fn summarizes_complexity_from_registry_and_result() {
         }),
         provide_inject_tree_summary: Some(ProvideInjectTreeSummary {
             max_depth: 3,
+            max_child_fanout: 2,
             provide_count: 1,
             inject_count: 2,
             ..ProvideInjectTreeSummary::default()
@@ -180,10 +183,11 @@ fn summarizes_complexity_from_registry_and_result() {
     assert_eq!(report.input.global_state_reference_count, 1);
     assert_eq!(report.input.provide_inject_max_depth, 3);
     assert_eq!(report.input.provide_inject_reference_count, 3);
+    assert_eq!(report.input.provide_inject_fanout_count, 2);
     assert_eq!(report.input.fallthrough_risk_count, 1);
     assert_eq!(report.input.reactive_node_count, 1);
     assert_eq!(report.input.reactive_edge_count, 1);
-    assert_eq!(report.total_score, 25);
+    assert_eq!(report.total_score, 27);
     assert_eq!(report.band, ComplexityBand::Moderate);
 }
 

--- a/crates/vize_curator/src/complexity.rs
+++ b/crates/vize_curator/src/complexity.rs
@@ -151,6 +151,11 @@ fn input_drivers(input: ComplexityInput) -> String {
     );
     push_driver(
         &mut drivers,
+        "provide fanout",
+        input.provide_inject_fanout_count,
+    );
+    push_driver(
+        &mut drivers,
         "fallthrough risks",
         input.fallthrough_risk_count,
     );

--- a/crates/vize_curator/src/complexity/tests.rs
+++ b/crates/vize_curator/src/complexity/tests.rs
@@ -7,6 +7,7 @@ fn complexity_markdown_explains_dimensions_and_hotspots() {
         component_count: 1,
         template_if_count: 2,
         prop_drilling_edge_count: 3,
+        provide_inject_fanout_count: 3,
         reactive_cycle_count: 1,
         ..ComplexityInput::default()
     };
@@ -24,10 +25,12 @@ fn complexity_markdown_explains_dimensions_and_hotspots() {
     let markdown = render_complexity_markdown(&report, &[hotspot]);
 
     assert!(markdown.contains("## Cross-file Complexity"));
-    assert!(markdown.contains("| Total score | 22 |"));
+    assert!(markdown.contains("| Total score | 26 |"));
     assert!(markdown.contains("| reactive-graph | 10 |"));
     assert!(markdown.contains("Feature\\|Panel.vue"));
-    assert!(markdown.contains("reactive-graph (10) via v-if=2, prop edges=3, reactive cycles=1"));
+    assert!(markdown.contains(
+        "reactive-graph (10) via v-if=2, prop edges=3, provide fanout=3, reactive cycles=1"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add provide/inject fanout to the cross-file complexity input
- score fanout above a single consumer using the existing explainable complexity model
- surface provider fanout in hotspot driver text and serialization tests

Refs #2747
Refs #2748

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p vize_croquis_cf --profile ci complexity -- --nocapture
- cargo test -p vize_curator --profile ci complexity -- --nocapture
- cargo clippy -p vize_croquis_cf -p vize_curator --lib --profile ci -- -D warnings
- cargo test -p vize_croquis_cf --profile ci
- cargo test -p vize_curator --profile ci

Note: source:lengths could not run locally because the local pnpm/MoonBit tooling stops before the script; the touched Rust file was checked directly at 347 lines against the 350-line limit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786224524&installation_id=136613492&pr_number=2785&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2785&signature=c963429d3cf6dc5faa1a31012a09a05db1ce1646ff47487639a0533799823700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Complexity reports now account for provide/inject fanout, giving a more complete hotspot score and updated total complexity values.
  * Hotspot explanations now include provide fanout details when relevant.

* **Bug Fixes**
  * Improved how provide/inject-related complexity is calculated so cases with heavy fanout are reflected more accurately in rankings and summaries.

* **Tests**
  * Updated coverage to verify the new fanout metric appears in scores, JSON output, and hotspot explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->