### PR TITLE
fix(ci): validate benchmark comparison ranges

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -65,6 +65,10 @@ jobs:
             echo "::error title=Invalid head_sha::head_sha must be a full lowercase 40-character commit SHA"
             exit 1
           fi
+          if [[ "$BENCHMARK_BASE_SHA" == "$BENCHMARK_HEAD_SHA" ]]; then
+            echo "::error title=Invalid benchmark range::base_sha must differ from head_sha"
+            exit 1
+          fi
           if [[ "$RUN_HEAD_SHA" != "$BENCHMARK_HEAD_SHA" ]]; then
             echo "::error title=Dispatch ref mismatch::run head_sha comes from --ref; dispatch with a branch or tag at $BENCHMARK_HEAD_SHA (got $RUN_HEAD_SHA)"
             exit 1
@@ -75,6 +79,7 @@ jobs:
         with:
           path: head
           ref: ${{ env.BENCHMARK_HEAD_SHA }}
+          fetch-depth: ${{ github.event_name == 'workflow_dispatch' && '0' || '1' }}
 
       - name: Checkout base
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -88,7 +93,13 @@ jobs:
         env:
           BASE_SHA: ${{ env.BENCHMARK_BASE_SHA }}
           HEAD_SHA: ${{ env.BENCHMARK_HEAD_SHA }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]] && \
