### PR TITLE
fix(ci): isolate vscode extension installs

### DIFF
--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -8,9 +8,7 @@ import {
   onigurumaWasmPath,
   textmateModulePath,
 } from "./support/textmate-deps.ts";
-
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-
 function readText(relativePath: string): string {
   return fs.readFileSync(path.join(root, relativePath), "utf-8");
 }
@@ -21,7 +19,6 @@ function readJson<T>(relativePath: string): T {
 
 function workspaceVersion(): string {
   const version = readText("Cargo.toml").match(/^version = "(.+)"$/m)?.[1];
-
   assert.ok(version);
   return version;
 }
@@ -39,7 +36,6 @@ function createStubGrammar(scopeName: string) {
     { match: "[<>{}()\\[\\].,:?=+\\-*/|&!]+", name: "punctuation.ts" },
     { match: "\"(?:\\\\.|[^\"])*\"|'(?:\\\\.|[^'])*'|`(?:\\\\.|[^`])*`", name: "string.ts" },
   ];
-
   return {
     scopeName,
     patterns,
@@ -466,14 +462,18 @@ test("zed-vize registers art-vue as a first-party language", () => {
 test("CI packages editor extension artifacts", () => {
   const workflow = readText(".github/workflows/check.yml");
   const buildTasks = readText("tools/vite-plus/tasks/build.ts");
+  const taskCommands = readText("tools/vite-plus/task-commands.ts");
   const testTasks = readText("tools/vite-plus/tasks/test-benchmark.ts");
-
   assert.match(
     workflow,
     /name: Check and package editor extensions[\s\S]*package:editor-extensions/,
   );
   assert.match(buildTasks, /package:vscode-extension[\s\S]*assert-vsix-package\.mjs/);
   assert.match(buildTasks, /package:editor-extensions[\s\S]*assert-vsix-package\.mjs/);
+  assert.match(
+    taskCommands,
+    /pnpm install --ignore-workspace --no-lockfile --prefer-offline --ignore-scripts/,
+  );
   assert.match(testTasks, /test:vscode-extension:vsix[\s\S]*assert-vsix-package\.mjs/);
   assert.match(testTasks, /test:vscode-extension:host[\s\S]*pnpm run test:host/);
   assert.match(buildTasks, /package:zed-extension[\s\S]*assert-zed-package\.mjs/);

--- a/tools/vite-plus/task-commands.ts
+++ b/tools/vite-plus/task-commands.ts
@@ -23,7 +23,7 @@ export const runPackageScriptDirectly = (taskName: string, packages: readonly Pa
  */
 export const installVscodeExtensionDependencies = runInDirectory(
   "editors/vscode",
-  "if [ -x node_modules/.bin/vp ]; then exit 0; fi && mkdir -p node_modules/.bin && pnpm install --ignore-workspace --no-lockfile --prefer-offline",
+  "if [ -x node_modules/.bin/vp ]; then exit 0; fi && mkdir -p node_modules/.bin && pnpm install --ignore-workspace --no-lockfile --prefer-offline --ignore-scripts",
 );
 
 /**


### PR DESCRIPTION
## Summary

- install the isolated VS Code extension dependencies with lifecycle scripts disabled explicitly
- keep pnpm 11 strict build policy from failing on `@vscode/vsce-sign` and `keytar`, whose scripts were already blocked under the previous allowlist
- add a workflow contract regression for the isolated install flags

## Root cause

The VS Code package intentionally installs outside the root workspace with `--ignore-workspace`. After pnpm 11 made blocked dependency scripts fatal, that isolated install could not inherit the root build policy and stopped on two unapproved scripts.

## Validation

- clean `editors/vscode` install with `pnpm install --ignore-workspace --no-lockfile --prefer-offline --ignore-scripts`
- `vp run --workspace-root package:editor-extensions`
- `node --test tests/tooling/editor-integrations.test.ts tests/tooling/github-workflows-check.test.ts`
- `vp run --workspace-root check:ci`
- `vp run source:lengths --check --base-ref origin/main --max-lines 350 --limit 50`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786773562&installation_id=136613492&pr_number=2955&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2955&signature=d8986ae4a43f983e765b20bd0ff2fefea1d4631f5e82a486717a3cc5d6e0fe4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VS Code extension dependency installation by preventing package installation scripts from running.
  * Added validation to ensure the installation command uses the expected offline and workspace-safe options.

* **Tests**
  * Expanded CI coverage to verify the editor extension dependency installation command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->