### PR TITLE
fix(parser): reject empty interpolation delimiters

### DIFF
--- a/crates/vize_armature/src/parser.rs
+++ b/crates/vize_armature/src/parser.rs
@@ -9,6 +9,7 @@
 
 mod attribute;
 mod callbacks;
+mod delimiters;
 mod element;
 #[cfg(test)]
 mod experimental_tests;
@@ -24,10 +25,8 @@ use vize_relief::{
     options::{ParserOptions, TemplateSyntaxMode, WhitespaceStrategy},
 };
 
-use crate::tokenizer::Tokenizer;
-
 use element::{note_html_tree_element_close, note_html_tree_element_open};
-use {callbacks::ParserCallbacks, whitespace::condense_whitespace};
+use whitespace::condense_whitespace;
 
 pub struct Parser<'a> {
     allocator: &'a Bump,
@@ -214,44 +213,15 @@ impl<'a> Parser<'a> {
         parser
     }
 
-    /// Whether the configured dialect recognizes Vue 1.x triple-mustache
-    /// raw-HTML interpolation (`{{{ expr }}}`). Resolved once per file from the
-    /// dialect capabilities; `false` for the default Vue 3 dialect.
-    #[cfg(feature = "legacy")]
-    fn raw_html_interpolation_enabled(&self) -> bool {
-        crate::legacy::LegacyDialectCapabilities::for_dialect(self.options.dialect)
-            .raw_html_interpolation
-    }
-
     /// Parse the source and return the AST
     pub fn parse(mut self) -> (RootNode<'a>, Vec<'a, CompilerError>) {
         // Initialize root node
         let root = RootNode::new(self.allocator, self.source);
         self.root = Some(root);
 
-        // Copy delimiters to avoid borrow issue
-        let delimiter_open: Vec<'a, u8> =
-            Vec::from_iter_in(self.options.delimiters.0.bytes(), self.allocator);
-        let delimiter_close: Vec<'a, u8> =
-            Vec::from_iter_in(self.options.delimiters.1.bytes(), self.allocator);
-
-        // We need to use a struct that implements Callbacks
-        // Create a wrapper that can capture the parser
-        let document = self.document;
-        let in_tag_comments = self.options.experimental_in_tag_comments;
-        #[cfg(feature = "legacy")]
-        let triple_mustache = self.raw_html_interpolation_enabled();
-        let mut tokenizer = Tokenizer::with_delimiters(
-            self.source,
-            ParserCallbacks { parser: &mut self },
-            &delimiter_open,
-            &delimiter_close,
-        );
-        tokenizer.set_tolerate_declarations(document);
-        tokenizer.set_in_tag_comments(in_tag_comments);
-        #[cfg(feature = "legacy")]
-        tokenizer.set_triple_mustache(triple_mustache);
-        tokenizer.tokenize();
+        if !self.tokenize_template() {
+            return self.into_result();
+        }
 
         // Handle any unclosed elements
         self.handle_unclosed_elements();
@@ -263,11 +233,7 @@ impl<'a> Parser<'a> {
             condense_whitespace(&mut root.children, self.options.is_pre_tag);
         }
 
-        let root = match self.root.take() {
-            Some(root) => root,
-            None => RootNode::new(self.allocator, self.source),
-        };
-        (root, self.errors)
+        self.into_result()
     }
 
     /// Get source slice

