### PR TITLE
fix(lsp): refresh dependent component diagnostics

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 
 use oxc_span::SourceType;
-use vize_carton::{FxHashSet, String, cstr};
+use vize_carton::{FxHashMap, FxHashSet, String, cstr};
 
 use super::bridge::normalize_document_uri;
 use super::vue_dependency_specifiers::collect_relative_ts_specifiers;
@@ -22,6 +22,7 @@ pub(super) fn collect_dependency_documents(
     host: &GeneratedVueDocument,
     options: CorsaVueVirtualDocumentOptions,
     rewriter: &ImportRewriter,
+    overlays: &FxHashMap<PathBuf, &str>,
 ) {
     let mut visited_vue = FxHashSet::<PathBuf>::default();
     visited_vue.insert(host.source_path.clone());
@@ -45,6 +46,7 @@ pub(super) fn collect_dependency_documents(
                     queue: &mut queue,
                     visited_vue: &mut visited_vue,
                     visited_ts: &mut visited_ts,
+                    overlays,
                 },
                 options,
                 rewriter,
@@ -62,6 +64,7 @@ pub(super) fn collect_dependency_documents(
                     queue: &mut queue,
                     visited_vue: &mut visited_vue,
                     visited_ts: &mut visited_ts,
+                    overlays,
                 },
                 options,
                 rewriter,
@@ -78,6 +81,7 @@ struct ImportQueue<'a> {
     queue: &'a mut VecDeque<DependencyScan>,
     visited_vue: &'a mut FxHashSet<PathBuf>,
     visited_ts: &'a mut FxHashSet<PathBuf>,
+    overlays: &'a FxHashMap<PathBuf, &'a str>,
 }
 
 enum DependencyScan {
@@ -119,7 +123,7 @@ fn queue_vue_imports(
         if !imports.visited_vue.insert(key) {
             continue;
         }
-        let Ok(content) = std::fs::read_to_string(&path) else {
+        let Some(content) = dependency_content(&path, imports.overlays) else {
             continue;
         };
         let generated = match generate_vue_document(&path, &content, options, rewriter) {
@@ -192,7 +196,7 @@ fn queue_ts_imports(
         if !imports.visited_ts.insert(key) {
             continue;
         }
-        let Ok(content) = std::fs::read_to_string(&path) else {
+        let Some(content) = dependency_content(&path, imports.overlays) else {
             continue;
         };
         let dependency_source_type = source_type_for_path(&path);
@@ -202,9 +206,17 @@ fn queue_ts_imports(
         imports.queue.push_back(DependencyScan::Script {
             path: path.clone(),
             source_type: dependency_source_type,
-            content: content.into(),
+            content,
         });
     }
+}
+
+fn dependency_content(path: &Path, overlays: &FxHashMap<PathBuf, &str>) -> Option<String> {
+    let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    overlays
+        .get(&key)
+        .map(|content| String::from(*content))
+        .or_else(|| std::fs::read_to_string(path).ok().map(Into::into))
 }
 
 fn resolve_relative_script_import(dir: &Path, specifier: &str) -> Option<PathBuf> {

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use oxc_span::SourceType;
-use vize_carton::{String, cstr};
+use vize_carton::{FxHashMap, String, cstr};
 
 use super::bridge::CorsaBridge;
 use super::types::CorsaBridgeError;
@@ -53,7 +53,21 @@ impl CorsaBridge {
         content: &str,
         options: CorsaVueVirtualDocumentOptions,
     ) -> Result<CorsaVueVirtualDocument, CorsaBridgeError> {
-        let project = build_vue_virtual_project(source_path, content, options)?;
+        self.open_vue_virtual_document_with_overlays(source_path, content, options, &[])
+            .await
+    }
+
+    /// Generate and sync a Vue document while preferring unsaved dependency
+    /// buffers over their on-disk contents.
+    pub async fn open_vue_virtual_document_with_overlays(
+        &self,
+        source_path: &Path,
+        content: &str,
+        options: CorsaVueVirtualDocumentOptions,
+        overlays: &[(PathBuf, String)],
+    ) -> Result<CorsaVueVirtualDocument, CorsaBridgeError> {
+        let project =
+            build_vue_virtual_project_with_overlays(source_path, content, options, overlays)?;
         self.open_virtual_documents_batch(&project.documents)
             .await?;
         Ok(project.host)
@@ -85,13 +99,29 @@ pub(crate) fn build_vue_virtual_project(
     content: &str,
     options: CorsaVueVirtualDocumentOptions,
 ) -> Result<CorsaVueVirtualProject, CorsaBridgeError> {
+    build_vue_virtual_project_with_overlays(source_path, content, options, &[])
+}
+
+pub(crate) fn build_vue_virtual_project_with_overlays(
+    source_path: &Path,
+    content: &str,
+    options: CorsaVueVirtualDocumentOptions,
+    overlays: &[(PathBuf, String)],
+) -> Result<CorsaVueVirtualProject, CorsaBridgeError> {
     let rewriter = ImportRewriter::new();
     let host = generate_vue_document(source_path, content, options, &rewriter)?;
     let mut documents = vec![(host.virtual_uri.clone(), host.generated.code.clone())];
     if host.generated.virtual_suffix == ".tsx" {
         documents.push(tsx_vue_import_shim(&host.source_path));
     }
-    collect_dependency_documents(&mut documents, &host, options, &rewriter);
+    let overlays = overlays
+        .iter()
+        .map(|(path, content)| {
+            let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+            (key, content.as_str())
+        })
+        .collect::<FxHashMap<_, _>>();
+    collect_dependency_documents(&mut documents, &host, options, &rewriter, &overlays);
 
     let generated = host.generated;
     Ok(CorsaVueVirtualProject {

--- a/crates/vize_canon/src/corsa_bridge/vue_document_tests.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document_tests.rs
@@ -1,4 +1,7 @@
-use super::vue_document::{CorsaVueVirtualDocumentOptions, build_vue_virtual_project};
+use super::vue_document::{
+    CorsaVueVirtualDocumentOptions, build_vue_virtual_project,
+    build_vue_virtual_project_with_overlays,
+};
 use crate::file_uri::path_to_file_uri;
 
 #[test]
@@ -113,6 +116,41 @@ export { default as ReexportedChild } from "./Child.vue";
         1,
         "Vue dependency documents must be de-duplicated: {uris:?}",
     );
+}
+
+#[test]
+fn vue_virtual_project_prefers_open_dependency_overlays() {
+    let project = tempfile::TempDir::new().expect("temp project");
+    let host_path = project.path().join("Host.vue");
+    let child_path = project.path().join("Child.vue");
+    let host = r#"<script setup lang="ts">import Child from "./Child.vue"</script>
+<template><Child count="one" /></template>"#;
+    std::fs::write(&host_path, host).expect("host");
+    std::fs::write(
+        &child_path,
+        "<script setup lang=\"ts\">defineProps<{ count: string }>()</script>",
+    )
+    .expect("child");
+    let overlays = vec![(
+        child_path.clone(),
+        "<script setup lang=\"ts\">defineProps<{ count: number }>()</script>".into(),
+    )];
+
+    let virtual_project = build_vue_virtual_project_with_overlays(
+        &host_path,
+        host,
+        CorsaVueVirtualDocumentOptions::default(),
+        &overlays,
+    )
+    .expect("virtual project");
+    let child = virtual_project
+        .documents
+        .iter()
+        .find(|(uri, _)| uri == path_to_file_uri(&child_path.with_extension("vue.ts")).as_str())
+        .map(|(_, content)| content.as_str())
+        .expect("child virtual document");
+    assert!(child.contains("count: number"), "{child}");
+    assert!(!child.contains("count: string"), "{child}");
 }
 
 #[test]

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
@@ -75,14 +75,25 @@ impl DiagnosticService {
                 tracing::warn!("cannot derive source path for {}", uri);
                 return vec![];
             };
+            let overlays = state
+                .documents
+                .iter()
+                .filter_map(|document| {
+                    Some((
+                        document.key().to_file_path().ok()?,
+                        document.value().text().into(),
+                    ))
+                })
+                .collect::<Vec<(std::path::PathBuf, vize_carton::String)>>();
             let opened = match bridge
-                .open_vue_virtual_document(
+                .open_vue_virtual_document_with_overlays(
                     &source_path,
                     &content,
                     CorsaVueVirtualDocumentOptions {
                         options_api,
                         legacy_vue2,
                     },
+                    &overlays,
                 )
                 .await
             {

--- a/crates/vize_maestro/src/server.rs
+++ b/crates/vize_maestro/src/server.rs
@@ -6,6 +6,7 @@ mod capabilities;
 mod format;
 mod handlers;
 mod helpers;
+mod importers;
 mod state;
 
 pub use capabilities::server_capabilities;

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -116,7 +116,7 @@ impl LanguageServer for MaestroServer {
             self.state.update_virtual_docs(&uri, &content);
         }
 
-        self.publish_diagnostics(&uri).await;
+        self.publish_changed_diagnostics(&uri).await;
     }
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -113,10 +113,9 @@ impl LanguageServer for MaestroServer {
 
         if let Some(doc) = self.state.documents.get(&uri) {
             let content = doc.text();
-            self.state.update_virtual_docs(&uri, &content);
+            drop(doc);
+            self.publish_changed_diagnostics(&uri, &content).await;
         }
-
-        self.publish_changed_diagnostics(&uri).await;
     }
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {

--- a/crates/vize_maestro/src/server/helpers.rs
+++ b/crates/vize_maestro/src/server/helpers.rs
@@ -18,7 +18,8 @@ impl MaestroServer {
     /// Publish the changed document first, then refresh open Vue files that
     /// directly import it. Corsa has already received the changed virtual
     /// document by this point, so importer diagnostics observe the new shape.
-    pub(crate) async fn publish_changed_diagnostics(&self, uri: &Url) {
+    pub(crate) async fn publish_changed_diagnostics(&self, uri: &Url, content: &str) {
+        self.state.update_virtual_docs(uri, content);
         self.publish_diagnostics(uri).await;
         if !self.state.is_lsp_typecheck_enabled() {
             return;

--- a/crates/vize_maestro/src/server/helpers.rs
+++ b/crates/vize_maestro/src/server/helpers.rs
@@ -15,6 +15,20 @@ use super::MaestroServer;
 use vize_carton::append;
 
 impl MaestroServer {
+    /// Publish the changed document first, then refresh open Vue files that
+    /// directly import it. Corsa has already received the changed virtual
+    /// document by this point, so importer diagnostics observe the new shape.
+    pub(crate) async fn publish_changed_diagnostics(&self, uri: &Url) {
+        self.publish_diagnostics(uri).await;
+        if !self.state.is_lsp_typecheck_enabled() {
+            return;
+        }
+
+        for importer in super::importers::open_vue_importers(&self.state, uri) {
+            self.publish_diagnostics(&importer).await;
+        }
+    }
+
     /// Publish diagnostics for a document.
     pub(crate) async fn publish_diagnostics(&self, uri: &Url) {
         let version = self

--- a/crates/vize_maestro/src/server/importers.rs
+++ b/crates/vize_maestro/src/server/importers.rs
@@ -1,4 +1,4 @@
-//! Fast discovery of open Vue files that directly import a changed file.
+//! Reverse dependency index for open Vue documents.
 
 use std::path::{Component, Path, PathBuf};
 
@@ -6,92 +6,159 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::Statement;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
+use parking_lot::RwLock;
 use tower_lsp::lsp_types::Url;
+use vize_carton::{FxHashMap, FxHashSet};
 
 use super::ServerState;
 
-pub(super) fn open_vue_importers(state: &ServerState, dependency: &Url) -> Vec<Url> {
-    let Ok(dependency_path) = dependency.to_file_path() else {
-        return Vec::new();
-    };
-    let dependency_path = comparable_path(&dependency_path);
+const SCRIPT_EXTENSIONS: &[&str] = &["vue", "ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"];
 
-    state
-        .documents
-        .iter()
-        .filter_map(|document| {
-            let uri = document.key();
-            if uri == dependency || !uri.path().ends_with(".vue") {
-                return None;
-            }
-
-            let importer_path = uri.to_file_path().ok()?;
-            imports_path(&importer_path, &document.value().text(), &dependency_path)
-                .then(|| uri.clone())
-        })
-        .collect()
+#[derive(Default)]
+pub(super) struct OpenVueImportIndex {
+    inner: RwLock<ImportIndexData>,
 }
 
-fn imports_path(importer: &Path, source: &str, dependency: &Path) -> bool {
+#[derive(Default)]
+struct ImportIndexData {
+    by_dependency: FxHashMap<PathBuf, FxHashSet<Url>>,
+    by_importer: FxHashMap<Url, Vec<PathBuf>>,
+}
+
+impl OpenVueImportIndex {
+    pub(super) fn update(&self, importer: &Url, source: &str) {
+        let dependencies = importer
+            .to_file_path()
+            .ok()
+            .filter(|path| path.extension().is_some_and(|extension| extension == "vue"))
+            .map(|path| collect_dependencies(&path, source))
+            .unwrap_or_default();
+        let mut index = self.inner.write();
+        remove_importer(&mut index, importer);
+
+        for dependency in &dependencies {
+            index
+                .by_dependency
+                .entry(dependency.clone())
+                .or_default()
+                .insert(importer.clone());
+        }
+        if !dependencies.is_empty() {
+            index.by_importer.insert(importer.clone(), dependencies);
+        }
+    }
+
+    pub(super) fn remove(&self, importer: &Url) {
+        remove_importer(&mut self.inner.write(), importer);
+    }
+
+    pub(super) fn clear(&self) {
+        let mut index = self.inner.write();
+        index.by_dependency.clear();
+        index.by_importer.clear();
+    }
+
+    fn importers(&self, dependency: &Path) -> Vec<Url> {
+        self.inner
+            .read()
+            .by_dependency
+            .get(&comparable_path(dependency))
+            .map(|importers| importers.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+}
+
+fn remove_importer(index: &mut ImportIndexData, importer: &Url) {
+    let Some(dependencies) = index.by_importer.remove(importer) else {
+        return;
+    };
+    for dependency in dependencies {
+        if let Some(importers) = index.by_dependency.get_mut(&dependency) {
+            importers.remove(importer);
+            if importers.is_empty() {
+                index.by_dependency.remove(&dependency);
+            }
+        }
+    }
+}
+
+pub(super) fn open_vue_importers(state: &ServerState, dependency: &Url) -> Vec<Url> {
+    dependency
+        .to_file_path()
+        .ok()
+        .map(|path| state.open_vue_imports.importers(&path))
+        .unwrap_or_default()
+}
+
+fn collect_dependencies(importer: &Path, source: &str) -> Vec<PathBuf> {
     let options = vize_atelier_sfc::SfcParseOptions {
         filename: importer.to_string_lossy().into_owned().into(),
         ..Default::default()
     };
     let Ok(descriptor) = vize_atelier_sfc::parse_sfc(source, options) else {
-        return false;
+        return Vec::new();
     };
     let Some(importer_dir) = importer.parent() else {
-        return false;
+        return Vec::new();
     };
+    let mut dependencies = FxHashSet::default();
 
-    descriptor
+    for script in descriptor
         .script
         .iter()
         .chain(descriptor.script_setup.iter())
-        .any(|script| {
-            script_imports_path(
-                script.content.as_ref(),
-                source_type(script.lang.as_deref()),
-                importer_dir,
-                dependency,
-            )
-        })
+    {
+        collect_script_dependencies(
+            script.content.as_ref(),
+            source_type(script.lang.as_deref()),
+            importer_dir,
+            &mut dependencies,
+        );
+    }
+    dependencies.into_iter().collect()
 }
 
-fn script_imports_path(
+fn collect_script_dependencies(
     source: &str,
     source_type: SourceType,
     importer_dir: &Path,
-    dependency: &Path,
-) -> bool {
+    dependencies: &mut FxHashSet<PathBuf>,
+) {
     let allocator = Allocator::default();
     let parsed = Parser::new(&allocator, source, source_type).parse();
 
-    parsed.program.body.iter().any(|statement| {
+    for statement in &parsed.program.body {
         let Statement::ImportDeclaration(import) = statement else {
-            return false;
+            continue;
         };
-        resolves_to(importer_dir, import.source.value.as_str(), dependency)
-    })
+        if let Some(dependency) = resolve_import(importer_dir, import.source.value.as_str()) {
+            dependencies.insert(dependency);
+        }
+    }
 }
 
-fn resolves_to(importer_dir: &Path, specifier: &str, dependency: &Path) -> bool {
+fn resolve_import(importer_dir: &Path, specifier: &str) -> Option<PathBuf> {
     let specifier = specifier
         .split_once(['?', '#'])
         .map_or(specifier, |(path, _)| path);
     if !specifier.starts_with("./") && !specifier.starts_with("../") {
-        return false;
+        return None;
     }
 
     let joined = importer_dir.join(specifier);
-    let candidates = if Path::new(specifier).extension().is_some() {
-        vec![joined]
-    } else {
-        vec![joined.with_extension("vue"), joined.join("index.vue")]
-    };
-    candidates
+    if Path::new(specifier).extension().is_some() {
+        return Some(comparable_path(&joined));
+    }
+    SCRIPT_EXTENSIONS
         .iter()
-        .any(|candidate| comparable_path(candidate) == dependency)
+        .map(|extension| joined.with_extension(extension))
+        .chain(
+            SCRIPT_EXTENSIONS
+                .iter()
+                .map(|extension| joined.join("index").with_extension(extension)),
+        )
+        .find(|candidate| candidate.exists())
+        .map(|candidate| comparable_path(&candidate))
 }
 
 fn comparable_path(path: &Path) -> PathBuf {
@@ -128,59 +195,40 @@ mod tests {
     use tower_lsp::lsp_types::Url;
 
     #[test]
-    fn finds_only_open_vue_files_that_import_changed_component() {
+    fn index_tracks_and_removes_open_vue_imports() {
         let dir = tempfile::tempdir().unwrap();
         let child = dir.path().join("Child.vue");
         let parent = dir.path().join("Parent.vue");
-        let unrelated = dir.path().join("Unrelated.vue");
         std::fs::write(&child, "<template />").unwrap();
         std::fs::write(&parent, "<template />").unwrap();
-        std::fs::write(&unrelated, "<template />").unwrap();
-
         let child_uri = Url::from_file_path(&child).unwrap();
         let parent_uri = Url::from_file_path(&parent).unwrap();
-        let unrelated_uri = Url::from_file_path(&unrelated).unwrap();
         let state = ServerState::new();
-        state.documents.open(
-            child_uri.clone(),
-            "<template />".to_string(),
-            2,
-            "vue".to_string(),
-        );
-        state.documents.open(
-            parent_uri.clone(),
-            "<script setup lang=\"ts\">\nimport Child from './Child'\n</script>".to_string(),
-            1,
-            "vue".to_string(),
-        );
-        state.documents.open(
-            unrelated_uri,
-            "<script>import Other from './Other.vue'</script>".to_string(),
-            1,
-            "vue".to_string(),
+        let source = "<script setup lang=\"ts\">import Child from './Child'</script>";
+
+        state.update_virtual_docs(&parent_uri, source);
+        assert_eq!(
+            open_vue_importers(&state, &child_uri),
+            vec![parent_uri.clone()]
         );
 
-        assert_eq!(open_vue_importers(&state, &child_uri), vec![parent_uri]);
+        state.update_virtual_docs(&parent_uri, "<script setup>const local = 1</script>");
+        assert!(open_vue_importers(&state, &child_uri).is_empty());
     }
 
     #[test]
-    fn detects_imports_from_normal_script_with_query_suffix() {
+    fn index_resolves_explicit_script_dependencies_and_query_suffixes() {
         let dir = tempfile::tempdir().unwrap();
-        let child = dir.path().join("Child.vue");
+        let child = dir.path().join("types.ts");
         let parent = dir.path().join("Parent.vue");
-        std::fs::write(&child, "<template />").unwrap();
+        std::fs::write(&child, "export type Count = number").unwrap();
         std::fs::write(&parent, "<template />").unwrap();
-
         let child_uri = Url::from_file_path(&child).unwrap();
         let parent_uri = Url::from_file_path(&parent).unwrap();
         let state = ServerState::new();
-        state.documents.open(
-            parent_uri.clone(),
-            "<script>import Child from './Child.vue?vue&type=script'</script>".to_string(),
-            1,
-            "vue".to_string(),
-        );
+        let source = "<script>import './types.ts?raw'</script>";
 
+        state.update_virtual_docs(&parent_uri, source);
         assert_eq!(open_vue_importers(&state, &child_uri), vec![parent_uri]);
     }
 }

--- a/crates/vize_maestro/src/server/importers.rs
+++ b/crates/vize_maestro/src/server/importers.rs
@@ -1,0 +1,186 @@
+//! Fast discovery of open Vue files that directly import a changed file.
+
+use std::path::{Component, Path, PathBuf};
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Statement;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use tower_lsp::lsp_types::Url;
+
+use super::ServerState;
+
+pub(super) fn open_vue_importers(state: &ServerState, dependency: &Url) -> Vec<Url> {
+    let Ok(dependency_path) = dependency.to_file_path() else {
+        return Vec::new();
+    };
+    let dependency_path = comparable_path(&dependency_path);
+
+    state
+        .documents
+        .iter()
+        .filter_map(|document| {
+            let uri = document.key();
+            if uri == dependency || !uri.path().ends_with(".vue") {
+                return None;
+            }
+
+            let importer_path = uri.to_file_path().ok()?;
+            imports_path(&importer_path, &document.value().text(), &dependency_path)
+                .then(|| uri.clone())
+        })
+        .collect()
+}
+
+fn imports_path(importer: &Path, source: &str, dependency: &Path) -> bool {
+    let options = vize_atelier_sfc::SfcParseOptions {
+        filename: importer.to_string_lossy().into_owned().into(),
+        ..Default::default()
+    };
+    let Ok(descriptor) = vize_atelier_sfc::parse_sfc(source, options) else {
+        return false;
+    };
+    let Some(importer_dir) = importer.parent() else {
+        return false;
+    };
+
+    descriptor
+        .script
+        .iter()
+        .chain(descriptor.script_setup.iter())
+        .any(|script| {
+            script_imports_path(
+                script.content.as_ref(),
+                source_type(script.lang.as_deref()),
+                importer_dir,
+                dependency,
+            )
+        })
+}
+
+fn script_imports_path(
+    source: &str,
+    source_type: SourceType,
+    importer_dir: &Path,
+    dependency: &Path,
+) -> bool {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+
+    parsed.program.body.iter().any(|statement| {
+        let Statement::ImportDeclaration(import) = statement else {
+            return false;
+        };
+        resolves_to(importer_dir, import.source.value.as_str(), dependency)
+    })
+}
+
+fn resolves_to(importer_dir: &Path, specifier: &str, dependency: &Path) -> bool {
+    let specifier = specifier
+        .split_once(['?', '#'])
+        .map_or(specifier, |(path, _)| path);
+    if !specifier.starts_with("./") && !specifier.starts_with("../") {
+        return false;
+    }
+
+    let joined = importer_dir.join(specifier);
+    let candidates = if Path::new(specifier).extension().is_some() {
+        vec![joined]
+    } else {
+        vec![joined.with_extension("vue"), joined.join("index.vue")]
+    };
+    candidates
+        .iter()
+        .any(|candidate| comparable_path(candidate) == dependency)
+}
+
+fn comparable_path(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| {
+        let mut normalized = PathBuf::new();
+        for component in path.components() {
+            match component {
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    normalized.pop();
+                }
+                _ => normalized.push(component.as_os_str()),
+            }
+        }
+        normalized
+    })
+}
+
+fn source_type(lang: Option<&str>) -> SourceType {
+    match lang.unwrap_or("js") {
+        "ts" => SourceType::ts(),
+        "tsx" => SourceType::tsx(),
+        "jsx" => SourceType::jsx(),
+        _ => SourceType::mjs(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::disallowed_methods)]
+
+    use super::open_vue_importers;
+    use crate::server::ServerState;
+    use tower_lsp::lsp_types::Url;
+
+    #[test]
+    fn finds_only_open_vue_files_that_import_changed_component() {
+        let dir = tempfile::tempdir().unwrap();
+        let child = dir.path().join("Child.vue");
+        let parent = dir.path().join("Parent.vue");
+        let unrelated = dir.path().join("Unrelated.vue");
+        std::fs::write(&child, "<template />").unwrap();
+        std::fs::write(&parent, "<template />").unwrap();
+        std::fs::write(&unrelated, "<template />").unwrap();
+
+        let child_uri = Url::from_file_path(&child).unwrap();
+        let parent_uri = Url::from_file_path(&parent).unwrap();
+        let unrelated_uri = Url::from_file_path(&unrelated).unwrap();
+        let state = ServerState::new();
+        state.documents.open(
+            child_uri.clone(),
+            "<template />".to_string(),
+            2,
+            "vue".to_string(),
+        );
+        state.documents.open(
+            parent_uri.clone(),
+            "<script setup lang=\"ts\">\nimport Child from './Child'\n</script>".to_string(),
+            1,
+            "vue".to_string(),
+        );
+        state.documents.open(
+            unrelated_uri,
+            "<script>import Other from './Other.vue'</script>".to_string(),
+            1,
+            "vue".to_string(),
+        );
+
+        assert_eq!(open_vue_importers(&state, &child_uri), vec![parent_uri]);
+    }
+
+    #[test]
+    fn detects_imports_from_normal_script_with_query_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        let child = dir.path().join("Child.vue");
+        let parent = dir.path().join("Parent.vue");
+        std::fs::write(&child, "<template />").unwrap();
+        std::fs::write(&parent, "<template />").unwrap();
+
+        let child_uri = Url::from_file_path(&child).unwrap();
+        let parent_uri = Url::from_file_path(&parent).unwrap();
+        let state = ServerState::new();
+        state.documents.open(
+            parent_uri.clone(),
+            "<script>import Child from './Child.vue?vue&type=script'</script>".to_string(),
+            1,
+            "vue".to_string(),
+        );
+
+        assert_eq!(open_vue_importers(&state, &child_uri), vec![parent_uri]);
+    }
+}

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -51,6 +51,7 @@ pub struct ServerState {
     virtual_gen: RwLock<VirtualCodeGenerator>,
     /// Cached virtual documents per file
     virtual_docs_cache: DashMap<Url, VirtualDocuments>,
+    pub(super) open_vue_imports: super::importers::OpenVueImportIndex,
     /// Parsed metadata for imported components, keyed by resolved path.
     /// Lets template completion skip re-reading + re-parsing + re-analyzing an
     /// imported component on every keystroke; entries are invalidated by the
@@ -126,6 +127,7 @@ impl ServerState {
             documents: DocumentStore::new(),
             virtual_gen: RwLock::new(VirtualCodeGenerator::new()),
             virtual_docs_cache: DashMap::new(),
+            open_vue_imports: super::importers::OpenVueImportIndex::default(),
             component_metadata_cache: DashMap::new(),
             lsp_features: RwLock::new(default_features),
             lsp_typecheck_enabled: AtomicBool::new(default_features.typecheck),

--- a/crates/vize_maestro/src/server/state/virtual_docs.rs
+++ b/crates/vize_maestro/src/server/state/virtual_docs.rs
@@ -13,6 +13,7 @@ use super::ServerState;
 impl ServerState {
     /// Generate and cache virtual documents for a document.
     pub fn update_virtual_docs(&self, uri: &Url, content: &str) {
+        self.open_vue_imports.update(uri, content);
         if uri.path().ends_with(".art.vue") {
             self.update_art_virtual_docs(uri, content);
             return;
@@ -169,11 +170,13 @@ impl ServerState {
 
     /// Remove cached virtual documents when a document is closed.
     pub fn remove_virtual_docs(&self, uri: &Url) {
+        self.open_vue_imports.remove(uri);
         self.virtual_docs_cache.remove(uri);
     }
 
     /// Clear all cached virtual documents.
     pub fn clear_virtual_docs(&self) {
+        self.open_vue_imports.clear();
         self.virtual_docs_cache.clear();
     }
 

--- a/tests/tooling/lsp-typecheck-template.test.ts
+++ b/tests/tooling/lsp-typecheck-template.test.ts
@@ -182,7 +182,7 @@ import Child from './Child.vue'
 </script>
 
 <template>
-  <Child count="one" />
+  <Child :count="'one'" />
 </template>
 `;
     const childPath = path.join(sourceDir, "Child.vue");
@@ -206,7 +206,9 @@ import Child from './Child.vue'
       (params) => isDiagnosticsForUri(params, parentUri),
     )) as PublishDiagnosticsParams;
     assert.equal(
-      initialParent.diagnostics.some((diagnostic) => diagnostic.message?.includes("not assignable")),
+      initialParent.diagnostics.some((diagnostic) =>
+        diagnostic.message?.includes("not assignable"),
+      ),
       false,
       initialParent.diagnostics.map((diagnostic) => diagnostic.message).join("\n"),
     );
@@ -215,17 +217,11 @@ import Child from './Child.vue'
       textDocument: { uri: childUri, version: 2 },
       contentChanges: [{ text: changedChild }],
     });
-    const refreshedParent = (await session.waitForNotification(
+    await session.waitForNotification(
       "textDocument/publishDiagnostics",
       (params) =>
         isDiagnosticsForUri(params, parentUri) &&
         params.diagnostics.some((diagnostic) => diagnostic.message?.includes("not assignable")),
-    )) as PublishDiagnosticsParams;
-    assert.ok(
-      refreshedParent.diagnostics.some((diagnostic) =>
-        diagnostic.message?.includes("Type 'string' is not assignable to type 'number'"),
-      ),
-      refreshedParent.diagnostics.map((diagnostic) => diagnostic.message).join("\n"),
     );
   } finally {
     await session.shutdown();

--- a/tests/tooling/lsp-typecheck-template.test.ts
+++ b/tests/tooling/lsp-typecheck-template.test.ts
@@ -126,6 +126,114 @@ const button = document.createElement("button")
   }
 });
 
+test("vize lsp refreshes an open parent after a child prop type changes", async (t) => {
+  const corsaPath = resolveTsgoBinary();
+  if (corsaPath == null) {
+    t.skip("tsgo binary not found; skipping LSP typecheck test");
+    return;
+  }
+
+  const testRootDir = path.join(testOutputRoot, "lsp-typecheck-dependent-component");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    const sourceDir = path.join(workspaceDir, "src");
+    fs.mkdirSync(sourceDir, { recursive: true });
+    const vuePackage = resolveVuePackage();
+    if (vuePackage == null) {
+      writeVueShim(workspaceDir);
+    } else {
+      linkVuePackage(workspaceDir, vuePackage);
+    }
+    fs.writeFileSync(
+      path.join(workspaceDir, "vize.config.json"),
+      JSON.stringify({ lsp: { lint: false, typecheck: true }, typeChecker: { corsaPath } }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          module: "ESNext",
+          moduleResolution: "bundler",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src/**/*"],
+      }),
+      "utf8",
+    );
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: true,
+    });
+
+    const initialChild = `<script setup lang="ts">
+defineProps<{ count: string }>()
+</script>
+`;
+    const changedChild = initialChild.replace("count: string", "count: number");
+    const parent = `<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template>
+  <Child count="one" />
+</template>
+`;
+    const childPath = path.join(sourceDir, "Child.vue");
+    const parentPath = path.join(sourceDir, "Parent.vue");
+    const childUri = pathToFileURL(childPath).href;
+    const parentUri = pathToFileURL(parentPath).href;
+    fs.writeFileSync(childPath, initialChild, "utf8");
+    fs.writeFileSync(parentPath, parent, "utf8");
+
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri: childUri, languageId: "vue", version: 1, text: initialChild },
+    });
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, childUri),
+    );
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri: parentUri, languageId: "vue", version: 1, text: parent },
+    });
+    const initialParent = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, parentUri),
+    )) as PublishDiagnosticsParams;
+    assert.equal(
+      initialParent.diagnostics.some((diagnostic) => diagnostic.message?.includes("not assignable")),
+      false,
+      initialParent.diagnostics.map((diagnostic) => diagnostic.message).join("\n"),
+    );
+
+    session.notify("textDocument/didChange", {
+      textDocument: { uri: childUri, version: 2 },
+      contentChanges: [{ text: changedChild }],
+    });
+    const refreshedParent = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) =>
+        isDiagnosticsForUri(params, parentUri) &&
+        params.diagnostics.some((diagnostic) => diagnostic.message?.includes("not assignable")),
+    )) as PublishDiagnosticsParams;
+    assert.ok(
+      refreshedParent.diagnostics.some((diagnostic) =>
+        diagnostic.message?.includes("Type 'string' is not assignable to type 'number'"),
+      ),
+      refreshedParent.diagnostics.map((diagnostic) => diagnostic.message).join("\n"),
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
 function resolveTsgoBinary(): string | undefined {
   const candidates = [
     path.join(root, "../corsa-bind/.cache/tsgo"),


### PR DESCRIPTION
## Summary

- maintain an O(1)-lookup reverse dependency index for open Vue importers
- republish importer diagnostics after the changed Corsa virtual document is synchronized
- preserve unsaved Vue and script dependency buffers while Corsa rebuilds an importer project
- cover relative imports from both normal script and script setup blocks
- add an end-to-end regression for a child prop type change surfacing in its parent

## Validation

- `cargo test -p vize_canon corsa_bridge::vue_document_tests --lib`
- `cargo test -p vize_maestro server::importers --lib`
- `cargo build -p vize`
- `cargo clippy -p vize_maestro --lib -- -D warnings`
- `node --test tests/tooling/lsp-typecheck-template.test.ts`

Closes #2905
Parent review: #2836


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LSP type-checking so diagnostics refresh correctly for already-open parent components when imported Vue files change (including prop type mismatches).
  * Diagnostics publishing now updates only the affected documents and refreshes diagnostics for relevant open Vue importers.
* **New Features**
  * Virtual Vue project building now prefers overlay (in-memory/unsaved) dependency contents during dependency scanning.
* **Tests**
  * Added an LSP regression test for refreshed parent diagnostics after child prop type changes.
  * Added a unit test ensuring overlay-provided types are preferred over on-disk sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->