### PR TITLE
fix(canon): avoid repeated nested branch guards

### DIFF
--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_component_props_source_nested_in_vif_is_wrapped_for_narrowing.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_component_props_source_nested_in_vif_is_wrapped_for_narrowing.snap
@@ -108,14 +108,10 @@ function __setup() {
     // v-for scope: value in elems[key]
     __vForList(elems[key]).forEach(([value]) => {
       void value;
-      if ((key === 'b')) {
-        void (value); // VBind
-        // @vize-map: expr -> 69:74
-      }
-      if ((key === 'b')) {
-        void (value); // VBind
-        // @vize-map: expr -> 96:101
-      }
+      void (value); // VBind
+      // @vize-map: expr -> 69:74
+      void (value); // VBind
+      // @vize-map: expr -> 96:101
     });
   }
 

--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_source_nested_in_vif_is_wrapped_for_narrowing.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_source_nested_in_vif_is_wrapped_for_narrowing.snap
@@ -107,14 +107,10 @@ function __setup() {
     // v-for scope: value in elems[key]
     __vForList(elems[key]).forEach(([value]) => {
       void value;
-      if ((key === 'b')) {
-        void (value); // VBind
-        // @vize-map: expr -> 69:74
-      }
-      if ((key === 'b')) {
-        void (value); // Interpolation
-        // @vize-map: expr -> 79:84
-      }
+      void (value); // VBind
+      // @vize-map: expr -> 69:74
+      void (value); // Interpolation
+      // @vize-map: expr -> 79:84
     });
   }
 

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_nested_v_if_v_else.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_nested_v_if_v_else.snap
@@ -118,14 +118,10 @@ function __setup() {
     // v-for scope: item in data
     __vForList(data).forEach(([item]) => {
       void item;
-      if (!(status === 'loading') && !(status === 'error')) {
-        void (item); // VBind
-        // @vize-map: expr -> 386:390
-      }
-      if (!(status === 'loading') && !(status === 'error')) {
-        void (item); // Interpolation
-        // @vize-map: expr -> 395:399
-      }
+      void (item); // VBind
+      // @vize-map: expr -> 386:390
+      void (item); // Interpolation
+      // @vize-map: expr -> 395:399
     });
   }
 

--- a/crates/vize_canon/src/virtual_ts/expressions.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions.rs
@@ -13,4 +13,4 @@ mod tests;
 
 pub(crate) use component_props::generate_component_prop_checks;
 pub(crate) use reserved_props::rewrite_reserved_template_prop;
-pub(crate) use statements::generate_expressions;
+pub(crate) use statements::{generate_expressions, generate_expressions_in_enclosing_guard};

--- a/crates/vize_canon/src/virtual_ts/expressions/statements.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/statements.rs
@@ -10,6 +10,8 @@ use super::reserved_props::rewrite_reserved_template_prop;
 use super::vif_chain::{
     VifControlFlowChain, VifControlFlowEmitContext, emit_vif_control_flow_chain,
 };
+use crate::virtual_ts::scope::remove_enclosing_vif_guard_prefix;
+use vize_carton::CompactString;
 use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::append;
@@ -59,6 +61,54 @@ pub(crate) fn generate_expressions(
         );
         index += 1;
     }
