### PR TITLE
fix(nix): isolate pinned Blacksmith tooling

### DIFF
--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -15,6 +15,14 @@ Use the Node.js version from `.node-version` and the Rust version from `rust-too
 workspace declares a minimum supported Rust version (MSRV) of `1.95.0` in `Cargo.toml`
 (`[workspace.package].rust-version`); contributions must compile under that version.
 
+The default Nix shell contains the reproducible local toolchain. Blacksmith Testbox support is
+optional and lives in a separate shell with the pinned Blacksmith CLI, `rsync`, and GitHub CLI:
+
+```sh
+nix develop             # local development
+nix develop .#testbox   # hosted Testbox workflows
+```
+
 Install dependencies from the workspace root:
 
 ```sh

--- a/flake.nix
+++ b/flake.nix
@@ -119,35 +119,26 @@
             }
           else
             null;
-        # Blacksmith CLI (Testbox). Distributed as a single prebuilt binary
-        # from a mutable `latest` channel, so — like the MoonBit block above —
-        # each platform pins the current binary's hash. The placeholder hashes
-        # below must be filled before this builds: run `nix build` once and
-        # paste the `got: sha256-…` value Nix reports for each platform, or
-        #   nix store prefetch-file --name blacksmith \
-        #     https://clireleases.blacksmith.sh/cli/latest/<os>/<arch>/blacksmith
-        #
-        # NOTE: the CLI self-updates in the background on every invocation,
-        # which cannot write into the read-only Nix store. If the pinned
-        # binary errors while trying to self-update, gate the update off (check
-        # `blacksmith --help` for the flag/env var) — the store path is the
-        # source of truth and is refreshed by bumping the hashes here.
+        # Blacksmith CLI (Testbox). Keep this optional hosted-test tool pinned
+        # independently from the default development shell so local onboarding
+        # never depends on its artifact or authentication service.
+        blacksmithVersion = "0.4.46";
         blacksmithArtifacts = {
           aarch64-darwin = {
-            url = "https://clireleases.blacksmith.sh/cli/latest/darwin/arm64/blacksmith";
-            hash = "sha256-wTCMj9d5siTpB01ljPFa3NAwN28lJicaJcc7AiqTRWw=";
+            url = "https://clireleases.blacksmith.sh/cli/v${blacksmithVersion}/darwin/arm64/blacksmith";
+            hash = "sha256-4DBbwkNpVHIzozeV2+hcJHlTG+jvlfWJzQd4C5JmQX4=";
           };
           x86_64-darwin = {
-            url = "https://clireleases.blacksmith.sh/cli/latest/darwin/amd64/blacksmith";
-            hash = "sha256-aT3dpCOy00OyuEp/08z9pZxA31lZQEQ1MhRdNzwNgxM=";
+            url = "https://clireleases.blacksmith.sh/cli/v${blacksmithVersion}/darwin/amd64/blacksmith";
+            hash = "sha256-XGVjxInIwYZXqyGhM8vzL5GkhWha3ZXkJ6mPDXgL3Cg=";
           };
           x86_64-linux = {
-            url = "https://clireleases.blacksmith.sh/cli/latest/linux/amd64/blacksmith";
+            url = "https://clireleases.blacksmith.sh/cli/v${blacksmithVersion}/linux/amd64/blacksmith";
             hash = "sha256-ABJrjw+yHuHcjPrEZNmRsCpn229Od87Hxja38i0CNVM=";
           };
           aarch64-linux = {
-            url = "https://clireleases.blacksmith.sh/cli/latest/linux/arm64/blacksmith";
-            hash = "sha256-6XF/S/sn4s6zktPJbadkXt0yALLIySppZTUeNvoiWss=";
+            url = "https://clireleases.blacksmith.sh/cli/v${blacksmithVersion}/linux/arm64/blacksmith";
+            hash = "sha256-1RJ9+sW0pIteoODzb/8I6Qh3JYyyd+VoQcsh97PQmAI=";
           };
         };
         blacksmith =
@@ -157,7 +148,7 @@
             in
             pkgs.stdenvNoCC.mkDerivation {
               pname = "blacksmith";
-              version = "latest";
+              version = blacksmithVersion;
               src = pkgs.fetchurl { inherit (artifact) url hash; };
               dontUnpack = true;
               nativeBuildInputs = lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
@@ -335,7 +326,6 @@
           ]
           ++ lib.optionals pkgs.stdenv.isDarwin [ workspaceXcrun ]
           ++ lib.optionals (moonbit != null) [ moonbit ]
