### PR TITLE
fix(fuzz): identify release evidence runs

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -25,6 +25,8 @@ on:
       - "tools/fuzz/**"
       - ".github/workflows/fuzz.yml"
 
+run-name: Fuzz ${{ github.event_name == 'workflow_dispatch' && format('{0}s', inputs.max-total-time) || github.event_name }} @ ${{ github.sha }}
+
 concurrency:
   group: fuzz-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -59,22 +61,29 @@ jobs:
       - name: Resolve max-total-time
         id: budget
         shell: bash
+        env:
+          REQUESTED_MAX_TOTAL_TIME: ${{ inputs.max-total-time }}
         run: |
           case "${{ github.event_name }}" in
             schedule)
               # Nightly long fuzz: 30 minutes/target — large enough to drive
               # libFuzzer past coverage plateaus on the seeded corpus.
-              echo "seconds=1800" >> "$GITHUB_OUTPUT"
+              seconds=1800
               ;;
             workflow_dispatch)
-              echo "seconds=${{ inputs.max-total-time }}" >> "$GITHUB_OUTPUT"
+              seconds="$REQUESTED_MAX_TOTAL_TIME"
               ;;
             *)
               # PR-gating short fuzz: 2 minutes/target — tight enough to keep
               # PR latency reasonable while still exercising every seed.
-              echo "seconds=120" >> "$GITHUB_OUTPUT"
+              seconds=120
               ;;
           esac
+          if [[ ! "$seconds" =~ ^[0-9]{1,4}$ ]] || (( 10#$seconds < 1 || 10#$seconds > 3600 )); then
+            echo "::error title=Invalid fuzz budget::max-total-time must be an integer from 1 to 3600 seconds"
+            exit 1
+          fi
+          echo "seconds=$seconds" >> "$GITHUB_OUTPUT"
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:

--- a/tests/tooling/fuzz-setup.test.ts
+++ b/tests/tooling/fuzz-setup.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -54,6 +56,10 @@ test("fuzz CI workflow gates short PR fuzz and schedules long nightly fuzz", () 
   };
 
   assert.match(workflow, /name:\s*Fuzz/);
+  assert.match(
+    workflow,
+    /^run-name:\s*Fuzz\s+\$\{\{\s*github\.event_name\s*==\s*'workflow_dispatch'\s*&&\s*format\(\s*'\{0\}s'\s*,\s*inputs\.max-total-time\s*\)\s*\|\|\s*github\.event_name\s*\}\}\s+@\s+\$\{\{\s*github\.sha\s*\}\}\s*$/m,
+  );
   assert.match(workflow, /schedule:[\s\S]*?-\s*cron:/);
   assert.match(workflow, /pull_request:[\s\S]*paths:/);
   assert.match(workflow, /"tests\/fuzz\/\*\*"/);
@@ -74,6 +80,40 @@ test("fuzz CI workflow gates short PR fuzz and schedules long nightly fuzz", () 
   assert.match(workflow, /-max_total_time=/);
   const fuzzJob = parsed.jobs.fuzz;
   assert.equal(fuzzJob["continue-on-error"], "${{ github.event_name == 'pull_request' }}");
+  const budgetStep = fuzzJob.steps.find((step) => step.id === "budget");
+  assert.deepEqual(budgetStep?.env, {
+    REQUESTED_MAX_TOTAL_TIME: "${{ inputs.max-total-time }}",
+  });
+  assert.match(budgetStep?.run ?? "", /seconds="\$REQUESTED_MAX_TOTAL_TIME"/);
+  assert.match(budgetStep?.run ?? "", /max-total-time must be an integer from 1 to 3600 seconds/);
+  assert.doesNotMatch(budgetStep?.run ?? "", /seconds=\$\{\{/);
+  const dispatchBudgetScript = (budgetStep?.run ?? "").replaceAll(
+    "${{ github.event_name }}",
+    "workflow_dispatch",
+  );
+  for (const [input, expectedStatus] of [
+    ["abc", 1],
+    ["0", 1],
+    ["3601", 1],
+    ["1", 0],
+    ["3600", 0],
+  ] as const) {
+    const output = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "vize-fuzz-budget-")), "output");
+    const result = spawnSync("bash", ["-c", dispatchBudgetScript], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: output,
+        REQUESTED_MAX_TOTAL_TIME: input,
+      },
+    });
+    assert.equal(result.status, expectedStatus, `${input}: ${result.stderr}${result.stdout}`);
+    if (expectedStatus === 0) {
+      assert.equal(fs.readFileSync(output, "utf8"), `seconds=${input}\n`);
+    } else {
+      assert.match(`${result.stderr}${result.stdout}`, /Invalid fuzz budget/);
+    }
+  }
   const fuzzStep = fuzzJob.steps.find((step) => step.id === "fuzz");
   assert.equal(fuzzStep?.["continue-on-error"], true);
   assert.match(fuzzStep?.run ?? "", /cargo \+nightly fuzz run "\$FUZZ_TARGET"/);


### PR DESCRIPTION
Closes #2866

## Summary

- give Fuzz runs a deterministic budget-and-SHA identity for release evidence lookup
- pass the manual budget through the environment instead of shell interpolation
- reject malformed, zero, and over-limit budgets before provisioning the fuzz toolchain
- lock the workflow contract with tooling tests

## Why

The release preflight correlates a manual fuzz gate by `Fuzz <budget>s @ <sha>`. Without a workflow `run-name`, a successful dispatch is invisible to that lookup and the preflight waits until timeout.

The same boundary accepted an unchecked string directly in shell source. Validating a bounded integer through `env` makes failures immediate and keeps workflow inputs out of executable script text.

## Verification

- `node --test tests/tooling/fuzz-setup.test.ts`
- `pnpm exec oxfmt --check .github/workflows/fuzz.yml tests/tooling/fuzz-setup.test.ts`
- `nix run nixpkgs#actionlint -- -ignore 'label "blacksmith-[^"]+" is unknown' .github/workflows/fuzz.yml`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786440182&installation_id=136613492&pr_number=2867&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2867&signature=d0ddbb22858b510ab395c54f1b32bf3d3d3038309efd2557d58c4655a88a12d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fuzzing workflows now validate configured time limits and reject invalid values.
  * Workflow runs display the selected maximum fuzzing time for manually triggered runs.

* **Tests**
  * Expanded validation coverage for fuzzing workflow configuration, run names, and time-limit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->