### PR TITLE
test(lsp): lock dependent diagnostic repair

### DIFF
--- a/tests/tooling/lsp-typecheck-template.test.ts
+++ b/tests/tooling/lsp-typecheck-template.test.ts
@@ -126,7 +126,7 @@ const button = document.createElement("button")
   }
 });
 
-test("vize lsp refreshes an open parent after a child prop type changes", async (t) => {
+test("vize lsp publishes and clears exact parent diagnostics after child prop edits", async (t) => {
   const corsaPath = resolveTsgoBinary();
   if (corsaPath == null) {
     t.skip("tsgo binary not found; skipping LSP typecheck test");
@@ -182,7 +182,7 @@ import Child from './Child.vue'
 </script>
 
 <template>
-  <Child :count="'one'" />
+  <Child data-label="😀" :count="'one'" />
 </template>
 `;
     const childPath = path.join(sourceDir, "Child.vue");
@@ -195,9 +195,12 @@ import Child from './Child.vue'
     session.notify("textDocument/didOpen", {
       textDocument: { uri: childUri, languageId: "vue", version: 1, text: initialChild },
     });
-    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
-      isDiagnosticsForUri(params, childUri),
-    );
+    const initialChildPublish = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, childUri),
+    )) as PublishDiagnosticsParams;
+    assert.equal(initialChildPublish.version, 1);
+    assert.deepEqual(initialChildPublish.diagnostics, []);
     session.notify("textDocument/didOpen", {
       textDocument: { uri: parentUri, languageId: "vue", version: 1, text: parent },
     });
@@ -205,24 +208,56 @@ import Child from './Child.vue'
       "textDocument/publishDiagnostics",
       (params) => isDiagnosticsForUri(params, parentUri),
     )) as PublishDiagnosticsParams;
-    assert.equal(
-      initialParent.diagnostics.some((diagnostic) =>
-        diagnostic.message?.includes("not assignable"),
-      ),
-      false,
-      initialParent.diagnostics.map((diagnostic) => diagnostic.message).join("\n"),
-    );
+    assert.equal(initialParent.version, 1);
+    assert.deepEqual(initialParent.diagnostics, []);
 
     session.notify("textDocument/didChange", {
       textDocument: { uri: childUri, version: 2 },
       contentChanges: [{ text: changedChild }],
     });
-    await session.waitForNotification(
+    const changedParent = (await session.waitForNotification(
       "textDocument/publishDiagnostics",
       (params) =>
         isDiagnosticsForUri(params, parentUri) &&
         params.diagnostics.some((diagnostic) => diagnostic.message?.includes("not assignable")),
-    );
+    )) as PublishDiagnosticsParams;
+    const bindingStart = offsetToPosition(parent, parent.indexOf("'one'"));
+    assert.equal(changedParent.version, 1);
+    assert.deepEqual(changedParent.diagnostics, [
+      {
+        code: 2322,
+        message: "Type 'string' is not assignable to type 'number'.",
+        range: {
+          start: bindingStart,
+          end: { line: bindingStart.line, character: bindingStart.character + "'one'".length },
+        },
+        severity: 1,
+        source: "vize/types",
+      },
+    ]);
+    const changedChildPublish = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, childUri) && params.version === 2,
+    )) as PublishDiagnosticsParams;
+    assert.deepEqual(changedChildPublish.diagnostics, []);
+
+    session.notify("textDocument/didChange", {
+      textDocument: { uri: childUri, version: 3 },
+      contentChanges: [{ text: initialChild }],
+    });
+    const repairedParent = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) =>
+        isDiagnosticsForUri(params, parentUri) &&
+        !params.diagnostics.some((diagnostic) => diagnostic.message?.includes("not assignable")),
+    )) as PublishDiagnosticsParams;
+    assert.equal(repairedParent.version, 1);
+    assert.deepEqual(repairedParent.diagnostics, []);
+    const repairedChildPublish = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, childUri) && params.version === 3,
+    )) as PublishDiagnosticsParams;
+    assert.deepEqual(repairedChildPublish.diagnostics, []);
   } finally {
     await session.shutdown();
     fs.rmSync(workspaceDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- patch an open child component from a string prop to a number prop in one live LSP session
- assert the parent receives exactly one authored-range TS2322 diagnostic, including source, severity, code, message, and UTF-16-safe range
- patch the child back and require the parent diagnostic to clear without restarting the server
- require exact empty diagnostics and document versions for child and parent publications

## Validation

- 20 consecutive runs of `node --test tests/tooling/lsp-typecheck-template.test.ts`
- `vp check`
- `vp run source:lengths --check --base-ref origin/main --max-lines 350 --limit 5`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786884234&installation_id=136613492&pr_number=2988&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2988&signature=ec2c2c544d9a7b774273aca3b58786497a3b88bb02a55d5cc78c60e620fc09d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for diagnostics in parent templates when a child component’s prop type changes.
  * Verified that detailed type-mismatch diagnostics appear with accurate severity, source, code, message, and location.
  * Confirmed diagnostics are cleared for both parent and child components after the prop type is restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->