### PR TITLE
fix(canon): allow undefined unknown listeners

### DIFF
--- a/crates/vize_canon/src/virtual_ts/scope/event_handler.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/event_handler.rs
@@ -194,7 +194,7 @@ fn matching_paren_index(input: &str, open_index: usize) -> Option<usize> {
 
 fn is_callable_handler_reference(content: &str) -> bool {
     let trimmed = content.trim();
-    if trimmed.is_empty() {
+    if trimmed.is_empty() || trimmed == "undefined" {
         return false;
     }
 
@@ -322,4 +322,22 @@ fn parse_bracket_member(input: &str, open_index: usize) -> Option<usize> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_callable_handler_reference;
+
+    #[test]
+    fn undefined_is_not_a_callable_handler_reference() {
+        assert!(!is_callable_handler_reference("undefined"));
+        assert!(!is_callable_handler_reference("  undefined  "));
+    }
+
+    #[test]
+    fn actual_handler_references_stay_callable() {
+        assert!(is_callable_handler_reference("handler"));
+        assert!(is_callable_handler_reference("handlers[key]"));
+        assert!(is_callable_handler_reference("form?.submit"));
+    }
 }

--- a/crates/vize_canon/tests/nuxt_false_positives.rs
+++ b/crates/vize_canon/tests/nuxt_false_positives.rs
@@ -104,6 +104,26 @@ fn accepts_typed_route_destructured_and_rest_props() {
     );
 }
 
+#[test]
+fn undefined_unknown_event_handler_stays_optional() {
+    let result = type_check_sfc(
+        UNDEFINED_EVENT_SFC,
+        &SfcTypeCheckOptions::new("UndefinedEvent.vue").with_virtual_ts(),
+    );
+    let virtual_ts = result.virtual_ts.expect("virtual ts should be generated");
+    assert!(virtual_ts.contains("undefined;  // handler expression"));
+    assert!(!virtual_ts.contains("=> handler)((undefined))"));
+
+    let project = create_project(&[("src/UndefinedEvent.vue", UNDEFINED_EVENT_SFC)]);
+    let Some(snapshot) = snapshot_project_diagnostics(project.path()) else {
+        return;
+    };
+    assert!(
+        snapshot.iter().all(|(_, code, _)| *code != Some(2345)),
+        "undefined listeners should not be required callbacks: {snapshot:#?}"
+    );
+}
+
 fn create_project(files: &[(&str, &str)]) -> tempfile::TempDir {
     let project = tempfile::tempdir().expect("temp project should be created");
     write_tsconfig(project.path());
@@ -286,4 +306,8 @@ const {
     <Icon v-if="appendIcon" :name="appendIcon" />
   </NuxtLink>
 </template>
+"#;
+
+const UNDEFINED_EVENT_SFC: &str = r#"<script setup lang="ts"></script>
+<template><UnknownComponent @unknownEvent="undefined" /></template>
 "#;


### PR DESCRIPTION
## Summary

- keep the `undefined` listener sentinel as a bare expression instead of treating it as a callable handler reference
- add focused callable-reference unit coverage for both the sentinel and real handlers
- exercise the exact SFC through virtual TypeScript generation and the Corsa-backed project type checker

## Validation

- `cargo test -p vize_canon --test nuxt_false_positives`
- `cargo test -p vize_canon virtual_ts::scope::event_handler::tests -- --nocapture`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `vp run --workspace-root check:ci`

Closes #2946

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786773835&installation_id=136613492&pr_number=2956&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2956&signature=33c8de74943fe99a2762073c813fa31989d22c55e257433a2088a8ba3c65802a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of event listeners using the `undefined` handler expression, including expressions with surrounding whitespace.
  * Prevented invalid type-checking errors for optional event handlers.

* **Tests**
  * Added regression coverage for `undefined` event handlers and validation of generated type-checking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->