### PR TITLE
fix(bench): require criterion baselines

### DIFF
--- a/bench/criterion-ab.mjs
+++ b/bench/criterion-ab.mjs
@@ -37,6 +37,14 @@ import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
+import {
+  compareBaselineExports,
+  critcmpArgs,
+  critcmpExportArgs,
+  parseCritcmpExport,
+  validateComparisonTable,
+} from "./criterion-baselines.mjs";
+
 // Criterion benches that exist under crates/*/benches and represent the hot
 // compiler/analysis/codegen paths. Each entry maps a cargo package to the
 // `[[bench]]` targets it owns; the `bench filter` narrows criterion to the
@@ -136,63 +144,21 @@ function benchSide({ side, checkoutDir, baseline, targetDir, suites }) {
   }
 }
 
-export function critcmpArgs({ targetDir, threshold }) {
-  const args = ["--target-dir", targetDir, "base", "head"];
-  if (threshold != null) {
-    // critcmp's own threshold only colorizes; we still parse the table below to
-    // decide pass/fail so the behaviour is identical across critcmp versions.
-    args.push("--threshold", String(threshold));
-  }
-  return args;
+function exportBaseline({ targetDir, baseline, outputPath }) {
+  const result = run("critcmp", critcmpExportArgs({ targetDir, baseline }), { capture: true });
+  const serialized = result.stdout ?? "";
+  const parsed = parseCritcmpExport(serialized, baseline);
+  writeFileSync(outputPath, serialized);
+  return parsed;
 }
 
-function critcmpCompare({ targetDir, threshold }) {
+function critcmpCompare({ targetDir, baselinePaths }) {
   // critcmp 0.1.8 does not read CRITERION_HOME. Point it at the same Cargo
-  // target directory used by both benchmark runs; critcmp appends `criterion`
-  // itself and fails the lane if either baseline is unavailable.
-  const args = critcmpArgs({ targetDir, threshold });
+  // target directory used by both benchmark runs. The exported snapshots keep
+  // the base sample stable while the head checkout reuses the shared target.
+  const args = critcmpArgs({ targetDir, baselinePaths });
   const result = run("critcmp", args, { capture: true });
   return `${result.stdout ?? ""}${result.stderr ?? ""}`;
-}
-
-/**
- * Parse a critcmp table into per-benchmark base/head nanosecond medians.
- * critcmp prints rows like:
- *   group/bench   1.00   3.2±0.1µs   1.04  3.4±0.2µs
- * where the two timing columns are base and head. We only need the ratio, which
- * critcmp already encodes as the leading multiplier on each side (1.00 for the
- * faster side). Rather than re-derive units we read the explicit factor columns.
- */
-export function parseCritcmpRegressions(table, thresholdPercent) {
-  if (thresholdPercent == null) {
-    return [];
-  }
-  const regressions = [];
-  for (const rawLine of table.split("\n")) {
-    const line = rawLine.trim();
-    if (!line || line.startsWith("group")) {
-      continue;
-    }
-    // Columns: <name> <baseFactor> <baseTime> <headFactor> <headTime>
-    const match = line.match(/^(\S+)\s+(\d+(?:\.\d+)?)\s+\S+\s+(\d+(?:\.\d+)?)\s+\S+/);
-    if (!match) {
-      continue;
-    }
-    const name = match[1];
-    const baseFactor = Number.parseFloat(match[2]);
-    const headFactor = Number.parseFloat(match[3]);
-    if (!Number.isFinite(baseFactor) || !Number.isFinite(headFactor) || baseFactor === 0) {
-      continue;
-    }
-    // critcmp normalises the faster column to 1.00; head/base ratio is the
-    // head factor when base is the 1.00 baseline, otherwise its reciprocal.
-    const ratio = headFactor / baseFactor;
-    const changePercent = (ratio - 1) * 100;
-    if (changePercent >= thresholdPercent) {
-      regressions.push({ name, changePercent });
-    }
-  }
-  return regressions;
 }
 
 export function resolveSuiteSelection(selection) {
@@ -237,8 +203,8 @@ export function renderSummary({ table, threshold, regressions, selection }) {
   }
   lines.push(
     threshold == null
-      ? "Report-only: micro-benchmark medians for base vs head (no gate)."
-      : `Regression threshold: ${threshold}%.`,
+      ? "Report-only: micro-benchmark mean estimates for base vs head (no gate)."
+      : `Regression threshold: ${threshold}% (median).`,
   );
   lines.push("");
   lines.push("```");
@@ -273,7 +239,11 @@ export function main(argv = process.argv.slice(2)) {
   }
 
   const suites = CRITERION_SUITES.filter((suite) => selection.selected.includes(suite.package));
-  // Base first, then head, into the shared target dir so critcmp sees both.
+  const basePath = resolve(targetDir, "criterion-ab-base.json");
+  const headPath = resolve(targetDir, "criterion-ab-head.json");
+  let baseExport;
+  let headExport;
+  // Export base before the head run can mutate the shared Criterion directory.
   if (suites.length > 0) {
     benchSide({
       side: "base",
@@ -282,6 +252,7 @@ export function main(argv = process.argv.slice(2)) {
       targetDir,
       suites,
     });
+    baseExport = exportBaseline({ targetDir, baseline: "base", outputPath: basePath });
     benchSide({
       side: "head",
       checkoutDir: headDir,
@@ -289,10 +260,16 @@ export function main(argv = process.argv.slice(2)) {
       targetDir,
       suites,
     });
+    headExport = exportBaseline({ targetDir, baseline: "head", outputPath: headPath });
   }
 
-  const table = suites.length > 0 ? critcmpCompare({ targetDir, threshold }) : "";
-  const regressions = parseCritcmpRegressions(table, threshold);
+  const table =
+    suites.length > 0 ? critcmpCompare({ targetDir, baselinePaths: [basePath, headPath] }) : "";
+  if (suites.length > 0) {
+    validateComparisonTable(table);
+  }
+  const regressions =
+    baseExport && headExport ? compareBaselineExports(baseExport, headExport, threshold) : [];
   const summary = renderSummary({ table, threshold, regressions, selection });
 
   if (args.out) {

--- a/bench/criterion-baselines.mjs
+++ b/bench/criterion-baselines.mjs
@@ -1,0 +1,62 @@
+export function critcmpExportArgs({ targetDir, baseline }) {
+  return ["--target-dir", targetDir, "--export", baseline];
+}
+
+export function critcmpArgs({ targetDir, baselinePaths }) {
+  return ["--target-dir", targetDir, ...baselinePaths];
+}
+
+export function parseCritcmpExport(serialized, expectedBaseline) {
+  const parsed = JSON.parse(serialized);
+  if (!isRecord(parsed) || parsed.name !== expectedBaseline || !isRecord(parsed.benchmarks)) {
+    throw new Error(`Invalid critcmp export for ${expectedBaseline}`);
+  }
+  if (Object.keys(parsed.benchmarks).length === 0) {
+    throw new Error(`critcmp export for ${expectedBaseline} contains no benchmarks`);
+  }
+  return parsed;
+}
+
+export function compareBaselineExports(base, head, thresholdPercent) {
+  const shared = Object.keys(base.benchmarks).filter((name) => name in head.benchmarks);
+  if (shared.length === 0) {
+    throw new Error("Criterion base and head exports contain no shared benchmarks");
+  }
+  if (thresholdPercent == null) {
+    return [];
+  }
+
+  const regressions = [];
+  for (const name of shared) {
+    const baseMedian = medianPointEstimate(base.benchmarks[name], `base/${name}`);
+    const headMedian = medianPointEstimate(head.benchmarks[name], `head/${name}`);
+    const changePercent = (headMedian / baseMedian - 1) * 100;
+    if (changePercent >= thresholdPercent) {
+      regressions.push({ name, changePercent });
+    }
+  }
+  return regressions;
+}
+
+export function validateComparisonTable(table) {
+  const lines = table.split("\n").filter((line) => line.trim().length > 0);
+  const columns = lines[0]?.trim().split(/\s+/);
+  if (columns?.join(" ") !== "group base head") {
+    throw new Error(`critcmp did not produce base/head columns: ${lines[0] ?? "empty output"}`);
+  }
+  if (lines.length < 3) {
+    throw new Error("critcmp produced no comparison rows");
+  }
+}
+
+function medianPointEstimate(benchmark, label) {
+  const value = benchmark?.criterion_estimates_v1?.median?.point_estimate;
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`Invalid Criterion median for ${label}`);
+  }
+  return value;
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value != null && !Array.isArray(value);
+}

--- a/tests/tooling/criterion-impact.test.ts
+++ b/tests/tooling/criterion-impact.test.ts
@@ -7,10 +7,16 @@ import { test } from "node:test";
 
 import {
   CRITERION_SUITES,
-  critcmpArgs,
   renderSummary,
   resolveSuiteSelection,
 } from "../../bench/criterion-ab.mjs";
+import {
+  compareBaselineExports,
+  critcmpArgs,
+  critcmpExportArgs,
+  parseCritcmpExport,
+  validateComparisonTable,
+} from "../../bench/criterion-baselines.mjs";
 import {
   changedPathsBetween,
   parseNameStatusZ,
@@ -166,21 +172,52 @@ test("Criterion driver validates scoped suite manifests", () => {
   );
 });
 
-test("Criterion driver points critcmp at the shared Cargo target", () => {
-  assert.deepEqual(critcmpArgs({ targetDir: "/work/head/target", threshold: undefined }), [
+test("Criterion driver snapshots both baselines before comparing them", () => {
+  assert.deepEqual(critcmpExportArgs({ targetDir: "/work/head/target", baseline: "base" }), [
     "--target-dir",
     "/work/head/target",
+    "--export",
     "base",
-    "head",
   ]);
-  assert.deepEqual(critcmpArgs({ targetDir: "/work/head/target", threshold: 10 }), [
-    "--target-dir",
-    "/work/head/target",
-    "base",
-    "head",
-    "--threshold",
-    "10",
+  assert.deepEqual(
+    critcmpArgs({
+      targetDir: "/work/head/target",
+      baselinePaths: ["/work/base.json", "/work/head.json"],
+    }),
+    ["--target-dir", "/work/head/target", "/work/base.json", "/work/head.json"],
+  );
+});
+
+test("Criterion baseline comparison fails closed and uses exported medians", () => {
+  const base = parseCritcmpExport(baselineExport("base", { shared: 100 }), "base");
+  const head = parseCritcmpExport(baselineExport("head", { shared: 125 }), "head");
+
+  assert.deepEqual(compareBaselineExports(base, head, 10), [
+    { name: "shared", changePercent: 25 },
   ]);
+  assert.throws(
+    () => parseCritcmpExport(baselineExport("base", {}), "base"),
+    /contains no benchmarks/,
+  );
+  assert.throws(
+    () =>
+      compareBaselineExports(
+        base,
+        parseCritcmpExport(baselineExport("head", { other: 90 }), "head"),
+        10,
+      ),
+    /no shared benchmarks/,
+  );
+});
+
+test("Criterion comparison table requires both base and head columns", () => {
+  assert.doesNotThrow(() =>
+    validateComparisonTable("group  base  head\n-----  ----  ----\nshared  1.00  1.12\n"),
+  );
+  assert.throws(
+    () => validateComparisonTable("group  head\n-----  ----\nshared  1.00\n"),
+    /did not produce base\/head columns/,
+  );
 });
 
 test("Criterion driver reports a useful summary when no suite is affected", () => {
@@ -192,3 +229,15 @@ test("Criterion driver reports a useful summary when no suite is affected", () =
   assert.match(summary, /Skipped: vize_atelier_sfc, vize_atelier_jsx/);
   assert.match(summary, /timing execution was skipped/);
 });
+
+function baselineExport(name: string, medians: Record<string, number>): string {
+  return JSON.stringify({
+    name,
+    benchmarks: Object.fromEntries(
+      Object.entries(medians).map(([benchmark, pointEstimate]) => [
+        benchmark,
+        { criterion_estimates_v1: { median: { point_estimate: pointEstimate } } },
+      ]),
+    ),
+  });
+}

--- a/tests/tooling/criterion-impact.test.ts
+++ b/tests/tooling/criterion-impact.test.ts
@@ -192,9 +192,7 @@ test("Criterion baseline comparison fails closed and uses exported medians", () 
   const base = parseCritcmpExport(baselineExport("base", { shared: 100 }), "base");
   const head = parseCritcmpExport(baselineExport("head", { shared: 125 }), "head");
 
-  assert.deepEqual(compareBaselineExports(base, head, 10), [
-    { name: "shared", changePercent: 25 },
-  ]);
+  assert.deepEqual(compareBaselineExports(base, head, 10), [{ name: "shared", changePercent: 25 }]);
   assert.throws(
     () => parseCritcmpExport(baselineExport("base", {}), "base"),
     /contains no benchmarks/,


### PR DESCRIPTION
## Summary

- export the base Criterion snapshot before the shared target is reused by the head run
- compare the exported base/head snapshots and fail closed unless both columns and shared benchmarks exist
- compute the optional regression gate from exported median estimates instead of parsing critcmp display columns

## Evidence

Run 29579393078 succeeded but its artifact contained only a `head` column. This change makes that artifact shape a hard failure.

## Validation

- `node --test tests/tooling/criterion-impact.test.ts tests/tooling/github-workflows-benchmark.test.ts`
- `vp check` (format clean; dependency resolution through a linked worktree produced unrelated existing warnings)
- `vp run source:lengths --check --base-ref origin/main --max-lines 350 --limit 5`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786883919&installation_id=136613492&pr_number=2987&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2987&signature=37ae91136caae0cda5cb44b9f983b7836d62ed16759b8a79a1881f588c2ae737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark comparisons now use explicit baseline snapshots for more reliable base-versus-head analysis.
  * Regression reports calculate changes from median benchmark estimates and identify results exceeding configured thresholds.
* **Bug Fixes**
  * Added validation to detect incomplete, invalid, or missing benchmark comparison data.
  * Comparison reports now require both baseline columns and valid benchmark results.
* **Documentation**
  * Updated report-only messaging and regression labels for clearer interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->