### PR TITLE
fix(lsp): resolve ambient global slot components

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -1,7 +1,6 @@
 //! Building a [`RegisteredFile`] from a source path. This owns the expensive,
-//! `&mut`-free work (SFC/template parse, virtual-TS generation, import
-//! rewriting) so it can be fanned out across rayon workers, returning a
-//! self-contained result the project absorbs after the join point.
+//! `&mut`-free work (SFC/template parse and virtual-TS generation) so it can run
+//! across rayon workers and return a self-contained result for the project.
 
 use std::path::{Path, PathBuf};
 
@@ -252,6 +251,7 @@ pub(super) fn virtual_ts_options_for_descriptor(
         css_modules,
         auto_import_stubs: Vec::new(),
         external_template_bindings: base.external_template_bindings.clone(),
+        reference_paths: base.reference_paths.clone(),
     }
 }
 

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -66,8 +66,32 @@ impl CorsaBridge {
         options: CorsaVueVirtualDocumentOptions,
         overlays: &[(PathBuf, String)],
     ) -> Result<CorsaVueVirtualDocument, CorsaBridgeError> {
-        let project =
-            build_vue_virtual_project_with_overlays(source_path, content, options, overlays)?;
+        self.open_vue_virtual_document_with_overlays_and_options(
+            source_path,
+            content,
+            options,
+            overlays,
+            &VirtualTsOptions::default(),
+        )
+        .await
+    }
+
+    /// Generate and sync a Vue document with editor-specific virtual-TS options.
+    pub async fn open_vue_virtual_document_with_overlays_and_options(
+        &self,
+        source_path: &Path,
+        content: &str,
+        options: CorsaVueVirtualDocumentOptions,
+        overlays: &[(PathBuf, String)],
+        virtual_ts_options: &VirtualTsOptions,
+    ) -> Result<CorsaVueVirtualDocument, CorsaBridgeError> {
+        let project = build_vue_virtual_project_with_overlays_and_options(
+            source_path,
+            content,
+            options,
+            overlays,
+            virtual_ts_options,
+        )?;
         self.open_virtual_documents_batch(&project.documents)
             .await?;
         Ok(project.host)
@@ -108,8 +132,30 @@ pub(crate) fn build_vue_virtual_project_with_overlays(
     options: CorsaVueVirtualDocumentOptions,
     overlays: &[(PathBuf, String)],
 ) -> Result<CorsaVueVirtualProject, CorsaBridgeError> {
+    build_vue_virtual_project_with_overlays_and_options(
+        source_path,
+        content,
+        options,
+        overlays,
+        &VirtualTsOptions::default(),
+    )
+}
+
+fn build_vue_virtual_project_with_overlays_and_options(
+    source_path: &Path,
+    content: &str,
+    options: CorsaVueVirtualDocumentOptions,
+    overlays: &[(PathBuf, String)],
+    virtual_ts_options: &VirtualTsOptions,
+) -> Result<CorsaVueVirtualProject, CorsaBridgeError> {
     let rewriter = ImportRewriter::new();
-    let host = generate_vue_document(source_path, content, options, &rewriter)?;
+    let host = generate_vue_document_with_options(
+        source_path,
+        content,
+        options,
+        virtual_ts_options,
+        &rewriter,
+    )?;
     let mut documents = vec![(host.virtual_uri.clone(), host.generated.code.clone())];
     if host.generated.virtual_suffix == ".tsx" {
         documents.push(tsx_vue_import_shim(&host.source_path));
@@ -144,10 +190,26 @@ pub(super) fn generate_vue_document(
     options: CorsaVueVirtualDocumentOptions,
     rewriter: &ImportRewriter,
 ) -> Result<GeneratedVueDocument, CorsaBridgeError> {
+    generate_vue_document_with_options(
+        source_path,
+        content,
+        options,
+        &VirtualTsOptions::default(),
+        rewriter,
+    )
+}
+
+fn generate_vue_document_with_options(
+    source_path: &Path,
+    content: &str,
+    options: CorsaVueVirtualDocumentOptions,
+    virtual_ts_options: &VirtualTsOptions,
+    rewriter: &ImportRewriter,
+) -> Result<GeneratedVueDocument, CorsaBridgeError> {
     let generated = generate_vue_document_virtual_ts_with_options(
         source_path,
         content,
-        &VirtualTsOptions::default(),
+        virtual_ts_options,
         rewriter,
         false,
         VueDocumentVirtualTsOptions {

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -2,6 +2,7 @@ mod anchors;
 mod component_export;
 mod emits;
 mod generics;
+mod global_components;
 mod imports;
 mod legacy_vue2;
 mod options_api;
@@ -17,8 +18,9 @@ use self::anchors::emit_setup_binding_anchors;
 use self::component_export::emit_default_export_declaration;
 use self::emits::{emit_emit_props_helper, emit_emits_type};
 use self::generics::{HoistedGenericAliases, generic_injection_point, references_any_identifier};
+use self::global_components::GlobalComponentPlan;
 use self::imports::{
-    collect_imported_names, emit_global_component_stubs, emit_reference_type_directives,
+    collect_imported_names, emit_reference_path_directives, emit_reference_type_directives,
     extract_declared_name,
 };
 pub use self::legacy_vue2::generate_virtual_ts_with_offsets_legacy_vue2;
@@ -156,6 +158,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         .lib_references
         .unwrap_or(DEFAULT_LIB_REFERENCES);
     emit_lib_reference_directives(&mut ts, lib_references);
+    emit_reference_path_directives(&mut ts, &options.reference_paths);
     let has_script_reference_types = emit_reference_type_directives(&mut ts, script_content);
     ts.push_str("// ============================================\n");
     ts.push_str("// Virtual TypeScript for Vue SFC Type Checking\n");
@@ -395,8 +398,10 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         aliases.emit_module_aliases(&mut ts);
     }
 
+    let global_components =
+        GlobalComponentPlan::new(summary, legacy_vue2, has_script_reference_types);
     let needs_imported_names = !options.auto_import_stubs.is_empty()
-        || (has_script_reference_types && !summary.component_usages.is_empty());
+        || (global_components.enabled() && !summary.component_usages.is_empty());
     let imported_names: FxHashSet<&str> = if needs_imported_names {
         profile!(
             "canon.virtual_ts.extract_imported_names",
@@ -433,13 +438,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             }
         });
     }
-    emit_global_component_stubs(
-        &mut ts,
-        summary,
-        options,
-        &imported_names,
-        has_script_reference_types,
-    );
+    global_components.emit(&mut ts, summary, options, &imported_names);
     ts.push('\n');
 
     // For an Options API component with no `defineProps` macro, derive a real
@@ -817,7 +816,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                     // Skip if already declared via script bindings (import/const)
                     if summary.bindings.bindings.contains_key(name)
                         || external_template_bindings.contains(name)
-                        || has_script_reference_types
+                        || global_components.keeps_unresolved_binding(name)
                     {
                         continue;
                     }

--- a/crates/vize_canon/src/virtual_ts/generator/global_components.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/global_components.rs
@@ -1,0 +1,107 @@
+use vize_carton::{FxHashSet, String, append, camelize, capitalize};
+use vize_croquis::{Croquis, ScopeData};
+
+use crate::virtual_ts::helpers::to_safe_identifier;
+use crate::virtual_ts::types::VirtualTsOptions;
+
+use super::imports::extract_declared_name;
+
+pub(super) struct GlobalComponentPlan<'a> {
+    slot_component_names: FxHashSet<&'a str>,
+    include_all: bool,
+}
+
+impl<'a> GlobalComponentPlan<'a> {
+    pub(super) fn new(summary: &'a Croquis, legacy_vue2: bool, include_all: bool) -> Self {
+        let slot_component_names = if legacy_vue2 {
+            FxHashSet::default()
+        } else {
+            summary
+                .scopes
+                .iter()
+                .filter_map(|scope| match scope.data() {
+                    ScopeData::VSlot(data) => data.component.as_deref(),
+                    _ => None,
+                })
+                .collect()
+        };
+        Self {
+            slot_component_names,
+            include_all,
+        }
+    }
+
+    pub(super) fn enabled(&self) -> bool {
+        self.include_all || !self.slot_component_names.is_empty()
+    }
+
+    pub(super) fn keeps_unresolved_binding(&self, name: &str) -> bool {
+        self.include_all || self.slot_component_names.contains(name)
+    }
+
+    pub(super) fn emit(
+        &self,
+        ts: &mut String,
+        summary: &Croquis,
+        options: &VirtualTsOptions,
+        imported_names: &FxHashSet<&str>,
+    ) {
+        if !self.enabled() || summary.component_usages.is_empty() {
+            return;
+        }
+
+        let external_template_bindings = options
+            .external_template_bindings
+            .iter()
+            .map(|name| name.as_str())
+            .collect::<FxHashSet<_>>();
+        let auto_import_stub_names = options
+            .auto_import_stubs
+            .iter()
+            .filter_map(|stub| extract_declared_name(stub))
+            .collect::<FxHashSet<_>>();
+
+        let mut emitted_refs = FxHashSet::default();
+        let mut has_header = false;
+        for usage in &summary.component_usages {
+            let name = usage.name.as_str();
+            if !self.include_all && !self.slot_component_names.contains(name) {
+                continue;
+            }
+            let camel_name = camelize(name);
+            let pascal_name = capitalize(camel_name.as_str());
+            let candidates = [name, camel_name.as_str(), pascal_name.as_str()];
+            if candidates.iter().any(|candidate| {
+                summary.bindings.bindings.contains_key(*candidate)
+                    || imported_names.contains(candidate)
+                    || external_template_bindings.contains(candidate)
+                    || auto_import_stub_names.contains(candidate)
+            }) {
+                continue;
+            }
+
+            let component_ref = to_safe_identifier(name);
+            if !emitted_refs.insert(component_ref.clone()) {
+                continue;
+            }
+
+            if !has_header {
+                ts.push_str("\n// Global component stubs (vue module augmentations)\n");
+                has_header = true;
+            }
+
+            append!(
+                *ts,
+                "declare const {component_ref}: import(\"vue\").GlobalComponents extends {{ \"{name}\": infer __C }} ? __C"
+            );
+            if pascal_name.as_str() == name {
+                ts.push_str(" : any;\n");
+            } else {
+                append!(
+                    *ts,
+                    " : import(\"vue\").GlobalComponents extends {{ \"{pascal_name}\": infer __C }} ? __C : any;\n"
+                );
+            }
+        }
+    }
+}

--- a/crates/vize_canon/src/virtual_ts/generator/imports.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/imports.rs
@@ -1,18 +1,34 @@
-//! Import-name extraction, `/// <reference types>` directives, and global
-//! component stub emission for the virtual TypeScript generator.
+//! Import-name extraction and `/// <reference types>` directives.
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{IdentifierReference, TSTypeName, TSTypeQueryExprName, TSTypeReference};
 use oxc_ast_visit::{Visit, walk};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_croquis::Croquis;
-
-use crate::virtual_ts::helpers::to_safe_identifier;
-use crate::virtual_ts::types::VirtualTsOptions;
 use vize_carton::append;
 use vize_carton::cstr;
-use vize_carton::{CompactString, FxHashSet, String, camelize, capitalize};
+use vize_carton::{CompactString, FxHashSet, String};
+use vize_croquis::Croquis;
+
+pub(super) fn emit_reference_path_directives(ts: &mut String, paths: &[String]) {
+    let mut seen = FxHashSet::default();
+    for path in paths {
+        if path.is_empty() || path.contains(['\n', '\r']) || !seen.insert(path.as_str()) {
+            continue;
+        }
+        ts.push_str("/// <reference path=\"");
+        for character in path.chars() {
+            match character {
+                '&' => ts.push_str("&amp;"),
+                '"' => ts.push_str("&quot;"),
+                '<' => ts.push_str("&lt;"),
+                '>' => ts.push_str("&gt;"),
+                _ => ts.push(character),
+            }
+        }
+        ts.push_str("\" />\n");
+    }
+}
 
 pub(super) fn emit_reference_type_directives(
     ts: &mut String,
@@ -217,66 +233,6 @@ fn record_type_query_root(name: &TSTypeQueryExprName<'_>, refs: &mut FxHashSet<C
         }
         TSTypeQueryExprName::TSImportType(_) => {}
         _ => {}
-    }
-}
-
-pub(super) fn emit_global_component_stubs(
-    ts: &mut String,
-    summary: &Croquis,
-    options: &VirtualTsOptions,
-    imported_names: &FxHashSet<&str>,
-    enabled: bool,
-) {
-    if !enabled || summary.component_usages.is_empty() {
-        return;
-    }
-
-    let external_template_bindings = options
-        .external_template_bindings
-        .iter()
-        .map(|name| name.as_str())
-        .collect::<FxHashSet<_>>();
-    let auto_import_stub_names = options
-        .auto_import_stubs
-        .iter()
-        .filter_map(|stub| extract_declared_name(stub))
-        .collect::<FxHashSet<_>>();
-
-    let mut emitted_refs = FxHashSet::default();
-    let mut has_header = false;
-    for usage in &summary.component_usages {
-        let name = usage.name.as_str();
-        if summary.bindings.bindings.contains_key(name)
-            || imported_names.contains(&name)
-            || external_template_bindings.contains(&name)
-            || auto_import_stub_names.contains(&name)
-        {
-            continue;
-        }
-
-        let component_ref = to_safe_identifier(name);
-        if !emitted_refs.insert(component_ref.clone()) {
-            continue;
-        }
-
-        if !has_header {
-            ts.push_str("\n// Global component stubs (vue module augmentations)\n");
-            has_header = true;
-        }
-
-        let pascal_name = capitalize(camelize(name).as_str());
-        append!(
-            *ts,
-            "declare const {component_ref}: \"{name}\" extends keyof import(\"vue\").GlobalComponents ? import(\"vue\").GlobalComponents[\"{name}\"]"
-        );
-        if pascal_name.as_str() == name {
-            ts.push_str(" : any;\n");
-        } else {
-            append!(
-                *ts,
-                " : \"{pascal_name}\" extends keyof import(\"vue\").GlobalComponents ? import(\"vue\").GlobalComponents[\"{pascal_name}\"] : any;\n"
-            );
-        }
     }
 }
 

--- a/crates/vize_canon/src/virtual_ts/tests/slot_component_bindings.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/slot_component_bindings.rs
@@ -1,14 +1,14 @@
 use super::generate_virtual_ts_with_offsets;
 use vize_croquis::{Analyzer, AnalyzerOptions};
 
+const TEMPLATE: &str =
+    r#"<el-badge><template #content="{ value }">{{ value.missing }}</template></el-badge>"#;
+
 #[test]
 fn kebab_case_slot_host_uses_pascal_case_setup_binding() {
     let script = r#"import { ElBadge } from 'element-plus'"#;
-    let template =
-        r#"<el-badge><template #content="{ value }">{{ value.missing }}</template></el-badge>"#;
-
     let allocator = vize_carton::Bump::new();
-    let (root, _) = vize_armature::parse(&allocator, template);
+    let (root, _) = vize_armature::parse(&allocator, TEMPLATE);
     let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
     analyzer.analyze_script_setup(script);
     analyzer.analyze_template(&root);
@@ -39,4 +39,106 @@ fn kebab_case_slot_host_uses_pascal_case_setup_binding() {
         "{}",
         output.code,
     );
+    assert!(
+        !output.code.contains("declare const el_badge:"),
+        "{}",
+        output.code
+    );
+}
+
+#[test]
+fn kebab_case_slot_host_uses_ambient_pascal_global_component() {
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, TEMPLATE);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let options = super::VirtualTsOptions {
+        external_template_bindings: vec!["ElBadge".into()],
+        ..Default::default()
+    };
+    let output = generate_virtual_ts_with_offsets(&summary, None, Some(&root), 0, 0, &options);
+
+    assert_eq!(
+        output
+            .code
+            .matches("typeof ElBadge extends { new (): { $slots: infer __S } }")
+            .count(),
+        1,
+        "{}",
+        output.code,
+    );
+    assert!(
+        !output.code.contains("declare const ElBadge:"),
+        "{}",
+        output.code
+    );
+    assert!(
+        !output
+            .code
+            .contains("const el_badge: any = undefined as any;"),
+        "{}",
+        output.code,
+    );
+    assert!(
+        !output.code.contains("declare const el_badge:"),
+        "{}",
+        output.code
+    );
+}
+
+#[test]
+fn unresolved_slot_host_uses_vue_global_components_fallback() {
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, TEMPLATE);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output =
+        generate_virtual_ts_with_offsets(&summary, None, Some(&root), 0, 0, &Default::default());
+
+    assert!(
+        output.code.contains(
+            "declare const el_badge: import(\"vue\").GlobalComponents extends { \"el-badge\": infer __C } ? __C : import(\"vue\").GlobalComponents extends { \"ElBadge\": infer __C } ? __C : any;"
+        ),
+        "{}",
+        output.code,
+    );
+    assert_eq!(
+        output
+            .code
+            .matches("typeof el_badge extends { new (): { $slots: infer __S } }")
+            .count(),
+        1,
+        "{}",
+        output.code,
+    );
+}
+
+#[test]
+fn editor_reference_paths_are_escaped_and_deduplicated() {
+    let summary = Analyzer::with_options(AnalyzerOptions::full()).finish();
+    let options = super::VirtualTsOptions {
+        reference_paths: vec![
+            "/tmp/app&docs/components.d.ts".into(),
+            "/tmp/app&docs/components.d.ts".into(),
+            "invalid\npath.d.ts".into(),
+        ],
+        ..Default::default()
+    };
+
+    let output = generate_virtual_ts_with_offsets(&summary, None, None, 0, 0, &options);
+
+    assert_eq!(
+        output
+            .code
+            .matches("/// <reference path=\"/tmp/app&amp;docs/components.d.ts\" />")
+            .count(),
+        1,
+        "{}",
+        output.code,
+    );
+    assert!(!output.code.contains("invalid"), "{}", output.code);
 }

