### PR TITLE
fix(vscode): preserve generated Vue import types

### DIFF
--- a/editors/vscode/typescript-vue-plugin/index.cjs
+++ b/editors/vscode/typescript-vue-plugin/index.cjs
@@ -1,6 +1,7 @@
 "use strict";
 
 const path = require("node:path");
+const { installVueVirtualModules } = require("./virtual-modules.cjs");
 
 const vueExtension = ".vue";
 
@@ -36,6 +37,8 @@ function createVueImportSupport(ts, info) {
   if (!originalFileExists || !originalReadFile) {
     return undefined;
   }
+
+  installVueVirtualModules(ts, info);
 
   return {
     fileExists: originalFileExists,

--- a/editors/vscode/typescript-vue-plugin/virtual-modules.cjs
+++ b/editors/vscode/typescript-vue-plugin/virtual-modules.cjs
@@ -1,0 +1,234 @@
+"use strict";
+
+const crypto = require("node:crypto");
+const { createRequire } = require("node:module");
+const path = require("node:path");
+
+const installedHosts = new WeakMap();
+const nativePackage = "@vizejs/native";
+const nativeAnchors = [
+  "@vizejs/vite-plugin",
+  "@vizejs/unplugin",
+  "@vizejs/rspack-plugin",
+  "@vizejs/vite-plugin-musea",
+  "vize",
+];
+
+function installVueVirtualModules(ts, info) {
+  const host = info.languageServiceHost;
+  if (!host) return false;
+
+  const installed = installedHosts.get(host);
+  if (installed !== undefined) return installed;
+
+  const projectRoot =
+    safeCall(() => info.project?.getCurrentDirectory?.()) ||
+    safeCall(() => host.getCurrentDirectory?.());
+  const native = loadNative(projectRoot);
+  if (!native) {
+    installedHosts.set(host, false);
+    return false;
+  }
+
+  const serverHost = info.serverHost || ts.sys;
+  const fileExists = bind(host.fileExists, host) || bind(serverHost.fileExists, serverHost);
+  const readFile = bind(host.readFile, host) || bind(serverHost.readFile, serverHost);
+  const getSnapshot = bind(host.getScriptSnapshot, host);
+  const getScriptKind = bind(host.getScriptKind, host);
+  const getScriptVersion = bind(host.getScriptVersion, host);
+  const resolveLiterals = bind(host.resolveModuleNameLiterals, host);
+  const resolveNames = bind(host.resolveModuleNames, host);
+  if (!fileExists || !readFile || !getSnapshot) {
+    installedHosts.set(host, false);
+    return false;
+  }
+
+  const snapshots = new Map();
+  const replacements = {
+    getScriptKind(fileName) {
+      return isVuePath(fileName)
+        ? ts.ScriptKind.TS
+        : (getScriptKind?.(fileName) ?? ts.ScriptKind.Unknown);
+    },
+    getScriptSnapshot(fileName) {
+      if (!isVuePath(fileName)) return getSnapshot(fileName);
+      const source = readSnapshotText(getSnapshot(fileName)) ?? readFile(fileName);
+      if (typeof source !== "string") return undefined;
+
+      const cached = snapshots.get(fileName);
+      if (cached?.source === source) return cached.snapshot;
+
+      try {
+        const result = native.typeCheck(source, {
+          filename: fileName,
+          includeVirtualTs: true,
+        });
+        if (typeof result?.virtualTs !== "string" || result.virtualTs.length === 0) {
+          throw new Error("native typeCheck returned no virtual TypeScript");
+        }
+        const snapshot = ts.ScriptSnapshot.fromString(result.virtualTs);
+        snapshots.set(fileName, { snapshot, source });
+        return snapshot;
+      } catch (error) {
+        logPluginError(info, "generate virtual module", error);
+        const snapshot = ts.ScriptSnapshot.fromString(fallbackVirtualModule());
+        snapshots.set(fileName, { snapshot, source });
+        return snapshot;
+      }
+    },
+    getScriptVersion(fileName) {
+      if (!isVuePath(fileName)) return getScriptVersion?.(fileName) ?? "0";
+      const snapshot = getSnapshot(fileName);
+      const source = readSnapshotText(snapshot) ?? readFile(fileName) ?? "";
+      return crypto.createHash("sha1").update(source).digest("base64url");
+    },
+    resolveModuleNameLiterals(...args) {
+      const [literals, containingFile] = args;
+      const previous = toArray(resolveLiterals?.(...args));
+      if (!Array.isArray(literals)) return previous;
+      return literals.map((literal, index) => {
+        if (previous[index]?.resolvedModule) return previous[index];
+        const resolvedModule = resolveVueModule(ts, literal?.text, containingFile, fileExists);
+        return resolvedModule
+          ? { resolvedModule }
+          : previous[index] || { resolvedModule: undefined };
+      });
+    },
+    resolveModuleNames(...args) {
+      const [names, containingFile] = args;
+      const previous = toArray(resolveNames?.(...args));
+      if (!Array.isArray(names)) return previous;
+      return names.map(
+        (name, index) => previous[index] || resolveVueModule(ts, name, containingFile, fileExists),
+      );
+    },
+  };
+
+  if (!installAtomically(host, replacements)) {
+    installedHosts.set(host, false);
+    return false;
+  }
+  installedHosts.set(host, true);
+  return true;
+}
+
+function loadNative(projectRoot) {
+  if (typeof projectRoot !== "string") return undefined;
+  const direct = tryRequire(require, nativePackage, projectRoot);
+  if (direct) return direct;
+
+  for (const anchor of nativeAnchors) {
+    try {
+      const anchorPath = require.resolve(anchor, { paths: [projectRoot] });
+      const native = tryRequire(createRequire(anchorPath), nativePackage);
+      if (native) return native;
+    } catch {
+      // Try the next package that carries the matching native binding.
+    }
+  }
+  return undefined;
+}
+
+function tryRequire(loader, specifier, searchRoot) {
+  try {
+    const resolved = searchRoot
+      ? require.resolve(specifier, { paths: [searchRoot] })
+      : loader.resolve(specifier);
+    const loaded = loader(resolved);
+    return typeof loaded?.typeCheck === "function" ? loaded : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveVueModule(ts, specifier, containingFile, fileExists) {
+  if (!isRelativeVueSpecifier(specifier) || typeof containingFile !== "string") return undefined;
+  const vuePath = path.resolve(path.dirname(containingFile), specifier);
+  if (!fileExists(vuePath)) return undefined;
+  return {
+    extension: ts.Extension.Ts,
+    isExternalLibraryImport: false,
+    resolvedFileName: vuePath,
+  };
+}
+
+function installAtomically(host, replacements) {
+  const entries = Object.entries(replacements);
+  if (!entries.every(([name]) => canAssignProperty(host, name))) return false;
+  const originals = new Map(
+    entries.map(([name]) => [name, { own: Object.hasOwn(host, name), value: host[name] }]),
+  );
+  try {
+    for (const [name, replacement] of entries) host[name] = replacement;
+    return true;
+  } catch {
+    for (const [name, original] of originals) {
+      try {
+        if (original.own) host[name] = original.value;
+        else delete host[name];
+      } catch {
+        // Best-effort rollback; the caller retains the unmodified language service.
+      }
+    }
+    return false;
+  }
+}
+
+function canAssignProperty(target, key) {
+  let current = target;
+  while (current) {
+    const descriptor = Object.getOwnPropertyDescriptor(current, key);
+    if (descriptor) {
+      return "writable" in descriptor ? descriptor.writable : typeof descriptor.set === "function";
+    }
+    current = Object.getPrototypeOf(current);
+  }
+  return Object.isExtensible(target);
+}
+
+function isRelativeVueSpecifier(specifier) {
+  return (
+    typeof specifier === "string" &&
+    isVuePath(specifier) &&
+    (specifier.startsWith("./") || specifier.startsWith("../"))
+  );
+}
+
+function isVuePath(fileName) {
+  return typeof fileName === "string" && fileName.toLowerCase().endsWith(".vue");
+}
+
+function readSnapshotText(snapshot) {
+  return snapshot ? snapshot.getText(0, snapshot.getLength()) : undefined;
+}
+
+function fallbackVirtualModule() {
+  return "declare const component: import('vue').DefineComponent<Record<string, unknown>>;\nexport default component;\n";
+}
+
+function logPluginError(info, phase, error) {
+  try {
+    const message = error instanceof Error ? error.message : String(error);
+    info?.project?.projectService?.logger?.info?.(`[vize] ${phase} failed: ${message}`);
+  } catch {
+    // Logging must never terminate tsserver.
+  }
+}
+
+function bind(fn, thisArg) {
+  return typeof fn === "function" ? fn.bind(thisArg) : undefined;
+}
+
+function safeCall(fn) {
+  try {
+    return fn();
+  } catch {
+    return undefined;
+  }
+}
+
+function toArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+module.exports = { installVueVirtualModules };

--- a/editors/vscode/typescript-vue-plugin/virtual-modules.cjs
+++ b/editors/vscode/typescript-vue-plugin/virtual-modules.cjs
@@ -57,6 +57,7 @@ function installVueVirtualModules(ts, info) {
 
       const cached = snapshots.get(fileName);
       if (cached?.source === source) return cached.snapshot;
+      const version = sourceVersion(source);
 
       try {
         const result = native.typeCheck(source, {
@@ -67,12 +68,12 @@ function installVueVirtualModules(ts, info) {
           throw new Error("native typeCheck returned no virtual TypeScript");
         }
         const snapshot = ts.ScriptSnapshot.fromString(result.virtualTs);
-        snapshots.set(fileName, { snapshot, source });
+        snapshots.set(fileName, { snapshot, source, version });
         return snapshot;
       } catch (error) {
         logPluginError(info, "generate virtual module", error);
         const snapshot = ts.ScriptSnapshot.fromString(fallbackVirtualModule());
-        snapshots.set(fileName, { snapshot, source });
+        snapshots.set(fileName, { snapshot, source, version });
         return snapshot;
       }
     },
@@ -80,7 +81,8 @@ function installVueVirtualModules(ts, info) {
       if (!isVuePath(fileName)) return getScriptVersion?.(fileName) ?? "0";
       const snapshot = getSnapshot(fileName);
       const source = readSnapshotText(snapshot) ?? readFile(fileName) ?? "";
-      return crypto.createHash("sha1").update(source).digest("base64url");
+      const cached = snapshots.get(fileName);
+      return cached?.source === source ? cached.version : sourceVersion(source);
     },
     resolveModuleNameLiterals(...args) {
       const [literals, containingFile] = args;
@@ -197,6 +199,10 @@ function isVuePath(fileName) {
 
 function readSnapshotText(snapshot) {
   return snapshot ? snapshot.getText(0, snapshot.getLength()) : undefined;
+}
+
+function sourceVersion(source) {
+  return crypto.createHash("sha1").update(source).digest("base64url");
 }
 
 function fallbackVirtualModule() {

--- a/editors/vscode/typescript-vue-plugin/virtual-modules.cjs
+++ b/editors/vscode/typescript-vue-plugin/virtual-modules.cjs
@@ -114,9 +114,6 @@ function installVueVirtualModules(ts, info) {
 
 function loadNative(projectRoot) {
   if (typeof projectRoot !== "string") return undefined;
-  const direct = tryRequire(require, nativePackage, projectRoot);
-  if (direct) return direct;
-
   for (const anchor of nativeAnchors) {
     try {
       const anchorPath = require.resolve(anchor, { paths: [projectRoot] });
@@ -126,7 +123,7 @@ function loadNative(projectRoot) {
       // Try the next package that carries the matching native binding.
     }
   }
-  return undefined;
+  return tryRequire(require, nativePackage, projectRoot);
 }
 
 function tryRequire(loader, specifier, searchRoot) {

--- a/tests/tooling/vscode-typescript-vue-plugin-types.test.ts
+++ b/tests/tooling/vscode-typescript-vue-plugin-types.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const require = createRequire(import.meta.url);
+const ts = require(
+  require.resolve("typescript", {
+    paths: [path.join(root, "editors/vscode"), path.join(root, "tests")],
+  }),
+) as typeof import("typescript");
+const initVuePlugin = require(
+  path.join(root, "editors/vscode/typescript-vue-plugin/index.cjs"),
+) as (modules: { typescript: typeof ts }) => {
+  create(info: {
+    languageService: import("typescript").LanguageService;
+    languageServiceHost: import("typescript").LanguageServiceHost;
+    project: { getCurrentDirectory(): string };
+    serverHost: typeof ts.sys;
+  }): import("typescript").LanguageService;
+};
+
+test("TypeScript Vue plugin exposes generated SFC component types", () => {
+  const project = createProject();
+  try {
+    const { bumpProjectVersion, host } = createHost(project.root, [
+      project.mainTs,
+      project.ambientDts,
+    ]);
+    const service = initVuePlugin({ typescript: ts }).create({
+      languageService: ts.createLanguageService(host),
+      languageServiceHost: host,
+      project: { getCurrentDirectory: () => project.root },
+      serverHost: ts.sys,
+    });
+    const source = fs.readFileSync(project.mainTs, "utf8");
+    const quickInfo = service.getQuickInfoAtPosition(
+      project.mainTs,
+      source.indexOf("App from") + 1,
+    );
+
+    assert.match(displayPartsText(quickInfo?.displayParts), /title: string/);
+    assert.match(
+      formatDiagnostics(service.getSemanticDiagnostics(project.mainTs)),
+      /Property 'title' is missing/,
+    );
+
+    fs.writeFileSync(
+      project.appVue,
+      '<script setup lang="ts">\ndefineProps<{ count: number }>();\n</script>\n',
+    );
+    bumpProjectVersion();
+
+    const refreshedInfo = service.getQuickInfoAtPosition(
+      project.mainTs,
+      source.indexOf("App from") + 1,
+    );
+    assert.match(displayPartsText(refreshedInfo?.displayParts), /count: number/);
+    assert.doesNotMatch(displayPartsText(refreshedInfo?.displayParts), /title: string/);
+    assert.equal(fs.readFileSync(project.nativeCalls, "utf8"), "11");
+  } finally {
+    fs.rmSync(project.root, { force: true, recursive: true });
+  }
+});
+
+function createProject() {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-vue-import-types-"));
+  const srcDir = path.join(rootDir, "src");
+  fs.mkdirSync(srcDir, { recursive: true });
+
+  const mainTs = path.join(srcDir, "main.ts");
+  fs.writeFileSync(
+    mainTs,
+    [
+      'import App from "./App.vue";',
+      'const props: InstanceType<typeof App>["$props"] = {};',
+      "props;",
+      "",
+    ].join("\n"),
+  );
+  const appVue = path.join(srcDir, "App.vue");
+  fs.writeFileSync(
+    appVue,
+    '<script setup lang="ts">\ndefineProps<{ title: string; count?: number }>();\n</script>\n',
+  );
+
+  const ambientDts = path.join(srcDir, "vite-client.d.ts");
+  fs.writeFileSync(
+    ambientDts,
+    'declare module "*.vue" {\n  const component: new () => { $props: {} };\n  export default component;\n}\n',
+  );
+
+  const vitePluginDir = path.join(rootDir, "node_modules/@vizejs/vite-plugin");
+  fs.mkdirSync(vitePluginDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(vitePluginDir, "package.json"),
+    JSON.stringify({ main: "index.cjs", name: "@vizejs/vite-plugin", version: "0.0.0" }),
+  );
+  fs.writeFileSync(path.join(vitePluginDir, "index.cjs"), '"use strict";\n');
+
+  const nativeDir = path.join(vitePluginDir, "node_modules/@vizejs/native");
+  fs.mkdirSync(nativeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(nativeDir, "package.json"),
+    JSON.stringify({ main: "index.cjs", name: "@vizejs/native", version: "0.0.0" }),
+  );
+  const nativeCalls = path.join(nativeDir, "calls.txt");
+  fs.writeFileSync(nativeCalls, "");
+  fs.writeFileSync(
+    path.join(nativeDir, "index.cjs"),
+    [
+      '"use strict";',
+      'const fs = require("node:fs");',
+      'const path = require("node:path");',
+      "exports.typeCheck = (source) => {",
+      '  fs.appendFileSync(path.join(__dirname, "calls.txt"), "1");',
+      "  const props = source.match(/defineProps<([\\s\\S]*?)>\\s*\\(\\s*\\)/)?.[1] || '{}';",
+      "  return { virtualTs: `declare const component: new () => { $props: ${props} };\\nexport default component;\\n` };",
+      "};",
+      "",
+    ].join("\n"),
+  );
+
+  return { ambientDts, appVue, mainTs, nativeCalls, root: rootDir };
+}
+
+function createHost(rootDir: string, rootFiles: string[]) {
+  const options: import("typescript").CompilerOptions = {
+    allowSyntheticDefaultImports: true,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2022,
+  };
+
+  let projectVersion = 0;
+  const host: import("typescript").LanguageServiceHost = {
+    directoryExists: (directoryName) => ts.sys.directoryExists(directoryName),
+    fileExists: (fileName) => ts.sys.fileExists(fileName),
+    getCompilationSettings: () => options,
+    getCurrentDirectory: () => rootDir,
+    getDefaultLibFileName: (compilerOptions) => ts.getDefaultLibFilePath(compilerOptions),
+    getDirectories: (directoryName) => ts.sys.getDirectories(directoryName),
+    getProjectVersion: () => String(projectVersion),
+    getScriptFileNames: () => rootFiles,
+    getScriptSnapshot(fileName) {
+      const source = ts.sys.readFile(fileName);
+      return source === undefined ? undefined : ts.ScriptSnapshot.fromString(source);
+    },
+    getScriptVersion: () => "0",
+    readDirectory: (rootDir, extensions, excludes, includes, depth) =>
+      ts.sys.readDirectory(rootDir, extensions, excludes, includes, depth),
+    readFile: (fileName, encoding) => ts.sys.readFile(fileName, encoding),
+    useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
+  };
+  return { bumpProjectVersion: () => projectVersion++, host };
+}
+
+function displayPartsText(parts: readonly import("typescript").SymbolDisplayPart[] | undefined) {
+  return parts?.map((part) => part.text).join("") ?? "";
+}
+
+function formatDiagnostics(diagnostics: readonly import("typescript").Diagnostic[]) {
+  return diagnostics
+    .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))
+    .join("\n");
+}

--- a/tests/tooling/vscode-typescript-vue-plugin-types.test.ts
+++ b/tests/tooling/vscode-typescript-vue-plugin-types.test.ts
@@ -61,7 +61,11 @@ test("TypeScript Vue plugin exposes generated SFC component types", () => {
     );
     assert.match(displayPartsText(refreshedInfo?.displayParts), /count: number/);
     assert.doesNotMatch(displayPartsText(refreshedInfo?.displayParts), /title: string/);
-    assert.equal(fs.readFileSync(project.nativeCalls, "utf8"), "11");
+    assert.equal(
+      Number(fs.readFileSync(project.nativeCalls, "utf8")),
+      2,
+      "expected one native generation per distinct SFC source",
+    );
   } finally {
     fs.rmSync(project.root, { force: true, recursive: true });
   }
@@ -109,7 +113,7 @@ function createProject() {
     JSON.stringify({ main: "index.cjs", name: "@vizejs/native", version: "0.0.0" }),
   );
   const nativeCalls = path.join(nativeDir, "calls.txt");
-  fs.writeFileSync(nativeCalls, "");
+  fs.writeFileSync(nativeCalls, "0");
   fs.writeFileSync(
     path.join(nativeDir, "index.cjs"),
     [
@@ -117,7 +121,9 @@ function createProject() {
       'const fs = require("node:fs");',
       'const path = require("node:path");',
       "exports.typeCheck = (source) => {",
-      '  fs.appendFileSync(path.join(__dirname, "calls.txt"), "1");',
+      '  const callsFile = path.join(__dirname, "calls.txt");',
+      '  const calls = Number(fs.readFileSync(callsFile, "utf8")) + 1;',
+      "  fs.writeFileSync(callsFile, String(calls));",
       "  const props = source.match(/defineProps<([\\s\\S]*?)>\\s*\\(\\s*\\)/)?.[1] || '{}';",
       "  return { virtualTs: `declare const component: new () => { $props: ${props} };\\nexport default component;\\n` };",
       "};",

--- a/tests/tooling/vscode-typescript-vue-plugin-types.test.ts
+++ b/tests/tooling/vscode-typescript-vue-plugin-types.test.ts
@@ -48,6 +48,11 @@ test("TypeScript Vue plugin exposes generated SFC component types", () => {
       formatDiagnostics(service.getSemanticDiagnostics(project.mainTs)),
       /Property 'title' is missing/,
     );
+    assert.equal(
+      nativeGenerationCount(project.nativeCalls),
+      1,
+      "expected one native generation across the initial queries",
+    );
 
     fs.writeFileSync(
       project.appVue,
@@ -62,9 +67,9 @@ test("TypeScript Vue plugin exposes generated SFC component types", () => {
     assert.match(displayPartsText(refreshedInfo?.displayParts), /count: number/);
     assert.doesNotMatch(displayPartsText(refreshedInfo?.displayParts), /title: string/);
     assert.equal(
-      Number(fs.readFileSync(project.nativeCalls, "utf8")),
+      nativeGenerationCount(project.nativeCalls),
       2,
-      "expected one native generation per distinct SFC source",
+      "expected one additional native generation after the SFC edit",
     );
   } finally {
     fs.rmSync(project.root, { force: true, recursive: true });
@@ -169,6 +174,10 @@ function createHost(rootDir: string, rootFiles: string[]) {
 
 function displayPartsText(parts: readonly import("typescript").SymbolDisplayPart[] | undefined) {
   return parts?.map((part) => part.text).join("") ?? "";
+}
+
+function nativeGenerationCount(callsFile: string) {
+  return Number(fs.readFileSync(callsFile, "utf8"));
 }
 
 function formatDiagnostics(diagnostics: readonly import("typescript").Diagnostic[]) {

--- a/tools/vscode-vize/sync-typescript-plugin.mjs
+++ b/tools/vscode-vize/sync-typescript-plugin.mjs
@@ -9,7 +9,7 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
 const extensionDir = path.join(root, "editors/vscode");
 const sourceDir = path.join(extensionDir, "typescript-vue-plugin");
 const packagePath = "node_modules/@vizejs/typescript-vue-plugin";
-const pluginFiles = ["index.cjs", "package.json"];
+const pluginFiles = ["index.cjs", "package.json", "virtual-modules.cjs"];
 
 const command = process.argv[2];
 

--- a/tools/vscode-vize/typescript-vue-plugin-vsix-policy.mjs
+++ b/tools/vscode-vize/typescript-vue-plugin-vsix-policy.mjs
@@ -6,13 +6,14 @@ const entryRoot = `extension/node_modules/${packageName}`;
 export const typescriptVuePluginRequiredFiles = [
   `${entryRoot}/index.cjs`,
   `${entryRoot}/package.json`,
+  `${entryRoot}/virtual-modules.cjs`,
 ];
 
 export const typescriptVuePluginAllowedEntry =
-  /^extension\/node_modules\/@vizejs\/typescript-vue-plugin\/(?:index\.cjs|package\.json)$/;
+  /^extension\/node_modules\/@vizejs\/typescript-vue-plugin\/(?:index\.cjs|package\.json|virtual-modules\.cjs)$/;
 
 export const forbiddenNonPluginNodeModules =
-  /^extension\/node_modules\/(?!@vizejs\/typescript-vue-plugin\/(?:index\.cjs|package\.json)$)/;
+  /^extension\/node_modules\/(?!@vizejs\/typescript-vue-plugin\/(?:index\.cjs|package\.json|virtual-modules\.cjs)$)/;
 
 export function assertTypeScriptVuePluginPackage({ packageJson, readJsonEntry, readTextEntry }) {
   assert.deepEqual(packageJson.contributes?.typescriptServerPlugins, [
@@ -26,4 +27,8 @@ export function assertTypeScriptVuePluginPackage({ packageJson, readJsonEntry, r
   assert.equal(pluginPackage.name, packageName);
   assert.equal(pluginPackage.main, "index.cjs");
   assert.match(readTextEntry(`${entryRoot}/index.cjs`), /function init\(\{ typescript: ts \}\)/);
+  assert.match(
+    readTextEntry(`${entryRoot}/virtual-modules.cjs`),
+    /function installVueVirtualModules\(ts, info\)/,
+  );
 }


### PR DESCRIPTION
Closes #2909.

## What changed

- resolve existing relative `.vue` imports to typed virtual modules in the VS Code TypeScript plugin;
- reuse the matching `@vizejs/native` virtual-TypeScript generator already installed through Vize tooling;
- generate only when TypeScript requests an imported SFC, cache by source content, and invalidate after edits;
- preserve the crash-free navigation/diagnostic fallback when native generation or host patching is unavailable;
- include and verify the new runtime module in packaged VSIX artifacts.

## Why

The plugin previously suppressed TS2307 and supplied navigation, while the actual import type came from the ambient `*.vue` shim. Every component therefore collapsed to `DefineComponent<{}, {}, any>`, losing props, emits, slots, and exposed instance members.

The native generator is already the source of truth for Vize SFC types. Feeding its virtual TypeScript directly into TypeScript's module graph keeps editor types aligned without implementing a second SFC analyzer in JavaScript.

## Validation

- `node --test tests/tooling/vscode-typescript-vue-plugin.test.ts tests/tooling/vscode-typescript-vue-plugin-module-resolution.test.ts tests/tooling/vscode-typescript-vue-plugin-types.test.ts`
- `vp check editors/vscode/typescript-vue-plugin/index.cjs editors/vscode/typescript-vue-plugin/virtual-modules.cjs tests/tooling/vscode-typescript-vue-plugin-types.test.ts tools/vscode-vize/sync-typescript-plugin.mjs tools/vscode-vize/typescript-vue-plugin-vsix-policy.mjs`
- `vp run test:vscode-extension:vsix`

The focused regression verifies precise required-prop quick info and diagnostics, edit invalidation, and one native generation per distinct SFC source.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786475351&installation_id=136613492&pr_number=2910&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2910&signature=292c41df4bb57a545c9279e97dc0c523510b6f52f18f32aa8980c2524db2e0a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Vue + TypeScript support in the VS Code plugin by adding an extra virtual-module setup for better `.vue` integration.
  * Component prop types in editor tooling now refresh more reliably after Vue SFC edits.
* **Bug Fixes**
  * More resilient behavior when native Vue type-checking is unavailable, with safe fallback handling.
* **Tests**
  * Added an end-to-end test validating Vue prop type inference and that edits trigger updated quick-info/diagnostics (including native call verification).
* **Chores**
  * Updated VSIX packaging and policy checks to include the new plugin runtime file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->