### PR TITLE
fix(atelier-sfc): tokenize template block boundaries

### DIFF
--- a/crates/vize_atelier_sfc/src/parse.rs
+++ b/crates/vize_atelier_sfc/src/parse.rs
@@ -5,6 +5,7 @@
 
 mod block;
 mod parse_sfc;
+mod template_boundary;
 
 #[cfg(test)]
 mod tests;

--- a/crates/vize_atelier_sfc/src/parse/block.rs
+++ b/crates/vize_atelier_sfc/src/parse/block.rs
@@ -3,12 +3,12 @@ use std::borrow::Cow;
 use vize_carton::{FxHashMap, String, cstr};
 
 // Tag name bytes for fast comparison
-const TAG_TEMPLATE: &[u8] = b"template";
+pub(super) const TAG_TEMPLATE: &[u8] = b"template";
 const TAG_SCRIPT: &[u8] = b"script";
 const TAG_STYLE: &[u8] = b"style";
 
-type BlockAttrs<'a> = FxHashMap<Cow<'a, str>, Cow<'a, str>>;
-type BlockParseOutput<'a> = (
+pub(super) type BlockAttrs<'a> = FxHashMap<Cow<'a, str>, Cow<'a, str>>;
+pub(super) type BlockParseOutput<'a> = (
     &'a [u8],       // tag name as bytes
     BlockAttrs<'a>, // attrs with borrowed strings
     Cow<'a, str>,   // content as borrowed string
@@ -18,22 +18,22 @@ type BlockParseOutput<'a> = (
     usize,          // end line
     usize,          // end column
 );
