### PR TITLE
fix(glyph): escape SFC block attribute values

### DIFF
--- a/crates/vize_glyph/src/attribute.rs
+++ b/crates/vize_glyph/src/attribute.rs
@@ -1,0 +1,53 @@
+//! Shared attribute serialization helpers.
+
+/// Write an attribute value with a safe quote style and escaped delimiters.
+///
+/// The callback keeps the common path allocation-free for callers that already
+/// own an output buffer. Double quotes are preferred unless the value contains
+/// double quotes but no single quotes, in which case single quotes avoid
+/// unnecessary entities.
+#[inline]
+pub(crate) fn write_attr_value(value: &str, mut write: impl FnMut(&str)) {
+    let contains_double_quote = value.contains('"');
+    if contains_double_quote && !value.contains('\'') {
+        write("'");
+        write(value);
+        write("'");
+        return;
+    }
+
+    write("\"");
+    if contains_double_quote {
+        let mut segments = value.split('"');
+        if let Some(first) = segments.next() {
+            write(first);
+        }
+        for segment in segments {
+            write("&quot;");
+            write(segment);
+        }
+    } else {
+        write(value);
+    }
+    write("\"");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_attr_value;
+
+    #[test]
+    fn selects_safe_quotes_and_escapes_delimiters() {
+        let cases = [
+            ("a'b", r#""a'b""#),
+            (r#"a"b"#, r#"'a"b'"#),
+            (r#"a"b'c"#, r#""a&quot;b'c""#),
+        ];
+
+        for (value, expected) in cases {
+            let mut output = String::new();
+            write_attr_value(value, |segment| output.push_str(segment));
+            assert_eq!(output, expected, "unexpected output for {value}");
+        }
+    }
+}

--- a/crates/vize_glyph/src/formatter.rs
+++ b/crates/vize_glyph/src/formatter.rs
@@ -371,8 +371,7 @@ fn write_attr(output: &mut Vec<u8>, name: &str, value: Option<&str>) {
     output.push(b' ');
     output.extend_from_slice(name.as_bytes());
     if let Some(value) = value {
-        output.extend_from_slice(b"=\"");
-        output.extend_from_slice(value.as_bytes());
-        output.push(b'"');
+        output.push(b'=');
+        crate::attribute::write_attr_value(value, |s| output.extend_from_slice(s.as_bytes()));
     }
 }

--- a/crates/vize_glyph/src/lib.rs
+++ b/crates/vize_glyph/src/lib.rs
@@ -32,12 +32,12 @@
 //!   <button @click="count++">{{count}}</button>
 //! </template>
 //! "#;
-//!
 //! let options = FormatOptions::default();
 //! let result = format_sfc(source, &options).unwrap();
 //! println!("{}", result.code);
 //! ```
 
+mod attribute;
 mod error;
 mod formatter;
 mod json;

--- a/crates/vize_glyph/src/template/attributes.rs
+++ b/crates/vize_glyph/src/template/attributes.rs
@@ -1,5 +1,8 @@
-use crate::options::{AttributeSortOrder, FormatOptions};
-use vize_carton::{String, ToCompactString};
+use crate::{
+    attribute::write_attr_value,
+    options::{AttributeSortOrder, FormatOptions},
+};
+use vize_carton::String;
 
 use super::helpers::template_literal_state_after_line_from;
 
@@ -133,13 +136,14 @@ pub(crate) fn attribute_priority(name: &str) -> u8 {
 }
 
 /// Render an attribute back to its string representation.
-#[allow(clippy::disallowed_macros)]
 pub(crate) fn render_attribute(attr: &ParsedAttribute) -> String {
     match &attr.value {
         Some(value) => {
-            let quote = attribute_quote(value);
-            let value = escape_attribute_value(value, quote);
-            format!("{}={}{}{}", attr.name, quote, value, quote).into()
+            let mut rendered = String::with_capacity(attr.name.len() + value.len() + 3);
+            rendered.push_str(&attr.name);
+            rendered.push('=');
+            write_attr_value(value, |segment| rendered.push_str(segment));
+            rendered
         }
         None => attr.name.clone(),
     }
@@ -255,30 +259,6 @@ fn write_indent(output: &mut Vec<u8>, indent: &[u8], depth: usize) {
     for _ in 0..depth {
         output.extend_from_slice(indent);
     }
-}
-
-fn attribute_quote(value: &str) -> char {
-    if value.contains('"') && !value.contains('\'') {
-        '\''
-    } else {
-        '"'
-    }
-}
-
-fn escape_attribute_value(value: &str, quote: char) -> String {
-    if !value.contains(quote) {
-        return value.to_compact_string();
-    }
-
-    let mut escaped = String::default();
-    for ch in value.chars() {
-        match (quote, ch) {
-            ('"', '"') => escaped.push_str("&quot;"),
-            ('\'', '\'') => escaped.push_str("&#39;"),
-            _ => escaped.push(ch),
-        }
-    }
-    escaped
 }
 
 #[cfg(test)]

--- a/crates/vize_glyph/tests/sfc_block_attributes.rs
+++ b/crates/vize_glyph/tests/sfc_block_attributes.rs
@@ -1,0 +1,93 @@
+use std::borrow::Cow;
+
+use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
+use vize_carton::{FxHashMap, String};
+use vize_glyph::{FormatOptions, format_sfc};
+
+type BlockAttrs<'a> = FxHashMap<Cow<'a, str>, Cow<'a, str>>;
+
+fn decoded_quote_entities(value: &str) -> String {
+    value.replace("&quot;", "\"").replace("&#39;", "'").into()
+}
+
+fn assert_quote_values_preserved(before: &BlockAttrs<'_>, after: &BlockAttrs<'_>) {
+    for name in ["data-single", "data-double", "data-both"] {
+        let before = before.get(name).expect("source attribute must be parsed");
+        let after = after
+            .get(name)
+            .expect("formatted attribute must still be parsed");
+        assert_eq!(
+            decoded_quote_entities(after),
+            decoded_quote_entities(before),
+            "attribute value changed for {name}"
+        );
+    }
+}
+
+#[test]
+fn root_block_attributes_escape_quotes_and_preserve_parse_results() {
+    let source = r#"<script data-single="a'b" data-double='a"b' data-both="a'b &quot;c&quot;">
+const classic = 1
+</script>
+
+<script setup data-single="a'b" data-double='a"b' data-both="a'b &quot;c&quot;">
+const setup = 1
+</script>
+
+<template data-single="a'b" data-double='a"b' data-both="a'b &quot;c&quot;">
+<div>content</div>
+</template>
+
+<style data-single="a'b" data-double='a"b' data-both="a'b &quot;c&quot;">
+.root { color: red; }
+</style>
+
+<i18n data-single="a'b" data-double='a"b' data-both="a'b &quot;c&quot;">
+{"content":"Content"}
+</i18n>
+"#;
+    let options = FormatOptions::default();
+
+    let first = format_sfc(source, &options).expect("source SFC must format");
+    let second = format_sfc(&first.code, &options).expect("formatted SFC must reformat");
+
+    assert_eq!(first.code, second.code, "formatting must be idempotent");
+
+    let serialized_attrs = r#"data-both="a'b &quot;c&quot;" data-double='a"b' data-single="a'b""#;
+    assert_eq!(
+        first.code.matches(serialized_attrs).count(),
+        5,
+        "script, script setup, template, style, and custom roots must share safe serialization"
+    );
+
+    let before = parse_sfc(source, SfcParseOptions::default()).expect("source SFC must parse");
+    let after = parse_sfc(&first.code, SfcParseOptions::default())
+        .expect("formatted SFC must remain parseable");
+
+    let before_attrs = [
+        &before.script.as_ref().expect("script block").attrs,
+        &before
+            .script_setup
+            .as_ref()
+            .expect("script setup block")
+            .attrs,
+        &before.template.as_ref().expect("template block").attrs,
+        &before.styles.first().expect("style block").attrs,
+        &before.custom_blocks.first().expect("custom block").attrs,
+    ];
+    let after_attrs = [
+        &after.script.as_ref().expect("script block").attrs,
+        &after
+            .script_setup
+            .as_ref()
+            .expect("script setup block")
+            .attrs,
+        &after.template.as_ref().expect("template block").attrs,
+        &after.styles.first().expect("style block").attrs,
+        &after.custom_blocks.first().expect("custom block").attrs,
+    ];
+
+    for (before, after) in before_attrs.into_iter().zip(after_attrs) {
+        assert_quote_values_preserved(before, after);
+    }
+}


### PR DESCRIPTION
## Summary

- share one quote-aware serializer between SFC root blocks and template attributes
- preserve attribute values containing single quotes, double quotes, or both
- cover script, script setup, template, style, and custom blocks with idempotence and reparse regressions

## Performance

- write directly into the caller output buffer on the common path
- keep existing over-limit source files at or below their base line counts
- avoid allocating an escaped copy unless the destination string itself must grow

## Verification

- cargo test -p vize_glyph --quiet
- cargo fmt --all -- --check
- cargo clippy -p vize_glyph --lib -- -D warnings
- cargo clippy -p vize_glyph --test sfc_block_attributes -- -D warnings
- git diff --check

Closes #2821