--- a/crates/vize_armature/src/parser/delimiters.rs
+++ b/crates/vize_armature/src/parser/delimiters.rs
@@ -1,0 +1,86 @@
+//! Interpolation delimiter validation and tokenizer setup.
+
+use super::{Parser, callbacks::ParserCallbacks};
+use crate::tokenizer::Tokenizer;
+use vize_carton::Vec;
+use vize_relief::{
+    RootNode,
+    errors::{CompilerError, ErrorCode},
+};
+
+impl<'a> Parser<'a> {
+    pub(super) fn tokenize_template(&mut self) -> bool {
+        if self.options.delimiters.0.is_empty() || self.options.delimiters.1.is_empty() {
+            let loc = self.create_loc(0, 0);
+            self.errors.push(CompilerError::with_message(
+                ErrorCode::ExtendPoint,
+                "Interpolation delimiters must both be non-empty.",
+                Some(loc),
+            ));
+            return false;
+        }
+
+        let delimiter_open: Vec<'a, u8> =
+            Vec::from_iter_in(self.options.delimiters.0.bytes(), self.allocator);
+        let delimiter_close: Vec<'a, u8> =
+            Vec::from_iter_in(self.options.delimiters.1.bytes(), self.allocator);
+        let document = self.document;
+        let in_tag_comments = self.options.experimental_in_tag_comments;
+        #[cfg(feature = "legacy")]
+        let triple_mustache = self.raw_html_interpolation_enabled();
+        let mut tokenizer = Tokenizer::with_delimiters(
+            self.source,
+            ParserCallbacks { parser: self },
+            &delimiter_open,
+            &delimiter_close,
+        );
+        tokenizer.set_tolerate_declarations(document);
+        tokenizer.set_in_tag_comments(in_tag_comments);
+        #[cfg(feature = "legacy")]
+        tokenizer.set_triple_mustache(triple_mustache);
+        tokenizer.tokenize();
+        true
+    }
+
+    pub(super) fn into_result(mut self) -> (RootNode<'a>, Vec<'a, CompilerError>) {
+        let root = self
+            .root
+            .take()
+            .unwrap_or_else(|| RootNode::new(self.allocator, self.source));
+        (root, self.errors)
+    }
+
+    #[cfg(feature = "legacy")]
+    fn raw_html_interpolation_enabled(&self) -> bool {
+        crate::legacy::LegacyDialectCapabilities::for_dialect(self.options.dialect)
+            .raw_html_interpolation
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::parse_with_options;
+    use vize_carton::Bump;
+    use vize_relief::{ErrorCode, options::ParserOptions};
+
+    #[test]
+    fn empty_interpolation_delimiters_are_rejected_without_partial_output() {
+        for (open, close) in [("", "}}"), ("{{", "")] {
+            let allocator = Bump::new();
+            let options = ParserOptions {
+                delimiters: (open.into(), close.into()),
+                ..ParserOptions::default()
+            };
+
+            let (root, errors) = parse_with_options(&allocator, "<p>{{ value }}</p>", options);
+
+            assert!(root.children.is_empty(), "{open:?}, {close:?}");
+            assert_eq!(errors.len(), 1, "{open:?}, {close:?}: {errors:?}");
+            assert_eq!(errors[0].code, ErrorCode::ExtendPoint);
+            assert_eq!(
+                errors[0].message.as_str(),
+                "Interpolation delimiters must both be non-empty."
+            );
+        }
+    }
+}

--- a/crates/vize_armature/src/tokenizer.rs
+++ b/crates/vize_armature/src/tokenizer.rs
@@ -124,6 +124,16 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
         }
     }
 
+    #[inline]
+    fn at_opening_delimiter(&self, c: u8) -> bool {
+        self.delimiter_open.first() == Some(&c)
+    }
+
+    #[inline]
+    fn at_closing_delimiter(&self, c: u8) -> bool {
+        self.delimiter_close.first() == Some(&c)
+    }
+
     /// Tolerate top-level markup declarations (e.g. `<!DOCTYPE html>`) instead of
     /// reporting them as recoverable errors. Used by document parse mode.
     pub fn set_tolerate_declarations(&mut self, tolerate: bool) {
@@ -237,5 +247,7 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
     }
 }
 
