### PR TITLE
fix(lsp): preserve type diagnostic codes

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
@@ -1,6 +1,6 @@
 //! Mapping Corsa virtual-document diagnostics back to the host SFC.
 
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Url};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url};
 
 use super::super::{VirtualTsResult, sources};
 use super::mapping::{map_diagnostic_with_source_mappings, source_offset_to_position};
@@ -181,10 +181,45 @@ pub(super) async fn collect_synced_virtual_result_diagnostics(
                     3 => DiagnosticSeverity::INFORMATION,
                     _ => DiagnosticSeverity::HINT,
                 }),
+                code: diag.code.map(corsa_diagnostic_code),
                 source: Some(sources::TYPE_CHECKER.to_string()),
                 message: rewrite_corsa_message(&diag.message),
                 ..Default::default()
             })
         })
         .collect()
+}
+
+fn corsa_diagnostic_code(code: serde_json::Value) -> NumberOrString {
+    match code {
+        serde_json::Value::Number(number) => number.as_i64().map_or_else(
+            || NumberOrString::String(number.to_string()),
+            |value| {
+                i32::try_from(value).map_or_else(
+                    |_| NumberOrString::String(number.to_string()),
+                    NumberOrString::Number,
+                )
+            },
+        ),
+        serde_json::Value::String(code) => NumberOrString::String(code),
+        other => NumberOrString::String(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::corsa_diagnostic_code;
+    use tower_lsp::lsp_types::NumberOrString;
+
+    #[test]
+    fn corsa_diagnostic_codes_preserve_lsp_number_and_string_shapes() {
+        assert_eq!(
+            corsa_diagnostic_code(serde_json::json!(2322)),
+            NumberOrString::Number(2322),
+        );
+        assert_eq!(
+            corsa_diagnostic_code(serde_json::json!("TS2322")),
+            NumberOrString::String("TS2322".to_string()),
+        );
+    }
 }

--- a/tests/snapshots/check/create-vue-patch-oracle.ts
+++ b/tests/snapshots/check/create-vue-patch-oracle.ts
@@ -137,6 +137,7 @@ test("create-vue clean, broken, and repaired patches agree across check and LSP"
         assert.ok(typeError, JSON.stringify(brokenPublish.diagnostics));
         assert.equal(typeError.source, "vize/types");
         assert.equal(typeError.severity, 1);
+        assert.equal(String(typeError.code).replace(/^TS/, ""), "2322");
         assert.match(typeError.message ?? "", /string.*not assignable.*number/i);
         assert.deepEqual(typeError.range?.start, { line: 1, character: 6 });
         assert.deepEqual(typeError.range?.end, { line: 1, character: 11 });


### PR DESCRIPTION
## Summary

- preserve Corsa diagnostic codes while remapping virtual TypeScript ranges back to Vue source
- keep numeric and string LSP code representations intact
- require the real create-vue broken-patch oracle to publish TS2322 to the editor

## Root cause

Corsa returned the TypeScript diagnostic code, but Vize rebuilt the remapped `Diagnostic` with only range, severity, source, and message. The defaulted `code` field made editor diagnostics less actionable than the CLI output.

## Validation

- `cargo test -p vize_maestro ide::diagnostics::corsa` (18 passed)
- `node --test --test-concurrency=1 tests/snapshots/check/create-vue-patch-oracle.ts` (1 passed)
- `VIZE_LSP_BIN=target/debug/vize node --test --test-concurrency=1 tests/tooling/lsp-*.test.ts` (2,163 passed)
- `vp run --filter './tests' test:check:fixtures` (31 passed)
- `cargo clippy -p vize_maestro -- -D warnings -D clippy::wildcard_imports`
- `SOURCE_LENGTH_BASE_REF=origin/main node --experimental-strip-types --test tests/tooling/source-file-lengths.test.ts` (7 passed)

Part of #2971.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786868023&installation_id=136613492&pr_number=2973&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2973&signature=9536302799d82de5aac873a040a2942c84dff62a2a19d1660766ae268417e718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Diagnostic results now display their associated codes in the editor.
  * Numeric and text-based diagnostic codes retain their original format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->