+}
+
+/// Generate expressions inside control flow that already enforces a common
+/// v-if guard, removing only that exact top-level guard prefix first.
+pub(crate) fn generate_expressions_in_enclosing_guard(
+    ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    exprs: &[&TemplateExpression],
+    template_prop_names: &FxHashSet<String>,
+    skipped_expression_ranges: &FxHashSet<(u32, u32)>,
+    template_offset: u32,
+    generation_scope: (&str, Option<&str>),
+) {
+    let (indent, enclosing_guard) = generation_scope;
+    let Some(enclosing_guard) = enclosing_guard else {
+        generate_expressions(
+            ts,
+            mappings,
+            exprs,
+            template_prop_names,
+            skipped_expression_ranges,
+            template_offset,
+            indent,
+        );
+        return;
+    };
+
+    let adjusted_expressions: Vec<_> = exprs
+        .iter()
+        .map(|expr| {
+            let mut adjusted = (**expr).clone();
+            adjusted.vif_guard = adjusted.vif_guard.as_ref().and_then(|guard| {
+                remove_enclosing_vif_guard_prefix(guard.as_str(), enclosing_guard)
+                    .map(|guard| CompactString::new(guard.as_str()))
+            });
+            adjusted
+        })
+        .collect();
+    let adjusted_expression_refs: Vec<_> = adjusted_expressions.iter().collect();
+    generate_expressions(
+        ts,
+        mappings,
+        &adjusted_expression_refs,
+        template_prop_names,
+        skipped_expression_ranges,
+        template_offset,
+        indent,
+    );
 }
 
 /// Generate a template expression with optional v-if narrowing.

--- a/crates/vize_canon/src/virtual_ts/scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope.rs
@@ -18,3 +18,4 @@ mod vif_guard;
 
 pub(crate) use closures::generate_scope_closures;
 pub(crate) use context::ScopeGenerationOptions;
+pub(crate) use vif_guard::remove_enclosing_vif_guard_prefix;

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -10,7 +10,9 @@ use vize_carton::profile;
 
 use vize_croquis::{Croquis, Scope, ScopeData, ScopeId, ScopeKind};
 
-use crate::virtual_ts::expressions::generate_expressions;
+use crate::virtual_ts::expressions::{
+    generate_expressions, generate_expressions_in_enclosing_guard,
+};
 use crate::virtual_ts::helpers::{get_dom_event_type, to_safe_identifier_fragment};
 use crate::virtual_ts::types::VizeMapping;
 
