### PR TITLE
fix(canon): refresh incremental typecheck snapshots

### DIFF
--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -3,12 +3,14 @@
 use std::path::{Path, PathBuf};
 
 use super::Diagnostic;
-use super::declaration_path::is_declaration_file;
 use super::error::{CorsaError, CorsaResult};
 use super::executor::CorsaExecutor;
 use super::virtual_project::VirtualProject;
 use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 use vize_carton::String;
+
+mod paths;
+use paths::{collect_project_paths, refreshed_paths};
 
 /// Result of type checking.
 #[derive(Debug, Default)]
@@ -96,7 +98,10 @@ pub trait TypeChecker: Send + Sync {
     /// Check a single file.
     fn check_file(&self, path: &Path, content: &str) -> CorsaResult<Vec<Diagnostic>>;
 
-    /// Check incrementally (only changed files).
+    /// Re-check a scanned project after source files changed.
+    ///
+    /// The result must observe the latest on-disk contents and include
+    /// diagnostics from dependents, not only the changed files themselves.
     fn check_incremental(&self, changed: &[PathBuf]) -> CorsaResult<TypeCheckResult>;
 }
 
@@ -223,35 +228,7 @@ impl BatchTypeChecker {
 
     /// Scan the project for source files.
     pub fn scan_project(&mut self) -> CorsaResult<()> {
-        let project_root = self.project.project_root().to_path_buf();
-
-        let mut paths: Vec<PathBuf> = Vec::new();
-        for entry in walkdir::WalkDir::new(&project_root)
-            .into_iter()
-            .filter_entry(|e| {
-                // Don't filter the root directory itself
-                if e.path() == project_root {
-                    return true;
-                }
-                // Skip node_modules and hidden directories
-                let name = e.file_name().to_string_lossy();
-                !name.starts_with('.') && name != "node_modules"
-            })
-        {
-            let entry = entry?;
-            let path = entry.path();
-
-            if !path.is_file() {
-                continue;
-            }
-
-            if !is_supported_input(path) {
-                continue;
-            }
-
-            paths.push(path.to_path_buf());
-        }
-
+        let paths = collect_project_paths(self.project.project_root())?;
         self.project.register_paths(&paths)?;
         self.scanned = true;
         Ok(())
@@ -293,17 +270,7 @@ impl TypeChecker for BatchTypeChecker {
             return Err(CorsaError::NotInitialized);
         }
 
-        let mut result = self
-            .executor
-            .check_with_servers(&self.project, self.server_count)?;
-        result
-            .diagnostics
-            .extend(self.project.diagnostics().iter().cloned());
-        if result.has_errors() {
-            result.success = false;
-            result.exit_code = result.exit_code.max(1);
-        }
-        Ok(result)
+        self.check_registered_project(&self.project)
     }
 
     fn check_file(&self, path: &Path, content: &str) -> CorsaResult<Vec<Diagnostic>> {
@@ -320,18 +287,39 @@ impl TypeChecker for BatchTypeChecker {
     }
 
     fn check_incremental(&self, changed: &[PathBuf]) -> CorsaResult<TypeCheckResult> {
-        // For now, just do a full check
-        // TODO: Implement proper incremental checking
-        let _ = changed;
-        self.check_project()
+        if !self.scanned {
+            return Err(CorsaError::NotInitialized);
+        }
+        if changed.is_empty() {
+            return self.check_project();
+        }
+
+        // Correctness before reuse: rebuilding the source snapshot guarantees
+        // that edits, additions, deletions, and dependent diagnostics are never
+        // checked against the stale virtual files captured by the initial scan.
+        // A dependency-aware persistent Corsa session can optimize this path
+        // without weakening this observable contract.
+        let mut refreshed = self.project.empty_with_same_options()?;
+        let paths = refreshed_paths(&self.project, changed)?;
+        refreshed.register_paths(&paths)?;
+        self.check_registered_project(&refreshed)
     }
 }
 
-fn is_supported_input(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "vue" | "ts" | "tsx" | "mts" | "cts"))
-        || is_declaration_file(path)
+impl BatchTypeChecker {
+    fn check_registered_project(&self, project: &VirtualProject) -> CorsaResult<TypeCheckResult> {
+        let mut result = self
+            .executor
+            .check_with_servers(project, self.server_count)?;
+        result
+            .diagnostics
+            .extend(project.diagnostics().iter().cloned());
+        if result.has_errors() {
+            result.success = false;
+            result.exit_code = result.exit_code.max(1);
+        }
+        Ok(result)
+    }
 }
 
 #[cfg(test)]

