### PR TITLE
fix(wasm): align public option types with implemented options

### DIFF
--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -38,6 +38,7 @@ pub fn compile_template_with_options<'a>(
         options,
         TemplateSyntaxMode::Standard,
         None,
+        CodegenOptions::default(),
     )
 }
 
@@ -48,7 +49,14 @@ pub fn compile_template_with_vue_parser_quirks<'a>(
     source: &'a str,
     options: DomCompilerOptions,
 ) -> (RootNode<'a>, Vec<CompilerError>, CodegenResult) {
-    compile_template_inner(allocator, source, options, TemplateSyntaxMode::Quirks, None)
+    compile_template_inner(
+        allocator,
+        source,
+        options,
+        TemplateSyntaxMode::Quirks,
+        None,
+        CodegenOptions::default(),
+    )
 }
 
 /// Compile a Vue template for DOM with an explicit template syntax mode.
@@ -59,7 +67,38 @@ pub fn compile_template_with_template_syntax<'a>(
     options: DomCompilerOptions,
     template_syntax: TemplateSyntaxMode,
 ) -> (RootNode<'a>, Vec<CompilerError>, CodegenResult) {
-    compile_template_inner(allocator, source, options, template_syntax, None)
+    compile_template_inner(
+        allocator,
+        source,
+        options,
+        template_syntax,
+        None,
+        CodegenOptions::default(),
+    )
+}
+
+/// Compile a Vue template with adapter-provided codegen defaults.
+///
+/// DOM-owned settings such as mode, source maps, and binding metadata still
+/// take precedence. This hook lets binding facades provide emission-only
+/// settings (for example runtime names and the source-map filename) without
+/// growing [`DomCompilerOptions`] and breaking downstream struct literals.
+#[doc(hidden)]
+pub fn compile_template_with_template_syntax_and_codegen_options<'a>(
+    allocator: &'a Bump,
+    source: &'a str,
+    options: DomCompilerOptions,
+    template_syntax: TemplateSyntaxMode,
+    codegen_options: CodegenOptions,
+) -> (RootNode<'a>, Vec<CompilerError>, CodegenResult) {
+    compile_template_inner(
+        allocator,
+        source,
+        options,
+        template_syntax,
+        None,
+        codegen_options,
+    )
 }
 
 /// Compile a Vue template for DOM with an explicit scope ID for hoisted static VNodes.
@@ -76,6 +115,7 @@ pub fn compile_template_with_options_and_hoisted_scope_id<'a>(
         options,
         TemplateSyntaxMode::Standard,
         hoisted_scope_id,
+        CodegenOptions::default(),
     )
 }
 
@@ -94,6 +134,7 @@ pub fn compile_template_with_vue_parser_quirks_and_hoisted_scope_id<'a>(
         options,
         TemplateSyntaxMode::Quirks,
         hoisted_scope_id,
+        CodegenOptions::default(),
     )
 }
 
@@ -112,6 +153,7 @@ pub fn compile_template_with_template_syntax_and_hoisted_scope_id<'a>(
         options,
         template_syntax,
         hoisted_scope_id,
+        CodegenOptions::default(),
     )
 }
 
@@ -131,6 +173,30 @@ pub fn compile_template_with_template_syntax_and_hoisted_scope_id_with_sections<
         options,
         template_syntax,
         hoisted_scope_id,
+        CodegenOptions::default(),
+    )
+}
+
+/// Compile a Vue template with section metadata and adapter-provided codegen
+/// defaults. See [`compile_template_with_template_syntax_and_codegen_options`].
+#[doc(hidden)]
+pub fn compile_template_with_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options<
+    'a,
+>(
+    allocator: &'a Bump,
+    source: &'a str,
+    options: DomCompilerOptions,
+    template_syntax: TemplateSyntaxMode,
+    hoisted_scope_id: Option<String>,
+    codegen_options: CodegenOptions,
+) -> (RootNode<'a>, Vec<CompilerError>, CodegenResultWithSections) {
+    compile_template_inner_with_sections(
+        allocator,
+        source,
+        options,
+        template_syntax,
+        hoisted_scope_id,
+        codegen_options,
     )
 }
 
@@ -140,6 +206,7 @@ fn compile_template_inner<'a>(
     options: DomCompilerOptions,
     template_syntax: TemplateSyntaxMode,
     hoisted_scope_id: Option<String>,
+    codegen_options: CodegenOptions,
 ) -> (RootNode<'a>, Vec<CompilerError>, CodegenResult) {
     let (root, errors, codegen_result) = compile_template_inner_with_sections(
         allocator,
@@ -147,6 +214,7 @@ fn compile_template_inner<'a>(
         options,
         template_syntax,
         hoisted_scope_id,
+        codegen_options,
     );
     (root, errors, codegen_result.into_result())
 }
@@ -157,6 +225,7 @@ fn compile_template_inner_with_sections<'a>(
     options: DomCompilerOptions,
     template_syntax: TemplateSyntaxMode,
     hoisted_scope_id: Option<String>,
+    codegen_options: CodegenOptions,
 ) -> (RootNode<'a>, Vec<CompilerError>, CodegenResultWithSections) {
     // Create parser options with DOM-specific settings
     let parser_opts = ParserOptions {
@@ -268,7 +337,7 @@ fn compile_template_inner_with_sections<'a>(
         inline: options.inline,
         cache_handlers: options.cache_handlers,
         binding_metadata: options.binding_metadata,
-        ..Default::default()
+        ..codegen_options
     };
     let codegen_result = profile!(
         "atelier.dom.template.codegen",

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -26,8 +26,10 @@ mod tests;
 pub use compile::{
     compile_template, compile_template_with_options,
     compile_template_with_options_and_hoisted_scope_id, compile_template_with_template_syntax,
+    compile_template_with_template_syntax_and_codegen_options,
     compile_template_with_template_syntax_and_hoisted_scope_id,
     compile_template_with_template_syntax_and_hoisted_scope_id_with_sections,
+    compile_template_with_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
 };
 #[allow(deprecated)]
 pub use compile::{

--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -27,7 +27,7 @@ use crate::types::{
     BindingMetadata, BindingType, SfcCompileOptions, SfcCompileResult, SfcDescriptor, SfcError,
     SfcMacroArtifact,
 };
-use vize_atelier_core::TemplateSyntaxMode;
+use vize_atelier_core::{CodegenOptions, TemplateSyntaxMode};
 
 use self::bindings::{
     collect_normal_script_bindings, croquis_to_legacy_bindings, merge_normal_script_bindings,
@@ -38,13 +38,13 @@ use self::helpers::{
 use self::normal_script::extract_normal_script_content;
 use self::output_module::{
     RenderFunctionName, append_component_render_export, append_css_modules_assignment,
-    rewrite_client_render_for_sfc_main,
+    finalize_output_mode, rewrite_client_render_for_sfc_main,
 };
 use self::styles::compile_styles;
 
 // Re-export ScriptCompileResult for public API
 pub use crate::compile_script::ScriptCompileResult;
-use vize_carton::{String, ToCompactString, cstr, profile};
+use vize_carton::{String, ToCompactString, profile};
 
 fn create_vapor_ssr_fallback_warning(descriptor: &SfcDescriptor) -> SfcError {
     SfcError {
@@ -70,15 +70,6 @@ fn create_v_model_reactive_const_warning(
         message,
         code: Some("V_MODEL_CONST_REACTIVE_DEMOTED".to_compact_string()),
         loc: Some(script_setup.loc.clone()),
-    }
-}
-
-fn create_standalone_import_warning() -> SfcError {
-    SfcError {
-        message: "Standalone SFC output still contains non-Vue ES module imports; CDN evaluation requires those dependencies to be provided separately."
-            .to_compact_string(),
-        code: Some("STANDALONE_EXTERNAL_IMPORT".to_compact_string()),
-        loc: None,
     }
 }
 
@@ -109,125 +100,17 @@ fn trim_trailing_newlines(code: &mut String) {
     }
 }
 
-fn runtime_module_name(_options: &SfcCompileOptions) -> &str {
-    "vue"
-}
-
-fn runtime_global_name(_options: &SfcCompileOptions) -> &str {
-    "Vue"
-}
-
-fn rewrite_runtime_import_line(
-    trimmed: &str,
-    runtime_module_name: &str,
-    runtime_global_name: &str,
-) -> Option<String> {
-    let rest = trimmed.strip_prefix("import {")?;
-    let (specifiers, rest) = rest.split_once("} from ")?;
-    let source = rest.trim().trim_end_matches(';');
-    let expected_double = cstr!("\"{runtime_module_name}\"");
-    let expected_single = cstr!("'{runtime_module_name}'");
-    if source != expected_double && source != expected_single {
-        return None;
-    }
-
-    let bindings: Vec<_> = specifiers
-        .split(',')
-        .filter_map(|specifier| {
-            let specifier = specifier.trim();
-            let specifier = specifier.strip_prefix("type ").unwrap_or(specifier).trim();
-            if specifier.is_empty() {
-                return None;
-            }
-
-            if let Some((imported, local)) = specifier.split_once(" as ") {
-                Some(cstr!("{}: {}", imported.trim(), local.trim()))
-            } else {
-                Some(specifier.to_compact_string())
-            }
-        })
-        .collect();
-
-    if bindings.is_empty() {
-        return Some(String::default());
-    }
-
-    let mut joined = String::default();
-    for (index, binding) in bindings.iter().enumerate() {
-        if index > 0 {
-            joined.push_str(", ");
-        }
-        joined.push_str(binding);
-    }
-
-    Some(cstr!("const {{ {} }} = {}", joined, runtime_global_name))
-}
-
-fn rewrite_module_sfc_to_standalone(
-    code: &str,
-    runtime_module_name: &str,
-    runtime_global_name: &str,
-) -> (String, bool) {
-    let mut output = String::with_capacity(code.len());
-    let mut has_external_imports = false;
-
-    for line in code.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with("import ") {
-            if let Some(rewritten) =
-                rewrite_runtime_import_line(trimmed, runtime_module_name, runtime_global_name)
-            {
-                if !rewritten.is_empty() {
-                    output.push_str(&rewritten);
-                    output.push('\n');
-                }
-                continue;
-            }
-            has_external_imports = true;
-        }
-
-        let mut rewritten = line
-            .replace("export function render(", "function render(")
-            .replace("export function ssrRender(", "function ssrRender(");
-        if let Some(index) = rewritten.find("export default")
-            && rewritten[..index].trim().is_empty()
-        {
-            rewritten.replace_range(index..index + "export default".len(), "return");
-        }
-        output.push_str(&rewritten);
-        output.push('\n');
-    }
-
-    (output, has_external_imports)
-}
-
-fn finalize_output_mode(
-    code: &mut String,
-    warnings: &mut Vec<SfcError>,
-    options: &SfcCompileOptions,
-) {
-    if !options.script.inline_template {
-        return;
-    }
-
-    let (rewritten, has_external_imports) = rewrite_module_sfc_to_standalone(
-        code,
-        runtime_module_name(options),
-        runtime_global_name(options),
-    );
-    *code = rewritten;
-
-    if has_external_imports {
-        warnings.push(create_standalone_import_warning());
-    }
-}
-
 /// Compile an SFC descriptor into JavaScript and CSS
 pub fn compile_sfc(
     descriptor: &SfcDescriptor,
     options: SfcCompileOptions,
 ) -> Result<SfcCompileResult, SfcError> {
-    compile_sfc_inner(descriptor, options, TemplateSyntaxMode::Standard)
+    compile_sfc_inner(
+        descriptor,
+        options,
+        TemplateSyntaxMode::Standard,
+        CodegenOptions::default(),
+    )
 }
 
 /// Compile an SFC descriptor with Vue parser quirk compatibility.
@@ -236,7 +119,12 @@ pub fn compile_sfc_with_vue_parser_quirks(
     descriptor: &SfcDescriptor,
     options: SfcCompileOptions,
 ) -> Result<SfcCompileResult, SfcError> {
-    compile_sfc_inner(descriptor, options, TemplateSyntaxMode::Quirks)
+    compile_sfc_inner(
+        descriptor,
+        options,
+        TemplateSyntaxMode::Quirks,
+        CodegenOptions::default(),
+    )
 }
 
 /// Compile an SFC descriptor with an explicit template syntax mode.
@@ -246,13 +134,33 @@ pub fn compile_sfc_with_template_syntax(
     options: SfcCompileOptions,
     template_syntax: TemplateSyntaxMode,
 ) -> Result<SfcCompileResult, SfcError> {
-    compile_sfc_inner(descriptor, options, template_syntax)
+    compile_sfc_inner(
+        descriptor,
+        options,
+        template_syntax,
+        CodegenOptions::default(),
+    )
+}
+
+/// Compile an SFC with adapter-provided codegen defaults.
+///
+/// This keeps emission-only binding settings out of the public SFC/DOM option
+/// structs while reusing the compiler core's canonical [`CodegenOptions`].
+#[doc(hidden)]
+pub fn compile_sfc_with_template_syntax_and_codegen_options(
+    descriptor: &SfcDescriptor,
+    options: SfcCompileOptions,
+    template_syntax: TemplateSyntaxMode,
+    codegen_options: CodegenOptions,
+) -> Result<SfcCompileResult, SfcError> {
+    compile_sfc_inner(descriptor, options, template_syntax, codegen_options)
 }
 
 fn compile_sfc_inner(
     descriptor: &SfcDescriptor,
     options: SfcCompileOptions,
     template_syntax: TemplateSyntaxMode,
+    codegen_options: CodegenOptions,
 ) -> Result<SfcCompileResult, SfcError> {
     let mut errors = Vec::new();
     let mut warnings = Vec::new();
@@ -346,6 +254,7 @@ fn compile_sfc_inner(
                     None,
                     &options.template,
                     template_syntax,
+                    &codegen_options,
                 )
             )
         } else {
@@ -373,6 +282,7 @@ fn compile_sfc_inner(
                         croquis: None,
                     },
                     template_syntax,
+                    &codegen_options,
                 )
             )
         };
@@ -414,7 +324,7 @@ fn compile_sfc_inner(
             Err(e) => return Err(e),
         }
 
-        finalize_output_mode(&mut code, &mut warnings, &options);
+        finalize_output_mode(&mut code, &mut warnings, &options, &codegen_options);
         trim_trailing_newlines(&mut code);
 
         return Ok(SfcCompileResult {
@@ -537,6 +447,7 @@ fn compile_sfc_inner(
                         None,
                         &options.template,
                         template_syntax,
+                        &codegen_options,
                     )
                 )
             } else {
@@ -564,6 +475,7 @@ fn compile_sfc_inner(
                             croquis: None,
                         },
                         template_syntax,
+                        &codegen_options,
                     )
                 )
             };
