### PR TITLE
ci(release): make exact-SHA gates dispatchable

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,14 +4,32 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
+  # GitHub records a workflow_dispatch run's head_sha from the branch or tag
+  # passed via --ref, not from a later checkout. Dispatch with a ref whose tip
+  # is exactly head_sha; the first step rejects mismatches so release evidence
+  # cannot be attributed to the wrong commit.
+  workflow_dispatch:
+    inputs:
+      base_sha:
+        description: Full lowercase 40-character base commit SHA
+        required: true
+        type: string
+      head_sha:
+        description: Full lowercase 40-character head SHA; --ref must be a branch or tag at this commit
+        required: true
+        type: string
+
+run-name: "Benchmark ${{ github.event_name == 'workflow_dispatch' && format('{0}...{1}', inputs.base_sha, inputs.head_sha) || format('PR #{0}', github.event.pull_request.number) }}"
 
 concurrency:
-  group: benchmark-${{ github.event.pull_request.number }}
+  group: benchmark-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}-{1}', inputs.base_sha, inputs.head_sha) || github.event.pull_request.number }}
   cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  BENCHMARK_BASE_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.base_sha || github.event.pull_request.base.sha }}
+  BENCHMARK_HEAD_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.head_sha || github.event.pull_request.head.sha }}
   # 1000 files keeps the fastest lane (compile, ~200us/file single-threaded)
   # above ~200ms so runner thermal drift between interleaved runs stays well
   # under the 5% threshold; at 300 files the lane ran ~65ms and perf-neutral
@@ -33,24 +51,43 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Validate dispatch SHAs
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          RUN_HEAD_SHA: ${{ github.sha }}
+        run: |
+          full_sha='^[0-9a-f]{40}$'
+          if [[ ! "$BENCHMARK_BASE_SHA" =~ $full_sha ]]; then
+            echo "::error title=Invalid base_sha::base_sha must be a full lowercase 40-character commit SHA"
+            exit 1
+          fi
+          if [[ ! "$BENCHMARK_HEAD_SHA" =~ $full_sha ]]; then
+            echo "::error title=Invalid head_sha::head_sha must be a full lowercase 40-character commit SHA"
+            exit 1
+          fi
+          if [[ "$RUN_HEAD_SHA" != "$BENCHMARK_HEAD_SHA" ]]; then
+            echo "::error title=Dispatch ref mismatch::run head_sha comes from --ref; dispatch with a branch or tag at $BENCHMARK_HEAD_SHA (got $RUN_HEAD_SHA)"
+            exit 1
+          fi
+
       - name: Checkout head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: head
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ env.BENCHMARK_HEAD_SHA }}
 
       - name: Checkout base
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: base
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ env.BENCHMARK_BASE_SHA }}
 
       - name: Check base checkout
         id: base-integrity
         working-directory: base
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ env.BENCHMARK_BASE_SHA }}
+          HEAD_SHA: ${{ env.BENCHMARK_HEAD_SHA }}
         run: |
           if git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- . ':(exclude)tests/_fixtures/_git/**'; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -111,8 +148,8 @@ jobs:
             echo "| skipped | base checkout is not buildable |"
           } > benchmark-summary.md
           printf '{"skipped":true,"reason":"base_metadata_invalid","base":"%s","head":"%s"}\n' \
-            "${{ github.event.pull_request.base.sha }}" \
-            "${{ github.event.pull_request.head.sha }}" \
+            "$BENCHMARK_BASE_SHA" \
+            "$BENCHMARK_HEAD_SHA" \
             > benchmark-results.json
 
       - name: Cache base CLI
@@ -121,7 +158,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: base/target/ci-opt/vize
-          key: ${{ runner.os }}-benchmark-base-cli-ci-opt-${{ github.event.pull_request.base.sha }}
+          key: ${{ runner.os }}-benchmark-base-cli-ci-opt-${{ env.BENCHMARK_BASE_SHA }}
 
       # The ci-opt profile is also injected via --config so the base checkout
       # builds even when it predates the profile's Cargo.toml definition, and
@@ -151,8 +188,8 @@ jobs:
             echo "| skipped | base checkout does not compile |"
           } > benchmark-summary.md
           printf '{"skipped":true,"reason":"base_not_buildable","base":"%s","head":"%s"}\n' \
