### PR TITLE
perf(ci): scope Criterion suites by impact

### DIFF
--- a/.github/workflows/criterion-bench.yml
+++ b/.github/workflows/criterion-bench.yml
@@ -6,9 +6,14 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "crates/**"
+      - ".cargo/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
       - "bench/criterion-ab.mjs"
+      - "bench/criterion-impact.mjs"
       - "bench/dialect-guard.mjs"
       - "bench/generate.mjs"
+      - "rust-toolchain.toml"
       - ".github/workflows/criterion-bench.yml"
 
 concurrency:
@@ -50,6 +55,7 @@ jobs:
         with:
           path: head
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Checkout base
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -59,18 +65,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
-        with:
-          wild-version: "0.9.0"
-
-      # Both sides bench into head/target so critcmp can read both baselines, so
-      # a single shared target disk is mounted (base and head compile into it).
-      - uses: ./head/.github/actions/setup-rust-sticky-cache
-        with:
-          key: criterion-bench
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('head/Cargo.lock') }}
-          target-path: head/target
-
       # The A/B driver is plain Node (no npm deps); pin the runtime so the
       # script never runs under an unexpected runner-default Node version.
       - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
@@ -79,15 +73,39 @@ jobs:
           cache: true
           run-install: false
 
+      - name: Select affected Criterion suites
+        id: impact
+        run: |
+          node head/bench/criterion-impact.mjs \
+            --repo-dir "$GITHUB_WORKSPACE/head" \
+            --base-sha "${{ github.event.pull_request.base.sha }}" \
+            --head-sha "${{ github.event.pull_request.head.sha }}" \
+            --out "$GITHUB_WORKSPACE/criterion-impact.json"
+
+      - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
+        if: steps.impact.outputs.has_suites == 'true'
+        with:
+          wild-version: "0.9.0"
+
+      # Both sides bench into head/target so critcmp can read both baselines, so
+      # a single shared target disk is mounted (base and head compile into it).
+      - uses: ./head/.github/actions/setup-rust-sticky-cache
+        if: steps.impact.outputs.has_suites == 'true'
+        with:
+          key: criterion-bench
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('head/Cargo.lock') }}
+          target-path: head/target
+
       - name: Cache critcmp
         id: cache-critcmp
+        if: steps.impact.outputs.has_suites == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cargo/bin/critcmp
           key: ${{ runner.os }}-critcmp-0.1.8
 
       - name: Install critcmp
-        if: steps.cache-critcmp.outputs.cache-hit != 'true'
+        if: steps.impact.outputs.has_suites == 'true' && steps.cache-critcmp.outputs.cache-hit != 'true'
         run: cargo install critcmp --version 0.1.8 --locked
 
       # Both checkouts save their criterion baselines into the head checkout's
@@ -98,6 +116,7 @@ jobs:
             --base-dir "$GITHUB_WORKSPACE/base" \
             --head-dir "$GITHUB_WORKSPACE/head" \
             --target-dir "$GITHUB_WORKSPACE/head/target" \
+            --selection "$GITHUB_WORKSPACE/criterion-impact.json" \
             ${CRITERION_AB_THRESHOLD:+--threshold "$CRITERION_AB_THRESHOLD"} \
             --out "$GITHUB_WORKSPACE/criterion-ab-summary.md"
 

--- a/.github/workflows/criterion-bench.yml
+++ b/.github/workflows/criterion-bench.yml
@@ -56,12 +56,14 @@ jobs:
           path: head
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Checkout base
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: base
           ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
@@ -75,21 +77,26 @@ jobs:
 
       - name: Select affected Criterion suites
         id: impact
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           node head/bench/criterion-impact.mjs \
             --repo-dir "$GITHUB_WORKSPACE/head" \
-            --base-sha "${{ github.event.pull_request.base.sha }}" \
-            --head-sha "${{ github.event.pull_request.head.sha }}" \
+            --base-sha "$PR_BASE_SHA" \
+            --head-sha "$PR_HEAD_SHA" \
             --out "$GITHUB_WORKSPACE/criterion-impact.json"
 
-      - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
+      - name: Setup Wild linker
+        uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         if: steps.impact.outputs.has_suites == 'true'
         with:
           wild-version: "0.9.0"
 
       # Both sides bench into head/target so critcmp can read both baselines, so
       # a single shared target disk is mounted (base and head compile into it).