@@ -634,7 +546,7 @@ fn compile_sfc_inner(
             code.push_str("\nexport default _sfc_main\n");
         }
 
-        finalize_output_mode(&mut code, &mut warnings, &options);
+        finalize_output_mode(&mut code, &mut warnings, &options, &codegen_options);
         trim_trailing_newlines(&mut code);
 
         return Ok(SfcCompileResult {
@@ -651,13 +563,16 @@ fn compile_sfc_inner(
     // Case 3: Script setup with inline template
     let Some(script_setup) = descriptor.script_setup.as_ref() else {
         return Ok(empty_component::compile_empty_component(
-            is_vapor,
-            &compiled_styles,
-            css,
-            errors,
-            warnings,
-            macro_artifacts,
-            &options,
+            empty_component::EmptyComponentContext {
+                is_vapor,
+                compiled_styles: &compiled_styles,
+                css,
+                errors,
+                warnings,
+                macro_artifacts,
+                options: &options,
+                codegen_options: &codegen_options,
+            },
         ));
     };
 
@@ -853,6 +768,7 @@ fn compile_sfc_inner(
                     Some(&script_bindings),
                     &options.template,
                     template_syntax,
+                    &codegen_options,
                 )
             ))
         } else {
@@ -875,6 +791,7 @@ fn compile_sfc_inner(
                         croquis: Some(croquis),
                     },
                     template_syntax,
+                    &codegen_options,
                 )
             ))
         }
@@ -1000,7 +917,7 @@ fn compile_sfc_inner(
     }
     code.push_str(&script_result.code);
 
