### PR TITLE
fix(croquis): preserve reactive declaration offsets

### DIFF
--- a/crates/vize_croquis/src/croquis/snapshot_tests.rs
+++ b/crates/vize_croquis/src/croquis/snapshot_tests.rs
@@ -88,9 +88,16 @@ function save() {
             && inject.local_name == "theme"
             && inject.default_value.as_deref() == Some("'light'")
     }));
-    assert!(snapshot.reactive_sources.iter().any(|source| {
-        source.name == "doubled" && source.kind == "computed" && source.category == "computed"
-    }));
+    let doubled = snapshot
+        .reactive_sources
+        .iter()
+        .find(|source| source.name == "doubled")
+        .expect("computed source should be exposed");
+    let doubled_offset = script.find("doubled").unwrap() as u32;
+    assert_eq!(doubled.kind, "computed");
+    assert_eq!(doubled.category, "computed");
+    assert_eq!(doubled.declaration_offset, doubled_offset);
+    assert_eq!(doubled.id, format!("reactive:doubled@{doubled_offset}"));
     assert!(
         snapshot
             .scopes

--- a/crates/vize_croquis/src/drawer/tests/snapshots/vize_croquis__drawer__tests__script__drawer_script_bindings.snap
+++ b/crates/vize_croquis/src/drawer/tests/snapshots/vize_croquis__drawer__tests__script__drawer_script_bindings.snap
@@ -1222,7 +1222,7 @@ Croquis {
                 ),
                 name: "count",
                 kind: Ref,
-                declaration_offset: 0,
+                declaration_offset: 19,
             },
         ],
         by_name: {

--- a/crates/vize_croquis/src/reactivity_overlay_tests.rs
+++ b/crates/vize_croquis/src/reactivity_overlay_tests.rs
@@ -1,5 +1,6 @@
 use crate::effect_graph::EffectGraph;
 use crate::reactivity::{ReactiveKind, ReactivityTracker};
+use crate::script_parser::parse_script_setup;
 use vize_carton::CompactString;
 
 #[test]
@@ -48,4 +49,26 @@ fn overlay_sorts_sources_by_id_and_losses_by_range() {
     assert_eq!(overlay.sources[1].name.as_str(), "earlier");
     assert_eq!(overlay.losses[0].kind, "refValueExtract");
     assert_eq!(overlay.losses[1].kind, "reactiveSpread");
+}
+
+#[test]
+fn parser_overlay_preserves_reactive_declaration_offsets() {
+    let source = r#"import { ref as vue_ref } from 'vue'
+const greeting = 'こんにちは👋'
+const count = vue_ref(0), state = shallowReactive({ count: 0 })
+const doubled = computed(() => count.value * 2)
+"#;
+    let overlay = parse_script_setup(source).reactivity.overlay();
+
+    for source_overlay in &overlay.sources {
+        assert_eq!(
+            source_overlay.declaration_offset as usize,
+            source.find(source_overlay.name.as_str()).unwrap(),
+            "overlay offset for `{}`",
+            source_overlay.name
+        );
+    }
+
+    let json = serde_json::to_string_pretty(&overlay).unwrap();
+    insta::assert_snapshot!(json);
 }

--- a/crates/vize_croquis/src/script_parser/extract/reactivity.rs
+++ b/crates/vize_croquis/src/script_parser/extract/reactivity.rs
@@ -23,11 +23,14 @@ pub fn detect_reactivity_call(
         .unwrap_or(callee_name);
 
     match resolved_name {
-        "ref" | "shallowRef" => Some((ReactiveKind::Ref, BindingType::SetupRef)),
+        "ref" => Some((ReactiveKind::Ref, BindingType::SetupRef)),
+        "shallowRef" => Some((ReactiveKind::ShallowRef, BindingType::SetupRef)),
         "computed" => Some((ReactiveKind::Computed, BindingType::SetupRef)),
-        "reactive" | "shallowReactive" => {
-            Some((ReactiveKind::Reactive, BindingType::SetupReactiveConst))
-        }
+        "reactive" => Some((ReactiveKind::Reactive, BindingType::SetupReactiveConst)),
+        "shallowReactive" => Some((
+            ReactiveKind::ShallowReactive,
+            BindingType::SetupReactiveConst,
+        )),
         "toRef" => Some((ReactiveKind::ToRef, BindingType::SetupRef)),
         "toRefs" => Some((ReactiveKind::ToRefs, BindingType::SetupRef)),
         "customRef" => Some((ReactiveKind::Ref, BindingType::SetupRef)),

--- a/crates/vize_croquis/src/script_parser/process/macros.rs
+++ b/crates/vize_croquis/src/script_parser/process/macros.rs
@@ -44,7 +44,7 @@ pub(in crate::script_parser) fn process_variable_declarator(
     match &declarator.id {
         BindingPattern::BindingIdentifier(id) => {
             let name = id.name.as_str();
-
+            let at = id.span.start;
             // Record definition span for Go-to-Definition
             result
                 .binding_spans
@@ -69,7 +69,7 @@ pub(in crate::script_parser) fn process_variable_declarator(
                     if macro_kind == MacroKind::DefineModel {
                         result
                             .reactivity
-                            .register(CompactString::new(name), ReactiveKind::Ref, 0);
+                            .register(CompactString::new(name), ReactiveKind::Ref, at);
                     }
                     if matches!(macro_kind, MacroKind::DefineProps | MacroKind::WithDefaults) {
                         result.reactivity.register(
@@ -93,7 +93,7 @@ pub(in crate::script_parser) fn process_variable_declarator(
 
                     result
                         .reactivity
-                        .register(CompactString::new(name), reactive_kind, 0);
+                        .register(CompactString::new(name), reactive_kind, at);
                     result.bindings.add(name, binding_type);
                     // Walk into the call's callback arguments to track nested scopes
                     walk_call_arguments(result, call, source);

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
@@ -38,7 +38,7 @@ ScriptParseResult {
                 ),
                 name: "count",
                 kind: Ref,
-                declaration_offset: 0,
+                declaration_offset: 19,
             },
             ReactiveSource {
                 id: ReactiveId(
@@ -46,7 +46,7 @@ ScriptParseResult {
                 ),
                 name: "doubled",
                 kind: Computed,
-                declaration_offset: 0,
+                declaration_offset: 52,
             },
             ReactiveSource {
                 id: ReactiveId(
@@ -54,7 +54,7 @@ ScriptParseResult {
                 ),
                 name: "state",
                 kind: Reactive,
-                declaration_offset: 0,
+                declaration_offset: 112,
             },
         ],
         by_name: {

--- a/crates/vize_croquis/src/script_parser/tests.rs
+++ b/crates/vize_croquis/src/script_parser/tests.rs
@@ -1,5 +1,9 @@
+mod reactivity_offsets;
+
+use self::reactivity_offsets::assert_reactive_source;
 use super::{ScriptParserOptions, parse_script, parse_script_setup, parse_script_with_options};
 use crate::croquis::ComponentShape;
+use crate::reactivity::ReactiveKind;
 use crate::scope::{ScopeData, ScopeKind};
 use vize_carton::{CompactString, append, cstr};
 use vize_relief::BindingType;
@@ -299,34 +303,20 @@ fn test_parse_define_emits_runtime_object_spread_local_literal() {
 }
 
 #[test]
-fn test_parse_plain_script_exported_bindings() {
-    let result = parse_script(
-        r#"
-export const foo = 'bar'
-export function hello() {}
-export class MyClass {}
-"#,
-    );
-
-    assert!(result.bindings.contains("foo"));
-    assert!(result.bindings.contains("hello"));
-    assert!(result.bindings.contains("MyClass"));
-    assert!(result.invalid_exports.is_empty());
-}
-
-#[test]
 fn test_parse_reactivity() {
-    let result = parse_script_setup(
-        r#"
+    let source = r#"
             const count = ref(0)
             const doubled = computed(() => count.value * 2)
             const state = reactive({ name: 'hello' })
-        "#,
-    );
+        "#;
+    let result = parse_script_setup(source);
 
     assert!(result.reactivity.is_reactive("count"));
     assert!(result.reactivity.is_reactive("doubled"));
     assert!(result.reactivity.is_reactive("state"));
+    assert_reactive_source(&result, source, "count", ReactiveKind::Ref);
+    assert_reactive_source(&result, source, "doubled", ReactiveKind::Computed);
+    assert_reactive_source(&result, source, "state", ReactiveKind::Reactive);
     insta::assert_debug_snapshot!(result);
 }
 

--- a/crates/vize_croquis/src/script_parser/tests/reactivity_offsets.rs
+++ b/crates/vize_croquis/src/script_parser/tests/reactivity_offsets.rs
@@ -1,0 +1,114 @@
+use super::super::{ScriptParseResult, parse_script, parse_script_setup};
+use crate::reactivity::ReactiveKind;
+
+#[test]
+fn plain_script_exported_bindings_are_collected() {
+    let result = parse_script(
+        r#"
+export const foo = 'bar'
+export function hello() {}
+export class MyClass {}
+"#,
+    );
+
+    assert!(result.bindings.contains("foo"));
+    assert!(result.bindings.contains("hello"));
+    assert!(result.bindings.contains("MyClass"));
+    assert!(result.invalid_exports.is_empty());
+}
+
+pub(super) fn assert_reactive_source(
+    result: &ScriptParseResult,
+    source: &str,
+    name: &str,
+    expected_kind: ReactiveKind,
+) {
+    let reactive_source = result
+        .reactivity
+        .lookup(name)
+        .unwrap_or_else(|| panic!("expected reactive source `{name}`"));
+    let expected_offset = source
+        .find(name)
+        .unwrap_or_else(|| panic!("expected `{name}` in test source"));
+
+    assert_eq!(reactive_source.kind, expected_kind, "kind for `{name}`");
+    assert_eq!(
+        reactive_source.declaration_offset as usize, expected_offset,
+        "declaration byte offset for `{name}`"
+    );
+    assert_eq!(
+        source.get(expected_offset..expected_offset + name.len()),
+        Some(name),
+        "offset for `{name}` should select its identifier"
+    );
+}
+
+#[test]
+fn declaration_offsets_are_utf8_bytes_for_multiple_declarators() {
+    let source = r#"const unicode_prefix = '東京🦀'
+const first_ref = ref(0), second_state = reactive({}), third_computed = computed(() => first_ref.value)
+"#;
+    let result = parse_script_setup(source);
+
+    let first_offset = source.find("first_ref").unwrap();
+    assert_ne!(
+        first_offset,
+        source[..first_offset].chars().count(),
+        "the fixture must distinguish UTF-8 byte and character offsets"
+    );
+    assert_reactive_source(&result, source, "first_ref", ReactiveKind::Ref);
+    assert_reactive_source(&result, source, "second_state", ReactiveKind::Reactive);
+    assert_reactive_source(&result, source, "third_computed", ReactiveKind::Computed);
+}
+
+#[test]
+fn alias_offset_is_not_confused_by_parameter_shadowing() {
+    let source = r#"import { ref as make_ref } from 'vue'
+const aliased_ref = make_ref(0)
+const invoke_shadowed = (make_ref: () => unknown) => {
+    const shadowed_result = make_ref()
+    return shadowed_result
+}
+"#;
+    let result = parse_script_setup(source);
+
+    assert_reactive_source(&result, source, "aliased_ref", ReactiveKind::Ref);
+    assert_eq!(result.reactivity.count(), 1);
+    assert!(result.reactivity.lookup("shadowed_result").is_none());
+}
+
+#[test]
+fn wrapper_kinds_keep_declaration_offsets() {
+    let source = r#"const ref_value = ref(0)
+const shallow_ref_value = shallowRef(0)
+const reactive_value = reactive({ count: 0 })
+const shallow_reactive_value = shallowReactive({ count: 0 })
+const computed_value = computed(() => ref_value.value)
+const to_ref_value = toRef(reactive_value, 'count')
+const to_refs_value = toRefs(reactive_value)
+const readonly_value = readonly(reactive_value)
+const shallow_readonly_value = shallowReadonly(reactive_value)
+const custom_ref_value = customRef(() => ({}))
+const template_ref_value = useTemplateRef('input')
+const model_value = defineModel<number>()
+"#;
+    let result = parse_script_setup(source);
+
+    for (name, kind) in [
+        ("ref_value", ReactiveKind::Ref),
+        ("shallow_ref_value", ReactiveKind::ShallowRef),
+        ("reactive_value", ReactiveKind::Reactive),
+        ("shallow_reactive_value", ReactiveKind::ShallowReactive),
+        ("computed_value", ReactiveKind::Computed),
+        ("to_ref_value", ReactiveKind::ToRef),
+        ("to_refs_value", ReactiveKind::ToRefs),
+        ("readonly_value", ReactiveKind::Readonly),
+        ("shallow_readonly_value", ReactiveKind::ShallowReadonly),
+        ("custom_ref_value", ReactiveKind::Ref),
+        ("template_ref_value", ReactiveKind::ShallowRef),
+        ("model_value", ReactiveKind::Ref),
+    ] {
+        assert_reactive_source(&result, source, name, kind);
+    }
+    assert_eq!(result.reactivity.count(), 12);
+}

--- a/crates/vize_croquis/src/snapshots/vize_croquis__reactivity_overlay_tests__parser_overlay_preserves_reactive_declaration_offsets.snap
+++ b/crates/vize_croquis/src/snapshots/vize_croquis__reactivity_overlay_tests__parser_overlay_preserves_reactive_declaration_offsets.snap
@@ -1,17 +1,17 @@
 ---
-source: crates/vize_croquis/src/effect_graph_builder_tests.rs
+source: crates/vize_croquis/src/reactivity_overlay_tests.rs
 expression: json
 ---
 {
   "summary": {
-    "sourceCount": 2,
+    "sourceCount": 3,
     "refSourceCount": 1,
-    "reactiveSourceCount": 0,
+    "reactiveSourceCount": 1,
     "computedSourceCount": 1,
     "readonlySourceCount": 0,
     "needsValueAccessCount": 2,
     "lossCount": 0,
-    "effectEdgeCount": 2,
+    "effectEdgeCount": 0,
     "effectCycleCount": 0
   },
   "sources": [
@@ -21,31 +21,28 @@ expression: json
       "kind": "ref",
       "category": "ref",
       "needsValueAccess": true,
-      "declarationOffset": 56
+      "declarationOffset": 82
     },
     {
       "id": 1,
+      "name": "state",
+      "kind": "shallowReactive",
+      "category": "reactive",
+      "needsValueAccess": false,
+      "declarationOffset": 102
+    },
+    {
+      "id": 2,
       "name": "doubled",
       "kind": "computed",
       "category": "computed",
       "needsValueAccess": true,
-      "declarationOffset": 77
+      "declarationOffset": 146
     }
   ],
   "losses": [],
   "effectGraph": {
-    "edges": [
-      {
-        "from": "doubled",
-        "to": "count",
-        "category": "effectEdge"
-      },
-      {
-        "from": "watchEffect@119",
-        "to": "doubled",
-        "category": "effectEdge"
-      }
-    ],
+    "edges": [],
     "cycle": null
   }
 }


### PR DESCRIPTION
## Summary
- keep identifier byte offsets for reactive declarations and defineModel
- preserve shallowRef and shallowReactive source kinds
- cover Unicode, multi-declarator, alias/shadowing, snapshot, and overlay paths

Refs #2746

## Validation
- cargo test -p vize_croquis --profile ci
- cargo test -p vize_atelier_sfc
- cargo test -p vize_patina
- cargo test -p vize_croquis_cf
- cargo test -p vize_canon
- cargo clippy -p vize_croquis --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786231091&installation_id=136613492&pr_number=2792&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2792&signature=d5c15e4f968cfc1f2d591aa480a873c32ce638cda2264342827f87fa50a1cd3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected classification of `shallowReactive` bindings.
  * Improved tracking of reactive declaration locations, including aliases, multiple declarations, and UTF-8 source text.
  * Preserved accurate metadata for Vue reactivity helpers such as `ref`, `computed`, `toRef`, `defineModel`, and related APIs.

* **Tests**
  * Added comprehensive coverage validating reactive source types, declaration offsets, exported bindings, and parsed script metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->