### PR TITLE
feat(release): bootstrap missing exact-SHA gates

### DIFF
--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -1,0 +1,302 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parse } from "yaml";
+
+import {
+  bootstrapRequiredWorkflowRuns,
+  createReleaseGateDispatchPlans,
+  releaseGateRunQualifiers,
+} from "../../tools/github/release-preflight-bootstrap.mjs";
+import {
+  requiredReleaseWorkflowEvidence,
+  requiredReleaseWorkflows,
+  selectRequiredWorkflowRuns,
+} from "../../tools/github/release-preflight-evidence.mjs";
+import { readRepoFile } from "./support/github-workflows.ts";
+import { releaseSha, successfulReleaseRun } from "./support/release-preflight.ts";
+
+function releasePlans() {
+  return createReleaseGateDispatchPlans({
+    ref: "v1.2.3",
+    headSha: releaseSha,
+    baseSha: "b".repeat(40),
+  });
+}
+
+function readWorkflow(file: string) {
+  return parse(readRepoFile(".github", "workflows", file)) as {
+    name?: string;
+    on?: { workflow_dispatch?: { inputs?: Record<string, Record<string, unknown>> } };
+    "run-name"?: string;
+  };
+}
+
+function findEvidenceRun<T extends { path: string }>(runs: T[], workflowName: string): T {
+  const evidence = requiredReleaseWorkflowEvidence.get(workflowName);
+  const run = runs.find((candidate) => candidate.path === evidence?.path);
+  assert.ok(run);
+  return run;
+}
+
+function findReleasePlan(workflowName: string) {
+  const plans = releasePlans();
+  const plan = plans.find((candidate) => candidate.workflowName === workflowName);
+  assert.ok(plan);
+  return plan;
+}
+
+test("release gate plans bind exact SHAs to expected evidence titles", () => {
+  assert.deepEqual(
+    releasePlans().map(({ workflowName, workflowId, expectedRunName }) => ({
+      workflowName,
+      workflowId,
+      expectedRunName,
+    })),
+    [
+      {
+        workflowName: "Benchmark",
+        workflowId: "benchmark.yml",
+        expectedRunName: `Benchmark ${"b".repeat(40)}...${releaseSha}`,
+      },
+      {
+        workflowName: "App E2E",
+        workflowId: "e2e.yml",
+        expectedRunName: `App E2E all @ ${releaseSha}`,
+      },
+      {
+        workflowName: "Native Smoke",
+        workflowId: "native-smoke.yml",
+        expectedRunName: "Native Smoke",
+      },
+      {
+        workflowName: "Fuzz",
+        workflowId: "fuzz.yml",
+        expectedRunName: `Fuzz 120s @ ${releaseSha}`,
+      },
+    ],
+  );
+});
+
+test("release gate plans reject ambiguous SHAs and missing refs", () => {
+  assert.throws(
+    () =>
+      createReleaseGateDispatchPlans({ ref: "v1.2.3", headSha: releaseSha, baseSha: releaseSha }),
+    /base SHA must differ/,
+  );
+  assert.throws(
+    () =>
+      createReleaseGateDispatchPlans({
+        ref: "v1.2.3",
+        headSha: "A".repeat(40),
+        baseSha: "b".repeat(40),
+      }),
+    /Release head SHA must be a full lowercase/,
+  );
+  assert.throws(
+    () =>
+      createReleaseGateDispatchPlans({
+        ref: "v1.2.3",
+        headSha: releaseSha,
+        baseSha: "short",
+      }),
+    /Release base SHA must be a full lowercase/,
+  );
+  for (const ref of [undefined, null, ""]) {
+    assert.throws(
+      () => createReleaseGateDispatchPlans({ ref, headSha: releaseSha, baseSha: "b".repeat(40) }),
+      /Release dispatch ref is required/,
+    );
+  }
+});
+
+test("Benchmark dispatch exposes an exact base and head range", () => {
+  const benchmark = readWorkflow(findReleasePlan("Benchmark").workflowId);
+  const benchmarkInputs = benchmark.on?.workflow_dispatch?.inputs ?? {};
+  assert.deepEqual(Object.keys(benchmarkInputs).sort(), ["base_sha", "head_sha"]);
+  assert.equal(benchmarkInputs.base_sha?.required, true);
+  assert.equal(benchmarkInputs.head_sha?.required, true);
+  assert.match(benchmark["run-name"] ?? "", /^Benchmark /);
+  assert.match(benchmark["run-name"] ?? "", /inputs\.base_sha/);
+  assert.match(benchmark["run-name"] ?? "", /\.\.\./);
+  assert.match(benchmark["run-name"] ?? "", /inputs\.head_sha/);
+});
+
+test("App E2E dispatch identifies the suite and immutable target", () => {
+  const e2e = readWorkflow(findReleasePlan("App E2E").workflowId);
+  const e2eInputs = e2e.on?.workflow_dispatch?.inputs ?? {};
+  const e2eSuiteInput = e2eInputs.suite;
+  assert.ok(e2eSuiteInput);
+  assert.equal(e2eSuiteInput.required, true);
+  assert.ok(Array.isArray(e2eSuiteInput.options));
+  assert.ok(e2eSuiteInput.options.includes("all"));
+  assert.equal(e2eInputs.target_sha?.required, false);
+  assert.match(e2e["run-name"] ?? "", /^App E2E /);
+  assert.match(e2e["run-name"] ?? "", /inputs\.suite/);
+  assert.match(e2e["run-name"] ?? "", / @ /);
+  assert.match(e2e["run-name"] ?? "", /inputs\.target_sha/);
+  assert.match(e2e["run-name"] ?? "", /github\.sha/);
+});
+
+test("Fuzz dispatch identifies its duration and target", () => {
+  const fuzz = readWorkflow(findReleasePlan("Fuzz").workflowId);
+  assert.equal(fuzz.on?.workflow_dispatch?.inputs?.["max-total-time"]?.default, "120");
+  assert.match(fuzz["run-name"] ?? "", /^Fuzz /);
+  assert.match(fuzz["run-name"] ?? "", /inputs\.max-total-time/);
+  assert.match(fuzz["run-name"] ?? "", /github\.sha/);
+});
+
+test("Native Smoke uses its stable workflow title as evidence", () => {
+  const native = readWorkflow(findReleasePlan("Native Smoke").workflowId);
+  assert.equal(native.name, "Native Smoke");
+  assert.equal(native["run-name"], undefined);
+});
+
+test("on-demand gates correlate expanded display titles, never workflow names", () => {
+  const plans = releasePlans();
+  const qualifiers = releaseGateRunQualifiers(plans);
+  const runs = requiredReleaseWorkflows.map((name, index) => successfulReleaseRun(name, index + 1));
+  assert.throws(
+    () => selectRequiredWorkflowRuns(runs, releaseSha, requiredReleaseWorkflows, qualifiers),
+    /Benchmark: missing workflow_dispatch run/,
+  );
+  for (const plan of plans) {
+    const run = findEvidenceRun(runs, plan.workflowName);
+    run.name = plan.expectedRunName;
+    run.display_title = `wrong display title for ${plan.workflowName}`;
+    run.event = "workflow_dispatch";
+  }
+  assert.throws(
+    () => selectRequiredWorkflowRuns(runs, releaseSha, requiredReleaseWorkflows, qualifiers),
+    /Benchmark: missing workflow_dispatch run/,
+  );
+  for (const plan of plans) {
+    const run = findEvidenceRun(runs, plan.workflowName);
+    run.name = plan.workflowName;
+    run.display_title = plan.expectedRunName;
+  }
+  assert.doesNotThrow(() =>
+    selectRequiredWorkflowRuns(runs, releaseSha, requiredReleaseWorkflows, qualifiers),
+  );
+});
+
+test("release gate bootstrap reuses exact-SHA scheduled evidence", async () => {
+  const plans = releasePlans();
+  const runs = requiredReleaseWorkflows.map((name, index) => successfulReleaseRun(name, index + 1));
+  const benchmarkPlan = findReleasePlan("Benchmark");
+  const benchmark = findEvidenceRun(runs, "Benchmark");
+  benchmark.display_title = benchmarkPlan.expectedRunName;
+  const dispatched: string[] = [];
+
+  const selected = await bootstrapRequiredWorkflowRuns({
+    sha: releaseSha,
+    dispatchPlans: plans,
+    listRuns: async () => runs,
+    dispatchWorkflow: async (plan) => dispatched.push(plan.workflowName),
+  });
+
+  assert.deepEqual(dispatched, []);
+  assert.deepEqual([...selected.keys()], requiredReleaseWorkflows);
+  for (const workflowName of ["App E2E", "Native Smoke", "Fuzz"]) {
+    assert.equal(findEvidenceRun(runs, workflowName).event, "schedule");
+  }
+});
+
+test("release gate bootstrap dispatches only missing gates and waits for exact evidence", async () => {
+  const plans = releasePlans();
+  const dispatched: string[] = [];
+  const alwaysPresent = requiredReleaseWorkflows
+    .filter((name) => !plans.some((plan) => plan.workflowName === name))
+    .map((name, index) => successfulReleaseRun(name, index + 1));
+  const dispatchedRuns = plans.map((plan, index) => ({
+    ...successfulReleaseRun(plan.workflowName, index + 10),
+    display_title: plan.expectedRunName,
+    event: "workflow_dispatch",
+  }));
+  let listCount = 0;
+  let clock = 0;
+
+  const selected = await bootstrapRequiredWorkflowRuns({
+    sha: releaseSha,
+    dispatchPlans: plans,
+    listRuns: async () => {
+      listCount += 1;
+      if (listCount === 1) return alwaysPresent;
+      if (listCount === 2) {
+        return dispatchedRuns.map((run) => ({ ...run, status: "in_progress", conclusion: null }));
+      }
+      return [...alwaysPresent, ...dispatchedRuns];
+    },
+    dispatchWorkflow: async (plan) => dispatched.push(plan.workflowName),
+    sleep: async (milliseconds) => {
+      clock += milliseconds;
+    },
+    now: () => clock,
+    timeoutMs: 10_000,
+    pollIntervalMs: 1_000,
+  });
+
+  assert.deepEqual(dispatched, ["Benchmark", "App E2E", "Native Smoke", "Fuzz"]);
+  assert.deepEqual([...selected.keys()], requiredReleaseWorkflows);
+});
+
+test("release gate bootstrap attempts every missing dispatch before reporting failures", async () => {
+  const attempts: string[] = [];
+  await assert.rejects(
+    bootstrapRequiredWorkflowRuns({
+      sha: releaseSha,
+      dispatchPlans: releasePlans(),
+      listRuns: async () => [],
+      dispatchWorkflow: async (plan) => {
+        attempts.push(plan.workflowName);
+        if (["Benchmark", "Fuzz"].includes(plan.workflowName)) {
+          throw new Error(`dispatch denied for ${plan.workflowName}`);
+        }
+      },
+    }),
+    /Failed to dispatch release gates:[\s\S]*Benchmark: dispatch denied[\s\S]*Fuzz: dispatch denied/,
+  );
+  assert.deepEqual(attempts, ["Benchmark", "App E2E", "Native Smoke", "Fuzz"]);
+});
+
+test("release gate bootstrap never retries or hides a red latest run", async () => {
+  const plans = releasePlans();
+  const runs = requiredReleaseWorkflows.map((name, index) => successfulReleaseRun(name, index + 1));
+  for (const plan of plans) {
+    const run = findEvidenceRun(runs, plan.workflowName);
+    run.display_title = plan.expectedRunName;
+    run.event = "workflow_dispatch";
+  }
+  const benchmark = findEvidenceRun(runs, "Benchmark");
+  benchmark.conclusion = "failure";
+  const dispatched: string[] = [];
+
+  await assert.rejects(
+    bootstrapRequiredWorkflowRuns({
+      sha: releaseSha,
+      dispatchPlans: plans,
+      listRuns: async () => runs,
+      dispatchWorkflow: async (plan) => dispatched.push(plan.workflowName),
+    }),
+    /Benchmark: completed\/failure/,
+  );
+  assert.deepEqual(dispatched, []);
+});
+
+test("release gate bootstrap reports a bounded wait timeout", async () => {
+  let clock = 0;
+  await assert.rejects(
+    bootstrapRequiredWorkflowRuns({
+      sha: releaseSha,
+      dispatchPlans: releasePlans(),
+      listRuns: async () => [],
+      dispatchWorkflow: async () => {},
+      sleep: async (milliseconds) => {
+        clock += milliseconds;
+      },
+      now: () => clock,
+      timeoutMs: 2,
+      pollIntervalMs: 1,
+    }),
+    /Timed out after 2ms[\s\S]*Check: missing/,
+  );
+});

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -47,30 +47,40 @@ function findReleasePlan(workflowName: string) {
 
 test("release gate plans bind exact SHAs to expected evidence titles", () => {
   assert.deepEqual(
-    releasePlans().map(({ workflowName, workflowId, expectedRunName }) => ({
+    releasePlans().map(({ workflowName, workflowId, ref, inputs, expectedRunName }) => ({
       workflowName,
       workflowId,
+      ref,
+      inputs,
       expectedRunName,
     })),
     [
       {
         workflowName: "Benchmark",
         workflowId: "benchmark.yml",
+        ref: "v1.2.3",
+        inputs: { base_sha: "b".repeat(40), head_sha: releaseSha },
         expectedRunName: `Benchmark ${"b".repeat(40)}...${releaseSha}`,
       },
       {
         workflowName: "App E2E",
         workflowId: "e2e.yml",
+        ref: "v1.2.3",
+        inputs: { suite: "all", target_sha: releaseSha },
         expectedRunName: `App E2E all @ ${releaseSha}`,
       },
       {
         workflowName: "Native Smoke",
         workflowId: "native-smoke.yml",
+        ref: "v1.2.3",
+        inputs: {},
         expectedRunName: "Native Smoke",
       },
       {
         workflowName: "Fuzz",
         workflowId: "fuzz.yml",
+        ref: "v1.2.3",
+        inputs: { "max-total-time": "120" },
         expectedRunName: `Fuzz 120s @ ${releaseSha}`,
       },
     ],
@@ -295,8 +305,9 @@ test("release gate bootstrap reports a bounded wait timeout", async () => {
       },
       now: () => clock,
       timeoutMs: 2,
-      pollIntervalMs: 1,
+      pollIntervalMs: 10,
     }),
     /Timed out after 2ms[\s\S]*Check: missing/,
   );
+  assert.equal(clock, 2);
 });

--- a/tools/github/release-preflight-bootstrap.mjs
+++ b/tools/github/release-preflight-bootstrap.mjs
@@ -1,0 +1,129 @@
+import {
+  latestRequiredWorkflowRun,
+  requiredReleaseWorkflows,
+  selectRequiredWorkflowRuns,
+} from "./release-preflight-evidence.mjs";
+
+export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
+  for (const [label, value] of [
+    ["head", headSha],
+    ["base", baseSha],
+  ]) {
+    if (!/^[0-9a-f]{40}$/.test(value)) {
+      throw new Error(`Release ${label} SHA must be a full lowercase commit SHA, got ${value}`);
+    }
+  }
+  if (baseSha === headSha)
+    throw new Error("Release base SHA must differ from the release head SHA");
+  if (!ref) throw new Error("Release dispatch ref is required");
+
+  const appE2eSuite = "all";
+  const fuzzMaxTotalTimeSeconds = "120";
+
+  return [
+    {
+      workflowName: "Benchmark",
+      workflowId: "benchmark.yml",
+      ref,
+      inputs: { base_sha: baseSha, head_sha: headSha },
+      expectedRunName: `Benchmark ${baseSha}...${headSha}`,
+    },
+    {
+      workflowName: "App E2E",
+      workflowId: "e2e.yml",
+      ref,
+      inputs: { suite: appE2eSuite, target_sha: headSha },
+      expectedRunName: `App E2E ${appE2eSuite} @ ${headSha}`,
+    },
+    {
+      workflowName: "Native Smoke",
+      workflowId: "native-smoke.yml",
+      ref,
+      inputs: {},
+      expectedRunName: "Native Smoke",
+    },
+    {
+      workflowName: "Fuzz",
+      workflowId: "fuzz.yml",
+      ref,
+      inputs: { "max-total-time": fuzzMaxTotalTimeSeconds },
+      expectedRunName: `Fuzz ${fuzzMaxTotalTimeSeconds}s @ ${headSha}`,
+    },
+  ];
+}
+
+export function releaseGateRunQualifiers(dispatchPlans) {
+  return new Map(
+    dispatchPlans.map((plan) => [
+      plan.workflowName,
+      (run) => run.event === "schedule" || run.display_title === plan.expectedRunName,
+    ]),
+  );
+}
+
+export async function bootstrapRequiredWorkflowRuns({
+  sha,
+  dispatchPlans,
+  listRuns,
+  dispatchWorkflow,
+  sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  now = Date.now,
+  timeoutMs = 105 * 60 * 1000,
+  pollIntervalMs = 15_000,
+  onWait = () => {},
+}) {
+  const qualifiers = releaseGateRunQualifiers(dispatchPlans);
+  let runs = await listRuns();
+  const dispatchErrors = [];
+  for (const plan of dispatchPlans) {
+    const run = latestRequiredWorkflowRun(
+      runs,
+      sha,
+      plan.workflowName,
+      qualifiers.get(plan.workflowName),
+    );
+    if (run == null) {
+      try {
+        await dispatchWorkflow(plan);
+      } catch (error) {
+        dispatchErrors.push(
+          `${plan.workflowName}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+  if (dispatchErrors.length > 0) {
+    throw new Error(
+      `Failed to dispatch release gates:\n${dispatchErrors.map((error) => `- ${error}`).join("\n")}`,
+    );
+  }
+
+  const deadline = now() + timeoutMs;
+  while (true) {
+    runs = await listRuns();
+    const missing = [];
+    const pending = [];
+    let failed = false;
+    for (const workflowName of requiredReleaseWorkflows) {
+      const run = latestRequiredWorkflowRun(runs, sha, workflowName, qualifiers.get(workflowName));
+      if (run == null) missing.push(workflowName);
+      else if (run.status !== "completed") pending.push(workflowName);
+      else if (run.conclusion !== "success") failed = true;
+    }
+
+    if (failed || (missing.length === 0 && pending.length === 0)) {
+      return selectRequiredWorkflowRuns(runs, sha, requiredReleaseWorkflows, qualifiers);
+    }
+    if (now() >= deadline) {
+      try {
+        return selectRequiredWorkflowRuns(runs, sha, requiredReleaseWorkflows, qualifiers);
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(`Timed out after ${timeoutMs}ms waiting for release gates.\n${detail}`);
+      }
+    }
+
+    onWait({ missing, pending });
+    await sleep(pollIntervalMs);
+  }
+}

--- a/tools/github/release-preflight-bootstrap.mjs
+++ b/tools/github/release-preflight-bootstrap.mjs
@@ -124,6 +124,6 @@ export async function bootstrapRequiredWorkflowRuns({
     }
 
     onWait({ missing, pending });
-    await sleep(pollIntervalMs);
+    await sleep(Math.min(pollIntervalMs, Math.max(0, deadline - now())));
   }
 }


### PR DESCRIPTION
## Summary

- define exact dispatch inputs and expanded run-name correlation for Benchmark, App E2E, Native Smoke, and Fuzz
- dispatch only missing release gates, then poll the exact release SHA with a bounded timeout
- reuse valid scheduled evidence while refusing wrong-title dispatches, red latest runs, and mutation retries

## Why

Release tags may not already have every expensive gate on the exact commit. This bootstrap layer fills only missing evidence and keeps dispatch/polling separate from both the evidence policy and the final publish workflow wiring.

## Verification

- `node --test tests/tooling/release-preflight-evidence.test.ts tests/tooling/release-preflight-bootstrap.test.ts` (9 passed)
- `oxfmt --check tools/github/release-preflight-bootstrap.mjs tests/tooling/release-preflight-bootstrap.test.ts`
- `git diff --check`
- both added files remain below the 350-line limit

Supports #2818.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786455255&installation_id=136613492&pr_number=2893&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2893&signature=23981eeabcfc4f5e28299454556511dd49de8ed64e29c42de9903088b6d4ea1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced release preflight “gate” bootstrapping with deterministic dispatch plans and tighter alignment between expected run identifiers and evidence selection (via expanded dispatch `display_title`).
  * Added stricter input validation for `ref` and full lowercase 40-hex base/head SHAs (rejecting identical SHAs), with workflow-specific dispatch input and `run-name` wiring (including defaults/stable naming where applicable).
  * Dispatches only missing gate workflows, polls until required runs are present and successful, and reports exactly what remains missing on timeout.
* **Tests**
  * Added coverage for dispatch plan determinism, workflow contract parsing, evidence correlation (including mismatch/fix), dispatch/error handling, early stop on failed conclusions, and bounded timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->