### PR TITLE
fix(fuzz): fail release evidence on crashes

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -45,13 +45,10 @@ jobs:
     # follow-up if platform-divergent panics ever appear in triage.
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 60
-    # The fuzz matrix is advisory at bootstrap. libFuzzer immediately surfaces
-    # real parser/compiler fixes (the first PR run already found one — see the
-    # `crash-*` reproducer artifact this job uploads) and triaging those is
-    # tracked per-fix, not gated through this workflow. Promote back to a
-    # required gate once a regression-only mode lands and the open finds are
-    # cleaned up.
-    continue-on-error: true
+    # Pull-request fuzzing is advisory to keep the short readiness lane moving.
+    # Scheduled and manually dispatched runs are release evidence and must fail
+    # after preserving and triaging any reproducer.
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -112,28 +109,22 @@ jobs:
           restore-keys: |
             fuzz-corpus-${{ matrix.target }}-
 
-      # While the fuzz harnesses are advisory, mask libFuzzer's non-zero exit
-      # so a discovered crash does not flip the GitHub check to FAILURE (which
-      # would block the PR even with the job-level `continue-on-error: true`).
-      # The crash gets a workflow warning + a reproducer artifact instead.
-      # Drop the `|| ...` masking when the matrix promotes back to a required
-      # gate.
       - name: Run fuzz target ${{ matrix.target }}
+        id: fuzz
+        continue-on-error: true
         working-directory: tests/fuzz
-        run: |
-          set +e
-          cargo +nightly fuzz run ${{ matrix.target }} \
-            -- -max_total_time=${{ steps.budget.outputs.seconds }} \
-               -max_len=65536 \
-               -timeout=25
-          status=$?
-          if [ "$status" -ne 0 ]; then
-            echo "::warning::libFuzzer ${{ matrix.target }} exited with $status — reproducer uploaded as artifact."
-          fi
-          exit 0
+        env:
+          FUZZ_MAX_TOTAL_TIME: ${{ steps.budget.outputs.seconds }}
+          FUZZ_TARGET: ${{ matrix.target }}
+        run: >-
+          cargo +nightly fuzz run "$FUZZ_TARGET" --
+          "-max_total_time=$FUZZ_MAX_TOTAL_TIME"
+          -max_len=65536
+          -timeout=25
 
       - name: Upload reproducers when libFuzzer crashed
-        if: hashFiles(format('tests/fuzz/artifacts/{0}/**', matrix.target)) != ''
+        id: upload-reproducers
+        if: always() && hashFiles(format('tests/fuzz/artifacts/{0}/**', matrix.target)) != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-reproducers-${{ matrix.target }}
@@ -141,7 +132,8 @@ jobs:
           if-no-files-found: ignore
 
       - name: Create or update fuzz triage fix
-        if: github.event_name != 'pull_request' && hashFiles(format('tests/fuzz/artifacts/{0}/**', matrix.target)) != ''
+        id: triage
+        if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && hashFiles(format('tests/fuzz/artifacts/{0}/**', matrix.target)) != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -176,3 +168,12 @@ jobs:
           else
             gh issue create --title "$title" --body-file "$body_file"
           fi
+
+      - name: Enforce fuzz result for release evidence
+        id: enforce
+        if: always()
+        env:
+          FUZZ_EVENT_NAME: ${{ github.event_name }}
+          FUZZ_OUTCOME: ${{ steps.fuzz.outcome || 'skipped' }}
+          FUZZ_TARGET: ${{ matrix.target }}
+        run: node tools/fuzz/enforce-result.mjs "$FUZZ_EVENT_NAME" "$FUZZ_TARGET" "$FUZZ_OUTCOME"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "shiki": "catalog:content",
     "tsdown": "catalog:vite-stack",
     "vite": "catalog:vite-stack",
-    "vite-plus": "catalog:vite-stack"
+    "vite-plus": "catalog:vite-stack",
+    "yaml": "2.9.0"
   },
   "packageManager": "pnpm@10.0.0",
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,6 +262,9 @@ importers:
       vite-plus:
         specifier: catalog:vite-stack
         version: 0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
 
   bench:
     devDependencies:

