### PR TITLE
fix(atelier-sfc): harden batch guard teardown

### DIFF
--- a/crates/vize_atelier_sfc/src/script/context/batch_epoch.rs
+++ b/crates/vize_atelier_sfc/src/script/context/batch_epoch.rs
@@ -54,10 +54,11 @@ impl Drop for TypeResolutionBatchGuard {
         let mut state = BATCH_EPOCH_STATE
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        state.active_batches = state
-            .active_batches
-            .checked_sub(1)
-            .expect("type-resolution batch guard dropped without an active batch");
+        debug_assert!(
+            state.active_batches > 0,
+            "type-resolution batch guard dropped without an active batch"
+        );
+        state.active_batches = state.active_batches.saturating_sub(1);
 
         let epoch = if state.active_batches == 0 {
             NO_EPOCH
@@ -76,6 +77,9 @@ impl Drop for TypeResolutionBatchGuard {
 /// is alive, imported-type caches skip repeated metadata checks within the
 /// current generation. Single compiles do not open a batch and always observe
 /// current filesystem metadata.
+///
+/// Bind the result to a named variable and keep it alive until all parallel
+/// work joins. `let _ = begin_type_resolution_batch();` drops it immediately.
 pub fn begin_type_resolution_batch() -> TypeResolutionBatchGuard {
     let mut state = BATCH_EPOCH_STATE
         .lock()

--- a/crates/vize_vitrine/src/napi/sfc/batch.rs
+++ b/crates/vize_vitrine/src/napi/sfc/batch.rs
@@ -211,6 +211,8 @@ pub fn compile_sfc_batch(
         .map_err(|message| Error::new(Status::InvalidArg, message))?;
     let standalone = opts.mode.as_deref() == Some("function");
     let start = Instant::now();
+    // This named guard must stay alive until the parallel reduce has joined.
+    #[deny(let_underscore_drop)]
     let _type_resolution_batch = vize_atelier_sfc::begin_type_resolution_batch();
     let option_bits = batch_options_bits(
         ssr,

--- a/crates/vize_vitrine/src/napi/sfc/batch_results.rs
+++ b/crates/vize_vitrine/src/napi/sfc/batch_results.rs
@@ -57,6 +57,8 @@ pub fn compile_sfc_batch_with_results(
     // Snapshot the filesystem for this batch: imported-type resolution treats
     // every file it stats as stable for the batch's duration, so the second and
     // later hits of a shared types barrel skip their revalidation syscalls.
+    // The named guard must stay alive until the parallel collection has joined.
+    #[deny(let_underscore_drop)]
     let _type_resolution_batch = vize_atelier_sfc::begin_type_resolution_batch();
 
     // Indexed parallel map keeps results in input order (deterministic) and


### PR DESCRIPTION
## Summary

- make batch-guard teardown non-panicking in release builds while retaining a debug invariant check
- document that callers must keep the returned guard in a named binding
- deny ignored Drop guards directly at both native batch call sites

## Verification

- cargo test -p vize_atelier_sfc batch_epoch::tests --quiet
- cargo check -p vize_vitrine --features napi
- cargo fmt --all -- --check
- git diff --check

Closes #2841

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786431796&installation_id=136613492&pr_number=2842&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2842&signature=4c449e686984e76c1ed0dfdbe2cc4e31a3598942144e1dbc38e4de70f7b23e65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safeguards for type-resolution batch lifecycle management.
  * Reduced the risk of unexpected failures when batch guards are released.

* **Documentation**
  * Clarified how batch guards should be retained and how to explicitly release them.

* **Code Quality**
  * Added stricter checks to prevent accidental premature release of batch resources during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->