--- a/crates/vize_canon/src/virtual_ts/types.rs
+++ b/crates/vize_canon/src/virtual_ts/types.rs
@@ -68,6 +68,9 @@ pub struct VirtualTsOptions {
     /// shadowing them with local `any` fallbacks, so their real props remain
     /// type-checkable.
     pub external_template_bindings: Vec<String>,
+    /// Ambient declaration files that editor virtual documents must load.
+    /// Paths are emitted as triple-slash references before generated code.
+    pub reference_paths: Vec<String>,
 }
 
 impl Default for VirtualTsOptions {
@@ -77,6 +80,7 @@ impl Default for VirtualTsOptions {
             css_modules: Vec::new(),
             auto_import_stubs: Vec::new(),
             external_template_bindings: Vec::new(),
+            reference_paths: Vec::new(),
         }
     }
 }

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
@@ -85,8 +85,16 @@ impl DiagnosticService {
                     ))
                 })
                 .collect::<Vec<(std::path::PathBuf, vize_carton::String)>>();
+            let virtual_ts_options = vize_canon::virtual_ts::VirtualTsOptions {
+                reference_paths: state
+                    .global_component_reference_paths()
+                    .iter()
+                    .map(|path| path.to_string_lossy().as_ref().into())
+                    .collect(),
+                ..Default::default()
+            };
             let opened = match bridge