-    finalize_output_mode(&mut code, &mut warnings, &options);
+    finalize_output_mode(&mut code, &mut warnings, &options, &codegen_options);
     trim_trailing_newlines(&mut code);
 
     Ok(SfcCompileResult {

--- a/crates/vize_atelier_sfc/src/compile/empty_component.rs
+++ b/crates/vize_atelier_sfc/src/compile/empty_component.rs
@@ -1,19 +1,33 @@
 use crate::types::{SfcCompileOptions, SfcCompileResult, SfcError, SfcMacroArtifact};
+use vize_atelier_core::CodegenOptions;
 use vize_carton::String;
 
-use super::output_module::append_css_modules_assignment;
+use super::output_module::{append_css_modules_assignment, finalize_output_mode};
 use super::styles::CompiledStyles;
-use super::{finalize_output_mode, trim_trailing_newlines};
+use super::trim_trailing_newlines;
 
-pub(super) fn compile_empty_component(
-    is_vapor: bool,
-    compiled_styles: &CompiledStyles,
-    css: Option<String>,
-    errors: Vec<SfcError>,
-    mut warnings: Vec<SfcError>,
-    macro_artifacts: Vec<SfcMacroArtifact>,
-    options: &SfcCompileOptions,
-) -> SfcCompileResult {
+pub(super) struct EmptyComponentContext<'a> {
+    pub(super) is_vapor: bool,
+    pub(super) compiled_styles: &'a CompiledStyles,
+    pub(super) css: Option<String>,
+    pub(super) errors: Vec<SfcError>,
+    pub(super) warnings: Vec<SfcError>,
+    pub(super) macro_artifacts: Vec<SfcMacroArtifact>,
+    pub(super) options: &'a SfcCompileOptions,
+    pub(super) codegen_options: &'a CodegenOptions,
+}
+
+pub(super) fn compile_empty_component(context: EmptyComponentContext<'_>) -> SfcCompileResult {
+    let EmptyComponentContext {
+        is_vapor,
+        compiled_styles,
+        css,
+        errors,
+        mut warnings,
+        macro_artifacts,
+        options,
+        codegen_options,
+    } = context;
     // Nuxt/Vue projects can contain empty placeholder SFCs; the host compiler
     // treats them as importable empty components, so Vize must not fail builds.
     let mut code = String::from("const _sfc_main = ");
@@ -28,7 +42,7 @@ pub(super) fn compile_empty_component(
     }
     code.push_str("\nexport default _sfc_main\n");
 
-    finalize_output_mode(&mut code, &mut warnings, options);
+    finalize_output_mode(&mut code, &mut warnings, options, codegen_options);
     trim_trailing_newlines(&mut code);
 
     SfcCompileResult {

--- a/crates/vize_atelier_sfc/src/compile/output_module.rs
+++ b/crates/vize_atelier_sfc/src/compile/output_module.rs
@@ -1,7 +1,8 @@
 //! Shared SFC render output assembly.
 
-use crate::types::{CssModuleMapping, css_modules_object_literal};
-use vize_carton::{String, ToCompactString};
+use crate::types::{CssModuleMapping, SfcCompileOptions, SfcError, css_modules_object_literal};
+use vize_atelier_core::CodegenOptions;
+use vize_carton::{String, ToCompactString, cstr};
 
 /// The render function a generated SFC component should expose.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -62,6 +63,121 @@ impl OutputModule {
         code.push('\n');
         code.push_str(&self.exports);
         code
+    }
+}
+
+fn create_standalone_import_warning() -> SfcError {
+    SfcError {
+        message: "Standalone SFC output still contains non-Vue ES module imports; CDN evaluation requires those dependencies to be provided separately."
+            .to_compact_string(),
+        code: Some("STANDALONE_EXTERNAL_IMPORT".to_compact_string()),
+        loc: None,
+    }
+}
+
+fn rewrite_runtime_import_line(
+    trimmed: &str,
+    runtime_module_name: &str,
+    runtime_global_name: &str,
+) -> Option<String> {
+    let rest = trimmed.strip_prefix("import {")?;
+    let (specifiers, rest) = rest.split_once("} from ")?;
+    let source = rest.trim().trim_end_matches(';');
+    let expected_double = cstr!("\"{runtime_module_name}\"");
+    let expected_single = cstr!("'{runtime_module_name}'");
+    if source != expected_double && source != expected_single {
+        return None;
+    }
+
+    let bindings: Vec<_> = specifiers
+        .split(',')
+        .filter_map(|specifier| {
+            let specifier = specifier.trim();
+            let specifier = specifier.strip_prefix("type ").unwrap_or(specifier).trim();
+            if specifier.is_empty() {
+                return None;
+            }
+
+            if let Some((imported, local)) = specifier.split_once(" as ") {
+                Some(cstr!("{}: {}", imported.trim(), local.trim()))
+            } else {
+                Some(specifier.to_compact_string())
+            }
+        })
+        .collect();
+
+    if bindings.is_empty() {
+        return Some(String::default());
+    }
+
+    let mut joined = String::default();
+    for (index, binding) in bindings.iter().enumerate() {
+        if index > 0 {
+            joined.push_str(", ");
+        }
+        joined.push_str(binding);
+    }
+
+    Some(cstr!("const {{ {} }} = {}", joined, runtime_global_name))
+}
+
+fn rewrite_module_sfc_to_standalone(
+    code: &str,
+    runtime_module_name: &str,
+    runtime_global_name: &str,
+) -> (String, bool) {
+    let mut output = String::with_capacity(code.len());
+    let mut has_external_imports = false;
+
+    for line in code.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("import ") {
+            if let Some(rewritten) =
+                rewrite_runtime_import_line(trimmed, runtime_module_name, runtime_global_name)
+            {
+                if !rewritten.is_empty() {
+                    output.push_str(&rewritten);
+                    output.push('\n');
+                }
+                continue;
+            }
+            has_external_imports = true;
+        }
+
+        let mut rewritten = line
+            .replace("export function render(", "function render(")
+            .replace("export function ssrRender(", "function ssrRender(");
+        if let Some(index) = rewritten.find("export default")
+            && rewritten[..index].trim().is_empty()
+        {
+            rewritten.replace_range(index..index + "export default".len(), "return");
+        }
+        output.push_str(&rewritten);
+        output.push('\n');
+    }
+
+    (output, has_external_imports)
+}
+
+pub(super) fn finalize_output_mode(
+    code: &mut String,
+    warnings: &mut Vec<SfcError>,
+    options: &SfcCompileOptions,
+    codegen_options: &CodegenOptions,
+) {
+    if !options.script.inline_template {
+        return;
+    }
+
+    let (rewritten, has_external_imports) = rewrite_module_sfc_to_standalone(
+        code,
+        codegen_options.runtime_module_name.as_str(),
+        codegen_options.runtime_global_name.as_str(),
+    );
+    *code = rewritten;
+
+    if has_external_imports {
+        warnings.push(create_standalone_import_warning());
     }
 }
 

--- a/crates/vize_atelier_sfc/src/compile_template.rs
+++ b/crates/vize_atelier_sfc/src/compile_template.rs
@@ -16,6 +16,7 @@ pub(crate) use extraction::{
 };
 pub(crate) use vapor::compile_template_block_vapor;
 
+use vize_atelier_core::CodegenOptions;
 use vize_atelier_core::TemplateSyntaxMode;
 use vize_carton::Bump;
 
@@ -68,6 +69,7 @@ pub(crate) fn compile_template_block(
     options: &TemplateCompileOptions,
     ctx: TemplateBlockCompileContext<'_>,
     template_syntax: TemplateSyntaxMode,
+    codegen_options: &CodegenOptions,
 ) -> Result<TemplateBlockCompileResult, SfcError> {
     let TemplateBlockCompileContext {
         scope_id,
@@ -186,12 +188,13 @@ pub(crate) fn compile_template_block(
     // Compile template
     let (_, errors, result) = profile!(
         "atelier.sfc.template.dom",
-        vize_atelier_dom::compile_template_with_template_syntax_and_hoisted_scope_id_with_sections(
+        vize_atelier_dom::compile_template_with_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
             &allocator,
             &template.content,
             dom_opts,
             template_syntax,
             hoisted_scope_attr,
+            codegen_options.clone(),
         )
     );
 

--- a/crates/vize_atelier_sfc/src/compile_template/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/tests.rs
@@ -43,9 +43,8 @@ export function render(_ctx) {
   return n0
 }"#;
 
-    let result = transform_vapor_template_output(vapor_code, None, &template, None)
+    let result = transform_vapor_template_output(vapor_code, None, &template, None, "vue")
         .expect("current Vapor output should be transformed");
-
     insta::assert_snapshot!(result.as_str());
 }
 
@@ -562,6 +561,7 @@ fn test_slice_template_parts_matches_line_scanner() {
                 croquis: None,
             },
             vize_atelier_core::TemplateSyntaxMode::Standard,
+            &vize_atelier_core::CodegenOptions::default(),
         )
         .expect("template should compile");
 

--- a/crates/vize_atelier_sfc/src/compile_template/vapor.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/vapor.rs
@@ -1,7 +1,7 @@
 //! Vapor mode template compilation.
 
 use super::string_tracking::{StringTrackState, count_braces_with_state};
-use vize_atelier_core::TemplateSyntaxMode;
+use vize_atelier_core::{CodegenOptions, TemplateSyntaxMode};
 use vize_atelier_vapor::{
     VaporCompilerOptions, compile_vapor_with_template_syntax_and_diagnostics,
 };
@@ -20,6 +20,7 @@ pub(crate) fn compile_template_block_vapor(
     bindings: Option<&BindingMetadata>,
     options: &TemplateCompileOptions,
     template_syntax: TemplateSyntaxMode,
+    codegen_options: &CodegenOptions,
 ) -> Result<TemplateBlockCompileResult, SfcError> {
     let allocator = Bump::new();
     let compiler_options = options.compiler_options.as_ref();
@@ -71,6 +72,7 @@ pub(crate) fn compile_template_block_vapor(
         has_scoped.then_some(scope_attr.as_str()),
         template,
         bindings,
+        codegen_options.runtime_module_name.as_str(),
     )?;
 
     Ok(TemplateBlockCompileResult {
@@ -111,14 +113,22 @@ pub(super) fn add_scope_id_to_template(template_line: &str, scope_id: &str) -> S
     template_line.to_compact_string()
 }
 
-fn rewrite_vapor_import(line: &str) -> String {
-    if line.contains("'vue/vapor'") {
-        line.replace("'vue/vapor'", "'vue'").into()
+fn rewrite_vapor_import(line: &str, runtime_module_name: &str) -> String {
+    let (source, replacement) = if line.contains("'vue/vapor'") {
+        ("'vue/vapor'", vize_carton::cstr!("'{runtime_module_name}'"))
     } else if line.contains("\"vue/vapor\"") {
-        line.replace("\"vue/vapor\"", "\"vue\"").into()
+        (
+            "\"vue/vapor\"",
+            vize_carton::cstr!("\"{runtime_module_name}\""),
+        )
+    } else if line.contains("'vue'") {
+        ("'vue'", vize_carton::cstr!("'{runtime_module_name}'"))
+    } else if line.contains("\"vue\"") {
+        ("\"vue\"", vize_carton::cstr!("\"{runtime_module_name}\""))
     } else {
-        line.to_compact_string()
-    }
+        return line.to_compact_string();
+    };
+    line.replace(source, replacement.as_str()).into()
 }
 
 fn is_render_signature(line: &str) -> bool {
@@ -133,6 +143,7 @@ pub(super) fn transform_vapor_template_output(
     scope_attr: Option<&str>,
     template: &SfcTemplateBlock,
     bindings: Option<&BindingMetadata>,
+    runtime_module_name: &str,
 ) -> Result<String, SfcError> {
     let lines: Vec<&str> = code.lines().collect();
     let mut output = String::default();
@@ -142,7 +153,7 @@ pub(super) fn transform_vapor_template_output(
         let line = lines[index];
         let trimmed = line.trim();
         if trimmed.starts_with("import ") {
-            output.push_str(&rewrite_vapor_import(line));
+            output.push_str(&rewrite_vapor_import(line, runtime_module_name));
             output.push('\n');
             index += 1;
             continue;

--- a/crates/vize_atelier_sfc/src/lib.rs
+++ b/crates/vize_atelier_sfc/src/lib.rs
@@ -58,6 +58,7 @@ pub use bundler::{
     extract_style_blocks, generate_bundler_scope_id, has_scoped_style, is_importable_asset_url,
     strip_css_comments_for_scoped, wrap_scoped_preprocessor_style,
 };
+pub use compile::compile_sfc_with_template_syntax_and_codegen_options;
 #[allow(deprecated)]
 pub use compile::compile_sfc_with_vue_parser_quirks;
 pub use compile::{ScriptCompileResult, compile_sfc, compile_sfc_with_template_syntax};
@@ -389,14 +390,8 @@ const isRootSelected = ref(false)
 </script>
 "#;
         let descriptor = parse_sfc(source, Default::default()).unwrap();
-        let script_setup = descriptor
-            .script_setup
-            .as_ref()
-            .expect("expected script setup block");
-        let template = descriptor
-            .template
-            .as_ref()
-            .expect("expected template block");
+        let script_setup = descriptor.script_setup.as_ref().unwrap();
+        let template = descriptor.template.as_ref().unwrap();
         let croquis = crate::script::analyze_script_setup_to_summary(&script_setup.content);
         let mut binding_metadata = crate::BindingMetadata::default();
         binding_metadata.is_script_setup = croquis.bindings.is_script_setup;
@@ -425,6 +420,7 @@ const isRootSelected = ref(false)
                 croquis: Some(croquis),
             },
             vize_atelier_core::TemplateSyntaxMode::Standard,
+            &vize_atelier_core::CodegenOptions::default(),
         )
         .expect("template compile should succeed");
         let template_code = template_output.code;

--- a/crates/vize_vitrine/src/wasm.rs
+++ b/crates/vize_vitrine/src/wasm.rs
@@ -15,6 +15,7 @@
 )]
 
 mod analyze;
+mod ast;
 mod compiler;
 mod cross_file;
 mod cross_file_complexity;

--- a/crates/vize_vitrine/src/wasm/ast.rs
+++ b/crates/vize_vitrine/src/wasm/ast.rs
@@ -1,0 +1,77 @@
+//! JSON projection for the WASM template AST API.
+
+use vize_atelier_core::{PropNode, RootNode, TemplateChildNode};
+
+pub(super) fn build_ast_json(root: &RootNode<'_>) -> serde_json::Value {
+    fn build_children(children: &[TemplateChildNode<'_>]) -> Vec<serde_json::Value> {
+        children.iter().map(build_child_json).collect()
+    }
+
+    fn build_child_json(child: &TemplateChildNode<'_>) -> serde_json::Value {
+        match child {
+            TemplateChildNode::Element(element) => {
+                let props: Vec<serde_json::Value> = element
+                    .props
+                    .iter()
+                    .map(|prop| match prop {
+                        PropNode::Attribute(attribute) => serde_json::json!({
+                            "type": "ATTRIBUTE",
+                            "name": attribute.name.as_str(),
+                            "value": attribute.value.as_ref().map(|value| value.content.as_str()),
+                        }),
+                        PropNode::Directive(directive) => serde_json::json!({
+                            "type": "DIRECTIVE",
+                            "name": directive.name.as_str(),
+                            "arg": directive.arg.as_ref().map(|argument| match argument {
+                                vize_atelier_core::ExpressionNode::Simple(expression) => expression.content.as_str().to_string(),
+                                _ => "<compound>".to_string(),
+                            }),
+                            "exp": directive.exp.as_ref().map(|expression| match expression {
+                                vize_atelier_core::ExpressionNode::Simple(expression) => expression.content.as_str().to_string(),
+                                _ => "<compound>".to_string(),
+                            }),
+                            "modifiers": directive.modifiers.iter().map(|modifier| modifier.content.as_str()).collect::<Vec<_>>(),
+                        }),
+                    })
+                    .collect();
+
+                serde_json::json!({
+                    "type": "ELEMENT",
+                    "tag": element.tag.as_str(),
+                    "tagType": format!("{:?}", element.tag_type),
+                    "props": props,
+                    "children": build_children(&element.children),
+                    "isSelfClosing": element.is_self_closing,
+                })
+            }
+            TemplateChildNode::Text(text) => serde_json::json!({
+                "type": "TEXT",
+                "content": text.content.as_str(),
+            }),
+            TemplateChildNode::Comment(comment) => serde_json::json!({
+                "type": "COMMENT",
+                "content": comment.content.as_str(),
+            }),
+            TemplateChildNode::Interpolation(interpolation) => serde_json::json!({
+                "type": "INTERPOLATION",
+                "content": match &interpolation.content {
+                    vize_atelier_core::ExpressionNode::Simple(expression) => expression.content.as_str(),
+                    _ => "<compound>",
+                }
+            }),
+            _ => serde_json::json!({
+                "type": "UNKNOWN"
+            }),
+        }
+    }
+
+    let children = build_children(&root.children);
+
+    serde_json::json!({
+        "type": "ROOT",
+        "children": children,
+        "helpers": root.helpers.iter().map(|helper| helper.name()).collect::<Vec<_>>(),
+        "components": root.components.iter().map(|component| component.as_str()).collect::<Vec<_>>(),
+        "directives": root.directives.iter().map(|directive| directive.as_str()).collect::<Vec<_>>(),
+    })
+}

--- a/crates/vize_vitrine/src/wasm/compiler.rs
+++ b/crates/vize_vitrine/src/wasm/compiler.rs
@@ -5,26 +5,42 @@ use vize_carton::Bump;
 use wasm_bindgen::prelude::*;
 
 use crate::{CompileResult, CompilerOptions, template_syntax::resolve_template_syntax};
-use vize_atelier_core::options::CodegenMode;
-use vize_atelier_core::parser::parse_with_options;
-use vize_atelier_dom::{DomCompilerOptions, compile_template_with_template_syntax};
+use vize_atelier_core::options::{CodegenMode, CodegenOptions};
+use vize_atelier_core::parser::parse_with_options_and_template_syntax;
+use vize_atelier_dom::{
+    DomCompilerOptions, compile_template_with_template_syntax_and_codegen_options,
+};
 use vize_atelier_sfc::compile_script::typescript::transform_typescript_to_js;
 use vize_atelier_sfc::{
     ScriptCompileOptions, SfcCompileOptions, SfcParseOptions, StyleCompileOptions,
-    TemplateCompileOptions, compile_sfc_with_template_syntax as sfc_compile_with_template_syntax,
+    TemplateCompileOptions,
+    compile_sfc_with_template_syntax_and_codegen_options as sfc_compile_with_template_syntax_and_codegen_options,
     parse_sfc,
 };
 use vize_atelier_ssr::{SsrCompilerOptions, compile_ssr_with_template_syntax};
 use vize_atelier_vapor::{VaporCompilerOptions, compile_vapor_with_template_syntax};
 
-use super::experimentals::{
-    experimental_dom_options, experimental_flags, experimental_parser_options,
-};
+use super::ast::build_ast_json;
+use super::experimentals::{compiler_parser_options, experimental_dom_options, experimental_flags};
 use super::options::{parse_compiler_options, parse_css_options};
 use super::serde::{to_js_value, to_json_js_value};
 use super::sfc_types::{
     SfcScriptResult, SfcWasmResult, descriptor_to_wasm, macro_artifact_to_wasm,
 };
+
+fn compiler_codegen_options(opts: &CompilerOptions, default_filename: &str) -> CodegenOptions {
+    let mut codegen_options = CodegenOptions {
+        filename: opts.filename.as_deref().unwrap_or(default_filename).into(),
+        ..CodegenOptions::default()
+    };
+    if let Some(runtime_module_name) = opts.runtime_module_name.as_deref() {
+        codegen_options.runtime_module_name = runtime_module_name.into();
+    }
+    if let Some(runtime_global_name) = opts.runtime_global_name.as_deref() {
+        codegen_options.runtime_global_name = runtime_global_name.into();
+    }
+    codegen_options
+}
 
 /// WASM Compiler instance
 #[wasm_bindgen]
@@ -64,11 +80,14 @@ impl Compiler {
     pub fn parse(&self, template: &str, options: JsValue) -> Result<JsValue, JsValue> {
         let parsed = parse_compiler_options(&options);
         let allocator = Bump::new();
+        let template_syntax = resolve_template_syntax(parsed.options.template_syntax.as_deref())
+            .map_err(|message| JsValue::from_str(&message))?;
 
-        let (root, errors) = parse_with_options(
+        let (root, errors) = parse_with_options_and_template_syntax(
             &allocator,
             template,
-            experimental_parser_options(&parsed.options),
+            compiler_parser_options(&parsed.options),
+            template_syntax,
         );
 
         if !errors.is_empty() {
@@ -183,6 +202,11 @@ impl Compiler {
             .unwrap_or(false);
 
         let mut opts = opts;
+        // Keep the template result's source-map identity aligned with the SFC
+        // descriptor even when the caller relies on the facade default.
+        if opts.filename.is_none() {
+            opts.filename = Some(filename.to_string());
+        }
         if source_is_ts {
             opts.is_ts = Some(true);
         }
@@ -197,6 +221,7 @@ impl Compiler {
         };
 
         let standalone = opts.mode.as_deref() == Some("function");
+        let codegen_options = compiler_codegen_options(&opts, filename.as_str());
         let sfc_opts = SfcCompileOptions {
             parse: SfcParseOptions {
                 filename: filename.clone(),
@@ -229,8 +254,12 @@ impl Compiler {
         let template_syntax = resolve_template_syntax(opts.template_syntax.as_deref())
             .map_err(|message| JsValue::from_str(&message))?;
 
-        let compile_result =
-            sfc_compile_with_template_syntax(&descriptor, sfc_opts, template_syntax);
+        let compile_result = sfc_compile_with_template_syntax_and_codegen_options(
+            &descriptor,
+            sfc_opts,
+            template_syntax,
+            codegen_options,
+        );
         let sfc_result = match compile_result {
             Ok(r) => r,
             Err(e) => return Err(JsValue::from_str(&e.message)),
@@ -294,7 +323,7 @@ impl Default for Compiler {
 }
 
 /// Internal compile function
-fn compile_internal(
+pub(super) fn compile_internal(
     template: &str,
     opts: &CompilerOptions,
     vapor: bool,
@@ -398,8 +427,13 @@ fn compile_internal(
         ..experimental_dom_options(opts)
     };
 
-    let (root, errors, result) =
-        compile_template_with_template_syntax(&allocator, template, dom_opts, template_syntax);
+    let (root, errors, result) = compile_template_with_template_syntax_and_codegen_options(
+        &allocator,
+        template,
+        dom_opts,
+        template_syntax,
+        compiler_codegen_options(opts, "template.vue"),
+    );
 
     let fatal: Vec<_> = errors
         .iter()
@@ -414,94 +448,19 @@ fn compile_internal(
 
     // Build AST JSON
     let ast = build_ast_json(&root);
+    let map = result
+        .map
+        .map(|map| serde_json::from_str(map.as_str()))
+        .transpose()
+        .map_err(|error| format!("Codegen emitted an invalid source map: {error}"))?;
 
     Ok(CompileResult {
         code: result.code.to_string(),
         preamble: result.preamble.to_string(),
         ast,
-        map: None,
+        map,
         helpers,
         templates: None,
-    })
-}
-
-/// Build AST JSON from root node
-fn build_ast_json(root: &vize_atelier_core::RootNode<'_>) -> serde_json::Value {
-    use vize_atelier_core::TemplateChildNode;
-
-    fn build_children(children: &[TemplateChildNode<'_>]) -> Vec<serde_json::Value> {
-        children
-            .iter()
-            .map(|child| build_child_json(child))
-            .collect()
-    }
-
-    fn build_child_json(child: &TemplateChildNode<'_>) -> serde_json::Value {
-        match child {
-            TemplateChildNode::Element(el) => {
-                let props: Vec<serde_json::Value> = el
-                    .props
-                    .iter()
-                    .map(|prop| match prop {
-                        vize_atelier_core::PropNode::Attribute(attr) => serde_json::json!({
-                            "type": "ATTRIBUTE",
-                            "name": attr.name.as_str(),
-                            "value": attr.value.as_ref().map(|v| v.content.as_str()),
-                        }),
-                        vize_atelier_core::PropNode::Directive(dir) => serde_json::json!({
-                            "type": "DIRECTIVE",
-                            "name": dir.name.as_str(),
-                            "arg": dir.arg.as_ref().map(|a| match a {
-                                vize_atelier_core::ExpressionNode::Simple(exp) => exp.content.as_str().to_string(),
-                                _ => "<compound>".to_string(),
-                            }),
-                            "exp": dir.exp.as_ref().map(|e| match e {
-                                vize_atelier_core::ExpressionNode::Simple(exp) => exp.content.as_str().to_string(),
-                                _ => "<compound>".to_string(),
-                            }),
-                            "modifiers": dir.modifiers.iter().map(|m: &vize_atelier_core::SimpleExpressionNode| m.content.as_str()).collect::<Vec<_>>(),
-                        }),
-                    })
-                    .collect();
-
-                serde_json::json!({
-                    "type": "ELEMENT",
-                    "tag": el.tag.as_str(),
-                    "tagType": format!("{:?}", el.tag_type),
-                    "props": props,
-                    "children": build_children(&el.children),
-                    "isSelfClosing": el.is_self_closing,
-                })
-            }
-            TemplateChildNode::Text(text) => serde_json::json!({
-                "type": "TEXT",
-                "content": text.content.as_str(),
-            }),
-            TemplateChildNode::Comment(comment) => serde_json::json!({
-                "type": "COMMENT",
-                "content": comment.content.as_str(),
-            }),
-            TemplateChildNode::Interpolation(interp) => serde_json::json!({
-                "type": "INTERPOLATION",
-                "content": match &interp.content {
-                    vize_atelier_core::ExpressionNode::Simple(exp) => exp.content.as_str(),
-                    _ => "<compound>",
-                }
-            }),
-            _ => serde_json::json!({
-                "type": "UNKNOWN"
-            }),
-        }
-    }
-
-    let children = build_children(&root.children);
-
-    serde_json::json!({
-        "type": "ROOT",
-        "children": children,
-        "helpers": root.helpers.iter().map(|h| h.name()).collect::<Vec<_>>(),
-        "components": root.components.iter().map(|c| c.as_str()).collect::<Vec<_>>(),
-        "directives": root.directives.iter().map(|d| d.as_str()).collect::<Vec<_>>(),
     })
 }
 

--- a/crates/vize_vitrine/src/wasm/experimentals.rs
+++ b/crates/vize_vitrine/src/wasm/experimentals.rs
@@ -9,8 +9,9 @@ pub(super) fn experimental_flags(opts: &CompilerOptions) -> (bool, bool) {
     )
 }
 
-pub(super) fn experimental_parser_options(opts: &CompilerOptions) -> ParserOptions {
+pub(super) fn compiler_parser_options(opts: &CompilerOptions) -> ParserOptions {
     ParserOptions {
+        custom_renderer: opts.custom_renderer.unwrap_or(false),
         experimental_in_tag_comments: opts.experimental_in_tag_comments.unwrap_or(false),
         ..Default::default()
     }

--- a/crates/vize_vitrine/src/wasm/options.rs
+++ b/crates/vize_vitrine/src/wasm/options.rs
@@ -5,54 +5,123 @@ use wasm_bindgen::prelude::*;
 use crate::CompilerOptions;
 use vize_atelier_sfc::{CssCompileOptions, CssTargets};
 
+// This is the canonical public `@vizejs/wasm` compiler-option inventory. The
+// declaration drift test reads the same entries and checks both directions:
+// every entry is parsed below and every `CompilerOptions` property is listed.
+macro_rules! define_compiler_option_inventory {
+    ($($variant:ident => ($name:literal, $ts_type:literal),)+) => {
+        #[derive(Clone, Copy)]
+        enum CompilerOption {
+            $($variant,)+
+        }
+
+        impl CompilerOption {
+            #[inline]
+            const fn name(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $name,)+
+                }
+            }
+        }
+    };
+}
+
+define_compiler_option_inventory! {
+    Mode => ("mode", r#""module" | "function""#),
+    PrefixIdentifiers => ("prefixIdentifiers", "boolean"),
+    HoistStatic => ("hoistStatic", "boolean"),
+    CacheHandlers => ("cacheHandlers", "boolean"),
+    ScopeId => ("scopeId", "string"),
+    Ssr => ("ssr", "boolean"),
+    SourceMap => ("sourceMap", "boolean"),
+    Filename => ("filename", "string"),
+    OutputMode => ("outputMode", r#""vdom" | "vapor""#),
+    IsTs => ("isTs", "boolean"),
+    CustomRenderer => ("customRenderer", "boolean"),
+    TemplateSyntax => ("templateSyntax", r#""standard" | "strict" | "quirks""#),
+    ExperimentalInTagComments => ("experimentalInTagComments", "boolean"),
+    ExperimentalPatternedTemplate => ("experimentalPatternedTemplate", "boolean"),
+    RuntimeModuleName => ("runtimeModuleName", "string"),
+    RuntimeGlobalName => ("runtimeGlobalName", "string"),
+    ScriptExt => ("scriptExt", r#""preserve" | "downcompile""#),
+    BindingMetadata => ("bindingMetadata", "BindingMetadata"),
+    VueParserQuirks => ("vueParserQuirks", "boolean"),
+}
+
 pub(crate) struct ParsedCompilerOptions {
     pub(crate) options: CompilerOptions,
     pub(crate) binding_metadata: Option<vize_atelier_core::options::BindingMetadata>,
 }
 
+pub(super) fn resolve_template_syntax_compat(
+    explicit: Option<String>,
+    vue_parser_quirks: Option<bool>,
+) -> Option<String> {
+    explicit.or_else(|| {
+        vue_parser_quirks
+            .filter(|enabled| *enabled)
+            .map(|_| "quirks".to_string())
+    })
+}
+
 pub(crate) fn parse_compiler_options(options: &JsValue) -> ParsedCompilerOptions {
-    let get_string = |key: &str| {
-        js_sys::Reflect::get(options, &JsValue::from_str(key))
+    let get_string = |option: CompilerOption| {
+        js_sys::Reflect::get(options, &JsValue::from_str(option.name()))
             .ok()
             .and_then(|value| value.as_string())
     };
 
-    let get_bool = |key: &str| {
-        js_sys::Reflect::get(options, &JsValue::from_str(key))
+    let get_bool = |option: CompilerOption| {
+        js_sys::Reflect::get(options, &JsValue::from_str(option.name()))
             .ok()
             .and_then(|value| value.as_bool())
     };
 
-    let binding_metadata = js_sys::Reflect::get(options, &JsValue::from_str("bindingMetadata"))
-        .ok()
-        .and_then(|value| {
-            if value.is_null() || value.is_undefined() {
-                return None;
-            }
-            let json = js_sys::JSON::stringify(&value).ok()?.as_string()?;
-            serde_json::from_str(&json).ok()
-        });
+    let binding_metadata = js_sys::Reflect::get(
+        options,
+        &JsValue::from_str(CompilerOption::BindingMetadata.name()),
+    )
+    .ok()
+    .and_then(|value| {
+        if value.is_null() || value.is_undefined() {
+            return None;
+        }
+        let json = js_sys::JSON::stringify(&value).ok()?.as_string()?;
+        serde_json::from_str(&json).ok()
+    });
+
+    let template_syntax = get_string(CompilerOption::TemplateSyntax);
+    let vue_parser_quirks = if template_syntax.is_none() {
+        get_bool(CompilerOption::VueParserQuirks)
+    } else {
+        None
+    };
+    let template_syntax = resolve_template_syntax_compat(template_syntax, vue_parser_quirks);
 
     ParsedCompilerOptions {
         options: CompilerOptions {
-            mode: get_string("mode"),
-            prefix_identifiers: get_bool("prefixIdentifiers"),
-            hoist_static: get_bool("hoistStatic"),
-            cache_handlers: get_bool("cacheHandlers"),
-            scope_id: get_string("scopeId"),
-            ssr: get_bool("ssr"),
-            source_map: get_bool("sourceMap"),
-            filename: get_string("filename"),
-            output_mode: get_string("outputMode"),
-            is_ts: get_bool("isTs"),
-            custom_renderer: get_bool("customRenderer"),
-            template_syntax: get_string("templateSyntax"),
-            experimental_in_tag_comments: get_bool("experimentalInTagComments"),
-            experimental_patterned_template: get_bool("experimentalPatternedTemplate"),
-            experimental_server_script: get_bool("experimentalServerScript"),
-            runtime_module_name: get_string("runtimeModuleName"),
-            runtime_global_name: get_string("runtimeGlobalName"),
-            script_ext: get_string("scriptExt"),
+            mode: get_string(CompilerOption::Mode),
+            prefix_identifiers: get_bool(CompilerOption::PrefixIdentifiers),
+            hoist_static: get_bool(CompilerOption::HoistStatic),
+            cache_handlers: get_bool(CompilerOption::CacheHandlers),
+            scope_id: get_string(CompilerOption::ScopeId),
+            ssr: get_bool(CompilerOption::Ssr),
+            source_map: get_bool(CompilerOption::SourceMap),
+            filename: get_string(CompilerOption::Filename),
+            output_mode: get_string(CompilerOption::OutputMode),
+            is_ts: get_bool(CompilerOption::IsTs),
+            custom_renderer: get_bool(CompilerOption::CustomRenderer),
+            template_syntax,
+            experimental_in_tag_comments: get_bool(CompilerOption::ExperimentalInTagComments),
+            experimental_patterned_template: get_bool(
+                CompilerOption::ExperimentalPatternedTemplate,
+            ),
+            // Reserved by the shared native type, but no WASM compiler stage
+            // implements it. Keep it out of the public WASM option inventory.
+            experimental_server_script: None,
+            runtime_module_name: get_string(CompilerOption::RuntimeModuleName),
+            runtime_global_name: get_string(CompilerOption::RuntimeGlobalName),
+            script_ext: get_string(CompilerOption::ScriptExt),
         },
         binding_metadata,
     }

--- a/crates/vize_vitrine/src/wasm/tests.rs
+++ b/crates/vize_vitrine/src/wasm/tests.rs
@@ -1,4 +1,12 @@
-use super::utf8_byte_to_utf16_offset;
+use super::{
+    compiler::compile_internal, options::resolve_template_syntax_compat, utf8_byte_to_utf16_offset,
+};
+use crate::CompilerOptions;
+use vize_atelier_core::CodegenOptions;
+use vize_atelier_sfc::{
+    ScriptCompileOptions, SfcCompileOptions, compile_sfc_with_template_syntax_and_codegen_options,
+    parse_sfc,
+};
 
 #[test]
 fn test_utf8_byte_to_utf16_offset_handles_multibyte_and_astral_chars() {
@@ -13,4 +21,127 @@ fn test_utf8_byte_to_utf16_offset_handles_multibyte_and_astral_chars() {
     assert_eq!(utf8_byte_to_utf16_offset(source, emoji_start), 2);
     assert_eq!(utf8_byte_to_utf16_offset(source, latin_b_start), 4);
     assert_eq!(utf8_byte_to_utf16_offset(source, source.len() as u32), 5);
+}
+
+#[test]
+fn legacy_vue_parser_quirks_only_falls_back_without_an_explicit_mode() {
+    assert_eq!(
+        resolve_template_syntax_compat(None, Some(true)).as_deref(),
+        Some("quirks")
+    );
+    assert_eq!(resolve_template_syntax_compat(None, Some(false)), None);
+    assert_eq!(
+        resolve_template_syntax_compat(Some("strict".to_string()), Some(true)).as_deref(),
+        Some("strict")
+    );
+}
+
+#[test]
+fn compiler_options_change_runtime_names_syntax_and_source_maps() {
+    let module = compile_internal(
+        "<div>{{ message }}</div>",
+        &CompilerOptions {
+            mode: Some("module".to_string()),
+            runtime_module_name: Some("@acme/vue-runtime".to_string()),
+            ..Default::default()
+        },
+        false,
+        None,
+    )
+    .expect("custom runtime module should compile");
+    assert!(module.preamble.contains("@acme/vue-runtime"));
+
+    let function = compile_internal(
+        "<div />",
+        &CompilerOptions {
+            runtime_global_name: Some("AcmeVue".to_string()),
+            ..Default::default()
+        },
+        false,
+        None,
+    )
+    .expect("custom runtime global should compile");
+    assert!(function.preamble.contains("AcmeVue") || function.code.contains("AcmeVue"));
+
+    let strict = CompilerOptions {
+        template_syntax: Some("strict".to_string()),
+        ..Default::default()
+    };
+    assert!(compile_internal("<div /><span></span>", &strict, false, None).is_err());
+
+    let with_map = compile_internal(
+        "<div>{{ message }}</div>",
+        &CompilerOptions {
+            source_map: Some(true),
+            filename: Some("src/Component.vue".to_string()),
+            ..Default::default()
+        },
+        false,
+        None,
+    )
+    .expect("source-map compile should succeed");
+    assert_eq!(
+        with_map
+            .map
+            .as_ref()
+            .and_then(|map| map["version"].as_u64()),
+        Some(3)
+    );
+    assert_eq!(
+        with_map
+            .map
+            .as_ref()
+            .and_then(|map| map["sources"][0].as_str()),
+        Some("src/Component.vue")
+    );
+}
+
+#[test]
+fn sfc_compiler_options_change_module_and_standalone_runtimes() {
+    let descriptor = parse_sfc("<template><div></div></template>", Default::default())
+        .expect("fixture should parse");
+    let codegen_options = CodegenOptions {
+        runtime_module_name: "@acme/vue-runtime".into(),
+        runtime_global_name: "AcmeVue".into(),
+        ..Default::default()
+    };
+
+    for vapor in [false, true] {
+        let module = compile_sfc_with_template_syntax_and_codegen_options(
+            &descriptor,
+            SfcCompileOptions {
+                vapor,
+                ..Default::default()
+            },
+            vize_atelier_core::TemplateSyntaxMode::Standard,
+            codegen_options.clone(),
+        )
+        .expect("module SFC should compile");
+        assert!(
+            module.code.contains("@acme/vue-runtime"),
+            "custom module name missing from vapor={vapor}:\n{}",
+            module.code
+        );
+
+        let standalone = compile_sfc_with_template_syntax_and_codegen_options(
+            &descriptor,
+            SfcCompileOptions {
+                script: ScriptCompileOptions {
+                    inline_template: true,
+                    ..Default::default()
+                },
+                vapor,
+                ..Default::default()
+            },
+            vize_atelier_core::TemplateSyntaxMode::Standard,
+            codegen_options.clone(),
+        )
+        .expect("standalone SFC should compile");
+        assert!(
+            standalone.code.contains("AcmeVue"),
+            "custom global name missing from vapor={vapor}:\n{}",
+            standalone.code
+        );
+        assert!(!standalone.code.contains("@acme/vue-runtime"));
+    }
 }

--- a/docs/content/guide/wasm.md
+++ b/docs/content/guide/wasm.md
@@ -20,6 +20,18 @@ vp install @vizejs/wasm
 
 ## API
 
+### Compiler option compatibility
+
+The `CompilerOptions` type is the supported option inventory for `compile`, `compileVapor`,
+`parseTemplate`, and `compileSfc`. Unknown object keys are ignored at the JavaScript boundary and
+are not compatibility promises. `vueParserQuirks` remains as a deprecated alias for
+`templateSyntax: "quirks"`; an explicit `templateSyntax` always takes precedence. The shared Rust
+field `experimentalServerScript` is reserved and is not exposed until a WASM compiler stage
+implements it. Each facade ignores supported fields that do not apply to its compiler stage:
+`bindingMetadata` only applies to direct template compilation. Runtime names apply to generated
+VDOM modules and SFC client output (VDOM or Vapor); source maps apply to VDOM output, including the
+template result returned by `compileSfc`. `outputMode` and `scriptExt` only apply to SFC compilation.
+
 ### Compile SFC
 
 Compile a Vue Single File Component into JavaScript:

--- a/npm/wasm/index.d.ts
+++ b/npm/wasm/index.d.ts
@@ -16,6 +16,42 @@ export type {
   LintResult,
 } from "./lint-format.js";
 
+/** Binding classification accepted by template identifier rewriting. */
+export type BindingType =
+  | "setup-let"
+  | "setup-maybe-ref"
+  | "setup-ref"
+  | "setup-reactive-const"
+  | "setup-const"
+  | "props"
+  | "props-aliased"
+  | "data"
+  | "options"
+  | "literal-const"
+  | "js-global-universal"
+  | "js-global-browser"
+  | "js-global-node"
+  | "js-global-deno"
+  | "js-global-bun"
+  | "vue-global"
+  | "external-module";
+
+export interface BindingMetadata {
+  bindings: Record<string, BindingType>;
+  propsAliases: Record<string, string>;
+  isScriptSetup: boolean;
+}
+
+/** Source Map v3 emitted for a directly compiled VDOM template. */
+export interface SourceMap {
+  version: 3;
+  file: string;
+  sources: string[];
+  sourcesContent: string[];
+  names: string[];
+  mappings: string;
+}
+
 /** Compiler options for template compilation */
 export interface CompilerOptions {
   /** Output mode: "module" or "function" */
@@ -30,9 +66,9 @@ export interface CompilerOptions {
   scopeId?: string;
   /** Whether in SSR mode */
   ssr?: boolean;
-  /** Whether to generate source map */
+  /** Whether to generate a source map for direct VDOM template compilation */
   sourceMap?: boolean;
-  /** Filename for source map */
+  /** Filename used for source-map identity, SFC parsing, and generated module IDs */
   filename?: string;
   /** Output mode: "vdom" or "vapor" */
   outputMode?: "vdom" | "vapor";
@@ -40,7 +76,21 @@ export interface CompilerOptions {
   isTs?: boolean;
   /** Whether the template targets a custom renderer instead of the DOM. */
   customRenderer?: boolean;
-  /** Enable Vue parser quirk compatibility for known edge cases. */
+  /** Template syntax compatibility mode. */
+  templateSyntax?: "standard" | "strict" | "quirks";
+  /** Enable Vue in-tag comments (`// ...`) inside opening tags. */
+  experimentalInTagComments?: boolean;
+  /** Enable `v-match` / `v-case` patterned template desugaring. */
+  experimentalPatternedTemplate?: boolean;
+  /** Runtime package imported by generated VDOM modules and SFC client output. */
+  runtimeModuleName?: string;
+  /** Runtime global read by function-mode VDOM and standalone SFC client output. */
+  runtimeGlobalName?: string;
+  /** SFC TypeScript output handling. */
+  scriptExt?: "preserve" | "downcompile";
+  /** Script binding information used by direct template compilation. */
+  bindingMetadata?: BindingMetadata;
+  /** @deprecated Use `templateSyntax: "quirks"`. */
   vueParserQuirks?: boolean;
 }
 
@@ -52,8 +102,8 @@ export interface CompileResult {
   preamble: string;
   /** AST (serialized) */
   ast: object;
-  /** Source map */
-  map?: object | null;
+  /** Source map, present when `sourceMap` is enabled for VDOM output. */
+  map?: SourceMap;
   /** Used helpers */
   helpers: string[];
   /** Template strings for Vapor mode static parts */
@@ -135,10 +185,7 @@ export interface SfcParseOptions {
 }
 
 /** SFC compile options */
-export interface SfcCompileOptions extends CompilerOptions {
-  /** Filename for the SFC */
-  filename?: string;
-}
+export interface SfcCompileOptions extends CompilerOptions {}
 
 /** Result of SFC compilation */
 export interface SfcCompileResult {
@@ -151,7 +198,7 @@ export interface SfcCompileResult {
     /** Generated JavaScript code */
     code: string;
     /** Binding metadata */
-    bindings?: object;
+    bindings?: BindingMetadata;
   };
   /** Generated CSS */
   css?: string;
@@ -161,6 +208,8 @@ export interface SfcCompileResult {
   warnings: string[];
   /** Compile-time macro artifacts */
   macroArtifacts?: MacroArtifact[];
+  /** Flat binding map for feeding a later template-only compile. */
+  bindingMetadata?: Record<string, BindingType>;
 }
 
 /** JSX/TSX compile options */
@@ -260,62 +309,35 @@ export declare class Compiler {
 }
 
 /** Compile template to VDom render function */
-export declare function compile(
-  template: string,
-  options?: CompilerOptions
-): CompileResult;
+export declare function compile(template: string, options?: CompilerOptions): CompileResult;
 
 /** Compile template to Vapor mode */
-export declare function compileVapor(
-  template: string,
-  options?: CompilerOptions
-): CompileResult;
+export declare function compileVapor(template: string, options?: CompilerOptions): CompileResult;
 
 /** Parse template to AST */
-export declare function parseTemplate(
-  template: string,
-  options?: CompilerOptions
-): object;
+export declare function parseTemplate(template: string, options?: CompilerOptions): object;
 
 /** Parse SFC (.vue file) */
-export declare function parseSfc(
-  source: string,
-  options?: SfcParseOptions
-): SfcDescriptor;
+export declare function parseSfc(source: string, options?: SfcParseOptions): SfcDescriptor;
 
 /** Compile SFC (.vue file) */
-export declare function compileSfc(
-  source: string,
-  options?: SfcCompileOptions
-): SfcCompileResult;
+export declare function compileSfc(source: string, options?: SfcCompileOptions): SfcCompileResult;
 
 /** Compile JSX/TSX to render code */
-export declare function compileJsx(
-  source: string,
-  options?: JsxCompileOptions
-): JsxCompileResult;
+export declare function compileJsx(source: string, options?: JsxCompileOptions): JsxCompileResult;
 
 /** Compile CSS with LightningCSS */
-export declare function compileCss(
-  css: string,
-  options?: CssCompileOptions
-): CssCompileResult;
+export declare function compileCss(css: string, options?: CssCompileOptions): CssCompileResult;
 
 /** Lint a Vue SFC */
-export declare function lintSfc(
-  source: string,
-  options?: LintOptions
-): LintResult;
+export declare function lintSfc(source: string, options?: LintOptions): LintResult;
 
 /** Format a Vue SFC */
-export declare function formatSfc(
-  source: string,
-  options?: FormatOptions
-): FormatResult;
+export declare function formatSfc(source: string, options?: FormatOptions): FormatResult;
 
 /** Initialize the WASM module */
 export declare function init(
-  moduleOrPath?: RequestInfo | URL | Response | BufferSource | WebAssembly.Module
+  moduleOrPath?: RequestInfo | URL | Response | BufferSource | WebAssembly.Module,
 ): Promise<void>;
 
 /** Check if the WASM module is initialized */

--- a/tests/tooling/wasm-compiler-options.test.ts
+++ b/tests/tooling/wasm-compiler-options.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const rustPath = path.join(root, "crates/vize_vitrine/src/wasm/options.rs");
+const declarationPath = path.join(root, "npm/wasm/index.d.ts");
+
+interface InventoryEntry {
+  field: string;
+  name: string;
+  type: string;
+}
+
+function inventory(source: string): InventoryEntry[] {
+  const block = source.slice(
+    source.indexOf("define_compiler_option_inventory! {"),
+    source.indexOf("pub(crate) struct ParsedCompilerOptions"),
+  );
+  return block
+    .split("\n")
+    .map((line) => line.match(/^\s*(\w+) => \("([^"]+)", (?:r#"(.+)"#|"([^"]+)")\),$/))
+    .filter((match): match is RegExpMatchArray => match !== null)
+    .map((match) => ({ field: match[1], name: match[2], type: match[3] ?? match[4] }));
+}
+
+function interfaceBody(source: string, name: string): string {
+  const declaration = source.indexOf(`export interface ${name}`);
+  assert.notEqual(declaration, -1, `${name} is not exported`);
+  const start = source.indexOf("{", declaration);
+  let depth = 0;
+  for (let index = start; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") depth -= 1;
+    if (depth === 0) return source.slice(start + 1, index);
+  }
+  throw new Error(`${name} has no closing brace`);
+}
+
+function classBody(source: string, name: string): string {
+  const declaration = source.indexOf(`export declare class ${name}`);
+  assert.notEqual(declaration, -1, `${name} is not exported`);
+  const start = source.indexOf("{", declaration);
+  const end = source.indexOf("\n}", start);
+  assert.notEqual(end, -1, `${name} has no closing brace`);
+  return source.slice(start + 1, end);
+}
+
+function properties(body: string): Map<string, string> {
+  const withoutComments = body.replace(/\/\*\*[\s\S]*?\*\//g, "");
+  return new Map(
+    [...withoutComments.matchAll(/^\s*(\w+)\?:\s*([^;]+);/gm)].map((match) => [
+      match[1],
+      match[2].replace(/\s+/g, " ").trim(),
+    ]),
+  );
+}
+
+test("WASM compiler option inventory matches parser and root declarations bidirectionally", () => {
+  const rust = fs.readFileSync(rustPath, "utf8");
+  const declarations = fs.readFileSync(declarationPath, "utf8");
+  const entries = inventory(rust);
+  assert.ok(entries.length > 0, "compiler option inventory is empty");
+
+  const inventoryFields = new Set(entries.map(({ field }) => field));
+  const inventoryNames = new Set(entries.map(({ name }) => name));
+  assert.equal(inventoryFields.size, entries.length, "inventory field variants must be unique");
+  assert.equal(inventoryNames.size, entries.length, "inventory JS names must be unique");
+
+  const parser = rust.slice(
+    rust.indexOf("pub(crate) fn parse_compiler_options"),
+    rust.indexOf("/// Parse CSS options"),
+  );
+  const parsedFields = new Set(
+    [...parser.matchAll(/CompilerOption::(\w+)/g)].map((match) => match[1]),
+  );
+  assert.doesNotMatch(parser, /JsValue::from_str\("/, "parser keys must use the inventory");
+  assert.deepEqual(parsedFields, inventoryFields, "parser and inventory fields drifted");
+
+  const declared = properties(interfaceBody(declarations, "CompilerOptions"));
+  assert.deepEqual(
+    new Set(declared.keys()),
+    inventoryNames,
+    "declaration and inventory keys drifted",
+  );
+  for (const entry of entries) {
+    assert.equal(declared.get(entry.name), entry.type, `${entry.name} has the wrong public type`);
+  }
+});
+
+test("every compiler facade uses the checked option declarations", () => {
+  const declarations = fs.readFileSync(declarationPath, "utf8");
+  const compiler = classBody(declarations, "Compiler");
+  const facades: Array<[string, string, RegExp]> = [
+    [
+      "Compiler.compile",
+      compiler,
+      /compile\(template: string, options\?: CompilerOptions\): CompileResult;/,
+    ],
+    [
+      "Compiler.compileVapor",
+      compiler,
+      /compileVapor\(template: string, options\?: CompilerOptions\): CompileResult;/,
+    ],
+    ["Compiler.parse", compiler, /parse\(template: string, options\?: CompilerOptions\): object;/],
+    [
+      "Compiler.compileSfc",
+      compiler,
+      /compileSfc\(source: string, options\?: SfcCompileOptions\): SfcCompileResult;/,
+    ],
+    [
+      "compile",
+      declarations,
+      /export declare function compile\(template: string, options\?: CompilerOptions\): CompileResult;/,
+    ],
+    [
+      "compileVapor",
+      declarations,
+      /export declare function compileVapor\(template: string, options\?: CompilerOptions\): CompileResult;/,
+    ],
+    [
+      "parseTemplate",
+      declarations,
+      /export declare function parseTemplate\(template: string, options\?: CompilerOptions\): object;/,
+    ],
+    [
+      "compileSfc",
+      declarations,
+      /export declare function compileSfc\(source: string, options\?: SfcCompileOptions\): SfcCompileResult;/,
+    ],
+  ];
+  for (const [facade, source, declaration] of facades) {
+    assert.match(source, declaration, `${facade} must use its checked option type`);
+  }
+  assert.match(declarations, /@deprecated Use `templateSyntax: "quirks"`/);
+  assert.doesNotMatch(interfaceBody(declarations, "CompilerOptions"), /experimentalServerScript/);
+});

--- a/tests/tooling/wasm-package-smoke.test.ts
+++ b/tests/tooling/wasm-package-smoke.test.ts
@@ -48,11 +48,63 @@ export class Compiler {
   compileCss() {}
   free() {}
 }
-export function compile() {}
+export function compile(_template, options = {}) {
+  if (options.templateSyntax === "strict") throw new Error("strict template syntax");
+  return {
+    code: options.runtimeGlobalName ? "const runtime = " + options.runtimeGlobalName : "code",
+    preamble: options.runtimeModuleName ? 'from "' + options.runtimeModuleName + '"' : "",
+    ast: { children: [{ isSelfClosing: options.vueParserQuirks === true }] },
+    map: options.sourceMap
+      ? {
+          version: 3,
+          file: options.filename ?? "template.vue",
+          sources: [options.filename ?? "template.vue"],
+          sourcesContent: [_template],
+          names: [],
+          mappings: "",
+        }
+      : undefined,
+  };
+}
 export function compileVapor() {}
-export function parseTemplate() {}
+export function parseTemplate(_template, options = {}) {
+  if (options.templateSyntax === "standard" && options.vueParserQuirks === true) {
+    throw new Error("standard template syntax");
+  }
+  return { children: [{ isSelfClosing: options.vueParserQuirks === true }] };
+}
 export function parseSfc() {}
-export function compileSfc() {}
+export function compileSfc(_source, options = {}) {
+  const runtime =
+    options.mode === "function"
+      ? options.runtimeGlobalName ?? "Vue"
+      : options.runtimeModuleName ?? "vue";
+  const filename = options.filename ?? "anonymous.vue";
+  return {
+    template: {
+      code: runtime,
+      preamble: runtime,
+      ast: {},
+      map: options.sourceMap
+        ? {
+            version: 3,
+            file: filename,
+            sources: [filename],
+            sourcesContent: [_source],
+            names: [],
+            mappings: "",
+          }
+        : undefined,
+      helpers: [],
+    },
+    script: {
+      code:
+        runtime +
+        "\\n" +
+        (options.scriptExt === "preserve" ? "const count: number = 1" : "const count = 1"),
+    },
+  };
+}
 export function compileJsx() {}
 export function compileCss() {}
 export function lintSfc(_source, options = {}) {
@@ -107,9 +159,46 @@ test("wasm package declarations type-check a strict consumer", (t) => {
 
   fs.writeFileSync(
     path.join(consumerDir, "consumer.ts"),
-    `import init, { formatSfc, lintSfc, type FormatResult, type LintResult } from "@vizejs/wasm";
+    `import init, {
+  compile,
+  formatSfc,
+  lintSfc,
+  type BindingMetadata,
+  type CompilerOptions,
+  type FormatResult,
+  type LintResult,
+} from "@vizejs/wasm";
 
 void init();
+
+const bindingMetadata: BindingMetadata = {
+  bindings: { message: "setup-ref" },
+  propsAliases: {},
+  isScriptSetup: true,
+};
+const compilerOptions: CompilerOptions = {
+  mode: "module",
+  prefixIdentifiers: true,
+  hoistStatic: true,
+  cacheHandlers: true,
+  scopeId: "data-v-smoke",
+  ssr: false,
+  sourceMap: true,
+  filename: "Smoke.vue",
+  outputMode: "vdom",
+  isTs: true,
+  customRenderer: false,
+  templateSyntax: "strict",
+  experimentalInTagComments: true,
+  experimentalPatternedTemplate: true,
+  runtimeModuleName: "@acme/vue-runtime",
+  runtimeGlobalName: "AcmeVue",
+  scriptExt: "preserve",
+  bindingMetadata,
+  vueParserQuirks: false,
+};
+const compiled = compile("<div />", compilerOptions);
+compiled.map?.sources[0]?.toUpperCase();
 
 const lint: LintResult = lintSfc("<template />", {
   enabledRules: ["vue/no-dupe-keys"],
@@ -135,6 +224,10 @@ console.log(formatted.code, formatted.changed);
 lintSfc("<template />", { severityOverrides: {} });
 // @ts-expect-error filename is not a formatter option
 formatSfc("<template />", { filename: "App.vue" });
+// @ts-expect-error this reserved shared option is not implemented by WASM
+compile("<div />", { experimentalServerScript: true });
+// @ts-expect-error scriptExt is a closed compatibility policy
+compile("<div />", { scriptExt: "ts" });
 `,
   );
   fs.writeFileSync(

--- a/tools/npm/smoke-wasm-package.mjs
+++ b/tools/npm/smoke-wasm-package.mjs
@@ -67,6 +67,57 @@ function assertFilesExist(packageDir) {
   }
 }
 
+function assertCompilerOptions(entry) {
+  const moduleResult = entry.compile("<div>{{ message }}</div>", {
+    mode: "module",
+    runtimeModuleName: "@acme/vue-runtime",
+    sourceMap: true,
+    filename: "src/Component.vue",
+  });
+  assert.match(moduleResult.preamble, /@acme\/vue-runtime/);
+  assert.equal(moduleResult.map?.version, 3);
+  assert.deepEqual(moduleResult.map?.sources, ["src/Component.vue"]);
+
+  const functionResult = entry.compile("<div></div>", {
+    mode: "function",
+    runtimeGlobalName: "AcmeVue",
+  });
+  assert.match(`${functionResult.preamble}\n${functionResult.code}`, /AcmeVue/);
+
+  const legacyQuirks = entry.compile("<div /><span></span>", { vueParserQuirks: true });
+  assert.equal(legacyQuirks.ast.children[0].isSelfClosing, true);
+  assert.throws(() => entry.compile("<div /><span></span>", { templateSyntax: "strict" }));
+  const parsedQuirks = entry.parseTemplate("<div />", { vueParserQuirks: true });
+  assert.equal(parsedQuirks.children[0].isSelfClosing, true);
+  assert.throws(() =>
+    entry.parseTemplate("<div />", {
+      templateSyntax: "standard",
+      vueParserQuirks: true,
+    }),
+  );
+
+  const typedSfc = '<script setup lang="ts">const count: number = 1</script>';
+  const preserved = entry.compileSfc(typedSfc, { scriptExt: "preserve" });
+  const downcompiled = entry.compileSfc(typedSfc, { scriptExt: "downcompile" });
+  assert.match(preserved.script.code, /count:\s*number/);
+  assert.doesNotMatch(downcompiled.script.code, /count:\s*number/);
+
+  const sfcSource = "<template><div></div></template>";
+  const moduleSfc = entry.compileSfc(sfcSource, {
+    runtimeModuleName: "@acme/vue-runtime",
+    sourceMap: true,
+  });
+  assert.match(moduleSfc.script.code, /@acme\/vue-runtime/);
+  assert.deepEqual(moduleSfc.template.map?.sources, ["anonymous.vue"]);
+  const standaloneSfc = entry.compileSfc(sfcSource, {
+    mode: "function",
+    runtimeModuleName: "@acme/vue-runtime",
+    runtimeGlobalName: "AcmeVue",
+  });
+  assert.match(standaloneSfc.script.code, /AcmeVue/);
+  assert.doesNotMatch(standaloneSfc.script.code, /@acme\/vue-runtime/);
+}
+
 async function assertEntryPoint(packageDir) {
   const entry = await import(
     `${pathToFileURL(path.join(packageDir, "index.js")).href}?smoke=${Date.now()}`
@@ -102,6 +153,7 @@ async function assertEntryPoint(packageDir) {
   const wasm = fs.readFileSync(path.join(packageDir, "vize_vitrine_bg.wasm"));
   await entry.init(wasm);
   assert.equal(entry.isInitialized(), true);
+  assertCompilerOptions(entry);
 
   const source = '<template>\n  <div  id="x"></div>\n</template>\n';
   const formattedSource = '<template>\n  <div id="x"></div>\n</template>\n';


### PR DESCRIPTION
## Summary

- define one Rust inventory for every supported JavaScript compiler option and bidirectionally check it against the public TypeScript declaration
- make runtime module/global names, template syntax, parser flags, filename, source maps, script extension, and binding metadata accurately typed and effective
- keep `vueParserQuirks` as a deprecated fallback while explicit `templateSyntax` wins; exclude the unimplemented reserved server-script flag
- pass emission-only defaults through canonical `CodegenOptions`, avoiding source-breaking fields on public DOM/SFC option structs
- verify direct VDOM, SFC module/standalone, parser compatibility, source-map identity, and TypeScript preservation against a real built WASM package

## Verification

- cargo check -p vize_atelier_dom -p vize_atelier_sfc -p vize_vitrine --features wasm
- cargo test -p vize_vitrine --features wasm wasm::tests
- cargo test -p vize_atelier_dom -p vize_atelier_sfc --lib
- node --test tests/tooling/wasm-compiler-options.test.ts tests/tooling/wasm-package-smoke.test.ts
- wasm-pack release build followed by tools/npm/smoke-wasm-package.mjs
- strict TypeScript consumer, oxfmt, oxlint, cargo fmt, and git diff checks

Closes #2829

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786437316&installation_id=136613492&pr_number=2858&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2858&signature=5cff9f7392d3ff64d635a24b0778266b8921e2f116c38ae7c92ab4552204df8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable template syntax, runtime names, script extensions, binding metadata, and source maps to WASM compiler APIs.
  * Added custom code-generation options for template and SFC compilation.
  * Added typed source map and binding metadata definitions.
  * Improved standalone and module output to use configured runtime settings.

* **Bug Fixes**
  * Added compatibility handling for the deprecated `vueParserQuirks` option.
  * Corrected source map propagation and template parsing behavior.

* **Documentation**
  * Documented supported compiler options, compatibility rules, and stage-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->