### PR TITLE
docs(stability): define Rust crate support tiers

### DIFF
--- a/crates/vize_armature/Cargo.toml
+++ b/crates/vize_armature/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Armature - The structural parser framework for Vize Vue templates"
+metadata.vize.stability = "alpha-supported"
 
 [features]
 # Opt-in support for legacy Vue lines (v0.10 / v0.11 / v1 / v2). Off by default so the

--- a/crates/vize_armature/README.md
+++ b/crates/vize_armature/README.md
@@ -1,5 +1,8 @@
 # vize_armature
 
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
 `vize_armature` tokenizes and parses Vue template syntax into the `vize_relief` AST.
 
 ## Highlights

--- a/crates/vize_atelier_core/Cargo.toml
+++ b/crates/vize_atelier_core/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Atelier Core - The core workshop for Vize Vue template parsing, transform lanes, and code generation"
+metadata.vize.stability = "alpha-supported"
 
 [features]
 # Opt-in support for legacy Vue lines (v0.10 / v0.11 / v1 / v2). Off by default

--- a/crates/vize_atelier_core/README.md
+++ b/crates/vize_atelier_core/README.md
@@ -1,5 +1,8 @@
 # vize_atelier_core
 
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
 `vize_atelier_core` contains the shared transform lane and code generation infrastructure used by the
 DOM, Vapor, and SSR compilers.
 

--- a/crates/vize_atelier_dom/Cargo.toml
+++ b/crates/vize_atelier_dom/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Atelier DOM - The DOM compiler workshop for Vize"
+metadata.vize.stability = "alpha-supported"
 
 [dependencies]
 vize_carton = { workspace = true }

--- a/crates/vize_atelier_dom/README.md
+++ b/crates/vize_atelier_dom/README.md
@@ -1,5 +1,8 @@
 # vize_atelier_dom
 
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
 `vize_atelier_dom` compiles Vue templates for the DOM runtime.
 
 ## Highlights

--- a/crates/vize_atelier_jsx/Cargo.toml
+++ b/crates/vize_atelier_jsx/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Atelier JSX - Shared JSX/TSX lowering layer for Vize"
+metadata.vize.stability = "compatibility-preview"
 
 [dependencies]
 # Internal crates

--- a/crates/vize_atelier_jsx/README.md
+++ b/crates/vize_atelier_jsx/README.md
@@ -1,0 +1,18 @@
+# vize_atelier_jsx
+
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
+`vize_atelier_jsx` parses and lowers Vue JSX/TSX into Vize's shared compiler representation.
+
+## Key Entry Points
+
+- `compile_jsx`
+- `lower_source`
+- `compile_to_vdom`
+- `compile_to_vapor`
+- `compile_to_ssr`
+
+## License
+
+MIT

--- a/crates/vize_atelier_sfc/Cargo.toml
+++ b/crates/vize_atelier_sfc/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Atelier SFC - The Single File Component workshop for Vize"
+metadata.vize.stability = "alpha-supported"
 
 [features]
 default = ["native"]

--- a/crates/vize_atelier_sfc/README.md
+++ b/crates/vize_atelier_sfc/README.md
@@ -1,5 +1,8 @@
 # vize_atelier_sfc
 
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
 `vize_atelier_sfc` parses and compiles Vue Single File Components.
 
 ## Highlights

--- a/crates/vize_atelier_ssr/Cargo.toml
+++ b/crates/vize_atelier_ssr/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Vue SSR compiler for Vize"
+metadata.vize.stability = "compatibility-preview"
 
 [dependencies]
 vize_carton = { workspace = true }

--- a/crates/vize_atelier_ssr/README.md
+++ b/crates/vize_atelier_ssr/README.md
@@ -1,5 +1,8 @@
 # vize_atelier_ssr
 
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
 `vize_atelier_ssr` compiles Vue templates for server-side rendering output.
 
 ## Highlights

--- a/crates/vize_atelier_vapor/Cargo.toml
+++ b/crates/vize_atelier_vapor/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Atelier Vapor - The Vapor mode compiler workshop for Vize"
+metadata.vize.stability = "experimental"
 
 [dependencies]
 vize_carton = { workspace = true }

