### PR TITLE
fix(lsp): complete props from open component buffers

### DIFF
--- a/crates/vize_maestro/src/ide/completion/component_props_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/component_props_tests.rs
@@ -164,6 +164,10 @@ import Child from './Child.vue'
     assert!(!has_label(&labels, "fresh-prop"), "{labels:?}");
 
     state.documents.close(&child_uri);
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+    assert!(has_label(&labels, "stale-prop"), "{labels:?}");
+    assert!(!has_label(&labels, "newer-prop"), "{labels:?}");
+
     state.documents.open(
         child_uri,
         "<script setup lang=\"ts\">defineProps<{ otherProp: string }>()</script>".to_string(),

--- a/crates/vize_maestro/src/ide/completion/component_props_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/component_props_tests.rs
@@ -1,6 +1,8 @@
 use std::fs;
 
-use tower_lsp::lsp_types::{CompletionResponse, CompletionTextEdit, Documentation, Url};
+use tower_lsp::lsp_types::{
+    CompletionResponse, CompletionTextEdit, Documentation, TextDocumentContentChangeEvent, Url,
+};
 
 use super::CompletionService;
 use crate::{ide::IdeContext, server::ServerState};
@@ -109,6 +111,68 @@ import Child from './Child.vue'
         CompletionTextEdit::InsertAndReplace(_) => panic!("expected a simple text edit"),
     };
     assert_eq!(edit.new_text, ":someMessage=\"$1\"");
