### PR TITLE
fix(cli): emit JSON for empty inputs

### DIFF
--- a/crates/vize/src/commands/inspector.rs
+++ b/crates/vize/src/commands/inspector.rs
@@ -24,6 +24,7 @@ use vize_carton::{String, ToCompactString};
 use vize_curator::inspector as curator_inspector;
 
 mod compare_error;
+mod no_inputs;
 
 #[derive(Debug, Clone, Copy, ValueEnum, Default, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -147,8 +148,7 @@ pub struct InspectorArgs {
 pub fn run(args: InspectorArgs) {
     let files = collect_files(&args.patterns, args.max_files);
     if files.is_empty() {
-        eprintln!("No .vue files found matching the patterns");
-        std::process::exit(1);
+        no_inputs::handle(args.format);
     }
 
     let source_files = collect_source_files(&files);

--- a/crates/vize/src/commands/inspector/no_inputs.rs
+++ b/crates/vize/src/commands/inspector/no_inputs.rs
@@ -1,0 +1,8 @@
+use super::InspectorOutputFormat;
+
+pub(super) fn handle(format: InspectorOutputFormat) {
+    eprintln!("No .vue files found matching the patterns");
+    if !matches!(format, InspectorOutputFormat::Json) {
+        std::process::exit(1);
+    }
+}

--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -86,7 +86,7 @@ pub fn run(args: LintArgs) {
     let collect_time = collect_start.elapsed();
 
     if files.is_empty() {
-        eprintln!("{}", patterns::no_lint_files_message(&args.patterns));
+        patterns::write_no_files(format, &args.patterns);
         return;
     }
     let help_level = match args.help_level.as_str() {

--- a/crates/vize/src/commands/lint/patterns.rs
+++ b/crates/vize/src/commands/lint/patterns.rs
@@ -23,6 +23,13 @@ pub(super) fn no_lint_files_message(patterns: &[vize_carton::String]) -> vize_ca
     vize_carton::cstr!("No {LINT_EXTENSIONS_DISPLAY} files found matching patterns: {patterns:?}")
 }
 
+pub(super) fn write_no_files(format: vize_patina::OutputFormat, patterns: &[vize_carton::String]) {
+    eprintln!("{}", no_lint_files_message(patterns));
+    if format == vize_patina::OutputFormat::Json {
+        super::stdout::write(vize_patina::format_results(&[], &[], format).as_bytes());
+    }
+}
+
 #[inline]
 pub(super) fn is_lint_extension(extension: &str) -> bool {
     LINT_EXTENSIONS.contains(&extension)

--- a/crates/vize/tests/inspector_empty_json_cli.rs
+++ b/crates/vize/tests/inspector_empty_json_cli.rs
@@ -1,0 +1,24 @@
+use std::process::Command;
+
+#[test]
+fn inspector_json_emits_an_empty_payload_when_patterns_match_no_files() {
+    let project = tempfile::tempdir().unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args(["inspector", "**/*.vue", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(stderr, "No .vue files found matching the patterns\n");
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["selectedFile"], serde_json::Value::Null);
+    assert_eq!(json["files"], serde_json::json!([]));
+}

--- a/crates/vize/tests/lint_supported_targets_cli.rs
+++ b/crates/vize/tests/lint_supported_targets_cli.rs
@@ -47,3 +47,28 @@ fn lint_reports_all_supported_extensions_when_patterns_match_no_files() {
 
     let _ = fs::remove_dir_all(project_root);
 }
+
+#[test]
+fn lint_json_emits_an_empty_array_when_patterns_match_no_files() {
+    let project_root = temp_project_dir("json-no-matching-files");
+    fs::create_dir_all(&project_root).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["lint", "--no-config", "**/*.vue", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_details(&output));
+    let stdout: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(stdout, serde_json::json!([]));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "No .vue, .html, .htm, .js, .mjs, .cjs, .ts, .mts, .cts, .jsx, or .tsx files found"
+        ),
+        "{stderr}"
+    );
+
+    let _ = fs::remove_dir_all(project_root);
+}


### PR DESCRIPTION
## Summary

- make `inspector --format json` emit a valid empty compiler payload when no Vue files match
- make `lint --format json` emit an empty JSON array under the same condition
- preserve the human-readable no-input message on stderr
- add CLI tests that parse and assert the exact empty machine-readable shapes

## Real-project evidence

- run `29593007941` found invalid empty stdout for Compiler and Linter on `docsify` and `vue-native-core`
- both pinned projects intentionally contain no `.vue` files at their registered revisions

## Verification

- `cargo fmt --check`
- `cargo test -p vize --test inspector_cli --test lint_supported_targets_cli`
- direct Compiler and Linter JSON invocations inside the pinned `docsify` fixture

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786895380&installation_id=136613492&pr_number=3000&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F3000&signature=eefae970eb51f13db4071ee778965d6e3feecda5defb339d7cb9b6351b920945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON output now remains valid when lint or inspector patterns match no files.
  * Lint commands return an empty JSON array instead of failing.
  * Inspector JSON output reports no selected file and an empty file list while preserving the diagnostic message.

* **Tests**
  * Added coverage for empty-input behavior in lint and inspector commands, including exit status, diagnostics, and JSON payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->