--- a/tests/tooling/fuzz-result.test.ts
+++ b/tests/tooling/fuzz-result.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { fuzzResultPolicy } from "../../tools/fuzz/enforce-result.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const script = path.join(root, "tools/fuzz/enforce-result.mjs");
+
+test("fuzz result policy keeps PRs advisory and release evidence strict", () => {
+  for (const outcome of ["failure", "cancelled", "skipped"]) {
+    assert.deepEqual(fuzzResultPolicy("pull_request", outcome), {
+      unsuccessful: true,
+      releaseBlocking: false,
+    });
+    for (const eventName of ["schedule", "workflow_dispatch"]) {
+      assert.deepEqual(fuzzResultPolicy(eventName, outcome), {
+        unsuccessful: true,
+        releaseBlocking: true,
+      });
+    }
+  }
+  assert.deepEqual(fuzzResultPolicy("workflow_dispatch", "success"), {
+    unsuccessful: false,
+    releaseBlocking: false,
+  });
+  assert.throws(() => fuzzResultPolicy("push", "failure"), /Unsupported fuzz event/);
+  assert.throws(() => fuzzResultPolicy("schedule", ""), /Unsupported fuzz outcome/);
+});
+
+test("fuzz result command reports the target, event, outcome, and gate decision", () => {
+  const advisory = spawnSync(process.execPath, [script, "pull_request", "sfc_parse", "failure"], {
+    encoding: "utf8",
+  });
+  assert.equal(advisory.status, 0);
+  assert.match(advisory.stderr, /warning.*sfc_parse.*failure.*pull_request/i);
+
+  const blocking = spawnSync(
+    process.execPath,
+    [script, "workflow_dispatch", "template_lexer", "failure"],
+    { encoding: "utf8" },
+  );
+  assert.equal(blocking.status, 1);
+  assert.match(blocking.stderr, /error.*template_lexer.*failure.*workflow_dispatch/i);
+});
+
+test("fuzz result command rejects malformed invocation", () => {
+  const result = spawnSync(process.execPath, [script, "pull_request", "sfc_parse"], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Usage: node tools\/fuzz\/enforce-result\.mjs/);
+});