-      - uses: ./head/.github/actions/setup-rust-sticky-cache
+      - name: Mount Criterion cache
+        uses: ./head/.github/actions/setup-rust-sticky-cache
         if: steps.impact.outputs.has_suites == 'true'
         with:
           key: criterion-bench

--- a/bench/criterion-ab.mjs
+++ b/bench/criterion-ab.mjs
@@ -33,7 +33,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { appendFileSync, existsSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -190,10 +190,46 @@ export function parseCritcmpRegressions(table, thresholdPercent) {
   return regressions;
 }
 
-export function renderSummary({ table, threshold, regressions }) {
+export function resolveSuiteSelection(selection) {
+  const inventory = CRITERION_SUITES.map((suite) => suite.package);
+  if (selection == null) {
+    return {
+      selected: inventory,
+      skipped: [],
+      reason: "Full inventory selected (no impact manifest supplied).",
+    };
+  }
+  if (!Array.isArray(selection.selected) || typeof selection.reason !== "string") {
+    throw new Error("Criterion impact manifest must contain selected[] and reason");
+  }
+  if (new Set(selection.selected).size !== selection.selected.length) {
+    throw new Error("Criterion impact manifest contains duplicate suites");
+  }
+  const unknown = selection.selected.filter((name) => !inventory.includes(name));
+  if (unknown.length > 0) {
+    throw new Error(`Criterion impact manifest contains unknown suites: ${unknown.join(", ")}`);
+  }
+  return {
+    selected: inventory.filter((name) => selection.selected.includes(name)),
+    skipped: inventory.filter((name) => !selection.selected.includes(name)),
+    reason: selection.reason,
+  };
+}
+
+export function renderSummary({ table, threshold, regressions, selection }) {
   const lines = [];
   lines.push("## Criterion A/B");
   lines.push("");
+  lines.push(`Selection: ${selection.reason}`);
+  lines.push("");
+  lines.push(`- Ran: ${selection.selected.join(", ") || "none"}`);
+  lines.push(`- Skipped: ${selection.skipped.join(", ") || "none"}`);
+  lines.push("");
+  if (selection.selected.length === 0) {
+    lines.push("No configured Criterion suite is affected; timing execution was skipped.");
+    lines.push("");
+    return `${lines.join("\n")}\n`;
+  }
   lines.push(
     threshold == null
       ? "Report-only: micro-benchmark medians for base vs head (no gate)."
@@ -220,6 +256,9 @@ export function main(argv = process.argv.slice(2)) {
   const headDir = resolve(requireArg(args, "head-dir"));
   const targetDir = resolve(requireArg(args, "target-dir"));
   const threshold = parsePositiveFloat(args.threshold);
+  const selection = resolveSuiteSelection(
+    args.selection ? JSON.parse(readFileSync(resolve(args.selection), "utf8")) : undefined,
+  );
 
   if (!existsSync(baseDir)) {
     throw new Error(`Base checkout not found: ${baseDir}`);
@@ -228,25 +267,28 @@ export function main(argv = process.argv.slice(2)) {
     throw new Error(`Head checkout not found: ${headDir}`);
   }
 
+  const suites = CRITERION_SUITES.filter((suite) => selection.selected.includes(suite.package));
   // Base first, then head, into the shared target dir so critcmp sees both.
-  benchSide({
-    side: "base",
-    checkoutDir: baseDir,
-    baseline: "base",
-    targetDir,
-    suites: CRITERION_SUITES,
-  });
-  benchSide({
-    side: "head",
-    checkoutDir: headDir,
-    baseline: "head",
-    targetDir,
-    suites: CRITERION_SUITES,
-  });
+  if (suites.length > 0) {
+    benchSide({
+      side: "base",
+      checkoutDir: baseDir,
+      baseline: "base",
+      targetDir,
+      suites,
+    });
+    benchSide({
+      side: "head",
+      checkoutDir: headDir,
+      baseline: "head",
+      targetDir,
+      suites,
+    });
+  }
 
-  const table = critcmpCompare({ targetDir, threshold });
+  const table = suites.length > 0 ? critcmpCompare({ targetDir, threshold }) : "";
   const regressions = parseCritcmpRegressions(table, threshold);
-  const summary = renderSummary({ table, threshold, regressions });
+  const summary = renderSummary({ table, threshold, regressions, selection });
 
   if (args.out) {
     writeFileSync(resolve(args.out), summary);

--- a/bench/criterion-impact.mjs
+++ b/bench/criterion-impact.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { dirname, relative, resolve, sep } from "node:path";
+import { pathToFileURL } from "node:url";
+import { appendFileSync, writeFileSync } from "node:fs";
+
+import { CRITERION_SUITES } from "./criterion-ab.mjs";
+
+const FULL_SWEEP_PATHS = new Set([
+  ".github/workflows/criterion-bench.yml",
+  "Cargo.lock",
+  "Cargo.toml",
+  "bench/criterion-ab.mjs",
+  "bench/criterion-impact.mjs",
+  "bench/dialect-guard.mjs",
+  "bench/generate.mjs",
+  "rust-toolchain.toml",
+]);
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) continue;
+    const key = arg.slice(2);
+    const value = argv[index + 1];
+    if (value == null || value.startsWith("--")) {
+      args[key] = true;
+    } else {
+      args[key] = value;
+      index++;
+    }
+  }
+  return args;
+}
+
+function requireArg(args, key) {
+  const value = args[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Missing required argument: --${key}`);
+  }
+  return value;
+}
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} exited with ${result.status}: ${result.stderr.trim()}`,
+    );
+  }
+  return result.stdout;
+}
+
+function normalizeRepoPath(path) {
+  return path.split(sep).join("/").replace(/^\.\//, "");
+}
+
+export function parseNameStatusZ(output) {
+  const fields = output.split("\0");
+  if (fields.at(-1) === "") fields.pop();
+  const paths = [];
+  for (let index = 0; index < fields.length; ) {
+    const status = fields[index++];
+    if (!/^(?:[ACDMRTUXB]|R\d+|C\d+)$/.test(status ?? "")) {
+      throw new Error(`Malformed git diff status: ${status ?? "<missing>"}`);
+    }
+    const path = fields[index++];
+    if (!path) throw new Error(`Missing path for git diff status ${status}`);
+    paths.push(normalizeRepoPath(path));
+    if (status.startsWith("R") || status.startsWith("C")) {
+      const destination = fields[index++];
+      if (!destination) throw new Error(`Missing destination for git diff status ${status}`);
+      paths.push(normalizeRepoPath(destination));
+    }
+  }
+  return [...new Set(paths)];
+}
+
+function workspacePackages(metadata, repoDir) {
+  if (!Array.isArray(metadata.workspace_members) || !Array.isArray(metadata.packages)) {
+    throw new Error("cargo metadata is missing workspace package data");
+  }
+  const members = new Set(metadata.workspace_members);
+  return metadata.packages
+    .filter((pkg) => members.has(pkg.id))
+    .map((pkg) => ({
+      id: pkg.id,
+      name: pkg.name,
+      root: normalizeRepoPath(relative(repoDir, dirname(pkg.manifest_path))),
+    }))
+    .sort((left, right) => right.root.length - left.root.length);
+}
+
+function dependencyGraph(metadata) {
+  if (!Array.isArray(metadata.resolve?.nodes)) {
+    throw new Error("cargo metadata is missing the resolved dependency graph");
+  }
+  return new Map(metadata.resolve.nodes.map((node) => [node.id, new Set(node.dependencies ?? [])]));
+}
+
+function ownerForPath(path, packages) {
+  return packages.find((pkg) => path === pkg.root || path.startsWith(`${pkg.root}/`));
+}
+
+function dependsOnAny(packageId, changedIds, graph) {
+  const pending = [packageId];
+  const visited = new Set();
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (changedIds.has(current)) return true;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    for (const dependency of graph.get(current) ?? []) pending.push(dependency);
+  }
+  return false;
+}
+
+export function selectCriterionSuites({ changedPaths, metadata, repoDir }) {
+  const inventory = CRITERION_SUITES.map((suite) => suite.package);
+  const normalizedPaths = [...new Set(changedPaths.map(normalizeRepoPath))].sort((left, right) =>
+    left.localeCompare(right),
+  );
+  const infrastructure = normalizedPaths.filter(
+    (path) => FULL_SWEEP_PATHS.has(path) || path.startsWith(".cargo/"),
+  );
+  if (infrastructure.length > 0) {
+    return {
+      mode: "full",
+      selected: inventory,
+      skipped: [],
+      reason: `Full sweep: shared benchmark or workspace infrastructure changed (${infrastructure.join(", ")}).`,
+    };
+  }
+
+  const packages = workspacePackages(metadata, repoDir);
+  const packageByName = new Map(packages.map((pkg) => [pkg.name, pkg]));
+  const missingSuites = inventory.filter((name) => !packageByName.has(name));
+  if (missingSuites.length > 0) {
+    throw new Error(
+      `Criterion package(s) missing from cargo metadata: ${missingSuites.join(", ")}`,
+    );
+  }
+
+  const rustPaths = normalizedPaths.filter((path) => path.startsWith("crates/"));
+  const unknownPaths = rustPaths.filter((path) => ownerForPath(path, packages) == null);
+  if (unknownPaths.length > 0) {
+    return {
+      mode: "full",
+      selected: inventory,
+      skipped: [],
+      reason: `Full sweep: changed Rust path is not owned by a workspace package (${unknownPaths.join(", ")}).`,
+    };
+  }
+
+  const changedPackages = [...new Set(rustPaths.map((path) => ownerForPath(path, packages)?.id))]
+    .filter(Boolean)
+    .sort((left, right) => left.localeCompare(right));
+  const changedIds = new Set(changedPackages);
+  const graph = dependencyGraph(metadata);
+  const selected = inventory.filter((name) =>
+    dependsOnAny(packageByName.get(name).id, changedIds, graph),
+  );
+  const skipped = inventory.filter((name) => !selected.includes(name));
+  const changedNames = packages
+    .filter((pkg) => changedIds.has(pkg.id))
+    .map((pkg) => pkg.name)
+    .sort();
+  return {
+    mode: "scoped",
+    selected,
+    skipped,
+    reason:
+      selected.length === 0
+        ? `No configured Criterion suite depends on changed package(s): ${changedNames.join(", ") || "none"}.`
+        : `Selected from reverse dependency impact of: ${changedNames.join(", ")}.`,
+  };
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const repoDir = resolve(requireArg(args, "repo-dir"));
+  const baseSha = requireArg(args, "base-sha");
+  const headSha = requireArg(args, "head-sha");
+  const out = resolve(requireArg(args, "out"));
+  for (const [label, sha] of [
+    ["base", baseSha],
+    ["head", headSha],
+  ]) {
+    if (!/^[0-9a-f]{40}$/.test(sha))
+      throw new Error(`${label} SHA must be a full lowercase commit SHA`);
+  }
+
+  const diff = run(
+    "git",
+    ["diff", "--name-status", "-z", "--find-renames", baseSha, headSha, "--"],
+    repoDir,
+  );
+  const metadata = JSON.parse(
+    run("cargo", ["metadata", "--format-version", "1", "--locked"], repoDir),
+  );
+  const selection = selectCriterionSuites({
+    changedPaths: parseNameStatusZ(diff),
+    metadata,
+    repoDir,
+  });
+  writeFileSync(out, `${JSON.stringify(selection, null, 2)}\n`);
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `has_suites=${selection.selected.length > 0 ? "true" : "false"}\n`,
+    );
+  }
+  process.stdout.write(
+    `${selection.reason}\nSelected: ${selection.selected.join(", ") || "none"}\n`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/bench/criterion-impact.mjs
+++ b/bench/criterion-impact.mjs
@@ -183,6 +183,19 @@ export function selectCriterionSuites({ changedPaths, metadata, repoDir }) {
   };
 }
 
+export function changedPathsBetween(repoDir, baseSha, headSha) {
+  const mergeBase = run("git", ["merge-base", baseSha, headSha], repoDir).trim();
+  if (!/^[0-9a-f]{40}$/.test(mergeBase)) {
+    throw new Error("git merge-base did not return a full lowercase commit SHA");
+  }
+  const diff = run(
+    "git",
+    ["diff", "--name-status", "-z", "--find-renames", mergeBase, headSha, "--"],
+    repoDir,
+  );
+  return parseNameStatusZ(diff);
+}
+
 export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   const repoDir = resolve(requireArg(args, "repo-dir"));
@@ -197,16 +210,11 @@ export function main(argv = process.argv.slice(2)) {
       throw new Error(`${label} SHA must be a full lowercase commit SHA`);
   }
 
-  const diff = run(
-    "git",
-    ["diff", "--name-status", "-z", "--find-renames", baseSha, headSha, "--"],
-    repoDir,
-  );
   const metadata = JSON.parse(
     run("cargo", ["metadata", "--format-version", "1", "--locked"], repoDir),
   );
   const selection = selectCriterionSuites({
-    changedPaths: parseNameStatusZ(diff),
+    changedPaths: changedPathsBetween(repoDir, baseSha, headSha),
     metadata,
     repoDir,
   });

--- a/tests/tooling/criterion-impact.test.ts
+++ b/tests/tooling/criterion-impact.test.ts
@@ -1,4 +1,8 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { test } from "node:test";
 
 import {
@@ -6,10 +10,26 @@ import {
   renderSummary,
   resolveSuiteSelection,
 } from "../../bench/criterion-ab.mjs";
-import { parseNameStatusZ, selectCriterionSuites } from "../../bench/criterion-impact.mjs";
+import {
+  changedPathsBetween,
+  parseNameStatusZ,
+  selectCriterionSuites,
+} from "../../bench/criterion-impact.mjs";
 
 const repoDir = "/repo";
 const suiteNames = CRITERION_SUITES.map((suite) => suite.package);
+
+function git(cwd: string, args: string[]): string {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
+  return result.stdout.trim();
+}
+
+function commit(cwd: string, message: string): string {
+  git(cwd, ["add", "."]);
+  git(cwd, ["-c", "user.name=Vize", "-c", "user.email=vize@example.com", "commit", "-qm", message]);
+  return git(cwd, ["rev-parse", "HEAD"]);
+}
 
 function metadata(dependencies: Record<string, string[]> = {}) {
   const names = ["vize", "vize_atelier_core", ...suiteNames];
@@ -37,6 +57,24 @@ test("Criterion impact parser preserves both sides of renamed Rust paths", () =>
     ),
     ["crates/vize/src/main.rs", "crates/old/src/lib.rs", "crates/new/src/lib.rs"],
   );
+});
+
+test("Criterion impact diff excludes base-only changes after the feature fork", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-criterion-impact-"));
+  fs.mkdirSync(path.join(root, "crates", "vize"), { recursive: true });
+  git(root, ["init", "-q", "--initial-branch=main"]);
+  fs.writeFileSync(path.join(root, "README.md"), "base\n");
+  commit(root, "base");
+
+  git(root, ["switch", "-qc", "feature"]);
+  fs.writeFileSync(path.join(root, "crates", "vize", "feature.rs"), "feature\n");
+  const headSha = commit(root, "feature");
+
+  git(root, ["switch", "-q", "main"]);
+  fs.writeFileSync(path.join(root, "Cargo.lock"), "base advanced\n");
+  const baseSha = commit(root, "advance base");
+
+  assert.deepEqual(changedPathsBetween(root, baseSha, headSha), ["crates/vize/feature.rs"]);
 });
 
 test("direct Criterion package changes select only their suite", () => {

--- a/tests/tooling/criterion-impact.test.ts
+++ b/tests/tooling/criterion-impact.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  CRITERION_SUITES,
+  renderSummary,
+  resolveSuiteSelection,
+} from "../../bench/criterion-ab.mjs";
+import { parseNameStatusZ, selectCriterionSuites } from "../../bench/criterion-impact.mjs";
+
+const repoDir = "/repo";
+const suiteNames = CRITERION_SUITES.map((suite) => suite.package);
+
+function metadata(dependencies: Record<string, string[]> = {}) {
+  const names = ["vize", "vize_atelier_core", ...suiteNames];
+  const packages = names.map((name) => ({
+    id: `${name}@0.1.0`,
+    name,
+    manifest_path: `${repoDir}/crates/${name}/Cargo.toml`,
+  }));
+  return {
+    packages,
+    workspace_members: packages.map((pkg) => pkg.id),
+    resolve: {
+      nodes: packages.map((pkg) => ({
+        id: pkg.id,
+        dependencies: (dependencies[pkg.name] ?? []).map((name) => `${name}@0.1.0`),
+      })),
+    },
+  };
+}
+
+test("Criterion impact parser preserves both sides of renamed Rust paths", () => {
+  assert.deepEqual(
+    parseNameStatusZ(
+      "M\0crates/vize/src/main.rs\0R100\0crates/old/src/lib.rs\0crates/new/src/lib.rs\0",
+    ),
+    ["crates/vize/src/main.rs", "crates/old/src/lib.rs", "crates/new/src/lib.rs"],
+  );
+});
+
+test("direct Criterion package changes select only their suite", () => {
+  const result = selectCriterionSuites({
+    changedPaths: ["crates/vize_glyph/src/lib.rs"],
+    metadata: metadata(),
+    repoDir,
+  });
+
+  assert.equal(result.mode, "scoped");
+  assert.deepEqual(result.selected, ["vize_glyph"]);
+});
+
+test("reverse dependency impact selects every suite that consumes a changed package", () => {
+  const dependencies = Object.fromEntries(suiteNames.map((name) => [name, ["vize_atelier_core"]]));
+  const result = selectCriterionSuites({
+    changedPaths: ["crates/vize_atelier_core/src/lib.rs"],
+    metadata: metadata(dependencies),
+    repoDir,
+  });
+
+  assert.deepEqual(result.selected, suiteNames);
+  assert.deepEqual(result.skipped, []);
+});
+
+test("CLI-only changes skip unrelated Criterion suites", () => {
+  const result = selectCriterionSuites({
+    changedPaths: ["crates/vize/src/build/input.rs"],
+    metadata: metadata(),
+    repoDir,
+  });
+
+  assert.equal(result.mode, "scoped");
+  assert.deepEqual(result.selected, []);
+  assert.deepEqual(result.skipped, suiteNames);
+  assert.match(result.reason, /vize/);
+});
+
+test("lockfiles and shared benchmark infrastructure select the full inventory", () => {
+  for (const changedPath of ["Cargo.lock", "bench/criterion-ab.mjs"]) {
+    const result = selectCriterionSuites({
+      changedPaths: [changedPath],
+      metadata: metadata(),
+      repoDir,
+    });
+    assert.equal(result.mode, "full", changedPath);
+    assert.deepEqual(result.selected, suiteNames, changedPath);
+  }
+});
+
+test("unowned foundational Rust paths fail safe to the full inventory", () => {
+  const result = selectCriterionSuites({
+    changedPaths: ["crates/foundation/config.rs"],
+    metadata: metadata(),
+    repoDir,
+  });
+
+  assert.equal(result.mode, "full");
+  assert.deepEqual(result.selected, suiteNames);
+  assert.match(result.reason, /not owned/);
+});
+
+test("incomplete workspace metadata fails closed", () => {
+  const incomplete = metadata();
+  incomplete.packages = incomplete.packages.filter((pkg) => pkg.name !== "vize_glyph");
+  incomplete.workspace_members = incomplete.packages.map((pkg) => pkg.id);
+
+  assert.throws(
+    () =>
+      selectCriterionSuites({
+        changedPaths: ["crates/vize/src/main.rs"],
+        metadata: incomplete,
+        repoDir,
+      }),
+    /Criterion package\(s\) missing/,
+  );
+});
+
+test("Criterion driver validates scoped suite manifests", () => {
+  const selection = resolveSuiteSelection({
+    selected: ["vize_glyph", "vize_atelier_sfc"],
+    reason: "fixture",
+  });
+  assert.deepEqual(selection.selected, ["vize_atelier_sfc", "vize_glyph"]);
+  assert.throws(
+    () => resolveSuiteSelection({ selected: ["unknown"], reason: "fixture" }),
+    /unknown suites/,
+  );
+});
+
+test("Criterion driver reports a useful summary when no suite is affected", () => {
+  const selection = resolveSuiteSelection({ selected: [], reason: "CLI-only change." });
+  const summary = renderSummary({ table: "", threshold: undefined, regressions: [], selection });
+
+  assert.match(summary, /Selection: CLI-only change\./);
+  assert.match(summary, /Ran: none/);
+  assert.match(summary, /Skipped: vize_atelier_sfc, vize_atelier_jsx/);
+  assert.match(summary, /timing execution was skipped/);
+});

--- a/tests/tooling/github-workflows-benchmark.test.ts
+++ b/tests/tooling/github-workflows-benchmark.test.ts
@@ -246,6 +246,7 @@ test("criterion bench workflow runs an A/B micro-benchmark and a dialect guard",
   assert.match(checkoutHead, /ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}/);
   assert.match(checkoutHead, /fetch-depth:\s*0/);
   assert.match(checkoutHead, /persist-credentials:\s*false/);
+  assert.match(checkoutBase, /ref:\s*\$\{\{\s*github\.event\.pull_request\.base\.sha\s*\}\}/);
   assert.match(checkoutBase, /persist-credentials:\s*false/);
 
   const impactStep = workflowStepBody(abJob, "Select affected Criterion suites");

--- a/tests/tooling/github-workflows-benchmark.test.ts
+++ b/tests/tooling/github-workflows-benchmark.test.ts
@@ -241,23 +241,46 @@ test("criterion bench workflow runs an A/B micro-benchmark and a dialect guard",
   assert.match(abJob, /runs-on:\s*blacksmith-32vcpu-ubuntu-2404/);
   assert.match(abJob, /contents:\s*read/);
   assert.doesNotMatch(abJob, /contents:\s*write/);
+  const checkoutHead = workflowStepBody(abJob, "Checkout head");
+  const checkoutBase = workflowStepBody(abJob, "Checkout base");
+  assert.match(checkoutHead, /ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}/);
+  assert.match(checkoutHead, /fetch-depth:\s*0/);
+  assert.match(checkoutHead, /persist-credentials:\s*false/);
+  assert.match(checkoutBase, /persist-credentials:\s*false/);
+
+  const impactStep = workflowStepBody(abJob, "Select affected Criterion suites");
+  assert.match(impactStep, /PR_BASE_SHA:\s*\$\{\{\s*github\.event\.pull_request\.base\.sha\s*\}\}/);
+  assert.match(impactStep, /PR_HEAD_SHA:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}/);
+  assert.match(impactStep, /--base-sha "\$PR_BASE_SHA"/);
+  assert.match(impactStep, /--head-sha "\$PR_HEAD_SHA"/);
+
+  for (const stepName of [
+    "Setup Wild linker",
+    "Mount Criterion cache",
+    "Cache critcmp",
+    "Install critcmp",
+  ]) {
+    assert.match(
+      workflowStepBody(abJob, stepName),
+      /if:\s*steps\.impact\.outputs\.has_suites == 'true'/,
+      stepName,
+    );
+  }
   assert.match(
-    abJob,
-    /path:\s*head[\s\S]*ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}/,
+    workflowStepBody(abJob, "Mount Criterion cache"),
+    /uses:\s*\.\/head\/\.github\/actions\/setup-rust-sticky-cache/,
   );
   assert.match(
-    abJob,
-    /path:\s*base[\s\S]*ref:\s*\$\{\{\s*github\.event\.pull_request\.base\.sha\s*\}\}/,
+    workflowStepBody(abJob, "Install critcmp"),
+    /cargo install critcmp --version 0\.1\.8 --locked/,
   );
