### PR TITLE
fix(bench): share criterion output directory

### DIFF
--- a/bench/criterion-ab.mjs
+++ b/bench/criterion-ab.mjs
@@ -39,6 +39,7 @@ import { pathToFileURL } from "node:url";
 
 import {
   compareBaselineExports,
+  criterionEnvironment,
   critcmpArgs,
   critcmpExportArgs,
   parseCritcmpExport,
@@ -110,7 +111,9 @@ function run(command, commandArgs, options = {}) {
     throw result.error;
   }
   if (result.status !== 0) {
-    throw new Error(`${command} ${commandArgs.join(" ")} exited with ${result.status}`);
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
+    const details = output ? `\n${output}` : "";
+    throw new Error(`${command} ${commandArgs.join(" ")} exited with ${result.status}${details}`);
   }
   return result;
 }
@@ -140,7 +143,10 @@ function benchSide({ side, checkoutDir, baseline, targetDir, suites }) {
       targetDir,
     });
     console.log(`\n==> [${side}] cargo ${args.join(" ")}`);
-    run("cargo", args, { cwd: checkoutDir });
+    run("cargo", args, {
+      cwd: checkoutDir,
+      env: criterionEnvironment(targetDir),
+    });
   }
 }
 

--- a/bench/criterion-baselines.mjs
+++ b/bench/criterion-baselines.mjs
@@ -2,6 +2,10 @@ export function critcmpExportArgs({ targetDir, baseline }) {
   return ["--target-dir", targetDir, "--export", baseline];
 }
 
+export function criterionEnvironment(targetDir) {
+  return { CARGO_TARGET_DIR: targetDir };
+}
+
 export function critcmpArgs({ targetDir, baselinePaths }) {
   return ["--target-dir", targetDir, ...baselinePaths];
 }

--- a/tests/tooling/criterion-impact.test.ts
+++ b/tests/tooling/criterion-impact.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../../bench/criterion-ab.mjs";
 import {
   compareBaselineExports,
+  criterionEnvironment,
   critcmpArgs,
   critcmpExportArgs,
   parseCritcmpExport,
@@ -173,6 +174,9 @@ test("Criterion driver validates scoped suite manifests", () => {
 });
 
 test("Criterion driver snapshots both baselines before comparing them", () => {
+  assert.deepEqual(criterionEnvironment("/work/head/target"), {
+    CARGO_TARGET_DIR: "/work/head/target",
+  });
   assert.deepEqual(critcmpExportArgs({ targetDir: "/work/head/target", baseline: "base" }), [
     "--target-dir",
     "/work/head/target",


### PR DESCRIPTION
## Summary

- pass the shared Cargo target to each Criterion harness through `CARGO_TARGET_DIR`
- keep cargo build artifacts and Criterion base/head data in the same explicit directory
- include captured stdout/stderr when a benchmark subprocess fails

## Root cause

`cargo bench --target-dir` controlled compilation output but did not set the runtime environment Criterion uses to choose its report directory. Base and head therefore wrote to separate checkout-local directories, leaving critcmp with only head data.

## Validation

- `node --test tests/tooling/criterion-impact.test.ts tests/tooling/github-workflows-benchmark.test.ts`
- `vp check` (format clean; linked-worktree dependency resolution only produced unrelated existing warnings)
- source files remain below the 350-line growth gate
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786885008&installation_id=136613492&pr_number=2991&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2991&signature=989215f2fea2c267d74afefbd8a45b5e59adbd3e480c1d64ab22252a0db941eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark failure messages by including relevant command output, making errors easier to diagnose.
  * Ensured benchmark runs consistently use the configured build target directory.

* **Tests**
  * Added coverage verifying that benchmark environment settings are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->