### PR TITLE
fix(lsp): harden package import resolution

### DIFF
--- a/crates/vize_maestro/src/server/importers.rs
+++ b/crates/vize_maestro/src/server/importers.rs
@@ -144,7 +144,11 @@ fn resolve_import(importer_dir: &Path, specifier: &str) -> Option<PathBuf> {
     let specifier = specifier
         .split_once(['?', '#'])
         .map_or(specifier, |(path, _)| path);
-    if specifier.starts_with("./") || specifier.starts_with("../") {
+    if specifier == "."
+        || specifier == ".."
+        || specifier.starts_with("./")
+        || specifier.starts_with("../")
+    {
         return resolve_relative_import(importer_dir, specifier);
     }
 
@@ -282,5 +286,37 @@ void plugin
             vec![parent_uri.clone()]
         );
         assert_eq!(open_vue_importers(&state, &common_uri), vec![parent_uri]);
+    }
+
+    #[test]
+    fn index_resolves_current_and_parent_directory_specifiers() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        let current_index = nested.join("index.ts");
+        let parent_index = dir.path().join("index.ts");
+        std::fs::write(&current_index, "export const current = 1").unwrap();
+        std::fs::write(&parent_index, "export const parent = 1").unwrap();
+        let parent_vue = nested.join("Parent.vue");
+        std::fs::write(&parent_vue, "<template />").unwrap();
+        let parent_uri = Url::from_file_path(&parent_vue).unwrap();
+        let current_uri = Url::from_file_path(&current_index).unwrap();
+        let parent_index_uri = Url::from_file_path(&parent_index).unwrap();
+        let state = ServerState::new();
+        let source = r#"<script setup lang="ts">
+import { current } from '.'
+import { parent } from '..'
+</script>"#;
+
+        state.update_virtual_docs(&parent_uri, source);
+
+        assert_eq!(
+            open_vue_importers(&state, &current_uri),
+            vec![parent_uri.clone()]
+        );
+        assert_eq!(
+            open_vue_importers(&state, &parent_index_uri),
+            vec![parent_uri]
+        );
     }
 }

--- a/crates/vize_maestro/src/server/importers/package.rs
+++ b/crates/vize_maestro/src/server/importers/package.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use serde_json::Value;
 use vize_carton::{CompactString, cstr};
@@ -22,11 +22,11 @@ pub(super) fn resolve_package_import(importer_dir: &Path, specifier: &str) -> Op
         .as_ref()
         .is_some_and(|manifest| manifest.get("exports").is_some());
 