--- a/crates/vize_canon/src/batch/type_checker/paths.rs
+++ b/crates/vize_canon/src/batch/type_checker/paths.rs
@@ -1,0 +1,67 @@
+//! Source discovery and refresh scope for batch type checking.
+
+use std::path::{Path, PathBuf};
+
+use super::super::declaration_path::is_declaration_file;
+use super::super::error::{CorsaError, CorsaResult};
+use super::super::virtual_project::VirtualProject;
+
+pub(super) fn collect_project_paths(project_root: &Path) -> CorsaResult<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for entry in walkdir::WalkDir::new(project_root)
+        .into_iter()
+        .filter_entry(|entry| {
+            if entry.path() == project_root {
+                return true;
+            }
+            let name = entry.file_name().to_string_lossy();
+            !name.starts_with('.') && name != "node_modules"
+        })
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() && is_supported_input(path) {
+            paths.push(path.to_path_buf());
+        }
+    }
+    Ok(paths)
+}
+
+pub(super) fn refreshed_paths(
+    project: &VirtualProject,
+    changed: &[PathBuf],
+) -> CorsaResult<Vec<PathBuf>> {
+    let project_root = project.project_root();
+    let mut paths = project.registered_original_paths_sorted();
+
+    for changed_path in changed {
+        let candidate = if changed_path.is_absolute() {
+            changed_path.clone()
+        } else {
+            project_root.join(changed_path)
+        };
+        if paths.iter().any(|path| path == &candidate) || !candidate.exists() {
+            continue;
+        }
+
+        let candidate = vize_carton::path::canonicalize_non_verbatim(&candidate);
+        if !candidate.starts_with(project_root) {
+            return Err(CorsaError::PathError { path: candidate });
+        }
+        if candidate.is_file() && is_supported_input(&candidate) {
+            paths.push(candidate);
+        }
+    }
+
+    paths.retain(|path| path.is_file());
+    paths.sort();
+    paths.dedup();
+    Ok(paths)
+}
+
+fn is_supported_input(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| matches!(extension, "vue" | "ts" | "tsx" | "mts" | "cts"))
+        || is_declaration_file(path)
+}

