### PR TITLE
feat(release): define exact-SHA gate evidence

### DIFF
--- a/tests/tooling/release-preflight-evidence.test.ts
+++ b/tests/tooling/release-preflight-evidence.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  assertRequiredWorkflowJobs,
+  requiredReleaseWorkflowEvidence,
+  requiredReleaseWorkflows,
+  selectRequiredWorkflowRuns,
+} from "../../tools/github/release-preflight-evidence.mjs";
+import { readRepoFile } from "./support/github-workflows.ts";
+import {
+  releaseSha,
+  successfulReleaseJob,
+  successfulReleaseRun,
+} from "./support/release-preflight.ts";
+
+test("release evidence paths identify the declared workflow names", () => {
+  for (const [workflowName, evidence] of requiredReleaseWorkflowEvidence) {
+    const workflow = readRepoFile(...evidence.path.split("/"));
+    assert.match(workflow, new RegExp(`^name: ${workflowName}$`, "m"));
+  }
+});
+
+test("required workflow selection fails closed for missing, stale, red, or wrong-origin gates", () => {
+  const greenRuns = requiredReleaseWorkflows.map((name, index) =>
+    successfulReleaseRun(name, index + 1),
+  );
+  assert.deepEqual(
+    [...selectRequiredWorkflowRuns(greenRuns, releaseSha).keys()],
+    requiredReleaseWorkflows,
+  );
+
+  assert.throws(
+    () =>
+      selectRequiredWorkflowRuns(
+        greenRuns.filter((run) => run.path !== ".github/workflows/fuzz.yml"),
+        releaseSha,
+      ),
+    /Fuzz: missing/,
+  );
+  assert.throws(
+    () =>
+      selectRequiredWorkflowRuns(
+        greenRuns.map((run) =>
+          run.path === ".github/workflows/miri.yml" ? { ...run, head_sha: "b".repeat(40) } : run,
+        ),
+        releaseSha,
+      ),
+    /Miri: missing/,
+  );
+  assert.throws(
+    () =>
+      selectRequiredWorkflowRuns(
+        greenRuns.map((run) =>
+          run.path === ".github/workflows/check.yml" ? { ...run, conclusion: "failure" } : run,
+        ),
+        releaseSha,
+      ),
+    /Check: completed\/failure/,
+  );
+  assert.throws(
+    () =>
+      selectRequiredWorkflowRuns(
+        greenRuns.map((run) =>
+          run.path === ".github/workflows/check.yml"
+            ? { ...run, head_branch: "release-candidate" }
+            : run,
+        ),
+        releaseSha,
+      ),
+    /Check: missing push run/,
+  );
+});
+
+test("newest matching run wins across cancellation, reruns, and concurrent runs", () => {
+  const greenRuns = requiredReleaseWorkflows
+    .filter((name) => name !== "App E2E")
+    .map((name, index) => successfulReleaseRun(name, index + 1));
+  const olderSuccess = {
+    ...successfulReleaseRun("App E2E", 50),
+    run_started_at: "2026-07-12T00:50:00Z",
+  };
+  const newerCancellation = {
+    ...successfulReleaseRun("App E2E", 51),
+    run_started_at: "2026-07-12T00:51:00Z",
+    conclusion: "cancelled",
+  };
+  assert.throws(
+    () => selectRequiredWorkflowRuns([...greenRuns, olderSuccess, newerCancellation], releaseSha),
+    /App E2E: completed\/cancelled/,
+  );
+
+  const rerunSuccess = {
+    ...olderSuccess,
+    run_attempt: 2,
+    run_started_at: "2026-07-12T01:00:00Z",
+  };
+  assert.doesNotThrow(() =>
+    selectRequiredWorkflowRuns([...greenRuns, rerunSuccess, newerCancellation], releaseSha),
+  );
+
+  const supersededPending = {
+    ...olderSuccess,
+    status: "queued",
+    conclusion: null,
+    run_started_at: "2026-07-12T00:40:00Z",
+  };
+  assert.doesNotThrow(() =>
+    selectRequiredWorkflowRuns(
+      [...greenRuns, supersededPending, successfulReleaseRun("App E2E", 52)],
+      releaseSha,
+    ),
+  );
+});
+
+test("matrix-sensitive release gates require every successful job", () => {
+  assert.doesNotThrow(() =>
+    assertRequiredWorkflowJobs("Check", [successfulReleaseJob("test-scripts")]),
+  );
+  assert.throws(() => assertRequiredWorkflowJobs("Check", []), /test-scripts/);
+
+  const appJobs = ["dev", "vrt", "preview", "build", "check", "lint"].map((suite) =>
+    successfulReleaseJob(`app-e2e (${suite})`),
+  );
+  assert.doesNotThrow(() => assertRequiredWorkflowJobs("App E2E", appJobs));
+  assert.throws(() => assertRequiredWorkflowJobs("App E2E", appJobs.slice(1)), /app-e2e \(dev\)/);
+
+  const targets = [
+    "linux-x64-gnu",
+    "linux-arm64-gnu",
+    "darwin-x64",
+    "darwin-arm64",
+    "win32-x64-msvc",
+    "win32-arm64-msvc",
+  ];
+  const nativeJobs = [
+    ...targets.map((target) => successfulReleaseJob(`Native host smoke (${target})`)),
+    ...targets.flatMap((target) =>
+      ["22", "24"].map((node) =>
+        successfulReleaseJob(`Fresh install smoke (${target}, Node ${node})`),
+      ),
+    ),
+  ];
+  assert.doesNotThrow(() => assertRequiredWorkflowJobs("Native Smoke", nativeJobs));
+  assert.throws(
+    () => assertRequiredWorkflowJobs("Native Smoke", nativeJobs.slice(1)),
+    /Native host smoke \(linux-x64-gnu\)/,
+  );
+});

