### PR TITLE
fix(build): honor general glob syntax

### DIFF
--- a/crates/vize/src/commands/build.rs
+++ b/crates/vize/src/commands/build.rs
@@ -53,6 +53,11 @@ impl From<TemplateSyntaxArg> for vize_atelier_core::TemplateSyntaxMode {
 #[allow(clippy::disallowed_types)]
 pub struct BuildArgs {
     /// File, directory, or glob inputs (output paths stay relative to their common root)
+    ///
+    /// Existing paths are literal. Globs support *, ?, [...], and recursive **;
+    /// quote patterns in the shell.
+    /// Backslashes are separators, not escapes. Use [*], [?], [[], or []] for
+    /// literal *, ?, [, or ].
     #[arg(default_value = "./**/*.vue")]
     pub patterns: Vec<String>,
 

--- a/crates/vize/src/commands/build/runner/collect.rs
+++ b/crates/vize/src/commands/build/runner/collect.rs
@@ -5,7 +5,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ignore::Walk;
+use ignore::WalkBuilder;
+
+use self::glob::{BuildGlob, GLOB_METACHARACTERS};
+
+mod glob;
 
 #[derive(Debug)]
 pub(super) struct CollectedFiles {
@@ -13,10 +17,18 @@ pub(super) struct CollectedFiles {
     pub roots: Vec<PathBuf>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub(super) enum InputError<'a> {
-    MissingLiteral { input: &'a str },
-    NonVueFile { input: &'a str },
+    MissingLiteral {
+        input: &'a str,
+    },
+    NonVueFile {
+        input: &'a str,
+    },
+    InvalidGlob {
+        input: &'a str,
+        error: ::glob::PatternError,
+    },
 }
 
 impl fmt::Display for InputError<'_> {
@@ -28,6 +40,9 @@ impl fmt::Display for InputError<'_> {
             Self::NonVueFile { input } => {
                 write!(formatter, "Build input is not a .vue file: {input}")
             }
+            Self::InvalidGlob { input, error } => {
+                write!(formatter, "Invalid glob pattern {input}: {error}")
+            }
         }
     }
 }
@@ -36,7 +51,7 @@ impl fmt::Display for InputError<'_> {
 enum BuildInput<'a> {
     File(&'a Path),
     Directory(&'a Path),
-    Glob { root: PathBuf, pattern: &'a str },
+    Glob(BuildGlob),
 }
 
 #[allow(clippy::disallowed_types)]
@@ -73,11 +88,12 @@ pub(super) fn collect_files<'a>(
                 roots.push(root.to_path_buf());
                 collect_walked_files(root, None, &mut files);
             }
-            BuildInput::Glob { root, pattern } => {
+            BuildInput::Glob(pattern) => {
+                let root = pattern.root();
                 if root.is_dir() {
-                    roots.push(root.clone());
+                    roots.push(root.to_path_buf());
                 }
-                collect_walked_files(&root, Some(pattern), &mut files);
+                collect_walked_files(root, Some(&pattern), &mut files);
             }
         }
     }
@@ -107,38 +123,26 @@ fn classify_input(input: &str) -> Result<BuildInput<'_>, InputError<'_>> {
     }
 
     if contains_glob_metacharacter(input) {
-        Ok(BuildInput::Glob {
-            root: glob_root(input),
-            pattern: input,
-        })
+        BuildGlob::new(input)
+            .map(BuildInput::Glob)
+            .map_err(|error| InputError::InvalidGlob { input, error })
     } else {
         Err(InputError::MissingLiteral { input })
     }
 }
 
-fn glob_root(pattern: &str) -> PathBuf {
-    let metacharacter = pattern
-        .find(['*', '?', '['])
-        .expect("glob roots are only derived from classified glob inputs");
-    let literal_prefix = &pattern[..metacharacter];
+fn collect_walked_files(root: &Path, pattern: Option<&BuildGlob>, files: &mut Vec<PathBuf>) {
+    let mut walker = WalkBuilder::new(root);
+    if let Some(max_depth) = pattern.and_then(BuildGlob::max_depth) {
+        walker.max_depth(Some(max_depth));
+    }
 
-    literal_prefix.rfind(['/', '\\']).map_or_else(
-        || PathBuf::from("."),
-        |separator| {
-            // Retaining the separator preserves filesystem roots such as `/`
-            // and `C:\\` while remaining equivalent for ordinary directories.
-            PathBuf::from(&literal_prefix[..=separator])
-        },
-    )
-}
-
-fn collect_walked_files(root: &Path, pattern: Option<&str>, files: &mut Vec<PathBuf>) {
-    for entry in Walk::new(root).flatten() {
+    for entry in walker.build().flatten() {
         let path = entry.path();
 
         if path.is_file()
             && is_vue_file(path)
-            && pattern.is_none_or(|pattern| pattern_matches(path, pattern))
+            && pattern.is_none_or(|pattern| pattern.matches(path))
         {
             files.push(path.to_path_buf());
         }
@@ -147,52 +151,12 @@ fn collect_walked_files(root: &Path, pattern: Option<&str>, files: &mut Vec<Path
 
 #[inline]
 fn contains_glob_metacharacter(input: &str) -> bool {
-    input.contains(['*', '?', '['])
+    input.contains(GLOB_METACHARACTERS)
 }
 
 #[inline]
 fn is_vue_file(path: &Path) -> bool {
     path.extension().is_some_and(|extension| extension == "vue")
-}
-
-/// Check whether a file path matches a glob-like pattern.
-#[allow(clippy::disallowed_types, clippy::disallowed_methods)]
-fn pattern_matches(path: &Path, pattern: &str) -> bool {
-    let path_str = path.to_string_lossy().replace('\\', "/");
-    let pattern = pattern.replace('\\', "/");
-
-    if pattern == "./**/*.vue" || pattern == "**/*.vue" {
-        return path_str.ends_with(".vue");
-    }
-
-    if pattern.contains("**/*.vue")
-        && let Some(prefix_end) = pattern.find("**")
-    {
-        let prefix = &pattern[..prefix_end];
-        let prefix_normalized = prefix.trim_end_matches('/');
-        let has_prefix_dir = prefix_normalized.is_empty()
-            || path_str.match_indices(prefix_normalized).any(|(idx, _)| {
-                path_str.as_bytes().get(idx + prefix_normalized.len()) == Some(&b'/')
-            });
-        return has_prefix_dir && path_str.ends_with(".vue");
-    }
-
-    if pattern.ends_with(".vue") {
-        if path_str == pattern {
-            return true;
-        }
-        if !path_str.ends_with(pattern.as_str()) {
-            return false;
-        }
-
-        let prefix_len = path_str.len() - pattern.len();
-        let Some(separator_idx) = prefix_len.checked_sub(1) else {
-            return false;
-        };
-        return path_str.as_bytes().get(separator_idx) == Some(&b'/');
-    }
-
-    path_str.ends_with(".vue")
 }
 
 #[cfg(test)]

--- a/crates/vize/src/commands/build/runner/collect/glob.rs
+++ b/crates/vize/src/commands/build/runner/collect/glob.rs
@@ -1,0 +1,126 @@
+//! Compiled build-input glob matching.
+//!
+//! Existing paths are classified before this module is used, so metacharacters
+//! in an existing file or directory remain literal. For actual patterns,
+//! backslashes are portable path separators rather than escapes. Literal glob
+//! metacharacters use bracket expressions: `[*]`, `[?]`, `[[]`, and `[]]`.
+
+use std::path::{Path, PathBuf};
+
+use ::glob::{MatchOptions, Pattern, PatternError};
+
+pub(super) const GLOB_METACHARACTERS: [char; 3] = ['*', '?', '['];
+
+#[derive(Debug)]
+pub(super) struct BuildGlob {
+    root: PathBuf,
+    pattern: Pattern,
+    max_depth: Option<usize>,
+}
+
+impl BuildGlob {
+    pub(super) fn new(input: &str) -> Result<Self, PatternError> {
+        let current_dir_prefix_len = current_dir_prefix_len(input);
+        let normalized = normalize_separators(&input[current_dir_prefix_len..]);
+        let pattern = Pattern::new(normalized.as_ref()).map_err(|error| PatternError {
+            pos: error.pos + current_dir_prefix_len,
+            msg: error.msg,
+        })?;
+
+        Ok(Self {
+            root: literal_root(input),
+            pattern,
+            max_depth: maximum_depth(normalized.as_ref()),
+        })
+    }
+
+    pub(super) fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub(super) const fn max_depth(&self) -> Option<usize> {
+        self.max_depth
+    }
+
+    #[allow(clippy::disallowed_methods)]
+    pub(super) fn matches(&self, path: &Path) -> bool {
+        let candidate = path.to_string_lossy();
+        let prefix_len = current_dir_prefix_len(candidate.as_ref());
+        let candidate = normalize_separators(&candidate[prefix_len..]);
+        self.pattern
+            .matches_with(candidate.as_ref(), match_options())
+    }
+}
+
+fn normalize_separators(value: &str) -> std::borrow::Cow<'_, str> {
+    #[cfg(windows)]
+    let (foreign, native) = ('/', "\\");
+    #[cfg(not(windows))]
+    let (foreign, native) = ('\\', "/");
+
+    if value.contains(foreign) {
+        value.replace(foreign, native).into()
+    } else {
+        value.into()
+    }
+}
+
+fn current_dir_prefix_len(value: &str) -> usize {
+    let mut prefix_len = 0;
+    let mut rest = value;
+    while let Some(stripped) = rest.strip_prefix("./").or_else(|| rest.strip_prefix(".\\")) {
+        prefix_len += 2;
+        rest = stripped;
+    }
+    prefix_len
+}
+
+fn first_metacharacter(pattern: &str) -> usize {
+    pattern
+        .find(GLOB_METACHARACTERS)
+        .expect("build globs always contain a metacharacter")
+}
+
+fn literal_root(pattern: &str) -> PathBuf {
+    let metacharacter = first_metacharacter(pattern);
+    let prefix = &pattern[..metacharacter];
+
+    prefix.rfind(['/', '\\']).map_or_else(
+        || PathBuf::from("."),
+        |separator| {
+            let root = normalize_separators(&prefix[..=separator]);
+            PathBuf::from(root.as_ref())
+        },
+    )
+}
+
+fn maximum_depth(pattern: &str) -> Option<usize> {
+    let metacharacter = first_metacharacter(pattern);
+    let suffix_start = pattern[..metacharacter]
+        .rfind(std::path::MAIN_SEPARATOR)
+        .map_or(0, |separator| separator + 1);
+    let mut depth = 0;
+
+    for component in pattern[suffix_start..]
+        .split(std::path::MAIN_SEPARATOR)
+        .filter(|component| !component.is_empty())
+    {
+        if component == "**" {
+            return None;
+        }
+        depth += 1;
+    }
+    Some(depth)
+}
+
+const fn match_options() -> MatchOptions {
+    MatchOptions {
+        case_sensitive: !cfg!(windows),
+        require_literal_separator: true,
+        require_literal_leading_dot: false,
+    }
+}
+
+#[cfg(test)]
+#[path = "glob_tests.rs"]
+mod tests;

--- a/crates/vize/src/commands/build/runner/collect/glob_tests.rs
+++ b/crates/vize/src/commands/build/runner/collect/glob_tests.rs
@@ -1,0 +1,94 @@
+#![allow(clippy::disallowed_macros, clippy::disallowed_methods)]
+
+use super::BuildGlob;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn matches_segment_wildcards_and_character_classes() {
+    let single_segment = BuildGlob::new("src/*/App?.vue").unwrap();
+    assert!(single_segment.matches(Path::new("src/admin/App1.vue")));
+    assert!(!single_segment.matches(Path::new("src/admin/deep/App1.vue")));
+    assert!(!single_segment.matches(Path::new("src/admin/App12.vue")));
+
+    let class = BuildGlob::new("src/[AB]*[0-9].vue").unwrap();
+    assert!(class.matches(Path::new("src/App2.vue")));
+    assert!(class.matches(Path::new("src/Button7.vue")));
+    assert!(!class.matches(Path::new("src/Card7.vue")));
+}
+
+#[test]
+fn recursive_wildcards_match_zero_or_many_directories() {
+    let recursive = BuildGlob::new("src/**/App.vue").unwrap();
+    assert_eq!(recursive.max_depth(), None);
+    assert!(recursive.matches(Path::new("src/App.vue")));
+    assert!(recursive.matches(Path::new("src/a/b/App.vue")));
+    assert!(!recursive.matches(Path::new("other/src/App.vue")));
+}
+
+#[test]
+fn rejects_invalid_patterns_with_original_positions() {
+    let unclosed = BuildGlob::new("./src/[AB.vue").unwrap_err();
+    assert_eq!(
+        unclosed.to_string(),
+        "Pattern syntax error near position 6: invalid range pattern"
+    );
+
+    let embedded_recursive = BuildGlob::new("src/foo**/App.vue").unwrap_err();
+    assert_eq!(
+        embedded_recursive.to_string(),
+        "Pattern syntax error near position 6: recursive wildcards must form a single path component"
+    );
+}
+
+#[test]
+fn preserves_deep_literal_prefixes_and_absolute_roots() {
+    let nested = BuildGlob::new("workspace/packages/ui/src/App?.vue").unwrap();
+    assert_eq!(nested.root(), Path::new("workspace/packages/ui/src/"));
+
+    let absolute = BuildGlob::new("/workspace/src/**/*.vue").unwrap();
+    assert_eq!(absolute.root(), Path::new("/workspace/src/"));
+    assert!(absolute.matches(Path::new("/workspace/src/nested/App.vue")));
+    assert!(!absolute.matches(Path::new("/other/workspace/src/App.vue")));
+
+    assert_eq!(BuildGlob::new("/**/*.vue").unwrap().root(), Path::new("/"));
+    let windows_root = BuildGlob::new(r"C:\**\*.vue").unwrap();
+    let expected_windows_root = if cfg!(windows) { r"C:\" } else { "C:/" };
+    assert_eq!(windows_root.root().to_string_lossy(), expected_windows_root);
+}
+
+#[test]
+fn bracket_expressions_escape_metacharacters() {
+    let escaped = BuildGlob::new("src/Component[[]old[]]-[*]-[?].vue").unwrap();
+    assert!(escaped.matches(Path::new("src/Component[old]-*-?.vue")));
+    assert!(!escaped.matches(Path::new("src/Componentxold]-*-?.vue")));
+}
+
+#[test]
+fn accepts_windows_separators_portably() {
+    let pattern = BuildGlob::new(r"C:\workspace\src\**\Card?.vue").unwrap();
+    assert!(pattern.matches(Path::new(r"C:\workspace\src\nested\Card1.vue")));
+    assert!(!pattern.matches(Path::new(r"C:\workspace\other\nested\Card1.vue")));
+}
+
+#[test]
+fn uses_native_case_sensitivity() {
+    let pattern = BuildGlob::new("src/card?.vue").unwrap();
+    assert_eq!(pattern.matches(Path::new("src/CardA.vue")), cfg!(windows));
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_matching_is_case_insensitive_and_accepts_forward_slashes() {
+    let pattern = BuildGlob::new("C:/workspace/src/card?.vue").unwrap();
+    assert!(pattern.matches(Path::new(r"C:\workspace\src\CardA.vue")));
+}
+
+#[test]
+fn glob_root_without_a_literal_directory_is_current_directory() {
+    let root_pattern = BuildGlob::new("*.vue").unwrap();
+    assert_eq!(root_pattern.root(), PathBuf::from("."));
+    assert_eq!(root_pattern.max_depth(), Some(1));
+
+    let nested = BuildGlob::new("src/*/App?.vue").unwrap();
+    assert_eq!(nested.max_depth(), Some(2));
+}

--- a/crates/vize/src/commands/build/runner/collect/tests.rs
+++ b/crates/vize/src/commands/build/runner/collect/tests.rs
@@ -4,10 +4,7 @@
     clippy::disallowed_types
 )]
 
-use super::{
-    BuildInput, classify_input, collect_files, contains_glob_metacharacter, glob_root,
-    pattern_matches,
-};
+use super::{BuildInput, classify_input, collect_files, contains_glob_metacharacter};
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -117,6 +114,21 @@ fn collect_files_rejects_non_vue_files_before_collecting_roots() {
 }
 
 #[test]
+fn collect_files_accepts_backslash_pattern_separators() {
+    let root = unique_case_dir("build-backslash-glob");
+    let app = root.join("src/App.vue");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(app.parent().unwrap()).unwrap();
+    fs::write(&app, "<template><div /></template>").unwrap();
+    let pattern = root.join("src/*.vue").to_string_lossy().replace('/', "\\");
+
+    let collected = collect_files(&[pattern]).unwrap();
+    let _ = fs::remove_dir_all(&root);
+
+    assert_eq!(collected.files, vec![app]);
+}
+
+#[test]
 fn existing_paths_with_metacharacters_remain_literals() {
     let root = unique_case_dir("build-literal-metacharacter");
     let file = root.join("Component[old].vue");
@@ -134,29 +146,20 @@ fn existing_paths_with_metacharacters_remain_literals() {
 #[test]
 fn classifies_windows_separators_and_glob_metacharacters_portably() {
     let pattern = r"C:\workspace\src\**\*.vue";
-    let BuildInput::Glob {
-        root,
-        pattern: classified_pattern,
-    } = classify_input(pattern).unwrap()
-    else {
+    let BuildInput::Glob(classified) = classify_input(pattern).unwrap() else {
         panic!("Windows-style glob should be classified as a glob");
     };
 
-    assert_eq!(root.to_string_lossy(), r"C:\workspace\src\");
-    assert_eq!(classified_pattern, pattern);
+    let expected_root = if cfg!(windows) {
+        r"C:\workspace\src\"
+    } else {
+        "C:/workspace/src/"
+    };
+    assert_eq!(classified.root().to_string_lossy(), expected_root);
     assert!(contains_glob_metacharacter(r"src\?.vue"));
     assert!(contains_glob_metacharacter(r"src\[AB].vue"));
     assert!(!contains_glob_metacharacter(r"C:\workspace\src\App.vue"));
-    assert!(pattern_matches(
-        Path::new(r"C:\workspace\src\App.vue"),
-        pattern
-    ));
-}
-
-#[test]
-fn glob_roots_preserve_absolute_filesystem_roots() {
-    assert_eq!(glob_root("/**/*.vue"), PathBuf::from("/"));
-    assert_eq!(glob_root(r"C:\**\*.vue").to_string_lossy(), r"C:\");
+    assert!(classified.matches(Path::new(r"C:\workspace\src\App.vue")));
 }
 
 fn unique_case_dir(name: &str) -> PathBuf {

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_build_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_build_help.snap
@@ -10,6 +10,8 @@ Arguments:
   [PATTERNS]...
           File, directory, or glob inputs (output paths stay relative to their common root)
 
+          Existing paths are literal. Globs support *, ?, [...], and recursive **; quote patterns in the shell. Backslashes are separators, not escapes. Use [*], [?], [[], or []] for literal *, ?, [, or ].
+
           [default: ./**/*.vue]
 
 Options:

--- a/crates/vize/tests/build_inputs_cli.rs
+++ b/crates/vize/tests/build_inputs_cli.rs
@@ -142,3 +142,121 @@ fn build_rejects_existing_non_vue_literal_before_writing_other_inputs() {
 
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn build_honors_segment_and_recursive_glob_syntax() {
+    let root = temp_project_dir("general-globs");
+    for file in [
+        "src/App1.vue",
+        "src/App12.vue",
+        "src/Button.vue",
+        "src/Card.vue",
+        "src/nested/App2.vue",
+        "src/nested/deep/App3.vue",
+    ] {
+        write_vue(&root, file);
+    }
+
+    let question = run_build(&root, &["src/App?.vue"], "dist-question");
+    assert_success(&question);
+    assert!(root.join("dist-question/App1.js").is_file());
+    assert!(!root.join("dist-question/App12.js").exists());
+
+    let class = run_build(&root, &["src/[AB]*.vue"], "dist-class");
+    assert_success(&class);
+    assert!(root.join("dist-class/App1.js").is_file());
+    assert!(root.join("dist-class/Button.js").is_file());
+    assert!(!root.join("dist-class/Card.js").exists());
+
+    let segment = run_build(&root, &["src/*/App?.vue"], "dist-segment");
+    assert_success(&segment);
+    assert!(root.join("dist-segment/nested/App2.js").is_file());
+    assert!(!root.join("dist-segment/nested/deep/App3.js").exists());
+
+    let recursive = run_build(&root, &["src/**/App?.vue"], "dist-recursive");
+    assert_success(&recursive);
+    assert!(root.join("dist-recursive/App1.js").is_file());
+    assert!(root.join("dist-recursive/nested/App2.js").is_file());
+    assert!(root.join("dist-recursive/nested/deep/App3.js").is_file());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn build_honors_absolute_globs_and_source_relative_outputs() {
+    let root = temp_project_dir("absolute-glob");
+    write_vue(&root, "src/App1.vue");
+    write_vue(&root, "src/nested/App2.vue");
+    write_vue(&root, "other/App3.vue");
+    let pattern = root.join("src/**/App?.vue").display().to_string();
+
+    let output = run_build(&root, &[&pattern], "dist");
+
+    assert_success(&output);
+    assert!(root.join("dist/App1.js").is_file());
+    assert!(root.join("dist/nested/App2.js").is_file());
+    assert!(!root.join("dist/other/App3.js").exists());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn build_reports_invalid_glob_syntax_exactly_before_writing() {
+    let root = temp_project_dir("invalid-glob");
+    write_vue(&root, "src/App.vue");
+    let pattern = "src/[AB.vue";
+
+    let output = run_build(&root, &[pattern], "dist");
+
+    assert!(!output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!(
+            "Invalid glob pattern {pattern}: Pattern syntax error near position 4: invalid range pattern\n"
+        )
+    );
+    assert!(!root.join("dist").exists());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(not(windows))]
+#[test]
+fn build_uses_bracket_expressions_to_escape_metacharacters() {
+    let root = temp_project_dir("escaped-glob");
+    write_vue(&root, "src/Component[old]-*-?.vue");
+    write_vue(&root, "src/Component-new.vue");
+    let pattern = "src/Component[[]old[]]-[*]-[?].vue";
+
+    let output = run_build(&root, &[pattern], "dist");
+
+    assert_success(&output);
+    assert!(root.join("dist/Component[old]-*-?.js").is_file());
+    assert!(!root.join("dist/Component-new.js").exists());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(windows)]
+#[test]
+fn build_accepts_native_windows_globs_case_insensitively() {
+    let root = temp_project_dir("windows-glob");
+    write_vue(&root, "src/CardA.vue");
+    let pattern = root.join("src/card?.vue").display().to_string();
+
+    let output = run_build(&root, &[&pattern], "dist");
+
+    assert_success(&output);
+    assert!(root.join("dist/CardA.js").is_file());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

- compile build input patterns once with the workspace glob implementation
- support `*`, `?`, character classes, and recursive `**` across path segments
- keep existing metacharacter filenames literal by classifying filesystem paths first
- walk only from the literal prefix and prune non-recursive patterns by maximum depth
- preserve empty-glob diagnostics, source-relative roots, and output collision planning

## Verification

- collector unit tests (8/8)
- `build_inputs_cli` (9/9)
- `cargo clippy -p vize --lib -- -D warnings`
- `cargo fmt --check`
- source-length checks

Closes #2871

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786451186&installation_id=136613492&pr_number=2881&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2881&signature=cd415a1c59690dc68a724446ae3c58248bdfaed6f8028d6e7b52a10dcb052e4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build input patterns now support `*`, `?`, character classes (`[...]`), and recursive `**`.
  * Glob patterns work with relative, absolute, and Windows-style path separators, including portable matching behavior.
* **Bug Fixes**
  * Invalid glob syntax is detected early and reported clearly before any build output is written.
* **Documentation**
  * Expanded `patterns` guidance, including shell quoting/escaping rules and how glob metacharacters should be matched literally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->