### PR TITLE
feat(release): bind immutable release metadata

### DIFF
--- a/tests/tooling/release-preflight-core.test.ts
+++ b/tests/tooling/release-preflight-core.test.ts
@@ -11,6 +11,10 @@ import {
 
 const sha = "a".repeat(40);
 const cargoToml = `[workspace]\n\n[workspace.package]\nversion = "1.2.3"\nedition = "2024"\n`;
+const packageManifests = [
+  { path: "npm/cli/package.json", content: '{"name":"vize","version":"1.2.3"}' },
+  { path: "editors/vscode/package.json", content: '{"name":"vize-vscode","version":"1.2.3"}' },
+];
 
 test("workspace release version comes only from the workspace package table", () => {
   assert.equal(workspaceVersionFromCargoToml(cargoToml), "1.2.3");
@@ -21,15 +25,17 @@ test("workspace release version comes only from the workspace package table", ()
 });
 
 test("release metadata binds the tag and every publishable package to one version", () => {
-  const packageManifests = [
-    { path: "npm/cli/package.json", content: '{"name":"vize","version":"1.2.3"}' },
-    { path: "editors/vscode/package.json", content: '{"name":"vize-vscode","version":"1.2.3"}' },
-  ];
   assert.equal(assertReleaseMetadata({ tag: "v1.2.3", sha, cargoToml, packageManifests }), "1.2.3");
+});
+
+test("release metadata rejects a tag that diverges from the workspace version", () => {
   assert.throws(
     () => assertReleaseMetadata({ tag: "v1.2.4", sha, cargoToml, packageManifests }),
     /does not match workspace version/,
   );
+});
+
+test("release metadata rejects a divergent publishable package version", () => {
   assert.throws(
     () =>
       assertReleaseMetadata({
@@ -43,9 +49,25 @@ test("release metadata binds the tag and every publishable package to one versio
       }),
     /npm\/wasm\/package\.json=1\.2\.2/,
   );
+});
+
+test("release metadata rejects a non-full commit SHA", () => {
   assert.throws(
     () => assertReleaseMetadata({ tag: "v1.2.3", sha: "main", cargoToml, packageManifests }),
     /full commit SHA/,
+  );
+});
+
+test("release metadata identifies malformed package manifests", () => {
+  assert.throws(
+    () =>
+      assertReleaseMetadata({
+        tag: "v1.2.3",
+        sha,
+        cargoToml,
+        packageManifests: [{ path: "npm/broken/package.json", content: "{" }],
+      }),
+    /Failed to parse release package manifest npm\/broken\/package\.json/,
   );
 });
 

--- a/tests/tooling/release-preflight-core.test.ts
+++ b/tests/tooling/release-preflight-core.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  assertReleaseCommitIsCurrentMain,
+  assertReleaseMetadata,
+  findReleaseBlockers,
+  remoteTagCommit,
+  workspaceVersionFromCargoToml,
+} from "../../tools/github/release-preflight-core.mjs";
+
+const sha = "a".repeat(40);
+const cargoToml = `[workspace]\n\n[workspace.package]\nversion = "1.2.3"\nedition = "2024"\n`;
+
+test("workspace release version comes only from the workspace package table", () => {
+  assert.equal(workspaceVersionFromCargoToml(cargoToml), "1.2.3");
+  assert.throws(
+    () => workspaceVersionFromCargoToml('[package]\nversion = "9.9.9"\n'),
+    /missing \[workspace\.package\]\.version/,
+  );
+});
+
+test("release metadata binds the tag and every publishable package to one version", () => {
+  const packageManifests = [
+    { path: "npm/cli/package.json", content: '{"name":"vize","version":"1.2.3"}' },
+    { path: "editors/vscode/package.json", content: '{"name":"vize-vscode","version":"1.2.3"}' },
+  ];
+  assert.equal(assertReleaseMetadata({ tag: "v1.2.3", sha, cargoToml, packageManifests }), "1.2.3");
+  assert.throws(
+    () => assertReleaseMetadata({ tag: "v1.2.4", sha, cargoToml, packageManifests }),
+    /does not match workspace version/,
+  );
+  assert.throws(
+    () =>
+      assertReleaseMetadata({
+        tag: "v1.2.3",
+        sha,
+        cargoToml,
+        packageManifests: [
+          ...packageManifests,
+          { path: "npm/wasm/package.json", content: '{"version":"1.2.2"}' },
+        ],
+      }),
+    /npm\/wasm\/package\.json=1\.2\.2/,
+  );
+  assert.throws(
+    () => assertReleaseMetadata({ tag: "v1.2.3", sha: "main", cargoToml, packageManifests }),
+    /full commit SHA/,
+  );
+});
+
+test("release metadata rejects private manifests in the publish inventory", () => {
+  assert.throws(
+    () =>
+      assertReleaseMetadata({
+        tag: "v1.2.3",
+        sha,
+        cargoToml,
+        packageManifests: [
+          { path: "npm/private/package.json", content: '{"private":true,"version":"1.2.3"}' },
+        ],
+      }),
+    /npm\/private\/package\.json is private/,
+  );
+});
+
+test("release commit must remain the exact current main tip", () => {
+  assert.doesNotThrow(() => assertReleaseCommitIsCurrentMain(sha, sha));
+  assert.throws(
+    () => assertReleaseCommitIsCurrentMain(sha, "b".repeat(40)),
+    /not the current origin\/main/,
+  );
+});
+
+test("P0, P1, and fuzz reproducer issues block without treating PRs as issues", () => {
+  const issues = [
+    { number: 1, title: "release break", labels: [{ name: "priority:p0" }] },
+    { number: 2, title: "correctness break", labels: ["PRIORITY:P1"] },
+    { number: 3, title: "fix(fuzz): parser crash", labels: [] },
+    { number: 4, title: "regular work", labels: [{ name: "area:ci" }] },
+    { number: 5, title: "fix(fuzz): open pull request", labels: [], pull_request: {} },
+  ];
+  assert.deepEqual(
+    findReleaseBlockers(issues).map((issue) => issue.number),
+    [1, 2, 3],
+  );
+});
+
+test("annotated remote tags resolve to their peeled commit", () => {
+  const tag = "v1.2.3";
+  const tagObject = "b".repeat(40);
+  assert.equal(
+    remoteTagCommit(`${tagObject}\trefs/tags/${tag}\n${sha}\trefs/tags/${tag}^{}\n`, tag),
+    sha,
+  );
+  assert.equal(remoteTagCommit(`${sha}\trefs/tags/${tag}\n`, tag), sha);
+  assert.equal(remoteTagCommit("", tag), undefined);
+});

--- a/tools/github/release-preflight-core.mjs
+++ b/tools/github/release-preflight-core.mjs
@@ -1,0 +1,79 @@
+import { parseReleaseVersion } from "./release-platforms.mjs";
+
+const releaseBlockingLabels = new Set(["priority:p0", "priority:p1"]);
+
+export function workspaceVersionFromCargoToml(content) {
+  let inWorkspacePackage = false;
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      inWorkspacePackage = trimmed === "[workspace.package]";
+      continue;
+    }
+    if (!inWorkspacePackage) continue;
+    const match = /^version\s*=\s*"([^"]+)"$/.exec(trimmed);
+    if (match) return match[1];
+  }
+  throw new Error("Cargo.toml is missing [workspace.package].version");
+}
+
+export function assertReleaseMetadata({ tag, sha, cargoToml, packageManifests }) {
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error(`Release SHA must be a full commit SHA, got ${sha}`);
+  }
+  parseReleaseVersion(tag);
+  const version = workspaceVersionFromCargoToml(cargoToml);
+  if (tag !== `v${version}`) {
+    throw new Error(`Release tag ${tag} does not match workspace version ${version}`);
+  }
+
+  const mismatches = [];
+  for (const manifest of packageManifests) {
+    const packageJson = JSON.parse(manifest.content);
+    if (packageJson.private === true) {
+      mismatches.push(`${manifest.path} is private`);
+      continue;
+    }
+    if (packageJson.version !== version) {
+      mismatches.push(`${manifest.path}=${String(packageJson.version)}`);
+    }
+  }
+  if (mismatches.length > 0) {
+    throw new Error(
+      `Release package versions must all equal ${version}:\n${mismatches
+        .map((value) => `- ${value}`)
+        .join("\n")}`,
+    );
+  }
+  return version;
+}
+
+export function assertReleaseCommitIsCurrentMain(sha, mainSha) {
+  if (sha !== mainSha) {
+    throw new Error(`Release commit ${sha} is not the current origin/main ${mainSha}`);
+  }
+}
+
+export function findReleaseBlockers(issues) {
+  return issues.filter((issue) => {
+    if (issue.pull_request != null) return false;
+    const labels = (issue.labels ?? []).map((label) =>
+      (typeof label === "string" ? label : (label.name ?? "")).toLowerCase(),
+    );
+    return (
+      labels.some((label) => releaseBlockingLabels.has(label)) ||
+      /^fix\(fuzz\):/i.test(issue.title ?? "")
+    );
+  });
+}
+
+export function remoteTagCommit(output, tag) {
+  const refs = new Map(
+    output
+      .trim()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => line.trim().split(/\s+/, 2).reverse()),
+  );
+  return refs.get(`refs/tags/${tag}^{}`) ?? refs.get(`refs/tags/${tag}`);
+}

