### PR TITLE
fix(patina): respect shadowed prop bindings

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -7,6 +7,7 @@ mod css;
 mod directives;
 mod jsx;
 mod jsx_fallback;
+mod no_mutating_props;
 mod no_top_level_ref;
 mod nuxt;
 mod script;

--- a/crates/vize_patina/src/linter/tests/no_mutating_props.rs
+++ b/crates/vize_patina/src/linter/tests/no_mutating_props.rs
@@ -1,0 +1,46 @@
+use super::Linter;
+
+fn no_mutating_props_linter() -> Linter {
+    Linter::new().with_enabled_rules(Some(vec!["vue/no-mutating-props".into()]))
+}
+
+#[test]
+fn allows_local_ref_that_shadows_an_implicit_prop_binding() {
+    let sfc = r#"<script setup lang="ts">
+import { ref } from 'vue'
+
+const props = defineProps<{ enabled?: boolean }>()
+const enabled = ref(props.enabled)
+</script>
+
+<template>
+  <Switch v-model="enabled" />
+</template>
+"#;
+    let result = no_mutating_props_linter().lint_sfc(sfc, "test.vue");
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "a local ref must shadow the implicit prop binding: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn allows_define_model_binding() {
+    let sfc = r#"<script setup lang="ts">
+const modelValue = defineModel<string>()
+</script>
+
+<template>
+  <input v-model="modelValue" />
+</template>
+"#;
+    let result = no_mutating_props_linter().lint_sfc(sfc, "test.vue");
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "defineModel is a writable local ref: {:?}",
+        result.diagnostics
+    );
+}

--- a/crates/vize_patina/src/rules/vue/no_mutating_props.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props.rs
@@ -175,15 +175,15 @@ impl Rule for NoMutatingProps {
 
             let mut names: FxHashSet<String> = FxHashSet::default();
 
-            // From defineProps
             for prop in analysis.macros.props() {
                 names.insert(prop.name.to_compact_string());
             }
 
-            // From destructured props
             for (name, binding_type) in analysis.bindings.iter() {
                 if matches!(binding_type, BindingType::Props | BindingType::PropsAliased) {
                     names.insert(name.to_compact_string());
+                } else {
+                    names.remove(name);
                 }
             }
 


### PR DESCRIPTION
## What changed

- Stop treating an implicit defineProps name as immutable when a writable setup binding shadows it.
- Cover local ref and defineModel bindings with SFC regression tests.

## Why

Real Vue component fixtures use writable locals with the same template name as a declared prop. The linter was resolving those names back to the prop and reporting false vue/no-mutating-props errors.

## Validation

- cargo test -p vize_patina
- cargo fmt --all -- --check
- vp run --workspace-root check:ci
- full lint runs against the new read-only fixture sandboxes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786523594&installation_id=136613492&pr_number=2927&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2927&signature=d7081d5735b3d52761dbb5c6127bedd76eb33401432e4645a2c084eca9e5874c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue prop mutation detection to correctly handle local bindings that shadow prop names.
  * Prevented false warnings for writable local refs created with `defineModel` and local `ref` declarations.

* **Tests**
  * Added coverage for shadowed props and writable model bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->