-                .open_vue_virtual_document_with_overlays(
+                .open_vue_virtual_document_with_overlays_and_options(
                     &source_path,
                     &content,
                     CorsaVueVirtualDocumentOptions {
@@ -94,6 +102,7 @@ impl DiagnosticService {
                         legacy_vue2,
                     },
                     &overlays,
+                    &virtual_ts_options,
                 )
                 .await
             {

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -9,6 +9,8 @@ mod virtual_docs;
 mod batch_cache;
 #[cfg(feature = "native")]
 mod corsa;
+#[cfg(feature = "native")]
+mod global_components;
 
 #[cfg(test)]
 mod config_tests;
@@ -105,6 +107,9 @@ pub struct ServerState {
     /// Workspace root path
     #[cfg(feature = "native")]
     workspace_root: RwLock<Option<PathBuf>>,
+    /// Project declaration files that augment Vue's global components.
+    #[cfg(feature = "native")]
+    global_component_reference_paths: RwLock<Option<Vec<PathBuf>>>,
     /// Batch type checker (lazy initialized, sync)
     #[cfg(feature = "native")]
     batch_checker: OnceLock<Arc<RwLock<BatchTypeChecker>>>,
@@ -157,6 +162,8 @@ impl ServerState {
             #[cfg(feature = "native")]
             workspace_root: RwLock::new(None),
             #[cfg(feature = "native")]
+            global_component_reference_paths: RwLock::new(None),
+            #[cfg(feature = "native")]
             batch_checker: OnceLock::new(),
             #[cfg(feature = "native")]
             batch_cache: BatchTypeCheckCache::new(),
@@ -167,6 +174,7 @@ impl ServerState {
     #[cfg(feature = "native")]
     pub fn set_workspace_root(&self, path: PathBuf) {
         *self.workspace_root.write() = Some(path);
+        *self.global_component_reference_paths.write() = None;
         // Invalidate batch cache when workspace changes
         self.batch_cache.invalidate();
     }

--- a/crates/vize_maestro/src/server/state/global_components.rs
+++ b/crates/vize_maestro/src/server/state/global_components.rs
@@ -1,0 +1,117 @@
+//! Discovery of project declarations that augment Vue global components.
+
+use std::path::{Path, PathBuf};
+
+use ignore::{DirEntry, WalkBuilder};
+
+use super::ServerState;
+
+impl ServerState {
+    pub(crate) fn global_component_reference_paths(&self) -> Vec<PathBuf> {
+        if let Some(paths) = self.global_component_reference_paths.read().as_ref() {
+            return paths.clone();
+        }
+
+        let paths = self.get_workspace_root().map_or_else(Vec::new, |root| {
+            collect_global_component_declarations(&root)
+        });
+        *self.global_component_reference_paths.write() = Some(paths.clone());
+        paths
+    }
+}
+
+fn collect_global_component_declarations(root: &Path) -> Vec<PathBuf> {
+    let mut builder = WalkBuilder::new(root);
+    builder
+        .hidden(false)
+        .ignore(false)
+        .git_global(false)
+        .git_ignore(false)
+        .git_exclude(false)
+        .parents(false)
+        .follow_links(false)
+        .filter_entry(should_visit);
+
+    let mut paths = Vec::new();
+    for entry in builder.build().flatten() {
+        let path = entry.path();
+        if !is_declaration_file(path) {
+            continue;
+        }
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        if metadata.len() > 4 * 1024 * 1024 {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        if content.contains("GlobalComponents") && content.contains("declare module") {
+            paths.push(std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()));
+        }
+    }
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+fn should_visit(entry: &DirEntry) -> bool {
+    if entry.depth() == 0 || !entry.file_type().is_some_and(|kind| kind.is_dir()) {
+        return true;
+    }
+    !matches!(
+        entry.file_name().to_str(),
+        Some(".git" | "node_modules" | "target" | "coverage" | "dist")
+    )
+}
+
+fn is_declaration_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            name.ends_with(".d.ts") || name.ends_with(".d.mts") || name.ends_with(".d.cts")
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_global_component_declarations;
+
+    #[test]
+    fn finds_hidden_project_augmentations_without_scanning_dependencies() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join(".nuxt")).unwrap();
+        std::fs::create_dir_all(root.path().join("node_modules/pkg")).unwrap();
+        std::fs::write(
+            root.path().join("components.d.ts"),
+            "declare module 'vue' { interface GlobalComponents { RootCard: unknown } }",
+        )
+        .unwrap();
+        std::fs::write(
+            root.path().join(".nuxt/components.d.ts"),
+            "declare module 'vue' { interface GlobalComponents { NuxtCard: unknown } }",
+        )
+        .unwrap();
+        std::fs::write(
+            root.path().join("node_modules/pkg/global.d.ts"),
+            "declare module 'vue' { interface GlobalComponents { DependencyCard: unknown } }",
+        )
+        .unwrap();
+        std::fs::write(root.path().join("unrelated.d.ts"), "interface Plain {}\n").unwrap();
+
+        let paths = collect_global_component_declarations(root.path());
+        assert_eq!(paths.len(), 2, "{paths:?}");
+        assert!(paths.iter().any(|path| path.ends_with("components.d.ts")));
+        assert!(
+            paths
+                .iter()
+                .any(|path| path.ends_with(".nuxt/components.d.ts"))
+        );
+        assert!(
+            paths
+                .iter()
+                .all(|path| !path.starts_with(root.path().join("node_modules")))
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- resolve slot host bindings across kebab, camel, and Pascal component names
- load project Vue global-component declarations into editor virtual documents
- keep imported, external, legacy, and non-slot unresolved component behavior isolated

## Validation
- `cargo test -p vize_canon -p vize_maestro`
- `cargo clippy -p vize_canon -p vize_maestro --lib -- -D warnings`
- `cargo fmt --all -- --check`
- Element Plus real-project oracle: clean, broken TS2339, and repaired CLI/LSP parity

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Vue editor tooling now recognizes workspace-wide global component declarations.
  - Virtual TypeScript documents support editor reference paths, including deduplication and safe escaping.
  - Editor integrations can provide custom TypeScript generation options when creating Vue virtual documents.

- **Bug Fixes**
  - Improved global component resolution across naming styles and slot templates.
  - Reduced incorrect unresolved-component declarations and improved fallback typing.
  - Diagnostics now include relevant workspace component declarations for more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->