### PR TITLE
fix(canon): unwrap imported refs in templates

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -32,8 +32,8 @@ use self::props_anchors::emit_setup_scope_prop_anchors;
 use self::setup_helpers::emit_setup_helpers;
 use self::setup_props::SetupPropsPlan;
 use self::spans::{
-    DEFINE_COMPONENT_REF, merge_overlapping_spans, preserved_template_usage,
-    rewrite_export_default_for_module_scope,
+    DEFINE_COMPONENT_REF, merge_overlapping_spans, rewrite_export_default_for_module_scope,
+    template_usage,
 };
 use super::{
     helpers::{
@@ -144,14 +144,14 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     let mut ts = String::default();
     let mut mappings: Vec<VizeMapping> = Vec::new();
     let preserve_unused_diagnostics = generation_options.preserve_unused_diagnostics;
-    let (template_referenced_names, has_template_scope) =
-        preserved_template_usage(summary, template_ast, generation_options);
+    let (template_usage_names, has_template_scope) =
+        template_usage(summary, template_ast, generation_options);
+    let template_referenced_names = preserve_unused_diagnostics.then_some(&template_usage_names);
     let reference_setup_bindings_comment = if preserve_unused_diagnostics {
         "Reference setup bindings used by template generation"
     } else {
         "Reference setup bindings (used in template/CSS v-bind)"
     };
-
     let lib_references = generation_options
         .lib_references
         .unwrap_or(DEFAULT_LIB_REFERENCES);
@@ -737,7 +737,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             let template_ref_unwraps = template_refs::TemplateRefUnwraps::collect(
                 summary,
                 options_api,
-                template_referenced_names.as_ref(),
+                Some(&template_usage_names),
                 script_content,
             );
             template_ref_unwraps.emit_type_captures(&mut ts);
@@ -846,7 +846,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                     &mut ts,
                     summary,
                     script_content,
-                    template_referenced_names.as_ref(),
+                    template_referenced_names,
                     reference_setup_bindings_comment,
                 )
             );
@@ -862,7 +862,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                 &mut ts,
                 summary,
                 script_content,
-                template_referenced_names.as_ref(),
+                template_referenced_names,
                 reference_setup_bindings_comment,
             )
         );
@@ -872,7 +872,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         &mut ts,
         summary,
         script_content,
-        template_referenced_names.as_ref(),
+        template_referenced_names,
         preserve_unused_diagnostics,
     );
 

--- a/crates/vize_canon/src/virtual_ts/generator/spans.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/spans.rs
@@ -5,19 +5,17 @@ use vize_atelier_sfc::script::resolve_template_used_identifiers;
 use vize_carton::{FxHashSet, String};
 use vize_croquis::{Croquis, ScopeData};
 
