### PR TITLE
fix(canon): retain incremental project membership

### DIFF
--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -226,7 +226,7 @@ impl BatchTypeChecker {
     pub fn scan_paths(&mut self, paths: &[PathBuf]) -> CorsaResult<()> {
         self.project.register_paths(paths)?;
         self.scanned = true;
-        self.incremental_paths.after_explicit_scan(&self.project);
+        self.incremental_paths.after_explicit_scan(paths);
         Ok(())
     }
 

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -1,7 +1,6 @@
 //! TypeChecker trait and BatchTypeChecker implementation.
 
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
 
 use super::Diagnostic;
 use super::error::{CorsaError, CorsaResult};
@@ -11,7 +10,7 @@ use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 use vize_carton::String;
 
 mod paths;
-use paths::{collect_project_paths, refresh_paths};
+use paths::{IncrementalPaths, collect_project_paths};
 
 /// Result of type checking.
 #[derive(Debug, Default)]
@@ -116,19 +115,8 @@ pub struct BatchTypeChecker {
     scanned: bool,
     /// Number of parallel Corsa CLI processes; `None` auto-tunes.
     server_count: Option<usize>,
-    /// Whether source discovery came from a project-wide scan.
-    ///
-    /// Only project scans may grow when incremental callers report a newly
-    /// created path. Explicit `scan_paths` scopes stay closed over their
-    /// original membership.
-    project_wide_scan: bool,
     /// Source membership carried across incremental checks.
-    ///
-    /// The initial scan remains immutable so full checks preserve their
-    /// original scope. Incremental checks evolve this separate path set as
-    /// files are created and deleted, preventing a newly added file from
-    /// disappearing on the next unrelated edit.
-    incremental_paths: Mutex<Option<Vec<PathBuf>>>,
+    incremental_paths: IncrementalPaths,
 }
 
 impl BatchTypeChecker {
@@ -162,8 +150,7 @@ impl BatchTypeChecker {
             executor,
             scanned: false,
             server_count: None,
-            project_wide_scan: false,
-            incremental_paths: Mutex::new(None),
+            incremental_paths: IncrementalPaths::new(),
         })
     }
 
@@ -239,10 +226,7 @@ impl BatchTypeChecker {
     pub fn scan_paths(&mut self, paths: &[PathBuf]) -> CorsaResult<()> {
         self.project.register_paths(paths)?;
         self.scanned = true;
-        *self
-            .incremental_paths
-            .get_mut()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+        self.incremental_paths.after_explicit_scan(&self.project);
         Ok(())
     }
 
@@ -251,11 +235,7 @@ impl BatchTypeChecker {
         let paths = collect_project_paths(self.project.project_root())?;
         self.project.register_paths(&paths)?;
         self.scanned = true;
-        self.project_wide_scan = true;
-        *self
-            .incremental_paths
-            .get_mut()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+        self.incremental_paths.after_project_scan(&self.project);
         Ok(())
     }
 
@@ -324,21 +304,10 @@ impl TypeChecker for BatchTypeChecker {
         // checked against the stale virtual files captured by the initial scan.
         // A dependency-aware persistent Corsa session can optimize this path
         // without weakening this observable contract.
-        let mut incremental_paths = self
-            .incremental_paths
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let paths = incremental_paths
-            .get_or_insert_with(|| self.project.registered_original_paths_sorted());
-        refresh_paths(
-            self.project.project_root(),
-            paths,
-            changed,
-            self.project_wide_scan,
-        )?;
+        let paths = self.incremental_paths.refresh(&self.project, changed)?;
 
         let mut refreshed = self.project.empty_with_same_options()?;
-        refreshed.register_paths(paths)?;
+        refreshed.register_paths(&paths)?;
         self.check_registered_project(&refreshed)
     }
 }

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -116,6 +116,12 @@ pub struct BatchTypeChecker {
     scanned: bool,
     /// Number of parallel Corsa CLI processes; `None` auto-tunes.
     server_count: Option<usize>,
+    /// Whether source discovery came from a project-wide scan.
+    ///
+    /// Only project scans may grow when incremental callers report a newly
+    /// created path. Explicit `scan_paths` scopes stay closed over their
+    /// original membership.
+    project_wide_scan: bool,
     /// Source membership carried across incremental checks.
     ///
     /// The initial scan remains immutable so full checks preserve their
@@ -156,6 +162,7 @@ impl BatchTypeChecker {
             executor,
             scanned: false,
             server_count: None,
+            project_wide_scan: false,
             incremental_paths: Mutex::new(None),
         })
     }
