### PR TITLE
fix(canon): map canon-server diagnostics

### DIFF
--- a/crates/vize/tests/check_server_cli.rs
+++ b/crates/vize/tests/check_server_cli.rs
@@ -1,0 +1,173 @@
+#![cfg(unix)]
+
+use std::{
+    io::{BufRead, Write},
+    path::{Path, PathBuf},
+    process::{Child, ChildStdin, ChildStdout, Command, Stdio},
+};
+
+use serde_json::Value;
+use vize_carton::corsa_resolver::{CorsaResolveRequest, resolve_corsa_executable};
+
+#[path = "support/vue_stub.rs"]
+mod vue_stub;
+
+const APP: &str = r#"<script setup lang="ts">
+import Child from './Child.vue'
+const count = 1
+</script>
+
+<template>
+  <Child :count="count" />
+</template>
+"#;
+const NUMERIC_CHILD: &str = r#"<script setup lang="ts">
+defineProps<{ count: number }>()
+</script>
+"#;
+const STRING_CHILD: &str = r#"<script setup lang="ts">
+defineProps<{ count: string }>()
+</script>
+"#;
+
+struct CheckServer {
+    child: Option<Child>,
+    stdin: Option<ChildStdin>,
+    stdout: std::io::BufReader<ChildStdout>,
+}
+
+impl CheckServer {
+    fn spawn(project_root: &Path, corsa_path: &Path) -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_vize"))
+            .args([
+                "check-server",
+                "--corsa-path",
+                corsa_path.to_str().unwrap(),
+                "--working-dir",
+                project_root.to_str().unwrap(),
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take().unwrap();
+        let stdout = std::io::BufReader::new(child.stdout.take().unwrap());
+        Self {
+            child: Some(child),
+            stdin: Some(stdin),
+            stdout,
+        }
+    }
+
+    fn check(&mut self, id: u64, uri: &Path, content: &str) -> Value {
+        self.request(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "check",
+            "params": { "uri": uri, "content": content }
+        }))
+    }
+
+    fn request(&mut self, request: Value) -> Value {
+        let stdin = self.stdin.as_mut().unwrap();
+        writeln!(stdin, "{request}").unwrap();
+        stdin.flush().unwrap();
+        let mut response = String::new();
+        self.stdout.read_line(&mut response).unwrap();
+        serde_json::from_str(&response).unwrap()
+    }
+
+    fn shutdown(mut self) {
+        let response = self.request(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "shutdown"
+        }));
+        assert_eq!(response["result"]["status"], "shutdown");
+        self.stdin.take();
+        assert!(self.child.take().unwrap().wait().unwrap().success());
+    }
+}
+
+impl Drop for CheckServer {
+    fn drop(&mut self) {
+        self.stdin.take();
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+#[test]
+fn check_server_maps_dependency_patch_diagnostics_to_the_parent_sfc() {
+    let Some(corsa_path) = resolve_corsa_executable(CorsaResolveRequest {
+        explicit_path: None,
+        project_root: Some(workspace_root()),
+    })
+    .ok() else {
+        return;
+    };
+    let project_root = create_project();
+    let app_path = project_root.join("src/App.vue");
+    let child_path = project_root.join("src/Child.vue");
+    let mut server = CheckServer::spawn(&project_root, &corsa_path);
+
+    let clean = server.check(1, &app_path, APP);
+    assert_eq!(clean["result"]["diagnostics"], serde_json::json!([]));
+
+    std::fs::write(&child_path, STRING_CHILD).unwrap();
+    let broken = server.check(2, &app_path, APP);
+    assert_eq!(broken["result"]["errorCount"], 1, "{broken:#}");
+    assert_eq!(
+        broken["result"]["diagnostics"],
+        serde_json::json!([{
+            "message": "Type 'number' is not assignable to type 'string'.",
+            "severity": "error",
+            "line": 7,
+            "column": 18,
+            "code": "TS2322"
+        }])
+    );
+
+    std::fs::write(&child_path, NUMERIC_CHILD).unwrap();
+    let repaired = server.check(3, &app_path, APP);
+    assert_eq!(repaired["result"]["diagnostics"], serde_json::json!([]));
+
+    server.shutdown();
+    std::fs::remove_dir_all(project_root).unwrap();
+}
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn create_project() -> PathBuf {
+    let project_root = workspace_root()
+        .join("target/vize-tests/tests")
+        .join(format!("check-server-patch-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    vue_stub::install_vue_jsx_type_stub(&project_root);
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(project_root.join("src/App.vue"), APP).unwrap();
+    std::fs::write(project_root.join("src/Child.vue"), NUMERIC_CHILD).unwrap();
+    project_root
+}

--- a/crates/vize/tests/check_server_cli.rs
+++ b/crates/vize/tests/check_server_cli.rs
@@ -18,7 +18,7 @@ const count = 1
 </script>
 
 <template>
-  <Child :count="count" />
+  <Child data-label="😀" :count="count" />
 </template>
 "#;
 const NUMERIC_CHILD: &str = r#"<script setup lang="ts">
@@ -126,7 +126,7 @@ fn check_server_maps_dependency_patch_diagnostics_to_the_parent_sfc() {
             "message": "Type 'number' is not assignable to type 'string'.",
             "severity": "error",
             "line": 7,
-            "column": 18,
+            "column": 34,
             "code": "TS2322"
         }])
     );

--- a/crates/vize_canon/src/corsa_server.rs
+++ b/crates/vize_canon/src/corsa_server.rs
@@ -29,6 +29,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use vize_carton::{FxHashMap, String, cstr};
 
+mod diagnostics;
+
 /// JSON-RPC Request
 #[derive(Debug, Deserialize)]
 pub struct JsonRpcRequest {
@@ -334,7 +336,7 @@ impl CorsaServer {
         .map_err(|e| cstr!("Failed to parse SFC: {}", e.message))?;
 
         // Run Corsa on the virtual TypeScript through the project-session API.
-        let mut diagnostics = self.run_corsa(&project)?;
+        let mut diagnostics = self.run_corsa(&project, content)?;
 
         // Merge in Vue-specific compile errors (e.g. props destructure default type
         // mismatch) so the socket-mode check matches the direct `vize check` runner.
@@ -349,61 +351,6 @@ impl CorsaServer {
             virtual_ts,
             error_count,
         })
-    }
-
-    /// Run Corsa on TypeScript content and parse diagnostics via project sessions.
-    fn run_corsa(
-        &mut self,
-        project: &crate::corsa_bridge::CorsaVueVirtualProject,
-    ) -> Result<Vec<Diagnostic>, String> {
-        if self.corsa_client.is_none() {
-            let client = crate::corsa_client::CorsaProjectClient::new(
-                self.config.corsa_path.as_deref(),
-                self.config.working_dir.as_deref(),
-            )?;
-            self.corsa_client = Some(client);
-        }
-
-        let client = self
-            .corsa_client
-            .as_mut()
-            .expect("corsa_client must be initialized above");
-
-        let documents: Vec<(&str, &str)> = project
-            .documents
-            .iter()
-            .map(|(uri, content)| (uri.as_str(), content.as_str()))
-            .collect();
-        client.did_open_batch_fast(&documents)?;
-        let corsa_diagnostics = client.request_diagnostics(&project.host.request_uri)?;
-
-        // Convert Corsa's editor-style diagnostics to the server payload.
-        let diagnostics = corsa_diagnostics
-            .into_iter()
-            .map(|d| {
-                let severity: String = match d.severity {
-                    Some(1) => "error".into(),
-                    Some(2) => "warning".into(),
-                    Some(3) => "info".into(),
-                    Some(4) => "hint".into(),
-                    _ => "error".into(),
-                };
-                let code = d.code.map(|c| match c {
-                    serde_json::Value::Number(n) => cstr!("TS{n}"),
-                    serde_json::Value::String(s) => s.into(),
-                    _ => cstr!("{c:?}"),
-                });
-                Diagnostic {
-                    message: d.message,
-                    severity,
-                    line: d.range.start.line + 1,
-                    column: d.range.start.character + 1,
-                    code,
-                }
-            })
-            .collect();
-
-        Ok(diagnostics)
     }
 
     fn working_dir(&self) -> PathBuf {

--- a/crates/vize_canon/src/corsa_server/diagnostics.rs
+++ b/crates/vize_canon/src/corsa_server/diagnostics.rs
@@ -60,13 +60,17 @@ impl CorsaServer {
                 Diagnostic {
                     message: diagnostic.message,
                     severity,
-                    line: line + 1,
-                    column: column + 1,
+                    line: one_based(line),
+                    column: one_based(column),
                     code,
                 }
             })
             .collect())
     }
