### PR TITLE
feat(canon): reuse incremental Corsa sessions

### DIFF
--- a/crates/vize_canon/src/batch/executor.rs
+++ b/crates/vize_canon/src/batch/executor.rs
@@ -5,6 +5,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Mutex;
 
 use super::declaration_path::is_declaration_file;
 use super::error::{CorsaError, CorsaNotFoundError, CorsaResult};
@@ -13,10 +14,7 @@ use super::materialize_lock::MaterializeLock;
 use super::type_checker::{
     DeclarationEmitOptions, DeclarationEmitResult, DeclarationOutput, TypeCheckResult,
 };
-use super::virtual_project::{
-    AUTO_IMPORT_STUBS_FILE, SHARED_HELPERS_FILE, VUE_MODULE_STUBS_FILE, VirtualProject,
-};
-use crate::{corsa_client::CorsaProjectClient, file_uri::path_to_file_uri};
+use super::virtual_project::VirtualProject;
 use oxc_span::SourceType;
 use vize_carton::{
     String,
@@ -29,14 +27,18 @@ const DECLARATION_HELPERS_FILE: &str = crate::virtual_ts::SHARED_PREAMBLE_FILE_N
 mod cli;
 mod declaration_maps;
 mod diagnostics;
+mod session;
 
 use cli::{auto_server_count, check_with_cli, check_with_cli_sharded};
-use diagnostics::map_batch_diagnostics;
+use session::IncrementalSessionState;
+#[cfg(test)]
+use session::collect_virtual_file_uris;
 
 /// Batch executor backed by `corsa`'s project-session diagnostics API.
 pub struct CorsaExecutor {
     /// Path to the resolved Corsa executable.
     corsa_path: PathBuf,
+    incremental_session: Mutex<IncrementalSessionState>,
 }
 
 impl CorsaExecutor {
@@ -55,7 +57,10 @@ impl CorsaExecutor {
         };
 
         match resolve_corsa_executable(request) {
-            Ok(corsa_path) => Ok(Self { corsa_path }),
+            Ok(corsa_path) => Ok(Self {
+                corsa_path,
+                incremental_session: Mutex::new(IncrementalSessionState::default()),
+            }),
             Err(CorsaResolveError::ExplicitNotFound { path, .. }) => {
                 Err(CorsaNotFoundError::new_explicit(project_root, &path))
             }
@@ -110,53 +115,6 @@ impl CorsaExecutor {
         self.check_with_project_session(project)
     }
 
-    fn check_with_project_session(&self, project: &VirtualProject) -> CorsaResult<TypeCheckResult> {
-        let corsa_path = self.corsa_path.to_string_lossy();
-        let mut client = match profile!(
-            "canon.corsa.session",
-            CorsaProjectClient::new_for_workspace(
-                Some(corsa_path.as_ref()),
-                project.virtual_root()
-            )
-        ) {
-            Ok(client) => client,
-            Err(error) if should_fallback_to_cli(&error) => {
-                warn_fallback(
-                    FallbackStep::SessionToCli,
-                    &map_corsa_error(error.as_str().into()),
-                );
-                return profile!(
-                    "canon.corsa.cli_fallback",
-                    check_with_cli(&self.corsa_path, project)
-                );
-            }
-            Err(error) => return Err(map_corsa_error(error)),
-        };
-        let uris = profile!(
-            "canon.corsa.collect_uris",
-            collect_virtual_file_uris(project.virtual_root())
-        )?;
-        let raw_diagnostics = profile!(
-            "canon.corsa.diagnostics",
-            client
-                .request_diagnostics_batch(&uris)
-                .map_err(map_corsa_error)
-        )?;
-        let diagnostics = profile!(
-            "canon.corsa.map_diagnostics",
-            map_batch_diagnostics(raw_diagnostics, project)
-        );
-        let success = diagnostics
-            .iter()
-            .all(|diagnostic| diagnostic.severity != 1);
-
-        Ok(TypeCheckResult {
-            exit_code: if success { 0 } else { 1 },
-            success,
-            diagnostics,
-        })
-    }
-
     /// Emit declaration files from the materialized virtual project.
     pub fn emit_declarations(
         &self,
@@ -209,52 +167,6 @@ impl CorsaExecutor {
             )?,
         })
     }
-}
-
-fn collect_virtual_file_uris(virtual_root: &Path) -> CorsaResult<Vec<String>> {
-    let mut uris = Vec::new();
-
-    for entry in walkdir::WalkDir::new(virtual_root) {
-        let entry = entry?;
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        if is_internal_virtual_project_file(virtual_root, path) {
-            continue;
-        }
-        if let Some("ts" | "tsx" | "mts" | "cts") =
-            path.extension().and_then(|extension| extension.to_str())
-        {
-            uris.push(path_to_file_uri(path));
-        }
-    }
-
-    uris.sort();
-    Ok(uris)
-}
-
-fn is_internal_virtual_project_file(virtual_root: &Path, path: &Path) -> bool {
-    is_internal_virtual_project_stub(path) || is_under_virtual_node_modules(virtual_root, path)
-}
-
-fn is_internal_virtual_project_stub(path: &Path) -> bool {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| {
-            matches!(
-                name,
-                AUTO_IMPORT_STUBS_FILE | VUE_MODULE_STUBS_FILE | SHARED_HELPERS_FILE
-            )
-        })
-}
-
-fn is_under_virtual_node_modules(virtual_root: &Path, path: &Path) -> bool {
-    path.strip_prefix(virtual_root)
-        .ok()
-        .and_then(|path| path.components().next())
-        .and_then(|component| component.as_os_str().to_str())
-        .is_some_and(|name| name == "node_modules")
 }
 
 fn collect_declaration_outputs(out_dir: &Path) -> CorsaResult<Vec<DeclarationOutput>> {

--- a/crates/vize_canon/src/batch/executor/session.rs
+++ b/crates/vize_canon/src/batch/executor/session.rs
@@ -1,0 +1,333 @@
+//! Corsa project-session execution, including persistent incremental snapshots.
+
+use std::{
+    hash::{Hash, Hasher},
+    path::{Path, PathBuf},
+};
+
+use crate::{corsa_client::CorsaProjectClient, file_uri::path_to_file_uri};
+use vize_carton::{FxHashMap, String, hash::hash_bytes, profile};
+
+use super::{
+    CorsaExecutor, FallbackStep, MaterializeLock, TypeCheckResult, VirtualProject, check_with_cli,
+    map_corsa_error, should_fallback_to_cli, warn_fallback,
+};
+use crate::batch::error::CorsaResult;
+use crate::batch::executor::diagnostics::map_batch_diagnostics;
+use crate::batch::virtual_project::{
+    AUTO_IMPORT_STUBS_FILE, SHARED_HELPERS_FILE, VUE_MODULE_STUBS_FILE,
+};
+
+#[derive(Default)]
+pub(super) struct IncrementalSessionState {
+    session: Option<IncrementalSession>,
+    starts: usize,
+    reuses: usize,
+    refreshes: usize,
+}
+
+struct IncrementalSession {
+    client: CorsaProjectClient,
+    snapshot: MaterializedSnapshot,
+}
+
+#[derive(Default)]
+struct MaterializedSnapshot {
+    revisions: FxHashMap<PathBuf, u64>,
+    uris: Vec<String>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct MaterializedDelta {
+    changed: Vec<PathBuf>,
+    created: Vec<PathBuf>,
+    deleted: Vec<PathBuf>,
+}
+
+impl CorsaExecutor {
+    pub(super) fn check_with_project_session(
+        &self,
+        project: &VirtualProject,
+    ) -> CorsaResult<TypeCheckResult> {
+        let corsa_path = self.corsa_path.to_string_lossy();
+        let mut client = match profile!(
+            "canon.corsa.session",
+            CorsaProjectClient::new_for_workspace(
+                Some(corsa_path.as_ref()),
+                project.virtual_root()
+            )
+        ) {
+            Ok(client) => client,
+            Err(error) if should_fallback_to_cli(&error) => {
+                warn_fallback(
+                    FallbackStep::SessionToCli,
+                    &map_corsa_error(error.as_str().into()),
+                );
+                return profile!(
+                    "canon.corsa.cli_fallback",
+                    check_with_cli(&self.corsa_path, project)
+                );
+            }
+            Err(error) => return Err(map_corsa_error(error)),
+        };
+        let uris = profile!(
+            "canon.corsa.collect_uris",
+            collect_virtual_file_uris(project.virtual_root())
+        )?;
+        check_session_client(&mut client, project, &uris)
+    }
+
+    pub(crate) fn check_incremental_session(
+        &self,
+        project: &VirtualProject,
+        servers: Option<usize>,
+    ) -> CorsaResult<TypeCheckResult> {
+        let session_result = {
+            let _materialize_lock = MaterializeLock::acquire(project.virtual_root())?;
+            profile!(
+                "canon.executor.materialize_incremental",
+                project.materialize()
+            )?;
+            let snapshot = profile!(
+                "canon.corsa.incremental.snapshot",
+                MaterializedSnapshot::capture(project.virtual_root())
+            )?;
+            let mut state = self
+                .incremental_session
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let result = state.check(&self.corsa_path, project, snapshot);
+            if result.is_err() {
+                state.session = None;
+            }
+            result
+        };
+
+        match session_result {
+            Ok(result) => Ok(result),
+            Err(error) => {
+                warn_fallback(FallbackStep::SessionToCli, &error);
+                self.check_with_servers(project, servers)
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn incremental_session_counts(&self) -> (usize, usize, usize) {
+        let state = self
+            .incremental_session
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        (state.starts, state.reuses, state.refreshes)
+    }
+}
+
+impl IncrementalSessionState {
+    fn check(
+        &mut self,
+        corsa_path: &Path,
+        project: &VirtualProject,
+        snapshot: MaterializedSnapshot,
+    ) -> CorsaResult<TypeCheckResult> {
+        if let Some(session) = &mut self.session {
+            let delta = snapshot.diff(&session.snapshot);
+            let refreshed = !delta.is_empty();
+            profile!(
+                "canon.corsa.incremental.refresh",
+                session.client.refresh_materialized_files(
+                    &delta.changed,
+                    &delta.created,
+                    &delta.deleted
+                )
+            )
+            .map_err(map_corsa_error)?;
+            session.snapshot = snapshot;
+            self.reuses += 1;
+            self.refreshes += usize::from(refreshed);
+        } else {
+            let corsa_path = corsa_path.to_string_lossy();
+            let client = profile!(
+                "canon.corsa.incremental.start",
+                CorsaProjectClient::new_for_workspace(
+                    Some(corsa_path.as_ref()),
+                    project.virtual_root()
+                )
+            )
+            .map_err(map_corsa_error)?;
+            self.session = Some(IncrementalSession { client, snapshot });
+            self.starts += 1;
+        }
+
+        let session = self.session.as_mut().expect("session initialized above");
+        check_session_client(&mut session.client, project, &session.snapshot.uris)
+    }
+}
+
+impl MaterializedSnapshot {
+    fn capture(virtual_root: &Path) -> CorsaResult<Self> {
+        let mut snapshot = Self::default();
+        for entry in walkdir::WalkDir::new(virtual_root) {
+            let entry = entry?;
+            let path = entry.path();
+            if entry.file_type().is_symlink() {
+                let target = std::fs::read_link(path)?;
+                snapshot
+                    .revisions
+                    .insert(path.to_path_buf(), hash_path(&target));
+                continue;
+            }
+            if !entry.file_type().is_file() {
+                continue;
+            }
+
+            let content = std::fs::read(path)?;
+            snapshot
+                .revisions
+                .insert(path.to_path_buf(), hash_bytes(&content));
+            if is_diagnostic_input(path)
+                && !is_under_virtual_node_modules(virtual_root, path)
+                && !is_internal_virtual_project_stub(path)
+            {
+                snapshot.uris.push(path_to_file_uri(path));
+            }
+        }
+        snapshot.uris.sort();
+        Ok(snapshot)
+    }
+
+    fn diff(&self, previous: &Self) -> MaterializedDelta {
+        let mut delta = MaterializedDelta::default();
+        for (path, revision) in &self.revisions {
+            match previous.revisions.get(path) {
+                None => delta.created.push(path.clone()),
+                Some(previous) if previous != revision => delta.changed.push(path.clone()),
+                Some(_) => {}
+            }
+        }
+        for path in previous.revisions.keys() {
+            if !self.revisions.contains_key(path) {
+                delta.deleted.push(path.clone());
+            }
+        }
+        delta.sort();
+        delta
+    }
+}
+
+impl MaterializedDelta {
+    fn is_empty(&self) -> bool {
+        self.changed.is_empty() && self.created.is_empty() && self.deleted.is_empty()
+    }
+
+    fn sort(&mut self) {
+        self.changed.sort();
+        self.created.sort();
+        self.deleted.sort();
+    }
+}
+
+fn hash_path(path: &Path) -> u64 {
+    let mut hasher = std::hash::DefaultHasher::new();
+    path.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn check_session_client(
+    client: &mut CorsaProjectClient,
+    project: &VirtualProject,
+    uris: &[String],
+) -> CorsaResult<TypeCheckResult> {
+    let raw_diagnostics = profile!(
+        "canon.corsa.diagnostics",
+        client
+            .request_diagnostics_batch(uris)
+            .map_err(map_corsa_error)
+    )?;
+    let diagnostics = profile!(
+        "canon.corsa.map_diagnostics",
+        map_batch_diagnostics(raw_diagnostics, project)
+    );
+    let success = diagnostics
+        .iter()
+        .all(|diagnostic| diagnostic.severity != 1);
+    Ok(TypeCheckResult {
+        exit_code: if success { 0 } else { 1 },
+        success,
+        diagnostics,
+    })
+}
+
+pub(super) fn collect_virtual_file_uris(virtual_root: &Path) -> CorsaResult<Vec<String>> {
+    let mut uris = Vec::new();
+    for entry in walkdir::WalkDir::new(virtual_root) {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file()
+            && !is_under_virtual_node_modules(virtual_root, path)
+            && !is_internal_virtual_project_stub(path)
+            && is_diagnostic_input(path)
+        {
+            uris.push(path_to_file_uri(path));
+        }
+    }
+    uris.sort();
+    Ok(uris)
+}
+
+fn is_diagnostic_input(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|extension| extension.to_str()),
+        Some("ts" | "tsx" | "mts" | "cts")
+    )
+}
+
+fn is_internal_virtual_project_stub(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            matches!(
+                name,
+                AUTO_IMPORT_STUBS_FILE | VUE_MODULE_STUBS_FILE | SHARED_HELPERS_FILE
+            )
+        })
+}
+
+fn is_under_virtual_node_modules(virtual_root: &Path, path: &Path) -> bool {
+    path.strip_prefix(virtual_root)
+        .ok()
+        .and_then(|path| path.components().next())
+        .and_then(|component| component.as_os_str().to_str())
+        .is_some_and(|name| name == "node_modules")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MaterializedDelta, MaterializedSnapshot};
+    use std::path::PathBuf;
+    use vize_carton::FxHashMap;
+
+    #[test]
+    fn snapshot_diff_classifies_created_changed_and_deleted_files() {
+        let previous = snapshot(&[("/virtual/changed.ts", 1), ("/virtual/deleted.ts", 2)]);
+        let current = snapshot(&[("/virtual/changed.ts", 3), ("/virtual/created.ts", 4)]);
+
+        assert_eq!(
+            current.diff(&previous),
+            MaterializedDelta {
+                changed: vec![PathBuf::from("/virtual/changed.ts")],
+                created: vec![PathBuf::from("/virtual/created.ts")],
+                deleted: vec![PathBuf::from("/virtual/deleted.ts")],
+            }
+        );
+    }
+
+    fn snapshot(entries: &[(&str, u64)]) -> MaterializedSnapshot {
+        MaterializedSnapshot {
+            revisions: entries
+                .iter()
+                .map(|(path, revision)| (PathBuf::from(path), *revision))
+                .collect::<FxHashMap<_, _>>(),
+            uris: Vec::new(),
+        }
+    }
+}

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -299,24 +299,39 @@ impl TypeChecker for BatchTypeChecker {
             return self.check_project();
         }
 
-        // Correctness before reuse: rebuilding the source snapshot guarantees
-        // that edits, additions, deletions, and dependent diagnostics are never
-        // checked against the stale virtual files captured by the initial scan.
-        // A dependency-aware persistent Corsa session can optimize this path
-        // without weakening this observable contract.
+        // Rebuilding source-derived virtual files preserves the observable
+        // correctness contract; the executor reuses Corsa's dependency graph
+        // after diffing the complete materialized snapshot.
         let paths = self.incremental_paths.refresh(&self.project, changed)?;
 
         let mut refreshed = self.project.empty_with_same_options()?;
         refreshed.register_paths(&paths)?;
-        self.check_registered_project(&refreshed)
+        self.check_registered_project_incremental(&refreshed)
     }
 }
 
 impl BatchTypeChecker {
     fn check_registered_project(&self, project: &VirtualProject) -> CorsaResult<TypeCheckResult> {
-        let mut result = self
+        let result = self
             .executor
             .check_with_servers(project, self.server_count)?;
+        Self::finish_registered_result(result, project)
+    }
+
+    fn check_registered_project_incremental(
+        &self,
+        project: &VirtualProject,
+    ) -> CorsaResult<TypeCheckResult> {
+        let result = self
+            .executor
+            .check_incremental_session(project, self.server_count)?;
+        Self::finish_registered_result(result, project)
+    }
+
+    fn finish_registered_result(
+        mut result: TypeCheckResult,
+        project: &VirtualProject,
+    ) -> CorsaResult<TypeCheckResult> {
         result
             .diagnostics
             .extend(project.diagnostics().iter().cloned());

--- a/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
@@ -66,6 +66,11 @@ const total: number = 1
         "repaired source retained stale TS2322: {:#?}",
         repaired.diagnostics
     );
+    assert_eq!(
+        checker.executor.incremental_session_counts(),
+        (1, 1, 1),
+        "broken and repaired patches should reuse one refreshed Corsa session"
+    );
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
@@ -141,6 +146,11 @@ const total: Total = 1
             .all(|diagnostic| diagnostic.code != Some(2322)),
         "dependency repair retained stale TS2322: {:#?}",
         repaired.diagnostics
+    );
+    assert_eq!(
+        checker.executor.incremental_session_counts(),
+        (1, 1, 1),
+        "dependency patches should reuse one refreshed Corsa session"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);
@@ -219,6 +229,11 @@ const outside: number = 'must stay outside the scan'
             .any(|diagnostic| diagnostic.file == included_path && diagnostic.code == Some(2322)),
         "out-of-scope refresh dropped the included diagnostic: {:#?}",
         outside_change.diagnostics
