### PR TITLE
fix(atelier-sfc): scope imported-type cache epochs

### DIFF
--- a/crates/vize_atelier_sfc/src/lib.rs
+++ b/crates/vize_atelier_sfc/src/lib.rs
@@ -69,7 +69,7 @@ pub use css::{
     compile_style_block, parse_css_ast, print_css_ast,
 };
 pub use parse::parse_sfc;
-pub use script::begin_type_resolution_batch;
+pub use script::{TypeResolutionBatchGuard, begin_type_resolution_batch};
 pub use types::{
     BindingMetadata, BindingType, BlockLocation, PadOption, PropsDestructure, ScriptCompileOptions,
     SfcCompileOptions, SfcCompileResult, SfcCustomBlock, SfcDescriptor, SfcError, SfcMacroArtifact,

--- a/crates/vize_atelier_sfc/src/script.rs
+++ b/crates/vize_atelier_sfc/src/script.rs
@@ -22,7 +22,7 @@ mod utils;
 
 // Re-export main types
 pub use analyze_script_bindings::{analyze_script_bindings, get_object_or_array_expression_keys};
-pub use context::{ScriptCompileContext, begin_type_resolution_batch};
+pub use context::{ScriptCompileContext, TypeResolutionBatchGuard, begin_type_resolution_batch};
 pub use define_emits::{
     DefineEmitsResult, extract_runtime_emits, gen_runtime_emits, process_define_emits,
 };

--- a/crates/vize_atelier_sfc/src/script/context.rs
+++ b/crates/vize_atelier_sfc/src/script/context.rs
@@ -3,12 +3,12 @@
 //! Holds all state during script compilation.
 //! Uses OXC for proper AST-based parsing instead of regex.
 
+mod batch_epoch;
 mod external_types;
 mod helpers;
 mod parse;
 mod props;
-
-pub use external_types::begin_type_resolution_batch;
+pub use batch_epoch::{TypeResolutionBatchGuard, begin_type_resolution_batch};
 
 use crate::types::{BindingMetadata, BindingType};
 use vize_carton::{CompactString, String, ToCompactString};

--- a/crates/vize_atelier_sfc/src/script/context/batch_epoch.rs
+++ b/crates/vize_atelier_sfc/src/script/context/batch_epoch.rs
@@ -1,0 +1,176 @@
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Sentinel for single-file/HMR resolution outside a batch. It never equals a
+/// live epoch, so every lookup revalidates its filesystem metadata.
+pub(super) const NO_EPOCH: u64 = 0;
+
+/// The generation shared by active batch scopes. Cache hits only pay this one
+/// relaxed load; lifecycle bookkeeping stays off the hot path.
+static ACTIVE_BATCH_EPOCH: AtomicU64 = AtomicU64::new(NO_EPOCH);
+
+#[derive(Debug)]
+struct BatchEpochState {
+    /// Generations are never recycled, including across overlapping scopes.
+    last_epoch: u64,
+    active_batches: usize,
+}
+
+static BATCH_EPOCH_STATE: Mutex<BatchEpochState> = Mutex::new(BatchEpochState {
+    last_epoch: NO_EPOCH,
+    active_batches: 0,
+});
+
+fn next_batch_epoch(state: &mut BatchEpochState) -> u64 {
+    let epoch = state
+        .last_epoch
+        .checked_add(1)
+        .expect("type-resolution batch epoch exhausted");
+    state.last_epoch = epoch;
+    epoch
+}
+
+/// A scoped filesystem-stability window for imported-type resolution.
+///
+/// Dropping the guard ends the batch. Normal returns, `?` error exits, and
+/// unwinding therefore all close the window. The guard is neither cloneable
+/// nor reusable.
+#[must_use = "hold the guard for the full type-resolution batch"]
+#[derive(Debug)]
+pub struct TypeResolutionBatchGuard {
+    epoch: u64,
+}
+
+impl TypeResolutionBatchGuard {
+    /// The unique generation issued when this batch scope began.
+    #[must_use]
+    pub const fn epoch(&self) -> u64 {
+        self.epoch
+    }
+}
+
+impl Drop for TypeResolutionBatchGuard {
+    fn drop(&mut self) {
+        let mut state = BATCH_EPOCH_STATE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.active_batches = state
+            .active_batches
+            .checked_sub(1)
+            .expect("type-resolution batch guard dropped without an active batch");
+
+        let epoch = if state.active_batches == 0 {
+            NO_EPOCH
+        } else {
+            // Never return to an older scope's generation after an out-of-order
+            // drop; split the validation window with a fresh generation.
+            next_batch_epoch(&mut state)
+        };
+        ACTIVE_BATCH_EPOCH.store(epoch, Ordering::Relaxed);
+    }
+}
+
+/// Open a scoped type-resolution batch.
+///
+/// Keep the returned guard alive until all parallel work has joined. While it
+/// is alive, imported-type caches skip repeated metadata checks within the
+/// current generation. Single compiles do not open a batch and always observe
+/// current filesystem metadata.
+pub fn begin_type_resolution_batch() -> TypeResolutionBatchGuard {
+    let mut state = BATCH_EPOCH_STATE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let active_batches = state
+        .active_batches
+        .checked_add(1)
+        .expect("too many overlapping type-resolution batches");
+    let epoch = next_batch_epoch(&mut state);
+    state.active_batches = active_batches;
+    ACTIVE_BATCH_EPOCH.store(epoch, Ordering::Relaxed);
+    TypeResolutionBatchGuard { epoch }
+}
+
+pub(super) fn current_batch_epoch() -> u64 {
+    // This generation is only compared for equality; cache contents have their
+    // own locks, and batch workers join before their guard is dropped.
+    ACTIVE_BATCH_EPOCH.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NO_EPOCH, begin_type_resolution_batch, current_batch_epoch};
+    use std::sync::Mutex;
+
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock_epoch_state() -> std::sync::MutexGuard<'static, ()> {
+        TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    #[test]
+    fn nested_scopes_never_reuse_epochs() {
+        let _lock = lock_epoch_state();
+        assert_eq!(current_batch_epoch(), NO_EPOCH);
+
+        let outer = begin_type_resolution_batch();
+        let inner = begin_type_resolution_batch();
+        assert!(inner.epoch() > outer.epoch());
+        assert_eq!(current_batch_epoch(), inner.epoch());
+
+        let inner_epoch = inner.epoch();
+        drop(inner);
+        let post_inner_epoch = current_batch_epoch();
+        assert!(post_inner_epoch > inner_epoch);
+        drop(outer);
+        assert_eq!(current_batch_epoch(), NO_EPOCH);
+
+        let next = begin_type_resolution_batch();
+        assert!(next.epoch() > post_inner_epoch);
+        drop(next);
+        assert_eq!(current_batch_epoch(), NO_EPOCH);
+    }
+
+    #[test]
+    fn concurrent_scopes_handle_out_of_order_drops() {
+        let _lock = lock_epoch_state();
+        let outer = begin_type_resolution_batch();
+        let (started_tx, started_rx) = std::sync::mpsc::sync_channel(0);
+        let (finish_tx, finish_rx) = std::sync::mpsc::sync_channel(0);
+
+        let concurrent = std::thread::spawn(move || {
+            let batch = begin_type_resolution_batch();
+            started_tx.send(batch.epoch()).unwrap();
+            finish_rx.recv().unwrap();
+            drop(batch);
+        });
+        let concurrent_epoch = started_rx.recv().unwrap();
+        assert!(concurrent_epoch > outer.epoch());
+
+        drop(outer);
+        assert!(current_batch_epoch() > concurrent_epoch);
+        finish_tx.send(()).unwrap();
+        concurrent.join().unwrap();
+        assert_eq!(current_batch_epoch(), NO_EPOCH);
+    }
+
+    #[test]
+    fn guard_closes_on_error_and_panic_exits() {
+        fn returns_error() -> Result<(), ()> {
+            let _batch = begin_type_resolution_batch();
+            Err(())
+        }
+
+        let _lock = lock_epoch_state();
+        assert!(returns_error().is_err());
+        assert_eq!(current_batch_epoch(), NO_EPOCH);
+
+        let result = std::panic::catch_unwind(|| {
+            let _batch = begin_type_resolution_batch();
+            panic!("exercise batch-guard unwind");
+        });
+        assert!(result.is_err());
+        assert_eq!(current_batch_epoch(), NO_EPOCH);
+    }
+}