-            "${{ github.event.pull_request.base.sha }}" \
-            "${{ github.event.pull_request.head.sha }}" \
+            "$BENCHMARK_BASE_SHA" \
+            "$BENCHMARK_HEAD_SHA" \
             > benchmark-results.json
 
       - name: Cache head CLI
@@ -161,7 +198,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: head/target/ci-opt/vize
-          key: ${{ runner.os }}-benchmark-head-cli-ci-opt-${{ github.event.pull_request.head.sha }}
+          key: ${{ runner.os }}-benchmark-head-cli-ci-opt-${{ env.BENCHMARK_HEAD_SHA }}
 
       - name: Build head CLI
         if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.cache-head-cli.outputs.cache-hit != 'true' && steps.build-base.outcome != 'failure'
@@ -183,8 +220,8 @@ jobs:
             --input "$GITHUB_WORKSPACE/head/bench/__in__" \
             --base-bin "$GITHUB_WORKSPACE/base/target/ci-opt/vize" \
             --head-bin "$GITHUB_WORKSPACE/head/target/ci-opt/vize" \
-            --base-label "${{ github.event.pull_request.base.sha }}" \
-            --head-label "${{ github.event.pull_request.head.sha }}" \
+            --base-label "$BENCHMARK_BASE_SHA" \
+            --head-label "$BENCHMARK_HEAD_SHA" \
             --runs "$VIZE_BENCH_RUNS" \
             --warmups "$VIZE_BENCH_WARMUPS" \
             --threshold "$VIZE_BENCH_REGRESSION_THRESHOLD_PERCENT" \
@@ -219,7 +256,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: head
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ env.BENCHMARK_HEAD_SHA }}
 
       - name: Download benchmark results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -228,6 +265,7 @@ jobs:
 
       - name: Read current PR labels
         id: pr-labels
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -259,7 +297,7 @@ jobs:
 
       - name: Enforce benchmark budget
         env:
-          PR_LABELS_JSON: ${{ steps.pr-labels.outputs.labels }}
+          PR_LABELS_JSON: ${{ github.event_name == 'pull_request' && steps.pr-labels.outputs.labels || '[]' }}
         run: >-
           node head/bench/enforce-pr-budget.mjs
           --json benchmark-results.json
@@ -269,7 +307,7 @@ jobs:
     name: pr-benchmark-comment
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 5
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     needs:
       - pr-benchmark
     permissions:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     # 02:23 UTC daily (~11:23 JST). Covers every suite including vrt.
     - cron: "23 2 * * *"
+  # A dispatch run's GitHub head_sha comes from --ref. Release evidence must
+  # therefore use a branch or tag whose tip is target_sha; suite=all validates
+  # that invariant before checkout. Existing one-suite and Testbox dispatches
+  # may omit target_sha and continue to run at the selected --ref tip.
   workflow_dispatch:
     inputs:
       suite:
@@ -23,18 +27,26 @@ on:
           - check
           - lint
           - build
+          - all
+      target_sha:
+        description: Full lowercase 40-character target SHA; --ref must be a branch or tag at this commit
+        required: false
+        type: string
       testbox_id:
         description: Blacksmith Testbox session ID
         required: false
         type: string
 
+run-name: App E2E ${{ github.event_name == 'workflow_dispatch' && (inputs.testbox_id || inputs.suite) || 'nightly' }} @ ${{ inputs.target_sha || github.sha }}
+
 concurrency:
-  group: app-e2e-${{ github.ref }}-${{ github.event.inputs.testbox_id || github.event.inputs.suite || github.event_name }}
+  group: app-e2e-${{ github.event_name == 'workflow_dispatch' && (inputs.testbox_id || inputs.suite) || github.ref }}-${{ github.event_name == 'workflow_dispatch' && (inputs.target_sha || github.sha) || github.event_name }}
   cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  E2E_TARGET_SHA: ${{ inputs.target_sha || github.sha }}
 
 jobs:
   testbox:
@@ -47,13 +59,30 @@ jobs:
     env:
       NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
     steps:
