### PR TITLE
fix(canon): reject lossy Corsa refresh paths

### DIFF
--- a/crates/vize_canon/src/lsp_client/materialized_refresh.rs
+++ b/crates/vize_canon/src/lsp_client/materialized_refresh.rs
@@ -17,7 +17,7 @@ impl CorsaProjectClient {
         created: &[PathBuf],
         deleted: &[PathBuf],
     ) -> Result<(), String> {
-        let Some(file_changes) = materialized_file_changes(changed, created, deleted) else {
+        let Some(file_changes) = materialized_file_changes(changed, created, deleted)? else {
             return Ok(());
         };
 
@@ -31,26 +31,34 @@ fn materialized_file_changes(
     changed: &[PathBuf],
     created: &[PathBuf],
     deleted: &[PathBuf],
-) -> Option<FileChanges> {
+) -> Result<Option<FileChanges>, String> {
     if changed.is_empty() && created.is_empty() && deleted.is_empty() {
-        return None;
+        return Ok(None);
     }
 
-    Some(FileChanges::Summary(FileChangeSummary {
-        changed: document_identifiers(changed),
-        created: document_identifiers(created),
-        deleted: document_identifiers(deleted),
-    }))
+    Ok(Some(FileChanges::Summary(FileChangeSummary {
+        changed: document_identifiers(changed)?,
+        created: document_identifiers(created)?,
+        deleted: document_identifiers(deleted)?,
+    })))
 }
 
-fn document_identifiers(paths: &[PathBuf]) -> Vec<DocumentIdentifier> {
-    let mut paths: Vec<_> = paths
-        .iter()
-        .map(|path| path.to_string_lossy().into_owned())
-        .collect();
+fn document_identifiers(paths: &[PathBuf]) -> Result<Vec<DocumentIdentifier>, String> {
+    let mut paths = paths.to_vec();
     paths.sort();
     paths.dedup();
-    paths.into_iter().map(DocumentIdentifier::from).collect()
+    paths
+        .into_iter()
+        .map(|path| {
+            let path_str = path.to_str().ok_or_else(|| {
+                cstr!(
+                    "Corsa cannot represent non-UTF-8 materialized path {:?}",
+                    path.as_os_str()
+                )
+            })?;
+            Ok(DocumentIdentifier::from(path_str))
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -69,8 +77,9 @@ mod tests {
         let created = vec![PathBuf::from("/workspace/created.ts")];
         let deleted = vec![PathBuf::from("/workspace/deleted.ts")];
 
-        let FileChanges::Summary(summary) =
-            materialized_file_changes(&changed, &created, &deleted).expect("changes should exist")
+        let FileChanges::Summary(summary) = materialized_file_changes(&changed, &created, &deleted)
+            .expect("paths should be representable")
+            .expect("changes should exist")
         else {
             panic!("expected a file-change summary");
         };
@@ -94,6 +103,26 @@ mod tests {
 
     #[test]
     fn skips_refresh_when_no_materialized_paths_changed() {
-        assert!(materialized_file_changes(&[], &[], &[]).is_none());
+        assert!(
+            materialized_file_changes(&[], &[], &[])
+                .expect("empty changes should be valid")
+                .is_none()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_distinct_non_utf8_paths_instead_of_merging_them() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let first = PathBuf::from(OsString::from_vec(b"/workspace/\x80.ts".to_vec()));
+        let second = PathBuf::from(OsString::from_vec(b"/workspace/\x81.ts".to_vec()));
+        assert_ne!(first, second);
+        assert_eq!(first.to_string_lossy(), second.to_string_lossy());
+
+        let error = materialized_file_changes(&[first, second], &[], &[])
+            .expect_err("lossy paths must not collapse into one refresh entry");
+        assert!(error.contains("cannot represent non-UTF-8 materialized path"));
     }
 }


### PR DESCRIPTION
## Summary

- deduplicate refresh inputs with lossless PathBuf keys
- reject non-UTF-8 paths that the Corsa string wire format cannot represent
- reproduce two distinct raw Unix paths that previously collapsed to one lossy string

## Validation

- cargo test -p vize_canon (551 unit tests plus integration tests)
- cargo clippy -p vize_canon --lib -- -D warnings
- node --test tests/tooling/source-file-lengths.test.ts
- vp check

Addresses the review follow-up from #2980 and progresses #2971.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786877077&installation_id=136613492&pr_number=2981&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2981&signature=07b6e51ba87e3ba6d81d878f84bf80e2036287e775331868c0e72ac739cb2923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file change detection reliability by reporting errors instead of silently assuming changes were unavailable.
  * Non-UTF-8 file paths are now rejected with a clear error rather than being incorrectly merged or identified.
  * Empty change sets continue to be handled cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->