--- a/crates/vize_atelier_vapor/README.md
+++ b/crates/vize_atelier_vapor/README.md
@@ -1,5 +1,8 @@
 # vize_atelier_vapor
 
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
 `vize_atelier_vapor` compiles Vue templates for Vapor mode.
 
 ## Highlights

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -2,6 +2,11 @@
 //!
 //! Vapor mode is a new compilation strategy that generates more efficient code
 //! by eliminating the virtual DOM overhead for static parts of the template.
+//!
+//! ## Stability
+//!
+//! **Experimental.** Public APIs and generated output may change in any release. See the
+//! [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
 
 #![allow(clippy::collapsible_match)]
 

--- a/crates/vize_canon/Cargo.toml
+++ b/crates/vize_canon/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Canon - The standard of correctness for Vize type checking"
+metadata.vize.stability = "compatibility-preview"
 
 [features]
 default = ["native"]

--- a/crates/vize_canon/README.md
+++ b/crates/vize_canon/README.md
@@ -1,5 +1,8 @@
 # vize_canon
 
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
 `vize_canon` provides Vue-aware type checking and virtual TypeScript generation.
 
 ## Highlights

--- a/crates/vize_carton/Cargo.toml
+++ b/crates/vize_carton/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Carton - The artist's toolbox for Vize compiler"
+metadata.vize.stability = "alpha-supported"
 
 [dependencies]
 # Arena allocator

--- a/crates/vize_carton/README.md
+++ b/crates/vize_carton/README.md
@@ -1,5 +1,8 @@
 # vize_carton
 
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
 `vize_carton` is the shared foundation crate for the Vize workspace.
 
 ## Highlights

--- a/crates/vize_croquis/Cargo.toml
+++ b/crates/vize_croquis/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Croquis - Semantic analysis layer for Vize. Quick sketches of meaning from Vue templates"
+metadata.vize.stability = "compatibility-preview"
 
 [dependencies]
 vize_carton.workspace = true

--- a/crates/vize_croquis/README.md
+++ b/crates/vize_croquis/README.md
@@ -1,5 +1,8 @@
 # vize_croquis
 
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
 `vize_croquis` is the semantic analysis layer for Vue templates and SFCs.
 
 ## Highlights

--- a/crates/vize_croquis_cf/Cargo.toml
+++ b/crates/vize_croquis_cf/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Cross-file semantic analysis for Vize Croquis"
+metadata.vize.stability = "experimental"
 
 [dependencies]
 vize_carton.workspace = true

--- a/crates/vize_croquis_cf/README.md
+++ b/crates/vize_croquis_cf/README.md
@@ -1,0 +1,17 @@
+# vize_croquis_cf
+
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
+`vize_croquis_cf` provides opt-in, cross-file semantic analysis for Vue projects.
+
+## Key Entry Points
+
+- `CrossFileAnalyzer`
+- `CrossFileOptions`
+- `DependencyGraph`
+- `ModuleRegistry`
+
+## License
+
+MIT

--- a/crates/vize_croquis_cf/src/lib.rs
+++ b/crates/vize_croquis_cf/src/lib.rs
@@ -1,5 +1,10 @@
 //! Cross-file semantic analysis for Vue projects.
 //!
+//! ## Stability
+//!
+//! **Experimental.** Public APIs may change or disappear in any release. See the
+//! [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+//!
 //! This module provides cross-file analysis capabilities that track relationships
 //! between Vue components across multiple files. These analyses are **opt-in** due
 //! to their performance overhead.

--- a/crates/vize_fresco/Cargo.toml
+++ b/crates/vize_fresco/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Fresco - Vue TUI framework (Terminal User Interface)"
+metadata.vize.stability = "incubating"
 
 [lib]
 name = "vize_fresco"

--- a/crates/vize_fresco/README.md
+++ b/crates/vize_fresco/README.md
@@ -1,5 +1,8 @@
 # vize_fresco
 
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
 `vize_fresco` is the terminal UI foundation used by Vize's TUI-oriented experiments.
 
 ## Highlights

--- a/crates/vize_fresco/src/lib.rs
+++ b/crates/vize_fresco/src/lib.rs
@@ -3,6 +3,11 @@
 //! A high-performance Terminal User Interface framework for Vue.js,
 //! similar to React Ink but built with Rust for performance.
 //!
+//! ## Stability
+//!
+//! **Incubating.** The API or crate may be replaced or removed in any release. See the
+//! [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+//!
 //! # Features
 //!
 //! - **Terminal Control**: Cross-platform terminal handling via crossterm