--- a/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
@@ -1,0 +1,208 @@
+use super::super::{BatchTypeChecker, create_project_case, resolve_test_tsgo_binary};
+use crate::batch::TypeChecker;
+
+#[test]
+fn observes_broken_and_repaired_vue_patch() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let clean_source = r#"<script setup lang="ts">
+const total: number = 1
+</script>
+
+<template><p>{{ total }}</p></template>
+"#;
+    let broken_source = clean_source.replace("= 1", "= 'broken'");
+    let project_root =
+        create_project_case("incremental-vue-patch", &[("src/App.vue", clean_source)]);
+    let app_path = project_root.join("src/App.vue");
+
+    let mut checker = BatchTypeChecker::new(&project_root).expect("checker should start");
+    checker.scan_project().expect("initial scan should succeed");
+
+    let clean = checker.check_project().expect("clean check should succeed");
+    assert!(
+        clean
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != Some(2322)),
+        "clean source unexpectedly reported TS2322: {:#?}",
+        clean.diagnostics
+    );
+
+    std::fs::write(&app_path, &broken_source).expect("broken patch should write");
+    let broken = checker
+        .check_incremental(std::slice::from_ref(&app_path))
+        .expect("broken incremental check should complete");
+    let type_error = broken
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.file == app_path && diagnostic.code == Some(2322))
+        .unwrap_or_else(|| {
+            panic!(
+                "broken patch did not report App.vue TS2322: {:#?}",
+                broken.diagnostics
+            )
+        });
+    assert_eq!((type_error.line, type_error.column), (1, 6));
+    assert!(
+        type_error
+            .message
+            .contains("not assignable to type 'number'"),
+        "unexpected TS2322 message: {}",
+        type_error.message
+    );
+
+    std::fs::write(&app_path, clean_source).expect("repair patch should write");
+    let repaired = checker
+        .check_incremental(std::slice::from_ref(&app_path))
+        .expect("repaired incremental check should complete");
+    assert!(
+        repaired
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != Some(2322)),
+        "repaired source retained stale TS2322: {:#?}",
+        repaired.diagnostics
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn refreshes_dependent_vue_diagnostics() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let app_source = r#"<script setup lang="ts">
+import type { Total } from './contract'
+const total: Total = 1
+</script>
+
+<template><p>{{ total }}</p></template>
+"#;
+    let project_root = create_project_case(
+        "incremental-dependent-patch",
+        &[
+            ("src/App.vue", app_source),
+            ("src/contract.ts", "export type Total = number\n"),
+        ],
+    );
+    let app_path = project_root.join("src/App.vue");
+    let contract_path = project_root.join("src/contract.ts");
+    let mut checker = BatchTypeChecker::new(&project_root).expect("checker should start");
+    checker.scan_project().expect("initial scan should succeed");
+
+    let clean = checker.check_project().expect("clean check should succeed");
+    assert!(
+        clean
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != Some(2322)),
+        "clean dependency unexpectedly reported TS2322: {:#?}",
+        clean.diagnostics
+    );
+
+    std::fs::write(&contract_path, "export type Total = string\n")
+        .expect("broken dependency patch should write");
+    let broken = checker
+        .check_incremental(std::slice::from_ref(&contract_path))
+        .expect("dependent incremental check should complete");
+    let dependent_error = broken
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.file == app_path && diagnostic.code == Some(2322))
+        .unwrap_or_else(|| {
+            panic!(
+                "dependency patch did not refresh App.vue TS2322: {:#?}",
+                broken.diagnostics
+            )
+        });
+    assert_eq!((dependent_error.line, dependent_error.column), (2, 6));
+    assert!(
+        dependent_error
+            .message
+            .contains("not assignable to type 'string'"),
+        "unexpected dependent TS2322 message: {}",
+        dependent_error.message
+    );
+
+    std::fs::write(&contract_path, "export type Total = number\n")
+        .expect("dependency repair should write");
+    let repaired = checker
+        .check_incremental(std::slice::from_ref(&contract_path))
+        .expect("repaired dependency check should complete");
+    assert!(
+        repaired
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != Some(2322)),
+        "dependency repair retained stale TS2322: {:#?}",
+        repaired.diagnostics
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn preserves_explicit_scan_scope() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let clean_source = r#"<script setup lang="ts">
+const included: number = 1
+</script>
+"#;
+    let project_root = create_project_case(
+        "incremental-explicit-scope",
+        &[
+            ("src/Included.vue", clean_source),
+            (
+                "src/OutsideScope.vue",
+                r#"<script setup lang="ts">
+const outside: number = 'must stay outside the scan'
+</script>
+"#,
+            ),
+        ],
+    );
+    let included_path = project_root.join("src/Included.vue");
+    let outside_path = project_root.join("src/OutsideScope.vue");
+    let mut checker = BatchTypeChecker::new(&project_root).expect("checker should start");
+    checker
+        .scan_paths(std::slice::from_ref(&included_path))
+        .expect("explicit scan should succeed");
+
+    let clean = checker.check_project().expect("clean check should succeed");
+    assert!(
+        clean.diagnostics.is_empty(),
+        "unexpected clean diagnostics: {clean:#?}"
+    );
+
+    std::fs::write(&included_path, clean_source.replace("= 1", "= 'broken'"))
+        .expect("included patch should write");
+    let broken = checker
+        .check_incremental(std::slice::from_ref(&included_path))
+        .expect("scoped incremental check should complete");
+    assert!(
+        broken
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.file == included_path && diagnostic.code == Some(2322)),
+        "included patch did not report TS2322: {:#?}",
+        broken.diagnostics
+    );
+    assert!(
+        broken
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.file != outside_path),
+        "incremental refresh expanded the explicit scan scope: {:#?}",
+        broken.diagnostics
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/type_checker/tests/scan.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/scan.rs
@@ -1,5 +1,8 @@
 use super::{BatchTypeChecker, unique_case_dir};
 