+    );
+    assert_eq!(
+        checker.executor.incremental_session_counts(),
+        (1, 1, 0),
+        "an unchanged materialized scope should reuse without refreshing Corsa"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);
@@ -302,6 +317,11 @@ const added: number = 'broken added file'
             .any(|diagnostic| diagnostic.file == app_path && diagnostic.code == Some(2322)),
         "deleting the added file dropped the unrelated App.vue diagnostic: {:#?}",
         after_delete.diagnostics
+    );
+    assert_eq!(
+        checker.executor.incremental_session_counts(),
+        (1, 2, 2),
+        "create, edit, and delete patches should reuse one refreshed Corsa session"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);


### PR DESCRIPTION
Closes part of #2971.

## Summary
- keep one Corsa `ProjectSession` alive across incremental batch checks
- diff the complete materialized project snapshot, including config, stubs, passthrough files, and runtime dependency symlink identities
- refresh exact changed/created/deleted paths, then fall back to the existing CLI ladder if the session fails
- assert real broken/repaired Vue patches, dependent diagnostics, unchanged explicit scope, and create/edit/delete behavior with exact session counters

## Validation
- `cargo test -p vize_canon` (552 unit tests plus integration tests)
- `cargo test -p vize_canon batch::type_checker::tests::scan::incremental -- --nocapture`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all -- --check`
- `vp check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786878120&installation_id=136613492&pr_number=2982&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2982&signature=f47c45f749792f77347b512ccea865c55959f2d3c1729f3d18264ee02f78acde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Incremental checks now reuse project sessions and refresh only changed files.
  * Added support for tracking created, modified, and deleted files during incremental updates.
  * Added fallback behavior when an incremental project session cannot be created.

* **Bug Fixes**
  * Improved diagnostic handling across full and incremental checks.
  * Ensured results correctly report failures when errors are detected.
  * Improved support for file additions, edits, deletions, and dependent-file updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->