--- a/crates/vize_atelier_sfc/src/script/context/external_types.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types.rs
@@ -14,6 +14,7 @@ use crate::script::build_interface_type_source;
 use crate::types::SfcParseOptions;
 
 use super::ScriptCompileContext;
+use super::batch_epoch::{NO_EPOCH, current_batch_epoch};
 use super::helpers::is_import_type_only;
 
 /// Type declarations and outgoing type-bearing specifiers extracted from one
@@ -33,7 +34,7 @@ type FileStamp = (Option<SystemTime>, u64);
 
 /// One cached file summary plus the metadata needed to revalidate it.
 ///
-/// `validated_epoch` records the [`BATCH_EPOCH`] in which the entry's
+/// `validated_epoch` records the active batch epoch in which the entry's
 /// [`FileStamp`] was last confirmed against disk. It is an atomic so a read
 /// hit can stamp it forward under the shared read guard, without upgrading to
 /// a write lock.
@@ -66,7 +67,7 @@ impl CachedFileSummary {
 /// the same type-barrel closure for every SFC (nuxt-ui re-reads ~200 files per
 /// component without this); outside a batch entries are revalidated against
 /// [`FileStamp`] on every use so on-disk edits are picked up, and within a
-/// batch the first hit revalidates and the rest reuse it (see [`BATCH_EPOCH`]).
+/// batch the first hit revalidates and the rest reuse it.
 static FILE_TYPE_CACHE: LazyLock<RwLock<FxHashMap<PathBuf, CachedFileSummary>>> =
     LazyLock::new(|| RwLock::new(FxHashMap::default()));
 
@@ -75,47 +76,6 @@ fn file_stamp(path: &Path) -> FileStamp {
         Ok(metadata) => (metadata.modified().ok(), metadata.len()),
         Err(_) => (None, 0),
     }
-}
-
-/// Monotonic batch generation. A batch compile snapshots its inputs up front
-/// and resolves a fixed set of files, so the type-resolution caches can treat
-/// the filesystem as stable for the batch's duration: once an entry is
-/// revalidated inside a batch, later hits in the *same* batch reuse it without
-/// re-issuing the `stat`/`metadata` syscall that dominates this path.
-///
-/// `0` is reserved for "no batch in flight" — single compiles (LSP edits, the
-/// dev-server one-file recompile) leave the epoch here and keep revalidating
-/// every hit, so an on-disk edit between compiles is still picked up exactly as
-/// before. [`begin_type_resolution_batch`] advances the epoch, never returning
-/// `0`, so each new batch invalidates the previous batch's "validated" stamps.
-static BATCH_EPOCH: AtomicU64 = AtomicU64::new(0);
-
-/// Sentinel meaning "this cache entry has not been revalidated inside any
-/// batch": it never equals a live epoch, so the first hit in a batch always
-/// pays one revalidation before the entry is trusted for the rest of it.
-const NO_EPOCH: u64 = 0;
-
-/// Open a new type-resolution batch and return its epoch.
-///
-/// Call this once before a batch of SFC compiles that share a filesystem
-/// snapshot (e.g. `compileSfcBatch*`). Within the returned epoch, the
-/// imported-type summary / canonicalization / resolution caches skip per-hit
-/// `stat` revalidation; the next batch advances the epoch and the first hit
-/// re-stats. Single compiles need not call this.
-pub fn begin_type_resolution_batch() -> u64 {
-    // `Relaxed` is enough: this is a generation counter, not a lock — readers
-    // only ever compare it for equality, and a batch publishes its files
-    // through rayon's join barriers, not through this value.
-    let previous = BATCH_EPOCH.fetch_add(1, Ordering::Relaxed);
-    // Skip the reserved `0` if the counter ever wraps back onto it.
-    if previous.wrapping_add(1) == NO_EPOCH {
-        BATCH_EPOCH.fetch_add(1, Ordering::Relaxed);
-    }
-    BATCH_EPOCH.load(Ordering::Relaxed)
-}
-
-fn current_batch_epoch() -> u64 {
-    BATCH_EPOCH.load(Ordering::Relaxed)
 }
 
 fn build_file_summary(path: &Path) -> Option<FileTypeSummary> {
@@ -1046,18 +1006,6 @@ const props = defineProps<ButtonProps>();
         assert_eq!(ctx.bindings.bindings.get("raw"), None);
 
         let _ = std::fs::remove_dir_all(project);
-    }
-
-    #[test]
-    fn batch_epochs_are_monotonic_and_never_reserved_zero() {
-        // Each batch must advance the epoch (so the previous batch's "validated
-        // this epoch" stamps stop matching) and never land on the reserved `0`
-        // that marks "no batch in flight".
-        let first = super::begin_type_resolution_batch();
-        let second = super::begin_type_resolution_batch();
-        assert_ne!(first, super::NO_EPOCH);
-        assert_ne!(second, super::NO_EPOCH);
-        assert!(second > first, "epoch must advance: {first} -> {second}");
     }
 
     #[test]

