### PR TITLE
feat(release): add resilient GitHub evidence client

### DIFF
--- a/tests/tooling/release-preflight-github.test.ts
+++ b/tests/tooling/release-preflight-github.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { githubApiPages, githubApiRequest } from "../../tools/github/release-preflight-github.mjs";
+
+const requestBase = {
+  apiUrl: "https://api.github.test",
+  repository: "owner/repository",
+  token: "secret",
+  resource: "actions/runs",
+};
+
+test("GitHub API GETs retry transient responses but mutations do not", async () => {
+  let calls = 0;
+  const waits: number[] = [];
+  const response = await githubApiRequest({
+    ...requestBase,
+    fetchImpl: async () => {
+      calls += 1;
+      return calls === 1
+        ? new Response("temporarily unavailable", { status: 503 })
+        : new Response("{}", { status: 200 });
+    },
+    sleep: async (milliseconds) => waits.push(milliseconds),
+  });
+  assert.equal(response.body, "{}");
+  assert.equal(calls, 2);
+  assert.deepEqual(waits, [1_000]);
+
+  calls = 0;
+  await assert.rejects(
+    githubApiRequest({
+      ...requestBase,
+      method: "POST",
+      fetchImpl: async () => {
+        calls += 1;
+        return new Response("temporarily unavailable", { status: 503 });
+      },
+    }),
+    /503/,
+  );
+  assert.equal(calls, 1);
+});
+
+test("GitHub API request timeout covers both headers and response body", async () => {
+  await assert.rejects(
+    githubApiRequest({
+      ...requestBase,
+      method: "POST",
+      requestTimeoutMs: 5,
+      fetchImpl: async (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new Error("aborted")), {
+            once: true,
+          });
+        }),
+    }),
+    /timed out after 5ms/,
+  );
+});
+
+test("GitHub API pagination keeps exact query filters and reads every page", async () => {
+  const urls: string[] = [];
+  const values = await githubApiPages({
+    ...requestBase,
+    collection: "workflow_runs",
+    query: { head_sha: "a".repeat(40) },
+    fetchImpl: async (url) => {
+      urls.push(String(url));
+      const page = new URL(String(url)).searchParams.get("page");
+      const workflowRuns =
+        page === "1" ? Array.from({ length: 100 }, (_, id) => ({ id })) : [{ id: 100 }];
+      return new Response(JSON.stringify({ workflow_runs: workflowRuns }), { status: 200 });
+    },
+  });
+
+  assert.equal(values.length, 101);
+  assert.equal(urls.length, 2);
+  for (const url of urls) {
+    assert.equal(new URL(url).searchParams.get("head_sha"), "a".repeat(40));
+    assert.equal(new URL(url).searchParams.get("per_page"), "100");
+  }
+});

--- a/tools/github/release-preflight-github.mjs
+++ b/tools/github/release-preflight-github.mjs
@@ -1,0 +1,114 @@
+const defaultSleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+function retryDelayMs(response, attempt) {
+  const retryAfterHeader = response.headers.get("retry-after");
+  const retryAfter = Number(retryAfterHeader);
+  if (retryAfterHeader != null && Number.isFinite(retryAfter) && retryAfter >= 0) {
+    return retryAfter * 1000;
+  }
+  return 2 ** (attempt - 1) * 1000;
+}
+
+function isRetryableResponse(response) {
+  return (
+    response.status === 429 ||
+    response.status >= 500 ||
+    (response.status === 403 && response.headers.has("retry-after"))
+  );
+}
+
+export async function githubApiRequest({
+  apiUrl,
+  repository,
+  token,
+  resource,
+  method = "GET",
+  body,
+  fetchImpl = globalThis.fetch,
+  requestTimeoutMs = 30_000,
+  sleep = defaultSleep,
+}) {
+  if (!Number.isFinite(requestTimeoutMs) || requestTimeoutMs <= 0) {
+    throw new Error(`GitHub API request timeout must be positive, got ${requestTimeoutMs}`);
+  }
+  const url = new URL(`${apiUrl}/repos/${repository}/${resource}`);
+  const maxAttempts = method === "GET" ? 3 : 1;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), requestTimeoutMs);
+    let response;
+    let detail;
+    try {
+      response = await fetchImpl(url, {
+        method,
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+          "x-github-api-version": "2022-11-28",
+        },
+        body: body == null ? undefined : JSON.stringify(body),
+        signal: controller.signal,
+      });
+      detail = (await response.text()).trim();
+    } catch (error) {
+      if (attempt < maxAttempts) {
+        await sleep(2 ** (attempt - 1) * 1000);
+        continue;
+      }
+      if (controller.signal.aborted) {
+        throw new Error(
+          `GitHub API ${method} ${url.pathname} timed out after ${requestTimeoutMs}ms`,
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (response.ok) return { body: detail, headers: response.headers, status: response.status };
+    if (attempt < maxAttempts && isRetryableResponse(response)) {
+      await sleep(retryDelayMs(response, attempt));
+      continue;
+    }
+    throw new Error(
+      `GitHub API ${method} ${url.pathname} failed: ${response.status} ${response.statusText}${detail === "" ? "" : `\n${detail}`}`,
+    );
+  }
+  throw new Error(`GitHub API ${method} ${url.pathname} exhausted its retry budget`);
+}
+
+export async function githubApiPages({
+  apiUrl,
+  repository,
+  token,
+  resource,
+  collection,
+  query = {},
+  ...requestOptions
+}) {
+  const values = [];
+  for (let page = 1; ; page += 1) {
+    const params = new URLSearchParams({ per_page: "100", page: String(page) });
+    for (const [name, value] of Object.entries(query)) params.set(name, value);
+    const response = await githubApiRequest({
+      apiUrl,
+      repository,
+      token,
+      resource: `${resource}?${params}`,
+      ...requestOptions,
+    });
+    let payload;
+    try {
+      payload = JSON.parse(response.body);
+    } catch {
+      throw new Error(`GitHub API ${resource} returned invalid JSON on page ${page}`);
+    }
+    const pageValues = collection == null ? payload : payload[collection];
+    if (!Array.isArray(pageValues)) {
+      throw new Error(`GitHub API ${resource} did not return ${collection ?? "an array"}`);
+    }
+    values.push(...pageValues);
+    if (pageValues.length < 100) return values;
+  }
+}


### PR DESCRIPTION
## Summary

- add a dependency-free GitHub REST client for release evidence reads
- retry bounded transient GET failures while keeping mutations single-attempt
- cover response-body timeouts and exact-query pagination

## Why

The exact-SHA release preflight needs to inspect paginated workflow, job, and blocker evidence without hanging or silently accepting partial API results. Keeping this transport layer isolated makes the later policy and workflow wiring smaller and independently reviewable.

## Verification

- `node --test tests/tooling/release-preflight-github.test.ts`
- `oxfmt --check tools/github/release-preflight-github.mjs tests/tooling/release-preflight-github.test.ts`
- source files remain below the 350-line limit

Supports #2818.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786453735&installation_id=136613492&pr_number=2890&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2890&signature=5a0a47ef230d78e4646c426830f37d303f7322557ea38f685bac0e3e22f1576c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->