-type BlockParseError = (&'static str, String);
-type BlockParseResult<'a> = Result<Option<BlockParseOutput<'a>>, BlockParseError>;
+pub(super) type BlockParseError = (&'static str, String);
+pub(super) type BlockParseResult<'a> = Result<Option<BlockParseOutput<'a>>, BlockParseError>;
 
-struct BlockEndSearch<'a> {
-    bytes: &'a [u8],
-    source: &'a str,
-    tag_name: &'a [u8],
-    pos: usize,
-    content_start: usize,
-    start_line: usize,
-    initial_last_newline: usize,
-    attrs: BlockAttrs<'a>,
+pub(super) struct BlockEndSearch<'a> {
+    pub(super) bytes: &'a [u8],
+    pub(super) source: &'a str,
+    pub(super) tag_name: &'a [u8],
+    pub(super) pos: usize,
+    pub(super) content_start: usize,
+    pub(super) start_line: usize,
+    pub(super) initial_last_newline: usize,
+    pub(super) attrs: BlockAttrs<'a>,
 }
 
 /// Build a uniform `(code, message)` error for any malformed block.
-fn build_malformed_error(tag_name: &[u8], reason: &str) -> BlockParseError {
+pub(super) fn build_malformed_error(tag_name: &[u8], reason: &str) -> BlockParseError {
     let tag_str = std::str::from_utf8(tag_name).unwrap_or("unknown");
     (
         "MALFORMED_BLOCK",
@@ -49,7 +49,7 @@ pub(super) fn tag_name_eq(name: &[u8], expected: &[u8]) -> bool {
 
 /// Fast byte slice prefix check
 #[inline(always)]
-fn starts_with_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+pub(super) fn starts_with_bytes(haystack: &[u8], needle: &[u8]) -> bool {
     haystack.len() >= needle.len() && haystack[..needle.len()].eq_ignore_ascii_case(needle)
 }
 
@@ -61,19 +61,19 @@ fn is_tag_name_char_fast(b: u8) -> bool {
 
 /// Fast whitespace check
 #[inline(always)]
-fn is_whitespace_fast(b: u8) -> bool {
+pub(super) fn is_whitespace_fast(b: u8) -> bool {
     matches!(b, b' ' | b'\t' | b'\n' | b'\r')
 }
 
 #[inline]
-fn advance_line(bytes: &[u8], base: usize, line: &mut usize, last_newline: &mut usize) {
+pub(super) fn advance_line(bytes: &[u8], base: usize, line: &mut usize, last_newline: &mut usize) {
     for offset in memchr_iter(b'\n', bytes) {
         *line += 1;
         *last_newline = base + offset;
     }
 }
 
-fn can_start_regex_literal(prev_significant_char: u8) -> bool {
+pub(super) fn can_start_regex_literal(prev_significant_char: u8) -> bool {
     matches!(
         prev_significant_char,
         b'=' | b'('
@@ -97,7 +97,7 @@ fn can_start_regex_literal(prev_significant_char: u8) -> bool {
     )
 }
 
-fn skip_regex_literal(
+pub(super) fn skip_regex_literal(
     bytes: &[u8],
     mut pos: usize,
     len: usize,
@@ -184,7 +184,7 @@ fn can_start_string_literal(prev_significant_char: u8, quote: u8) -> bool {
             || prev_significant_char == b')'))
 }
 
-fn skip_script_string_literal(
+pub(super) fn skip_script_string_literal(
     bytes: &[u8],
     mut pos: usize,
     len: usize,
@@ -323,7 +323,12 @@ fn skip_template_expression(
 /// Find the end of a closing tag `</tag_name` followed by optional whitespace and `>`.
 /// Returns the position immediately after `>`, or `None` if no valid closing tag at `pos`.
 #[inline]
-fn find_closing_tag_end(bytes: &[u8], pos: usize, len: usize, tag_name: &[u8]) -> Option<usize> {
+pub(super) fn find_closing_tag_end(
+    bytes: &[u8],
+    pos: usize,
+    len: usize,
+    tag_name: &[u8],
+) -> Option<usize> {
     // Need at least "</" + tag_name + ">"
     if pos + 2 + tag_name.len() >= len {
         return None;
@@ -522,109 +527,16 @@ pub(super) fn parse_block_fast<'a>(
 
     // Handle known tags with static closing tags
     if tag_name.eq_ignore_ascii_case(TAG_TEMPLATE) {
-        // Template block: handle nested template tags
-        let mut depth = 1;
-
-        // Check for closing template tag, handling whitespace before the closing '>'
-        // This handles cases like:
-        //   </template>       - normal
-        //   </template\n   >  - closing '>' on next line
-        fn is_closing_template_tag(bytes: &[u8], pos: usize, len: usize) -> Option<usize> {
-            // Check if we have "</template" (without the final ">")
-            const CLOSING_TAG_PREFIX: &[u8] = b"</template";
-            if pos + CLOSING_TAG_PREFIX.len() > len {
-                return None;
-            }
-            if !bytes[pos..pos + CLOSING_TAG_PREFIX.len()].eq_ignore_ascii_case(CLOSING_TAG_PREFIX)
-            {
-                return None;
-            }
-            // Find the closing '>' allowing whitespace
-            let mut check_pos = pos + CLOSING_TAG_PREFIX.len();
-            while check_pos < len {
-                match bytes[check_pos] {
-                    b'>' => return Some(check_pos + 1), // Return position after '>'
-                    b' ' | b'\t' | b'\n' | b'\r' => check_pos += 1,
-                    _ => return None, // Invalid character in closing tag
-                }
-            }
-            None
-        }
-
-        while pos < len {
-            let Some(lt_offset) = memchr(b'<', &bytes[pos..]) else {
-                advance_line(&bytes[pos..], pos, &mut line, &mut last_newline);
-                break;
-            };
-
-            advance_line(
-                &bytes[pos..pos + lt_offset],
-                pos,
-                &mut line,
-                &mut last_newline,
-            );
-            pos += lt_offset;
-
-            // Check for closing tag using byte comparison
-            if let Some(end_tag_pos) = is_closing_template_tag(bytes, pos, len) {
-                depth -= 1;
-                if depth == 0 {
-                    let content_end = pos;
-                    let end_pos = end_tag_pos;
-                    let col = pos - last_newline + (end_pos - pos);
-                    let content = Cow::Borrowed(&source[content_start..content_end]);
-                    return Ok(Some((
-                        tag_name,
-                        attrs,
-                        content,
-                        content_start,
-                        content_end,
-                        end_pos,
-                        line,
-                        col,
-                    )));
-                }
-                pos = end_tag_pos;
-                continue;
-            }
-
-            // Check for nested opening tag
-            if starts_with_bytes(&bytes[pos + 1..], TAG_TEMPLATE) {
-                let tag_check_pos = pos + 1 + TAG_TEMPLATE.len();
-                if tag_check_pos < len {
-                    let next_char = bytes[tag_check_pos];
-                    if next_char == b' '
-                        || next_char == b'>'
-                        || next_char == b'\n'
-                        || next_char == b'\t'
-                        || next_char == b'\r'
-                    {
-                        // Check if self-closing
-                        let mut check_pos = tag_check_pos;
-                        let mut is_self_closing_nested = false;
-                        while check_pos < len && bytes[check_pos] != b'>' {
-                            if bytes[check_pos] == b'/'
-                                && check_pos + 1 < len
-                                && bytes[check_pos + 1] == b'>'
-                            {
-                                is_self_closing_nested = true;
-                                break;
-                            }
-                            check_pos += 1;
-                        }
-                        if !is_self_closing_nested {
-                            depth += 1;
-                        }
-                    }
-                }
-            }
-
-            pos += 1;
-        }
-        return Err(build_malformed_error(
+        return super::template_boundary::find_template_block_end(BlockEndSearch {
+            bytes,
+            source,
             tag_name,
-            "the closing tag is missing",
-        ));
+            pos,
+            content_start,
+            start_line,
+            initial_last_newline: start,
+            attrs,
+        });
     }
 
     if tag_name.eq_ignore_ascii_case(TAG_STYLE) {

--- a/crates/vize_atelier_sfc/src/parse/snapshots/vize_atelier_sfc__parse__tests__multiline_closing_tag_complex.snap
+++ b/crates/vize_atelier_sfc/src/parse/snapshots/vize_atelier_sfc__parse__tests__multiline_closing_tag_complex.snap
@@ -11,7 +11,7 @@ SfcTemplateBlock {
         tag_end: 235,
         start_line: 5,
         start_column: 1,
-        end_line: 11,
+        end_line: 12,
         end_column: 21,
     },
     lang: None,

--- a/crates/vize_atelier_sfc/src/parse/template_boundary.rs
+++ b/crates/vize_atelier_sfc/src/parse/template_boundary.rs
@@ -1,0 +1,251 @@
+//! Allocation-free structural boundary scanning for root `<template>` blocks.
+
+mod fast_path;
+mod interpolation;
+
+#[cfg(test)]
+mod tests;
+
+use self::{fast_path::find_flat_template_end, interpolation::skip_template_interpolation};
+use super::block::{
+    BlockEndSearch, BlockParseResult, TAG_TEMPLATE, advance_line, build_malformed_error,
+    find_closing_tag_end, is_whitespace_fast, starts_with_bytes,
+};
+use memchr::{memchr, memchr2, memchr3, memmem};
+use std::borrow::Cow;
+
+#[inline]
+fn is_opening_tag_named(bytes: &[u8], pos: usize, len: usize, expected_name: &[u8]) -> bool {
+    let name_start = pos + 1;
+    let name_end = name_start + expected_name.len();
+    name_end < len
+        && starts_with_bytes(&bytes[name_start..], expected_name)
+        && (is_whitespace_fast(bytes[name_end])
+            || bytes[name_end] == b'/'
+            || bytes[name_end] == b'>')
+}
+
+#[inline]
+fn raw_text_tag_name(bytes: &[u8], pos: usize, len: usize) -> Option<&'static [u8]> {
+    match bytes[pos + 1].to_ascii_lowercase() {
+        b's' if is_opening_tag_named(bytes, pos, len, b"script") => Some(b"script"),
+        b's' if is_opening_tag_named(bytes, pos, len, b"style") => Some(b"style"),
+        b't' if is_opening_tag_named(bytes, pos, len, b"textarea") => Some(b"textarea"),
+        b't' if is_opening_tag_named(bytes, pos, len, b"title") => Some(b"title"),
+        _ => None,
+    }
+}
+
+fn find_raw_text_element_end(
+    bytes: &[u8],
+    mut pos: usize,
+    len: usize,
+    tag_name: &[u8],
+) -> Option<usize> {
+    while pos < len {
+        let lt_offset = memchr(b'<', &bytes[pos..])?;
+        pos += lt_offset;
+        if let Some(end_tag_pos) = find_closing_tag_end(bytes, pos, len, tag_name) {
+            return Some(end_tag_pos);
+        }
+        pos += 1;
+    }
+    None
+}
+
+/// Find the end of an HTML opening tag without treating `>` inside a quoted
+/// attribute as the tag boundary. The returned position is immediately after
+/// `>` and the boolean records whether the tag is self-closing.
+#[inline]
+fn find_opening_tag_end(bytes: &[u8], pos: usize, len: usize) -> Option<(usize, bool)> {
+    debug_assert_eq!(bytes[pos], b'<');
+    let mut cursor = pos + 2;
+
+    while cursor < len {
+        let candidate = memchr3(b'>', b'"', b'\'', &bytes[cursor..])?;
+        cursor += candidate;
+
+        match bytes[cursor] {
+            b'>' => {
+                let mut before_end = cursor;
+                while before_end > pos + 1 && is_whitespace_fast(bytes[before_end - 1]) {
+                    before_end -= 1;
+                }
+                let self_closing = before_end > pos + 1 && bytes[before_end - 1] == b'/';
+                return Some((cursor + 1, self_closing));
+            }
+            quote @ (b'"' | b'\'') => {
+                cursor += 1;
+                let closing_quote = memchr(quote, &bytes[cursor..])?;
+                cursor += closing_quote + 1;
+            }
+            _ => unreachable!("memchr3 returned an unexpected byte"),
+        }
+    }
+
+    None
+}
+
+/// Find the structural end of a root `<template>` block.
+///
+/// The slow path jumps between `<`/`{` candidates and skips actual HTML tags as
+/// a unit, so template-shaped text in attributes, comments, raw-text elements,
+/// and Vue interpolations cannot mutate nesting depth.
+pub(super) fn find_template_block_end<'a>(search: BlockEndSearch<'a>) -> BlockParseResult<'a> {
+    let BlockEndSearch {
+        bytes,
+        source,
+        tag_name,
+        mut pos,
+        content_start,
+        start_line,
+        initial_last_newline,
+        attrs,
+    } = search;
+    let len = bytes.len();
+    let mut line = start_line;
+    let mut last_newline = initial_last_newline;
+    let mut depth = 1usize;
+
+    if let Some((content_end, end_pos)) = find_flat_template_end(bytes, content_start, len) {
+        advance_line(
+            &bytes[content_start..content_end],
+            content_start,
+            &mut line,
+            &mut last_newline,
+        );
+        let col = content_end - last_newline + (end_pos - content_end);
+        let content = Cow::Borrowed(&source[content_start..content_end]);
+        return Ok(Some((
+            tag_name,
+            attrs,
+            content,
+            content_start,
+            content_end,
+            end_pos,
+            line,
+            col,
+        )));
+    }
+
+    while pos < len {
+        let Some(candidate_offset) = memchr2(b'<', b'{', &bytes[pos..]) else {
+            advance_line(&bytes[pos..], pos, &mut line, &mut last_newline);
+            break;
+        };
+
+        advance_line(
+            &bytes[pos..pos + candidate_offset],
+            pos,
+            &mut line,
+            &mut last_newline,
+        );
+        pos += candidate_offset;
+
+        if bytes[pos] == b'{' {
+            if pos + 1 < len && bytes[pos + 1] == b'{' {
+                if let Some(interpolation_end) =
+                    skip_template_interpolation(bytes, pos, len, &mut line, &mut last_newline)
+                {
+                    pos = interpolation_end;
+                } else {
+                    // An unclosed interpolation is a template-parser error, not
+                    // an SFC block-boundary error. Resume structural scanning so
+                    // the root closing tag remains visible to that later stage.
+                    pos += 2;
+                }
+                continue;
+            }
+            pos += 1;
+            continue;
+        }
+
+        if bytes[pos..].starts_with(b"<!--") {
+            let comment_body_start = pos + 4;
+            if let Some(comment_end_offset) = memmem::find(&bytes[comment_body_start..], b"-->") {
+                let comment_end = comment_body_start + comment_end_offset + 3;
+                advance_line(&bytes[pos..comment_end], pos, &mut line, &mut last_newline);
+                pos = comment_end;
+                continue;
+            }
+            break;
+        }
+
+        if bytes[pos..].starts_with(b"<![CDATA[") {
+            let cdata_body_start = pos + 9;
+            if let Some(cdata_end_offset) = memmem::find(&bytes[cdata_body_start..], b"]]>") {
+                let cdata_end = cdata_body_start + cdata_end_offset + 3;
+                advance_line(&bytes[pos..cdata_end], pos, &mut line, &mut last_newline);
+                pos = cdata_end;
+                continue;
+            }
+            break;
+        }
+
+        if pos + 1 < len && matches!(bytes[pos + 1], b'!' | b'?') {
+            if let Some((declaration_end, _)) = find_opening_tag_end(bytes, pos, len) {
+                advance_line(
+                    &bytes[pos..declaration_end],
+                    pos,
+                    &mut line,
+                    &mut last_newline,
+                );
+                pos = declaration_end;
+                continue;
+            }
+            break;
+        }
+
+        if let Some(end_tag_pos) = find_closing_tag_end(bytes, pos, len, TAG_TEMPLATE) {
+            depth -= 1;
+            if depth == 0 {
+                let content_end = pos;
+                let col = pos - last_newline + (end_tag_pos - pos);
+                let content = Cow::Borrowed(&source[content_start..content_end]);
+                return Ok(Some((
+                    tag_name,
+                    attrs,
+                    content,
+                    content_start,
+                    content_end,
+                    end_tag_pos,
+                    line,
+                    col,
+                )));
+            }
+            advance_line(&bytes[pos..end_tag_pos], pos, &mut line, &mut last_newline);
+            pos = end_tag_pos;
+            continue;
+        }
+
+        if pos + 1 < len && bytes[pos + 1].is_ascii_alphabetic() {
+            let nested_template = is_opening_tag_named(bytes, pos, len, TAG_TEMPLATE);
+            let raw_text_tag = raw_text_tag_name(bytes, pos, len);
+            if let Some((tag_end, self_closing)) = find_opening_tag_end(bytes, pos, len) {
+                let scan_end = if !self_closing && let Some(raw_text_tag) = raw_text_tag {
+                    let Some(raw_text_end) =
+                        find_raw_text_element_end(bytes, tag_end, len, raw_text_tag)
+                    else {
+                        break;
+                    };
+                    raw_text_end
+                } else {
+                    tag_end
+                };
+                advance_line(&bytes[pos..scan_end], pos, &mut line, &mut last_newline);
+                if nested_template && !self_closing {
+                    depth += 1;
+                }
+                pos = scan_end;
+                continue;
+            }
+        }
+
+        pos += 1;
+    }
+
+    Err(build_malformed_error(
+        tag_name,
+        "the closing tag is missing",
+    ))
+}

--- a/crates/vize_atelier_sfc/src/parse/template_boundary/fast_path.rs
+++ b/crates/vize_atelier_sfc/src/parse/template_boundary/fast_path.rs
@@ -1,0 +1,87 @@
+//! Fast-path detection for flat root templates.
+
+use super::super::block::{find_closing_tag_end, is_whitespace_fast};
+use super::{super::block::TAG_TEMPLATE, interpolation::skip_template_interpolation};
+use super::{is_opening_tag_named, raw_text_tag_name};
+use memchr::{memchr, memmem};
+
+fn last_quote_opens_value(prefix: &[u8], quote: u8) -> bool {
+    let Some(quote_pos) = memchr::memrchr(quote, prefix) else {
+        return false;
+    };
+    let mut before_quote = quote_pos;
+    while before_quote > 0 && is_whitespace_fast(prefix[before_quote - 1]) {
+        before_quote -= 1;
+    }
+    before_quote > 0 && prefix[before_quote - 1] == b'='
+}
+
+fn template_close_has_ambiguous_context(
+    bytes: &[u8],
+    content_start: usize,
+    close_start: usize,
+    len: usize,
+) -> bool {
+    let prefix = &bytes[content_start..close_start];
+    if last_quote_opens_value(prefix, b'"') || last_quote_opens_value(prefix, b'\'') {
+        return true;
+    }
+
+    if let Some(interpolation_offset) = memmem::rfind(prefix, b"{{") {
+        let interpolation_start = content_start + interpolation_offset;
+        let mut line = 0;
+        let mut last_newline = 0;
+        if skip_template_interpolation(
+            bytes,
+            interpolation_start,
+            len,
+            &mut line,
+            &mut last_newline,
+        )
+        .is_none_or(|interpolation_end| interpolation_end > close_start)
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Flat templates dominate production SFCs. Detect the common case with the
+/// same `<`-only scan as the original parser and reserve the lexical state
+/// machine for nested or ambiguous template candidates.
+pub(super) fn find_flat_template_end(
+    bytes: &[u8],
+    content_start: usize,
+    len: usize,
+) -> Option<(usize, usize)> {
+    let mut pos = content_start;
+    while pos < len {
+        let lt_offset = memchr(b'<', &bytes[pos..])?;
+        pos += lt_offset;
+
+        if bytes[pos..].starts_with(b"<!--")
+            || bytes[pos..].starts_with(b"<![CDATA[")
+            || (pos + 1 < len && matches!(bytes[pos + 1], b'!' | b'?'))
+            || (pos + 1 < len
+                && bytes[pos + 1].is_ascii_alphabetic()
+                && raw_text_tag_name(bytes, pos, len).is_some())
+        {
+            return None;
+        }
+
+        if let Some(end_tag_pos) = find_closing_tag_end(bytes, pos, len, TAG_TEMPLATE) {
+            if template_close_has_ambiguous_context(bytes, content_start, pos, len) {
+                return None;
+            }
+            return Some((pos, end_tag_pos));
+        }
+
+        if is_opening_tag_named(bytes, pos, len, TAG_TEMPLATE) {
+            return None;
+        }
+
+        pos += 1;
+    }
+    None
+}

--- a/crates/vize_atelier_sfc/src/parse/template_boundary/interpolation.rs
+++ b/crates/vize_atelier_sfc/src/parse/template_boundary/interpolation.rs
@@ -1,0 +1,149 @@
+//! JavaScript-aware Vue interpolation skipping for template boundary scanning.
+
+use super::super::block::{
+    advance_line, can_start_regex_literal, skip_regex_literal, skip_script_string_literal,
+};
+use memchr::{memchr, memchr2, memchr3, memmem};
+
+/// Skip a Vue interpolation while ignoring delimiter-like text inside JavaScript
+/// strings, template literals, comments, and regular expressions.
+pub(super) fn skip_template_interpolation(
+    bytes: &[u8],
+    mut pos: usize,
+    len: usize,
+    line: &mut usize,
+    last_newline: &mut usize,
+) -> Option<usize> {
+    debug_assert!(bytes[pos..].starts_with(b"{{"));
+    let original_line = *line;
+    let original_last_newline = *last_newline;
+    let body_start = pos + 2;
+
+    // Most interpolations are identifiers or simple expressions. Accept the
+    // first delimiter immediately when no token before it can hide `}}`; this
+    // keeps the common path on SIMD searches instead of the JS recovery loop.
+    if let Some(close_offset) = memmem::find(&bytes[body_start..], b"}}") {
+        let close_start = body_start + close_offset;
+        let body = &bytes[body_start..close_start];
+        if memchr3(b'\'', b'"', b'`', body).is_none() && memchr2(b'/', b'{', body).is_none() {
+            let interpolation_end = close_start + 2;
+            advance_line(&bytes[pos..interpolation_end], pos, line, last_newline);
+            return Some(interpolation_end);
+        }
+    }
+
+    let mut brace_depth = 0usize;
+    let mut prev_significant_char = b'{';
+    pos = body_start;
+
+    while pos < len {
+        let b = bytes[pos];
+
+        if b == b'\n' {
+            *line += 1;
+            *last_newline = pos;
+            prev_significant_char = b'\n';
+            pos += 1;
+            continue;
+        }
+
+        if matches!(b, b' ' | b'\t' | b'\r') {
+            pos += 1;
+            continue;
+        }
+
+        if b == b'/' && pos + 1 < len && bytes[pos + 1] == b'/' {
+            pos += 2;
+            if let Some(newline_offset) = memchr(b'\n', &bytes[pos..]) {
+                pos += newline_offset;
+            } else {
+                pos = len;
+            }
+            continue;
+        }
+
+        if b == b'/' && pos + 1 < len && bytes[pos + 1] == b'*' {
+            pos += 2;
+            if let Some(end_offset) = memmem::find(&bytes[pos..], b"*/") {
+                advance_line(&bytes[pos..pos + end_offset], pos, line, last_newline);
+                pos += end_offset + 2;
+            } else {
+                pos = len;
+            }
+            continue;
+        }
+
+        if b == b'/'
+            && can_start_regex_literal(prev_significant_char)
+            && let Some(next_pos) = skip_regex_literal(bytes, pos, len, line, last_newline)
+        {
+            prev_significant_char = b'/';
+            pos = next_pos;
+            continue;
+        }
+
+        if matches!(b, b'\'' | b'"' | b'`') {
+            let string_start = pos;
+            let line_before_string = *line;
+            let last_newline_before_string = *last_newline;
+            let string_end = skip_script_string_literal(bytes, pos, len, b, line, last_newline);
+            let string_closed = string_end > string_start && bytes[string_end - 1] == b;
+
+            // Recover a malformed JS string at the interpolation delimiter. A
+            // valid string may contain `}}`, so only use this path when the
+            // quote scanner did not find its real closing delimiter.
+            if !string_closed
+                && let Some(close_offset) =
+                    memmem::find(&bytes[string_start + 1..string_end], b"}}")
+            {
+                let interpolation_end = string_start + 1 + close_offset + 2;
+                *line = line_before_string;
+                *last_newline = last_newline_before_string;
+                advance_line(
+                    &bytes[string_start..interpolation_end],
+                    string_start,
+                    line,
+                    last_newline,
+                );
+                return Some(interpolation_end);
+            }
+
+            pos = string_end;
+            prev_significant_char = b;
+            continue;
+        }
+
+        match b {
+            b'{' => {
+                brace_depth += 1;
+                prev_significant_char = b;
+                pos += 1;
+            }
+            b'}' if brace_depth == 0 && pos + 1 < len && bytes[pos + 1] == b'}' => {
+                return Some(pos + 2);
+            }
+            b'}' => {
+                brace_depth = brace_depth.saturating_sub(1);
+                prev_significant_char = b;
+                pos += 1;
+            }
+            b'\\' => {
+                if pos + 1 < len && bytes[pos + 1] == b'\n' {
+                    *line += 1;
+                    *last_newline = pos + 1;
+                }
+                pos = (pos + 2).min(len);
+            }
+            _ => {
+                prev_significant_char = b;
+                pos += 1;
+            }
+        }
+    }
+
+    // Leave line tracking untouched when the interpolation is malformed so the
+    // caller can recover through the outer malformed-block diagnostic.
+    *line = original_line;
+    *last_newline = original_last_newline;
+    None
+}

--- a/crates/vize_atelier_sfc/src/parse/template_boundary/tests.rs
+++ b/crates/vize_atelier_sfc/src/parse/template_boundary/tests.rs
@@ -1,0 +1,157 @@
+use crate::parse_sfc;
+
+#[test]
+fn ignores_template_tokens_in_non_markup_contexts() {
+    let cases = [
+        (
+            "opening tag in an HTML comment",
+            "<template><!-- <template> --><div>after</div></template><style>.ok {}</style>",
+        ),
+        (
+            "closing tag in an HTML comment",
+            "<template><!-- </template> --><div>after</div></template><style>.ok {}</style>",
+        ),
+        (
+            "opening tag in a quoted attribute",
+            r#"<template><div title="<template>">after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "closing tag in a quoted attribute",
+            r#"<template><div title="</template>">after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "opening tag in an interpolation string",
+            r#"<template>{{ "<template>" }}<div>after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "closing tag in an interpolation string",
+            r#"<template>{{ '</template>' }}<div>after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "delimiter and opening tag in an interpolation string",
+            r#"<template>{{ "}} <template>" }}<div>after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "delimiter and opening tag in an interpolation comment",
+            r#"<template>{{ /* }} <template> */ value }}<div>after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "opening tag in an interpolation template literal",
+            r#"<template>{{ `<template>` }}<div>after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "closing tag in an interpolation template literal",
+            r#"<template>{{ `</template>` }}<div>after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "opening tag in a malformed interpolation string",
+            r#"<template>{{ "<template> }}<div>after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "closing tag in a malformed interpolation string",
+            r#"<template>{{ '</template> }}<div>after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "tags in a regular expression",
+            r#"<template>{{ /<template>|<\/template>/.test(value) }}<div>after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "delimiter and tags in a regex after a newline",
+            r#"<template>{{ (
+  /}} <template> <\/template>/.test(value)
+) }}<div>after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "tags in a nested interpolation expression",
+            r#"<template>{{ ({ open: "<template>", close: '</template>' }) }}<div>after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "tags in script raw text",
+            r#"<template><script>const open = "<template>"; const close = "</template>"</script><div>after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "tags in textarea raw text",
+            r#"<template><textarea><template> and </template></textarea><div>after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "template-prefixed custom elements",
+            r#"<template><template-card></template-card><templateSlot></templateSlot><div>after</div></template><style>.ok {}</style>"#,
+        ),
+        (
+            "tags in CDATA-like text",
+            r#"<template><![CDATA[<template> </template>]]><div>after</div></template><style>.ok {}</style>"#,
+        ),
+    ];
+
+    for (name, source) in cases {
+        let result = parse_sfc(source, Default::default())
+            .unwrap_or_else(|error| panic!("{name} must parse: {error:?}"));
+        let template = result
+            .template
+            .unwrap_or_else(|| panic!("{name} must preserve the root template"));
+
+        assert!(
+            template.content.contains("after</div>"),
+            "{name} truncated the template: {}",
+            template.content
+        );
+        assert_eq!(result.styles.len(), 1, "{name} swallowed the style block");
+    }
+}
+
+#[test]
+fn balances_real_nested_templates_and_custom_elements() {
+    let source = r#"<template>
+  <template
+    v-if="show"
+    data-marker="> <template> </template>"
+  >
+    <template-card data-close="</template>">
+      <x-template>custom element</x-template>
+    </template-card>
+    <template data-marker="/>">
+      nested template
+    </template>
+  </template>
+  <template data-marker="</template>" />
+  <div>after</div>
+</template>
+
+<docs>{"marker":"<template>"}</docs>"#;
+
+    let result = parse_sfc(source, Default::default()).expect("adversarial SFC must parse");
+    let template = result.template.expect("root template must be preserved");
+
+    assert!(template.content.contains("<template-card"));
+    assert!(template.content.contains("nested template"));
+    assert!(template.content.contains("<div>after</div>"));
+    assert_eq!(result.custom_blocks.len(), 1);
+    assert_eq!(result.custom_blocks[0].block_type, "docs");
+    assert_eq!(
+        result.custom_blocks[0].content,
+        r#"{"marker":"<template>"}"#
+    );
+}
+
+#[test]
+fn tracks_lines_across_a_multiline_nested_closing_tag() {
+    let source =
+        "<template>\n  <template>nested</template\n  >\n</template>\n<style>.ok {}</style>";
+    let result = parse_sfc(source, Default::default()).expect("nested template must parse");
+
+    let template = result.template.expect("root template must be preserved");
+    assert_eq!(template.loc.end_line, 4);
+    assert_eq!(result.styles.len(), 1);
+    assert_eq!(result.styles[0].loc.start_line, 5);
+}
+
+#[test]
+fn unclosed_interpolation_keeps_the_root_boundary_visible() {
+    let source = "<template>\n  <div>{{ unclosed\n</template>\n<style>.ok {}</style>";
+    let result = parse_sfc(source, Default::default())
+        .expect("template diagnostics must not become an SFC boundary error");
+
+    let template = result.template.expect("root template must be preserved");
+    assert!(template.content.contains("{{ unclosed"));
+    assert_eq!(result.styles.len(), 1);
+}


### PR DESCRIPTION
## Summary

- replace raw substring depth tracking with an allocation-free template boundary scanner
- skip comments, CDATA, quoted attributes, raw-text elements, and JavaScript-aware Vue interpolations
- preserve real nested and self-closing template handling
- retain a less-than-only fast path for the common flat-template case

## Performance

The all-sizes SFC benchmark measured 17.849 microseconds versus 17.660 microseconds on the same-commit baseline (+1.1%, within the stability budget).

## Verification

- cargo test -p vize_atelier_sfc
- cargo test -p vize_atelier_sfc template_boundary --quiet
- cargo clippy -p vize_atelier_sfc --lib -- -D warnings
- cargo fmt --all -- --check
- git diff --check

Closes #2827

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786432321&installation_id=136613492&pr_number=2844&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2844&signature=53b3308799b331e6103c4e411e334456eeebdd9337d18eb30f9b98749bccbb03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved root `<template>` boundary detection in SFCs, correctly handling nested `<template>` tags, Vue `{{ ... }}` interpolations, HTML comments, quoted attributes, and raw-text elements like `<script>`, `<style>`, `<textarea>`, and `<title>` (including CDATA-like content).
  * Prevented template-like sequences inside strings, comments, regexes, and template literals from prematurely truncating template content.
  * More resilient handling of malformed or unclosed constructs to avoid incorrect boundary failures.
* **Tests**
  * Expanded adversarial and nesting test coverage for complex template parsing and accurate source location tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->