+             ! git -C "$GITHUB_WORKSPACE/head" merge-base --is-ancestor "$BASE_SHA" "$HEAD_SHA"; then
+            echo "::error title=Invalid benchmark range::base_sha must be an ancestor of head_sha"
+            exit 1
+          fi
           if git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- . ':(exclude)tests/_fixtures/_git/**'; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             {

--- a/tests/tooling/github-workflows-benchmark.test.ts
+++ b/tests/tooling/github-workflows-benchmark.test.ts
@@ -3,6 +3,15 @@ import { test } from "node:test";
 
 import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
 
+function workflowStepBody(job: string, stepName: string): string {
+  const marker = `\n      - name: ${stepName}\n`;
+  const start = job.indexOf(marker);
+  assert.notEqual(start, -1, `missing step ${stepName}`);
+  const bodyStart = start + 1;
+  const nextStep = job.indexOf("\n      - ", bodyStart + marker.length);
+  return job.slice(bodyStart, nextStep === -1 ? undefined : nextStep);
+}
+
 test("benchmark workflow comments from trusted code after a read-only benchmark run", () => {
   const workflow = readRepoFile(".github", "workflows", "benchmark.yml");
   const benchmarkJob = workflowJobBody(workflow, "pr-benchmark");
@@ -77,6 +86,9 @@ test("benchmark dispatch validates exact SHA evidence and runs the existing budg
   const benchmarkJob = workflowJobBody(workflow, "pr-benchmark");
   const budgetJob = workflowJobBody(workflow, "pr-benchmark-budget");
   const commentJob = workflowJobBody(workflow, "pr-benchmark-comment");
+  const validateDispatchStep = workflowStepBody(benchmarkJob, "Validate dispatch SHAs");
+  const checkoutHeadStep = workflowStepBody(benchmarkJob, "Checkout head");
+  const checkBaseStep = workflowStepBody(benchmarkJob, "Check base checkout");
 
   assert.match(
     workflow,
@@ -96,15 +108,33 @@ test("benchmark dispatch validates exact SHA evidence and runs the existing budg
   assert.match(workflow, /head_sha from the branch or tag/);
   assert.match(workflow, /passed via --ref, not from a later checkout/);
 
-  assert.match(benchmarkJob, /name:\s*Validate dispatch SHAs/);
-  assert.match(benchmarkJob, /if:\s*\$\{\{\s*github\.event_name == 'workflow_dispatch'\s*\}\}/);
-  assert.match(benchmarkJob, /full_sha='\^\[0-9a-f\]\{40\}\$'/);
-  assert.match(benchmarkJob, /! "\$BENCHMARK_BASE_SHA" =~ \$full_sha/);
-  assert.match(benchmarkJob, /! "\$BENCHMARK_HEAD_SHA" =~ \$full_sha/);
-  assert.match(benchmarkJob, /RUN_HEAD_SHA:\s*\$\{\{\s*github\.sha\s*\}\}/);
-  assert.match(benchmarkJob, /"\$RUN_HEAD_SHA" != "\$BENCHMARK_HEAD_SHA"/);
-  assert.match(benchmarkJob, /run head_sha comes from --ref/);
-  assert.match(benchmarkJob, /dispatch with a branch or tag/);
+  assert.match(
+    validateDispatchStep,
+    /if:\s*\$\{\{\s*github\.event_name == 'workflow_dispatch'\s*\}\}/,
+  );
+  assert.match(validateDispatchStep, /full_sha='\^\[0-9a-f\]\{40\}\$'/);
+  assert.match(validateDispatchStep, /! "\$BENCHMARK_BASE_SHA" =~ \$full_sha/);
+  assert.match(validateDispatchStep, /! "\$BENCHMARK_HEAD_SHA" =~ \$full_sha/);
+  assert.match(validateDispatchStep, /"\$BENCHMARK_BASE_SHA" == "\$BENCHMARK_HEAD_SHA"/);
+  assert.match(validateDispatchStep, /base_sha must differ from head_sha/);
+  assert.match(validateDispatchStep, /RUN_HEAD_SHA:\s*\$\{\{\s*github\.sha\s*\}\}/);
+  assert.match(validateDispatchStep, /"\$RUN_HEAD_SHA" != "\$BENCHMARK_HEAD_SHA"/);
+  assert.match(validateDispatchStep, /run head_sha comes from --ref/);
+  assert.match(validateDispatchStep, /dispatch with a branch or tag/);
+  assert.match(
+    checkoutHeadStep,
+    /fetch-depth:\s*\$\{\{\s*github\.event_name == 'workflow_dispatch' && '0' \|\| '1'\s*\}\}/,
+  );
+  assert.match(checkBaseStep, /EVENT_NAME:\s*\$\{\{\s*github\.event_name\s*\}\}/);
+  assert.match(checkBaseStep, /"\$EVENT_NAME" == "workflow_dispatch"/);
+  assert.match(checkBaseStep, /merge-base --is-ancestor "\$BASE_SHA" "\$HEAD_SHA"/);
+  assert.match(checkBaseStep, /base_sha must be an ancestor of head_sha/);
+
+  const validateIndex = benchmarkJob.indexOf("- name: Validate dispatch SHAs");
+  const ancestryIndex = benchmarkJob.indexOf("- name: Check base checkout");
+  const benchmarkIndex = benchmarkJob.indexOf("- name: Compare base and head");
+  assert.ok(validateIndex < ancestryIndex, "SHA equality must be validated before ancestry");
+  assert.ok(ancestryIndex < benchmarkIndex, "ancestry must be validated before benchmarking");
 
   assert.match(budgetJob, /name:\s*pr-benchmark/);
   assert.match(budgetJob, /--labels-json "\$PR_LABELS_JSON"/);


### PR DESCRIPTION
## Summary

- reject benchmark dispatches whose base and head resolve to the same commit
- fetch the dispatched head history and require the base commit to be its ancestor
- lock the fail-closed diagnostics into the benchmark workflow regression test

## Verification

- `node --test tests/tooling/github-workflows-benchmark.test.ts`
- Oxfmt / Oxlint
- `nix run nixpkgs#actionlint -- .github/workflows/benchmark.yml`
- `git diff --check`

Closes #2860

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786438641&installation_id=136613492&pr_number=2861&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2861&signature=2f5bee007f3bdd8e11efab09822712be8fa353d232541f5e9d7f07708fb69de2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark workflow validation for manually triggered runs.
  * Prevented benchmark comparisons when the base and head revisions are identical or unrelated.
  * Added safer checkout handling to ensure accurate revision history and comparisons.
* **Tests**
  * Expanded automated coverage for revision validation, checkout depth, and ancestry checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->