### PR TITLE
fix(fixtures): avoid nested hydration failures

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -49,7 +49,9 @@ jobs:
             echo "::error title=Empty fixture shard::shard $FIXTURE_SHARD_INDEX selected no projects"
             exit 1
           fi
-          git submodule update --init --recursive --depth 1 -- "${fixture_paths[@]}"
+          mkdir -p "$FIXTURE_REPORT_DIR"
+          printf '%s\n' "${fixture_paths[@]}" > "$FIXTURE_REPORT_DIR/selected-fixtures.txt"
+          git submodule update --init --depth 1 -- "${fixture_paths[@]}"
 
       - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -61,7 +61,10 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(hydration?.run ?? "", /--list-fixture-paths/);
   assert.match(hydration?.run ?? "", /--shard-index "\$FIXTURE_SHARD_INDEX"/);
   assert.match(hydration?.run ?? "", /--shard-count "\$FIXTURE_SHARD_COUNT"/);
-  assert.match(hydration?.run ?? "", /git submodule update --init --recursive --depth 1/);
+  assert.match(hydration?.run ?? "", /mkdir -p "\$FIXTURE_REPORT_DIR"/);
+  assert.match(hydration?.run ?? "", /selected-fixtures\.txt/);
+  assert.match(hydration?.run ?? "", /git submodule update --init --depth 1/);
+  assert.doesNotMatch(hydration?.run ?? "", /--recursive/);
   assert.match(hydration?.run ?? "", /"\$\{fixture_paths\[@\]\}"/);
   assert.match(run?.run ?? "", /tools\/fixtures\/tool-matrix-report\.mjs/);
   assert.match(run?.run ?? "", /--vize-bin target\/ci\/vize/);


### PR DESCRIPTION
## Summary

- hydrate only the registered top-level fixture gitlinks
- avoid recursing into broken or historical nested submodule metadata owned by upstream projects
- persist the selected fixture list before hydration so failed shards still upload useful evidence

## Failure evidence

- Real Project Matrix run `29593007941`, shard `2/11`
- `element` contains a historical nested gitlink without a matching `.gitmodules` URL

## Verification

- `node --test tests/tooling/real-project-matrix-workflow.test.ts`
- `vp exec oxfmt --check .github/workflows/real-project-matrix.yml tests/tooling/real-project-matrix-workflow.test.ts`
- `vp exec oxlint --deny-warnings tests/tooling/real-project-matrix-workflow.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/2999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786894934&installation_id=136613492&pr_number=2999&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F2999&signature=1a53a324fe6274f1c90541bd39d990852657e18f8b8108d5984b59445de85019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fixture setup for automated project checks by using a shallow, non-recursive submodule update.
  * Ensured only the selected fixture shard is hydrated, reducing unnecessary setup work.

* **Tests**
  * Added validation for fixture report directory creation and selected fixture handling.
  * Updated checks to confirm recursive submodule initialization is not used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->