### PR TITLE
fix(ci): bound readiness suite execution

### DIFF
--- a/.github/actions/app-readiness/action.yml
+++ b/.github/actions/app-readiness/action.yml
@@ -80,7 +80,8 @@ runs:
       shell: bash
       run: |
         set -o pipefail
-        vp run --filter './tests' test:readiness:check 2>&1 \
+        timeout --signal=TERM --kill-after=15s 2m \
+          vp run --filter './tests' test:readiness:check 2>&1 \
           | tee target/app-readiness-logs/check.log
 
     - name: Lint CLI fixture
@@ -89,7 +90,8 @@ runs:
       shell: bash
       run: |
         set -o pipefail
-        vp run --filter './tests' test:readiness:lint 2>&1 \
+        timeout --signal=TERM --kill-after=15s 2m \
+          vp run --filter './tests' test:readiness:lint 2>&1 \
           | tee target/app-readiness-logs/lint.log
 
     - name: Build compiler fixture
@@ -98,7 +100,8 @@ runs:
       shell: bash
       run: |
         set -o pipefail
-        vp run --filter './tests' test:readiness:build 2>&1 \
+        timeout --signal=TERM --kill-after=15s 3m \
+          vp run --filter './tests' test:readiness:build 2>&1 \
           | tee target/app-readiness-logs/build.log
 
     - name: Run representative dev smoke
@@ -107,11 +110,12 @@ runs:
       shell: bash
       run: |
         set -o pipefail
-        vp run --filter './tests' test:readiness:dev 2>&1 \
+        timeout --signal=TERM --kill-after=15s 3m \
+          vp run --filter './tests' test:readiness:dev 2>&1 \
           | tee target/app-readiness-logs/dev.log
 
     - name: Upload app readiness artifacts
-      if: ${{ failure() || steps.check.outcome == 'failure' || steps.lint.outcome == 'failure' || steps.build.outcome == 'failure' || steps.dev.outcome == 'failure' }}
+      if: ${{ cancelled() || failure() || steps.check.outcome == 'failure' || steps.lint.outcome == 'failure' || steps.build.outcome == 'failure' || steps.dev.outcome == 'failure' }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: app-readiness-artifacts

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -183,22 +183,29 @@ test("local app readiness action keeps setup, diagnostics, and aggregation bound
   assert.match(installBrowser, /playwright install chromium/);
   assert.doesNotMatch(action, /playwright install --with-deps chromium/);
 
-  for (const [id, script, log] of [
-    ["check", "test:readiness:check", "check.log"],
-    ["lint", "test:readiness:lint", "lint.log"],
-    ["build", "test:readiness:build", "build.log"],
-    ["dev", "test:readiness:dev", "dev.log"],
+  for (const [id, script, log, timeout] of [
+    ["check", "test:readiness:check", "check.log", "2m"],
+    ["lint", "test:readiness:lint", "lint.log", "2m"],
+    ["build", "test:readiness:build", "build.log", "3m"],
+    ["dev", "test:readiness:dev", "dev.log", "3m"],
   ] as const) {
     const step = yamlStepBody(action, { id });
     assert.match(step, /continue-on-error:\s*true/);
     assert.match(step, /shell:\s*bash/);
+    assert.ok(step.includes("set -o pipefail"));
+    assert.ok(step.includes(`timeout --signal=TERM --kill-after=15s ${timeout}`));
     assert.ok(step.includes(script));
     assert.ok(step.includes(`tee target/app-readiness-logs/${log}`));
   }
 
-  assert.match(action, /name:\s*app-readiness-artifacts/);
-  assert.match(action, /target\/app-readiness-logs\//);
-  assert.match(action, /if-no-files-found:\s*ignore/);
+  const upload = yamlStepBody(action, { name: "Upload app readiness artifacts" });
+  assert.match(upload, /if:\s*\$\{\{\s*cancelled\(\)\s*\|\|\s*failure\(\)/);
+  for (const id of ["check", "lint", "build", "dev"]) {
+    assert.match(upload, new RegExp(`steps\\.${id}\\.outcome\\s*==\\s*['"]failure['"]`));
+  }
+  assert.match(upload, /name:\s*app-readiness-artifacts/);
+  assert.match(upload, /target\/app-readiness-logs\//);
+  assert.match(upload, /if-no-files-found:\s*ignore/);
   assert.match(action, /## Fast app readiness/);
   for (const [outcome, step] of [
     ["CHECK_OUTCOME", "check"],


### PR DESCRIPTION
## Summary

- cap compiler check/lint suites at 2 minutes and build/dev suites at 3 minutes
- preserve pipefail, tee logs, per-step outcomes, and run-all aggregation
- upload diagnostic artifacts when the job is cancelled as well as when a suite fails
- assert both behaviors through order-independent composite-action tests

## Verification

- `node --test tests/tooling/e2e-workflow.test.ts` (4/4)
- `npx oxfmt --check tests/tooling/e2e-workflow.test.ts .github/actions/app-readiness/action.yml`
- `git diff --check`

Closes #2880

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786451187&installation_id=136613492&pr_number=2884&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2884&signature=d22ab1e555c04e912eac447238eae73d904931a189d3f374972b3590b73930a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * App readiness validation is now bounded with per-suite time limits to prevent stalled `check`, `lint`, `build`, and `dev` runs.
  * App readiness artifacts are now uploaded on both failures and workflow cancellations (while still tolerating missing diagnostic files).
* **Tests**
  * Updated E2E tooling coverage to verify enforced timeout behavior for each readiness step.
  * Added assertions for the artifact upload step’s cancellation/failure conditions and missing-file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->