-  assert.match(abJob, /uses:\s*\.\/head\/\.github\/actions\/setup-rust-sticky-cache/);
-  assert.match(abJob, /node head\/bench\/criterion-impact\.mjs/);
-  assert.match(abJob, /--base-sha "\$\{\{\s*github\.event\.pull_request\.base\.sha\s*\}\}"/);
-  assert.match(abJob, /--head-sha "\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}"/);
-  assert.match(abJob, /if:\s*steps\.impact\.outputs\.has_suites == 'true'/);
-  assert.match(abJob, /cargo install critcmp --version 0\.1\.8 --locked/);
-  assert.match(abJob, /node head\/bench\/criterion-ab\.mjs/);
-  assert.match(abJob, /--target-dir "\$GITHUB_WORKSPACE\/head\/target"/);
-  assert.match(abJob, /--selection "\$GITHUB_WORKSPACE\/criterion-impact\.json"/);
+  const runStep = workflowStepBody(abJob, "Run criterion A/B");
+  assert.match(runStep, /node head\/bench\/criterion-ab\.mjs/);
+  assert.match(runStep, /--target-dir "\$GITHUB_WORKSPACE\/head\/target"/);
+  const impactPath = impactStep.match(/--out "([^"]+)"/)?.[1];
+  const selectionPath = runStep.match(/--selection "([^"]+)"/)?.[1];
+  assert.equal(impactPath, "$GITHUB_WORKSPACE/criterion-impact.json");
+  assert.equal(selectionPath, impactPath);
 
   // Dialect guard: build vize with legacy OFF and ON, then assert byte-identical
   // Vue 3 codegen plus a small A/B timing budget.

