### PR TITLE
fix(canon): map generated guards to template spans

### DIFF
--- a/crates/vize_canon/src/virtual_ts/expressions/statements.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/statements.rs
@@ -98,7 +98,19 @@ pub(crate) fn generate_expression(
             .as_ref()
             .map_or_else(|| guard.as_str(), |s| s.as_str());
         // Wrap in if block for type narrowing
+        let gen_guard_start = ts.len();
         append!(*ts, "{indent}if ({generated_guard}) {{\n");
+        let gen_guard_end = ts.len();
+        mappings.push(VizeMapping {
+            gen_range: generated_text_range(
+                &ts[gen_guard_start..gen_guard_end],
+                generated_guard,
+                gen_guard_start,
+            ),
+            src_range: (template_offset + expr.start) as usize
+                ..(template_offset + expr.end) as usize,
+            sub_spans: Vec::new(),
+        });
         generate_expression_statement(
             ts,
             mappings,

--- a/crates/vize_canon/tests/guard_diagnostic_position.rs
+++ b/crates/vize_canon/tests/guard_diagnostic_position.rs
@@ -1,0 +1,42 @@
+use vize_canon::{SfcBlockType, VirtualProject};
+
+#[test]
+fn generated_guard_positions_map_inside_a_short_sfc() {
+    let temp_dir = tempfile::tempdir().expect("temp project should be created");
+    let project_root = temp_dir.path().canonicalize().unwrap();
+    let source_path = project_root.join("App.vue");
+    let source = r#"<script setup lang="ts">
+const value = { kind: 'x' as 'x' | 'y' }
+</script>
+<template><div v-if="value.kind === 'x'">{{ value.kind }}</div></template>
+"#;
+    std::fs::write(&source_path, source).unwrap();
+
+    let mut project = VirtualProject::new(&project_root).unwrap();
+    project.register_path(&source_path).unwrap();
+    let virtual_file = project.find_by_original(&source_path).unwrap();
+    let guard = "value.kind === 'x'";
+    let virtual_offset = virtual_file
+        .content
+        .match_indices(guard)
+        .last()
+        .expect("guarded interpolation should repeat the generated guard")
+        .0;
+    assert!(
+        virtual_offset > source.len(),
+        "the regression requires a generated offset past the source EOF"
+    );
+    let prefix = &virtual_file.content[..virtual_offset];
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u32;
+    let column = prefix
+        .rsplit_once('\n')
+        .map_or(prefix.len(), |(_, tail)| tail.len()) as u32;
+
+    let original = project
+        .map_to_original(&virtual_file.virtual_path, line, column)
+        .expect("generated guard diagnostics must not be dropped");
+
+    assert_eq!(original.path, source_path);
+    assert_eq!(original.block_type, Some(SfcBlockType::Template));
+    assert!(original.line < source.lines().count() as u32);
+}


### PR DESCRIPTION
## Summary

- map generated v-if guard wrappers back to their guarded template expressions
- keep unrelated generated helper diagnostics unmapped instead of exposing false positives
- cover guard offsets beyond a short SFC's EOF through the public position-mapping API

## Validation

- `cargo test -p vize_canon`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo clippy -p vize_canon --test guard_diagnostic_position -- -D warnings`
- `corepack pnpm vp run --workspace-root check:ci`
- source file length budget against `origin/main`
- exact short-SFC CLI reproduction: both TS2367 diagnostics surface without style padding

Closes #2950

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786776023&installation_id=136613492&pr_number=2960&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2960&signature=b7edebfee11a828cdfdb13d8cdafbfe24b1b01819a3bfea0f2b26d0eb485266f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source mapping for generated TypeScript guard conditions.
  * Diagnostic locations inside conditional template expressions now correctly map back to the original Vue template source.
  * Added coverage to prevent regressions in diagnostics for short single-file components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->