-    if let Some(target) = manifest
-        .as_ref()
-        .and_then(|manifest| package_export_target(manifest, subpath))
-        .and_then(|target| resolve_package_target(&package_root, target.as_str()))
-    {
+    if let Some(target) = manifest.as_ref().and_then(|manifest| {
+        package_export_target(manifest, subpath)
+            .iter()
+            .find_map(|target| resolve_package_target(&package_root, target.as_str()))
+    }) {
         return Some(comparable_path(&target));
     }
 
@@ -79,11 +79,18 @@ fn split_package_specifier(specifier: &str) -> Option<(&str, Option<&str>)> {
     Some((first, subpath))
 }
 
-fn package_export_target(manifest: &Value, subpath: Option<&str>) -> Option<CompactString> {
-    let exports = manifest.get("exports")?;
+fn package_export_target(manifest: &Value, subpath: Option<&str>) -> Vec<CompactString> {
+    let Some(exports) = manifest.get("exports") else {
+        return Vec::new();
+    };
     let key = subpath.map_or_else(|| cstr!("."), |subpath| cstr!("./{subpath}"));
     match exports.get(key.as_str()) {
-        Some(entry) => return conditional_export_target(entry).map(CompactString::from),
+        Some(entry) => {
+            return conditional_export_targets(entry)
+                .into_iter()
+                .map(CompactString::from)
+                .collect();
+        }
         None if subpath.is_none()
             && exports.as_object().is_none_or(|conditions| {
                 conditions
@@ -91,13 +98,18 @@ fn package_export_target(manifest: &Value, subpath: Option<&str>) -> Option<Comp
                     .all(|condition| !condition.starts_with('.'))
             }) =>
         {
-            return conditional_export_target(exports).map(CompactString::from);
+            return conditional_export_targets(exports)
+                .into_iter()
+                .map(CompactString::from)
+                .collect();
         }
         None => {}
     }
 
-    exports
-        .as_object()?
+    let Some(conditions) = exports.as_object() else {
+        return Vec::new();
+    };
+    conditions
         .iter()
         .filter_map(|(pattern, entry)| {
             let capture = export_pattern_capture(pattern, key.as_str())?;
@@ -105,10 +117,13 @@ fn package_export_target(manifest: &Value, subpath: Option<&str>) -> Option<Comp
             Some((prefix_len, pattern.len(), entry, capture))
         })
         .max_by_key(|(prefix_len, pattern_len, _, _)| (*prefix_len, *pattern_len))
-        .and_then(|(_, _, entry, capture)| {
-            conditional_export_target(entry)
+        .map(|(_, _, entry, capture)| {
+            conditional_export_targets(entry)
+                .into_iter()
                 .map(|target| CompactString::from(target.replace('*', capture)))
+                .collect::<Vec<_>>()
         })
+        .unwrap_or_default()
 }
 
 fn export_pattern_capture<'a>(pattern: &str, requested: &'a str) -> Option<&'a str> {
@@ -124,25 +139,44 @@ fn export_pattern_capture<'a>(pattern: &str, requested: &'a str) -> Option<&'a s
     requested.get(prefix.len()..requested.len() - suffix.len())
 }
 
-fn conditional_export_target(value: &Value) -> Option<&str> {
+fn conditional_export_targets(value: &Value) -> Vec<&str> {
     match value {
-        Value::String(target) => Some(target),
-        Value::Array(targets) => targets.iter().find_map(conditional_export_target),
+        Value::String(target) => vec![target.as_str()],
+        Value::Array(targets) => {
+            let mut collected = Vec::new();
+            for entry in targets {
+                collected.extend(conditional_export_targets(entry));
+            }
+            collected
+        }
         Value::Object(conditions) => ["types", "import", "require", "default"]
             .iter()
             .find_map(|condition| {
-                conditions
-                    .get(*condition)
-                    .and_then(conditional_export_target)
+                let targets = conditional_export_targets(conditions.get(*condition)?);
+                (!targets.is_empty()).then_some(targets)
             })
-            .or_else(|| conditions.values().find_map(conditional_export_target)),
-        _ => None,
+            .or_else(|| {
+                conditions
+                    .values()
+                    .map(conditional_export_targets)
+                    .find(|targets| !targets.is_empty())
+            })
+            .unwrap_or_default(),
+        _ => Vec::new(),
     }
 }
 
 fn resolve_package_target(package_root: &Path, target: &str) -> Option<PathBuf> {
-    let target = target.strip_prefix("./").unwrap_or(target);
-    resolve_package_candidate(package_root.join(target))
+    let relative = Path::new(target.strip_prefix("./").unwrap_or(target));
+    if relative.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
+        return None;
+    }
+    resolve_package_candidate(package_root.join(relative))
 }
 
 fn resolve_package_candidate(base: PathBuf) -> Option<PathBuf> {
@@ -221,14 +255,18 @@ mod tests {
             }
         });
         assert_eq!(
-            package_export_target(&manifest, None).as_deref(),
+            package_export_target(&manifest, None)
+                .first()
+                .map(|target| target.as_str()),
             Some("./dist/index.d.mts")
         );
         assert_eq!(
-            package_export_target(&manifest, Some("auto-routes")).as_deref(),
+            package_export_target(&manifest, Some("auto-routes"))
+                .first()
+                .map(|target| target.as_str()),
             Some("./routes.d.cts")
         );
