### PR TITLE
perf(ci): skip Tool Benchmark for non-runtime changes

### DIFF
--- a/.github/workflows/tool-benchmark.yml
+++ b/.github/workflows/tool-benchmark.yml
@@ -62,8 +62,57 @@ env:
   VIZE_TOOL_BENCH_WARMUPS: ${{ github.event_name == 'workflow_dispatch' && inputs.warmups || '1' }}
 
 jobs:
+  tool-benchmark-impact:
+    name: tool-benchmark-impact
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      runtime: ${{ steps.changes.outputs.runtime }}
+    steps:
+      # Unknown paths match `**` and run the benchmark. Negations remove only
+      # areas known not to affect any measured CLI/native/Vite/Nuxt runtime.
+      - name: Detect measured runtime changes
+        id: changes
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          predicate-quantifier: every
+          filters: |
+            runtime:
+              - '**'
+              - '!**/*.md'
+              - '!.changeset/**'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/PULL_REQUEST_TEMPLATE.md'
+              - '!.github/actions/app-readiness/**'
+              - '!.github/workflows/check.yml'
+              - '!.github/workflows/criterion-bench.yml'
+              - '!.github/workflows/deploy-docs.yml'
+              - '!.github/workflows/e2e.yml'
+              - '!.github/workflows/fuzz.yml'
+              - '!.github/workflows/miri.yml'
+              - '!.github/workflows/native-smoke.yml'
+              - '!.github/workflows/pkg-pr-new.yml'
+              - '!.github/workflows/release*.yml'
+              - '!.github/workflows/title-policy.yml'
+              - '!editors/**'
+              - '!tests/**'
+              - '!tools/github/**'
+              - '!tools/moon/cmd/check_warning_budget/**'
+              - '!tools/moon/cmd/enforce_rust_source_coverage/**'
+              - '!tools/moon/cmd/github/**'
+              - '!tools/moon/cmd/npm_tag/**'
+              - '!tools/moon/cmd/publish*/**'
+              - '!tools/moon/cmd/release/**'
+              - '!tools/moon/cmd/source_file_lengths/**'
+
   tool-benchmark:
     name: tool-benchmark
+    needs: tool-benchmark-impact
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || needs.tool-benchmark-impact.outputs.runtime == 'true') }}
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 75
     permissions:

--- a/tests/tooling/tool-benchmark-trigger.test.ts
+++ b/tests/tooling/tool-benchmark-trigger.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("Tool Benchmark ignores only known non-runtime pull request paths", () => {
+  const workflow = parse(
+    fs.readFileSync(path.join(root, ".github", "workflows", "tool-benchmark.yml"), "utf8"),
+  ) as Record<string, unknown>;
+  const events = workflow.on as { pull_request?: { "paths-ignore"?: string[] } };
+  const jobs = workflow.jobs as Record<
+    string,
+    {
+      if?: string;
+      needs?: string;
+      outputs?: Record<string, string>;
+      steps?: Array<Record<string, unknown>>;
+    }
+  >;
+  const impact = jobs["tool-benchmark-impact"];
+  const changeDetection = impact.steps?.[0]?.with as {
+    filters: string;
+    "predicate-quantifier"?: string;
+  };
+  const filters = parse(String(changeDetection.filters)) as {
+    runtime?: string[];
+  };
+
+  assert.equal(events.pull_request?.["paths-ignore"], undefined);
+  assert.equal(changeDetection["predicate-quantifier"], "every");
+  const expectedRuntimePatterns = [
+    "**",
+    "!**/*.md",
+    "!.changeset/**",
+    "!.github/ISSUE_TEMPLATE/**",
+    "!.github/PULL_REQUEST_TEMPLATE.md",
+    "!.github/actions/app-readiness/**",
+    "!.github/workflows/check.yml",
+    "!.github/workflows/criterion-bench.yml",
+    "!.github/workflows/deploy-docs.yml",
+    "!.github/workflows/e2e.yml",
+    "!.github/workflows/fuzz.yml",
+    "!.github/workflows/miri.yml",
+    "!.github/workflows/native-smoke.yml",
+    "!.github/workflows/pkg-pr-new.yml",
+    "!.github/workflows/release*.yml",
+    "!.github/workflows/title-policy.yml",
+    "!editors/**",
+    "!tests/**",
+    "!tools/github/**",
+    "!tools/moon/cmd/check_warning_budget/**",
+    "!tools/moon/cmd/enforce_rust_source_coverage/**",
+    "!tools/moon/cmd/github/**",
+    "!tools/moon/cmd/npm_tag/**",
+    "!tools/moon/cmd/publish*/**",
+    "!tools/moon/cmd/release/**",
+    "!tools/moon/cmd/source_file_lengths/**",
+  ];
+  assert.deepEqual([...(filters.runtime ?? [])].sort(), expectedRuntimePatterns.toSorted());
+  assert.match(impact.if ?? "", /github\.event_name == 'pull_request'/);
+  assert.equal(impact.outputs?.runtime, "${{ steps.changes.outputs.runtime }}");
+  assert.equal(jobs["tool-benchmark"].needs, "tool-benchmark-impact");
+  const benchmarkIf = jobs["tool-benchmark"].if ?? "";
+  assert.match(benchmarkIf, /always\(\).* !cancelled\(\)/);
+  assert.match(benchmarkIf, /github\.event_name != 'pull_request'/);
+  assert.match(benchmarkIf, /outputs\.runtime == 'true'/);
+});


### PR DESCRIPTION
## Summary

- use a lightweight PR-files impact job and skip the heavy benchmark only when every changed path belongs to a known non-runtime area
- keep unknown paths and all compiler/CLI/native/Vite/Nuxt/benchmark/dependency changes fail-closed to the full run
- lock the exact ignore inventory with an executable workflow test

## Why

Release automation, docs, tests, editor-only changes, and GitHub tooling cannot affect any runtime measured by this workflow, but currently pay roughly ten minutes to build and benchmark every product. The classifier starts from `**` and subtracts only known non-runtime areas, so unknown paths remain fail-closed to the full run. Keeping classification inside the workflow also avoids event-level diff truncation.

Scheduled and manual benchmark runs are unchanged.

## Verification

- `node --test tests/tooling/github-workflows-benchmark.test.ts tests/tooling/github-workflows.test.ts tests/tooling/tool-benchmark-trigger.test.ts tests/tooling/tool-benchmark.test.ts` (19 passed)
- `oxfmt --check .github/workflows/tool-benchmark.yml tests/tooling/tool-benchmark-trigger.test.ts`
- `git diff --check`

Closes #2889.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the tool benchmark workflow to include a PR-only impact check that determines whether runtime-related changes warrant running the heavy benchmark.
  - Adjusted the main benchmark job to run conditionally for pull requests, while preserving existing behavior for non–pull request events.

- **Tests**
  - Added a workflow-validation test that parses the benchmark workflow and verifies the pull request trigger, runtime path filter patterns, and the conditional dependencies between the impact and benchmark jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->