### PR TITLE
fix(ci): guard semver checks by event baseline

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -74,16 +74,16 @@ jobs:
         run: vp run --workspace-root check:ci
   semver-checks:
     name: cargo-semver-checks (${{ matrix.crate }})
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 25
     permissions:
       contents: read
     # Matrix legs run in parallel and keep breaking changes attributed per crate.
-    # PRs compare against base; pushes compare against the previous main commit.
+    # PRs compare against base; pushes compare against previous main. Schedules lack an exact base.
     # Conventional breaking markers (`type(scope)!:` / `BREAKING CHANGE:`) are major.
     # Keep this list in sync with crates published by tools/moon/cmd/publish_crates.
-    # New crates are omitted until first publish so registry fallback cannot hit
-    # "not found in registry"; dependents of those crates are omitted with them.
+    # Omit unpublished crates and their dependents so registry fallback cannot hit "not found".
     strategy:
       fail-fast: false
       matrix:

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -77,6 +77,20 @@ test("check workflow runs declared Node engine compatibility matrix", () => {
   assert.doesNotMatch(job, /vscode-typescript-vue-plugin\.test\.ts/);
 });
 
+test("check workflow only runs SemVer checks with an exact Git event baseline", () => {
+  const workflow = readRepoFile(".github", "workflows", "check.yml");
+  const job = workflowJobBody(workflow, "semver-checks");
+
+  assert.match(
+    job,
+    /if:\s*\$\{\{\s*github\.event_name == 'pull_request' \|\| github\.event_name == 'push'\s*\}\}/,
+  );
+  assert.match(
+    job,
+    /BASELINE_REV:\s*\$\{\{\s*github\.event_name == 'pull_request' && github\.event\.pull_request\.base\.sha \|\| \(github\.event_name == 'push' && github\.event\.before \|\| ''\)\s*\}\}/,
+  );
+});
+
 test("check workflow comments a detailed PR test report for each head push", () => {
   const workflow = readRepoFile(".github", "workflows", "check.yml");
   const reportJob = workflowJobBody(workflow, "test-report");


### PR DESCRIPTION
## Summary

- run the SemVer matrix only for pull-request and push events
- preserve the exact PR-base and previous-main comparison paths
- lock the event/baseline contract with a workflow tooling test

## Root cause

Scheduled events provide neither a pull-request base SHA nor `github.event.before`. The job therefore fell back to comparing the workspace with the published release while inspecting only the latest commit for a breaking marker. That produced a false failure after accepted breaking changes had accumulated on `main`.

## Impact

Daily checks stop spending eleven matrix jobs on a comparison whose base cannot be reconstructed. Pull requests and pushes keep the existing SemVer gate with an exact Git baseline.

## Verification

- `node --test tests/tooling/github-workflows-check.test.ts`
- `vp run actrun:lint`
- `vp run actrun:dry-run`
- `git diff --check`

Closes #2813

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786426765&installation_id=136613492&pr_number=2814&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2814&signature=f2cfaa7e55f775060ca2302014c16529048be9959949ebffb745a12aef686d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Limited the semantic version check workflow to run only on pull requests and push events, avoiding unintended executions for other triggers.
  * Corrected how the baseline revision is determined per event type to ensure accurate comparisons.

* **Tests**
  * Added tests to verify the workflow event gating and that the baseline revision environment value is set appropriately for pull requests and pushes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->