### PR TITLE
test(canon): cover generic defaulted object spreads

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
@@ -199,3 +199,43 @@ function clear() {
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn preserves_optional_object_spreads_after_with_defaults() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "issue-2810-generic-with-defaults-object-spread",
+        &[(
+            "src/Panel.vue",
+            r#"<script setup lang="ts" generic="T">
+interface Props {
+  value?: T;
+  options?: { label?: string };
+  disabled?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  disabled: false
+});
+</script>
+
+<template>
+  <div v-bind="{ ...props.options }" />
+</template>
+"#,
+        )],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.is_empty(),
+        "optional object props must remain spreadable after unrelated defaults: {snapshot:#?}"
+    );
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
## Summary

- add an exact regression for generic optional object spreads passed through withDefaults
- verify the fix delivered by #2913 remains covered independently

## Validation

- cargo fmt --all -- --check
- cargo test -p vize_canon preserves_optional_object_spreads_after_with_defaults -- --nocapture
- cargo test -p vize_canon
- cargo clippy -p vize_canon --lib -- -D warnings
- source_file_lengths --check --base-ref origin/main

Closes #2810

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786514743&installation_id=136613492&pr_number=2918&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2918&signature=4e1f9e52ddd3ba4f48e93b05dae13bd480afd5a9b8658f30f4e310c17e21fba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->