### PR TITLE
fix(release): make editor registry publication explicit

### DIFF
--- a/.github/workflows/release-open-vsx.yml
+++ b/.github/workflows/release-open-vsx.yml
@@ -1,21 +1,24 @@
-name: Release Open VSX
+name: Publish Open VSX (optional)
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag_name:
-        description: Release tag to publish to Open VSX
+        description: Published GitHub Release tag to publish to Open VSX
         required: true
         type: string
+
+run-name: Publish Open VSX (optional) - ${{ inputs.tag_name }}
+
+concurrency:
+  group: publish-open-vsx-${{ inputs.tag_name }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  OVSX_PAT: ${{ secrets.OVSX_PAT }}
   PUBLISH_RESOLUTION_RETRY_LIMIT: 24
   PUBLISH_RESOLUTION_RETRY_DELAY: 10
 
@@ -25,8 +28,31 @@ jobs:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 15
     environment: open-vsx-registry
+    env:
+      OVSX_PAT: ${{ secrets.OVSX_PAT }}
     steps:
+      - name: Resolve release tag
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG_NAME: ${{ inputs.tag_name }}
+        run: |
+          test -n "$RELEASE_TAG_NAME"
+          resolved_tag=$(gh release view "$RELEASE_TAG_NAME" --repo "$GITHUB_REPOSITORY" --json isDraft,tagName --jq 'select(.isDraft == false) | .tagName')
+          test "$resolved_tag" = "$RELEASE_TAG_NAME"
+          printf 'tag_name=%s\n' "$resolved_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Require Open VSX credentials
+        run: |
+          if [ -z "${OVSX_PAT:-}" ]; then
+            echo "::error::OVSX_PAT is required in the protected open-vsx-registry environment."
+            exit 1
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.release.outputs.tag_name }}
+          persist-credentials: false
 
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
@@ -35,26 +61,13 @@ jobs:
           run-install: false
       - uses: ./.github/actions/setup-moonbit
 
-      - name: Resolve release tag
-        id: release
-        env:
-          RELEASE_TAG_NAME: ${{ github.event.release.tag_name || inputs.tag_name }}
-        run: |
-          test -n "$RELEASE_TAG_NAME"
-          printf 'tag_name=%s\n' "$RELEASE_TAG_NAME" >> "$GITHUB_OUTPUT"
-
       - name: Download VSIX from GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release download "${{ steps.release.outputs.tag_name }}" --pattern "*.vsix" --dir open-vsx-artifacts
 
-      - name: Skip publish when OVSX_PAT is absent
-        if: env.OVSX_PAT == ''
-        run: echo "OVSX_PAT is not configured; skipping Open VSX publish."
-
       - name: Publish Open VSX extension
-        if: env.OVSX_PAT != ''
         run: |
-          vsix=$(find open-vsx-artifacts -name '*.vsix' -print -quit)
-          test -n "$vsix"
-          moon run --target native tools/moon/cmd/publish_open_vsx_extension -- "$vsix"
+          mapfile -t vsix_files < <(find open-vsx-artifacts -type f -name '*.vsix' -print)
+          test "${#vsix_files[@]}" -eq 1
+          moon run --target native tools/moon/cmd/publish_open_vsx_extension -- "${vsix_files[0]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,13 +209,13 @@ jobs:
           name: editor-extensions
           path: editor-extension-artifacts
 
-      - name: Skip publish when VSCE_PAT is absent
-        if: env.VSCE_PAT == ''
-        run: echo "VSCE_PAT is not configured; skipping VS Code Marketplace publish."
-
+      - name: Require VS Code Marketplace credentials
+        run: |
+          if [ -z "${VSCE_PAT:-}" ]; then
+            echo "::error::VSCE_PAT is required in the protected vscode-marketplace environment."
+            exit 1
+          fi
       - name: Publish VS Code extension
-        if: env.VSCE_PAT != ''
-        continue-on-error: true
         run: moon run --target native tools/moon/cmd/publish_vscode_extension -- editor-extension-artifacts/editors/vscode/dist/vize.vsix
 
   build-release-packages:

--- a/docs/release/v1-alpha-go-no-go.md
+++ b/docs/release/v1-alpha-go-no-go.md
@@ -67,7 +67,10 @@ moon run --target native tools/moon/cmd/release -- alpha -y
   - root npm packages
   - WASM npm package
   - crates.io publishing
