### PR TITLE
fix(bench): capture criterion failure output

### DIFF
--- a/bench/criterion-ab.mjs
+++ b/bench/criterion-ab.mjs
@@ -134,6 +134,14 @@ export function cargoBenchArgs({ pkg, benches, baseline, targetDir }) {
   return args;
 }
 
+export function criterionBenchRunOptions({ checkoutDir, targetDir }) {
+  return {
+    cwd: checkoutDir,
+    env: criterionEnvironment(targetDir),
+    capture: true,
+  };
+}
+
 function benchSide({ side, checkoutDir, baseline, targetDir, suites }) {
   for (const suite of suites) {
     const args = cargoBenchArgs({
@@ -143,10 +151,7 @@ function benchSide({ side, checkoutDir, baseline, targetDir, suites }) {
       targetDir,
     });
     console.log(`\n==> [${side}] cargo ${args.join(" ")}`);
-    run("cargo", args, {
-      cwd: checkoutDir,
-      env: criterionEnvironment(targetDir),
-    });
+    run("cargo", args, criterionBenchRunOptions({ checkoutDir, targetDir }));
   }
 }
 

--- a/tests/tooling/criterion-impact.test.ts
+++ b/tests/tooling/criterion-impact.test.ts
@@ -7,6 +7,7 @@ import { test } from "node:test";
 
 import {
   CRITERION_SUITES,
+  criterionBenchRunOptions,
   renderSummary,
   resolveSuiteSelection,
 } from "../../bench/criterion-ab.mjs";
@@ -174,6 +175,17 @@ test("Criterion driver validates scoped suite manifests", () => {
 });
 
 test("Criterion driver snapshots both baselines before comparing them", () => {
+  assert.deepEqual(
+    criterionBenchRunOptions({
+      checkoutDir: "/work/head",
+      targetDir: "/work/head/target",
+    }),
+    {
+      cwd: "/work/head",
+      env: { CARGO_TARGET_DIR: "/work/head/target" },
+      capture: true,
+    },
+  );
   assert.deepEqual(criterionEnvironment("/work/head/target"), {
     CARGO_TARGET_DIR: "/work/head/target",
   });


### PR DESCRIPTION
## Summary

- capture each Cargo Criterion run so subprocess failures include benchmark stdout and stderr
- keep the shared CARGO_TARGET_DIR contract explicit in a focused tooling test

## Validation

- node --test tests/tooling/criterion-impact.test.ts tests/tooling/github-workflows-benchmark.test.ts (18 passed)
- oxfmt --check bench/criterion-ab.mjs tests/tooling/criterion-impact.test.ts
- git diff --check

Follow-up to the actionable review on #2991.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786885528&installation_id=136613492&pr_number=2992&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2992&signature=4fdcdfca0a97f7190ce544fa2b2a846a3dba5d7998b00889c1a08a8aa108186b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->