### PR TITLE
feat(croquis-cf): score reactive effect graphs

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer.rs
+++ b/crates/vize_croquis_cf/src/analyzer.rs
@@ -22,6 +22,10 @@ mod tests_fallthrough;
 mod tests_element_id;
 
 #[cfg(test)]
+#[path = "analyzer/tests_complexity_effect_graph.rs"]
+mod tests_complexity_effect_graph;
+
+#[cfg(test)]
 mod tests_provide_inject;
 
 #[cfg(test)]

--- a/crates/vize_croquis_cf/src/analyzer/core.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core.rs
@@ -11,8 +11,9 @@ mod single_file;
 
 use super::types::CrossFileOptions;
 use crate::graph::DependencyGraph;
-use crate::registry::ModuleRegistry;
-use vize_croquis::AnalyzerOptions;
+use crate::registry::{FileId, ModuleRegistry};
+use vize_carton::FxHashMap;
+use vize_croquis::{AnalyzerOptions, EffectGraphSummary};
 
 /// Cross-file analyzer for Vue projects.
 pub struct CrossFileAnalyzer {
@@ -22,6 +23,8 @@ pub struct CrossFileAnalyzer {
     registry: ModuleRegistry,
     /// Dependency graph.
     graph: DependencyGraph,
+    /// Parser-built local reactive effect summaries by file.
+    effect_graph_summaries: FxHashMap<FileId, EffectGraphSummary>,
     /// Single-file analyzer options.
     single_file_options: AnalyzerOptions,
 }

--- a/crates/vize_croquis_cf/src/analyzer/core/accessors.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/accessors.rs
@@ -31,6 +31,7 @@ impl CrossFileAnalyzer {
     pub fn clear(&mut self) {
         self.registry.clear();
         self.graph = DependencyGraph::new();
+        self.effect_graph_summaries.clear();
     }
 
     pub(super) fn count_edges(&self) -> usize {

--- a/crates/vize_croquis_cf/src/analyzer/core/constructors.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/constructors.rs
@@ -12,6 +12,7 @@ impl CrossFileAnalyzer {
             options,
             registry: ModuleRegistry::new(),
             graph: DependencyGraph::new(),
+            effect_graph_summaries: Default::default(),
             single_file_options: AnalyzerOptions::full(),
         }
     }
@@ -22,6 +23,7 @@ impl CrossFileAnalyzer {
             options,
             registry: ModuleRegistry::with_project_root(root.as_ref()),
             graph: DependencyGraph::new(),
+            effect_graph_summaries: Default::default(),
             single_file_options: AnalyzerOptions::full(),
         }
     }

--- a/crates/vize_croquis_cf/src/analyzer/core/files.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/files.rs
@@ -2,7 +2,7 @@ use super::CrossFileAnalyzer;
 use crate::graph::{DependencyEdge, ModuleNode};
 use crate::registry::FileId;
 use std::path::Path;
-use vize_croquis::Croquis;
+use vize_croquis::{Croquis, build_effect_graph_from_script};
 
 impl CrossFileAnalyzer {
     /// Add a file to be analyzed.
@@ -14,6 +14,8 @@ impl CrossFileAnalyzer {
 
         // Register in module registry (takes ownership of analysis)
         let (file_id, is_new) = self.registry.register(path, source, analysis);
+        self.effect_graph_summaries
+            .insert(file_id, build_effect_graph_from_script(source).summary());
 
         if is_new {
             // Add to dependency graph
@@ -64,6 +66,8 @@ impl CrossFileAnalyzer {
 
         // Register in module registry (takes ownership of analysis)
         let (file_id, is_new) = self.registry.register(path, source, analysis);
+        self.effect_graph_summaries
+            .insert(file_id, build_effect_graph_from_script(source).summary());
 
         if is_new {
             // Add to dependency graph

--- a/crates/vize_croquis_cf/src/analyzer/core/run.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/run.rs
@@ -114,9 +114,17 @@ impl CrossFileAnalyzer {
             result.diagnostics.extend(diags);
         }
 
-        result.complexity_report =
-            rules::summarize_complexity_with_graph(&self.registry, &self.graph, &result);
-        result.complexity_hotspots = rules::summarize_complexity_hotspots(&self.registry, &result);
+        result.complexity_report = rules::summarize_complexity_with_effect_graphs(
+            &self.registry,
+            &self.graph,
+            &self.effect_graph_summaries,
+            &result,
+        );
+        result.complexity_hotspots = rules::summarize_complexity_hotspots_with_effect_graphs(
+            &self.registry,
+            &self.effect_graph_summaries,
+            &result,
+        );
 
         dedupe_diagnostics(&mut result.diagnostics);
         sort_diagnostics(&mut result.diagnostics);

--- a/crates/vize_croquis_cf/src/analyzer/tests_complexity_effect_graph.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_complexity_effect_graph.rs
@@ -1,0 +1,179 @@
+use super::{CrossFileAnalyzer, CrossFileOptions};
+use serde_json::json;
+
+const ALPHA_SOURCE: &str = r#"
+import { computed, ref } from 'vue'
+const count = ref(0)
+const doubled = computed(() => count.value * 2)
+"#;
+
+const BETA_SOURCE: &str = r#"
+import { computed, ref, watch, watchEffect } from 'vue'
+const count = ref(0)
+const doubled = computed(() => count.value * 2)
+watchEffect(() => console.log(doubled.value))
+watch(count, () => {})
+"#;
+
+#[test]
+fn parser_effect_graphs_drive_global_and_hotspot_complexity() {
+    let mut analyzer = CrossFileAnalyzer::new(CrossFileOptions::minimal());
+    analyzer.add_file("Alpha.vue", ALPHA_SOURCE);
+    analyzer.add_file("Beta.vue", BETA_SOURCE);
+
+    let result = analyzer.analyze();
+    let input = result.complexity_report.input;
+
+    assert_eq!(input.reactive_node_count, 4);
+    assert_eq!(input.reactive_edge_count, 4);
+    assert_eq!(input.reactive_cycle_count, 0);
+    assert_eq!(result.complexity_report.dimensions.reactive_graph, 12);
+    assert_eq!(result.complexity_hotspots.len(), 2);
+    assert_eq!(result.complexity_hotspots[0].file_name, "Beta.vue");
+    assert_eq!(result.complexity_hotspots[1].file_name, "Alpha.vue");
+
+    let hotspot_input = result
+        .complexity_hotspots
+        .iter()
+        .fold((0, 0, 0), |counts, hotspot| {
+            (
+                counts.0 + hotspot.input.reactive_node_count,
+                counts.1 + hotspot.input.reactive_edge_count,
+                counts.2 + hotspot.input.reactive_cycle_count,
+            )
+        });
+    assert_eq!(hotspot_input, (4, 4, 0));
+
+    assert_eq!(
+        serde_json::to_value(&result.complexity_hotspots).unwrap(),
+        json!([
+            {
+                "fileId": 1,
+                "fileName": "Beta.vue",
+                "componentName": "Beta",
+                "input": {
+                    "componentCount": 1,
+                    "templateIfCount": 0,
+                    "templateForCount": 0,
+                    "templateLogicalOperatorCount": 0,
+                    "componentTreeVIfMaxDepth": 0,
+                    "componentTreeVForMaxDepth": 0,
+                    "componentTreeScopedSlotMaxDepth": 0,
+                    "componentTreeTemplateNestingScore": 0,
+                    "slotCount": 0,
+                    "propDrillingEdgeCount": 0,
+                    "globalStateReferenceCount": 0,
+                    "provideInjectMaxDepth": 0,
+                    "provideInjectReferenceCount": 0,
+                    "provideInjectFanoutCount": 0,
+                    "fallthroughRiskCount": 0,
+                    "reactiveNodeCount": 2,
+                    "reactiveEdgeCount": 3,
+                    "reactiveCycleCount": 0
+                },
+                "dimensions": {
+                    "templateControlFlow": 1,
+                    "slotUsage": 0,
+                    "propDrilling": 0,
+                    "globalState": 0,
+                    "provideInject": 0,
+                    "fallthroughAttrs": 0,
+                    "reactiveGraph": 8
+                },
+                "totalScore": 9,
+                "dominantDimension": { "dimension": "reactive-graph", "score": 8 }
+            },
+            {
+                "fileId": 0,
+                "fileName": "Alpha.vue",
+                "componentName": "Alpha",
+                "input": {
+                    "componentCount": 1,
+                    "templateIfCount": 0,
+                    "templateForCount": 0,
+                    "templateLogicalOperatorCount": 0,
+                    "componentTreeVIfMaxDepth": 0,
+                    "componentTreeVForMaxDepth": 0,
+                    "componentTreeScopedSlotMaxDepth": 0,
+                    "componentTreeTemplateNestingScore": 0,
+                    "slotCount": 0,
+                    "propDrillingEdgeCount": 0,
+                    "globalStateReferenceCount": 0,
+                    "provideInjectMaxDepth": 0,
+                    "provideInjectReferenceCount": 0,
+                    "provideInjectFanoutCount": 0,
+                    "fallthroughRiskCount": 0,
+                    "reactiveNodeCount": 2,
+                    "reactiveEdgeCount": 1,
+                    "reactiveCycleCount": 0
+                },
+                "dimensions": {
+                    "templateControlFlow": 1,
+                    "slotUsage": 0,
+                    "propDrilling": 0,
+                    "globalState": 0,
+                    "provideInject": 0,
+                    "fallthroughAttrs": 0,
+                    "reactiveGraph": 4
+                },
+                "totalScore": 5,
+                "dominantDimension": { "dimension": "reactive-graph", "score": 4 }
+            }
+        ])
+    );
+}
+
+#[test]
+fn parser_effect_cycles_and_plain_controls_are_not_inferred_from_diagnostics() {
+    let mut cyclic = CrossFileAnalyzer::new(CrossFileOptions::minimal());
+    cyclic.add_file(
+        "Cycle.vue",
+        r#"
+import { computed } from 'vue'
+const left = computed(() => right.value)
+const right = computed(() => left.value)
+"#,
+    );
+    let cyclic_result = cyclic.analyze();
+    assert_eq!(cyclic_result.complexity_report.input.reactive_node_count, 2);
+    assert_eq!(cyclic_result.complexity_report.input.reactive_edge_count, 2);
+    assert_eq!(
+        cyclic_result.complexity_report.input.reactive_cycle_count,
+        1
+    );
+    assert_eq!(
+        cyclic_result.complexity_hotspots[0]
+            .dimensions
+            .reactive_graph,
+        16
+    );
+
+    let mut plain = CrossFileAnalyzer::new(CrossFileOptions::all());
+    plain.add_file("Plain.vue", "const value = 1\nconsole.log(value)");
+    let plain_result = plain.analyze();
+    assert_eq!(plain_result.complexity_report.input.reactive_node_count, 0);
+    assert_eq!(plain_result.complexity_report.input.reactive_edge_count, 0);
+    assert_eq!(plain_result.complexity_report.input.reactive_cycle_count, 0);
+    assert_eq!(
+        plain_result.complexity_hotspots[0]
+            .dimensions
+            .reactive_graph,
+        0
+    );
+}
+
+#[test]
+fn equally_scored_effect_hotspots_use_filename_order() {
+    let mut analyzer = CrossFileAnalyzer::new(CrossFileOptions::minimal());
+    analyzer.add_file("Zulu.vue", ALPHA_SOURCE);
+    analyzer.add_file("Alpha.vue", ALPHA_SOURCE);
+
+    let names: Vec<_> = analyzer
+        .analyze()
+        .complexity_hotspots
+        .into_iter()
+        .map(|hotspot| hotspot.file_name)
+        .collect();
+
+    assert_eq!(names, ["Alpha.vue", "Zulu.vue"]);
+}

--- a/crates/vize_croquis_cf/src/rules.rs
+++ b/crates/vize_croquis_cf/src/rules.rs
@@ -35,7 +35,9 @@ pub use boundary::{BoundaryInfo, BoundaryKind, analyze_boundaries};
 pub use complexity::{
     ComplexityBand, ComplexityDimension, ComplexityDimensionBreakdown, ComplexityDimensionScores,
     ComplexityHotspot, ComplexityInput, ComplexityReport, band_for_score,
-    summarize_complexity_hotspots, summarize_complexity_with_graph,
+};
+pub(crate) use complexity::{
+    summarize_complexity_hotspots_with_effect_graphs, summarize_complexity_with_effect_graphs,
 };
 pub use component_resolution::{ComponentResolutionIssue, analyze_component_resolution};
 pub use element_id::{UniqueIdIssue, analyze_element_ids};

--- a/crates/vize_croquis_cf/src/rules/complexity.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity.rs
@@ -5,11 +5,13 @@ mod nesting;
 
 use crate::analyzer::CrossFileResult;
 use crate::graph::DependencyGraph;
-use crate::registry::ModuleRegistry;
+use crate::registry::{FileId, ModuleRegistry};
 use crate::rules::cross_file_reactivity::CrossFileReactivityIssueKind;
-use vize_croquis::{ScopeKind, TemplateExpressionKind};
+use vize_carton::FxHashMap;
+use vize_croquis::{EffectGraphSummary, ScopeKind, TemplateExpressionKind};
 
-pub use hotspots::{ComplexityHotspot, summarize_complexity_hotspots};
+pub use hotspots::ComplexityHotspot;
+pub(crate) use hotspots::summarize_complexity_hotspots_with_effect_graphs;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -194,39 +196,36 @@ pub(super) fn summarize_complexity(
     registry: &ModuleRegistry,
     result: &CrossFileResult,
 ) -> ComplexityReport {
-    ComplexityReport::from_input(complexity_input(registry, result))
+    ComplexityReport::from_input(complexity_input(registry, &FxHashMap::default(), result))
 }
 
-/// Summarize complexity with component-tree template nesting signals.
-pub fn summarize_complexity_with_graph(
+#[cfg(test)]
+pub(super) fn summarize_complexity_with_effects(
     registry: &ModuleRegistry,
-    graph: &DependencyGraph,
+    effect_graphs: &FxHashMap<FileId, EffectGraphSummary>,
     result: &CrossFileResult,
 ) -> ComplexityReport {
-    let mut input = complexity_input(registry, result);
+    ComplexityReport::from_input(complexity_input(registry, effect_graphs, result))
+}
+
+pub(crate) fn summarize_complexity_with_effect_graphs(
+    registry: &ModuleRegistry,
+    graph: &DependencyGraph,
+    effect_graphs: &FxHashMap<FileId, EffectGraphSummary>,
+    result: &CrossFileResult,
+) -> ComplexityReport {
+    let mut input = complexity_input(registry, effect_graphs, result);
     nesting::add_component_tree_template_nesting(&mut input, registry, graph);
     ComplexityReport::from_input(input)
 }
 
-fn complexity_input(registry: &ModuleRegistry, result: &CrossFileResult) -> ComplexityInput {
+fn complexity_input(
+    registry: &ModuleRegistry,
+    effect_graphs: &FxHashMap<FileId, EffectGraphSummary>,
+    result: &CrossFileResult,
+) -> ComplexityInput {
     let mut input = ComplexityInput {
         fallthrough_risk_count: fallthrough_risk_count(result),
-        // Provide/inject references have their own dimension and are not
-        // necessarily reactive. Only tracker-produced issues contribute here.
-        reactive_edge_count: result
-            .reactivity_issues
-            .len()
-            .saturating_add(result.cross_file_reactivity_issues.len()),
-        reactive_cycle_count: result
-            .cross_file_reactivity_issues
-            .iter()
-            .filter(|issue| {
-                matches!(
-                    issue.kind,
-                    CrossFileReactivityIssueKind::CircularReactiveDependency { .. }
-                )
-            })
-            .count(),
         global_state_reference_count: result
             .reactivity_issues
             .iter()
@@ -296,6 +295,9 @@ fn complexity_input(registry: &ModuleRegistry, result: &CrossFileResult) -> Comp
             .map(|usage| usage.props.len())
             .sum::<usize>();
         input.reactive_node_count += analysis.reactivity.count();
+        let effect_graph = effect_graphs.get(&entry.id).copied().unwrap_or_default();
+        input.reactive_edge_count += effect_graph.edge_count;
+        input.reactive_cycle_count += effect_graph.cycle_count;
     }
 
     input

--- a/crates/vize_croquis_cf/src/rules/complexity/hotspots.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity/hotspots.rs
@@ -4,7 +4,7 @@ use crate::analyzer::CrossFileResult;
 use crate::registry::{FileId, ModuleEntry, ModuleRegistry};
 use crate::rules::ReactivityIssueKind;
 use vize_carton::{CompactString, FxHashMap};
-use vize_croquis::{ScopeKind, TemplateExpressionKind};
+use vize_croquis::{EffectGraphSummary, ScopeKind, TemplateExpressionKind};
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -18,12 +18,12 @@ pub struct ComplexityHotspot {
     pub dominant_dimension: Option<ComplexityDimensionBreakdown>,
 }
 
-/// Rank Vue files by their local contribution to the cross-file complexity score.
-pub fn summarize_complexity_hotspots(
+pub(crate) fn summarize_complexity_hotspots_with_effect_graphs(
     registry: &ModuleRegistry,
+    effect_graphs: &FxHashMap<FileId, EffectGraphSummary>,
     result: &CrossFileResult,
 ) -> Vec<ComplexityHotspot> {
-    let mut inputs = local_inputs(registry);
+    let mut inputs = local_inputs(registry, effect_graphs);
     add_fallthrough_inputs(&mut inputs, result);
     add_reactivity_inputs(&mut inputs, result);
     add_provide_inject_inputs(&mut inputs, result);
@@ -40,14 +40,20 @@ pub fn summarize_complexity_hotspots(
     hotspots
 }
 
-fn local_inputs(registry: &ModuleRegistry) -> FxHashMap<FileId, ComplexityInput> {
+fn local_inputs(
+    registry: &ModuleRegistry,
+    effect_graphs: &FxHashMap<FileId, EffectGraphSummary>,
+) -> FxHashMap<FileId, ComplexityInput> {
     registry
         .vue_components()
-        .map(|entry| (entry.id, local_input(entry)))
+        .map(|entry| {
+            let effect_graph = effect_graphs.get(&entry.id).copied().unwrap_or_default();
+            (entry.id, local_input(entry, effect_graph))
+        })
         .collect()
 }
 
-fn local_input(entry: &ModuleEntry) -> ComplexityInput {
+fn local_input(entry: &ModuleEntry, effect_graph: EffectGraphSummary) -> ComplexityInput {
     let analysis = &entry.analysis;
 
     ComplexityInput {
@@ -80,6 +86,8 @@ fn local_input(entry: &ModuleEntry) -> ComplexityInput {
             .map(|usage| usage.props.len())
             .sum(),
         reactive_node_count: analysis.reactivity.count(),
+        reactive_edge_count: effect_graph.edge_count,
+        reactive_cycle_count: effect_graph.cycle_count,
         ..ComplexityInput::default()
     }
 }
@@ -103,7 +111,6 @@ fn add_reactivity_inputs(
 ) {
     for issue in &result.reactivity_issues {
         let input = inputs.entry(issue.file_id).or_default();
-        input.reactive_edge_count += 1;
         if matches!(issue.kind, ReactivityIssueKind::ShouldUseStoreToRefs { .. }) {
             input.global_state_reference_count += 1;
         }
@@ -111,15 +118,8 @@ fn add_reactivity_inputs(
 
     for issue in &result.cross_file_reactivity_issues {
         let input = inputs.entry(issue.file_id).or_default();
-        input.reactive_edge_count += 1;
-        match issue.kind {
-            CrossFileReactivityIssueKind::StoreDestructured { .. } => {
-                input.global_state_reference_count += 1;
-            }
-            CrossFileReactivityIssueKind::CircularReactiveDependency { .. } => {
-                input.reactive_cycle_count += 1;
-            }
-            _ => {}
+        if let CrossFileReactivityIssueKind::StoreDestructured { .. } = issue.kind {
+            input.global_state_reference_count += 1;
         }
     }
 }

--- a/crates/vize_croquis_cf/src/rules/complexity_hotspots_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity_hotspots_tests.rs
@@ -1,6 +1,7 @@
 use super::{
     ComplexityDimension, CrossFileReactivityIssue, CrossFileReactivityIssueKind, FallthroughInfo,
-    ProvideInjectMatch, ReactivityIssue, ReactivityIssueKind, summarize_complexity_hotspots,
+    ProvideInjectMatch, ReactivityIssue, ReactivityIssueKind,
+    summarize_complexity_hotspots_with_effect_graphs,
 };
 use crate::analyzer::CrossFileResult;
 use crate::diagnostics::DiagnosticSeverity;
@@ -8,7 +9,7 @@ use crate::registry::ModuleRegistry;
 use vize_carton::{CompactString, FxHashSet, smallvec};
 use vize_croquis::analysis::{ComponentUsage, PassedProp, SlotUsage, TemplateExpression};
 use vize_croquis::reactivity::ReactiveKind;
-use vize_croquis::{Croquis, ScopeId, TemplateExpressionKind, VForScopeData};
+use vize_croquis::{Croquis, EffectGraphSummary, ScopeId, TemplateExpressionKind, VForScopeData};
 
 #[test]
 fn ranks_hotspots_with_dimension_inputs_and_json_shape() {
@@ -110,7 +111,28 @@ fn ranks_hotspots_with_dimension_inputs_and_json_shape() {
         ..CrossFileResult::default()
     };
 
-    let hotspots = summarize_complexity_hotspots(&registry, &result);
+    let effect_graphs = vize_carton::FxHashMap::from_iter([
+        (
+            parent_id,
+            EffectGraphSummary {
+                node_count: 2,
+                edge_count: 1,
+                cycle_count: 0,
+                cycle_node_count: 0,
+            },
+        ),
+        (
+            child_id,
+            EffectGraphSummary {
+                node_count: 3,
+                edge_count: 2,
+                cycle_count: 1,
+                cycle_node_count: 2,
+            },
+        ),
+    ]);
+    let hotspots =
+        summarize_complexity_hotspots_with_effect_graphs(&registry, &effect_graphs, &result);
 
     assert_eq!(hotspots.len(), 2);
     assert_eq!(hotspots[0].file_id, child_id);

--- a/crates/vize_croquis_cf/src/rules/complexity_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity_tests.rs
@@ -1,8 +1,8 @@
-use super::complexity::summarize_complexity;
+use super::complexity::{summarize_complexity, summarize_complexity_with_effects};
 use super::{
     ComplexityBand, ComplexityDimension, ComplexityInput, ComplexityReport, FallthroughInfo,
     FallthroughSummary, ProvideInjectTreeSummary, ReactivityIssue, ReactivityIssueKind,
-    summarize_complexity_with_graph,
+    summarize_complexity_with_effect_graphs,
 };
 use crate::analyzer::CrossFileResult;
 use crate::graph::{DependencyEdge, DependencyGraph, ModuleNode};
@@ -12,7 +12,7 @@ use vize_croquis::croquis::{
     ComponentUsage, EventListener, PassedProp, SlotUsage, TemplateExpression,
     TemplateExpressionKind,
 };
-use vize_croquis::{Croquis, ScopeId, VForScopeData, VSlotScopeData};
+use vize_croquis::{Croquis, EffectGraphSummary, ScopeId, VForScopeData, VSlotScopeData};
 
 #[test]
 fn scores_each_complexity_dimension() {
@@ -173,7 +173,14 @@ fn summarizes_complexity_from_registry_and_result() {
         ..CrossFileResult::default()
     };
 
-    let report = summarize_complexity(&registry, &result);
+    let effect_graphs = vize_carton::FxHashMap::from_iter([(
+        file_id,
+        EffectGraphSummary {
+            edge_count: 1,
+            ..EffectGraphSummary::default()
+        },
+    )]);
+    let report = summarize_complexity_with_effects(&registry, &effect_graphs, &result);
 
     assert_eq!(report.input.template_if_count, 1);
     assert_eq!(report.input.template_for_count, 1);
@@ -293,7 +300,12 @@ fn summarizes_component_tree_template_nesting() {
     graph.add_node(component_node(child_id, "Child.vue", "Child"));
     graph.add_edge(parent_id, child_id, DependencyEdge::ComponentUsage);
 
-    let report = summarize_complexity_with_graph(&registry, &graph, &CrossFileResult::default());
+    let report = summarize_complexity_with_effect_graphs(
+        &registry,
+        &graph,
+        &vize_carton::FxHashMap::default(),
+        &CrossFileResult::default(),
+    );
 
     assert_eq!(report.input.template_if_count, 1);
     assert_eq!(report.input.template_for_count, 2);

--- a/crates/vize_vitrine/src/wasm/cross_file_complexity.rs
+++ b/crates/vize_vitrine/src/wasm/cross_file_complexity.rs
@@ -92,4 +92,74 @@ mod tests {
     fn complexity_hotspots_json_serializes_empty_list() {
         assert_eq!(complexity_hotspots_json(&[]), json!([]));
     }
+
+    #[test]
+    fn parser_effect_graph_counts_reach_wasm_complexity_json() {
+        const SOURCE: &str = r#"
+import { computed, ref, watch, watchEffect } from 'vue'
+const count = ref(0)
+const doubled = computed(() => count.value * 2)
+watchEffect(() => console.log(doubled.value))
+watch(count, () => {})
+"#;
+
+        let mut drawer =
+            vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full());
+        drawer.analyze_script_setup(SOURCE);
+        let mut analyzer =
+            vize_croquis_cf::CrossFileAnalyzer::new(vize_croquis_cf::CrossFileOptions::minimal());
+        analyzer.add_file_with_analysis("Reactive.vue", SOURCE, drawer.finish());
+        let result = analyzer.analyze();
+
+        assert_eq!(
+            complexity_report_json(&result.complexity_report),
+            json!({
+                "input": {
+                    "componentCount": 1,
+                    "templateIfCount": 0,
+                    "templateForCount": 0,
+                    "templateLogicalOperatorCount": 0,
+                    "componentTreeVIfMaxDepth": 0,
+                    "componentTreeVForMaxDepth": 0,
+                    "componentTreeScopedSlotMaxDepth": 0,
+                    "componentTreeTemplateNestingScore": 0,
+                    "slotCount": 0,
+                    "propDrillingEdgeCount": 0,
+                    "globalStateReferenceCount": 0,
+                    "provideInjectMaxDepth": 0,
+                    "provideInjectReferenceCount": 0,
+                    "provideInjectFanoutCount": 0,
+                    "fallthroughRiskCount": 0,
+                    "reactiveNodeCount": 2,
+                    "reactiveEdgeCount": 3,
+                    "reactiveCycleCount": 0
+                },
+                "dimensions": {
+                    "templateControlFlow": 1,
+                    "slotUsage": 0,
+                    "propDrilling": 0,
+                    "globalState": 0,
+                    "provideInject": 0,
+                    "fallthroughAttrs": 0,
+                    "reactiveGraph": 8
+                },
+                "cyclomaticScore": 1,
+                "cognitiveScore": 0,
+                "totalScore": 9,
+                "band": "low"
+            })
+        );
+        assert_eq!(
+            complexity_hotspots_json(&result.complexity_hotspots),
+            json!([{
+                "fileId": 0,
+                "fileName": "Reactive.vue",
+                "componentName": "Reactive",
+                "input": result.complexity_report.input,
+                "dimensions": result.complexity_report.dimensions,
+                "totalScore": 9,
+                "dominantDimension": { "dimension": "reactive-graph", "score": 8 }
+            }])
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- derive reactive complexity edges and cycles from parser-built Croquis effect graphs
- keep global reports and per-file hotspots on the same effect summary inputs
- remove diagnostic and dependency-injection counts from reactive graph scoring
- verify non-zero effect graph values reach the WASM complexity payload

Refs #2748
Refs #2746

## Validation
- cargo test -p vize_croquis_cf --profile ci
- cargo test -p vize_vitrine --no-default-features --features wasm --profile ci
- cargo clippy -p vize_croquis_cf --lib --profile ci -- -D warnings
- cargo clippy -p vize_vitrine --lib --no-default-features --features wasm --profile ci -- -D warnings
- cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786232607&installation_id=136613492&pr_number=2795&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2795&signature=d69de82997555e32fe9635683eba8032d01e633a8ef422cb5473cec38b156181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Cross-file complexity analysis now includes reactive effect-graph metrics.
  * Complexity reports and hotspots provide more accurate reactive graph dimensions, including edges and cycles.
  * Reactive graph data is reflected in exported complexity JSON results.

* **Bug Fixes**
  * Improved detection of cross-file reactive cycles and complexity hotspots.
  * Ensured deterministic hotspot ordering when scores are equal.

* **Tests**
  * Added coverage for reactive graphs, cycles, non-reactive code, and complexity reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->