### PR TITLE
feat(croquis-cf): expose fallthrough usage facts

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/core/run.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/run.rs
@@ -30,6 +30,7 @@ impl CrossFileAnalyzer {
             let usage_facts = rules::collect_fallthrough_usage_facts(&self.registry, &self.graph);
             result.fallthrough_component_facts =
                 rules::collect_fallthrough_component_facts(&info, &usage_facts);
+            result.fallthrough_usage_facts = usage_facts;
             result.fallthrough_summary = Some(rules::summarize_fallthrough(&info));
             result.fallthrough_info = info;
             result.diagnostics.extend(diags);

--- a/crates/vize_croquis_cf/src/analyzer/tests_snapshots.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_snapshots.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use vize_carton::append;
 use vize_croquis::AnalyzerOptions;
 
+mod fallthrough;
 mod full;
 mod graph;
 mod provide_inject;

--- a/crates/vize_croquis_cf/src/analyzer/tests_snapshots/fallthrough.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_snapshots/fallthrough.rs
@@ -1,0 +1,175 @@
+use super::*;
+use vize_carton::{CompactString, smallvec};
+use vize_croquis::analysis::{ComponentUsage, EventListener, PassedProp};
+use vize_croquis::macros::PropDefinition;
+use vize_croquis::{Croquis, ScopeId};
+
+fn prop(name: &str, start: u32, end: u32, dynamic: bool) -> PassedProp {
+    PassedProp {
+        name: CompactString::new(name),
+        value: None,
+        start,
+        end,
+        is_dynamic: dynamic,
+    }
+}
+
+fn event(name: &str, start: u32, end: u32) -> EventListener {
+    EventListener {
+        name: CompactString::new(name),
+        handler: None,
+        modifiers: smallvec![],
+        start,
+        end,
+    }
+}
+
+fn usage(
+    name: &str,
+    start: u32,
+    end: u32,
+    props: Vec<PassedProp>,
+    events: Vec<EventListener>,
+    has_spread_attrs: bool,
+) -> ComponentUsage {
+    ComponentUsage {
+        name: CompactString::new(name),
+        start,
+        end,
+        props: props.into_iter().collect(),
+        events: events.into_iter().collect(),
+        slots: smallvec![],
+        has_spread_attrs,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    }
+}
+
+fn declare_prop(analysis: &mut Croquis, name: &str) {
+    analysis.macros.add_prop(PropDefinition {
+        name: CompactString::new(name),
+        prop_type: None,
+        required: false,
+        default_value: None,
+    });
+}
+
+fn sorted_diagnostics(result: &crate::analyzer::CrossFileResult) -> Vec<String> {
+    let mut diagnostics = result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            let mut related = diagnostic.related_files.clone();
+            related.sort_by_key(|related| (related.0.as_u32(), related.1, related.2.clone()));
+            format!(
+                "{:?}@{}:{}:{} related={:?}",
+                diagnostic.kind,
+                diagnostic.primary_file.as_u32(),
+                diagnostic.primary_offset,
+                diagnostic.primary_end_offset,
+                related
+            )
+        })
+        .collect::<Vec<_>>();
+    diagnostics.sort();
+    diagnostics
+}
+
+#[test]
+fn test_snapshot_fallthrough_usage_facts() {
+    let mut analyzer =
+        CrossFileAnalyzer::new(CrossFileOptions::default().with_fallthrough_attrs(true));
+
+    let mut panel = Croquis::new();
+    panel.template_info.root_element_count = 2;
+    panel.template_info.content_end = 120;
+    declare_prop(&mut panel, "kind");
+
+    let mut forwarder = Croquis::new();
+    forwarder.template_info.root_element_count = 1;
+    forwarder.template_info.uses_attrs = true;
+    forwarder.template_info.binds_attrs_explicitly = true;
+    forwarder.template_info.content_end = 90;
+
+    let mut app = Croquis::new();
+    app.used_components.insert(CompactString::new("Panel"));
+    app.used_components.insert(CompactString::new("Forwarder"));
+    app.component_usages.push(usage(
+        "Panel",
+        10,
+        90,
+        vec![
+            prop("kind", 18, 29, false),
+            prop("trackingId", 34, 58, true),
+            prop("class", 59, 72, false),
+        ],
+        vec![event("close", 73, 88)],
+        true,
+    ));
+    app.component_usages.push(usage(
+        "Forwarder",
+        100,
+        150,
+        vec![prop("data-testid", 110, 135, false)],
+        vec![event("focus", 136, 148)],
+        false,
+    ));
+
+    let mut shell = Croquis::new();
+    shell.used_components.insert(CompactString::new("Panel"));
+    shell.component_usages.push(usage(
+        "Panel",
+        20,
+        60,
+        vec![prop("telemetryKey", 28, 48, false)],
+        vec![],
+        false,
+    ));
+
+    analyzer.add_file_with_analysis(Path::new("Panel.vue"), "", panel);
+    analyzer.add_file_with_analysis(Path::new("Forwarder.vue"), "", forwarder);
+    analyzer.add_file_with_analysis(Path::new("App.vue"), "", app);
+    analyzer.add_file_with_analysis(Path::new("Shell.vue"), "", shell);
+    analyzer.rebuild_component_edges();
+
+    let result = analyzer.analyze();
+
+    assert_eq!(result.fallthrough_usage_facts.len(), 3);
+    assert_eq!(result.fallthrough_component_facts.len(), 4);
+    assert_eq!(
+        result
+            .fallthrough_summary
+            .expect("fallthrough summary should be populated")
+            .risky_unconsumed_fallthrough_attr_count,
+        2
+    );
+
+    let mut output = String::new();
+    output.push_str("=== Fallthrough Usage Facts ===\n\n");
+    output.push_str("== Summary ==\n");
+    append!(
+        output,
+        "{}\n",
+        serde_json::to_string_pretty(&result.fallthrough_summary).unwrap()
+    );
+    output.push_str("\n== Usage Facts ==\n");
+    append!(
+        output,
+        "{}\n",
+        serde_json::to_string_pretty(&result.fallthrough_usage_facts).unwrap()
+    );
+    output.push_str("\n== Component Facts ==\n");
+    append!(
+        output,
+        "{}\n",
+        serde_json::to_string_pretty(&result.fallthrough_component_facts).unwrap()
+    );
+    output.push_str("\n== Diagnostics ==\n");
+    append!(
+        output,
+        "{}\n",
+        serde_json::to_string_pretty(&sorted_diagnostics(&result)).unwrap()
+    );
+
+    assert_snapshot!(output);
+}

