### PR TITLE
fix(test): stabilize VueFes visual parity

### DIFF
--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -1719,9 +1719,11 @@ function setupVuefesWorktree(opts?: { enableVize?: boolean; variant?: string }):
     fs.writeFileSync(vuefesPackageJson, JSON.stringify(pkg, null, "\t") + "\n");
   }
 
-  addPnpmOverrides(vuefesPackageJson, {
-    vite: "^8.0.0",
-  });
+  if (enableVize) {
+    addPnpmOverrides(vuefesPackageJson, {
+      vite: "^8.0.0",
+    });
+  }
   patchVuefesVisualFixture(vuefesDir);
 
   installPnpmDependencies(vuefesDir, {
@@ -1807,7 +1809,10 @@ export function createVuefesVisualParityApps(mode: VuefesVisualParityMode = "dev
   const candidatePort = mode === "preview" ? 5333 : 5327;
 
   return {
-    reference: createVuefesVisualParityApp("reference", referencePort, mode),
+    // The pinned Vite 8 toolchain cannot serve the upstream Nuxt 4.0 fixture in dev mode.
+    // Use its production build as the stable compiler reference while still exercising the
+    // Vize candidate in both dev and preview modes.
+    reference: createVuefesVisualParityApp("reference", referencePort, "preview"),
     candidate: createVuefesVisualParityApp("candidate", candidatePort, mode),
   };
 }

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -1719,11 +1719,7 @@ function setupVuefesWorktree(opts?: { enableVize?: boolean; variant?: string }):
     fs.writeFileSync(vuefesPackageJson, JSON.stringify(pkg, null, "\t") + "\n");
   }
 
-  if (enableVize) {
-    addPnpmOverrides(vuefesPackageJson, {
-      vite: "^8.0.0",
-    });
-  }
+  if (enableVize) addPnpmOverrides(vuefesPackageJson, { vite: "^8.0.0" });
   patchVuefesVisualFixture(vuefesDir);
 
   installPnpmDependencies(vuefesDir, {
@@ -1809,9 +1805,7 @@ export function createVuefesVisualParityApps(mode: VuefesVisualParityMode = "dev
   const candidatePort = mode === "preview" ? 5333 : 5327;
 
   return {
-    // The pinned Vite 8 toolchain cannot serve the upstream Nuxt 4.0 fixture in dev mode.
-    // Use its production build as the stable compiler reference while still exercising the
-    // Vize candidate in both dev and preview modes.
+    // Use the upstream production build as the stable reference for both candidate modes.
     reference: createVuefesVisualParityApp("reference", referencePort, "preview"),
     candidate: createVuefesVisualParityApp("candidate", candidatePort, mode),
   };


### PR DESCRIPTION
## Summary

- keep the VueFes reference on its upstream Rolldown-Vite toolchain
- use the upstream production build as the stable visual reference
- continue exercising Vize candidates in both dev and preview modes with Vite 8

## Validation

- `vp check tests/_helpers/apps.ts`
- `vp lint --max-warnings 0 tests/_helpers/apps.ts`
- `vp fmt --check tests/_helpers/apps.ts`
- `vp exec --filter ./tests -- playwright test --config app/playwright.vrt.config.ts vuefes.spec.ts` (38 passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786891184&installation_id=136613492&pr_number=2994&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2994&signature=101360f8e633f73b96fcedf3db5ee7c001185dd25d618e35ebf94b8790c4bcbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated test fixture setup so the Vite version override is applied only when Vize is enabled.
  * Improved visual parity checks by always generating the reference app from the preview build for more consistent comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->