### PR TITLE
test(croquis-cf): snapshot provide inject tree output

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/tests_snapshots.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_snapshots.rs
@@ -6,4 +6,5 @@ use vize_croquis::AnalyzerOptions;
 
 mod full;
 mod graph;
+mod provide_inject;
 mod reactivity;

--- a/crates/vize_croquis_cf/src/analyzer/tests_snapshots/provide_inject.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_snapshots/provide_inject.rs
@@ -1,0 +1,123 @@
+use super::*;
+use vize_carton::CompactString;
+
+#[test]
+fn test_snapshot_provide_inject_tree_outputs() {
+    let mut analyzer =
+        CrossFileAnalyzer::new(CrossFileOptions::default().with_provide_inject(true));
+
+    analyzer.add_file_with_analysis(
+        Path::new("App.vue"),
+        "",
+        script_analysis(
+            r#"import { provide, ref } from 'vue'
+const theme = ref('dark')
+provide('theme', theme)"#,
+            &["Layout"],
+        ),
+    );
+    analyzer.add_file_with_analysis(
+        Path::new("Layout.vue"),
+        "",
+        script_analysis("// pass-through layout", &["Panel", "Sidebar"]),
+    );
+    analyzer.add_file_with_analysis(
+        Path::new("Panel.vue"),
+        "",
+        script_analysis(
+            r#"import { inject, provide, ref } from 'vue'
+const theme = inject('theme')
+const panelState = ref({ open: true })
+provide('panelState', panelState)"#,
+            &["Button"],
+        ),
+    );
+    analyzer.add_file_with_analysis(
+        Path::new("Button.vue"),
+        "",
+        script_analysis(
+            r#"import { inject } from 'vue'
+const panelState = inject('panelState')"#,
+            &[],
+        ),
+    );
+    analyzer.add_file_with_analysis(
+        Path::new("Sidebar.vue"),
+        "",
+        script_analysis(
+            r#"import { inject } from 'vue'
+const theme = inject('theme')"#,
+            &[],
+        ),
+    );
+    analyzer.add_file_with_analysis(
+        Path::new("Orphan.vue"),
+        "",
+        script_analysis(
+            r#"import { inject } from 'vue'
+const missing = inject('missing', 'fallback')"#,
+            &[],
+        ),
+    );
+    analyzer.add_file_with_analysis(
+        Path::new("UnusedProvider.vue"),
+        "",
+        script_analysis(
+            r#"import { provide } from 'vue'
+provide('stale', 1)"#,
+            &[],
+        ),
+    );
+    analyzer.rebuild_component_edges();
+
+    let result = analyzer.analyze();
+    let tree = result
+        .provide_inject_tree
+        .as_ref()
+        .expect("tree should be built");
+    let summary = result
+        .provide_inject_tree_summary
+        .expect("tree summary should be built");
+
+    assert_eq!(summary.root_count, 3);
+    assert_eq!(summary.node_count, 7);
+    assert_eq!(summary.pass_through_component_count, 1);
+    assert_eq!(summary.provider_component_count, 3);
+    assert_eq!(summary.injector_component_count, 4);
+    assert_eq!(summary.matched_inject_count, 3);
+    assert_eq!(summary.unmatched_inject_count, 1);
+    assert_eq!(summary.max_depth, 4);
+    assert_eq!(summary.max_child_fanout, 2);
+    assert_eq!(summary.max_provider_consumer_count, 2);
+
+    let mut output = String::new();
+    output.push_str("=== Provide/Inject Tree Outputs ===\n\n");
+    output.push_str("== Summary ==\n");
+    output.push_str(
+        serde_json::to_string_pretty(&summary)
+            .expect("summary should serialize")
+            .as_str(),
+    );
+    output.push_str("\n\n== Tree JSON ==\n");
+    output.push_str(
+        serde_json::to_string_pretty(tree)
+            .expect("tree should serialize")
+            .as_str(),
+    );
+    output.push_str("\n\n== Markdown ==\n");
+    output.push_str(tree.to_markdown(analyzer.registry()).as_str());
+
+    assert_snapshot!(output);
+}
+
+fn script_analysis(script: &str, components: &[&str]) -> vize_croquis::Croquis {
+    let mut analyzer = vize_croquis::Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    for component in components {
+        analyzer
+            .croquis_mut()
+            .used_components
+            .insert(CompactString::new(*component));
+    }
+    analyzer.finish()
+}

