### PR TITLE
fix(ci): restore npm security audits

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,33 +22,5 @@
     "vite-plus": "catalog:vite-stack",
     "yaml": "2.9.0"
   },
-  "packageManager": "pnpm@10.0.0",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ],
-    "overrides": {
-      "@azure/msal-node>uuid": "11.1.1",
-      "@unhead/vue": "2.1.15",
-      "defu": "6.1.7",
-      "devalue": "5.8.1",
-      "dompurify": "3.4.11",
-      "esbuild": "0.28.1",
-      "h3": "1.15.11",
-      "hono": "4.12.25",
-      "launch-editor": "2.14.1",
-      "nanotar": "0.3.0",
-      "nitropack": "2.13.4",
-      "node-forge": "1.4.0",
-      "nuxt": "4.4.8",
-      "qs": "6.15.2",
-      "shell-quote": "1.8.4",
-      "simple-git": "3.36.0",
-      "srvx": "0.11.15",
-      "svgo": "4.0.1",
-      "tar": "7.5.16",
-      "vite@>=7.0.0 <7.3.5": "7.3.5",
-      "yaml": "2.9.0"
-    }
-  }
+  "packageManager": "pnpm@11.13.1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,29 @@ packages:
   - "tests"
   - "bench"
 
+overrides:
+  "@azure/msal-node>uuid": "11.1.1"
+  "@unhead/vue": "2.1.15"
+  defu: "6.1.7"
+  devalue: "5.8.1"
+  dompurify: "3.4.11"
+  esbuild: "0.28.1"
+  h3: "1.15.11"
+  hono: "4.12.25"
+  launch-editor: "2.14.1"
+  nanotar: "0.3.0"
+  nitropack: "2.13.4"
+  node-forge: "1.4.0"
+  nuxt: "4.4.8"
+  qs: "6.15.2"
+  shell-quote: "1.8.4"
+  simple-git: "3.36.0"
+  srvx: "0.11.15"
+  svgo: "4.0.1"
+  tar: "7.5.16"
+  "vite@>=7.0.0 <7.3.5": "7.3.5"
+  yaml: "2.9.0"
+
 catalogs:
   # Shared repo and file-system utilities.
   repo-tooling:
@@ -127,3 +150,10 @@ peerDependencyRules:
   allowedVersions:
     vite: "*"
     vitest: "*"
+
+allowBuilds:
+  "@parcel/watcher": false
+  core-js: false
+  esbuild: true
+  puppeteer: false
+  vue-demi: false

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -228,9 +228,18 @@ test("PR test report keeps the test file inventory collapsed with a short toggle
 
 test("check workflow runs JS package unit tests and production dependency audit", () => {
   const workflow = readRepoFile(".github", "workflows", "check.yml");
+  const packageJson = JSON.parse(readRepoFile("package.json"));
+  const pnpmWorkspace = readRepoFile("pnpm-workspace.yaml");
   const jsPackageJob = workflowJobBody(workflow, "test-js-packages");
   const auditJob = workflowJobBody(workflow, "security-audit");
 
+  assert.equal(packageJson.packageManager, "pnpm@11.13.1");
+  assert.equal(packageJson.pnpm, undefined);
+  assert.match(pnpmWorkspace, /^overrides:\n/m);
+  assert.match(
+    pnpmWorkspace,
+    /^allowBuilds:\n  "@parcel\/watcher": false\n  core-js: false\n  esbuild: true\n  puppeteer: false\n  vue-demi: false$/m,
+  );
   assert.match(jsPackageJob, /vp run --workspace-root test:js/);
   assert.match(jsPackageJob, /key:\s*test-js-packages/);
   assert.match(auditJob, /vp exec pnpm audit --prod --audit-level moderate/);


### PR DESCRIPTION
## Summary

- upgrade the pinned package manager from pnpm 10.0.0 to 11.13.1 so audits use npm's supported bulk advisory endpoint
- migrate pnpm settings to `pnpm-workspace.yaml` and replace the removed build allowlist setting with explicit pnpm 11 decisions
- add a workflow contract regression for the package-manager pin and build-script policy

## Root cause

The npm registry retired `/-/npm/v1/security/audits{,/quick}`. pnpm 10 still calls those endpoints, so every PR's `security-audit` job failed with HTTP 410 before evaluating advisories.

## Validation

- `CI=true vp install --frozen-lockfile --prefer-offline`
- `vp exec pnpm --version` → `11.13.1`
- `vp exec pnpm audit --prod --audit-level moderate` → passes; one low advisory remains below the configured moderate gate
- `cargo audit --deny warnings`
- `node --test tests/tooling/github-workflows-check.test.ts tests/tooling/language-engineering-practices.test.ts`
- `vp run --workspace-root check:ci`
- `vp run source:lengths --check --base-ref origin/main --max-lines 350 --limit 50`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786770258&installation_id=136613492&pr_number=2952&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2952&signature=f6415a214da22b047f76f339c95581b39c4ce9c9d2640b07ea4ae478dbd0ba98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project tooling configuration for more consistent package management and workspace builds.
  * Refined build-time package handling and version controls across the project.

* **Tests**
  * Expanded automated checks to verify package manager and workspace configuration.
  * Continued validating JavaScript tests and production security checks in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->