### PR TITLE
fix(lsp): resolve package import definitions

### DIFF
--- a/crates/vize_maestro/src/ide/definition.rs
+++ b/crates/vize_maestro/src/ide/definition.rs
@@ -1,6 +1,4 @@
-//! Definition provider for Vue SFC files.
-//!
-//! Provides go-to-definition for template bindings, components, imports, and Corsa.
+//! Go-to-definition for Vue SFC template bindings, components, imports, and Corsa.
 pub mod bindings;
 #[cfg(all(test, feature = "native"))]
 mod corsa_tests;
@@ -9,6 +7,7 @@ mod html;
 #[cfg(all(test, feature = "native"))]
 mod html_tests;
 mod inline_art;
+mod module_specifier;
 pub(crate) mod script;
 mod service;
 mod template;

--- a/crates/vize_maestro/src/ide/definition/module_specifier.rs
+++ b/crates/vize_maestro/src/ide/definition/module_specifier.rs
@@ -1,0 +1,249 @@
+//! Go-to-definition for import and export module specifiers.
+
+use std::{
+    fs,
+    path::{Component, Path, PathBuf},
+};
+
+use serde_json::Value;
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Position, Range, Url};
+use vize_carton::cstr;
+
+use super::IdeContext;
+
+#[cfg(test)]
+#[path = "module_specifier_tests.rs"]
+mod tests;
+
+pub(super) fn definition(ctx: &IdeContext<'_>) -> Option<GotoDefinitionResponse> {
+    let specifier = specifier_at_offset(&ctx.content, ctx.offset)?;
+    let target = resolve_specifier(ctx.uri, specifier)?;
+    let uri = Url::from_file_path(target).ok()?;
+    let origin = Position::new(0, 0);
+
+    Some(GotoDefinitionResponse::Scalar(Location {
+        uri,
+        range: Range::new(origin, origin),
+    }))
+}
+
+pub(super) fn specifier_at_offset(content: &str, offset: usize) -> Option<&str> {
+    if offset > content.len() || !content.is_char_boundary(offset) {
+        return None;
+    }
+
+    let line_start = content[..offset].rfind('\n').map_or(0, |index| index + 1);
+    let line_end = content[offset..]
+        .find('\n')
+        .map_or(content.len(), |index| offset + index);
+    let line = &content[line_start..line_end];
+    let relative_offset = offset - line_start;
+    let bytes = line.as_bytes();
+    let mut cursor = 0;
+
+    while cursor < bytes.len() {
+        let quote = bytes[cursor];
+        if quote != b'\'' && quote != b'"' {
+            cursor += 1;
+            continue;
+        }
+
+        let start = cursor;
+        cursor += 1;
+        while cursor < bytes.len() {
+            if bytes[cursor] == b'\\' {
+                cursor = (cursor + 2).min(bytes.len());
+                continue;
+            }
+            if bytes[cursor] == quote {
+                let end = cursor;
+                if relative_offset > start
+                    && relative_offset <= end
+                    && is_module_context(&line[..start])
+                {
+                    return Some(&line[start + 1..end]);
+                }
+                cursor += 1;
+                break;
+            }
+            cursor += 1;
+        }
+    }
+
+    None
+}
+
+fn is_module_context(prefix: &str) -> bool {
+    let prefix = prefix.trim_end();
+    prefix == "import"
+        || prefix.ends_with(" from")
+        || prefix.ends_with("import(")
+        || prefix.ends_with("require(")
+}
+
+pub(super) fn resolve_specifier(current_uri: &Url, specifier: &str) -> Option<PathBuf> {
+    let current_file = current_uri.to_file_path().ok()?;
+    let current_dir = current_file.parent()?;
+
+    if specifier.starts_with("./") || specifier.starts_with("../") {
+        return resolve_file_candidate(&current_dir.join(specifier));
+    }
+    if specifier.starts_with('/') || specifier.starts_with('#') {
+        return None;
+    }
+
+    let (package_name, subpath) = split_package_specifier(specifier)?;
+    let mut ancestor = Some(current_dir);
+    while let Some(dir) = ancestor {
+        let package_root = dir.join("node_modules").join(package_name);
+        if package_root.join("package.json").is_file() {
+            return resolve_package_entry(&package_root, subpath);
+        }
+        ancestor = dir.parent();
+    }
+    None
+}
+
+fn split_package_specifier(specifier: &str) -> Option<(&str, &str)> {
+    if specifier.is_empty() {
+        return None;
+    }
+    if specifier.starts_with('@') {
+        let scope_end = specifier.find('/')?;
+        let package_end = specifier[scope_end + 1..]
+            .find('/')
+            .map_or(specifier.len(), |index| scope_end + 1 + index);
+        if package_end == scope_end + 1 {
+            return None;
+        }
+        return Some((
+            &specifier[..package_end],
+            specifier[package_end..].trim_start_matches('/'),
+        ));
+    }
+
+    let package_end = specifier.find('/').unwrap_or(specifier.len());
+    Some((
+        &specifier[..package_end],
+        specifier[package_end..].trim_start_matches('/'),
+    ))
+}
+
+fn resolve_package_entry(package_root: &Path, subpath: &str) -> Option<PathBuf> {
+    let manifest = fs::read_to_string(package_root.join("package.json")).ok()?;
+    let manifest: Value = serde_json::from_str(&manifest).ok()?;
+
+    if let Some(exports) = manifest.get("exports") {
+        let export_key = if subpath.is_empty() {
+            cstr!(".")
+        } else {
+            cstr!("./{subpath}")
+        };
+        let target = select_export(exports, &export_key)?;
+        return resolve_package_target(package_root, &target);
+    }
+
+    if !subpath.is_empty() {
+        return resolve_package_target(package_root, subpath);
+    }
+
+    for field in ["types", "typings", "module", "main"] {
+        if let Some(target) = manifest.get(field).and_then(Value::as_str)
+            && let Some(path) = resolve_package_target(package_root, target)
+        {
+            return Some(path);
+        }
+    }
+    resolve_file_candidate(&package_root.join("index"))
+}
+
+fn select_export(exports: &Value, key: &str) -> Option<String> {
+    if let Some(object) = exports.as_object() {
+        if let Some(value) = object.get(key) {
+            return select_conditional_target(value, None);
+        }
+        for (pattern, value) in object {
+            let Some((prefix, suffix)) = pattern.split_once('*') else {
+                continue;
+            };
+            if let Some(replacement) = key
+                .strip_prefix(prefix)
+                .and_then(|key| key.strip_suffix(suffix))
+            {
+                return select_conditional_target(value, Some(replacement));
+            }
+        }
+        if key == "." && !object.keys().any(|key| key.starts_with('.')) {
+            return select_conditional_target(exports, None);
+        }
+        return None;
+    }
+    (key == ".").then(|| select_conditional_target(exports, None))?
+}
+
+fn select_conditional_target(value: &Value, replacement: Option<&str>) -> Option<String> {
+    if let Some(target) = value.as_str() {
+        return Some(match replacement {
+            Some(replacement) => target.replace('*', replacement),
+            None => target.to_string(),
+        });
+    }
+    if let Some(array) = value.as_array() {
+        return array
+            .iter()
+            .find_map(|value| select_conditional_target(value, replacement));
+    }
+    let object = value.as_object()?;
+    for condition in ["types", "typings", "import", "default", "node", "require"] {
+        if let Some(value) = object.get(condition)
+            && let Some(target) = select_conditional_target(value, replacement)
+        {
+            return Some(target);
+        }
+    }
+    object
+        .values()
+        .find_map(|value| select_conditional_target(value, replacement))
+}
+
+fn resolve_package_target(package_root: &Path, target: &str) -> Option<PathBuf> {
+    let relative = target.strip_prefix("./").unwrap_or(target);
+    let relative_path = Path::new(relative);
+    if relative_path.is_absolute()
+        || relative_path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir | Component::RootDir))
+    {
+        return None;
+    }
+    resolve_file_candidate(&package_root.join(relative_path))
+}
+
+fn resolve_file_candidate(candidate: &Path) -> Option<PathBuf> {
+    if candidate.is_file() {
+        return candidate.canonicalize().ok();
+    }
+    for extension in [
+        "vue", "d.ts", "d.mts", "d.cts", "ts", "tsx", "mts", "cts", "js", "mjs", "cjs",
+    ] {
+        let with_extension = candidate.with_extension(extension);
+        if with_extension.is_file() {
+            return with_extension.canonicalize().ok();
+        }
+    }
+    if candidate.is_dir() {
+        for basename in [
+            "index.d.ts",
+            "index.d.mts",
+            "index.d.cts",
+            "index.ts",
+            "index.js",
+        ] {
+            let index = candidate.join(basename);
+            if index.is_file() {
+                return index.canonicalize().ok();
+            }
+        }
+    }
+    None
+}

