### PR TITLE
feat(release): verify immutable release targets

### DIFF
--- a/tests/tooling/release-preflight-runner.test.ts
+++ b/tests/tooling/release-preflight-runner.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { test } from "node:test";
+
+import {
+  parseReleasePreflightMode,
+  readPackageManifests,
+} from "../../tools/github/release-preflight.mjs";
+import { workspaceVersionFromCargoToml } from "../../tools/github/release-preflight-core.mjs";
+import { repoRoot } from "./_helpers/moonbit.ts";
+import { writeFakeCommand } from "./support/fake-command.ts";
+
+const sha = "a".repeat(40);
+
+test("release preflight CLI fails closed on unknown or ambiguous modes", () => {
+  assert.equal(parseReleasePreflightMode([]), "bootstrap");
+  assert.equal(parseReleasePreflightMode(["--verify-only"]), "verify-only");
+  assert.equal(parseReleasePreflightMode(["--target-only"]), "target-only");
+  assert.throws(() => parseReleasePreflightMode(["--verify-onyl"]), /Usage:/);
+  assert.throws(() => parseReleasePreflightMode(["--verify-only", "--target-only"]), /Usage:/);
+});
+
+test("target-only mode verifies HEAD, current main, and the peeled remote tag", () => {
+  const tempDir = fs.mkdtempSync(path.join(tmpdir(), "vize-release-target-"));
+  const binDir = path.join(tempDir, "bin");
+  const version = workspaceVersionFromCargoToml(
+    fs.readFileSync(path.join(repoRoot, "Cargo.toml"), "utf8"),
+  );
+  fs.mkdirSync(binDir, { recursive: true });
+  writeFakeCommand(
+    binDir,
+    "git",
+    [
+      "const args = process.argv.slice(2);",
+      "const command = args.join(' ');",
+      "if (command === 'rev-parse HEAD') console.log(process.env.TEST_RELEASE_SHA);",
+      "else if (command === 'rev-parse refs/remotes/origin/main') console.log(process.env.TEST_MAIN_SHA);",
+      "else if (args[0] === 'fetch') process.exit(0);",
+      "else if (args[0] === 'ls-remote') {",
+      "  console.log(`${process.env.TEST_TAG_OBJECT}\\trefs/tags/${process.env.TEST_TAG}`);",
+      "  console.log(`${process.env.TEST_TAG_SHA}\\trefs/tags/${process.env.TEST_TAG}^{}`);",
+      "} else if (args[0] === 'rev-list') console.log(`${process.env.TEST_RELEASE_SHA} ${process.env.TEST_BASE_SHA}`);",
+      "else if (args[0] === 'merge-base') process.exit(0);",
+      "else process.exit(2);",
+    ].join("\n"),
+  );
+  const run = (overrides: Record<string, string> = {}) =>
+    spawnSync(process.execPath, ["tools/github/release-preflight.mjs", "--target-only"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        GITHUB_REF_TYPE: "tag",
+        GITHUB_REF_NAME: `v${version}`,
+        GITHUB_SHA: sha,
+        TEST_RELEASE_SHA: sha,
+        TEST_MAIN_SHA: sha,
+        TEST_TAG: `v${version}`,
+        TEST_TAG_OBJECT: "c".repeat(40),
+        TEST_TAG_SHA: sha,
+        TEST_BASE_SHA: "b".repeat(40),
+        ...overrides,
+      },
+    });
+
+  try {
+    const success = run();
+    assert.equal(success.status, 0, `${success.stderr}\n${success.stdout}`.trim());
+    assert.match(run({ TEST_MAIN_SHA: "d".repeat(40) }).stderr, /not the current origin\/main/);
+    assert.match(run({ TEST_TAG_SHA: "e".repeat(40) }).stderr, /Remote tag .* points to/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("release metadata inventory discovers every non-private npm and editor package", () => {
+  assert.deepEqual(
+    readPackageManifests().map((manifest) => manifest.path),
+    [
+      "editors/vscode-art/package.json",
+      "editors/vscode/package.json",
+      "npm/builder/rspack/package.json",
+      "npm/builder/unplugin/package.json",
+      "npm/builder/vite-musea/package.json",
+      "npm/builder/vite/package.json",
+      "npm/cli/package.json",
+      "npm/framework/musea-nuxt/package.json",
+      "npm/framework/nuxt/package.json",
+      "npm/fresco-native/package.json",
+      "npm/fresco/package.json",
+      "npm/mcp-musea/package.json",
+      "npm/native/package.json",
+      "npm/oxint/package.json",
+      "npm/wasm/package.json",
+    ],
+  );
+});

--- a/tests/tooling/release-preflight-runner.test.ts
+++ b/tests/tooling/release-preflight-runner.test.ts
@@ -29,6 +29,11 @@ test("target-only mode verifies HEAD, current main, and the peeled remote tag", 
   const version = workspaceVersionFromCargoToml(
     fs.readFileSync(path.join(repoRoot, "Cargo.toml"), "utf8"),
   );
+  const trackedManifests = spawnSync("git", ["ls-files", "-z", "--", "editors", "npm"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  assert.equal(trackedManifests.status, 0, trackedManifests.stderr);
   fs.mkdirSync(binDir, { recursive: true });
   writeFakeCommand(
     binDir,
@@ -39,6 +44,7 @@ test("target-only mode verifies HEAD, current main, and the peeled remote tag", 
       "if (command === 'rev-parse HEAD') console.log(process.env.TEST_RELEASE_SHA);",
       "else if (command === 'rev-parse refs/remotes/origin/main') console.log(process.env.TEST_MAIN_SHA);",
       "else if (args[0] === 'fetch') process.exit(0);",
+      "else if (args[0] === 'ls-files') process.stdout.write(JSON.parse(process.env.TEST_PACKAGE_MANIFESTS).join('\\0') + '\\0');",
       "else if (args[0] === 'ls-remote') {",
       "  console.log(`${process.env.TEST_TAG_OBJECT}\\trefs/tags/${process.env.TEST_TAG}`);",
       "  console.log(`${process.env.TEST_TAG_SHA}\\trefs/tags/${process.env.TEST_TAG}^{}`);",
@@ -63,6 +69,7 @@ test("target-only mode verifies HEAD, current main, and the peeled remote tag", 
         TEST_TAG_OBJECT: "c".repeat(40),
         TEST_TAG_SHA: sha,
         TEST_BASE_SHA: "b".repeat(40),
+        TEST_PACKAGE_MANIFESTS: JSON.stringify(trackedManifests.stdout.split("\0").filter(Boolean)),
         ...overrides,
       },
     });
@@ -70,8 +77,12 @@ test("target-only mode verifies HEAD, current main, and the peeled remote tag", 
   try {
     const success = run();
     assert.equal(success.status, 0, `${success.stderr}\n${success.stdout}`.trim());
-    assert.match(run({ TEST_MAIN_SHA: "d".repeat(40) }).stderr, /not the current origin\/main/);
-    assert.match(run({ TEST_TAG_SHA: "e".repeat(40) }).stderr, /Remote tag .* points to/);
+    const mainMismatch = run({ TEST_MAIN_SHA: "d".repeat(40) });
+    assert.equal(mainMismatch.status, 1);
+    assert.match(mainMismatch.stderr, /not the current origin\/main/);
+    const tagMismatch = run({ TEST_TAG_SHA: "e".repeat(40) });
+    assert.equal(tagMismatch.status, 1);
+    assert.match(tagMismatch.stderr, /Remote tag .* points to/);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
@@ -98,4 +109,21 @@ test("release metadata inventory discovers every non-private npm and editor pack
       "npm/wasm/package.json",
     ],
   );
+});
+
+test("release metadata inventory ignores untracked package manifests", () => {
+  const untrackedDirectory = path.join(repoRoot, "npm", `.preflight-untracked-${process.pid}`);
+  fs.mkdirSync(untrackedDirectory, { recursive: true });
+  fs.writeFileSync(
+    path.join(untrackedDirectory, "package.json"),
+    '{"name":"untracked-release-output","version":"9.9.9"}',
+  );
+  try {
+    assert.equal(
+      readPackageManifests().some((manifest) => manifest.path.includes(".preflight-untracked-")),
+      false,
+    );
+  } finally {
+    fs.rmSync(untrackedDirectory, { recursive: true, force: true });
+  }
 });

--- a/tools/github/release-preflight.mjs
+++ b/tools/github/release-preflight.mjs
@@ -87,25 +87,24 @@ function releaseParentSha(sha) {
 }
 
 export function readPackageManifests() {
+  const manifestPaths = runGit(["ls-files", "-z", "--", ...releasePackageRoots])
+    .stdout.split("\0")
+    .filter((relativePath) => relativePath.endsWith("/package.json"));
   const manifests = [];
-  const visit = (directory) => {
-    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-      const absolutePath = path.join(directory, entry.name);
-      if (entry.isDirectory()) {
-        visit(absolutePath);
-        continue;
-      }
-      if (!entry.isFile() || entry.name !== "package.json") continue;
-
-      const content = fs.readFileSync(absolutePath, "utf8");
-      if (JSON.parse(content).private === true) continue;
-      manifests.push({
-        path: path.relative(root, absolutePath).split(path.sep).join("/"),
-        content,
+  for (const relativePath of manifestPaths) {
+    const content = fs.readFileSync(path.join(root, relativePath), "utf8");
+    let packageJson;
+    try {
+      packageJson = JSON.parse(content);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to parse tracked package manifest ${relativePath}: ${detail}`, {
+        cause: error,
       });
     }
-  };
-  for (const relativeRoot of releasePackageRoots) visit(path.join(root, relativeRoot));
+    if (packageJson.private === true) continue;
+    manifests.push({ path: relativePath, content });
+  }
   return manifests.sort((left, right) => left.path.localeCompare(right.path));
 }
 

--- a/tools/github/release-preflight.mjs
+++ b/tools/github/release-preflight.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  bootstrapRequiredWorkflowRuns,
+  createReleaseGateDispatchPlans,
+  releaseGateRunQualifiers,
+} from "./release-preflight-bootstrap.mjs";
+import {
+  assertReleaseCommitIsCurrentMain,
+  assertReleaseMetadata,
+  findReleaseBlockers,
+  remoteTagCommit,
+} from "./release-preflight-core.mjs";
+import {
+  assertRequiredWorkflowJobs,
+  requiredReleaseWorkflows,
+  selectRequiredWorkflowRuns,
+  workflowRequiresJobEvidence,
+} from "./release-preflight-evidence.mjs";
+import { githubApiPages, githubApiRequest } from "./release-preflight-github.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const releasePackageRoots = ["editors", "npm"];
+
+function runGit(args, acceptedExitCodes = [0], cwd = root) {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 30_000,
+  });
+  if (result.error?.code === "ETIMEDOUT") {
+    throw new Error(`git ${args.join(" ")} timed out after 30000ms`);
+  }
+  if (result.error != null) throw result.error;
+  if (!acceptedExitCodes.includes(result.status)) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+    throw new Error(
+      [`git ${args.join(" ")} failed with exit ${result.status}`, detail]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+  return result;
+}
+
+function verifyGitReleaseTarget(tag, sha) {
+  const head = runGit(["rev-parse", "HEAD"]).stdout.trim();
+  if (head !== sha) {
+    throw new Error(`Checked out HEAD ${head} does not match release event SHA ${sha}`);
+  }
+  runGit(["fetch", "--quiet", "--no-tags", "origin", "+refs/heads/main:refs/remotes/origin/main"]);
+  const mainSha = runGit(["rev-parse", "refs/remotes/origin/main"]).stdout.trim();
+  assertReleaseCommitIsCurrentMain(sha, mainSha);
+
+  const remoteTag = runGit([
+    "ls-remote",
+    "--exit-code",
+    "--tags",
+    "origin",
+    `refs/tags/${tag}`,
+    `refs/tags/${tag}^{}`,
+  ]).stdout;
+  const target = remoteTagCommit(remoteTag, tag);
+  if (target !== sha) {
+    const targetDescription = typeof target === "string" ? target : "nothing";
+    throw new Error(`Remote tag ${tag} points to ${targetDescription}, expected ${sha}`);
+  }
+}
+
+function releaseParentSha(sha) {
+  const revision = runGit(["rev-list", "--parents", "-n", "1", sha]).stdout.trim().split(/\s+/);
+  if (revision.length !== 2 || revision[0] !== sha) {
+    throw new Error(`Release commit ${sha} must have exactly one parent for benchmark comparison`);
+  }
+  const baseSha = revision[1];
+  const ancestry = runGit(["merge-base", "--is-ancestor", baseSha, sha], [0, 1]);
+  if (ancestry.status !== 0) {
+    throw new Error(`Benchmark base ${baseSha} is not an ancestor of release commit ${sha}`);
+  }
+  return baseSha;
+}
+
+export function readPackageManifests() {
+  const manifests = [];
+  const visit = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(absolutePath);
+        continue;
+      }
+      if (!entry.isFile() || entry.name !== "package.json") continue;
+
+      const content = fs.readFileSync(absolutePath, "utf8");
+      if (JSON.parse(content).private === true) continue;
+      manifests.push({
+        path: path.relative(root, absolutePath).split(path.sep).join("/"),
+        content,
+      });
+    }
+  };
+  for (const relativeRoot of releasePackageRoots) visit(path.join(root, relativeRoot));
+  return manifests.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+export function verifyReleaseTarget(env = process.env) {
+  const tag = env.GITHUB_REF_NAME ?? "";
+  const sha = env.GITHUB_SHA ?? "";
+  if (env.GITHUB_REF_TYPE !== "tag") {
+    throw new Error(
+      `Release preflight requires a tag event, got ${env.GITHUB_REF_TYPE ?? "unknown"}`,
+    );
+  }
+  const version = assertReleaseMetadata({
+    tag,
+    sha,
+    cargoToml: fs.readFileSync(path.join(root, "Cargo.toml"), "utf8"),
+    packageManifests: readPackageManifests(),
+  });
+  verifyGitReleaseTarget(tag, sha);
+  return { tag, sha, version, baseSha: releaseParentSha(sha) };
+}
+
+export async function verifyReleasePreflight(env = process.env, { bootstrap = true } = {}) {
+  const { tag, sha, version, baseSha } = verifyReleaseTarget(env);
+  const repository = env.GITHUB_REPOSITORY ?? "";
+  const token = env.GITHUB_TOKEN ?? "";
+  const apiUrl = env.GITHUB_API_URL ?? "https://api.github.com";
+  if (repository === "" || token === "") {
+    throw new Error("GITHUB_REPOSITORY and GITHUB_TOKEN are required");
+  }
+
+  const listRuns = () =>
+    githubApiPages({
+      apiUrl,
+      repository,
+      token,
+      resource: "actions/runs",
+      collection: "workflow_runs",
+      query: { head_sha: sha },
+    });
+  const dispatchPlans = createReleaseGateDispatchPlans({ ref: tag, headSha: sha, baseSha });
+  let selectedRuns;
+  if (bootstrap) {
+    let previousWaitState = "";
+    selectedRuns = await bootstrapRequiredWorkflowRuns({
+      sha,
+      dispatchPlans,
+      listRuns,
+      dispatchWorkflow: async (plan) => {
+        console.log(`Dispatching ${plan.workflowName} on ${plan.ref} for ${sha}.`);
+        await githubApiRequest({
+          apiUrl,
+          repository,
+          token,
+          resource: `actions/workflows/${encodeURIComponent(plan.workflowId)}/dispatches`,
+          method: "POST",
+          body: { ref: plan.ref, inputs: plan.inputs },
+        });
+      },
+      onWait: ({ missing, pending }) => {
+        const state = JSON.stringify({ missing, pending });
+        if (state === previousWaitState) return;
+        previousWaitState = state;
+        console.log(
+          `Waiting for exact-SHA release gates (missing: ${missing.join(", ") || "none"}; pending: ${pending.join(", ") || "none"}).`,
+        );
+      },
+    });
+  } else {
+    selectedRuns = selectRequiredWorkflowRuns(
+      await listRuns(),
+      sha,
+      requiredReleaseWorkflows,
+      releaseGateRunQualifiers(dispatchPlans),
+    );
+  }
+
+  const [issues] = await Promise.all([
+    githubApiPages({
+      apiUrl,
+      repository,
+      token,
+      resource: "issues",
+      collection: null,
+      query: { state: "open" },
+    }),
+    ...[...selectedRuns]
+      .filter(([workflowName]) => workflowRequiresJobEvidence(workflowName))
+      .map(async ([workflowName, run]) => {
+        const jobs = await githubApiPages({
+          apiUrl,
+          repository,
+          token,
+          resource: `actions/runs/${run.id}/jobs`,
+          collection: "jobs",
+        });
+        assertRequiredWorkflowJobs(workflowName, jobs);
+      }),
+  ]);
+  const blockers = findReleaseBlockers(issues);
+  if (blockers.length > 0) {
+    throw new Error(
+      `Release-blocking issues remain open:\n${blockers
+        .map((issue) => `- #${issue.number} ${issue.title}`)
+        .join("\n")}`,
+    );
+  }
+  verifyGitReleaseTarget(tag, sha);
+  console.log(`Release preflight passed for ${tag} (${sha}) at workspace version ${version}.`);
+  console.log(`Required workflows: ${requiredReleaseWorkflows.join(", ")}`);
+}
+
+export function parseReleasePreflightMode(args) {
+  if (args.length === 0) return "bootstrap";
+  if (args.length === 1 && args[0] === "--verify-only") return "verify-only";
+  if (args.length === 1 && args[0] === "--target-only") return "target-only";
+  throw new Error("Usage: node tools/github/release-preflight.mjs [--verify-only|--target-only]");
+}
+
+const entrypoint = process.argv[1]
+  ? fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  : false;
+if (entrypoint) {
+  const command = Promise.resolve().then(() => {
+    const mode = parseReleasePreflightMode(process.argv.slice(2));
+    if (mode === "target-only") return verifyReleaseTarget();
+    return verifyReleasePreflight(process.env, { bootstrap: mode === "bootstrap" });
+  });
+  command.catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- add the release preflight CLI that binds the checked-out tag, current main, peeled remote tag, and single benchmark parent
- inventory every non-private npm/editor package and enforce one workspace release version
- bootstrap or verify exact-SHA workflow evidence, matrix jobs, and open release blockers
- revalidate the immutable Git target after all API checks before reporting success

## Modes

- default: dispatch missing expensive gates and wait for exact evidence
- `--verify-only`: perform a read-only final revalidation
- `--target-only`: validate tag/main/package metadata without API access

## Verification

- `node --test tests/tooling/release-preflight-*.test.ts` (32 passed)
- `vp check tools/github/release-preflight.mjs tests/tooling/release-preflight-runner.test.ts`
- `oxfmt --check tools/github/release-preflight.mjs tests/tooling/release-preflight-runner.test.ts`
- `git diff --check`
- both added files remain below the 350-line limit

Supports #2818.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786461201&installation_id=136613492&pr_number=2897&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2897&signature=240076529a218d7a9d35fb3028dccc127f38eaa3762e98fc5aa12f9d88259497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a standalone release preflight CLI to validate GitHub tag targets, commit ancestry, release metadata, required workflow evidence, and blocking open issues.
  - Introduced `verify-only` and `target-only` modes for focused checks.
  - Added optional bootstrapping to prepare required release gate workflows automatically.
  - Improved success/failure reporting and displays required workflows.

- **Tests**
  - Added automated coverage for safe mode parsing, target-only success/failure scenarios (including tag/commit mismatches), and manifest inventory behavior (including ignoring untracked package locations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->