### PR TITLE
test(lsp): add real-world patch oracle

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -234,8 +234,8 @@ jobs:
         with:
           key: vue-parity
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
-      - name: Install JS dependencies
-        run: vp install --frozen-lockfile --prefer-offline
+      - name: Hydrate fixture and install JS dependencies
+        run: git submodule update --init --depth 1 tests/_fixtures/_git/create-vue && vp install --frozen-lockfile --prefer-offline
       - name: Build vize CLI
         run: cargo build --profile ci -p vize
       - name: Check Vue compiler and typecheck parity

--- a/tests/_helpers/realworld-patch.ts
+++ b/tests/_helpers/realworld-patch.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+type FixtureRegistry = {
+  projects: FixtureRegistryEntry[];
+};
+
+export type FixtureRegistryEntry = {
+  id: string;
+  displayName: string;
+  fixturePath: string;
+  revision: string;
+};
+
+export type PinnedFixtureWorkspace = {
+  entry: FixtureRegistryEntry;
+  upstreamDir: string;
+  workspaceDir: string;
+  applyExactPatch(relativePath: string, expected: string, replacement: string): string;
+  read(relativePath: string): string;
+  resolve(relativePath: string): string;
+  write(relativePath: string, content: string): void;
+};
+
+type PinnedFixtureOptions = {
+  fixtureId: string;
+  includePaths: string[];
+};
+
+/**
+ * Copies selected files from a pinned third-party fixture into an isolated
+ * mutable workspace. The upstream gitlink is checked before and after the
+ * callback so patch-oracle tests cannot silently dirty external repositories.
+ */
+export async function withPinnedFixtureWorkspace<T>(
+  options: PinnedFixtureOptions,
+  run: (fixture: PinnedFixtureWorkspace) => Promise<T>,
+): Promise<T> {
+  const entry = readFixtureEntry(options.fixtureId);
+  const upstreamDir = path.join(repoRoot, entry.fixturePath);
+  assert.ok(
+    fs.existsSync(upstreamDir),
+    `fixture ${entry.id} is not hydrated; run git submodule update --init ${entry.fixturePath}`,
+  );
+
+  const initialRevision = git(upstreamDir, "rev-parse", "HEAD");
+  assert.equal(initialRevision, entry.revision, `${entry.id} must stay pinned to the registry`);
+  assert.equal(git(upstreamDir, "status", "--porcelain"), "", `${entry.id} must start clean`);
+
+  const outputRoot = path.join(repoRoot, "target/vize-tests/realworld-patches");
+  fs.mkdirSync(outputRoot, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(outputRoot, `${entry.id}-`));
+
+  for (const relativePath of options.includePaths) {
+    const source = resolveInside(upstreamDir, relativePath);
+    const target = resolveInside(workspaceDir, relativePath);
+    assert.ok(fs.existsSync(source), `${entry.id} is missing ${relativePath}`);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.cpSync(source, target, { recursive: true });
+  }
+
+  const fixture: PinnedFixtureWorkspace = {
+    entry,
+    upstreamDir,
+    workspaceDir,
+    applyExactPatch(relativePath, expected, replacement) {
+      const filePath = resolveInside(workspaceDir, relativePath);
+      const source = fs.readFileSync(filePath, "utf8");
+      const first = source.indexOf(expected);
+      assert.notEqual(first, -1, `${relativePath} does not contain the expected patch anchor`);
+      assert.equal(
+        source.indexOf(expected, first + expected.length),
+        -1,
+        `${relativePath} patch anchor must be unique`,
+      );
+      const patched = `${source.slice(0, first)}${replacement}${source.slice(first + expected.length)}`;
+      fs.writeFileSync(filePath, patched, "utf8");
+      return patched;
+    },
+    read(relativePath) {
+      return fs.readFileSync(resolveInside(workspaceDir, relativePath), "utf8");
+    },
+    resolve(relativePath) {
+      return resolveInside(workspaceDir, relativePath);
+    },
+    write(relativePath, content) {
+      const filePath = resolveInside(workspaceDir, relativePath);
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, content, "utf8");
+    },
+  };
+
+  try {
+    return await run(fixture);
+  } finally {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    assert.equal(
+      git(upstreamDir, "rev-parse", "HEAD"),
+      initialRevision,
+      `${entry.id} revision changed during patch-oracle execution`,
+    );
+    assert.equal(
+      git(upstreamDir, "status", "--porcelain"),
+      "",
+      `${entry.id} was dirtied by patch-oracle execution`,
+    );
+  }
+}
+
+export function symlinkDirectory(source: string, target: string): void {
+  fs.rmSync(target, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.symlinkSync(source, target, process.platform === "win32" ? "junction" : "dir");
+}
+
+function readFixtureEntry(id: string): FixtureRegistryEntry {
+  const registry = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "tests/_fixtures/vue-ecosystem-fixtures.json"), "utf8"),
+  ) as FixtureRegistry;
+  const entry = registry.projects.find((project) => project.id === id);
+  assert.ok(entry, `fixture registry does not contain ${id}`);
+  return entry;
+}
+
+function resolveInside(root: string, relativePath: string): string {
+  assert.equal(path.isAbsolute(relativePath), false, `expected a relative path: ${relativePath}`);
+  const resolved = path.resolve(root, relativePath);
+  assert.ok(
+    resolved === root || resolved.startsWith(`${root}${path.sep}`),
+    `path escapes fixture workspace: ${relativePath}`,
+  );
+  return resolved;
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, LANG: "C", LC_ALL: "C" },
+  }).trim();
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -16,7 +16,7 @@
     "test:readiness:lint": "node --test --test-concurrency=1 tooling/cli-lint-contract.test.ts",
     "test:readiness:build": "node --test --test-concurrency=1 snapshots/build/generic.ts snapshots/build/elk.ts",
     "test:readiness:dev": "VIZE_TEST_WORKTREE_ID=${VIZE_TEST_WORKTREE_ID:-ci-readiness} playwright test --config app/playwright.config.ts app/dev/misskey.spec.ts",
