### PR TITLE
fix(parser): preserve table control flow in quirks

### DIFF
--- a/crates/vize_armature/src/parser/element/table.rs
+++ b/crates/vize_armature/src/parser/element/table.rs
@@ -73,7 +73,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn handle_in_table_start_tag(&mut self, tag: &str, offset: usize) {
-        if self.open_table_count == 0 {
+        if self.open_table_count == 0 || self.template_syntax.is_quirks() {
             return;
         }
 

--- a/crates/vize_atelier_dom/tests/table_control_flow.rs
+++ b/crates/vize_atelier_dom/tests/table_control_flow.rs
@@ -1,0 +1,24 @@
+use vize_atelier_core::TemplateSyntaxMode;
+use vize_atelier_dom::{DomCompilerOptions, compile_template_with_template_syntax};
+use vize_carton::Bump;
+
+#[test]
+fn quirks_preserves_adjacent_table_control_flow() {
+    let allocator = Bump::new();
+    let source = r#"<table>
+  <template v-if="hasRows"><tr><td>row</td></tr></template>
+  <tr v-else><td>empty</td></tr>
+</table>"#;
+    let (_, errors, result) = compile_template_with_template_syntax(
+        &allocator,
+        source,
+        DomCompilerOptions::default(),
+        TemplateSyntaxMode::Quirks,
+    );
+
+    assert!(errors.is_empty(), "{errors:?}");
+    assert!(result.code.contains("hasRows"));
+    assert!(result.code.contains("? (_openBlock()"));
+    assert!(result.code.contains(": (_openBlock()"));
+    assert!(result.code.contains("\"tr\", { key: 1 }"));
+}


### PR DESCRIPTION
## Summary
- keep Vue quirks mode from inserting implicit table sections that split adjacent `v-if` / `v-else` branches
- add regression coverage for table control flow
- verify the affected HeyUI fixture against the official compiler (0 official errors / 0 Vize errors)

## Validation
- `cargo test -p vize_atelier_dom --test table_control_flow`
- `cargo test -p vize_armature`
- `cargo clippy -p vize_armature --lib -- -D warnings`
- `cargo clippy -p vize_atelier_dom --lib -- -D warnings`
- `vp run --workspace-root check:ci`
- source-length policy test
- real HeyUI compiler comparison

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786532942&installation_id=136613492&pr_number=2936&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2936&signature=e53f6595acb89cf62fa258d4757ea38d2e597784b126737b2be43f674e699899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of conditional template branches inside tables when using quirks mode.
  - Prevented incorrect table insertion behavior that could disrupt adjacent conditional branches.

- **Tests**
  - Added regression coverage confirming valid compilation and correct table row rendering for adjacent conditional branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->