-  - VS Code marketplace publishing
+  - required VS Code Marketplace publishing and exact-version visibility
+- [ ] Open VSX is an optional channel. Publish it only when the editor owner explicitly dispatches
+      [`release-open-vsx.yml`](../../.github/workflows/release-open-vsx.yml) for an existing,
+      published GitHub Release tag; it is not part of the official release completion signal.
 - [ ] npm owner verifies every package is visible with the expected prerelease dist-tag:
 
 ```bash
@@ -137,6 +140,19 @@ cargo yank --vers <bad-version> vize
 - [ ] If docs are wrong, revert the docs commit or redeploy the previous known-good Pages artifact.
 - [ ] If the VS Code extension is broken, publish a fixed pre-release and update the marketplace
       description. Do not unpublish without editor owner and release captain approval.
+
+### Partial editor publication recovery
+
+- If VS Code Marketplace publication fails, the required job prevents GitHub Release creation.
+  Restore the `VSCE_PAT` secret in the protected `vscode-marketplace` environment, then rerun the
+  failed jobs in the same Release workflow. Do not recreate or force-push the tag. The publisher
+  skips the exact version when it is already visible, so rerunning after a partial publish is safe.
+- Open VSX does not run automatically. For an existing published GitHub Release, restore `OVSX_PAT`
+  in the protected `open-vsx-registry` environment and manually dispatch the optional workflow with
+  that release tag. It checks out the same tag and requires exactly one attached VSIX. Re-dispatching
+  is safe when the exact version is already visible.
+- A publisher exit code is never sufficient evidence by itself. Both registry jobs stay red until
+  the exact extension version is visible in the destination registry.
 
 ## Communication
 

--- a/tests/tooling/github-workflows-release-publish.test.ts
+++ b/tests/tooling/github-workflows-release-publish.test.ts
@@ -161,41 +161,49 @@ test("release workflow creates GitHub Releases only after registry publishing su
   assert.notEqual(createRelease, -1);
 });
 
-test("release workflow does not block GitHub releases on VS Code Marketplace token expiry", () => {
+test("release workflow requires VS Code Marketplace publication", () => {
   const workflow = readRepoFile(".github", "workflows", "release.yml");
   const publishJob = workflowJobBody(workflow, "release-vscode-extension");
 
-  assert.match(publishJob, /name:\s*Skip publish when VSCE_PAT is absent/);
-  assert.match(
-    publishJob,
-    /name:\s*Publish VS Code extension[\s\S]*if:\s*env\.VSCE_PAT != ''[\s\S]*continue-on-error:\s*true[\s\S]*tools\/moon\/cmd\/publish_vscode_extension/,
-  );
+  assert.match(publishJob, /environment:\s*vscode-marketplace/);
+  assert.match(publishJob, /VSCE_PAT:\s*\$\{\{ secrets\.VSCE_PAT \}\}/);
+  assert.match(publishJob, /name:\s*Require VS Code Marketplace credentials/);
+  assert.match(publishJob, /if \[ -z "\$\{VSCE_PAT:-\}" \]/);
+  assert.match(publishJob, /VSCE_PAT is required in the protected vscode-marketplace environment/);
+  assert.match(publishJob, /name:\s*Publish VS Code extension/);
+  assert.match(publishJob, /tools\/moon\/cmd\/publish_vscode_extension/);
+  assert.doesNotMatch(publishJob, /Skip publish|continue-on-error|if:\s*env\.VSCE_PAT/);
 });
 
-test("Open VSX workflow publishes the VS Code extension when configured", () => {
+test("Open VSX publication is an explicit, fail-closed opt-in", () => {
   const workflow = readRepoFile(".github", "workflows", "release-open-vsx.yml");
   const publishJob = workflowJobBody(workflow, "release-open-vsx-extension");
 
-  assert.match(workflow, /on:\s*\n\s*release:\s*\n\s*types:\s*\[published\]/);
+  assert.match(workflow, /name:\s*Publish Open VSX \(optional\)/);
+  assert.match(workflow, /group:\s*publish-open-vsx-\$\{\{ inputs\.tag_name \}\}/);
+  assert.match(workflow, /cancel-in-progress:\s*false/);
+  assert.doesNotMatch(workflow, /\n\s*release:\s*\n\s*types:\s*\[published\]/);
   assert.match(
     workflow,
-    /workflow_dispatch:\s*\n\s*inputs:\s*\n\s*tag_name:\s*\n\s*description:\s*Release tag to publish to Open VSX[\s\S]*required:\s*true[\s\S]*type:\s*string/,
+    /workflow_dispatch:\s*\n\s*inputs:\s*\n\s*tag_name:\s*\n\s*description:\s*Published GitHub Release tag to publish to Open VSX[\s\S]*required:\s*true[\s\S]*type:\s*string/,
   );
   assert.match(publishJob, /environment:\s*open-vsx-registry/);
-  assert.match(workflow, /OVSX_PAT:\s*\$\{\{ secrets\.OVSX_PAT \}\}/);
+  assert.match(publishJob, /OVSX_PAT:\s*\$\{\{ secrets\.OVSX_PAT \}\}/);
   assert.match(publishJob, /name:\s*Resolve release tag/);
-  assert.match(
-    publishJob,
-    /RELEASE_TAG_NAME:\s*\$\{\{ github\.event\.release\.tag_name \|\| inputs\.tag_name \}\}/,
-  );
+  assert.match(publishJob, /RELEASE_TAG_NAME:\s*\$\{\{ inputs\.tag_name \}\}/);
+  assert.match(publishJob, /gh release view "\$RELEASE_TAG_NAME" --repo "\$GITHUB_REPOSITORY"/);
+  assert.match(publishJob, /--json isDraft,tagName/);
+  assert.match(publishJob, /select\(\.isDraft == false\)/);
   assert.match(publishJob, /tag_name=%s\\n/);
+  assert.match(publishJob, /name:\s*Require Open VSX credentials/);
+  assert.match(publishJob, /if \[ -z "\$\{OVSX_PAT:-\}" \]/);
+  assert.match(publishJob, /OVSX_PAT is required in the protected open-vsx-registry environment/);
+  assert.match(publishJob, /ref:\s*\$\{\{ steps\.release\.outputs\.tag_name \}\}/);
+  assert.match(publishJob, /persist-credentials:\s*false/);
   assert.match(publishJob, /name:\s*Download VSIX from GitHub Release/);
   assert.match(publishJob, /gh release download "\$\{\{ steps\.release\.outputs\.tag_name \}\}"/);
   assert.match(publishJob, /--pattern "\*\.vsix"/);
-  assert.match(publishJob, /name:\s*Skip publish when OVSX_PAT is absent/);
-  assert.match(
-    publishJob,
-    /name:\s*Publish Open VSX extension[\s\S]*if:\s*env\.OVSX_PAT != ''[\s\S]*tools\/moon\/cmd\/publish_open_vsx_extension/,
-  );
-  assert.doesNotMatch(publishJob, /continue-on-error:\s*true/);
+  assert.match(publishJob, /test "\$\{#vsix_files\[@\]\}" -eq 1/);
+  assert.match(publishJob, /tools\/moon\/cmd\/publish_open_vsx_extension/);
+  assert.doesNotMatch(publishJob, /Skip publish|continue-on-error|if:\s*env\.OVSX_PAT/);
 });

--- a/tests/tooling/moonbit-editor-registry-visibility.test.ts
+++ b/tests/tooling/moonbit-editor-registry-visibility.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { test } from "node:test";
+
+import { runMoonScript } from "./_helpers/moonbit.ts";
+import { writeFakeCommand } from "./support/fake-command.ts";
+
+const scenarios = [
+  {
+    script: "publish_vscode_extension",
+    metadataCommand: "show",
+    registry: "VS Code Marketplace",
+  },
+  {
+    script: "publish_open_vsx_extension",
+    metadataCommand: "get",
+    registry: "Open VSX",
+  },
+] as const;
+
+for (const scenario of scenarios) {
+  for (const publishExit of [0, 42]) {
+    const outcome = publishExit === 0 ? "successful" : "failed";
+    test(`${scenario.script} rejects an unconfirmed ${outcome} publish`, () => {
+      const tempDir = mkdtempSync(path.join(tmpdir(), "editor-registry-visibility-"));
+      const binDir = path.join(tempDir, "bin");
+      const manifestPath = path.join(tempDir, "package.json");
+      const vsixPath = path.join(tempDir, "vize.vsix");
+      const callsPath = path.join(tempDir, "calls.json");
+
+      try {
+        fs.mkdirSync(binDir, { recursive: true });
+        writeFileSync(
+          manifestPath,
+          `${JSON.stringify({ publisher: "ubugeeei", name: "vize", version: "0.57.0" })}\n`,
+        );
+        writeFileSync(vsixPath, "vsix");
+        writeFakeCommand(
+          binDir,
+          "vp",
+          [
+            "const fs = require('node:fs');",
+            "const args = process.argv.slice(2);",
+            "const calls = fs.existsSync(process.env.CALLS_PATH) ? JSON.parse(fs.readFileSync(process.env.CALLS_PATH, 'utf8')) : [];",
+            "calls.push(args);",
+            "fs.writeFileSync(process.env.CALLS_PATH, JSON.stringify(calls));",
+            "if (args[4] === 'show' || args[4] === 'get') process.exit(1);",
+            "if (args[4] === 'create-namespace') process.exit(0);",
+            "if (args[4] === 'publish') process.exit(Number(process.env.PUBLISH_EXIT));",
+            "process.exit(1);",
+          ].join("\n"),
+        );
+
+        const result = runMoonScript(scenario.script, [vsixPath, manifestPath], {
+          env: {
+            PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+            CALLS_PATH: callsPath,
+            PUBLISH_EXIT: String(publishExit),
+            PUBLISH_RESOLUTION_RETRY_LIMIT: "1",
+            PUBLISH_RESOLUTION_RETRY_DELAY: "0",
+          },
+        });
+
+        assert.equal(result.status, publishExit === 0 ? 1 : publishExit);
+        if (publishExit === 0) {
+          assert.match(result.stderr, new RegExp(`${scenario.registry} did not expose`));
+        }
+        const calls = JSON.parse(fs.readFileSync(callsPath, "utf8")) as string[][];
+        assert.equal(calls.filter((args) => args[4] === scenario.metadataCommand).length, 2);
+        assert.equal(calls.filter((args) => args[4] === "publish").length, 1);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+  }
+}

--- a/tests/tooling/moonbit-publish-open-vsx.test.ts
+++ b/tests/tooling/moonbit-publish-open-vsx.test.ts
@@ -45,7 +45,9 @@ test("publish_open_vsx_extension publishes a packaged VSIX with ovsx", () => {
         "  process.exit(1);",
         "}",
         "if (args[0] === 'dlx' && args[2] === 'ovsx@^1.0.0' && args[3] === 'ovsx' && args[4] === 'create-namespace') {",
-        "  process.exit(0);",
+        "  if (process.env.NAMESPACE_ERROR === 'auth') { console.error('token is not authorized'); process.exit(17); }",
+        "  console.error('Namespace already exists');",
+        "  process.exit(17);",
         "}",
         "if (args[0] === 'dlx' && args[2] === 'ovsx@^1.0.0' && args[3] === 'ovsx' && args[4] === 'publish') {",
         "  state.published = true;",
@@ -56,17 +58,33 @@ test("publish_open_vsx_extension publishes a packaged VSIX with ovsx", () => {
       ].join("\n"),
     );
 
-    const result = runMoonScript("publish_open_vsx_extension", [vsixPath, manifestPath], {
-      env: {
-        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
-        CALLS_PATH: callsPath,
-        STATE_PATH: statePath,
-      },
-    });
+    const runPublish = (namespaceError?: string) =>
+      runMoonScript("publish_open_vsx_extension", [vsixPath, manifestPath], {
+        env: {
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          CALLS_PATH: callsPath,
+          STATE_PATH: statePath,
+          NAMESPACE_ERROR: namespaceError ?? "",
+        },
+      });
+
+    const rejected = runPublish("auth");
+    assert.equal(rejected.status, 1);
+    assert.match(rejected.stderr, /token is not authorized/);
+    assert.doesNotMatch(rejected.stdout, /continuing to publish/);
+    const rejectedCalls = JSON.parse(fs.readFileSync(callsPath, "utf8")) as string[][];
+    assert.deepEqual(
+      rejectedCalls.map((call) => call[4]),
+      ["get", "create-namespace"],
+    );
+
+    writeFileSync(callsPath, "[]");
+    const result = runPublish();
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
+    assert.match(result.stdout, /already exists; continuing to publish/);
 
     const calls = JSON.parse(fs.readFileSync(callsPath, "utf8")) as string[][];
-    assert.deepEqual(calls.at(-2), [
+    assert.deepEqual(calls.at(-3), [
       "dlx",
       "-p",
       "ovsx@^1.0.0",
@@ -74,7 +92,8 @@ test("publish_open_vsx_extension publishes a packaged VSIX with ovsx", () => {
       "create-namespace",
       "ubugeeei",
     ]);
-    assert.deepEqual(calls.at(-1), ["dlx", "-p", "ovsx@^1.0.0", "ovsx", "publish", vsixPath]);
+    assert.deepEqual(calls.at(-2), ["dlx", "-p", "ovsx@^1.0.0", "ovsx", "publish", vsixPath]);
+    assert.equal(calls.at(-1)?.[4], "get");
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }

--- a/tests/tooling/moonbit-publish.test.ts
+++ b/tests/tooling/moonbit-publish.test.ts
@@ -537,7 +537,7 @@ test("publish_vscode_extension adds pre-release when NPM_TAG is not latest", () 
       [
         "const fs = require('node:fs');",
         "const args = process.argv.slice(2);",
-        "if (args[0] === 'dlx' && args[3] === 'vsce' && args[4] === 'show') process.exit(1);",
+        "if (args[0] === 'dlx' && args[3] === 'vsce' && args[4] === 'show') { if (fs.existsSync(process.env.VP_ARGS_LOG)) { process.stdout.write(JSON.stringify({ versions: [{ version: '0.57.0' }] })); process.exit(0); } process.exit(1); }",
         "fs.writeFileSync(process.env.VP_ARGS_LOG, args.join('\\n'));",
         "process.exit(0);",
       ].join("\n"),

--- a/tools/moon/cmd/publish_open_vsx_extension/main.mbt
+++ b/tools/moon/cmd/publish_open_vsx_extension/main.mbt
@@ -1,23 +1,23 @@
+///|
 /// Publishes the VS Code extension to Open VSX in a rerun-safe way.
 /// Release retries are common when a tag is force-pushed to re-run a partially
 /// completed workflow. This script mirrors the VS Code Marketplace publish
 /// guard by checking Open VSX metadata before publishing and after any non-zero
 /// publish exit.
-
 struct ExtensionInfo {
   extension_id : String
   publisher : String
   version : String
 }
 
+///|
 fn parse_int(value : String) -> Int? {
-  try {
-    Some(@string.parse_int(value))
-  } catch {
+  Some(@string.parse_int(value)) catch {
     _ => None
   }
 }
 
+///|
 fn int_at_least_or(value : String, minimum : Int, fallback : Int) -> Int {
   match parse_int(value) {
     Some(parsed) if parsed >= minimum => parsed
@@ -25,6 +25,7 @@ fn int_at_least_or(value : String, minimum : Int, fallback : Int) -> Int {
   }
 }
 
+///|
 fn env_int_at_least(name : String, minimum : Int, fallback : Int) -> Int {
   match @sys.get_env_var(name) {
     Some(value) if value != "" => int_at_least_or(value, minimum, fallback)
@@ -32,23 +33,28 @@ fn env_int_at_least(name : String, minimum : Int, fallback : Int) -> Int {
   }
 }
 
+///|
 fn read_package_json(path : String) -> Json? {
-  try {
-    Some(@json.parse(@xfs.read_file_to_string(path)))
-  } catch {
+  Some(@json.parse(@xfs.read_file_to_string(path))) catch {
     _ => None
   }
 }
 
+///|
 fn extension_info_from_package_json(value : Json) -> ExtensionInfo? {
   guard value is Object(obj) else { return None }
   guard obj.get("publisher") is Some(String(publisher)) else { return None }
   guard obj.get("name") is Some(String(name)) else { return None }
   guard obj.get("version") is Some(String(version)) else { return None }
   guard publisher != "" && name != "" && version != "" else { return None }
-  Some(ExtensionInfo::{ extension_id: publisher + "." + name, publisher, version })
+  Some(ExtensionInfo::{
+    extension_id: publisher + "." + name,
+    publisher,
+    version,
+  })
 }
 
+///|
 fn json_has_extension_version(value : Json, expected : String) -> Bool {
   guard value is Object(obj) else { return false }
   if obj.get("version") is Some(String(version)) && version == expected {
@@ -57,28 +63,24 @@ fn json_has_extension_version(value : Json, expected : String) -> Bool {
   guard obj.get("versions") is Some(Array(versions)) else { return false }
   for item in versions {
     guard item is Object(version_obj) else { continue }
-    if version_obj.get("version") is Some(String(version)) && version == expected {
+    if version_obj.get("version") is Some(String(version)) &&
+      version == expected {
       return true
     }
   }
   false
 }
 
-async fn extension_version_is_visible(vp_bin : String, extension_id : String, version : String) -> Bool {
-  let (exit_code, stdout, _) = @process.collect_output(
-    vp_bin,
-    [
-      "dlx",
-      "-p",
-      "ovsx@^1.0.0",
-      "ovsx",
-      "get",
-      extension_id,
-      "--metadata",
-      "--versionRange",
-      version,
-    ],
-  )
+///|
+async fn extension_version_is_visible(
+  vp_bin : String,
+  extension_id : String,
+  version : String,
+) -> Bool {
+  let (exit_code, stdout, _) = @process.collect_output(vp_bin, [
+    "dlx", "-p", "ovsx@^1.0.0", "ovsx", "get", extension_id, "--metadata", "--versionRange",
+    version,
+  ])
   if exit_code != 0 {
     return false
   }
@@ -86,14 +88,11 @@ async fn extension_version_is_visible(vp_bin : String, extension_id : String, ve
   if body == "" {
     return false
   }
-  let parsed = try {
-    @json.parse(body)
-  } catch {
-    _ => return false
-  }
+  let parsed = @json.parse(body) catch { _ => return false }
   json_has_extension_version(parsed, version)
 }
 
+///|
 async fn wait_for_extension_visibility(
   vp_bin : String,
   extension_id : String,
@@ -119,16 +118,34 @@ async fn wait_for_extension_visibility(
   false
 }
 
-async fn ensure_namespace(vp_bin : String, publisher : String) -> Unit {
-  let exit_code = @process.run(
-    vp_bin,
-    ["dlx", "-p", "ovsx@^1.0.0", "ovsx", "create-namespace", publisher],
-  )
-  if exit_code != 0 {
-    println("Open VSX namespace \{publisher} may already exist; continuing to publish.")
+///|
+async fn ensure_namespace(vp_bin : String, publisher : String) -> Bool {
+  let (exit_code, stdout, stderr) = @process.collect_output(vp_bin, [
+    "dlx", "-p", "ovsx@^1.0.0", "ovsx", "create-namespace", publisher,
+  ])
+  if exit_code == 0 {
+    return true
   }
+  let detail = [
+      stdout.text().trim().to_owned(),
+      stderr.text().trim().to_owned(),
+    ]
+    .filter(text => text != "")
+    .join("\n")
+  if detail.to_lower().contains("already exists") {
+    println(
+      "Open VSX namespace \{publisher} already exists; continuing to publish.",
+    )
+    return true
+  }
+  let suffix = if detail == "" { "" } else { "\n" + detail }
+  @stdio.stderr.write(
+    "Failed to ensure Open VSX namespace \{publisher} (exit \{exit_code}).\{suffix}\n",
+  )
+  false
 }
 
+///|
 async fn run_app() -> Int {
   let args = @tool.cli_args()
   if args.is_empty() || args.length() > 2 {
@@ -147,7 +164,9 @@ async fn run_app() -> Int {
       match extension_info_from_package_json(value) {
         Some(info) => info
         None => {
-          @stdio.stderr.write("Failed to read extension metadata from \{package_json_path}\n")
+          @stdio.stderr.write(
+            "Failed to read extension metadata from \{package_json_path}\n",
+          )
           return 1
         }
       }
@@ -160,49 +179,58 @@ async fn run_app() -> Int {
     Some(value) if value != "" => value
     _ => "vp"
   }
-  let resolution_attempts = env_int_at_least("PUBLISH_RESOLUTION_RETRY_LIMIT", 1, 24)
-  let resolution_delay_seconds = env_int_at_least("PUBLISH_RESOLUTION_RETRY_DELAY", 0, 10)
+  let resolution_attempts = env_int_at_least(
+    "PUBLISH_RESOLUTION_RETRY_LIMIT", 1, 24,
+  )
+  let resolution_delay_seconds = env_int_at_least(
+    "PUBLISH_RESOLUTION_RETRY_DELAY", 0, 10,
+  )
   if extension_version_is_visible(
-    vp_bin,
-    extension_info.extension_id,
-    extension_info.version,
-  ) {
+      vp_bin,
+      extension_info.extension_id,
+      extension_info.version,
+    ) {
     println(
       "\{extension_info.extension_id} \{extension_info.version} is already published, skipping Open VSX publish.",
     )
     return 0
   }
-  ensure_namespace(vp_bin, extension_info.publisher)
+  if !ensure_namespace(vp_bin, extension_info.publisher) {
+    return 1
+  }
 
-  let exit_code = @process.run(
-    vp_bin,
-    [
-      "dlx",
-      "-p",
-      "ovsx@^1.0.0",
-      "ovsx",
-      "publish",
-      @tool.resolve_path(args[0]),
-    ],
-  )
-  if exit_code == 0 {
+  let exit_code = @process.run(vp_bin, [
+    "dlx",
+    "-p",
+    "ovsx@^1.0.0",
+    "ovsx",
+    "publish",
+    @tool.resolve_path(args[0]),
+  ])
+  if wait_for_extension_visibility(
+      vp_bin,
+      extension_info.extension_id,
+      extension_info.version,
+      resolution_attempts,
+      resolution_delay_seconds,
+    ) {
+    if exit_code != 0 {
+      println(
+        "\{extension_info.extension_id} \{extension_info.version} was published despite a non-zero ovsx publish exit.",
+      )
+    }
     return 0
   }
-  if wait_for_extension_visibility(
-    vp_bin,
-    extension_info.extension_id,
-    extension_info.version,
-    resolution_attempts,
-    resolution_delay_seconds,
-  ) {
-    println(
-      "\{extension_info.extension_id} \{extension_info.version} was published despite a non-zero ovsx publish exit.",
+  if exit_code == 0 {
+    @stdio.stderr.write(
+      "Open VSX did not expose \{extension_info.extension_id} \{extension_info.version} before the visibility deadline.\n",
     )
-    return 0
+    return 1
   }
   exit_code
 }
 
+///|
 async fn main {
   @sys.exit(run_app())
 }

--- a/tools/moon/cmd/publish_vscode_extension/main.mbt
+++ b/tools/moon/cmd/publish_vscode_extension/main.mbt
@@ -1,3 +1,4 @@
+///|
 /// Publishes the VS Code extension in a rerun-safe way.
 /// Release retries are common when a tag is force-pushed to re-run a partially
 /// completed workflow. npm packages and crates are already idempotent in this
@@ -8,20 +9,19 @@
 /// 3. Skip publish entirely when the exact version is already visible.
 /// 4. Treat a non-zero `vsce publish` exit as success if the version becomes
 ///    visible immediately after the attempted publish.
-
 struct ExtensionInfo {
   extension_id : String
   version : String
 }
 
+///|
 fn parse_int(value : String) -> Int? {
-  try {
-    Some(@string.parse_int(value))
-  } catch {
+  Some(@string.parse_int(value)) catch {
     _ => None
   }
 }
 
+///|
 fn int_at_least_or(value : String, minimum : Int, fallback : Int) -> Int {
   match parse_int(value) {
     Some(parsed) if parsed >= minimum => parsed
@@ -29,6 +29,7 @@ fn int_at_least_or(value : String, minimum : Int, fallback : Int) -> Int {
   }
 }
 
+///|
 fn env_int_at_least(name : String, minimum : Int, fallback : Int) -> Int {
   match @sys.get_env_var(name) {
     Some(value) if value != "" => int_at_least_or(value, minimum, fallback)
@@ -36,14 +37,14 @@ fn env_int_at_least(name : String, minimum : Int, fallback : Int) -> Int {
   }
 }
 
+///|
 fn read_package_json(path : String) -> Json? {
-  try {
-    Some(@json.parse(@xfs.read_file_to_string(path)))
-  } catch {
+  Some(@json.parse(@xfs.read_file_to_string(path))) catch {
     _ => None
   }
 }
 
+///|
 fn extension_info_from_package_json(value : Json) -> ExtensionInfo? {
   guard value is Object(obj) else { return None }
   guard obj.get("publisher") is Some(String(publisher)) else { return None }
@@ -53,23 +54,29 @@ fn extension_info_from_package_json(value : Json) -> ExtensionInfo? {
   Some(ExtensionInfo::{ extension_id: publisher + "." + name, version })
 }
 
+///|
 fn json_has_extension_version(value : Json, expected : String) -> Bool {
   guard value is Object(obj) else { return false }
   guard obj.get("versions") is Some(Array(versions)) else { return false }
   for item in versions {
     guard item is Object(version_obj) else { continue }
-    if version_obj.get("version") is Some(String(version)) && version == expected {
+    if version_obj.get("version") is Some(String(version)) &&
+      version == expected {
       return true
     }
   }
   false
 }
 
-async fn extension_version_is_visible(vp_bin : String, extension_id : String, version : String) -> Bool {
-  let (exit_code, stdout, _) = @process.collect_output(
-    vp_bin,
-    ["dlx", "-p", "@vscode/vsce@^3.3.2", "vsce", "show", extension_id, "--json"],
-  )
+///|
+async fn extension_version_is_visible(
+  vp_bin : String,
+  extension_id : String,
+  version : String,
+) -> Bool {
+  let (exit_code, stdout, _) = @process.collect_output(vp_bin, [
+    "dlx", "-p", "@vscode/vsce@^3.3.2", "vsce", "show", extension_id, "--json",
+  ])
   if exit_code != 0 {
     return false
   }
@@ -77,14 +84,11 @@ async fn extension_version_is_visible(vp_bin : String, extension_id : String, ve
   if body == "" {
     return false
   }
-  let parsed = try {
-    @json.parse(body)
-  } catch {
-    _ => return false
-  }
+  let parsed = @json.parse(body) catch { _ => return false }
   json_has_extension_version(parsed, version)
 }
 
+///|
 async fn wait_for_extension_visibility(
   vp_bin : String,
   extension_id : String,
@@ -95,7 +99,9 @@ async fn wait_for_extension_visibility(
   let mut attempt = 1
   while attempt <= max_attempts {
     if extension_version_is_visible(vp_bin, extension_id, version) {
-      println("\{extension_id} \{version} is visible in the VS Code Marketplace.")
+      println(
+        "\{extension_id} \{version} is visible in the VS Code Marketplace.",
+      )
       return true
     }
     if attempt >= max_attempts {
@@ -110,6 +116,7 @@ async fn wait_for_extension_visibility(
   false
 }
 
+///|
 async fn run_app() -> Int {
   let args = @tool.cli_args()
   if args.is_empty() || args.length() > 2 {
@@ -128,7 +135,9 @@ async fn run_app() -> Int {
       match extension_info_from_package_json(value) {
         Some(info) => info
         None => {
-          @stdio.stderr.write("Failed to read extension metadata from \{package_json_path}\n")
+          @stdio.stderr.write(
+            "Failed to read extension metadata from \{package_json_path}\n",
+          )
           return 1
         }
       }
@@ -141,13 +150,17 @@ async fn run_app() -> Int {
     Some(value) if value != "" => value
     _ => "vp"
   }
-  let resolution_attempts = env_int_at_least("PUBLISH_RESOLUTION_RETRY_LIMIT", 1, 24)
-  let resolution_delay_seconds = env_int_at_least("PUBLISH_RESOLUTION_RETRY_DELAY", 0, 10)
+  let resolution_attempts = env_int_at_least(
+    "PUBLISH_RESOLUTION_RETRY_LIMIT", 1, 24,
+  )
+  let resolution_delay_seconds = env_int_at_least(
+    "PUBLISH_RESOLUTION_RETRY_DELAY", 0, 10,
+  )
   if extension_version_is_visible(
-    vp_bin,
-    extension_info.extension_id,
-    extension_info.version,
-  ) {
+      vp_bin,
+      extension_info.extension_id,
+      extension_info.version,
+    ) {
     println(
       "\{extension_info.extension_id} \{extension_info.version} is already published, skipping VS Code Marketplace publish.",
     )
@@ -172,24 +185,30 @@ async fn run_app() -> Int {
     publish_args.push("--pre-release")
   }
   let exit_code = @process.run(vp_bin, publish_args)
-  if exit_code == 0 {
+  if wait_for_extension_visibility(
+      vp_bin,
+      extension_info.extension_id,
+      extension_info.version,
+      resolution_attempts,
+      resolution_delay_seconds,
+    ) {
+    if exit_code != 0 {
+      println(
+        "\{extension_info.extension_id} \{extension_info.version} was published despite a non-zero vsce publish exit.",
+      )
+    }
     return 0
   }
-  if wait_for_extension_visibility(
-    vp_bin,
-    extension_info.extension_id,
-    extension_info.version,
-    resolution_attempts,
-    resolution_delay_seconds,
-  ) {
-    println(
-      "\{extension_info.extension_id} \{extension_info.version} was published despite a non-zero vsce publish exit.",
+  if exit_code == 0 {
+    @stdio.stderr.write(
+      "VS Code Marketplace did not expose \{extension_info.extension_id} \{extension_info.version} before the visibility deadline.\n",
     )
-    return 0
+    return 1
   }
   exit_code
 }
 
+///|
 async fn main {
   @sys.exit(run_app())
 }


### PR DESCRIPTION
## Summary

- make VS Code Marketplace publication a required release dependency with protected-environment credentials
- remove missing-token skips and masked publisher failures
- require the exact extension version to become visible even after a zero publisher exit
- define Open VSX as an explicit optional channel dispatched only for an existing published GitHub Release
- make Open VSX fail closed on missing credentials, ambiguous VSIX assets, publisher failure, and missing exact-version visibility
- document rerun-safe recovery for partial editor publication

## Release contract

- VS Code Marketplace: required before GitHub Release creation
- Open VSX: optional, manual, post-release channel with its own protected environment

## Verification

- workflow and publisher tests (25/25)
- VS Code/Open VSX zero-exit and nonzero-exit visibility failure contracts
- delayed visibility and already-published rerun contracts
- MoonBit format check
- Oxfmt and diff checks
- source-length comparison against main

Closes #2873

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786451603&installation_id=136613492&pr_number=2885&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2885&signature=e88fe1c3d3b5030b01579c3062b97f4111d117d8e19981669964df49f5fe7d21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Publishing**
  * VS Code Marketplace publishing now requires valid credentials and fails clearly when unavailable.
  * Published extension versions are verified as visible before release completion, improving rerun and failure handling.
  * Open VSX publishing is now an explicit manual action tied to an existing release and requires credentials.

* **Documentation**
  * Added guidance for verifying publication and recovering from partial editor publication failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->