### PR TITLE
fix(cli): replace source files atomically

### DIFF
--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -79,6 +79,8 @@ dirs.workspace = true
 # Process allocator for native CLI hot paths
 mimalloc.workspace = true
 
-[dev-dependencies]
+# Exclusive same-directory temporary files for atomic source replacement
 tempfile.workspace = true
+
+[dev-dependencies]
 insta.workspace = true

--- a/crates/vize/src/commands.rs
+++ b/crates/vize/src/commands.rs
@@ -1,3 +1,4 @@
+mod atomic_write;
 pub mod build;
 pub mod check;
 #[cfg(unix)]

--- a/crates/vize/src/commands/atomic_write.rs
+++ b/crates/vize/src/commands/atomic_write.rs
@@ -1,0 +1,231 @@
+//! Failure-safe replacement for source-mutating commands.
+
+use std::borrow::Cow;
+use std::fs::{self, File, Permissions};
+use std::io::{self, Write};
+use std::path::Path;
+
+use tempfile::NamedTempFile;
+
+/// Replace an existing file only after its successor is fully written and synced.
+///
+/// `tempfile` creates the sibling with exclusive create semantics, so an
+/// existing file or symlink can never redirect writes. Its persist operation
+/// uses an overwriting rename on Unix and `MoveFileExW(REPLACE_EXISTING)` on
+/// Windows, without deleting the destination first.
+pub(super) fn atomic_write(path: &Path, contents: &[u8]) -> io::Result<()> {
+    atomic_write_with(path, contents, &mut OsOperations)
+}
+
+fn atomic_write_with<O: AtomicWriteOperations>(
+    path: &Path,
+    contents: &[u8],
+    operations: &mut O,
+) -> io::Result<()> {
+    let (path, permissions) = resolve_write_target(path)?;
+    let path = path.as_ref();
+    let directory = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".vize-write-")
+        .suffix(".tmp")
+        .tempfile_in(directory)?;
+
+    operations.write_all(temporary.as_file_mut(), contents)?;
+    operations.flush(temporary.as_file_mut())?;
+    temporary.as_file().set_permissions(permissions)?;
+    operations.sync_all(temporary.as_file())?;
+    operations.replace(temporary, path)
+}
+
+fn resolve_write_target(path: &Path) -> io::Result<(Cow<'_, Path>, Permissions)> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() {
+        let target = fs::canonicalize(path)?;
+        let permissions = fs::metadata(&target)?.permissions();
+        Ok((Cow::Owned(target), permissions))
+    } else {
+        Ok((Cow::Borrowed(path), metadata.permissions()))
+    }
+}
+
+trait AtomicWriteOperations {
+    fn write_all(&mut self, file: &mut File, contents: &[u8]) -> io::Result<()>;
+    fn flush(&mut self, file: &mut File) -> io::Result<()>;
+    fn sync_all(&mut self, file: &File) -> io::Result<()>;
+    fn replace(&mut self, temporary: NamedTempFile, path: &Path) -> io::Result<()>;
+}
+
+struct OsOperations;
+
+impl AtomicWriteOperations for OsOperations {
+    fn write_all(&mut self, file: &mut File, contents: &[u8]) -> io::Result<()> {
+        file.write_all(contents)
+    }
+
+    fn flush(&mut self, file: &mut File) -> io::Result<()> {
+        file.flush()
+    }
+
+    fn sync_all(&mut self, file: &File) -> io::Result<()> {
+        file.sync_all()
+    }
+
+    fn replace(&mut self, temporary: NamedTempFile, path: &Path) -> io::Result<()> {
+        temporary.persist(path).map(drop).map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AtomicWriteOperations, OsOperations, atomic_write, atomic_write_with};
+    use std::fs::{self, File};
+    use std::io::{self, Write};
+    use std::path::Path;
+    use tempfile::NamedTempFile;
+
+    const ORIGINAL: &[u8] = b"original source\n";
+    const REPLACEMENT: &[u8] = b"complete replacement\n";
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum FailureStage {
+        Write,
+        Flush,
+        Sync,
+        Replace,
+    }
+
+    struct FailingOperations(FailureStage);
+
+    impl FailingOperations {
+        fn injected_failure() -> io::Error {
+            io::Error::other("injected atomic write failure")
+        }
+    }
+
+    impl AtomicWriteOperations for FailingOperations {
+        fn write_all(&mut self, file: &mut File, contents: &[u8]) -> io::Result<()> {
+            if self.0 == FailureStage::Write {
+                file.write_all(&contents[..contents.len() / 2])?;
+                return Err(Self::injected_failure());
+            }
+            file.write_all(contents)
+        }
+
+        fn flush(&mut self, file: &mut File) -> io::Result<()> {
+            file.flush()?;
+            if self.0 == FailureStage::Flush {
+                return Err(Self::injected_failure());
+            }
+            Ok(())
+        }
+
+        fn sync_all(&mut self, file: &File) -> io::Result<()> {
+            file.sync_all()?;
+            if self.0 == FailureStage::Sync {
+                return Err(Self::injected_failure());
+            }
+            Ok(())
+        }
+
+        fn replace(&mut self, temporary: NamedTempFile, path: &Path) -> io::Result<()> {
+            if self.0 == FailureStage::Replace {
+                return Err(Self::injected_failure());
+            }
+            OsOperations.replace(temporary, path)
+        }
+    }
+
+    #[test]
+    fn replacement_preserves_permissions_and_cleans_up() {
+        let project = tempfile::tempdir().unwrap();
+        let path = project.path().join("App.vue");
+        fs::write(&path, ORIGINAL).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o640)).unwrap();
+        }
+        let original_permissions = fs::metadata(&path).unwrap().permissions();
+
+        atomic_write(&path, REPLACEMENT).unwrap();
+
+        assert_eq!(fs::read(&path).unwrap(), REPLACEMENT);
+        let replaced_permissions = fs::metadata(&path).unwrap().permissions();
+        assert_eq!(
+            replaced_permissions.readonly(),
+            original_permissions.readonly()
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(replaced_permissions.mode(), original_permissions.mode());
+        }
+        assert_no_temporary_files(project.path());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replacement_follows_a_symlink_without_replacing_it() {
+        use std::os::unix::fs::symlink;
+
+        let project = tempfile::tempdir().unwrap();
+        let target_directory = project.path().join("target");
+        let link_directory = project.path().join("link");
+        fs::create_dir_all(&target_directory).unwrap();
+        fs::create_dir_all(&link_directory).unwrap();
+        let target = target_directory.join("App.vue");
+        let link = link_directory.join("App.vue");
+        fs::write(&target, ORIGINAL).unwrap();
+        symlink(&target, &link).unwrap();
+
+        atomic_write(&link, REPLACEMENT).unwrap();
+
+        assert!(
+            fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(fs::read(&target).unwrap(), REPLACEMENT);
+        assert_eq!(fs::read(&link).unwrap(), REPLACEMENT);
+        assert_no_temporary_files(&target_directory);
+        assert_no_temporary_files(&link_directory);
+    }
+
+    #[test]
+    fn every_pre_replace_failure_preserves_original_bytes() {
+        let project = tempfile::tempdir().unwrap();
+        let path = project.path().join("App.vue");
+
+        for stage in [
+            FailureStage::Write,
+            FailureStage::Flush,
+            FailureStage::Sync,
+            FailureStage::Replace,
+        ] {
+            fs::write(&path, ORIGINAL).unwrap();
+            let result = atomic_write_with(&path, REPLACEMENT, &mut FailingOperations(stage));
+            assert!(result.is_err(), "{stage:?} should fail");
+            assert_eq!(fs::read(&path).unwrap(), ORIGINAL, "failed at {stage:?}");
+            assert_no_temporary_files(project.path());
+        }
+    }
+
+    fn assert_no_temporary_files(directory: &Path) {
+        let temporary_count = fs::read_dir(directory)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(".vize-write-")
+            })
+            .count();
+        assert_eq!(temporary_count, 0);
+    }
+}

