### PR TITLE
ci(canon): require tsgo for Rust tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -384,8 +384,7 @@ jobs:
       - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version-file: ".node-version"
-          run-install: false
-
+          run-install: true
       - uses: ./.github/actions/setup-rust-sticky-cache
         with:
           key: clippy-test
@@ -396,6 +395,7 @@ jobs:
       - name: Install Pkl CLI
         run: npm install --global @pkl-community/pkl@0.27.2
       - name: Test
+        env: { VIZE_TEST_REQUIRE_TSGO: "1" }
         run: cargo test --workspace && cargo test -p vize_vitrine --no-default-features --features wasm
 
   coverage:

--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -19,7 +19,9 @@ mod package_exports_types;
 mod recent_issues;
 mod scan;
 mod template_block;
+mod tsgo;
 mod tsx_sfc;
+use tsgo::resolve_test_tsgo_binary;
 #[test]
 fn batch_type_checker_snapshots_vue_diagnostics() {
     if resolve_test_tsgo_binary().is_none() {
@@ -2130,22 +2132,6 @@ fn corsa_type_mismatch_snapshot(
     });
     let _ = std::fs::remove_dir_all(&project_root);
     result
-}
-
-fn resolve_test_tsgo_binary() -> Option<PathBuf> {
-    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
-        return None;
-    }
-
-    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)?;
-    let sibling_cache = workspace_root.parent()?.join("corsa-bind/.cache/tsgo");
-    if sibling_cache.exists() {
-        return Some(sibling_cache);
-    }
-
-    vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
 }
 
 fn link_workspace_node_modules(project_root: &Path) -> std::io::Result<()> {

--- a/crates/vize_canon/src/batch/type_checker/tests/tsgo.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/tsgo.rs
@@ -1,0 +1,22 @@
+use std::path::{Path, PathBuf};
+
+pub(super) fn resolve_test_tsgo_binary() -> Option<PathBuf> {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return None;
+    }
+
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)?;
+    let sibling_cache = workspace_root.parent()?.join("corsa-bind/.cache/tsgo");
+    if sibling_cache.exists() {
+        return Some(sibling_cache);
+    }
+
+    let resolved = vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root);
+    assert!(
+        resolved.is_some() || std::env::var_os("VIZE_TEST_REQUIRE_TSGO").is_none(),
+        "VIZE_TEST_REQUIRE_TSGO is set, but no tsgo executable was found"
+    );
+    resolved
+}


### PR DESCRIPTION
## Summary

- install workspace JS dependencies in the Rust test job so the pinned native TypeScript binary is available
- make CI fail when tsgo cannot be resolved instead of silently skipping integration coverage
- preserve the explicit `VIZE_TEST_DISABLE_TSGO` opt-out for environments without tsgo

## Validation

- `VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon`
- `VIZE_TEST_DISABLE_TSGO=1 VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon emit_only -- --nocapture`
- `cargo clippy -p vize_canon -- -D warnings`
- parsed `.github/workflows/check.yml` as YAML
- `corepack pnpm exec vp run source:lengths --check --base-ref origin/main --max-lines 350 --limit 50`

Follow-up to the CI coverage review on #2922.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786518824&installation_id=136613492&pr_number=2923&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2923&signature=0aebc5727f57ada91a5e753b51c1c170ff2c7655abd109559d8995d6a8d74693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test setup to automatically locate the required `tsgo` executable from the workspace, using a local cache when available and a workspace-ancestor discovery fallback.
  * Tests now honor environment switches to disable the tool or require it (`VIZE_TEST_DISABLE_TSGO` / `VIZE_TEST_REQUIRE_TSGO`), with clearer failure messaging when it’s missing.
* **Chores**
  * Updated automated checks to install needed dependencies and set the environment flag that enforces the TypeScript tool requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->