### PR TITLE
fix(typecheck): resolve kebab slot component bindings

### DIFF
--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -163,7 +163,6 @@ pub(crate) fn generate_scope_closures(
             }
             continue;
         }
-
         let ctx = ScopeGenContext {
             summary,
             virtual_ts_options,
@@ -307,7 +306,6 @@ fn generate_scope_node(
         }
         ScopeData::VSlot(data) => {
             append!(*ts, "\n{indent}// v-slot scope: #{}\n", data.name);
-
             let props_pattern = data.props_pattern.as_deref().unwrap_or("slotProps");
             let safe_slot_name = to_safe_identifier_fragment(data.name.as_str());
             let props_type = slot_props_type(
@@ -324,7 +322,6 @@ fn generate_scope_node(
                 props_pattern,
                 &props_type,
             );
-            // Mark slot prop variables as used
             if data.prop_names.is_empty() {
                 // Simple identifier (no destructuring)
                 append!(*ts, "{inner_indent}void {props_pattern};\n");

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -166,6 +166,7 @@ pub(crate) fn generate_scope_closures(
 
         let ctx = ScopeGenContext {
             summary,
+            virtual_ts_options,
             expressions_by_scope: &expressions_by_scope,
             skipped_expression_ranges: &skipped_expression_ranges,
             children_map: &children_map,
@@ -310,6 +311,8 @@ fn generate_scope_node(
             let props_pattern = data.props_pattern.as_deref().unwrap_or("slotProps");
             let safe_slot_name = to_safe_identifier_fragment(data.name.as_str());
             let props_type = slot_props_type(
+                ctx.summary,
+                ctx.virtual_ts_options,
                 data.component.as_deref(),
                 data.name.as_str(),
                 ctx.summary.scopes.is_v_slot_name_static(scope.id),

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -212,6 +212,7 @@ pub(super) fn generate_component_props(
         }
         let props_ctx = VForPropsContext {
             summary,
+            options: ctx.options,
             components_by_scope: &components_by_scope,
             children_map: ctx.children_map,
             vfor_enclosing_guards: &vfor_enclosing_guards,
@@ -341,6 +342,8 @@ fn generate_closure_component_props_recursive(
                 data.name
             );
             let props_type = slot_props_type(
+                ctx.summary,
+                ctx.options,
                 data.component.as_deref(),
                 data.name.as_str(),
                 ctx.summary.scopes.is_v_slot_name_static(scope.id),

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -201,7 +201,6 @@ pub(super) fn generate_component_props(
         );
     }
 
-    // Emit value checks for components in closure scopes (v-for and v-slot)
     for scope in summary.scopes.iter() {
         if !matches!(scope.kind, ScopeKind::VFor | ScopeKind::VSlot) {
             continue;
@@ -249,7 +248,6 @@ fn generate_closure_component_props_recursive(
 ) {
     let scope_id = scope.id.as_u32();
     let inner_indent = vize_carton::cstr!("{indent}  ");
-
     match scope.data() {
         ScopeData::VFor(data) => {
             let enclosing_guard = ctx.vfor_enclosing_guards.get(&scope_id).map(String::as_str);
@@ -363,7 +361,6 @@ fn generate_closure_component_props_recursive(
                     append!(*ts, "{inner_indent}void {prop_name};\n");
                 }
             }
-
             // Emit component prop checks for this scope
             if let Some(usages) = ctx.components_by_scope.get(&scope_id) {
                 for &(idx, usage) in usages {

--- a/crates/vize_canon/src/virtual_ts/scope/context.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/context.rs
@@ -12,6 +12,7 @@ use crate::virtual_ts::types::{VirtualTsCheckOptions, VirtualTsOptions};
 /// Context for recursive scope generation, bundling shared parameters.
 pub(crate) struct ScopeGenContext<'a> {
     pub(crate) summary: &'a Croquis,
+    pub(crate) virtual_ts_options: &'a VirtualTsOptions,
     pub(crate) expressions_by_scope: &'a FxHashMap<u32, Vec<&'a vize_croquis::TemplateExpression>>,
     pub(crate) skipped_expression_ranges: &'a FxHashSet<(u32, u32)>,
     pub(crate) children_map: &'a FxHashMap<u32, Vec<ScopeId>>,
@@ -32,6 +33,7 @@ pub(crate) struct ScopeGenerationOptions<'a> {
 /// Context for recursive component prop checks inside v-for scopes.
 pub(crate) struct VForPropsContext<'a> {
     pub(crate) summary: &'a Croquis,
+    pub(crate) options: &'a VirtualTsOptions,
     pub(crate) components_by_scope: &'a FxHashMap<u32, Vec<(usize, &'a ComponentUsage)>>,
     pub(crate) children_map: &'a FxHashMap<u32, Vec<ScopeId>>,
     pub(crate) vfor_enclosing_guards: &'a FxHashMap<u32, String>,

--- a/crates/vize_canon/src/virtual_ts/scope/emit.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/emit.rs
@@ -3,8 +3,11 @@
 use vize_carton::String;
 use vize_carton::append;
 use vize_carton::cstr;
+use vize_carton::{camelize, capitalize};
+use vize_croquis::Croquis;
 
 use crate::virtual_ts::helpers::to_safe_identifier;
+use crate::virtual_ts::types::VirtualTsOptions;
 
 /// Type annotation for a `v-slot` scope's props. When the slot is on a child
 /// component (`component` is `Some`), the props are inferred from that child's
@@ -15,13 +18,15 @@ use crate::virtual_ts::helpers::to_safe_identifier;
 /// the child has no typed slot — it falls back to `any` so untyped or built-in
 /// slot hosts never produce a false positive.
 pub(super) fn slot_props_type(
+    summary: &Croquis,
+    options: &VirtualTsOptions,
     component: Option<&str>,
     slot_name: &str,
     slot_name_is_static: bool,
 ) -> String {
     match component {
         Some(component) => {
-            let component_ref = to_safe_identifier(component);
+            let component_ref = component_binding_reference(summary, options, component);
             if slot_name_is_static {
                 cstr!(
                     "typeof {component_ref} extends {{ new (): {{ $slots: infer __S }} }} ? (\"{slot_name}\" extends keyof __S ? (NonNullable<__S[\"{slot_name}\"]> extends (props: infer __P, ...args: any[]) => any ? __P : any) : any) : any"
@@ -34,6 +39,26 @@ pub(super) fn slot_props_type(
         }
         None => "any".into(),
     }
+}
+
+fn component_binding_reference(
+    summary: &Croquis,
+    options: &VirtualTsOptions,
+    template_name: &str,
+) -> String {
+    let camel_name = camelize(template_name);
+    let pascal_name = capitalize(camel_name.as_str());
+    for candidate in [template_name, camel_name.as_str(), pascal_name.as_str()] {
+        if summary.bindings.bindings.contains_key(candidate)
+            || options
+                .external_template_bindings
+                .iter()
+                .any(|name| name.as_str() == candidate)
+        {
+            return to_safe_identifier(candidate);
+        }
+    }
+    to_safe_identifier(template_name)
 }
 
 /// Split a `v-slot` props expression that carries its own TypeScript

--- a/crates/vize_canon/src/virtual_ts/scope/emit.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/emit.rs
@@ -3,7 +3,7 @@
 use vize_carton::String;
 use vize_carton::append;
 use vize_carton::cstr;
-use vize_carton::{FxHashSet, camelize, capitalize};
+use vize_carton::{camelize, capitalize};
 use vize_croquis::Croquis;
 
 use crate::virtual_ts::helpers::to_safe_identifier;
@@ -48,14 +48,12 @@ fn component_binding_reference(
 ) -> String {
     let camel_name = camelize(template_name);
     let pascal_name = capitalize(camel_name.as_str());
-    let external_template_bindings: FxHashSet<&str> = options
-        .external_template_bindings
-        .iter()
-        .map(|name| name.as_str())
-        .collect();
     for candidate in [template_name, camel_name.as_str(), pascal_name.as_str()] {
         if summary.bindings.bindings.contains_key(candidate)
-            || external_template_bindings.contains(candidate)
+            || options
+                .external_template_bindings
+                .iter()
+                .any(|name| name.as_str() == candidate)
         {
             return to_safe_identifier(candidate);
         }

--- a/crates/vize_canon/src/virtual_ts/scope/emit.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/emit.rs
@@ -3,7 +3,7 @@
 use vize_carton::String;
 use vize_carton::append;
 use vize_carton::cstr;
-use vize_carton::{camelize, capitalize};
+use vize_carton::{FxHashSet, camelize, capitalize};
 use vize_croquis::Croquis;
 
 use crate::virtual_ts::helpers::to_safe_identifier;
@@ -48,12 +48,14 @@ fn component_binding_reference(
 ) -> String {
     let camel_name = camelize(template_name);
     let pascal_name = capitalize(camel_name.as_str());
+    let external_template_bindings: FxHashSet<&str> = options
+        .external_template_bindings
+        .iter()
+        .map(|name| name.as_str())
+        .collect();
     for candidate in [template_name, camel_name.as_str(), pascal_name.as_str()] {
         if summary.bindings.bindings.contains_key(candidate)
-            || options
-                .external_template_bindings
-                .iter()
-                .any(|name| name.as_str() == candidate)
+            || external_template_bindings.contains(candidate)
         {
             return to_safe_identifier(candidate);
         }

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -12,6 +12,7 @@ mod legacy_nuxt2_page_context;
 mod no_check_template_bindings;
 mod options_api_props_spread;
 mod options_api_setup_spread;
+mod slot_component_bindings;
 mod unused_refs;
 mod vif_chain;
 fn assert_virtual_ts_snapshot(name: &str, value: &str) {
@@ -999,49 +1000,6 @@ function handleUpdate(value: string) {
         output.code.as_str(),
     );
 }
-
-#[test]
-fn test_kebab_case_slot_host_uses_pascal_case_setup_binding() {
-    use vize_croquis::{Analyzer, AnalyzerOptions};
-
-    let script = r#"import { ElBadge } from 'element-plus'"#;
-    let template =
-        r#"<el-badge><template #content="{ value }">{{ value.missing }}</template></el-badge>"#;
-
-    let allocator = vize_carton::Bump::new();
-    let (root, _) = vize_armature::parse(&allocator, template);
-    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
-    analyzer.analyze_script_setup(script);
-    analyzer.analyze_template(&root);
-    let summary = analyzer.finish();
-
-    let output = generate_virtual_ts_with_offsets(
-        &summary,
-        Some(script),
-        Some(&root),
-        0,
-        0,
-        &Default::default(),
-    );
-
-    assert_eq!(
-        output
-            .code
-            .matches("typeof ElBadge extends { new (): { $slots: infer __S } }")
-            .count(),
-        1,
-        "{}",
-        output.code,
-    );
-    assert!(
-        !output
-            .code
-            .contains("typeof el_badge extends { new (): { $slots: infer __S } }"),
-        "{}",
-        output.code,
-    );
-}
-
 #[test]
 fn test_check_props_option_disables_component_prop_checks() {
     use vize_croquis::{Analyzer, AnalyzerOptions};

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -1001,6 +1001,48 @@ function handleUpdate(value: string) {
 }
 
 #[test]
+fn test_kebab_case_slot_host_uses_pascal_case_setup_binding() {
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let script = r#"import { ElBadge } from 'element-plus'"#;
+    let template =
+        r#"<el-badge><template #content="{ value }">{{ value.missing }}</template></el-badge>"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts_with_offsets(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert_eq!(
+        output
+            .code
+            .matches("typeof ElBadge extends { new (): { $slots: infer __S } }")
+            .count(),
+        1,
+        "{}",
+        output.code,
+    );
+    assert!(
+        !output
+            .code
+            .contains("typeof el_badge extends { new (): { $slots: infer __S } }"),
+        "{}",
+        output.code,
+    );
+}
+
+#[test]
 fn test_check_props_option_disables_component_prop_checks() {
     use vize_croquis::{Analyzer, AnalyzerOptions};
 

--- a/crates/vize_canon/src/virtual_ts/tests/slot_component_bindings.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/slot_component_bindings.rs
@@ -1,0 +1,42 @@
+use super::generate_virtual_ts_with_offsets;
+use vize_croquis::{Analyzer, AnalyzerOptions};
+
+#[test]
+fn kebab_case_slot_host_uses_pascal_case_setup_binding() {
+    let script = r#"import { ElBadge } from 'element-plus'"#;
+    let template =
+        r#"<el-badge><template #content="{ value }">{{ value.missing }}</template></el-badge>"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts_with_offsets(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert_eq!(
+        output
+            .code
+            .matches("typeof ElBadge extends { new (): { $slots: infer __S } }")
+            .count(),
+        1,
+        "{}",
+        output.code,
+    );
+    assert!(
+        !output
+            .code
+            .contains("typeof el_badge extends { new (): { $slots: infer __S } }"),
+        "{}",
+        output.code,
+    );
+}


### PR DESCRIPTION
## Summary

- resolve kebab-case slot hosts through their camelized and PascalCase bindings
- preserve external template binding resolution for generated virtual TypeScript
- add a strict regression test that rejects the untyped raw tag fallback

## Verification

- `cargo test -p vize_canon`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual TypeScript generation for slot props when components use kebab-case names.
  * Slot host component references now resolve to the correct PascalCase setup binding, avoiding incorrect identifier helpers.
  * Recursive scope handling for v-for/v-slot now consistently respects virtual TypeScript configuration options when computing slot prop types.
* **Tests**
  * Added a regression test covering kebab-case component names with PascalCase setup bindings in slot hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->