### PR TITLE
fix(lsp): preserve diagnostic range ends

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics/corsa/mapping.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/mapping.rs
@@ -90,7 +90,7 @@ fn map_generated_offset_to_source(
     mapping
         .src_range
         .start
-        .saturating_add(generated_relative.min(source_len.saturating_sub(1)))
+        .saturating_add(generated_relative.min(source_len))
 }
 
 pub(super) fn line_character_to_byte_offset(
@@ -212,5 +212,18 @@ mod tests {
                 .src_range,
             200..220
         );
+    }
+
+    #[test]
+    fn diagnostic_mapping_preserves_exclusive_range_end() {
+        let mapping = VizeMapping {
+            gen_range: 20..40,
+            src_range: 200..220,
+            sub_spans: Vec::new(),
+        };
+
+        assert_eq!(map_generated_offset_to_source(&mapping, 20), 200);
+        assert_eq!(map_generated_offset_to_source(&mapping, 39), 219);
+        assert_eq!(map_generated_offset_to_source(&mapping, 40), 220);
     }
 }


### PR DESCRIPTION
## Summary

- map exclusive diagnostic end offsets to the full source range end
- keep contained start offsets and last-character offsets unchanged
- add exact boundary assertions for start, last character, and exclusive end

## Verification

- `cargo test -p vize_maestro diagnostic_mapping_ -- --nocapture`
- `cargo test -p vize_maestro`
- `cargo clippy -p vize_maestro --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected diagnostic position mapping at the end of source spans.
  * Preserved exclusive range boundaries so diagnostics now point to the correct endpoint.

* **Tests**
  * Added coverage confirming accurate mapping at span starts, pre-end positions, and exclusive end boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->