### PR TITLE
fix(build): preserve source-relative output paths

### DIFF
--- a/crates/vize/src/commands/build.rs
+++ b/crates/vize/src/commands/build.rs
@@ -52,7 +52,7 @@ impl From<TemplateSyntaxArg> for vize_atelier_core::TemplateSyntaxMode {
 #[derive(Args, Default)]
 #[allow(clippy::disallowed_types)]
 pub struct BuildArgs {
-    /// Glob pattern(s) to match .vue files (default: ./**/*.vue)
+    /// File, directory, or glob inputs (output paths stay relative to their common root)
     #[arg(default_value = "./**/*.vue")]
     pub patterns: Vec<String>,
 

--- a/crates/vize/src/commands/build/runner.rs
+++ b/crates/vize/src/commands/build/runner.rs
@@ -7,12 +7,11 @@ mod cache;
 mod collect;
 mod compile;
 mod compile_stats;
+mod output;
 mod profile_facts;
 mod settings;
 
 use std::{
-    fs,
-    path::PathBuf,
     sync::{Mutex, atomic::Ordering},
     time::{Duration, Instant},
 };
@@ -20,7 +19,6 @@ use std::{
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use vize_carton::String;
 use vize_carton::cstr;
-use vize_carton::profile;
 use vize_carton::profiler::global_profiler;
 
 use crate::profile_support;
@@ -30,13 +28,14 @@ use vize_curator::profile::{
 
 use super::{
     BuildArgs, OutputFormat,
-    config::{CompileError, CompileStats, ErrorPhase, FileProfile, get_output_extension},
+    config::{CompileError, CompileStats, ErrorPhase, FileProfile},
 };
 
 use cache::StatsCompileCache;
-use collect::collect_files;
+use collect::{CollectedFiles, collect_files};
 use compile::compile_file_with_profile;
 use compile_stats::compile_file_stats_with_cache;
+use output::{CompiledBuildOutput, plan_inputs, preflight_outputs, write_outputs};
 use settings::{CompileFileSettings, load_build_config, template_syntax_mode};
 
 /// Main entry point for the build command.
@@ -71,14 +70,37 @@ pub(crate) fn run(args: BuildArgs) {
         std::process::exit(1);
     }
 
-    let files = collect_files(&args.patterns);
+    let CollectedFiles { mut files, roots } = collect_files(&args.patterns);
 
     if files.is_empty() {
         eprintln!("No .vue files found matching the patterns");
         std::process::exit(1);
     }
 
-    let stats = CompileStats::new(files.len());
+    let stats_only = matches!(args.format, OutputFormat::Stats);
+    let planned_inputs = if stats_only {
+        Vec::new()
+    } else {
+        let inputs = match plan_inputs(std::mem::take(&mut files), &roots) {
+            Ok(inputs) => inputs,
+            Err(error) => {
+                eprintln!("\x1b[31mError:\x1b[0m {error}");
+                std::process::exit(1);
+            }
+        };
+        if let Err(error) = preflight_outputs(&inputs, &args.output, args.format, args.script_ext) {
+            eprintln!("\x1b[31mError:\x1b[0m {error}");
+            std::process::exit(1);
+        }
+        inputs
+    };
+
+    let total_files = if stats_only {
+        files.len()
+    } else {
+        planned_inputs.len()
+    };
+    let stats = CompileStats::new(total_files);
     let collect_elapsed = start.elapsed();
 
     if args.profile {
@@ -87,7 +109,7 @@ pub(crate) fn run(args: BuildArgs) {
         profiler.enable();
         eprintln!(
             "Found {} files in {:.4}s. Compiling using {} threads...",
-            files.len(),
+            total_files,
             collect_elapsed.as_secs_f64(),
             rayon::current_num_threads()
         );
@@ -115,7 +137,6 @@ pub(crate) fn run(args: BuildArgs) {
         record_profile_totals: args.profile,
     };
 
-    let stats_only = matches!(args.format, OutputFormat::Stats);
     let results: Vec<_> = if stats_only {
         let compile_cache = StatsCompileCache::default();
         files.par_iter().for_each(|path| {
@@ -149,10 +170,10 @@ pub(crate) fn run(args: BuildArgs) {
         });
         Vec::new()
     } else {
-        files
+        planned_inputs
             .par_iter()
-            .map(
-                |path| match compile_file_with_profile(path, compile_settings, &stats) {
+            .map(|input| {
+                match compile_file_with_profile(&input.source, compile_settings, &stats) {
                     Ok((output, profile)) => {
                         stats.success.fetch_add(1, Ordering::Relaxed);
                         stats
@@ -172,7 +193,7 @@ pub(crate) fn run(args: BuildArgs) {
                             p.push(profile);
                         }
 
-                        Some((path.clone(), output))
+                        Some(CompiledBuildOutput { input, output })
                     }
                     Err(err) => {
                         stats.failed.fetch_add(1, Ordering::Relaxed);
@@ -183,8 +204,8 @@ pub(crate) fn run(args: BuildArgs) {
 
                         None
                     }
-                },
-            )
+                }
+            })
             .collect()
     };
     let compile_elapsed = compile_start.elapsed();
@@ -193,66 +214,14 @@ pub(crate) fn run(args: BuildArgs) {
     match args.format {
         OutputFormat::Stats => {}
         OutputFormat::Js | OutputFormat::Json => {
-            // Create the output directory once per build, then write every
-            // generated file. Calling `create_dir_all` from each worker looked
-            // harmless but showed up in profiles as repeated metadata syscalls,
-            // especially when benchmarking many generated SFCs.
-            match profile!(
-                "cli.build.output.create_dir_all",
-                fs::create_dir_all(&args.output)
+            if let Err(error) = write_outputs(
+                results.into_iter().flatten(),
+                &args.output,
+                args.format,
+                args.script_ext,
             ) {
-                Ok(()) => global_profiler().record_fs_create_dir_all(),
-                Err(error) => {
-                    global_profiler().record_fs_create_dir_all_failure();
-                    eprintln!(
-                        "Failed to create output directory {}: {error}",
-                        args.output.display()
-                    );
-                    std::process::exit(1);
-                }
-            }
-
-            for (path, output) in results.into_iter().flatten() {
-                let ext = match args.format {
-                    OutputFormat::Js => get_output_extension(&output.script_lang, args.script_ext),
-                    OutputFormat::Json => "json",
-                    // Panic path by control-flow invariant: this match is inside
-                    // the `OutputFormat::Js | OutputFormat::Json` arm above.
-                    // Keeping the enum match explicit lets the compiler keep
-                    // checking newly added output formats here.
-                    OutputFormat::Stats => unreachable!(),
-                };
-
-                let filename = path
-                    .file_name()
-                    .map(|f| PathBuf::from(f).with_extension(ext))
-                    .unwrap_or_else(|| PathBuf::from("output").with_extension(ext));
-                let out_path = args.output.join(filename);
-
-                let content: String = match args.format {
-                    OutputFormat::Js => output.code,
-                    OutputFormat::Json =>
-                    {
-                        #[allow(clippy::disallowed_methods)]
-                        serde_json::to_string_pretty(&output)
-                            .unwrap_or_default()
-                            .into()
-                    }
-                    // Panic path by the same outer-match invariant as `ext`.
-                    OutputFormat::Stats => unreachable!(),
-                };
-
-                let bytes = content.len();
-                match profile!(
-                    "cli.build.output.write",
-                    fs::write(&out_path, content.as_str())
-                ) {
-                    Ok(()) => global_profiler().record_fs_write(bytes),
-                    Err(error) => {
-                        global_profiler().record_fs_write_failure(bytes);
-                        eprintln!("Failed to write {}: {}", out_path.display(), error);
-                    }
-                }
+                eprintln!("\x1b[31mError:\x1b[0m {error}");
+                std::process::exit(1);
             }
         }
     }

--- a/crates/vize/src/commands/build/runner/collect.rs
+++ b/crates/vize/src/commands/build/runner/collect.rs
@@ -6,13 +6,23 @@ use ignore::Walk;
 use vize_carton::cstr;
 use vize_carton::{String, ToCompactString};
 
+pub(super) struct CollectedFiles {
+    pub files: Vec<PathBuf>,
+    pub roots: Vec<PathBuf>,
+}
+
 /// Collect `.vue` files matching the given glob patterns.
 #[allow(clippy::disallowed_types)]
-pub(super) fn collect_files(patterns: &[std::string::String]) -> Vec<PathBuf> {
+pub(super) fn collect_files(patterns: &[std::string::String]) -> CollectedFiles {
     let mut files = Vec::new();
+    let mut roots = Vec::new();
 
     for pattern in patterns {
         let (root, glob_pattern) = parse_pattern(pattern);
+        let root_path = PathBuf::from(root.as_str());
+        if root_path.is_dir() {
+            roots.push(root_path);
+        }
 
         for entry in Walk::new(&root).flatten() {
             let path = entry.path();
@@ -28,7 +38,9 @@ pub(super) fn collect_files(patterns: &[std::string::String]) -> Vec<PathBuf> {
 
     files.sort();
     files.dedup();
-    files
+    roots.sort();
+    roots.dedup();
+    CollectedFiles { files, roots }
 }
 
 /// Extract a root directory and glob pattern from a user-provided pattern string.
@@ -127,12 +139,13 @@ mod tests {
         )
         .unwrap();
 
-        let files = collect_files(&vec![root.display().to_string()]);
+        let collected = collect_files(&vec![root.display().to_string()]);
         let _ = fs::remove_dir_all(&root);
 
         let mut expected = vec![component_dir.join("Nested.vue"), src.join("App.vue")];
         expected.sort();
-        assert_eq!(files, expected);
+        assert_eq!(collected.files, expected);
+        assert_eq!(collected.roots, vec![root]);
     }
 
     #[test]
@@ -146,10 +159,32 @@ mod tests {
         fs::write(&app, "<template><div /></template>").unwrap();
         fs::write(sibling, "<template><div /></template>").unwrap();
 
-        let files = collect_files(&vec![app.display().to_string()]);
+        let collected = collect_files(&vec![app.display().to_string()]);
         let _ = fs::remove_dir_all(&root);
 
-        assert_eq!(files, vec![app]);
+        assert_eq!(collected.files, vec![app]);
+        assert_eq!(collected.roots, vec![src]);
+    }
+
+    #[test]
+    fn collect_files_keeps_empty_searched_roots() {
+        let root = unique_case_dir("build-empty-searched-root");
+        let alpha = root.join("packages/alpha/src");
+        let beta = root.join("packages/beta/src");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&alpha).unwrap();
+        fs::create_dir_all(&beta).unwrap();
+        let app = alpha.join("App.vue");
+        fs::write(&app, "<template><div /></template>").unwrap();
+
+        let collected = collect_files(&[
+            alpha.to_string_lossy().into_owned(),
+            beta.to_string_lossy().into_owned(),
+        ]);
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(collected.files, vec![app]);
+        assert_eq!(collected.roots, vec![alpha, beta]);
     }
 
     fn unique_case_dir(name: &str) -> PathBuf {

--- a/crates/vize/src/commands/build/runner/output.rs
+++ b/crates/vize/src/commands/build/runner/output.rs
@@ -1,0 +1,228 @@
+//! Deterministic build output planning and writing.
+
+mod plan;
+
+use std::{
+    fs, io,
+    io::Write as _,
+    path::{Path, PathBuf},
+};
+
+use vize_carton::profiler::global_profiler;
+use vize_carton::{String, profile};
+
+use super::super::{
+    OutputFormat, ScriptExtension,
+    config::{CompileOutput, get_output_extension},
+};
+
+use plan::{OutputPath, destination, validate_output_paths};
+pub(super) use plan::{PlannedInput, plan_inputs, preflight_outputs};
+
+pub(super) struct CompiledBuildOutput<'a> {
+    pub input: &'a PlannedInput,
+    pub output: CompileOutput,
+}
+
+#[derive(Debug)]
+pub(super) enum OutputError {
+    CurrentDirectory(io::Error),
+    NoCommonRoot,
+    SourceOutsideRoot {
+        source: PathBuf,
+        root: PathBuf,
+    },
+    Collision {
+        first_source: PathBuf,
+        first_output: PathBuf,
+        second_source: PathBuf,
+        second_output: PathBuf,
+    },
+    CreateDirectory {
+        path: PathBuf,
+        source: io::Error,
+    },
+    Serialize {
+        source_path: PathBuf,
+        output_path: PathBuf,
+        source: serde_json::Error,
+    },
+    Write {
+        source_path: PathBuf,
+        output_path: PathBuf,
+        source: io::Error,
+    },
+}
+
+impl std::fmt::Display for OutputError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CurrentDirectory(error) => {
+                write!(
+                    formatter,
+                    "failed to resolve the current directory: {error}"
+                )
+            }
+            Self::NoCommonRoot => write!(formatter, "input roots have no common ancestor"),
+            Self::SourceOutsideRoot { source, root } => write!(
+                formatter,
+                "input {} is outside the common root {}",
+                source.display(),
+                root.display()
+            ),
+            Self::Collision {
+                first_source,
+                first_output,
+                second_source,
+                second_output,
+            } => write!(
+                formatter,
+                "output collision: {} -> {} conflicts with {} -> {}",
+                first_source.display(),
+                first_output.display(),
+                second_source.display(),
+                second_output.display()
+            ),
+            Self::CreateDirectory { path, source } => write!(
+                formatter,
+                "failed to create output directory {}: {source}",
+                path.display()
+            ),
+            Self::Serialize {
+                source_path,
+                output_path,
+                source,
+            } => write!(
+                formatter,
+                "failed to serialize {} -> {}: {source}",
+                source_path.display(),
+                output_path.display()
+            ),
+            Self::Write {
+                source_path,
+                output_path,
+                source,
+            } => write!(
+                formatter,
+                "failed to write {} -> {}: {source}",
+                source_path.display(),
+                output_path.display()
+            ),
+        }
+    }
+}
+
+pub(super) fn write_outputs<'a>(
+    outputs: impl IntoIterator<Item = CompiledBuildOutput<'a>>,
+    output_directory: &Path,
+    format: OutputFormat,
+    script_extension: ScriptExtension,
+) -> Result<(), OutputError> {
+    let outputs: Vec<_> = outputs.into_iter().collect();
+    let paths: Vec<_> = outputs
+        .iter()
+        .map(|compiled| {
+            let extension = match format {
+                OutputFormat::Js => {
+                    get_output_extension(&compiled.output.script_lang, script_extension)
+                }
+                OutputFormat::Json => "json",
+                OutputFormat::Stats => unreachable!(),
+            };
+            OutputPath {
+                source: &compiled.input.source,
+                output: destination(compiled.input, output_directory, extension),
+            }
+        })
+        .collect();
+    validate_output_paths(&paths, output_directory)?;
+
+    // Serialize every output before mutating the destination tree. Besides
+    // surfacing serialization failures, this keeps them atomic with preflight.
+    let prepared: Result<Vec<_>, OutputError> = outputs
+        .into_iter()
+        .zip(paths)
+        .map(|(compiled, path)| {
+            let content: String = match format {
+                OutputFormat::Js => compiled.output.code,
+                OutputFormat::Json =>
+                {
+                    #[allow(clippy::disallowed_methods)]
+                    serde_json::to_string_pretty(&compiled.output)
+                        .map_err(|source| OutputError::Serialize {
+                            source_path: compiled.input.source.clone(),
+                            output_path: path.output.clone(),
+                            source,
+                        })?
+                        .into()
+                }
+                OutputFormat::Stats => unreachable!(),
+            };
+            Ok((compiled.input, path.output, content))
+        })
+        .collect();
+    let prepared = prepared?;
+
+    let mut directories: Vec<_> = prepared
+        .iter()
+        .filter_map(|(_, output, _)| output.parent().map(Path::to_path_buf))
+        .collect();
+    directories.sort();
+    directories.dedup();
+    for directory in directories {
+        match profile!(
+            "cli.build.output.create_dir_all",
+            fs::create_dir_all(&directory)
+        ) {
+            Ok(()) => global_profiler().record_fs_create_dir_all(),
+            Err(source) => {
+                global_profiler().record_fs_create_dir_all_failure();
+                return Err(OutputError::CreateDirectory {
+                    path: directory,
+                    source,
+                });
+            }
+        }
+    }
+
+    let stderr = io::stderr();
+    let mut report = io::BufWriter::new(stderr.lock());
+    let mut first_write_error = None;
+    for (input, output, content) in prepared {
+        let bytes = content.len();
+        match profile!(
+            "cli.build.output.write",
+            fs::write(&output, content.as_str())
+        ) {
+            Ok(()) => {
+                global_profiler().record_fs_write(bytes);
+                let _ = writeln!(
+                    report,
+                    "Built: {} -> {}",
+                    input.source.display(),
+                    output.display()
+                );
+            }
+            Err(source) => {
+                global_profiler().record_fs_write_failure(bytes);
+                let _ = writeln!(
+                    report,
+                    "Failed to write {} -> {}: {source}",
+                    input.source.display(),
+                    output.display()
+                );
+                let error = OutputError::Write {
+                    source_path: input.source.clone(),
+                    output_path: output,
+                    source,
+                };
+                first_write_error.get_or_insert(error);
+            }
+        }
+    }
+    let _ = report.flush();
+    first_write_error.map_or(Ok(()), Err)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize/src/commands/build/runner/output/plan.rs
+++ b/crates/vize/src/commands/build/runner/output/plan.rs
@@ -1,0 +1,204 @@
+use std::path::{Component, Path, PathBuf};
+
+use vize_carton::String;
+
+use super::{OutputError, OutputFormat, ScriptExtension};
+
+pub(crate) struct PlannedInput {
+    pub(crate) source: PathBuf,
+    pub(super) relative_source: PathBuf,
+}
+
+pub(crate) fn plan_inputs(
+    files: Vec<PathBuf>,
+    roots: &[PathBuf],
+) -> Result<Vec<PlannedInput>, OutputError> {
+    let cwd = std::env::current_dir().map_err(OutputError::CurrentDirectory)?;
+    let mut normalized_roots: Vec<_> = roots
+        .iter()
+        .map(|root| normalize_absolute(root, &cwd))
+        .collect();
+    normalized_roots.sort();
+    normalized_roots.dedup();
+
+    let mut normalized_files: Vec<_> = files
+        .into_iter()
+        .map(|source| {
+            let normalized = normalize_absolute(&source, &cwd);
+            (source, normalized)
+        })
+        .collect();
+    normalized_files.sort_by(|left, right| left.1.cmp(&right.1).then_with(|| left.0.cmp(&right.0)));
+    normalized_files.dedup_by(|left, right| left.1 == right.1);
+
+    if normalized_roots.is_empty() {
+        normalized_roots.extend(
+            normalized_files
+                .iter()
+                .filter_map(|(_, source)| source.parent().map(Path::to_path_buf)),
+        );
+        normalized_roots.sort();
+        normalized_roots.dedup();
+    }
+
+    let root = common_root(&normalized_roots).ok_or(OutputError::NoCommonRoot)?;
+    normalized_files
+        .into_iter()
+        .map(|(source, normalized)| {
+            let relative_source =
+                normalized
+                    .strip_prefix(&root)
+                    .map_err(|_| OutputError::SourceOutsideRoot {
+                        source: source.clone(),
+                        root: root.clone(),
+                    })?;
+            Ok(PlannedInput {
+                source,
+                relative_source: relative_source.to_path_buf(),
+            })
+        })
+        .collect()
+}
+
+pub(crate) fn preflight_outputs(
+    inputs: &[PlannedInput],
+    output_directory: &Path,
+    format: OutputFormat,
+    script_extension: ScriptExtension,
+) -> Result<(), OutputError> {
+    let Some(extension) = fixed_extension(format, script_extension) else {
+        return Ok(());
+    };
+    let paths: Vec<_> = inputs
+        .iter()
+        .map(|input| OutputPath {
+            source: &input.source,
+            output: destination(input, output_directory, extension),
+        })
+        .collect();
+    validate_output_paths(&paths, output_directory)
+}
+
+fn fixed_extension(
+    format: OutputFormat,
+    script_extension: ScriptExtension,
+) -> Option<&'static str> {
+    match (format, script_extension) {
+        (OutputFormat::Js, ScriptExtension::Downcompile) => Some("js"),
+        (OutputFormat::Json, _) => Some("json"),
+        (OutputFormat::Js, ScriptExtension::Preserve) | (OutputFormat::Stats, _) => None,
+    }
+}
+
+pub(super) fn destination(
+    input: &PlannedInput,
+    output_directory: &Path,
+    extension: &str,
+) -> PathBuf {
+    output_directory.join(input.relative_source.with_extension(extension))
+}
+
+pub(super) struct OutputPath<'a> {
+    pub source: &'a Path,
+    pub output: PathBuf,
+}
+
+struct ComparableOutput<'a> {
+    source: &'a Path,
+    output: &'a Path,
+    normalized: PathBuf,
+    key: String,
+}
+
+pub(super) fn validate_output_paths(
+    paths: &[OutputPath<'_>],
+    output_directory: &Path,
+) -> Result<(), OutputError> {
+    let cwd = std::env::current_dir().map_err(OutputError::CurrentDirectory)?;
+    let root = normalize_absolute(output_directory, &cwd);
+    let mut comparable: Vec<_> = paths
+        .iter()
+        .map(|path| {
+            let normalized = normalize_absolute(&path.output, &cwd);
+            let key = portable_key(&normalized);
+            ComparableOutput {
+                source: path.source,
+                output: &path.output,
+                normalized,
+                key,
+            }
+        })
+        .collect();
+    comparable.sort_by(|left, right| {
+        left.key
+            .cmp(&right.key)
+            .then_with(|| left.source.cmp(right.source))
+    });
+
+    for pair in comparable.windows(2) {
+        if pair[0].key == pair[1].key {
+            return Err(collision(&pair[0], &pair[1]));
+        }
+    }
+    for path in &comparable {
+        let mut parent = path.normalized.parent();
+        while let Some(candidate) = parent {
+            if candidate == root || !candidate.starts_with(&root) {
+                break;
+            }
+            let key = portable_key(candidate);
+            if let Ok(index) = comparable.binary_search_by(|entry| entry.key.cmp(&key)) {
+                return Err(collision(&comparable[index], path));
+            }
+            parent = candidate.parent();
+        }
+    }
+    Ok(())
+}
+
+fn collision(first: &ComparableOutput<'_>, second: &ComparableOutput<'_>) -> OutputError {
+    OutputError::Collision {
+        first_source: first.source.to_path_buf(),
+        first_output: first.output.to_path_buf(),
+        second_source: second.source.to_path_buf(),
+        second_output: second.output.to_path_buf(),
+    }
+}
+
+fn common_root(paths: &[PathBuf]) -> Option<PathBuf> {
+    let mut root = paths.first()?.clone();
+    while !paths.iter().all(|path| path.starts_with(&root)) {
+        if !root.pop() {
+            return None;
+        }
+    }
+    Some(root)
+}
+
+fn normalize_absolute(path: &Path, cwd: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let _ = normalized.pop();
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}
+
+fn portable_key(path: &Path) -> String {
+    path.to_string_lossy()
+        .replace('\\', "/")
+        .to_lowercase()
+        .into()
+}

--- a/crates/vize/src/commands/build/runner/output/tests.rs
+++ b/crates/vize/src/commands/build/runner/output/tests.rs
@@ -1,0 +1,121 @@
+use std::path::{Path, PathBuf};
+
+use super::{OutputError, plan_inputs, preflight_outputs};
+use crate::commands::build::{OutputFormat, ScriptExtension};
+use vize_carton::cstr;
+
+#[test]
+fn preserves_directories_for_duplicate_basenames() {
+    let case = tempfile::tempdir().unwrap();
+    let root = case.path().join("src");
+    let files = vec![root.join("a/index.vue"), root.join("b/index.vue")];
+
+    let planned = plan_inputs(files.clone(), std::slice::from_ref(&root)).unwrap();
+
+    assert_eq!(relative_sources(&planned, &root), files);
+    preflight_outputs(
+        &planned,
+        &case.path().join("dist"),
+        OutputFormat::Js,
+        ScriptExtension::Downcompile,
+    )
+    .unwrap();
+}
+
+#[test]
+fn planning_is_independent_of_file_and_root_order() {
+    let case = tempfile::tempdir().unwrap();
+    let packages = case.path().join("packages");
+    let alpha = packages.join("alpha/src");
+    let beta = packages.join("beta/src");
+    let forward_files = vec![alpha.join("index.vue"), beta.join("index.vue")];
+    let reverse_files = forward_files.iter().rev().cloned().collect::<Vec<_>>();
+
+    let forward = plan_inputs(forward_files, &[alpha.clone(), beta.clone()]).unwrap();
+    let reverse = plan_inputs(reverse_files, &[beta, alpha]).unwrap();
+
+    assert_eq!(planned_pairs(&forward), planned_pairs(&reverse));
+    assert_eq!(
+        forward
+            .iter()
+            .map(|input| input.relative_source.as_path())
+            .collect::<Vec<_>>(),
+        [
+            Path::new("alpha/src/index.vue"),
+            Path::new("beta/src/index.vue")
+        ]
+    );
+}
+
+#[test]
+fn empty_searched_root_does_not_later_reshape_existing_outputs() {
+    let case = tempfile::tempdir().unwrap();
+    let packages = case.path().join("packages");
+    let alpha = packages.join("alpha/src");
+    let beta = packages.join("beta/src");
+    let alpha_file = alpha.join("index.vue");
+    let beta_file = beta.join("index.vue");
+
+    let initial = plan_inputs(vec![alpha_file.clone()], &[alpha.clone(), beta.clone()]).unwrap();
+    let expanded = plan_inputs(vec![alpha_file, beta_file], &[alpha, beta]).unwrap();
+
+    assert_eq!(initial[0].relative_source, expanded[0].relative_source);
+    assert_eq!(initial[0].relative_source, Path::new("alpha/src/index.vue"));
+}
+
+#[test]
+fn rejects_parent_file_and_child_directory_collision() {
+    let case = tempfile::tempdir().unwrap();
+    let root = case.path().join("src");
+    let files = vec![root.join("a.vue"), root.join("a.js/index.vue")];
+    let planned = plan_inputs(files, std::slice::from_ref(&root)).unwrap();
+
+    let error = preflight_outputs(
+        &planned,
+        &case.path().join("dist"),
+        OutputFormat::Js,
+        ScriptExtension::Downcompile,
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, OutputError::Collision { .. }));
+    let message = cstr!("{error}");
+    assert!(message.contains("a.vue"), "{message}");
+    assert!(message.contains("a.js/index.vue"), "{message}");
+    assert!(message.contains("a.js/index.js"), "{message}");
+}
+
+#[test]
+fn rejects_case_only_output_collision_portably() {
+    let case = tempfile::tempdir().unwrap();
+    let root = case.path().join("src");
+    let planned = plan_inputs(
+        vec![root.join("Card.vue"), root.join("card.vue")],
+        std::slice::from_ref(&root),
+    )
+    .unwrap();
+
+    let error = preflight_outputs(
+        &planned,
+        &case.path().join("dist"),
+        OutputFormat::Js,
+        ScriptExtension::Downcompile,
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, OutputError::Collision { .. }));
+}
+
+fn relative_sources(planned: &[super::PlannedInput], root: &Path) -> Vec<PathBuf> {
+    planned
+        .iter()
+        .map(|input| root.join(&input.relative_source))
+        .collect()
+}
+
+fn planned_pairs(planned: &[super::PlannedInput]) -> Vec<(PathBuf, PathBuf)> {
+    planned
+        .iter()
+        .map(|input| (input.source.clone(), input.relative_source.clone()))
+        .collect()
+}

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_build_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_build_help.snap
@@ -8,7 +8,7 @@ Usage: build [OPTIONS] [PATTERNS]...
 
 Arguments:
   [PATTERNS]...
-          Glob pattern(s) to match .vue files (default: ./**/*.vue)
+          File, directory, or glob inputs (output paths stay relative to their common root)
 
           [default: ./**/*.vue]
 

--- a/crates/vize/tests/build_output_paths_cli.rs
+++ b/crates/vize/tests/build_output_paths_cli.rs
@@ -1,0 +1,186 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+const ALPHA: &str = "<template><div>alpha</div></template>";
+const BETA: &str = "<template><div>beta</div></template>";
+
+#[test]
+fn build_preserves_paths_for_duplicate_basenames() {
+    let project = tempfile::tempdir().unwrap();
+    write_file(project.path(), "src/a/index.vue", ALPHA.as_bytes());
+    write_file(project.path(), "src/b/index.vue", BETA.as_bytes());
+
+    let output = run_build(project.path(), &["src"], "dist", &[]);
+
+    assert_success(&output);
+    assert!(project.path().join("dist/a/index.js").is_file());
+    assert!(project.path().join("dist/b/index.js").is_file());
+    assert!(!project.path().join("dist/index.js").exists());
+    let stderr = std::str::from_utf8(&output.stderr)
+        .unwrap()
+        .replace('\\', "/");
+    let first = stderr
+        .find("Built: src/a/index.vue -> dist/a/index.js")
+        .unwrap();
+    let second = stderr
+        .find("Built: src/b/index.vue -> dist/b/index.js")
+        .unwrap();
+    assert!(first < second, "{stderr}");
+}
+
+#[test]
+fn build_multiple_roots_is_independent_of_pattern_order() {
+    let project = tempfile::tempdir().unwrap();
+    write_file(
+        project.path(),
+        "packages/alpha/src/index.vue",
+        ALPHA.as_bytes(),
+    );
+    write_file(
+        project.path(),
+        "packages/beta/src/index.vue",
+        BETA.as_bytes(),
+    );
+    let forward_patterns = ["packages/alpha/src", "packages/beta/src/**/*.vue"];
+    let reverse_patterns = ["packages/beta/src/**/*.vue", "packages/alpha/src"];
+
+    let forward = run_build(project.path(), &forward_patterns, "dist-forward", &[]);
+    let reverse = run_build(project.path(), &reverse_patterns, "dist-reverse", &[]);
+
+    assert_success(&forward);
+    assert_success(&reverse);
+    let forward_files = output_files(&project.path().join("dist-forward"));
+    let reverse_files = output_files(&project.path().join("dist-reverse"));
+    assert_eq!(forward_files, reverse_files);
+    assert_eq!(
+        forward_files
+            .iter()
+            .map(|(path, _)| path.as_path())
+            .collect::<Vec<_>>(),
+        [
+            Path::new("alpha/src/index.js"),
+            Path::new("beta/src/index.js")
+        ]
+    );
+}
+
+#[test]
+fn build_rejects_fixed_extension_collision_before_compiling_or_writing() {
+    let project = tempfile::tempdir().unwrap();
+    write_file(project.path(), "src/a.vue", &[0xff]);
+    write_file(project.path(), "src/a.js/index.vue", &[0xff]);
+
+    let output = run_build(project.path(), &["src"], "dist", &[]);
+
+    assert!(!output.status.success());
+    let stderr = std::str::from_utf8(&output.stderr)
+        .unwrap()
+        .replace('\\', "/");
+    assert!(stderr.contains("output collision"), "{stderr}");
+    assert!(stderr.contains("src/a.vue -> dist/a.js"), "{stderr}");
+    assert!(
+        stderr.contains("src/a.js/index.vue -> dist/a.js/index.js"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("error(s) occurred"), "{stderr}");
+    assert!(!project.path().join("dist").exists());
+}
+
+#[test]
+fn build_rejects_preserved_extension_collision_before_first_write() {
+    let project = tempfile::tempdir().unwrap();
+    write_file(project.path(), "src/a.vue", ALPHA.as_bytes());
+    write_file(project.path(), "src/a.js/index.vue", BETA.as_bytes());
+
+    let output = run_build(
+        project.path(),
+        &["src"],
+        "dist",
+        &["--script-ext", "preserve"],
+    );
+
+    assert!(!output.status.success());
+    let stderr = std::str::from_utf8(&output.stderr)
+        .unwrap()
+        .replace('\\', "/");
+    assert!(stderr.contains("output collision"), "{stderr}");
+    assert!(!project.path().join("dist").exists());
+}
+
+#[test]
+fn build_reports_write_failures_and_finishes_independent_outputs() {
+    let project = tempfile::tempdir().unwrap();
+    write_file(project.path(), "src/a.vue", ALPHA.as_bytes());
+    write_file(project.path(), "src/b.vue", BETA.as_bytes());
+    fs::create_dir_all(project.path().join("dist/a.js")).unwrap();
+
+    let output = run_build(project.path(), &["src"], "dist", &[]);
+
+    assert!(!output.status.success());
+    let stderr = std::str::from_utf8(&output.stderr)
+        .unwrap()
+        .replace('\\', "/");
+    assert!(
+        stderr.contains("Failed to write src/a.vue -> dist/a.js"),
+        "{stderr}"
+    );
+    assert!(project.path().join("dist/b.js").is_file(), "{stderr}");
+    assert!(stderr.contains("Built: src/b.vue -> dist/b.js"), "{stderr}");
+}
+
+fn run_build(root: &Path, patterns: &[&str], output: &str, extra: &[&str]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vize"));
+    command
+        .current_dir(root)
+        .arg("build")
+        .arg("--format")
+        .arg("js");
+    for pattern in patterns {
+        command.arg(pattern);
+    }
+    command
+        .arg("--output")
+        .arg(output)
+        .args(extra)
+        .output()
+        .unwrap()
+}
+
+fn write_file(root: &Path, relative: &str, content: &[u8]) {
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+fn output_files(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+    let mut files = Vec::new();
+    collect_output_files(root, root, &mut files);
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+    files
+}
+
+fn collect_output_files(root: &Path, directory: &Path, files: &mut Vec<(PathBuf, Vec<u8>)>) {
+    for entry in fs::read_dir(directory).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_dir() {
+            collect_output_files(root, &path, files);
+        } else {
+            files.push((
+                path.strip_prefix(root).unwrap().to_path_buf(),
+                fs::read(path).unwrap(),
+            ));
+        }
+    }
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        std::str::from_utf8(&output.stdout).unwrap(),
+        std::str::from_utf8(&output.stderr).unwrap()
+    );
+}

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -106,15 +106,15 @@ vize build --profile src
 
 Key options:
 
-| Option                | Description                                   |
-| --------------------- | --------------------------------------------- |
-| `-o, --output`        | Output directory                              |
-| `-f, --format`        | Output format: `js`, `json`, `stats`          |
-| `--ssr`               | Enable SSR compilation                        |
-| `--script-ext`        | `preserve` or `downcompile`                   |
-| `-j, --threads`       | Thread count override                         |
-| `--profile`           | Print timing profile                          |
-| `--continue-on-error` | Keep compiling and report failures at the end |
+| Option                | Description                                                            |
+| --------------------- | ---------------------------------------------------------------------- |
+| `-o, --output`        | Source-relative output below the common input root; rejects collisions |
+| `-f, --format`        | Output format: `js`, `json`, `stats`                                   |
+| `--ssr`               | Enable SSR compilation                                                 |
+| `--script-ext`        | `preserve` or `downcompile`                                            |
+| `-j, --threads`       | Thread count override                                                  |
+| `--profile`           | Print timing profile                                                   |
+| `--continue-on-error` | Keep compiling and report failures at the end                          |
 
 ## Format
 


### PR DESCRIPTION
## Summary

- derive build outputs from a stable common input root instead of flattening basenames
- reject exact, case-only, and file/directory path collisions before the first write
- keep preserve-extension validation ahead of directory creation and output writes
- report deterministic source-to-output mappings and document the root policy

## Verification

- cargo fmt --all --check
- cargo test -p vize --lib
- cargo test -p vize --test build_cli --test build_output_paths_cli
- cargo clippy -p vize --lib -- -D warnings -D clippy::wildcard_imports

Closes #2823

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786433789&installation_id=136613492&pr_number=2850&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2850&signature=a54cf04872994d0c4f8f1376b93a91e5223c4b2e3866cc6a4cd33097d8cc583b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `build` output paths now preserve source-relative directory structure under the common input root.
  - Detects and rejects output-path collisions before compilation/writing (including duplicate basename scenarios).
  - `build` input patterns now accept files, directories, or globs while keeping consistent root-relative outputs.
- **Bug Fixes**
  - Improved determinism: generated output sets are stable regardless of pattern ordering.
- **Tests**
  - Added CLI integration coverage for path mapping, collision handling, and continued builds after a write failure.
- **Documentation**
  - Refreshed `vize build -o/--output` option docs to clarify source-relative output and collision behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #2849