### PR TITLE
ci(fixtures): run real-project tool matrix

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -1,0 +1,107 @@
+name: Real Project Matrix
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly full ecosystem sweep. Manual dispatches provide on-demand release evidence.
+    - cron: "37 5 * * 0"
+
+concurrency:
+  group: real-project-matrix-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  real-project-matrix:
+    name: real projects (${{ matrix.shard }}/11)
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    env:
+      FIXTURE_SHARD_COUNT: "11"
+      FIXTURE_SHARD_INDEX: ${{ matrix.shard }}
+      FIXTURE_REPORT_DIR: real-project-results/shard-${{ matrix.shard }}
+    steps:
+      - name: Checkout matrix commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Select and hydrate fixture shard
+        shell: bash
+        run: |
+          mapfile -t fixture_paths < <(
+            node tools/fixtures/tool-matrix-report.mjs \
+              --list-fixture-paths \
+              --shard-index "$FIXTURE_SHARD_INDEX" \
+              --shard-count "$FIXTURE_SHARD_COUNT"
+          )
+          if (( ${#fixture_paths[@]} == 0 )); then
+            echo "::error title=Empty fixture shard::shard $FIXTURE_SHARD_INDEX selected no projects"
+            exit 1
+          fi
+          git submodule update --init --recursive --depth 1 -- "${fixture_paths[@]}"
+
+      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: false
+
+      - uses: ./.github/actions/setup-moonbit
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Setup Wild linker
+        uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
+        with:
+          wild-version: "0.9.0"
+
+      - uses: ./.github/actions/setup-rust-sticky-cache
+        with:
+          key: real-project-matrix-${{ matrix.shard }}
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
+
+      - name: Install JavaScript dependencies
+        run: vp install --frozen-lockfile --prefer-offline
+
+      - name: Build Vize CLI
+        run: cargo build --profile ci -p vize
+
+      - name: Exercise real projects with every core tool
+        run: |
+          node tools/fixtures/tool-matrix-report.mjs \
+            --shard-index "$FIXTURE_SHARD_INDEX" \
+            --shard-count "$FIXTURE_SHARD_COUNT" \
+            --vize-bin target/ci/vize \
+            --timeout-ms 600000 \
+            --output-dir "$FIXTURE_REPORT_DIR"
+
+      - name: Publish shard summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          if [[ -f "$FIXTURE_REPORT_DIR/summary.md" ]]; then
+            cat "$FIXTURE_REPORT_DIR/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No fixture tool report was produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload shard report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: real-project-matrix-${{ matrix.shard }}
+          path: ${{ env.FIXTURE_REPORT_DIR }}
+          if-no-files-found: error
+          retention-days: 30

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parse } from "yaml";
+
+import { readRepoFile } from "./support/github-workflows.ts";
+
+type WorkflowStep = {
+  if?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+};
+
+type WorkflowJob = {
+  env?: Record<string, string>;
+  "runs-on"?: string;
+  steps?: WorkflowStep[];
+  strategy?: { "fail-fast"?: boolean; matrix?: { shard?: number[] } };
+  "timeout-minutes"?: number;
+};
+
+test("real-project workflow schedules every balanced fixture shard", () => {
+  const workflow = parse(readRepoFile(".github", "workflows", "real-project-matrix.yml")) as {
+    concurrency?: { "cancel-in-progress"?: boolean; group?: string };
+    jobs?: Record<string, WorkflowJob>;
+    on?: { schedule?: Array<{ cron?: string }>; workflow_dispatch?: unknown };
+    permissions?: Record<string, string>;
+  };
+  const job = workflow.jobs?.["real-project-matrix"];
+
+  assert.ok(job);
+  assert.deepEqual(workflow.permissions, { contents: "read" });
+  assert.equal(workflow.on?.schedule?.[0]?.cron, "37 5 * * 0");
+  assert.ok("workflow_dispatch" in (workflow.on ?? {}));
+  assert.deepEqual(workflow.concurrency, {
+    group: "real-project-matrix-${{ github.ref }}",
+    "cancel-in-progress": true,
+  });
+  assert.equal(job["runs-on"], "blacksmith-32vcpu-ubuntu-2404");
+  assert.equal(job["timeout-minutes"], 120);
+  assert.equal(job.strategy?.["fail-fast"], false);
+  assert.deepEqual(job.strategy?.matrix?.shard, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  assert.deepEqual(job.env, {
+    FIXTURE_SHARD_COUNT: "11",
+    FIXTURE_SHARD_INDEX: "${{ matrix.shard }}",
+    FIXTURE_REPORT_DIR: "real-project-results/shard-${{ matrix.shard }}",
+  });
+});
+
+test("real-project workflow hydrates only its shard and runs every core tool", () => {
+  const workflow = parse(readRepoFile(".github", "workflows", "real-project-matrix.yml")) as {
+    jobs?: Record<string, WorkflowJob>;
+  };
+  const steps = workflow.jobs?.["real-project-matrix"]?.steps ?? [];
+  const hydration = steps.find((step) => step.name === "Select and hydrate fixture shard");
+  const run = steps.find((step) => step.name === "Exercise real projects with every core tool");
+  const summary = steps.find((step) => step.name === "Publish shard summary");
+  const upload = steps.find((step) => step.name === "Upload shard report");
+
+  assert.match(hydration?.run ?? "", /--list-fixture-paths/);
+  assert.match(hydration?.run ?? "", /--shard-index "\$FIXTURE_SHARD_INDEX"/);
+  assert.match(hydration?.run ?? "", /--shard-count "\$FIXTURE_SHARD_COUNT"/);
+  assert.match(hydration?.run ?? "", /git submodule update --init --recursive --depth 1/);
+  assert.match(hydration?.run ?? "", /"\$\{fixture_paths\[@\]\}"/);
+  assert.match(run?.run ?? "", /tools\/fixtures\/tool-matrix-report\.mjs/);
+  assert.match(run?.run ?? "", /--vize-bin target\/ci\/vize/);
+  assert.match(run?.run ?? "", /--timeout-ms 600000/);
+  assert.match(run?.run ?? "", /--output-dir "\$FIXTURE_REPORT_DIR"/);
+  assert.equal(summary?.if, "${{ always() }}");
+  assert.match(summary?.run ?? "", /summary\.md/);
+  assert.equal(upload?.if, "${{ always() }}");
+  assert.match(upload?.uses ?? "", /^actions\/upload-artifact@[0-9a-f]{40}$/);
+  assert.deepEqual(upload?.with, {
+    name: "real-project-matrix-${{ matrix.shard }}",
+    path: "${{ env.FIXTURE_REPORT_DIR }}",
+    "if-no-files-found": "error",
+    "retention-days": 30,
+  });
+});


### PR DESCRIPTION
## Summary

- run the real-project Vize tool matrix weekly and on demand
- balance all 131 registered fixtures across 11 independent shards
- hydrate only each shard's fixture submodules, then exercise Compiler, TypeChecker, Linter, and Formatter
- retain per-project machine-readable reports and publish a shard summary even after failures

## Verification

- `node --test tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/fixture-tool-matrix-report.test.ts`
- `vp exec oxfmt --check .github/workflows/real-project-matrix.yml tests/tooling/real-project-matrix-workflow.test.ts`
- `vp exec oxlint --deny-warnings tests/tooling/real-project-matrix-workflow.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786894441&installation_id=136613492&pr_number=2998&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2998&signature=c8ec6144bbe997f076db17a0dd2604bb46d76cc53411eb7cb2b3e0ac49f0519b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated weekly and on-demand test sweep across 11 parallel shards.
  * Added per-shard result summaries and downloadable report artifacts retained for 30 days.
  * Added targeted fixture selection to improve coverage of real project scenarios.

* **Tests**
  * Added coverage verifying workflow scheduling, permissions, sharding, timeouts, fixture handling, summaries, and report uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->