@@ -244,6 +251,7 @@ impl BatchTypeChecker {
         let paths = collect_project_paths(self.project.project_root())?;
         self.project.register_paths(&paths)?;
         self.scanned = true;
+        self.project_wide_scan = true;
         *self
             .incremental_paths
             .get_mut()
@@ -322,7 +330,12 @@ impl TypeChecker for BatchTypeChecker {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let paths = incremental_paths
             .get_or_insert_with(|| self.project.registered_original_paths_sorted());
-        refresh_paths(self.project.project_root(), paths, changed)?;
+        refresh_paths(
+            self.project.project_root(),
+            paths,
+            changed,
+            self.project_wide_scan,
+        )?;
 
         let mut refreshed = self.project.empty_with_same_options()?;
         refreshed.register_paths(paths)?;

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -1,6 +1,7 @@
 //! TypeChecker trait and BatchTypeChecker implementation.
 
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use super::Diagnostic;
 use super::error::{CorsaError, CorsaResult};
@@ -10,7 +11,7 @@ use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 use vize_carton::String;
 
 mod paths;
-use paths::{collect_project_paths, refreshed_paths};
+use paths::{collect_project_paths, refresh_paths};
 
 /// Result of type checking.
 #[derive(Debug, Default)]
@@ -115,6 +116,13 @@ pub struct BatchTypeChecker {
     scanned: bool,
     /// Number of parallel Corsa CLI processes; `None` auto-tunes.
     server_count: Option<usize>,
+    /// Source membership carried across incremental checks.
+    ///
+    /// The initial scan remains immutable so full checks preserve their
+    /// original scope. Incremental checks evolve this separate path set as
+    /// files are created and deleted, preventing a newly added file from
+    /// disappearing on the next unrelated edit.
+    incremental_paths: Mutex<Option<Vec<PathBuf>>>,
 }
 
 impl BatchTypeChecker {
@@ -148,6 +156,7 @@ impl BatchTypeChecker {
             executor,
             scanned: false,
             server_count: None,
+            incremental_paths: Mutex::new(None),
         })
     }
 
@@ -223,6 +232,10 @@ impl BatchTypeChecker {
     pub fn scan_paths(&mut self, paths: &[PathBuf]) -> CorsaResult<()> {
         self.project.register_paths(paths)?;
         self.scanned = true;
+        *self
+            .incremental_paths
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
         Ok(())
     }
 
@@ -231,6 +244,10 @@ impl BatchTypeChecker {
         let paths = collect_project_paths(self.project.project_root())?;
         self.project.register_paths(&paths)?;
         self.scanned = true;
+        *self
+            .incremental_paths
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
         Ok(())
     }
 
@@ -299,9 +316,16 @@ impl TypeChecker for BatchTypeChecker {
         // checked against the stale virtual files captured by the initial scan.
         // A dependency-aware persistent Corsa session can optimize this path
         // without weakening this observable contract.
+        let mut incremental_paths = self
+            .incremental_paths
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let paths = incremental_paths
+            .get_or_insert_with(|| self.project.registered_original_paths_sorted());
+        refresh_paths(self.project.project_root(), paths, changed)?;
+
         let mut refreshed = self.project.empty_with_same_options()?;
-        let paths = refreshed_paths(&self.project, changed)?;
-        refreshed.register_paths(&paths)?;
+        refreshed.register_paths(paths)?;
         self.check_registered_project(&refreshed)
     }
 }

--- a/crates/vize_canon/src/batch/type_checker/paths.rs
+++ b/crates/vize_canon/src/batch/type_checker/paths.rs
@@ -1,7 +1,7 @@
 //! Source discovery and refresh scope for batch type checking.
 
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, MutexGuard};
+use std::sync::Mutex;
 
 use super::super::declaration_path::is_declaration_file;
 use super::super::error::{CorsaError, CorsaResult};
@@ -26,8 +26,23 @@ impl IncrementalPaths {
         }
     }
 
