### PR TITLE
fix(tasks): keep default workspace workflows local

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,70 @@ cargo test -p <crate>
 
 Before opening a PR that changes shared tooling, release automation, native bindings, or compiler behavior, run the relevant workspace task from CI locally when practical.
 
+The root build, test, and lint workflows are local by default and need no hosted credentials:
+
+```sh
+vp run --workspace-root build
+vp run --workspace-root test
+vp run --workspace-root lint
+```
+
+Inside the Nix development shell, `vp build`, `vp test`, and `vp lint` are shorthand for these
+workspace tasks.
+
+For one-command Linux CI parity, enter the dedicated Testbox shell. The default `nix develop` shell
+intentionally omits Blacksmith and does not need its hosted artifact or credentials:
+
+```sh
+nix develop .#testbox
+```
+
+Then run the guarded lifecycle below. It clears any old box ID before warmup, skips remote tasks if
+authentication, push, or warmup fails, and always attempts to stop a successfully warmed box even
+when a task fails:
+
+```sh
+run_testbox_checks() {
+  unset BLACKSMITH_TESTBOX_ID testbox_output
+  "$VIZE_BLACKSMITH_BIN" auth login || return
+  git push --set-upstream origin "$(git branch --show-current)" || return
+
+  if testbox_output="$(vp run --workspace-root testbox:warmup)"; then
+    BLACKSMITH_TESTBOX_ID="$(printf '%s\n' "$testbox_output" | tail -n1)"
+  else
+    warmup_status=$?
+    unset testbox_output
+    return "$warmup_status"
+  fi
+  if [ -z "$BLACKSMITH_TESTBOX_ID" ]; then
+    printf '%s\n' "Testbox warmup returned no box id." >&2
+    unset BLACKSMITH_TESTBOX_ID testbox_output
+    return 1
+  fi
+  export BLACKSMITH_TESTBOX_ID
+
+  if vp run --workspace-root build:testbox &&
+    vp run --workspace-root test:testbox &&
+    vp run --workspace-root lint:testbox; then
+    testbox_status=0
+  else
+    testbox_status=$?
+  fi
+  if vp run --workspace-root testbox:stop; then
+    stop_status=0
+  else
+    stop_status=$?
+  fi
+  unset BLACKSMITH_TESTBOX_ID testbox_output
+
+  if [ "$testbox_status" -ne 0 ]; then
+    return "$testbox_status"
+  fi
+  return "$stop_status"
+}
+run_testbox_checks
+```
+
 For GitHub Actions changes, use `actrun` to lint or preview the workflow graph before pushing:
 
 ```sh

--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -45,6 +45,70 @@ cargo test -p <crate>
 Before opening a PR that changes shared tooling, release automation, native bindings, or compiler
 behavior, run the relevant workspace task from CI locally when practical.
 
+The root build, test, and lint workflows are local by default and need no hosted credentials:
+
+```sh
+vp run --workspace-root build
+vp run --workspace-root test
+vp run --workspace-root lint
+```
+
+Inside the Nix development shell, `vp build`, `vp test`, and `vp lint` are shorthand for these
+workspace tasks.
+
+For one-command Linux CI parity, enter the dedicated Testbox shell. The default `nix develop` shell
+intentionally omits Blacksmith and does not need its hosted artifact or credentials:
+
+```sh
+nix develop .#testbox
+```
+
+Then run the guarded lifecycle below. It clears any old box ID before warmup, skips remote tasks if
+authentication, push, or warmup fails, and always attempts to stop a successfully warmed box even
+when a task fails:
+
+```sh
+run_testbox_checks() {
+  unset BLACKSMITH_TESTBOX_ID testbox_output
+  "$VIZE_BLACKSMITH_BIN" auth login || return
+  git push --set-upstream origin "$(git branch --show-current)" || return
+
+  if testbox_output="$(vp run --workspace-root testbox:warmup)"; then
+    BLACKSMITH_TESTBOX_ID="$(printf '%s\n' "$testbox_output" | tail -n1)"
+  else
+    warmup_status=$?
+    unset testbox_output
+    return "$warmup_status"
+  fi
+  if [ -z "$BLACKSMITH_TESTBOX_ID" ]; then
+    printf '%s\n' "Testbox warmup returned no box id." >&2
+    unset BLACKSMITH_TESTBOX_ID testbox_output
+    return 1
+  fi
+  export BLACKSMITH_TESTBOX_ID
+
+  if vp run --workspace-root build:testbox &&
+    vp run --workspace-root test:testbox &&
+    vp run --workspace-root lint:testbox; then
+    testbox_status=0
+  else
+    testbox_status=$?
+  fi
+  if vp run --workspace-root testbox:stop; then
+    stop_status=0
+  else
+    stop_status=$?
+  fi
+  unset BLACKSMITH_TESTBOX_ID testbox_output
+
+  if [ "$testbox_status" -ne 0 ]; then
+    return "$testbox_status"
+  fi
+  return "$stop_status"
+}
+run_testbox_checks
+```
+
 For GitHub Actions changes, use `actrun` to lint or preview the workflow graph before pushing:
 
 ```sh

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -400,7 +400,7 @@ Zed starting point:
 
 ## Local Development
 