--- a/crates/vize_croquis_cf/src/analyzer/tests_snapshots/snapshots/vize_croquis_cf__analyzer__tests_snapshots__fallthrough__snapshot_fallthrough_usage_facts.snap
+++ b/crates/vize_croquis_cf/src/analyzer/tests_snapshots/snapshots/vize_croquis_cf__analyzer__tests_snapshots__fallthrough__snapshot_fallthrough_usage_facts.snap
@@ -1,0 +1,233 @@
+---
+source: crates/vize_croquis_cf/src/analyzer/tests_snapshots/fallthrough.rs
+expression: output
+---
+=== Fallthrough Usage Facts ===
+
+== Summary ==
+{
+  "componentCount": 4,
+  "componentsWithPassedAttrs": 2,
+  "componentsConsumingFallthroughAttrs": 1,
+  "componentsWithPotentialIssues": 1,
+  "inheritAttrsDisabledCount": 0,
+  "usesAttrsCount": 1,
+  "bindsAttrsCount": 1,
+  "multiRootCount": 1,
+  "multiRootWithoutAttrsCount": 1,
+  "passedAttrCount": 7,
+  "declaredPropCount": 1,
+  "undeclaredPassedAttrCount": 6,
+  "consumedFallthroughAttrCount": 2,
+  "unconsumedFallthroughAttrCount": 4,
+  "safeStandardFallthroughAttrCount": 4,
+  "riskyUnconsumedFallthroughAttrCount": 2,
+  "maxPassedAttrs": 5,
+  "maxRootElementCount": 2
+}
+
+== Usage Facts ==
+[
+  {
+    "parentFileId": 2,
+    "childFileId": 0,
+    "componentName": "Panel",
+    "usageStart": 10,
+    "usageEnd": 90,
+    "hasSpreadAttrs": true,
+    "attrs": [
+      {
+        "name": "kind",
+        "kind": "prop",
+        "sourceStart": 18,
+        "sourceEnd": 29,
+        "dynamic": false,
+        "declaredProp": true,
+        "standardHtmlAttr": false,
+        "fallthrough": false
+      },
+      {
+        "name": "trackingId",
+        "kind": "prop",
+        "sourceStart": 34,
+        "sourceEnd": 58,
+        "dynamic": true,
+        "declaredProp": false,
+        "standardHtmlAttr": false,
+        "fallthrough": true
+      },
+      {
+        "name": "class",
+        "kind": "prop",
+        "sourceStart": 59,
+        "sourceEnd": 72,
+        "dynamic": false,
+        "declaredProp": false,
+        "standardHtmlAttr": true,
+        "fallthrough": true
+      },
+      {
+        "name": "onClose",
+        "kind": "listener",
+        "sourceStart": 73,
+        "sourceEnd": 88,
+        "dynamic": true,
+        "declaredProp": false,
+        "standardHtmlAttr": true,
+        "fallthrough": true
+      }
+    ]
+  },
+  {
+    "parentFileId": 3,
+    "childFileId": 0,
+    "componentName": "Panel",
+    "usageStart": 20,
+    "usageEnd": 60,
+    "hasSpreadAttrs": false,
+    "attrs": [
+      {
+        "name": "telemetryKey",
+        "kind": "prop",
+        "sourceStart": 28,
+        "sourceEnd": 48,
+        "dynamic": false,
+        "declaredProp": false,
+        "standardHtmlAttr": false,
+        "fallthrough": true
+      }
+    ]
+  },
+  {
+    "parentFileId": 2,
+    "childFileId": 1,
+    "componentName": "Forwarder",
+    "usageStart": 100,
+    "usageEnd": 150,
+    "hasSpreadAttrs": false,
+    "attrs": [
+      {
+        "name": "data-testid",
+        "kind": "prop",
+        "sourceStart": 110,
+        "sourceEnd": 135,
+        "dynamic": false,
+        "declaredProp": false,
+        "standardHtmlAttr": true,
+        "fallthrough": true
+      },
+      {
+        "name": "onFocus",
+        "kind": "listener",
+        "sourceStart": 136,
+        "sourceEnd": 148,
+        "dynamic": true,
+        "declaredProp": false,
+        "standardHtmlAttr": true,
+        "fallthrough": true
+      }
+    ]
+  }
+]
+
+== Component Facts ==
+[
+  {
+    "fileId": 0,
+    "usageCount": 2,
+    "parentCount": 2,
+    "spreadUsageCount": 1,
+    "passedAttrCount": 5,
+    "usageAttrCount": 5,
+    "propAttrCount": 4,
+    "listenerAttrCount": 1,
+    "dynamicAttrCount": 2,
+    "declaredPropAttrCount": 1,
+    "fallthroughAttrCount": 4,
+    "consumedFallthroughAttrCount": 0,
+    "unconsumedFallthroughAttrCount": 4,
+    "safeStandardFallthroughAttrCount": 2,
+    "riskyUnconsumedFallthroughAttrCount": 2,
+    "declaredPropCount": 1,
+    "rootElementCount": 2,
+    "inheritAttrsDisabled": false,
+    "usesAttrs": false,
+    "bindsAttrs": false,
+    "hasPotentialIssues": true
+  },
+  {
+    "fileId": 1,
+    "usageCount": 1,
+    "parentCount": 1,
+    "spreadUsageCount": 0,
+    "passedAttrCount": 2,
+    "usageAttrCount": 2,
+    "propAttrCount": 1,
+    "listenerAttrCount": 1,
+    "dynamicAttrCount": 1,
+    "declaredPropAttrCount": 0,
+    "fallthroughAttrCount": 2,
+    "consumedFallthroughAttrCount": 2,
+    "unconsumedFallthroughAttrCount": 0,
+    "safeStandardFallthroughAttrCount": 2,
+    "riskyUnconsumedFallthroughAttrCount": 0,
+    "declaredPropCount": 0,
+    "rootElementCount": 1,
+    "inheritAttrsDisabled": false,
+    "usesAttrs": true,
+    "bindsAttrs": true,
+    "hasPotentialIssues": false
+  },
+  {
+    "fileId": 2,
+    "usageCount": 0,
+    "parentCount": 0,
+    "spreadUsageCount": 0,
+    "passedAttrCount": 0,
+    "usageAttrCount": 0,
+    "propAttrCount": 0,
+    "listenerAttrCount": 0,
+    "dynamicAttrCount": 0,
+    "declaredPropAttrCount": 0,
+    "fallthroughAttrCount": 0,
+    "consumedFallthroughAttrCount": 0,
+    "unconsumedFallthroughAttrCount": 0,
+    "safeStandardFallthroughAttrCount": 0,
+    "riskyUnconsumedFallthroughAttrCount": 0,
+    "declaredPropCount": 0,
+    "rootElementCount": 0,
+    "inheritAttrsDisabled": false,
+    "usesAttrs": false,
+    "bindsAttrs": false,
+    "hasPotentialIssues": false
+  },
+  {
+    "fileId": 3,
+    "usageCount": 0,
+    "parentCount": 0,
+    "spreadUsageCount": 0,
+    "passedAttrCount": 0,
+    "usageAttrCount": 0,
+    "propAttrCount": 0,
+    "listenerAttrCount": 0,
+    "dynamicAttrCount": 0,
+    "declaredPropAttrCount": 0,
+    "fallthroughAttrCount": 0,
+    "consumedFallthroughAttrCount": 0,
+    "unconsumedFallthroughAttrCount": 0,
+    "safeStandardFallthroughAttrCount": 0,
+    "riskyUnconsumedFallthroughAttrCount": 0,
+    "declaredPropCount": 0,
+    "rootElementCount": 0,
+    "inheritAttrsDisabled": false,
+    "usesAttrs": false,
+    "bindsAttrs": false,
+    "hasPotentialIssues": false
+  }
+]
+
+== Diagnostics ==
+[
+  "MultiRootMissingAttrs@0:0:120 related=[(FileId(2), 34, \"trackingId passed to <Panel>\"), (FileId(2), 59, \"class passed to <Panel>\"), (FileId(2), 73, \"onClose passed to <Panel>\"), (FileId(3), 28, \"telemetryKey passed to <Panel>\")]",
+  "UnusedFallthroughAttrs { passed_attrs: [\"telemetryKey\", \"trackingId\"] }@0:0:120 related=[(FileId(2), 34, \"trackingId passed to <Panel>\"), (FileId(3), 28, \"telemetryKey passed to <Panel>\")]"
+]