+#[cfg(test)]
+mod empty_delimiter_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/vize_armature/src/tokenizer/empty_delimiter_tests.rs
+++ b/crates/vize_armature/src/tokenizer/empty_delimiter_tests.rs
@@ -1,0 +1,44 @@
+use super::{
+    Tokenizer,
+    tests::{TestCallbacks, TokenEvent},
+};
+use vize_relief::ErrorCode;
+
+fn tokenize(input: &str, open: &[u8], close: &[u8]) -> TestCallbacks {
+    let callbacks = TestCallbacks::default();
+    let mut tokenizer = Tokenizer::with_delimiters(input, callbacks, open, close);
+    tokenizer.tokenize();
+    tokenizer.callbacks
+}
+
+#[test]
+fn empty_opening_delimiter_treats_input_as_text() {
+    let callbacks = tokenize("{{ msg }}", b"", b"}}");
+
+    assert!(callbacks.errors.is_empty());
+    assert!(callbacks.events.contains(&TokenEvent::Text(0, 9)));
+    assert!(
+        !callbacks
+            .events
+            .iter()
+            .any(|event| matches!(event, TokenEvent::Interpolation(..)))
+    );
+}
+
+#[test]
+fn empty_closing_delimiter_reports_unfinished_interpolation() {
+    let callbacks = tokenize("{{ msg }}", b"{{", b"");
+
+    assert!(
+        callbacks
+            .errors
+            .contains(&(ErrorCode::MissingInterpolationEnd, 9))
+    );
+    assert!(callbacks.events.contains(&TokenEvent::Text(0, 9)));
+    assert!(
+        !callbacks
+            .events
+            .iter()
+            .any(|event| matches!(event, TokenEvent::Interpolation(..)))
+    );
+}

--- a/crates/vize_armature/src/tokenizer/states.rs
+++ b/crates/vize_armature/src/tokenizer/states.rs
@@ -191,7 +191,7 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             self.section_start = self.index;
         } else if c == AMP {
             self.start_entity();
-        } else if !self.callbacks.is_in_v_pre() && c == self.delimiter_open[0] {
+        } else if !self.callbacks.is_in_v_pre() && self.at_opening_delimiter(c) {
             self.state = State::InterpolationOpen;
             self.delimiter_index = 0;
             self.state_interpolation_open(c);
@@ -230,7 +230,7 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
     }
 
     pub(super) fn state_interpolation(&mut self, c: u8) {
-        if c == self.delimiter_close[0] {
+        if self.at_closing_delimiter(c) {
             self.state = State::InterpolationClose;
             self.delimiter_index = 0;
             self.state_interpolation_close(c);
@@ -846,7 +846,7 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             if matches!(sequence, Sequence::TitleEnd | Sequence::TextareaEnd) {
                 if c == AMP {
                     self.start_entity();
-                } else if !self.callbacks.is_in_v_pre() && c == self.delimiter_open[0] {
+                } else if !self.callbacks.is_in_v_pre() && self.at_opening_delimiter(c) {
                     self.state = State::InterpolationOpen;
                     self.delimiter_index = 0;
                     self.state_interpolation_open(c);

--- a/crates/vize_armature/src/tokenizer/tests.rs
+++ b/crates/vize_armature/src/tokenizer/tests.rs
@@ -9,7 +9,7 @@ use vize_relief::ErrorCode;
 // ========================================================================
 
 #[derive(Debug, PartialEq)]
-enum TokenEvent {
+pub(super) enum TokenEvent {
     Text(usize, usize),
     TextEntity(char, usize, usize),
     Interpolation(usize, usize),
@@ -32,9 +32,9 @@ enum TokenEvent {
 }
 
 #[derive(Debug, Default)]
-struct TestCallbacks {
-    events: Vec<TokenEvent>,
-    errors: Vec<(ErrorCode, usize)>,
+pub(super) struct TestCallbacks {
+    pub(super) events: Vec<TokenEvent>,
+    pub(super) errors: Vec<(ErrorCode, usize)>,
 }
 
 impl Callbacks for TestCallbacks {


### PR DESCRIPTION
## Summary

- reject empty opening or closing interpolation delimiters with one deterministic compiler diagnostic and an empty parse tree;
- make the public tokenizer treat missing delimiter bytes as non-matching input instead of indexing empty slices;
- isolate delimiter setup and regression tests so existing over-limit parser/tokenizer files do not grow.

## Verification

- `cargo test -p vize_armature`
- `cargo test -p vize_armature --features legacy`
- `cargo clippy -p vize_armature --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2903

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786469642&installation_id=136613492&pr_number=2904&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2904&signature=de3477aa7f7379479830cda8f634d6f59625aea9c3d25725e5f8dbdf711922ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of custom interpolation delimiters.
  * Empty delimiter configurations are now rejected with clear parsing errors.
  * Prevented incorrect interpolation detection when delimiters are missing or incomplete.

* **Tests**
  * Added coverage for empty opening and closing delimiter scenarios.
  * Confirmed affected input remains plain text when interpolation cannot be parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->