### PR TITLE
fix(ci): pin source-length comparison base

### DIFF
--- a/tests/tooling/source-file-lengths.test.ts
+++ b/tests/tooling/source-file-lengths.test.ts
@@ -18,21 +18,36 @@ function writeLines(filePath: string, count: number): void {
   fs.writeFileSync(filePath, `${lines.join("\n")}\n`);
 }
 
-function resolveBaseRef(): string | undefined {
-  if (process.env.SOURCE_LENGTH_BASE_REF) {
-    return process.env.SOURCE_LENGTH_BASE_REF;
+function resolveBaseRef(cwd = repoRoot, env: NodeJS.ProcessEnv = process.env): string | undefined {
+  if (env.SOURCE_LENGTH_BASE_REF) {
+    return env.SOURCE_LENGTH_BASE_REF;
   }
-  if (!process.env.GITHUB_BASE_REF) {
+  if (!env.GITHUB_BASE_REF) {
     return undefined;
   }
 
-  const result = spawnSync(
-    "git",
-    ["fetch", "--no-tags", "--depth=1", "origin", process.env.GITHUB_BASE_REF],
-    { cwd: repoRoot, encoding: "utf8" },
+  assert.ok(env.GITHUB_EVENT_PATH, "GITHUB_EVENT_PATH is required for pull-request source checks");
+  let event: unknown;
+  try {
+    event = JSON.parse(fs.readFileSync(env.GITHUB_EVENT_PATH, "utf8"));
+  } catch (error) {
+    throw new Error(`Failed to read pull-request event ${env.GITHUB_EVENT_PATH}`, {
+      cause: error,
+    });
+  }
+  const baseSha = (event as { pull_request?: { base?: { sha?: unknown } } }).pull_request?.base
+    ?.sha;
+  assert.ok(
+    typeof baseSha === "string" && /^[0-9a-f]{40}$/.test(baseSha),
+    "pull_request.base.sha must be a full lowercase commit SHA",
   );
+
+  const result = spawnSync("git", ["fetch", "--no-tags", "--depth=1", "origin", baseSha], {
+    cwd,
+    encoding: "utf8",
+  });
   assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
-  return "FETCH_HEAD";
+  return baseSha;
 }
 
 test("source length script checks the current checkout", () => {
@@ -47,6 +62,79 @@ test("source length script checks the current checkout", () => {
   assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
   assert.match(result.stdout, /Source files scanned: \d+/);
   assert.match(result.stdout, /Files over 350 lines: \d+/);
+});
+
+test("source length comparison keeps the event base when the branch advances", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-source-length-base-"));
+  const remote = path.join(root, "remote.git");
+  const publisher = path.join(root, "publisher");
+  const checkout = path.join(root, "checkout");
+  const eventPath = path.join(root, "event.json");
+  fs.mkdirSync(remote);
+  fs.mkdirSync(publisher);
+  fs.mkdirSync(checkout);
+  runGit(remote, ["init", "--bare", "-q"]);
+  runGit(publisher, ["init", "-q", "--initial-branch=main"]);
+  writeLines(path.join(publisher, "large.ts"), 351);
+  runGit(publisher, ["add", "large.ts"]);
+  runGit(publisher, [
+    "-c",
+    "user.name=Vize",
+    "-c",
+    "user.email=vize@example.com",
+    "commit",
+    "-qm",
+    "event base",
+  ]);
+  const eventBaseSha = runGit(publisher, ["rev-parse", "HEAD"]);
+  runGit(publisher, ["remote", "add", "origin", remote]);
+  runGit(publisher, ["push", "-q", "-u", "origin", "main"]);
+
+  writeLines(path.join(publisher, "large.ts"), 352);
+  runGit(publisher, ["add", "large.ts"]);
+  runGit(publisher, [
+    "-c",
+    "user.name=Vize",
+    "-c",
+    "user.email=vize@example.com",
+    "commit",
+    "-qm",
+    "advance main",
+  ]);
+  const advancedSha = runGit(publisher, ["rev-parse", "HEAD"]);
+  runGit(publisher, ["push", "-q", "origin", "main"]);
+
+  runGit(checkout, ["init", "-q"]);
+  runGit(checkout, ["remote", "add", "origin", remote]);
+  fs.writeFileSync(eventPath, JSON.stringify({ pull_request: { base: { sha: eventBaseSha } } }));
+
+  const resolved = resolveBaseRef(checkout, {
+    GITHUB_BASE_REF: "main",
+    GITHUB_EVENT_PATH: eventPath,
+  });
+  assert.ok(resolved);
+  assert.equal(resolved, eventBaseSha);
+  assert.equal(runGit(checkout, ["rev-parse", resolved]), eventBaseSha);
+  assert.notEqual(resolved, advancedSha);
+});
+
+test("source length comparison preserves an explicit local base override", () => {
+  assert.equal(resolveBaseRef(repoRoot, { SOURCE_LENGTH_BASE_REF: "local-base" }), "local-base");
+});
+
+test("source length comparison rejects malformed pull-request metadata", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-source-length-event-"));
+  const eventPath = path.join(root, "event.json");
+  fs.writeFileSync(eventPath, JSON.stringify({ pull_request: { base: { sha: "main" } } }));
+
+  assert.throws(
+    () =>
+      resolveBaseRef(root, {
+        GITHUB_BASE_REF: "main",
+        GITHUB_EVENT_PATH: eventPath,
+      }),
+    /pull_request\.base\.sha must be a full lowercase commit SHA/,
+  );
 });
 
 test("source length script rejects grown over-limit files", () => {


### PR DESCRIPTION
Closes #2868

## Summary

- resolve the source-length baseline from the immutable pull-request event SHA
- fetch and compare the exact base commit instead of the moving base branch
- preserve explicit local base overrides and validate malformed event metadata
- reproduce a base-branch advance with a local bare remote regression test

## Why

The previous gate fetched `origin/$GITHUB_BASE_REF` while the job was running. If main advanced after the pull-request merge commit was created, unrelated reductions from newer main appeared as growth in the older checkout. Rebasing only restarted the full matrix and left the race intact.

Using `pull_request.base.sha` keeps the comparison tied to the same snapshot GitHub used to construct the tested merge commit.

## Verification

- `node --test --test-name-pattern='source length comparison' tests/tooling/source-file-lengths.test.ts`
- `oxfmt --check tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786440543&installation_id=136613492&pr_number=2870&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2870&signature=4f86c226d5a4387a9fdab329d16dd56f53e6fb8a7356e388a6138f9589fef4a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->