--- a/crates/vize_croquis_cf/src/analyzer/tests_snapshots/snapshots/vize_croquis_cf__analyzer__tests_snapshots__provide_inject__snapshot_provide_inject_tree_outputs.snap
+++ b/crates/vize_croquis_cf/src/analyzer/tests_snapshots/snapshots/vize_croquis_cf__analyzer__tests_snapshots__provide_inject__snapshot_provide_inject_tree_outputs.snap
@@ -1,0 +1,148 @@
+---
+source: crates/vize_croquis_cf/src/analyzer/tests_snapshots/provide_inject.rs
+expression: output
+---
+=== Provide/Inject Tree Outputs ===
+
+== Summary ==
+{
+  "rootCount": 3,
+  "nodeCount": 7,
+  "leafComponentCount": 4,
+  "passThroughComponentCount": 1,
+  "providerComponentCount": 3,
+  "injectorComponentCount": 4,
+  "provideCount": 3,
+  "injectCount": 4,
+  "defaultedInjectCount": 1,
+  "matchedInjectCount": 3,
+  "unmatchedInjectCount": 1,
+  "maxDepth": 4,
+  "maxChildFanout": 2,
+  "maxProviderConsumerCount": 2
+}
+
+== Tree JSON ==
+{
+  "roots": [
+    {
+      "fileId": 0,
+      "componentName": "App",
+      "provides": [
+        {
+          "key": "theme",
+          "valueType": null,
+          "offset": 61,
+          "consumerCount": 2
+        }
+      ],
+      "injects": [],
+      "children": [
+        {
+          "fileId": 1,
+          "componentName": "Layout",
+          "provides": [],
+          "injects": [],
+          "children": [
+            {
+              "fileId": 2,
+              "componentName": "Panel",
+              "provides": [
+                {
+                  "key": "panelState",
+                  "valueType": null,
+                  "offset": 112,
+                  "consumerCount": 1
+                }
+              ],
+              "injects": [
+                {
+                  "key": "theme",
+                  "hasDefault": false,
+                  "provider": 0,
+                  "offset": 57
+                }
+              ],
+              "children": [
+                {
+                  "fileId": 3,
+                  "componentName": "Button",
+                  "provides": [],
+                  "injects": [
+                    {
+                      "key": "panelState",
+                      "hasDefault": false,
+                      "provider": 2,
+                      "offset": 48
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            },
+            {
+              "fileId": 4,
+              "componentName": "Sidebar",
+              "provides": [],
+              "injects": [
+                {
+                  "key": "theme",
+                  "hasDefault": false,
+                  "provider": 0,
+                  "offset": 43
+                }
+              ],
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "fileId": 5,
+      "componentName": "Orphan",
+      "provides": [],
+      "injects": [
+        {
+          "key": "missing",
+          "hasDefault": true,
+          "provider": null,
+          "offset": 45
+        }
+      ],
+      "children": []
+    },
+    {
+      "fileId": 6,
+      "componentName": "UnusedProvider",
+      "provides": [
+        {
+          "key": "stale",
+          "valueType": null,
+          "offset": 30,
+          "consumerCount": 0
+        }
+      ],
+      "injects": [],
+      "children": []
+    }
+  ]
+}
+
+== Markdown ==
+## Provide/Inject Tree
+
+📦 **App**
+  🔹 provide(`"theme"`) → 2 consumer(s)
+  📦 **Layout**
+    📦 **Panel**
+      🔹 provide(`"panelState"`) → 1 consumer(s)
+      🔸 inject(`"theme"`) ✅
+      📦 **Button**
+        🔸 inject(`"panelState"`) ✅
+    📦 **Sidebar**
+      🔸 inject(`"theme"`) ✅
+📦 **Orphan**
+  🔸 inject(`"missing"`) (has default) ❌ _no provider_
+📦 **UnusedProvider**
+  🔹 provide(`"stale"`) ⚠️ _unused_


### PR DESCRIPTION
## Summary
- add a fixture-backed provide/inject tree snapshot covering pass-through nodes, fan-out, unused provides, and defaulted unmatched injects
- snapshot the typed tree summary, serialized tree, and Markdown renderer output

Refs #2747

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p vize_croquis_cf --profile ci test_snapshot_provide_inject_tree_outputs -- --nocapture
- cargo test -p vize_croquis_cf --profile ci
- cargo clippy -p vize_croquis_cf --lib --profile ci -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786226071&installation_id=136613492&pr_number=2786&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2786&signature=e9a2b09f69bcae630a5094f1032cb18dea85e240241da7c99f7c8fc2bcf13019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added snapshot coverage for component interaction analysis across multiple Vue files.
  * Expanded validation of analysis output, including summary metrics, tree output, and Markdown rendering.
  * Included scenarios for matched and unmatched injected values, fallback handling, missing links, and unused providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->