### PR TITLE
fix(fixtures): preserve failed tool reports

### DIFF
--- a/tests/tooling/fixture-tool-matrix-report.test.ts
+++ b/tests/tooling/fixture-tool-matrix-report.test.ts
@@ -18,6 +18,13 @@ function run(args: string[]) {
   return { outputDir, result };
 }
 
+function writeFakeVize(directory: string, body: string) {
+  const executable = path.join(directory, "fake-vize.mjs");
+  fs.writeFileSync(executable, `#!/usr/bin/env node\n${body}\n`);
+  fs.chmodSync(executable, 0o755);
+  return executable;
+}
+
 test("fixture tool matrix plans every registered project across all four required tools", () => {
   const { outputDir, result } = run(["--dry-run"]);
   try {
@@ -84,6 +91,106 @@ test("fixture tool matrix rejects unknown projects, tools, and invalid timeouts"
       assert.equal(fs.existsSync(path.join(outputDir, "summary.json")), false);
     } finally {
       fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("fixture tool matrix dry-run resolves a relative executable without invoking it", () => {
+  const fakeDir = fs.mkdtempSync(path.join(root, "fixture-tool-matrix-probe-"));
+  const marker = path.join(fakeDir, "invoked");
+  const executable = writeFakeVize(
+    fakeDir,
+    `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(marker)}, "invoked");`,
+  );
+  const relativeExecutable = path.relative(root, executable);
+  const { outputDir, result } = run([
+    "--dry-run",
+    "--project",
+    "vue-vben-admin",
+    "--tool",
+    "compiler",
+    "--vize-bin",
+    relativeExecutable,
+  ]);
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.existsSync(marker), false, "dry-run must not probe the executable");
+    const report = JSON.parse(fs.readFileSync(path.join(outputDir, "summary.json"), "utf8"));
+    assert.equal(report.command.vize, executable);
+    assert.match(report.projects[0].runs[0].command, new RegExp(`^${executable}`));
+  } finally {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
+});
+
+test("fixture tool matrix preserves raw output for failed invocations", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-fixture-tool-failure-"));
+  const executable = writeFakeVize(
+    fakeDir,
+    `if (process.argv[2] === "--version") process.exit(0);\nprocess.stdout.write("not json");\nprocess.stderr.write("synthetic failure");\nprocess.exit(2);`,
+  );
+  const { outputDir, result } = run([
+    "--project",
+    "vue-vben-admin",
+    "--tool",
+    "compiler",
+    "--vize-bin",
+    executable,
+  ]);
+  try {
+    assert.equal(result.status, 1);
+    const report = JSON.parse(fs.readFileSync(path.join(outputDir, "summary.json"), "utf8"));
+    assert.equal(report.summary.failedRuns, 1);
+    const rawPath = path.resolve(root, report.projects[0].runs[0].outputPath);
+    assert.equal(fs.existsSync(rawPath), true, "failed run output must exist");
+    const raw = JSON.parse(fs.readFileSync(rawPath, "utf8"));
+    assert.equal(raw.exitCode, 2);
+    assert.equal(raw.stdout, "not json");
+    assert.equal(raw.stderr, "synthetic failure");
+  } finally {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
+});
+
+test("fixture tool matrix preserves raw output for invalid JSON and spawn errors", () => {
+  const cases = [
+    {
+      name: "invalid-json",
+      body: `if (process.argv[2] === "--version") process.exit(0);\nprocess.stdout.write("not json");`,
+      expected: { exitCode: 0, stdout: "not json", parseError: true, spawnError: false },
+    },
+    {
+      name: "spawn-error",
+      body: `import fs from "node:fs"; import { fileURLToPath } from "node:url";\nif (process.argv[2] === "--version") { fs.unlinkSync(fileURLToPath(import.meta.url)); process.exit(0); }`,
+      expected: { exitCode: null, stdout: "", parseError: false, spawnError: true },
+    },
+  ] as const;
+
+  for (const fixtureCase of cases) {
+    const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), `vize-${fixtureCase.name}-`));
+    const executable = writeFakeVize(fakeDir, fixtureCase.body);
+    const { outputDir, result } = run([
+      "--project",
+      "vue-vben-admin",
+      "--tool",
+      "compiler",
+      "--vize-bin",
+      executable,
+    ]);
+    try {
+      assert.equal(result.status, 1, fixtureCase.name);
+      const report = JSON.parse(fs.readFileSync(path.join(outputDir, "summary.json"), "utf8"));
+      const rawPath = path.resolve(root, report.projects[0].runs[0].outputPath);
+      const raw = JSON.parse(fs.readFileSync(rawPath, "utf8"));
+      assert.equal(raw.exitCode, fixtureCase.expected.exitCode, fixtureCase.name);
+      assert.equal(raw.stdout, fixtureCase.expected.stdout, fixtureCase.name);
+      assert.equal("parseError" in raw, fixtureCase.expected.parseError, fixtureCase.name);
+      assert.equal("spawnError" in raw, fixtureCase.expected.spawnError, fixtureCase.name);
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+      fs.rmSync(fakeDir, { recursive: true, force: true });
     }
   }
 });

