### PR TITLE
fix(canon): resolve imported boolean keys in generic props

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator/setup_helpers.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/setup_helpers.rs
@@ -12,7 +12,7 @@ use crate::virtual_ts::helpers::{VUE_SETUP_HELPERS, VUE_SETUP_HELPERS_HOISTED};
 
 mod boolean_keys;
 
-use boolean_keys::collect_define_props_boolean_keys;
+use boolean_keys::{DefinePropsBooleanKeys, collect_define_props_boolean_keys};
 
 pub(super) fn emit_setup_helpers(
     ts: &mut String,
@@ -45,15 +45,22 @@ pub(super) fn emit_setup_helpers(
     }
 }
 
-fn emit_define_props_boolean_keys_type(ts: &mut String, keys: &[String]) {
-    if keys.is_empty() {
+fn emit_define_props_boolean_keys_type(ts: &mut String, collection: &DefinePropsBooleanKeys) {
+    if collection.keys.is_empty() && !collection.has_unresolved_references {
         ts.push_str("  type __VizeDefinePropsBooleanKeys<_T> = never;\n");
         return;
     }
 
     ts.push_str("  type __VizeDefinePropsBooleanKeys<_T> =\n");
-    for (index, key) in keys.iter().enumerate() {
-        let separator = if index == 0 { "    " } else { "  | " };
+    if collection.has_unresolved_references {
+        ts.push_str("    __VizeBooleanKey<_T>\n");
+    }
+    for (index, key) in collection.keys.iter().enumerate() {
+        let separator = if index == 0 && !collection.has_unresolved_references {
+            "    "
+        } else {
+            "  | "
+        };
         let mut key_literal = String::default();
         push_ts_string_literal(&mut key_literal, key.as_str());
         append!(

--- a/crates/vize_canon/src/virtual_ts/generator/setup_helpers/boolean_keys.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/setup_helpers/boolean_keys.rs
@@ -10,7 +10,12 @@ use oxc_span::SourceType;
 use vize_carton::{FxHashMap, FxHashSet, String, ToCompactString};
 use vize_croquis::macros::DEFINE_PROPS;
 
-pub(super) fn collect_define_props_boolean_keys(script: &str) -> Option<Vec<String>> {
+pub(super) struct DefinePropsBooleanKeys {
+    pub(super) keys: Vec<String>,
+    pub(super) has_unresolved_references: bool,
+}
+
+pub(super) fn collect_define_props_boolean_keys(script: &str) -> Option<DefinePropsBooleanKeys> {
     let allocator = Allocator::default();
     let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
     if parsed.panicked {
@@ -23,6 +28,7 @@ pub(super) fn collect_define_props_boolean_keys(script: &str) -> Option<Vec<Stri
         keys: FxHashSet::default(),
         resolving: Vec::new(),
         saw_type_only_define_props: false,
+        has_unresolved_references: false,
     };
     collector.visit_program(&parsed.program);
     if !collector.saw_type_only_define_props {
@@ -31,7 +37,10 @@ pub(super) fn collect_define_props_boolean_keys(script: &str) -> Option<Vec<Stri
 
     let mut keys: Vec<String> = collector.keys.into_iter().collect();
     keys.sort_unstable();
-    Some(keys)
+    Some(DefinePropsBooleanKeys {
+        keys,
+        has_unresolved_references: collector.has_unresolved_references,
+    })
 }
 
 struct TypeDeclarations<'a> {
@@ -85,6 +94,7 @@ struct DefinePropsBooleanKeyCollector<'a> {
     keys: FxHashSet<String>,
     resolving: Vec<String>,
     saw_type_only_define_props: bool,
+    has_unresolved_references: bool,
 }
 
 impl<'a> Visit<'a> for DefinePropsBooleanKeyCollector<'a> {
@@ -117,6 +127,8 @@ impl<'a> DefinePropsBooleanKeyCollector<'a> {
                     self.collect_from_interface(interface);
                 } else if let Some(alias) = self.declarations.aliases.get(name).copied() {
                     self.collect_from_type(&alias.type_annotation);
+                } else {
+                    self.has_unresolved_references = true;
                 }
                 self.resolving.pop();
             }
@@ -143,6 +155,8 @@ impl<'a> DefinePropsBooleanKeyCollector<'a> {
                     self.collect_from_interface(parent);
                 } else if let Some(alias) = self.declarations.aliases.get(name).copied() {
                     self.collect_from_type(&alias.type_annotation);
+                } else {
+                    self.has_unresolved_references = true;
                 }
                 self.resolving.pop();
             }
@@ -261,7 +275,8 @@ defineProps<Props<Record<string, unknown>>>();
         )
         .expect("type-only defineProps should be detected");
 
-        assert_eq!(keys, vec!["active", "disabled"]);
+        assert_eq!(keys.keys, vec!["active", "disabled"]);
+        assert!(!keys.has_unresolved_references);
     }
 
     #[test]
@@ -277,6 +292,23 @@ defineProps<Props<Record<string, unknown>>>();
         )
         .expect("type-only defineProps should be detected");
 
-        assert!(keys.is_empty());
+        assert!(keys.keys.is_empty());
+        assert!(!keys.has_unresolved_references);
+    }
+
+    #[test]
+    fn records_unresolved_imported_heritage() {
+        let keys = collect_define_props_boolean_keys(
+            r#"
+interface Props<T> extends ImportedBase {
+  value: T;
+}
+defineProps<Props<string>>();
+"#,
+        )
+        .expect("type-only defineProps should be detected");
+
+        assert!(keys.keys.is_empty());
+        assert!(keys.has_unresolved_references);
     }
 }


### PR DESCRIPTION
## Summary

- distinguish unresolved imported prop references from local generic props with no boolean keys
- fall back to the type-level boolean-key resolver only for those unresolved external references
- add collector coverage and exercise the exact #2806 project with tsgo

## Validation

- cargo fmt --all -- --check
- cargo test -p vize_canon records_unresolved_imported_heritage -- --nocapture
- cargo test -p vize_canon normalizes_imported_inherited_boolean_prop_in_generic_setup -- --nocapture
- VIZE_TEST_DISABLE_TSGO=1 cargo test -p vize_canon
- cargo clippy -p vize_canon --lib -- -D warnings
- source_file_lengths --check --base-ref origin/main

Follow-up to #2916. Resolves the implementation gap tracked by #2806.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786516158&installation_id=136613492&pr_number=2920&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2920&signature=3286d15dcab3b6066f8024ce5374a74ea2d11632a662774e0a7bab0039890b92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of boolean props when their type definitions include unresolved or imported references.
  * Preserved boolean prop information instead of incorrectly treating unresolved cases as having no keys.
  * Updated generated type definitions to accurately reflect available and unresolved boolean prop keys.

* **Tests**
  * Added coverage for unresolved inherited type references and updated existing boolean-prop tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->