-          ++ lib.optionals (blacksmith != null) [ blacksmith ]
           ++ commonNativeBuildInputs;
 
           RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
@@ -378,6 +368,19 @@
             echo "Then: vp check / vp fmt / vp dev / vp build"
           '';
         };
+        testboxDevShell = devShell.overrideAttrs (previous: {
+          nativeBuildInputs =
+            (previous.nativeBuildInputs or [ ])
+            ++ [
+              pkgs.gh
+              pkgs.rsync
+            ]
+            ++ lib.optionals (blacksmith != null) [ blacksmith ];
+          shellHook = (previous.shellHook or "") + ''
+            echo "Blacksmith Testbox tools ready (CLI ${blacksmithVersion})."
+            echo "First use: blacksmith auth login"
+          '';
+        });
       in
       {
         apps = {
@@ -390,7 +393,10 @@
           shell = devShell.inputDerivation;
         };
 
-        devShells.default = devShell;
+        devShells = {
+          default = devShell;
+          testbox = testboxDevShell;
+        };
         formatter = pkgs.nixfmt;
 
         packages = {

--- a/tests/tooling/nix-testbox.test.ts
+++ b/tests/tooling/nix-testbox.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+test("Nix isolates the pinned Blacksmith CLI from the default dev shell", () => {
+  const flake = readRepoFile("flake.nix");
+  const contributing = readRepoFile("docs/content/contributing.md");
+  const defaultShell = flake.match(
+    /devShell = pkgs\.mkShell \{([\s\S]*?)\n\s*\};\n\s*testboxDevShell/,
+  )?.[1];
+  const testboxShell = flake.match(
+    /testboxDevShell = devShell\.overrideAttrs \(previous: \{([\s\S]*?)\n\s*\}\);/,
+  )?.[1];
+  const sourceUrls = [...flake.matchAll(/url = "([^"]+)";/g)].map((match) => match[1]);
+
+  assert.ok(defaultShell, "default dev shell");
+  assert.ok(testboxShell, "Testbox dev shell");
+  assert.doesNotMatch(defaultShell, /blacksmith/i);
+  assert.match(testboxShell, /previous\.nativeBuildInputs/);
+  assert.match(testboxShell, /pkgs\.gh/);
+  assert.match(testboxShell, /pkgs\.rsync/);
+  assert.match(testboxShell, /\[ blacksmith \]/);
+  assert.match(flake, /blacksmithVersion = "0\.4\.46";/);
+  assert.ok(sourceUrls.length > 0, "fixed-output source URLs");
+  for (const sourceUrl of sourceUrls) assert.doesNotMatch(sourceUrl, /\/latest\//);
+  assert.match(
+    flake,
+    /clireleases\.blacksmith\.sh\/cli\/v\$\{blacksmithVersion\}\/darwin\/arm64\/blacksmith/,
+  );
+  assert.match(
+    flake,
+    /clireleases\.blacksmith\.sh\/cli\/v\$\{blacksmithVersion\}\/linux\/amd64\/blacksmith/,
+  );
+  assert.match(flake, /devShells = \{[\s\S]*default = devShell;[\s\S]*testbox = testboxDevShell;/);
+  assert.match(contributing, /nix develop\s+# local development/);
+  assert.match(contributing, /nix develop \.#testbox\s+# hosted Testbox workflows/);
+});


### PR DESCRIPTION
## Summary

- pin the official Blacksmith CLI v0.4.46 artifacts and hashes for all supported Nix platforms
- keep the default development shell independent from hosted Testbox tooling
- expose Blacksmith, rsync, and GitHub CLI through `nix develop .#testbox` with regression coverage and contributor docs

## Verification

- `nix fmt -- --check flake.nix`
- `nix flake check --all-systems --no-build`
- `nix develop --command true`
- `nix develop .#testbox --command blacksmith --version`
- default/Testbox closure inspection
- `node --test tests/tooling/package-manifests.test.ts`
- Oxfmt / Oxlint / `git diff --check`

Closes #2831

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786438487&installation_id=136613492&pr_number=2859&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2859&signature=c16d2a9f4fe956103c1d547935710de065c2e3f3d1791ac9ae73842aa6d169c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Nix development shell for Blacksmith Testbox workflows.
  * Pinned the Blacksmith CLI to version 0.4.46 for consistent tooling across supported platforms.
  * Kept the default development shell focused on local development tools.

* **Documentation**
  * Added setup instructions for entering the standard development shell and optional Testbox shell.

* **Tests**
  * Added coverage validating shell configuration, CLI pinning, platform downloads, and setup documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->