### PR TITLE
fix(release): make crate dry-run rerun-safe

### DIFF
--- a/tests/tooling/moonbit-publish-crates.test.ts
+++ b/tests/tooling/moonbit-publish-crates.test.ts
@@ -18,12 +18,10 @@ type CargoPackage = {
   dependencies: CargoDependency[];
   manifest_path: string;
   publish: string[] | null;
+  version: string;
 };
 
-type CargoDependency = {
-  kind: "dev" | "build" | null;
-  name: string;
-};
+type CargoDependency = { name: string };
 
 function getScriptCrateArray(variableName: string): string[] {
   const scriptPath = path.join(repoRoot, "tools", "moon", "cmd", "publish_crates", "main.mbt");
@@ -70,14 +68,12 @@ test("publish_crates script keeps publishable workspace dependencies ordered", (
     assert.ok(pkg, `Missing package metadata for ${crateName}`);
 
     for (const dependency of pkg.dependencies) {
-      if (dependency.kind === "dev") {
-        continue;
-      }
-
       const dependencyOrder = publishOrder.get(dependency.name);
-      if (dependencyOrder == null) {
-        continue;
-      }
+      if (!packages.has(dependency.name)) continue;
+      assert.ok(
+        dependencyOrder != null,
+        `${crateName} cannot depend on deferred workspace crate ${dependency.name}`,
+      );
 
       const crateOrder = publishOrder.get(crateName);
       assert.ok(crateOrder != null, `Missing publish order for ${crateName}`);
@@ -114,10 +110,14 @@ test("publish_crates only blocks crates that depend on first-publish exclusions"
   assert.deepEqual(getBlockedByPendingFirstPublishCrates(), ["vize_canon", "vize_patina"]);
 });
 
-test("publish_crates runs as a native MoonBit script", () => {
+test("publish_crates native script covers publish and idempotent dry-run modes", () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "moonbit-publish-crates-"));
   const binDir = path.join(tempDir, "bin");
   const cargoLogPath = path.join(tempDir, "cargo.log");
+  const curlLogPath = path.join(tempDir, "curl.log");
+  const publishedCrates = getPublishedCrates();
+  const version = getMetadata().packages.find((pkg) => pkg.name === publishedCrates[0])?.version;
+  assert.ok(version);
 
   try {
     fs.mkdirSync(binDir, { recursive: true });
@@ -126,16 +126,30 @@ test("publish_crates runs as a native MoonBit script", () => {
       "cargo",
       [
         "const fs = require('node:fs');",
-        "fs.appendFileSync(process.env.CARGO_LOG, process.argv.slice(2).join(' ') + '\\n');",
-        "const [command] = process.argv.slice(2);",
-        "if (command === 'publish' || command === 'info') process.exit(0);",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.CARGO_LOG, args.join(' ') + '\\n');",
+        "const [command] = args;",
+        "if (command === 'package' && process.env.TEST_FAIL_PACKAGE) process.exit(1);",
+        "const unresolved = (process.env.TEST_UNRESOLVED_CRATES || '').split(',');",
+        "if (command === 'info' && unresolved.includes(args.at(-1).split('@')[0])) { console.error('not in registry index'); process.exit(1); }",
+        "if (command === 'package' || command === 'publish' || command === 'info') process.exit(0);",
         "process.exit(1);",
       ].join("\n"),
     );
     writeFakeCommand(
       binDir,
       "curl",
-      ["process.stdout.write(JSON.stringify({ versions: [] }));", "process.exit(0);"].join("\n"),
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "if (process.env.CURL_LOG) fs.appendFileSync(process.env.CURL_LOG, args.join(' ') + '\\n');",
+        "const crateName = args.at(-1).split('/').at(-1);",
+        "if (crateName === process.env.TEST_CURL_FAIL_CRATE) { console.error('registry unavailable'); process.exit(22); }",
+        "if (crateName === process.env.TEST_CURL_MALFORMED_CRATE) { process.stdout.write('{bad json'); process.exit(0); }",
+        "const published = (process.env.TEST_PUBLISHED_CRATES || '').split(',').includes(crateName);",
+        "const versions = published ? [{ num: process.env.TEST_PUBLISHED_VERSION }] : [];",
+        "process.stdout.write(JSON.stringify({ versions }));",
+      ].join("\n"),
     );
 
     const result = runMoonScript("publish_crates", [], {
@@ -150,10 +164,126 @@ test("publish_crates runs as a native MoonBit script", () => {
 
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
     const logLines = fs.readFileSync(cargoLogPath, "utf8").trim().split("\n");
-    assert.match(logLines[0] ?? "", /^publish -p vize_carton$/);
+    assert.match(logLines[0] ?? "", /^publish --locked -p vize_carton$/);
     assert.match(logLines[1] ?? "", /^info --registry crates-io vize_carton@/);
-    assert.match(logLines.at(-2) ?? "", /^publish -p vize_fresco$/);
+    assert.match(logLines.at(-2) ?? "", /^publish --locked -p vize_fresco$/);
     assert.match(logLines.at(-1) ?? "", /^info --registry crates-io vize_fresco@/);
+
+    const runDryRun = (alreadyPublished: string[], extraEnv: Record<string, string> = {}) => {
+      fs.writeFileSync(cargoLogPath, "");
+      fs.writeFileSync(curlLogPath, "");
+      return runMoonScript("publish_crates", ["--dry-run"], {
+        cwd: repoRoot,
+        env: {
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          CARGO_LOG: cargoLogPath,
+          CURL_LOG: curlLogPath,
+          TEST_PUBLISHED_CRATES: alreadyPublished.join(","),
+          TEST_PUBLISHED_VERSION: version,
+          ...extraEnv,
+        },
+      });
+    };
+    const expectedPackage = [
+      "package",
+      "--locked",
+      "--no-verify",
+      ...publishedCrates.flatMap((name) => ["-p", name]),
+    ].join(" ");
+    const expectedFrontier = (crateName: string) =>
+      ["publish", "--dry-run", "--locked", "-p", crateName].join(" ");
+    const expectedInfo = (crateName: string) => `info --registry crates-io ${crateName}@${version}`;
+
+    const nonePublished = runDryRun([]);
+    assert.equal(nonePublished.status, 0, nonePublished.stderr);
+    assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
+      expectedPackage,
+      expectedFrontier(publishedCrates[0]),
+    ]);
+    const curlCalls = fs.readFileSync(curlLogPath, "utf8").trim().split("\n");
+    assert.equal(curlCalls.length, 1);
+    assert.match(
+      curlCalls[0],
+      /--connect-timeout 5 --max-time 15 --retry 2 --retry-delay 1 --retry-all-errors/,
+    );
+
+    const somePublished = publishedCrates.slice(0, 5);
+    const partial = runDryRun(somePublished);
+    assert.equal(partial.status, 0, partial.stderr);
+    assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
+      expectedPackage,
+      ...somePublished.map(expectedInfo),
+      expectedFrontier(publishedCrates[5]),
+    ]);
+    assert.match(partial.stdout, /vize_carton .* already published and resolvable/i);
+    assert.match(partial.stdout, /registry-resolvable frontier vize_atelier_dom/i);
+    assert.equal(fs.readFileSync(curlLogPath, "utf8").trim().split("\n").length, 6);
+
+    const allPublished = runDryRun(publishedCrates);
+    assert.equal(allPublished.status, 0, allPublished.stderr);
+    assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
+      expectedPackage,
+      ...publishedCrates.map(expectedInfo),
+    ]);
+    assert.match(allPublished.stdout, /Every crate .* already published and resolvable/);
+
+    for (const [envName, diagnostic] of [
+      ["TEST_CURL_FAIL_CRATE", /curl exit 22/],
+      ["TEST_CURL_MALFORMED_CRATE", /invalid JSON/],
+    ] as const) {
+      const failedQuery = runDryRun([], { [envName]: publishedCrates[0] });
+      assert.notEqual(failedQuery.status, 0);
+      assert.match(failedQuery.stderr, diagnostic);
+      assert.equal(fs.readFileSync(cargoLogPath, "utf8").trim(), expectedPackage);
+      assert.equal(fs.readFileSync(curlLogPath, "utf8").trim().split("\n").length, 1);
+    }
+
+    const unresolvedPrefix = runDryRun(somePublished, {
+      TEST_UNRESOLVED_CRATES: publishedCrates[2],
+    });
+    assert.notEqual(unresolvedPrefix.status, 0);
+    assert.match(unresolvedPrefix.stderr, /could not resolve .*vize_armature/i);
+    assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
+      expectedPackage,
+      ...somePublished.slice(0, 3).map(expectedInfo),
+    ]);
+    assert.equal(fs.readFileSync(curlLogPath, "utf8").trim().split("\n").length, 3);
+
+    const unresolvedAll = runDryRun(publishedCrates, {
+      TEST_UNRESOLVED_CRATES: publishedCrates.at(-1) ?? "",
+    });
+    assert.notEqual(unresolvedAll.status, 0);
+    assert.match(unresolvedAll.stderr, /could not resolve .*vize_fresco/i);
+    assert.doesNotMatch(unresolvedAll.stdout, /Every crate/);
+    const unresolvedAllCargo = fs.readFileSync(cargoLogPath, "utf8");
+    assert.equal(
+      unresolvedAllCargo.trim().split("\n").at(-1),
+      expectedInfo(publishedCrates.at(-1) ?? ""),
+    );
+    assert.doesNotMatch(unresolvedAllCargo, /^publish --dry-run/m);
+
+    const packageFailure = runDryRun([], { TEST_FAIL_PACKAGE: "1" });
+    assert.notEqual(packageFailure.status, 0);
+    assert.match(packageFailure.stderr, /Crate package validation failed/);
+    assert.equal(fs.readFileSync(cargoLogPath, "utf8").trim(), expectedPackage);
+    assert.equal(fs.readFileSync(curlLogPath, "utf8"), "");
+
+    for (const invalidArgs of [["--unknown"], ["--dry-run", "extra"]]) {
+      fs.writeFileSync(cargoLogPath, "");
+      fs.writeFileSync(curlLogPath, "");
+      const invalid = runMoonScript("publish_crates", invalidArgs, {
+        cwd: repoRoot,
+        env: {
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          CARGO_LOG: cargoLogPath,
+          CURL_LOG: curlLogPath,
+        },
+      });
+      assert.notEqual(invalid.status, 0);
+      assert.match(invalid.stderr, /Usage: .*publish_crates.*\[--dry-run\]/);
+      assert.equal(fs.readFileSync(cargoLogPath, "utf8"), "");
+      assert.equal(fs.readFileSync(curlLogPath, "utf8"), "");
+    }
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }
@@ -173,7 +303,7 @@ test("publish_crates treats a non-zero cargo publish exit as success when the cr
         "const fs = require('node:fs');",
         "const args = process.argv.slice(2);",
         "fs.appendFileSync(process.env.CARGO_LOG, args.join(' ') + '\\n');",
-        "if (args[0] === 'publish' && args[2] === 'vize_carton') process.exit(1);",
+        "if (args[0] === 'publish' && args.at(-1) === 'vize_carton') process.exit(1);",
         "if (args[0] === 'publish' || args[0] === 'info') process.exit(0);",
         "process.exit(1);",
       ].join("\n"),
