### PR TITLE
fix(ci): cover documentation-only benchmark changes

### DIFF
--- a/.github/workflows/tool-benchmark.yml
+++ b/.github/workflows/tool-benchmark.yml
@@ -84,6 +84,7 @@ jobs:
             runtime:
               - '**'
               - '!**/*.md'
+              - '!docs/**'
               - '!.changeset/**'
               - '!.github/ISSUE_TEMPLATE/**'
               - '!.github/PULL_REQUEST_TEMPLATE.md'

--- a/tests/tooling/tool-benchmark-trigger.test.ts
+++ b/tests/tooling/tool-benchmark-trigger.test.ts
@@ -22,19 +22,24 @@ test("Tool Benchmark ignores only known non-runtime pull request paths", () => {
     }
   >;
   const impact = jobs["tool-benchmark-impact"];
-  const changeDetection = impact.steps?.[0]?.with as {
+  assert.ok(impact, "missing tool-benchmark-impact job");
+  const changeDetection = impact.steps?.find((step) => step.id === "changes");
+  assert.ok(changeDetection, "missing changes step");
+  assert.match(String(changeDetection.uses), /^dorny\/paths-filter@/);
+  const filterInput = changeDetection.with as {
     filters: string;
     "predicate-quantifier"?: string;
   };
-  const filters = parse(String(changeDetection.filters)) as {
+  const filters = parse(String(filterInput.filters)) as {
     runtime?: string[];
   };
 
   assert.equal(events.pull_request?.["paths-ignore"], undefined);
-  assert.equal(changeDetection["predicate-quantifier"], "every");
+  assert.equal(filterInput["predicate-quantifier"], "every");
   const expectedRuntimePatterns = [
     "**",
     "!**/*.md",
+    "!docs/**",
     "!.changeset/**",
     "!.github/ISSUE_TEMPLATE/**",
     "!.github/PULL_REQUEST_TEMPLATE.md",


### PR DESCRIPTION
## Summary

- classify the complete `docs/**` tree as non-runtime, including images and configuration files
- bind the classifier contract test to the `id: changes` paths-filter step that produces the job output
- preserve fail-closed behavior for unknown paths and full benchmark execution for non-PR events

## Validation

- `node --test tests/tooling/tool-benchmark-trigger.test.ts tests/tooling/github-workflows-benchmark.test.ts tests/tooling/github-workflows.test.ts tests/tooling/tool-benchmark.test.ts` (19 passed)
- `pnpm exec oxfmt --check .github/workflows/tool-benchmark.yml tests/tooling/tool-benchmark-trigger.test.ts`
- `git diff --check`

Follow-up to #2894. Relates to #2889.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786457701&installation_id=136613492&pr_number=2895&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2895&signature=15ff16fa106330d0d68780ec3da7ceb64768e7689494d76d001303d399ffece8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation-only changes no longer trigger measured runtime benchmark workflows.
  * Benchmark change detection now more accurately identifies relevant runtime updates.

* **Tests**
  * Improved validation of benchmark workflow filtering and trigger configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->