-    "test:check:fixtures": "node --test --test-concurrency=1 snapshots/check/typecheck-errors.ts snapshots/check/typecheck-vue-imports.ts snapshots/check/compiler-macros.ts snapshots/check/style-preprocessors.ts snapshots/check/ecosystem-products.ts snapshots/check/generic-build.ts snapshots/check/nuxt-parity.ts snapshots/check/toolchain-parity.ts snapshots/check/options-api.ts snapshots/check/class-component.ts snapshots/check/zz-intentional-errors-fixtures.ts"
+    "test:check:fixtures": "node --test --test-concurrency=1 snapshots/check/typecheck-errors.ts snapshots/check/typecheck-vue-imports.ts snapshots/check/compiler-macros.ts snapshots/check/style-preprocessors.ts snapshots/check/ecosystem-products.ts snapshots/check/generic-build.ts snapshots/check/nuxt-parity.ts snapshots/check/toolchain-parity.ts snapshots/check/options-api.ts snapshots/check/class-component.ts snapshots/check/create-vue-patch-oracle.ts snapshots/check/zz-intentional-errors-fixtures.ts"
   },
   "devDependencies": {
     "@apollo/client": "3.14.1",

--- a/tests/snapshots/check/create-vue-patch-oracle.ts
+++ b/tests/snapshots/check/create-vue-patch-oracle.ts
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import {
+  repoRoot,
+  symlinkDirectory,
+  withPinnedFixtureWorkspace,
+} from "../../_helpers/realworld-patch.ts";
+import {
+  completionLabels,
+  hoverToText,
+  isDiagnosticsForUri,
+  offsetToPosition,
+} from "../../tooling/support/lsp/assertions.ts";
+import type { PublishDiagnosticsParams } from "../../tooling/support/lsp/protocol.ts";
+import { LspSession } from "../../tooling/support/lsp/session.ts";
+
+const appPath = "template/bare/typescript/src/App.vue";
+
+test("create-vue clean, broken, and repaired patches agree across check and LSP", async () => {
+  const corsaPath = resolveTsgoBinary();
+
+  await withPinnedFixtureWorkspace(
+    { fixtureId: "create-vue", includePaths: [appPath] },
+    async (fixture) => {
+      symlinkVueTypes(fixture.workspaceDir);
+      fixture.write(
+        "tsconfig.json",
+        `${JSON.stringify(
+          {
+            compilerOptions: {
+              lib: ["ES2022", "DOM", "DOM.Iterable"],
+              module: "ESNext",
+              moduleResolution: "bundler",
+              noEmit: true,
+              skipLibCheck: true,
+              strict: true,
+              target: "ES2022",
+            },
+            include: ["template/bare/typescript/src/**/*.vue"],
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      fixture.write(
+        "vize.config.json",
+        `${JSON.stringify(
+          {
+            lsp: { completion: true, editor: true, hover: true, lint: false, typecheck: true },
+            typeChecker: { corsaPath },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      fixture.applyExactPatch(
+        appPath,
+        '<script setup lang="ts"></script>',
+        `<script setup lang="ts">\nconst count: number = 1\nconst label = 'ready'\n</script>`,
+      );
+      const cleanSource = fixture.applyExactPatch(
+        appPath,
+        "  <h1>You did it!</h1>",
+        "  <h1>{{ label }}</h1>\n  <p>{{ count }}</p>",
+      );
+      const appFile = fixture.resolve(appPath);
+      const appUri = pathToFileURL(appFile).href;
+
+      assertCleanCheck(runCheck(fixture.workspaceDir, corsaPath));
+
+      const session = new LspSession();
+      try {
+        await session.initialize(fixture.workspaceDir, {
+          completion: true,
+          editor: true,
+          hover: true,
+          lint: false,
+          typecheck: true,
+        });
+        session.notify("textDocument/didOpen", {
+          textDocument: { uri: appUri, languageId: "vue", version: 1, text: cleanSource },
+        });
+        const cleanPublish = (await session.waitForNotification(
+          "textDocument/publishDiagnostics",
+          (params) => isDiagnosticsForUri(params, appUri) && params.version === 1,
+        )) as PublishDiagnosticsParams;
+        assert.deepEqual(cleanPublish.diagnostics, [], JSON.stringify(cleanPublish.diagnostics));
+
+        const completion = await session.request("textDocument/completion", {
+          textDocument: { uri: appUri },
+          position: offsetToPosition(
+            cleanSource,
+            cleanSource.indexOf("{{ count }}") + "{{ cou".length,
+          ),
+        });
+        const labels = completionLabels(completion);
+        assert.ok(labels.includes("count"), labels.join(", "));
+        assert.ok(!labels.includes("v-if"), labels.join(", "));
+
+        const hover = (await session.request("textDocument/hover", {
+          textDocument: { uri: appUri },
+          position: offsetToPosition(
+            cleanSource,
+            cleanSource.indexOf("{{ count }}") + "{{ count".length,
+          ),
+        })) as { contents?: unknown } | null;
+        const hoverText = hoverToText(hover);
+        assert.match(hoverText, /count/);
+        assert.match(hoverText, /number/i);
+
+        const brokenSource = fixture.applyExactPatch(
+          appPath,
+          "const count: number = 1",
+          "const count: number = 'broken'",
+        );
+        session.notify("textDocument/didChange", {
+          textDocument: { uri: appUri, version: 2 },
+          contentChanges: [{ text: brokenSource }],
+        });
+        const brokenPublish = (await session.waitForNotification(
+          "textDocument/publishDiagnostics",
+          (params) =>
+            isDiagnosticsForUri(params, appUri) &&
+            params.diagnostics.some((diagnostic) =>
+              diagnostic.message?.includes("not assignable to type 'number'"),
+            ),
+        )) as PublishDiagnosticsParams;
+        assert.equal(brokenPublish.version, 2, JSON.stringify(brokenPublish));
+        const typeError = brokenPublish.diagnostics.find((diagnostic) =>
+          diagnostic.message?.includes("not assignable to type 'number'"),
+        );
+        assert.ok(typeError, JSON.stringify(brokenPublish.diagnostics));
+        assert.equal(typeError.source, "vize/types");
+        assert.equal(typeError.severity, 1);
+        assert.match(typeError.message ?? "", /string.*not assignable.*number/i);
+        assert.deepEqual(typeError.range?.start, { line: 1, character: 6 });
+        assert.deepEqual(typeError.range?.end, { line: 1, character: 11 });
+
+        const brokenCheck = runCheck(fixture.workspaceDir, corsaPath);
+        assert.equal(brokenCheck.status, 1, brokenCheck.stderr);
+        assert.equal(brokenCheck.report.errorCount, 1, JSON.stringify(brokenCheck.report));
+        assert.match(
+          brokenCheck.report.files[0]?.diagnostics.join("\n") ?? "",
+          /TS2322.*string.*not assignable.*number/i,
+        );
+
+        const repairedSource = fixture.applyExactPatch(
+          appPath,
+          "const count: number = 'broken'",
+          "const count: number = 2",
+        );
+        session.notify("textDocument/didChange", {
+          textDocument: { uri: appUri, version: 3 },
+          contentChanges: [{ text: repairedSource }],
+        });
+        const repairedPublish = (await session.waitForNotification(
+          "textDocument/publishDiagnostics",
+          (params) =>
+            isDiagnosticsForUri(params, appUri) &&
+            params.version === 3 &&
+            params.diagnostics.every(
+              (diagnostic) => !diagnostic.message?.includes("not assignable to type 'number'"),
+            ),
+        )) as PublishDiagnosticsParams;
+        assert.deepEqual(
+          repairedPublish.diagnostics,
+          [],
+          JSON.stringify(repairedPublish.diagnostics),
+        );
+        assertCleanCheck(runCheck(fixture.workspaceDir, corsaPath));
+      } finally {
+        await session.shutdown();
+      }
+    },
+  );
+});
+
+type CheckReport = {
+  errorCount: number;
+  fileCount: number;
+  files: Array<{ file: string; diagnostics: string[] }>;
+};
+
+function assertCleanCheck(result: ReturnType<typeof runCheck>): void {
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.report.fileCount, 1, JSON.stringify(result.report));
+  assert.equal(result.report.errorCount, 0, JSON.stringify(result.report));
+  assert.deepEqual(result.report.files[0]?.diagnostics, []);
+}
+
+function runCheck(
+  workspaceDir: string,
+  corsaPath: string,
+): { status: number | null; stderr: string; report: CheckReport } {
+  const [command, ...prefixArgs] = resolveVizeCommand();
+  const result = spawnSync(
+    command,
+    [...prefixArgs, "check", appPath, "--format", "json", "--quiet", "--corsa-path", corsaPath],
+    { cwd: workspaceDir, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  if (result.error != null) throw result.error;
+  return { status: result.status, stderr: result.stderr, report: JSON.parse(result.stdout) };
+}
+
+function resolveVizeCommand(): string[] {
+  const candidates = [
+    process.env.VIZE_TEST_BIN,
+    path.join(repoRoot, "target/debug/vize"),
+    path.join(repoRoot, "target/ci/vize"),
+    path.join(repoRoot, "target/release/vize"),
+    "vize",
+  ].filter((candidate): candidate is string => Boolean(candidate));
+  for (const candidate of candidates) {
+    if (spawnSync(candidate, ["--version"], { cwd: repoRoot }).status === 0) return [candidate];
+  }
+  return ["cargo", "run", "-q", "-p", "vize", "--"];
+}
+
+function resolveTsgoBinary(): string {
+  const candidates = [
+    process.env.VIZE_TEST_TSGO,
+    path.join(repoRoot, "../corsa-bind/.cache/tsgo"),
+    path.join(repoRoot, "node_modules/.bin/tsgo"),
+    path.join(repoRoot, "tests/node_modules/.bin/tsgo"),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+  const binary = candidates.find((candidate) => fs.existsSync(candidate));
+  assert.ok(binary, "tsgo binary is required for real-world patch oracles");
+  return binary;
+}
+
+function symlinkVueTypes(workspaceDir: string): void {
+  const candidates = [
+    path.join(repoRoot, "node_modules/vue"),
+    path.join(repoRoot, "tests/node_modules/vue"),
+  ];
+  const vuePackage = candidates.find((candidate) => fs.existsSync(candidate));
+  assert.ok(vuePackage, "Vue package is required for real-world patch oracles");
+  symlinkDirectory(vuePackage, path.join(workspaceDir, "node_modules/vue"));
+  const vueNamespace = path.join(path.dirname(vuePackage), "@vue");
+  if (fs.existsSync(vueNamespace)) {
+    symlinkDirectory(vueNamespace, path.join(workspaceDir, "node_modules/@vue"));
+  }
+}

--- a/tests/tooling/snapshot-baselines.test.ts
+++ b/tests/tooling/snapshot-baselines.test.ts
@@ -22,6 +22,8 @@ const completeCheckSnapshotTests = [
 
 const assertionOnlyCheckTests = {
   "class-component": "class-component vue-tsc parity has known upstream-noisy diagnostics",
+  "create-vue-patch-oracle":
+    "patch oracle asserts exact live CLI and LSP behavior across document versions",
   directus: "real-world smoke lane is too large for a deterministic complete baseline",
   "element-plus": "real-world smoke lane is too large for a deterministic complete baseline",
   "frontend-phpcon": "real-world smoke lane is too large for a deterministic complete baseline",

--- a/tests/tooling/support/lsp/session.ts
+++ b/tests/tooling/support/lsp/session.ts
@@ -179,11 +179,16 @@ export class LspSession {
     try {
       await this.request("shutdown", undefined, 10000);
     } finally {
-      this.notify("exit", undefined);
-      this.process.stdin.end();
-      await new Promise<void>((resolve) => {
+      const exited = new Promise<void>((resolve) => {
+        if (this.process.exitCode != null || this.process.signalCode != null) {
+          resolve();
+          return;
+        }
+
         const timeout = setTimeout(() => {
-          this.process.kill("SIGKILL");
+          if (!this.process.kill("SIGKILL")) {
+            resolve();
+          }
         }, 5000);
 
         this.process.once("exit", () => {
@@ -191,6 +196,10 @@ export class LspSession {
           resolve();
         });
       });
+
+      this.notify("exit", undefined);
+      this.process.stdin.end();
+      await exited;
     }
   }
 


### PR DESCRIPTION
## Summary

- add a pinned create-vue patch oracle that exercises clean, broken, and repaired states without modifying the upstream fixture
- assert CLI TS2322 reporting plus versioned LSP diagnostics, authored ranges, completion boundaries, and hover type information
- make LSP test shutdown race-safe and hydrate only the required fixture in the Vue parity job

## Root cause

The existing fixture suite checked generated snapshots and injected errors, but it did not prove that one real Vue file stayed consistent across CLI checking and a live editor session as the document changed. Aggregate execution also exposed a race where the test client could miss a fast LSP process exit and wait forever.

## Validation

- `vp run --filter './tests' test:check:fixtures` (31 passed)
- `VIZE_LSP_BIN=target/ci/vize node --test --test-concurrency=1 tests/tooling/lsp-*.test.ts` (2,163 passed)
- `vp run --workspace-root check:ci` (14 tasks passed)
- `SOURCE_LENGTH_BASE_REF=origin/main node --experimental-strip-types --test tests/tooling/source-file-lengths.test.ts` (7 passed)
- `node --test --test-concurrency=1 tests/tooling/github-workflows-check.test.ts tests/tooling/github-workflows-setup.test.ts` (23 passed)

Part of #2971.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786866971&installation_id=136613492&pr_number=2972&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2972&signature=da2a7b745c863b99a909a79ef88692905275be940700f46b373a4607840f784b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language-server shutdown behavior to resolve promptly when the process has already exited, while still safely terminating if needed.

* **Tests**
  * Updated fixture test setup to initialize required pinned fixtures before installing JavaScript dependencies.
  * Added robust test utilities for working with pinned “realworld” fixtures in isolated workspaces and verifying upstream repo immutability.
  * Expanded snapshot baseline coverage with an additional assertion-only test case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->