### PR TITLE
test(fixtures): add real-project tool matrix

### DIFF
--- a/tests/tooling/fixture-tool-matrix-report.test.ts
+++ b/tests/tooling/fixture-tool-matrix-report.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const toolPath = path.join(root, "tools", "fixtures", "tool-matrix-report.mjs");
+
+function run(args: string[]) {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-fixture-tool-matrix-"));
+  const result = spawnSync(process.execPath, [toolPath, ...args, "--output-dir", outputDir], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  return { outputDir, result };
+}
+
+test("fixture tool matrix plans every registered project across all four required tools", () => {
+  const { outputDir, result } = run(["--dry-run"]);
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    const report = JSON.parse(fs.readFileSync(path.join(outputDir, "summary.json"), "utf8"));
+    assert.equal(report.schema, "vize.fixtureToolMatrixReport");
+    assert.equal(report.summary.projectCount, 131);
+    assert.equal(report.summary.toolCount, 4);
+    assert.equal(report.summary.runCount, 524);
+    assert.equal(report.summary.plannedRuns, 524);
+    assert.equal(report.projects.length, 131);
+    for (const project of report.projects) {
+      assert.deepEqual(
+        project.runs.map((entry: { tool: string }) => entry.tool),
+        ["compiler", "typechecker", "linter", "formatter"],
+        `${project.id} should exercise every requested tool`,
+      );
+    }
+  } finally {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+test("fixture tool matrix emits read-only commands with machine-readable diagnostics", () => {
+  const { outputDir, result } = run([
+    "--dry-run",
+    "--project",
+    "vue-vben-admin",
+    "--tool",
+    "compiler,typechecker,linter,formatter",
+  ]);
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    const report = JSON.parse(fs.readFileSync(path.join(outputDir, "summary.json"), "utf8"));
+    const runs = Object.fromEntries(
+      report.projects[0].runs.map((entry: { tool: string }) => [entry.tool, entry]),
+    ) as Record<string, { command: string }>;
+    assert.match(runs.compiler.command, /inspector .*--format json --template-syntax quirks/);
+    assert.match(
+      runs.typechecker.command,
+      /check .*--format json --no-config --tsconfig playground\/tsconfig\.json/,
+    );
+    assert.match(runs.linter.command, /lint .*--format json --preset ecosystem --no-config/);
+    assert.match(runs.formatter.command, /fmt .*--check --no-config/);
+    for (const entry of Object.values(runs)) {
+      assert.doesNotMatch(entry.command, /(?:^|\s)--write(?:\s|$)/);
+      assert.doesNotMatch(entry.command, /(?:^|\s)-w(?:\s|$)/);
+    }
+  } finally {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+test("fixture tool matrix rejects unknown projects, tools, and invalid timeouts", () => {
+  for (const [args, message] of [
+    [["--dry-run", "--project", "not-a-project"], /Unknown fixture project: not-a-project/],
+    [["--dry-run", "--tool", "not-a-tool"], /Unknown fixture tool: not-a-tool/],
+    [["--dry-run", "--timeout-ms", "0"], /--timeout-ms must be a positive integer/],
+  ] as const) {
+    const { outputDir, result } = run([...args]);
+    try {
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, message);
+      assert.equal(fs.existsSync(path.join(outputDir, "summary.json")), false);
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  }
+});

--- a/tools/fixtures/tool-matrix-report.mjs
+++ b/tools/fixtures/tool-matrix-report.mjs
@@ -1,0 +1,332 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..");
+const registryPath = join(repoRoot, "tests", "_fixtures", "vue-ecosystem-fixtures.json");
+const schema = "vize.fixtureToolMatrixReport";
+const supportedTools = ["compiler", "typechecker", "linter", "formatter"];
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const registry = readJson(registryPath);
+  const projects = select(registry.projects, args.projects, "project");
+  const tools =
+    args.tools.length === 0 ? supportedTools : select(supportedTools, args.tools, "tool");
+  assertRegistryCoverage(registry, projects, tools);
+
+  const outputDir = resolve(
+    repoRoot,
+    args.outputDir ?? join("__agent_only", "fixture-tool-matrix", timestampSlug(new Date())),
+  );
+  const launch = resolveVizeLaunch(args.vizeBin, args.dryRun);
+  mkdirSync(outputDir, { recursive: true });
+
+  const report = {
+    schema,
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    registryPath: relative(repoRoot, registryPath),
+    command: {
+      vize: launch.label,
+      dryRun: args.dryRun,
+      timeoutMs: args.timeoutMs,
+      tools,
+    },
+    summary: {
+      projectCount: projects.length,
+      toolCount: tools.length,
+      runCount: projects.length * tools.length,
+      plannedRuns: 0,
+      okRuns: 0,
+      findingsRuns: 0,
+      failedRuns: 0,
+      missingFixtureRuns: 0,
+    },
+    projects: [],
+  };
+
+  for (const project of projects) {
+    const projectReport = {
+      id: project.id,
+      fixturePath: project.fixturePath,
+      revision: project.revision,
+      runs: [],
+    };
+    for (const tool of tools) {
+      const run = runTool(project, tool, args, launch, outputDir);
+      projectReport.runs.push(run);
+      report.summary[summaryKey(run.status)] += 1;
+    }
+    report.projects.push(projectReport);
+  }
+
+  const jsonPath = join(outputDir, "summary.json");
+  const markdownPath = join(outputDir, "summary.md");
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+  writeFileSync(markdownPath, renderMarkdown(report));
+  process.stdout.write(`Wrote ${relative(repoRoot, jsonPath)}\n`);
+  process.stdout.write(`Wrote ${relative(repoRoot, markdownPath)}\n`);
+
+  if (report.summary.failedRuns > 0 || report.summary.missingFixtureRuns > 0) {
+    process.exitCode = 1;
+  }
+}
+
+function parseArgs(argv) {
+  const args = {
+    dryRun: false,
+    outputDir: null,
+    projects: [],
+    timeoutMs: 300_000,
+    tools: [],
+    vizeBin: null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = () => {
+      if (argv[index + 1] == null) throw new Error(`${arg} requires a value`);
+      return argv[++index];
+    };
+    if (arg === "--dry-run") args.dryRun = true;
+    else if (arg === "--help" || arg === "-h") return printHelpAndExit();
+    else if (arg === "--output-dir") args.outputDir = value();
+    else if (arg.startsWith("--output-dir=")) args.outputDir = arg.slice(13);
+    else if (arg === "--project") args.projects.push(...splitCsv(value()));
+    else if (arg.startsWith("--project=")) args.projects.push(...splitCsv(arg.slice(10)));
+    else if (arg === "--timeout-ms") args.timeoutMs = positiveInteger(value(), arg);
+    else if (arg.startsWith("--timeout-ms="))
+      args.timeoutMs = positiveInteger(arg.slice(13), "--timeout-ms");
+    else if (arg === "--tool") args.tools.push(...splitCsv(value()));
+    else if (arg.startsWith("--tool=")) args.tools.push(...splitCsv(arg.slice(7)));
+    else if (arg === "--vize-bin") args.vizeBin = value();
+    else if (arg.startsWith("--vize-bin=")) args.vizeBin = arg.slice(11);
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  args.projects = [...new Set(args.projects)];
+  args.tools = [...new Set(args.tools)];
+  return args;
+}
+
+function printHelpAndExit() {
+  process.stdout.write(`Usage: node tools/fixtures/tool-matrix-report.mjs [options]\n\n`);
+  process.stdout.write(
+    `Exercise every registered real project with compiler, typechecker, linter, and formatter.\n\n`,
+  );
+  process.stdout.write(`  --project <id[,id]>  Limit registry projects\n`);
+  process.stdout.write(`  --tool <name[,name]> Limit tool surfaces\n`);
+  process.stdout.write(`  --output-dir <dir>   Report directory\n`);
+  process.stdout.write(`  --vize-bin <path>    Vize executable\n`);
+  process.stdout.write(`  --timeout-ms <n>     Per-run timeout\n`);
+  process.stdout.write(`  --dry-run            Plan without invoking Vize\n`);
+  process.exit(0);
+}
+
+function runTool(project, tool, args, launch, outputDir) {
+  const cwd = resolve(repoRoot, project.fixturePath);
+  const commandArgs = [...launch.prefix, ...toolArgs(project, tool)];
+  const base = {
+    tool,
+    command: displayCommand(launch.command, commandArgs),
+    cwd: relative(repoRoot, cwd),
+    durationMs: 0,
+    exitCode: null,
+    outputPath: null,
+  };
+  if (args.dryRun) return { ...base, status: "planned" };
+  if (!existsSync(cwd)) return { ...base, status: "missing-fixture" };
+
+  const startedAt = Date.now();
+  const result = spawnSync(launch.command, commandArgs, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, LANG: "C", LC_ALL: "C" },
+    maxBuffer: 1024 * 1024 * 1024,
+    timeout: args.timeoutMs,
+  });
+  const rawPath = join(outputDir, `${project.id}-${tool}.json`);
+  const completed = {
+    ...base,
+    durationMs: Date.now() - startedAt,
+    exitCode: result.status,
+    outputPath: relative(repoRoot, rawPath),
+  };
+  if (result.error != null) {
+    return { ...completed, status: "failed", failure: errorMessage(result.error) };
+  }
+  if (result.status !== 0 && result.status !== 1) {
+    return { ...completed, status: "failed", failure: failureOutput(result) };
+  }
+
+  const payload = {
+    schema: "vize.fixtureToolRun",
+    version: 1,
+    project: project.id,
+    tool,
+    exitCode: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+  if (tool !== "formatter") {
+    try {
+      payload.parsed = JSON.parse(result.stdout);
+    } catch (error) {
+      return {
+        ...completed,
+        status: "failed",
+        failure: `invalid JSON output: ${errorMessage(error)}`,
+      };
+    }
+  }
+  writeFileSync(rawPath, `${JSON.stringify(payload, null, 2)}\n`);
+  return { ...completed, status: result.status === 0 ? "ok" : "findings" };
+}
+
+function toolArgs(project, tool) {
+  if (tool === "compiler") {
+    return ["inspector", ...project.vueGlobs, "--format", "json", "--template-syntax", "quirks"];
+  }
+  if (tool === "linter") {
+    return [
+      "lint",
+      ...project.vueGlobs,
+      "--format",
+      "json",
+      "--preset",
+      "ecosystem",
+      "--no-config",
+    ];
+  }
+  if (tool === "typechecker") {
+    const args = ["check", ...project.vueGlobs, "--format", "json", "--no-config"];
+    if (project.tsconfig != null) args.push("--tsconfig", project.tsconfig);
+    return args;
+  }
+  return ["fmt", ...project.vueGlobs, "--check", "--no-config"];
+}
+
+function assertRegistryCoverage(registry, projects, tools) {
+  for (const tool of tools) {
+    if (!registry.requiredToolCoverage.includes(tool)) {
+      throw new Error(`Registry does not require tool coverage: ${tool}`);
+    }
+  }
+  for (const project of projects) {
+    for (const tool of tools) {
+      if (!project.coverage.includes(tool)) {
+        throw new Error(`${project.id} does not declare ${tool} coverage`);
+      }
+    }
+  }
+}
+
+function resolveVizeLaunch(vizeBin, dryRun) {
+  const candidates = [
+    vizeBin,
+    process.env.VIZE_BIN,
+    join(repoRoot, "target", "ci", executableName("vize")),
+    join(repoRoot, "target", "debug", executableName("vize")),
+    join(repoRoot, "target", "release", executableName("vize")),
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    const probe = spawnSync(candidate, ["--version"], { encoding: "utf8" });
+    if (probe.status === 0) return { command: candidate, prefix: [], label: candidate };
+  }
+  if (vizeBin != null && !dryRun) throw new Error(`Vize executable is not runnable: ${vizeBin}`);
+  return {
+    command: "cargo",
+    prefix: ["run", "-q", "-p", "vize", "--"],
+    label: "cargo run -q -p vize --",
+  };
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    "# Vize Fixture Tool Matrix Report",
+    "",
+    `Projects: ${report.summary.projectCount}`,
+    `Tools: ${report.command.tools.join(", ")}`,
+    `Runs: ${report.summary.runCount}`,
+    "",
+    "| Project | Tool | Status | Exit | Duration (ms) | Output |",
+    "| --- | --- | --- | ---: | ---: | --- |",
+  ];
+  for (const project of report.projects) {
+    for (const run of project.runs) {
+      lines.push(
+        `| ${project.id} | ${run.tool} | ${run.status} | ${run.exitCode ?? "-"} | ${run.durationMs} | ${run.outputPath == null ? "-" : `\`${run.outputPath}\``} |`,
+      );
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function summaryKey(status) {
+  return {
+    planned: "plannedRuns",
+    ok: "okRuns",
+    findings: "findingsRuns",
+    failed: "failedRuns",
+    "missing-fixture": "missingFixtureRuns",
+  }[status];
+}
+
+function select(items, selected, kind) {
+  if (selected.length === 0) return items;
+  const byId = new Map(items.map((item) => [typeof item === "string" ? item : item.id, item]));
+  return selected.map((id) => {
+    if (!byId.has(id)) throw new Error(`Unknown fixture ${kind}: ${id}`);
+    return byId.get(id);
+  });
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+function splitCsv(value) {
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+function positiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0)
+    throw new Error(`${name} must be a positive integer`);
+  return parsed;
+}
+function timestampSlug(date) {
+  return date
+    .toISOString()
+    .replace(/\.\d{3}Z$/, "Z")
+    .replace(/[:.]/g, "-");
+}
+function executableName(name) {
+  return process.platform === "win32" ? `${name}.exe` : name;
+}
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+function failureOutput(result) {
+  return { stdout: truncate(result.stdout), stderr: truncate(result.stderr) };
+}
+function truncate(value) {
+  return value.length <= 4000 ? value : `${value.slice(0, 4000)}\n...<truncated>`;
+}
+function displayCommand(command, args) {
+  return [command, ...args].map(shellQuote).join(" ");
+}
+function shellQuote(value) {
+  return /^[A-Za-z0-9_./:=@*-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${errorMessage(error)}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- add a read-only real-project tool-matrix reporter
- enumerate every registered fixture across compiler, typechecker, linter, and formatter
- record per-project commands, outcomes, timing, and raw machine-readable output
- enforce the complete 131 × 4 = 524 run contract with focused tests

## Why

The fixture registry declared tool coverage for every real project, but no executable contract proved that every project was actually scheduled for all four core tools. This adds the missing execution-plan invariant before the full fixture runs are wired into Actions.

## Validation

- `node --test tests/tooling/fixture-tool-matrix-report.test.ts tests/tooling/compiler-fixture-diff-report.test.ts`
- `oxlint tools/fixtures/tool-matrix-report.mjs tests/tooling/fixture-tool-matrix-report.test.ts`
- `oxfmt --check tools/fixtures/tool-matrix-report.mjs tests/tooling/fixture-tool-matrix-report.test.ts`
- dry-run report confirms 131 projects, 4 tools, and 524 planned runs

The full tooling suite is delegated to GitHub Actions because the isolated worktree does not share a valid dependency/build-artifact installation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786892909&installation_id=136613492&pr_number=2995&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2995&signature=b98d22024f579b46814f0c983bfd744874f3d743b0f37dbfbd2d235d0b93976b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line report generator for evaluating fixture projects with compiler, typechecker, linter, and formatter tools.
  * Supports project and tool selection, dry runs, configurable output directories, execution timeouts, and custom executable paths.
  * Produces machine-readable JSON summaries, Markdown reports, and detailed per-run artifacts.
  * Reports missing fixtures, failed runs, execution details, and diagnostic output.

* **Tests**
  * Added coverage for report schemas, tool commands, validation errors, and dry-run aggregate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->