### PR TITLE
fix(canon): detect every unused SFC generic

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
@@ -1,5 +1,6 @@
 use super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
 
+mod emit_only;
 mod inherited_boolean;
 
 #[test]

--- a/crates/vize_canon/src/batch/type_checker/tests/generic_props/emit_only.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_props/emit_only.rs
@@ -1,0 +1,90 @@
+use super::*;
+
+fn assert_no_unused_generic_diagnostics(
+    case_name: &str,
+    files: &[(&str, &str)],
+    failure_message: &str,
+) {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case(case_name, files);
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "noUnusedParameters": true,
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.vue", "src/**/*.ts"]
+}"#,
+    )
+    .unwrap();
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(snapshot.is_empty(), "{failure_message}: {snapshot:#?}");
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn retains_generic_parameters_used_only_by_emits() {
+    assert_no_unused_generic_diagnostics(
+        "emit-only-generic-parameter",
+        &[(
+            "src/Emitter.vue",
+            r#"<script setup lang="ts" generic="T extends string">
+const emit = defineEmits<{ change: [value: T] }>();
+
+emit("change", "valid" as T);
+// @ts-expect-error numbers are outside the generic payload constraint
+emit("change", 1);
+</script>
+"#,
+        )],
+        "emit-only SFC generics must not produce unused Props parameters",
+    );
+}
+
+#[test]
+fn retains_each_generic_parameter_used_by_props_or_emits() {
+    assert_no_unused_generic_diagnostics(
+        "split-props-and-emits-generic-parameters",
+        &[
+            (
+                "src/types.ts",
+                r#"export interface LocalProps<T> {
+  value: T;
+}
+"#,
+            ),
+            (
+                "src/Emitter.vue",
+                r#"<script setup lang="ts" generic="T extends string, U extends number">
+import type { LocalProps } from "./types";
+
+defineProps<LocalProps<T>>();
+const emit = defineEmits<{ change: [value: U] }>();
+
+emit("change", 1 as U);
+// @ts-expect-error strings are outside the generic payload constraint
+emit("change", "invalid");
+</script>
+"#,
+            ),
+        ],
+        "every SFC generic must be retained across props and emits",
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/props/setup_scoped.rs
+++ b/crates/vize_canon/src/virtual_ts/props/setup_scoped.rs
@@ -1,4 +1,9 @@
-use vize_carton::{String, append, cstr};
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{TSTypeName, TSTypeReference};
+use oxc_ast_visit::{Visit, walk};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{CompactString, FxHashSet, String, append, cstr};
 use vize_croquis::Croquis;
 
 use super::{append_model_props_type_literal, extract_generic_names};
@@ -65,19 +70,57 @@ pub(super) fn unused_generic_comment(
         return "";
     };
     let names = extract_generic_names(generic);
-    let uses_generic = names
-        .split(',')
-        .map(str::trim)
-        .filter(|name| !name.is_empty())
-        .any(|name| {
-            props_source
-                .split(|ch: char| !(ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()))
-                .any(|token| token == name)
-        });
-    if uses_generic {
+    let type_references = collect_type_reference_names(props_source);
+    let uses_every_generic = type_references.is_some_and(|type_references| {
+        names
+            .split(',')
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .all(|name| {
+                type_references
+                    .iter()
+                    .any(|type_reference| type_reference.as_str() == name)
+            })
+    });
+    if uses_every_generic {
         ""
     } else {
         "// @ts-ignore TS6196: SFC generic may be used by emits or slots.\n"
+    }
+}
+
+#[derive(Default)]
+struct TypeReferenceNames {
+    names: FxHashSet<CompactString>,
+}
+
+impl<'a> Visit<'a> for TypeReferenceNames {
+    fn visit_ts_type_reference(&mut self, ty: &TSTypeReference<'a>) {
+        record_type_name_root(&ty.type_name, &mut self.names);
+        walk::walk_ts_type_reference(self, ty);
+    }
+}
+
+fn collect_type_reference_names(props_source: &str) -> Option<FxHashSet<CompactString>> {
+    let source = cstr!("type __VizeProps = {props_source};");
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source.as_str(), SourceType::ts()).parse();
+    if parsed.panicked || !parsed.errors.is_empty() {
+        return None;
+    }
+
+    let mut references = TypeReferenceNames::default();
+    references.visit_program(&parsed.program);
+    Some(references.names)
+}
+
+fn record_type_name_root(name: &TSTypeName<'_>, names: &mut FxHashSet<CompactString>) {
+    match name {
+        TSTypeName::IdentifierReference(identifier) => {
+            names.insert(CompactString::new(identifier.name.as_str()));
+        }
+        TSTypeName::QualifiedName(qualified) => record_type_name_root(&qualified.left, names),
+        TSTypeName::ThisExpression(_) => {}
     }
 }
 
@@ -92,6 +135,16 @@ mod tests {
             "// @ts-ignore TS6196: SFC generic may be used by emits or slots.\n"
         );
         assert_eq!(unused_generic_comment(Some("T"), "LocalProps<T>"), "");
+        assert_eq!(
+            unused_generic_comment(Some("T, U"), "LocalProps<T>"),
+            "// @ts-ignore TS6196: SFC generic may be used by emits or slots.\n"
+        );
+        assert_eq!(unused_generic_comment(Some("T, U"), "LocalProps<T, U>"), "");
+        assert_eq!(
+            unused_generic_comment(Some("T"), r#"{ T: string; kind: "T" }"#),
+            "// @ts-ignore TS6196: SFC generic may be used by emits or slots.\n"
+        );
+        assert_eq!(unused_generic_comment(Some("T"), "{ value: T }"), "");
         assert_eq!(
             unused_generic_comment(Some("T"), "SomeTTProps"),
             "// @ts-ignore TS6196: SFC generic may be used by emits or slots.\n"


### PR DESCRIPTION
## Summary

- parse generated props type sources as TypeScript before deciding whether an SFC generic is retained
- require every SFC generic to appear as a type reference instead of accepting any raw token match
- cover emit-only and split props/emits generic parameters with real tsgo diagnostics

## Validation

- `cargo test -p vize_canon`
- `cargo clippy -p vize_canon -- -D warnings`
- `cargo build --profile ci -p vize`
- `corepack pnpm exec vp run source:lengths --check --base-ref origin/main --max-lines 350 --limit 50`

Follow-up to #2914.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786518137&installation_id=136613492&pr_number=2922&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2922&signature=8bbd23e83122d851fbb83cae07b11e2c6d5fc3cf87d08d0db94aa625437a23fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TypeScript diagnostics for Vue components using generic parameters with `defineProps` and `defineEmits`.
  - Prevented valid generic parameters from being incorrectly reported as unused.
  - Improved detection of generic type usage in inline object types and components with multiple generic parameters.
  - TypeScript suppression comments are now generated more accurately when generic parameters are genuinely unused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->