### PR TITLE
fix(codegen): avoid unused slot outlet prop hoists

### DIFF
--- a/crates/vize_atelier_core/src/transforms/hoist_static.rs
+++ b/crates/vize_atelier_core/src/transforms/hoist_static.rs
@@ -470,7 +470,7 @@ fn inject_scope_id<'a>(
 
 /// Check if an element has static props that can be hoisted as an object.
 fn has_static_props(el: &ElementNode<'_>) -> bool {
-    if el.props.is_empty() {
+    if el.tag_type == ElementType::Slot || el.props.is_empty() {
         return false;
     }
 

--- a/crates/vize_atelier_dom/tests/slot_outlet_hoist.rs
+++ b/crates/vize_atelier_dom/tests/slot_outlet_hoist.rs
@@ -1,0 +1,21 @@
+use vize_atelier_dom::compile_template;
+use vize_carton::Bump;
+
+#[test]
+fn slot_outlet_does_not_create_an_unused_generic_prop_hoist() {
+    let allocator = Bump::new();
+    let (_, errors, result) = compile_template(
+        &allocator,
+        r#"<section><slot name="title" class="headline">Fallback</slot></section>"#,
+    );
+
+    assert!(errors.is_empty(), "unexpected compiler errors: {errors:?}");
+    assert!(
+        !result.preamble.contains("_hoisted_"),
+        "slot outlet codegen cannot consume generic prop hoists:\n{}",
+        result.preamble
+    );
+    assert!(result.code.contains("_renderSlot(_ctx.$slots, \"title\""));
+    assert!(result.code.contains("{ class: \"headline\" }"));
+    assert!(result.code.contains("Fallback"));
+}


### PR DESCRIPTION
## Summary

- exclude slot outlets from generic element-prop hoisting because their dedicated codegen path cannot consume `hoisted_props_index`
- preserve inline slot name and static slot-prop generation
- prevent dead top-level declarations such as `const _hoisted_1 = { name: "title" }`

## Verification

- dedicated slot-outlet integration regression
- `cargo clippy -p vize_atelier_core -p vize_atelier_dom --lib -- -D warnings`
- Rust formatting
- source-length comparison against main
- audited against the official Vue compiler while reviewing #2869

Closes #2886

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786452269&installation_id=136613492&pr_number=2887&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2887&signature=957f81e1959cb8b0879cb6ff7fbe2ebc0573c6a7d93994cea13962019d7d4c85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed slot elements being incorrectly treated as eligible for static property hoisting.
  * Prevented unused generated code from appearing when compiling named slots with fallback content.

* **Tests**
  * Added coverage confirming correct slot rendering and preservation of slot outlet properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->