### PR TITLE
fix(lsp): map component prop diagnostics exactly

### DIFF
--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -30,7 +30,7 @@ pub use generator::{
     generate_virtual_ts_with_offsets_legacy_vue2, generate_virtual_ts_with_offsets_options_api,
 };
 pub use helpers::{DECLARATION_HELPERS_DTS, SHARED_PREAMBLE_DTS, SHARED_PREAMBLE_FILE_NAME};
-pub use types::{TemplateGlobal, VirtualTsOptions, VirtualTsOutput, VizeMapping};
+pub use types::{TemplateGlobal, VirtualTsOptions, VirtualTsOutput, VizeMapping, VizeSubSpan};
 #[cfg(any(test, feature = "native"))]
 pub(crate) use types::{VirtualTsCheckOptions, VirtualTsGenerationOptions};
 

--- a/crates/vize_canon/src/virtual_ts/expressions.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions.rs
@@ -4,6 +4,8 @@
 //! v-if narrowing) and component prop value type assertions.
 
 mod component_props;
+#[cfg(test)]
+mod component_props_tests;
 mod reserved_props;
 mod statements;
 mod vif_chain;
@@ -11,6 +13,6 @@ mod vif_chain;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use component_props::generate_component_prop_checks;
+pub(crate) use component_props::{ComponentPropSource, generate_component_prop_checks};
 pub(crate) use reserved_props::rewrite_reserved_template_prop;
 pub(crate) use statements::{generate_expressions, generate_expressions_in_enclosing_guard};

--- a/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
@@ -6,7 +6,7 @@
 //! across the component boundary.
 
 use super::super::helpers::{to_camel_case, to_safe_identifier_fragment};
-use super::super::types::VizeMapping;
+use super::super::types::{VizeMapping, VizeSubSpan};
 use super::reserved_props::rewrite_reserved_template_prop;
 use vize_carton::FxHashSet;
 use vize_carton::String;
@@ -62,6 +62,32 @@ fn is_checkable_prop(prop: &PassedProp) -> bool {
     !prop.name_is_dynamic && prop.name.as_str() != "key" && prop.name.as_str() != "ref"
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct ComponentPropSource<'a> {
+    pub(crate) template: Option<&'a str>,
+    pub(crate) offset: u32,
+}
+
+impl<'a> ComponentPropSource<'a> {
+    pub(crate) const fn new(template: Option<&'a str>, offset: u32) -> Self {
+        Self { template, offset }
+    }
+}
+
+fn dynamic_prop_value_source_range(
+    source_context: ComponentPropSource<'_>,
+    prop: &PassedProp,
+) -> Option<std::ops::Range<usize>> {
+    let source = source_context.template?;
+    let value = prop.value.as_ref()?.as_str();
+    let prop_start = prop.start as usize;
+    let prop_end = prop.end as usize;
+    let raw_prop = source.get(prop_start..prop_end)?;
+    let relative_start = raw_prop.rfind(value)?;
+    let source_start = source_context.offset as usize + prop_start + relative_start;
+    Some(source_start..source_start + value.len())
+}
+
 fn collect_generated_class_bindings<'a>(
     usage: &'a ComponentUsage,
     template_prop_names: &FxHashSet<String>,