-pub(super) fn preserved_template_usage(
+pub(super) fn template_usage(
     summary: &Croquis,
     template_ast: Option<&vize_relief::RootNode<'_>>,
     generation_options: crate::virtual_ts::types::VirtualTsGenerationOptions<'_>,
-) -> (Option<FxHashSet<String>>, bool) {
-    let names = generation_options.preserve_unused_diagnostics.then(|| {
-        collect_template_referenced_names(
-            summary,
-            template_ast,
-            generation_options.extra_template_referenced_names,
-        )
-    });
-    let has_scope = template_ast.is_some() || names.as_ref().is_some_and(|names| !names.is_empty());
+) -> (FxHashSet<String>, bool) {
+    let names = collect_template_referenced_names(
+        summary,
+        template_ast,
+        generation_options.extra_template_referenced_names,
+    );
+    let has_scope = template_ast.is_some() || !names.is_empty();
     (names, has_scope)
 }
 
@@ -84,6 +82,17 @@ fn collect_template_referenced_names(
     }
 
     names
+}
+
+pub(super) fn is_local_setup_binding(summary: &Croquis, name: &str) -> bool {
+    let Some(&(start, end)) = summary.binding_spans.get(name) else {
+        return true;
+    };
+
+    !summary
+        .import_statements
+        .iter()
+        .any(|import| start >= import.start && end <= import.end)
 }
 
 fn collect_expression_identifiers(names: &mut FxHashSet<String>, expression: &str) {
@@ -219,17 +228,6 @@ fn wrap_default_export_object(
     output.push(')');
     output.push_str(&text[object_end..]);
     Some(output)
-}
-
-pub(super) fn is_local_setup_binding(summary: &Croquis, name: &str) -> bool {
-    let Some(&(start, end)) = summary.binding_spans.get(name) else {
-        return true;
-    };
-
-    !summary
-        .import_statements
-        .iter()
-        .any(|import| start >= import.start && end <= import.end)
 }
 
 #[cfg(test)]

--- a/crates/vize_canon/src/virtual_ts/generator/template_refs.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/template_refs.rs
@@ -34,14 +34,15 @@ impl TemplateRefUnwraps {
             .bindings
             .iter()
             .filter(|(name, _)| {
-                template_referenced_names
-                    .is_none_or(|referenced| referenced.contains(name.as_str()))
+                template_referenced_names.is_none_or(|referenced| {
+                    referenced.contains(name.as_str())
+                        || is_local_setup_binding(summary, name.as_str())
+                })
             })
             .filter(|(name, _)| !options_api_setup_binding_names.contains(name.as_str()))
             .filter(|(name, binding_type)| {
                 summary.reactivity.needs_value_access(name.as_str())
                     || matches!(binding_type, BindingType::SetupMaybeRef)
-                        && is_local_setup_binding(summary, name.as_str())
             })
             .map(|(name, _)| String::from(name.as_str()))
             .collect();

--- a/crates/vize_canon/tests/imported_ref_unwrap.rs
+++ b/crates/vize_canon/tests/imported_ref_unwrap.rs
@@ -1,0 +1,120 @@
+use std::path::Path;
+
+use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait, SfcTypeCheckOptions, type_check_sfc};
+
+#[test]
+fn imported_ref_is_unwrapped_in_template_scope() {
+    let result = type_check_sfc(
+        APP_SFC,
+        &SfcTypeCheckOptions::new("App.vue").with_virtual_ts(),
+    );
+    let virtual_ts = result.virtual_ts.expect("virtual ts should be generated");
+
+    assert!(
+        virtual_ts.contains("type __R_sharedRef = typeof sharedRef;"),
+        "imported refs need a pre-template type capture:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("var sharedRef: __U<__R_sharedRef> = undefined as any;"),
+        "imported refs need an unwrapped template shadow:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("var format: __U<__R_format> = undefined as any;"),
+        "non-ref named imports should keep their type through the same safe helper:\n{virtual_ts}"
+    );
+    assert!(
+        !virtual_ts.contains("type __R_BooleanProp"),
+        "default component imports should not be shadowed:\n{virtual_ts}"
+    );
+}
+
+#[test]
+fn imported_ref_satisfies_primitive_component_prop() {
+    let project = tempfile::tempdir().expect("temp project should be created");
+    write_project(project.path());
+
+    let mut checker = BatchTypeChecker::new(project.path()).expect("checker should start");
+    checker.scan_project().expect("project should scan");
+    let result = checker.check_project().expect("project should type check");
+    let relevant: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.file.ends_with("App.vue") && matches!(diagnostic.code, Some(2322 | 2345))
+        })
+        .collect();
+
+    assert!(
+        relevant.is_empty(),
+        "an imported Ref<boolean> should satisfy a boolean prop: {relevant:#?}"
+    );
+}
+
+fn write_project(root: &Path) {
+    write_file(
+        root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write_file(
+        root,
+        "node_modules/vue/package.json",
+        r#"{ "name": "vue", "types": "index.d.ts" }"#,
+    );
+    write_file(
+        root,
+        "node_modules/vue/index.d.ts",
+        r#"export interface Ref<T = unknown, S = T> { value: T }
+export function ref<T>(value: T): Ref<T, T>;
+export interface ComponentPublicInstance {
+  $attrs: Record<string, unknown>;
+  $slots: Record<string, unknown>;
+  $refs: Record<string, unknown>;
+  $emit: (...args: unknown[]) => void;
+}
+"#,
+    );
+    write_file(root, "src/App.vue", APP_SFC);
+    write_file(
+        root,
+        "src/other.ts",
+        "import { ref } from 'vue';\nexport const sharedRef = ref(false);\nexport function format(value: boolean): string { return String(value); }\n",
+    );
+    write_file(
+        root,
+        "src/BooleanProp.vue",
+        r#"<script setup lang="ts">
+defineProps<{ boolProp?: boolean }>()
+</script>
+<template><div /></template>
+"#,
+    );
+}
+
+fn write_file(root: &Path, path: &str, source: &str) {
+    let path = root.join(path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("parent directory should be created");
+    }
+    std::fs::write(path, source).expect("fixture should be written");
+}
+
+const APP_SFC: &str = r#"<script setup lang="ts">
+import { format, sharedRef } from "./other.ts";
+import BooleanProp from "./BooleanProp.vue";
+</script>
+
+<template>
+  <BooleanProp :boolProp="sharedRef" />
+  <div>{{ format(sharedRef) }}</div>
+</template>
+"#;


### PR DESCRIPTION
## Summary

- collect template usage names independently from unused-local diagnostic preservation
- include referenced named imports in the safe Vue ref-unwrapping aliases while leaving default component imports untouched
- cover an imported `Ref<boolean>` and an ordinary imported function through generated virtual TypeScript and a real multi-file Corsa project

## Validation

- `cargo test -p vize_canon --test imported_ref_unwrap`
- `cargo test -p vize_canon --lib virtual_ts::`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `vp run --workspace-root check:ci`
- source length gate against `origin/main`

Closes #2947

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786774597&installation_id=136613492&pr_number=2958&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2958&signature=332f73f58a327fbdfe9b2aed707a33465d8428ca0b7e5e3bdac4446d0f9dbb12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved template type handling for imported reactive references.
  - Imported `Ref` values now unwrap correctly in template scope and satisfy compatible component prop types without spurious type errors.
  - Refined template binding detection to better capture template-referenced identifiers and local setup bindings.
- **Tests**
  - Added integration tests covering imported refs used in template bindings and component props, including a fixture-based type-check scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->