### PR TITLE
test(lsp): harden Misskey gate assertions

### DIFF
--- a/tests/performance/misskey-lsp-incremental.test.ts
+++ b/tests/performance/misskey-lsp-incremental.test.ts
@@ -83,6 +83,11 @@ test(
             });
             return waitForDiagnostics(session, componentUri, 1);
           });
+          assert.equal(
+            cleanPublish.diagnostics.length,
+            0,
+            `expected no clean diagnostics: ${JSON.stringify(cleanPublish.diagnostics)}`,
+          );
           baseline = normalizeDiagnostics(cleanPublish.diagnostics);
 
           const completion = await metrics.measure("completion", () =>

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -273,29 +273,6 @@ test("check workflow blocks on Rust source and branch coverage budgets", () => {
   assert.match(branchJob, /continue-on-error:\s*true/);
 });
 
-test("check workflow gates Vue parity against official compiler and vue-tsc fixtures", () => {
-  const workflow = readRepoFile(".github", "workflows", "check.yml");
-  const job = workflowJobBody(workflow, "vue-parity");
-  const action = readRepoFile(".github", "actions", "check-vue-parity", "action.yml");
-  const testsPackage = JSON.parse(readRepoFile("tests", "package.json"));
-
-  assert.match(job, /uses:\s*\.\/\.github\/actions\/check-vue-parity/);
-  assert.match(action, /vp install --frozen-lockfile --prefer-offline/);
-  assert.match(action, /cargo build --profile ci -p vize/);
-  assert.match(action, /vp run --filter '\.\/tests' test:check:fixtures/);
-  assert.match(action, /tests\/_fixtures\/_git\/create-vue/);
-  assert.match(action, /tests\/_fixtures\/_git\/misskey/);
-  assert.match(action, /VIZE_LSP_BIN:\s*target\/ci\/vize/);
-  assert.match(action, /vp run --filter '\.\/tests' test:performance:lsp-incremental/);
-  assert.match(action, /misskey-lsp-incremental\/summary\.md/);
-  assert.match(action, /name:\s*misskey-lsp-incremental-metrics/);
-  assert.match(action, /retention-days:\s*14/);
-  assert.equal(
-    testsPackage.scripts["test:performance:lsp-incremental"],
-    "node --test --test-concurrency=1 performance/misskey-lsp-incremental.test.ts",
-  );
-});
-
 test("check workflow only installs Playwright browsers on cache misses", () => {
   const workflow = readRepoFile(".github", "workflows", "check.yml");
 

--- a/tests/tooling/github-workflows-vue-parity.test.ts
+++ b/tests/tooling/github-workflows-vue-parity.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parse } from "yaml";
+
+import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
+
+type CompositeActionStep = {
+  env?: Record<string, string>;
+  if?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, number | string>;
+};
+
+test("Vue parity structurally gates compiler fixtures and incremental LSP behavior", () => {
+  const workflow = readRepoFile(".github", "workflows", "check.yml");
+  const job = workflowJobBody(workflow, "vue-parity");
+  const action = parse(readRepoFile(".github", "actions", "check-vue-parity", "action.yml")) as {
+    runs?: { steps?: CompositeActionStep[]; using?: string };
+  };
+  const testsPackage = JSON.parse(readRepoFile("tests", "package.json"));
+
+  assert.match(job, /uses:\s*\.\/\.github\/actions\/check-vue-parity/);
+  assert.equal(action.runs?.using, "composite");
+  const steps = action.runs?.steps ?? [];
+  const hydration = steps.find(
+    (step) => step.name === "Hydrate fixtures and install JS dependencies",
+  );
+  assert.match(hydration?.run ?? "", /tests\/_fixtures\/_git\/create-vue/);
+  assert.match(hydration?.run ?? "", /tests\/_fixtures\/_git\/misskey/);
+  assert.match(hydration?.run ?? "", /vp install --frozen-lockfile --prefer-offline/);
+  assert.equal(
+    steps.find((step) => step.name === "Build vize CLI")?.run,
+    "cargo build --profile ci -p vize",
+  );
+  assert.equal(
+    steps.find((step) => step.name === "Check Vue compiler and typecheck parity")?.run,
+    "vp run --filter './tests' test:check:fixtures",
+  );
+
+  const incremental = steps.find((step) => step.name === "Check incremental LSP against Misskey");
+  assert.deepEqual(incremental?.env, { VIZE_LSP_BIN: "target/ci/vize" });
+  assert.equal(incremental?.run, "vp run --filter './tests' test:performance:lsp-incremental");
+
+  const summary = steps.find((step) => step.name === "Publish incremental LSP summary");
+  assert.equal(summary?.if, "${{ always() }}");
+  assert.match(summary?.run ?? "", /misskey-lsp-incremental\/summary\.md/);
+  assert.match(summary?.run ?? "", /GITHUB_STEP_SUMMARY/);
+
+  const upload = steps.find((step) => step.name === "Upload incremental LSP metrics");
+  assert.equal(upload?.if, "${{ always() }}");
+  assert.match(upload?.uses ?? "", /^actions\/upload-artifact@[0-9a-f]{40}$/);
+  assert.deepEqual(upload?.with, {
+    name: "misskey-lsp-incremental-metrics",
+    path: "target/vize-tests/metrics/misskey-lsp-incremental/",
+    "if-no-files-found": "warn",
+    "retention-days": 14,
+  });
+  assert.equal(
+    testsPackage.scripts["test:performance:lsp-incremental"],
+    "node --test --test-concurrency=1 performance/misskey-lsp-incremental.test.ts",
+  );
+});


### PR DESCRIPTION
## Summary

- require the pinned Misskey clean baseline to publish exactly zero diagnostics before it can become the repair oracle
- parse the Vue parity composite action as YAML and assert each hydration, build, incremental LSP, summary, and artifact step structurally
- move the focused workflow contract into its own 64-line test so the existing test file stays below the 350-line source limit

Follow-up to both actionable review threads on #2977.

## Verification

- `VIZE_LSP_BIN=target/debug/vize vp run --filter './tests' test:performance:lsp-incremental`\n- `vp check tests/performance/misskey-lsp-incremental.test.ts tests/tooling/github-workflows-check.test.ts tests/tooling/github-workflows-vue-parity.test.ts`\n- `node --test tests/tooling/github-workflows-check.test.ts tests/tooling/github-workflows-vue-parity.test.ts`\n- `SOURCE_LENGTH_BASE_REF=origin/main node --test --test-name-pattern "source length script checks the current checkout" tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786874221&installation_id=136613492&pr_number=2978&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2978&signature=ee5e390309dae511e11e4b38ffc86ff43f83d92654c4f0cb5a28f36e43757f34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened validation to ensure initial diagnostics are empty during incremental language-service performance testing.
  * Added coverage to verify the Vue parity workflow and its composite action configuration, including required build, fixture, performance, and reporting steps.
  * Removed redundant workflow wiring checks now covered by the dedicated Vue parity test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->