--- a/tests/tooling/github-workflows-benchmark.test.ts
+++ b/tests/tooling/github-workflows-benchmark.test.ts
@@ -219,7 +219,10 @@ test("criterion bench workflow runs an A/B micro-benchmark and a dialect guard",
   // Only runs on PRs and only when Rust or the bench harness changes.
   assert.match(workflow, /\n  pull_request:\n/);
   assert.match(workflow, /paths:\n\s+- "crates\/\*\*"/);
+  assert.match(workflow, /- "Cargo\.lock"/);
+  assert.match(workflow, /- "Cargo\.toml"/);
   assert.match(workflow, /- "bench\/criterion-ab\.mjs"/);
+  assert.match(workflow, /- "bench\/criterion-impact\.mjs"/);
   assert.match(workflow, /- "bench\/dialect-guard\.mjs"/);
   assert.match(workflow, /FORCE_JAVASCRIPT_ACTIONS_TO_NODE24:\s*true/);
 
@@ -247,9 +250,14 @@ test("criterion bench workflow runs an A/B micro-benchmark and a dialect guard",
     /path:\s*base[\s\S]*ref:\s*\$\{\{\s*github\.event\.pull_request\.base\.sha\s*\}\}/,
   );
   assert.match(abJob, /uses:\s*\.\/head\/\.github\/actions\/setup-rust-sticky-cache/);
+  assert.match(abJob, /node head\/bench\/criterion-impact\.mjs/);
+  assert.match(abJob, /--base-sha "\$\{\{\s*github\.event\.pull_request\.base\.sha\s*\}\}"/);
+  assert.match(abJob, /--head-sha "\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}"/);
+  assert.match(abJob, /if:\s*steps\.impact\.outputs\.has_suites == 'true'/);
   assert.match(abJob, /cargo install critcmp --version 0\.1\.8 --locked/);
   assert.match(abJob, /node head\/bench\/criterion-ab\.mjs/);
   assert.match(abJob, /--target-dir "\$GITHUB_WORKSPACE\/head\/target"/);
+  assert.match(abJob, /--selection "\$GITHUB_WORKSPACE\/criterion-impact\.json"/);
 
   // Dialect guard: build vize with legacy OFF and ON, then assert byte-identical
   // Vue 3 codegen plus a small A/B timing budget.


### PR DESCRIPTION
## Summary

- derive changed Rust packages from immutable PR SHAs and the locked Cargo workspace graph
- run only Criterion suites whose package or transitive dependencies can be affected, while keeping infrastructure and unknown paths on the full sweep
- skip linker/cache/critcmp setup when no suite is affected and report every selected/skipped suite with the reason

## Validation

- `node --test tests/tooling/criterion-impact.test.ts tests/tooling/github-workflows-benchmark.test.ts tests/tooling/github-workflows.test.ts` (24 passed)
- `vp check bench/criterion-impact.mjs bench/criterion-ab.mjs tests/tooling/criterion-impact.test.ts tests/tooling/github-workflows-benchmark.test.ts .github/workflows/criterion-bench.yml` (0 warnings)
- real workspace graph: `crates/vize` selects none; `vize_atelier_core` selects its four dependent suites; `vize_glyph` selects formatter only
- `git diff --check`

Closes #2888.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786464590&installation_id=136613492&pr_number=2900&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2900&signature=eb132a9ed356601a034c64edaba04cde434cac95732c75d4212a91be03dad5e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Benchmark runs now auto-compute an “affected suites” set and execute only those Criterion suites, with a full-sweep fallback when core benchmark/workspace infrastructure changes.
  * Added suite-selection reporting to benchmark summaries (what ran vs skipped and why).
  * CI workflow now selects affected suites and gates related benchmark preparation steps accordingly.
* **Bug Fixes**
  * Unsupported/unowned path changes now safely fall back to comprehensive coverage.
* **Tests**
  * Expanded suite-selection and workflow assertions, including rename parsing and “no suites affected” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->