### PR TITLE
fix(atelier): bound TypeScript expression nesting

### DIFF
--- a/crates/vize_atelier_core/src/transforms/transform_expression.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression.rs
@@ -16,20 +16,18 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_carton::{Box, Bump, String};
 
-/// Maximum bracket nesting depth allowed before handing source to OXC.
+/// Maximum delimiter nesting depth allowed before handing source to OXC.
 ///
 /// OXC recurses for nested brackets; stack overflow (#956) and a parser timeout
 /// at depth 32 (#2944) cannot be caught, so every entry point shares this guard.
 pub const MAX_EXPRESSION_NESTING_DEPTH: usize = 31;
 
-/// Returns the maximum bracket nesting depth in `content`. Only counts
-/// `(`, `[`, `{` and their closers — these are what drive recursion in the
-/// JS parser and the recursive AST walkers in `prefix` / `rewrite`. Strings
-/// and template literals are skipped so contents like `"((((((((..."` don't
-/// trigger a false positive.
+/// Returns the maximum delimiter nesting depth in `content`. Brackets and
+/// TypeScript angle brackets use separate counters so `>` cannot close an array
+/// or object. Strings and template literals are skipped.
 pub fn expression_nesting_depth(content: &str) -> usize {
     let bytes = content.as_bytes();
-    let mut depth: usize = 0;
+    let (mut bracket_depth, mut angle_depth) = (0usize, 0usize);
     let mut max_depth: usize = 0;
     let mut i = 0;
     while i < bytes.len() {
@@ -65,17 +63,13 @@ pub fn expression_nesting_depth(content: &str) -> usize {
                 i = i.saturating_add(2);
                 continue;
             }
-            b'(' | b'[' | b'{' => {
-                depth += 1;
-                if depth > max_depth {
-                    max_depth = depth;
-                }
-            }
-            b')' | b']' | b'}' => {
-                depth = depth.saturating_sub(1);
-            }
+            b'(' | b'[' | b'{' => bracket_depth += 1,
+            b')' | b']' | b'}' => bracket_depth = bracket_depth.saturating_sub(1),
+            b'<' => angle_depth += 1,
+            b'>' => angle_depth = angle_depth.saturating_sub(1),
             _ => {}
         }
+        max_depth = max_depth.max(bracket_depth + angle_depth);
         i += 1;
     }
     max_depth

--- a/crates/vize_atelier_core/tests/expression_nesting_guard.rs
+++ b/crates/vize_atelier_core/tests/expression_nesting_guard.rs
@@ -5,11 +5,13 @@ use vize_atelier_core::steps::expression::{
 };
 
 const TIMEOUT_REPRODUCER: &str = "\nd=\nd=efnuiProps<{[dnuiProps<{[d=efnuiProps<{[dnuiProps<{[defnuiProps<{[  cts<{[  oefnuiProps<{[dnuiProps<{[defnuiProps<{[  cts<{[  oo>>efnuiProps<{[  cts<{[  oefnuiProps<{[dnuiProps<{[defnuiProps<{[  cts<{[  oo>>> \x1a\x1a\x1a\x1a\x1atr";
+const SLOW_TYPE_ARGUMENT_REPRODUCER: &str = "eu.tfpS<{[ erntro-Coro-Couo<tidon<cttnS<{[ erntro-rntro-Coro-Couo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tuo<tidon<cttnS<{[ erntro-Coro-Coug<tidon<cttn<tidon<cttopti<nn<ctstrCoro[Couo<tidon<cttn<tuo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tidon<cttopti<nn<ctstrin<n<<on<ta<ts";
+const TIMEOUT_TYPE_ARGUMENT_REPRODUCER: &str = "eu.tfpS<{[ erntro-Coro-Couo<tidon<cttnS<{[ erntro-rntro-Coro-Couo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tuo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tidottn<tuo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tidon<cttopti<nn<ctsttro-Coro-Couo<tidon<cttnS<{[ erntro-rntro-Coro-Couo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tuo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tidottn<tuo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tidon<cttoptrin<n<<on<ta<ts";
 
 #[test]
 fn expression_guard_rejects_the_js_ts_timeout_reproducer() {
     assert_eq!(TIMEOUT_REPRODUCER.len(), 222);
-    assert_eq!(expression_nesting_depth(TIMEOUT_REPRODUCER), 32);
+    assert_eq!(expression_nesting_depth(TIMEOUT_REPRODUCER), 46);
     assert!(expression_exceeds_max_depth(TIMEOUT_REPRODUCER));
     assert!(!is_event_handler_reference_expression(TIMEOUT_REPRODUCER));
     assert!(!is_function_expression(TIMEOUT_REPRODUCER));
@@ -30,4 +32,28 @@ fn expression_guard_preserves_the_documented_boundary() {
 
     assert!(!expression_exceeds_max_depth(&allowed));
     assert!(expression_exceeds_max_depth(&rejected));
+}
+
+#[test]
+fn expression_guard_rejects_nested_type_argument_reproducers() {
+    assert_eq!(SLOW_TYPE_ARGUMENT_REPRODUCER.len(), 282);
+    assert_eq!(TIMEOUT_TYPE_ARGUMENT_REPRODUCER.len(), 456);
+
+    for reproducer in [
+        SLOW_TYPE_ARGUMENT_REPRODUCER,
+        TIMEOUT_TYPE_ARGUMENT_REPRODUCER,
+    ] {
+        assert!(expression_nesting_depth(reproducer) > MAX_EXPRESSION_NESTING_DEPTH);
+        assert!(expression_exceeds_max_depth(reproducer));
+        assert!(!is_event_handler_reference_expression(reproducer));
+        assert!(!is_function_expression(reproducer));
+        assert_eq!(
+            prefix_identifiers_in_expression(reproducer).as_str(),
+            reproducer
+        );
+        assert_eq!(
+            strip_typescript_from_expression(reproducer).as_str(),
+            reproducer
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- include TypeScript angle-bracket nesting in the shared pre-OXC depth guard
- keep bracket and angle counters separate so comparison closers cannot reduce array/object depth
- lock both the slow-unit and timeout/OOM artifacts into exact regression tests

## Validation
- replayed both exact `js_ts_expression` artifacts from run `29477106092`: 8.2 s / timeout before, 0 ms each after
- `cargo test -p vize_atelier_core --test expression_nesting_guard -- --nocapture`
- `cargo clippy -p vize_atelier_core --lib -- -D warnings`
- workspace warning-budget check via `vp check`
- source file length budget against `origin/main`

Closes #2961

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786781372&installation_id=136613492&pr_number=2966&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2966&signature=b731bab46993a6e0cd1596d3c6d1f05ba84423672e35fc535e053a0e1f23f1ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of deeply nested expressions involving TypeScript generic type arguments.
  * More reliably prevents excessive nesting from causing processing issues.
  * Preserves expressions correctly when applying identifier prefixing and TypeScript type stripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->