### PR TITLE
fix(atelier): stop recursive v-for parameter extraction

### DIFF
--- a/crates/vize_atelier_core/src/codegen/v_for/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/helpers.rs
@@ -22,7 +22,10 @@ pub(crate) fn extract_for_params(expr: &ExpressionNode<'_>, params: &mut Vec<Str
 /// Recursively extract parameter names from a destructuring pattern string.
 pub(crate) fn extract_destructure_params(trimmed: &str, params: &mut Vec<String>) {
     if trimmed.contains(',') && !trimmed.starts_with('{') && !trimmed.starts_with('[') {
-        for part in split_top_level(trimmed) {
+        for part in split_top_level(trimmed)
+            .into_iter()
+            .filter(|part| *part != trimmed)
+        {
             let part = part.trim();
             if !part.is_empty() {
                 extract_destructure_params(part, params);
@@ -290,6 +293,19 @@ mod tests {
         );
 
         assert_eq!(params, ["first", "secondId"]);
+    }
+
+    #[test]
+    fn test_extract_destructure_params_stops_on_unbalanced_nesting() {
+        for malformed in ["$data.[label, value]", "(dep(, file)"] {
+            let mut params = Vec::new();
+            extract_destructure_params(malformed, &mut params);
+            assert!(params.is_empty(), "unexpected params for {malformed:?}");
+        }
+
+        let mut params = Vec::new();
+        extract_destructure_params("item, index", &mut params);
+        assert_eq!(params, ["item", "index"]);
     }
 
     #[test]

--- a/crates/vize_atelier_ssr/src/codegen/helpers.rs
+++ b/crates/vize_atelier_ssr/src/codegen/helpers.rs
@@ -353,14 +353,15 @@ pub(crate) fn extract_destructure_params(value: &str, params: &mut FxHashSet<Str
         extract_destructure_params(value[1..value.len() - 1].trim(), params);
         return;
     }
-
     if value.contains(',') && !value.starts_with('{') && !value.starts_with('[') {
-        for part in split_top_level(value) {
+        for part in split_top_level(value)
+            .into_iter()
+            .filter(|part| *part != value)
+        {
             extract_destructure_params(part.trim(), params);
         }
         return;
     }
-
     if value.starts_with('{') && value.ends_with('}') {
         for part in split_top_level(&value[1..value.len() - 1]) {
             let part = part.trim();
@@ -391,7 +392,6 @@ pub(crate) fn extract_destructure_params(value: &str, params: &mut FxHashSet<Str
         collect_identifier_param(value, params);
     }
 }
-
 fn collect_identifier_param(value: &str, params: &mut FxHashSet<String>) {
     if is_valid_identifier(value) {
         params.insert(value.to_compact_string());


### PR DESCRIPTION
## Summary

- stop malformed comma-separated `v-for` aliases from recursing when top-level splitting makes no progress
- apply the same fail-closed behavior to DOM and SSR parameter extraction
- add focused regressions for both fuzz reproducer shapes while preserving valid `item, index` aliases

## Root cause

Unbalanced `[` or `(` nesting kept the comma below the top level. `split_top_level` therefore returned the original string unchanged, and parameter extraction recursively called itself with the same input until stack overflow.

Closes #2942.
Closes #2943.

## Validation

- `cargo test -p vize_atelier_core codegen::v_for::helpers::tests -- --nocapture`
- `cargo test -p vize_atelier_ssr`
- `cargo clippy -p vize_atelier_core -p vize_atelier_ssr --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `corepack pnpm exec vp run source:lengths --check --base-ref origin/main --max-lines 350 --limit 50`
- `corepack pnpm exec vp run --workspace-root check:ci`
- replayed both original `template_compile` artifacts under ASan/libFuzzer; both completed without a crash

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786769335&installation_id=136613492&pr_number=2951&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2951&signature=438c4d676207280b368842ef3d381313a2cefb1e24d9d510c58f4c735546a07d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or unbalanced destructuring patterns.
  * Prevented incorrect parameter extraction when commas appear inside quoted or nested content.
  * Preserved correct extraction for valid comma-separated identifiers such as `item, index`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->