### PR TITLE
fix(build): preserve distinct sources across symlinked parents

### DIFF
--- a/crates/vize/src/commands/build/runner/output/plan.rs
+++ b/crates/vize/src/commands/build/runner/output/plan.rs
@@ -1,12 +1,18 @@
 use std::path::{Component, Path, PathBuf};
 
-use vize_carton::String;
+use vize_carton::{FxHashSet, String};
 
 use super::{OutputError, OutputFormat, ScriptExtension};
 
 pub(crate) struct PlannedInput {
     pub(crate) source: PathBuf,
     pub(super) relative_source: PathBuf,
+}
+
+struct ComparableSource {
+    source: PathBuf,
+    normalized: PathBuf,
+    layout_key: String,
 }
 
 pub(crate) fn plan_inputs(
@@ -21,15 +27,17 @@ pub(crate) fn plan_inputs(
     normalized_roots.sort();
     normalized_roots.dedup();
 
-    let mut normalized_files: Vec<_> = files
+    let normalized_files: Vec<_> = files
         .into_iter()
         .map(|source| {
             let normalized = normalize_absolute(&source, &cwd);
             (source, normalized)
         })
         .collect();
-    normalized_files.sort_by(|left, right| left.1.cmp(&right.1).then_with(|| left.0.cmp(&right.0)));
-    normalized_files.dedup_by(|left, right| left.1 == right.1);
+    // Lexical normalization defines output layout, not filesystem identity.
+    // Resolve identity only for paths competing for the same portable layout
+    // so the ordinary one-file-per-layout path stays syscall-free.
+    let normalized_files = deduplicate_source_aliases(normalized_files, &cwd);
 
     if normalized_roots.is_empty() {
         normalized_roots.extend(
@@ -58,6 +66,66 @@ pub(crate) fn plan_inputs(
             })
         })
         .collect()
+}
+
+fn deduplicate_source_aliases(
+    normalized_files: Vec<(PathBuf, PathBuf)>,
+    cwd: &Path,
+) -> Vec<(PathBuf, PathBuf)> {
+    let mut keyed: Vec<_> = normalized_files
+        .into_iter()
+        .map(|(source, normalized)| ComparableSource {
+            layout_key: portable_key(&normalized),
+            source,
+            normalized,
+        })
+        .collect();
+    keyed.sort_by(|left, right| {
+        left.layout_key
+            .cmp(&right.layout_key)
+            .then_with(|| left.normalized.cmp(&right.normalized))
+            .then_with(|| left.source.cmp(&right.source))
+    });
+    let mut files = keyed.into_iter().peekable();
+    let mut unique = Vec::with_capacity(files.len());
+    let mut identities = FxHashSet::default();
+
+    while let Some(first) = files.next() {
+        let has_same_layout = files
+            .peek()
+            .is_some_and(|candidate| candidate.layout_key == first.layout_key);
+        if !has_same_layout {
+            unique.push((first.source, first.normalized));
+            continue;
+        }
+
+        identities.clear();
+        identities.insert(source_identity(&first.source, cwd));
+        let layout_key = first.layout_key.clone();
+        unique.push((first.source, first.normalized));
+        while files
+            .peek()
+            .is_some_and(|candidate| candidate.layout_key == layout_key)
+        {
+            let candidate = files.next().expect("peeked source must exist");
+            if identities.insert(source_identity(&candidate.source, cwd)) {
+                unique.push((candidate.source, candidate.normalized));
+            }
+        }
+    }
+    unique.sort_by(|left, right| left.1.cmp(&right.1).then_with(|| left.0.cmp(&right.0)));
+    unique
+}
+
+fn source_identity(source: &Path, cwd: &Path) -> PathBuf {
+    let absolute = if source.is_absolute() {
+        source.to_path_buf()
+    } else {
+        cwd.join(source)
+    };
+    // If identity cannot be proven, keep the spelling distinct and let the
+    // collision preflight fail closed instead of silently dropping a source.
+    std::fs::canonicalize(&absolute).unwrap_or(absolute)
 }
 
 pub(crate) fn preflight_outputs(

--- a/crates/vize/src/commands/build/runner/output/tests.rs
+++ b/crates/vize/src/commands/build/runner/output/tests.rs
@@ -106,6 +106,104 @@ fn rejects_case_only_output_collision_portably() {
     assert!(matches!(error, OutputError::Collision { .. }));
 }
 
+#[test]
+fn deduplicates_aliases_of_the_same_source_and_output() {
+    let case = tempfile::tempdir().unwrap();
+    let root = case.path().join("src");
+    let nested = root.join("nested");
+    std::fs::create_dir_all(&nested).unwrap();
+    let source = root.join("App.vue");
+    std::fs::write(&source, "<template><div /></template>").unwrap();
+
+    let planned = plan_inputs(
+        vec![source.clone(), nested.join("../App.vue")],
+        std::slice::from_ref(&root),
+    )
+    .unwrap();
+
+    assert_eq!(planned.len(), 1);
+    assert_eq!(planned[0].source, source);
+    assert_eq!(planned[0].relative_source, Path::new("App.vue"));
+}
+
+#[cfg(any(unix, windows))]
+#[test]
+fn deduplicates_portable_layout_aliases_of_the_same_source() {
+    let case = tempfile::tempdir().unwrap();
+    let root = case.path().join("src");
+    std::fs::create_dir_all(&root).unwrap();
+    let source = root.join("Target.vue");
+    let alias = root.join("target.vue");
+    std::fs::write(&source, "<template><div /></template>").unwrap();
+    if !alias.exists() && !symlink_file(&source, &alias) {
+        return;
+    }
+
+    let planned = plan_inputs(vec![source.clone(), alias], std::slice::from_ref(&root)).unwrap();
+
+    assert_eq!(planned.len(), 1);
+    assert_eq!(planned[0].source, source);
+    preflight_outputs(
+        &planned,
+        &case.path().join("dist"),
+        OutputFormat::Js,
+        ScriptExtension::Downcompile,
+    )
+    .unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn preserves_distinct_sources_crossing_a_symlinked_parent() {
+    let case = tempfile::tempdir().unwrap();
+    let external = tempfile::tempdir().unwrap();
+    let root = case.path().join("src");
+    let direct = root.join("Target.vue");
+    let linked = root.join("link/../Target.vue");
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::create_dir_all(external.path().join("nested")).unwrap();
+    std::fs::write(&direct, "<template><div>direct</div></template>").unwrap();
+    std::fs::write(
+        external.path().join("Target.vue"),
+        "<template><div>linked</div></template>",
+    )
+    .unwrap();
+    if !symlink_directory(&external.path().join("nested"), &root.join("link")) {
+        return;
+    }
+
+    let planned = plan_inputs(
+        vec![direct.clone(), linked.clone()],
+        &[root.clone(), root.join("link/..")],
+    )
+    .unwrap();
+
+    assert_eq!(planned.len(), 2);
+    let error = preflight_outputs(
+        &planned,
+        &case.path().join("dist"),
+        OutputFormat::Js,
+        ScriptExtension::Downcompile,
+    )
+    .unwrap_err();
+    let OutputError::Collision {
+        first_source,
+        first_output,
+        second_source,
+        second_output,
+    } = error
+    else {
+        panic!("expected output collision");
+    };
+    let mut sources = [first_source, second_source];
+    let mut expected_sources = [direct, linked];
+    sources.sort();
+    expected_sources.sort();
+    assert_eq!(sources, expected_sources);
+    assert_eq!(first_output, case.path().join("dist/Target.js"));
+    assert_eq!(second_output, first_output);
+}
+
 fn relative_sources(planned: &[super::PlannedInput], root: &Path) -> Vec<PathBuf> {
     planned
         .iter()
@@ -118,4 +216,44 @@ fn planned_pairs(planned: &[super::PlannedInput]) -> Vec<(PathBuf, PathBuf)> {
         .iter()
         .map(|input| (input.source.clone(), input.relative_source.clone()))
         .collect()
+}
+
+#[cfg(unix)]
+fn symlink_directory(source: &Path, target: &Path) -> bool {
+    match std::os::unix::fs::symlink(source, target) {
+        Ok(()) => true,
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::Unsupported | std::io::ErrorKind::PermissionDenied
+            ) =>
+        {
+            false
+        }
+        Err(error) => panic!("failed to create directory symlink: {error}"),
+    }
+}
+
+#[cfg(any(unix, windows))]
+fn symlink_file(source: &Path, target: &Path) -> bool {
+    #[cfg(unix)]
+    let result = std::os::unix::fs::symlink(source, target);
+    #[cfg(windows)]
+    let result = std::os::windows::fs::symlink_file(source, target);
+
+    match result {
+        Ok(()) => true,
+        #[cfg(windows)]
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => false,
+        #[cfg(unix)]
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::Unsupported | std::io::ErrorKind::PermissionDenied
+            ) =>
+        {
+            false
+        }
+        Err(error) => panic!("failed to create file symlink: {error}"),
+    }
 }

--- a/crates/vize/tests/build_output_paths_cli.rs
+++ b/crates/vize/tests/build_output_paths_cli.rs
@@ -89,6 +89,61 @@ fn build_rejects_fixed_extension_collision_before_compiling_or_writing() {
     assert!(!project.path().join("dist").exists());
 }
 
+#[cfg(unix)]
+#[test]
+fn build_rejects_distinct_sources_crossing_a_symlinked_parent() {
+    let project = tempfile::tempdir().unwrap();
+    let external = tempfile::tempdir().unwrap();
+    write_file(project.path(), "src/Target.vue", ALPHA.as_bytes());
+    write_file(external.path(), "Target.vue", BETA.as_bytes());
+    fs::create_dir_all(external.path().join("nested")).unwrap();
+    let link = project.path().join("src/link");
+    if !symlink_directory(&external.path().join("nested"), &link) {
+        return;
+    }
+
+    let output = run_build(
+        project.path(),
+        &["src/Target.vue", "src/link/../Target.vue"],
+        "dist",
+        &[],
+    );
+
+    assert!(!output.status.success());
+    let stderr = std::str::from_utf8(&output.stderr)
+        .unwrap()
+        .replace('\\', "/");
+    assert!(stderr.contains("output collision"), "{stderr}");
+    assert!(
+        stderr.contains("src/Target.vue -> dist/Target.js"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("src/link/../Target.vue -> dist/Target.js"),
+        "{stderr}"
+    );
+    assert!(!project.path().join("dist").exists());
+}
+
+#[test]
+fn build_deduplicates_aliases_of_the_same_source_and_output() {
+    let project = tempfile::tempdir().unwrap();
+    write_file(project.path(), "src/Target.vue", ALPHA.as_bytes());
+    fs::create_dir_all(project.path().join("src/nested")).unwrap();
+
+    let output = run_build(
+        project.path(),
+        &["src/Target.vue", "src/nested/../Target.vue"],
+        "dist",
+        &[],
+    );
+
+    assert_success(&output);
+    assert!(project.path().join("dist/Target.js").is_file());
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert_eq!(stderr.matches("Built:").count(), 1, "{stderr}");
+}
+
 #[test]
 fn build_rejects_preserved_extension_collision_before_first_write() {
     let project = tempfile::tempdir().unwrap();
@@ -153,6 +208,22 @@ fn write_file(root: &Path, relative: &str, content: &[u8]) {
     let path = root.join(relative);
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     fs::write(path, content).unwrap();
+}
+
+#[cfg(unix)]
+fn symlink_directory(source: &Path, target: &Path) -> bool {
+    match std::os::unix::fs::symlink(source, target) {
+        Ok(()) => true,
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::Unsupported | std::io::ErrorKind::PermissionDenied
+            ) =>
+        {
+            false
+        }
+        Err(error) => panic!("failed to create directory symlink: {error}"),
+    }
 }
 
 fn output_files(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {


### PR DESCRIPTION
## Summary

- keep lexical paths for output layout while using canonical identity only for potential portable-layout aliases
- deduplicate aliases that resolve to the same source
- preserve distinct sources that normalize to the same output and report the existing preflight collision before compilation
- avoid canonicalization on the common non-colliding path
- scope the crossing-symlink-parent regression to Unix, where the tested `link/..` lookup semantics apply

## Verification

- output planner unit tests (8/8)
- `build_output_paths_cli` (7/7)
- `cargo clippy -p vize --lib -- -D warnings`
- `cargo fmt --check`
- independent portability and TOCTOU review

Closes #2872

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786451187&installation_id=136613492&pr_number=2883&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2883&signature=df74a2eec36cdbde501f8cf1b1ed6b996e78291f0d222841e7a3e34ebfefe45b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build input deduplication for equivalent path aliases, avoiding redundant input processing and duplicate planned outputs.
  * Refined “portable layout” handling so identical underlying sources don’t compete unnecessarily.
  * Kept output collision detection working correctly for distinct sources, including cases involving symlinked directories, and prevented incomplete output directories from being created.
* **Tests**
  * Added coverage for alias-based deduplication and symlink-related output collision scenarios (platform-gated where applicable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->