--- a/tests/tooling/fuzz-setup.test.ts
+++ b/tests/tooling/fuzz-setup.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const fuzzWorkspace = "tests/fuzz";
@@ -37,6 +38,20 @@ test("fuzz workspace declares libfuzzer-sys and an isolated [workspace]", () => 
 
 test("fuzz CI workflow gates short PR fuzz and schedules long nightly fuzz", () => {
   const workflow = readRepoFile(".github/workflows/fuzz.yml");
+  const parsed = parse(workflow) as {
+    jobs: {
+      fuzz: {
+        "continue-on-error": string;
+        steps: Array<{
+          "continue-on-error"?: boolean;
+          env?: Record<string, string>;
+          id?: string;
+          if?: string;
+          run?: string;
+        }>;
+      };
+    };
+  };
 
   assert.match(workflow, /name:\s*Fuzz/);
   assert.match(workflow, /schedule:[\s\S]*?-\s*cron:/);
@@ -57,12 +72,37 @@ test("fuzz CI workflow gates short PR fuzz and schedules long nightly fuzz", () 
 
   assert.match(workflow, /cargo \+nightly fuzz run/);
   assert.match(workflow, /-max_total_time=/);
+  const fuzzJob = parsed.jobs.fuzz;
+  assert.equal(fuzzJob["continue-on-error"], "${{ github.event_name == 'pull_request' }}");
+  const fuzzStep = fuzzJob.steps.find((step) => step.id === "fuzz");
+  assert.equal(fuzzStep?.["continue-on-error"], true);
+  assert.match(fuzzStep?.run ?? "", /cargo \+nightly fuzz run "\$FUZZ_TARGET"/);
+  assert.deepEqual(fuzzStep?.env, {
+    FUZZ_MAX_TOTAL_TIME: "${{ steps.budget.outputs.seconds }}",
+    FUZZ_TARGET: "${{ matrix.target }}",
+  });
+  const enforceStep = fuzzJob.steps.find((step) => step.id === "enforce");
+  assert.match(enforceStep?.run ?? "", /tools\/fuzz\/enforce-result\.mjs/);
+  assert.deepEqual(enforceStep?.env, {
+    FUZZ_EVENT_NAME: "${{ github.event_name }}",
+    FUZZ_OUTCOME: "${{ steps.fuzz.outcome || 'skipped' }}",
+    FUZZ_TARGET: "${{ matrix.target }}",
+  });
 
   // Reproducers on failure must be uploaded so triage does not have to
   // re-run the fuzzer to recover the failing input.
   assert.match(workflow, /upload-artifact[\s\S]*tests\/fuzz\/artifacts\//);
   assert.match(workflow, /issues:\s*write/);
-  assert.match(workflow, /github\.event_name != 'pull_request'/);
+  const uploadStep = fuzzJob.steps.find((step) => step.id === "upload-reproducers");
+  assert.equal(
+    uploadStep?.if,
+    "always() && hashFiles(format('tests/fuzz/artifacts/{0}/**', matrix.target)) != ''",
+  );
+  const triageStep = fuzzJob.steps.find((step) => step.id === "triage");
+  assert.equal(
+    triageStep?.if,
+    "always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && hashFiles(format('tests/fuzz/artifacts/{0}/**', matrix.target)) != ''",
+  );
   assert.match(workflow, /gh issue (create|comment)/);
 });
 

--- a/tools/fuzz/enforce-result.mjs
+++ b/tools/fuzz/enforce-result.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const outcomes = new Set(["success", "failure", "cancelled", "skipped"]);
+const events = new Set(["pull_request", "schedule", "workflow_dispatch"]);
+const releaseEvents = new Set(["schedule", "workflow_dispatch"]);
+
+export function fuzzResultPolicy(eventName, outcome) {
+  if (!events.has(eventName)) {
+    throw new Error(`Unsupported fuzz event: ${eventName || "empty"}`);
+  }
+  if (!outcomes.has(outcome)) {
+    throw new Error(`Unsupported fuzz outcome: ${outcome || "empty"}`);
+  }
+  const unsuccessful = outcome !== "success";
+  return {
+    unsuccessful,
+    releaseBlocking: unsuccessful && releaseEvents.has(eventName),
+  };
+}
+
+export function reportFuzzResult(eventName, target, outcome) {
+  const policy = fuzzResultPolicy(eventName, outcome);
+  if (!policy.unsuccessful) {
+    console.log(`Fuzz target ${target} completed successfully.`);
+    return 0;
+  }
+
+  const message = `Fuzz target ${target} finished with ${outcome} on ${eventName}.`;
+  if (policy.releaseBlocking) {
+    console.error(`::error::${message} Release evidence must be green.`);
+    return 1;
+  }
+  console.warn(`::warning::${message} Pull-request fuzzing is advisory.`);
+  return 0;
+}
+
+const entrypoint = process.argv[1]
+  ? fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  : false;
+if (entrypoint) {
+  const [eventName, target, outcome, extra] = process.argv.slice(2);
+  try {
+    if (!eventName || !target || !outcome || extra != null) {
+      throw new Error("Usage: node tools/fuzz/enforce-result.mjs <event-name> <target> <outcome>");
+    }
+    process.exitCode = reportFuzzResult(eventName, target, outcome);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- preserve advisory pull-request fuzzing while making scheduled and manual exact-SHA runs release-blocking
- retain the real fuzz step outcome, then upload reproducers and create/update triage issues before enforcing failure
- fail non-PR runs even when compilation or harness failures produce no artifact
- centralize and directly test the event/outcome policy with actionable target-specific annotations

## Verification

- node --test tests/tooling/fuzz-result.test.ts tests/tooling/fuzz-setup.test.ts
- node --test tests/tooling/github-workflows.test.ts tests/tooling/github-workflows-check.test.ts
- oxfmt --check on changed JavaScript/TypeScript files
- oxlint --deny-warnings on changed JavaScript/TypeScript files
- git diff --check

Closes #2856

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786436827&installation_id=136613492&pr_number=2857&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2857&signature=4331415f29c398380b390414bf63e2a4469c6aa199e125389f224bc361002394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fuzz-result enforcement reporting that distinguishes advisory (pull requests) vs release-blocking outcomes.
  * Introduced an enforcement step to ensure non–pull request fuzz results correctly gate the workflow.

* **Bug Fixes**
  * Adjusted fuzz job behavior to be advisory only for pull request runs; release-evidence runs now fail when appropriate.
  * Improved reproducitor/triage updates to occur only when relevant crash artifacts exist.

* **Tests**
  * Added coverage for fuzz-result policy logic, CLI exit codes/messages, and workflow configuration.

* **Chores**
  * Pinned the YAML dependency version for tooling stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->