### PR TITLE
test(canon): enforce required tsgo resolution

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/tsgo.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/tsgo.rs
@@ -7,16 +7,37 @@ pub(super) fn resolve_test_tsgo_binary() -> Option<PathBuf> {
 
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
-        .and_then(Path::parent)?;
-    let sibling_cache = workspace_root.parent()?.join("corsa-bind/.cache/tsgo");
-    if sibling_cache.exists() {
-        return Some(sibling_cache);
+        .and_then(Path::parent);
+    resolve_test_tsgo_binary_from(
+        workspace_root,
+        std::env::var_os("VIZE_TEST_REQUIRE_TSGO").is_some(),
+    )
+}
+
+fn resolve_test_tsgo_binary_from(
+    workspace_root: Option<&Path>,
+    require_tsgo: bool,
+) -> Option<PathBuf> {
+    if let Some(sibling_cache) = workspace_root
+        .and_then(Path::parent)
+        .map(|parent| parent.join("corsa-bind/.cache/tsgo"))
+    {
+        if sibling_cache.exists() {
+            return Some(sibling_cache);
+        }
     }
 
-    let resolved = vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root);
+    let resolved =
+        workspace_root.and_then(vize_carton::corsa_resolver::discover_corsa_in_ancestors);
     assert!(
-        resolved.is_some() || std::env::var_os("VIZE_TEST_REQUIRE_TSGO").is_none(),
+        resolved.is_some() || !require_tsgo,
         "VIZE_TEST_REQUIRE_TSGO is set, but no tsgo executable was found"
     );
     resolved
+}
+
+#[test]
+#[should_panic(expected = "VIZE_TEST_REQUIRE_TSGO is set")]
+fn required_tsgo_rejects_missing_workspace_root() {
+    let _ = resolve_test_tsgo_binary_from(None, true);
 }


### PR DESCRIPTION
## Summary
- keep required tsgo resolution fail-closed when the workspace root cannot be derived
- preserve sibling-cache and ancestor discovery precedence
- add a focused regression test for the shallow-path escape hatch reported in review

## Validation
- `VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon`
- `cargo clippy -p vize_canon -- -D warnings`
- `cargo fmt --all -- --check`
- `corepack pnpm exec vp run source:lengths --check --base-ref origin/main --max-lines 350 --limit 50`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786521050&installation_id=136613492&pr_number=2926&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2926&signature=cb190b5109f3272bf23a151097cfefe24c7cc63c699226c6e3883be415bf4c56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test handling for locating the TypeScript compiler binary.
  * Added coverage to ensure tests fail as expected when the compiler is required but no workspace root is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->