@@ -220,8 +222,7 @@ fn generate_scope_node(
 
     match scope.data() {
         ScopeData::VFor(data) => {
-            // When the v-for element is nested inside an enclosing `v-if`, wrap
-            // the whole `__vForList(source).forEach(...)` loop in `if (guard) {}`
+            // For a v-for nested in `v-if`, wrap the whole loop in `if (guard) {}`
             // so TypeScript narrows identifiers used in the v-for source
             // expression (e.g. `elems[key]` with `key` narrowed by the parent
             // `v-if="key === 'b'"`). Without this the source is evaluated outside
@@ -231,9 +232,7 @@ fn generate_scope_node(
             // are recorded as expressions in this scope carrying that enclosing
             // guard; any deeper `v-if` nested *inside* the loop body extends the
             // guard with extra `&& (...)` terms. The enclosing guard is therefore
-            // the longest `&&`-separated prefix common to every direct expression
-            // in the scope — conservative enough never to import a nested
-            // branch's condition.
+            // the longest common `&&`-separated prefix of direct expressions.
             let enclosing_guard: Option<String> = ctx
                 .expressions_by_scope
                 .get(&scope_id)
@@ -281,14 +280,14 @@ fn generate_scope_node(
             if let Some(exprs) = ctx.expressions_by_scope.get(&scope_id)
                 && ctx.check_options.check_template_bindings
             {
-                generate_expressions(
+                generate_expressions_in_enclosing_guard(
                     ts,
                     mappings,
                     exprs,
                     ctx.template_prop_names,
                     ctx.skipped_expression_ranges,
                     ctx.template_offset,
-                    &vfor_inner_indent,
+                    (&vfor_inner_indent, enclosing_guard),
                 );
             }
 

--- a/crates/vize_canon/src/virtual_ts/scope/vif_guard.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/vif_guard.rs
@@ -19,6 +19,28 @@ pub(super) fn common_vif_guard_prefix_for_guards(guards: &[&str]) -> Option<Stri
     common_guard_prefix_from_terms(first, rest.iter().copied())
 }
 
+/// Remove a guard prefix that is already active in the surrounding generated
+/// control flow.
+///
+/// Guards are compared term-by-term so conditions containing nested `&&`
+/// expressions are not truncated accidentally. If `prefix` is not an exact
+/// top-level prefix, the original guard is preserved.
+pub(crate) fn remove_enclosing_vif_guard_prefix(guard: &str, prefix: &str) -> Option<String> {
+    let guard_terms = split_guard_terms(guard);
+    let prefix_terms = split_guard_terms(prefix);
+    if prefix_terms.len() > guard_terms.len()
+        || !prefix_terms
+            .iter()
+            .zip(guard_terms.iter())
+            .all(|(prefix_term, guard_term)| prefix_term == guard_term)
+    {
+        return Some(String::from(guard));
+    }
+
+    let remaining = &guard_terms[prefix_terms.len()..];
+    (!remaining.is_empty()).then(|| String::from(remaining.join(" && ").as_str()))
+}
+
 fn common_guard_prefix_from_terms<'a>(
     first: &'a str,
     rest: impl Iterator<Item = &'a str>,
@@ -132,4 +154,40 @@ fn references_any_alias(term: &str, aliases: &[&str]) -> bool {
     extract_identifiers_oxc(term)
         .iter()
         .any(|identifier| aliases.iter().any(|alias| identifier.as_str() == *alias))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::remove_enclosing_vif_guard_prefix;
+
+    #[test]
+    fn removes_an_exact_enclosing_guard() {
+        assert_eq!(
+            remove_enclosing_vif_guard_prefix(
+                "!(item.type === 'hunk-bar')",
+                "!(item.type === 'hunk-bar')"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn removes_only_complete_top_level_guard_terms() {
+        assert_eq!(
+            remove_enclosing_vif_guard_prefix(
+                "(ready && enabled) && !(item.type === 'hunk-bar')",
+                "(ready && enabled)",
+            )
+            .as_deref(),
+            Some("!(item.type === 'hunk-bar')")
+        );
+    }
+
+    #[test]
+    fn preserves_a_guard_when_the_prefix_does_not_match() {
+        assert_eq!(
+            remove_enclosing_vif_guard_prefix("(ready) && (visible)", "(enabled)").as_deref(),
+            Some("(ready) && (visible)")
+        );
+    }
 }

--- a/crates/vize_canon/src/virtual_ts/tests/vif_chain.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/vif_chain.rs
@@ -2,7 +2,7 @@ use super::generate_virtual_ts;
 use vize_croquis::{Analyzer, AnalyzerOptions};
 
 #[test]
-fn test_prefixed_v_else_branch_keeps_negated_branch_guard() {
+fn test_prefixed_v_else_branch_reuses_the_enclosing_v_for_guard() {
     let script = r#"const isOpen = true
 type Item =
   | { kind: 'anchor'; hash: string; key: string }
@@ -29,8 +29,15 @@ const navItems: Item[] = []
     assert!(
         output
             .code
-            .contains("} else if ((isOpen) && !(item.kind === 'page')) {"),
-        "prefixed v-else branch should retain the negated discriminant guard:\n{}",
+            .contains("if ((isOpen)) {\n\n    // v-for scope"),
+        "the common outer guard should wrap the complete v-for:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains("if (item.kind === 'page') {")
+            && output.code.contains("} else {")
+            && !output.code.contains("(isOpen) && !(item.kind === 'page')"),
+        "the inner chain should reuse the active guard and preserve a plain else branch:\n{}",
         output.code
     );
 }
@@ -77,6 +84,36 @@ const aimAtReports: AimAtReport[] = []
     assert!(
         !output.code.contains("if ((aimAtReport.kind === 'summary')) {\n\n    // v-for scope: aimAtReport in aimAtReports"),
         "v-for enclosing guard must not reference its own alias before declaration:\n{}",
+        output.code
+    );
+}
+
+#[test]
+fn nested_else_v_for_does_not_recheck_narrowed_discriminant() {
+    let script = r#"interface BarItem { type: 'hunk-bar'; lines: number }
+interface LineItem { type: 'line'; text: string }
+type ViewItem = BarItem | { type: 'section'; lines: LineItem[] }
+const items: ViewItem[] = []
+"#;
+    let template = r#"<template v-for="(item, i) in items" :key="i">
+  <button v-if="item.type === 'hunk-bar'">{{ item.lines }}</button>
+  <div v-else>
+    <div v-for="(row, j) in item.lines" :key="j">{{ row.text }}</div>
+  </div>
+</template>"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+
+    assert_eq!(
+        output.code.matches("!(item.type === 'hunk-bar')").count(),
+        1,
+        "the v-else branch already narrows item; nested scopes must not compare it again:\n{}",
         output.code
     );
 }

--- a/crates/vize_canon/tests/nested_vif_narrowing.rs
+++ b/crates/vize_canon/tests/nested_vif_narrowing.rs
@@ -1,0 +1,82 @@
+use std::path::Path;
+
+use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait};
+use vize_carton::cstr;
+
+#[test]
+fn nested_else_v_for_keeps_the_outer_discriminant_narrowing() {
+    let project = tempfile::tempdir().expect("temp project should be created");
+    write_project_file(
+        project.path(),
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write_project_file(
+        project.path(),
+        "node_modules/vue/package.json",
+        r#"{ "name": "vue", "types": "index.d.ts" }"#,
+    );
+    write_project_file(
+        project.path(),
+        "node_modules/vue/index.d.ts",
+        r#"export interface Ref<T = unknown> { value: T }
+export function ref<T>(value: T): Ref<T>;
+export function computed<T>(getter: () => T): Readonly<Ref<T>>;
+"#,
+    );
+
+    let source = cstr!(
+        "{NESTED_VIF_SFC}\n<style>\n{}</style>\n",
+        ".pad {}\n".repeat(400)
+    );
+    write_project_file(project.path(), "src/App.vue", source.as_str());
+
+    let mut checker = BatchTypeChecker::new(project.path()).expect("Corsa should be available");
+    checker.scan_project().expect("project should scan");
+    let result = checker.check_project().expect("project should type check");
+    let discriminant_errors: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == Some(2367))
+        .collect();
+
+    assert!(
+        discriminant_errors.is_empty(),
+        "the nested v-for must not compare an already narrowed discriminant: {discriminant_errors:#?}"
+    );
+}
+
+fn write_project_file(project_root: &Path, path: &str, source: &str) {
+    let path = project_root.join(path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, source).unwrap();
+}
+
+const NESTED_VIF_SFC: &str = r#"<script setup lang="ts">
+import { computed, ref } from "vue";
+interface BarItem { type: "hunk-bar"; lines: number }
+interface LineItem { type: "line"; text: string }
+type ViewItem = BarItem | { type: "section"; lines: LineItem[] }
+const rows = ref<(LineItem | BarItem)[]>([]);
+const items = computed<ViewItem[]>(() => []);
+</script>
+
+<template>
+  <template v-for="(item, i) in items" :key="i">
+    <button v-if="item.type === 'hunk-bar'">{{ item.lines }}</button>
+    <div v-else>
+      <div v-for="(row, j) in item.lines" :key="j">{{ row.text }}</div>
+    </div>
+  </template>
+</template>"#;


### PR DESCRIPTION
## Summary

- remove v-if guard prefixes that are already active around a generated v-for
- preserve nested top-level guard terms and ordinary inner if/else chains
- cover the original nested discriminated-union SFC with structural and Corsa type-check regressions

## Validation

- `cargo test -p vize_canon`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `corepack pnpm vp run --workspace-root check:ci`
- source file length budget against `origin/main`

Closes #2949

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786775298&installation_id=136613492&pr_number=2959&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2959&signature=d5465000bc8c3778b9bba9ff922751d93371961fbbe1ea32d42d5b5b577a765e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested `v-if`, `v-else`, and `v-for` combinations.
  * Prevented redundant condition checks after a discriminated union has already been narrowed.
  * Ensured generated logic correctly reuses enclosing conditions across nested loops and branches.

* **Tests**
  * Added coverage for nested conditional and loop scenarios.
  * Verified that generated TypeScript no longer reports incorrect comparison diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->