--- a/crates/vize_atelier_sfc/tests/imported_type_cache.rs
+++ b/crates/vize_atelier_sfc/tests/imported_type_cache.rs
@@ -1,0 +1,66 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use vize_atelier_sfc::{
+    SfcCompileOptions, SfcCompileResult, SfcParseOptions, begin_type_resolution_batch, compile_sfc,
+    parse_sfc,
+};
+use vize_carton::ToCompactString;
+
+fn temp_project_dir() -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "vize-sfc-imported-type-cache-{}-{nonce}",
+        std::process::id()
+    ))
+}
+
+fn compile_imported_props(source: &str, component: &Path) -> SfcCompileResult {
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("SFC should parse");
+    let mut options = SfcCompileOptions::default();
+    options.script.id = Some(component.to_string_lossy().as_ref().to_compact_string());
+    compile_sfc(&descriptor, options).expect("SFC should compile")
+}
+
+fn rewrite_with_newer_mtime(path: &Path, content: &str) {
+    let previous_mtime = std::fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .expect("type file should have an mtime");
+    std::fs::write(path, content).unwrap();
+    std::fs::File::options()
+        .write(true)
+        .open(path)
+        .unwrap()
+        .set_times(std::fs::FileTimes::new().set_modified(previous_mtime + Duration::from_secs(1)))
+        .unwrap();
+}
+
+#[test]
+fn single_compile_revalidates_imported_types_after_batch() {
+    let project = temp_project_dir();
+    std::fs::create_dir_all(&project).unwrap();
+    let component = project.join("App.vue");
+    let types = project.join("types.ts");
+    let source = r#"<script setup lang="ts">
+import type { Props } from './types'
+defineProps<Props>()
+</script>"#;
+
+    std::fs::write(&types, "export interface Props { first: string }\n").unwrap();
+    let batch = {
+        let _batch = begin_type_resolution_batch();
+        compile_imported_props(source, &component)
+    };
+    assert!(batch.code.contains("first: {"), "{}", batch.code);
+
+    // Same-length replacement: only metadata revalidation can detect it.
+    rewrite_with_newer_mtime(&types, "export interface Props { other: string }\n");
+    let hmr = compile_imported_props(source, &component);
+    assert!(hmr.code.contains("other: {"), "{}", hmr.code);
+    assert!(!hmr.code.contains("first: {"), "{}", hmr.code);
+
+    let _ = std::fs::remove_dir_all(project);
+}

