### PR TITLE
fix(formatter): advance past literal less-than text

### DIFF
--- a/crates/vize_glyph/src/template/formatter.rs
+++ b/crates/vize_glyph/src/template/formatter.rs
@@ -95,13 +95,12 @@ impl<'a> TemplateFormatter<'a> {
 
             // Tag start
             if source[pos] == b'<' {
-                self.flush_text_buffer(&mut output, &mut line_buffer, depth);
-
                 // Closing tag
                 if pos + 1 < len
                     && source[pos + 1] == b'/'
                     && let Some((tag_name, end_pos)) = parse_closing_tag(source, pos)
                 {
+                    self.flush_text_buffer(&mut output, &mut line_buffer, depth);
                     depth = depth.saturating_sub(1);
                     self.write_indent(&mut output, depth);
                     output.extend_from_slice(b"</");
@@ -116,6 +115,7 @@ impl<'a> TemplateFormatter<'a> {
                 if let Some((tag_name, attrs, is_self_closing, end_pos)) =
                     self.parse_opening_tag(source, pos)
                 {
+                    self.flush_text_buffer(&mut output, &mut line_buffer, depth);
                     // Sort attributes if enabled
                     let mut sorted_attrs = attrs;
                     if self.options.sort_attributes {
@@ -228,6 +228,13 @@ impl<'a> TemplateFormatter<'a> {
                     pos = end_pos;
                     continue;
                 }
+
+                // A literal `<` in text (for example `<< Back`) is not an
+                // opening tag. Consume it as text so the cursor always makes
+                // progress instead of repeatedly retrying the same byte.
+                line_buffer.push(b'<');
+                pos += 1;
+                continue;
             }
 
             // Accumulate text content until newline or tag

--- a/crates/vize_glyph/src/template/formatter.rs
+++ b/crates/vize_glyph/src/template/formatter.rs
@@ -95,7 +95,6 @@ impl<'a> TemplateFormatter<'a> {
 
             // Tag start
             if source[pos] == b'<' {
-                // Closing tag
                 if pos + 1 < len
                     && source[pos + 1] == b'/'
                     && let Some((tag_name, end_pos)) = parse_closing_tag(source, pos)
@@ -110,13 +109,10 @@ impl<'a> TemplateFormatter<'a> {
                     pos = end_pos;
                     continue;
                 }
-
-                // Opening tag
                 if let Some((tag_name, attrs, is_self_closing, end_pos)) =
                     self.parse_opening_tag(source, pos)
                 {
                     self.flush_text_buffer(&mut output, &mut line_buffer, depth);
-                    // Sort attributes if enabled
                     let mut sorted_attrs = attrs;
                     if self.options.sort_attributes {
                         sort_attributes(&mut sorted_attrs, self.options);
@@ -228,10 +224,7 @@ impl<'a> TemplateFormatter<'a> {
                     pos = end_pos;
                     continue;
                 }
-
-                // A literal `<` in text (for example `<< Back`) is not an
-                // opening tag. Consume it as text so the cursor always makes
-                // progress instead of repeatedly retrying the same byte.
+                // Keep a non-tag `<` as text and advance past it.
                 line_buffer.push(b'<');
                 pos += 1;
                 continue;

--- a/crates/vize_glyph/tests/template_literal_less_than.rs
+++ b/crates/vize_glyph/tests/template_literal_less_than.rs
@@ -1,0 +1,16 @@
+use vize_glyph::{FormatOptions, format_template};
+
+#[test]
+fn literal_less_than_text_is_preserved_without_hanging() {
+    let source = r#"<router-link> << {{ label }}</router-link>"#;
+    let options = FormatOptions::default();
+
+    let first = format_template(source, &options).unwrap();
+    let second = format_template(&first, &options).unwrap();
+
+    assert_eq!(
+        first.as_str(),
+        "<router-link>\n  << {{ label }}\n</router-link>"
+    );
+    assert_eq!(first, second);
+}


### PR DESCRIPTION
## Summary
- treat a literal less-than byte as text when it does not start a valid tag
- prevent the template formatter cursor from retrying the same byte forever
- cover the double less-than Back shape reproduced by the pinned Vux fixture

## Validation
- cargo test -p vize_glyph (122 passed)
- cargo clippy -p vize_glyph --lib -- -D warnings
- vp run --workspace-root check:ci
- all SFCs in the 33-fixture classic batch completed fmt --check with a 60s per-project ceiling

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786530485&installation_id=136613492&pr_number=2933&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2933&signature=bf612f5350b963247944e5e383218ec6f97e512322f775d3f1ba226f0aa56d42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template formatting behavior around opening and closing tags to prevent incorrect buffering.
  * Correctly preserves literal `<` characters inside template text (`<< ... >>`) without hanging or malformed output.
  * Ensures formatting is stable when re-applied to already-formatted templates.

* **Tests**
  * Added a new test to cover literal less-than handling and verify repeat (idempotent) formatting results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->