--- a/tests/tooling/support/release-preflight.ts
+++ b/tests/tooling/support/release-preflight.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+
+import { requiredReleaseWorkflowEvidence } from "../../../tools/github/release-preflight-evidence.mjs";
+
+export const releaseSha = "a".repeat(40);
+
+export function successfulReleaseRun(name: string, id: number) {
+  const evidence = requiredReleaseWorkflowEvidence.get(name);
+  assert.ok(evidence, `Missing release evidence configuration for ${name}`);
+  return {
+    id,
+    name,
+    display_title: `${name} release evidence`,
+    path: evidence.path,
+    event: evidence.events[0],
+    head_branch: ["push", "schedule"].includes(evidence.events[0]) ? "main" : "v1.2.3",
+    head_sha: releaseSha,
+    status: "completed",
+    conclusion: "success",
+    created_at: `2026-07-12T00:${String(id).padStart(2, "0")}:00Z`,
+    run_started_at: `2026-07-12T00:${String(id).padStart(2, "0")}:00Z`,
+    updated_at: `2026-07-12T00:${String(id).padStart(2, "0")}:00Z`,
+    html_url: `https://example.test/runs/${id}`,
+  };
+}
+
+export function successfulReleaseJob(name: string) {
+  return { name, status: "completed", conclusion: "success" };
+}

