### PR TITLE
fix(atelier): guard recursive static expression parsing

### DIFF
--- a/crates/vize_atelier_core/src/codegen/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/helpers.rs
@@ -15,12 +15,10 @@ use oxc_syntax::scope::ScopeFlags;
 use vize_carton::{FxHashSet, ToCompactString};
 use vize_croquis::builtins::is_global_allowed;
 
-/// Decode HTML entities (numeric character references) in a string
-/// Supports &#xHHHH; (hex) and &#NNNN; (decimal) formats
+/// Decode HTML numeric character references in hex or decimal form.
 pub fn decode_html_entities(s: &str) -> String {
-    // Numeric entity decoding only ever triggers on `&`. Without one, the
-    // result is the input verbatim, so skip the per-char state machine and
-    // its intermediate growth and copy the string in a single pass.
+    // Numeric decoding only triggers on `&`; otherwise skip the state machine
+    // and copy the input in a single pass.
     if !s.contains('&') {
         return String::from(s);
     }
@@ -414,8 +412,10 @@ pub fn is_constant_simple_expression(
     }
 
     // Expressions that already reference runtime context/setup/props are dynamic.
-    // This keeps patch flags for transformed bindings such as `_ctx.foo`.
     let content = exp.content.as_str();
+    if crate::steps::expression::expression_exceeds_max_depth(content) {
+        return false;
+    }
     if content.contains("_ctx.")
         || content.contains("$setup.")
         || content.contains("__props.")

--- a/crates/vize_atelier_core/src/codegen/patch_flag.rs
+++ b/crates/vize_atelier_core/src/codegen/patch_flag.rs
@@ -10,8 +10,7 @@ use vize_carton::String;
 use vize_carton::ToCompactString;
 use vize_carton::is_builtin_directive;
 
-/// Check if an interpolation references only constant bindings (LiteralConst or SetupConst)
-/// These bindings never change at runtime, so no TEXT patch flag is needed.
+/// Check whether an interpolation only references bindings constant at runtime.
 fn is_constant_interpolation(
     expr: &ExpressionNode<'_>,
     bindings: Option<&BindingMetadata>,
@@ -23,9 +22,7 @@ fn is_constant_interpolation(
 
     match expr {
         ExpressionNode::Simple(simple) => {
-            // Check if the expression is a simple identifier that's a constant
-            // Both LiteralConst (e.g., const x = 'hello') and SetupConst (e.g., class Foo {})
-            // are constant at runtime and don't need TEXT patch flag
+            // LiteralConst and SetupConst identifiers need no TEXT patch flag.
             let name = simple.content.as_str();
             matches!(
                 bindings.bindings.get(name),
@@ -45,7 +42,6 @@ fn is_const_handler(expr: &ExpressionNode<'_>, bindings: Option<&BindingMetadata
 
     match expr {
         ExpressionNode::Simple(simple) => {
-            // Check if the expression is a simple identifier that's a constant
             let name = simple.content.as_str();
             matches!(
                 bindings.bindings.get(name),
@@ -79,6 +75,9 @@ fn is_string_literal(content: &str) -> bool {
 }
 
 fn is_static_object_or_array_literal(content: &str) -> bool {
+    if crate::steps::expression::expression_exceeds_max_depth(content) {
+        return false;
+    }
     let mut wrapped = String::with_capacity(content.len() + 2);
     wrapped.push('(');
     wrapped.push_str(content);

--- a/crates/vize_atelier_dom/tests/expression_nesting_guard.rs
+++ b/crates/vize_atelier_dom/tests/expression_nesting_guard.rs
@@ -1,0 +1,22 @@
+use vize_atelier_dom::compile_template;
+use vize_carton::{Bump, String};
+
+#[test]
+fn compile_survives_deep_bound_expression_without_recursive_static_analysis() {
+    let allocator = Bump::new();
+    let mut source = String::with_capacity(2_736);
+    source.push_str(r#"<li :key="S"#);
+    for _ in 0..2_704 {
+        source.push('[');
+    }
+    source.push_str(r#"">item</li>"#);
+
+    let (_, errors, result) = compile_template(&allocator, &source);
+
+    assert!(errors.is_empty(), "unexpected compiler errors: {errors:?}");
+    assert!(
+        result.code.contains("S[[[["),
+        "template compilation must preserve the bound expression:\n{}",
+        result.code
+    );
+}


### PR DESCRIPTION
## Summary
- stop static-expression probes before OXC receives an expression beyond the shared nesting limit
- guard both patch-flag literal detection and static-hoist dependency detection
- add an integration regression with 2,704 nested array delimiters

## Validation
- replayed the exact `template_compile` artifact from run `29477106092`: stack overflow before, 2 ms success after
- `cargo test -p vize_atelier_dom --test expression_nesting_guard -- --nocapture`
- `cargo clippy -p vize_atelier_core --lib -- -D warnings`
- `cargo clippy -p vize_atelier_dom --test expression_nesting_guard -- -D warnings`
- workspace warning-budget check via `vp check`
- source file length budget against `origin/main`

Closes #2964

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786781249&installation_id=136613492&pr_number=2965&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2965&signature=b67bd8f77a6297f3519e24f290bd429c67c6e5c747a58c0669a441db0ef9c03b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of deeply nested template expressions during compilation.
  - Prevented excessively deep expressions from triggering unsafe or overly intensive static analysis.
  - Preserved bound expressions correctly in generated output, including highly nested syntax.

- **Documentation**
  - Clarified supported numeric HTML entity decoding and expression-processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->