--- a/tools/github/release-preflight-core.mjs
+++ b/tools/github/release-preflight-core.mjs
@@ -29,7 +29,15 @@ export function assertReleaseMetadata({ tag, sha, cargoToml, packageManifests })
 
   const mismatches = [];
   for (const manifest of packageManifests) {
-    const packageJson = JSON.parse(manifest.content);
+    let packageJson;
+    try {
+      packageJson = JSON.parse(manifest.content);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to parse release package manifest ${manifest.path}: ${detail}`, {
+        cause: error,
+      });
+    }
     if (packageJson.private === true) {
       mismatches.push(`${manifest.path} is private`);
       continue;


### PR DESCRIPTION
## Summary

- bind the release tag to a full immutable commit SHA and the workspace version
- require every publishable npm/editor manifest to match the release version
- reject releases when main advances or P0/P1/fuzz blockers remain open
- resolve annotated tags through their peeled commit

## Why

Workflow evidence is only meaningful after the tag, commit, and package metadata are proven to describe one immutable release target. This keeps target policy independent from Git/process orchestration and publish workflow wiring.

## Verification

- `node --test tests/tooling/release-preflight-core.test.ts` (6 passed)
- `oxfmt --check tools/github/release-preflight-core.mjs tests/tooling/release-preflight-core.test.ts`
- `git diff --check`
- both added files remain below the 350-line limit

Supports #2818.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786460475&installation_id=136613492&pr_number=2896&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2896&signature=f17ed7c7c67330b8b8042b711a630d2be4e49764a25ab5670e599885fdb5255b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added release preflight validation for workspace versioning, release tag format, full commit SHA input, and consistent versions across publishable package manifests (with private packages flagged).
  * Added checks that the release commit matches the current `origin/main` tip.
  * Added release-blocker detection based on issue semantics (label priority and `fix(fuzz):` title matching), ignoring PR entries.
  * Added remote tag resolution with support for annotated tags.
* **Tests**
  * Added automated coverage for all release validation and blocker-detection scenarios, including malformed inputs and mismatch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->