--- a/tools/github/release-preflight-evidence.mjs
+++ b/tools/github/release-preflight-evidence.mjs
@@ -1,0 +1,186 @@
+export const requiredReleaseWorkflows = [
+  "Check",
+  "Benchmark",
+  "Native Smoke",
+  "Fuzz",
+  "Miri",
+  "App E2E",
+  "Deploy docs",
+];
+
+export const requiredReleaseWorkflowEvidence = new Map([
+  [
+    "Check",
+    { path: ".github/workflows/check.yml", events: ["push"], branches: { push: ["main"] } },
+  ],
+  ["Benchmark", { path: ".github/workflows/benchmark.yml", events: ["workflow_dispatch"] }],
+  [
+    "Native Smoke",
+    {
+      path: ".github/workflows/native-smoke.yml",
+      events: ["schedule", "workflow_dispatch"],
+      branches: { schedule: ["main"] },
+    },
+  ],
+  [
+    "Fuzz",
+    {
+      path: ".github/workflows/fuzz.yml",
+      events: ["schedule", "workflow_dispatch"],
+      branches: { schedule: ["main"] },
+    },
+  ],
+  ["Miri", { path: ".github/workflows/miri.yml", events: ["push"], branches: { push: ["main"] } }],
+  [
+    "App E2E",
+    {
+      path: ".github/workflows/e2e.yml",
+      events: ["schedule", "workflow_dispatch"],
+      branches: { schedule: ["main"] },
+    },
+  ],
+  [
+    "Deploy docs",
+    {
+      path: ".github/workflows/deploy-docs.yml",
+      events: ["push", "workflow_dispatch"],
+      branches: { push: ["main"] },
+    },
+  ],
+]);
+
+const nativeSmokeTargets = [
+  "linux-x64-gnu",
+  "linux-arm64-gnu",
+  "darwin-x64",
+  "darwin-arm64",
+  "win32-x64-msvc",
+  "win32-arm64-msvc",
+];
+
+const requiredJobNames = new Map([
+  ["Check", ["test-scripts"]],
+  ["Benchmark", ["pr-benchmark-budget"]],
+  [
+    "Fuzz",
+    [
+      "Fuzz sfc_parse",
+      "Fuzz template_lexer",
+      "Fuzz js_ts_expression",
+      "Fuzz css_parse",
+      "Fuzz template_compile",
+    ],
+  ],
+  [
+    "App E2E",
+    [
+      "app-e2e (dev)",
+      "app-e2e (vrt)",
+      "app-e2e (preview)",
+      "app-e2e (build)",
+      "app-e2e (check)",
+      "app-e2e (lint)",
+    ],
+  ],
+  [
+    "Native Smoke",
+    [
+      ...nativeSmokeTargets.map((target) => `Native host smoke (${target})`),
+      ...nativeSmokeTargets.flatMap((target) =>
+        ["22", "24"].map((nodeVersion) => `Fresh install smoke (${target}, Node ${nodeVersion})`),
+      ),
+    ],
+  ],
+]);
+
+function compareRuns(left, right) {
+  const order = (run) => [
+    Date.parse(run.run_started_at ?? run.created_at ?? run.updated_at ?? "") || 0,
+    Number(run.run_attempt ?? 0),
+    Number(run.id ?? 0),
+  ];
+  const leftOrder = order(left);
+  const rightOrder = order(right);
+  for (let index = 0; index < leftOrder.length; index += 1) {
+    if (leftOrder[index] !== rightOrder[index]) return rightOrder[index] - leftOrder[index];
+  }
+  return 0;
+}
+
+function matchesEvidence(run, evidence) {
+  if (run.path !== evidence.path || !evidence.events.includes(run.event)) return false;
+  const branches = evidence.branches?.[run.event];
+  return branches == null || branches.includes(run.head_branch);
+}
+
+export function latestRequiredWorkflowRun(runs, sha, workflowName, qualifier = () => true) {
+  const evidence = requiredReleaseWorkflowEvidence.get(workflowName);
+  if (evidence == null) {
+    throw new Error(`Release evidence is not configured for ${workflowName}`);
+  }
+  return runs
+    .filter((run) => run.head_sha === sha && matchesEvidence(run, evidence) && qualifier(run))
+    .sort(compareRuns)[0];
+}
+
+export function selectRequiredWorkflowRuns(
+  runs,
+  sha,
+  required = requiredReleaseWorkflows,
+  qualifiers = new Map(),
+) {
+  const selected = new Map();
+  const failures = [];
+  for (const workflowName of required) {
+    const evidence = requiredReleaseWorkflowEvidence.get(workflowName);
+    if (evidence == null) {
+      throw new Error(`Release evidence is not configured for ${workflowName}`);
+    }
+    const current = latestRequiredWorkflowRun(
+      runs,
+      sha,
+      workflowName,
+      qualifiers.get(workflowName),
+    );
+    if (current == null) {
+      failures.push(
+        `${workflowName}: missing ${evidence.events.join("/")} run from ${evidence.path} for ${sha}`,
+      );
+    } else if (current.status !== "completed" || current.conclusion !== "success") {
+      failures.push(
+        `${workflowName}: ${current.status}/${current.conclusion ?? "no conclusion"} (${current.html_url ?? "no URL"})`,
+      );
+    } else {
+      selected.set(workflowName, current);
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(
+      `Required release gates are not green on ${sha}:\n${failures
+        .map((failure) => `- ${failure}`)
+        .join("\n")}`,
+    );
+  }
+  return selected;
+}
+
+export function workflowRequiresJobEvidence(workflowName) {
+  return requiredJobNames.has(workflowName);
+}
+
+export function assertRequiredWorkflowJobs(workflowName, jobs) {
+  for (const jobName of requiredJobNames.get(workflowName) ?? []) {
+    const matching = jobs.filter((job) => job.name === jobName);
+    if (matching.length !== 1) {
+      throw new Error(
+        `${workflowName} must contain exactly one successful ${jobName} job; found ${matching.length}`,
+      );
+    }
+    const job = matching[0];
+    if (job.status !== "completed" || job.conclusion !== "success") {
+      throw new Error(
+        `${workflowName} required job ${job.name} is ${job.status}/${job.conclusion ?? "no conclusion"}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- define the required release workflow evidence by immutable workflow path, event, branch, and exact head SHA
- select the newest matching run and fail closed on missing, stale, pending, cancelled, or red evidence
- require every matrix-sensitive release job exactly once and successfully

## Why

The release preflight must reason about exact workflow identity rather than mutable display names or the latest branch result. This keeps the evidence policy isolated from API transport and from the later dispatch/workflow wiring.

## Verification

- `node --test tests/tooling/release-preflight-evidence.test.ts` (4 passed)
- `oxfmt --check tools/github/release-preflight-evidence.mjs tests/tooling/release-preflight-evidence.test.ts tests/tooling/support/release-preflight.ts`
- `git diff --check`
- every added source remains below the 350-line limit

Supports #2818.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786454556&installation_id=136613492&pr_number=2892&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2892&signature=ffc7c8ec957b1bf7cd8a96a40ddd70b1f84e8aee1bea7f8934a251fecca02c01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->