-    pub(super) fn after_explicit_scan(&mut self, project: &VirtualProject) {
-        self.replace_paths(project);
+    pub(super) fn after_explicit_scan(&mut self, paths: &[PathBuf]) {
+        let was_project_wide = std::mem::replace(&mut self.allow_new_paths, false);
+        let current = self
+            .paths
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if was_project_wide {
+            current.clear();
+        }
+        current.extend(
+            paths
+                .iter()
+                .filter(|path| path.is_file())
+                .map(|path| vize_carton::path::canonicalize_non_verbatim(path)),
+        );
+        current.sort();
+        current.dedup();
     }
 
     pub(super) fn after_project_scan(&mut self, project: &VirtualProject) {
@@ -35,11 +50,11 @@ impl IncrementalPaths {
         self.replace_paths(project);
     }
 
-    pub(super) fn refresh<'a>(
-        &'a self,
+    pub(super) fn refresh(
+        &self,
         project: &VirtualProject,
         changed: &[PathBuf],
-    ) -> CorsaResult<MutexGuard<'a, Vec<PathBuf>>> {
+    ) -> CorsaResult<Vec<PathBuf>> {
         let mut paths = self
             .paths
             .lock()
@@ -50,7 +65,7 @@ impl IncrementalPaths {
             changed,
             self.allow_new_paths,
         )?;
-        Ok(paths)
+        Ok(paths.clone())
     }
 
     fn replace_paths(&mut self, project: &VirtualProject) {
@@ -89,6 +104,7 @@ pub(super) fn refresh_paths(
     changed: &[PathBuf],
     allow_new_paths: bool,
 ) -> CorsaResult<()> {
+    let mut refreshed_paths = paths.clone();
     for changed_path in changed {
         let candidate = if changed_path.is_absolute() {
             changed_path.clone()
@@ -104,17 +120,18 @@ pub(super) fn refresh_paths(
             return Err(CorsaError::PathError { path: candidate });
         }
         if allow_new_paths
-            && !paths.iter().any(|path| path == &candidate)
+            && !refreshed_paths.iter().any(|path| path == &candidate)
             && candidate.is_file()
             && is_supported_input(&candidate)
         {
-            paths.push(candidate);
+            refreshed_paths.push(candidate);
         }
     }
 
-    paths.retain(|path| path.is_file());
-    paths.sort();
-    paths.dedup();
+    refreshed_paths.retain(|path| path.is_file());
+    refreshed_paths.sort();
+    refreshed_paths.dedup();
+    *paths = refreshed_paths;
     Ok(())
 }
 
@@ -123,4 +140,30 @@ fn is_supported_input(path: &Path) -> bool {
         .and_then(|extension| extension.to_str())
         .is_some_and(|extension| matches!(extension, "vue" | "ts" | "tsx" | "mts" | "cts"))
         || is_declaration_file(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::refresh_paths;
+
+    #[test]
+    fn validation_error_does_not_partially_grow_membership() {
+        let project = tempfile::tempdir().expect("project tempdir should exist");
+        let outside = tempfile::tempdir().expect("outside tempdir should exist");
+        let existing = project.path().join("existing.ts");
+        let added = project.path().join("added.ts");
+        let outside_file = outside.path().join("outside.ts");
+        std::fs::write(&existing, "export {}\n").expect("existing file should write");
+        std::fs::write(&added, "export {}\n").expect("added file should write");
+        std::fs::write(&outside_file, "export {}\n").expect("outside file should write");
+
+        let project_root = vize_carton::path::canonicalize_non_verbatim(project.path());
+        let existing = vize_carton::path::canonicalize_non_verbatim(&existing);
+        let mut paths = vec![existing.clone()];
+        let error = refresh_paths(&project_root, &mut paths, &[added, outside_file], true)
+            .expect_err("outside path should reject the whole refresh");
+
+        assert!(matches!(error, crate::batch::CorsaError::PathError { .. }));
+        assert_eq!(paths, vec![existing]);
+    }
 }

--- a/crates/vize_canon/src/batch/type_checker/paths.rs
+++ b/crates/vize_canon/src/batch/type_checker/paths.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 
 use super::super::declaration_path::is_declaration_file;
 use super::super::error::{CorsaError, CorsaResult};
-use super::super::virtual_project::VirtualProject;
 
 pub(super) fn collect_project_paths(project_root: &Path) -> CorsaResult<Vec<PathBuf>> {
     let mut paths = Vec::new();
@@ -27,20 +26,18 @@ pub(super) fn collect_project_paths(project_root: &Path) -> CorsaResult<Vec<Path
     Ok(paths)
 }
 
-pub(super) fn refreshed_paths(
-    project: &VirtualProject,
+pub(super) fn refresh_paths(
+    project_root: &Path,
+    paths: &mut Vec<PathBuf>,
     changed: &[PathBuf],
-) -> CorsaResult<Vec<PathBuf>> {
-    let project_root = project.project_root();
-    let mut paths = project.registered_original_paths_sorted();
-
+) -> CorsaResult<()> {
     for changed_path in changed {
         let candidate = if changed_path.is_absolute() {
             changed_path.clone()
         } else {
             project_root.join(changed_path)
         };
-        if paths.iter().any(|path| path == &candidate) || !candidate.exists() {
+        if !candidate.exists() {
             continue;
         }
 
@@ -48,7 +45,10 @@ pub(super) fn refreshed_paths(
         if !candidate.starts_with(project_root) {
             return Err(CorsaError::PathError { path: candidate });
         }
-        if candidate.is_file() && is_supported_input(&candidate) {
+        if !paths.iter().any(|path| path == &candidate)
+            && candidate.is_file()
+            && is_supported_input(&candidate)
+        {
             paths.push(candidate);
         }
     }
@@ -56,7 +56,7 @@ pub(super) fn refreshed_paths(
     paths.retain(|path| path.is_file());
     paths.sort();
     paths.dedup();
-    Ok(paths)
+    Ok(())
 }
 
 fn is_supported_input(path: &Path) -> bool {

--- a/crates/vize_canon/src/batch/type_checker/paths.rs
+++ b/crates/vize_canon/src/batch/type_checker/paths.rs
@@ -30,6 +30,7 @@ pub(super) fn refresh_paths(
     project_root: &Path,
     paths: &mut Vec<PathBuf>,
     changed: &[PathBuf],
+    allow_new_paths: bool,
 ) -> CorsaResult<()> {
     for changed_path in changed {
         let candidate = if changed_path.is_absolute() {
@@ -45,7 +46,8 @@ pub(super) fn refresh_paths(
         if !candidate.starts_with(project_root) {
             return Err(CorsaError::PathError { path: candidate });
         }
-        if !paths.iter().any(|path| path == &candidate)
+        if allow_new_paths
+            && !paths.iter().any(|path| path == &candidate)
             && candidate.is_file()
             && is_supported_input(&candidate)
         {

--- a/crates/vize_canon/src/batch/type_checker/paths.rs
+++ b/crates/vize_canon/src/batch/type_checker/paths.rs
@@ -1,9 +1,66 @@
 //! Source discovery and refresh scope for batch type checking.
 
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
 
 use super::super::declaration_path::is_declaration_file;
 use super::super::error::{CorsaError, CorsaResult};
+use super::super::virtual_project::VirtualProject;
+
+/// Source membership carried across incremental checks.
+///
+/// The initial virtual project stays immutable so full checks preserve their
+/// original scope. This state evolves separately as project-wide scans observe
+/// creates and all scans observe deletes. Explicit `scan_paths` scopes never
+/// grow from an out-of-scope change notification.
+pub(super) struct IncrementalPaths {
+    allow_new_paths: bool,
+    paths: Mutex<Vec<PathBuf>>,
+}
+
+impl IncrementalPaths {
+    pub(super) fn new() -> Self {
+        Self {
+            allow_new_paths: false,
+            paths: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub(super) fn after_explicit_scan(&mut self, project: &VirtualProject) {
+        self.replace_paths(project);
+    }
+
+    pub(super) fn after_project_scan(&mut self, project: &VirtualProject) {
+        self.allow_new_paths = true;
+        self.replace_paths(project);
+    }
+
+    pub(super) fn refresh<'a>(
+        &'a self,
+        project: &VirtualProject,
+        changed: &[PathBuf],
+    ) -> CorsaResult<MutexGuard<'a, Vec<PathBuf>>> {
+        let mut paths = self
+            .paths
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        refresh_paths(
+            project.project_root(),
+            &mut paths,
+            changed,
+            self.allow_new_paths,
+        )?;
+        Ok(paths)
+    }
+
+    fn replace_paths(&mut self, project: &VirtualProject) {
+        *self
+            .paths
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            project.registered_original_paths_sorted();
+    }
+}
 
 pub(super) fn collect_project_paths(project_root: &Path) -> CorsaResult<Vec<PathBuf>> {
     let mut paths = Vec::new();

--- a/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
@@ -206,3 +206,78 @@ const outside: number = 'must stay outside the scan'
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn retains_added_files_across_incremental_refreshes() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let clean_source = r#"<script setup lang="ts">
+const initial: number = 1
+</script>
+"#;
+    let project_root =
+        create_project_case("incremental-added-file", &[("src/App.vue", clean_source)]);
+    let app_path = project_root.join("src/App.vue");
+    let added_path = project_root.join("src/Added.vue");
+    let mut checker = BatchTypeChecker::new(&project_root).expect("checker should start");
+    checker.scan_project().expect("initial scan should succeed");
+
+    std::fs::write(
+        &added_path,
+        r#"<script setup lang="ts">
+const added: number = 'broken added file'
+</script>
+"#,
+    )
+    .expect("added file should write");
+    let after_add = checker
+        .check_incremental(std::slice::from_ref(&added_path))
+        .expect("added-file check should complete");
+    assert!(
+        after_add
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.file == added_path && diagnostic.code == Some(2322)),
+        "added file did not report TS2322: {:#?}",
+        after_add.diagnostics
+    );
+
+    std::fs::write(&app_path, clean_source.replace("= 1", "= 'broken app'"))
+        .expect("app patch should write");
+    let after_unrelated_edit = checker
+        .check_incremental(std::slice::from_ref(&app_path))
+        .expect("second incremental check should complete");
+    assert!(
+        after_unrelated_edit
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.file == added_path && diagnostic.code == Some(2322)),
+        "unrelated edit dropped the added file from the project: {:#?}",
+        after_unrelated_edit.diagnostics
+    );
+    assert!(
+        after_unrelated_edit
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.file == app_path && diagnostic.code == Some(2322)),
+        "second incremental check did not observe the App.vue patch: {:#?}",
+        after_unrelated_edit.diagnostics
+    );
+
+    std::fs::remove_file(&added_path).expect("added file should delete");
+    let after_delete = checker
+        .check_incremental(std::slice::from_ref(&added_path))
+        .expect("deleted-file check should complete");
+    assert!(
+        after_delete
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.file != added_path),
+        "deleted file retained stale diagnostics: {:#?}",
+        after_delete.diagnostics
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
@@ -204,6 +204,18 @@ const outside: number = 'must stay outside the scan'
         broken.diagnostics
     );
 
+    let outside_change = checker
+        .check_incremental(std::slice::from_ref(&outside_path))
+        .expect("out-of-scope incremental check should complete");
+    assert!(
+        outside_change
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.file != outside_path),
+        "a changed path expanded the explicit scan scope: {:#?}",
+        outside_change.diagnostics
+    );
+
     let _ = std::fs::remove_dir_all(&project_root);
 }
 

--- a/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
@@ -173,14 +173,11 @@ const outside: number = 'must stay outside the scan'
     let outside_path = project_root.join("src/OutsideScope.vue");
     let mut checker = BatchTypeChecker::new(&project_root).expect("checker should start");
     checker
+        .scan_project()
+        .expect("project-wide scan should succeed");
+    checker
         .scan_paths(std::slice::from_ref(&included_path))
         .expect("explicit scan should succeed");
-
-    let clean = checker.check_project().expect("clean check should succeed");
-    assert!(
-        clean.diagnostics.is_empty(),
-        "unexpected clean diagnostics: {clean:#?}"
-    );
 
     std::fs::write(&included_path, clean_source.replace("= 1", "= 'broken'"))
         .expect("included patch should write");
@@ -213,6 +210,14 @@ const outside: number = 'must stay outside the scan'
             .iter()
             .all(|diagnostic| diagnostic.file != outside_path),
         "a changed path expanded the explicit scan scope: {:#?}",
+        outside_change.diagnostics
+    );
+    assert!(
+        outside_change
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.file == included_path && diagnostic.code == Some(2322)),
+        "out-of-scope refresh dropped the included diagnostic: {:#?}",
         outside_change.diagnostics
     );
 
@@ -288,6 +293,14 @@ const added: number = 'broken added file'
             .iter()
             .all(|diagnostic| diagnostic.file != added_path),
         "deleted file retained stale diagnostics: {:#?}",
+        after_delete.diagnostics
+    );
+    assert!(
+        after_delete
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.file == app_path && diagnostic.code == Some(2322)),
+        "deleting the added file dropped the unrelated App.vue diagnostic: {:#?}",
         after_delete.diagnostics
     );
 


### PR DESCRIPTION
## Summary

- keep source membership across consecutive incremental checks
- retain newly added files through unrelated edits
- remove deleted files and their stale diagnostics

## Verification

- `cargo test -p vize_canon`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `vp check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786874984&installation_id=136613492&pr_number=2979&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2979&signature=0e86d19465a4219f5179bde403ff1d85a8475a29893d6537c0428a6d7be8dcee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incremental type checking by refreshing the set of tracked source files during incremental refreshes.
  * Explicit incremental scan scope is preserved, preventing diagnostics from appearing outside the intended scope.
  * Newly added source files now remain covered across later incremental refreshes, and their diagnostics are removed when the file is deleted.
  * Full project scans update path tracking appropriately (including allowing newly discovered inputs when applicable).

* **Tests**
  * Added/extended incremental type-checking tests for scope preservation and added-file retention/removal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->