### PR TITLE
fix(atelier): bound expression parser nesting

### DIFF
--- a/crates/vize_atelier_core/src/transforms/transform_expression.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression.rs
@@ -18,9 +18,9 @@ use vize_carton::{Box, Bump, String};
 
 /// Maximum bracket nesting depth allowed before handing source to OXC.
 ///
-/// OXC recurses for nested brackets and stack overflow cannot be caught with
-/// `catch_unwind`, so every expression entry point shares this guard. (#956)
-pub const MAX_EXPRESSION_NESTING_DEPTH: usize = 256;
+/// OXC recurses for nested brackets; stack overflow (#956) and a parser timeout
+/// at depth 32 (#2944) cannot be caught, so every entry point shares this guard.
+pub const MAX_EXPRESSION_NESTING_DEPTH: usize = 31;
 
 /// Returns the maximum bracket nesting depth in `content`. Only counts
 /// `(`, `[`, `{` and their closers — these are what drive recursion in the

--- a/crates/vize_atelier_core/tests/expression_nesting_guard.rs
+++ b/crates/vize_atelier_core/tests/expression_nesting_guard.rs
@@ -1,0 +1,33 @@
+use vize_atelier_core::steps::expression::{
+    MAX_EXPRESSION_NESTING_DEPTH, expression_exceeds_max_depth, expression_nesting_depth,
+    is_event_handler_reference_expression, is_function_expression,
+    prefix_identifiers_in_expression, strip_typescript_from_expression,
+};
+
+const TIMEOUT_REPRODUCER: &str = "\nd=\nd=efnuiProps<{[dnuiProps<{[d=efnuiProps<{[dnuiProps<{[defnuiProps<{[  cts<{[  oefnuiProps<{[dnuiProps<{[defnuiProps<{[  cts<{[  oo>>efnuiProps<{[  cts<{[  oefnuiProps<{[dnuiProps<{[defnuiProps<{[  cts<{[  oo>>> \x1a\x1a\x1a\x1a\x1atr";
+
+#[test]
+fn expression_guard_rejects_the_js_ts_timeout_reproducer() {
+    assert_eq!(TIMEOUT_REPRODUCER.len(), 222);
+    assert_eq!(expression_nesting_depth(TIMEOUT_REPRODUCER), 32);
+    assert!(expression_exceeds_max_depth(TIMEOUT_REPRODUCER));
+    assert!(!is_event_handler_reference_expression(TIMEOUT_REPRODUCER));
+    assert!(!is_function_expression(TIMEOUT_REPRODUCER));
+    assert_eq!(
+        prefix_identifiers_in_expression(TIMEOUT_REPRODUCER).as_str(),
+        TIMEOUT_REPRODUCER
+    );
+    assert_eq!(
+        strip_typescript_from_expression(TIMEOUT_REPRODUCER).as_str(),
+        TIMEOUT_REPRODUCER
+    );
+}
+
+#[test]
+fn expression_guard_preserves_the_documented_boundary() {
+    let allowed = "(".repeat(MAX_EXPRESSION_NESTING_DEPTH);
+    let rejected = "(".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1);
+
+    assert!(!expression_exceeds_max_depth(&allowed));
+    assert!(expression_exceeds_max_depth(&rejected));
+}

--- a/tests/fuzz/Cargo.toml
+++ b/tests/fuzz/Cargo.toml
@@ -22,6 +22,7 @@ oxc_allocator = { version = "=0.127.0", git = "https://github.com/oxc-project/ox
 oxc_parser = { version = "=0.127.0", git = "https://github.com/oxc-project/oxc", rev = "8265ed94b8f743a11dbf6f81fdd6fd248906f366" }
 oxc_span = { version = "=0.127.0", git = "https://github.com/oxc-project/oxc", rev = "8265ed94b8f743a11dbf6f81fdd6fd248906f366" }
 vize_armature = { path = "../../crates/vize_armature" }
+vize_atelier_core = { path = "../../crates/vize_atelier_core" }
 vize_atelier_sfc = { path = "../../crates/vize_atelier_sfc", default-features = false, features = [
   "native",
 ] }

--- a/tests/fuzz/fuzz_targets/js_ts_expression.rs
+++ b/tests/fuzz/fuzz_targets/js_ts_expression.rs
@@ -9,12 +9,13 @@ use libfuzzer_sys::fuzz_target;
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
+use vize_atelier_core::steps::expression::expression_exceeds_max_depth;
 
 fuzz_target!(|data: &[u8]| {
     let Ok(source) = std::str::from_utf8(data) else {
         return;
     };
-    if exceeds_expression_nesting_limit(source, 256) {
+    if expression_exceeds_max_depth(source) {
         return;
     }
 
@@ -26,20 +27,3 @@ fuzz_target!(|data: &[u8]| {
     );
     let _ = parser.parse_expression();
 });
-
-fn exceeds_expression_nesting_limit(source: &str, limit: usize) -> bool {
-    let mut depth = 0usize;
-    for byte in source.bytes() {
-        match byte {
-            b'(' | b'[' | b'{' => {
-                depth += 1;
-                if depth > limit {
-                    return true;
-                }
-            }
-            b')' | b']' | b'}' => depth = depth.saturating_sub(1),
-            _ => {}
-        }
-    }
-    false
-}


### PR DESCRIPTION
## Summary

- reject JS/TS expressions before OXC when bracket nesting exceeds the proven safe boundary
- share the production guard with the `js_ts_expression` fuzz target so fuzzing and runtime behavior cannot drift
- pin the exact 222-byte timeout artifact and the 31/32 nesting boundary in deterministic regression tests

## Root cause

The existing guard allowed 256 nested delimiters. The uploaded fuzz artifact reaches depth 32 and stalls OXC's expression parser before the guard can reject it.

Closes #2944.

## Validation

- `cargo test -p vize_atelier_core --test expression_nesting_guard`
- `cargo clippy -p vize_atelier_core --test expression_nesting_guard -- -D warnings`
- `cargo fmt --all -- --check`
- `corepack pnpm exec vp run --workspace-root check:ci`
- `corepack pnpm exec vp run source:lengths --check --base-ref origin/main --max-lines 350 --limit 50`
- replayed the exact uploaded artifact with `cargo +nightly fuzz run --fuzz-dir tests/fuzz js_ts_expression`; it now exits immediately instead of timing out

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786770356&installation_id=136613492&pr_number=2953&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2953&signature=8b8323f78ecfda42309f005580b143bd5f26ecee63479f7ed86de8eb77934159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deeply nested JavaScript and TypeScript expressions to prevent parser timeouts and stack overflows.
  * Applied consistent nesting-depth validation across expression processing and fuzz testing.

* **Tests**
  * Added coverage for maximum-depth boundary behavior and deeply nested expression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->