@@ -102,7 +128,7 @@ pub(crate) fn generate_component_prop_checks(
     usage: &ComponentUsage,
     idx: usize,
     template_prop_names: &FxHashSet<String>,
-    template_offset: u32,
+    source_context: ComponentPropSource<'_>,
     indent: &str,
 ) {
     let component_type_name = to_safe_identifier_fragment(usage.name.as_str());
@@ -111,8 +137,9 @@ pub(crate) fn generate_component_prop_checks(
             continue;
         }
         if prop.value.is_some() && prop.is_dynamic {
-            let prop_src_start = (template_offset + prop.start) as usize;
-            let prop_src_end = (template_offset + prop.end) as usize;
+            let prop_src_start = (source_context.offset + prop.start) as usize;
+            let prop_src_end = (source_context.offset + prop.end) as usize;
+            let value_src_range = dynamic_prop_value_source_range(source_context, prop);
             let generated_value = profile!(
                 "canon.virtual_ts.prop_check.value",
                 generated_prop_value(prop, template_prop_names).unwrap_or_default()
@@ -133,11 +160,15 @@ pub(crate) fn generate_component_prop_checks(
                 append!(*ts, "{indent}if ({guard}) {{\n");
             }
 
-            let gen_stmt_start = ts.len();
             let check_name = cstr!("__vize_prop_check_{idx}_{safe_prop_name}");
+            let gen_stmt_start = ts.len();
+            append!(*ts, "{expr_indent}const ");
+            let check_name_start = ts.len();
+            ts.push_str(check_name.as_str());
+            let check_name_end = ts.len();
             append!(
                 *ts,
-                "{expr_indent}const {check_name}: __{component_type_name}_{idx}_prop_{safe_prop_name} = {};\n",
+                ": __{component_type_name}_{idx}_prop_{safe_prop_name} = {};\n",
                 generated_value.as_str(),
             );
             let gen_stmt_end = ts.len();
@@ -145,7 +176,13 @@ pub(crate) fn generate_component_prop_checks(
             mappings.push(VizeMapping {
                 gen_range: gen_stmt_start..gen_stmt_end,
                 src_range: prop_src_start..prop_src_end,
-                sub_spans: Vec::new(),
+                sub_spans: value_src_range
+                    .map(|src_range| VizeSubSpan {
+                        gen_range: check_name_start..check_name_end,
+                        src_range,
+                    })
+                    .into_iter()
+                    .collect(),
             });
 
             if usage.vif_guard.is_some() {
@@ -160,7 +197,7 @@ pub(crate) fn generate_component_prop_checks(
         usage,
         idx,
         template_prop_names,
-        template_offset,
+        source_context.offset,
         indent,
     );
 }
@@ -267,48 +304,5 @@ fn generate_generic_props_call(
 
     if usage.vif_guard.is_some() {
         append!(*ts, "{indent}}}\n");
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use vize_croquis::{Analyzer, AnalyzerOptions};
-
-    use crate::virtual_ts::generate_virtual_ts;
-
-    #[test]
-    fn generic_props_call_merges_static_and_dynamic_class_bindings() {
-        let script = r#"import TeacherCard from "./TeacherCard.vue"
-const teacher = { name: "Ada" }
-const isLoading = false
-"#;
-        let template = r#"<TeacherCard
-  class="ma-1"
-  :teacher="teacher"
-  :class="{ 'loading-place-holder': isLoading }"
-/>"#;
-
-        let allocator = vize_carton::Bump::new();
-        let (root, _) = vize_armature::parse(&allocator, template);
-        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
-        analyzer.analyze_script_setup(script);
-        analyzer.analyze_template(&root);
-        let summary = analyzer.finish();
-
-        let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
-
-        assert!(
-            output
-                .code
-                .contains("\"class\": [\"ma-1\", { 'loading-place-holder': isLoading }]"),
-            "expected merged class binding in generic props call:\n{}",
-            output.code
-        );
-        assert_eq!(
-            output.code.matches("\"class\":").count(),
-            1,
-            "class should be emitted once in the props object:\n{}",
-            output.code
-        );
     }
 }

--- a/crates/vize_canon/src/virtual_ts/expressions/component_props_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/component_props_tests.rs
@@ -1,0 +1,70 @@
+use vize_croquis::{Analyzer, AnalyzerOptions};
+
+use crate::virtual_ts::generate_virtual_ts;
+
+#[test]
+fn generic_props_call_merges_static_and_dynamic_class_bindings() {
+    let script = r#"import TeacherCard from "./TeacherCard.vue"
+const teacher = { name: "Ada" }
+const isLoading = false
+"#;
+    let template = r#"<TeacherCard
+  class="ma-1"
+  :teacher="teacher"
+  :class="{ 'loading-place-holder': isLoading }"
+/>"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+
+    assert!(
+        output
+            .code
+            .contains("\"class\": [\"ma-1\", { 'loading-place-holder': isLoading }]"),
+        "expected merged class binding in generic props call:\n{}",
+        output.code
+    );
+    assert_eq!(
+        output.code.matches("\"class\":").count(),
+        1,
+        "class should be emitted once in the props object:\n{}",
+        output.code
+    );
+}
+
+#[test]
+fn component_prop_check_maps_synthetic_name_to_bound_expression() {
+    let script = r#"import Child from "./Child.vue"
+const benchmarkMirror = 1
+"#;
+    let template = r#"<Child :code="String(benchmarkMirror)" />"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+    let expression = "String(benchmarkMirror)";
+    let source_start = template.find(expression).expect("bound expression present");
+    let source_range = source_start..source_start + expression.len();
+    let sub_span = output
+        .mappings
+        .iter()
+        .flat_map(|mapping| &mapping.sub_spans)
+        .find(|span| span.src_range == source_range)
+        .expect("component prop check should preserve the exact bound expression range");
+
+    assert!(
+        output.code[sub_span.gen_range.clone()].starts_with("__vize_prop_check_"),
+        "synthetic check identifier should map to the bound expression: {sub_span:?}"
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -10,7 +10,7 @@ use vize_carton::profile;
 
 use vize_croquis::{Croquis, Scope, ScopeData, ScopeKind, analysis::ComponentUsage};
 
-use crate::virtual_ts::expressions::generate_component_prop_checks;
+use crate::virtual_ts::expressions::{ComponentPropSource, generate_component_prop_checks};
 use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier, to_safe_identifier_fragment};
 use crate::virtual_ts::types::VizeMapping;
 
@@ -195,7 +195,7 @@ pub(super) fn generate_component_props(
                 usage,
                 idx,
                 ctx.template_prop_names,
-                ctx.template_offset,
+                ComponentPropSource::new(ctx.template_source, ctx.template_offset),
                 "  "
             )
         );
@@ -216,7 +216,7 @@ pub(super) fn generate_component_props(
             children_map: ctx.children_map,
             vfor_enclosing_guards: &vfor_enclosing_guards,
             template_prop_names: ctx.template_prop_names,
-            template_offset: ctx.template_offset,
+            source_context: ComponentPropSource::new(ctx.template_source, ctx.template_offset),
         };
         profile!(
             "canon.virtual_ts.closure_component_props",
@@ -299,7 +299,7 @@ fn generate_closure_component_props_recursive(
                             usage,
                             idx,
                             ctx.template_prop_names,
-                            ctx.template_offset,
+                            ctx.source_context,
                             &vfor_inner_indent,
                         )
                     );
@@ -372,7 +372,7 @@ fn generate_closure_component_props_recursive(
                             usage,
                             idx,
                             ctx.template_prop_names,
-                            ctx.template_offset,
+                            ctx.source_context,
                             &inner_indent,
                         )
                     );

--- a/crates/vize_canon/src/virtual_ts/scope/context.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/context.rs
@@ -6,6 +6,7 @@ use vize_carton::String;
 
 use vize_croquis::{Croquis, EventHandlerScopeData, ScopeId, analysis::ComponentUsage};
 
+use crate::virtual_ts::expressions::ComponentPropSource;
 use crate::virtual_ts::types::{VirtualTsCheckOptions, VirtualTsOptions};
 
 /// Context for recursive scope generation, bundling shared parameters.
@@ -35,7 +36,7 @@ pub(crate) struct VForPropsContext<'a> {
     pub(crate) children_map: &'a FxHashMap<u32, Vec<ScopeId>>,
     pub(crate) vfor_enclosing_guards: &'a FxHashMap<u32, String>,
     pub(crate) template_prop_names: &'a FxHashSet<String>,
-    pub(crate) template_offset: u32,
+    pub(crate) source_context: ComponentPropSource<'a>,
 }
 
 pub(super) struct EventHandlerExprContext<'a> {

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/mapping.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/mapping.rs
@@ -46,13 +46,30 @@ fn mapping_for_generated_offset(
 ) -> Option<&vize_canon::virtual_ts::VizeMapping> {
     mappings
         .iter()
-        .find(|mapping| offset >= mapping.gen_range.start && offset <= mapping.gen_range.end)
+        .filter(|mapping| offset >= mapping.gen_range.start && offset <= mapping.gen_range.end)
+        .min_by_key(|mapping| {
+            mapping
+                .gen_range
+                .end
+                .saturating_sub(mapping.gen_range.start)
+        })
 }
 
 fn map_generated_offset_to_source(
     mapping: &vize_canon::virtual_ts::VizeMapping,
     generated_offset: usize,
 ) -> usize {
+    if let Some(span) = mapping.sub_spans.iter().find(|span| {
+        generated_offset >= span.gen_range.start && generated_offset <= span.gen_range.end
+    }) {
+        let generated_relative = generated_offset.saturating_sub(span.gen_range.start);
+        let source_len = span.src_range.end.saturating_sub(span.src_range.start);
+        return span
+            .src_range
+            .start
+            .saturating_add(generated_relative.min(source_len));
+    }
+
     let generated_relative = generated_offset.saturating_sub(mapping.gen_range.start);
     let source_len = mapping
         .src_range
@@ -124,4 +141,49 @@ pub(super) fn source_offset_to_position(source: &str, offset: usize) -> (u32, u3
     }
 
     (line, character)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{map_generated_offset_to_source, mapping_for_generated_offset};
+    use vize_canon::virtual_ts::{VizeMapping, VizeSubSpan};
+
+    #[test]
+    fn diagnostic_mapping_prefers_exact_expression_sub_span() {
+        let mappings = [VizeMapping {
+            gen_range: 10..80,
+            src_range: 100..140,
+            sub_spans: vec![VizeSubSpan {
+                gen_range: 20..43,
+                src_range: 107..130,
+            }],
+        }];
+        let mapping = mapping_for_generated_offset(&mappings, 20).expect("mapping present");
+
+        assert_eq!(map_generated_offset_to_source(mapping, 20), 107);
+        assert_eq!(map_generated_offset_to_source(mapping, 43), 130);
+    }
+
+    #[test]
+    fn diagnostic_mapping_prefers_the_narrowest_generated_range() {
+        let mappings = [
+            VizeMapping {
+                gen_range: 0..100,
+                src_range: 0..100,
+                sub_spans: Vec::new(),
+            },
+            VizeMapping {
+                gen_range: 20..40,
+                src_range: 200..220,
+                sub_spans: Vec::new(),
+            },
+        ];
+
+        assert_eq!(
+            mapping_for_generated_offset(&mappings, 30)
+                .expect("mapping present")
+                .src_range,
+            200..220
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- map synthetic component-prop checks back to the exact Vue binding expression
- make Corsa diagnostics prefer sub-token spans and the narrowest generated mapping
- cover exact mapping and overlapping-range selection regressions

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p vize_canon -p vize_maestro -p vize -- -D warnings -D clippy::wildcard_imports`
- `cargo test -p vize_canon -p vize_maestro`
- Misskey frontend overlay oracle: exact TS2322 range repaired from character 24 to 23

Refs #2971

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786872658&installation_id=136613492&pr_number=2975&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2975&signature=45ceae63399200a07ee40375729352ae869859609d355bf6a85561f6da218686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue component prop diagnostics by mapping errors to the precise bound value instead of the entire prop.
  * Corrected source-location handling for component props used in loops and slots.
  * Improved diagnostic selection when generated ranges overlap, including more accurate handling of sub-ranges and boundary offsets.

* **Tests**
  * Added coverage for merged static and dynamic class bindings.
  * Added validation that generated prop checks map back to the correct template expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->