### PR TITLE
fix(build): reject nonexistent literal inputs

### DIFF
--- a/crates/vize/src/commands/build/runner.rs
+++ b/crates/vize/src/commands/build/runner.rs
@@ -32,7 +32,7 @@ use super::{
 };
 
 use cache::StatsCompileCache;
-use collect::{CollectedFiles, collect_files};
+use collect::{CollectedFiles, collect_files_or_exit};
 use compile::compile_file_with_profile;
 use compile_stats::compile_file_stats_with_cache;
 use output::{CompiledBuildOutput, plan_inputs, preflight_outputs, write_outputs};
@@ -70,7 +70,7 @@ pub(crate) fn run(args: BuildArgs) {
         std::process::exit(1);
     }
 
-    let CollectedFiles { mut files, roots } = collect_files(&args.patterns);
+    let CollectedFiles { mut files, roots } = collect_files_or_exit(&args.patterns);
 
     if files.is_empty() {
         eprintln!("No .vue files found matching the patterns");

--- a/crates/vize/src/commands/build/runner/collect.rs
+++ b/crates/vize/src/commands/build/runner/collect.rs
@@ -1,37 +1,83 @@
 //! File collection and glob pattern matching for the build command.
 
-use std::path::PathBuf;
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
 
 use ignore::Walk;
-use vize_carton::cstr;
-use vize_carton::{String, ToCompactString};
 
+#[derive(Debug)]
 pub(super) struct CollectedFiles {
     pub files: Vec<PathBuf>,
     pub roots: Vec<PathBuf>,
 }
 
-/// Collect `.vue` files matching the given glob patterns.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum InputError<'a> {
+    MissingLiteral { input: &'a str },
+    NonVueFile { input: &'a str },
+}
+
+impl fmt::Display for InputError<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingLiteral { input } => {
+                write!(formatter, "Build input does not exist: {input}")
+            }
+            Self::NonVueFile { input } => {
+                write!(formatter, "Build input is not a .vue file: {input}")
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum BuildInput<'a> {
+    File(&'a Path),
+    Directory(&'a Path),
+    Glob { root: PathBuf, pattern: &'a str },
+}
+
 #[allow(clippy::disallowed_types)]
-pub(super) fn collect_files(patterns: &[std::string::String]) -> CollectedFiles {
+pub(super) fn collect_files_or_exit(patterns: &[std::string::String]) -> CollectedFiles {
+    collect_files(patterns).unwrap_or_else(|error| {
+        eprintln!("{error}");
+        std::process::exit(1);
+    })
+}
+
+/// Collect `.vue` files from literal files, directories, and glob patterns.
+#[allow(clippy::disallowed_types)]
+pub(super) fn collect_files<'a>(
+    patterns: &'a [std::string::String],
+) -> Result<CollectedFiles, InputError<'a>> {
+    // Validate every literal before starting an expensive walk. A typo or an
+    // unsupported file must not affect collection roots or scan other inputs.
+    let inputs = patterns
+        .iter()
+        .map(|pattern| classify_input(pattern))
+        .collect::<Result<Vec<_>, _>>()?;
     let mut files = Vec::new();
     let mut roots = Vec::new();
 
-    for pattern in patterns {
-        let (root, glob_pattern) = parse_pattern(pattern);
-        let root_path = PathBuf::from(root.as_str());
-        if root_path.is_dir() {
-            roots.push(root_path);
-        }
-
-        for entry in Walk::new(&root).flatten() {
-            let path = entry.path();
-
-            if path.is_file()
-                && path.extension().is_some_and(|ext| ext == "vue")
-                && pattern_matches(path, &glob_pattern)
-            {
+    for input in inputs {
+        match input {
+            BuildInput::File(path) => {
                 files.push(path.to_path_buf());
+                if let Some(parent) = path.parent() {
+                    roots.push(parent.to_path_buf());
+                }
+            }
+            BuildInput::Directory(root) => {
+                roots.push(root.to_path_buf());
+                collect_walked_files(root, None, &mut files);
+            }
+            BuildInput::Glob { root, pattern } => {
+                if root.is_dir() {
+                    roots.push(root.clone());
+                }
+                collect_walked_files(&root, Some(pattern), &mut files);
             }
         }
     }
@@ -40,45 +86,80 @@ pub(super) fn collect_files(patterns: &[std::string::String]) -> CollectedFiles 
     files.dedup();
     roots.sort();
     roots.dedup();
-    CollectedFiles { files, roots }
+    Ok(CollectedFiles { files, roots })
 }
 
-/// Extract a root directory and glob pattern from a user-provided pattern string.
-fn parse_pattern(pattern: &str) -> (String, String) {
-    if let Some(pos) = pattern.find(['*', '?']) {
-        let root_part = &pattern[..pos];
-        if let Some(last_slash) = root_part.rfind('/') {
-            let root = &pattern[..last_slash];
-            let root = if root.is_empty() { "." } else { root };
-            return (root.to_compact_string(), pattern.to_compact_string());
+fn classify_input(input: &str) -> Result<BuildInput<'_>, InputError<'_>> {
+    let path = Path::new(input);
+    if let Ok(metadata) = path.metadata() {
+        if metadata.is_file() {
+            return if is_vue_file(path) {
+                Ok(BuildInput::File(path))
+            } else {
+                Err(InputError::NonVueFile { input })
+            };
+        }
+        return if metadata.is_dir() {
+            Ok(BuildInput::Directory(path))
+        } else {
+            Err(InputError::MissingLiteral { input })
+        };
+    }
+
+    if contains_glob_metacharacter(input) {
+        Ok(BuildInput::Glob {
+            root: glob_root(input),
+            pattern: input,
+        })
+    } else {
+        Err(InputError::MissingLiteral { input })
+    }
+}
+
+fn glob_root(pattern: &str) -> PathBuf {
+    let metacharacter = pattern
+        .find(['*', '?', '['])
+        .expect("glob roots are only derived from classified glob inputs");
+    let literal_prefix = &pattern[..metacharacter];
+
+    literal_prefix.rfind(['/', '\\']).map_or_else(
+        || PathBuf::from("."),
+        |separator| {
+            // Retaining the separator preserves filesystem roots such as `/`
+            // and `C:\\` while remaining equivalent for ordinary directories.
+            PathBuf::from(&literal_prefix[..=separator])
+        },
+    )
+}
+
+fn collect_walked_files(root: &Path, pattern: Option<&str>, files: &mut Vec<PathBuf>) {
+    for entry in Walk::new(root).flatten() {
+        let path = entry.path();
+
+        if path.is_file()
+            && is_vue_file(path)
+            && pattern.is_none_or(|pattern| pattern_matches(path, pattern))
+        {
+            files.push(path.to_path_buf());
         }
     }
+}
 
-    let path = std::path::Path::new(pattern);
-    if path.is_dir() {
-        return (pattern.to_compact_string(), cstr!("{}/**/*.vue", pattern));
-    }
+#[inline]
+fn contains_glob_metacharacter(input: &str) -> bool {
+    input.contains(['*', '?', '['])
+}
 
-    if path.is_file()
-        && pattern.ends_with(".vue")
-        && let Some(parent) = path.parent()
-    {
-        let parent_str = parent.to_string_lossy();
-        let parent_str = if parent_str.is_empty() {
-            "."
-        } else {
-            &parent_str
-        };
-        return (parent_str.to_compact_string(), pattern.to_compact_string());
-    }
-
-    (".".into(), pattern.to_compact_string())
+#[inline]
+fn is_vue_file(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| extension == "vue")
 }
 
 /// Check whether a file path matches a glob-like pattern.
 #[allow(clippy::disallowed_types, clippy::disallowed_methods)]
-fn pattern_matches(path: &std::path::Path, pattern: &str) -> bool {
-    let path_str = path.to_string_lossy().replace("\\", "/");
+fn pattern_matches(path: &Path, pattern: &str) -> bool {
+    let path_str = path.to_string_lossy().replace('\\', "/");
+    let pattern = pattern.replace('\\', "/");
 
     if pattern == "./**/*.vue" || pattern == "**/*.vue" {
         return path_str.ends_with(".vue");
@@ -97,16 +178,14 @@ fn pattern_matches(path: &std::path::Path, pattern: &str) -> bool {
     }
 
     if pattern.ends_with(".vue") {
-        let pattern_normalized = pattern.replace("\\", "/");
-        if path_str == pattern_normalized {
+        if path_str == pattern {
             return true;
         }
-
-        if !path_str.ends_with(pattern_normalized.as_str()) {
+        if !path_str.ends_with(pattern.as_str()) {
             return false;
         }
 
-        let prefix_len = path_str.len() - pattern_normalized.len();
+        let prefix_len = path_str.len() - pattern.len();
         let Some(separator_idx) = prefix_len.checked_sub(1) else {
             return false;
         };
@@ -117,88 +196,4 @@ fn pattern_matches(path: &std::path::Path, pattern: &str) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::collect_files;
-    use std::{
-        fs,
-        path::{Path, PathBuf},
-    };
-    use vize_carton::ToCompactString;
-
-    #[test]
-    fn collect_files_ignores_vue_extension_directories() {
-        let root = unique_case_dir("build-vue-extension-directories");
-        let src = root.join("src");
-        let component_dir = src.join("Directory.vue");
-        let _ = fs::remove_dir_all(&root);
-        fs::create_dir_all(&component_dir).unwrap();
-        fs::write(src.join("App.vue"), "<template><div /></template>").unwrap();
-        fs::write(
-            component_dir.join("Nested.vue"),
-            "<template><div /></template>",
-        )
-        .unwrap();
-
-        let collected = collect_files(&vec![root.display().to_string()]);
-        let _ = fs::remove_dir_all(&root);
-
-        let mut expected = vec![component_dir.join("Nested.vue"), src.join("App.vue")];
-        expected.sort();
-        assert_eq!(collected.files, expected);
-        assert_eq!(collected.roots, vec![root]);
-    }
-
-    #[test]
-    fn collect_files_keeps_direct_vue_file_patterns() {
-        let root = unique_case_dir("build-direct-vue-file");
-        let src = root.join("src");
-        let _ = fs::remove_dir_all(&root);
-        fs::create_dir_all(&src).unwrap();
-        let app = src.join("App.vue");
-        let sibling = src.join("Sibling.vue");
-        fs::write(&app, "<template><div /></template>").unwrap();
-        fs::write(sibling, "<template><div /></template>").unwrap();
-
-        let collected = collect_files(&vec![app.display().to_string()]);
-        let _ = fs::remove_dir_all(&root);
-
-        assert_eq!(collected.files, vec![app]);
-        assert_eq!(collected.roots, vec![src]);
-    }
-
-    #[test]
-    fn collect_files_keeps_empty_searched_roots() {
-        let root = unique_case_dir("build-empty-searched-root");
-        let alpha = root.join("packages/alpha/src");
-        let beta = root.join("packages/beta/src");
-        let _ = fs::remove_dir_all(&root);
-        fs::create_dir_all(&alpha).unwrap();
-        fs::create_dir_all(&beta).unwrap();
-        let app = alpha.join("App.vue");
-        fs::write(&app, "<template><div /></template>").unwrap();
-
-        let collected = collect_files(&[
-            alpha.to_string_lossy().into_owned(),
-            beta.to_string_lossy().into_owned(),
-        ]);
-        let _ = fs::remove_dir_all(&root);
-
-        assert_eq!(collected.files, vec![app]);
-        assert_eq!(collected.roots, vec![alpha, beta]);
-    }
-
-    fn unique_case_dir(name: &str) -> PathBuf {
-        static NEXT_CASE_ID: std::sync::atomic::AtomicUsize =
-            std::sync::atomic::AtomicUsize::new(0);
-        let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("target")
-            .join("vize-tests")
-            .join(format!(
-                "{}-{}-{}",
-                name,
-                std::process::id(),
-                case_id.to_compact_string()
-            ))
-    }
-}
+mod tests;

--- a/crates/vize/src/commands/build/runner/collect/tests.rs
+++ b/crates/vize/src/commands/build/runner/collect/tests.rs
@@ -1,0 +1,174 @@
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use super::{
+    BuildInput, classify_input, collect_files, contains_glob_metacharacter, glob_root,
+    pattern_matches,
+};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+use vize_carton::ToCompactString;
+
+#[test]
+fn collect_files_ignores_vue_extension_directories() {
+    let root = unique_case_dir("build-vue-extension-directories");
+    let src = root.join("src");
+    let component_dir = src.join("Directory.vue");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&component_dir).unwrap();
+    fs::write(src.join("App.vue"), "<template><div /></template>").unwrap();
+    fs::write(
+        component_dir.join("Nested.vue"),
+        "<template><div /></template>",
+    )
+    .unwrap();
+
+    let collected = collect_files(&[root.display().to_string()]).unwrap();
+    let _ = fs::remove_dir_all(&root);
+
+    let mut expected = vec![component_dir.join("Nested.vue"), src.join("App.vue")];
+    expected.sort();
+    assert_eq!(collected.files, expected);
+    assert_eq!(collected.roots, vec![root]);
+}
+
+#[test]
+fn collect_files_keeps_direct_vue_file_patterns() {
+    let root = unique_case_dir("build-direct-vue-file");
+    let src = root.join("src");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&src).unwrap();
+    let app = src.join("App.vue");
+    fs::write(&app, "<template><div /></template>").unwrap();
+    fs::write(src.join("Sibling.vue"), "<template><div /></template>").unwrap();
+
+    let collected = collect_files(&[app.display().to_string()]).unwrap();
+    let _ = fs::remove_dir_all(&root);
+
+    assert_eq!(collected.files, vec![app]);
+    assert_eq!(collected.roots, vec![src]);
+}
+
+#[test]
+fn collect_files_keeps_empty_searched_roots() {
+    let root = unique_case_dir("build-empty-searched-root");
+    let alpha = root.join("packages/alpha/src");
+    let beta = root.join("packages/beta/src");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&alpha).unwrap();
+    fs::create_dir_all(&beta).unwrap();
+    let app = alpha.join("App.vue");
+    fs::write(&app, "<template><div /></template>").unwrap();
+
+    let collected = collect_files(&[
+        alpha.to_string_lossy().into_owned(),
+        beta.to_string_lossy().into_owned(),
+    ])
+    .unwrap();
+    let _ = fs::remove_dir_all(&root);
+
+    assert_eq!(collected.files, vec![app]);
+    assert_eq!(collected.roots, vec![alpha, beta]);
+}
+
+#[test]
+fn collect_files_rejects_missing_literals_but_accepts_empty_globs() {
+    let root = unique_case_dir("build-missing-literal");
+    let missing_literal = root.join("Missing.vue").display().to_string();
+    let error = collect_files(std::slice::from_ref(&missing_literal)).unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        format!("Build input does not exist: {missing_literal}")
+    );
+
+    let empty_glob = root.join("missing/**/*.vue").display().to_string();
+    assert!(
+        collect_files(std::slice::from_ref(&empty_glob))
+            .unwrap()
+            .files
+            .is_empty()
+    );
+}
+
+#[test]
+fn collect_files_rejects_non_vue_files_before_collecting_roots() {
+    let root = unique_case_dir("build-non-vue-literal");
+    let app = root.join("src/App.vue");
+    let readme = root.join("README.md");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(app.parent().unwrap()).unwrap();
+    fs::write(&app, "<template><div /></template>").unwrap();
+    fs::write(&readme, "not an SFC").unwrap();
+    let inputs = [app.display().to_string(), readme.display().to_string()];
+
+    let error = collect_files(&inputs).unwrap_err();
+    let _ = fs::remove_dir_all(&root);
+
+    assert_eq!(
+        error.to_string(),
+        format!("Build input is not a .vue file: {}", readme.display())
+    );
+}
+
+#[test]
+fn existing_paths_with_metacharacters_remain_literals() {
+    let root = unique_case_dir("build-literal-metacharacter");
+    let file = root.join("Component[old].vue");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    fs::write(&file, "<template><div /></template>").unwrap();
+
+    assert!(matches!(
+        classify_input(file.to_str().unwrap()).unwrap(),
+        BuildInput::File(path) if path == file
+    ));
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn classifies_windows_separators_and_glob_metacharacters_portably() {
+    let pattern = r"C:\workspace\src\**\*.vue";
+    let BuildInput::Glob {
+        root,
+        pattern: classified_pattern,
+    } = classify_input(pattern).unwrap()
+    else {
+        panic!("Windows-style glob should be classified as a glob");
+    };
+
+    assert_eq!(root.to_string_lossy(), r"C:\workspace\src\");
+    assert_eq!(classified_pattern, pattern);
+    assert!(contains_glob_metacharacter(r"src\?.vue"));
+    assert!(contains_glob_metacharacter(r"src\[AB].vue"));
+    assert!(!contains_glob_metacharacter(r"C:\workspace\src\App.vue"));
+    assert!(pattern_matches(
+        Path::new(r"C:\workspace\src\App.vue"),
+        pattern
+    ));
+}
+
+#[test]
+fn glob_roots_preserve_absolute_filesystem_roots() {
+    assert_eq!(glob_root("/**/*.vue"), PathBuf::from("/"));
+    assert_eq!(glob_root(r"C:\**\*.vue").to_string_lossy(), r"C:\");
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("vize-tests")
+        .join(format!(
+            "{}-{}-{}",
+            name,
+            std::process::id(),
+            case_id.to_compact_string()
+        ))
+}

--- a/crates/vize/tests/build_inputs_cli.rs
+++ b/crates/vize/tests/build_inputs_cli.rs
@@ -1,0 +1,144 @@
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+fn temp_project_dir(test_name: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "vize-build-inputs-cli-{}-{test_name}-{nonce}",
+        std::process::id()
+    ))
+}
+
+fn write_vue(root: &Path, relative_path: &str) {
+    let path = root.join(relative_path);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, "<template><div /></template>").unwrap();
+}
+
+fn run_build(root: &Path, inputs: &[&str], output: &str) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vize"));
+    command
+        .current_dir(root)
+        .args(["build", "--format", "js", "--output", output])
+        .args(inputs);
+    command.output().unwrap()
+}
+
+#[test]
+fn build_rejects_missing_relative_vue_literal_without_scanning_project() {
+    let root = temp_project_dir("missing-relative-file");
+    write_vue(&root, "src/Unrelated.vue");
+
+    let input = "src/Missing.vue";
+    let output = run_build(&root, &[input], "dist");
+
+    assert!(!output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!("Build input does not exist: {input}\n")
+    );
+    assert!(!root.join("dist").exists());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn build_rejects_missing_absolute_directory_literal_with_exact_input() {
+    let root = temp_project_dir("missing-absolute-directory");
+    fs::create_dir_all(&root).unwrap();
+    let input = format!(
+        "{}{}",
+        root.join("missing-components").display(),
+        std::path::MAIN_SEPARATOR
+    );
+
+    let output = run_build(&root, &[&input], "dist");
+
+    assert!(!output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!("Build input does not exist: {input}\n")
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn build_keeps_empty_glob_and_default_glob_diagnostics_distinct() {
+    let root = temp_project_dir("glob-semantics");
+    write_vue(&root, "src/Unrelated.vue");
+
+    let empty_glob = "src/Missing*.vue";
+    let empty = run_build(&root, &[empty_glob], "dist-empty");
+    assert!(!empty.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&empty.stderr),
+        "No .vue files found matching the patterns\n"
+    );
+
+    let default = run_build(&root, &[], "dist-default");
+    assert!(
+        default.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&default.stdout),
+        String::from_utf8_lossy(&default.stderr)
+    );
+    assert!(root.join("dist-default/src/Unrelated.js").is_file());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn build_accepts_relative_files_and_absolute_directories() {
+    let root = temp_project_dir("valid-literals");
+    write_vue(&root, "src/App.vue");
+
+    let relative = run_build(&root, &["src/App.vue"], "dist-relative");
+    assert!(
+        relative.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&relative.stderr)
+    );
+    assert!(root.join("dist-relative/App.js").is_file());
+
+    let absolute_directory = root.join("src").display().to_string();
+    let absolute = run_build(&root, &[&absolute_directory], "dist-absolute");
+    assert!(
+        absolute.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&absolute.stderr)
+    );
+    assert!(root.join("dist-absolute/App.js").is_file());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn build_rejects_existing_non_vue_literal_before_writing_other_inputs() {
+    let root = temp_project_dir("non-vue-file");
+    write_vue(&root, "src/App.vue");
+    fs::write(root.join("README.md"), "not an SFC").unwrap();
+
+    let output = run_build(&root, &["src/App.vue", "README.md"], "dist");
+
+    assert!(!output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Build input is not a .vue file: README.md\n"
+    );
+    assert!(!root.join("dist").exists());
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
Closes #2848

## Summary

- classify build inputs as literal files, literal directories, or glob patterns before walking
- reject nonexistent literals and existing non-`.vue` file literals with the exact input
- validate every literal before collection so invalid files cannot alter source-relative output roots
- preserve empty-glob behavior and the output planning introduced by #2850

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p vize commands::build::runner::collect::tests --lib`
- `cargo test -p vize --test build_inputs_cli --test build_output_paths_cli`
- `cargo clippy -p vize -- -D warnings -D clippy::wildcard_imports`
- focused integration-test Clippy
- `git diff --check`

## Focused follow-ups

- #2871 tracks complete `*`, `?`, character-class, and recursive glob semantics
- #2872 tracks distinct source identities across symlinked parents

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786441973&installation_id=136613492&pr_number=2875&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2875&signature=61fca656946d8e9d8210b5c98540656446cafbefcfac305ce30f54a804450281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build input validation for missing files, invalid directories, and non-Vue files.
  - Preserved correct handling of literal paths, directories, and glob patterns.
  - Prevented unintended project-wide scanning when explicit inputs are invalid.

- **Tests**
  - Added coverage for build input classification, cross-platform paths, glob behavior, and CLI success and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->