### PR TITLE
fix(release): guard local tag publication

### DIFF
--- a/tests/tooling/_helpers/moonbit.ts
+++ b/tests/tooling/_helpers/moonbit.ts
@@ -71,6 +71,9 @@ export function runMoonScript(
     ...process.env,
     ...options.env,
   };
+  // Moon commands can launch their own `node --test` processes. Do not leak
+  // the parent runner's private child marker into those independent runners.
+  delete env.NODE_TEST_CONTEXT;
   if (!hasExplicitEnvValue(options.env, "TMPDIR")) {
     env.TMPDIR = moonbitTempDir;
   }

--- a/tests/tooling/moonbit-helper.test.ts
+++ b/tests/tooling/moonbit-helper.test.ts
@@ -11,6 +11,32 @@ import { writeFakeCommand } from "./support/fake-command.ts";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
+test("runMoonScript does not leak the parent Node test context", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "moonbit-helper-node-context-"));
+  const binDir = path.join(tempDir, "bin");
+  const logPath = path.join(tempDir, "node-context.log");
+
+  try {
+    fs.mkdirSync(binDir, { recursive: true });
+    writeFakeCommand(
+      binDir,
+      "moon",
+      `require('node:fs').writeFileSync(${JSON.stringify(logPath)}, process.env.NODE_TEST_CONTEXT ?? 'absent');`,
+    );
+    const moonCommand = path.join(binDir, process.platform === "win32" ? "moon.cmd" : "moon");
+
+    const result = runMoonScript("release", [], {
+      cwd: tempDir,
+      env: { MOON_BIN: moonCommand, NODE_TEST_CONTEXT: "child-v8" },
+    });
+
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
+    assert.equal(fs.readFileSync(logPath, "utf8"), "absent");
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("runMoonScript falls back to the GitHub runner shim when MOON_BIN is unavailable", () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "moonbit-helper-"));
   const runnerTemp = path.join(tempDir, "runner-temp");

--- a/tests/tooling/moonbit-release.test.ts
+++ b/tests/tooling/moonbit-release.test.ts
@@ -4,7 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import { moonScriptPath, repoRoot, runMoonScript } from "./_helpers/moonbit.ts";
+import { repoRoot, runMoonScript } from "./_helpers/moonbit.ts";
+import { writeFakeCommand } from "./support/fake-command.ts";
 
 function writeTempFile(contents: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-release-test-"));
@@ -186,15 +187,161 @@ test("release script includes nested release packages in extra synced manifests"
   }
 });
 
