### PR TITLE
fix(e2e): prevent fixture hook mutations

### DIFF
--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -145,12 +145,30 @@ function ensureLocalVizePackagesBuilt(): void {
   }
 }
 
-function installPnpmDependencies(cwd: string): void {
+interface PnpmInstallOptions {
+  env?: NodeJS.ProcessEnv;
+  ignoreScripts?: boolean;
+  timeout?: number;
+}
+export function installPnpmDependencies(cwd: string, options: PnpmInstallOptions = {}): void {
   console.log(`[vize:setup] pnpm install in ${cwd}...`);
-  execSync("npx -y pnpm@10 install --no-frozen-lockfile --prefer-offline", {
+  const args = ["-y", "pnpm@10", "install", "--no-frozen-lockfile"];
+  if (options.ignoreScripts) args.push("--ignore-scripts");
+  args.push("--prefer-offline");
+  const executable = process.platform === "win32" ? (process.env.ComSpec ?? "cmd.exe") : "npx";
+  const executableArgs =
+    process.platform === "win32" ? ["/d", "/s", "/c", "npx.cmd", ...args] : args;
+  execFileSync(executable, executableArgs, {
     cwd,
+    env: {
+      ...process.env,
+      ...options.env,
+      GIT_CEILING_DIRECTORIES: path.dirname(cwd),
+      HUSKY: "0",
+      SKIP_INSTALL_SIMPLE_GIT_HOOKS: "1",
+    },
     stdio: "inherit",
-    timeout: 600_000,
+    timeout: options.timeout ?? 600_000,
   });
 }
 
@@ -747,10 +765,7 @@ function setupElkWorktree(opts?: { enableVize?: boolean; variant?: string }): st
   });
   patchElkBuildEnvTime(path.join(elkDir, "modules", "build-env.ts"));
 
-  console.log(`[elk:${enableVize ? "candidate" : "reference"}:setup] pnpm install...`);
-  execSync("npx -y pnpm@10 install --no-frozen-lockfile", {
-    cwd: elkDir,
-    stdio: "inherit",
+  installPnpmDependencies(elkDir, {
     timeout: 300_000,
   });
 
@@ -879,16 +894,13 @@ function setupMisskeyWorktree(opts?: {
     vite: "^8.0.0",
   });
 
-  console.log(`[misskey:${enableVize ? "candidate" : "reference"}:setup] pnpm install...`);
-  execSync("npx -y pnpm@10 install --no-frozen-lockfile --ignore-scripts", {
-    cwd: misskeyDir,
+  installPnpmDependencies(misskeyDir, {
     env: {
-      ...process.env,
       CYPRESS_INSTALL_BINARY: "0",
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1",
       PUPPETEER_SKIP_DOWNLOAD: "1",
     },
-    stdio: "inherit",
+    ignoreScripts: true,
     timeout: 300_000,
   });
 
@@ -1240,15 +1252,10 @@ function setupNpmxWorktree(opts?: { enableVize?: boolean; variant?: string }): s
     vite: "^8.0.0",
   });
 
-  console.log(`[npmx.dev:${enableVize ? "candidate" : "reference"}:setup] pnpm install...`);
-  execSync("npx -y pnpm@10 install --no-frozen-lockfile --ignore-scripts", {
-    cwd: npmxDir,
-    stdio: "inherit",
+  installPnpmDependencies(npmxDir, {
+    env: NPMX_E2E_ENV,
+    ignoreScripts: true,
     timeout: 300_000,
-    env: {
-      ...process.env,
-      ...NPMX_E2E_ENV,
-    },
   });
   for (const script of ["generate:lexicons", "generate:sprite"]) {
     console.log(`[npmx.dev:${enableVize ? "candidate" : "reference"}:setup] pnpm ${script}...`);
@@ -1550,17 +1557,9 @@ function setupFrontendPhpconWorktree(opts?: { enableVize?: boolean; variant?: st
   });
   patchFrontendPhpconVisualFixture(frontendDir);
 
-  console.log(
-    `[frontend-phpcon-do-website:${enableVize ? "candidate" : "reference"}:setup] pnpm install...`,
-  );
-  execSync("npx -y pnpm@10 install --no-frozen-lockfile", {
-    cwd: frontendDir,
-    stdio: "inherit",
+  installPnpmDependencies(frontendDir, {
+    env: FRONTEND_PHPCON_E2E_ENV,
     timeout: 300_000,
-    env: {
-      ...process.env,
-      ...FRONTEND_PHPCON_E2E_ENV,
-    },
   });
 
   if (enableVize) {
@@ -1725,10 +1724,7 @@ function setupVuefesWorktree(opts?: { enableVize?: boolean; variant?: string }):
   });
   patchVuefesVisualFixture(vuefesDir);
 
-  console.log(`[vuefes-2025:${enableVize ? "candidate" : "reference"}:setup] pnpm install...`);
-  execSync("npx -y pnpm@10 install --no-frozen-lockfile", {
-    cwd: vuefesDir,
-    stdio: "inherit",
+  installPnpmDependencies(vuefesDir, {
     timeout: 300_000,
   });
 

--- a/tests/tooling/playwright-app-config.test.ts
+++ b/tests/tooling/playwright-app-config.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { installPnpmDependencies } from "../_helpers/apps.ts";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 function readRepoFile(...segments: string[]): string {
@@ -23,3 +25,100 @@ test("app e2e Playwright config keeps CI runs guarded and debuggable", () => {
   assert.match(config, /trace:\s*process\.env\.CI \? "off" : "retain-on-failure"/);
   assert.match(config, /video:\s*process\.env\.CI \? "off" : "retain-on-failure"/);
 });
+
+test("external fixture installs use the guarded helper", () => {
+  const apps = readRepoFile("tests", "_helpers", "apps.ts");
+  assert.doesNotMatch(apps, /execSync\("npx -y pnpm@10 install\b/);
+});
+
+test("fixture install child cannot discover or mutate the parent Git repository", () => {
+  const tempRoot = fs.mkdtempSync(path.join(root, ".fixture-install-safety-"));
+  const fixtureDir = path.join(tempRoot, "fixture");
+  const binDir = path.join(tempRoot, "bin");
+  const probeScript = path.join(tempRoot, "probe.cjs");
+  const probeOutput = path.join(tempRoot, "probe.json");
+
+  try {
+    fs.mkdirSync(fixtureDir);
+    fs.mkdirSync(binDir);
+    writeInstallProbe(probeScript);
+    writeNpxShim(binDir, probeScript);
+
+    const before = snapshotParentGitState();
+    installPnpmDependencies(fixtureDir, {
+      env: {
+        ...process.env,
+        FIXTURE_INSTALL_PROBE: probeOutput,
+        GIT_CEILING_DIRECTORIES: root,
+        HUSKY: "1",
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        SKIP_INSTALL_SIMPLE_GIT_HOOKS: "0",
+      },
+      timeout: 10_000,
+    });
+
+    assert.deepEqual(snapshotParentGitState(), before);
+    const probe = JSON.parse(fs.readFileSync(probeOutput, "utf8"));
+    assert.deepEqual(probe.argv, [
+      "-y",
+      "pnpm@10",
+      "install",
+      "--no-frozen-lockfile",
+      "--prefer-offline",
+    ]);
+    assert.equal(probe.env.GIT_CEILING_DIRECTORIES, tempRoot);
+    assert.equal(probe.env.HUSKY, "0");
+    assert.equal(probe.env.SKIP_INSTALL_SIMPLE_GIT_HOOKS, "1");
+    assert.notEqual(probe.gitStatus, 0);
+    assert.notEqual(probe.gitTopLevel, root);
+  } finally {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+});
+
+function snapshotParentGitState() {
+  const hooksDir = path.join(root, ".git", "hooks");
+  return {
+    config: fs.readFileSync(path.join(root, ".git", "config")),
+    hooks: fs.existsSync(hooksDir)
+      ? fs
+          .readdirSync(hooksDir)
+          .sort()
+          .map((name) => [name, fs.readFileSync(path.join(hooksDir, name))])
+      : [],
+  };
+}
+
+function writeInstallProbe(probeScript: string): void {
+  fs.writeFileSync(
+    probeScript,
+    `const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const git = spawnSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" });
+fs.writeFileSync(process.env.FIXTURE_INSTALL_PROBE, JSON.stringify({
+  argv: process.argv.slice(2),
+  env: {
+    GIT_CEILING_DIRECTORIES: process.env.GIT_CEILING_DIRECTORIES,
+    HUSKY: process.env.HUSKY,
+    SKIP_INSTALL_SIMPLE_GIT_HOOKS: process.env.SKIP_INSTALL_SIMPLE_GIT_HOOKS,
+  },
+  gitStatus: git.status,
+  gitTopLevel: git.stdout.trim(),
+}));
+`,
+  );
+}
+
+function writeNpxShim(binDir: string, probeScript: string): void {
+  if (process.platform === "win32") {
+    fs.writeFileSync(
+      path.join(binDir, "npx.cmd"),
+      `@echo off\r\n"${process.execPath}" "${probeScript}" %*\r\n`,
+    );
+    return;
+  }
+
+  const shim = path.join(binDir, "npx");
+  fs.writeFileSync(shim, `#!/bin/sh\nexec "${process.execPath}" "${probeScript}" "$@"\n`);
+  fs.chmodSync(shim, 0o755);
+}


### PR DESCRIPTION
## Summary

- route every exported-fixture dependency install through one guarded helper
- prevent Git discovery from escaping the fixture with `GIT_CEILING_DIRECTORIES`
- disable Simple Git Hooks and Husky after caller-provided environment values
- use shell-free `npx` on Unix and an explicit `cmd.exe` path for Windows
- prove the child environment and parent `.git/config` / `.git/hooks` invariants at runtime

## Root cause

Exported fixture directories intentionally have no `.git`. During lifecycle scripts, Git discovery therefore walked up to the Vize checkout. ELK and Reka UI run hook installers during dependency setup, which could replace the parent checkout's pre-commit hook.

## Impact

App E2E setup no longer mutates persistent Git state outside its fixture worktree. The centralized helper makes new exported fixtures safe by default while preserving fixture-specific flags, timeouts, and download guards.

## Verification

- `node --test tests/tooling/playwright-app-config.test.ts`
- `vp check tests/_helpers/apps.ts tests/tooling/playwright-app-config.test.ts`
- `git diff --check`
- runtime probe verifies the child cannot resolve the parent Git root
- runtime snapshot verifies parent config and every hook remain byte-identical
- `tests/_helpers/apps.ts` shrinks from 2196 to 2192 lines

Closes #2819


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented app/fixture dependency installs from altering the parent repository’s git-hook state.
  * Standardized pnpm installation behavior via a shared helper, ensuring consistent `pnpm@10 install` options (offline preference, no frozen lockfile), controlled script handling, timeouts, environment injection, and correct Windows `npx` handling.
* **Tests**
  * Added Playwright/Node tests that verify fixture-safe installs, including absence of legacy `npx -y pnpm@10 install` patterns.
  * Assert parent `.git` configuration/hooks remain unchanged and validate the probed install argv and key env values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->