### PR TITLE
ci(e2e): hydrate only exercised fixtures

### DIFF
--- a/.github/actions/hydrate-app-fixtures/action.yml
+++ b/.github/actions/hydrate-app-fixtures/action.yml
@@ -1,0 +1,26 @@
+name: Hydrate app fixtures
+description: Checkout only the pinned fixtures exercised by App E2E
+
+runs:
+  using: composite
+  steps:
+    - name: Hydrate exercised app fixtures
+      shell: bash
+      run: |
+        git submodule update --init --recursive --depth 1 \
+          tests/_fixtures/_git/ant-design-vue \
+          tests/_fixtures/_git/directus \
+          tests/_fixtures/_git/element-plus \
+          tests/_fixtures/_git/elk \
+          tests/_fixtures/_git/frontend-phpcon-do-website \
+          tests/_fixtures/_git/hoppscotch \
+          tests/_fixtures/_git/misskey \
+          tests/_fixtures/_git/naive-ui \
+          tests/_fixtures/_git/npmx.dev \
+          tests/_fixtures/_git/nuxt-ui \
+          tests/_fixtures/_git/primevue \
+          tests/_fixtures/_git/reka-ui \
+          tests/_fixtures/_git/voicevox \
+          tests/_fixtures/_git/vue-vben-admin \
+          tests/_fixtures/_git/vuefes-2025 \
+          tests/_fixtures/_git/vuetify

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -154,7 +154,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ env.E2E_TARGET_SHA }}
-          submodules: recursive
+
+      - uses: ./.github/actions/hydrate-app-fixtures
 
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
@@ -231,7 +232,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ env.E2E_TARGET_SHA }}
-          submodules: recursive
+
+      - uses: ./.github/actions/hydrate-app-fixtures
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -238,10 +238,14 @@ test("app e2e dispatch pins validated exact-SHA checkouts and run evidence", () 
   assert.match(workflow, /branch or tag whose tip is target_sha/);
   assert.match(workflow, /E2E_TARGET_SHA:\s*\$\{\{\s*inputs\.target_sha \|\| github\.sha\s*\}\}/);
 
-  const checkouts = workflow.match(
-    /ref:\s*\$\{\{\s*env\.E2E_TARGET_SHA\s*\}\}\n\s+submodules:\s*recursive/g,
-  );
+  const checkouts = workflow.match(/ref:\s*\$\{\{\s*env\.E2E_TARGET_SHA\s*\}\}/g);
   assert.equal(checkouts?.length, 2, "both Testbox and app-e2e must pin checkout");
+  assert.doesNotMatch(workflow, /submodules:\s*recursive/);
+  assert.equal(
+    workflow.match(/uses:\s*\.\/\.github\/actions\/hydrate-app-fixtures/g)?.length,
+    2,
+    "both full E2E jobs must hydrate only their exercised fixtures",
+  );
   assert.match(workflow, /name:\s*Validate optional target SHA/);
   assert.match(
     workflow,
@@ -270,4 +274,32 @@ test("app e2e dispatch pins validated exact-SHA checkouts and run evidence", () 
     2,
     "both dispatch paths explain the ref constraint",
   );
+});
+
+test("full app e2e hydrates only fixtures referenced by its scripts", () => {
+  const action = readRepoFile(".github", "actions", "hydrate-app-fixtures", "action.yml");
+  const fixtures = [
+    "ant-design-vue",
+    "directus",
+    "element-plus",
+    "elk",
+    "frontend-phpcon-do-website",
+    "hoppscotch",
+    "misskey",
+    "naive-ui",
+    "npmx.dev",
+    "nuxt-ui",
+    "primevue",
+    "reka-ui",
+    "voicevox",
+    "vue-vben-admin",
+    "vuefes-2025",
+    "vuetify",
+  ];
+
+  assert.match(action, /git submodule update --init --recursive --depth 1/);
+  for (const fixture of fixtures) {
+    assert.match(action, new RegExp(`tests/_fixtures/_git/${fixture.replace(".", "\\.")}`));
+  }
+  assert.equal(action.match(/tests\/_fixtures\/_git\//g)?.length, fixtures.length);
 });


### PR DESCRIPTION
## Summary

- stop recursively cloning every fixture in Testbox and nightly App E2E checkouts
- hydrate only the 16 pinned repositories referenced by the existing dev, VRT, preview, build, check, and lint suites
- share the explicit fixture inventory through a local composite action
- guard both checkout sites and the bounded inventory with tooling tests

## Why

The fixture registry is growing and includes large upstream repositories. Full recursive checkout makes unrelated fixtures part of every E2E suite even when no test consumes them.

## Verification

- `node --test tests/tooling/e2e-workflow.test.ts tests/tooling/e2e-tasks.test.ts`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `vp run --workspace-root check:ci`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786528926&installation_id=136613492&pr_number=2931&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2931&signature=ff491675d229741cbba449642aa9cd1f6af664d9a4a89fa295e78c629248b2be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end workflow validation to ensure tests use the intended source revision.
  * Added checks confirming only approved app fixtures are hydrated with shallow submodule updates.

* **Chores**
  * Added automated fixture setup for end-to-end testing.
  * Updated E2E workflows to use the new fixture hydration step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->