+      - name: Validate optional target SHA
+        if: ${{ inputs.target_sha != '' }}
+        env:
+          REQUESTED_TARGET_SHA: ${{ inputs.target_sha }}
+          RUN_HEAD_SHA: ${{ github.sha }}
+        run: |
+          if [[ ! "$REQUESTED_TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=Invalid target_sha::target_sha must be a full lowercase 40-character commit SHA"
+            exit 1
+          fi
+          if [[ "$RUN_HEAD_SHA" != "$REQUESTED_TARGET_SHA" ]]; then
+            echo "::error title=Dispatch ref mismatch::run head_sha comes from --ref; dispatch with a branch or tag at $REQUESTED_TARGET_SHA (got $RUN_HEAD_SHA)"
+            exit 1
+          fi
+
       - name: Begin Testbox
+        id: begin-testbox
         uses: useblacksmith/begin-testbox@233448af4bfdc6fca509a7f0974411ac6d8a8043 # v2
         with:
           testbox_id: ${{ inputs.testbox_id }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ env.E2E_TARGET_SHA }}
           submodules: recursive
 
       - name: Setup Vite+ and Node.js
@@ -88,7 +117,7 @@ jobs:
 
       - name: Run Testbox
         uses: useblacksmith/run-testbox@5ca05834db1d3813554d1dd109e5f2087a8d7cbc # v2
-        if: always()
+        if: ${{ always() && steps.begin-testbox.outcome == 'success' }}
 
   app-e2e:
     name: app-e2e (${{ matrix.suite }})
@@ -100,13 +129,37 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # workflow_dispatch: pick one suite. schedule: run every suite,
-        # including vrt, because nothing else exercises the visual regression
-        # baselines today.
-        suite: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.suite)) || fromJSON('["dev","vrt","preview","build","check","lint"]') }}
+        # workflow_dispatch: pick one suite, or `all` for release evidence.
+        # schedule: run every suite, including vrt, because nothing else
+        # exercises the visual regression baselines today.
+        suite: ${{ github.event_name == 'workflow_dispatch' && inputs.suite != 'all' && fromJSON(format('["{0}"]', inputs.suite)) || fromJSON('["dev","vrt","preview","build","check","lint"]') }}
     steps:
