### PR TITLE
fix(lsp): preserve mapping end boundaries

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics/corsa/mapping.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/mapping.rs
@@ -25,7 +25,7 @@ pub(super) fn map_diagnostic_with_source_mappings(
     let end_offset = import_source_map.get_original_offset(end_offset_post as u32) as usize;
     let start_mapping = mapping_for_generated_offset(mappings, start_offset)?;
     let src_start = map_generated_offset_to_source(start_mapping, start_offset);
-    let src_end = mapping_for_generated_offset(mappings, end_offset)
+    let src_end = mapping_for_diagnostic_end_offset(mappings, start_mapping, end_offset)
         .map(|mapping| map_generated_offset_to_source(mapping, end_offset))
         .unwrap_or_else(|| {
             let generated_len = end_offset.saturating_sub(start_offset);
@@ -46,13 +46,25 @@ fn mapping_for_generated_offset(
 ) -> Option<&vize_canon::virtual_ts::VizeMapping> {
     mappings
         .iter()
-        .filter(|mapping| offset >= mapping.gen_range.start && offset <= mapping.gen_range.end)
+        .filter(|mapping| mapping.gen_range.contains(&offset))
         .min_by_key(|mapping| {
             mapping
                 .gen_range
                 .end
                 .saturating_sub(mapping.gen_range.start)
         })
+}
+
+fn mapping_for_diagnostic_end_offset<'a>(
+    mappings: &'a [vize_canon::virtual_ts::VizeMapping],
+    start_mapping: &'a vize_canon::virtual_ts::VizeMapping,
+    end_offset: usize,
+) -> Option<&'a vize_canon::virtual_ts::VizeMapping> {
+    if end_offset > start_mapping.gen_range.start && end_offset <= start_mapping.gen_range.end {
+        Some(start_mapping)
+    } else {
+        mapping_for_generated_offset(mappings, end_offset)
+    }
 }
 
 fn map_generated_offset_to_source(
@@ -145,7 +157,10 @@ pub(super) fn source_offset_to_position(source: &str, offset: usize) -> (u32, u3
 
 #[cfg(test)]
 mod tests {
-    use super::{map_generated_offset_to_source, mapping_for_generated_offset};
+    use super::{
+        map_generated_offset_to_source, mapping_for_diagnostic_end_offset,
+        mapping_for_generated_offset,
+    };
     use vize_canon::virtual_ts::{VizeMapping, VizeSubSpan};
 
     #[test]
@@ -182,6 +197,18 @@ mod tests {
         assert_eq!(
             mapping_for_generated_offset(&mappings, 30)
                 .expect("mapping present")
+                .src_range,
+            200..220
+        );
+        assert_eq!(
+            mapping_for_generated_offset(&mappings, 40)
+                .expect("mapping present")
+                .src_range,
+            0..100
+        );
+        assert_eq!(
+            mapping_for_diagnostic_end_offset(&mappings, &mappings[1], 40)
+                .expect("end mapping present")
                 .src_range,
             200..220
         );


### PR DESCRIPTION
## Summary

- keep generated source-map lookup end-exclusive
- retain the diagnostic start mapping when its half-open range covers the diagnostic end
- lock overlapping `0..100` and `20..40` behavior at offset `40` with a regression test

Follow-up to the actionable range-boundary review on #2975.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p vize_maestro -- -D warnings -D clippy::wildcard_imports`
- `cargo test -p vize_maestro`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786873175&installation_id=136613492&pr_number=2976&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2976&signature=8b012245eb4ae011a71169f93f3ab9ce5ef5ba500c6f727988eedadec32b9e51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic positioning when source mappings span generated code.
  * Ensured diagnostic end locations remain accurate when they fall within the same mapped range.
  * Improved handling of generated offsets at mapping boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->