--- a/crates/vize_croquis_cf/src/analyzer/types.rs
+++ b/crates/vize_croquis_cf/src/analyzer/types.rs
@@ -186,6 +186,9 @@ pub struct CrossFileResult {
     /// Fallthrough attribute information per component.
     pub fallthrough_info: Vec<rules::FallthroughInfo>,
 
+    /// Per-usage fallthrough facts with parent-side source ranges.
+    pub fallthrough_usage_facts: Vec<rules::FallthroughUsageFact>,
+
     /// Fallthrough attribute summary, populated when fallthrough analysis is enabled.
     pub fallthrough_summary: Option<rules::FallthroughSummary>,
 


### PR DESCRIPTION
## Summary
- expose per-usage fallthrough facts on CrossFileResult so consumers can read parent-side source ranges
- add analyzer snapshot coverage for declared props, dynamic attrs, listeners, spread usage, aggregate facts, and related diagnostics

Refs #2749

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p vize_croquis_cf --profile ci test_snapshot_fallthrough_usage_facts -- --nocapture
- cargo test -p vize_croquis_cf --profile ci
- cargo clippy -p vize_croquis_cf --lib --profile ci -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786228433&installation_id=136613492&pr_number=2787&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2787&signature=a7cb0c9357e761b0eddf9743e83efeebfe1e4996e6dd6c5ac2d2f8fc127699d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fallthrough analysis results now correctly include usage details.
  * Fallthrough risk summaries and related component information are now reported consistently.

* **Tests**
  * Added coverage and snapshot validation for fallthrough analysis, including usage facts, component facts, risk metrics, and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->