-This repository uses `Nix + Vite+ (vp)` for local development. In this workspace, `vp` will use `pnpm` automatically.
+Local tasks stay local; [CI parity](./contributing.md#common-checks) uses `nix develop .#testbox`.
 
 ```bash
 nix develop

--- a/flake.nix
+++ b/flake.nix
@@ -166,6 +166,27 @@
             }
           else
             null;
+        clearTestboxEnvironment = ''
+          unset VIZE_TESTBOX_SHELL VIZE_BLACKSMITH_BIN
+        '';
+        activateTestboxEnvironment = lib.optionalString (blacksmith != null) ''
+          export VIZE_TESTBOX_SHELL=1
+          export VIZE_BLACKSMITH_BIN="${blacksmith}/bin/blacksmith"
+        '';
+        testboxEnvironmentCheck =
+          assert blacksmith != null;
+          pkgs.runCommand "vize-testbox-environment" { } ''
+            export VIZE_TESTBOX_SHELL=inherited
+            export VIZE_BLACKSMITH_BIN=/host/blacksmith
+            ${clearTestboxEnvironment}
+            test -z "''${VIZE_TESTBOX_SHELL:-}"
+            test -z "''${VIZE_BLACKSMITH_BIN:-}"
+            ${activateTestboxEnvironment}
+            test "$VIZE_TESTBOX_SHELL" = 1
+            test "$VIZE_BLACKSMITH_BIN" = "${blacksmith}/bin/blacksmith"
+            test -x "$VIZE_BLACKSMITH_BIN"
+            touch "$out"
+          '';
         nodejs = pkgs.nodejs_24;
         pnpm = pkgs.pnpm;
         workspaceVp = pkgs.writeShellApplication {
@@ -200,7 +221,7 @@
             if local_vp="$(resolve_local_vp)"; then
               if [ "$current_dir" = "$workspace_root" ] && [ "$#" -eq 1 ]; then
                 case "$1" in
-                  check | fmt | dev | build)
+                  build | check | dev | fmt | lint | test | *:*)
                     exec "$local_vp" run --workspace-root "$1"
                     ;;
                 esac
@@ -331,6 +352,7 @@
           RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
 
           shellHook = ''
+            ${clearTestboxEnvironment}
             export VIZE_WORKSPACE_ROOT="$PWD"
             export PATH="${workspaceVp}/bin:$VIZE_WORKSPACE_ROOT/node_modules/.bin:$PATH"
             export PLAYWRIGHT_BROWSERS_PATH="$PWD/.cache/ms-playwright"
@@ -365,7 +387,7 @@
               ''echo "MoonBit native toolchain is not available for ${system}; install it separately if needed."''
             }
             echo "Run: vp install --frozen-lockfile"
-            echo "Then: vp check / vp fmt / vp dev / vp build"
+            echo "Local defaults: vp check / vp fmt / vp dev / vp build / vp test / vp lint"
           '';
         };
         testboxDevShell = devShell.overrideAttrs (previous: {
@@ -377,8 +399,12 @@
             ]
             ++ lib.optionals (blacksmith != null) [ blacksmith ];
           shellHook = (previous.shellHook or "") + ''
+            ${activateTestboxEnvironment}
             echo "Blacksmith Testbox tools ready (CLI ${blacksmithVersion})."
-            echo "First use: blacksmith auth login"
+            echo "Pinned CLI: $VIZE_BLACKSMITH_BIN"
+            echo 'First use: "$VIZE_BLACKSMITH_BIN" auth login'
+            echo "After pushing the current HEAD, see CONTRIBUTING.md for warmup and safe ID capture."
+            echo "Then: vp build:testbox / vp test:testbox / vp lint:testbox; stop with vp testbox:stop"
           '';
         });
       in
@@ -391,6 +417,7 @@
         checks = {
           package = vize;
           shell = devShell.inputDerivation;
+          testbox-environment = testboxEnvironmentCheck;
         };
 
         devShells = {

--- a/tests/tooling/local-default-tasks.test.ts
+++ b/tests/tooling/local-default-tasks.test.ts
@@ -1,0 +1,321 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { buildTasks } from "../../tools/vite-plus/tasks/build.ts";
+import { checkTasks } from "../../tools/vite-plus/tasks/check.ts";
+import { testAndBenchmarkTasks } from "../../tools/vite-plus/tasks/test-benchmark.ts";
+import { inTestbox, testboxTasks } from "../../tools/vite-plus/tasks/testbox.ts";
+import { shellQuote } from "../../tools/vite-plus/task-helpers.ts";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const pushCurrentBranchCommand = 'git push --set-upstream origin "$(git branch --show-current)"';
+
+const createFakeBlacksmith = (body: string) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "vize-blacksmith-"));
+  const executable = path.join(directory, "blacksmith");
+  fs.writeFileSync(executable, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+  return { directory, executable };
+};
+
+const extractTestboxLifecycle = (guide: string): string => {
+  const lifecycle = guide.match(
+    /```sh\n(run_testbox_checks\(\) \{[\s\S]*?\nrun_testbox_checks)\n```/,
+  )?.[1];
+  assert.ok(lifecycle, "guarded Testbox lifecycle");
+  return lifecycle;
+};
+
+type TaskShape = {
+  cache?: boolean;
+  command: string;
+};
+
+const taskShape = (value: unknown) => value as TaskShape;
+
+const assertLocalDefault = (
+  localValue: unknown,
+  testboxValue: unknown,
+  nestedTasks: readonly string[],
+) => {
+  const local = taskShape(localValue);
+  const testbox = taskShape(testboxValue);
+
+  assert.equal(local.cache, false);
+  assert.doesNotMatch(local.command, /blacksmith|BLACKSMITH_TESTBOX_ID/);
+  assert.equal(testbox.cache, false);
+  assert.match(
+    testbox.command,
+    /"\$VIZE_BLACKSMITH_BIN" testbox run --id "\$BLACKSMITH_TESTBOX_ID"/,
+  );
+
+  const expectedCommand = nestedTasks.map((task) => `vp run --workspace-root ${task}`).join(" && ");
+  assert.ok(local.command.includes(expectedCommand));
+  assert.ok(testbox.command.includes(shellQuote(expectedCommand)));
+
+  for (const nestedTask of nestedTasks) {
+    const command = `vp run --workspace-root ${nestedTask}`;
+    assert.ok(local.command.includes(command));
+    assert.ok(testbox.command.includes(command));
+  }
+};
+
+test("workspace build, test, and lint default to their local task graphs", () => {
+  assertLocalDefault(buildTasks.build, buildTasks["build:testbox"], ["build:rust", "build:all"]);
+  assertLocalDefault(testAndBenchmarkTasks.test, testAndBenchmarkTasks["test:testbox"], [
+    "test:rust",
+    "test:js",
+    "test:scripts",
+    "test:zed-extension:unit",
+  ]);
+  assertLocalDefault(checkTasks.lint, checkTasks["lint:testbox"], ["check"]);
+
+  const ci = taskShape(checkTasks.ci);
+  assert.equal(ci.cache, false);
+  assert.match(ci.command, /vp run --workspace-root test(?:\s|$)/);
+  assert.doesNotMatch(ci.command, /blacksmith|test:testbox/);
+});
+
+test("Testbox commands fail with an actionable lifecycle when the box id is absent", () => {
+  const result = spawnSync(
+    "/bin/sh",
+    ["-c", `blacksmith() { :; }\n${inTestbox("printf should-not-run")}`],
+    {
+      encoding: "utf8",
+      env: { PATH: "", VIZE_TESTBOX_SHELL: "1", VIZE_BLACKSMITH_BIN: process.execPath },
+    },
+  );
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /BLACKSMITH_TESTBOX_ID is unset/);
+  assert.match(result.stderr, /"\$VIZE_BLACKSMITH_BIN" auth login/);
+  assert.match(result.stderr, /git push --set-upstream origin/);
+  assert.match(result.stderr, /vp run --workspace-root testbox:warmup/);
+  assert.match(result.stderr, /guarded lifecycle in CONTRIBUTING\.md/);
+});
+
+test("Testbox commands require the dedicated Nix shell", () => {
+  const result = spawnSync("/bin/sh", ["-c", inTestbox("printf should-not-run")], {
+    encoding: "utf8",
+    env: { PATH: process.env.PATH ?? "" },
+  });
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /require the pinned Blacksmith environment/);
+  assert.match(result.stderr, /nix develop \.#testbox/);
+  assert.doesNotMatch(result.stderr, /BLACKSMITH_TESTBOX_ID is unset/);
+});
+
+test("Testbox commands reject an inherited marker without the pinned executable", () => {
+  const result = spawnSync("/bin/sh", ["-c", inTestbox("printf should-not-run")], {
+    encoding: "utf8",
+    env: { PATH: process.env.PATH ?? "", VIZE_TESTBOX_SHELL: "1" },
+  });
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Pinned Blacksmith CLI is unavailable/);
+  assert.doesNotMatch(result.stderr, /BLACKSMITH_TESTBOX_ID is unset/);
+});
+
+test("Testbox warmup diagnoses branch and authentication prerequisites", () => {
+  const command = taskShape(testboxTasks["testbox:warmup"]).command;
+  const syntax = spawnSync("sh", ["-n"], { encoding: "utf8", input: command });
+
+  assert.equal(syntax.status, 0, syntax.stderr);
+  assert.match(command, /git branch --show-current/);
+  assert.match(command, /git ls-remote --heads origin/);
+  assert.match(command, /git rev-parse HEAD/);
+  assert.match(command, /local_sha/);
+  assert.match(command, /remote_sha/);
+  assert.match(command, /could not query origin/);
+  assert.match(command, /git push --set-upstream origin/);
+  assert.match(command, /"\$VIZE_BLACKSMITH_BIN" testbox warmup \.github\/workflows\/e2e\.yml/);
+  assert.match(command, /--ref "\$branch" --job testbox/);
+  assert.match(
+    command,
+    new RegExp(pushCurrentBranchCommand.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+  );
+});
+
+test("Testbox warmup distinguishes origin failures from an unpushed branch", () => {
+  const command = taskShape(testboxTasks["testbox:warmup"]).command;
+  const fake = createFakeBlacksmith(
+    "printf '%s\\n' \"$*\" >> \"$FAKE_BLACKSMITH_LOG\"\nprintf '%s\\n' tbx_testbox_id",
+  );
+  const blacksmithLog = path.join(fake.directory, "calls.log");
+  const harness = [
+    "git() {",
+    '  if [ "$1" = "branch" ]; then printf \'%s\\n\' "$FAKE_BRANCH"; return; fi',
+    '  if [ "$1" = "rev-parse" ]; then printf \'%s\\n\' "$FAKE_LOCAL_SHA"; return; fi',
+    "  if [ \"$FAKE_REMOTE\" = \"error\" ]; then printf '%s\\n' 'credential detail that must stay hidden' >&2; return 3; fi",
+    '  if [ "$FAKE_REMOTE" != "missing" ]; then printf \'%s\\n\' "$FAKE_REMOTE_SHA refs/heads/$FAKE_BRANCH"; fi',
+    "}",
+    "blacksmith() { printf '%s\\n' 'host Blacksmith must not run' >&2; return 91; }",
+    command,
+  ].join("\n");
+
+  const runWarmup = (extraEnv: NodeJS.ProcessEnv) =>
+    spawnSync("sh", ["-c", harness], {
+      encoding: "utf8",
+      env: {
+        PATH: process.env.PATH ?? "",
+        VIZE_TESTBOX_SHELL: "1",
+        VIZE_BLACKSMITH_BIN: fake.executable,
+        FAKE_BLACKSMITH_LOG: blacksmithLog,
+        FAKE_BRANCH: "feature/testbox",
+        FAKE_LOCAL_SHA: "deadbeef",
+        FAKE_REMOTE_SHA: "deadbeef",
+        ...extraEnv,
+      },
+    });
+
+  try {
+    const remoteError = runWarmup({ FAKE_REMOTE: "error" });
+    assert.equal(remoteError.status, 2);
+    assert.match(remoteError.stderr, /could not query origin/);
+    assert.doesNotMatch(remoteError.stderr, /credential detail/);
+
+    const hostileBranch = "feature/'$(printf-pwned)'";
+    assert.equal(spawnSync("git", ["check-ref-format", "--branch", hostileBranch]).status, 0);
+    const missingBranch = runWarmup({ FAKE_REMOTE: "missing", FAKE_BRANCH: hostileBranch });
+    assert.equal(missingBranch.status, 2);
+    assert.match(missingBranch.stderr, /cannot find the current branch on origin/);
+    assert.ok(missingBranch.stderr.includes(`Push it first: ${pushCurrentBranchCommand}`));
+    assert.ok(!missingBranch.stderr.includes(hostileBranch));
+
+    const staleBranch = runWarmup({ FAKE_REMOTE: "found", FAKE_LOCAL_SHA: "cafebabe" });
+    assert.equal(staleBranch.status, 2);
+    assert.match(staleBranch.stderr, /needs the current HEAD on origin/);
+    assert.ok(staleBranch.stderr.includes(`Push it first: ${pushCurrentBranchCommand}`));
+
+    const success = runWarmup({ FAKE_REMOTE: "found" });
+    assert.equal(success.status, 0);
+    assert.equal(success.stdout, "tbx_testbox_id\n");
+    assert.doesNotMatch(success.stderr, /host Blacksmith/);
+    assert.match(
+      fs.readFileSync(blacksmithLog, "utf8"),
+      /^testbox warmup \.github\/workflows\/e2e\.yml --ref feature\/testbox --job testbox\n$/,
+    );
+  } finally {
+    fs.rmSync(fake.directory, { recursive: true, force: true });
+  }
+});
+
+test("the Nix shell exposes local and opt-in Testbox task aliases", () => {
+  const flake = fs.readFileSync(path.join(root, "flake.nix"), "utf8");
+  const defaultShell = flake.match(
+    /devShell = pkgs\.mkShell \{([\s\S]*?)\n\s*\};\n\s*testboxDevShell/,
+  )?.[1];
+  const testboxShell = flake.match(
+    /testboxDevShell = devShell\.overrideAttrs \(previous: \{([\s\S]*?)\n\s*\}\);/,
+  )?.[1];
+
+  for (const taskName of ["build", "test", "lint"]) {
+    assert.match(flake, new RegExp(`(?:\\||\\s)${taskName}(?:\\s|\\||\\))`));
+  }
+
+  assert.match(flake, /\| \*:\*\)/);
+  assert.match(flake, /exec "\$local_vp" run --workspace-root "\$1"/);
+  assert.ok(defaultShell, "default dev shell");
+  assert.match(defaultShell, /\$\{clearTestboxEnvironment\}/);
+  assert.doesNotMatch(defaultShell, /activateTestboxEnvironment/);
+  assert.ok(testboxShell, "Testbox dev shell");
+  assert.match(testboxShell, /\$\{activateTestboxEnvironment\}/);
+  assert.match(flake, /unset VIZE_TESTBOX_SHELL VIZE_BLACKSMITH_BIN/);
+  assert.match(flake, /export VIZE_TESTBOX_SHELL=1/);
+  assert.match(flake, /export VIZE_BLACKSMITH_BIN="\$\{blacksmith\}\/bin\/blacksmith"/);
+  assert.match(flake, /testbox-environment = testboxEnvironmentCheck/);
+  assert.match(testboxShell, /safe ID capture/);
+  assert.match(testboxShell, /vp build:testbox \/ vp test:testbox \/ vp lint:testbox/);
+});
+
+test("contributor docs use workspace-explicit commands outside the Nix aliases", () => {
+  for (const relativePath of ["CONTRIBUTING.md", "docs/content/contributing.md"]) {
+    const guide = fs.readFileSync(path.join(root, relativePath), "utf8");
+
+    for (const taskName of ["build", "test", "lint"]) {
+      assert.match(guide, new RegExp(`vp run --workspace-root ${taskName}`));
+    }
+    assert.match(guide, /Inside the Nix development shell/);
+    assert.match(guide, /nix develop \.#testbox/);
+    assert.match(guide, /default `nix develop` shell\s+intentionally omits Blacksmith/);
+    const lifecycle = extractTestboxLifecycle(guide);
+    assert.ok(
+      lifecycle.indexOf("unset BLACKSMITH_TESTBOX_ID") < lifecycle.indexOf("testbox:warmup"),
+    );
+    assert.match(lifecycle, /"\$VIZE_BLACKSMITH_BIN" auth login/);
+    assert.match(lifecycle, /if testbox_output="\$\(vp run --workspace-root testbox:warmup\)"/);
+    assert.match(lifecycle, /if vp run --workspace-root testbox:stop/);
+  }
+});
+
+test("documented Testbox lifecycle rejects stale ids and always stops after task failure", () => {
+  const guides = ["CONTRIBUTING.md", "docs/content/contributing.md"].map((relativePath) =>
+    fs.readFileSync(path.join(root, relativePath), "utf8"),
+  );
+  const lifecycle = extractTestboxLifecycle(guides[0]);
+  assert.equal(extractTestboxLifecycle(guides[1]), lifecycle);
+  const definition = lifecycle.replace(/\nrun_testbox_checks$/, "");
+  const fake = createFakeBlacksmith('[ "$1 $2" = "auth login" ]');
+  const log = path.join(fake.directory, "lifecycle.log");
+  const harness = [
+    'git() { if [ "$1" = "branch" ]; then printf \'%s\\n\' feature/testbox; fi; }',
+    "vp() {",
+    '  printf \'%s|id=%s\\n\' "$*" "${BLACKSMITH_TESTBOX_ID-unset}" >> "$FAKE_LIFECYCLE_LOG"',
+    '  case "$*" in',
+    '    "run --workspace-root testbox:warmup")',
+    "      if [ \"$FAKE_WARMUP_STATUS\" -eq 0 ]; then printf '%s\\n' fresh-box; fi",
+    '      return "$FAKE_WARMUP_STATUS" ;;',
+    '    "run --workspace-root build:testbox") return "${FAKE_TASK_STATUS:-0}" ;;',
+    '    "run --workspace-root testbox:stop") return "${FAKE_STOP_STATUS:-0}" ;;',
+    "  esac",
+    "}",
+    definition,
+    "run_testbox_checks",
+    "lifecycle_status=$?",
+    'printf \'final|id=%s\\n\' "${BLACKSMITH_TESTBOX_ID-unset}" >> "$FAKE_LIFECYCLE_LOG"',
+    'exit "$lifecycle_status"',
+  ].join("\n");
+  const runLifecycle = (extraEnv: NodeJS.ProcessEnv) =>
+    spawnSync("/bin/sh", ["-c", harness], {
+      encoding: "utf8",
+      env: {
+        PATH: process.env.PATH ?? "",
+        VIZE_BLACKSMITH_BIN: fake.executable,
+        FAKE_LIFECYCLE_LOG: log,
+        BLACKSMITH_TESTBOX_ID: "stale-box",
+        ...extraEnv,
+      },
+    });
+
+  try {
+    const failedWarmup = runLifecycle({ FAKE_WARMUP_STATUS: "17" });
+    assert.equal(failedWarmup.status, 17);
+    assert.equal(
+      fs.readFileSync(log, "utf8"),
+      "run --workspace-root testbox:warmup|id=unset\nfinal|id=unset\n",
+    );
+
+    fs.writeFileSync(log, "");
+    const failedTask = runLifecycle({ FAKE_WARMUP_STATUS: "0", FAKE_TASK_STATUS: "23" });
+    assert.equal(failedTask.status, 23);
+    assert.equal(
+      fs.readFileSync(log, "utf8"),
+      [
+        "run --workspace-root testbox:warmup|id=unset",
+        "run --workspace-root build:testbox|id=fresh-box",
+        "run --workspace-root testbox:stop|id=fresh-box",
+        "final|id=unset",
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    fs.rmSync(fake.directory, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/nix-testbox.test.ts
+++ b/tests/tooling/nix-testbox.test.ts
@@ -24,10 +24,17 @@ test("Nix isolates the pinned Blacksmith CLI from the default dev shell", () => 
   assert.ok(defaultShell, "default dev shell");
   assert.ok(testboxShell, "Testbox dev shell");
   assert.doesNotMatch(defaultShell, /blacksmith/i);
+  assert.doesNotMatch(defaultShell, /VIZE_TESTBOX_SHELL/);
+  assert.match(defaultShell, /\$\{clearTestboxEnvironment\}/);
   assert.match(testboxShell, /previous\.nativeBuildInputs/);
   assert.match(testboxShell, /pkgs\.gh/);
   assert.match(testboxShell, /pkgs\.rsync/);
   assert.match(testboxShell, /\[ blacksmith \]/);
+  assert.match(testboxShell, /\$\{activateTestboxEnvironment\}/);
+  assert.match(flake, /unset VIZE_TESTBOX_SHELL VIZE_BLACKSMITH_BIN/);
+  assert.match(flake, /export VIZE_TESTBOX_SHELL=1/);
+  assert.match(flake, /export VIZE_BLACKSMITH_BIN="\$\{blacksmith\}\/bin\/blacksmith"/);
+  assert.match(flake, /testbox-environment = testboxEnvironmentCheck/);
   assert.match(flake, /blacksmithVersion = "0\.4\.46";/);
   assert.ok(sourceUrls.length > 0, "fixed-output source URLs");
   for (const sourceUrl of sourceUrls) assert.doesNotMatch(sourceUrl, /\/latest\//);

--- a/tools/vite-plus/tasks/build.ts
+++ b/tools/vite-plus/tasks/build.ts
@@ -20,6 +20,7 @@ const packageVscodeExtension = [
   "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
   injectVscodeTypeScriptPlugin,
 ].join(" && ");
+const localBuildCommand = runTasks("build:rust", "build:all");
 
 /**
  * Build and packaging tasks for the repository's compiled artifacts.
@@ -31,9 +32,10 @@ const packageVscodeExtension = [
  * forcing unrelated test or release commands into the same module.
  */
 export const buildTasks = defineTasks({
-  // `vp build` runs inside a Blacksmith Testbox; the underlying build:* tasks
-  // stay local. See tools/vite-plus/tasks/testbox.ts.
-  build: noCacheTask(inTestbox(runTasks("build:rust", "build:all"))),
+  // Local is the default so a clean checkout never needs hosted credentials.
+  // Testbox remains an explicit CI-parity opt-in with the same task graph.
+  build: noCacheTask(localBuildCommand),
+  "build:testbox": noCacheTask(inTestbox(localBuildCommand)),
   "build:all": noCacheTask(runTasks("build:runtime", "package:editor-extensions")),
   "build:rust": task("cargo build --workspace", { input: cacheInputs.rust }),
   "build:runtime": noCacheTask(runTasks("build:native", "build:wasm", "build:packages")),

--- a/tools/vite-plus/tasks/check.ts
+++ b/tools/vite-plus/tasks/check.ts
@@ -24,6 +24,7 @@ import { inTestbox } from "./testbox.ts";
 const ciPackageCheckCommand = runInPackages("check", ciCheckedPackages, {
   concurrencyLimit: 1,
 });
+const localLintCommand = runTask("check");
 const directPackageCheckCommand = runPackageScriptDirectly("check", directCheckPackages);
 const rustClippyCommand = "cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports";
 const strictRepoCheckCommand = moonScript("check_warning_budget", "--", localVp, "check");
@@ -86,8 +87,8 @@ export const checkTasks = defineTasks({
   "fmt:js": noCacheTask(runInPackages("fmt", checkedPackages)),
   "fmt:rust": task("cargo fmt --all", { input: cacheInputs.rust }),
   "fmt:all": noCacheTask(runTask("fmt")),
-  // `vp lint` runs inside a Blacksmith Testbox; `check` stays local.
-  lint: noCacheTask(inTestbox(runTask("check"))),
+  lint: noCacheTask(localLintCommand),
+  "lint:testbox": noCacheTask(inTestbox(localLintCommand)),
   "lint:fix": noCacheTask(runTask("check:fix")),
   "lint:rust": task(rustClippyCommand, { input: cacheInputs.rust }),
   "lint:all": noCacheTask(runTasks("lint:rust", "check")),

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -19,6 +19,12 @@ const packageVscodeExtension = [
   "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
   injectVscodeTypeScriptPlugin,
 ].join(" && ");
+const localTestCommand = runTasks(
+  "test:rust",
+  "test:js",
+  "test:scripts",
+  "test:zed-extension:unit",
+);
 
 const jsPackageTestCommand = runInPackages("test", testedPackages, {
   concurrencyLimit: 1,
@@ -84,11 +90,8 @@ const rustBranchCoverageCommand = [
  * performance regressions difficult to miss.
  */
 export const testAndBenchmarkTasks = defineTasks({
-  // `vp test` runs inside a Blacksmith Testbox; the underlying test:* tasks
-  // stay local. See tools/vite-plus/tasks/testbox.ts.
-  test: noCacheTask(
-    inTestbox(runTasks("test:rust", "test:js", "test:scripts", "test:zed-extension:unit")),
-  ),
+  test: noCacheTask(localTestCommand),
+  "test:testbox": noCacheTask(inTestbox(localTestCommand)),
   "test:rust": task("cargo test --workspace", { input: cacheInputs.rust }),
   // Use the CI-profile native build instead of the release-profile one.
   // The release build was ~3m+ on GitHub Actions and was being immediately

--- a/tools/vite-plus/tasks/testbox.ts
+++ b/tools/vite-plus/tasks/testbox.ts
@@ -5,24 +5,54 @@ import { defineTasks, noCacheTask, shellQuote } from "../task-helpers.ts";
  *
  * A testbox syncs the local working tree to a Blacksmith Linux microVM that is
  * running the real CI environment, then executes commands there (1-3s
- * incremental syncs after the first). This lets `vp test|lint|build` run
- * against the exact CI toolchain from a macOS workstation.
+ * incremental syncs after the first). The default build, test, and lint tasks
+ * stay local; their `*:testbox` variants run the same graph in the CI image.
  *
- * The CLI ships from the dev shell (see the `blacksmith` derivation in
- * flake.nix). `blacksmith testbox run` requires an explicit `--id` on every
- * call and has no concept of a "current" box, so the id is threaded through
- * `BLACKSMITH_TESTBOX_ID`. Typical flow:
- *
- *   # once per session — warms a box from the current Git branch.
- *   export BLACKSMITH_TESTBOX_ID="$(vp testbox:warmup | tail -n1)"
- *   vp test        # runs the suite inside the box
- *   vp testbox:stop
- *
- * `tail -n1` assumes warmup prints the id last; adjust once verified against a
- * real run. Auth is interactive on first use (browser login).
+ * The CLI ships only from the dedicated Testbox shell (`nix develop
+ * .#testbox`; see the `blacksmith` derivation in flake.nix). `blacksmith
+ * testbox run` requires an explicit `--id` on every call and has no concept of
+ * a "current" box, so the id is threaded through `BLACKSMITH_TESTBOX_ID`.
+ * The documented lifecycle clears any stale id before warmup, exports a new id
+ * only after success, and always stops a successfully warmed box after tasks.
+ * Warmup returns the box id on stdout; `tail -n1` keeps the exported value
+ * stable if the CLI also prints progress. Auth is interactive on first use.
  */
-const REQUIRE_ID =
-  "${BLACKSMITH_TESTBOX_ID:?BLACKSMITH_TESTBOX_ID is unset — warm a box first: vp testbox:warmup}";
+const blacksmithBin = '"$VIZE_BLACKSMITH_BIN"';
+const pushCurrentBranchCommand = 'git push --set-upstream origin "$(git branch --show-current)"';
+const missingShellDiagnostic = [
+  "Testbox tasks require the pinned Blacksmith environment.",
+  "Enter the dedicated shell first: nix develop .#testbox",
+];
+const requireBlacksmithCli = [
+  'if [ "${VIZE_TESTBOX_SHELL:-}" != "1" ]; then',
+  `  printf '%s\\n' ${missingShellDiagnostic.map(shellQuote).join(" ")} >&2`,
+  "  exit 2",
+  "fi",
+  'if [ -z "${VIZE_BLACKSMITH_BIN:-}" ] || [ ! -x "$VIZE_BLACKSMITH_BIN" ]; then',
+  `  printf '%s\\n' ${shellQuote(
+    "Pinned Blacksmith CLI is unavailable inside the Testbox shell. Exit and re-enter: nix develop .#testbox",
+  )} >&2`,
+  "  exit 2",
+  "fi",
+].join("\n");
+
+const missingIdDiagnostic = [
+  "BLACKSMITH_TESTBOX_ID is unset.",
+  "Use the guarded lifecycle in CONTRIBUTING.md. It clears stale ids before warmup:",
+  "  unset BLACKSMITH_TESTBOX_ID",
+  '  "$VIZE_BLACKSMITH_BIN" auth login',
+  `  ${pushCurrentBranchCommand}`,
+  "  vp run --workspace-root testbox:warmup",
+];
+const requireTestboxId = [
+  'if [ -z "${BLACKSMITH_TESTBOX_ID:-}" ]; then',
+  `  printf '%s\\n' ${missingIdDiagnostic.map(shellQuote).join(" ")} >&2`,
+  "  exit 2",
+  "fi",
+].join("\n");
+
+const withTestboxId = (command: string) =>
+  `${requireBlacksmithCli}\n${requireTestboxId}\n${command}`;
 
 /**
  * Wrap a workspace command so it runs inside the testbox instead of locally.
@@ -30,7 +60,46 @@ const REQUIRE_ID =
  * it is forwarded verbatim to the box, which has the synced tree and CI tools.
  */
 export const inTestbox = (command: string): string =>
-  `blacksmith testbox run --id "${REQUIRE_ID}" ${shellQuote(command)}`;
+  withTestboxId(
+    `${blacksmithBin} testbox run --id "$BLACKSMITH_TESTBOX_ID" ${shellQuote(command)}`,
+  );
+
+const warmupCommand = [
+  requireBlacksmithCli,
+  'branch="$(git branch --show-current)"',
+  'if [ -z "$branch" ]; then',
+  `  printf '%s\\n' ${shellQuote(
+    "Testbox warmup needs a named branch. Check one out, push it, and retry.",
+  )} >&2`,
+  "  exit 2",
+  "fi",
+  'if ! remote_branch="$(git ls-remote --heads origin "refs/heads/$branch" 2>/dev/null)"; then',
+  `  printf '%s\\n' ${shellQuote(
+    "Testbox warmup could not query origin. Check the Git remote, network access, and Git credentials, then retry.",
+  )} >&2`,
+  "  exit 2",
+  "fi",
+  'if [ -z "$remote_branch" ]; then',
+  `  printf '%s\\n' ${shellQuote("Testbox warmup cannot find the current branch on origin.")} ${shellQuote(
+    `Push it first: ${pushCurrentBranchCommand}`,
+  )} >&2`,
+  "  exit 2",
+  "fi",
+  'local_sha="$(git rev-parse HEAD)"',
+  'remote_sha="${remote_branch%%[[:space:]]*}"',
+  'if [ "$local_sha" != "$remote_sha" ]; then',
+  `  printf '%s\\n' ${shellQuote("Testbox warmup needs the current HEAD on origin.")} ${shellQuote(
+    `Push it first: ${pushCurrentBranchCommand}`,
+  )} >&2`,
+  "  exit 2",
+  "fi",
+  `if ! ${blacksmithBin} testbox warmup .github/workflows/e2e.yml --ref "$branch" --job testbox; then`,
+  `  printf '%s\\n' ${shellQuote(
+    'Blacksmith warmup failed. Authenticate with "$VIZE_BLACKSMITH_BIN" auth login, verify repository access, and retry.',
+  )} >&2`,
+  "  exit 1",
+  "fi",
+].join("\n");
 
 /**
  * Lifecycle helpers. Warmup targets the dedicated Testbox workflow on the
@@ -38,8 +107,8 @@ export const inTestbox = (command: string): string =>
  * Testbox workflow changes need to be pushed before warmup can see them.
  */
 export const testboxTasks = defineTasks({
-  "testbox:warmup": noCacheTask(
-    'blacksmith testbox warmup .github/workflows/e2e.yml --ref "$(git branch --show-current)" --job testbox',
+  "testbox:warmup": noCacheTask(warmupCommand),
+  "testbox:stop": noCacheTask(
+    withTestboxId(`${blacksmithBin} testbox stop --id "$BLACKSMITH_TESTBOX_ID"`),
   ),
-  "testbox:stop": noCacheTask(`blacksmith testbox stop --id "${REQUIRE_ID}"`),
 });


### PR DESCRIPTION
Closes #2830

## Summary

- keep workspace build, test, and lint local by default, with explicit Testbox variants over the same task graphs
- isolate the pinned Blacksmith CLI in `nix develop .#testbox` and invoke its exact Nix-store binary
- require a named, pushed branch whose remote SHA equals local HEAD before warmup
- document a guarded lifecycle that clears stale IDs, aborts on warmup failure, and still stops a fresh box after task failure
- lock local/Testbox task equivalence, shell isolation, hostile branch diagnostics, and lifecycle behavior with executable regressions

## Safety and DX

- the default shell clears inherited Testbox markers and pinned-binary paths
- copy/paste diagnostics never interpolate an untrusted branch name
- a failed warmup cannot reuse an older `BLACKSMITH_TESTBOX_ID`
- hosted credentials are never required for default build/test/lint

## Verification

- 15/15 focused tooling and documentation tests
- focused `vp check` on changed TypeScript
- Oxfmt and Nixfmt checks
- source-length growth gate
- current-system runtime Nix Testbox-environment check
- `nix flake check --all-systems --no-build`
- real default/Testbox shell isolation and pinned CLI 0.4.46 smokes
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786442756&installation_id=136613492&pr_number=2878&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2878&signature=dfb4f5fc2e12eff96315abe2eb7ce22a8b077ba6ba7bb3cb10ff33a829e724de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->