--- a/crates/vize_vitrine/src/napi/sfc/batch.rs
+++ b/crates/vize_vitrine/src/napi/sfc/batch.rs
@@ -211,7 +211,7 @@ pub fn compile_sfc_batch(
         .map_err(|message| Error::new(Status::InvalidArg, message))?;
     let standalone = opts.mode.as_deref() == Some("function");
     let start = Instant::now();
-    vize_atelier_sfc::begin_type_resolution_batch();
+    let _type_resolution_batch = vize_atelier_sfc::begin_type_resolution_batch();
     let option_bits = batch_options_bits(
         ssr,
         vapor,

--- a/crates/vize_vitrine/src/napi/sfc/batch_results.rs
+++ b/crates/vize_vitrine/src/napi/sfc/batch_results.rs
@@ -57,7 +57,7 @@ pub fn compile_sfc_batch_with_results(
     // Snapshot the filesystem for this batch: imported-type resolution treats
     // every file it stats as stable for the batch's duration, so the second and
     // later hits of a shared types barrel skip their revalidation syscalls.
-    vize_atelier_sfc::begin_type_resolution_batch();
+    let _type_resolution_batch = vize_atelier_sfc::begin_type_resolution_batch();
 
     // Indexed parallel map keeps results in input order (deterministic) and
     // collects lock-free, replacing the previous contended `Mutex<Vec>`.


### PR DESCRIPTION
## Summary

- scope imported-type cache epochs with an RAII guard
- restore metadata revalidation after batch compilation
- handle nested and overlapping batches without recycling generations
- cover post-batch HMR, error, panic, and out-of-order drop paths

## Performance

Cache hits retain the existing single relaxed atomic load. Mutex bookkeeping runs only once at batch entry and exit.

## Verification

- cargo test -p vize_atelier_sfc --test imported_type_cache --quiet
- cargo test -p vize_atelier_sfc batch_epoch::tests --quiet
- cargo test -p vize_atelier_sfc -q
- cargo check -p vize_vitrine
- cargo test -p vize_vitrine --lib -q
- cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check
- cargo semver-checks check-release --package vize_atelier_sfc --baseline-rev origin/main
- git diff --check

Closes #2828

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786430843&installation_id=136613492&pr_number=2840&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2840&signature=a1e83006f3be92d90def77d4efbd0650b4811234eaf9ce6024a376b389ea0142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type-resolution cache revalidation during single and batch compilations.
  - Updated imported type changes are now detected reliably, even when file contents remain the same length.

- **Improvements**
  - Added scoped type-resolution batch handling to keep cache state consistent across concurrent and nested compilation tasks.
  - Enhanced cleanup behavior when batches complete, encounter errors, or unwind after panics.

- **Tests**
  - Added coverage for imported type updates and batch lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->