### PR TITLE
fix(canon): preserve generic defaults in setup scope

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
@@ -99,3 +99,47 @@ mount(Child, {
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn preserves_generic_parameter_when_default_differs_from_constraint() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "issue-2811-generic-default-scope",
+        &[(
+            "src/Foo.vue",
+            r#"<script setup lang="ts" generic="T extends string | number = string">
+import { ref } from "vue";
+
+interface Props {
+  value?: T;
+}
+
+const props = defineProps<Props>();
+const state = ref(props.value);
+
+function setValue(value: T) {
+  state.value = value;
+}
+</script>
+
+<template>
+  <slot :set-value :state />
+</template>
+"#,
+        )],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.is_empty(),
+        "generic defaults must not replace T inside the SFC declaration: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -16,7 +16,7 @@ mod template_refs;
 use self::anchors::emit_setup_binding_anchors;
 use self::component_export::emit_default_export_declaration;
 use self::emits::{emit_emit_props_helper, emit_emits_type};
-use self::generics::{generic_injection_point, references_any_identifier};
+use self::generics::{HoistedGenericAliases, generic_injection_point, references_any_identifier};
 use self::imports::{
     collect_imported_names, emit_global_component_stubs, emit_reference_type_directives,
     extract_declared_name,
@@ -269,10 +269,6 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         merge_overlapping_spans(module_spans)
     });
 
-    // For a `<script setup generic="...">` SFC, hoisted type declarations are
-    // lifted verbatim to module scope, but the generic parameters only live on
-    // `__setup<...>()`. A lifted declaration that mentions a generic parameter
-    // (e.g. `type Option = { key: T }`) would reference an unbound name there.
     // Re-declare the SFC generics as defaulted parameters on each such
     // declaration (`type Option<T extends string = any> = ...`) so the
     // reference resolves at module scope while bare uses (`Option[]`) still
@@ -398,6 +394,9 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             }
         });
     }
+    let hoisted_generic_aliases =
+        HoistedGenericAliases::collect(summary, script_content, generic_param);
+    hoisted_generic_aliases.emit_module_aliases(&mut ts);
 
     let needs_imported_names = !options.auto_import_stubs.is_empty()
         || (has_script_reference_types && !summary.component_usages.is_empty());
@@ -471,6 +470,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     let async_prefix = if is_async { "async " } else { "" };
     let generic_params = generic_param.map(|g| cstr!("<{g}>")).unwrap_or_default();
     append!(ts, "{async_prefix}function __setup{generic_params}() {{\n",);
+    hoisted_generic_aliases.emit_setup_aliases(&mut ts);
 
     // Setup helpers (only valid inside setup scope)
     emit_setup_helpers(

--- a/crates/vize_canon/src/virtual_ts/generator/generics.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/generics.rs
@@ -1,7 +1,76 @@
 //! Helpers for splicing `<script setup generic="...">` type parameters into
 //! hoisted type/interface declarations lifted to module scope.
 
-use vize_carton::String;
+use vize_carton::{String, append};
+use vize_croquis::Croquis;
+
+use crate::virtual_ts::props::{
+    add_generic_defaults, extract_generic_names, strip_const_modifiers,
+};
+
+#[derive(Default)]
+pub(super) struct HoistedGenericAliases {
+    generic_decl: String,
+    generic_names: String,
+    type_names: Vec<String>,
+}
+
+impl HoistedGenericAliases {
+    pub(super) fn collect(
+        summary: &Croquis,
+        script: Option<&str>,
+        generic_param: Option<&str>,
+    ) -> Self {
+        let Some((script, generic_param)) = script.zip(generic_param) else {
+            return Self::default();
+        };
+        let generic_names = extract_generic_names(generic_param);
+        let names: Vec<String> = generic_names
+            .split(',')
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(String::from)
+            .collect();
+        let type_names = summary
+            .type_exports
+            .iter()
+            .filter(|export| export.hoisted)
+            .filter_map(|export| {
+                let source = &script[export.start as usize..export.end as usize];
+                (references_any_identifier(source, &names)
+                    && generic_injection_point(source, export.name.as_str()).is_some())
+                .then(|| String::from(export.name.as_str()))
+            })
+            .collect();
+
+        Self {
+            generic_decl: strip_const_modifiers(&add_generic_defaults(generic_param)),
+            generic_names,
+            type_names,
+        }
+    }
+
+    pub(super) fn emit_module_aliases(&self, ts: &mut String) {
+        for (index, type_name) in self.type_names.iter().enumerate() {
+            append!(
+                *ts,
+                "type __VizeHoistedGeneric{index}<{}> = {type_name}<{}>;\n",
+                self.generic_decl,
+                self.generic_names
+            );
+        }
+    }
+
+    pub(super) fn emit_setup_aliases(&self, ts: &mut String) {
+        for (index, type_name) in self.type_names.iter().enumerate() {
+            append!(
+                *ts,
+                "  type {type_name} = __VizeHoistedGeneric{index}<{}>;\n",
+                self.generic_names
+            );
+        }
+    }
+}
 
 pub(super) fn is_ident_byte(b: u8) -> bool {
     b == b'_' || b == b'$' || b.is_ascii_alphanumeric()


### PR DESCRIPTION
## Summary

- preserve the active SFC generic parameters when setup code references a hoisted local type without explicit arguments
- keep public component type defaults unchanged
- add the complete issue reproduction as a project-backed TypeScript diagnostic test

## Root cause

Generic-dependent setup types are lifted to module scope so they can participate in the exported component contract. A bare `Props` reference inside `__setup<T>()` then resolved through the lifted declaration's public default (`string`) instead of the active setup parameter (`T extends string | number`), producing a false TS2322.

The generated module now creates a synthetic generic bridge and shadows the lifted type inside setup with the active generic arguments.

## Validation

- regression test fails before the fix with the reported TS2322 and passes after it
- `cargo test -p vize_canon` (525/525 unit tests, all integration tests passing)
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `node --test tests/tooling/source-file-lengths.test.ts` (7/7 passing)

Fixes #2811.

Reported by @MickaelOth.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786512005&installation_id=136613492&pr_number=2912&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2912&signature=4077e1bbd2eff2162904609ae897744ca58aa1d259a8b049800c95f2e6a8c6fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript support for Vue generic declarations used in hoisted types and interfaces.
  * Preserved generic parameters when defaults differ from their constraints.
  * Prevented incorrect type substitutions that could cause erroneous type-checking diagnostics.

* **Tests**
  * Added regression coverage for generic props with constrained and defaulted type parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->