### PR TITLE
fix(bench): surface criterion comparisons

### DIFF
--- a/bench/criterion-ab.mjs
+++ b/bench/criterion-ab.mjs
@@ -101,7 +101,7 @@ function run(command, commandArgs, options = {}) {
   if (result.error) {
     throw result.error;
   }
-  if (result.status !== 0 && !options.allowFailure) {
+  if (result.status !== 0) {
     throw new Error(`${command} ${commandArgs.join(" ")} exited with ${result.status}`);
   }
   return result;
@@ -136,17 +136,22 @@ function benchSide({ side, checkoutDir, baseline, targetDir, suites }) {
   }
 }
 
-function critcmpCompare({ targetDir, threshold }) {
-  // `--target-dir` points criterion at <dir>/criterion; critcmp reads the same
-  // location via CRITERION_HOME so both baselines resolve without extra flags.
-  const env = { CRITERION_HOME: resolve(targetDir, "criterion") };
-  const args = ["base", "head"];
+export function critcmpArgs({ targetDir, threshold }) {
+  const args = ["--target-dir", targetDir, "base", "head"];
   if (threshold != null) {
     // critcmp's own threshold only colorizes; we still parse the table below to
     // decide pass/fail so the behaviour is identical across critcmp versions.
     args.push("--threshold", String(threshold));
   }
-  const result = run("critcmp", args, { capture: true, allowFailure: true, env });
+  return args;
+}
+
+function critcmpCompare({ targetDir, threshold }) {
+  // critcmp 0.1.8 does not read CRITERION_HOME. Point it at the same Cargo
+  // target directory used by both benchmark runs; critcmp appends `criterion`
+  // itself and fails the lane if either baseline is unavailable.
+  const args = critcmpArgs({ targetDir, threshold });
+  const result = run("critcmp", args, { capture: true });
   return `${result.stdout ?? ""}${result.stderr ?? ""}`;
 }
 

--- a/tests/tooling/criterion-impact.test.ts
+++ b/tests/tooling/criterion-impact.test.ts
@@ -7,6 +7,7 @@ import { test } from "node:test";
 
 import {
   CRITERION_SUITES,
+  critcmpArgs,
   renderSummary,
   resolveSuiteSelection,
 } from "../../bench/criterion-ab.mjs";
@@ -163,6 +164,23 @@ test("Criterion driver validates scoped suite manifests", () => {
     () => resolveSuiteSelection({ selected: ["unknown"], reason: "fixture" }),
     /unknown suites/,
   );
+});
+
+test("Criterion driver points critcmp at the shared Cargo target", () => {
+  assert.deepEqual(critcmpArgs({ targetDir: "/work/head/target", threshold: undefined }), [
+    "--target-dir",
+    "/work/head/target",
+    "base",
+    "head",
+  ]);
+  assert.deepEqual(critcmpArgs({ targetDir: "/work/head/target", threshold: 10 }), [
+    "--target-dir",
+    "/work/head/target",
+    "base",
+    "head",
+    "--threshold",
+    "10",
+  ]);
 });
 
 test("Criterion driver reports a useful summary when no suite is affected", () => {


### PR DESCRIPTION
## Summary
- pass the shared Cargo target to critcmp 0.1.8 explicitly
- fail the Criterion lane when comparison data cannot be loaded
- cover the exact critcmp argument contract with a focused test

## Validation
- `node --test tests/tooling/criterion-impact.test.ts tests/tooling/github-workflows-benchmark.test.ts` (16/16)
- `vp check`
- source-length base comparison
- `git diff --check`
- full `vp run --workspace-root test:scripts` reached 2,853 passing tests; its only failure is the pre-existing linked-worktree `.git/config` directory assumption in `playwright-app-config.test.ts`

Progresses #2971.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786882315&installation_id=136613492&pr_number=2985&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2985&signature=7ecde7caf941ff8ace352cd684016c9b9ea4e57d5cbf398ac7a6a232d5cb3a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Benchmark comparisons now report subprocess failures instead of silently continuing.
  * Missing baselines and failed comparison commands are surfaced clearly.

* **Improvements**
  * Criterion comparison arguments are handled more consistently, including optional threshold settings.
  * Benchmark tooling behavior is now validated across threshold and non-threshold scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->