### PR TITLE
fix(canon): resolve dynamic member component emits

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload.rs
@@ -1,5 +1,7 @@
 use super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
 
+mod dynamic_member_component_events;
+
 #[test]
 fn batch_type_checker_accepts_component_fallthrough_touch_listener() {
     if resolve_test_tsgo_binary().is_none() {

--- a/crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload/dynamic_member_component_events.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload/dynamic_member_component_events.rs
@@ -1,0 +1,58 @@
+use super::*;
+
+#[test]
+fn infers_dynamic_member_component_listener_payload() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "dynamic-member-component-listener-payload",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts">
+interface Payload {
+  value: string;
+}
+
+defineEmits<{
+  change: [payload: Payload];
+}>();
+</script>
+"#,
+            ),
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+import Child from "./Child.vue";
+
+const Components = { Child };
+
+interface Payload {
+  value: string;
+}
+
+function handleChange(payload: Payload) {
+  payload.value.toUpperCase();
+}
+</script>
+
+<template>
+  <component :is="Components.Child" @change="handleChange($event)" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.is_empty(),
+        "dynamic member component listener should infer child emit payload: {snapshot:#?}"
+    );
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/virtual_ts/scope/component_events.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events.rs
@@ -30,7 +30,7 @@ pub(super) fn generate_component_event_types(
     let component_name = data.target_component.as_ref()?;
     let scope_id = scope.id.as_u32();
     let safe_event_name = to_safe_identifier(data.event_name.as_str());
-    let component_ref = to_safe_identifier(component_name.as_str());
+    let component_ref = component_reference_expression(component_name.as_str());
     let component_type_name = to_safe_identifier_fragment(component_name.as_str());
     let pascal_event = to_pascal_case(data.event_name.as_str());
     let on_handler = cstr!("on{pascal_event}");
@@ -148,6 +148,18 @@ pub(super) fn generate_component_event_types(
         listener_type,
         listener_type_expr,
     })
+}
+
+fn component_reference_expression(name: &str) -> String {
+    if name.split('.').all(|segment| {
+        let mut bytes = segment.bytes();
+        matches!(bytes.next(), Some(b'_' | b'$' | b'a'..=b'z' | b'A'..=b'Z'))
+            && bytes.all(|byte| byte == b'_' || byte == b'$' || byte.is_ascii_alphanumeric())
+    }) {
+        String::from(name)
+    } else {
+        to_safe_identifier(name)
+    }
 }
 
 struct EmitInferenceContext<'a> {

--- a/crates/vize_croquis/src/drawer/template/tests.rs
+++ b/crates/vize_croquis/src/drawer/template/tests.rs
@@ -171,6 +171,32 @@ fn dynamic_component_v_on_uses_is_binding_as_target_component() {
 }
 
 #[test]
+fn dynamic_component_v_on_keeps_static_member_target() {
+    use crate::scope::ScopeData;
+    use vize_armature::parse;
+    use vize_carton::Bump;
+
+    let template = r#"<component :is="Components.Child" @change="handle"></component>"#;
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, template);
+    assert!(errors.is_empty(), "Template should parse without errors");
+
+    let mut drawer = Drawer::with_options(DrawerOptions::full());
+    drawer.draw_template(&root);
+    let summary = drawer.finish();
+    let event = summary
+        .scopes
+        .iter()
+        .find_map(|scope| match scope.data() {
+            ScopeData::EventHandler(data) => Some(data),
+            _ => None,
+        })
+        .expect("dynamic component listener should create an event scope");
+
+    assert_eq!(event.target_component.as_deref(), Some("Components.Child"));
+}
+
+#[test]
 fn nested_v_scope_shadows_outer() {
     use vize_armature::parse;
     use vize_carton::Bump;

--- a/crates/vize_croquis/src/drawer/template/visit_element/second_pass.rs
+++ b/crates/vize_croquis/src/drawer/template/visit_element/second_pass.rs
@@ -210,17 +210,19 @@ fn expression_identifier(exp: &ExpressionNode<'_>) -> Option<CompactString> {
         ExpressionNode::Simple(simple) => simple.content.as_str(),
         ExpressionNode::Compound(compound) => compound.loc.source.as_str(),
     };
-    parse_identifier_expression(source)
+    parse_component_reference_expression(source)
 }
 
-fn parse_identifier_expression(source: &str) -> Option<CompactString> {
+fn parse_component_reference_expression(source: &str) -> Option<CompactString> {
     let allocator = Allocator::default();
     let source_type = SourceType::from_path("expr.ts").unwrap_or_default();
     let expression = Parser::new(&allocator, source, source_type)
         .parse_expression()
         .ok()?;
     match expression {
-        Expression::Identifier(identifier) => Some(CompactString::new(identifier.name.as_str())),
+        Expression::Identifier(_) | Expression::StaticMemberExpression(_) => {
+            Some(CompactString::new(source.trim()))
+        }
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary
- retain parser-validated static member chains used by dynamic `:is` bindings
- emit `typeof Components.Child` instead of falling back to a DOM event target
- cover both Croquis target collection and the exact cross-file emit payload regression

## Validation
- `cargo test -p vize_croquis`
- `cargo test -p vize_canon`
- `cargo clippy -p vize_croquis -p vize_canon --lib -- -D warnings`
- `cargo fmt --all -- --check`
- source-length policy check

Closes #2812

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786514131&installation_id=136613492&pr_number=2915&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2915&signature=e161f024a4eb6bc10f85160b25cecadd538e510ce05814cc3bb167223ee4671d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of dynamic components that use static member paths, such as `Components.Child`.
  * Preserved valid component references for more accurate event-handler type inference.

* **Tests**
  * Added regression coverage for dynamic component event payload inference and member-path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->