### PR TITLE
fix(release): make vp run release reliable

### DIFF
--- a/tests/tooling/support/pty-command.py
+++ b/tests/tooling/support/pty-command.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Run a command in a pseudo-terminal and answer after a prompt appears."""
+
+import errno
+import os
+import pty
+import select
+import signal
+import sys
+import time
+
+
+def main() -> int:
+    if len(sys.argv) < 4:
+        raise SystemExit("usage: pty-command.py PROMPT RESPONSE COMMAND [ARG ...]")
+
+    prompt = sys.argv[1].encode()
+    response = sys.argv[2].encode()
+    command = sys.argv[3:]
+    child_pid, terminal_fd = pty.fork()
+    if child_pid == 0:
+        os.execvp(command[0], command)
+
+    output = bytearray()
+    answered = False
+    deadline = time.monotonic() + 25
+    status = None
+    while status is None:
+        if time.monotonic() >= deadline:
+            os.kill(child_pid, signal.SIGTERM)
+            os.waitpid(child_pid, 0)
+            return 124
+
+        readable, _, _ = select.select([terminal_fd], [], [], 0.1)
+        if readable:
+            try:
+                chunk = os.read(terminal_fd, 4096)
+            except OSError as error:
+                if error.errno != errno.EIO:
+                    raise
+                chunk = b""
+            if chunk:
+                os.write(sys.stdout.fileno(), chunk)
+                output.extend(chunk)
+                if not answered and prompt in output:
+                    os.write(terminal_fd, response)
+                    answered = True
+
+        waited_pid, child_status = os.waitpid(child_pid, os.WNOHANG)
+        if waited_pid == child_pid:
+            status = child_status
+
+    os.close(terminal_fd)
+    if not answered:
+        return 125
+    return os.waitstatus_to_exitcode(status)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tooling/task-shell.test.ts
+++ b/tests/tooling/task-shell.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -13,7 +14,9 @@ import {
   withRustTaskEnvironment,
 } from "../../tools/vite-plus/task-shell.ts";
 import {
+  localVp,
   moonCommandForEnvironment,
+  moonRegistryRefreshCommandForEnvironment,
   moonRegistryUpdateGuardForEnvironment,
 } from "../../tools/vite-plus/task-commands.ts";
 import { checkTasks } from "../../tools/vite-plus/tasks/check.ts";
@@ -105,13 +108,68 @@ test("MoonBit task commands leave explicit MoonBit shims untouched", () => {
   );
 });
 
-test("release task forwards extra vp run arguments into the MoonBit script", () => {
+test("release registry refreshes use an explicit MoonBit shim", () => {
+  assert.equal(
+    moonRegistryRefreshCommandForEnvironment(
+      { MOON_BIN: "/runner-temp/moonbit-shims/moon" },
+      () => true,
+    ),
+    "/runner-temp/moonbit-shims/moon update",
+  );
+});
+
+test("release task refreshes the MoonBit registry and forwards vp run arguments", () => {
   const command = (releaseTasks.release as { command: string }).command;
 
+  assert.match(
+    command,
+    /moon update && .*moon run -q --target native tools\/moon\/cmd\/release -- "\$@"/,
+  );
   assert.match(command, /moon run -q --target native tools\/moon\/cmd\/release -- "\$@"/);
   assert.doesNotMatch(command, /env -u MOON_HOME/);
   assert.match(command, / --$/);
 });
+
+function gitRepositoryState() {
+  const read = (...args: string[]) => {
+    const result = spawnSync("git", args, { encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    return result.stdout;
+  };
+  return {
+    head: read("rev-parse", "HEAD"),
+    status: read("status", "--porcelain=v1", "--untracked-files=all"),
+    tags: read("tag", "--list"),
+  };
+}
+
+test(
+  "release task prompts through a controlling terminal and aborts without mutation",
+  { skip: process.platform === "win32" },
+  () => {
+    const before = gitRepositoryState();
+    const result = spawnSync(
+      "python3",
+      [
+        "tests/tooling/support/pty-command.py",
+        "Proceed with release? [y/N]",
+        "n\n",
+        localVp,
+        "run",
+        "release",
+        "minor",
+      ],
+      { encoding: "utf8", timeout: 30_000 },
+    );
+    const output = result.stdout + result.stderr;
+
+    assert.equal(result.error, undefined, output);
+    assert.equal(result.status, 1, output);
+    assert.match(output, /Proceed with release\? \[y\/N\]/);
+    assert.match(output, /Aborted\./);
+    assert.deepEqual(gitRepositoryState(), before);
+  },
+);
 
 test("repository JS check enforces the v1 alpha warning budget", () => {
   const command = (checkTasks["check:repo"] as { command: string }).command;

--- a/tools/moon/cmd/release/main.mbt
+++ b/tools/moon/cmd/release/main.mbt
@@ -399,11 +399,13 @@ fn replace_native_binary_lockfile_catalog(
 /// non-interactive terminals must fail with an explicit message instead of
 /// hanging on stdin reads.
 async fn has_interactive_terminal() -> Bool {
-  let (exit_code, _, _) = @process.collect_output(
-    "sh",
-    ["-c", "test -t 0 && test -t 1"],
-  )
-  exit_code == 0
+  @process.run("sh", ["-c", "test -t 0 && test -t 1"]) == 0
+}
+
+/// Prompts through the controlling terminal because task runners keep stdin.
+async fn confirm_release() -> Bool {
+  let command = "printf 'Proceed with release? [y/N] ' > /dev/tty; IFS= read -r answer < /dev/tty; case \"$answer\" in y|Y|yes|Yes|YES) exit 0 ;; *) exit 1 ;; esac"
+  @process.run("sh", ["-c", command]) == 0
 }
 
 /// Filters a list of candidate paths down to the ones that currently exist.
@@ -559,12 +561,7 @@ async fn run_app() -> Int {
       )
       return 1
     }
-    @stdio.stdout.write("Proceed with release? [y/N] ")
-    let answer = match @stdio.stdin.read_until("\n") {
-      Some(input) => input.trim().to_lower()
-      None => ""
-    }
-    if answer != "y" && answer != "yes" {
+    if !confirm_release() {
       println("Aborted.")
       return 1
     }

--- a/tools/vite-plus/task-commands.ts
+++ b/tools/vite-plus/task-commands.ts
@@ -99,8 +99,27 @@ export const moonRegistryUpdateGuardForEnvironment = (
   return `( [ -d ${workspaceMoonRegistryIndex} ] || ${moonCommandForEnvironment(env, pathExists)} update )`;
 };
 
+export const moonRegistryRefreshCommandForEnvironment = (
+  env: NodeJS.ProcessEnv = process.env,
+  pathExists: (path: string) => boolean = existsSync,
+) => `${moonCommandForEnvironment(env, pathExists)} update`;
+
 const moonCommand = moonCommandForEnvironment();
 const moonRegistryUpdateGuard = moonRegistryUpdateGuardForEnvironment();
+const moonRegistryRefreshCommand = moonRegistryRefreshCommandForEnvironment();
+
+const moonScriptCommand = (registrySetup: string | null, name: string, args: string[]) =>
+  [
+    ...(registrySetup == null ? [] : [registrySetup, "&&"]),
+    moonCommand,
+    "run",
+    "-q",
+    "--target",
+    "native",
+    `${moonToolsModule}/cmd/${name}`,
+    "--",
+    ...args,
+  ].join(" ");
 
 /**
  * Executes a repository MoonBit command package.
@@ -111,17 +130,17 @@ const moonRegistryUpdateGuard = moonRegistryUpdateGuardForEnvironment();
  * `--` so each package owns its own CLI parsing.
  */
 export const moonScript = (name: string, ...args: string[]) =>
-  [
-    ...(moonRegistryUpdateGuard == null ? [] : [moonRegistryUpdateGuard, "&&"]),
-    moonCommand,
-    "run",
-    "-q",
-    "--target",
-    "native",
-    `${moonToolsModule}/cmd/${name}`,
-    "--",
-    ...args,
-  ].join(" ");
+  moonScriptCommand(moonRegistryUpdateGuard, name, args);
+
+/**
+ * Executes a MoonBit command after refreshing the registry index.
+ *
+ * Release tasks use this slower path because resolving a newly pinned package
+ * against an existing but stale index must fail before any release files are
+ * changed. Regular development tasks keep the cheaper initialize-once path.
+ */
+export const moonScriptWithFreshRegistry = (name: string, ...args: string[]) =>
+  moonScriptCommand(moonRegistryRefreshCommand, name, args);
 
 export const devApp = (target?: string) =>
   target == null ? moonScript("dev_app") : moonScript("dev_app", target);

--- a/tools/vite-plus/task-helpers.ts
+++ b/tools/vite-plus/task-helpers.ts
@@ -4,6 +4,7 @@ export {
   installVscodeExtensionDependencies,
   localVp,
   moonScript,
+  moonScriptWithFreshRegistry,
   runInDirectory,
   runInPackages,
   runInVscodeExtension,

--- a/tools/vite-plus/tasks/release.ts
+++ b/tools/vite-plus/tasks/release.ts
@@ -2,6 +2,7 @@ import {
   defineTasks,
   installVscodeExtensionDependencies,
   moonScript,
+  moonScriptWithFreshRegistry,
   noCacheTask,
   runInPackages,
   runTask,
@@ -17,7 +18,9 @@ import {
  * catalog readable even as the repository gains more package families.
  */
 export const releaseTasks = defineTasks({
-  release: noCacheTask(moonScript("release", '"$@"'), { forwardArguments: true }),
+  release: noCacheTask(moonScriptWithFreshRegistry("release", '"$@"'), {
+    forwardArguments: true,
+  }),
   "publish:wasm": noCacheTask(
     `${moonScript("build_vize_wasm_package")} && ${moonScript("publish_npm_package", "npm/wasm")}`,
   ),


### PR DESCRIPTION
## Summary

- Refresh the MoonBit registry before running the local release task.
- Keep the cheaper initialize-once registry behavior for regular development tasks.
- Read release confirmation from the controlling terminal so `vp run release minor` remains interactive.
- Add regression coverage for registry refresh, argument forwarding, and terminal handling.

## Root cause

The release task only initialized a missing registry index, so an existing stale index could not resolve newly pinned MoonBit dependencies. After dependency resolution, the release script checked terminal state through a captured child process and read from task stdin, but Vite+ owns that stdin instead of forwarding it to the MoonBit command.

## Validation

- `node --test tests/tooling/moonbit-release.test.ts tests/tooling/task-shell.test.ts tests/tooling/source-file-lengths.test.ts`
- `moon check --target native` in `tools/moon`
- `vp run --workspace-root check:ci`
- Manual `vp run release minor` verification through the confirmation prompt, aborted with `n` before mutation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786884638&installation_id=136613492&pr_number=2989&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2989&signature=a36b03228f900aec786d06482bb935f8e82625129d01fe8d1da9299f10de7a00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release commands now refresh the MoonBit registry before running the MoonBit release script.

* **Bug Fixes**
  * Improved interactive terminal detection to ensure release confirmation is shown only when appropriate.
  * Release confirmation is read from the controlling terminal and only accepts valid “yes” responses; other answers abort cleanly.

* **Tests**
  * Expanded test coverage for registry-refresh command composition and release argument forwarding.
  * Added PTY-based utilities to reliably verify the interactive confirmation flow and abort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->