### PR TITLE
ci(e2e): add a fast pull-request readiness lane

### DIFF
--- a/.github/actions/app-readiness/action.yml
+++ b/.github/actions/app-readiness/action.yml
@@ -1,0 +1,152 @@
+name: App readiness
+description: Run the bounded compiler, lint, build, and dev readiness suites
+
+runs:
+  using: composite
+  steps:
+    - name: Hydrate pinned app fixtures
+      shell: bash
+      run: |
+        git submodule update --init --recursive --depth 1 \
+          tests/_fixtures/_git/elk \
+          tests/_fixtures/_git/misskey
+
+    - name: Setup Rust
+      id: rust-toolchain
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+    - name: Setup Wild linker
+      uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
+      with:
+        wild-version: "0.9.0"
+
+    - uses: ./.github/actions/setup-rust-sticky-cache
+      with:
+        key: app-readiness
+        cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('Cargo.lock') }}
+
+    - name: Setup Vite+ and Node.js
+      uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+      with:
+        node-version-file: ".node-version"
+        cache: true
+        run-install: false
+
+    - uses: ./.github/actions/setup-moonbit
+
+    - name: Install JS dependencies
+      shell: bash
+      run: |
+        vp install --frozen-lockfile --prefer-offline \
+          --filter './tests...' \
+          --filter './npm/native...' \
+          --filter './npm/cli...' \
+          --filter './npm/builder/vite...' \
+          --filter './npm/framework/nuxt...' \
+          --filter './npm/builder/vite-musea...' \
+          --filter './npm/framework/musea-nuxt...'
+
+    - name: Build native package
+      shell: bash
+      run: vp run --filter './npm/native' build:ci
+
+    - name: Build vize CLI
+      shell: bash
+      run: cargo build --profile ci -p vize
+
+    - name: Cache Playwright browsers
+      id: cache-playwright
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+    - name: Install Playwright OS dependencies
+      shell: bash
+      run: vp exec --filter './tests' -- playwright install-deps chromium
+
+    - name: Install Playwright browser
+      if: steps.cache-playwright.outputs.cache-hit != 'true'
+      shell: bash
+      run: vp exec --filter './tests' -- playwright install chromium
+
+    - name: Prepare readiness logs
+      shell: bash
+      run: mkdir -p target/app-readiness-logs
+
+    - name: Check compiler fixture
+      id: check
+      continue-on-error: true
+      shell: bash
+      run: |
+        set -o pipefail
+        vp run --filter './tests' test:readiness:check 2>&1 \
+          | tee target/app-readiness-logs/check.log
+
+    - name: Lint CLI fixture
+      id: lint
+      continue-on-error: true
+      shell: bash
+      run: |
+        set -o pipefail
+        vp run --filter './tests' test:readiness:lint 2>&1 \
+          | tee target/app-readiness-logs/lint.log
+
+    - name: Build compiler fixture
+      id: build
+      continue-on-error: true
+      shell: bash
+      run: |
+        set -o pipefail
+        vp run --filter './tests' test:readiness:build 2>&1 \
+          | tee target/app-readiness-logs/build.log
+
+    - name: Run representative dev smoke
+      id: dev
+      continue-on-error: true
+      shell: bash
+      run: |
+        set -o pipefail
+        vp run --filter './tests' test:readiness:dev 2>&1 \
+          | tee target/app-readiness-logs/dev.log
+
+    - name: Upload app readiness artifacts
+      if: ${{ failure() || steps.check.outcome == 'failure' || steps.lint.outcome == 'failure' || steps.build.outcome == 'failure' || steps.dev.outcome == 'failure' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: app-readiness-artifacts
+        path: |
+          target/app-readiness-logs/
+          tests/app/results/
+          tests/app/screenshots/
+          tests/app/playwright-report/
+          tests/playwright-report/
+        if-no-files-found: ignore
+        retention-days: 7
+
+    - name: Report app readiness
+      if: ${{ !cancelled() }}
+      shell: bash
+      env:
+        CHECK_OUTCOME: ${{ steps.check.outcome }}
+        LINT_OUTCOME: ${{ steps.lint.outcome }}
+        BUILD_OUTCOME: ${{ steps.build.outcome }}
+        DEV_OUTCOME: ${{ steps.dev.outcome }}
+      run: |
+        {
+          echo "## Fast app readiness"
+          echo
+          echo "| Suite | Outcome |"
+          echo "| --- | --- |"
+          echo "| check | $CHECK_OUTCOME |"
+          echo "| lint | $LINT_OUTCOME |"
+          echo "| build | $BUILD_OUTCOME |"
+          echo "| dev | $DEV_OUTCOME |"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        for outcome in "$CHECK_OUTCOME" "$LINT_OUTCOME" "$BUILD_OUTCOME" "$DEV_OUTCOME"; do
+          if [[ "$outcome" != "success" ]]; then
+            echo "::error title=Fast app readiness failed::See the failed Actions step, job summary, and captured suite logs in app-readiness-artifacts"
+            exit 1
+          fi
+        done

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,11 +1,11 @@
 name: App E2E
 
 on:
-  # App E2E (dev/preview/build/check/lint) and VRT are slow
-  # workflows that historically gated every PR. They are now run nightly and
-  # on demand so PR review latency is bounded by faster gates (Check,
-  # Benchmark, Native Smoke). Regressions caught by the nightly run still
-  # block release through the readiness gates.
+  # Keep PR feedback scoped to surfaces that can affect compiler/package/app
+  # behavior. The fast lane below uses focused pinned fixtures; the full
+  # App E2E and VRT matrices remain nightly/on-demand release evidence.
+  pull_request:
+    branches: [main]
   schedule:
     # 02:23 UTC daily (~11:23 JST). Covers every suite including vrt.
     - cron: "23 2 * * *"
@@ -37,7 +37,7 @@ on:
         required: false
         type: string
 
-run-name: App E2E ${{ github.event_name == 'workflow_dispatch' && (inputs.testbox_id || inputs.suite) || 'nightly' }} @ ${{ inputs.target_sha || github.sha }}
+run-name: App E2E ${{ github.event_name == 'pull_request' && format('readiness-pr-{0}', github.event.pull_request.number) || (github.event_name == 'workflow_dispatch' && (inputs.testbox_id || inputs.suite) || 'nightly') }} @ ${{ inputs.target_sha || github.sha }}
 
 concurrency:
   group: app-e2e-${{ github.event_name == 'workflow_dispatch' && (inputs.testbox_id || inputs.suite) || github.ref }}-${{ github.event_name == 'workflow_dispatch' && (inputs.target_sha || github.sha) || github.event_name }}
@@ -49,6 +49,74 @@ env:
   E2E_TARGET_SHA: ${{ inputs.target_sha || github.sha }}
 
 jobs:
+  app-readiness:
+    name: app-readiness
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 15
+    permissions:
+      contents: read # required by actions/checkout
+      pull-requests: read # required by dorny/paths-filter
+    env:
+      NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
+      VIZE_TEST_WORKTREE_ID: ci-readiness
+    steps:
+      # Keep this job present on every PR so it can be a required context.
+      # Irrelevant/docs-only changes stop after this read-only API query.
+      - name: Detect app readiness changes
+        id: changes
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            readiness:
+              - '.github/actions/app-readiness/**'
+              - '.cargo/**'
+              - '.github/actions/setup-moonbit/**'
+              - '.github/actions/setup-rust-sticky-cache/**'
+              - '.github/workflows/e2e.yml'
+              - '.gitmodules'
+              - '.node-version'
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - 'crates/**'
+              - 'npm/native/**'
+              - 'npm/cli/**'
+              - 'npm/builder/vite/**'
+              - 'npm/framework/nuxt/**'
+              - 'npm/builder/vite-musea/**'
+              - 'npm/framework/musea-nuxt/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'rust-toolchain.toml'
+              - 'tests/package.json'
+              - 'tests/tsconfig.json'
+              - 'tests/_fixtures/_git/elk'
+              - 'tests/_fixtures/_git/misskey'
+              - 'tests/_fixtures/_projects/compiler-macros/**'
+              - 'tests/_helpers/**'
+              - 'tests/app/dev/misskey.spec.ts'
+              - 'tests/app/playwright.config.ts'
+              - 'tests/snapshots/check/compiler-macros.ts'
+              - 'tests/snapshots/check/__snapshots__/compiler-macros-check.snap'
+              - 'tests/snapshots/build/elk.ts'
+              - 'tests/tooling/cli-lint-contract.test.ts'
+              - 'tools/moon/**'
+              - 'tools/vite-plus/**'
+              - 'tsconfig.json'
+              - 'tsconfig.node.json'
+              - 'vite.config.ts'
+
+      - name: Checkout readiness source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: steps.changes.outputs.readiness == 'true'
+        with:
+          persist-credentials: false
+
+      - name: Run app readiness
+        if: steps.changes.outputs.readiness == 'true'
+        uses: ./.github/actions/app-readiness
+
   testbox:
     name: Testbox
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.testbox_id != '' }}
@@ -121,7 +189,7 @@ jobs:
 
   app-e2e:
     name: app-e2e (${{ matrix.suite }})
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.testbox_id == '' }}
+    if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.testbox_id == '') }}
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 90
     permissions:

--- a/tests/package.json
+++ b/tests/package.json
@@ -11,6 +11,11 @@
     "test:inspect": "node --test --test-concurrency=1 snapshots/inspect/npmx.ts snapshots/inspect/elk.ts snapshots/inspect/vuefes.ts",
     "test:lint": "VIZE_TEST_WORKTREE_ID=${VIZE_TEST_WORKTREE_ID:-lint} node --test --test-concurrency=1 snapshots/lint/ant-design-vue.ts snapshots/lint/directus.ts snapshots/lint/element-plus.ts snapshots/lint/elk.ts snapshots/lint/hoppscotch.ts snapshots/lint/misskey.ts snapshots/lint/naive-ui.ts snapshots/lint/npmx.ts snapshots/lint/nuxt-ui.ts snapshots/lint/primevue.ts snapshots/lint/reka-ui.ts snapshots/lint/voicevox.ts snapshots/lint/vue-vben-admin.ts snapshots/lint/vuefes.ts snapshots/lint/vuetify.ts",
     "test:build": "node --test snapshots/build/elk.ts snapshots/build/misskey.ts snapshots/build/npmx.ts snapshots/build/vuefes.ts",
+    "test:readiness": "pnpm test:readiness:check && pnpm test:readiness:lint && pnpm test:readiness:build && pnpm test:readiness:dev",
+    "test:readiness:check": "node --test --test-concurrency=1 snapshots/check/compiler-macros.ts",
+    "test:readiness:lint": "node --test --test-concurrency=1 tooling/cli-lint-contract.test.ts",
+    "test:readiness:build": "node --test --test-concurrency=1 snapshots/build/elk.ts",
+    "test:readiness:dev": "VIZE_TEST_WORKTREE_ID=${VIZE_TEST_WORKTREE_ID:-ci-readiness} playwright test --config app/playwright.config.ts app/dev/misskey.spec.ts",
     "test:check:fixtures": "node --test --test-concurrency=1 snapshots/check/typecheck-errors.ts snapshots/check/typecheck-vue-imports.ts snapshots/check/compiler-macros.ts snapshots/check/style-preprocessors.ts snapshots/check/ecosystem-products.ts snapshots/check/generic-build.ts snapshots/check/nuxt-parity.ts snapshots/check/toolchain-parity.ts snapshots/check/options-api.ts snapshots/check/class-component.ts snapshots/check/zz-intentional-errors-fixtures.ts"
   },
   "devDependencies": {

--- a/tests/tooling/e2e-tasks.test.ts
+++ b/tests/tooling/e2e-tasks.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
@@ -38,6 +39,52 @@ test("workspace exposes app e2e task aliases with scoped cache inputs", () => {
   assert.match(taskGroups, /"test:e2e:vrt":\s*task\(runInPackages\("test:vrt", \["\.\/tests"\]\)/);
   assert.match(taskGroups, /input:\s*cacheInputs\.e2e/);
   assert.match(testPackage.scripts?.["test:dev:ci"] ?? "", /app\/dev\/nuxt-ui\.spec\.ts/);
+});
+
+test("fast app readiness aliases use bounded pinned fixtures", () => {
+  const testPackage = JSON.parse(readRepoFile("tests", "package.json")) as {
+    scripts?: Record<string, string>;
+  };
+  const scripts = testPackage.scripts ?? {};
+
+  assert.equal(
+    scripts["test:readiness"],
+    "pnpm test:readiness:check && pnpm test:readiness:lint && pnpm test:readiness:build && pnpm test:readiness:dev",
+  );
+  assert.equal(
+    scripts["test:readiness:check"],
+    "node --test --test-concurrency=1 snapshots/check/compiler-macros.ts",
+  );
+  assert.equal(
+    scripts["test:readiness:lint"],
+    "node --test --test-concurrency=1 tooling/cli-lint-contract.test.ts",
+  );
+  assert.equal(
+    scripts["test:readiness:build"],
+    "node --test --test-concurrency=1 snapshots/build/elk.ts",
+  );
+  assert.equal(
+    scripts["test:readiness:dev"],
+    "VIZE_TEST_WORKTREE_ID=${VIZE_TEST_WORKTREE_ID:-ci-readiness} playwright test --config app/playwright.config.ts app/dev/misskey.spec.ts",
+  );
+
+  assertExists("tests", "snapshots", "check", "compiler-macros.ts");
+  assertExists("tests", "tooling", "cli-lint-contract.test.ts");
+  assertExists("tests", "snapshots", "build", "elk.ts");
+  assertExists("tests", "app", "dev", "misskey.spec.ts");
+
+  for (const fixture of ["elk", "misskey"]) {
+    const gitlink = execFileSync(
+      "git",
+      ["ls-files", "--stage", `tests/_fixtures/_git/${fixture}`],
+      { cwd: root, encoding: "utf8" },
+    );
+    assert.match(
+      gitlink,
+      new RegExp(`^160000 [0-9a-f]{40} 0\\ttests/_fixtures/_git/${fixture}\\n$`),
+      `${fixture} must remain pinned to an exact gitlink commit`,
+    );
+  }
 });
 
 test("real-world browser smoke inventory stays wired into app e2e scripts", () => {

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -1,61 +1,215 @@
 import assert from "node:assert/strict";
-import fs from "node:fs";
-import path from "node:path";
 import { test } from "node:test";
-import { fileURLToPath } from "node:url";
 
-const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
 
-function readRepoFile(...segments: string[]): string {
-  return fs.readFileSync(path.join(root, ...segments), "utf8");
-}
+const yamlStepBody = (document: string, selector: { id: string } | { name: string }): string => {
+  const lines = document.split(/\r?\n/);
+  const marker = "id" in selector ? `id: ${selector.id}` : `- name: ${selector.name}`;
+  const markerIndex = lines.findIndex((line) => line.trim() === marker);
+  assert.notEqual(markerIndex, -1, `YAML step ${marker}`);
 
-test("app e2e workflow runs on schedule + workflow_dispatch and uploads failure artifacts", () => {
+  let start = markerIndex;
+  while (start >= 0 && !lines[start].trimStart().startsWith("- ")) start -= 1;
+  assert.ok(start >= 0, `YAML list item for ${marker}`);
+  const indentation = lines[start].search(/\S/);
+  let end = start + 1;
+  while (end < lines.length) {
+    const line = lines[end];
+    if (
+      line.trim() !== "" &&
+      line.search(/\S/) === indentation &&
+      line.trimStart().startsWith("- ")
+    ) {
+      break;
+    }
+    end += 1;
+  }
+  return lines.slice(start, end).join("\n");
+};
+
+test("full app e2e workflow remains nightly/on-demand and uploads failure artifacts", () => {
   const workflow = readRepoFile(".github", "workflows", "e2e.yml");
+  const appJob = workflowJobBody(workflow, "app-e2e");
 
-  // App E2E and VRT are slow and now run nightly on schedule plus on demand
-  // via workflow_dispatch. They no longer block PR merges (faster gates take
-  // over there). Regressions still gate release via the readiness pipeline.
+  // Expensive real-world matrices remain nightly/on-demand. Pull requests use
+  // the focused readiness job asserted below.
   assert.match(workflow, /schedule:[\s\S]*?- cron:\s*"/);
-  assert.doesNotMatch(workflow, /pull_request:/);
-  assert.match(workflow, /name: app-e2e \(\$\{\{ matrix\.suite \}\}\)/);
-  assert.match(workflow, /fail-fast:\s*false/);
+  assert.match(appJob, /name: app-e2e \(\$\{\{ matrix\.suite \}\}\)/);
+  assert.match(
+    appJob,
+    /if:\s*\$\{\{\s*github\.event_name != 'pull_request' && \(github\.event_name != 'workflow_dispatch' \|\| inputs\.testbox_id == ''\)\s*\}\}/,
+  );
+  assert.match(appJob, /fail-fast:\s*false/);
   // Scheduled runs exercise every suite, including vrt.
-  assert.match(workflow, /fromJSON\('\["dev","vrt","preview","build","check","lint"\]'\)/);
+  assert.match(appJob, /fromJSON\('\["dev","vrt","preview","build","check","lint"\]'\)/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /type:\s*choice/);
   assert.match(workflow, /- all/);
   assert.match(
-    workflow,
+    appJob,
     /github\.event_name == 'workflow_dispatch' && inputs\.suite != 'all' && fromJSON\(format\('\["\{0\}"\]', inputs\.suite\)\) \|\| fromJSON\('\["dev","vrt","preview","build","check","lint"\]'\)/,
   );
   for (const suite of ["dev", "vrt", "preview", "check", "lint", "build"]) {
     assert.match(workflow, new RegExp(`- ${suite}`));
-    assert.match(workflow, new RegExp(`${suite}\\)\\n\\s+`));
+    assert.match(appJob, new RegExp(`${suite}\\)\\n\\s+`));
   }
 
-  assert.match(workflow, /--filter '\.\/tests\.\.\.'/);
-  assert.match(workflow, /--filter '\.\/npm\/native\.\.\.'/);
-  assert.match(workflow, /--filter '\.\/npm\/builder\/vite\.\.\.'/);
-  assert.match(workflow, /Build native package/);
-  assert.match(workflow, /Build vize CLI/);
-  assert.match(workflow, /cargo build --profile ci -p vize/);
-  assert.match(workflow, /uses: \.\/\.github\/actions\/setup-moonbit/);
-  assert.match(workflow, /Cache Playwright browsers/);
-  assert.match(workflow, /contains\(fromJSON\('\["dev","vrt"\]'\), matrix\.suite\)/);
-  assert.match(workflow, /vp exec --filter '\.\/tests' -- playwright install --with-deps chromium/);
-  assert.match(workflow, /RUN_BUILD_TESTS=1 vp run --filter '\.\/tests' test:preview/);
-  assert.match(workflow, /vp run --filter '\.\/tests' test:dev:ci/);
-  assert.match(workflow, /vp run --filter '\.\/tests' test:check/);
-  assert.match(workflow, /vp run --filter '\.\/tests' test:lint/);
-  assert.doesNotMatch(workflow, /pnpm --dir tests/);
-  assert.match(workflow, /- name: Upload app e2e artifacts\s+if: failure\(\)/);
-  assert.match(workflow, /name: app-e2e-artifacts-\$\{\{ matrix\.suite \}\}/);
-  assert.match(workflow, /tests\/app\/results\//);
-  assert.match(workflow, /tests\/app\/screenshots\//);
-  assert.match(workflow, /tests\/app\/playwright-report\//);
-  assert.match(workflow, /tests\/playwright-report\//);
-  assert.match(workflow, /if-no-files-found:\s*ignore/);
+  assert.match(appJob, /--filter '\.\/tests\.\.\.'/);
+  assert.match(appJob, /--filter '\.\/npm\/native\.\.\.'/);
+  assert.match(appJob, /--filter '\.\/npm\/builder\/vite\.\.\.'/);
+  assert.match(appJob, /Build native package/);
+  assert.match(appJob, /Build vize CLI/);
+  assert.match(appJob, /cargo build --profile ci -p vize/);
+  assert.match(appJob, /uses: \.\/\.github\/actions\/setup-moonbit/);
+  assert.match(appJob, /Cache Playwright browsers/);
+  assert.match(appJob, /contains\(fromJSON\('\["dev","vrt"\]'\), matrix\.suite\)/);
+  assert.match(appJob, /vp exec --filter '\.\/tests' -- playwright install --with-deps chromium/);
+  assert.match(appJob, /RUN_BUILD_TESTS=1 vp run --filter '\.\/tests' test:preview/);
+  assert.match(appJob, /vp run --filter '\.\/tests' test:dev:ci/);
+  assert.match(appJob, /vp run --filter '\.\/tests' test:check/);
+  assert.match(appJob, /vp run --filter '\.\/tests' test:lint/);
+  assert.doesNotMatch(appJob, /pnpm --dir tests/);
+  assert.match(appJob, /- name: Upload app e2e artifacts\s+if: failure\(\)/);
+  assert.match(appJob, /name: app-e2e-artifacts-\$\{\{ matrix\.suite \}\}/);
+  assert.match(appJob, /tests\/app\/results\//);
+  assert.match(appJob, /tests\/app\/screenshots\//);
+  assert.match(appJob, /tests\/app\/playwright-report\//);
+  assert.match(appJob, /tests\/playwright-report\//);
+  assert.match(appJob, /if-no-files-found:\s*ignore/);
+});
+
+test("pull requests run one path-filtered fast app readiness job", () => {
+  const workflow = readRepoFile(".github", "workflows", "e2e.yml");
+  const job = workflowJobBody(workflow, "app-readiness");
+  const pullRequestBlock = workflow.slice(
+    workflow.indexOf("\n  pull_request:\n"),
+    workflow.indexOf("\n  schedule:\n"),
+  );
+
+  assert.match(pullRequestBlock, /branches:\s*\[main\]/);
+  assert.doesNotMatch(pullRequestBlock, /paths:/);
+  assert.match(
+    workflow,
+    /run-name:[^\n]*format\('readiness-pr-\{0\}', github\.event\.pull_request\.number\)/,
+  );
+
+  for (const path of [
+    "'.github/actions/app-readiness/**'",
+    "'.github/workflows/e2e.yml'",
+    "'.gitmodules'",
+    "'Cargo.lock'",
+    "'crates/**'",
+    "'npm/native/**'",
+    "'npm/cli/**'",
+    "'npm/builder/vite/**'",
+    "'npm/framework/nuxt/**'",
+    "'pnpm-lock.yaml'",
+    "'tests/package.json'",
+    "'tests/tsconfig.json'",
+    "'tests/_fixtures/_git/elk'",
+    "'tests/_fixtures/_git/misskey'",
+    "'tests/_fixtures/_projects/compiler-macros/**'",
+    "'tests/_helpers/**'",
+    "'tests/app/dev/misskey.spec.ts'",
+    "'tests/snapshots/check/compiler-macros.ts'",
+    "'tests/snapshots/build/elk.ts'",
+    "'tests/tooling/cli-lint-contract.test.ts'",
+    "'tools/moon/**'",
+    "'tools/vite-plus/**'",
+    "'tsconfig.json'",
+    "'vite.config.ts'",
+  ]) {
+    assert.match(job, new RegExp(`- ${path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  }
+  assert.doesNotMatch(job, /- ['"]docs\/\*\*/);
+  for (const broadPath of ["npm", "tests", "tools"]) {
+    assert.doesNotMatch(job, new RegExp(`- ['"]${broadPath}/\\*\\*['"]`));
+  }
+
+  assert.match(job, /if:\s*\$\{\{\s*github\.event_name == 'pull_request'\s*\}\}/);
+  assert.match(job, /runs-on:\s*blacksmith-32vcpu-ubuntu-2404/);
+  assert.match(job, /timeout-minutes:\s*15/);
+  assert.match(job, /contents:\s*read\s*# required by actions\/checkout/);
+  assert.match(job, /pull-requests:\s*read\s*# required by dorny\/paths-filter/);
+  assert.match(
+    job,
+    /uses:\s*dorny\/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706\s*# v4\.0\.2/,
+  );
+  assert.match(job, /id:\s*changes/);
+  assert.match(job, /filters:\s*\|\n\s+readiness:/);
+  const checkout = yamlStepBody(job, { name: "Checkout readiness source" });
+  assert.match(checkout, /uses:\s*actions\/checkout@[0-9a-f]{40}\s*# v6/);
+  assert.match(checkout, /if:\s*steps\.changes\.outputs\.readiness == 'true'/);
+  assert.match(checkout, /persist-credentials:\s*false/);
+  const readiness = yamlStepBody(job, { name: "Run app readiness" });
+  assert.match(readiness, /if:\s*steps\.changes\.outputs\.readiness == 'true'/);
+  assert.match(readiness, /uses:\s*\.\/\.github\/actions\/app-readiness/);
+  assert.doesNotMatch(job, /cargo build|vp run|app-readiness-artifacts/);
+});
+
+test("local app readiness action keeps setup, diagnostics, and aggregation bounded", () => {
+  const action = readRepoFile(".github", "actions", "app-readiness", "action.yml");
+
+  assert.match(action, /runs:\n\s+using:\s*composite/);
+  assert.match(
+    action,
+    /git submodule update --init --recursive --depth 1[\s\S]*tests\/_fixtures\/_git\/elk[\s\S]*tests\/_fixtures\/_git\/misskey/,
+  );
+  const setupRust = yamlStepBody(action, { name: "Setup Rust" });
+  assert.match(setupRust, /id:\s*rust-toolchain/);
+  assert.match(setupRust, /uses:\s*dtolnay\/rust-toolchain@[0-9a-f]{40}\s*# stable/);
+  assert.match(action, /uses:\s*wild-linker\/action@[0-9a-f]{40}\s*# v0\.9\.0/);
+  assert.match(action, /uses:\s*\.\/\.github\/actions\/setup-rust-sticky-cache/);
+  assert.match(
+    action,
+    /cache-key-suffix:[^\n]*steps\.rust-toolchain\.outputs\.cachekey[^\n]*hashFiles\('Cargo\.lock'\)/,
+  );
+  assert.match(action, /uses:\s*\.\/\.github\/actions\/setup-moonbit/);
+  assert.match(action, /cargo build --profile ci -p vize/);
+
+  const browserCache = yamlStepBody(action, { name: "Cache Playwright browsers" });
+  assert.match(browserCache, /id:\s*cache-playwright/);
+  const installDependencies = yamlStepBody(action, {
+    name: "Install Playwright OS dependencies",
+  });
+  assert.match(installDependencies, /shell:\s*bash/);
+  assert.match(
+    installDependencies,
+    /run:\s*vp exec --filter '\.\/tests' -- playwright install-deps chromium/,
+  );
+  const installBrowser = yamlStepBody(action, { name: "Install Playwright browser" });
+  assert.match(installBrowser, /if:\s*steps\.cache-playwright\.outputs\.cache-hit != 'true'/);
+  assert.match(installBrowser, /playwright install chromium/);
+  assert.doesNotMatch(action, /playwright install --with-deps chromium/);
+
+  for (const [id, script, log] of [
+    ["check", "test:readiness:check", "check.log"],
+    ["lint", "test:readiness:lint", "lint.log"],
+    ["build", "test:readiness:build", "build.log"],
+    ["dev", "test:readiness:dev", "dev.log"],
+  ] as const) {
+    const step = yamlStepBody(action, { id });
+    assert.match(step, /continue-on-error:\s*true/);
+    assert.match(step, /shell:\s*bash/);
+    assert.ok(step.includes(script));
+    assert.ok(step.includes(`tee target/app-readiness-logs/${log}`));
+  }
+
+  assert.match(action, /name:\s*app-readiness-artifacts/);
+  assert.match(action, /target\/app-readiness-logs\//);
+  assert.match(action, /if-no-files-found:\s*ignore/);
+  assert.match(action, /## Fast app readiness/);
+  for (const [outcome, step] of [
+    ["CHECK_OUTCOME", "check"],
+    ["LINT_OUTCOME", "lint"],
+    ["BUILD_OUTCOME", "build"],
+    ["DEV_OUTCOME", "dev"],
+  ]) {
+    assert.ok(action.includes(`${outcome}: \${{ steps.${step}.outcome }}`));
+  }
+  assert.match(action, /failed Actions step/);
+  assert.match(action, /captured suite logs in app-readiness-artifacts/);
 });
 
 test("app e2e dispatch pins validated exact-SHA checkouts and run evidence", () => {

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -11,6 +11,7 @@ import { readRepoFile, root, workflowJobBody } from "./support/github-workflows.
 test("PR CI jobs cap runtime with explicit timeouts", () => {
   const checkWorkflow = readRepoFile(".github", "workflows", "check.yml");
   const benchmarkWorkflow = readRepoFile(".github", "workflows", "benchmark.yml");
+  const e2eWorkflow = readRepoFile(".github", "workflows", "e2e.yml");
   const toolBenchmarkWorkflow = readRepoFile(".github", "workflows", "tool-benchmark.yml");
 
   for (const [jobName, minutes] of [
@@ -39,6 +40,8 @@ test("PR CI jobs cap runtime with explicit timeouts", () => {
       new RegExp(`timeout-minutes:\\s*${minutes}\\b`),
     );
   }
+
+  assert.match(workflowJobBody(e2eWorkflow, "app-readiness"), /timeout-minutes:\s*15\b/);
 
   for (const [jobName, minutes] of [
     ["pr-benchmark", 30],

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -171,7 +171,7 @@ test("App E2E workflow keeps Blacksmith Testbox dispatch hydration separate", ()
   assert.doesNotMatch(job, /vp run --workspace-root test|cargo test --workspace/);
   assert.match(
     appJob,
-    /if:\s*\$\{\{\s*github\.event_name != 'workflow_dispatch' \|\| inputs\.testbox_id == ''\s*\}\}/,
+    /if:\s*\$\{\{\s*github\.event_name != 'pull_request' && \(github\.event_name != 'workflow_dispatch' \|\| inputs\.testbox_id == ''\)\s*\}\}/,
   );
 });
 


### PR DESCRIPTION
Closes #2834

## Summary

- return a stable `app-readiness` check on every pull request, with lightweight success for unrelated changes
- run focused compiler snapshot, CLI lint, pinned Elk build, and pinned Misskey dev smokes for relevant paths
- keep the full nightly/dispatch E2E and VRT matrix unchanged
- isolate the bounded heavy lane in a local composite action with pinned setup, cache, Playwright, log, and artifact contracts
- aggregate all four suite outcomes without hiding later failures

## Safety and DX

- read-only contents and pull-request permissions
- full-SHA external action pins and exact fixture gitlinks
- checkout credentials are not persisted
- Playwright OS dependencies install even when the browser cache is warm
- docs-only changes still produce the future required context without provisioning the toolchain
- all changed source files remain below the 350-line limit

## Verification

- 65 workflow/task contract tests
- source-length regression suite
- `actionlint` with the repository's Blacksmith runner labels
- YAML parse
- `zizmor` with no findings
- `oxfmt --check`
- `oxlint`
- `git diff --check`

The PR changes a readiness path, so Actions will exercise the full lane before merge. The `app-readiness` ruleset requirement will be added only after this PR and its main run are green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786442333&installation_id=136613492&pr_number=2876&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2876&signature=508c7092cc62b639620ea55f17accb984a5e05b8d084bb412984932730670d12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pull-request “app readiness” workflow that runs only when app/compiler/package-related files change.
  * Runs compiler fixture checks, CLI linting, fixture builds, and a representative dev Playwright test.
  * Produces per-step diagnostic logs and aggregates results on failure.
* **Bug Fixes**
  * Tightened CI gating so longer e2e testbox runs don’t execute on pull requests.
  * Added explicit runtime limits for readiness.
* **Tests**
  * Added/updated checks to validate the readiness script chain, workflow configuration, and fixture immutability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->