--- a/crates/vize_musea/Cargo.toml
+++ b/crates/vize_musea/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Musea - Component gallery and documentation for Vize Vue components"
+metadata.vize.stability = "experimental"
 
 [dependencies]
 vize_carton.workspace = true

--- a/crates/vize_musea/README.md
+++ b/crates/vize_musea/README.md
@@ -1,5 +1,8 @@
 # vize_musea
 
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
 `vize_musea` is the Rust core for Musea art files, docs, palette generation, autogen, and VRT
 support.
 

--- a/crates/vize_musea/src/lib.rs
+++ b/crates/vize_musea/src/lib.rs
@@ -2,6 +2,11 @@
 //!
 //! Musea - Component gallery and documentation for Vize.
 //!
+//! ## Stability
+//!
+//! **Experimental.** Public APIs may change or disappear in any release. See the
+//! [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+//!
 //! ## Name Origin
 //!
 //! **Musea** (plural of museum) represents a gallery space where art is

--- a/crates/vize_patina/Cargo.toml
+++ b/crates/vize_patina/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Patina - The quality checker for Vize code linting"
+metadata.vize.stability = "compatibility-preview"
 
 [dependencies]
 # Internal crates

--- a/crates/vize_patina/README.md
+++ b/crates/vize_patina/README.md
@@ -1,5 +1,8 @@
 # vize_patina
 
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
 `vize_patina` lints Vue Single File Components.
 
 ## Highlights

--- a/crates/vize_relief/Cargo.toml
+++ b/crates/vize_relief/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Relief - The sculptured AST surface for Vize Vue templates"
+metadata.vize.stability = "alpha-supported"
 
 [features]
 # Opt-in support for legacy Vue lines (v0.10 / v0.11 / v1 / v2). Off by default

--- a/crates/vize_relief/README.md
+++ b/crates/vize_relief/README.md
@@ -1,5 +1,8 @@
 # vize_relief
 
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
 `vize_relief` defines the shared AST, compiler errors, and compiler options used throughout the
 Vize workspace.
 

--- a/docs/content/architecture/crates.md
+++ b/docs/content/architecture/crates.md
@@ -4,20 +4,23 @@ title: Crates
 
 # Crate Reference
 
