### PR TITLE
fix(vitrine): synchronize complexity wasm schema

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -396,7 +396,7 @@ jobs:
       - name: Install Pkl CLI
         run: npm install --global @pkl-community/pkl@0.27.2
       - name: Test
-        run: cargo test --workspace
+        run: cargo test --workspace && cargo test -p vize_vitrine --no-default-features --features wasm
 
   coverage:
     runs-on: blacksmith-32vcpu-ubuntu-2404

--- a/crates/vize_vitrine/src/wasm/cross_file_complexity.rs
+++ b/crates/vize_vitrine/src/wasm/cross_file_complexity.rs
@@ -27,6 +27,7 @@ mod tests {
                 component_count: 1,
                 template_if_count: 2,
                 prop_drilling_edge_count: 1,
+                provide_inject_fanout_count: 4,
                 ..ComplexityInput::default()
             },
             dimensions: ComplexityDimensionScores {
@@ -62,6 +63,7 @@ mod tests {
                         "globalStateReferenceCount": 0,
                         "provideInjectMaxDepth": 0,
                         "provideInjectReferenceCount": 0,
+                        "provideInjectFanoutCount": 4,
                         "fallthroughRiskCount": 0,
                         "reactiveNodeCount": 0,
                         "reactiveEdgeCount": 0,

--- a/playground/src/wasm/types/analysis.test.ts
+++ b/playground/src/wasm/types/analysis.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, expectTypeOf, it } from "vite-plus/test";
+import type {
+  CrossFileComplexityHotspot,
+  CrossFileComplexityInput,
+  CrossFileResult,
+} from "./analysis";
+
+const complexityInputFixture = {
+  componentCount: 1,
+  templateIfCount: 2,
+  templateForCount: 3,
+  templateLogicalOperatorCount: 4,
+  componentTreeVIfMaxDepth: 5,
+  componentTreeVForMaxDepth: 6,
+  componentTreeScopedSlotMaxDepth: 7,
+  componentTreeTemplateNestingScore: 8,
+  slotCount: 9,
+  propDrillingEdgeCount: 10,
+  globalStateReferenceCount: 11,
+  provideInjectMaxDepth: 12,
+  provideInjectReferenceCount: 13,
+  provideInjectFanoutCount: 14,
+  fallthroughRiskCount: 15,
+  reactiveNodeCount: 16,
+  reactiveEdgeCount: 17,
+  reactiveCycleCount: 18,
+} satisfies CrossFileComplexityInput;
+
+const complexityHotspotFixture = {
+  fileId: 7,
+  fileName: "App.vue",
+  componentName: "App",
+  input: complexityInputFixture,
+  dimensions: {
+    templateControlFlow: 1,
+    slotUsage: 2,
+    propDrilling: 3,
+    globalState: 4,
+    provideInject: 5,
+    fallthroughAttrs: 6,
+    reactiveGraph: 7,
+  },
+  totalScore: 28,
+  dominantDimension: {
+    dimension: "reactive-graph",
+    score: 7,
+  },
+} satisfies CrossFileComplexityHotspot;
+
+describe("CrossFileComplexityInput", () => {
+  it("keeps the serialized WASM input shape in sync", () => {
+    expect(Object.keys(complexityInputFixture)).toEqual([
+      "componentCount",
+      "templateIfCount",
+      "templateForCount",
+      "templateLogicalOperatorCount",
+      "componentTreeVIfMaxDepth",
+      "componentTreeVForMaxDepth",
+      "componentTreeScopedSlotMaxDepth",
+      "componentTreeTemplateNestingScore",
+      "slotCount",
+      "propDrillingEdgeCount",
+      "globalStateReferenceCount",
+      "provideInjectMaxDepth",
+      "provideInjectReferenceCount",
+      "provideInjectFanoutCount",
+      "fallthroughRiskCount",
+      "reactiveNodeCount",
+      "reactiveEdgeCount",
+      "reactiveCycleCount",
+    ]);
+    expect(complexityInputFixture.provideInjectFanoutCount).toBe(14);
+    expectTypeOf<CrossFileComplexityInput["provideInjectFanoutCount"]>().toEqualTypeOf<number>();
+  });
+
+  it("keeps ranked hotspots on the cross-file result contract", () => {
+    const result = {
+      complexityHotspots: [complexityHotspotFixture],
+    } satisfies Pick<CrossFileResult, "complexityHotspots">;
+
+    expect(result.complexityHotspots[0]?.dominantDimension).toEqual({
+      dimension: "reactive-graph",
+      score: 7,
+    });
+    expectTypeOf<CrossFileResult["complexityHotspots"]>().toEqualTypeOf<
+      CrossFileComplexityHotspot[]
+    >();
+  });
+});

--- a/playground/src/wasm/types/analysis.ts
+++ b/playground/src/wasm/types/analysis.ts
@@ -107,6 +107,7 @@ export interface CrossFileComplexityInput {
   globalStateReferenceCount: number;
   provideInjectMaxDepth: number;
   provideInjectReferenceCount: number;
+  provideInjectFanoutCount: number;
   fallthroughRiskCount: number;
   reactiveNodeCount: number;
   reactiveEdgeCount: number;
@@ -132,10 +133,35 @@ export interface CrossFileComplexityReport {
   band: "low" | "moderate" | "high" | "extreme";
 }
 
+export type CrossFileComplexityDimension =
+  | "template-control-flow"
+  | "slot-usage"
+  | "prop-drilling"
+  | "global-state"
+  | "provide-inject"
+  | "fallthrough-attrs"
+  | "reactive-graph";
+
+export interface CrossFileComplexityDimensionBreakdown {
+  dimension: CrossFileComplexityDimension;
+  score: number;
+}
+
+export interface CrossFileComplexityHotspot {
+  fileId: number;
+  fileName: string;
+  componentName: string | null;
+  input: CrossFileComplexityInput;
+  dimensions: CrossFileComplexityDimensions;
+  totalScore: number;
+  dominantDimension: CrossFileComplexityDimensionBreakdown | null;
+}
+
 export interface CrossFileResult {
   diagnostics: CrossFileDiagnostic[];
   circularDependencies: string[][];
   complexityReport: CrossFileComplexityReport;
+  complexityHotspots: CrossFileComplexityHotspot[];
   stats: CrossFileStats;
   filePaths: string[];
 }


### PR DESCRIPTION
## Summary
- synchronize `provideInjectFanoutCount` between Rust WASM JSON and the Playground contract
- type the ranked `complexityHotspots` payload already returned at runtime
- add exact key, runtime shape, and type-level contract tests
- run `vize_vitrine` WASM feature tests explicitly in Actions so the contract cannot silently execute zero tests

Refs #2748

## Validation
- `cargo test -p vize_vitrine --profile ci --no-default-features --features wasm`
- `cargo clippy -p vize_vitrine --no-default-features --features wasm --profile ci -- -D warnings`
- `vp test playground/src/wasm/types/analysis.test.ts`
- `vp check`
- `vp fmt --check playground/src/wasm/types/analysis.ts playground/src/wasm/types/analysis.test.ts .github/workflows/check.yml`
- `node --test tests/tooling/github-workflows.test.ts`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786229933&installation_id=136613492&pr_number=2790&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2790&signature=fda535e7ac591ef31f3c8b5905bbba8c47b3edcf7f3f1aaed0fc85642d24cdf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended WASM cross-file analysis results with `complexityHotspots`, including dominant dimension details.
  * Added `provideInjectFanoutCount` to the complexity input to track provide/inject fan-out.

* **Tests**
  * Added new TypeScript contract tests to validate exact shape and serialized key set for cross-file complexity inputs and hotspots.
  * Updated Rust/WASM test coverage to exercise the crate’s WASM feature contracts in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->