### PR TITLE
test(lsp): refresh component prop completions

### DIFF
--- a/tests/tooling/lsp-template-completion.test.ts
+++ b/tests/tooling/lsp-template-completion.test.ts
@@ -3,8 +3,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { pathToFileURL } from "node:url";
-import { completionLabels, offsetToPosition } from "./support/lsp/assertions.ts";
+import {
+  completionLabels,
+  isDiagnosticsForUri,
+  offsetToPosition,
+} from "./support/lsp/assertions.ts";
 import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
 import { LspSession } from "./support/lsp/session.ts";
 
 // Template completion contexts are parse-driven (typecheck:false, no corsa).
@@ -27,8 +32,9 @@ defineProps<{ diskOnly: string }>()
     const openChildSource = `<script setup lang="ts">
 defineProps<{ label: string; disabled?: boolean }>()
 </script>
-<template><button /></template>
+<template><button></button></template>
 `;
+    const changedChildSource = openChildSource.replace("disabled?: boolean", "loading?: number");
     fs.writeFileSync(path.join(workspaceDir, "Child.vue"), childSource, "utf8");
 
     // Two spaces after <Child so the cursor sits inside the opening tag,
@@ -145,26 +151,58 @@ const count = ref(0)
 
     await session.waitForNotification("textDocument/publishDiagnostics");
 
-    await t.test(
-      "inside an opening component tag surfaces the child's props plus directives",
-      async () => {
-        const offset = parentSource.indexOf("<Child ") + "<Child ".length;
+    await t.test("component prop completion tracks unsaved child edits and repair", async () => {
+      const offset = parentSource.indexOf("<Child ") + "<Child ".length;
+      const requestLabels = async (): Promise<string[]> => {
         const response = await session.request("textDocument/completion", {
           textDocument: { uri: parentUri },
           position: offsetToPosition(parentSource, offset),
         });
-
-        const labels = completionLabels(
+        return completionLabels(
           response as Array<{ label: string }> | { items?: Array<{ label: string }> } | null,
         );
-        assert.ok(labels.includes("label"), labels.join(", "));
-        assert.ok(labels.includes("disabled"), labels.join(", "));
-        assert.ok(!labels.includes("disk-only"), labels.join(", "));
-        assert.ok(labels.includes("v-if"), labels.join(", "));
-        assert.ok(labels.includes(":"), labels.join(", "));
-        assert.ok(!labels.includes("Transition"), labels.join(", "));
-      },
-    );
+      };
+
+      const labels = await requestLabels();
+      assert.ok(labels.includes("label"), labels.join(", "));
+      assert.ok(labels.includes("disabled"), labels.join(", "));
+      assert.ok(!labels.includes("disk-only"), labels.join(", "));
+      assert.ok(labels.includes("v-if"), labels.join(", "));
+      assert.ok(labels.includes(":"), labels.join(", "));
+      assert.ok(!labels.includes("Transition"), labels.join(", "));
+
+      session.notify("textDocument/didChange", {
+        textDocument: { uri: childUri, version: 2 },
+        contentChanges: [{ text: changedChildSource }],
+      });
+      const changedPublish = (await session.waitForNotification(
+        "textDocument/publishDiagnostics",
+        (params) => isDiagnosticsForUri(params, childUri) && params.version === 2,
+      )) as PublishDiagnosticsParams;
+      assert.deepEqual(changedPublish.diagnostics, []);
+
+      const changedLabels = await requestLabels();
+      assert.ok(changedLabels.includes("label"), changedLabels.join(", "));
+      assert.ok(changedLabels.includes("loading"), changedLabels.join(", "));
+      assert.ok(!changedLabels.includes("disabled"), changedLabels.join(", "));
+      assert.ok(!changedLabels.includes("disk-only"), changedLabels.join(", "));
+
+      session.notify("textDocument/didChange", {
+        textDocument: { uri: childUri, version: 3 },
+        contentChanges: [{ text: openChildSource }],
+      });
+      const repairedPublish = (await session.waitForNotification(
+        "textDocument/publishDiagnostics",
+        (params) => isDiagnosticsForUri(params, childUri) && params.version === 3,
+      )) as PublishDiagnosticsParams;
+      assert.deepEqual(repairedPublish.diagnostics, []);
+
+      const repairedLabels = await requestLabels();
+      assert.ok(repairedLabels.includes("label"), repairedLabels.join(", "));
+      assert.ok(repairedLabels.includes("disabled"), repairedLabels.join(", "));
+      assert.ok(!repairedLabels.includes("loading"), repairedLabels.join(", "));
+      assert.ok(!repairedLabels.includes("disk-only"), repairedLabels.join(", "));
+    });
 
     await t.test("after '<' surfaces built-in components and directive snippets", async () => {
       const offset = ltSource.indexOf("  <") + "  <".length;


### PR DESCRIPTION
## Summary

- require component prop completion to use an open child overlay instead of stale disk content
- patch the child props in one LSP session and assert new props appear while removed and disk-only props stay excluded
- repair the child overlay and require the original completion set to return
- keep both changed and repaired child publications exactly diagnostic-free

## Validation

- 50 consecutive runs of `node --test tests/tooling/lsp-template-completion.test.ts`
- `vp check`
- `vp run source:lengths --check --base-ref origin/main --max-lines 350 --limit 5`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786884701&installation_id=136613492&pr_number=2990&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2990&signature=9f8be11e4c24655a5e4f053015936361c89c7f899bba4323b29f65c6e09b0296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify component prop completions update after unsaved child-component edits.
  * Confirmed completions correctly reflect added and removed props.
  * Added regression checks ensuring completions return to their original state after changes are reverted.
  * Verified diagnostics remain clear throughout the edit and recovery flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->