### PR TITLE
fix(release): distinguish missing crate versions

### DIFF
--- a/tests/tooling/moonbit-publish-crates.test.ts
+++ b/tests/tooling/moonbit-publish-crates.test.ts
@@ -37,17 +37,10 @@ function getScriptCrateArray(variableName: string): string[] {
   return Array.from(arrayBody.matchAll(/"([^"]+)"/g), ([, crateName]) => crateName);
 }
 
-function getPublishedCrates(): string[] {
-  return getScriptCrateArray("published_crates");
-}
-
-function getPendingFirstPublishCrates(): string[] {
-  return getScriptCrateArray("pending_first_publish_crates");
-}
-
-function getBlockedByPendingFirstPublishCrates(): string[] {
-  return getScriptCrateArray("blocked_by_pending_first_publish_crates");
-}
+const getPublishedCrates = () => getScriptCrateArray("published_crates");
+const getPendingFirstPublishCrates = () => getScriptCrateArray("pending_first_publish_crates");
+const getBlockedByPendingFirstPublishCrates = () =>
+  getScriptCrateArray("blocked_by_pending_first_publish_crates");
 
 function getMetadata(): CargoMetadata {
   return JSON.parse(
@@ -143,12 +136,17 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
         "const fs = require('node:fs');",
         "const args = process.argv.slice(2);",
         "if (process.env.CURL_LOG) fs.appendFileSync(process.env.CURL_LOG, args.join(' ') + '\\n');",
-        "const crateName = args.at(-1).split('/').at(-1);",
-        "if (crateName === process.env.TEST_CURL_FAIL_CRATE) { console.error('registry unavailable'); process.exit(22); }",
-        "if (crateName === process.env.TEST_CURL_MALFORMED_CRATE) { process.stdout.write('{bad json'); process.exit(0); }",
+        "const endpoint = args.at(-1).split('/');",
+        "const crateName = endpoint.at(-2);",
+        "const version = endpoint.at(-1);",
+        "if (crateName === process.env.TEST_CURL_FAIL_CRATE) { console.error('registry unavailable'); process.exit(7); }",
+        "if (crateName === process.env.TEST_CURL_MALFORMED_CRATE) { fs.writeSync(1, '{bad jsonVIZE_HTTP_STATUS:200'); process.exit(0); }",
+        "if (crateName === process.env.TEST_CURL_SCHEMA_CRATE) { fs.writeSync(1, JSON.stringify({ version: { crate: crateName } }) + 'VIZE_HTTP_STATUS:200'); process.exit(0); }",
+        "if (crateName === process.env.TEST_CURL_SERVER_ERROR_CRATE) { fs.writeSync(1, JSON.stringify({ errors: [{ detail: 'unavailable' }] }) + 'VIZE_HTTP_STATUS:500'); process.exit(22); }",
         "const published = (process.env.TEST_PUBLISHED_CRATES || '').split(',').includes(crateName);",
-        "const versions = published ? [{ num: process.env.TEST_PUBLISHED_VERSION }] : [];",
-        "process.stdout.write(JSON.stringify({ versions }));",
+        "const body = published ? { version: { crate: crateName, num: version } } : { errors: [{ detail: 'Not Found' }] };",
+        "fs.writeSync(1, JSON.stringify(body) + 'VIZE_HTTP_STATUS:' + (published ? '200' : '404'));",
+        "process.exit(published ? 0 : 22);",
       ].join("\n"),
     );
 
@@ -202,10 +200,18 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
     ]);
     const curlCalls = fs.readFileSync(curlLogPath, "utf8").trim().split("\n");
     assert.equal(curlCalls.length, 1);
-    assert.match(
-      curlCalls[0],
-      /--connect-timeout 5 --max-time 15 --retry 2 --retry-delay 1 --retry-all-errors/,
-    );
+    for (const flag of [
+      "--fail-with-body",
+      "--connect-timeout 5",
+      "--max-time 15",
+      "--retry 2",
+      "--retry-delay 1",
+      "--retry-connrefused",
+    ]) {
+      assert.ok(curlCalls[0].includes(flag), `missing ${flag}`);
+    }
+    assert.match(curlCalls[0], /--write-out VIZE_HTTP_STATUS:%\{http_code\}/);
+    assert.ok(curlCalls[0].endsWith(`/vize_carton/${version}`));
 
     const somePublished = publishedCrates.slice(0, 5);
     const partial = runDryRun(somePublished);
