### PR TITLE
fix(vite-plugin): support Vite 7 parser imports

### DIFF
--- a/npm/builder/vite/package.json
+++ b/npm/builder/vite/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@vizejs/native": "workspace:*",
+    "oxc-parser": "catalog:oxc",
     "tinyglobby": "catalog:repo-tooling",
     "vize": "workspace:*"
   },

--- a/npm/builder/vite/src/utils/module-output.ts
+++ b/npm/builder/vite/src/utils/module-output.ts
@@ -1,4 +1,4 @@
-import { parseSync } from "vite";
+import { parseSync } from "oxc-parser";
 
 const OUTPUT_PARSE_ID = "vize-output.tsx";
 const SFC_MAIN_NAME = "_sfc_main";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -718,6 +718,9 @@ importers:
       '@vizejs/native':
         specifier: workspace:*
         version: link:../../native
+      oxc-parser:
+        specifier: catalog:oxc
+        version: 0.133.0
       tinyglobby:
         specifier: catalog:repo-tooling
         version: 0.2.16

--- a/tests/tooling/bundler-plugin-manifests.test.ts
+++ b/tests/tooling/bundler-plugin-manifests.test.ts
@@ -14,6 +14,7 @@ interface ExportEntry {
 }
 
 interface BundlerPluginManifest {
+  dependencies?: Record<string, string>;
   engines?: Record<string, string>;
   exports?: Record<string, ExportEntry | string>;
   name?: string;
@@ -134,6 +135,18 @@ test("Vite integrations accept Nuxt 3.19's Vite 7.3 range and Vite 8", () => {
     vitePin.startsWith("npm:@voidzero-dev/vite-plus-core@"),
     `vite catalog pin should alias the VoidZero proxy, got ${vitePin}`,
   );
+});
+
+test("@vizejs/vite-plugin does not import Vite 8-only parser APIs", () => {
+  const manifest = readManifest("builder/vite");
+  const moduleOutput = fs.readFileSync(
+    path.join(root, "npm/builder/vite/src/utils/module-output.ts"),
+    "utf-8",
+  );
+
+  assert.equal(manifest.dependencies?.["oxc-parser"], "catalog:oxc");
+  assert.match(moduleOutput, /import \{ parseSync \} from "oxc-parser";/);
+  assert.doesNotMatch(moduleOutput, /from ["']vite["']/);
 });
 
 test("all three bundler-plugin packages require Node >= 22", () => {


### PR DESCRIPTION
## Summary

- import `parseSync` from the package-owned `oxc-parser` dependency
- keep the declared Vite 7.3 and Vite 8 peer range
- add an executable manifest/source contract that rejects Vite-only parser imports

## Root cause

`@vizejs/vite-plugin` statically imported `parseSync` from `vite`. That export exists in Vite 8 but not Vite 7, so Vite 7 failed while loading the plugin before configuration could run.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --dir npm/builder/vite run check`
- `corepack pnpm --dir npm/builder/vite run build`
- `corepack pnpm --dir npm/builder/vite run test` (23/23 passing)
- `node --test tests/tooling/bundler-plugin-manifests.test.ts` (6/6 passing)
- `node --test tests/tooling/source-file-lengths.test.ts` (7/7 passing)

Fixes #2863.

Reported by @wattanx.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786511604&installation_id=136613492&pr_number=2911&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2911&signature=64a664c51ef92c13fad222935d52dcf9066ccf0884178e791af14b27dcb0df20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer Vite versions by using a dedicated parser for module output processing.
  * Added validation to prevent reliance on Vite-only parser APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->