### PR TITLE
fix(canon): retain imported emits generics

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
@@ -241,3 +241,104 @@ const props = withDefaults(defineProps<Props>(), {
     );
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn imported_define_emits_type_marks_generic_parameter_as_used() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case(
+        "issue-2808-imported-generic-emits",
+        &[
+            (
+                "src/types.ts",
+                r#"export interface ExampleValue {
+  value: number;
+}
+
+export interface ExampleProps {
+  firstValue?: ExampleValue | ExampleValue[];
+  secondValue?: ExampleValue | ExampleValue[];
+  additionalNumberValue?: number;
+  disabled?: boolean;
+  reversed?: boolean;
+  mode?: "a" | "b" | "c";
+}
+
+export type ExampleEmits<
+  T extends ExampleValue | ExampleValue[] = ExampleValue | ExampleValue[]
+> = {
+  change: [value: T];
+};
+"#,
+            ),
+            (
+                "src/Example.vue",
+                r#"<script
+  setup
+  lang="ts"
+  generic="
+    T extends ExampleValue | ExampleValue[] = ExampleValue | ExampleValue[]
+  "
+>
+  import {
+    type ExampleEmits,
+    type ExampleProps,
+    type ExampleValue
+  } from "./types";
+
+  const props = withDefaults(defineProps<ExampleProps>(), {
+    firstValue: undefined,
+    secondValue: undefined,
+    additionalNumberValue: 0,
+    disabled: false,
+    reversed: false,
+    mode: "b"
+  });
+
+  const emit = defineEmits<ExampleEmits<T>>();
+  emit("change", props.firstValue as T);
+  // @ts-expect-error number is outside the ExampleEmits<T> payload constraint
+  emit("change", 1);
+</script>
+
+<template>
+  <slot :emit :props />
+</template>
+"#,
+            ),
+        ],
+    );
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "noUnusedParameters": true,
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.vue", "src/**/*.ts"]
+}"#,
+    )
+    .unwrap();
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.is_empty(),
+        "an imported defineEmits type argument must mark T as used: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -3,8 +3,8 @@ mod template_bindings;
 mod template_names;
 mod with_defaults;
 use super::helpers::{is_reserved_identifier, to_safe_identifier};
-use setup_scoped::props_type_ref;
 pub(crate) use setup_scoped::{PropsTypeEmission, generate_setup_scoped_props_artifact};
+use setup_scoped::{props_type_ref, unused_generic_comment};
 use template_bindings::{emit_macro_template_prop_bindings, should_skip_template_prop_binding};
 pub(crate) use template_names::collect_template_prop_names;
 use vize_carton::{FxHashSet, String, append, cstr};
@@ -231,7 +231,6 @@ pub(crate) fn generate_props_type(
         .any(|te| te.name.as_str() == "Props");
 
     // Build generic suffix for Props type declaration (with `= any` defaults).
-    // `const` modifiers are illegal on type-alias parameters (TS1277).
     let generic_decl = generic_param
         .map(|g| {
             let with_defaults = strip_const_modifiers(&add_generic_defaults(g));
@@ -249,6 +248,7 @@ pub(crate) fn generate_props_type(
             .strip_prefix('<')
             .and_then(|s| s.strip_suffix('>'))
             .unwrap_or(type_args.as_str());
+        ts.push_str(unused_generic_comment(generic_param, inner_type));
         // Always emit Props alias so it's available in template and default export.
         if has_models {
             append!(*ts, "export type Props{generic_decl} = {inner_type} & ");

--- a/crates/vize_canon/src/virtual_ts/props/setup_scoped.rs
+++ b/crates/vize_canon/src/virtual_ts/props/setup_scoped.rs
@@ -56,3 +56,45 @@ pub(super) fn props_type_ref(
                 .unwrap_or_else(|| "Props".into())
         })
 }
+
+pub(super) fn unused_generic_comment(
+    generic_param: Option<&str>,
+    props_source: &str,
+) -> &'static str {
+    let Some(generic) = generic_param else {
+        return "";
+    };
+    let names = extract_generic_names(generic);
+    let uses_generic = names
+        .split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .any(|name| {
+            props_source
+                .split(|ch: char| !(ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()))
+                .any(|token| token == name)
+        });
+    if uses_generic {
+        ""
+    } else {
+        "// @ts-ignore TS6196: SFC generic may be used by emits or slots.\n"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::unused_generic_comment;
+
+    #[test]
+    fn suppresses_only_props_aliases_that_omit_sfc_generics() {
+        assert_eq!(
+            unused_generic_comment(Some("T"), "ImportedProps"),
+            "// @ts-ignore TS6196: SFC generic may be used by emits or slots.\n"
+        );
+        assert_eq!(unused_generic_comment(Some("T"), "LocalProps<T>"), "");
+        assert_eq!(
+            unused_generic_comment(Some("T"), "SomeTTProps"),
+            "// @ts-ignore TS6196: SFC generic may be used by emits or slots.\n"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- suppress TS6196 on generated Props aliases only when an imported prop type omits every SFC generic parameter
- keep the public Props shape unchanged so generic Boolean and listener inference remain intact
- cover the reported imported defineEmits<ExampleEmits<T>> case with noUnusedParameters enabled

## Validation
- cargo fmt --all -- --check
- cargo test -p vize_canon (533 unit tests plus integration tests, with tsgo)
- cargo clippy -p vize_canon -- -D warnings
- cargo build --profile ci -p vize
- compiler-macros readiness snapshot update and clean rerun
- source:lengths --check --base-ref origin/main --max-lines 350

Closes #2808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue TypeScript type generation for components using generic props.
  * Prevents incorrect “unused parameter” diagnostics by conditionally adding a `// `@ts-ignore` TS6196` comment when an SFC generic isn’t used.
  * Ensures generics are treated as used when referenced indirectly via imported `defineEmits` types.
* **Tests**
  * Added snapshot coverage for generic parameter diagnostics in temporary Vue TypeScript projects.
  * Added unit tests for the new generic-usage comment helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->