### PR TITLE
fix(atelier): distinguish dynamic branch keys in quirks

### DIFF
--- a/crates/vize_atelier_core/src/lane.rs
+++ b/crates/vize_atelier_core/src/lane.rs
@@ -10,6 +10,8 @@ pub mod element;
 pub mod patterned_template;
 #[path = "transform/structural.rs"]
 pub mod structural;
+#[path = "transform/structural_keys.rs"]
+mod structural_keys;
 #[path = "transform/traverse.rs"]
 pub mod traverse;
 

--- a/crates/vize_atelier_core/src/transform/structural.rs
+++ b/crates/vize_atelier_core/src/transform/structural.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 use super::context::clone_expression;
+use super::structural_keys::extract_key_value_str;
 use super::traverse::traverse_children;
 use super::{ExitFns, ParentNode, TransformContext};
 
@@ -356,13 +357,16 @@ pub(crate) fn transform_v_if_with_directive<'a>(
 
             // Check for key collision with existing branches (vuejs/core #13881)
             let has_key_collision = if let Some(ref new_key) = user_key {
-                let new_key_str = extract_key_value_str(new_key);
+                let new_key_str = extract_key_value_str(new_key, ctx.template_syntax_quirks());
                 if let Some(parent) = &ctx.parent {
                     let children = parent.children_mut();
                     if let TemplateChildNode::If(if_node) = &children[if_idx] {
                         if_node.branches.iter().any(|existing_branch| {
                             if let Some(ref existing_key) = existing_branch.user_key {
-                                let existing_key_str = extract_key_value_str(existing_key);
+                                let existing_key_str = extract_key_value_str(
+                                    existing_key,
+                                    ctx.template_syntax_quirks(),
+                                );
                                 matches!((&new_key_str, &existing_key_str), (Some(nk), Some(ek)) if nk == ek)
                             } else {
                                 false
@@ -551,16 +555,5 @@ mod tests {
         let errors = transform_errors(r#"<div v-if="ok">yes</div><div v-else>no</div>"#);
 
         assert!(errors.is_empty(), "Unexpected errors: {:?}", errors);
-    }
-}
-
-/// Extract key value string from a PropNode for comparison
-fn extract_key_value_str(prop: &PropNode<'_>) -> Option<String> {
-    match prop {
-        PropNode::Attribute(attr) => attr.value.as_ref().map(|v| v.content.clone()),
-        PropNode::Directive(dir) => dir.exp.as_ref().map(|exp| match exp {
-            ExpressionNode::Simple(s) => s.content.clone(),
-            ExpressionNode::Compound(c) => c.loc.source.clone(),
-        }),
     }
 }

--- a/crates/vize_atelier_core/src/transform/structural_keys.rs
+++ b/crates/vize_atelier_core/src/transform/structural_keys.rs
@@ -1,0 +1,52 @@
+//! Branch-key comparison helpers for structural directives.
+
+use vize_carton::String;
+
+use crate::{ExpressionNode, PropNode};
+
+/// Extract a key identity when two branches can be proven to use the same key.
+pub(super) fn extract_key_value_str(
+    prop: &PropNode<'_>,
+    template_syntax_quirks: bool,
+) -> Option<String> {
+    match prop {
+        PropNode::Attribute(attr) => attr.value.as_ref().map(|value| value.content.clone()),
+        PropNode::Directive(dir) => {
+            let expression = dir.exp.as_ref()?;
+            if template_syntax_quirks && !is_stable_quirks_key(expression) {
+                return None;
+            }
+            Some(match expression {
+                ExpressionNode::Simple(simple) => simple.content.clone(),
+                ExpressionNode::Compound(compound) => compound.loc.source.clone(),
+            })
+        }
+    }
+}
+
+fn is_stable_quirks_key(expression: &ExpressionNode<'_>) -> bool {
+    let ExpressionNode::Simple(simple) = expression else {
+        return false;
+    };
+    if simple.is_static {
+        return true;
+    }
+
+    let source = simple.content.trim();
+    matches!(source, "true" | "false" | "null")
+        || source.parse::<f64>().is_ok()
+        || is_quoted_literal(source)
+}
+
+fn is_quoted_literal(source: &str) -> bool {
+    let Some(first) = source.as_bytes().first() else {
+        return false;
+    };
+    let Some(last) = source.as_bytes().last() else {
+        return false;
+    };
+    if first != last || !matches!(first, b'\'' | b'"' | b'`') {
+        return false;
+    }
+    *first != b'`' || !source.contains("${")
+}

--- a/crates/vize_atelier_dom/tests/branch_keys.rs
+++ b/crates/vize_atelier_dom/tests/branch_keys.rs
@@ -1,0 +1,45 @@
+use vize_atelier_core::{ErrorCode, TemplateSyntaxMode};
+use vize_atelier_dom::{DomCompilerOptions, compile_template_with_template_syntax};
+use vize_carton::Bump;
+
+fn compile_errors(source: &str, syntax: TemplateSyntaxMode) -> Vec<ErrorCode> {
+    let allocator = Bump::new();
+    let (_, errors, _) = compile_template_with_template_syntax(
+        &allocator,
+        source,
+        DomCompilerOptions::default(),
+        syntax,
+    );
+    errors.into_iter().map(|error| error.code).collect()
+}
+
+#[test]
+fn quirks_allows_runtime_branch_key_expressions() {
+    let errors = compile_errors(
+        r#"<div v-if="ok" :key="effect"/><div v-else :key="effect"/>"#,
+        TemplateSyntaxMode::Quirks,
+    );
+
+    assert!(!errors.contains(&ErrorCode::VIfSameKey), "{errors:?}");
+}
+
+#[test]
+fn quirks_rejects_duplicate_literal_branch_keys() {
+    for source in [
+        r#"<div v-if="ok" key="same"/><div v-else key="same"/>"#,
+        r#"<div v-if="ok" :key="1"/><div v-else :key="1"/>"#,
+    ] {
+        let errors = compile_errors(source, TemplateSyntaxMode::Quirks);
+        assert!(errors.contains(&ErrorCode::VIfSameKey), "{errors:?}");
+    }
+}
+
+#[test]
+fn standard_keeps_vue_three_dynamic_branch_key_check() {
+    let errors = compile_errors(
+        r#"<div v-if="ok" :key="effect"/><div v-else :key="effect"/>"#,
+        TemplateSyntaxMode::Standard,
+    );
+
+    assert!(errors.contains(&ErrorCode::VIfSameKey), "{errors:?}");
+}


### PR DESCRIPTION
## Summary
- avoid treating runtime key expressions as certainly identical in template quirks mode
- keep duplicate static and literal branch-key diagnostics
- preserve Vue 3 standard-mode behavior
- verify the affected HeyUI carousel against the official compiler (0 official errors / 0 Vize errors)

## Validation
- `cargo test -p vize_atelier_dom --test branch_keys`
- `cargo test -p vize_atelier_core`
- `cargo clippy -p vize_atelier_core --lib -- -D warnings`
- `cargo clippy -p vize_atelier_dom --lib -- -D warnings`
- `vp run --workspace-root check:ci`
- source-length policy test
- real HeyUI compiler comparison

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786533370&installation_id=136613492&pr_number=2937&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2937&signature=1e28b6178a4fd833ccd44f27efcaa98b91f25fed9532ab307d38d3329a01b8a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of keys on conditional template branches.
  * Quirks mode now correctly permits runtime-generated branch keys while still detecting duplicate literal keys.
  * Standard mode continues to detect duplicate dynamic branch keys.
  * Key comparisons now consistently support static strings, numbers, booleans, null values, and eligible quoted expressions.
* **Tests**
  * Added coverage for conditional branch key validation across supported template syntax modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->