+#[path = "incremental.rs"]
+mod incremental;
+
 #[test]
 fn test_batch_type_checker_scan() {
     let project_root = unique_case_dir("scan");

--- a/crates/vize_canon/src/batch/virtual_project/mapping.rs
+++ b/crates/vize_canon/src/batch/virtual_project/mapping.rs
@@ -27,6 +27,13 @@ impl VirtualProject {
         files
     }
 
+    /// Original paths registered in this project, in deterministic order.
+    pub(crate) fn registered_original_paths_sorted(&self) -> Vec<PathBuf> {
+        let mut paths: Vec<_> = self.original_index.keys().cloned().collect();
+        paths.sort();
+        paths
+    }
+
     /// Parser diagnostics collected while registering source files.
     pub fn diagnostics(&self) -> &[Diagnostic] {
         &self.diagnostics

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -63,6 +63,25 @@ impl VirtualProject {
         Ok(project)
     }
 
+    /// Create an empty project snapshot with the same generation settings.
+    ///
+    /// This is used by correctness-safe refreshes: source files are registered
+    /// again from disk, while every caller-configured Vue dialect and virtual
+    /// TypeScript option remains identical to the original scan.
+    pub(crate) fn empty_with_same_options(&self) -> CorsaResult<Self> {
+        let mut project = Self::new(&self.project_root)?;
+        project.set_tsconfig_path(self.tsconfig_path.clone());
+        project.virtual_ts_options = self.virtual_ts_options.clone();
+        project.virtual_ts_check_options = self.virtual_ts_check_options;
+        project.options_api = self.options_api;
+        project.legacy_vue2 = self.legacy_vue2;
+        project.jsx_typecheck = self.jsx_typecheck;
+        project.dialect = self.dialect;
+        project.template_syntax = self.template_syntax;
+        project.experimental_in_tag_comments = self.experimental_in_tag_comments;
+        Ok(project)
+    }
+
     /// Set the tsconfig path to extend.
     pub fn set_tsconfig_path(&mut self, tsconfig_path: Option<PathBuf>) {
         self.tsconfig_path = tsconfig_path.map(vize_carton::path::normalize_windows_verbatim_path);


### PR DESCRIPTION
## Summary

- rebuild the registered virtual-project snapshot before incremental checks so edits, additions, deletions, and dependent diagnostics use current disk contents
- preserve explicit scan_paths scope while including newly changed supported files
- add clean, broken, and repaired Vue patch coverage plus cross-file dependent invalidation and a false-positive scope guard

## Validation

- cargo test -p vize_canon (545 unit tests plus integration tests)
- cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check
- git diff --check

Tracks #2971. This establishes the correctness contract; dependency-aware persistent-session performance remains a separate measured follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786869060&installation_id=136613492&pr_number=2974&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2974&signature=8dc241e5e6e4e59714893cc13eb6363c10cc9478254ea34d999ecef80e459914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Incremental type checks now refresh changed files and related dependencies without requiring a full project scan.
  - Project scanning recognizes supported Vue and TypeScript source and declaration files while excluding hidden paths and `node_modules`.

- **Bug Fixes**
  - Updated diagnostics now appear when dependencies change, and stale errors are cleared after fixes.
  - Incremental checks preserve explicitly selected scan scopes, preventing unrelated files from being reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->