### PR TITLE
feat(canon): refresh materialized Corsa sessions

### DIFF
--- a/crates/vize_canon/src/lsp_client.rs
+++ b/crates/vize_canon/src/lsp_client.rs
@@ -17,6 +17,7 @@ mod diagnostics;
 mod diagnostics_api;
 mod lifecycle;
 mod lifecycle_setup;
+mod materialized_refresh;
 pub(crate) mod paths;
 mod queries;
 mod session;

--- a/crates/vize_canon/src/lsp_client/materialized_refresh.rs
+++ b/crates/vize_canon/src/lsp_client/materialized_refresh.rs
@@ -1,0 +1,99 @@
+use super::CorsaProjectClient;
+use corsa::{
+    api::{DocumentIdentifier, FileChangeSummary, FileChanges},
+    runtime::block_on,
+};
+use std::path::PathBuf;
+use vize_carton::{String, cstr};
+
+impl CorsaProjectClient {
+    /// Refresh an on-disk project session after materialized files change.
+    ///
+    /// Paths are forwarded as filesystem identifiers so Corsa can invalidate
+    /// the affected dependency graph without replacing the project session.
+    pub fn refresh_materialized_files(
+        &mut self,
+        changed: &[PathBuf],
+        created: &[PathBuf],
+        deleted: &[PathBuf],
+    ) -> Result<(), String> {
+        let Some(file_changes) = materialized_file_changes(changed, created, deleted) else {
+            return Ok(());
+        };
+
+        self.clear_diagnostics_cache();
+        block_on(self.session.refresh(Some(file_changes)))
+            .map_err(|error| cstr!("Failed to refresh materialized Corsa files: {error}"))
+    }
+}
+
+fn materialized_file_changes(
+    changed: &[PathBuf],
+    created: &[PathBuf],
+    deleted: &[PathBuf],
+) -> Option<FileChanges> {
+    if changed.is_empty() && created.is_empty() && deleted.is_empty() {
+        return None;
+    }
+
+    Some(FileChanges::Summary(FileChangeSummary {
+        changed: document_identifiers(changed),
+        created: document_identifiers(created),
+        deleted: document_identifiers(deleted),
+    }))
+}
+
+fn document_identifiers(paths: &[PathBuf]) -> Vec<DocumentIdentifier> {
+    let mut paths: Vec<_> = paths
+        .iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect();
+    paths.sort();
+    paths.dedup();
+    paths.into_iter().map(DocumentIdentifier::from).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::materialized_file_changes;
+    use corsa::api::{DocumentIdentifier, FileChanges};
+    use std::path::PathBuf;
+
+    #[test]
+    fn groups_deduplicated_materialized_paths_by_change_kind() {
+        let changed = vec![
+            PathBuf::from("/workspace/b.ts"),
+            PathBuf::from("/workspace/a.ts"),
+            PathBuf::from("/workspace/a.ts"),
+        ];
+        let created = vec![PathBuf::from("/workspace/created.ts")];
+        let deleted = vec![PathBuf::from("/workspace/deleted.ts")];
+
+        let FileChanges::Summary(summary) =
+            materialized_file_changes(&changed, &created, &deleted).expect("changes should exist")
+        else {
+            panic!("expected a file-change summary");
+        };
+
+        assert_eq!(
+            summary.changed,
+            vec![
+                DocumentIdentifier::from("/workspace/a.ts"),
+                DocumentIdentifier::from("/workspace/b.ts"),
+            ]
+        );
+        assert_eq!(
+            summary.created,
+            vec![DocumentIdentifier::from("/workspace/created.ts")]
+        );
+        assert_eq!(
+            summary.deleted,
+            vec![DocumentIdentifier::from("/workspace/deleted.ts")]
+        );
+    }
+
+    #[test]
+    fn skips_refresh_when_no_materialized_paths_changed() {
+        assert!(materialized_file_changes(&[], &[], &[]).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- add an on-disk Corsa project-session refresh API
- send deterministic changed, created, and deleted file summaries
- clear stale diagnostics before snapshot refresh and skip empty deltas

## Validation

- cargo test -p vize_canon (550 unit tests plus integration tests)
- cargo clippy -p vize_canon --lib -- -D warnings
- node --test tests/tooling/source-file-lengths.test.ts
- vp check

Progresses #2971.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786876588&installation_id=136613492&pr_number=2980&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2980&signature=792cd8af15eba64ffd9d192c0eacb2c6789d3143d4ed6ed1e5bb502257b45f29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for refreshing materialized project files after changes, including created, updated, and deleted files.
  * File paths are normalized and deduplicated before refresh processing.

* **Bug Fixes**
  * Diagnostics are cleared during materialized file refreshes to keep results current.
  * Refreshes are skipped when no file changes are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->