### PR TITLE
fix(parser): recover Vue atelier quirks

### DIFF
--- a/crates/vize_armature/src/parser/element/errors.rs
+++ b/crates/vize_armature/src/parser/element/errors.rs
@@ -8,6 +8,11 @@ use super::super::Parser;
 impl<'a> Parser<'a> {
     /// Handle error
     pub(in crate::parser) fn on_error_impl(&mut self, code: ErrorCode, index: usize) {
+        if self.template_syntax.is_quirks() && code == ErrorCode::MissingWhitespaceBetweenAttributes
+        {
+            return;
+        }
+
         let len = self.source.len();
         let start = index.min(len);
         let end = (index + 1).min(len);

--- a/crates/vize_armature/src/parser/element/tags.rs
+++ b/crates/vize_armature/src/parser/element/tags.rs
@@ -250,6 +250,10 @@ impl<'a> Parser<'a> {
             return;
         }
 
+        if self.template_syntax.is_quirks() && (self.options.is_void_tag)(tag.as_str()) {
+            return;
+        }
+
         let loc = self.create_loc(start.saturating_sub(2), end + 1); // Include </ and >
         self.errors
             .push(CompilerError::new(ErrorCode::InvalidEndTag, Some(loc)));

--- a/crates/vize_armature/tests/template_syntax_quirks.rs
+++ b/crates/vize_armature/tests/template_syntax_quirks.rs
@@ -1,0 +1,46 @@
+use vize_armature::{parse_with_options, parse_with_options_and_template_syntax};
+use vize_carton::Bump;
+use vize_relief::{
+    errors::ErrorCode,
+    options::{ParserOptions, TemplateSyntaxMode},
+};
+
+#[test]
+fn quirks_accepts_adjacent_attributes_recovered_by_vue_compiler() {
+    let allocator = Bump::new();
+    let source = r#"<div id="a"class="b"></div>"#;
+    let (_, standard_errors) = parse_with_options(&allocator, source, ParserOptions::default());
+    let (_, quirks_errors) = parse_with_options_and_template_syntax(
+        &allocator,
+        source,
+        ParserOptions::default(),
+        TemplateSyntaxMode::Quirks,
+    );
+
+    assert!(
+        standard_errors
+            .iter()
+            .any(|error| error.code == ErrorCode::MissingWhitespaceBetweenAttributes)
+    );
+    assert!(quirks_errors.is_empty(), "{quirks_errors:?}");
+}
+
+#[test]
+fn quirks_ignores_closing_tags_for_void_elements() {
+    let allocator = Bump::new();
+    let source = "<img></img>";
+    let (_, standard_errors) = parse_with_options(&allocator, source, ParserOptions::default());
+    let (_, quirks_errors) = parse_with_options_and_template_syntax(
+        &allocator,
+        source,
+        ParserOptions::default(),
+        TemplateSyntaxMode::Quirks,
+    );
+
+    assert!(
+        standard_errors
+            .iter()
+            .any(|error| error.code == ErrorCode::InvalidEndTag)
+    );
+    assert!(quirks_errors.is_empty(), "{quirks_errors:?}");
+}


### PR DESCRIPTION
## Summary
- suppress adjacent-attribute recovery diagnostics in quirks mode
- ignore unmatched closing tags for void elements in quirks mode
- cover both official Vue compiler compatibility cases

## Verification
- cargo test -p vize_armature
- cargo clippy -p vize_armature --lib -- -D warnings
- vp run --workspace-root check:ci
- real fixture compare: vue2-elm and vue-manage-system both officialErrors=0 / vizeErrors=0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786531533&installation_id=136613492&pr_number=2934&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2934&signature=c01f9d6a07ba0e3ae9a8c08306ec369b75bf5a8e68924cc992c70b3dd51a5083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quirks-mode template parsing to tolerate missing whitespace between adjacent attributes.
  * Allowed closing tags for void elements in quirks mode without reporting parsing errors.
  * Preserved strict validation and error reporting in standard parsing mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->