### PR TITLE
refactor(croquis-cf): share provide inject file ordering

### DIFF
--- a/crates/vize_croquis_cf/src/rules/provide_inject/index.rs
+++ b/crates/vize_croquis_cf/src/rules/provide_inject/index.rs
@@ -204,7 +204,7 @@ impl ProvideInjectIndex {
         })
     }
 
-    fn compare_files(&self, left: FileId, right: FileId) -> Ordering {
+    pub(crate) fn compare_files(&self, left: FileId, right: FileId) -> Ordering {
         stable_rank(&self.stable_file_order, left)
             .cmp(&stable_rank(&self.stable_file_order, right))
             .then_with(|| left.as_u32().cmp(&right.as_u32()))
@@ -257,4 +257,33 @@ fn extract_provide_inject(
     let provides = analysis.provide_inject.provides().to_vec();
     let injects = analysis.provide_inject.injects().to_vec();
     (provides, injects)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProvideInjectIndex;
+    use crate::registry::FileId;
+    use std::cmp::Ordering;
+    use vize_carton::FxHashMap;
+
+    #[test]
+    fn shared_file_order_places_known_paths_before_missing_entries() {
+        let first = FileId::new(7);
+        let second = FileId::new(3);
+        let missing_low = FileId::new(1);
+        let missing_high = FileId::new(9);
+        let index = ProvideInjectIndex {
+            provides: FxHashMap::default(),
+            injects: FxHashMap::default(),
+            component_parents: FxHashMap::default(),
+            stable_file_order: FxHashMap::from_iter([(first, 0), (second, 1)]),
+        };
+
+        assert_eq!(index.compare_files(first, second), Ordering::Less);
+        assert_eq!(index.compare_files(second, missing_low), Ordering::Less);
+        assert_eq!(
+            index.compare_files(missing_low, missing_high),
+            Ordering::Less
+        );
+    }
 }

--- a/crates/vize_croquis_cf/src/rules/provide_inject/tree.rs
+++ b/crates/vize_croquis_cf/src/rules/provide_inject/tree.rs
@@ -73,12 +73,12 @@ pub(crate) fn build_provide_inject_tree_with_index(
     }
 
     for children in child_map.values_mut() {
-        children.sort_by(|left, right| compare_files(registry, *left, *right));
+        children.sort_by(|left, right| index.compare_files(*left, *right));
         children.dedup();
     }
 
     let root_ids = select_root_ids(
-        registry,
+        index,
         &included_nodes,
         &nodes_with_parent,
         &child_map,
@@ -214,7 +214,7 @@ fn provider_for_branch(
 }
 
 fn select_root_ids(
-    registry: &ModuleRegistry,
+    index: &ProvideInjectIndex,
     included_nodes: &FxHashSet<FileId>,
     nodes_with_parent: &FxHashSet<FileId>,
     child_map: &FxHashMap<FileId, Vec<FileId>>,
@@ -235,7 +235,7 @@ fn select_root_ids(
         .filter_map(|branch| branch.path.first().copied())
         .filter(|file_id| !covered.contains(file_id))
         .collect::<Vec<_>>();
-    cyclic_starts.sort_by(|left, right| compare_files(registry, *left, *right));
+    cyclic_starts.sort_by(|left, right| index.compare_files(*left, *right));
     cyclic_starts.dedup();
     roots.extend(cyclic_starts.iter().copied());
     for root in cyclic_starts {
@@ -246,13 +246,13 @@ fn select_root_ids(
         .iter()
         .copied()
         .filter(|file_id| !covered.contains(file_id))
-        .min_by(|left, right| compare_files(registry, *left, *right))
+        .min_by(|left, right| index.compare_files(*left, *right))
     {
         roots.push(root);
         mark_reachable(root, child_map, &mut covered);
     }
 
-    roots.sort_by(|left, right| compare_files(registry, *left, *right));
+    roots.sort_by(|left, right| index.compare_files(*left, *right));
     roots.dedup();
     roots
 }
@@ -270,17 +270,5 @@ fn mark_reachable(
         if let Some(children) = child_map.get(&file_id) {
             pending.extend(children.iter().copied());
         }
-    }
-}
-
-fn compare_files(registry: &ModuleRegistry, left: FileId, right: FileId) -> std::cmp::Ordering {
-    match (registry.get(left), registry.get(right)) {
-        (Some(left_entry), Some(right_entry)) => left_entry
-            .path
-            .cmp(&right_entry.path)
-            .then_with(|| left.as_u32().cmp(&right.as_u32())),
-        (Some(_), None) => std::cmp::Ordering::Less,
-        (None, Some(_)) => std::cmp::Ordering::Greater,
-        (None, None) => left.as_u32().cmp(&right.as_u32()),
     }
 }


### PR DESCRIPTION
## Summary
- reuse the provide/inject index ordering for tree children and roots
- preserve path-first ordering and FileId tie-breaks for missing registry entries
- remove the duplicate tree comparator and pin its fallback contract

## Validation
- cargo test -p vize_croquis_cf provide_inject
- cargo test -p vize_croquis_cf --lib
- cargo clippy -p vize_croquis_cf --lib -- -D warnings
- cargo fmt --all -- --check
- git diff --check

Follow-up to #2796.
Refs #2747

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786236103&installation_id=136613492&pr_number=2798&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2798&signature=ddf8f558093fa170eebde7ca9433d347b2916ca1898fa7470dc82d57cebf87ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency-tree ordering for more consistent display of known and unavailable file entries.
  - Ensured root and child nodes follow the same ordering rules throughout the tree.

- **Tests**
  - Added coverage for ordering files with known and missing stable positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->