--- a/crates/vize_maestro/src/ide/definition/module_specifier_tests.rs
+++ b/crates/vize_maestro/src/ide/definition/module_specifier_tests.rs
@@ -1,0 +1,155 @@
+use std::{fs, path::Path};
+
+use tempfile::tempdir;
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Url};
+
+use super::{resolve_specifier, specifier_at_offset};
+use crate::{
+    ide::{DefinitionService, IdeContext},
+    server::ServerState,
+};
+
+#[test]
+fn finds_only_module_specifier_strings_at_the_cursor() {
+    for (source, marker, expected) in [
+        ("import { ref } from 'vue'", "vue", "vue"),
+        ("import 'theme.css'", "theme", "theme.css"),
+        ("export * from \"pkg/subpath\"", "subpath", "pkg/subpath"),
+        ("const lazy = import('./lazy')", "lazy')", "./lazy"),
+        ("const value = require('@scope/pkg')", "scope", "@scope/pkg"),
+    ] {
+        let offset = source.find(marker).expect("marker");
+        assert_eq!(
+            specifier_at_offset(source, offset),
+            Some(expected),
+            "{source}"
+        );
+    }
+
+    let source = "const ordinary = 'vue'";
+    assert_eq!(
+        specifier_at_offset(source, source.find("vue").unwrap()),
+        None
+    );
+}
+
+#[test]
+fn resolves_hoisted_package_types_export() {
+    let workspace = tempdir().unwrap();
+    let source = workspace.path().join("packages/app/src/App.vue");
+    write(&source, "<script setup lang=\"ts\"></script>");
+    let package = workspace.path().join("node_modules/vue-router");
+    write(
+        &package.join("package.json"),
+        r#"{"exports":{".":{"import":"./dist/index.js","types":"./dist/index.d.ts"}}}"#,
+    );
+    write(&package.join("dist/index.js"), "export {};");
+    write(
+        &package.join("dist/index.d.ts"),
+        "export interface Route {}\n",
+    );
+
+    let resolved = resolve_specifier(&file_url(&source), "vue-router").unwrap();
+    assert_eq!(
+        resolved,
+        package.join("dist/index.d.ts").canonicalize().unwrap()
+    );
+}
+
+#[test]
+fn definition_service_navigates_module_specifier_to_types_export() {
+    let workspace = tempdir().unwrap();
+    let source = workspace.path().join("src/App.vue");
+    let content =
+        "<script setup lang=\"ts\">\nimport type { Route } from 'vue-router'\n</script>\n";
+    write(&source, content);
+    let package = workspace.path().join("node_modules/vue-router");
+    write(
+        &package.join("package.json"),
+        r#"{"exports":{".":{"types":"./dist/index.d.ts"}}}"#,
+    );
+    let declaration = package.join("dist/index.d.ts");
+    write(&declaration, "export interface Route {}\n");
+
+    let uri = file_url(&source);
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), content.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, content);
+    let offset = content.find("vue-router").unwrap() + 1;
+    let context = IdeContext::new(&state, &uri, offset).unwrap();
+
+    let definition = DefinitionService::definition(&context).unwrap();
+    let GotoDefinitionResponse::Scalar(location) = definition else {
+        panic!("module specifier definition must be a scalar location");
+    };
+    assert_eq!(location.uri, file_url(&declaration.canonicalize().unwrap()));
+}
+
+#[test]
+fn resolves_scoped_wildcard_declaration_subpath() {
+    let workspace = tempdir().unwrap();
+    let source = workspace.path().join("src/App.vue");
+    write(&source, "<script setup lang=\"ts\"></script>");
+    let package = workspace.path().join("node_modules/@scope/router");
+    write(
+        &package.join("package.json"),
+        r#"{"exports":{"./feature/*":{"types":"./types/*.d.mts"}}}"#,
+    );
+    write(
+        &package.join("types/navigation.d.mts"),
+        "export type Target = string;\n",
+    );
+
+    let resolved =
+        resolve_specifier(&file_url(&source), "@scope/router/feature/navigation").unwrap();
+    assert_eq!(
+        resolved,
+        package
+            .join("types/navigation.d.mts")
+            .canonicalize()
+            .unwrap()
+    );
+}
+
+#[test]
+fn resolves_relative_declarations_and_rejects_package_escape() {
+    let workspace = tempdir().unwrap();
+    let source = workspace.path().join("src/App.vue");
+    write(&source, "<script setup lang=\"ts\"></script>");
+    write(
+        &workspace.path().join("src/model.d.cts"),
+        "export type Model = {};\n",
+    );
+    let package = workspace.path().join("node_modules/unsafe");
+    write(
+        &package.join("package.json"),
+        r#"{"exports":{".":{"types":"../outside.d.ts"}}}"#,
+    );
+    write(
+        &workspace.path().join("node_modules/outside.d.ts"),
+        "export {};\n",
+    );
+
+    assert_eq!(
+        resolve_specifier(&file_url(&source), "./model"),
+        Some(
+            workspace
+                .path()
+                .join("src/model.d.cts")
+                .canonicalize()
+                .unwrap()
+        ),
+    );
+    assert_eq!(resolve_specifier(&file_url(&source), "unsafe"), None);
+}
+
+fn write(path: &Path, content: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+fn file_url(path: &Path) -> Url {
+    Url::from_file_path(path).unwrap()
+}

--- a/crates/vize_maestro/src/ide/definition/service.rs
+++ b/crates/vize_maestro/src/ide/definition/service.rs
@@ -16,7 +16,7 @@ use tower_lsp::lsp_types::GotoDefinitionResponse;
 #[cfg(feature = "native")]
 use vize_canon::CorsaBridge;
 
-use super::{IdeContext, helpers, script, template};
+use super::{IdeContext, helpers, module_specifier, script, template};
 #[cfg(feature = "native")]
 use crate::ide::corsa_support;
 use crate::ide::is_component_tag;
@@ -27,7 +27,9 @@ impl super::DefinitionService {
     pub fn definition(ctx: &IdeContext) -> Option<GotoDefinitionResponse> {
         match ctx.block_type? {
             BlockType::Template => Self::definition_in_template_sync(ctx),
-            BlockType::Script | BlockType::ScriptSetup => script::definition_in_script(ctx),
+            BlockType::Script | BlockType::ScriptSetup => {
+                module_specifier::definition(ctx).or_else(|| script::definition_in_script(ctx))
+            }
             BlockType::Style(_) => script::definition_in_style(ctx),
             BlockType::Art(ArtCursorPosition::VariantTemplate(_)) => {
                 Self::definition_in_template_sync(ctx)
@@ -194,6 +196,10 @@ impl super::DefinitionService {
         ctx: &IdeContext<'_>,
         corsa_bridge: Option<Arc<CorsaBridge>>,
     ) -> Option<GotoDefinitionResponse> {
+        if let Some(definition) = module_specifier::definition(ctx) {
+            return Some(definition);
+        }
+
         if let Some(definition) = script::definition_in_script(ctx) {
             let is_define_art_source =
                 crate::ide::musea::define_art_source_at_offset(&ctx.content, ctx.uri, ctx.offset)


### PR DESCRIPTION
## Summary

- resolve definition requests made on import/export module specifiers
- honor hoisted and scoped packages plus exact and wildcard `exports` entries
- prefer declaration conditions and support `.d.ts`, `.d.mts`, and `.d.cts` targets
- reject package targets that escape their package root

## Root cause

Corsa definition lookup could resolve imported bindings to their local alias, but returned no location for the module specifier itself. Maestro had no filesystem fallback for bare package specifiers, so package import-path navigation was empty even when typechecking resolved the package.

## Impact

Go to Definition on package import paths now opens the declaration selected by `exports.types`, including hoisted workspace dependencies and scoped subpaths.

Part of #2971.

## Validation

- `cargo test -p vize_maestro --all-features` (525 unit, 3 integration, 1 doc passed; 1 environment-dependent test ignored)
- `cargo test -p vize_maestro module_specifier --all-features` (5 passed)
- `cargo clippy -p vize_maestro --lib --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- Vue Router real-world clean/broken/repaired patch oracle with package navigation (passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786898098&installation_id=136613492&pr_number=3001&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F3001&signature=556b265a5cce987469a169bf44c162a02a8961fa2829f34fe393cacf1462ee30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Go-to-definition now resolves module imports from relative paths and installed packages.
  * Supports package exports, type declarations, wildcard subpaths, directory indexes, and common JavaScript/TypeScript/Vue extensions.
  * Module definitions can be opened directly from script and Vue file imports.

* **Bug Fixes**
  * Prevents invalid absolute, hash-based, and workspace-escaping package paths from being resolved.

* **Tests**
  * Added coverage for relative imports, package types, wildcard exports, Vue files, and invalid paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->