### PR TITLE
test(typecheck): gate Pinia generic stores

### DIFF
--- a/.github/actions/check-vue-parity/action.yml
+++ b/.github/actions/check-vue-parity/action.yml
@@ -10,6 +10,7 @@ runs:
         git submodule update --init --depth 1 \
           tests/_fixtures/_git/create-vue \
           tests/_fixtures/_git/misskey \
+          tests/_fixtures/_git/pinia \
           tests/_fixtures/_git/vue-router
         vp install --frozen-lockfile --prefer-offline
 

--- a/tests/_helpers/realworld-typecheck.ts
+++ b/tests/_helpers/realworld-typecheck.ts
@@ -28,7 +28,18 @@ export function runVizeCheck(
   const [command, ...prefixArgs] = resolveVizeCommand();
   const result = runCommand(
     command,
-    [...prefixArgs, "check", ...patterns, "--format", "json", "--quiet", "--corsa-path", corsaPath],
+    [
+      ...prefixArgs,
+      "check",
+      ...patterns,
+      "--tsconfig",
+      "tsconfig.json",
+      "--format",
+      "json",
+      "--quiet",
+      "--corsa-path",
+      corsaPath,
+    ],
     workspaceDir,
   );
   return { ...result, report: JSON.parse(result.stdout) as CheckReport };

--- a/tests/package.json
+++ b/tests/package.json
@@ -16,7 +16,7 @@
     "test:readiness:lint": "node --test --test-concurrency=1 tooling/cli-lint-contract.test.ts",
     "test:readiness:build": "node --test --test-concurrency=1 snapshots/build/generic.ts snapshots/build/elk.ts",
     "test:readiness:dev": "VIZE_TEST_WORKTREE_ID=${VIZE_TEST_WORKTREE_ID:-ci-readiness} playwright test --config app/playwright.config.ts app/dev/misskey.spec.ts",
-    "test:check:fixtures": "node --test --test-concurrency=1 snapshots/check/typecheck-errors.ts snapshots/check/typecheck-vue-imports.ts snapshots/check/compiler-macros.ts snapshots/check/style-preprocessors.ts snapshots/check/ecosystem-products.ts snapshots/check/generic-build.ts snapshots/check/nuxt-parity.ts snapshots/check/toolchain-parity.ts snapshots/check/options-api.ts snapshots/check/class-component.ts snapshots/check/create-vue-patch-oracle.ts snapshots/check/vue-router-patch-oracle.ts snapshots/check/zz-intentional-errors-fixtures.ts",
+    "test:check:fixtures": "node --test --test-concurrency=1 snapshots/check/typecheck-errors.ts snapshots/check/typecheck-vue-imports.ts snapshots/check/compiler-macros.ts snapshots/check/style-preprocessors.ts snapshots/check/ecosystem-products.ts snapshots/check/generic-build.ts snapshots/check/nuxt-parity.ts snapshots/check/toolchain-parity.ts snapshots/check/options-api.ts snapshots/check/class-component.ts snapshots/check/create-vue-patch-oracle.ts snapshots/check/vue-router-patch-oracle.ts snapshots/check/pinia-generic-store-oracle.ts snapshots/check/zz-intentional-errors-fixtures.ts",
     "test:performance:lsp-incremental": "node --test --test-concurrency=1 performance/misskey-lsp-incremental.test.ts"
   },
   "devDependencies": {

--- a/tests/snapshots/check/pinia-generic-store-oracle.ts
+++ b/tests/snapshots/check/pinia-generic-store-oracle.ts
@@ -1,0 +1,280 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { symlinkDirectory, withPinnedFixtureWorkspace } from "../../_helpers/realworld-patch.ts";
+import {
+  type CommandResult,
+  resolveTsgoBinary,
+  resolveVueTscBinary,
+  runVizeCheck,
+  runVueTsc,
+  symlinkVueTypes,
+  type VizeCheckResult,
+} from "../../_helpers/realworld-typecheck.ts";
+import {
+  completionLabels,
+  isDiagnosticsForUri,
+  offsetToPosition,
+} from "../../tooling/support/lsp/assertions.ts";
+import type {
+  LspDiagnostic,
+  PublishDiagnosticsParams,
+} from "../../tooling/support/lsp/protocol.ts";
+import { LspSession } from "../../tooling/support/lsp/session.ts";
+
+const appPath = "packages/playground/src/views/CounterSetupStore.vue";
+const storePath = "packages/playground/src/stores/counterSetup.ts";
+const piniaTypesPath = "packages/pinia/src/types.ts";
+const cleanIncrement = `  function increment(amount = 1) {
+    if (typeof amount !== 'number') {
+      amount = 1
+    }
+    state.incrementedTimes++
+    state.n += amount
+  }`;
+const brokenIncrement = `  function increment(amount = '1') {
+    const numericAmount = Number(amount)
+    state.incrementedTimes++
+    state.n += numericAmount
+  }`;
+
+test("Pinia generic stores stay exact across dependency edits", async () => {
+  const corsaPath = resolveTsgoBinary();
+  const vueTscPath = resolveVueTscBinary();
+
+  await withPinnedFixtureWorkspace(
+    {
+      fixtureId: "pinia",
+      includePaths: [appPath, storePath, piniaTypesPath, "packages/playground/src/vite-env.d.ts"],
+    },
+    async (fixture) => {
+      symlinkVueTypes(fixture.workspaceDir);
+      fixture.write("packages/pinia/src/rootStore.d.ts", "export interface Pinia {}\n");
+      fixture.write("packages/pinia/src/index.d.ts", piniaDeclaration);
+      fixture.write(
+        "packages/pinia/package.json",
+        `${JSON.stringify({ name: "pinia", type: "module", types: "./src/index.d.ts" }, null, 2)}\n`,
+      );
+      symlinkDirectory(fixture.resolve("packages/pinia"), fixture.resolve("node_modules/pinia"));
+      fixture.write("tsconfig.json", `${JSON.stringify(tsconfig, null, 2)}\n`);
+      fixture.write(
+        "vize.config.json",
+        `${JSON.stringify(
+          {
+            lsp: { completion: true, editor: true, hover: true, lint: false, typecheck: true },
+            typeChecker: { corsaPath },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      const cleanSource = fixture.applyExactPatch(
+        appPath,
+        `    <button @click="counter.increment(10)">+10</button>`,
+        `    <button @click="counter.increment()">+10</button>`,
+      );
+      const storeSource = fixture.read(storePath);
+      const appFile = fixture.resolve(appPath);
+      const storeFile = fixture.resolve(storePath);
+      const appUri = pathToFileURL(appFile).href;
+      const storeUri = pathToFileURL(storeFile).href;
+
+      assertCleanParity(
+        runVizeCheck(fixture.workspaceDir, corsaPath, [appPath]),
+        runVueTsc(fixture.workspaceDir, vueTscPath),
+      );
+
+      const session = new LspSession();
+      try {
+        await session.initialize(fixture.workspaceDir, {
+          completion: true,
+          editor: true,
+          hover: true,
+          lint: false,
+          typecheck: true,
+        });
+        session.notify("textDocument/didOpen", {
+          textDocument: {
+            uri: storeUri,
+            languageId: "typescript",
+            version: 1,
+            text: storeSource,
+          },
+        });
+        session.notify("textDocument/didOpen", {
+          textDocument: { uri: appUri, languageId: "vue", version: 1, text: cleanSource },
+        });
+        const cleanPublish = await waitForAppDiagnostics(session, appUri, false);
+        assert.deepEqual(cleanPublish.diagnostics, [], JSON.stringify(cleanPublish.diagnostics));
+
+        const memberOffset = cleanSource.indexOf("counter.n") + "coun".length;
+        const completion = await session.request("textDocument/completion", {
+          textDocument: { uri: appUri },
+          position: offsetToPosition(cleanSource, memberOffset),
+        });
+        const labels = completionLabels(completion);
+        for (const label of ["counter", "n", "useCounter"]) {
+          assert.ok(labels.includes(label), `${label}: ${labels.join(", ")}`);
+        }
+        assert.ok(!labels.includes("v-if"), labels.join(", "));
+
+        const brokenStore = fixture.applyExactPatch(storePath, cleanIncrement, brokenIncrement);
+        session.notify("textDocument/didChange", {
+          textDocument: { uri: storeUri, version: 2 },
+          contentChanges: [{ text: brokenStore }],
+        });
+        const brokenPublish = await waitForAppDiagnostics(session, appUri, true);
+        assertSingleMismatch(brokenPublish.diagnostics, cleanSource);
+        assertBrokenParity(
+          runVizeCheck(fixture.workspaceDir, corsaPath, [appPath]),
+          runVueTsc(fixture.workspaceDir, vueTscPath),
+        );
+
+        const repairedStore = fixture.applyExactPatch(storePath, brokenIncrement, cleanIncrement);
+        session.notify("textDocument/didChange", {
+          textDocument: { uri: storeUri, version: 3 },
+          contentChanges: [{ text: repairedStore }],
+        });
+        const repairedPublish = await waitForAppDiagnostics(session, appUri, false);
+        assert.deepEqual(
+          repairedPublish.diagnostics,
+          [],
+          JSON.stringify(repairedPublish.diagnostics),
+        );
+        assertCleanParity(
+          runVizeCheck(fixture.workspaceDir, corsaPath, [appPath]),
+          runVueTsc(fixture.workspaceDir, vueTscPath),
+        );
+      } finally {
+        await session.shutdown();
+      }
+    },
+  );
+});
+
+function assertCleanParity(vize: VizeCheckResult, vueTsc: CommandResult): void {
+  assert.equal(vueTsc.status, 0, vueTsc.stderr || vueTsc.stdout);
+  assert.doesNotMatch(`${vueTsc.stdout}\n${vueTsc.stderr}`, /error TS\d+:/);
+  assert.equal(vize.status, 0, vize.stderr || vize.stdout);
+  assert.deepEqual(
+    {
+      errorCount: vize.report.errorCount,
+      fileCount: vize.report.fileCount,
+      files: vize.report.files,
+      warningCount: vize.report.warningCount,
+    },
+    { errorCount: 0, fileCount: 1, files: [{ diagnostics: [], file: appPath }], warningCount: 0 },
+  );
+}
+
+function assertBrokenParity(vize: VizeCheckResult, vueTsc: CommandResult): void {
+  assert.equal(vize.status, 1, vize.stderr || vize.stdout);
+  assert.equal(vize.report.fileCount, 1, JSON.stringify(vize.report));
+  assert.equal(vize.report.errorCount, 1, JSON.stringify(vize.report));
+  assert.equal(vize.report.warningCount, 0, JSON.stringify(vize.report));
+  assert.equal(vize.report.files.length, 1, JSON.stringify(vize.report));
+  assert.equal(vize.report.files[0]?.file, appPath, JSON.stringify(vize.report));
+  assert.match(
+    vize.report.files[0]?.diagnostics.join("\n") ?? "",
+    /TS2345.*number.*not assignable.*string/i,
+  );
+  assert.equal(vueTsc.status, 2, vueTsc.stderr || vueTsc.stdout);
+  const output = `${vueTsc.stdout}\n${vueTsc.stderr}`;
+  assert.equal([...output.matchAll(/error TS2345:/g)].length, 1, output);
+  assert.doesNotMatch(output, /error TS(?!2345)\d+:/, output);
+}
+
+async function waitForAppDiagnostics(
+  session: LspSession,
+  uri: string,
+  expectMismatch: boolean,
+): Promise<PublishDiagnosticsParams> {
+  return (await session.waitForNotification(
+    "textDocument/publishDiagnostics",
+    (params) =>
+      isDiagnosticsForUri(params, uri) &&
+      params.version === 1 &&
+      hasMismatch(params.diagnostics) === expectMismatch,
+    120_000,
+  )) as PublishDiagnosticsParams;
+}
+
+function hasMismatch(diagnostics: LspDiagnostic[]): boolean {
+  return diagnostics.some(
+    (diagnostic) =>
+      String(diagnostic.code).replace(/^TS/, "") === "2345" &&
+      /number.*not assignable.*string/i.test(diagnostic.message ?? ""),
+  );
+}
+
+function assertSingleMismatch(diagnostics: LspDiagnostic[], source: string): void {
+  assert.equal(diagnostics.length, 1, JSON.stringify(diagnostics));
+  const [diagnostic] = diagnostics;
+  assert.ok(hasMismatch([diagnostic]), JSON.stringify(diagnostic));
+  assert.equal(diagnostic.source, "vize/types");
+  assert.equal(diagnostic.severity, 1);
+  const start = offsetToPosition(source, source.indexOf("counter.increment(100)") + 18);
+  assert.deepEqual(diagnostic.range, {
+    start,
+    end: { line: start.line, character: start.character + 3 },
+  });
+}
+
+const tsconfig = {
+  compilerOptions: {
+    lib: ["ES2022", "DOM", "DOM.Iterable"],
+    module: "ESNext",
+    moduleResolution: "bundler",
+    noEmit: true,
+    paths: { pinia: ["./packages/pinia/src/index.d.ts"] },
+    skipLibCheck: true,
+    strict: true,
+    target: "ES2022",
+    types: ["vite/client"],
+  },
+  include: [appPath, storePath, piniaTypesPath, "packages/**/*.d.ts"],
+};
+
+const piniaDeclaration = `import type {
+  DefineSetupStoreOptions,
+  StoreDefinition,
+  _ExtractActionsFromSetupStore,
+  _ExtractGettersFromSetupStore,
+  _ExtractStateFromSetupStore,
+} from './types'
+
+export type * from './types'
+
+export interface SetupStoreHelpers {
+  action: <Fn extends (...args: any[]) => any>(fn: Fn, name?: string) => Fn
+}
+
+export interface SetupStoreDefinition<Id extends string, SS>
+  extends StoreDefinition<
+    Id,
+    _ExtractStateFromSetupStore<SS>,
+    _ExtractGettersFromSetupStore<SS>,
+    _ExtractActionsFromSetupStore<SS>
+  > {}
+
+export declare function defineStore<
+  Id extends string,
+  SS,
+>(
+  id: Id,
+  storeSetup: (helpers: SetupStoreHelpers) => SS,
+  options?: DefineSetupStoreOptions<
+    Id,
+    _ExtractStateFromSetupStore<SS>,
+    _ExtractGettersFromSetupStore<SS>,
+    _ExtractActionsFromSetupStore<SS>
+  >
+): SetupStoreDefinition<Id, SS>
+
+export declare function acceptHMRUpdate<T extends StoreDefinition>(
+  initialUseStore: T,
+  hot: unknown
+): (newModule: unknown) => void
+`;

--- a/tests/tooling/github-workflows-vue-parity.test.ts
+++ b/tests/tooling/github-workflows-vue-parity.test.ts
@@ -29,6 +29,7 @@ test("Vue parity structurally gates compiler fixtures and incremental LSP behavi
   );
   assert.match(hydration?.run ?? "", /tests\/_fixtures\/_git\/create-vue/);
   assert.match(hydration?.run ?? "", /tests\/_fixtures\/_git\/misskey/);
+  assert.match(hydration?.run ?? "", /tests\/_fixtures\/_git\/pinia/);
   assert.match(hydration?.run ?? "", /tests\/_fixtures\/_git\/vue-router/);
   assert.match(hydration?.run ?? "", /vp install --frozen-lockfile --prefer-offline/);
   assert.equal(

--- a/tests/tooling/snapshot-baselines.test.ts
+++ b/tests/tooling/snapshot-baselines.test.ts
@@ -24,6 +24,8 @@ const assertionOnlyCheckTests = {
   "class-component": "class-component vue-tsc parity has known upstream-noisy diagnostics",
   "create-vue-patch-oracle":
     "patch oracle asserts exact live CLI and LSP behavior across document versions",
+  "pinia-generic-store-oracle":
+    "library patch oracle asserts generic store inference and dependency refresh behavior",
   "vue-router-patch-oracle":
     "library patch oracle asserts exact package-resolution behavior across document versions",
   directus: "real-world smoke lane is too large for a deterministic complete baseline",


### PR DESCRIPTION
## Summary
- add a pinned Pinia generic-store oracle across Vize check, vue-tsc, and LSP dependency refreshes
- require the clean, broken, and repaired states to produce exactly 0, 1 TS2345, and 0 diagnostics
- hydrate the Pinia fixture in the Vue parity action and keep patch checks rooted at their explicit tsconfig

Part of #2971.

## Testing
- `node --test --test-concurrency=1 tooling/github-workflows-vue-parity.test.ts tooling/snapshot-baselines.test.ts snapshots/check/create-vue-patch-oracle.ts snapshots/check/vue-router-patch-oracle.ts snapshots/check/pinia-generic-store-oracle.ts`
- `vp run --filter ./tests test:check:fixtures` (33 passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for checking a Pinia-based Vue fixture.
  * Added a snapshot baseline declaration for the new fixture test.
  * Updated workflow validation to ensure the Pinia fixture is hydrated and installed during parity checks.

* **Chores**
  * Improved readability of test command configuration without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->