### PR TITLE
fix(canon): preserve symlinked incremental inputs

### DIFF
--- a/crates/vize_canon/src/batch/executor/session.rs
+++ b/crates/vize_canon/src/batch/executor/session.rs
@@ -132,15 +132,17 @@ impl IncrementalSessionState {
         if let Some(session) = &mut self.session {
             let delta = snapshot.diff(&session.snapshot);
             let refreshed = !delta.is_empty();
-            profile!(
-                "canon.corsa.incremental.refresh",
-                session.client.refresh_materialized_files(
-                    &delta.changed,
-                    &delta.created,
-                    &delta.deleted
+            if refreshed {
+                profile!(
+                    "canon.corsa.incremental.refresh",
+                    session.client.refresh_materialized_files(
+                        &delta.changed,
+                        &delta.created,
+                        &delta.deleted
+                    )
                 )
-            )
-            .map_err(map_corsa_error)?;
+                .map_err(map_corsa_error)?;
+            }
             session.snapshot = snapshot;
             self.reuses += 1;
             self.refreshes += usize::from(refreshed);
@@ -174,6 +176,13 @@ impl MaterializedSnapshot {
                 snapshot
                     .revisions
                     .insert(path.to_path_buf(), hash_path(&target));
+                if path.is_file()
+                    && is_diagnostic_input(path)
+                    && !is_under_virtual_node_modules(virtual_root, path)
+                    && !is_internal_virtual_project_stub(path)
+                {
+                    snapshot.uris.push(path_to_file_uri(path));
+                }
                 continue;
             }
             if !entry.file_type().is_file() {
@@ -301,33 +310,4 @@ fn is_under_virtual_node_modules(virtual_root: &Path, path: &Path) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{MaterializedDelta, MaterializedSnapshot};
-    use std::path::PathBuf;
-    use vize_carton::FxHashMap;
-
-    #[test]
-    fn snapshot_diff_classifies_created_changed_and_deleted_files() {
-        let previous = snapshot(&[("/virtual/changed.ts", 1), ("/virtual/deleted.ts", 2)]);
-        let current = snapshot(&[("/virtual/changed.ts", 3), ("/virtual/created.ts", 4)]);
-
-        assert_eq!(
-            current.diff(&previous),
-            MaterializedDelta {
-                changed: vec![PathBuf::from("/virtual/changed.ts")],
-                created: vec![PathBuf::from("/virtual/created.ts")],
-                deleted: vec![PathBuf::from("/virtual/deleted.ts")],
-            }
-        );
-    }
-
-    fn snapshot(entries: &[(&str, u64)]) -> MaterializedSnapshot {
-        MaterializedSnapshot {
-            revisions: entries
-                .iter()
-                .map(|(path, revision)| (PathBuf::from(path), *revision))
-                .collect::<FxHashMap<_, _>>(),
-            uris: Vec::new(),
-        }
-    }
-}
+mod tests;

--- a/crates/vize_canon/src/batch/executor/session.rs
+++ b/crates/vize_canon/src/batch/executor/session.rs
@@ -173,10 +173,14 @@ impl MaterializedSnapshot {
             let path = entry.path();
             if entry.file_type().is_symlink() {
                 let target = std::fs::read_link(path)?;
-                snapshot
-                    .revisions
-                    .insert(path.to_path_buf(), hash_path(&target));
-                if path.is_file()
+                let resolves_to_file = path.is_file();
+                let revision = if resolves_to_file {
+                    hash_bytes(&std::fs::read(path)?)
+                } else {
+                    hash_path(&target)
+                };
+                snapshot.revisions.insert(path.to_path_buf(), revision);
+                if resolves_to_file
                     && is_diagnostic_input(path)
                     && !is_under_virtual_node_modules(virtual_root, path)
                     && !is_internal_virtual_project_stub(path)

--- a/crates/vize_canon/src/batch/executor/session/tests.rs
+++ b/crates/vize_canon/src/batch/executor/session/tests.rs
@@ -1,0 +1,49 @@
+use super::{MaterializedDelta, MaterializedSnapshot};
+use std::path::PathBuf;
+use vize_carton::FxHashMap;
+
+#[test]
+fn snapshot_diff_classifies_created_changed_and_deleted_files() {
+    let previous = snapshot(&[("/virtual/changed.ts", 1), ("/virtual/deleted.ts", 2)]);
+    let current = snapshot(&[("/virtual/changed.ts", 3), ("/virtual/created.ts", 4)]);
+
+    assert_eq!(
+        current.diff(&previous),
+        MaterializedDelta {
+            changed: vec![PathBuf::from("/virtual/changed.ts")],
+            created: vec![PathBuf::from("/virtual/created.ts")],
+            deleted: vec![PathBuf::from("/virtual/deleted.ts")],
+        }
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn snapshot_keeps_symlinked_typescript_files_as_diagnostic_inputs() {
+    use crate::file_uri::path_to_file_uri;
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().expect("temporary project should be created");
+    let virtual_root = temp.path().join("canon");
+    let target = temp.path().join("external.ts");
+    let linked = virtual_root.join("linked.ts");
+    std::fs::create_dir_all(&virtual_root).expect("virtual root should be created");
+    std::fs::write(&target, "export const value = 1\n").expect("target should be written");
+    symlink(&target, &linked).expect("source symlink should be created");
+
+    let snapshot = MaterializedSnapshot::capture(&virtual_root)
+        .expect("materialized snapshot should be captured");
+
+    assert!(snapshot.revisions.contains_key(&linked));
+    assert_eq!(snapshot.uris, vec![path_to_file_uri(&linked)]);
+}
+
+fn snapshot(entries: &[(&str, u64)]) -> MaterializedSnapshot {
+    MaterializedSnapshot {
+        revisions: entries
+            .iter()
+            .map(|(path, revision)| (PathBuf::from(path), *revision))
+            .collect::<FxHashMap<_, _>>(),
+        uris: Vec::new(),
+    }
+}

--- a/crates/vize_canon/src/batch/executor/session/tests.rs
+++ b/crates/vize_canon/src/batch/executor/session/tests.rs
@@ -31,11 +31,15 @@ fn snapshot_keeps_symlinked_typescript_files_as_diagnostic_inputs() {
     std::fs::write(&target, "export const value = 1\n").expect("target should be written");
     symlink(&target, &linked).expect("source symlink should be created");
 
-    let snapshot = MaterializedSnapshot::capture(&virtual_root)
+    let before = MaterializedSnapshot::capture(&virtual_root)
         .expect("materialized snapshot should be captured");
+    std::fs::write(&target, "export const value = 2\n").expect("target should be updated");
+    let after = MaterializedSnapshot::capture(&virtual_root)
+        .expect("updated materialized snapshot should be captured");
 
-    assert!(snapshot.revisions.contains_key(&linked));
-    assert_eq!(snapshot.uris, vec![path_to_file_uri(&linked)]);
+    assert!(after.revisions.contains_key(&linked));
+    assert_eq!(after.uris, vec![path_to_file_uri(&linked)]);
+    assert_eq!(after.diff(&before).changed, vec![linked]);
 }
 
 fn snapshot(entries: &[(&str, u64)]) -> MaterializedSnapshot {


### PR DESCRIPTION
Follow-up to #2982. Addresses both actionable review findings from the merged PR.

## Summary
- skip Corsa refresh calls entirely when the materialized snapshot delta is empty
- retain symlinked TypeScript source files in the incremental diagnostic URI set
- move snapshot tests into a dedicated module and add a real Unix symlink regression fixture

## Validation
- `cargo test -p vize_canon` (553 unit tests plus integration tests)
- `cargo test -p vize_canon batch::executor::session -- --nocapture`
- `cargo test -p vize_canon batch::type_checker::tests::scan::incremental -- --nocapture`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786878536&installation_id=136613492&pr_number=2983&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2983&signature=20d6903ef2401961608ea367e9a8c3db350c36f6e469952fcf5a0e95482416ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoided unnecessary refresh operations when the incremental snapshot has no changes, improving performance.
  * Enhanced diagnostic input handling for symlinked TypeScript files so updates are reflected correctly.
  * Improved snapshot diff behavior to reliably report changed, created, and deleted paths.
* **Tests**
  * Added unit tests covering snapshot diff classification and symlink-based diagnostic input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->