@@ -197,7 +327,7 @@ test("publish_crates treats a non-zero cargo publish exit as success when the cr
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
     assert.match(result.stdout, /already resolvable despite a non-zero cargo publish exit/i);
     const logLines = fs.readFileSync(cargoLogPath, "utf8").trim().split("\n");
-    assert.equal(logLines[0], "publish -p vize_carton");
+    assert.equal(logLines[0], "publish --locked -p vize_carton");
     assert.match(logLines[1] ?? "", /^info --registry crates-io vize_carton@/);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });

--- a/tools/moon/cmd/publish_crates/main.mbt
+++ b/tools/moon/cmd/publish_crates/main.mbt
@@ -88,89 +88,21 @@ fn workspace_version_from_content(content : String) -> String? {
   None
 }
 
-/// Returns `true` when the crates.io API already reports the target version.
-/// This check is used both before and after `cargo publish` so reruns and
-/// partial-success cases remain safe.
-fn json_has_published_version(value : Json, version : String) -> Bool {
-  guard value is Object(root) else { return false }
-  guard root.get("versions") is Some(Array(versions)) else { return false }
-  for item in versions {
-    guard item is Object(version_obj) else { continue }
-    if version_obj.get("num") is Some(String(num)) && num == version {
-      return true
-    }
-  }
-  false
-}
-
-/// Queries crates.io to see whether `crate_name@version` has already been published.
-async fn crate_is_published(crate_name : String, version : String) -> Bool {
-  let (exit_code, body) = @process.collect_stdout(
-    "curl",
-    [
-      "-sf",
-      "-H",
-      "User-Agent: vize-release-publish (https://github.com/ubugeeei-prod/vize)",
-      "https://crates.io/api/v1/crates/" + crate_name,
-    ],
-  )
-  if exit_code != 0 {
-    return false
-  }
-  let parsed = try {
-    @json.parse(body.text())
-  } catch {
-    _ => return false
-  }
-  json_has_published_version(parsed, version)
-}
-
-/// Checks whether the published crate can be resolved by Cargo.
-/// A crate may appear in the HTTP API before the registry index and Cargo
-/// metadata are fully updated. This helper verifies the state that downstream
-/// releases actually depend on.
-async fn crate_is_resolvable(crate_name : String, version : String) -> Bool {
-  let (exit_code, _, _) = @process.collect_output(
-    "cargo",
-    ["info", "--registry", "crates-io", crate_name + "@" + version],
-  )
-  exit_code == 0
-}
-
-/// Waits until `cargo info crate@version` succeeds or a timeout is reached.
-async fn wait_for_resolution(
-  crate_name : String,
-  version : String,
-  max_attempts : Int,
-  delay_seconds : Int,
-) -> Int {
-  let mut attempt = 1
-  while attempt <= max_attempts {
-    if crate_is_resolvable(crate_name, version) {
-      println("\{crate_name} v\{version} is resolvable from crates.io.")
-      return 0
-    }
-    if attempt >= max_attempts {
-      @stdio.stderr.write(
-        "Timed out waiting for \{crate_name} v\{version} to become resolvable from crates.io.\n",
-      )
-      return 1
-    }
-    println(
-      "Waiting for \{crate_name} v\{version} to become resolvable from crates.io... (\{attempt}/\{max_attempts})",
-    )
-    @async.sleep(delay_seconds * 1000)
-    attempt = attempt + 1
-  }
-  1
-}
-
 /// Main entry point for ordered and rerun-safe crates.io publishing.
 /// Each crate is published serially, retried on transient failure, and then
 /// verified through Cargo resolution before the next dependent crate is
 /// attempted. This avoids the common race where a dependent crate publishes
 /// before crates.io index propagation catches up.
 async fn run_app() -> Int {
+  let args = @tool.cli_args()
+  let dry_run = args.length() == 1 && args[0] == "--dry-run"
+  if !args.is_empty() && !dry_run {
+    @stdio.stderr.write(
+      "Usage: moon run --target native tools/moon/cmd/publish_crates -- [--dry-run]\n",
+    )
+    return 1
+  }
+
   let cargo_toml = match @tool.read_file_to_string("Cargo.toml") {
     Some(content) => content
     None => {
@@ -205,6 +137,65 @@ async fn run_app() -> Int {
     )
   }
 
+  if dry_run {
+    let package_args = ["package", "--locked", "--no-verify"]
+    for crate_name in published_crates {
+      package_args.push("-p")
+      package_args.push(crate_name)
+    }
+    println("Packaging the complete supported crate plan for v\{version}...")
+    if @process.run("cargo", package_args) != 0 {
+      @stdio.stderr.write("Crate package validation failed for v\{version}.\n")
+      return 1
+    }
+
+    let mut frontier : String? = None
+    for crate_name in published_crates {
+      match query_crate_version(crate_name, version) {
+        QueryFailed(message) => {
+          @stdio.stderr.write("Release registry check failed: " + message + "\n")
+          return 1
+        }
+        Missing => {
+          frontier = Some(crate_name)
+          break
+        }
+        Published =>
+          match crate_resolution_error(crate_name, version) {
+            Some(message) => {
+              @stdio.stderr.write("Release registry check failed: " + message + "\n")
+              return 1
+            }
+            None =>
+              println(
+                "\{crate_name} v\{version} is already published and resolvable.",
+              )
+          }
+      }
+    }
+    let frontier = match frontier {
+      Some(frontier) => frontier
+      None => {
+        println(
+          "Every crate in the v\{version} publish plan is already published and resolvable.",
+        )
+        return 0
+      }
+    }
+    println("Dry-running registry-resolvable frontier \{frontier} v\{version}...")
+    if @process.run(
+      "cargo",
+      ["publish", "--dry-run", "--locked", "-p", frontier],
+    ) != 0 {
+      @stdio.stderr.write("Crate publish dry-run failed for \{frontier} v\{version}.\n")
+      return 1
+    }
+    println(
+      "Package validation covered all supported crates; registry dry-run covered \{frontier}.",
+    )
+    return 0
+  }
+
   for crate_name in published_crates {
     println("Publishing \{crate_name} v\{version}...")
     if crate_is_published(crate_name, version) {
@@ -225,7 +216,7 @@ async fn run_app() -> Int {
     while attempt <= max_attempts {
       let (publish_exit, publish_stdout, publish_stderr) = @process.collect_output(
         "cargo",
-        ["publish", "-p", crate_name],
+        ["publish", "--locked", "-p", crate_name],
       )
       if publish_exit == 0 {
         published = true

--- a/tools/moon/cmd/publish_crates/registry.mbt
+++ b/tools/moon/cmd/publish_crates/registry.mbt
@@ -1,0 +1,132 @@
+/// Result of querying crates.io for one exact crate version.
+enum CrateVersionState {
+  Published
+  Missing
+  QueryFailed(String)
+}
+
+/// Parses the crates.io response without turning protocol failures into a
+/// false "not published" result.
+fn published_version_state(value : Json, crate_name : String, version : String) -> CrateVersionState {
+  guard value is Object(root) else {
+    return QueryFailed("crates.io returned a non-object response for \{crate_name}@\{version}")
+  }
+  guard root.get("versions") is Some(Array(versions)) else {
+    return QueryFailed("crates.io response for \{crate_name}@\{version} has no versions array")
+  }
+  for item in versions {
+    guard item is Object(version_obj) else {
+      return QueryFailed("crates.io returned an invalid version entry for \{crate_name}@\{version}")
+    }
+    guard version_obj.get("num") is Some(String(num)) else {
+      return QueryFailed("crates.io returned a version without num for \{crate_name}@\{version}")
+    }
+    if num == version {
+      return Published
+    }
+  }
+  Missing
+}
+
+/// Queries crates.io for an exact version. Dry-run callers consume the full
+/// state so transport and schema failures stop the release preflight.
+async fn query_crate_version(crate_name : String, version : String) -> CrateVersionState {
+  let (exit_code, body, stderr) = @process.collect_output(
+    "curl",
+    [
+      "-sf",
+      "--connect-timeout",
+      "5",
+      "--max-time",
+      "15",
+      "--retry",
+      "2",
+      "--retry-delay",
+      "1",
+      "--retry-all-errors",
+      "-H",
+      "User-Agent: vize-release-publish (https://github.com/ubugeeei-prod/vize)",
+      "https://crates.io/api/v1/crates/" + crate_name,
+    ],
+  )
+  if exit_code != 0 {
+    let detail = stderr.text().trim().to_owned()
+    let suffix = if detail == "" { "" } else { ": " + detail }
+    return QueryFailed(
+      "crates.io query for \{crate_name}@\{version} failed with curl exit \{exit_code}\{suffix}",
+    )
+  }
+  let parsed = try {
+    @json.parse(body.text())
+  } catch {
+    _ =>
+      return QueryFailed(
+        "crates.io returned invalid JSON for \{crate_name}@\{version}",
+      )
+  }
+  published_version_state(parsed, crate_name, version)
+}
+
+/// Actual publication preserves its conservative fallback: an inconclusive
+/// API query is treated as unpublished and delegated to cargo's idempotent
+/// publish/re-resolution path.
+async fn crate_is_published(crate_name : String, version : String) -> Bool {
+  match query_crate_version(crate_name, version) {
+    Published => true
+    Missing | QueryFailed(_) => false
+  }
+}
+
+/// Returns an actionable error when Cargo cannot resolve an allegedly
+/// published version from the registry index.
+async fn crate_resolution_error(crate_name : String, version : String) -> String? {
+  let (exit_code, stdout, stderr) = @process.collect_output(
+    "cargo",
+    ["info", "--registry", "crates-io", crate_name + "@" + version],
+  )
+  if exit_code == 0 {
+    return None
+  }
+  let detail = [stdout.text().trim().to_owned(), stderr.text().trim().to_owned()]
+    .filter(text => text != "")
+    .join("\n")
+  let suffix = if detail == "" { "" } else { "\n" + detail }
+  Some(
+    "Cargo could not resolve published prerequisite \{crate_name}@\{version} (exit \{exit_code})\{suffix}",
+  )
+}
+
+async fn crate_is_resolvable(crate_name : String, version : String) -> Bool {
+  match crate_resolution_error(crate_name, version) {
+    None => true
+    Some(_) => false
+  }
+}
+
+/// Waits until `cargo info crate@version` succeeds or a timeout is reached.
+async fn wait_for_resolution(
+  crate_name : String,
+  version : String,
+  max_attempts : Int,
+  delay_seconds : Int,
+) -> Int {
+  let mut attempt = 1
+  while attempt <= max_attempts {
+    if crate_is_resolvable(crate_name, version) {
+      println("\{crate_name} v\{version} is resolvable from crates.io.")
+      return 0
+    }
+    if attempt >= max_attempts {
+      @stdio.stderr.write(
+        "Timed out waiting for \{crate_name} v\{version} to become resolvable from crates.io.\n",
+      )
+      return 1
+    }
+    println(
+      "Waiting for \{crate_name} v\{version} to become resolvable from crates.io... (\{attempt}/\{max_attempts})",
+    )
+    @async.sleep(delay_seconds * 1000)
+    attempt = attempt + 1
+  }
+  1
+}


### PR DESCRIPTION
Closes #2874

## Summary

- add a credential-free dry-run mode to the canonical ordered crate publisher
- package all 11 supported crates with the lockfile before any registry credential is requested
- query exact target-version state and publish-dry-run only the first registry-resolvable unpublished frontier
- keep actual publication ordered, locked, retry-safe, and unchanged in scope
- bound crates.io API connection, request, and retry time

## Why

Cargo verifies a packaged crate against registry dependencies, not sibling packages selected in the same multi-package publish command. A new exact-version downstream crate is therefore not publish-dry-runnable until its internal dependencies reach crates.io.

The split validation is truthful: package construction covers the complete supported plan, while publish dry-run covers the currently resolvable frontier. Partial and complete reruns remain idempotent.

## Verification

- focused MoonBit/Node fixture suite: 6/6
- none-published, partial-prefix, all-published, package-failure, and invalid-argument contracts
- real `cargo package --locked --no-verify` for all 11 supported crates on clean main
- MoonBit parse
- `oxfmt --check`
- `oxlint`
- source-length growth check
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786442627&installation_id=136613492&pr_number=2877&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2877&signature=82bd89782061a8a2e7235c33899216d6ed235434137057088644a8bfde94db33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dry-run mode for publishing crates.
  * Added preflight packaging and registry checks to identify crates requiring publication.
  * Added readiness checks that wait for newly published crate versions to become resolvable.
  * Improved handling and reporting of registry, packaging, publishing, and command-line errors.

* **Bug Fixes**
  * Publishing now consistently uses locked dependency versions.
  * Improved detection of unavailable or malformed registry responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->