### PR TITLE
fix(patina): allow inherited router targets

### DIFF
--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -35,7 +35,6 @@ use super::config::{LintResult, Linter};
 
 use ecosystem_hint::source_may_contain_ecosystem_template_rule;
 pub(crate) use offset::offset_result;
-
 pub(crate) enum TemplateAnalysis<'a> {
     Disabled,
     Precomputed(&'a Croquis),
@@ -69,6 +68,7 @@ const SEMANTIC_TEMPLATE_RULES: &[&str] = &[
     "vue/no-undefined-refs",
     "vue/no-mutating-props",
     "a11y/no-refer-to-non-existent-id",
+    "ecosystem/router-link-require-to",
 ];
 const SHARED_SFC_DESCRIPTOR_RULES: &[&str] = &[
     "vue/no-reserved-component-names",

--- a/crates/vize_patina/src/linter/tests/basic.rs
+++ b/crates/vize_patina/src/linter/tests/basic.rs
@@ -157,7 +157,7 @@ const items = ['a', 'b'];
 
 #[test]
 fn test_ecosystem_template_rules_are_enabled_by_default() {
-    let source = r#"<template><RouterLink>Home</RouterLink></template>"#;
+    let source = r#"<template><RouterLink>Home</RouterLink><footer>Footer</footer></template>"#;
 
     let happy_path = Linter::with_preset(LintPreset::HappyPath);
     let happy_path_result = happy_path.lint_sfc(source, "test.vue");

--- a/crates/vize_patina/src/rules/ecosystem/router_link_require_to.rs
+++ b/crates/vize_patina/src/rules/ecosystem/router_link_require_to.rs
@@ -27,14 +27,18 @@ impl Rule for RouterLinkRequireTo {
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if !is_router_link_tag(element.tag.as_str()) || has_to_prop(element) {
+        let tag = element.tag.as_str();
+        if !is_router_link_tag(tag)
+            || has_navigation_target(element, is_nuxt_link_tag(tag))
+            || can_inherit_root_navigation_target(ctx)
+        {
             return;
         }
 
         ctx.error_with_help(
-            "RouterLink components must declare a `to` target",
+            "RouterLink components must declare a navigation target",
             &element.loc,
-            "Add `to` or `:to` so navigation is explicit and typed-route tooling can infer the target.",
+            "Add `to` or `:to` (`href` or `:href` is also valid on NuxtLink) so navigation is explicit and typed-route tooling can infer the target.",
         );
     }
 }
@@ -43,22 +47,45 @@ pub(super) fn is_router_link_tag(tag: &str) -> bool {
     matches!(tag, "RouterLink" | "router-link" | "NuxtLink" | "nuxt-link")
 }
 
-fn has_to_prop(element: &ElementNode<'_>) -> bool {
+fn is_nuxt_link_tag(tag: &str) -> bool {
+    matches!(tag, "NuxtLink" | "nuxt-link")
+}
+
+fn can_inherit_root_navigation_target(ctx: &LintContext<'_>) -> bool {
+    ctx.parent_element().is_none()
+        && ctx.sfc_descriptor().is_some()
+        && ctx.analysis().is_some_and(|analysis| {
+            analysis.template_info.root_element_count <= 1
+                && !analysis.macros.all_calls().iter().any(|call| {
+                    call.name == "defineOptions"
+                        && call.runtime_args.as_ref().is_some_and(|args| {
+                            args.contains("inheritAttrs") && args.contains("false")
+                        })
+                })
+        })
+}
+
+fn has_navigation_target(element: &ElementNode<'_>, allow_href: bool) -> bool {
     element.props.iter().any(|prop| match prop {
-        PropNode::Attribute(attr) => attr.name.as_str() == "to",
-        PropNode::Directive(directive) => is_to_bind_directive(directive),
+        PropNode::Attribute(attr) => {
+            attr.name.as_str() == "to" || (allow_href && attr.name.as_str() == "href")
+        }
+        PropNode::Directive(directive) => is_navigation_bind_directive(directive, allow_href),
     })
 }
 
-fn is_to_bind_directive(directive: &DirectiveNode<'_>) -> bool {
+fn is_navigation_bind_directive(directive: &DirectiveNode<'_>, allow_href: bool) -> bool {
     if directive.name.as_str() != "bind" {
         return false;
     }
 
-    matches!(
-        directive.arg.as_ref(),
-        Some(ExpressionNode::Simple(arg)) if arg.is_static && arg.content.as_str() == "to"
-    )
+    match directive.arg.as_ref() {
+        None => true,
+        Some(ExpressionNode::Simple(arg)) if arg.is_static => {
+            arg.content.as_str() == "to" || (allow_href && arg.content.as_str() == "href")
+        }
+        _ => false,
+    }
 }
 
 #[cfg(test)]
@@ -85,6 +112,62 @@ mod tests {
         let result =
             create_linter().lint_template(r#"<router-link :to="{ name: 'home' }" />"#, "test.vue");
         assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn accepts_nuxt_href_aliases() {
+        let linter = create_linter();
+        let static_result = linter.lint_template(r#"<NuxtLink href="/docs" />"#, "test.vue");
+        let bound_result = linter.lint_template(r#"<nuxt-link :href="route" />"#, "test.vue");
+
+        assert_eq!(static_result.error_count, 0);
+        assert_eq!(bound_result.error_count, 0);
+    }
+
+    #[test]
+    fn accepts_object_v_bind_that_can_supply_the_target() {
+        let result =
+            create_linter().lint_template(r#"<RouterLink v-bind="linkProps" />"#, "test.vue");
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn router_link_still_requires_to_instead_of_href() {
+        let result = create_linter().lint_template(r#"<RouterLink href="/docs" />"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn accepts_single_root_link_that_inherits_fallthrough_attrs() {
+        let result = create_linter().lint_sfc(
+            r#"<script setup lang="ts">
+defineProps<{ class?: string }>()
+</script>
+<template><NuxtLink class="card"><slot /></NuxtLink></template>"#,
+            "LinkedCard.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn reports_single_root_link_when_attr_inheritance_is_disabled() {
+        let result = create_linter().lint_sfc(
+            r#"<script setup lang="ts">
+defineOptions({ inheritAttrs: false })
+</script>
+<template><NuxtLink class="card"><slot /></NuxtLink></template>"#,
+            "LinkedCard.vue",
+        );
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn reports_targetless_link_in_a_fragment() {
+        let result = create_linter().lint_sfc(
+            r#"<template><NuxtLink>Docs</NuxtLink><footer>Footer</footer></template>"#,
+            "FragmentCard.vue",
+        );
+        assert_eq!(result.error_count, 1);
     }
 
     #[test]

--- a/crates/vize_patina/src/rules/ecosystem/snapshots/vize_patina__rules__ecosystem__router_link_require_to__tests__reports_missing_to.snap
+++ b/crates/vize_patina/src/rules/ecosystem/snapshots/vize_patina__rules__ecosystem__router_link_require_to__tests__reports_missing_to.snap
@@ -6,11 +6,11 @@ expression: result.diagnostics
     LintDiagnostic {
         rule_name: "ecosystem/router-link-require-to",
         severity: Error,
-        message: "RouterLink components must declare a `to` target",
+        message: "RouterLink components must declare a navigation target",
         start: 0,
         end: 10,
         help: Some(
-            "Add `to` or `:to` so navigation is explicit and typed-route tooling can infer the target.",
+            "Add `to` or `:to` (`href` or `:href` is also valid on NuxtLink) so navigation is explicit and typed-route tooling can infer the target.",
         ),
         labels: [],
         fix: None,


### PR DESCRIPTION
## Summary

- accept `href` targets on `NuxtLink` while keeping `RouterLink` restricted to `to`
- accept object `v-bind` and single-root fallthrough attrs that can supply the navigation target
- keep targetless fragments and components with `inheritAttrs: false` diagnostic
- run the rule with full SFC semantic context

## Verification

- `cargo test -p vize_patina router_link_require_to` (10 passed)
- `cargo test -p vize_patina` (2,145 passed)
- `node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all -- --check`
- full lint runs across the 11 new fixture sandboxes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786524426&installation_id=136613492&pr_number=2929&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2929&signature=2a3a4e88f1c65922305da5f0ccef9c47c0ee4e60cdbef636416c208c12120da3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template linting for Vue Router and Nuxt link components.
  * Router links now require an explicit `to` target.
  * Nuxt links accept `href` as an alternative, including statically bound and inherited attribute scenarios.
  * Prevented incorrect `href` acceptance on RouterLink/router-link.
  * Expanded validation across layouts, fragments, and root-element attribute inheritance.
* **Tests**
  * Updated template coverage to reflect the new ecosystem semantic rule behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->