### PR TITLE
fix(croquis-cf): accept effect graph summaries

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer.rs
+++ b/crates/vize_croquis_cf/src/analyzer.rs
@@ -26,6 +26,10 @@ mod tests_element_id;
 mod tests_complexity_effect_graph;
 
 #[cfg(test)]
+#[path = "analyzer/tests_complexity_effect_graph_overflow.rs"]
+mod tests_complexity_effect_graph_overflow;
+
+#[cfg(test)]
 mod tests_provide_inject;
 
 #[cfg(test)]

--- a/crates/vize_croquis_cf/src/analyzer/core/accessors.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/accessors.rs
@@ -3,6 +3,8 @@ use crate::graph::DependencyGraph;
 use crate::registry::{FileId, ModuleRegistry};
 use std::path::Path;
 use vize_croquis::Croquis;
+#[cfg(test)]
+use vize_croquis::EffectGraphSummary;
 
 impl CrossFileAnalyzer {
     /// Get the module registry.
@@ -25,6 +27,11 @@ impl CrossFileAnalyzer {
     /// Get file path by ID.
     pub fn get_file_path(&self, file_id: FileId) -> Option<&Path> {
         self.registry.get(file_id).map(|e| e.path.as_path())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn effect_graph_summary(&self, file_id: FileId) -> Option<EffectGraphSummary> {
+        self.effect_graph_summaries.get(&file_id).copied()
     }
 
     /// Clear all data and reset.

--- a/crates/vize_croquis_cf/src/analyzer/core/files.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/files.rs
@@ -2,46 +2,21 @@ use super::CrossFileAnalyzer;
 use crate::graph::{DependencyEdge, ModuleNode};
 use crate::registry::FileId;
 use std::path::Path;
-use vize_croquis::{Croquis, build_effect_graph_from_script};
+use vize_croquis::{
+    Croquis, EffectGraphScript, EffectGraphSummary, build_effect_graph_from_sfc_scripts,
+};
 
 impl CrossFileAnalyzer {
-    /// Add a file to be analyzed.
+    /// Add a raw JavaScript, JSX, TypeScript, or TSX module to be analyzed.
+    ///
+    /// SFC containers must be parsed by the caller; use
+    /// [`Self::add_file_with_analysis_and_effect_summary`] for `.vue` source.
     pub fn add_file(&mut self, path: impl AsRef<Path>, source: &str) -> FileId {
         let path = path.as_ref();
 
         // Analyze the file with single-file analyzer
         let analysis = self.analyze_single_file(source, path);
-
-        // Register in module registry (takes ownership of analysis)
-        let (file_id, is_new) = self.registry.register(path, source, analysis);
-        self.effect_graph_summaries
-            .insert(file_id, build_effect_graph_from_script(source).summary());
-
-        if is_new {
-            // Add to dependency graph
-            let mut node = ModuleNode::new(file_id, path.to_string_lossy().as_ref());
-
-            // Extract component name
-            if let Some(entry) = self.registry.get(file_id) {
-                node.component_name = entry.component_name.clone();
-            }
-
-            // Mark entry points
-            let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            if filename == "App.vue"
-                || filename == "main.ts"
-                || filename == "main.js"
-                || filename == "index.vue"
-            {
-                node.is_entry = true;
-            }
-
-            self.graph.add_node(node);
-        }
-
-        self.update_dependency_edges(file_id);
-
-        file_id
+        self.add_file_with_analysis(path, source, analysis)
     }
 
     /// Add multiple files.
@@ -56,18 +31,35 @@ impl CrossFileAnalyzer {
     /// This is useful when the caller has already performed analysis (e.g., WASM bindings
     /// that parse both script and template content). The analysis should include
     /// `used_components` populated from template analysis for component usage edges.
+    /// `source` must be the corresponding raw script module when automatic effect
+    /// summary construction is desired. SFC callers should use the explicit-summary API.
     pub fn add_file_with_analysis(
         &mut self,
         path: impl AsRef<Path>,
         source: &str,
         analysis: Croquis,
     ) -> FileId {
+        let effect_summary = automatic_effect_summary(path.as_ref(), source);
+        self.add_file_with_analysis_and_effect_summary(path, source, analysis, effect_summary)
+    }
+
+    /// Add a file with pre-computed semantic analysis and effect summary.
+    ///
+    /// SFC callers should prefer this API after parsing the descriptor and
+    /// summarizing the actual `<script>` and `<script setup>` block contents.
+    /// This avoids treating the full SFC container as JavaScript or TypeScript.
+    pub fn add_file_with_analysis_and_effect_summary(
+        &mut self,
+        path: impl AsRef<Path>,
+        source: &str,
+        analysis: Croquis,
+        effect_summary: EffectGraphSummary,
+    ) -> FileId {
         let path = path.as_ref();
 
         // Register in module registry (takes ownership of analysis)
         let (file_id, is_new) = self.registry.register(path, source, analysis);
-        self.effect_graph_summaries
-            .insert(file_id, build_effect_graph_from_script(source).summary());
+        self.record_effect_graph_summary(file_id, effect_summary);
 
         if is_new {
             // Add to dependency graph
@@ -94,6 +86,10 @@ impl CrossFileAnalyzer {
         self.update_dependency_edges(file_id);
 
         file_id
+    }
+
+    fn record_effect_graph_summary(&mut self, file_id: FileId, effect_summary: EffectGraphSummary) {
+        self.effect_graph_summaries.insert(file_id, effect_summary);
     }
 
     /// Rebuild import and import-backed component usage edges.
@@ -136,4 +132,13 @@ impl CrossFileAnalyzer {
             }
         }
     }
+}
+
+fn automatic_effect_summary(path: &Path, source: &str) -> EffectGraphSummary {
+    let extension = path.extension().and_then(|extension| extension.to_str());
+    let lang = match extension {
+        Some("js" | "jsx" | "ts" | "tsx") => extension,
+        _ => Some("ts"),
+    };
+    build_effect_graph_from_sfc_scripts(None, Some(EffectGraphScript::new(source, lang))).summary()
 }

--- a/crates/vize_croquis_cf/src/analyzer/core/single_file.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/single_file.rs
@@ -17,6 +17,11 @@ impl CrossFileAnalyzer {
             // the WASM bindings which properly parse SFC.
             // For cross-file analysis, we treat Vue SFC source as script setup.
             analyzer.analyze_script_setup(source);
+        } else if path
+            .extension()
+            .is_some_and(|extension| matches!(extension.to_str(), Some("jsx" | "tsx")))
+        {
+            analyzer.analyze_script_plain_jsx(source);
         } else {
             analyzer.analyze_script_plain(source);
         }

--- a/crates/vize_croquis_cf/src/analyzer/tests_complexity_effect_graph.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_complexity_effect_graph.rs
@@ -1,5 +1,10 @@
 use super::{CrossFileAnalyzer, CrossFileOptions};
 use serde_json::json;
+use vize_carton::cstr;
+use vize_croquis::{
+    Analyzer, AnalyzerOptions, Croquis, EffectGraphSummary, build_effect_graph_from_script,
+    build_effect_graph_from_script_setup,
+};
 
 const ALPHA_SOURCE: &str = r#"
 import { computed, ref } from 'vue'
@@ -18,8 +23,8 @@ watch(count, () => {})
 #[test]
 fn parser_effect_graphs_drive_global_and_hotspot_complexity() {
     let mut analyzer = CrossFileAnalyzer::new(CrossFileOptions::minimal());
-    analyzer.add_file("Alpha.vue", ALPHA_SOURCE);
-    analyzer.add_file("Beta.vue", BETA_SOURCE);
+    add_vue_script(&mut analyzer, "Alpha.vue", ALPHA_SOURCE);
+    add_vue_script(&mut analyzer, "Beta.vue", BETA_SOURCE);
 
     let result = analyzer.analyze();
     let input = result.complexity_report.input;
@@ -126,7 +131,8 @@ fn parser_effect_graphs_drive_global_and_hotspot_complexity() {
 #[test]
 fn parser_effect_cycles_and_plain_controls_are_not_inferred_from_diagnostics() {
     let mut cyclic = CrossFileAnalyzer::new(CrossFileOptions::minimal());
-    cyclic.add_file(
+    add_vue_script(
+        &mut cyclic,
         "Cycle.vue",
         r#"
 import { computed } from 'vue'
@@ -149,7 +155,11 @@ const right = computed(() => left.value)
     );
 
     let mut plain = CrossFileAnalyzer::new(CrossFileOptions::all());
-    plain.add_file("Plain.vue", "const value = 1\nconsole.log(value)");
+    add_vue_script(
+        &mut plain,
+        "Plain.vue",
+        "const value = 1\nconsole.log(value)",
+    );
     let plain_result = plain.analyze();
     assert_eq!(plain_result.complexity_report.input.reactive_node_count, 0);
     assert_eq!(plain_result.complexity_report.input.reactive_edge_count, 0);
@@ -165,8 +175,8 @@ const right = computed(() => left.value)
 #[test]
 fn equally_scored_effect_hotspots_use_filename_order() {
     let mut analyzer = CrossFileAnalyzer::new(CrossFileOptions::minimal());
-    analyzer.add_file("Zulu.vue", ALPHA_SOURCE);
-    analyzer.add_file("Alpha.vue", ALPHA_SOURCE);
+    add_vue_script(&mut analyzer, "Zulu.vue", ALPHA_SOURCE);
+    add_vue_script(&mut analyzer, "Alpha.vue", ALPHA_SOURCE);
 
     let names: Vec<_> = analyzer
         .analyze()
@@ -176,4 +186,114 @@ fn equally_scored_effect_hotspots_use_filename_order() {
         .collect();
 
     assert_eq!(names, ["Alpha.vue", "Zulu.vue"]);
+}
+
+#[test]
+fn raw_module_add_file_builds_effect_summary_without_sfc_container_parsing() {
+    let mut analyzer = CrossFileAnalyzer::new(CrossFileOptions::minimal());
+    let alpha = analyzer.add_file("Alpha.ts", ALPHA_SOURCE);
+    let beta = analyzer.add_file("Beta.ts", BETA_SOURCE);
+
+    assert_eq!(
+        analyzer.effect_graph_summary(alpha).unwrap(),
+        build_effect_graph_from_script(ALPHA_SOURCE).summary()
+    );
+    assert_eq!(
+        analyzer.effect_graph_summary(beta).unwrap(),
+        build_effect_graph_from_script(BETA_SOURCE).summary()
+    );
+}
+
+#[test]
+fn explicit_sfc_effect_summary_drives_complexity_and_replaces_previous_value() {
+    let mut analyzer = CrossFileAnalyzer::new(CrossFileOptions::minimal());
+    let source = r#"<script setup lang="ts">const label = '日本語🙂'</script>
+<template><p>{{ label }}</p></template>"#;
+    let expected = EffectGraphSummary {
+        node_count: 9,
+        edge_count: 6,
+        cycle_count: 2,
+        cycle_node_count: 4,
+    };
+    let file_id = analyzer.add_file_with_analysis_and_effect_summary(
+        "Explicit.vue",
+        source,
+        Croquis::default(),
+        expected,
+    );
+
+    assert_eq!(analyzer.effect_graph_summary(file_id), Some(expected));
+    let result = analyzer.analyze();
+    assert_eq!(result.complexity_report.input.reactive_edge_count, 6);
+    assert_eq!(result.complexity_report.input.reactive_cycle_count, 2);
+    assert_eq!(
+        serde_json::to_value(&result.complexity_hotspots).unwrap(),
+        json!([{
+            "fileId": 0,
+            "fileName": "Explicit.vue",
+            "componentName": "Explicit",
+            "input": {
+                "componentCount": 1,
+                "templateIfCount": 0,
+                "templateForCount": 0,
+                "templateLogicalOperatorCount": 0,
+                "componentTreeVIfMaxDepth": 0,
+                "componentTreeVForMaxDepth": 0,
+                "componentTreeScopedSlotMaxDepth": 0,
+                "componentTreeTemplateNestingScore": 0,
+                "slotCount": 0,
+                "propDrillingEdgeCount": 0,
+                "globalStateReferenceCount": 0,
+                "provideInjectMaxDepth": 0,
+                "provideInjectReferenceCount": 0,
+                "provideInjectFanoutCount": 0,
+                "fallthroughRiskCount": 0,
+                "reactiveNodeCount": 0,
+                "reactiveEdgeCount": 6,
+                "reactiveCycleCount": 2
+            },
+            "dimensions": {
+                "templateControlFlow": 1,
+                "slotUsage": 0,
+                "propDrilling": 0,
+                "globalState": 0,
+                "provideInject": 0,
+                "fallthroughAttrs": 0,
+                "reactiveGraph": 32
+            },
+            "totalScore": 33,
+            "dominantDimension": { "dimension": "reactive-graph", "score": 32 }
+        }])
+    );
+
+    let updated = analyzer.add_file_with_analysis_and_effect_summary(
+        "Explicit.vue",
+        source,
+        Croquis::default(),
+        EffectGraphSummary::default(),
+    );
+    assert_eq!(updated, file_id);
+    assert_eq!(
+        analyzer.effect_graph_summary(file_id),
+        Some(EffectGraphSummary::default())
+    );
+    let updated_result = analyzer.analyze();
+    assert_eq!(
+        updated_result.complexity_report.input.reactive_edge_count,
+        0
+    );
+    assert_eq!(
+        updated_result.complexity_report.input.reactive_cycle_count,
+        0
+    );
+}
+
+fn add_vue_script(analyzer: &mut CrossFileAnalyzer, path: &str, script: &str) {
+    let mut croquis = Analyzer::with_options(AnalyzerOptions::full());
+    croquis.analyze_script_setup(script);
+    let analysis = croquis.finish();
+    let effect_summary = build_effect_graph_from_script_setup(script).summary();
+    let source = cstr!("<script setup lang=\"ts\">\n{script}\n</script>");
+
+    analyzer.add_file_with_analysis_and_effect_summary(path, &source, analysis, effect_summary);
 }

--- a/crates/vize_croquis_cf/src/analyzer/tests_complexity_effect_graph_overflow.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_complexity_effect_graph_overflow.rs
@@ -1,0 +1,77 @@
+use super::{CrossFileAnalyzer, CrossFileOptions};
+use vize_croquis::{Croquis, EffectGraphSummary};
+
+#[test]
+fn explicit_max_effect_summaries_saturate_global_and_hotspot_counts() {
+    let mut analyzer = CrossFileAnalyzer::new(CrossFileOptions::minimal());
+    let summary = EffectGraphSummary {
+        edge_count: usize::MAX,
+        cycle_count: usize::MAX,
+        ..EffectGraphSummary::default()
+    };
+    for path in ["A.vue", "B.vue"] {
+        analyzer.add_file_with_analysis_and_effect_summary(path, "", Croquis::default(), summary);
+    }
+
+    let result = analyzer.analyze();
+    assert_eq!(
+        result.complexity_report.input.reactive_edge_count,
+        usize::MAX
+    );
+    assert_eq!(
+        result.complexity_report.input.reactive_cycle_count,
+        usize::MAX
+    );
+    assert_eq!(result.complexity_hotspots.len(), 2);
+    assert!(result.complexity_hotspots.iter().all(|hotspot| {
+        hotspot.input.reactive_edge_count == usize::MAX
+            && hotspot.input.reactive_cycle_count == usize::MAX
+    }));
+}
+
+#[test]
+fn clear_drops_explicit_effect_summaries_before_file_ids_are_reused() {
+    let mut analyzer = CrossFileAnalyzer::new(CrossFileOptions::minimal());
+    analyzer.add_file_with_analysis_and_effect_summary(
+        "Before.vue",
+        "",
+        Croquis::default(),
+        EffectGraphSummary {
+            edge_count: 7,
+            cycle_count: 3,
+            ..EffectGraphSummary::default()
+        },
+    );
+
+    analyzer.clear();
+    analyzer.add_file_with_analysis_and_effect_summary(
+        "After.vue",
+        "",
+        Croquis::default(),
+        EffectGraphSummary::default(),
+    );
+    let result = analyzer.analyze();
+
+    assert_eq!(result.complexity_report.input.reactive_edge_count, 0);
+    assert_eq!(result.complexity_report.input.reactive_cycle_count, 0);
+}
+
+#[test]
+fn raw_jsx_and_tsx_modules_use_matching_parser_modes() {
+    let source = r#"
+import { computed } from 'vue'
+const render = () => <strong>ready</strong>
+const left = computed(() => right.value)
+const right = computed(() => left.value)
+"#;
+    for path in ["Plain.jsx", "Typed.tsx"] {
+        let mut analyzer = CrossFileAnalyzer::new(CrossFileOptions::minimal());
+        let file_id = analyzer.add_file(path, source);
+        let summary = analyzer.effect_graph_summary(file_id).unwrap();
+        let analysis = analyzer.get_analysis(file_id).unwrap();
+
+        assert_eq!(analysis.reactivity.count(), 2, "path={path}");
+        assert_eq!(summary.edge_count, 2, "path={path}");
+        assert_eq!(summary.cycle_count, 1, "path={path}");
+    }
+}

--- a/crates/vize_croquis_cf/src/lib.rs
+++ b/crates/vize_croquis_cf/src/lib.rs
@@ -29,9 +29,9 @@
 //!
 //! let mut analyzer = CrossFileAnalyzer::new(options);
 //!
-//! // Add files to analyze
-//! analyzer.add_file("src/components/Parent.vue", parent_source);
-//! analyzer.add_file("src/components/Child.vue", child_source);
+//! // Add extracted JS/TS script modules. Parse full SFC containers first.
+//! analyzer.add_file("src/components/Parent.vue", parent_script_setup);
+//! analyzer.add_file("src/components/Child.vue", child_script_setup);
 //!
 //! // Run cross-file analysis
 //! let result = analyzer.analyze();

--- a/crates/vize_croquis_cf/src/rules/complexity.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity.rs
@@ -1,7 +1,10 @@
 //! Cross-file complexity scoring.
 
+mod counts;
 mod hotspots;
 mod nesting;
+
+use counts::{add_count, fallthrough_risk_count, logical_operator_count};
 
 use crate::analyzer::CrossFileResult;
 use crate::graph::DependencyGraph;
@@ -265,56 +268,57 @@ fn complexity_input(
 
     for entry in registry.vue_components() {
         let analysis = &entry.analysis;
-        input.component_count = input.component_count.saturating_add(1);
+        add_count(&mut input.component_count, 1);
 
-        input.template_if_count += analysis
-            .template_expressions
-            .iter()
-            .filter(|expr| expr.kind == TemplateExpressionKind::VIf)
-            .count();
-        input.template_logical_operator_count += analysis
-            .template_expressions
-            .iter()
-            .filter(|expr| expr.kind == TemplateExpressionKind::VIf)
-            .map(|expr| logical_operator_count(expr.content.as_str()))
-            .sum::<usize>();
-        input.template_for_count += analysis
-            .scopes
-            .iter()
-            .filter(|scope| scope.kind == ScopeKind::VFor)
-            .count();
-        input.slot_count += analysis.macros.slots().len();
-        input.slot_count += analysis
-            .component_usages
-            .iter()
-            .map(|usage| usage.slots.len())
-            .sum::<usize>();
-        input.prop_drilling_edge_count += analysis
-            .component_usages
-            .iter()
-            .map(|usage| usage.props.len())
-            .sum::<usize>();
-        input.reactive_node_count += analysis.reactivity.count();
+        add_count(
+            &mut input.template_if_count,
+            analysis
+                .template_expressions
+                .iter()
+                .filter(|expr| expr.kind == TemplateExpressionKind::VIf)
+                .count(),
+        );
+        add_count(
+            &mut input.template_logical_operator_count,
+            analysis
+                .template_expressions
+                .iter()
+                .filter(|expr| expr.kind == TemplateExpressionKind::VIf)
+                .map(|expr| logical_operator_count(expr.content.as_str()))
+                .fold(0usize, usize::saturating_add),
+        );
+        add_count(
+            &mut input.template_for_count,
+            analysis
+                .scopes
+                .iter()
+                .filter(|scope| scope.kind == ScopeKind::VFor)
+                .count(),
+        );
+        add_count(&mut input.slot_count, analysis.macros.slots().len());
+        add_count(
+            &mut input.slot_count,
+            analysis
+                .component_usages
+                .iter()
+                .map(|usage| usage.slots.len())
+                .fold(0usize, usize::saturating_add),
+        );
+        add_count(
+            &mut input.prop_drilling_edge_count,
+            analysis
+                .component_usages
+                .iter()
+                .map(|usage| usage.props.len())
+                .fold(0usize, usize::saturating_add),
+        );
+        add_count(&mut input.reactive_node_count, analysis.reactivity.count());
         let effect_graph = effect_graphs.get(&entry.id).copied().unwrap_or_default();
-        input.reactive_edge_count += effect_graph.edge_count;
-        input.reactive_cycle_count += effect_graph.cycle_count;
+        add_count(&mut input.reactive_edge_count, effect_graph.edge_count);
+        add_count(&mut input.reactive_cycle_count, effect_graph.cycle_count);
     }
 
     input
-}
-
-fn fallthrough_risk_count(result: &CrossFileResult) -> usize {
-    if let Some(summary) = result.fallthrough_summary {
-        return summary
-            .components_with_potential_issues
-            .saturating_add(summary.risky_unconsumed_fallthrough_attr_count);
-    }
-
-    result
-        .fallthrough_info
-        .iter()
-        .filter(|info| info.has_potential_issues())
-        .count()
 }
 
 fn weighted(count: usize, weight: u32) -> u32 {
@@ -340,11 +344,4 @@ fn cyclomatic_score(input: ComplexityInput) -> u32 {
 
 fn cognitive_score(input: ComplexityInput) -> u32 {
     weighted(input.component_tree_template_nesting_score, 1)
-}
-
-fn logical_operator_count(content: &str) -> usize {
-    content
-        .matches("&&")
-        .count()
-        .saturating_add(content.matches("||").count())
 }

--- a/crates/vize_croquis_cf/src/rules/complexity/counts.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity/counts.rs
@@ -1,0 +1,26 @@
+use crate::analyzer::CrossFileResult;
+
+pub(super) fn add_count(total: &mut usize, count: usize) {
+    *total = total.saturating_add(count);
+}
+
+pub(super) fn fallthrough_risk_count(result: &CrossFileResult) -> usize {
+    if let Some(summary) = result.fallthrough_summary {
+        return summary
+            .components_with_potential_issues
+            .saturating_add(summary.risky_unconsumed_fallthrough_attr_count);
+    }
+
+    result
+        .fallthrough_info
+        .iter()
+        .filter(|info| info.has_potential_issues())
+        .count()
+}
+
+pub(super) fn logical_operator_count(content: &str) -> usize {
+    content
+        .matches("&&")
+        .count()
+        .saturating_add(content.matches("||").count())
+}

--- a/crates/vize_croquis_cf/src/rules/complexity/hotspots.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity/hotspots.rs
@@ -73,18 +73,19 @@ fn local_input(entry: &ModuleEntry, effect_graph: EffectGraphSummary) -> Complex
             .iter()
             .filter(|expr| expr.kind == TemplateExpressionKind::VIf)
             .map(|expr| logical_operator_count(expr.content.as_str()))
-            .sum(),
-        slot_count: analysis.macros.slots().len()
-            + analysis
+            .fold(0usize, usize::saturating_add),
+        slot_count: analysis.macros.slots().len().saturating_add(
+            analysis
                 .component_usages
                 .iter()
                 .map(|usage| usage.slots.len())
-                .sum::<usize>(),
+                .fold(0usize, usize::saturating_add),
+        ),
         prop_drilling_edge_count: analysis
             .component_usages
             .iter()
             .map(|usage| usage.props.len())
-            .sum(),
+            .fold(0usize, usize::saturating_add),
         reactive_node_count: analysis.reactivity.count(),
         reactive_edge_count: effect_graph.edge_count,
         reactive_cycle_count: effect_graph.cycle_count,
@@ -97,11 +98,11 @@ fn add_fallthrough_inputs(
     result: &CrossFileResult,
 ) {
     for info in &result.fallthrough_info {
-        inputs
-            .entry(info.file_id)
-            .or_default()
-            .fallthrough_risk_count += usize::from(info.has_potential_issues())
-            .saturating_add(info.risky_unconsumed_fallthrough_attr_count());
+        let input = inputs.entry(info.file_id).or_default();
+        input.fallthrough_risk_count = input.fallthrough_risk_count.saturating_add(
+            usize::from(info.has_potential_issues())
+                .saturating_add(info.risky_unconsumed_fallthrough_attr_count()),
+        );
     }
 }
 
@@ -112,14 +113,16 @@ fn add_reactivity_inputs(
     for issue in &result.reactivity_issues {
         let input = inputs.entry(issue.file_id).or_default();
         if matches!(issue.kind, ReactivityIssueKind::ShouldUseStoreToRefs { .. }) {
-            input.global_state_reference_count += 1;
+            input.global_state_reference_count =
+                input.global_state_reference_count.saturating_add(1);
         }
     }
 
     for issue in &result.cross_file_reactivity_issues {
         let input = inputs.entry(issue.file_id).or_default();
         if let CrossFileReactivityIssueKind::StoreDestructured { .. } = issue.kind {
-            input.global_state_reference_count += 1;
+            input.global_state_reference_count =
+                input.global_state_reference_count.saturating_add(1);
         }
     }
 }
@@ -130,12 +133,15 @@ fn add_provide_inject_inputs(
 ) {
     for matched in &result.provide_inject_matches {
         let provider = inputs.entry(matched.provider).or_default();
-        provider.provide_inject_reference_count += 1;
-        provider.provide_inject_fanout_count += 1;
+        provider.provide_inject_reference_count =
+            provider.provide_inject_reference_count.saturating_add(1);
+        provider.provide_inject_fanout_count =
+            provider.provide_inject_fanout_count.saturating_add(1);
 
         // A dependency injection edge is not inherently a reactive edge.
         let consumer = inputs.entry(matched.consumer).or_default();
-        consumer.provide_inject_reference_count += 1;
+        consumer.provide_inject_reference_count =
+            consumer.provide_inject_reference_count.saturating_add(1);
 
         let depth = matched.path.len();
         for file_id in &matched.path {


### PR DESCRIPTION
## Summary

- accept precomputed effect graph summaries alongside Croquis analysis
- use the supplied edge and cycle counts in global complexity and hotspot scoring
- preserve deterministic, saturating counts across updates and analyzer resets
- parse raw JS, JSX, TS, and TSX modules in their matching language modes

## Validation

- `cargo test -p vize_croquis_cf --all-features` (209 tests + doctests)
- `cargo test -p vize_vitrine --all-features` (22 tests + doctests)
- `cargo clippy -p vize_croquis_cf --lib --all-features -- -D warnings`
- `cargo clippy -p vize_croquis_cf --all-targets --all-features -- -D warnings -D clippy::wildcard_imports -A clippy::disallowed_types -A clippy::disallowed_macros`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p vize_croquis_cf --all-features --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Refs #2746
Refs #2748

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786238967&installation_id=136613492&pr_number=2803&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2803&signature=8d1f83d4ae28dc6d196b9b3c8bcfe9bef1dc6edf554f943caae8406685daf316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented complexity and hotspot metrics from overflowing when processing very large counts.
  - Improved reactive edge and cycle tracking when files are reanalyzed or cleared.
  - Corrected analysis for JSX and TSX modules by using the appropriate parsing mode.
  - Improved handling of explicitly supplied effect summaries for more accurate complexity results.

- **Documentation**
  - Updated the usage example to reflect the recommended script-analysis workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->