### PR TITLE
fix(croquis): build complete SFC effect summaries

### DIFF
--- a/crates/vize_croquis/src/effect_graph.rs
+++ b/crates/vize_croquis/src/effect_graph.rs
@@ -9,8 +9,12 @@
 //! the lint rule can be developed against a stable shape.
 
 mod builder;
+mod cycles;
 
-pub use builder::{build_effect_graph_from_script, build_effect_graph_from_script_setup};
+pub use builder::{
+    EffectGraphScript, build_effect_graph_from_script, build_effect_graph_from_script_setup,
+    build_effect_graph_from_sfc_scripts,
+};
 
 use serde::Serialize;
 use vize_carton::CompactString;
@@ -43,6 +47,22 @@ pub struct EffectGraphSummary {
     pub cycle_node_count: usize,
 }
 
+impl EffectGraphSummary {
+    /// Combine summaries for effect graphs known to be independent.
+    ///
+    /// Counts use saturating addition so aggregation remains conservative for
+    /// arbitrarily large generated inputs. The operation is deterministic and
+    /// order-independent.
+    pub fn merged(self, other: Self) -> Self {
+        Self {
+            node_count: self.node_count.saturating_add(other.node_count),
+            edge_count: self.edge_count.saturating_add(other.edge_count),
+            cycle_count: self.cycle_count.saturating_add(other.cycle_count),
+            cycle_node_count: self.cycle_node_count.saturating_add(other.cycle_node_count),
+        }
+    }
+}
+
 impl EffectGraph {
     /// Add a `from → to` dependency edge.
     pub fn add_edge(&mut self, from: impl Into<EffectNodeId>, to: impl Into<EffectNodeId>) {
@@ -72,16 +92,13 @@ impl EffectGraph {
 
     /// Summarize edge and cycle counts for reports and diagnostics.
     pub fn summary(&self) -> EffectGraphSummary {
-        let cycle = self.find_cycle();
+        let (cycle_count, cycle_node_count) = cycles::cycle_summary(&self.edges);
 
         EffectGraphSummary {
             node_count: self.node_count(),
             edge_count: self.edges.len(),
-            cycle_count: usize::from(cycle.is_some()),
-            cycle_node_count: cycle
-                .as_ref()
-                .map(|cycle| cycle.len().saturating_sub(1))
-                .unwrap_or_default(),
+            cycle_count,
+            cycle_node_count,
         }
     }
 
@@ -149,7 +166,7 @@ impl EffectGraph {
 
 #[cfg(test)]
 mod tests {
-    use super::EffectGraph;
+    use super::{EffectGraph, EffectGraphSummary};
 
     #[test]
     fn detects_two_node_cycle() {
@@ -192,5 +209,71 @@ mod tests {
         g.add_edge("a", "b");
         g.add_edge("a", "b");
         assert_eq!(g.edges().count(), 1);
+    }
+
+    #[test]
+    fn summary_counts_each_cyclic_component_and_self_loop() {
+        let mut g = EffectGraph::default();
+        for (from, to) in [("a", "b"), ("b", "a"), ("b", "c"), ("c", "d"), ("d", "c")] {
+            g.add_edge(from, to);
+        }
+        assert_eq!(g.summary().cycle_count, 2);
+        assert_eq!(g.summary().cycle_node_count, 4);
+
+        let mut self_loop = EffectGraph::default();
+        self_loop.add_edge("self", "self");
+        assert_eq!(self_loop.summary().cycle_count, 1);
+        assert_eq!(self_loop.summary().cycle_node_count, 1);
+    }
+
+    #[test]
+    fn summary_merge_is_order_independent_and_saturating() {
+        let script = EffectGraphSummary {
+            node_count: 2,
+            edge_count: 3,
+            cycle_count: 1,
+            cycle_node_count: 2,
+        };
+        let setup = EffectGraphSummary {
+            node_count: 4,
+            edge_count: 5,
+            cycle_count: 1,
+            cycle_node_count: 3,
+        };
+        let expected = EffectGraphSummary {
+            node_count: 6,
+            edge_count: 8,
+            cycle_count: 2,
+            cycle_node_count: 5,
+        };
+
+        assert_eq!(script.merged(setup), expected);
+        assert_eq!(setup.merged(script), expected);
+        assert_eq!(script.merged(EffectGraphSummary::default()), script);
+        assert_eq!(EffectGraphSummary::default().merged(script), script);
+        assert_eq!(
+            script.merged(setup).merged(EffectGraphSummary {
+                node_count: 1,
+                ..EffectGraphSummary::default()
+            }),
+            script.merged(setup.merged(EffectGraphSummary {
+                node_count: 1,
+                ..EffectGraphSummary::default()
+            }))
+        );
+        assert_eq!(
+            expected.merged(EffectGraphSummary {
+                node_count: usize::MAX,
+                edge_count: usize::MAX,
+                cycle_count: usize::MAX,
+                cycle_node_count: usize::MAX,
+            }),
+            EffectGraphSummary {
+                node_count: usize::MAX,
+                edge_count: usize::MAX,
+                cycle_count: usize::MAX,
+                cycle_node_count: usize::MAX,
+            }
+        );
     }
 }

--- a/crates/vize_croquis/src/effect_graph/builder.rs
+++ b/crates/vize_croquis/src/effect_graph/builder.rs
@@ -1,7 +1,12 @@
 //! Parser-driven effect graph construction.
 
+mod context;
 mod deps;
+mod sfc;
 
+pub use sfc::{EffectGraphScript, build_effect_graph_from_sfc_scripts};
+
+use context::{EffectBuildContext, context_for_program, variable_declaration_from_statement};
 use deps::collect_argument_deps;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
@@ -25,28 +30,27 @@ fn build_effect_graph_from_source(source: &str, path: &str) -> EffectGraph {
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap_or_default();
     let ret = Parser::new(&allocator, source, source_type).parse();
-    if ret.panicked {
+    if ret.panicked || !ret.errors.is_empty() {
         return EffectGraph::default();
     }
     build_effect_graph_from_program(&ret.program)
 }
 
 pub(crate) fn build_effect_graph_from_program(program: &Program<'_>) -> EffectGraph {
-    let mut api_aliases = FxHashMap::default();
-    let mut reactive_sources = FxHashSet::default();
-
-    for statement in program.body.iter() {
-        collect_vue_api_aliases(statement, &mut api_aliases);
-    }
-    for statement in program.body.iter() {
-        collect_reactive_sources(statement, &api_aliases, &mut reactive_sources);
-    }
-
+    let context = context_for_program(program, None, "");
     let mut graph = EffectGraph::default();
-    for statement in program.body.iter() {
-        collect_effect_edges(statement, &api_aliases, &reactive_sources, &mut graph);
-    }
+    collect_program_effect_edges(program, &context, &mut graph);
     graph
+}
+
+fn collect_program_effect_edges(
+    program: &Program<'_>,
+    context: &EffectBuildContext,
+    graph: &mut EffectGraph,
+) {
+    for statement in &program.body {
+        collect_effect_edges(statement, context, graph);
+    }
 }
 
 fn collect_vue_api_aliases(
@@ -56,7 +60,7 @@ fn collect_vue_api_aliases(
     let Statement::ImportDeclaration(import) = statement else {
         return;
     };
-    if import.source.value.as_str() != "vue" {
+    if import.source.value.as_str() != "vue" || import.import_kind.is_type() {
         return;
     }
     let Some(specifiers) = &import.specifiers else {
@@ -64,10 +68,12 @@ fn collect_vue_api_aliases(
     };
 
     for specifier in specifiers.iter() {
-        if let oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier {
+        if let oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier
+            && !specifier.import_kind.is_type()
+        {
             let imported = specifier.imported.name().as_str();
             let local = specifier.local.name.as_str();
-            if (is_reactive_api(imported) || is_effect_api(imported)) && imported != local {
+            if is_reactive_api(imported) || is_effect_api(imported) {
                 api_aliases.insert(CompactString::new(local), CompactString::new(imported));
             }
         }
@@ -77,9 +83,10 @@ fn collect_vue_api_aliases(
 fn collect_reactive_sources(
     statement: &Statement<'_>,
     api_aliases: &FxHashMap<CompactString, CompactString>,
+    blocked_api_names: &FxHashSet<CompactString>,
     reactive_sources: &mut FxHashSet<CompactString>,
 ) {
-    let Statement::VariableDeclaration(declaration) = statement else {
+    let Some(declaration) = variable_declaration_from_statement(statement) else {
         return;
     };
 
@@ -90,7 +97,9 @@ fn collect_reactive_sources(
         let Some(call) = declarator.init.as_ref().and_then(call_from_expression) else {
             continue;
         };
-        if call_api_name(call, api_aliases).is_some_and(|name| is_reactive_api(name.as_str())) {
+        if call_api_name(call, api_aliases, blocked_api_names)
+            .is_some_and(|name| is_reactive_api(name.as_str()))
+        {
             reactive_sources.insert(CompactString::new(identifier.name.as_str()));
         }
     }
@@ -98,25 +107,21 @@ fn collect_reactive_sources(
 
 fn collect_effect_edges(
     statement: &Statement<'_>,
-    api_aliases: &FxHashMap<CompactString, CompactString>,
-    reactive_sources: &FxHashSet<CompactString>,
+    context: &EffectBuildContext,
     graph: &mut EffectGraph,
 ) {
-    match statement {
-        Statement::VariableDeclaration(declaration) => {
-            collect_variable_effect_edges(declaration, api_aliases, reactive_sources, graph);
-        }
-        Statement::ExpressionStatement(statement) => {
-            collect_call_effect_edges(&statement.expression, api_aliases, reactive_sources, graph);
-        }
-        _ => {}
+    if let Some(declaration) = variable_declaration_from_statement(statement) {
+        collect_variable_effect_edges(declaration, context, graph);
+        return;
+    }
+    if let Statement::ExpressionStatement(statement) = statement {
+        collect_call_effect_edges(&statement.expression, context, graph);
     }
 }
 
 fn collect_variable_effect_edges(
     declaration: &VariableDeclaration<'_>,
-    api_aliases: &FxHashMap<CompactString, CompactString>,
-    reactive_sources: &FxHashSet<CompactString>,
+    context: &EffectBuildContext,
     graph: &mut EffectGraph,
 ) {
     for declarator in declaration.declarations.iter() {
@@ -124,49 +129,55 @@ fn collect_variable_effect_edges(
             continue;
         };
         let Some(call) = call_from_expression(init) else {
-            collect_call_effect_edges(init, api_aliases, reactive_sources, graph);
+            collect_call_effect_edges(init, context, graph);
             continue;
         };
 
-        let Some(api_name) = call_api_name(call, api_aliases) else {
-            collect_call_effect_edges(init, api_aliases, reactive_sources, graph);
+        let Some(api_name) = call_api_name(call, &context.api_aliases, &context.blocked_api_names)
+        else {
+            collect_call_effect_edges(init, context, graph);
             continue;
         };
 
         if api_name == "computed" {
             if let BindingPattern::BindingIdentifier(identifier) = &declarator.id {
-                let from = CompactString::new(identifier.name.as_str());
-                add_edges_from_first_arg(&from, call, reactive_sources, graph);
+                let source_name = CompactString::new(identifier.name.as_str());
+                let from = context
+                    .reactive_node_ids
+                    .get(&source_name)
+                    .cloned()
+                    .unwrap_or_else(|| scoped_node_name(&context.prefix, &source_name));
+                add_edges_from_first_arg(&from, call, context, graph);
             }
         } else if is_effect_api(api_name.as_str()) {
-            let from = effect_node_name(api_name.as_str(), call.span.start);
-            add_edges_from_first_arg(&from, call, reactive_sources, graph);
+            let from = effect_node_name(&context.prefix, api_name.as_str(), call.span.start);
+            add_edges_from_first_arg(&from, call, context, graph);
         }
     }
 }
 
 fn collect_call_effect_edges(
     expression: &Expression<'_>,
-    api_aliases: &FxHashMap<CompactString, CompactString>,
-    reactive_sources: &FxHashSet<CompactString>,
+    context: &EffectBuildContext,
     graph: &mut EffectGraph,
 ) {
     let Some(call) = call_from_expression(expression) else {
         return;
     };
-    let Some(api_name) = call_api_name(call, api_aliases) else {
+    let Some(api_name) = call_api_name(call, &context.api_aliases, &context.blocked_api_names)
+    else {
         return;
     };
     if is_effect_api(api_name.as_str()) {
-        let from = effect_node_name(api_name.as_str(), call.span.start);
-        add_edges_from_first_arg(&from, call, reactive_sources, graph);
+        let from = effect_node_name(&context.prefix, api_name.as_str(), call.span.start);
+        add_edges_from_first_arg(&from, call, context, graph);
     }
 }
 
 fn add_edges_from_first_arg(
     from: &CompactString,
     call: &CallExpression<'_>,
-    reactive_sources: &FxHashSet<CompactString>,
+    context: &EffectBuildContext,
     graph: &mut EffectGraph,
 ) {
     let Some(arg) = call.arguments.first() else {
@@ -175,10 +186,10 @@ fn add_edges_from_first_arg(
 
     let mut deps = std::collections::BTreeSet::new();
     let excluded = FxHashSet::default();
-    collect_argument_deps(arg, reactive_sources, &excluded, &mut deps);
+    collect_argument_deps(arg, &context.reactive_sources, &excluded, &mut deps);
     for dep in deps {
-        if dep != *from {
-            graph.add_edge(from.clone(), dep);
+        if let Some(target) = context.reactive_node_ids.get(&dep) {
+            graph.add_edge(from.clone(), target.clone());
         }
     }
 }
@@ -201,11 +212,15 @@ fn call_from_expression<'a>(expression: &'a Expression<'a>) -> Option<&'a CallEx
 fn call_api_name(
     call: &CallExpression<'_>,
     api_aliases: &FxHashMap<CompactString, CompactString>,
+    blocked_api_names: &FxHashSet<CompactString>,
 ) -> Option<CompactString> {
     let Expression::Identifier(identifier) = &call.callee else {
         return None;
     };
     let raw = identifier.name.as_str();
+    if blocked_api_names.contains(raw) {
+        return None;
+    }
     Some(
         api_aliases
             .get(raw)
@@ -214,8 +229,16 @@ fn call_api_name(
     )
 }
 
-fn effect_node_name(api_name: &str, start: u32) -> CompactString {
-    cstr!("{api_name}@{start}")
+fn scoped_node_name(prefix: &str, name: &str) -> CompactString {
+    if prefix.is_empty() {
+        CompactString::new(name)
+    } else {
+        cstr!("{prefix}:{name}")
+    }
+}
+
+fn effect_node_name(prefix: &str, api_name: &str, start: u32) -> CompactString {
+    scoped_node_name(prefix, &cstr!("{api_name}@{start}"))
 }
 
 fn is_reactive_api(name: &str) -> bool {

--- a/crates/vize_croquis/src/effect_graph/builder/context.rs
+++ b/crates/vize_croquis/src/effect_graph/builder/context.rs
@@ -1,0 +1,134 @@
+use super::deps::collect_binding_pattern_names;
+use super::{collect_reactive_sources, collect_vue_api_aliases, scoped_node_name};
+use oxc_ast::ast::{Declaration, Program, Statement, VariableDeclaration};
+use vize_carton::{CompactString, FxHashMap, FxHashSet};
+
+#[derive(Debug, Default, Clone)]
+pub(super) struct EffectBuildContext {
+    pub(super) api_aliases: FxHashMap<CompactString, CompactString>,
+    pub(super) blocked_api_names: FxHashSet<CompactString>,
+    pub(super) reactive_sources: FxHashSet<CompactString>,
+    pub(super) reactive_node_ids: FxHashMap<CompactString, CompactString>,
+    pub(super) prefix: CompactString,
+}
+
+pub(super) fn context_for_program(
+    program: &Program<'_>,
+    inherited: Option<&EffectBuildContext>,
+    prefix: &str,
+) -> EffectBuildContext {
+    let mut context = inherited.cloned().unwrap_or_default();
+    context.prefix = CompactString::new(prefix);
+
+    let mut local_bindings = FxHashSet::default();
+    for statement in &program.body {
+        collect_top_level_bindings(statement, &mut local_bindings);
+    }
+    for binding in local_bindings {
+        context.api_aliases.remove(&binding);
+        context.blocked_api_names.insert(binding.clone());
+        context.reactive_sources.remove(&binding);
+        context.reactive_node_ids.remove(&binding);
+    }
+    for statement in &program.body {
+        collect_vue_api_aliases(statement, &mut context.api_aliases);
+    }
+    for api_name in context.api_aliases.keys() {
+        context.blocked_api_names.remove(api_name);
+    }
+
+    let mut local_reactive_sources = FxHashSet::default();
+    for statement in &program.body {
+        collect_reactive_sources(
+            statement,
+            &context.api_aliases,
+            &context.blocked_api_names,
+            &mut local_reactive_sources,
+        );
+    }
+    for source in local_reactive_sources {
+        context.reactive_sources.insert(source.clone());
+        context
+            .reactive_node_ids
+            .insert(source.clone(), scoped_node_name(prefix, &source));
+    }
+    context
+}
+
+pub(super) fn variable_declaration_from_statement<'a>(
+    statement: &'a Statement<'a>,
+) -> Option<&'a VariableDeclaration<'a>> {
+    match statement {
+        Statement::VariableDeclaration(declaration) => Some(declaration),
+        Statement::ExportNamedDeclaration(export) => match export.declaration.as_ref() {
+            Some(Declaration::VariableDeclaration(declaration)) => Some(declaration),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn collect_top_level_bindings(statement: &Statement<'_>, bindings: &mut FxHashSet<CompactString>) {
+    if let Some(declaration) = variable_declaration_from_statement(statement) {
+        collect_variable_bindings(declaration, bindings);
+        return;
+    }
+    match statement {
+        Statement::FunctionDeclaration(function) => collect_named_binding(&function.id, bindings),
+        Statement::ClassDeclaration(class) => collect_named_binding(&class.id, bindings),
+        Statement::ExportNamedDeclaration(export) => {
+            if let Some(declaration) = &export.declaration {
+                match declaration {
+                    Declaration::FunctionDeclaration(function) => {
+                        collect_named_binding(&function.id, bindings);
+                    }
+                    Declaration::ClassDeclaration(class) => {
+                        collect_named_binding(&class.id, bindings);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Statement::ImportDeclaration(import) => {
+            if import.import_kind.is_type() {
+                return;
+            }
+            for specifier in import.specifiers.iter().flatten() {
+                let local = match specifier {
+                    oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(specifier) => {
+                        if specifier.import_kind.is_type() {
+                            continue;
+                        }
+                        &specifier.local
+                    }
+                    oxc_ast::ast::ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => {
+                        &specifier.local
+                    }
+                    oxc_ast::ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(
+                        specifier,
+                    ) => &specifier.local,
+                };
+                bindings.insert(CompactString::new(local.name.as_str()));
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_variable_bindings(
+    declaration: &VariableDeclaration<'_>,
+    bindings: &mut FxHashSet<CompactString>,
+) {
+    for declarator in &declaration.declarations {
+        collect_binding_pattern_names(&declarator.id, bindings);
+    }
+}
+
+fn collect_named_binding(
+    identifier: &Option<oxc_ast::ast::BindingIdentifier<'_>>,
+    bindings: &mut FxHashSet<CompactString>,
+) {
+    if let Some(identifier) = identifier {
+        bindings.insert(CompactString::new(identifier.name.as_str()));
+    }
+}

--- a/crates/vize_croquis/src/effect_graph/builder/deps.rs
+++ b/crates/vize_croquis/src/effect_graph/builder/deps.rs
@@ -256,7 +256,7 @@ fn collect_binding_pattern_names_from_params(
     }
 }
 
-fn collect_binding_pattern_names(
+pub(super) fn collect_binding_pattern_names(
     pattern: &BindingPattern<'_>,
     names: &mut FxHashSet<CompactString>,
 ) {

--- a/crates/vize_croquis/src/effect_graph/builder/sfc.rs
+++ b/crates/vize_croquis/src/effect_graph/builder/sfc.rs
@@ -1,0 +1,65 @@
+use super::{EffectBuildContext, collect_program_effect_edges, context_for_program};
+use crate::effect_graph::EffectGraph;
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+/// One parsed SFC script block and its declared language.
+#[derive(Debug, Clone, Copy)]
+pub struct EffectGraphScript<'a> {
+    /// Raw contents of one `<script>` block.
+    pub source: &'a str,
+    /// Declared SFC language (`js`, `jsx`, `ts`, or `tsx`).
+    pub lang: Option<&'a str>,
+}
+
+impl<'a> EffectGraphScript<'a> {
+    /// Create a script-block input for effect graph construction.
+    pub const fn new(source: &'a str, lang: Option<&'a str>) -> Self {
+        Self { source, lang }
+    }
+
+    fn virtual_path(self) -> &'static str {
+        match self.lang.map(str::trim) {
+            Some(lang) if lang.eq_ignore_ascii_case("jsx") => "script.jsx",
+            Some(lang) if lang.eq_ignore_ascii_case("tsx") => "script.tsx",
+            Some(lang) if lang.eq_ignore_ascii_case("ts") => "script.ts",
+            _ => "script.js",
+        }
+    }
+}
+
+/// Build one effect graph across the normal and setup scopes of an SFC.
+///
+/// Normal-script bindings remain visible to setup, while scoped node IDs keep
+/// same-named declarations in the two blocks distinct.
+pub fn build_effect_graph_from_sfc_scripts(
+    script: Option<EffectGraphScript<'_>>,
+    setup: Option<EffectGraphScript<'_>>,
+) -> EffectGraph {
+    let mut graph = EffectGraph::default();
+    let mut script_context = EffectBuildContext::default();
+
+    if let Some(block) = script {
+        let allocator = Allocator::default();
+        let source_type = SourceType::from_path(block.virtual_path()).unwrap_or_default();
+        let parsed = Parser::new(&allocator, block.source, source_type).parse();
+        if !parsed.panicked && parsed.errors.is_empty() {
+            script_context = context_for_program(&parsed.program, None, "script");
+            collect_program_effect_edges(&parsed.program, &script_context, &mut graph);
+        }
+    }
+
+    if let Some(block) = setup {
+        let allocator = Allocator::default();
+        let source_type = SourceType::from_path(block.virtual_path()).unwrap_or_default();
+        let parsed = Parser::new(&allocator, block.source, source_type).parse();
+        if !parsed.panicked && parsed.errors.is_empty() {
+            let inherited = script.map(|_| &script_context);
+            let setup_context = context_for_program(&parsed.program, inherited, "setup");
+            collect_program_effect_edges(&parsed.program, &setup_context, &mut graph);
+        }
+    }
+
+    graph
+}

--- a/crates/vize_croquis/src/effect_graph/cycles.rs
+++ b/crates/vize_croquis/src/effect_graph/cycles.rs
@@ -1,0 +1,82 @@
+use super::EffectEdge;
+use std::collections::{BTreeMap, BTreeSet};
+use vize_carton::CompactString;
+
+pub(super) fn cycle_summary(edges: &[EffectEdge]) -> (usize, usize) {
+    let mut forward: BTreeMap<CompactString, Vec<CompactString>> = BTreeMap::new();
+    let mut reverse: BTreeMap<CompactString, Vec<CompactString>> = BTreeMap::new();
+    let mut nodes = BTreeSet::new();
+    for edge in edges {
+        nodes.insert(edge.from.clone());
+        nodes.insert(edge.to.clone());
+        forward
+            .entry(edge.from.clone())
+            .or_default()
+            .push(edge.to.clone());
+        reverse
+            .entry(edge.to.clone())
+            .or_default()
+            .push(edge.from.clone());
+    }
+
+    let mut visited = BTreeSet::new();
+    let mut finish_order = Vec::with_capacity(nodes.len());
+    for node in &nodes {
+        if visited.contains(node) {
+            continue;
+        }
+        let mut pending = vec![(node.clone(), false)];
+        while let Some((current, expanded)) = pending.pop() {
+            if expanded {
+                finish_order.push(current);
+                continue;
+            }
+            if !visited.insert(current.clone()) {
+                continue;
+            }
+            pending.push((current.clone(), true));
+            if let Some(children) = forward.get(&current) {
+                pending.extend(
+                    children
+                        .iter()
+                        .rev()
+                        .filter(|child| !visited.contains(*child))
+                        .cloned()
+                        .map(|child| (child, false)),
+                );
+            }
+        }
+    }
+
+    let mut assigned = BTreeSet::new();
+    let mut cycle_count = 0usize;
+    let mut cycle_node_count = 0usize;
+    while let Some(node) = finish_order.pop() {
+        if !assigned.insert(node.clone()) {
+            continue;
+        }
+        let mut component = vec![node.clone()];
+        let mut pending = vec![node];
+        while let Some(current) = pending.pop() {
+            for parent in reverse.get(&current).into_iter().flatten() {
+                if assigned.insert(parent.clone()) {
+                    component.push(parent.clone());
+                    pending.push(parent.clone());
+                }
+            }
+        }
+
+        let cyclic = component.len() > 1
+            || component.iter().any(|member| {
+                forward
+                    .get(member)
+                    .is_some_and(|children| children.contains(member))
+            });
+        if cyclic {
+            cycle_count = cycle_count.saturating_add(1);
+            cycle_node_count = cycle_node_count.saturating_add(component.len());
+        }
+    }
+
+    (cycle_count, cycle_node_count)
+}

--- a/crates/vize_croquis/src/effect_graph_builder_tests.rs
+++ b/crates/vize_croquis/src/effect_graph_builder_tests.rs
@@ -1,4 +1,7 @@
-use crate::effect_graph::{EffectGraph, build_effect_graph_from_script_setup};
+use crate::effect_graph::{
+    EffectGraph, EffectGraphScript, EffectGraphSummary, build_effect_graph_from_script_setup,
+    build_effect_graph_from_sfc_scripts,
+};
 use crate::script_parser::parse_script_setup;
 use vize_carton::{CompactString, cstr};
 
@@ -86,6 +89,40 @@ const right = computed(() => left.value)
 }
 
 #[test]
+fn parser_built_summary_counts_self_loop_and_disconnected_cycles() {
+    let source = r#"
+import { computed } from 'vue'
+const selfCycle = computed(() => selfCycle.value)
+const leftA = computed(() => rightA.value)
+const rightA = computed(() => leftA.value)
+const leftB = computed(() => rightB.value)
+const rightB = computed(() => leftB.value)
+"#;
+    let graph =
+        build_effect_graph_from_sfc_scripts(None, Some(EffectGraphScript::new(source, Some("ts"))));
+
+    assert_eq!(
+        edge_pairs(&graph),
+        [
+            (cstr!("setup:leftA"), cstr!("setup:rightA")),
+            (cstr!("setup:leftB"), cstr!("setup:rightB")),
+            (cstr!("setup:rightA"), cstr!("setup:leftA")),
+            (cstr!("setup:rightB"), cstr!("setup:leftB")),
+            (cstr!("setup:selfCycle"), cstr!("setup:selfCycle")),
+        ]
+    );
+    assert_eq!(
+        graph.summary(),
+        EffectGraphSummary {
+            node_count: 5,
+            edge_count: 5,
+            cycle_count: 3,
+            cycle_node_count: 5,
+        }
+    );
+}
+
+#[test]
 fn ignores_shadowed_callback_parameters_when_collecting_deps() {
     let graph = build_effect_graph_from_script_setup(
         r#"
@@ -115,4 +152,170 @@ watchEffect(() => {
         serde_json::to_string_pretty(&parsed.reactivity.overlay_with_effect_graph(&graph)).unwrap();
 
     insta::assert_snapshot!(json);
+}
+
+#[test]
+fn sfc_source_languages_preserve_effect_cycles() {
+    for (lang, jsx) in [
+        (None, ""),
+        (Some("js"), ""),
+        (Some("ts"), "const typed: number = 1"),
+        (Some("jsx"), "const render = () => <strong>ready</strong>"),
+        (
+            Some("tsx"),
+            "const render = (): JSX.Element => <strong>ready</strong>",
+        ),
+    ] {
+        let source = format!(
+            r#"
+import {{ computed }} from 'vue'
+{jsx}
+const left = computed(() => right.value)
+const right = computed(() => left.value)
+"#
+        );
+        let graph = build_effect_graph_from_sfc_scripts(
+            None,
+            Some(EffectGraphScript::new(source.as_str(), lang)),
+        );
+
+        assert_eq!(
+            graph.summary(),
+            EffectGraphSummary {
+                node_count: 2,
+                edge_count: 2,
+                cycle_count: 1,
+                cycle_node_count: 2,
+            },
+            "lang={lang:?}"
+        );
+    }
+}
+
+#[test]
+fn split_sfc_scripts_share_outer_sources_and_keep_scoped_cycles_distinct() {
+    let script = r#"
+import { computed, ref } from 'vue'
+export const shared = ref(0)
+const left = computed(() => right.value)
+const right = computed(() => left.value)
+"#;
+    let setup = r#"
+import { computed, watch } from 'vue'
+watch(shared, () => console.log(shared.value))
+const left = computed(() => right.value)
+const right = computed(() => left.value)
+"#;
+    let graph = build_effect_graph_from_sfc_scripts(
+        Some(EffectGraphScript::new(script, Some("ts"))),
+        Some(EffectGraphScript::new(setup, Some("ts"))),
+    );
+
+    assert_eq!(
+        graph.summary(),
+        EffectGraphSummary {
+            node_count: 6,
+            edge_count: 5,
+            cycle_count: 2,
+            cycle_node_count: 4,
+        }
+    );
+    assert!(
+        graph
+            .edges()
+            .any(|edge| edge.from.starts_with("setup:watch@") && edge.to == "script:shared")
+    );
+}
+
+#[test]
+fn malformed_sfc_block_does_not_discard_a_valid_sibling_summary() {
+    let script = r#"
+import { computed } from 'vue'
+const left = computed(() => right.value)
+const right = computed(() => left.value)
+"#;
+    let malformed_setup = r#"
+import { computed } from 'vue'
+const setupLeft = computed(() => setupRight.value)
+const setupRight = computed(() => setupLeft.value)
+const broken = (
+"#;
+    let graph = build_effect_graph_from_sfc_scripts(
+        Some(EffectGraphScript::new(script, Some("js"))),
+        Some(EffectGraphScript::new(malformed_setup, Some("js"))),
+    );
+
+    assert_eq!(
+        graph.summary(),
+        EffectGraphSummary {
+            node_count: 2,
+            edge_count: 2,
+            cycle_count: 1,
+            cycle_node_count: 2,
+        }
+    );
+}
+
+#[test]
+fn setup_declarations_shadow_normal_script_reactive_sources() {
+    let script = r#"
+import { ref } from 'vue'
+const shared = ref(0)
+"#;
+    let setup = r#"
+import { watch } from 'vue'
+function shared() { return 1 }
+watch(shared, () => {})
+"#;
+    let graph = build_effect_graph_from_sfc_scripts(
+        Some(EffectGraphScript::new(script, Some("js"))),
+        Some(EffectGraphScript::new(setup, Some("js"))),
+    );
+
+    assert_eq!(graph.summary(), EffectGraphSummary::default());
+}
+
+#[test]
+fn setup_local_bindings_block_inherited_api_names_without_leaking_other_aliases() {
+    let script = r#"
+import {
+  ref as vueRef,
+  computed,
+  watch as observe,
+  watchEffect as fx,
+} from 'vue'
+export const outer = vueRef(0)
+"#;
+    let setup = r#"
+const ref = (value) => ({ value })
+const computed = (getter) => getter()
+const observe = (source, callback) => callback(source)
+const fakeSource = ref(1)
+const fakeComputed = computed(() => outer.value)
+observe(outer, () => {})
+fx(() => fakeSource.value)
+fx(() => outer.value)
+"#;
+    let graph = build_effect_graph_from_sfc_scripts(
+        Some(EffectGraphScript::new(script, Some("js"))),
+        Some(EffectGraphScript::new(setup, Some("js"))),
+    );
+    let fx_offset = setup.find("fx(() => outer.value)").unwrap();
+
+    assert_eq!(
+        edge_pairs(&graph),
+        [(
+            cstr!("setup:watchEffect@{fx_offset}"),
+            cstr!("script:outer"),
+        )]
+    );
+    assert_eq!(
+        graph.summary(),
+        EffectGraphSummary {
+            node_count: 2,
+            edge_count: 1,
+            cycle_count: 0,
+            cycle_node_count: 0,
+        }
+    );
 }

--- a/crates/vize_croquis/src/lib.rs
+++ b/crates/vize_croquis/src/lib.rs
@@ -102,8 +102,8 @@ pub use croquis::{
 };
 pub use drawer::{Drawer, DrawerOptions};
 pub use effect_graph::{
-    EffectGraph, EffectGraphSummary, build_effect_graph_from_script,
-    build_effect_graph_from_script_setup,
+    EffectGraph, EffectGraphScript, EffectGraphSummary, build_effect_graph_from_script,
+    build_effect_graph_from_script_setup, build_effect_graph_from_sfc_scripts,
 };
 pub use reactivity_overlay::{
     ReactivityEffectEdgeOverlay, ReactivityEffectGraphOverlay, ReactivityLossOverlay,


### PR DESCRIPTION
## Summary
- build effect summaries from complete SFC descriptors across JS, JSX, TS, and TSX script blocks
- preserve normal-script reactive sources in setup while respecting local API aliases and value shadowing
- report every cyclic SCC, including self dependencies and disconnected cycles
- make summary merge and count accumulation deterministic and saturating

## Validation
- cargo test -p vize_croquis --lib (248 passed)
- cargo test -p vize_croquis --doc (7 passed)
- cargo clippy -p vize_croquis --lib -- -D warnings
- cargo fmt --all -- --check
- source-length and diff checks

Refs #2746
Refs #2748
Follow-up to #2795

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786237926&installation_id=136613492&pr_number=2801&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2801&signature=49d0cf73d5a69e061bb58cd96fe294a572ec75ca06e2e0fb8dae99b1a385f4e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added effect-graph analysis for Vue single-file component script and setup blocks.
  - Added support for JavaScript, TypeScript, JSX, and TSX script languages.
  - Improved handling of scoped bindings, aliases, and inherited reactive sources.

- **Bug Fixes**
  - Improved cycle detection, including self-loops and disconnected cycles.
  - Invalid script blocks no longer discard results from valid blocks.
  - Enhanced handling of shadowed or locally defined bindings.

- **Improvements**
  - Effect-graph summaries can now be combined safely, including large counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->