### PR TITLE
perf(cli): stream quiet patina aggregation

### DIFF
--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -1,5 +1,6 @@
 //! Lint command - Lint Vue and script files
 
+mod aggregate;
 mod args;
 mod collect;
 mod cross_file;
@@ -13,6 +14,7 @@ mod tests;
 pub use args::LintArgs;
 
 use crate::profile_support;
+use aggregate::{LintRunAccumulator, should_retain_file_results};
 use collect::{collect_lint_files, load_lint_ignore_set, resolve_lint_config_path};
 use cross_file::apply_sfc_cross_file_lint;
 use fix::lint_source_with_optional_fix;
@@ -47,7 +49,7 @@ pub fn run(args: LintArgs) {
         );
         std::process::exit(2);
     });
-    let render_details = should_render_lint_details(format, args.quiet);
+    let render_details = aggregate::should_render_details(format, args.quiet);
     crate::config::write_schema(None);
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let (loaded_config, linter_config, linter_features) = if args.no_config {
@@ -134,7 +136,7 @@ pub fn run(args: LintArgs) {
 
     let lint_start = Instant::now();
     let cross_file_enabled = args.cross_file || args.cross_file_tree || args.cross_file_complexity;
-    let retain_file_results = should_retain_lint_file_results(render_details, cross_file_enabled);
+    let retain_file_results = should_retain_file_results(render_details, cross_file_enabled);
     let lint_run = files
         .par_iter()
         .filter_map(|path| {
@@ -201,18 +203,13 @@ pub fn run(args: LintArgs) {
         })
         .fold(
             || LintRunAccumulator::new(retain_file_results),
-            |mut accumulator, file_result| {
-                accumulator.push(file_result);
-                accumulator
-            },
+            LintRunAccumulator::push,
         )
         .reduce(
             || LintRunAccumulator::new(retain_file_results),
             LintRunAccumulator::merge,
         );
-    let quiet_totals =
-        (!retain_file_results).then_some((lint_run.error_count, lint_run.warning_count));
-    let mut results = lint_run.results.unwrap_or_default();
+    let (mut results, quiet_totals) = lint_run.into_parts();
     let lint_time = lint_start.elapsed();
 
     let mut cross_file_report = None;
@@ -232,13 +229,7 @@ pub fn run(args: LintArgs) {
         .map(|start| start.elapsed())
         .unwrap_or(Duration::ZERO);
 
-    let (lint_error_count, total_warnings) = quiet_totals.unwrap_or_else(|| {
-        results
-            .iter()
-            .fold((0, 0), |(errors, warnings), (_, _, _, result)| {
-                (errors + result.error_count, warnings + result.warning_count)
-            })
-    });
+    let (lint_error_count, total_warnings) = aggregate::totals(quiet_totals, &results);
     let total_errors = lint_error_count + write_failures.load(Ordering::Relaxed);
 
     let output_start = Instant::now();
@@ -417,49 +408,4 @@ fn severity_overrides(entries: Vec<(String, LintRuleSeverity)>) -> Vec<(String, 
             LintRuleSeverity::Error => Some((name, Severity::Error)),
         })
         .collect()
-}
-
-#[inline]
-fn should_render_lint_details(format: OutputFormat, quiet: bool) -> bool {
-    format.renders_details_when_quiet() || !quiet
-}
-
-struct LintRunAccumulator {
-    error_count: usize,
-    warning_count: usize,
-    results: Option<Vec<cross_file::CliLintFileResult>>,
-}
-
-impl LintRunAccumulator {
-    fn new(retain_file_results: bool) -> Self {
-        Self {
-            error_count: 0,
-            warning_count: 0,
-            results: retain_file_results.then(Vec::new),
-        }
-    }
-
-    fn push(&mut self, file_result: cross_file::CliLintFileResult) {
-        self.error_count += file_result.3.error_count;
-        self.warning_count += file_result.3.warning_count;
-        if let Some(results) = self.results.as_mut() {
-            results.push(file_result);
-        }
-    }
-
-    fn merge(mut self, other: Self) -> Self {
-        self.error_count += other.error_count;
-        self.warning_count += other.warning_count;
-        match (self.results.as_mut(), other.results) {
-            (Some(results), Some(other_results)) => results.extend(other_results),
-            (None, None) => {}
-            _ => unreachable!("lint accumulators must use the same retention mode"),
-        }
-        self
-    }
-}
-
-#[inline]
-fn should_retain_lint_file_results(render_details: bool, cross_file_enabled: bool) -> bool {
-    render_details || cross_file_enabled
 }

--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -133,7 +133,9 @@ pub fn run(args: LintArgs) {
     }
 
     let lint_start = Instant::now();
-    let mut results: Vec<_> = files
+    let cross_file_enabled = args.cross_file || args.cross_file_tree || args.cross_file_complexity;
+    let retain_file_results = should_retain_lint_file_results(render_details, cross_file_enabled);
+    let lint_run = files
         .par_iter()
         .filter_map(|path| {
             let file_start = args.profile.then(Instant::now);
@@ -197,11 +199,23 @@ pub fn run(args: LintArgs) {
 
             Some((path.clone(), filename, source, result))
         })
-        .collect();
+        .fold(
+            || LintRunAccumulator::new(retain_file_results),
+            |mut accumulator, file_result| {
+                accumulator.push(file_result);
+                accumulator
+            },
+        )
+        .reduce(
+            || LintRunAccumulator::new(retain_file_results),
+            LintRunAccumulator::merge,
+        );
+    let quiet_totals =
+        (!retain_file_results).then_some((lint_run.error_count, lint_run.warning_count));
+    let mut results = lint_run.results.unwrap_or_default();
     let lint_time = lint_start.elapsed();
 
     let mut cross_file_report = None;
-    let cross_file_enabled = args.cross_file || args.cross_file_tree || args.cross_file_complexity;
     let cross_file_start = args.profile.then(Instant::now);
     if cross_file_enabled {
         cross_file_report = profile!(
@@ -218,15 +232,14 @@ pub fn run(args: LintArgs) {
         .map(|start| start.elapsed())
         .unwrap_or(Duration::ZERO);
 
-    let total_errors: usize = results
-        .iter()
-        .map(|(_, _, _, result)| result.error_count)
-        .sum::<usize>()
-        + write_failures.load(Ordering::Relaxed);
-    let total_warnings: usize = results
-        .iter()
-        .map(|(_, _, _, result)| result.warning_count)
-        .sum();
+    let (lint_error_count, total_warnings) = quiet_totals.unwrap_or_else(|| {
+        results
+            .iter()
+            .fold((0, 0), |(errors, warnings), (_, _, _, result)| {
+                (errors + result.error_count, warnings + result.warning_count)
+            })
+    });
+    let total_errors = lint_error_count + write_failures.load(Ordering::Relaxed);
 
     let output_start = Instant::now();
     if render_details {
@@ -409,4 +422,44 @@ fn severity_overrides(entries: Vec<(String, LintRuleSeverity)>) -> Vec<(String, 
 #[inline]
 fn should_render_lint_details(format: OutputFormat, quiet: bool) -> bool {
     format.renders_details_when_quiet() || !quiet
+}
+
+struct LintRunAccumulator {
+    error_count: usize,
+    warning_count: usize,
+    results: Option<Vec<cross_file::CliLintFileResult>>,
+}
+
+impl LintRunAccumulator {
+    fn new(retain_file_results: bool) -> Self {
+        Self {
+            error_count: 0,
+            warning_count: 0,
+            results: retain_file_results.then(Vec::new),
+        }
+    }
+
+    fn push(&mut self, file_result: cross_file::CliLintFileResult) {
+        self.error_count += file_result.3.error_count;
+        self.warning_count += file_result.3.warning_count;
+        if let Some(results) = self.results.as_mut() {
+            results.push(file_result);
+        }
+    }
+
+    fn merge(mut self, other: Self) -> Self {
+        self.error_count += other.error_count;
+        self.warning_count += other.warning_count;
+        match (self.results.as_mut(), other.results) {
+            (Some(results), Some(other_results)) => results.extend(other_results),
+            (None, None) => {}
+            _ => unreachable!("lint accumulators must use the same retention mode"),
+        }
+        self
+    }
+}
+
+#[inline]
+fn should_retain_lint_file_results(render_details: bool, cross_file_enabled: bool) -> bool {
+    render_details || cross_file_enabled
 }

--- a/crates/vize/src/commands/lint/aggregate.rs
+++ b/crates/vize/src/commands/lint/aggregate.rs
@@ -1,0 +1,109 @@
+//! Result retention and summary aggregation for parallel lint runs.
+
+use super::cross_file::CliLintFileResult;
+use vize_patina::OutputFormat;
+
+pub(super) struct LintRunAccumulator {
+    error_count: usize,
+    warning_count: usize,
+    results: Option<Vec<CliLintFileResult>>,
+}
+
+impl LintRunAccumulator {
+    pub(super) fn new(retain_file_results: bool) -> Self {
+        Self {
+            error_count: 0,
+            warning_count: 0,
+            results: retain_file_results.then(Vec::new),
+        }
+    }
+
+    pub(super) fn push(mut self, file_result: CliLintFileResult) -> Self {
+        self.error_count += file_result.3.error_count;
+        self.warning_count += file_result.3.warning_count;
+        if let Some(results) = self.results.as_mut() {
+            results.push(file_result);
+        }
+        self
+    }
+
+    pub(super) fn merge(mut self, other: Self) -> Self {
+        self.error_count += other.error_count;
+        self.warning_count += other.warning_count;
+        match (self.results.as_mut(), other.results) {
+            (Some(results), Some(other_results)) => results.extend(other_results),
+            (None, None) => {}
+            _ => unreachable!("lint accumulators must use the same retention mode"),
+        }
+        self
+    }
+
+    pub(super) fn into_parts(self) -> (Vec<CliLintFileResult>, Option<(usize, usize)>) {
+        let quiet_totals = self
+            .results
+            .is_none()
+            .then_some((self.error_count, self.warning_count));
+        (self.results.unwrap_or_default(), quiet_totals)
+    }
+}
+
+pub(super) fn totals(
+    quiet_totals: Option<(usize, usize)>,
+    results: &[CliLintFileResult],
+) -> (usize, usize) {
+    quiet_totals.unwrap_or_else(|| {
+        results
+            .iter()
+            .fold((0, 0), |(errors, warnings), (_, _, _, result)| {
+                (errors + result.error_count, warnings + result.warning_count)
+            })
+    })
+}
+
+#[inline]
+pub(super) fn should_retain_file_results(render_details: bool, cross_file_enabled: bool) -> bool {
+    render_details || cross_file_enabled
+}
+
+#[inline]
+pub(super) fn should_render_details(format: OutputFormat, quiet: bool) -> bool {
+    format.renders_details_when_quiet() || !quiet
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CliLintFileResult, LintRunAccumulator, should_retain_file_results};
+    use std::path::PathBuf;
+    use vize_patina::LintResult;
+
+    #[test]
+    fn quiet_text_uses_summary_only_collection_without_cross_file_analysis() {
+        assert!(!should_retain_file_results(false, false));
+        assert!(should_retain_file_results(true, false));
+        assert!(should_retain_file_results(false, true));
+    }
+
+    #[test]
+    fn quiet_accumulator_drops_file_payloads_and_reduces_totals() {
+        let first = LintRunAccumulator::new(false).push(file_result("First.vue", 2, 3));
+        let second = LintRunAccumulator::new(false).push(file_result("Second.vue", 5, 7));
+        let (results, totals) = first.merge(second).into_parts();
+
+        assert_eq!(totals, Some((7, 10)));
+        assert!(results.is_empty());
+    }
+
+    fn file_result(filename: &str, error_count: usize, warning_count: usize) -> CliLintFileResult {
+        (
+            PathBuf::from(filename),
+            filename.into(),
+            "<template />".into(),
+            LintResult {
+                filename: filename.into(),
+                diagnostics: Vec::new(),
+                error_count,
+                warning_count,
+            },
+        )
+    }
+}

--- a/crates/vize/src/commands/lint/tests/format_output.rs
+++ b/crates/vize/src/commands/lint/tests/format_output.rs
@@ -1,62 +1,21 @@
-use super::super::{
-    LintRunAccumulator, should_render_lint_details, should_retain_lint_file_results,
-};
-use std::path::PathBuf;
-use vize_patina::{LintResult, OutputFormat};
+use super::super::aggregate::should_render_details;
+use vize_patina::OutputFormat;
 
 #[test]
 fn quiet_text_output_skips_detailed_diagnostics() {
-    assert!(!should_render_lint_details(OutputFormat::Text, true));
+    assert!(!should_render_details(OutputFormat::Text, true));
 }
 
 #[test]
 fn json_output_remains_machine_readable_in_quiet_mode() {
-    assert!(should_render_lint_details(OutputFormat::Json, true));
+    assert!(should_render_details(OutputFormat::Json, true));
 }
 
 #[test]
 fn report_formats_render_in_quiet_mode() {
-    assert!(should_render_lint_details(OutputFormat::Ansi, true));
-    assert!(should_render_lint_details(OutputFormat::Plain, true));
-    assert!(should_render_lint_details(OutputFormat::Markdown, true));
-    assert!(should_render_lint_details(OutputFormat::Html, true));
-    assert!(should_render_lint_details(OutputFormat::Agent, true));
-}
-
-#[test]
-fn quiet_text_uses_summary_only_collection_without_cross_file_analysis() {
-    assert!(!should_retain_lint_file_results(false, false));
-    assert!(should_retain_lint_file_results(true, false));
-    assert!(should_retain_lint_file_results(false, true));
-}
-
-#[test]
-fn quiet_accumulator_drops_file_payloads_and_reduces_totals() {
-    let mut first = LintRunAccumulator::new(false);
-    first.push(file_result("First.vue", 2, 3));
-    let mut second = LintRunAccumulator::new(false);
-    second.push(file_result("Second.vue", 5, 7));
-    let accumulator = first.merge(second);
-
-    assert_eq!(accumulator.error_count, 7);
-    assert_eq!(accumulator.warning_count, 10);
-    assert!(accumulator.results.is_none());
-}
-
-fn file_result(
-    filename: &str,
-    error_count: usize,
-    warning_count: usize,
-) -> super::super::cross_file::CliLintFileResult {
-    (
-        PathBuf::from(filename),
-        filename.into(),
-        "<template />".into(),
-        LintResult {
-            filename: filename.into(),
-            diagnostics: Vec::new(),
-            error_count,
-            warning_count,
-        },
-    )
+    assert!(should_render_details(OutputFormat::Ansi, true));
+    assert!(should_render_details(OutputFormat::Plain, true));
+    assert!(should_render_details(OutputFormat::Markdown, true));
+    assert!(should_render_details(OutputFormat::Html, true));
+    assert!(should_render_details(OutputFormat::Agent, true));
 }

--- a/crates/vize/src/commands/lint/tests/format_output.rs
+++ b/crates/vize/src/commands/lint/tests/format_output.rs
@@ -1,5 +1,8 @@
-use super::super::should_render_lint_details;
-use vize_patina::OutputFormat;
+use super::super::{
+    LintRunAccumulator, should_render_lint_details, should_retain_lint_file_results,
+};
+use std::path::PathBuf;
+use vize_patina::{LintResult, OutputFormat};
 
 #[test]
 fn quiet_text_output_skips_detailed_diagnostics() {
@@ -18,4 +21,42 @@ fn report_formats_render_in_quiet_mode() {
     assert!(should_render_lint_details(OutputFormat::Markdown, true));
     assert!(should_render_lint_details(OutputFormat::Html, true));
     assert!(should_render_lint_details(OutputFormat::Agent, true));
+}
+
+#[test]
+fn quiet_text_uses_summary_only_collection_without_cross_file_analysis() {
+    assert!(!should_retain_lint_file_results(false, false));
+    assert!(should_retain_lint_file_results(true, false));
+    assert!(should_retain_lint_file_results(false, true));
+}
+
+#[test]
+fn quiet_accumulator_drops_file_payloads_and_reduces_totals() {
+    let mut first = LintRunAccumulator::new(false);
+    first.push(file_result("First.vue", 2, 3));
+    let mut second = LintRunAccumulator::new(false);
+    second.push(file_result("Second.vue", 5, 7));
+    let accumulator = first.merge(second);
+
+    assert_eq!(accumulator.error_count, 7);
+    assert_eq!(accumulator.warning_count, 10);
+    assert!(accumulator.results.is_none());
+}
+
+fn file_result(
+    filename: &str,
+    error_count: usize,
+    warning_count: usize,
+) -> super::super::cross_file::CliLintFileResult {
+    (
+        PathBuf::from(filename),
+        filename.into(),
+        "<template />".into(),
+        LintResult {
+            filename: filename.into(),
+            diagnostics: Vec::new(),
+            error_count,
+            warning_count,
+        },
+    )
 }

--- a/crates/vize/tests/lint_rule_severity_cli.rs
+++ b/crates/vize/tests/lint_rule_severity_cli.rs
@@ -74,3 +74,48 @@ const handleStepClick = (stepIndex: number) => {
         "{stdout}"
     );
 }
+
+#[test]
+fn quiet_lint_reduces_warning_totals_and_preserves_max_warnings_exit() {
+    let project_root = tempfile::tempdir().unwrap();
+    write_file(
+        project_root.path(),
+        "vize.config.json",
+        r#"{
+  "linter": {
+    "preset": "ecosystem",
+    "rules": {
+      "script/custom-event-name-casing": "warn"
+    }
+  }
+}"#,
+    );
+    let source = r#"<script setup lang="ts">
+const emit = defineEmits(["update:current-step-index"])
+emit("update:current-step-index", 1)
+</script>
+"#;
+    write_file(project_root.path(), "src/First.vue", source);
+    write_file(project_root.path(), "src/Second.vue", source);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root.path())
+        .args([
+            "lint",
+            "--quiet",
+            "--config",
+            "vize.config.json",
+            "--max-warnings",
+            "0",
+            "src/*.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(stdout.contains("2 warnings in 2 files"), "{stdout}");
+    assert!(!stdout.contains("custom-event-name-casing"), "{stdout}");
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert!(stderr.contains("Too many warnings (2 > max 0)"), "{stderr}");
+}


### PR DESCRIPTION
## Summary

- reduce quiet text lint outcomes into per-worker error/warning totals instead of retaining every source and diagnostic result;
- retain the existing full result path for detailed report formats and cross-file analysis;
- preserve profiling rows, fix/write-failure handling, text summaries, and `--max-warnings` exit behavior.

## Performance evidence

Measured with the same 3,000 generated SFC corpus (19 MB), debug binaries, and three runs per revision on macOS:

| | Base median | Branch median |
|---|---:|---:|
| Peak RSS | 75.5 MB | 38.0 MB |
| Wall time | 0.90 s | 0.89 s |

## Verification

- `cargo test -p vize commands::lint::tests::format_output --lib`
- `cargo test -p vize --test lint_rule_severity_cli`
- `cargo clippy -p vize --lib --bins -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2901

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786467848&installation_id=136613492&pr_number=2902&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2902&signature=f06b48e2907c942e11ce7aa1fea2bdc06506d01ec8dd1ad2eec63497d841926c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Quiet lint output now uses aggregated totals for warnings and errors without listing individual diagnostics.
  - Detailed diagnostics are rendered consistently with the selected output format, including correct behavior in quiet mode when applicable.

- **Bug Fixes**
  - Improved aggregation of lint results for parallel runs, ensuring cross-file checks and max-warning enforcement work reliably.
  - Reduced unnecessary retention of per-file diagnostics when concise output is selected.

- **Tests**
  - Added a CLI test validating quiet-mode warning totals and max-warning exit behavior.
  - Updated lint output formatting tests to match the new detail-rendering rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->