-        assert_eq!(package_export_target(&manifest, Some("missing")), None);
+        assert!(package_export_target(&manifest, Some("missing")).is_empty());
 
         let conditional_root = serde_json::json!({
             "exports": {
@@ -237,14 +275,16 @@ mod tests {
             }
         });
         assert_eq!(
-            package_export_target(&conditional_root, None).as_deref(),
+            package_export_target(&conditional_root, None)
+                .first()
+                .map(|target| target.as_str()),
             Some("./index.d.ts")
         );
 
         let subpaths_only = serde_json::json!({
             "exports": { "./feature": { "types": "./feature.d.ts" } }
         });
-        assert_eq!(package_export_target(&subpaths_only, None), None);
+        assert!(package_export_target(&subpaths_only, None).is_empty());
     }
 
     #[test]
@@ -299,6 +339,45 @@ mod tests {
 
         assert_eq!(
             resolve_package_import(dir.path(), "runtime-package"),
+            Some(std::fs::canonicalize(&declaration).unwrap())
+        );
+    }
+
+    #[test]
+    fn package_exports_reject_targets_escaping_the_package_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let package = dir.path().join("node_modules/escaper");
+        std::fs::create_dir_all(&package).unwrap();
+        // A real file just outside the package that a malformed target points at.
+        std::fs::write(
+            dir.path().join("node_modules/secret.d.ts"),
+            "export declare const secret: unknown",
+        )
+        .unwrap();
+        std::fs::write(
+            package.join("package.json"),
+            r#"{ "exports": { ".": "../secret.d.ts" } }"#,
+        )
+        .unwrap();
+
+        assert_eq!(resolve_package_import(dir.path(), "escaper"), None);
+    }
+
+    #[test]
+    fn package_exports_fall_back_across_array_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        let package = dir.path().join("node_modules/array-exports");
+        let declaration = package.join("dist/index.d.ts");
+        std::fs::create_dir_all(declaration.parent().unwrap()).unwrap();
+        std::fs::write(&declaration, "export declare const value: number").unwrap();
+        std::fs::write(
+            package.join("package.json"),
+            r#"{ "exports": { ".": ["./missing.d.ts", "./dist/index.d.ts"] } }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_package_import(dir.path(), "array-exports"),
             Some(std::fs::canonicalize(&declaration).unwrap())
         );
     }


### PR DESCRIPTION
Follow-up to #3005 (already merged), addressing CodeRabbit review findings on the package-import resolution added there. The original branch was merged and deleted before these could land, so they ship here off `main`.

Three correctness/security fixes in the open-Vue reverse-dependency importer:

**Exact `.` and `..` relative specifiers.** Node/TS treat bare `.` and `..` as relative imports (resolving to `./index` and `../index`), but the dispatch only matched `./` and `../` prefixes, so they fell through to package resolution and failed to resolve.

```rust
if specifier == "."
    || specifier == ".."
    || specifier.starts_with("./")
    || specifier.starts_with("../")
{
    return resolve_relative_import(importer_dir, specifier);
}
```

**Reject export targets that escape the package root.** `package_root.join(target)` accepted absolute paths and `../` components, so malformed dependency metadata could associate an import with files outside the package. `resolve_package_target` now rejects parent/root/prefix components before joining (while still allowing bare-relative targets like `main: "index.js"`).

```rust
let relative = Path::new(target.strip_prefix("./").unwrap_or(target));
if relative.components().any(|component| {
    matches!(component, Component::ParentDir | Component::RootDir | Component::Prefix(_))
}) {
    return None;
}
resolve_package_candidate(package_root.join(relative))
```

**Array export fallback at the file level.** `conditional_export_target` collapsed an array to its first string, so a first entry that failed to resolve to an existing file blocked later valid fallbacks. `package_export_target` now returns all candidate targets in priority order and resolution tries each until one resolves.

Added regressions for `.`/`..` specifiers, an escaping export target, and a broken-first/valid-second array; existing direct-call assertions updated for the new `Vec` return.

Validated with `cargo check -p vize_maestro` and `cargo fmt`. Full clippy/test run is left to CI (the sandbox disk can't build the test binary).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import discovery for directory-style specifiers such as `"."` and `".."`.
  * Added support for resolving multiple package export targets, including fallback to the first valid option.
  * Prevented package imports from resolving outside the package directory through malformed paths.
  * Improved handling of conditional and array-based package exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->