### PR TITLE
docs(wasm): align compileSfc examples with result shape

### DIFF
--- a/docs/content/guide/wasm.md
+++ b/docs/content/guide/wasm.md
@@ -40,9 +40,9 @@ const result = compileSfc(
   { filename: "App.vue" },
 );
 
-console.log(result.code);
-// → import { ref, toDisplayString, ... } from 'vue'
-// → ...compiled render function...
+console.log(result.script.code); // compiled <script> / <script setup>
+console.log(result.template?.code); // compiled render function, when a template exists
+console.log(result.css); // compiled styles, when styles exist
 ```
 
 ### Lint SFC
@@ -103,14 +103,18 @@ Build interactive Vue compilation playgrounds that run entirely in the browser. 
 ```javascript
 // React to editor changes and compile in real-time
 editor.onChange((source) => {
-  const { code, errors } = compileSfc(source, {
+  const result = compileSfc(source, {
     filename: "Playground.vue",
   });
 
-  if (errors.length === 0) {
-    preview.update(code);
+  if (result.errors.length === 0) {
+    preview.update({
+      script: result.script.code,
+      template: result.template?.code,
+      css: result.css,
+    });
   } else {
-    diagnostics.show(errors);
+    diagnostics.show(result.errors);
   }
 });
 ```
@@ -123,10 +127,10 @@ Embed live, editable Vue examples in your documentation:
 // Compile documentation examples on the fly
 const examples = document.querySelectorAll("[data-vue-example]");
 for (const el of examples) {
-  const { code } = compileSfc(el.textContent, {
+  const result = compileSfc(el.textContent, {
     filename: `example-${el.id}.vue`,
   });
-  // Mount the compiled component...
+  // Use result.script.code, result.template?.code, and result.css to mount it.
 }
 ```
 
@@ -186,5 +190,6 @@ For production use, consider lazy-loading the WASM module:
 // Lazy-load the compiler only when needed
 const compiler = await import("@vizejs/wasm");
 await compiler.default(); // init()
-const { code } = compiler.compileSfc(source, opts);
+const result = compiler.compileSfc(source, opts);
+console.log(result.script.code, result.template?.code, result.css);
 ```

--- a/tests/tooling/docs-wasm.test.ts
+++ b/tests/tooling/docs-wasm.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("WASM guide uses the public nested SFC compile result", () => {
+  const guide = fs.readFileSync(path.join(root, "docs/content/guide/wasm.md"), "utf8");
+
+  assert.doesNotMatch(guide, /result\.code\b/);
+  assert.doesNotMatch(
+    guide,
+    /const\s+\{\s*code(?:\s*,\s*errors)?\s*\}\s*=\s*(?:compiler\.)?compileSfc\b/,
+  );
+  assert.match(guide, /result\.script\.code/);
+  assert.match(guide, /result\.template\?\.code/);
+  assert.match(guide, /result\.css/);
+  assert.match(guide, /result\.errors/);
+});


### PR DESCRIPTION
## Summary

- read compiled script output from `result.script.code`
- read optional render output from `result.template?.code`
- surface optional CSS and the existing `errors` field in every use case
- add a docs contract test that rejects the nonexistent top-level `code` shape

## Root cause

The guide treated `compileSfc` like the template-only compiler and read a top-level `code`. The public `SfcCompileResult` instead separates script, template, and CSS outputs.

## Impact

Every documented `compileSfc` example now matches the runtime and TypeScript contract instead of logging `undefined` or destructuring a missing property.

## Verification

- `node --test tests/tooling/docs-wasm.test.ts`
- `vp check docs/content/guide/wasm.md tests/tooling/docs-wasm.test.ts`
- `vp run --filter './docs' build`
- `git diff --check`

Closes #2817

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786427810&installation_id=136613492&pr_number=2835&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2835&signature=f0c0c8e3183e240eda2fe408bb24e8b2e84839c13d586bb31cdc032a92bc8695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated WASM API examples to reflect the current `compileSfc` result format.
  - Examples now show separate script, template, CSS, and error handling.
  - Updated playground and bundle-size examples to use the structured compilation results.

- **Tests**
  - Added coverage ensuring the WASM guide uses the current public API shape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->