@@ -228,8 +234,10 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
     assert.match(allPublished.stdout, /Every crate .* already published and resolvable/);
 
     for (const [envName, diagnostic] of [
-      ["TEST_CURL_FAIL_CRATE", /curl exit 22/],
+      ["TEST_CURL_FAIL_CRATE", /curl exit 7/],
       ["TEST_CURL_MALFORMED_CRATE", /invalid JSON/],
+      ["TEST_CURL_SCHEMA_CRATE", /version without num/],
+      ["TEST_CURL_SERVER_ERROR_CRATE", /HTTP 500/],
     ] as const) {
       const failedQuery = runDryRun([], { [envName]: publishedCrates[0] });
       assert.notEqual(failedQuery.status, 0);
@@ -311,7 +319,10 @@ test("publish_crates treats a non-zero cargo publish exit as success when the cr
     writeFakeCommand(
       binDir,
       "curl",
-      ["process.stdout.write(JSON.stringify({ versions: [] }));", "process.exit(0);"].join("\n"),
+      [
+        "require('node:fs').writeSync(1, JSON.stringify({ errors: [{ detail: 'Not Found' }] }) + 'VIZE_HTTP_STATUS:404');",
+        "process.exit(22);",
+      ].join("\n"),
     );
 
     const result = runMoonScript("publish_crates", [], {

--- a/tools/moon/cmd/publish_crates/registry.mbt
+++ b/tools/moon/cmd/publish_crates/registry.mbt
@@ -11,21 +11,19 @@ fn published_version_state(value : Json, crate_name : String, version : String) 
   guard value is Object(root) else {
     return QueryFailed("crates.io returned a non-object response for \{crate_name}@\{version}")
   }
-  guard root.get("versions") is Some(Array(versions)) else {
-    return QueryFailed("crates.io response for \{crate_name}@\{version} has no versions array")
+  guard root.get("version") is Some(Object(version_obj)) else {
+    return QueryFailed("crates.io response for \{crate_name}@\{version} has no version object")
   }
-  for item in versions {
-    guard item is Object(version_obj) else {
-      return QueryFailed("crates.io returned an invalid version entry for \{crate_name}@\{version}")
-    }
-    guard version_obj.get("num") is Some(String(num)) else {
-      return QueryFailed("crates.io returned a version without num for \{crate_name}@\{version}")
-    }
-    if num == version {
-      return Published
-    }
+  guard version_obj.get("crate") is Some(String(returned_crate)) else {
+    return QueryFailed("crates.io returned a version without crate for \{crate_name}@\{version}")
   }
-  Missing
+  guard version_obj.get("num") is Some(String(returned_version)) else {
+    return QueryFailed("crates.io returned a version without num for \{crate_name}@\{version}")
+  }
+  if returned_crate != crate_name || returned_version != version {
+    return QueryFailed("crates.io returned mismatched identity for \{crate_name}@\{version}")
+  }
+  Published
 }
 
 /// Queries crates.io for an exact version. Dry-run callers consume the full
@@ -34,7 +32,8 @@ async fn query_crate_version(crate_name : String, version : String) -> CrateVers
   let (exit_code, body, stderr) = @process.collect_output(
     "curl",
     [
-      "-sf",
+      "-sS",
+      "--fail-with-body",
       "--connect-timeout",
       "5",
       "--max-time",
@@ -43,21 +42,47 @@ async fn query_crate_version(crate_name : String, version : String) -> CrateVers
       "2",
       "--retry-delay",
       "1",
-      "--retry-all-errors",
+      "--retry-connrefused",
+      "--write-out",
+      "VIZE_HTTP_STATUS:%{http_code}",
       "-H",
       "User-Agent: vize-release-publish (https://github.com/ubugeeei-prod/vize)",
-      "https://crates.io/api/v1/crates/" + crate_name,
+      "https://crates.io/api/v1/crates/" + crate_name + "/" + version,
     ],
   )
+  let response_parts : Array[String] = body
+    .text()
+    .split("VIZE_HTTP_STATUS:")
+    .map(view => view.to_owned())
+    .collect()
+  if response_parts.length() == 2 && response_parts[1] == "404" {
+    return Missing
+  }
   if exit_code != 0 {
     let detail = stderr.text().trim().to_owned()
     let suffix = if detail == "" { "" } else { ": " + detail }
+    if response_parts.length() == 2 && response_parts[1] != "000" {
+      return QueryFailed(
+        "crates.io query for \{crate_name}@\{version} returned HTTP \{response_parts[1]} (curl exit \{exit_code})\{suffix}",
+      )
+    }
     return QueryFailed(
       "crates.io query for \{crate_name}@\{version} failed with curl exit \{exit_code}\{suffix}",
     )
   }
+  if response_parts.length() != 2 {
+    return QueryFailed(
+      "crates.io query for \{crate_name}@\{version} returned no HTTP status",
+    )
+  }
+  let status = response_parts[1]
+  if status != "200" {
+    return QueryFailed(
+      "crates.io query for \{crate_name}@\{version} returned HTTP \{status}",
+    )
+  }
   let parsed = try {
-    @json.parse(body.text())
+    @json.parse(response_parts[0])
   } catch {
     _ =>
       return QueryFailed(


### PR DESCRIPTION
## Summary

- query the exact crates.io crate-version endpoint
- treat HTTP 404 as an unpublished version while keeping transport, schema, and server failures fatal
- retain bounded retries for transient failures and verify the returned crate/version identity
- cover real curl exit behavior for 404/500 plus malformed and schema-invalid responses

## Verification

- `node --test tests/tooling/moonbit-publish-crates.test.ts` (6/6, CI MoonBit toolchain)
- `npx oxfmt --check tests/tooling/moonbit-publish-crates.test.ts`
- `npx oxlint tests/tooling/moonbit-publish-crates.test.ts`
- real `publish_crates --dry-run` from an independent clean clone: all 11 packages and registry resolutions succeeded

Closes #2879

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786451186&installation_id=136613492&pr_number=2882&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2882&signature=7e7365c83be41735a6417e18abc87100cc5c3466b193182480957c93bd4704e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crate registry querying and version parsing to match the latest response shape and correctly treat HTTP 404 as “missing.”
  * Enhanced publish/regression handling so already-resolvable crates don’t fail the flow on non-zero publish results.
  * Improved error reporting for malformed responses, schema/identity mismatches, and server/connection failures.
* **Tests**
  * Updated fake HTTP behavior and assertions to validate status handling, request retry options, and dry-run failure diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->