### PR TITLE
fix(croquis-cf): separate injection from reactive complexity

### DIFF
--- a/crates/vize_croquis_cf/src/rules.rs
+++ b/crates/vize_croquis_cf/src/rules.rs
@@ -15,6 +15,8 @@ mod complexity;
 #[cfg(test)]
 mod complexity_hotspots_tests;
 #[cfg(test)]
+mod complexity_injection_tests;
+#[cfg(test)]
 mod complexity_tests;
 mod component_resolution;
 pub(crate) mod cross_file_reactivity;

--- a/crates/vize_croquis_cf/src/rules/complexity.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity.rs
@@ -211,11 +211,12 @@ pub fn summarize_complexity_with_graph(
 fn complexity_input(registry: &ModuleRegistry, result: &CrossFileResult) -> ComplexityInput {
     let mut input = ComplexityInput {
         fallthrough_risk_count: fallthrough_risk_count(result),
+        // Provide/inject references have their own dimension and are not
+        // necessarily reactive. Only tracker-produced issues contribute here.
         reactive_edge_count: result
             .reactivity_issues
             .len()
-            .saturating_add(result.cross_file_reactivity_issues.len())
-            .saturating_add(result.provide_inject_matches.len()),
+            .saturating_add(result.cross_file_reactivity_issues.len()),
         reactive_cycle_count: result
             .cross_file_reactivity_issues
             .iter()

--- a/crates/vize_croquis_cf/src/rules/complexity/hotspots.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity/hotspots.rs
@@ -133,9 +133,9 @@ fn add_provide_inject_inputs(
         provider.provide_inject_reference_count += 1;
         provider.provide_inject_fanout_count += 1;
 
+        // A dependency injection edge is not inherently a reactive edge.
         let consumer = inputs.entry(matched.consumer).or_default();
         consumer.provide_inject_reference_count += 1;
-        consumer.reactive_edge_count += 1;
 
         let depth = matched.path.len();
         for file_id in &matched.path {

--- a/crates/vize_croquis_cf/src/rules/complexity_hotspots_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity_hotspots_tests.rs
@@ -115,12 +115,13 @@ fn ranks_hotspots_with_dimension_inputs_and_json_shape() {
     assert_eq!(hotspots[0].file_name, "Child.vue");
     assert_eq!(hotspots[0].component_name.as_deref(), Some("Child"));
     assert_eq!(hotspots[0].input.fallthrough_risk_count, 2);
-    assert_eq!(hotspots[0].input.reactive_edge_count, 3);
+    assert_eq!(hotspots[0].input.reactive_edge_count, 2);
     assert_eq!(hotspots[0].input.reactive_cycle_count, 1);
     assert_eq!(hotspots[0].input.provide_inject_max_depth, 2);
+    assert_eq!(hotspots[0].input.provide_inject_reference_count, 1);
     assert_eq!(hotspots[0].dimensions.fallthrough_attrs, 8);
-    assert_eq!(hotspots[0].dimensions.reactive_graph, 16);
-    assert_eq!(hotspots[0].total_score, 30);
+    assert_eq!(hotspots[0].dimensions.reactive_graph, 14);
+    assert_eq!(hotspots[0].total_score, 28);
     assert_eq!(
         hotspots[0].dominant_dimension.unwrap().dimension,
         ComplexityDimension::ReactiveGraph
@@ -132,6 +133,7 @@ fn ranks_hotspots_with_dimension_inputs_and_json_shape() {
     assert_eq!(hotspots[1].input.template_logical_operator_count, 1);
     assert_eq!(hotspots[1].input.slot_count, 1);
     assert_eq!(hotspots[1].input.prop_drilling_edge_count, 1);
+    assert_eq!(hotspots[1].input.provide_inject_reference_count, 1);
     assert_eq!(hotspots[1].input.provide_inject_fanout_count, 1);
     assert_eq!(hotspots[1].dimensions.template_control_flow, 4);
     assert_eq!(hotspots[1].total_score, 17);

--- a/crates/vize_croquis_cf/src/rules/complexity_injection_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity_injection_tests.rs
@@ -1,0 +1,33 @@
+use super::ProvideInjectMatch;
+use super::complexity::summarize_complexity;
+use crate::analyzer::CrossFileResult;
+use crate::registry::ModuleRegistry;
+use vize_carton::CompactString;
+use vize_croquis::Croquis;
+
+#[test]
+fn plain_provide_inject_matches_do_not_count_as_reactive_edges() {
+    let mut registry = ModuleRegistry::new();
+    let (provider, _) = registry.register("Provider.vue", "", Croquis::new());
+    let (consumer, _) = registry.register("Consumer.vue", "", Croquis::new());
+    let result = CrossFileResult {
+        provide_inject_matches: vec![ProvideInjectMatch {
+            provider,
+            consumer,
+            key: CompactString::new("theme"),
+            key_identity: CompactString::new("string:theme"),
+            path: vec![provider, consumer],
+            type_match: None,
+            provide_offset: 10,
+            inject_offset: 20,
+        }],
+        ..CrossFileResult::default()
+    };
+
+    let report = summarize_complexity(&registry, &result);
+
+    assert_eq!(report.input.provide_inject_reference_count, 1);
+    assert_eq!(report.input.reactive_edge_count, 0);
+    assert_eq!(report.dimensions.reactive_graph, 0);
+    assert_eq!(report.dimensions.provide_inject, 1);
+}


### PR DESCRIPTION
## Summary
- stop counting every provide/inject match as a reactive graph edge
- keep dependency-injection references and fan-out in their dedicated complexity dimension
- cover global reports and per-file hotspots with plain, non-reactive provide/inject facts

Refs #2748

## Validation
- `cargo test -p vize_croquis_cf --profile ci complexity -- --nocapture`
- `cargo test -p vize_croquis_cf --profile ci`
- `cargo clippy -p vize_croquis_cf --lib --profile ci -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786230055&installation_id=136613492&pr_number=2791&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2791&signature=1fc3e1496ae33fffb5d7519063bbdac165757a7adfcb3050a6869360e86e79ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated complexity hotspot scoring so plain provide/inject references are not counted as reactive edges.
  * Provide/inject references are now tracked separately, improving the accuracy of reactive graph metrics.

* **Tests**
  * Added coverage confirming correct provide/inject reference counts and complexity scores.
  * Updated hotspot scoring expectations to reflect the corrected calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->