### PR TITLE
fix(release): gate publication on verified preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
   release-vscode-extension:
     name: Release VS Code extension
     runs-on: blacksmith-32vcpu-ubuntu-2404
-    needs: build-editor-extensions
+    needs: [build-editor-extensions, release-preflight]
     timeout-minutes: 15
     environment: vscode-marketplace
     permissions:
@@ -596,12 +596,48 @@ jobs:
             npm/framework/musea-nuxt \
             npm/framework/nuxt
 
+  release-preflight-bootstrap:
+    permissions:
+      actions: write
+      contents: read
+      issues: read
+    uses: ./.github/workflows/release-preflight.yml
+
+  release-preflight:
+    name: Final release preflight
+    needs:
+      - release-preflight-bootstrap
+      - build-cli
+      - build-editor-extensions
+      - build-wasm-package
+      - smoke-release-packages
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+      issues: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: ".node-version"
+
+      - name: Revalidate immutable target, gates, and blockers after build fan-in
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node tools/github/release-preflight.mjs --verify-only
+
   # npm Trusted Publishing/provenance currently rejects self-hosted runners.
   # Keep the publish edge on GitHub-hosted runners; build and smoke jobs stay on Blacksmith.
   release-npm-native:
     name: Release @vizejs/native to npm
     runs-on: ubuntu-24.04
-    needs: [plan-release-platforms, build-native-all]
+    needs: [plan-release-platforms, build-native-all, release-preflight]
     timeout-minutes: 30
     environment: npm
     permissions:
@@ -657,7 +693,7 @@ jobs:
   release-npm-fresco-native:
     name: Release @vizejs/fresco-native to npm
     runs-on: ubuntu-24.04
-    needs: build-native-all
+    needs: [build-native-all, release-preflight]
     timeout-minutes: 20
     environment: npm
     permissions:
@@ -699,7 +735,7 @@ jobs:
   release-npm-wasm:
     name: Release @vizejs/wasm to npm
     runs-on: ubuntu-24.04
-    needs: build-wasm-package
+    needs: [build-wasm-package, release-preflight]
     timeout-minutes: 30
     environment: npm
     permissions:
@@ -733,7 +769,12 @@ jobs:
   release-npm-vite-plugin:
     name: Release @vizejs/vite-plugin to npm
     runs-on: ubuntu-24.04
-    needs: [build-release-packages, release-npm-native, release-npm-cli, smoke-release-packages]
+    needs:
+      - build-release-packages
+      - release-npm-native
+      - release-npm-cli
+      - smoke-release-packages
+      - release-preflight
     timeout-minutes: 15
     environment: npm
     permissions:
@@ -766,6 +807,7 @@ jobs:
       - build-release-packages
       - release-npm-native
       - smoke-release-packages
+      - release-preflight
     timeout-minutes: 15
     environment: npm
     permissions:
@@ -800,7 +842,7 @@ jobs:
   release-npm-unplugin:
     name: Release @vizejs/unplugin to npm
     runs-on: ubuntu-24.04
-    needs: [build-release-packages, release-npm-native, smoke-release-packages]
+    needs: [build-release-packages, release-npm-native, smoke-release-packages, release-preflight]
     timeout-minutes: 15
     environment: npm
     permissions:
@@ -829,7 +871,11 @@ jobs:
   release-npm-fresco:
     name: Release @vizejs/fresco to npm
     runs-on: ubuntu-24.04
-    needs: [build-release-packages, release-npm-fresco-native, smoke-release-packages]
+    needs:
+      - build-release-packages
+      - release-npm-fresco-native
+      - smoke-release-packages
+      - release-preflight
     timeout-minutes: 15
     environment: npm
     permissions:
@@ -858,7 +904,7 @@ jobs:
   release-npm-musea-mcp-server:
     name: Release @vizejs/musea-mcp-server to npm
     runs-on: ubuntu-24.04
