### PR TITLE
fix(canon): preserve parent type packages

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -219,7 +219,6 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             &mut tsconfig_input_cache,
         )
     };
-
     // Explicit subsets omit ambient roots; pull package-local `.d.ts` files
     // back in so global types stay in scope without widening package checks.
     if !args.patterns.is_empty() && program_tsconfig_path.is_some() {
@@ -244,6 +243,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     } else {
         program_tsconfig_path
     };
+    resolve::retain_project_files(&mut files, &project_root);
     let mut virtual_ts_options = build_virtual_ts_options(&config, config_dir);
     let tsconfig = program_tsconfig_path.as_deref();
     let nuxt_root = &nuxt_project_root;

--- a/crates/vize/src/commands/check/runner/resolve.rs
+++ b/crates/vize/src/commands/check/runner/resolve.rs
@@ -123,6 +123,15 @@ pub(super) fn project_root_has_package_boundary(project_root: &Path) -> bool {
     project_root.join("package.json").is_file()
 }
 
+pub(super) fn retain_project_files(files: &mut Vec<PathBuf>, project_root: &Path) {
+    // Ambient `compilerOptions.types` packages can resolve from an ancestor
+    // `node_modules` outside the source root. The virtual project extends the
+    // real tsconfig and lets TypeScript load those packages normally; trying to
+    // mirror them as source roots fails because they have no path relative to
+    // the virtual project root.
+    files.retain(|path| path.starts_with(project_root));
+}
+
 fn has_source_input_outside_root(root: &Path, files: &[PathBuf]) -> bool {
     files.iter().any(|file| {
         !path_has_component(file, "node_modules")

--- a/crates/vize/tests/check_tsconfig_types_cli.rs
+++ b/crates/vize/tests/check_tsconfig_types_cli.rs
@@ -191,3 +191,74 @@ void label;
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn check_loads_parent_type_packages_without_mirroring_them_as_sources() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let workspace = unique_case_dir("parent-types");
+    let _ = std::fs::remove_dir_all(&workspace);
+    std::fs::create_dir_all(&workspace).unwrap();
+    link_workspace_vue(&workspace).unwrap();
+    write(
+        &workspace,
+        "node_modules/@types/vize-external/index.d.ts",
+        "declare const externalFixtureValue: string;\n",
+    );
+    write(&workspace, "packages/router/package.json", "{}\n");
+    write(
+        &workspace,
+        "packages/router/tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["vize-external"],
+    "noEmit": true
+  }
+}"#,
+    );
+    write(
+        &workspace,
+        "packages/playground/src/App.vue",
+        r#"<script setup lang="ts">
+const message: string = externalFixtureValue;
+</script>
+
+<template>{{ message }}</template>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&workspace)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "packages/router/tsconfig.json",
+            "packages/playground/src/App.vue",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "parent type package check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Failed to strip prefix from path"),
+        "{stdout}\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], 0, "{stdout}\n{stderr}");
+    assert_eq!(json["fileCount"], 1, "{stdout}\n{stderr}");
+
+    let _ = std::fs::remove_dir_all(&workspace);
+}


### PR DESCRIPTION
## Summary

- keep ambient type packages resolved from ancestor `node_modules` out of the mirrored source file list
- let the extended real tsconfig load those packages normally
- cover the nested-package regression that previously failed with `Failed to strip prefix from path`

## Verification

- `cargo test -p vize --test check_reference_types_cli`
- `cargo test -p vize`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all -- --check`
- `vp run --workspace-root check:ci`
- full `vue-router` fixture typecheck now returns structured diagnostics without crashing

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786524375&installation_id=136613492&pr_number=2928&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2928&signature=1bd184ce6ed087769ee2af732ac57de8657714f3962cf6cbb17f59d059b171df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TypeScript checking for projects that use type packages located in parent directories.
  - Prevented external type package files from being incorrectly included as project source files.
  - Ensured valid projects report accurate file and error counts without path-related diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->