### PR TITLE
fix(wasm): expose patina and glyph facades

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,7 +342,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: npm/wasm
-          key: ${{ runner.os }}-release-wasm-${{ hashFiles('crates/**/*.rs', 'Cargo.lock', 'npm/wasm/package.json', 'npm/wasm/index.js', 'npm/wasm/index.d.ts', 'tools/moon/cmd/build_vize_wasm_package') }}
+          key: ${{ runner.os }}-release-wasm-${{ hashFiles('crates/**/*.rs', 'Cargo.lock', 'npm/wasm/package.json', 'npm/wasm/index.js', 'npm/wasm/index.d.ts', 'npm/wasm/lint-format.d.ts', 'tools/moon/cmd/build_vize_wasm_package') }}
 
       - name: Install wasm-bindgen-cli
         if: steps.cache-wasm.outputs.cache-hit != 'true'

--- a/docs/content/guide/wasm.md
+++ b/docs/content/guide/wasm.md
@@ -54,13 +54,15 @@ import init, { lintSfc } from "@vizejs/wasm";
 
 await init();
 
-const diagnostics = lintSfc(source, {
+const result = lintSfc(source, {
   filename: "App.vue",
   locale: "en", // 'en' | 'ja' | 'zh'
 });
 
-for (const d of diagnostics) {
-  console.log(`${d.severity}: ${d.message} (line ${d.line})`);
+for (const diagnostic of result.diagnostics) {
+  console.log(
+    `${diagnostic.severity}: ${diagnostic.message} (line ${diagnostic.location.start.line})`,
+  );
 }
 ```
 
@@ -73,11 +75,9 @@ import init, { formatSfc } from "@vizejs/wasm";
 
 await init();
 
-const formatted = formatSfc(source, {
-  filename: "App.vue",
-});
+const formatted = formatSfc(source, { printWidth: 80 });
 
-console.log(formatted);
+console.log(formatted.code);
 ```
 
 ## Initialization
@@ -174,10 +174,12 @@ All WASM APIs that produce diagnostics (lint, compile errors) support localized 
 Pass the `locale` option to any API that produces diagnostics:
 
 ```javascript
-const diagnostics = lintSfc(source, {
+const result = lintSfc(source, {
   filename: "App.vue",
   locale: "ja", // Lint messages in Japanese
 });
+
+console.log(result.diagnostics);
 ```
 
 ## Bundle Size

--- a/npm/wasm/index.d.ts
+++ b/npm/wasm/index.d.ts
@@ -4,6 +4,18 @@
  * This package provides WebAssembly bindings for the Vue compiler implemented in Rust.
  */
 
+import type { FormatOptions, FormatResult, LintOptions, LintResult } from "./lint-format.js";
+
+export type {
+  FormatOptions,
+  FormatResult,
+  LintDiagnostic,
+  LintOptions,
+  LintPosition,
+  LintPreset,
+  LintResult,
+} from "./lint-format.js";
+
 /** Compiler options for template compilation */
 export interface CompilerOptions {
   /** Output mode: "module" or "function" */
@@ -288,6 +300,18 @@ export declare function compileCss(
   css: string,
   options?: CssCompileOptions
 ): CssCompileResult;
+
+/** Lint a Vue SFC */
+export declare function lintSfc(
+  source: string,
+  options?: LintOptions
+): LintResult;
+
+/** Format a Vue SFC */
+export declare function formatSfc(
+  source: string,
+  options?: FormatOptions
+): FormatResult;
 
 /** Initialize the WASM module */
 export declare function init(

--- a/npm/wasm/index.js
+++ b/npm/wasm/index.js
@@ -13,6 +13,8 @@ import initWasm, {
   compileSfc as wasmCompileSfc,
   compileJsx as wasmCompileJsx,
   compileCss as wasmCompileCss,
+  lintSfc as wasmLintSfc,
+  formatSfc as wasmFormatSfc,
 } from "./vize_vitrine.js";
 
 let initialized = false;
@@ -34,9 +36,17 @@ export async function init(moduleOrPath) {
     return initPromise;
   }
 
-  initPromise = initWasm(moduleOrPath).then(() => {
-    initialized = true;
-  });
+  const initOptions =
+    moduleOrPath === undefined ? undefined : { module_or_path: moduleOrPath };
+  initPromise = initWasm(initOptions).then(
+    () => {
+      initialized = true;
+    },
+    (error) => {
+      initPromise = null;
+      throw error;
+    }
+  );
 
   return initPromise;
 }
@@ -235,6 +245,30 @@ export function compileJsx(source, options = {}) {
 export function compileCss(css, options = {}) {
   ensureInitialized();
   return wasmCompileCss(css, options);
+}
+
+/**
+ * Lint a Vue SFC.
+ *
+ * @param {string} source
+ * @param {object} [options]
+ * @returns {object}
+ */
+export function lintSfc(source, options = {}) {
+  ensureInitialized();
+  return wasmLintSfc(source, options);
+}
+
+/**
+ * Format a Vue SFC.
+ *
+ * @param {string} source
+ * @param {object} [options]
+ * @returns {object}
+ */
+export function formatSfc(source, options = {}) {
+  ensureInitialized();
+  return wasmFormatSfc(source, options);
 }
 
 export default init;

--- a/npm/wasm/lint-format.d.ts
+++ b/npm/wasm/lint-format.d.ts
@@ -1,0 +1,93 @@
+/** Built-in lint preset. */
+export type LintPreset =
+  | "general-recommended"
+  | "happy-path"
+  | "essential"
+  | "incremental"
+  | "ecosystem"
+  | "opinionated"
+  | "nuxt";
+
+/** Options for linting a Vue SFC. */
+export interface LintOptions {
+  /** Filename reported in the result (default: "anonymous.vue"). */
+  filename?: string;
+  /** Built-in lint preset (default: "ecosystem"). */
+  preset?: LintPreset;
+  /** Run only the named rules. */
+  enabledRules?: string[];
+  /** Locale for diagnostic messages (default: "en"). */
+  locale?: "en" | "ja" | "zh";
+}
+
+/** One-based source position reported by the linter. */
+export interface LintPosition {
+  /** One-based line number. */
+  line: number;
+  /** One-based column number. */
+  column: number;
+  /** Byte offset in the original source. */
+  offset: number;
+}
+
+/** Diagnostic reported by the linter. */
+export interface LintDiagnostic {
+  /** Rule that produced the diagnostic. */
+  rule: string;
+  /** Diagnostic severity. */
+  severity: "error" | "warning";
+  /** Localized diagnostic message. */
+  message: string;
+  /** Location in the original source. */
+  location: {
+    start: LintPosition;
+    end: LintPosition;
+  };
+  /** Optional remediation hint. */
+  help: string | undefined;
+}
+
+/** Result of linting a Vue SFC. */
+export interface LintResult {
+  /** Filename associated with the source. */
+  filename: string;
+  /** Number of error diagnostics. */
+  errorCount: number;
+  /** Number of warning diagnostics. */
+  warningCount: number;
+  /** Diagnostics in source order. */
+  diagnostics: LintDiagnostic[];
+}
+
+/** Options for formatting a Vue SFC. */
+export interface FormatOptions {
+  printWidth?: number;
+  tabWidth?: number;
+  useTabs?: boolean;
+  semi?: boolean;
+  singleQuote?: boolean;
+  jsxSingleQuote?: boolean;
+  trailingComma?: "none" | "es5" | "all";
+  bracketSpacing?: boolean;
+  bracketSameLine?: boolean;
+  arrowParens?: "always" | "avoid";
+  endOfLine?: "lf" | "crlf" | "cr" | "auto";
+  quoteProps?: "as-needed" | "consistent" | "preserve";
+  singleAttributePerLine?: boolean;
+  vueIndentScriptAndStyle?: boolean;
+  sortAttributes?: boolean;
+  attributeSortOrder?: "alphabetical" | "as-written";
+  mergeBindAndNonBindAttrs?: boolean;
+  maxAttributesPerLine?: number | null;
+  attributeGroups?: string[][] | null;
+  normalizeDirectiveShorthands?: boolean;
+  sortBlocks?: boolean;
+}
+
+/** Result of formatting a Vue SFC. */
+export interface FormatResult {
+  /** Formatted source. */
+  code: string;
+  /** Whether the source changed. */
+  changed: boolean;
+}

--- a/npm/wasm/package.json
+++ b/npm/wasm/package.json
@@ -15,6 +15,7 @@
   "files": [
     "index.js",
     "index.d.ts",
+    "lint-format.d.ts",
     "vize_vitrine_bg.wasm",
     "vize_vitrine.js",
     "vize_vitrine.d.ts",

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -546,6 +546,7 @@ test("wasm package publishes the wrapper entrypoint and raw wasm assets", () => 
   for (const file of [
     "index.js",
     "index.d.ts",
+    "lint-format.d.ts",
     "vize_vitrine.js",
     "vize_vitrine.d.ts",
     "vize_vitrine_bg.wasm",
@@ -553,7 +554,6 @@ test("wasm package publishes the wrapper entrypoint and raw wasm assets", () => 
     assert.ok(wasmPackage.files?.includes(file), `@vizejs/wasm files include ${file}`);
   }
 });
-
 test("workspace TypeScript package builds use vp pack", () => {
   const packages = [
     ["npm/fresco", "vp pack", "vp pack --watch"],

--- a/tests/tooling/wasm-package-smoke.test.ts
+++ b/tests/tooling/wasm-package-smoke.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -13,17 +14,31 @@ function copyRepoFile(targetDir: string, relativePath: string): void {
   fs.copyFileSync(path.join(root, relativePath), path.join(targetDir, path.basename(relativePath)));
 }
 
-test("wasm package smoke validates manifest, files, exports, and init guard", async () => {
+test("wasm package smoke validates exports, init guards, and runtime APIs", async () => {
   const packageDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-wasm-smoke-"));
 
   copyRepoFile(packageDir, "npm/wasm/package.json");
   copyRepoFile(packageDir, "npm/wasm/index.js");
   copyRepoFile(packageDir, "npm/wasm/index.d.ts");
+  copyRepoFile(packageDir, "npm/wasm/lint-format.d.ts");
   fs.writeFileSync(path.join(packageDir, "vize_vitrine.d.ts"), "export {};\n");
-  fs.writeFileSync(path.join(packageDir, "vize_vitrine_bg.wasm"), "");
+  fs.writeFileSync(
+    path.join(packageDir, "vize_vitrine_bg.wasm"),
+    Buffer.from([0x00, 0x61, 0x73, 0x6d]),
+  );
   fs.writeFileSync(
     path.join(packageDir, "vize_vitrine.js"),
-    `export default async function init() {}
+    `export default async function init(options) {
+  if (options == null || !("module_or_path" in options)) {
+    throw new Error("expected wasm-bindgen init options");
+  }
+  if (options.module_or_path.byteLength === 0) {
+    throw new Error("invalid wasm bytes");
+  }
+  if (options.module_or_path instanceof URL) {
+    await fetch(options.module_or_path);
+  }
+}
 export class Compiler {
   compile() {}
   compileVapor() {}
@@ -40,6 +55,26 @@ export function parseSfc() {}
 export function compileSfc() {}
 export function compileJsx() {}
 export function compileCss() {}
+export function lintSfc(_source, options = {}) {
+  return {
+    filename: options.filename ?? "anonymous.vue",
+    errorCount: 0,
+    warningCount: 1,
+    diagnostics: [{
+      help: undefined,
+      location: {
+        start: { line: 2, column: 7, offset: 17 },
+        end: { line: 2, column: 9, offset: 19 },
+      },
+      message: "Multiple consecutive spaces",
+      rule: "vue/no-multi-spaces",
+      severity: "warning",
+    }],
+  };
+}
+export function formatSfc(source) {
+  return { code: source.replace("  id", " id"), changed: true };
+}
 `,
   );
 
@@ -59,4 +94,73 @@ test("wasm package smoke fails when wrapper entrypoint is missing", async () => 
   fs.writeFileSync(path.join(packageDir, "vize_vitrine_bg.wasm"), "");
 
   await assert.rejects(() => smokeWasmPackage(packageDir), /index\.js is missing/);
+});
+
+test("wasm package declarations type-check a strict consumer", (t) => {
+  const consumerDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-wasm-types-"));
+  const packageDir = path.join(consumerDir, "node_modules", "@vizejs", "wasm");
+  fs.mkdirSync(packageDir, { recursive: true });
+  copyRepoFile(packageDir, "npm/wasm/package.json");
+  copyRepoFile(packageDir, "npm/wasm/index.d.ts");
+  copyRepoFile(packageDir, "npm/wasm/lint-format.d.ts");
+  t.after(() => fs.rmSync(consumerDir, { force: true, recursive: true }));
+
+  fs.writeFileSync(
+    path.join(consumerDir, "consumer.ts"),
+    `import init, { formatSfc, lintSfc, type FormatResult, type LintResult } from "@vizejs/wasm";
+
+void init();
+
+const lint: LintResult = lintSfc("<template />", {
+  enabledRules: ["vue/no-dupe-keys"],
+  filename: "App.vue",
+  locale: "ja",
+  preset: "essential",
+});
+const diagnostic = lint.diagnostics[0];
+if (diagnostic) {
+  const help: string | undefined = diagnostic.help;
+  console.log(help, diagnostic.location.start.offset);
+}
+
+const formatted: FormatResult = formatSfc("<template />", {
+  attributeGroups: [["id", "class"]],
+  maxAttributesPerLine: null,
+  printWidth: 80,
+  trailingComma: "all",
+});
+console.log(formatted.code, formatted.changed);
+
+// @ts-expect-error severity overrides are not supported by the WASM binding
+lintSfc("<template />", { severityOverrides: {} });
+// @ts-expect-error filename is not a formatter option
+formatSfc("<template />", { filename: "App.vue" });
+`,
+  );
+  fs.writeFileSync(
+    path.join(consumerDir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        lib: ["ESNext", "DOM"],
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        noEmit: true,
+        skipLibCheck: false,
+        strict: true,
+      },
+      include: ["consumer.ts"],
+    }),
+  );
+
+  const tsgo =
+    process.env.TSGO_PATH ??
+    path.join(root, "node_modules", "@typescript", "native-preview", "bin", "tsgo.js");
+  const result = spawnSync(
+    process.execPath,
+    [tsgo, "-p", path.join(consumerDir, "tsconfig.json")],
+    {
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 });

--- a/tools/npm/smoke-wasm-package.mjs
+++ b/tools/npm/smoke-wasm-package.mjs
@@ -11,12 +11,13 @@ import { pathToFileURL } from "node:url";
 const REQUIRED_FILES = [
   "index.js",
   "index.d.ts",
+  "lint-format.d.ts",
   "vize_vitrine.js",
   "vize_vitrine.d.ts",
   "vize_vitrine_bg.wasm",
 ];
 
-const REQUIRED_EXPORTS = [
+const EXPECTED_EXPORTS = [
   "Compiler",
   "compile",
   "compileCss",
@@ -24,8 +25,10 @@ const REQUIRED_EXPORTS = [
   "compileSfc",
   "compileVapor",
   "default",
+  "formatSfc",
   "init",
   "isInitialized",
+  "lintSfc",
   "parseSfc",
   "parseTemplate",
 ];
@@ -68,13 +71,57 @@ async function assertEntryPoint(packageDir) {
   const entry = await import(
     `${pathToFileURL(path.join(packageDir, "index.js")).href}?smoke=${Date.now()}`
   );
-  for (const exportName of REQUIRED_EXPORTS) {
-    assert.ok(exportName in entry, `missing export ${exportName}`);
-  }
+  assert.deepEqual(Object.keys(entry).sort(), EXPECTED_EXPORTS);
 
   assert.equal(entry.default, entry.init);
   assert.equal(entry.isInitialized(), false);
   assert.throws(() => entry.compile("<div />"), /Call `await init\(\)` first/);
+  assert.throws(() => entry.lintSfc("<template />"), /Call `await init\(\)` first/);
+  assert.throws(() => entry.formatSfc("<template />"), /Call `await init\(\)` first/);
+
+  await assert.rejects(() => entry.init(new Uint8Array()), /.+/);
+  assert.equal(entry.isInitialized(), false);
+
+  const failedUrl = new URL("https://vize.invalid/vize_vitrine_bg.wasm");
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const inputUrl =
+      typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (inputUrl === failedUrl.href) {
+      throw new Error("intentional WASM fetch failure");
+    }
+    return originalFetch(input, init);
+  };
+  try {
+    await assert.rejects(() => entry.init(failedUrl), /intentional WASM fetch failure/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  assert.equal(entry.isInitialized(), false);
+
+  const wasm = fs.readFileSync(path.join(packageDir, "vize_vitrine_bg.wasm"));
+  await entry.init(wasm);
+  assert.equal(entry.isInitialized(), true);
+
+  const source = '<template>\n  <div  id="x"></div>\n</template>\n';
+  const formattedSource = '<template>\n  <div id="x"></div>\n</template>\n';
+  const lintResult = entry.lintSfc(source, {
+    filename: "Smoke.vue",
+    locale: "en",
+    enabledRules: ["vue/no-multi-spaces"],
+  });
+  assert.equal(lintResult.filename, "Smoke.vue");
+  assert.equal(lintResult.errorCount, 0);
+  assert.equal(lintResult.warningCount, 1);
+  assert.equal(lintResult.diagnostics.length, 1);
+  assert.equal(lintResult.diagnostics[0].rule, "vue/no-multi-spaces");
+  assert.equal(lintResult.diagnostics[0].severity, "warning");
+  assert.equal(lintResult.diagnostics[0].location.start.offset, 17);
+  assert.equal(lintResult.diagnostics[0].help, undefined);
+
+  const formatResult = entry.formatSfc(source, { printWidth: 80 });
+  assert.equal(formatResult.code, formattedSource);
+  assert.equal(formatResult.changed, true);
 }
 
 export async function smokeWasmPackage(packageDir) {


### PR DESCRIPTION
## Summary

- expose initialization-guarded lintSfc and formatSfc functions from the package root
- publish Rust-faithful lint, formatter, result, and option declarations
- let initialization recover after a failed URL, fetch, or invalid module attempt
- align guide examples with the actual aggregate result shapes

## Release safety

- require the complete façade export allowlist
- verify invalid initialization can retry with the real generated WASM artifact
- assert a deterministic lint diagnostic and exact formatter output
- type-check a strict consumer, including unsupported-option failures
- keep declaration files below the repository source-length budget

## Verification

- release-equivalent WASM build with wasm-bindgen 0.2.121
- node tools/npm/smoke-wasm-package.mjs against the generated package
- node --test tests/tooling/wasm-package-smoke.test.ts tests/tooling/docs-wasm.test.ts
- focused oxlint and strict tsgo checks
- git diff --check

Closes #2816