### PR TITLE
fix(croquis-cf): report spread attrs on multi-root components

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/tests_fallthrough.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_fallthrough.rs
@@ -1,9 +1,24 @@
 use super::{CrossFileAnalyzer, CrossFileOptions};
+use crate::diagnostics::CrossFileDiagnosticKind;
 use std::path::Path;
-use vize_carton::{CompactString, smallvec};
+use vize_armature::parse;
+use vize_carton::{Bump, CompactString, smallvec};
 use vize_croquis::analysis::{ComponentUsage, EventListener, PassedProp};
 use vize_croquis::macros::PropDefinition;
-use vize_croquis::{Croquis, ScopeId};
+use vize_croquis::{Analyzer, AnalyzerOptions, Croquis, ScopeId};
+
+fn analyze_template(template: &str) -> Croquis {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, template);
+    assert!(
+        errors.is_empty(),
+        "template should parse cleanly: {errors:?}"
+    );
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_template(&root);
+    analyzer.finish()
+}
 
 #[test]
 fn fallthrough_component_facts_are_populated_from_analyzer() {
@@ -70,4 +85,72 @@ fn fallthrough_component_facts_are_populated_from_analyzer() {
     assert_eq!(fact.fallthrough_attr_count, 2);
     assert_eq!(fact.risky_unconsumed_fallthrough_attr_count, 1);
     assert!(fact.has_potential_issues);
+}
+
+#[test]
+fn parsed_spread_attrs_report_multi_root_child() {
+    let mut analyzer =
+        CrossFileAnalyzer::new(CrossFileOptions::default().with_fallthrough_attrs(true));
+    let child_id = analyzer.add_file_with_analysis(
+        Path::new("Child.vue"),
+        "",
+        analyze_template("<main></main><aside></aside>"),
+    );
+    let parent_id = analyzer.add_file_with_analysis(
+        Path::new("Parent.vue"),
+        "",
+        analyze_template(r#"<Child v-bind="attrs" />"#),
+    );
+    analyzer.rebuild_component_edges();
+
+    let result = analyzer.analyze();
+    let usage = result
+        .fallthrough_usage_facts
+        .iter()
+        .find(|fact| fact.child_file_id == child_id)
+        .expect("parsed component usage should be retained");
+    assert_eq!(usage.parent_file_id, parent_id);
+    assert!(usage.has_spread_attrs);
+    assert!(usage.attrs.is_empty());
+
+    let diagnostic = result
+        .diagnostics
+        .iter()
+        .find(|diagnostic| {
+            matches!(
+                diagnostic.kind,
+                CrossFileDiagnosticKind::MultiRootMissingAttrs
+            )
+        })
+        .expect("spread attrs should report the multi-root child");
+    assert_eq!(diagnostic.primary_file, child_id);
+    assert_eq!(diagnostic.related_files.len(), 1);
+    assert_eq!(diagnostic.related_files[0].0, parent_id);
+    assert_eq!(diagnostic.related_files[0].1, usage.usage_start);
+}
+
+#[test]
+fn parsed_spread_attrs_allow_explicit_attrs_binding() {
+    let mut analyzer =
+        CrossFileAnalyzer::new(CrossFileOptions::default().with_fallthrough_attrs(true));
+    analyzer.add_file_with_analysis(
+        Path::new("Child.vue"),
+        "",
+        analyze_template(r#"<main v-bind="$attrs"></main><aside></aside>"#),
+    );
+    analyzer.add_file_with_analysis(
+        Path::new("Parent.vue"),
+        "",
+        analyze_template(r#"<Child v-bind="attrs" />"#),
+    );
+    analyzer.rebuild_component_edges();
+
+    let result = analyzer.analyze();
+
+    assert_eq!(result.fallthrough_usage_facts.len(), 1);
+    assert!(result.fallthrough_usage_facts[0].has_spread_attrs);
+    assert!(result.diagnostics.iter().all(|diagnostic| !matches!(
+        diagnostic.kind,
+        CrossFileDiagnosticKind::MultiRootMissingAttrs
+    )));
 }

--- a/crates/vize_croquis_cf/src/analyzer/tests_snapshots/snapshots/vize_croquis_cf__analyzer__tests_snapshots__fallthrough__snapshot_fallthrough_usage_facts.snap
+++ b/crates/vize_croquis_cf/src/analyzer/tests_snapshots/snapshots/vize_croquis_cf__analyzer__tests_snapshots__fallthrough__snapshot_fallthrough_usage_facts.snap
@@ -228,6 +228,6 @@ expression: output
 
 == Diagnostics ==
 [
-  "MultiRootMissingAttrs@0:0:120 related=[(FileId(2), 34, \"trackingId passed to <Panel>\"), (FileId(2), 59, \"class passed to <Panel>\"), (FileId(2), 73, \"onClose passed to <Panel>\"), (FileId(3), 28, \"telemetryKey passed to <Panel>\")]",
+  "MultiRootMissingAttrs@0:0:120 related=[(FileId(2), 10, \"v-bind spread passed to <Panel>\"), (FileId(2), 34, \"trackingId passed to <Panel>\"), (FileId(2), 59, \"class passed to <Panel>\"), (FileId(2), 73, \"onClose passed to <Panel>\"), (FileId(3), 28, \"telemetryKey passed to <Panel>\")]",
   "UnusedFallthroughAttrs { passed_attrs: [\"telemetryKey\", \"trackingId\"] }@0:0:120 related=[(FileId(2), 34, \"trackingId passed to <Panel>\"), (FileId(3), 28, \"telemetryKey passed to <Panel>\")]"
 ]

--- a/crates/vize_croquis_cf/src/rules/fallthrough.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough.rs
@@ -139,6 +139,14 @@ pub fn analyze_fallthrough(
                     component_name: fact.component_name.clone(),
                 }),
         );
+        if fact.has_spread_attrs {
+            related.push(FallthroughUsageRelated {
+                parent_file_id: fact.parent_file_id,
+                attr_name: cstr!("v-bind spread"),
+                source_start: fact.usage_start,
+                component_name: fact.component_name.clone(),
+            });
+        }
     }
 
     // Merge passed attrs into infos
@@ -154,10 +162,9 @@ pub fn analyze_fallthrough(
     for info in &infos {
         // Check for multiple root elements without explicit $attrs binding
         if info.root_element_count > 1 && !info.binds_attrs {
-            let has_fallthrough = info
-                .passed_attrs
-                .iter()
-                .any(|attr| !info.declared_props.contains(attr));
+            let has_fallthrough = fallthrough_related_map
+                .get(&info.file_id)
+                .is_some_and(|related| !related.is_empty());
 
             if has_fallthrough {
                 // Use offset 0 to point to <template> tag start (wasm.rs adds tag_start offset)

--- a/crates/vize_croquis_cf/src/rules/fallthrough/diagnostics_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough/diagnostics_tests.rs
@@ -85,3 +85,94 @@ fn diagnostics_include_parent_usage_related_locations() {
     assert_eq!(unused.related_files[0].0, parent_id);
     assert_eq!(unused.related_files[0].1, 34);
 }
+
+#[test]
+fn spread_attrs_report_multi_root_with_parent_usage_location() {
+    let mut registry = ModuleRegistry::new();
+
+    let parent_analysis = {
+        let mut analysis = Croquis::new();
+        analysis.component_usages.push(ComponentUsage {
+            name: CompactString::new("Panel"),
+            start: 23,
+            end: 54,
+            props: smallvec![],
+            events: smallvec![],
+            slots: smallvec![],
+            has_spread_attrs: true,
+            scope_id: ScopeId::ROOT,
+            vif_guard: None,
+        });
+        analysis
+    };
+    let mut panel_analysis = Croquis::new();
+    panel_analysis.template_info.root_element_count = 2;
+
+    let (parent_id, _) = registry.register("Parent.vue", "", parent_analysis);
+    let (panel_id, _) = registry.register("Panel.vue", "", panel_analysis);
+
+    let mut graph = DependencyGraph::new();
+    graph.add_node(graph_node(parent_id, "Parent.vue", "Parent"));
+    graph.add_node(graph_node(panel_id, "Panel.vue", "Panel"));
+    graph.add_edge(parent_id, panel_id, DependencyEdge::ComponentUsage);
+
+    let (_infos, diagnostics) = analyze_fallthrough(&registry, &graph);
+    let multi_root = diagnostics
+        .iter()
+        .find(|diagnostic| {
+            matches!(
+                diagnostic.kind,
+                CrossFileDiagnosticKind::MultiRootMissingAttrs
+            )
+        })
+        .expect("spread attrs should trigger a multi-root diagnostic");
+
+    assert_eq!(multi_root.primary_file, panel_id);
+    assert_eq!(multi_root.related_files.len(), 1);
+    assert_eq!(multi_root.related_files[0].0, parent_id);
+    assert_eq!(multi_root.related_files[0].1, 23);
+    assert_eq!(
+        multi_root.related_files[0].2,
+        "v-bind spread passed to <Panel>"
+    );
+    assert!(diagnostics.iter().all(|diagnostic| !matches!(
+        diagnostic.kind,
+        CrossFileDiagnosticKind::UnusedFallthroughAttrs { .. }
+    )));
+}
+
+#[test]
+fn spread_attrs_are_safe_when_multi_root_component_binds_attrs() {
+    let mut registry = ModuleRegistry::new();
+
+    let mut parent_analysis = Croquis::new();
+    parent_analysis.component_usages.push(ComponentUsage {
+        name: CompactString::new("Panel"),
+        start: 10,
+        end: 40,
+        props: smallvec![],
+        events: smallvec![],
+        slots: smallvec![],
+        has_spread_attrs: true,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    });
+    let mut panel_analysis = Croquis::new();
+    panel_analysis.template_info.root_element_count = 2;
+    panel_analysis.template_info.binds_attrs_explicitly = true;
+
+    let (parent_id, _) = registry.register("Parent.vue", "", parent_analysis);
+    let (panel_id, _) = registry.register("Panel.vue", "", panel_analysis);
+
+    let mut graph = DependencyGraph::new();
+    graph.add_node(graph_node(parent_id, "Parent.vue", "Parent"));
+    graph.add_node(graph_node(panel_id, "Panel.vue", "Panel"));
+    graph.add_edge(parent_id, panel_id, DependencyEdge::ComponentUsage);
+
+    let (_infos, diagnostics) = analyze_fallthrough(&registry, &graph);
+
+    assert!(diagnostics.iter().all(|diagnostic| !matches!(
+        diagnostic.kind,
+        CrossFileDiagnosticKind::MultiRootMissingAttrs
+    )));
+}


### PR DESCRIPTION
## Summary
- treat parent-side `v-bind` spreads as evidence of fallthrough attrs when the child has multiple roots
- attach the parent component usage as a related diagnostic location
- add unit, parser-driven analyzer, false-positive boundary, and snapshot coverage

Refs #2749

## Validation
- `cargo test -p vize_croquis_cf --profile ci spread_attrs -- --nocapture`
- `cargo test -p vize_croquis_cf --profile ci`
- `cargo clippy -p vize_croquis_cf --lib --profile ci -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786229314&installation_id=136613492&pr_number=2788&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2788&signature=50535afe94e31622a12aea1a8834d92db13fbcb09d66cf4a8dba0ebb93051d99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallthrough-attribute diagnostics for components with multiple root elements.
  * `v-bind` spread attributes are now correctly recognized and reported with the relevant parent usage location.
  * Suppressed incorrect warnings when multi-root components explicitly bind `$attrs`.

* **Tests**
  * Added coverage for spread-attribute fallthrough across component boundaries and related diagnostic behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->