### PR TITLE
fix(sfc): preserve real block boundaries

### DIFF
--- a/crates/vize_atelier_sfc/src/parse/block.rs
+++ b/crates/vize_atelier_sfc/src/parse/block.rs
@@ -1,6 +1,10 @@
+mod compat;
+
 use memchr::{memchr, memchr_iter, memmem};
 use std::borrow::Cow;
 use vize_carton::{FxHashMap, String, cstr};
+
+use compat::{can_start_string_literal, is_void_block};
 
 // Tag name bytes for fast comparison
 pub(super) const TAG_TEMPLATE: &[u8] = b"template";
@@ -155,33 +159,6 @@ pub(super) fn skip_regex_literal(
     }
 
     None
-}
-
-fn can_start_string_literal(prev_significant_char: u8, quote: u8) -> bool {
-    matches!(
-        prev_significant_char,
-        b'=' | b'('
-            | b'['
-            | b','
-            | b':'
-            | b'{'
-            | b';'
-            | b'\n'
-            | b'?'
-            | b'&'
-            | b'|'
-            | b'+'
-            | b'-'
-            | b'*'
-            | b'!'
-            | b'>'
-            | b'<'
-            | b'%'
-            | b'^'
-    ) || (quote == b'`'
-        && (prev_significant_char.is_ascii_alphanumeric()
-            || prev_significant_char == b'_'
-            || prev_significant_char == b')'))
 }
 
 pub(super) fn skip_script_string_literal(
@@ -520,6 +497,19 @@ pub(super) fn parse_block_fast<'a>(
     }
 
     let content_start = pos;
+
+    if is_void_block(tag_name) {
+        return Ok(Some((
+            tag_name,
+            attrs,
+            Cow::Borrowed(""),
+            content_start,
+            content_start,
+            pos,
+            start_line,
+            pos - start,
+        )));
+    }
 
     // Find closing tag based on tag type
     let mut line = start_line;

--- a/crates/vize_atelier_sfc/src/parse/block/compat.rs
+++ b/crates/vize_atelier_sfc/src/parse/block/compat.rs
@@ -1,0 +1,31 @@
+pub(super) fn can_start_string_literal(prev_significant_char: u8, quote: u8) -> bool {
+    matches!(
+        prev_significant_char,
+        b'=' | b'('
+            | b'['
+            | b','
+            | b':'
+            | b'{'
+            | b';'
+            | b'\n'
+            | b'?'
+            | b'&'
+            | b'|'
+            | b'+'
+            | b'-'
+            | b'*'
+            | b'!'
+            | b'>'
+            | b'<'
+            | b'%'
+            | b'^'
+    ) || prev_significant_char.is_ascii_alphabetic()
+        || (quote == b'`'
+            && (prev_significant_char.is_ascii_alphanumeric()
+                || prev_significant_char == b'_'
+                || prev_significant_char == b')'))
+}
+
+pub(super) fn is_void_block(tag_name: &[u8]) -> bool {
+    std::str::from_utf8(tag_name).is_ok_and(vize_carton::is_void_tag)
+}

--- a/crates/vize_atelier_sfc/src/parse/parse_sfc.rs
+++ b/crates/vize_atelier_sfc/src/parse/parse_sfc.rs
@@ -207,7 +207,9 @@ pub fn parse_sfc<'a>(
                     });
                 } else {
                     // Custom block - use borrowed tag name
-                    if let Ok(tag_str) = std::str::from_utf8(tag_name) {
+                    if let Ok(tag_str) = std::str::from_utf8(tag_name)
+                        && !vize_carton::is_void_tag(tag_str)
+                    {
                         descriptor.custom_blocks.push(SfcCustomBlock {
                             block_type: Cow::Borrowed(tag_str),
                             content,

--- a/crates/vize_atelier_sfc/tests/sfc_block_boundaries.rs
+++ b/crates/vize_atelier_sfc/tests/sfc_block_boundaries.rs
@@ -1,0 +1,25 @@
+use vize_atelier_sfc::parse_sfc;
+
+#[test]
+fn top_level_html_void_elements_are_not_custom_blocks() {
+    let source = r#"<script src="https://example.com/component.js"></script>
+<link rel="stylesheet" href="https://example.com/component.css">"#;
+    let descriptor = parse_sfc(source, Default::default()).unwrap();
+
+    assert!(descriptor.script.is_some());
+    assert!(descriptor.custom_blocks.is_empty());
+}
+
+#[test]
+fn return_string_with_comment_opener_does_not_hide_script_close() {
+    let source = r#"<script setup>
+function accept() {
+  return "image/*"
+}
+</script>
+<template><input :accept="accept()" /></template>"#;
+    let descriptor = parse_sfc(source, Default::default()).unwrap();
+
+    assert!(descriptor.script_setup.is_some());
+    assert!(descriptor.template.is_some());
+}


### PR DESCRIPTION
## Summary
- ignore top-level HTML void elements instead of requiring custom-block closing tags
- recognize strings after JavaScript keywords so comment-like text cannot hide `</script>`
- split boundary helpers to keep the scanner below its source-length baseline

## Verification
- cargo test -p vize_atelier_sfc
- cargo clippy -p vize_atelier_sfc --lib -- -D warnings
- vp run --workspace-root check:ci
- full additional fixtures: 216/216 DOM, SSR, and Vapor runs completed
- LSP: 74/74 source-bearing projects reported diagnostics and semantic-token responses
- official compare regressions: vue-multiselect and Vue.NetCore both officialErrors=0 / vizeErrors=0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786532256&installation_id=136613492&pr_number=2935&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2935&signature=5594fd8d86b1bef413460df718f5319520cd58dff4811abaab9e03489e09d76e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing of HTML void elements so they no longer appear incorrectly as custom blocks.
  - Corrected handling of void elements without requiring closing tags.
  - Fixed script parsing when strings contain HTML-like comment sequences, ensuring closing script tags are detected correctly.
  - Improved recognition of string literals in supported syntax contexts.

- **Tests**
  - Added coverage for void elements, script and link tags, and script/template boundary cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->