-> **⚠️ Work in Progress:** Vize is under active development. Crate APIs are still changing.
+> **⚠️ Work in Progress:** Vize is under active development. See the canonical
+> [Rust crate support tiers](../stability.md#rust-crate-support-tiers) before depending on a public
+> API.
 
-Vize's Rust workspace is organized around 18 primary crates. Each crate owns one reusable lane so
+Vize's Rust workspace is organized around 20 primary crates. Each crate owns one reusable lane so
 parsing, semantic analysis, code generation, linting, formatting, type checking, and
 editor tooling can share the same syntax model.
 
 ## Foundation
 
-| Crate           | Role                                                                                      |
-| --------------- | ----------------------------------------------------------------------------------------- |
-| `vize_carton`   | Shared allocator, strings, hash collections, flags, profiler, i18n, and DOM/tag utilities |
-| `vize_relief`   | Shared Vue template AST, compiler errors, and compiler options                            |
-| `vize_armature` | Vue template tokenizer and parser                                                         |
-| `vize_croquis`  | Semantic analysis, scope tracking, binding metadata, reactivity, and virtual TS helpers   |
+| Crate             | Role                                                                                      |
+| ----------------- | ----------------------------------------------------------------------------------------- |
+| `vize_carton`     | Shared allocator, strings, hash collections, flags, profiler, i18n, and DOM/tag utilities |
+| `vize_relief`     | Shared Vue template AST, compiler errors, and compiler options                            |
+| `vize_armature`   | Vue template tokenizer and parser                                                         |
+| `vize_croquis`    | Semantic analysis, scope tracking, binding metadata, reactivity, and virtual TS helpers   |
+| `vize_croquis_cf` | Opt-in cross-file semantic analysis and project-wide diagnostics                          |
 
 ## Compilation
 
@@ -28,6 +31,7 @@ editor tooling can share the same syntax model.
 | `vize_atelier_vapor` | Vapor-mode template compilation                               |
 | `vize_atelier_ssr`   | Server-side rendering template compilation                    |
 | `vize_atelier_sfc`   | `.vue` parsing plus script, template, and style orchestration |
+| `vize_atelier_jsx`   | Shared JSX/TSX parsing, lowering, and compiler integration    |
 
 ## Developer Tools
 

--- a/docs/content/stability.md
+++ b/docs/content/stability.md
@@ -27,7 +27,8 @@ The v1 alpha line uses these rules:
 | Documented CLI commands and flags    | Should avoid silent behavior changes                                               |
 | Documented config fields             | Should keep names and value shapes stable unless release notes call out a change   |
 | Diagnostic codes listed in docs      | Should remain recognizable so suppressions and fix reports stay useful             |
-| Rust crate internals                 | May change without migration support before v1 stable                              |
+| Published Rust crate APIs            | Follow the per-crate tier and deprecation contract below                           |
+| Unexported Rust crate internals      | May change without migration support before v1 stable                              |
 | Generated code and virtual TS output | May change when needed for correctness, compatibility, performance, or diagnostics |
 
 ## Runtime Support
@@ -75,6 +76,55 @@ the move is called out in release notes when it changes. Downstream packagers sh
 | Compatibility preview | `@vizejs/unplugin`, `@vizejs/rspack-plugin`, `@vizejs/nuxt`, `@vizejs/musea-nuxt`             | Expected to work for common host setups, but host-framework compatibility can move quickly.    |
 | Experimental          | `oxlint-plugin-vize`, `@vizejs/vite-plugin-musea`, `@vizejs/musea-mcp-server`, `@vizejs/wasm` | Public packages, but APIs, commands, output, and workflow shape may change during alpha.       |
 | Incubating            | `@vizejs/fresco`, `@vizejs/fresco-native`, editor extension packages                          | Useful for development and feedback, but not yet part of the v1 alpha production-ready target. |
+
+## Rust Crate Support Tiers
+
+This table is the canonical compatibility contract for crates.io consumers. It covers every crate
+whose Cargo metadata permits publishing, including crates temporarily deferred by the release
+publisher while their first crates.io release is prepared. Private modules and implementation
+details are not compatibility surfaces.
+
+<!-- rust-crate-support:start -->
+
+| Crate                | Tier                  | Intended audience                         | Public entrypoint                               | Removal / deprecation                  |
+| -------------------- | --------------------- | ----------------------------------------- | ----------------------------------------------- | -------------------------------------- |
+| `vize_carton`        | Alpha-supported       | Vize compiler and library authors         | `vize_carton::{Allocator, Bump, FxHashMap}`     | One minor with `#[deprecated]`         |
+| `vize_relief`        | Alpha-supported       | AST and compiler integration authors      | `vize_relief::{RootNode, CompilerOptions}`      | One minor with `#[deprecated]`         |
+| `vize_armature`      | Alpha-supported       | Tools that parse Vue templates            | `vize_armature::{parse, Parser, Tokenizer}`     | One minor with `#[deprecated]`         |
+| `vize_croquis`       | Compatibility preview | Semantic and type-aware tooling authors   | `vize_croquis::{Croquis, Drawer}`               | One minor with `#[deprecated]`         |
+| `vize_croquis_cf`    | Experimental          | Opt-in whole-project analysis experiments | `vize_croquis_cf::CrossFileAnalyzer`            | No minimum; note breaks when practical |
+| `vize_atelier_core`  | Alpha-supported       | Custom Vue compiler backend authors       | `vize_atelier_core::{transform, generate}`      | One minor with `#[deprecated]`         |
+| `vize_atelier_dom`   | Alpha-supported       | VDOM compiler and bundler integrations    | `vize_atelier_dom::compile_template`            | One minor with `#[deprecated]`         |
+| `vize_atelier_vapor` | Experimental          | Opt-in Vapor compiler integrations        | `vize_atelier_vapor::compile_vapor`             | No minimum; note breaks when practical |
+| `vize_atelier_ssr`   | Compatibility preview | SSR and framework integration authors     | `vize_atelier_ssr::compile_ssr`                 | One minor with `#[deprecated]`         |
+| `vize_atelier_sfc`   | Alpha-supported       | SFC tooling and bundler authors           | `vize_atelier_sfc::{parse_sfc, compile_sfc}`    | One minor with `#[deprecated]`         |
+| `vize_atelier_jsx`   | Compatibility preview | JSX/TSX compiler and tooling authors      | `vize_atelier_jsx::{compile_jsx, lower_source}` | One minor with `#[deprecated]`         |
+| `vize_musea`         | Experimental          | Musea gallery and documentation tools     | `vize_musea::{parse_art, transform_to_csf}`     | No minimum; note breaks when practical |
+| `vize_fresco`        | Incubating            | TUI experiments                           | `vize_fresco::{RenderTree, LayoutEngine}`       | No minimum                             |
+| `vize_canon`         | Compatibility preview | Type-checker and editor integrations      | `vize_canon::{type_check_sfc, TypeChecker}`     | One minor with `#[deprecated]`         |
+| `vize_patina`        | Compatibility preview | Linter and Oxlint integrations            | `vize_patina::{lint, Linter}`                   | One minor with `#[deprecated]`         |
+
+<!-- rust-crate-support:end -->
+
+Each crate also records its tier in `package.metadata.vize.stability`. CI compares those Cargo
+metadata values, this table, and the complete release-publisher crate set so adding, removing, or
+reclassifying a publishable crate cannot silently change the contract.
+
+### SemVer gate interpretation
+
+`cargo-semver-checks` runs for the release publisher's crates that have resolvable registry
+baselines. A crate waiting for its first publish, or blocked on one, joins that matrix once its
+baseline is available. Until then, the metadata/table/release-list check still applies.
+
+| Tier                                    | CI interpretation                                                                                                      |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Alpha-supported / Compatibility preview | An API break must be fixed or follow the support policy's deprecation window and carry a conventional breaking marker. |
+| Experimental                            | The gate catches accidental drift; an intentional break may use a breaking marker without a deprecation window.        |
+| Incubating                              | The same detection applies, but the entire API or crate may be replaced or removed in any release.                     |
+
+The breaking markers recognized by CI are a `!` in the conventional change title or a
+`BREAKING CHANGE:` footer. Passing the gate with either marker does not waive the deprecation
+window for alpha-supported or compatibility-preview crates.
 
 ## What Counts as Stable Enough for Alpha
 

--- a/docs/release/support-policy.md
+++ b/docs/release/support-policy.md
@@ -7,15 +7,16 @@ copy or a blog post, this page wins.
 
 ## Scope of this policy
 
-This policy applies to all surfaces in the `alpha-supported` and `preview` tiers as listed on the
-stability page. `experimental` and `incubating` surfaces are explicitly out of scope: they may
-change or disappear in any release.
+This policy applies to all surfaces in the `alpha-supported` and `compatibility-preview` tiers as
+listed on the stability page. `experimental` and `incubating` surfaces are explicitly out of scope:
+they may change or disappear in any release.
 
 In-scope surfaces:
 
 - **CLI**: `vize` binary, its subcommands, and their documented flags.
 - **Config**: `vize.config.*` keys and their value shapes.
-- **Public Rust crates**: items reachable through a published crate's `pub` API.
+- **Public Rust crates**: items reachable through the `pub` API of a published crate in the
+  `alpha-supported` or `compatibility-preview` tier.
 - **Public npm packages**: items in each package's exported entrypoints.
 - **Patina lint rules**: rule names, default severities, and message ids.
 - **Type-checker diagnostics**: error codes listed in the docs.
@@ -29,7 +30,7 @@ While Vize is in `0.x` alpha:
 | Remove or rename a CLI subcommand, flag, or env var            | Breaking       |
 | Remove or rename a config key                                  | Breaking       |
 | Tighten a config value's accepted shape                        | Breaking       |
-| Remove a `pub` item from a published Rust crate                | Breaking       |
+| Remove a `pub` item from an alpha/preview published Rust crate | Breaking       |
 | Remove or rename an export from a published npm package        | Breaking       |
 | Promote a Patina rule from `warn` to `error` by default        | Breaking       |
 | Demote a Patina rule from `error` to `warn` by default         | Non-breaking   |
@@ -50,14 +51,14 @@ Once Vize reaches v1 stable, the same table applies with `0.x` replaced by SemVe
 
 Vize keeps deprecated surfaces working for a minimum window before removal:
 
-| Surface                | Minimum deprecation window before removal |
-| ---------------------- | ----------------------------------------- |
-| Public Rust crate item | One minor release with a `#[deprecated]`  |
-| npm package entrypoint | One minor release with a console warning  |
-| CLI flag or subcommand | One minor release with a stderr warning   |
-| Config key             | One minor release with a stderr warning   |
-| Patina rule (name)     | One minor release with a stderr warning   |
-| Diagnostic code (id)   | One minor release with a release note     |
+| Surface                       | Minimum deprecation window before removal |
+| ----------------------------- | ----------------------------------------- |
+| Alpha/preview Rust crate item | One minor release with a `#[deprecated]`  |
+| npm package entrypoint        | One minor release with a console warning  |
+| CLI flag or subcommand        | One minor release with a stderr warning   |
+| Config key                    | One minor release with a stderr warning   |
+| Patina rule (name)            | One minor release with a stderr warning   |
+| Diagnostic code (id)          | One minor release with a release note     |
 
 A "minor release" means one published version with `minor` or higher SemVer bump; weekly patches
 do not count. When two deprecations are linked, both removal points must satisfy this window.

--- a/tests/tooling/docs-stability.test.ts
+++ b/tests/tooling/docs-stability.test.ts
@@ -1,10 +1,30 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const rustStabilityLink =
+  "https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers";
+
+type CargoPackage = {
+  manifest_path: string;
+  metadata: { vize?: { stability?: string } };
+  name: string;
+  publish: string[] | null;
+  readme: string | null;
+  targets: Array<{ crate_types: string[]; kind: string[]; src_path: string }>;
+};
+
+type RustCrateRow = {
+  audience: string;
+  crateName: string;
+  deprecation: string;
+  entrypoint: string;
+  tier: string;
+};
 
 test("stability page documents v1 alpha support tiers", () => {
   const stability = fs.readFileSync(path.join(root, "docs/content/stability.md"), "utf8");
@@ -39,6 +59,89 @@ test("stability page documents v1 alpha support tiers", () => {
     assert.match(stability, new RegExp(escapeRegExp(`\`${packageName}\``)));
   }
 });
+
+test("Rust crate stability table matches Cargo metadata and crate documentation", () => {
+  const stability = fs.readFileSync(path.join(root, "docs/content/stability.md"), "utf8");
+  const table = stability.match(
+    /<!-- rust-crate-support:start -->(?<body>[\s\S]*?)<!-- rust-crate-support:end -->/,
+  )?.groups?.body;
+  assert.ok(table, "missing checked Rust crate support table");
+
+  const rows = table
+    .split("\n")
+    .filter((line) => /^\| `vize_[^`]+`/.test(line))
+    .map(parseRustCrateRow);
+  const rowsByCrate = new Map(rows.map((row) => [row.crateName, row]));
+  assert.equal(rowsByCrate.size, rows.length, "each publishable crate must have exactly one row");
+
+  const metadata = JSON.parse(
+    execFileSync("cargo", ["metadata", "--no-deps", "--format-version", "1"], {
+      cwd: root,
+      encoding: "utf8",
+    }),
+  ) as { packages: CargoPackage[] };
+  const publishableCrates = metadata.packages.filter(
+    (pkg) =>
+      path.relative(root, pkg.manifest_path).startsWith(`crates${path.sep}`) &&
+      (pkg.publish === null || pkg.publish.length > 0),
+  );
+
+  assert.deepEqual(
+    [...rowsByCrate.keys()].toSorted(),
+    publishableCrates.map((pkg) => pkg.name).toSorted(),
+  );
+
+  const tierLabels = new Map([
+    ["alpha-supported", "Alpha-supported"],
+    ["compatibility-preview", "Compatibility preview"],
+    ["experimental", "Experimental"],
+    ["incubating", "Incubating"],
+  ]);
+
+  for (const pkg of publishableCrates) {
+    const row = rowsByCrate.get(pkg.name);
+    assert.ok(row, `missing support row for ${pkg.name}`);
+    const tier = pkg.metadata.vize?.stability;
+    assert.ok(tier, `${pkg.name} must declare package.metadata.vize.stability`);
+    assert.equal(row.tier, tierLabels.get(tier), `${pkg.name} tier drift`);
+    assert.ok(row.audience, `${pkg.name} must name its intended audience`);
+    assert.match(row.entrypoint, /^`vize_[^`]+/);
+    assert.ok(row.deprecation, `${pkg.name} must define a deprecation policy`);
+
+    assert.ok(pkg.readme, `${pkg.name} must ship a README`);
+    const readmePath = path.resolve(path.dirname(pkg.manifest_path), pkg.readme);
+    assert.match(fs.readFileSync(readmePath, "utf8"), new RegExp(escapeRegExp(rustStabilityLink)));
+
+    if (tier === "experimental" || tier === "incubating") {
+      const libTarget = pkg.targets.find(
+        (target) => target.kind.includes("lib") || target.crate_types.includes("rlib"),
+      );
+      assert.ok(libTarget, `${pkg.name} must expose a library target`);
+      assert.match(
+        fs.readFileSync(libTarget.src_path, "utf8"),
+        new RegExp(`\\*\\*${tier === "experimental" ? "Experimental" : "Incubating"}`),
+        `${pkg.name} rustdoc must disclose its ${tier} status`,
+      );
+    }
+  }
+});
+
+function parseRustCrateRow(line: string): RustCrateRow {
+  const cells = line
+    .split("|")
+    .slice(1, -1)
+    .map((cell) => cell.trim());
+  assert.equal(cells.length, 5, `invalid Rust support table row: ${line}`);
+  const crateName = cells[0].match(/^`(?<name>vize_[^`]+)`$/)?.groups?.name;
+  assert.ok(crateName, `invalid crate name in support table: ${cells[0]}`);
+  return {
+    crateName,
+    tier: cells[1],
+    audience: cells[2],
+    entrypoint: cells[3],
+    deprecation: cells[4],
+  };
+}
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/tests/tooling/moonbit-publish-crates.test.ts
+++ b/tests/tooling/moonbit-publish-crates.test.ts
@@ -89,21 +89,21 @@ test("publish_crates script keeps publishable workspace dependencies ordered", (
   }
 });
 
-test("publish_crates includes every publishable crate package after first publish exclusions", () => {
-  const publishedCrates = new Set(getPublishedCrates());
-  const pendingFirstPublishCrates = new Set(getPendingFirstPublishCrates());
-  const blockedByPendingFirstPublishCrates = new Set(getBlockedByPendingFirstPublishCrates());
-  const missingCrates = getMetadata()
+test("publish_crates exactly partitions every publishable workspace crate", () => {
+  const releaseCrates = [
+    ...getPublishedCrates(),
+    ...getPendingFirstPublishCrates(),
+    ...getBlockedByPendingFirstPublishCrates(),
+  ];
+  const publishableCrates = getMetadata()
     .packages.filter((pkg) =>
       path.relative(repoRoot, pkg.manifest_path).startsWith(`crates${path.sep}`),
     )
     .filter((pkg) => pkg.publish === null || pkg.publish.length > 0)
-    .map((pkg) => pkg.name)
-    .filter((crateName) => !publishedCrates.has(crateName))
-    .filter((crateName) => !pendingFirstPublishCrates.has(crateName))
-    .filter((crateName) => !blockedByPendingFirstPublishCrates.has(crateName));
+    .map((pkg) => pkg.name);
 
-  assert.deepEqual(missingCrates, []);
+  assert.equal(new Set(releaseCrates).size, releaseCrates.length, "release crate lists overlap");
+  assert.deepEqual(releaseCrates.toSorted(), publishableCrates.toSorted());
 });
 
 test("publish_crates only defers crates that have not been created on crates.io", () => {


### PR DESCRIPTION
## Summary

- define one canonical support tier, audience, entrypoint, and deprecation policy for every publishable Rust crate
- mirror tiers into Cargo metadata and link each shipped README to the contract
- disclose experimental/incubating status in rustdoc and align the release support policy
- fail CI when Cargo metadata, the documentation table, or publisher crate partitions drift

## Verification

- node --test tests/tooling/docs-stability.test.ts
- node --test --test-name-pattern="exactly partitions|only defers|only blocks" tests/tooling/moonbit-publish-crates.test.ts
- cargo metadata --no-deps --format-version 1
- cargo fmt --all --check
- targeted clippy, rustdoc, and doctests for experimental/incubating crates
- Vite+ formatting and lint checks for all changed files

Closes #2833

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786435827&installation_id=136613492&pr_number=2855&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2855&signature=ee9b4c52e80aa88fc9cbfd9dc068423d87b00480ead33041511ab47af0652251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->