+}
+
+#[test]
+fn template_component_prop_completion_tracks_open_child_buffer() {
+    let dir = tempfile::tempdir().unwrap();
+    let child_path = dir.path().join("Child.vue");
+    fs::write(
+        &child_path,
+        "<script setup lang=\"ts\">defineProps<{ staleProp: string }>()</script>",
+    )
+    .unwrap();
+    let source = r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+<template><Child  /></template>
+"#;
+    let parent_path = dir.path().join("Parent.vue");
+    fs::write(&parent_path, source).unwrap();
+
+    let parent_uri = Url::from_file_path(&parent_path).unwrap();
+    let child_uri = Url::from_file_path(&child_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(parent_uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.documents.open(
+        child_uri.clone(),
+        "<script setup lang=\"ts\">defineProps<{ freshProp: string }>()</script>".to_string(),
+        3,
+        "vue".to_string(),
+    );
+
+    let offset = source.find("<Child  />").unwrap() + "<Child ".len();
+    let ctx = IdeContext::new(&state, &parent_uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+    assert!(has_label(&labels, "fresh-prop"), "{labels:?}");
+    assert!(!has_label(&labels, "stale-prop"), "{labels:?}");
+
+    state.documents.apply_changes(
+        &child_uri,
+        vec![TextDocumentContentChangeEvent {
+            range: None,
+            range_length: None,
+            text: "<script setup lang=\"ts\">defineProps<{ newerProp: string }>()</script>"
+                .to_string(),
+        }],
+        4,
+    );
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+    assert!(has_label(&labels, "newer-prop"), "{labels:?}");
+    assert!(!has_label(&labels, "fresh-prop"), "{labels:?}");
+
+    state.documents.close(&child_uri);
+    state.documents.open(
+        child_uri,
+        "<script setup lang=\"ts\">defineProps<{ otherProp: string }>()</script>".to_string(),
+        4,
+        "vue".to_string(),
+    );
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+    assert!(has_label(&labels, "other-prop"), "{labels:?}");
+    assert!(!has_label(&labels, "newer-prop"), "{labels:?}");
 }
 
 #[cfg(feature = "native")]

--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -10,6 +10,7 @@
 
 mod art;
 mod bindings;
+mod component_cache;
 mod component_docs;
 mod component_meta;
 mod components;
@@ -30,7 +31,8 @@ use bindings::analyzed_template_binding_completions;
 use components::builtin_component_completions;
 
 pub(crate) use art::{complete_art, complete_inline_art};
-pub(crate) use component_meta::{CachedComponentMetadata, component_metadata};
+pub(crate) use component_cache::CachedComponentMetadata;
+pub(crate) use component_meta::component_metadata;
 pub(crate) use directives::{contextual_directive_completions, vize_directive_completions};
 // Consumed via `template::*` by unit tests in the parent completion module; the
 // `allow` keeps non-test builds warning-free while preserving the public path.

--- a/crates/vize_maestro/src/ide/completion/template/component_cache.rs
+++ b/crates/vize_maestro/src/ide/completion/template/component_cache.rs
@@ -23,26 +23,33 @@ pub(super) fn cached_component_metadata(
     let open = open_component(ctx, resolved);
     let (content, len, modified, version, hash) = if let Some((content, len, version, hash)) = open
     {
+        if let Some(entry) = cache.get(resolved)
+            && entry.len == len
+            && entry.version == Some(version)
+            && entry.hash == Some(hash)
+        {
+            return Some(entry.metadata.clone());
+        }
         (content, len, None, Some(version), Some(hash))
     } else {
         let metadata = std::fs::metadata(resolved).ok()?;
+        let len = metadata.len();
+        let modified = metadata.modified().ok();
+        if let Some(entry) = cache.get(resolved)
+            && entry.len == len
+            && entry.modified == modified
+            && entry.version.is_none()
+        {
+            return Some(entry.metadata.clone());
+        }
         (
             std::fs::read_to_string(resolved).ok()?,
-            metadata.len(),
-            metadata.modified().ok(),
+            len,
+            modified,
             None,
             None,
         )
     };
-
-    if let Some(entry) = cache.get(resolved)
-        && entry.len == len
-        && entry.modified == modified
-        && entry.version == version
-        && entry.hash == hash
-    {
-        return Some(entry.metadata.clone());
-    }
 
     let metadata = Arc::new(extract_component_metadata(
         &content,

--- a/crates/vize_maestro/src/ide/completion/template/component_cache.rs
+++ b/crates/vize_maestro/src/ide/completion/template/component_cache.rs
@@ -36,6 +36,7 @@ pub(super) fn cached_component_metadata(
         let len = metadata.len();
         let modified = metadata.modified().ok();
         if let Some(entry) = cache.get(resolved)
+            && modified.is_some()
             && entry.len == len
             && entry.modified == modified
             && entry.version.is_none()

--- a/crates/vize_maestro/src/ide/completion/template/component_cache.rs
+++ b/crates/vize_maestro/src/ide/completion/template/component_cache.rs
@@ -1,0 +1,134 @@
+//! Version-aware metadata cache for imported components.
+
+use std::{path::Path, sync::Arc};
+
+use crate::ide::IdeContext;
+
+use super::component_meta::{ComponentMetadata, extract_component_metadata};
+
+#[derive(Clone)]
+pub(crate) struct CachedComponentMetadata {
+    len: u64,
+    modified: Option<std::time::SystemTime>,
+    version: Option<i32>,
+    hash: Option<u64>,
+    metadata: Arc<ComponentMetadata>,
+}
+
+pub(super) fn cached_component_metadata(
+    ctx: &IdeContext,
+    resolved: &Path,
+) -> Option<Arc<ComponentMetadata>> {
+    let cache = ctx.state.component_metadata_cache();
+    let open = open_component(ctx, resolved);
+    let (content, len, modified, version, hash) = if let Some((content, len, version, hash)) = open
+    {
+        (content, len, None, Some(version), Some(hash))
+    } else {
+        let metadata = std::fs::metadata(resolved).ok()?;
+        (
+            std::fs::read_to_string(resolved).ok()?,
+            metadata.len(),
+            metadata.modified().ok(),
+            None,
+            None,
+        )
+    };
+
+    if let Some(entry) = cache.get(resolved)
+        && entry.len == len
+        && entry.modified == modified
+        && entry.version == version
+        && entry.hash == hash
+    {
+        return Some(entry.metadata.clone());
+    }
+
+    let metadata = Arc::new(extract_component_metadata(
+        &content,
+        &resolved.to_string_lossy(),
+        ctx.state.options_api_enabled(),
+        ctx.state.legacy_vue2_enabled(),
+    ));
+    cache.insert(
+        resolved.to_path_buf(),
+        CachedComponentMetadata {
+            len,
+            modified,
+            version,
+            hash,
+            metadata: metadata.clone(),
+        },
+    );
+    Some(metadata)
+}
+
+fn open_component(ctx: &IdeContext<'_>, resolved: &Path) -> Option<(String, u64, i32, u64)> {
+    if let Ok(uri) = tower_lsp::lsp_types::Url::from_file_path(resolved)
+        && let Some(document) = ctx.state.documents.get(&uri)
+    {
+        return Some(open_stamp(&document));
+    }
+
+    ctx.state.documents.iter().find_map(|document| {
+        let path = document.key().to_file_path().ok()?;
+        (std::fs::canonicalize(path).ok().as_deref() == Some(resolved))
+            .then(|| open_stamp(document.value()))
+    })
+}
+
+fn open_stamp(document: &crate::document::Document) -> (String, u64, i32, u64) {
+    let content = document.text();
+    let hash = vize_carton::hash::hash_str(&content);
+    (
+        content,
+        document.content.len_bytes() as u64,
+        document.version,
+        hash,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::disallowed_methods)]
+
+    use super::cached_component_metadata;
+    use crate::{ide::IdeContext, server::ServerState};
+    use std::sync::Arc;
+    use tower_lsp::lsp_types::Url;
+
+    #[test]
+    fn disk_metadata_cache_hits_then_invalidates_on_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let component = dir.path().join("Widget.vue");
+        std::fs::write(
+            &component,
+            "<script setup lang=\"ts\">defineProps<{ a: string }>()</script>",
+        )
+        .unwrap();
+        let state = ServerState::new();
+        let uri = Url::parse("file:///host.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            "<template />".to_string(),
+            1,
+            "vue".to_string(),
+        );
+        let ctx = IdeContext::new(&state, &uri, 0).unwrap();
+
+        let first = cached_component_metadata(&ctx, &component).unwrap();
+        let second = cached_component_metadata(&ctx, &component).unwrap();
+        assert_eq!(first.props[0].type_detail.as_deref(), Some("string"));
+        assert!(first.props[0].required);
+        assert!(Arc::ptr_eq(&first, &second));
+
+        std::fs::write(
+            &component,
+            "<script setup lang=\"ts\">defineProps<{ a: string; bb: number }>()</script>",
+        )
+        .unwrap();
+        let third = cached_component_metadata(&ctx, &component).unwrap();
+        assert!(!Arc::ptr_eq(&first, &third));
+        assert!(third.props.len() > first.props.len());
+    }
+}

--- a/crates/vize_maestro/src/ide/completion/template/component_meta.rs
+++ b/crates/vize_maestro/src/ide/completion/template/component_meta.rs
@@ -12,6 +12,7 @@ use vize_relief::BindingType;
 use crate::ide::definition::helpers as definition_helpers;
 use crate::ide::{IdeContext, is_component_tag, kebab_to_pascal, pascal_to_kebab};
 
+use super::component_cache::cached_component_metadata;
 use super::component_docs;
 use super::tag_context::{
     is_dynamic_prop_prefix, is_prop_completion_prefix, is_slot_completion_prefix,
@@ -69,15 +70,6 @@ pub(crate) struct ComponentMetadata {
     slots: Vec<ComponentSlot>,
 }
 
-/// Cached metadata for an imported component, keyed by resolved path.
-/// `len` + `modified` invalidate the entry when the file changes on disk.
-#[derive(Clone)]
-pub(crate) struct CachedComponentMetadata {
-    pub len: u64,
-    pub modified: Option<std::time::SystemTime>,
-    pub metadata: Arc<ComponentMetadata>,
-}
-
 #[derive(Debug, Clone)]
 pub(crate) struct ComponentProp {
     pub(crate) name: String,
@@ -123,41 +115,6 @@ pub(crate) fn component_metadata(
     None
 }
 
-/// Return parsed metadata, reusing it while length + mtime stay unchanged.
-pub(super) fn cached_component_metadata(
-    ctx: &IdeContext,
-    resolved: &std::path::Path,
-) -> Option<Arc<ComponentMetadata>> {
-    let cache = ctx.state.component_metadata_cache();
-    let (len, modified) = std::fs::metadata(resolved)
-        .map(|meta| (meta.len(), meta.modified().ok()))
-        .unwrap_or((0, None));
-
-    if let Some(entry) = cache.get(resolved)
-        && entry.len == len
-        && entry.modified == modified
-    {
-        return Some(entry.metadata.clone());
-    }
-
-    let component_content = std::fs::read_to_string(resolved).ok()?;
-    let metadata = Arc::new(extract_component_metadata(
-        &component_content,
-        &resolved.to_string_lossy(),
-        ctx.state.options_api_enabled(),
-        ctx.state.legacy_vue2_enabled(),
-    ));
-    cache.insert(
-        resolved.to_path_buf(),
-        CachedComponentMetadata {
-            len,
-            modified,
-            metadata: metadata.clone(),
-        },
-    );
-    Some(metadata)
-}
-
 fn art_component_path(ctx: &IdeContext<'_>, component_name: &str) -> Option<String> {
     if !ctx.uri.path().ends_with(".art.vue") {
         return None;
@@ -193,7 +150,7 @@ fn art_component_path(ctx: &IdeContext<'_>, component_name: &str) -> Option<Stri
     (component_name == stem || pascal_component == pascal_stem).then(|| component_path.to_string())
 }
 
-fn extract_component_metadata(
+pub(super) fn extract_component_metadata(
     content: &str,
     filename: &str,
     options_api: bool,
@@ -499,69 +456,5 @@ mod slot_prop_name_tests {
     #[test]
     fn returns_none_for_non_object_slot_props() {
         assert_eq!(extract_slot_prop_names("Props"), None);
-    }
-}
-
-#[cfg(test)]
-mod cache_tests {
-    use super::cached_component_metadata;
-    use crate::ide::IdeContext;
-    use crate::server::ServerState;
-    use tower_lsp::lsp_types::Url;
-
-    #[test]
-    fn component_metadata_cache_hits_then_invalidates_on_change() {
-        let dir = tempfile::tempdir().unwrap();
-        let component = dir.path().join("Widget.vue");
-        std::fs::write(
-            &component,
-            "<script setup lang=\"ts\">\nconst props = defineProps<{ a: string }>()\n</script>\n",
-        )
-        .unwrap();
-
-        let state = ServerState::new();
-        let uri = Url::parse("file:///host.vue").unwrap();
-        state.documents.open(
-            uri.clone(),
-            "<template></template>".to_string(),
-            1,
-            "vue".to_string(),
-        );
-        let ctx = IdeContext::new(&state, &uri, 0).unwrap();
-
-        let first = cached_component_metadata(&ctx, &component).unwrap();
-        let second = cached_component_metadata(&ctx, &component).unwrap();
-        let prop = first
-            .props
-            .iter()
-            .find(|prop| prop.name == "a")
-            .expect("defineProps type member should be extracted");
-        assert_eq!(prop.type_detail.as_deref(), Some("string"));
-        assert!(prop.required);
-        assert!(
-            std::sync::Arc::ptr_eq(&first, &second),
-            "an unchanged component file should hit the cache (same Arc, no re-parse)",
-        );
-        let first_prop_count = first.props.len();
-
-        // Rewrite with a different length so the file stamp changes; the next
-        // lookup must recompute rather than serve the stale cached parse.
-        std::fs::write(
-            &component,
-            "<script setup lang=\"ts\">\nconst props = defineProps<{ a: string; bb: number }>()\n</script>\n",
-        )
-        .unwrap();
-
-        let third = cached_component_metadata(&ctx, &component).unwrap();
-        assert!(
-            !std::sync::Arc::ptr_eq(&first, &third),
-            "a changed component file must invalidate the cached entry",
-        );
-        assert!(
-            third.props.len() > first_prop_count,
-            "recomputed metadata should reflect the added prop ({} -> {})",
-            first_prop_count,
-            third.props.len(),
-        );
     }
 }

--- a/crates/vize_maestro/src/ide/completion/template/self_component.rs
+++ b/crates/vize_maestro/src/ide/completion/template/self_component.rs
@@ -2,7 +2,8 @@
 
 use std::sync::Arc;
 
-use super::component_meta::{ComponentMetadata, cached_component_metadata};
+use super::component_cache::cached_component_metadata;
+use super::component_meta::ComponentMetadata;
 use crate::ide::IdeContext;
 
 pub(super) fn metadata(ctx: &IdeContext, component_name: &str) -> Option<Arc<ComponentMetadata>> {

--- a/tests/tooling/lsp-template-completion.test.ts
+++ b/tests/tooling/lsp-template-completion.test.ts
@@ -21,6 +21,10 @@ test("vize lsp surfaces template completion contexts", async (t) => {
 
   try {
     const childSource = `<script setup lang="ts">
+defineProps<{ diskOnly: string }>()
+</script>
+`;
+    const openChildSource = `<script setup lang="ts">
 defineProps<{ label: string; disabled?: boolean }>()
 </script>
 <template><button /></template>
@@ -111,6 +115,7 @@ const count = ref(0)
     });
 
     const parentUri = pathToFileURL(parentPath).href;
+    const childUri = pathToFileURL(path.join(workspaceDir, "Child.vue")).href;
     const ltUri = pathToFileURL(ltPath).href;
     const commentUri = pathToFileURL(commentPath).href;
     const styleUri = pathToFileURL(stylePath).href;
@@ -129,6 +134,7 @@ const count = ref(0)
       });
     };
 
+    openDocument(childUri, openChildSource);
     openDocument(parentUri, parentSource);
     openDocument(ltUri, ltSource);
     openDocument(commentUri, commentSource);
@@ -153,6 +159,7 @@ const count = ref(0)
         );
         assert.ok(labels.includes("label"), labels.join(", "));
         assert.ok(labels.includes("disabled"), labels.join(", "));
+        assert.ok(!labels.includes("disk-only"), labels.join(", "));
         assert.ok(labels.includes("v-if"), labels.join(", "));
         assert.ok(labels.includes(":"), labels.join(", "));
         assert.ok(!labels.includes("Transition"), labels.join(", "));


### PR DESCRIPTION
## Summary

- prefer open Vue document buffers when extracting imported component metadata
- cache open buffers by document version and content hash while retaining length/mtime caching for closed files
- split cache ownership out of the component metadata extractor
- cover unsaved changes, repeated changes, reopen collisions, and the real LSP completion flow

## Validation

- `cargo test -p vize_maestro component_prop_completion --lib`
- `cargo test -p vize_maestro disk_metadata_cache_hits_then_invalidates_on_change --lib`
- `cargo build -p vize`
- `cargo clippy -p vize_maestro --lib -- -D warnings`
- `node --test tests/tooling/lsp-template-completion.test.ts`

Closes #2906
Parent review: #2836

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786472651&installation_id=136613492&pr_number=2908&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2908&signature=9e18245e840e248dd71d8b67f2f0c6cabef982a80ea75bea99aaf0c65faf4be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue component prop completion so suggested props always reflect the currently opened child document, including unsaved (virtual) changes.
  * Enhanced component metadata caching to invalidate and refresh suggestions when component content changes.

* **Tests**
  * Added/updated a Vue completion test to confirm completions include newly provided props (`label`, `disabled`) and exclude `disk-only` across open → update → close → reopen cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->