-    needs: [build-release-packages, release-npm-native, smoke-release-packages]
+    needs: [build-release-packages, release-npm-native, smoke-release-packages, release-preflight]
     timeout-minutes: 15
     environment: npm
     permissions:
@@ -887,7 +933,7 @@ jobs:
   release-npm-vite-plugin-musea:
     name: Release @vizejs/vite-plugin-musea to npm
     runs-on: ubuntu-24.04
-    needs: [build-release-packages, release-npm-native, smoke-release-packages]
+    needs: [build-release-packages, release-npm-native, smoke-release-packages, release-preflight]
     timeout-minutes: 15
     environment: npm
     permissions:
@@ -916,7 +962,7 @@ jobs:
   release-npm-rspack-plugin:
     name: Release @vizejs/rspack-plugin to npm
     runs-on: ubuntu-24.04
-    needs: [build-release-packages, release-npm-native, smoke-release-packages]
+    needs: [build-release-packages, release-npm-native, smoke-release-packages, release-preflight]
     timeout-minutes: 15
     environment: npm
     permissions:
@@ -945,7 +991,7 @@ jobs:
   release-npm-musea-nuxt:
     name: Release @vizejs/musea-nuxt to npm
     runs-on: ubuntu-24.04
-    needs: [build-release-packages, release-npm-native, smoke-release-packages]
+    needs: [build-release-packages, release-npm-native, smoke-release-packages, release-preflight]
     timeout-minutes: 15
     environment: npm
     permissions:
@@ -981,6 +1027,7 @@ jobs:
       - release-npm-musea-nuxt
       - release-npm-cli
       - smoke-release-packages
+      - release-preflight
     timeout-minutes: 15
     environment: npm
     permissions:
@@ -1009,6 +1056,7 @@ jobs:
   release-crates:
     name: Release crates to crates.io
     runs-on: blacksmith-32vcpu-ubuntu-2404
+    needs: release-preflight
     timeout-minutes: 30
     environment: crates-io
     permissions:
@@ -1057,6 +1105,7 @@ jobs:
       - release-npm-musea-nuxt
       - release-npm-nuxt
       - release-crates
+      - release-preflight
     timeout-minutes: 20
     # `id-token: write` is required by sigstore/cosign-installer to mint the
     # keyless signing certificate, and by anchore/sbom-action when it uploads
@@ -1187,7 +1236,7 @@ jobs:
   release-npm-cli:
     name: Release vize CLI to npm
     runs-on: ubuntu-24.04
-    needs: [build-release-packages, release-npm-native, smoke-release-packages]
+    needs: [build-release-packages, release-npm-native, smoke-release-packages, release-preflight]
     timeout-minutes: 15
     environment: npm
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -194,7 +193,6 @@ jobs:
           node-version-file: ".node-version"
           run-install: false
       - uses: ./.github/actions/setup-moonbit
-
       - name: Cache pnpm store for VS Code extension tooling
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
@@ -202,13 +200,11 @@ jobs:
           key: ${{ runner.os }}-pnpm-vscode-release-${{ hashFiles('.node-version') }}-v1
           restore-keys: |
             ${{ runner.os }}-pnpm-vscode-release-
-
       - name: Download editor extension artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: editor-extensions
           path: editor-extension-artifacts
-
       - name: Require VS Code Marketplace credentials
         run: |
           if [ -z "${VSCE_PAT:-}" ]; then
@@ -596,42 +592,12 @@ jobs:
             npm/framework/musea-nuxt \
             npm/framework/nuxt
 
-  release-preflight-bootstrap:
+  release-preflight:
     permissions:
       actions: write
       contents: read
       issues: read
     uses: ./.github/workflows/release-preflight.yml
-
-  release-preflight:
-    name: Final release preflight
-    needs:
-      - release-preflight-bootstrap
-      - build-cli
-      - build-editor-extensions
-      - build-wasm-package
-      - smoke-release-packages
-    runs-on: blacksmith-32vcpu-ubuntu-2404
-    timeout-minutes: 15
-    permissions:
-      actions: read
-      contents: read
-      issues: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version-file: ".node-version"
-
-      - name: Revalidate immutable target, gates, and blockers after build fan-in
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: node tools/github/release-preflight.mjs --verify-only
-
   # npm Trusted Publishing/provenance currently rejects self-hosted runners.
   # Keep the publish edge on GitHub-hosted runners; build and smoke jobs stay on Blacksmith.
   release-npm-native:
@@ -645,7 +611,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -701,7 +666,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -744,7 +708,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-moonbit
-
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -770,11 +733,13 @@ jobs:
     name: Release @vizejs/vite-plugin to npm
     runs-on: ubuntu-24.04
     needs:
-      - build-release-packages
-      - release-npm-native
-      - release-npm-cli
-      - smoke-release-packages
-      - release-preflight
+      [
+        build-release-packages,
+        release-npm-native,
+        release-npm-cli,
+        smoke-release-packages,
+        release-preflight,
+      ]
     timeout-minutes: 15
     environment: npm
     permissions:
@@ -782,7 +747,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -803,11 +767,13 @@ jobs:
     name: Release oxlint-plugin-vize to npm
     runs-on: ubuntu-24.04
     needs:
-      - plan-release-platforms
-      - build-release-packages
-      - release-npm-native
-      - smoke-release-packages
-      - release-preflight
+      [
+        plan-release-platforms,
+        build-release-packages,
+        release-npm-native,
+        smoke-release-packages,
+        release-preflight,
+      ]
     timeout-minutes: 15
     environment: npm
     permissions:
@@ -815,7 +781,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -850,7 +815,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -872,10 +836,7 @@ jobs:
     name: Release @vizejs/fresco to npm
     runs-on: ubuntu-24.04
     needs:
-      - build-release-packages
-      - release-npm-fresco-native
-      - smoke-release-packages
-      - release-preflight
+      [build-release-packages, release-npm-fresco-native, smoke-release-packages, release-preflight]
     timeout-minutes: 15
     environment: npm
     permissions:
@@ -883,7 +844,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -912,7 +872,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -941,7 +900,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -970,7 +928,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -999,7 +956,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -1021,13 +977,15 @@ jobs:
     name: Release @vizejs/nuxt to npm
     runs-on: ubuntu-24.04
     needs:
-      - build-release-packages
-      - release-npm-vite-plugin
-      - release-npm-vite-plugin-musea
-      - release-npm-musea-nuxt
-      - release-npm-cli
-      - smoke-release-packages
-      - release-preflight
+      [
+        build-release-packages,
+        release-npm-vite-plugin,
+        release-npm-vite-plugin-musea,
+        release-npm-musea-nuxt,
+        release-npm-cli,
+        smoke-release-packages,
+        release-preflight,
+      ]
     timeout-minutes: 15
     environment: npm
     permissions:
@@ -1035,7 +993,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -1065,19 +1022,15 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-moonbit
-
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-
       - uses: ./.github/actions/setup-rust-sticky-cache
         with:
           key: release-crates
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
-
       - name: Get crates.io token via Trusted Publishing
         id: crates-io-auth
         uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
-
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
@@ -1115,7 +1068,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
       - name: Download CLI artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1244,7 +1196,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:

--- a/tests/tooling/github-workflows-release-publish.test.ts
+++ b/tests/tooling/github-workflows-release-publish.test.ts
@@ -63,47 +63,16 @@ test("every publication edge waits for credential-free release preflight", () =>
     assert.ok(jobNeeds(jobs[jobName]).includes("release-preflight"), jobName);
   }
 
