### PR TITLE
test(lsp): gate incremental Misskey sessions

### DIFF
--- a/.github/actions/check-vue-parity/action.yml
+++ b/.github/actions/check-vue-parity/action.yml
@@ -1,0 +1,44 @@
+name: Check Vue parity
+description: Gate compiler fixtures and incremental LSP behavior against pinned Vue projects
+
+runs:
+  using: composite
+  steps:
+    - name: Hydrate fixtures and install JS dependencies
+      shell: bash
+      run: |
+        git submodule update --init --depth 1 \
+          tests/_fixtures/_git/create-vue \
+          tests/_fixtures/_git/misskey
+        vp install --frozen-lockfile --prefer-offline
+
+    - name: Build vize CLI
+      shell: bash
+      run: cargo build --profile ci -p vize
+
+    - name: Check Vue compiler and typecheck parity
+      shell: bash
+      run: vp run --filter './tests' test:check:fixtures
+
+    - name: Check incremental LSP against Misskey
+      shell: bash
+      env:
+        VIZE_LSP_BIN: target/ci/vize
+      run: vp run --filter './tests' test:performance:lsp-incremental
+
+    - name: Publish incremental LSP summary
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        if [ -s target/vize-tests/metrics/misskey-lsp-incremental/summary.md ]; then
+          cat target/vize-tests/metrics/misskey-lsp-incremental/summary.md >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+    - name: Upload incremental LSP metrics
+      if: ${{ always() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: misskey-lsp-incremental-metrics
+        path: target/vize-tests/metrics/misskey-lsp-incremental/
+        if-no-files-found: warn
+        retention-days: 14

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -234,12 +234,7 @@ jobs:
         with:
           key: vue-parity
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
-      - name: Hydrate fixture and install JS dependencies
-        run: git submodule update --init --depth 1 tests/_fixtures/_git/create-vue && vp install --frozen-lockfile --prefer-offline
-      - name: Build vize CLI
-        run: cargo build --profile ci -p vize
-      - name: Check Vue compiler and typecheck parity
-        run: vp run --filter './tests' test:check:fixtures
+      - uses: ./.github/actions/check-vue-parity
 
   test-scripts:
     runs-on: blacksmith-32vcpu-ubuntu-2404

--- a/tests/_helpers/realworld-patch.ts
+++ b/tests/_helpers/realworld-patch.ts
@@ -41,16 +41,7 @@ export async function withPinnedFixtureWorkspace<T>(
   options: PinnedFixtureOptions,
   run: (fixture: PinnedFixtureWorkspace) => Promise<T>,
 ): Promise<T> {
-  const entry = readFixtureEntry(options.fixtureId);
-  const upstreamDir = path.join(repoRoot, entry.fixturePath);
-  assert.ok(
-    fs.existsSync(upstreamDir),
-    `fixture ${entry.id} is not hydrated; run git submodule update --init ${entry.fixturePath}`,
-  );
-
-  const initialRevision = git(upstreamDir, "rev-parse", "HEAD");
-  assert.equal(initialRevision, entry.revision, `${entry.id} must stay pinned to the registry`);
-  assert.equal(git(upstreamDir, "status", "--porcelain"), "", `${entry.id} must start clean`);
+  const { entry, upstreamDir, initialRevision } = openPinnedFixture(options.fixtureId);
 
   const outputRoot = path.join(repoRoot, "target/vize-tests/realworld-patches");
   fs.mkdirSync(outputRoot, { recursive: true });
@@ -99,16 +90,7 @@ export async function withPinnedFixtureWorkspace<T>(
     return await run(fixture);
   } finally {
     fs.rmSync(workspaceDir, { recursive: true, force: true });
-    assert.equal(
-      git(upstreamDir, "rev-parse", "HEAD"),
-      initialRevision,
-      `${entry.id} revision changed during patch-oracle execution`,
-    );
-    assert.equal(
-      git(upstreamDir, "status", "--porcelain"),
-      "",
-      `${entry.id} was dirtied by patch-oracle execution`,
-    );
+    assertPinnedFixtureUnchanged(entry, upstreamDir, initialRevision);
   }
 }
 
@@ -125,6 +107,40 @@ function readFixtureEntry(id: string): FixtureRegistryEntry {
   const entry = registry.projects.find((project) => project.id === id);
   assert.ok(entry, `fixture registry does not contain ${id}`);
   return entry;
+}
+
+function openPinnedFixture(fixtureId: string): {
+  entry: FixtureRegistryEntry;
+  upstreamDir: string;
+  initialRevision: string;
+} {
+  const entry = readFixtureEntry(fixtureId);
+  const upstreamDir = path.join(repoRoot, entry.fixturePath);
+  assert.ok(
+    fs.existsSync(upstreamDir),
+    `fixture ${entry.id} is not hydrated; run git submodule update --init ${entry.fixturePath}`,
+  );
+  const initialRevision = git(upstreamDir, "rev-parse", "HEAD");
+  assert.equal(initialRevision, entry.revision, `${entry.id} must stay pinned to the registry`);
+  assert.equal(git(upstreamDir, "status", "--porcelain"), "", `${entry.id} must start clean`);
+  return { entry, upstreamDir, initialRevision };
+}
+
+function assertPinnedFixtureUnchanged(
+  entry: FixtureRegistryEntry,
+  upstreamDir: string,
+  initialRevision: string,
+): void {
+  assert.equal(
+    git(upstreamDir, "rev-parse", "HEAD"),
+    initialRevision,
+    `${entry.id} revision changed during patch-oracle execution`,
+  );
+  assert.equal(
+    git(upstreamDir, "status", "--porcelain"),
+    "",
+    `${entry.id} was dirtied by patch-oracle execution`,
+  );
 }
 
 function resolveInside(root: string, relativePath: string): string {

--- a/tests/package.json
+++ b/tests/package.json
@@ -16,7 +16,8 @@
     "test:readiness:lint": "node --test --test-concurrency=1 tooling/cli-lint-contract.test.ts",
     "test:readiness:build": "node --test --test-concurrency=1 snapshots/build/generic.ts snapshots/build/elk.ts",
     "test:readiness:dev": "VIZE_TEST_WORKTREE_ID=${VIZE_TEST_WORKTREE_ID:-ci-readiness} playwright test --config app/playwright.config.ts app/dev/misskey.spec.ts",
-    "test:check:fixtures": "node --test --test-concurrency=1 snapshots/check/typecheck-errors.ts snapshots/check/typecheck-vue-imports.ts snapshots/check/compiler-macros.ts snapshots/check/style-preprocessors.ts snapshots/check/ecosystem-products.ts snapshots/check/generic-build.ts snapshots/check/nuxt-parity.ts snapshots/check/toolchain-parity.ts snapshots/check/options-api.ts snapshots/check/class-component.ts snapshots/check/create-vue-patch-oracle.ts snapshots/check/zz-intentional-errors-fixtures.ts"
+    "test:check:fixtures": "node --test --test-concurrency=1 snapshots/check/typecheck-errors.ts snapshots/check/typecheck-vue-imports.ts snapshots/check/compiler-macros.ts snapshots/check/style-preprocessors.ts snapshots/check/ecosystem-products.ts snapshots/check/generic-build.ts snapshots/check/nuxt-parity.ts snapshots/check/toolchain-parity.ts snapshots/check/options-api.ts snapshots/check/class-component.ts snapshots/check/create-vue-patch-oracle.ts snapshots/check/zz-intentional-errors-fixtures.ts",
+    "test:performance:lsp-incremental": "node --test --test-concurrency=1 performance/misskey-lsp-incremental.test.ts"
   },
   "devDependencies": {
     "@apollo/client": "3.14.1",

--- a/tests/performance/misskey-lsp-incremental.test.ts
+++ b/tests/performance/misskey-lsp-incremental.test.ts
@@ -1,0 +1,305 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { withPinnedFixtureWorkspace } from "../_helpers/realworld-patch.ts";
+import {
+  completionLabels,
+  hoverToText,
+  isDiagnosticsForUri,
+  offsetToPosition,
+} from "../tooling/support/lsp/assertions.ts";
+import type { LspDiagnostic, PublishDiagnosticsParams } from "../tooling/support/lsp/protocol.ts";
+import { LspSession } from "../tooling/support/lsp/session.ts";
+import { countFiles, IncrementalMetrics } from "./support/incremental-metrics.ts";
+
+const componentPath = "packages/frontend/src/components/MkDivider.vue";
+const dependencyPath = "packages/frontend/src/components/MkCodeInline.vue";
+const symbol = "benchmarkMirror";
+const waitTimeoutMs = 120_000;
+
+test(
+  "Misskey LSP clean, leaf, and shared edits stay exact in one production session",
+  { timeout: 300_000 },
+  async () => {
+    await withPinnedFixtureWorkspace(
+      { fixtureId: "misskey", includePaths: ["packages/frontend"] },
+      async (fixture) => {
+        const workspaceDir = path.join(fixture.workspaceDir, "packages/frontend");
+        const sourceDir = path.join(workspaceDir, "src");
+        const componentFile = fixture.resolve(componentPath);
+        const componentUri = pathToFileURL(componentFile).href;
+        const dependencyFile = fixture.resolve(dependencyPath);
+        const dependencyUri = pathToFileURL(dependencyFile).href;
+        const cleanDependency = fixture.read(dependencyPath);
+        const brokenDependency = replaceExactly(
+          cleanDependency,
+          "\tcode: string;",
+          "\tcode: number;",
+        );
+        const cleanSource = prepareComponent(fixture.read(componentPath));
+        const leafBrokenSource = replaceExactly(
+          cleanSource,
+          `const ${symbol}: number = 1;`,
+          `const ${symbol}: number = 'leaf-broken';`,
+        );
+        const vueFiles = countFiles(sourceDir, new Set([".vue"]));
+        const sourceFiles = countFiles(sourceDir, new Set([".vue", ".ts", ".tsx"]));
+        assert.ok(vueFiles >= 500, `expected a monorepo-scale fixture, got ${vueFiles} Vue files`);
+
+        const session = new LspSession();
+        const metrics = new IncrementalMetrics(session.processId);
+        let baseline: string[] = [];
+        let failure: unknown;
+
+        try {
+          await metrics.measure("initialize", () =>
+            session.initialize(workspaceDir, {
+              completion: true,
+              editor: true,
+              hover: true,
+              lint: false,
+              typecheck: true,
+            }),
+          );
+          session.notify("textDocument/didOpen", {
+            textDocument: {
+              uri: dependencyUri,
+              languageId: "vue",
+              version: 1,
+              text: cleanDependency,
+            },
+          });
+
+          const cleanPublish = await metrics.measure("coldOpen", async () => {
+            session.notify("textDocument/didOpen", {
+              textDocument: {
+                uri: componentUri,
+                languageId: "vue",
+                version: 1,
+                text: cleanSource,
+              },
+            });
+            return waitForDiagnostics(session, componentUri, 1);
+          });
+          baseline = normalizeDiagnostics(cleanPublish.diagnostics);
+
+          const completion = await metrics.measure("completion", () =>
+            session.request(
+              "textDocument/completion",
+              {
+                textDocument: { uri: componentUri },
+                position: positionInsideTemplateSymbol(cleanSource, "benchmarkM"),
+              },
+              waitTimeoutMs,
+            ),
+          );
+          assert.ok(
+            completionLabels(completion as never).includes(symbol),
+            JSON.stringify(completion),
+          );
+
+          const hover = (await metrics.measure("hover", () =>
+            session.request(
+              "textDocument/hover",
+              {
+                textDocument: { uri: componentUri },
+                position: positionInsideTemplateSymbol(cleanSource, symbol),
+              },
+              waitTimeoutMs,
+            ),
+          )) as { contents?: unknown } | null;
+          const hoverText = hoverToText(hover);
+          assert.match(hoverText, new RegExp(symbol));
+          assert.match(hoverText, /number/i);
+
+          const warmPublish = await changeVue(session, metrics, {
+            name: "warmNoop",
+            uri: componentUri,
+            version: 2,
+            source: cleanSource,
+          });
+          assert.deepEqual(normalizeDiagnostics(warmPublish.diagnostics), baseline);
+
+          const leafBroken = await changeVue(session, metrics, {
+            name: "leafBroken",
+            uri: componentUri,
+            version: 3,
+            source: leafBrokenSource,
+            expectError: true,
+          });
+          assertSingleInjectedMismatch(leafBroken.diagnostics, baseline, leafBrokenSource);
+
+          const leafRepaired = await changeVue(session, metrics, {
+            name: "leafRepaired",
+            uri: componentUri,
+            version: 4,
+            source: cleanSource,
+          });
+          assert.deepEqual(normalizeDiagnostics(leafRepaired.diagnostics), baseline);
+
+          const sharedBroken = await metrics.measure("sharedBroken", async () => {
+            session.notify("textDocument/didChange", {
+              textDocument: { uri: dependencyUri, version: 2 },
+              contentChanges: [{ text: brokenDependency }],
+            });
+            return waitForDiagnostics(session, componentUri, 4, true);
+          });
+          assertSingleInjectedMismatch(sharedBroken.diagnostics, baseline, cleanSource, "binding");
+
+          const sharedRepaired = await metrics.measure("sharedRepaired", async () => {
+            session.notify("textDocument/didChange", {
+              textDocument: { uri: dependencyUri, version: 3 },
+              contentChanges: [{ text: cleanDependency }],
+            });
+            return waitForDiagnostics(session, componentUri, 4, false);
+          });
+          assert.deepEqual(normalizeDiagnostics(sharedRepaired.diagnostics), baseline);
+
+          session.notify("textDocument/didClose", { textDocument: { uri: componentUri } });
+          session.notify("textDocument/didClose", { textDocument: { uri: dependencyUri } });
+        } catch (error) {
+          failure = error;
+        }
+        try {
+          await session.shutdown();
+        } catch (error) {
+          failure ??= error;
+        }
+        metrics.write(
+          {
+            fixture: "misskey/packages/frontend",
+            revision: fixture.entry.revision,
+            vueFiles,
+            sourceFiles,
+            baselineDiagnostics: baseline.length,
+          },
+          failure,
+        );
+        if (failure != null) throw failure;
+      },
+    );
+  },
+);
+
+function prepareComponent(source: string): string {
+  let patched = replaceExactly(
+    source,
+    '<script setup lang="ts">\n',
+    `<script setup lang="ts">\nimport MkCodeInline from './MkCodeInline.vue';\n\nconst ${symbol}: number = 1;\n`,
+  );
+  return replaceExactly(
+    patched,
+    "</div>\n</template>",
+    `\t<MkCodeInline :code="String(${symbol})" /><span>{{ ${symbol} }}</span>\n</div>\n</template>`,
+  );
+}
+
+function replaceExactly(source: string, expected: string, replacement: string): string {
+  const first = source.indexOf(expected);
+  assert.notEqual(first, -1, `missing patch anchor: ${expected}`);
+  assert.equal(
+    source.indexOf(expected, first + expected.length),
+    -1,
+    "patch anchor must be unique",
+  );
+  return `${source.slice(0, first)}${replacement}${source.slice(first + expected.length)}`;
+}
+
+async function changeVue(
+  session: LspSession,
+  metrics: IncrementalMetrics,
+  change: { name: string; uri: string; version: number; source: string; expectError?: boolean },
+): Promise<PublishDiagnosticsParams> {
+  return metrics.measure(change.name, async () => {
+    session.notify("textDocument/didChange", {
+      textDocument: { uri: change.uri, version: change.version },
+      contentChanges: [{ text: change.source }],
+    });
+    return waitForDiagnostics(session, change.uri, change.version, change.expectError);
+  });
+}
+
+async function waitForDiagnostics(
+  session: LspSession,
+  uri: string,
+  version: number,
+  expectError?: boolean,
+): Promise<PublishDiagnosticsParams> {
+  return (await session.waitForNotification(
+    "textDocument/publishDiagnostics",
+    (params) => {
+      if (!isDiagnosticsForUri(params, uri) || params.version !== version) return false;
+      return expectError == null || hasInjectedMismatch(params.diagnostics) === expectError;
+    },
+    waitTimeoutMs,
+  )) as PublishDiagnosticsParams;
+}
+
+function hasInjectedMismatch(diagnostics: LspDiagnostic[]): boolean {
+  return diagnostics.some(
+    (diagnostic) =>
+      String(diagnostic.code).replace(/^TS/, "") === "2322" &&
+      /string.*not assignable.*number/i.test(diagnostic.message ?? ""),
+  );
+}
+
+function assertSingleInjectedMismatch(
+  diagnostics: LspDiagnostic[],
+  baseline: string[],
+  source: string,
+  expectedRange: "declaration" | "binding" = "declaration",
+): void {
+  const injected = diagnostics.filter(
+    (diagnostic) =>
+      String(diagnostic.code).replace(/^TS/, "") === "2322" &&
+      /string.*not assignable.*number/i.test(diagnostic.message ?? ""),
+  );
+  assert.equal(injected.length, 1, JSON.stringify(diagnostics));
+  const [diagnostic] = injected;
+  assert.equal(diagnostic.source, "vize/types");
+  assert.equal(diagnostic.severity, 1);
+  if (expectedRange === "declaration") {
+    const declarationOffset = source.indexOf(`const ${symbol}`);
+    assert.notEqual(declarationOffset, -1);
+    const start = offsetToPosition(source, declarationOffset + "const ".length);
+    const end = { line: start.line, character: start.character + symbol.length };
+    assert.deepEqual(diagnostic.range?.start, start);
+    assert.deepEqual(diagnostic.range?.end, end);
+  } else {
+    const bindingOffset = source.indexOf(`String(${symbol})`);
+    assert.notEqual(bindingOffset, -1);
+    const start = offsetToPosition(source, bindingOffset);
+    const end = { line: start.line, character: start.character + `String(${symbol})`.length };
+    assert.deepEqual(diagnostic.range?.start, start);
+    assert.deepEqual(diagnostic.range?.end, end);
+  }
+  assert.deepEqual(
+    normalizeDiagnostics(diagnostics.filter((item) => item !== diagnostic)),
+    baseline,
+  );
+}
+
+function normalizeDiagnostics(diagnostics: LspDiagnostic[]): string[] {
+  return diagnostics
+    .map((diagnostic) =>
+      JSON.stringify({
+        code: diagnostic.code,
+        message: diagnostic.message,
+        range: diagnostic.range,
+        severity: diagnostic.severity,
+        source: diagnostic.source,
+      }),
+    )
+    .sort();
+}
+
+function positionInsideTemplateSymbol(
+  source: string,
+  prefix: string,
+): { line: number; character: number } {
+  const templateOffset = source.indexOf(`{{ ${symbol} }}`);
+  assert.notEqual(templateOffset, -1);
+  return offsetToPosition(source, templateOffset + "{{ ".length + prefix.length);
+}

--- a/tests/performance/support/incremental-metrics.ts
+++ b/tests/performance/support/incremental-metrics.ts
@@ -1,0 +1,138 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { inspect } from "node:util";
+import { performance } from "node:perf_hooks";
+
+import { repoRoot } from "../../_helpers/realworld-patch.ts";
+
+export const incrementalMetricsDir = path.join(
+  repoRoot,
+  "target/vize-tests/metrics/misskey-lsp-incremental",
+);
+
+type MetricContext = {
+  fixture: string;
+  revision: string;
+  vueFiles: number;
+  sourceFiles: number;
+  baselineDiagnostics: number;
+};
+
+export class IncrementalMetrics {
+  private readonly timingsMs: Record<string, number> = {};
+  private readonly rssSamplesKiB: Record<string, number> = {};
+  private readonly processId: number;
+
+  constructor(processId: number) {
+    this.processId = processId;
+  }
+
+  async measure<T>(name: string, operation: () => Promise<T>): Promise<T> {
+    const startedAt = performance.now();
+    try {
+      return await operation();
+    } finally {
+      this.timingsMs[name] = performance.now() - startedAt;
+      this.sampleRss(name);
+    }
+  }
+
+  sampleRss(name: string): void {
+    const rss = processRssKiB(this.processId);
+    if (rss != null) this.rssSamplesKiB[name] = rss;
+  }
+
+  write(context: MetricContext, failure?: unknown): void {
+    fs.mkdirSync(incrementalMetricsDir, { recursive: true });
+    const sampledPeakRssKiB = Math.max(0, ...Object.values(this.rssSamplesKiB));
+    const data = {
+      schemaVersion: 1,
+      status: failure == null ? "passed" : "failed",
+      failure:
+        failure instanceof Error ? failure.message : failure == null ? null : inspect(failure),
+      commit: gitHead(),
+      fixture: context.fixture,
+      fixtureRevision: context.revision,
+      corpus: {
+        vueFiles: context.vueFiles,
+        vueAndTypeScriptFiles: context.sourceFiles,
+        baselineDiagnostics: context.baselineDiagnostics,
+      },
+      runtime: {
+        platform: process.platform,
+        architecture: process.arch,
+        node: process.version,
+        cpuCount: os.cpus().length,
+        cpuModel: os.cpus()[0]?.model ?? "unknown",
+      },
+      timingsMs: this.timingsMs,
+      rssSamplesKiB: this.rssSamplesKiB,
+      sampledPeakRssKiB,
+      note: "Latency and RSS are report-only; diagnostic, completion, hover, and repair oracles are gated.",
+    };
+    fs.writeFileSync(
+      path.join(incrementalMetricsDir, "metrics.json"),
+      `${JSON.stringify(data, null, 2)}\n`,
+    );
+    fs.writeFileSync(path.join(incrementalMetricsDir, "summary.md"), renderMarkdown(data));
+  }
+}
+
+export function countFiles(root: string, extensions: ReadonlySet<string>): number {
+  let count = 0;
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const filePath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      count += countFiles(filePath, extensions);
+    } else if (extensions.has(path.extname(entry.name))) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function processRssKiB(processId: number): number | null {
+  if (process.platform === "win32") return null;
+  const result = spawnSync("ps", ["-o", "rss=", "-p", String(processId)], { encoding: "utf8" });
+  if (result.status !== 0) return null;
+  const value = Number.parseInt(result.stdout.trim(), 10);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function gitHead(): string {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim() : "unknown";
+}
+
+function renderMarkdown(data: {
+  status: string;
+  fixture: string;
+  fixtureRevision: string;
+  corpus: { vueFiles: number; vueAndTypeScriptFiles: number; baselineDiagnostics: number };
+  timingsMs: Record<string, number>;
+  sampledPeakRssKiB: number;
+}): string {
+  const lines = [
+    "## Misskey LSP Incremental Oracle",
+    "",
+    `Status: **${data.status}**. Fixture: \`${data.fixture}@${data.fixtureRevision}\`.`,
+    "",
+    `Corpus: ${data.corpus.vueFiles} Vue files; ${data.corpus.vueAndTypeScriptFiles} Vue/TS files; ${data.corpus.baselineDiagnostics} baseline diagnostics.`,
+    "",
+    "| Stage | Time |",
+    "| --- | ---: |",
+  ];
+  for (const [stage, milliseconds] of Object.entries(data.timingsMs)) {
+    lines.push(`| ${stage} | ${milliseconds.toFixed(1)} ms |`);
+  }
+  lines.push(
+    "",
+    `Sampled peak LSP RSS: ${data.sampledPeakRssKiB > 0 ? `${(data.sampledPeakRssKiB / 1024).toFixed(1)} MiB` : "unavailable"}.`,
+    "",
+    "Timing and RSS are report-only. The clean/broken/repaired diagnostics, completion, hover, and dependency propagation are hard assertions.",
+    "",
+  );
+  return lines.join("\n");
+}

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -276,10 +276,24 @@ test("check workflow blocks on Rust source and branch coverage budgets", () => {
 test("check workflow gates Vue parity against official compiler and vue-tsc fixtures", () => {
   const workflow = readRepoFile(".github", "workflows", "check.yml");
   const job = workflowJobBody(workflow, "vue-parity");
+  const action = readRepoFile(".github", "actions", "check-vue-parity", "action.yml");
+  const testsPackage = JSON.parse(readRepoFile("tests", "package.json"));
 
-  assert.match(job, /vp install --frozen-lockfile --prefer-offline/);
-  assert.match(job, /cargo build --profile ci -p vize/);
-  assert.match(job, /vp run --filter '\.\/tests' test:check:fixtures/);
+  assert.match(job, /uses:\s*\.\/\.github\/actions\/check-vue-parity/);
+  assert.match(action, /vp install --frozen-lockfile --prefer-offline/);
+  assert.match(action, /cargo build --profile ci -p vize/);
+  assert.match(action, /vp run --filter '\.\/tests' test:check:fixtures/);
+  assert.match(action, /tests\/_fixtures\/_git\/create-vue/);
+  assert.match(action, /tests\/_fixtures\/_git\/misskey/);
+  assert.match(action, /VIZE_LSP_BIN:\s*target\/ci\/vize/);
+  assert.match(action, /vp run --filter '\.\/tests' test:performance:lsp-incremental/);
+  assert.match(action, /misskey-lsp-incremental\/summary\.md/);
+  assert.match(action, /name:\s*misskey-lsp-incremental-metrics/);
+  assert.match(action, /retention-days:\s*14/);
+  assert.equal(
+    testsPackage.scripts["test:performance:lsp-incremental"],
+    "node --test --test-concurrency=1 performance/misskey-lsp-incremental.test.ts",
+  );
 });
 
 test("check workflow only installs Playwright browsers on cache misses", () => {

--- a/tests/tooling/support/lsp/session.ts
+++ b/tests/tooling/support/lsp/session.ts
@@ -86,6 +86,12 @@ export class LspSession {
     });
   }
 
+  /** Operating-system process id for report-only latency/RSS measurements. */
+  get processId(): number {
+    assert.ok(this.process.pid, "vize lsp process id is unavailable");
+    return this.process.pid;
+  }
+
   async initialize(
     workspaceDir: string,
     initializationOptions: LspInitializationOptions = {


### PR DESCRIPTION
## Summary

- add a copy-isolated LSP oracle over pinned Misskey `packages/frontend` (`810faa8e`, 583 Vue / 888 Vue+TS+TSX files)
- exercise clean baseline, completion, typed hover, warm no-op, leaf TS2322, dependency-propagated TS2322, and exact repair in one production LSP process
- hard-gate diagnostic count/code/source/severity/exact range and zero residual false positives while publishing report-only latency/RSS artifacts
- run the oracle in the existing Vue parity job and keep the upstream fixture revision and worktree read-only

Advances #2971.

## Representative local run

- baseline diagnostics: `0`
- cold open: `240.5 ms`
- completion: `3.2 ms`
- hover: `7.2 ms`
- leaf broken/repaired: `135.9 / 115.1 ms`
- shared dependency broken/repaired: `193.1 / 190.3 ms`
- sampled peak LSP RSS: `30.2 MiB`

Timing and RSS are report-only. Correctness assertions are blocking.

## Verification

- `cargo build -p vize`
- `VIZE_LSP_BIN=target/debug/vize vp run --filter './tests' test:performance:lsp-incremental`\n- `vp check <all eight changed files>`\n- `node --test tests/tooling/github-workflows-check.test.ts`\n- `SOURCE_LENGTH_BASE_REF=origin/main node --test --test-name-pattern "source length script checks the current checkout" tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786873642&installation_id=136613492&pr_number=2977&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2977&signature=aeee5b37dee34ba1a4f200b93843adfc11e951f2e570b3d1f026f784dcc20fcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Vue compiler and type-checking parity validation.
  * Added incremental LSP performance testing against a real-world Vue project.
  * Added diagnostics, completion, hover, timing, memory, and test-result reporting.

* **Bug Fixes**
  * Improved fixture validation to detect unexpected revisions or working-tree changes.

* **Chores**
  * Consolidated CI parity checks into a reusable workflow action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->