--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -16,6 +16,7 @@ use vize_glyph::{
     format_sfc_with_allocator,
 };
 
+use super::atomic_write::atomic_write;
 use crate::{config, profile_support};
 use vize_curator::profile::{
     ProfileFileRow, ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report,
@@ -504,51 +505,6 @@ struct FormatFileResult {
     profile: Option<FormatFileProfile>,
 }
 
-/// Write `contents` to `path` atomically via a sibling temp file + rename (#970).
-/// The temp file lives in the same directory (same-fs rename, atomic on Unix).
-/// On Windows, remove-then-rename is used as a fallback.
-fn atomic_write(path: &Path, contents: &[u8]) -> std::io::Result<()> {
-    use std::io::Write;
-
-    let dir = path.parent().unwrap_or_else(|| Path::new("."));
-    let file_name = path
-        .file_name()
-        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "no file name"))?
-        .to_string_lossy();
-    let pid = std::process::id();
-    let mut counter: u64 = 0;
-    let temp_path = loop {
-        counter = counter.wrapping_add(1);
-        let candidate = dir.join(format!(".{}.vize-fmt.{}.{}.tmp", file_name, pid, counter));
-        if !candidate.exists() {
-            break candidate;
-        }
-    };
-
-    let result = (|| -> std::io::Result<()> {
-        let mut file = fs::File::create(&temp_path)?;
-        file.write_all(contents)?;
-        file.sync_all()?;
-        drop(file);
-
-        #[cfg(windows)]
-        {
-            // Windows rename fails if the destination exists; remove it first.
-            // The window between remove and rename is narrow but real; the
-            // source is still recoverable from the temp file on failure.
-            let _ = fs::remove_file(path);
-        }
-
-        fs::rename(&temp_path, path)
-    })();
-
-    if result.is_err() {
-        // Best-effort cleanup; ignore secondary failure.
-        let _ = fs::remove_file(&temp_path);
-    }
-    result
-}
-
 struct FormatFileProfile {
     row: ProfileFileRow,
     read_time: Duration,
@@ -556,13 +512,8 @@ struct FormatFileProfile {
 
 #[cfg(test)]
 mod tests {
-    use super::{atomic_write, format_file_source};
-    use std::{
-        fs,
-        path::{Path, PathBuf},
-        time::{SystemTime, UNIX_EPOCH},
-    };
-    use vize_carton::{String, ToCompactString};
+    use super::format_file_source;
+    use std::path::Path;
 
     #[test]
     fn format_file_source_formats_standalone_tsx() {
@@ -577,59 +528,5 @@ mod tests {
         .unwrap();
 
         insta::assert_snapshot!(result.code.as_str());
-    }
-
-    #[test]
-    fn atomic_write_preserves_source_when_no_changes() {
-        let root = unique_case_dir("atomic-write-noop");
-        fs::create_dir_all(&root).unwrap();
-        let path = root.join("A.vue");
-        fs::write(&path, b"<template>before</template>").unwrap();
-
-        atomic_write(&path, b"<template>after</template>").unwrap();
-
-        assert_eq!(fs::read(&path).unwrap(), b"<template>after</template>");
-        let stray: Vec<_> = fs::read_dir(&root)
-            .unwrap()
-            .filter_map(Result::ok)
-            .filter(|entry| entry.file_name().to_string_lossy().contains("vize-fmt"))
-            .collect();
-        assert!(stray.is_empty(), "temp file should be renamed away");
-        let _ = fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn atomic_write_leaves_original_intact_on_failure() {
-        let root = unique_case_dir("atomic-write-failure");
-        fs::create_dir_all(&root).unwrap();
-        // Point the "destination" at a path under a non-existent directory so
-        // rename fails; the original is unaffected because no destination
-        // existed yet — but the temp file must be cleaned up.
-        let parent = root.join("nope-this-does-not-exist");
-        let dest = parent.join("A.vue");
-
-        let result = atomic_write(&dest, b"new contents");
-        assert!(result.is_err());
-        let _ = fs::remove_dir_all(&root);
-    }
-
-    fn unique_case_dir(name: &str) -> PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let mut dir_name = String::from(name);
-        dir_name.push('-');
-        let pid = std::process::id().to_compact_string();
-        dir_name.push_str(pid.as_str());
-        dir_name.push('-');
-        let nanos = nanos.to_compact_string();
-        dir_name.push_str(nanos.as_str());
-        std::env::current_dir()
-            .unwrap()
-            .join("target")
-            .join("vize-tests")
-            .join("fmt")
-            .join(dir_name.as_str())
     }
 }

--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -87,7 +87,6 @@ pub fn run(args: LintArgs) {
         eprintln!("{}", patterns::no_lint_files_message(&args.patterns));
         return;
     }
-
     let help_level = match args.help_level.as_str() {
         "none" => HelpLevel::None,
         "short" => HelpLevel::Short,
@@ -125,8 +124,7 @@ pub fn run(args: LintArgs) {
             vize_patina::rules::type_aware::NoReactivityLoss::new(),
         ));
     }
-    let error_count = AtomicUsize::new(0);
-    let warning_count = AtomicUsize::new(0);
+    let write_failures = AtomicUsize::new(0);
     let profile_rows = args.profile.then(|| Mutex::new(Vec::new()));
     if args.profile {
         let profiler = global_profiler();
@@ -160,13 +158,14 @@ pub fn run(args: LintArgs) {
             let result = profile!("cli.lint.file.lint", {
                 lint_source_with_optional_fix(&linter, path, source, &filename, args.fix)
             });
-            let (source, result, fixed) = result;
+            let (source, result, fixed) = result
+                .inspect_err(|_| {
+                    write_failures.fetch_add(1, Ordering::Relaxed);
+                })
+                .ok()?;
             let lint_time = lint_file_start
                 .map(|start| start.elapsed())
                 .unwrap_or(Duration::ZERO);
-
-            error_count.fetch_add(result.error_count, Ordering::Relaxed);
-            warning_count.fetch_add(result.warning_count, Ordering::Relaxed);
 
             if let (Some(file_start), Some(profile_rows)) = (file_start, profile_rows.as_ref()) {
                 let note = if fixed {
@@ -222,7 +221,8 @@ pub fn run(args: LintArgs) {
     let total_errors: usize = results
         .iter()
         .map(|(_, _, _, result)| result.error_count)
-        .sum();
+        .sum::<usize>()
+        + write_failures.load(Ordering::Relaxed);
     let total_warnings: usize = results
         .iter()
         .map(|(_, _, _, result)| result.warning_count)

--- a/crates/vize/src/commands/lint/fix.rs
+++ b/crates/vize/src/commands/lint/fix.rs
@@ -1,8 +1,9 @@
 //! Lint source selection and fix application.
 
-use std::{fs, path::Path};
+use std::path::Path;
 
 use super::collect::{is_plain_script_path, is_standalone_html_path};
+use crate::commands::atomic_write::atomic_write;
 use vize_carton::{String, ToCompactString, profiler::global_profiler};
 use vize_patina::{JsxLang, LintResult, Linter, TextEdit};
 
@@ -12,23 +13,22 @@ pub(super) fn lint_source_with_optional_fix(
     mut source: String,
     filename: &str,
     should_fix: bool,
-) -> (String, LintResult, bool) {
+) -> std::io::Result<(String, LintResult, bool)> {
     let initial_result = lint_source(linter, path, &source, filename);
     if should_fix
         && let Some(fixed_source) = apply_lint_fixes(&source, &initial_result)
         && fixed_source != source
     {
-        if let Err(error) = fs::write(path, fixed_source.as_bytes()) {
+        atomic_write(path, fixed_source.as_bytes()).inspect_err(|error| {
             global_profiler().record_fs_write_failure(fixed_source.len());
             eprintln!("Failed to write {}: {}", path.display(), error);
-        } else {
-            global_profiler().record_fs_write(fixed_source.len());
-            source = fixed_source;
-            let result = lint_source(linter, path, &source, filename);
-            return (source, result, true);
-        }
+        })?;
+        global_profiler().record_fs_write(fixed_source.len());
+        source = fixed_source;
+        let result = lint_source(linter, path, &source, filename);
+        return Ok((source, result, true));
     }
-    (source, initial_result, false)
+    Ok((source, initial_result, false))
 }
 
 fn lint_source(linter: &Linter, path: &Path, source: &str, filename: &str) -> LintResult {

--- a/crates/vize/tests/source_write_atomic_cli.rs
+++ b/crates/vize/tests/source_write_atomic_cli.rs
@@ -1,0 +1,56 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+
+#[test]
+fn lint_fix_write_failure_is_nonzero_and_preserves_source() {
+    let project = tempfile::tempdir().unwrap();
+    let source_path = project.path().join("App.vue");
+    let original = r#"<template><button v-on:click="save">Save</button></template>"#;
+    fs::write(&source_path, original).unwrap();
+
+    // A direct write can still truncate an existing writable file in a
+    // read-only directory; an atomic writer must fail before replacement.
+    let original_permissions = fs::metadata(project.path()).unwrap().permissions();
+    let mut read_only_directory = original_permissions.clone();
+    read_only_directory.set_mode(0o500);
+    fs::set_permissions(project.path(), read_only_directory).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .args(["lint", "--fix", "--no-config"])
+        .arg(&source_path)
+        .output()
+        .unwrap();
+
+    fs::set_permissions(project.path(), original_permissions).unwrap();
+    assert!(!output.status.success(), "{output:?}");
+    assert_eq!(fs::read_to_string(&source_path).unwrap(), original);
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Failed to write"),
+        "{output:?}"
+    );
+}
+
+#[test]
+fn fmt_write_preserves_source_permissions() {
+    let project = tempfile::tempdir().unwrap();
+    let source_path = project.path().join("App.vue");
+    let original = "<template><div/></template>";
+    fs::write(&source_path, original).unwrap();
+    fs::set_permissions(&source_path, fs::Permissions::from_mode(0o640)).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .args(["fmt", "--write", "--no-config"])
+        .arg(&source_path)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert_ne!(fs::read_to_string(&source_path).unwrap(), original);
+    assert_eq!(
+        fs::metadata(&source_path).unwrap().permissions().mode() & 0o777,
+        0o640
+    );
+}


### PR DESCRIPTION
## Summary

- replace formatter and lint-fix writes through one same-directory atomic replacement helper
- preserve source permissions and never delete the destination before replacement
- propagate lint write failures to a non-zero command result
- cover partial write, flush, sync, replace, permission, cleanup, and real CLI failure paths

## Safety

Temporary files use exclusive creation. The complete replacement is flushed and synced before an overwriting rename; Windows uses MoveFileExW with replace-existing semantics through tempfile 3.27.

## Verification

- cargo fmt --all -- --check
- cargo test -p vize -q
- cargo test -p vize commands::atomic_write::tests --lib -q
- cargo test -p vize --test source_write_atomic_cli -q
- cargo test -p vize --test lint_fix_cli -q
- cargo check -p vize --no-default-features --features glyph
- cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
- git diff --check

Closes #2822

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786432086&installation_id=136613492&pr_number=2843&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2843&signature=6b4dd6d7db733b1d576774d9be25d476a272f4ab320a9a3990ff5f964259a84a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Formatting and lint fixes now write changes more safely using atomic replacement, preserving original file contents when failures occur.
  * File permissions are maintained after formatting, and symlink targets are handled without replacing the symlink itself.
  * Lint reporting now correctly accounts for write failures and returns non-success when updates can’t be applied.
* **Tests**
  * Added CLI integration tests covering write-failure behavior, permission preservation, and atomic update guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->