### PR TITLE
test(canon): cover inherited generic boolean props

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
@@ -1,5 +1,7 @@
 use super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
 
+mod inherited_boolean;
+
 #[test]
 fn batch_type_checker_exposes_generic_props_inherited_from_pick() {
     if resolve_test_tsgo_binary().is_none() {

--- a/crates/vize_canon/src/batch/type_checker/tests/generic_props/inherited_boolean.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_props/inherited_boolean.rs
@@ -1,0 +1,55 @@
+use super::*;
+
+#[test]
+fn normalizes_imported_inherited_boolean_prop_in_generic_setup() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "issue-2806-generic-inherited-boolean-prop",
+        &[
+            (
+                "src/base.ts",
+                r#"export interface BaseProps {
+  disabled?: boolean;
+}
+"#,
+            ),
+            (
+                "src/Foo.vue",
+                r#"<script setup lang="ts" generic="T">
+import { computed } from "vue";
+import type { BaseProps } from "./base";
+
+interface FooProps extends BaseProps {
+  value?: T;
+}
+
+const props = defineProps<FooProps>();
+
+function takesBoolean(value: boolean): boolean {
+  return value;
+}
+
+const disabled = computed(() => takesBoolean(props.disabled));
+</script>
+
+<template>
+  <div>{{ disabled }}</div>
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.is_empty(),
+        "imported inherited Boolean props must normalize to boolean: {snapshot:#?}"
+    );
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
## Summary
- lock the reported imported `BaseProps` inheritance case into the batch checker suite
- verify a generic SFC normalizes an optional Boolean prop before setup usage
- confirm the #2912 generic scope fix covers the original TS2345 regression

## Validation
- `cargo test -p vize_canon`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo fmt --all -- --check`
- source-length policy check

Closes #2806

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786514355&installation_id=136613492&pr_number=2916&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2916&signature=ed497fbb4311822a17f9c4fa1fcbe9d876b5d70f94a0ddf5e87fb67bfe84ac28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type checking for generic components that inherit optional boolean props, preventing incorrect diagnostics.

* **Tests**
  * Added coverage for imported interfaces with inherited `disabled` boolean props in generic Vue components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->