### PR TITLE
perf(canon): skip empty generic alias emission

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -269,14 +269,9 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         merge_overlapping_spans(module_spans)
     });
 
-    // Re-declare the SFC generics as defaulted parameters on each such
-    // declaration (`type Option<T extends string = any> = ...`) so the
-    // reference resolves at module scope while bare uses (`Option[]`) still
-    // work via the `= any` defaults.
+    // Re-declare SFC generics on hoisted declarations with safe defaults.
     let generic_injection: Option<(String, Vec<String>)> = generic_param.map(|g| {
-        // `const` modifiers are only legal on function/method/class type
-        // parameters (TS1277); the spliced copies live on `type`/`interface`
-        // declarations and must drop them.
+        // Type aliases/interfaces cannot retain function-only `const` modifiers (TS1277).
         let defaults = strip_const_modifiers(&add_generic_defaults(g));
         let names = extract_generic_names(g)
             .split(',')
@@ -396,7 +391,9 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     }
     let hoisted_generic_aliases =
         HoistedGenericAliases::collect(summary, script_content, generic_param);
-    hoisted_generic_aliases.emit_module_aliases(&mut ts);
+    if let Some(aliases) = &hoisted_generic_aliases {
+        aliases.emit_module_aliases(&mut ts);
+    }
 
     let needs_imported_names = !options.auto_import_stubs.is_empty()
         || (has_script_reference_types && !summary.component_usages.is_empty());
@@ -470,7 +467,9 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     let async_prefix = if is_async { "async " } else { "" };
     let generic_params = generic_param.map(|g| cstr!("<{g}>")).unwrap_or_default();
     append!(ts, "{async_prefix}function __setup{generic_params}() {{\n",);
-    hoisted_generic_aliases.emit_setup_aliases(&mut ts);
+    if let Some(aliases) = &hoisted_generic_aliases {
+        aliases.emit_setup_aliases(&mut ts);
+    }
 
     // Setup helpers (only valid inside setup scope)
     emit_setup_helpers(

--- a/crates/vize_canon/src/virtual_ts/generator/generics.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/generics.rs
@@ -8,7 +8,6 @@ use crate::virtual_ts::props::{
     add_generic_defaults, extract_generic_names, strip_const_modifiers,
 };
 
-#[derive(Default)]
 pub(super) struct HoistedGenericAliases {
     generic_decl: String,
     generic_names: String,
@@ -20,10 +19,8 @@ impl HoistedGenericAliases {
         summary: &Croquis,
         script: Option<&str>,
         generic_param: Option<&str>,
-    ) -> Self {
-        let Some((script, generic_param)) = script.zip(generic_param) else {
-            return Self::default();
-        };
+    ) -> Option<Self> {
+        let (script, generic_param) = script.zip(generic_param)?;
         let generic_names = extract_generic_names(generic_param);
         let names: Vec<String> = generic_names
             .split(',')
@@ -31,7 +28,7 @@ impl HoistedGenericAliases {
             .filter(|name| !name.is_empty())
             .map(String::from)
             .collect();
-        let type_names = summary
+        let type_names: Vec<String> = summary
             .type_exports
             .iter()
             .filter(|export| export.hoisted)
@@ -43,11 +40,15 @@ impl HoistedGenericAliases {
             })
             .collect();
 
-        Self {
+        if type_names.is_empty() {
+            return None;
+        }
+
+        Some(Self {
             generic_decl: strip_const_modifiers(&add_generic_defaults(generic_param)),
             generic_names,
             type_names,
-        }
+        })
     }
 
     pub(super) fn emit_module_aliases(&self, ts: &mut String) {


### PR DESCRIPTION
## Summary

- skip collecting and emitting hoisted generic aliases when an SFC has no referenced generic declarations
- avoid allocating an empty alias container on the normal non-generic SFC path
- follow up the noisy benchmark result observed on #2912 with a concrete hot-path reduction

## Validation

- cargo fmt --all -- --check
- cargo test -p vize_canon
- cargo clippy -p vize_canon --lib -- -D warnings
- source_file_lengths --check --base-ref origin/main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786514807&installation_id=136613492&pr_number=2919&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2919&signature=0b8de92176faf3223d1750d4d5fd4bdbeeb0c406eec41dfe9034bf4f5d2fa487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->