### PR TITLE
fix(maestro): show dynamic key and ref props

### DIFF
--- a/crates/vize_maestro/src/ide/hover/component_tag/items.rs
+++ b/crates/vize_maestro/src/ide/hover/component_tag/items.rs
@@ -4,7 +4,9 @@ pub(super) fn prop_items(usage: &ComponentUsage) -> Vec<String> {
     usage
         .props
         .iter()
-        .filter(|prop| prop.name != "key" && prop.name != "ref")
+        .filter(|prop| {
+            prop.name_is_dynamic || (prop.name.as_str() != "key" && prop.name.as_str() != "ref")
+        })
         .map(format_prop)
         .collect()
 }
@@ -69,9 +71,10 @@ fn format_slot(slot: &SlotUsage) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_event, format_prop, format_slot};
+    use super::{format_event, format_prop, format_slot, prop_items};
     use vize_carton::{CompactString, smallvec};
-    use vize_croquis::croquis::{EventListener, PassedProp, SlotUsage};
+    use vize_croquis::ScopeId;
+    use vize_croquis::croquis::{ComponentUsage, EventListener, PassedProp, SlotUsage};
 
     #[test]
     fn formats_runtime_directive_names_without_presenting_them_as_static() {
@@ -103,5 +106,38 @@ mod tests {
         assert_eq!(format_prop(&prop), r#"`:[propName]="value"`"#);
         assert_eq!(format_event(&event), r#"`@[eventName].once="handler"`"#);
         assert_eq!(format_slot(&slot), "`#[slotName] { row }`");
+    }
+
+    #[test]
+    fn runtime_key_and_ref_names_are_not_filtered_as_reserved_props() {
+        let prop = |name, name_is_dynamic| PassedProp {
+            name: CompactString::new(name),
+            name_is_dynamic,
+            value: Some(CompactString::new("value")),
+            start: 0,
+            end: 10,
+            is_dynamic: true,
+        };
+        let usage = ComponentUsage {
+            name: CompactString::new("Child"),
+            start: 0,
+            end: 40,
+            props: smallvec![
+                prop("key", false),
+                prop("key", true),
+                prop("ref", false),
+                prop("ref", true),
+            ],
+            events: smallvec![],
+            slots: smallvec![],
+            has_spread_attrs: false,
+            scope_id: ScopeId::ROOT,
+            vif_guard: None,
+        };
+
+        assert_eq!(
+            prop_items(&usage),
+            ["`:[key]=\"value\"`", "`:[ref]=\"value\"`"]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- keep static key and ref props hidden from component-tag hover
- show runtime :[key] and :[ref] arguments because their resolved names are not statically reserved
- cover both static and runtime forms with an exact hover-items regression

## Validation
- cargo test -p vize_maestro --lib
- cargo test -p vize_maestro runtime_key_and_ref_names_are_not_filtered_as_reserved_props
- cargo clippy -p vize_maestro --lib -- -D warnings
- cargo fmt --all -- --check
- diff check

Refs #2749
Follow-up to #2797

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786237637&installation_id=136613492&pr_number=2799&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2799&signature=5917c056ef5e593a15cde2b967f696251f9bf6cb631ab49504a4b66fa1e70669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dynamic `key` and `ref` properties are now correctly retained in component hover information.
  * Static `key` and `ref` properties continue to be handled as reserved properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->