### PR TITLE
test(fixtures): enforce balanced tool shards

### DIFF
--- a/tests/tooling/fixture-tool-matrix-report.test.ts
+++ b/tests/tooling/fixture-tool-matrix-report.test.ts
@@ -194,3 +194,84 @@ test("fixture tool matrix preserves raw output for invalid JSON and spawn errors
     }
   }
 });
+
+test("fixture tool matrix shards every project exactly once with balanced sizes", () => {
+  const projectIds = new Set<string>();
+  const shardSizes: number[] = [];
+  for (let index = 0; index < 11; index += 1) {
+    const { outputDir, result } = run([
+      "--dry-run",
+      "--shard-index",
+      String(index),
+      "--shard-count",
+      "11",
+    ]);
+    try {
+      assert.equal(result.status, 0, result.stderr);
+      const report = JSON.parse(fs.readFileSync(path.join(outputDir, "summary.json"), "utf8"));
+      assert.equal(report.command.shardIndex, index);
+      assert.equal(report.command.shardCount, 11);
+      assert.equal(report.summary.runCount, report.summary.projectCount * 4);
+      shardSizes.push(report.summary.projectCount);
+      for (const project of report.projects) {
+        assert.equal(
+          projectIds.has(project.id),
+          false,
+          `${project.id} must appear in only one shard`,
+        );
+        projectIds.add(project.id);
+      }
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  }
+  assert.equal(projectIds.size, 131);
+  assert.deepEqual(
+    [...new Set(shardSizes)].sort((a, b) => a - b),
+    [11, 12],
+  );
+  assert.equal(
+    shardSizes.reduce((sum, size) => sum + size, 0),
+    131,
+  );
+});
+
+test("fixture tool matrix lists exactly the fixture paths selected by a shard", () => {
+  const args = ["--shard-index", "3", "--shard-count", "11"];
+  const planned = run(["--dry-run", ...args]);
+  const listed = run(["--list-fixture-paths", ...args]);
+  try {
+    assert.equal(planned.result.status, 0, planned.result.stderr);
+    assert.equal(listed.result.status, 0, listed.result.stderr);
+    const report = JSON.parse(
+      fs.readFileSync(path.join(planned.outputDir, "summary.json"), "utf8"),
+    );
+    assert.deepEqual(
+      listed.result.stdout.trim().split("\n"),
+      report.projects.map((project: { fixturePath: string }) => project.fixturePath),
+    );
+    assert.equal(fs.existsSync(path.join(listed.outputDir, "summary.json")), false);
+  } finally {
+    fs.rmSync(planned.outputDir, { recursive: true, force: true });
+    fs.rmSync(listed.outputDir, { recursive: true, force: true });
+  }
+});
+
+test("fixture tool matrix rejects invalid shard bounds", () => {
+  for (const [args, message] of [
+    [["--dry-run", "--shard-index", "-1"], /--shard-index must be a non-negative integer/],
+    [["--dry-run", "--shard-count", "0"], /--shard-count must be a positive integer/],
+    [
+      ["--dry-run", "--shard-index", "2", "--shard-count", "2"],
+      /--shard-index must be less than --shard-count/,
+    ],
+  ] as const) {
+    const { outputDir, result } = run([...args]);
+    try {
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, message);
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  }
+});

--- a/tools/fixtures/tool-matrix-report.mjs
+++ b/tools/fixtures/tool-matrix-report.mjs
@@ -13,10 +13,16 @@ const supportedTools = ["compiler", "typechecker", "linter", "formatter"];
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const registry = readJson(registryPath);
-  const projects = select(registry.projects, args.projects, "project");
+  const selectedProjects = select(registry.projects, args.projects, "project");
+  const projects = selectShard(selectedProjects, args.shardIndex, args.shardCount);
   const tools =
     args.tools.length === 0 ? supportedTools : select(supportedTools, args.tools, "tool");
   assertRegistryCoverage(registry, projects, tools);
+
+  if (args.listFixturePaths) {
+    process.stdout.write(`${projects.map((project) => project.fixturePath).join("\n")}\n`);
+    return;
+  }
 
   const outputDir = resolve(
     repoRoot,
@@ -35,6 +41,8 @@ function main() {
       dryRun: args.dryRun,
       timeoutMs: args.timeoutMs,
       tools,
+      shardIndex: args.shardIndex,
+      shardCount: args.shardCount,
     },
     summary: {
       projectCount: projects.length,
@@ -79,8 +87,11 @@ function main() {
 function parseArgs(argv) {
   const args = {
     dryRun: false,
+    listFixturePaths: false,
     outputDir: null,
     projects: [],
+    shardCount: 1,
+    shardIndex: 0,
     timeoutMs: 300_000,
     tools: [],
     vizeBin: null,
@@ -92,11 +103,18 @@ function parseArgs(argv) {
       return argv[++index];
     };
     if (arg === "--dry-run") args.dryRun = true;
+    else if (arg === "--list-fixture-paths") args.listFixturePaths = true;
     else if (arg === "--help" || arg === "-h") return printHelpAndExit();
     else if (arg === "--output-dir") args.outputDir = value();
     else if (arg.startsWith("--output-dir=")) args.outputDir = arg.slice(13);
     else if (arg === "--project") args.projects.push(...splitCsv(value()));
     else if (arg.startsWith("--project=")) args.projects.push(...splitCsv(arg.slice(10)));
+    else if (arg === "--shard-count") args.shardCount = positiveInteger(value(), arg);
+    else if (arg.startsWith("--shard-count="))
+      args.shardCount = positiveInteger(arg.slice(14), "--shard-count");
+    else if (arg === "--shard-index") args.shardIndex = nonNegativeInteger(value(), arg);
+    else if (arg.startsWith("--shard-index="))
+      args.shardIndex = nonNegativeInteger(arg.slice(14), "--shard-index");
     else if (arg === "--timeout-ms") args.timeoutMs = positiveInteger(value(), arg);
     else if (arg.startsWith("--timeout-ms="))
       args.timeoutMs = positiveInteger(arg.slice(13), "--timeout-ms");
@@ -108,6 +126,9 @@ function parseArgs(argv) {
   }
   args.projects = [...new Set(args.projects)];
   args.tools = [...new Set(args.tools)];
+  if (args.shardIndex >= args.shardCount) {
+    throw new Error("--shard-index must be less than --shard-count");
+  }
   return args;
 }
 
@@ -118,6 +139,9 @@ function printHelpAndExit() {
   );
   process.stdout.write(`  --project <id[,id]>  Limit registry projects\n`);
   process.stdout.write(`  --tool <name[,name]> Limit tool surfaces\n`);
+  process.stdout.write(`  --shard-index <n>    Zero-based project shard index\n`);
+  process.stdout.write(`  --shard-count <n>    Total balanced project shards\n`);
+  process.stdout.write(`  --list-fixture-paths Print selected fixture paths and exit\n`);
   process.stdout.write(`  --output-dir <dir>   Report directory\n`);
   process.stdout.write(`  --vize-bin <path>    Vize executable\n`);
   process.stdout.write(`  --timeout-ms <n>     Per-run timeout\n`);
@@ -295,6 +319,10 @@ function select(items, selected, kind) {
   });
 }
 
+function selectShard(projects, shardIndex, shardCount) {
+  return projects.filter((_, index) => index % shardCount === shardIndex);
+}
+
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
 }
@@ -308,6 +336,12 @@ function positiveInteger(value, name) {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed <= 0)
     throw new Error(`${name} must be a positive integer`);
+  return parsed;
+}
+function nonNegativeInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0)
+    throw new Error(`${name} must be a non-negative integer`);
   return parsed;
 }
 function timestampSlug(date) {


### PR DESCRIPTION
## Summary

- add deterministic zero-based sharding to the real-project tool matrix
- expose the exact fixture paths selected for hydration before a shard runs
- prove 11 shards cover all 131 projects exactly once with balanced 11/12-project sizes
- reject negative, zero, and out-of-range shard arguments

## Why

Running all 524 project/tool combinations in one job would make fixture hydration and failure attribution unnecessarily coarse. This adds the tested selection contract needed by the follow-up Actions matrix without changing CI yet.

## Validation

- `node --test tests/tooling/fixture-tool-matrix-report.test.ts tests/tooling/compiler-fixture-diff-report.test.ts` (11/11)
- `oxlint tools/fixtures/tool-matrix-report.mjs tests/tooling/fixture-tool-matrix-report.test.ts`
- `oxfmt --check tools/fixtures/tool-matrix-report.mjs tests/tooling/fixture-tool-matrix-report.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786893891&installation_id=136613492&pr_number=2997&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2997&signature=ebc7ccc20e1d548878f1757f31ddd4da6e4bfd8c60a5c51bbafe77f01df64f1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dividing fixture projects across multiple shards for parallel execution.
  * Added an option to list the fixture paths selected for a shard.
  * Reports now include shard selection details.
  * Added validation and help text for shard-related options.

* **Bug Fixes**
  * Ensured shard assignments are deterministic, complete, and balanced.
  * Prevented summary files from being created when only listing fixture paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->