+      - name: Validate target SHA
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          REQUESTED_SUITE: ${{ inputs.suite }}
+          REQUESTED_TARGET_SHA: ${{ inputs.target_sha }}
+          RUN_HEAD_SHA: ${{ github.sha }}
+        run: |
+          if [[ -z "$REQUESTED_TARGET_SHA" ]]; then
+            if [[ "$REQUESTED_SUITE" == "all" ]]; then
+              echo "::error title=Missing target_sha::target_sha is required when suite=all"
+              exit 1
+            fi
+            exit 0
+          fi
+          if [[ ! "$REQUESTED_TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=Invalid target_sha::target_sha must be a full lowercase 40-character commit SHA"
+            exit 1
+          fi
+          if [[ "$RUN_HEAD_SHA" != "$REQUESTED_TARGET_SHA" ]]; then
+            echo "::error title=Dispatch ref mismatch::run head_sha comes from --ref; dispatch with a branch or tag at $REQUESTED_TARGET_SHA (got $RUN_HEAD_SHA)"
+            exit 1
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ env.E2E_TARGET_SHA }}
           submodules: recursive
 
       - name: Setup Rust

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -24,6 +24,11 @@ test("app e2e workflow runs on schedule + workflow_dispatch and uploads failure 
   assert.match(workflow, /fromJSON\('\["dev","vrt","preview","build","check","lint"\]'\)/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /type:\s*choice/);
+  assert.match(workflow, /- all/);
+  assert.match(
+    workflow,
+    /github\.event_name == 'workflow_dispatch' && inputs\.suite != 'all' && fromJSON\(format\('\["\{0\}"\]', inputs\.suite\)\) \|\| fromJSON\('\["dev","vrt","preview","build","check","lint"\]'\)/,
+  );
   for (const suite of ["dev", "vrt", "preview", "check", "lint", "build"]) {
     assert.match(workflow, new RegExp(`- ${suite}`));
     assert.match(workflow, new RegExp(`${suite}\\)\\n\\s+`));
@@ -51,4 +56,57 @@ test("app e2e workflow runs on schedule + workflow_dispatch and uploads failure 
   assert.match(workflow, /tests\/app\/playwright-report\//);
   assert.match(workflow, /tests\/playwright-report\//);
   assert.match(workflow, /if-no-files-found:\s*ignore/);
+});
+
+test("app e2e dispatch pins validated exact-SHA checkouts and run evidence", () => {
+  const workflow = readRepoFile(".github", "workflows", "e2e.yml");
+
+  assert.match(
+    workflow,
+    /target_sha:\n\s+description:\s*Full lowercase 40-character target SHA; --ref must be a branch or tag at this commit\n\s+required:\s*false\n\s+type:\s*string/,
+  );
+  assert.match(
+    workflow,
+    /run-name:[^\n]*inputs\.testbox_id \|\| inputs\.suite[^\n]*'nightly'[^\n]*inputs\.target_sha \|\| github\.sha/,
+  );
+  assert.match(
+    workflow,
+    /group:[^\n]*inputs\.testbox_id \|\| inputs\.suite[^\n]*github\.ref[^\n]*inputs\.target_sha \|\| github\.sha[^\n]*github\.event_name/,
+  );
+  assert.match(workflow, /head_sha comes from --ref/);
+  assert.match(workflow, /branch or tag whose tip is target_sha/);
+  assert.match(workflow, /E2E_TARGET_SHA:\s*\$\{\{\s*inputs\.target_sha \|\| github\.sha\s*\}\}/);
+
+  const checkouts = workflow.match(
+    /ref:\s*\$\{\{\s*env\.E2E_TARGET_SHA\s*\}\}\n\s+submodules:\s*recursive/g,
+  );
+  assert.equal(checkouts?.length, 2, "both Testbox and app-e2e must pin checkout");
+  assert.match(workflow, /name:\s*Validate optional target SHA/);
+  assert.match(
+    workflow,
+    /name:\s*Validate optional target SHA\n\s+if:\s*\$\{\{\s*inputs\.target_sha != ''\s*\}\}/,
+  );
+  assert.match(workflow, /name:\s*Validate target SHA/);
+  assert.match(workflow, /REQUESTED_SUITE:\s*\$\{\{\s*inputs\.suite\s*\}\}/);
+  assert.match(workflow, /"\$REQUESTED_SUITE" == "all"/);
+  assert.match(workflow, /target_sha is required when suite=all/);
+  assert.match(
+    workflow,
+    /if \[\[ -z "\$REQUESTED_TARGET_SHA" \]\]; then[\s\S]*if \[\[ "\$REQUESTED_SUITE" == "all" \]\]; then[\s\S]*exit 1[\s\S]*fi\n\s+exit 0/,
+  );
+  assert.equal(
+    workflow.match(/\^\[0-9a-f\]\{40\}\$/g)?.length,
+    2,
+    "both dispatch paths validate a full SHA",
+  );
+  assert.equal(
+    workflow.match(/"\$RUN_HEAD_SHA" != "\$REQUESTED_TARGET_SHA"/g)?.length,
+    2,
+    "both dispatch paths bind requested checkout to workflow run head_sha",
+  );
+  assert.equal(
+    workflow.match(/run head_sha comes from --ref/g)?.length,
+    2,
+    "both dispatch paths explain the ref constraint",
+  );
 });

--- a/tests/tooling/github-workflows-benchmark.test.ts
+++ b/tests/tooling/github-workflows-benchmark.test.ts
@@ -12,13 +12,15 @@ test("benchmark workflow comments from trusted code after a read-only benchmark 
   assert.match(benchmarkJob, /contents:\s*read/);
   assert.doesNotMatch(benchmarkJob, /issues:\s*write/);
   assert.doesNotMatch(benchmarkJob, /pull-requests:\s*write/);
+  assert.match(benchmarkJob, /path:\s*head[\s\S]*ref:\s*\$\{\{\s*env\.BENCHMARK_HEAD_SHA\s*\}\}/);
+  assert.match(benchmarkJob, /path:\s*base[\s\S]*ref:\s*\$\{\{\s*env\.BENCHMARK_BASE_SHA\s*\}\}/);
   assert.match(
-    benchmarkJob,
-    /path:\s*head[\s\S]*ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}/,
+    workflow,
+    /BENCHMARK_HEAD_SHA:\s*\$\{\{\s*github\.event_name == 'workflow_dispatch' && inputs\.head_sha \|\| github\.event\.pull_request\.head\.sha\s*\}\}/,
   );
   assert.match(
-    benchmarkJob,
-    /path:\s*base[\s\S]*ref:\s*\$\{\{\s*github\.event\.pull_request\.base\.sha\s*\}\}/,
+    workflow,
+    /BENCHMARK_BASE_SHA:\s*\$\{\{\s*github\.event_name == 'workflow_dispatch' && inputs\.base_sha \|\| github\.event\.pull_request\.base\.sha\s*\}\}/,
   );
   assert.match(benchmarkJob, /name:\s*pr-benchmark/);
   assert.doesNotMatch(benchmarkJob, /node base\/bench\/comment-pr\.mjs/);
@@ -31,13 +33,11 @@ test("benchmark workflow comments from trusted code after a read-only benchmark 
   assert.match(budgetJob, /issues:\s*read/);
   assert.doesNotMatch(budgetJob, /issues:\s*write/);
   assert.doesNotMatch(budgetJob, /pull-requests:\s*write/);
-  assert.match(
-    budgetJob,
-    /path:\s*head[\s\S]*ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}/,
-  );
+  assert.match(budgetJob, /path:\s*head[\s\S]*ref:\s*\$\{\{\s*env\.BENCHMARK_HEAD_SHA\s*\}\}/);
   assert.match(budgetJob, /uses:\s*actions\/download-artifact@[0-9a-f]{40}\s*# v8\.0\.1/);
   assert.match(budgetJob, /name:\s*pr-benchmark/);
   assert.match(budgetJob, /name:\s*Read current PR labels/);
+  assert.match(budgetJob, /if:\s*\$\{\{\s*github\.event_name == 'pull_request'\s*\}\}/);
   assert.match(budgetJob, /GITHUB_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/);
   assert.match(budgetJob, /process\.env\.GITHUB_API_URL \?\? "https:\/\/api\.github\.com"/);
   assert.match(budgetJob, /labels\.map\(\(label\) => label\.name\)/);
@@ -45,8 +45,16 @@ test("benchmark workflow comments from trusted code after a read-only benchmark 
     budgetJob,
     /node head\/bench\/enforce-pr-budget\.mjs[\s\S]*--json benchmark-results\.json[\s\S]*--labels-json "\$PR_LABELS_JSON"/,
   );
+  assert.match(
+    budgetJob,
+    /PR_LABELS_JSON:\s*\$\{\{\s*github\.event_name == 'pull_request' && steps\.pr-labels\.outputs\.labels \|\| '\[\]'\s*\}\}/,
+  );
 
   assert.match(commentJob, /needs:\n\s+- pr-benchmark\b/);
+  assert.match(
+    commentJob,
+    /if:\s*\$\{\{\s*github\.event_name == 'pull_request' && github\.event\.pull_request\.head\.repo\.full_name == github\.repository\s*\}\}/,
+  );
   assert.match(commentJob, /actions:\s*read/);
   assert.match(commentJob, /contents:\s*read/);
   assert.match(commentJob, /issues:\s*write/);
@@ -62,6 +70,46 @@ test("benchmark workflow comments from trusted code after a read-only benchmark 
     commentJob,
     /node bench\/comment-pr\.mjs --body benchmark-summary\.md --comment-key "\$BENCHMARK_COMMENT_KEY"/,
   );
+});
+
+test("benchmark dispatch validates exact SHA evidence and runs the existing budget", () => {
+  const workflow = readRepoFile(".github", "workflows", "benchmark.yml");
+  const benchmarkJob = workflowJobBody(workflow, "pr-benchmark");
+  const budgetJob = workflowJobBody(workflow, "pr-benchmark-budget");
+  const commentJob = workflowJobBody(workflow, "pr-benchmark-comment");
+
+  assert.match(
+    workflow,
+    /workflow_dispatch:\n\s+inputs:\n\s+base_sha:[\s\S]*required:\s*true[\s\S]*head_sha:[\s\S]*required:\s*true/,
+  );
+  assert.match(workflow, /base_sha:[\s\S]*type:\s*string/);
+  assert.match(workflow, /head_sha:[\s\S]*type:\s*string/);
+  assert.match(
+    workflow,
+    /run-name:\s*"Benchmark [^\n]*inputs\.base_sha[^\n]*inputs\.head_sha[^\n]*PR #\{0\}[^\n]*"/,
+  );
+  assert.match(
+    workflow,
+    /group:[^\n]*dispatch-\{0\}-\{1\}[^\n]*inputs\.base_sha[^\n]*inputs\.head_sha/,
+  );
+  assert.match(workflow, /group:[^\n]*\|\| github\.event\.pull_request\.number[^\n]*\}\}/);
+  assert.match(workflow, /head_sha from the branch or tag/);
+  assert.match(workflow, /passed via --ref, not from a later checkout/);
+
+  assert.match(benchmarkJob, /name:\s*Validate dispatch SHAs/);
+  assert.match(benchmarkJob, /if:\s*\$\{\{\s*github\.event_name == 'workflow_dispatch'\s*\}\}/);
+  assert.match(benchmarkJob, /full_sha='\^\[0-9a-f\]\{40\}\$'/);
+  assert.match(benchmarkJob, /! "\$BENCHMARK_BASE_SHA" =~ \$full_sha/);
+  assert.match(benchmarkJob, /! "\$BENCHMARK_HEAD_SHA" =~ \$full_sha/);
+  assert.match(benchmarkJob, /RUN_HEAD_SHA:\s*\$\{\{\s*github\.sha\s*\}\}/);
+  assert.match(benchmarkJob, /"\$RUN_HEAD_SHA" != "\$BENCHMARK_HEAD_SHA"/);
+  assert.match(benchmarkJob, /run head_sha comes from --ref/);
+  assert.match(benchmarkJob, /dispatch with a branch or tag/);
+
+  assert.match(budgetJob, /name:\s*pr-benchmark/);
+  assert.match(budgetJob, /--labels-json "\$PR_LABELS_JSON"/);
+  assert.match(budgetJob, /\|\| '\[\]'/);
+  assert.doesNotMatch(commentJob, /github\.event_name == 'workflow_dispatch'/);
 });
 
 test("tool benchmark workflow produces docs artifacts, PR comments, and conventional commits", () => {

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -161,8 +161,13 @@ test("App E2E workflow keeps Blacksmith Testbox dispatch hydration separate", ()
     /if:\s*\$\{\{\s*github\.event_name == 'workflow_dispatch' && inputs\.testbox_id != ''\s*\}\}/,
   );
   assert.match(job, /uses:\s*useblacksmith\/begin-testbox@[0-9a-f]{40}\s*# v2/);
+  assert.match(job, /id:\s*begin-testbox/);
   assert.match(job, /testbox_id:\s*\$\{\{\s*inputs\.testbox_id\s*\}\}/);
   assert.match(job, /uses:\s*useblacksmith\/run-testbox@[0-9a-f]{40}\s*# v2/);
+  assert.match(
+    job,
+    /if:\s*\$\{\{\s*always\(\) && steps\.begin-testbox\.outcome == 'success'\s*\}\}/,
+  );
   assert.doesNotMatch(job, /vp run --workspace-root test|cargo test --workspace/);
   assert.match(
     appJob,


### PR DESCRIPTION
## Summary

- add a strict base/head SHA dispatch path to the existing benchmark and budget jobs
- require the dispatch ref tip to equal the requested head so run metadata is valid release evidence
- add `suite=all` and an explicit target SHA to App E2E while preserving nightly, one-suite, and Testbox flows
- keep PR-only label and comment behavior isolated from release dispatches

## Release evidence

```bash
gh workflow run benchmark.yml --ref main -f base_sha=<base-sha> -f head_sha=<main-tip-sha>
gh workflow run e2e.yml --ref main -f suite=all -f target_sha=<main-tip-sha>
```

Both commands fail early if `--ref` no longer points at the requested head.

## Verification

- 69 workflow tooling tests
- actionlint
- strict workflow expression validation
- YAML parse and format checks
- git diff --check

Closes #2846

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786434888&installation_id=136613492&pr_number=2852&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2852&signature=9db99e83eea363ede71cdd1e4ce06683bf0f87d68e88a4cb0b79673d6d9b15a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->