-test("release script bypasses local git hooks when committing", () => {
-  const script = fs.readFileSync(moonScriptPath("release"), "utf8");
+test("release script creates immutable tags and pushes main and tag atomically", () => {
+  const fixture = runRepositoryGuardFixture({ branch: "main" });
 
-  assert.ok(
-    script.includes('["commit", "--allow-empty", "--no-verify", "-m", "chore: release \\{tag}"]'),
-    "force-tag release commits must bypass local hooks",
+  try {
+    assert.equal(fixture.result.status, 0, fixture.result.stderr);
+    assert.match(fixture.gitLog, /^commit --no-verify -m chore: release v0\.290\.1$/m);
+    assert.match(fixture.gitLog, /^tag -a v0\.290\.1 -m Release 0\.290\.1$/m);
+    assert.match(fixture.gitLog, /^push --atomic origin main refs\/tags\/v0\.290\.1$/m);
+    assert.doesNotMatch(fixture.gitLog, /--force-tag|(?:^|\s)--force(?:\s|$)|--allow-empty/);
+  } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
+test("release script explains local cleanup after an atomic push failure", () => {
+  const fixture = runRepositoryGuardFixture({ branch: "main", pushFails: true });
+
+  try {
+    assert.equal(fixture.result.status, 1);
+    assert.match(fixture.result.stderr, /Failed to atomically push main and the release tag/);
+    assert.match(fixture.result.stderr, /git tag -d v0\.290\.1/);
+    assert.match(fixture.result.stderr, /git reset --hard origin\/main/);
+  } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
+test("release script rejects the removed force-tag escape hatch", () => {
+  const result = runMoonScript("release", ["patch", "-y", "--force-tag"]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /--force-tag is not supported; published release tags are immutable/);
+});
+
+interface RepositoryGuardOptions {
+  branch: string;
+  dirty?: boolean;
+  ancestor?: boolean;
+  headSha?: string;
+  remoteSha?: string;
+  localTagExists?: boolean;
+  remoteTagExists?: boolean;
+  pushFails?: boolean;
+  stagedFiles?: boolean;
+  manifestTestFails?: boolean;
+}
+
+function runRepositoryGuardFixture(options: RepositoryGuardOptions) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-release-guard-"));
+  const binDir = path.join(tempDir, "bin");
+  const gitLogPath = path.join(tempDir, "git.log");
+  const cargoTomlPath = path.join(tempDir, "Cargo.toml");
+  const cargoToml = '[workspace.package]\nversion = "0.290.0"\n';
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(path.join(tempDir, "npm"));
+  fs.mkdirSync(path.join(tempDir, "tests/tooling"), { recursive: true });
+  fs.writeFileSync(gitLogPath, "");
+  fs.writeFileSync(cargoTomlPath, cargoToml);
+  fs.writeFileSync(path.join(tempDir, "pnpm-workspace.yaml"), "");
+  fs.writeFileSync(path.join(tempDir, "pnpm-lock.yaml"), "");
+  fs.writeFileSync(
+    path.join(tempDir, "tests/tooling/package-manifests.test.ts"),
+    options.manifestTestFails ? 'throw new Error("manifest drift");\n' : "",
   );
-  assert.ok(
-    script.includes('["commit", "--no-verify", "-m", "chore: release \\{tag}"]'),
-    "normal release commits must bypass local hooks",
+  writeFakeCommand(binDir, "cargo", "process.exit(0);");
+  writeFakeCommand(
+    binDir,
+    "git",
+    [
+      "const fs = require('node:fs');",
+      "const args = process.argv.slice(2);",
+      "fs.appendFileSync(process.env.GIT_LOG, args.join(' ') + '\\n');",
+      "if (args[0] === 'branch') { console.log(process.env.TEST_BRANCH); process.exit(0); }",
+      "if (args[0] === 'status') { if (process.env.TEST_DIRTY === 'true') console.log(' M Cargo.toml'); process.exit(0); }",
+      "if (args[0] === 'fetch') process.exit(0);",
+      "if (args[0] === 'merge-base') process.exit(process.env.TEST_ANCESTOR === 'false' ? 1 : 0);",
+      "if (args[0] === 'rev-parse' && args.includes('--verify')) process.exit(process.env.LOCAL_TAG_EXISTS === 'true' ? 0 : 1);",
+      "if (args[0] === 'rev-parse') { console.log(args.at(-1) === 'HEAD' ? process.env.TEST_HEAD_SHA : process.env.TEST_REMOTE_SHA); process.exit(0); }",
+      "if (args[0] === 'ls-remote' && process.env.REMOTE_TAG_EXISTS === 'true') { console.log('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\\t' + args.at(-1)); process.exit(0); }",
+      "if (args[0] === 'ls-remote') process.exit(2);",
+      "if (args[0] === 'diff' && args.includes('--cached')) { if (process.env.TEST_STAGED_FILES !== 'false') console.log('Cargo.toml'); process.exit(0); }",
+      "if (args[0] === 'push') process.exit(process.env.TEST_PUSH_FAIL === 'true' ? 1 : 0);",
+      "if (['add', 'commit', 'tag'].includes(args[0])) process.exit(0);",
+      "process.exit(1);",
+    ].join("\n"),
   );
+
+  const result = runMoonScript("release", ["patch", "-y"], {
+    cwd: tempDir,
+    env: {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      GIT_LOG: gitLogPath,
+      TEST_BRANCH: options.branch,
+      TEST_DIRTY: String(options.dirty ?? false),
+      TEST_ANCESTOR: String(options.ancestor ?? true),
+      TEST_HEAD_SHA: options.headSha ?? "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      TEST_REMOTE_SHA: options.remoteSha ?? "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      LOCAL_TAG_EXISTS: String(options.localTagExists ?? false),
+      REMOTE_TAG_EXISTS: String(options.remoteTagExists),
+      TEST_PUSH_FAIL: String(options.pushFails ?? false),
+      TEST_STAGED_FILES: String(options.stagedFiles ?? true),
+      VIZE_RELEASE_GUARD_SCRIPT: path.join(repoRoot, "tools/github/release-local-guard.mjs"),
+    },
+  });
+  const gitLog = fs.readFileSync(gitLogPath, "utf8");
+  return { cargoToml, cargoTomlPath, gitLog, result, tempDir };
+}
+
+test("release script refuses to create an empty release commit", () => {
+  const fixture = runRepositoryGuardFixture({ branch: "main", stagedFiles: false });
+
+  try {
+    assert.equal(fixture.result.status, 1);
+    assert.match(fixture.result.stderr, /No release changes were staged/);
+    assert.doesNotMatch(fixture.gitLog, /^(?:commit|tag|push)\b/m);
+  } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
+test("release script explains cleanup after manifest verification fails", () => {
+  const fixture = runRepositoryGuardFixture({ branch: "main", manifestTestFails: true });
+
+  try {
+    assert.equal(fixture.result.status, 1);
+    assert.match(fixture.result.stderr, /package manifest alignment tests failed/);
+    assert.match(fixture.result.stderr, /git reset --hard origin\/main/);
+    assert.doesNotMatch(fixture.gitLog, /^(?:tag|push)\b/m);
+  } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
+test("release repository guard rejects unsafe refs before mutation", () => {
+  const cases: Array<[RepositoryGuardOptions, RegExp]> = [
+    [{ branch: "feature/unsafe-release" }, /must be prepared from the local main branch/],
+    [{ branch: "" }, /must be prepared from the local main branch/],
+    [{ branch: "main", dirty: true }, /uncommitted changes/],
+    [{ branch: "main", ancestor: false }, /HEAD is not reachable from the current origin\/main/],
+    [
+      { branch: "main", remoteSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+      /HEAD must exactly match the current origin\/main/,
+    ],
+    [{ branch: "main", localTagExists: true }, /Tag v0\.290\.1 already exists locally/],
+    [{ branch: "main", remoteTagExists: true }, /Remote tag v0\.290\.1 already exists/],
+  ];
+  for (const [options, message] of cases) {
+    const fixture = runRepositoryGuardFixture(options);
+    try {
+      assert.equal(fixture.result.status, 1);
+      assert.match(fixture.result.stderr, message);
+      assert.doesNotMatch(fixture.gitLog, /^(?:add|commit|tag|push)\b/m);
+      assert.equal(fs.readFileSync(fixture.cargoTomlPath, "utf8"), fixture.cargoToml);
+    } finally {
+      fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+    }
+  }
 });

--- a/tests/tooling/release-local-guard.test.ts
+++ b/tests/tooling/release-local-guard.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { verifyLocalReleaseGuard } from "../../tools/github/release-local-guard.mjs";
+import { writeFakeCommand } from "./support/fake-command.ts";
+
+const HEAD_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OTHER_SHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+interface GuardFixture {
+  branch?: string;
+  dirty?: boolean;
+  ancestor?: boolean;
+  headSha?: string;
+  remoteSha?: string;
+  localTagExists?: boolean;
+  remoteTagExists?: boolean;
+  hangs?: boolean;
+}
+
+function runGuard(
+  options: GuardFixture = {},
+  timeoutMs = 30_000,
+): { error?: Error; gitLog: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-local-release-guard-"));
+  const bin = path.join(root, "bin");
+  const log = path.join(root, "git.log");
+  fs.mkdirSync(bin, { recursive: true });
+  fs.writeFileSync(log, "");
+  const fixture = JSON.stringify(options);
+  writeFakeCommand(
+    bin,
+    "git",
+    [
+      "const fs = require('node:fs');",
+      `const fixture = ${fixture};`,
+      "const args = process.argv.slice(2);",
+      `fs.appendFileSync(${JSON.stringify(log)}, args.join(' ') + '\\n');`,
+      "if (fixture.hangs) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1000);",
+      "if (args[0] === 'branch') { console.log(fixture.branch ?? 'main'); process.exit(0); }",
+      "if (args[0] === 'status') { if (fixture.dirty) console.log(' M Cargo.toml'); process.exit(0); }",
+      "if (args[0] === 'fetch') process.exit(0);",
+      "if (args[0] === 'merge-base') process.exit(fixture.ancestor === false ? 1 : 0);",
+      "if (args[0] === 'rev-parse' && args.includes('--verify')) process.exit(fixture.localTagExists ? 0 : 1);",
+      `if (args[0] === 'rev-parse') { console.log(args.at(-1) === 'HEAD' ? (fixture.headSha ?? '${HEAD_SHA}') : (fixture.remoteSha ?? '${HEAD_SHA}')); process.exit(0); }`,
+      `if (args[0] === 'ls-remote') { if (fixture.remoteTagExists) console.log('${OTHER_SHA}\\t' + args.at(-1)); process.exit(fixture.remoteTagExists ? 0 : 2); }`,
+      "process.exit(1);",
+    ].join("\n"),
+  );
+
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${bin}${path.delimiter}${originalPath ?? ""}`;
+  let error: Error | undefined;
+  try {
+    verifyLocalReleaseGuard("v0.290.1", root, timeoutMs);
+  } catch (caught) {
+    error = caught instanceof Error ? caught : new Error(String(caught));
+  } finally {
+    process.env.PATH = originalPath;
+  }
+  const gitLog = fs.readFileSync(log, "utf8");
+  fs.rmSync(root, { recursive: true, force: true });
+  return { error, gitLog };
+}
+
+test("local release guard accepts only the exact clean main tip", () => {
+  const safe = runGuard();
+
+  assert.equal(safe.error, undefined);
+  assert.match(safe.gitLog, /^branch --show-current$/m);
+  assert.match(safe.gitLog, /^fetch --quiet --no-tags origin /m);
+  assert.match(safe.gitLog, /^ls-remote --exit-code --tags origin refs\/tags\/v0\.290\.1$/m);
+  assert.doesNotMatch(safe.gitLog, /^(?:add|commit|tag|push)\b/m);
+});
+
+test("local release guard bounds stalled git commands", () => {
+  const result = runGuard({ hangs: true }, 20);
+
+  assert.match(result.error?.message ?? "", /git branch --show-current timed out after 20ms/);
+});
+
+test("local release guard rejects unsafe repository states", () => {
+  const cases: Array<[GuardFixture, RegExp]> = [
+    [{ branch: "feature/release" }, /local main branch/],
+    [{ branch: "" }, /local main branch/],
+    [{ dirty: true }, /uncommitted changes/],
+    [{ ancestor: false }, /not reachable from the current origin\/main/],
+    [{ remoteSha: OTHER_SHA }, /exactly match the current origin\/main/],
+    [{ localTagExists: true }, /already exists locally/],
+    [{ remoteTagExists: true }, /already exists and release tags are immutable/],
+  ];
+
+  for (const [fixture, expected] of cases) {
+    const result = runGuard(fixture);
+    assert.match(result.error?.message ?? "", expected);
+    assert.doesNotMatch(result.gitLog, /^(?:add|commit|tag|push)\b/m);
+  }
+});

--- a/tools/github/release-local-guard.mjs
+++ b/tools/github/release-local-guard.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseReleaseVersion } from "./release-platforms.mjs";
+
+const DEFAULT_GIT_TIMEOUT_MS = 30_000;
+
+function runGit(
+  args,
+  acceptedExitCodes = [0],
+  cwd = process.cwd(),
+  timeoutMs = DEFAULT_GIT_TIMEOUT_MS,
+) {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: timeoutMs,
+  });
+  if (result.error?.code === "ETIMEDOUT") {
+    throw new Error(`git ${args.join(" ")} timed out after ${timeoutMs}ms.`);
+  }
+  if (result.error != null) throw result.error;
+  if (result.signal != null) {
+    throw new Error(`git ${args.join(" ")} was terminated by ${result.signal}.`);
+  }
+  if (!acceptedExitCodes.includes(result.status)) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+    throw new Error(
+      [`git ${args.join(" ")} failed with exit ${result.status}`, detail]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+  return result;
+}
+
+export function verifyLocalReleaseGuard(
+  tag,
+  cwd = process.cwd(),
+  timeoutMs = DEFAULT_GIT_TIMEOUT_MS,
+) {
+  const git = (args, acceptedExitCodes = [0]) => runGit(args, acceptedExitCodes, cwd, timeoutMs);
+  parseReleaseVersion(tag);
+  if (git(["branch", "--show-current"]).stdout.trim() !== "main") {
+    throw new Error("Releases must be prepared from the local main branch.");
+  }
+  if (git(["status", "--porcelain"]).stdout.trim() !== "") {
+    throw new Error("There are uncommitted changes. Please commit or stash them first.");
+  }
+
+  git(["fetch", "--quiet", "--no-tags", "origin", "+refs/heads/main:refs/remotes/origin/main"]);
+  // A local commit or divergence is a different failure from a merely stale,
+  // behind checkout, which the exact SHA comparison below diagnoses.
+  if (
+    git(["merge-base", "--is-ancestor", "HEAD", "refs/remotes/origin/main"], [0, 1]).status !== 0
+  ) {
+    throw new Error("HEAD is not reachable from the current origin/main.");
+  }
+  const head = git(["rev-parse", "HEAD"]).stdout.trim();
+  const remoteMain = git(["rev-parse", "refs/remotes/origin/main"]).stdout.trim();
+  if (head !== remoteMain) {
+    throw new Error("HEAD must exactly match the current origin/main before preparing a release.");
+  }
+
+  const tagRef = `refs/tags/${tag}`;
+  if (git(["rev-parse", "--verify", "--quiet", tagRef], [0, 1]).status === 0) {
+    throw new Error(`Tag ${tag} already exists locally.`);
+  }
+  if (git(["ls-remote", "--exit-code", "--tags", "origin", tagRef], [0, 2]).status === 0) {
+    throw new Error(`Remote tag ${tag} already exists and release tags are immutable.`);
+  }
+}
+
+const entrypoint = process.argv[1]
+  ? fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  : false;
+if (entrypoint) {
+  const [tag, extra] = process.argv.slice(2);
+  Promise.resolve()
+    .then(() => {
+      if (tag == null || extra != null) {
+        throw new Error("Usage: node tools/github/release-local-guard.mjs <release-tag>");
+      }
+      verifyLocalReleaseGuard(tag);
+      console.log(`Local release guard passed for ${tag}.`);
+    })
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    });
+}

--- a/tools/moon/cmd/release/main.mbt
+++ b/tools/moon/cmd/release/main.mbt
@@ -419,16 +419,42 @@ fn stage_files(files : Array[String]) -> Array[String] {
   staged
 }
 
+/// Runs the shared immutable-tag and current-main guard before any mutation.
+/// Tests may override the script path while exercising isolated repositories.
+async fn run_local_release_guard(tag : String) -> Bool {
+  let script = match @sys.get_env_var(
+    "VIZE_RELEASE_GUARD_SCRIPT",
+  ) {
+    Some(value) if value != "" => value
+    _ => "tools/github/release-local-guard.mjs"
+  }
+  if !@tool.path_exists(script) {
+    @stdio.stderr.write(
+      "Release preflight script not found: " + script + "\n",
+    )
+    return false
+  }
+
+  let exit_code = @process.run(
+    "node",
+    [script, tag],
+  )
+  if exit_code != 0 {
+    @stdio.stderr.write(
+      "Release preflight failed before repository mutation.\n",
+    )
+    return false
+  }
+
+  true
+}
+
 /// Main entry point for release preparation and publication kickoff.
 /// The function computes the next version, confirms the operation when running
 /// interactively, verifies the repository is in a publishable state, updates
 /// all synchronized manifests, creates the release commit, tags it, and pushes
-/// both the branch and the tag so the tag-triggered publishing workflow can
-/// take over.
-/// When `--force-tag` is passed, an existing release tag is rewritten and
-/// force-pushed. This is useful when the release workflow itself needs a fix
-/// and the same release version must be re-driven through GitHub Actions
-/// without publishing duplicate packages.
+/// the branch and immutable tag atomically so the tag-triggered publishing
+/// workflow can take over without exposing a partially-updated release.
 async fn run_app() -> Int {
   let args = @tool.cli_args()
   if args.length() == 3 && args[0] == "--print-bump" {
@@ -474,22 +500,23 @@ async fn run_app() -> Int {
   }
   if args.is_empty() {
     @stdio.stderr.write(
-      "Usage: moon run --target native tools/moon/cmd/release -- <patch|minor|major|alpha|beta|rc|release> [-y] [--force-tag]\n",
+      "Usage: moon run --target native tools/moon/cmd/release -- <patch|minor|major|alpha|beta|rc|release> [-y]\n",
     )
     return 1
   }
 
   let bump = args[0]
   let mut auto_confirm = false
-  let mut force_tag = false
   for i in 1..<args.length() {
     if args[i] == "-y" {
       auto_confirm = true
       continue
     }
     if args[i] == "--force-tag" {
-      force_tag = true
-      continue
+      @stdio.stderr.write(
+        "Error: --force-tag is not supported; published release tags are immutable.\n",
+      )
+      return 1
     }
     if args[i] != "-y" {
       @stdio.stderr.write("Unknown release arguments\n")
@@ -543,25 +570,8 @@ async fn run_app() -> Int {
     }
   }
 
-  let (status_exit, status_output) = @process.collect_stdout("git", ["status", "--porcelain"])
-  if status_exit != 0 {
-    @stdio.stderr.write("Failed to inspect git status\n")
+  if !run_local_release_guard(tag) {
     return 1
-  }
-  if status_output.text().trim() != "" {
-    @stdio.stderr.write(
-      "Error: There are uncommitted changes. Please commit or stash them first.\n",
-    )
-    return 1
-  }
-
-  let (tag_exit, _, _) = @process.collect_output("git", ["rev-parse", tag])
-  if tag_exit == 0 && !force_tag {
-    @stdio.stderr.write("Error: Tag \{tag} already exists.\n")
-    return 1
-  }
-  if tag_exit == 0 && force_tag {
-    println("Tag \{tag} already exists and will be force-updated.")
   }
 
   println("Updating Cargo.toml...")
@@ -789,11 +799,11 @@ async fn run_app() -> Int {
     @stdio.stderr.write("Failed to inspect staged release files\n")
     return 1
   }
-  let commit_args = if staged_output.text().trim() == "" && force_tag {
-    ["commit", "--allow-empty", "--no-verify", "-m", "chore: release \{tag}"]
-  } else {
-    ["commit", "--no-verify", "-m", "chore: release \{tag}"]
+  if staged_output.text().trim() == "" {
+    @stdio.stderr.write("No release changes were staged; refusing to create an empty release.\n")
+    return 1
   }
+  let commit_args = ["commit", "--no-verify", "-m", "chore: release \{tag}"]
   if @process.run("git", commit_args) != 0 {
     @stdio.stderr.write("Failed to create the release commit\n")
     return 1
@@ -802,34 +812,24 @@ async fn run_app() -> Int {
   println("Verifying manifest alignment with tests/tooling/package-manifests.test.ts...")
   if @process.run("node", ["--test", "tests/tooling/package-manifests.test.ts"]) != 0 {
     @stdio.stderr.write(
-      "Error: package manifest alignment tests failed against the release commit. Inspect tests/tooling/package-manifests.test.ts, fix the drift, amend the release commit, and retry.\n",
+      "Error: package manifest alignment tests failed against the release commit. Inspect tests/tooling/package-manifests.test.ts, then run `git reset --hard origin/main` after confirming there is no work to keep, fix the drift, and retry.\n",
     )
     return 1
   }
 
   println("Creating tag \{tag}...")
-  let git_tag_args = if force_tag {
-    ["tag", "-fa", tag, "-m", "Release \{new_version}"]
-  } else {
-    ["tag", "-a", tag, "-m", "Release \{new_version}"]
-  }
+  let git_tag_args = ["tag", "-a", tag, "-m", "Release \{new_version}"]
   if @process.run("git", git_tag_args) != 0 {
     @stdio.stderr.write("Failed to create the git tag\n")
     return 1
   }
 
-  println("Pushing to remote...")
-  if @process.run("git", ["push", "origin", "main"]) != 0 {
-    @stdio.stderr.write("Failed to push main\n")
-    return 1
-  }
-  let git_push_tag_args = if force_tag {
-    ["push", "--force", "origin", "refs/tags/" + tag]
-  } else {
-    ["push", "origin", tag]
-  }
-  if @process.run("git", git_push_tag_args) != 0 {
-    @stdio.stderr.write("Failed to push the release tag\n")
+  println("Pushing main and tag atomically...")
+  if @process.run(
+    "git",
+    ["push", "--atomic", "origin", "main", "refs/tags/" + tag],
+  ) != 0 {
+    @stdio.stderr.write("Failed to atomically push main and the release tag\nRemote refs were unchanged. Before retrying, run `git tag -d \{tag}`, fetch origin/main, and remove the generated release commit (for example, `git reset --hard origin/main` after confirming there is no work to keep).\n")
     return 1
   }
 


### PR DESCRIPTION
## Summary

- require a clean local `main` exactly equal to freshly fetched `origin/main`
- reject detached/feature/ahead/behind states and existing local or remote release tags before mutation
- remove force-tag and empty-release escape hatches
- create an immutable annotated tag and push `main` plus the tag atomically
- exercise every unsafe repository state through the shared guard and the release command

## Verification

- node --test tests/tooling/release-local-guard.test.ts
- MoonBit release tooling suite
- vp check / formatting
- git diff --check

Closes #2853
Refs #2818

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786435170&installation_id=136613492&pr_number=2854&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2854&signature=8535998da1e6a013095390590e9d84867b6ee57187a21b03494b13aeeb53b79a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local release preflight check that requires a clean `main`, verifies it matches `origin/main`, and blocks reuse of an existing release tag locally or on the remote.
  * Releases now create annotated tags and publish `main` plus the tag together via an atomic push.
* **Bug Fixes**
  * Rejects the `--force-tag` option and removes any overwrite/force-push behavior.
  * Refuses to proceed when no release changes are staged.
* **Tests**
  * Added scenarios for unsafe-state rejection, atomic-push failure reporting with cleanup guidance, and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->