### PR TITLE
fix(lsp): respect package export condition blocking

### DIFF
--- a/crates/vize_maestro/src/server/importers/package.rs
+++ b/crates/vize_maestro/src/server/importers/package.rs
@@ -154,18 +154,8 @@ fn collect_conditional_export_targets(
                 let Some(entry) = conditions.get(condition) else {
                     continue;
                 };
-                let previous_len = targets.len();
                 collect_conditional_export_targets(entry, capture, targets);
-                if targets.len() > previous_len {
-                    return;
-                }
-            }
-            for entry in conditions.values() {
-                let previous_len = targets.len();
-                collect_conditional_export_targets(entry, capture, targets);
-                if targets.len() > previous_len {
-                    return;
-                }
+                return;
             }
         }
         _ => {}

--- a/crates/vize_maestro/src/server/importers/package/tests.rs
+++ b/crates/vize_maestro/src/server/importers/package/tests.rs
@@ -160,3 +160,62 @@ fn package_export_arrays_fall_back_without_escaping_the_package() {
         None
     );
 }
+
+#[test]
+fn package_export_conditions_block_empty_and_unknown_targets() {
+    let dir = tempfile::tempdir().unwrap();
+    let package = dir.path().join("node_modules/conditional-package");
+    let runtime = package.join("dist/runtime.mjs");
+    let declaration = package.join("dist/runtime.d.mts");
+    let browser = package.join("dist/browser.d.ts");
+    std::fs::create_dir_all(runtime.parent().unwrap()).unwrap();
+    std::fs::write(&runtime, "export const runtime = true").unwrap();
+    std::fs::write(&declaration, "export declare const runtime: true").unwrap();
+    std::fs::write(&browser, "export declare const browser: true").unwrap();
+    std::fs::write(
+        package.join("package.json"),
+        r#"{
+  "exports": {
+    ".": { "types": null, "import": "./dist/runtime.mjs" },
+    "./unknown": { "browser": "./dist/browser.d.ts" }
+  }
+}"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolve_package_import(dir.path(), "conditional-package"),
+        None
+    );
+    assert_eq!(
+        resolve_package_import(dir.path(), "conditional-package/unknown"),
+        None
+    );
+}
+
+#[test]
+fn package_export_patterns_prefer_the_longest_prefix_before_total_length() {
+    let dir = tempfile::tempdir().unwrap();
+    let package = dir.path().join("node_modules/pattern-package");
+    let expected = package.join("types/admin/settings.d.ts");
+    let longer_pattern = package.join("types/settings/admin.d.ts");
+    std::fs::create_dir_all(expected.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(longer_pattern.parent().unwrap()).unwrap();
+    std::fs::write(&expected, "export declare const selected: 'prefix'").unwrap();
+    std::fs::write(&longer_pattern, "export declare const selected: 'length'").unwrap();
+    std::fs::write(
+        package.join("package.json"),
+        r#"{
+  "exports": {
+    "./features/admin/*": "./types/admin/*.d.ts",
+    "./features/*/settings": "./types/settings/*.d.ts"
+  }
+}"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolve_package_import(dir.path(), "pattern-package/features/admin/settings"),
+        Some(std::fs::canonicalize(&expected).unwrap())
+    );
+}


### PR DESCRIPTION
## Summary
- stop package export resolution when the selected declaration condition is null or empty
- leave unsupported export conditions unresolved instead of guessing an environment
- pin Node-compatible wildcard specificity when prefix length and total pattern length disagree

## Validation
- `cargo test -p vize_maestro`
- `cargo clippy -p vize_maestro -- -D warnings -D clippy::wildcard_imports`
- `node --test --test-concurrency=1 tests/snapshots/check/vue-router-dmts-oracle.ts`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package export resolution for conditional entries, including correct handling of `types`, `import`, `require`, and `default` conditions.
  * Fixed resolution when a `types` condition is explicitly `null`.
  * Corrected export pattern matching to select the most specific matching path.

* **Tests**
  * Added coverage for conditional exports and overlapping package export patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->