-  const bootstrap = jobs["release-preflight-bootstrap"];
-  assert.ok(bootstrap);
-  assert.equal(bootstrap.uses, "./.github/workflows/release-preflight.yml");
-  assert.deepEqual(bootstrap.permissions, {
+  const preflight = jobs["release-preflight"];
+  assert.ok(preflight);
+  assert.equal(preflight.uses, "./.github/workflows/release-preflight.yml");
+  assert.deepEqual(preflight.permissions, {
     actions: "write",
     contents: "read",
     issues: "read",
   });
-  assert.deepEqual(jobNeeds(bootstrap), []);
-
-  const preflight = jobs["release-preflight"];
-  assert.ok(preflight);
-  assert.deepEqual(jobNeeds(preflight).toSorted(), [
-    "build-cli",
-    "build-editor-extensions",
-    "build-wasm-package",
-    "release-preflight-bootstrap",
-    "smoke-release-packages",
-  ]);
-  assert.equal(preflight["runs-on"], "blacksmith-32vcpu-ubuntu-2404");
-  assert.equal(preflight["timeout-minutes"], 15);
-  assert.deepEqual(preflight.permissions, {
-    actions: "read",
-    contents: "read",
-    issues: "read",
-  });
-  const checkout = preflight.steps?.find((step) => step.uses?.startsWith("actions/checkout@"));
-  assert.equal(checkout?.with?.["fetch-depth"], 0);
-  assert.equal(checkout?.with?.["persist-credentials"], false);
-  assert.ok(
-    preflight.steps?.some(
-      (step) => step.run === "node tools/github/release-preflight.mjs --verify-only",
-    ),
-  );
-
-  for (const job of [bootstrap, preflight]) {
-    assert.doesNotMatch(
-      JSON.stringify(job),
-      /environment|id-token|secrets\.|crates-io-auth-action/,
-    );
-  }
+  assert.deepEqual(jobNeeds(preflight), []);
+  assert.doesNotMatch(JSON.stringify(preflight), /environment|id-token|secrets\./);
 });
 
 test("release workflow does not pin a separate hard-coded Node version for VS Code publishing", () => {

--- a/tests/tooling/github-workflows-release-publish.test.ts
+++ b/tests/tooling/github-workflows-release-publish.test.ts
@@ -1,7 +1,110 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { parse } from "yaml";
 
 import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
+
+type ReleaseJob = {
+  environment?: string;
+  needs?: string | string[];
+  permissions?: Record<string, string>;
+  "runs-on"?: string;
+  steps?: Array<{
+    env?: Record<string, string>;
+    run?: string;
+    uses?: string;
+    with?: Record<string, unknown>;
+  }>;
+  "timeout-minutes"?: number;
+  uses?: string;
+};
+
+function jobNeeds(job: ReleaseJob): string[] {
+  if (job.needs == null) return [];
+  return Array.isArray(job.needs) ? job.needs : [job.needs];
+}
+
+test("every publication edge waits for credential-free release preflight", () => {
+  const source = readRepoFile(".github", "workflows", "release.yml");
+  const workflow = parse(source) as { jobs?: Record<string, ReleaseJob> };
+  const jobs = workflow.jobs ?? {};
+  const publishJobs = Object.entries(jobs)
+    .filter(([, job]) => {
+      const serialized = JSON.stringify(job);
+      return (
+        ["npm", "crates-io", "vscode-marketplace"].includes(job.environment ?? "") ||
+        /publish_npm_package|npm publish|cargo publish|vsce publish|crates-io-auth-action@|softprops\/action-gh-release@/.test(
+          serialized,
+        )
+      );
+    })
+    .map(([name]) => name)
+    .sort();
+
+  assert.deepEqual(publishJobs, [
+    "create-github-release",
+    "release-crates",
+    "release-npm-cli",
+    "release-npm-fresco",
+    "release-npm-fresco-native",
+    "release-npm-musea-mcp-server",
+    "release-npm-musea-nuxt",
+    "release-npm-native",
+    "release-npm-nuxt",
+    "release-npm-oxlint-plugin",
+    "release-npm-rspack-plugin",
+    "release-npm-unplugin",
+    "release-npm-vite-plugin",
+    "release-npm-vite-plugin-musea",
+    "release-npm-wasm",
+    "release-vscode-extension",
+  ]);
+  for (const jobName of publishJobs) {
+    assert.ok(jobNeeds(jobs[jobName]).includes("release-preflight"), jobName);
+  }
+
+  const bootstrap = jobs["release-preflight-bootstrap"];
+  assert.ok(bootstrap);
+  assert.equal(bootstrap.uses, "./.github/workflows/release-preflight.yml");
+  assert.deepEqual(bootstrap.permissions, {
+    actions: "write",
+    contents: "read",
+    issues: "read",
+  });
+  assert.deepEqual(jobNeeds(bootstrap), []);
+
+  const preflight = jobs["release-preflight"];
+  assert.ok(preflight);
+  assert.deepEqual(jobNeeds(preflight).toSorted(), [
+    "build-cli",
+    "build-editor-extensions",
+    "build-wasm-package",
+    "release-preflight-bootstrap",
+    "smoke-release-packages",
+  ]);
+  assert.equal(preflight["runs-on"], "blacksmith-32vcpu-ubuntu-2404");
+  assert.equal(preflight["timeout-minutes"], 15);
+  assert.deepEqual(preflight.permissions, {
+    actions: "read",
+    contents: "read",
+    issues: "read",
+  });
+  const checkout = preflight.steps?.find((step) => step.uses?.startsWith("actions/checkout@"));
+  assert.equal(checkout?.with?.["fetch-depth"], 0);
+  assert.equal(checkout?.with?.["persist-credentials"], false);
+  assert.ok(
+    preflight.steps?.some(
+      (step) => step.run === "node tools/github/release-preflight.mjs --verify-only",
+    ),
+  );
+
+  for (const job of [bootstrap, preflight]) {
+    assert.doesNotMatch(
+      JSON.stringify(job),
+      /environment|id-token|secrets\.|crates-io-auth-action/,
+    );
+  }
+});
 
 test("release workflow does not pin a separate hard-coded Node version for VS Code publishing", () => {
   const workflow = readRepoFile(".github", "workflows", "release.yml");
@@ -114,7 +217,11 @@ test("release workflow smokes the wasm package wrapper before publishing", () =>
   assert.match(buildJob, /npm\/wasm\/index\.d\.ts/);
   assert.match(buildJob, /moon run --target native tools\/moon\/cmd\/build_vize_wasm_package --/);
   assert.match(buildJob, /name:\s*release-package-vize-wasm/);
-  assert.match(publishJob, /needs:\s*build-wasm-package/);
+  const publishWorkflow = parse(workflow) as { jobs?: Record<string, ReleaseJob> };
+  const publishWasm = publishWorkflow.jobs?.["release-npm-wasm"];
+  assert.ok(publishWasm);
+  assert.ok(jobNeeds(publishWasm).includes("build-wasm-package"));
+  assert.ok(jobNeeds(publishWasm).includes("release-preflight"));
   assert.match(publishJob, /name:\s*release-package-vize-wasm/);
   assert.match(publishJob, /path:\s*npm\/wasm/);
 


### PR DESCRIPTION
## Summary

- run the reusable exact-SHA preflight in parallel with package builds so validation does not extend the critical path
- make every npm, crates.io, VS Code Marketplace, and GitHub Release publication job wait for the verified preflight
- discover publish-capable jobs semantically and fail tests when a new credentialed edge omits the preflight dependency

## Validation

- `node --test tests/tooling/github-workflows-release-publish.test.ts tests/tooling/release-preflight-workflow.test.ts tests/tooling/github-workflows.test.ts` (20 passed)
- `vp check .github/workflows/release.yml tests/tooling/github-workflows-release-publish.test.ts`
- source-length contract: `.github/workflows/release.yml` remains at the 1,216-line base
- `git diff --check`

Closes #2818.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a release preflight verification gate that must pass before publishing packages and creating GitHub Releases.
  * Updated release workflows so publication jobs depend on the new preflight step, including WASM publishing.

* **Bug Fixes**
  * Improved release safety by ensuring publishing cannot proceed unless the preflight checks complete successfully.

* **Tests**
  * Expanded CI workflow validation to confirm required job dependencies, permissions, and credential-related restrictions, including updated WASM job requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->