### PR TITLE
test(canon): cover generic listener shorthand

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload.rs
@@ -1,5 +1,6 @@
 use super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
 
+mod callback_prop_shorthand;
 mod dynamic_member_component_events;
 
 #[test]

--- a/crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload/callback_prop_shorthand.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload/callback_prop_shorthand.rs
@@ -1,0 +1,59 @@
+use super::*;
+
+#[test]
+fn infers_generic_callback_prop_through_listener_shorthand() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "issue-2807-generic-callback-listener-shorthand",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script lang="ts">
+export interface ChildProps<T> {
+  items: T[];
+  onChoose?: (item: T) => void;
+}
+</script>
+
+<script setup lang="ts" generic="T">
+defineProps<ChildProps<T>>();
+</script>
+"#,
+            ),
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+import Child from "./Child.vue";
+
+interface Item {
+  value: number;
+}
+
+const items: Item[] = [{ value: 1 }];
+
+function onChoose(item: Item) {
+  item.value.toFixed(0);
+}
+</script>
+
+<template>
+  <Child :items @choose="onChoose" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.is_empty(),
+        "listener shorthand must share generic inference with callback props: {snapshot:#?}"
+    );
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
## Summary
- lock the reported module-script `ChildProps<T>` case into the batch checker suite
- verify `@choose` shares `T = Item` inference with the `items` prop
- confirm the #2912 generic scope fix covers the original TS2345 regression

## Validation
- `cargo test -p vize_canon`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo fmt --all -- --check`
- source-length policy check

Closes #2807

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786514366&installation_id=136613492&pr_number=2917&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2917&signature=62d72e5e6ea80ec20de291ba4266d31590c63eb17a0f223bdb4f28fd2818b801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for generic callback prop inference when using listener shorthand in Vue components.
  * Verified that valid generic component usage produces no diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->