+}
+
+fn one_based(position: u32) -> u32 {
+    position.saturating_add(1)
 }
 
 fn map_host_position_to_source(
@@ -97,4 +101,15 @@ fn map_host_position_to_source(
         .saturating_add(delta)
         .min(source_range.end.saturating_sub(1));
     Some(source_line_index.line_col(source_offset))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::one_based;
+
+    #[test]
+    fn one_based_positions_saturate_at_the_protocol_boundary() {
+        assert_eq!(one_based(0), 1);
+        assert_eq!(one_based(u32::MAX), u32::MAX);
+    }
 }

--- a/crates/vize_canon/src/corsa_server/diagnostics.rs
+++ b/crates/vize_canon/src/corsa_server/diagnostics.rs
@@ -1,0 +1,100 @@
+use super::{CorsaServer, Diagnostic};
+use crate::corsa_bridge::CorsaVueVirtualProject;
+use vize_carton::{String, cstr, line_index::LineIndex};
+
+impl CorsaServer {
+    /// Run Corsa and map its virtual TypeScript diagnostics back to the SFC.
+    pub(super) fn run_corsa(
+        &mut self,
+        project: &CorsaVueVirtualProject,
+        source: &str,
+    ) -> Result<Vec<Diagnostic>, String> {
+        if self.corsa_client.is_none() {
+            let client = crate::corsa_client::CorsaProjectClient::new(
+                self.config.corsa_path.as_deref(),
+                self.config.working_dir.as_deref(),
+            )?;
+            self.corsa_client = Some(client);
+        }
+
+        let client = self
+            .corsa_client
+            .as_mut()
+            .expect("corsa_client must be initialized above");
+        let documents: Vec<(&str, &str)> = project
+            .documents
+            .iter()
+            .map(|(uri, content)| (uri.as_str(), content.as_str()))
+            .collect();
+        client.did_open_batch_fast(&documents)?;
+        let corsa_diagnostics = client.request_diagnostics(&project.host.request_uri)?;
+        let virtual_line_index = LineIndex::new(&project.host.code);
+        let source_line_index = LineIndex::new(source);
+
+        Ok(corsa_diagnostics
+            .into_iter()
+            .map(|diagnostic| {
+                let severity: String = match diagnostic.severity {
+                    Some(1) => "error".into(),
+                    Some(2) => "warning".into(),
+                    Some(3) => "info".into(),
+                    Some(4) => "hint".into(),
+                    _ => "error".into(),
+                };
+                let code = diagnostic.code.map(|code| match code {
+                    serde_json::Value::Number(number) => cstr!("TS{number}"),
+                    serde_json::Value::String(code) => code.into(),
+                    _ => cstr!("{code:?}"),
+                });
+                let (line, column) = map_host_position_to_source(
+                    project,
+                    &virtual_line_index,
+                    &source_line_index,
+                    diagnostic.range.start.line,
+                    diagnostic.range.start.character,
+                )
+                .unwrap_or((
+                    diagnostic.range.start.line,
+                    diagnostic.range.start.character,
+                ));
+                Diagnostic {
+                    message: diagnostic.message,
+                    severity,
+                    line: line + 1,
+                    column: column + 1,
+                    code,
+                }
+            })
+            .collect())
+    }
+}
+
+fn map_host_position_to_source(
+    project: &CorsaVueVirtualProject,
+    virtual_line_index: &LineIndex<'_>,
+    source_line_index: &LineIndex<'_>,
+    line: u32,
+    column: u32,
+) -> Option<(u32, u32)> {
+    let rewritten_offset = virtual_line_index.line_col_to_offset(line, column)?;
+    let generated_offset = project
+        .host
+        .import_source_map
+        .get_original_offset(u32::try_from(rewritten_offset).ok()?)
+        as usize;
+    let mapping = project
+        .host
+        .mappings
+        .iter()
+        .find(|mapping| mapping.gen_range.contains(&generated_offset))?;
+    let (generated_range, source_range) = mapping
+        .sub_span_for_gen(generated_offset)
+        .map(|span| (&span.gen_range, &span.src_range))
+        .unwrap_or((&mapping.gen_range, &mapping.src_range));
+    let delta = generated_offset.saturating_sub(generated_range.start);
+    let source_offset = source_range
+        .start
+        .saturating_add(delta)
+        .min(source_range.end.saturating_sub(1));
+    Some(source_line_index.line_col(source_offset))
+}

--- a/crates/vize_canon/src/lsp_client/lifecycle_setup.rs
+++ b/crates/vize_canon/src/lsp_client/lifecycle_setup.rs
@@ -129,6 +129,7 @@ pub(super) fn write_temp_tsconfig(temp_dir_path: &Path) -> Result<(), String> {
             "target": "ES2022",
             "module": "ESNext",
             "moduleResolution": "bundler",
+            "allowImportingTsExtensions": true,
             "lib": ["ES2022", "DOM", "DOM.Iterable"],
             "strict": true,
             "noEmit": true,

--- a/crates/vize_carton/src/line_index.rs
+++ b/crates/vize_carton/src/line_index.rs
@@ -79,6 +79,33 @@ impl<'a> LineIndex<'a> {
         let (line, character) = self.line_col(offset);
         Position { line, character }
     }
+
+    /// Convert an LSP `(line, UTF-16 column)` position to a byte offset.
+    pub fn line_col_to_offset(&self, line: u32, column: u32) -> Option<usize> {
+        let line = usize::try_from(line).ok()?;
+        let start = *self.line_starts.get(line)?;
+        let end = self
+            .line_starts
+            .get(line + 1)
+            .map(|next| next.saturating_sub(1))
+            .unwrap_or(self.source.len());
+        let mut current_column = 0u32;
+        let mut offset = start;
+
+        if column == 0 {
+            return Some(offset);
+        }
+
+        for ch in self.source[start..end].chars() {
+            offset += ch.len_utf8();
+            current_column += ch.len_utf16() as u32;
+            if current_column >= column {
+                return (current_column == column).then_some(offset);
+            }
+        }
+
+        (current_column == column).then_some(offset)
+    }
 }
 
 /// Convert a byte offset to `(line, column)`, both 0-indexed for LSP, with
@@ -125,6 +152,18 @@ mod tests {
         assert_eq!(offset_to_line_col(source, emoji_bytes), (0, 2));
         // Just after the trailing 'x': 3 UTF-16 code units.
         assert_eq!(offset_to_line_col(source, emoji_bytes + 1), (0, 3));
+    }
+
+    #[test]
+    fn converts_utf16_positions_back_to_byte_offsets() {
+        let source = "plain\n😀x";
+        let index = LineIndex::new(source);
+
+        assert_eq!(index.line_col_to_offset(1, 0), Some(6));
+        assert_eq!(index.line_col_to_offset(1, 2), Some(10));
+        assert_eq!(index.line_col_to_offset(1, 3), Some(11));
+        assert_eq!(index.line_col_to_offset(1, 1), None);
+        assert_eq!(index.line_col_to_offset(2, 0), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- map persistent check-server diagnostics from rewritten virtual TypeScript back to exact Vue SFC positions
- keep UTF-16 LSP columns exact and allow generated `.vue.ts` imports in scratch Corsa sessions
- add a real check-server clean → dependency break → repair patch oracle with exact TS2322 code and 7:18 location

## Validation
- `cargo test -p vize_carton --lib`
- `cargo test -p vize_canon --lib --features native`
- `cargo test -p vize --test check_cli --test check_server_cli`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `vp check`
- `vp run --workspace-root source:lengths --check --base-ref origin/main --max-lines 350 --limit 20`
- `cargo fmt --all -- --check`

Progresses #2971.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786880406&installation_id=136613492&pr_number=2984&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2984&signature=c4dea16d39f7ca1415c632fc6ae9a95c88581ccecd6e94a6bd08de339fb196e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue single-file component TypeScript diagnostics with more accurate source locations and stable diagnostic codes.
  * Diagnostics now reliably clear after issues are fixed.
* **Improvements**
  * Enhanced Unicode-aware position handling for better diagnostic accuracy.
  * Improved TypeScript compatibility by allowing imports that include file extensions.
* **Tests**
  * Added an end-to-end Unix-only CLI integration test for `check-server`, covering error detection, update after edits, and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->