--- a/tools/fixtures/tool-matrix-report.mjs
+++ b/tools/fixtures/tool-matrix-report.mjs
@@ -154,34 +154,39 @@ function runTool(project, tool, args, launch, outputDir) {
     exitCode: result.status,
     outputPath: relative(repoRoot, rawPath),
   };
-  if (result.error != null) {
-    return { ...completed, status: "failed", failure: errorMessage(result.error) };
-  }
-  if (result.status !== 0 && result.status !== 1) {
-    return { ...completed, status: "failed", failure: failureOutput(result) };
-  }
-
   const payload = {
     schema: "vize.fixtureToolRun",
     version: 1,
     project: project.id,
     tool,
     exitCode: result.status,
-    stdout: result.stdout,
-    stderr: result.stderr,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
   };
-  if (tool !== "formatter") {
+  if (result.error != null) {
+    payload.spawnError = errorMessage(result.error);
+  } else if (tool !== "formatter" && (result.status === 0 || result.status === 1)) {
     try {
       payload.parsed = JSON.parse(result.stdout);
     } catch (error) {
-      return {
-        ...completed,
-        status: "failed",
-        failure: `invalid JSON output: ${errorMessage(error)}`,
-      };
+      payload.parseError = errorMessage(error);
     }
   }
   writeFileSync(rawPath, `${JSON.stringify(payload, null, 2)}\n`);
+
+  if (result.error != null) {
+    return { ...completed, status: "failed", failure: errorMessage(result.error) };
+  }
+  if (result.status !== 0 && result.status !== 1) {
+    return { ...completed, status: "failed", failure: failureOutput(result) };
+  }
+  if (payload.parseError != null) {
+    return {
+      ...completed,
+      status: "failed",
+      failure: `invalid JSON output: ${payload.parseError}`,
+    };
+  }
   return { ...completed, status: result.status === 0 ? "ok" : "findings" };
 }
 
@@ -230,10 +235,16 @@ function resolveVizeLaunch(vizeBin, dryRun) {
     join(repoRoot, "target", "ci", executableName("vize")),
     join(repoRoot, "target", "debug", executableName("vize")),
     join(repoRoot, "target", "release", executableName("vize")),
-  ].filter(Boolean);
+  ]
+    .filter(Boolean)
+    .map((candidate) => resolve(candidate));
   for (const candidate of candidates) {
     if (!existsSync(candidate)) continue;
-    const probe = spawnSync(candidate, ["--version"], { encoding: "utf8" });
+    if (dryRun) return { command: candidate, prefix: [], label: candidate };
+    const probe = spawnSync(candidate, ["--version"], {
+      encoding: "utf8",
+      timeout: 10_000,
+    });
     if (probe.status === 0) return { command: candidate, prefix: [], label: candidate };
   }
   if (vizeBin != null && !dryRun) throw new Error(`Vize executable is not runnable: ${vizeBin}`);


### PR DESCRIPTION
## Summary

- persist raw tool output for abnormal exits, invalid JSON, and spawn failures
- keep every report output reference valid for post-failure diagnosis
- resolve executable candidates to absolute paths before fixture-directory execution
- avoid executable probes in dry-run mode and bound real probes to 10 seconds

## Why

The first real-project matrix harness could report an artifact path without creating the artifact on failed invocations. Relative executable paths could also pass the probe and then fail after changing into a fixture directory. These follow-up fixes address both review findings from #2995.

## Validation

- `node --test tests/tooling/fixture-tool-matrix-report.test.ts tests/tooling/compiler-fixture-diff-report.test.ts` (8/8)
- `oxlint tools/fixtures/tool-matrix-report.mjs tests/tooling/fixture-tool-matrix-report.test.ts`
- `oxfmt --check tools/fixtures/tool-matrix-report.mjs tests/tooling/fixture-tool-matrix-report.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786893368&installation_id=136613492&pr_number=2996&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2996&signature=39c3eea62e3cd4b37ad02643be5170777a973e3023bf28c7a4d90606b9d50c7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tool-matrix reporting for failed or malformed command executions.
  - Raw output now remains available with exit codes, standard output, standard error, and relevant parsing or launch errors.
  - Relative executable paths are resolved correctly during dry runs.
  - Tool version checks now stop after a defined timeout, improving reliability when commands do not respond.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->