### PR TITLE
fix(lsp): refresh global component declarations

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
@@ -88,6 +88,7 @@ impl DiagnosticService {
             let virtual_ts_options = vize_canon::virtual_ts::VirtualTsOptions {
                 reference_paths: state
                     .global_component_reference_paths()
+                    .await
                     .iter()
                     .map(|path| path.to_string_lossy().as_ref().into())
                     .collect(),

--- a/crates/vize_maestro/src/server.rs
+++ b/crates/vize_maestro/src/server.rs
@@ -8,6 +8,7 @@ mod handlers;
 mod helpers;
 mod importers;
 mod state;
+mod workspace_files;
 
 pub use capabilities::server_capabilities;
 #[cfg(feature = "native")]

--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -165,16 +165,7 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
                 supported: Some(true),
                 change_notifications: Some(OneOf::Left(true)),
             }),
-            file_operations: features.file_rename.then_some(
-                WorkspaceFileOperationsServerCapabilities {
-                    did_create: None,
-                    will_create: None,
-                    did_rename: Some(file_rename_registration_options()),
-                    will_rename: Some(file_rename_registration_options()),
-                    did_delete: None,
-                    will_delete: None,
-                },
-            ),
+            file_operations: workspace_file_operations(features),
         }),
 
         // Features not yet implemented
@@ -191,6 +182,40 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
 
         // Default for other fields
         ..Default::default()
+    }
+}
+
+fn workspace_file_operations(
+    features: LspFeatureConfig,
+) -> Option<WorkspaceFileOperationsServerCapabilities> {
+    let track_declarations = cfg!(feature = "native") && features.typecheck;
+    if !track_declarations && !features.file_rename {
+        return None;
+    }
+    Some(WorkspaceFileOperationsServerCapabilities {
+        did_create: track_declarations.then(declaration_file_registration_options),
+        will_create: None,
+        did_rename: Some(if features.file_rename {
+            file_rename_registration_options()
+        } else {
+            declaration_file_registration_options()
+        }),
+        will_rename: features.file_rename.then(file_rename_registration_options),
+        did_delete: track_declarations.then(declaration_file_registration_options),
+        will_delete: None,
+    })
+}
+
+fn declaration_file_registration_options() -> FileOperationRegistrationOptions {
+    FileOperationRegistrationOptions {
+        filters: vec![FileOperationFilter {
+            scheme: Some("file".to_string()),
+            pattern: FileOperationPattern {
+                glob: "**/*.d.{ts,mts,cts}".to_string(),
+                matches: Some(FileOperationPatternKind::File),
+                options: None,
+            },
+        }],
     }
 }
 

--- a/crates/vize_maestro/src/server/capabilities/tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests.rs
@@ -175,7 +175,7 @@ fn code_actions_require_both_lint_and_code_action_features() {
 }
 
 #[test]
-fn file_rename_flag_only_controls_workspace_file_operations() {
+fn declaration_events_remain_registered_when_file_rename_is_disabled() {
     let mut features = all_features();
     let enabled_capabilities = server_capabilities(features);
     let enabled = enabled_capabilities
@@ -191,7 +191,13 @@ fn file_rename_flag_only_controls_workspace_file_operations() {
         .expect("workspace capabilities should still be advertised");
 
     assert!(workspace.workspace_folders.is_some());
-    assert!(workspace.file_operations.is_none());
+    let operations = workspace
+        .file_operations
+        .expect("type checking must continue tracking declaration files");
+    assert!(operations.did_create.is_some());
+    assert!(operations.did_delete.is_some());
+    assert!(operations.did_rename.is_some());
+    assert!(operations.will_rename.is_none());
 }
 
 #[test]
@@ -254,5 +260,25 @@ fn file_rename_registration_mentions_declaration_files() {
             file_glob.contains(extension),
             "rename operations should include declaration shims: {file_glob}"
         );
+    }
+}
+
+#[test]
+fn declaration_file_operations_cover_create_delete_and_rename() {
+    let mut features = all_features();
+    features.file_rename = false;
+    let operations = server_capabilities(features)
+        .workspace
+        .and_then(|workspace| workspace.file_operations)
+        .expect("declaration tracking should be advertised");
+
+    for options in [
+        operations.did_create,
+        operations.did_delete,
+        operations.did_rename,
+    ] {
+        let options = options.expect("every declaration event must be registered");
+        assert_eq!(options.filters.len(), 1);
+        assert_eq!(options.filters[0].pattern.glob, "**/*.d.{ts,mts,cts}");
     }
 }

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -9,32 +9,33 @@ use tower_lsp::{
     jsonrpc::Result,
     lsp_types::{
         CodeActionParams, CodeActionResponse, CodeLens, CodeLensParams, CompletionItem,
-        CompletionParams, CompletionResponse, DidChangeConfigurationParams,
-        DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-        DidSaveTextDocumentParams, DocumentFormattingParams, DocumentHighlight,
-        DocumentHighlightParams, DocumentLink, DocumentLinkParams, DocumentRangeFormattingParams,
-        DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, FoldingRange,
-        FoldingRangeKind, FoldingRangeParams, GotoDefinitionParams, GotoDefinitionResponse, Hover,
-        HoverParams, InitializeParams, InitializeResult, InitializedParams, InlayHint,
-        InlayHintParams, Location, MessageType, Position, PrepareRenameResponse, Range,
-        ReferenceParams, RenameFilesParams, RenameParams, SemanticTokensParams,
-        SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult, ServerInfo,
-        SymbolInformation, SymbolKind, TextDocumentPositionParams, TextEdit, WorkspaceEdit,
-        WorkspaceSymbolParams,
+        CompletionParams, CompletionResponse, CreateFilesParams, DeleteFilesParams,
+        DidChangeConfigurationParams, DidChangeTextDocumentParams, DidChangeWatchedFilesParams,
+        DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
+        DocumentFormattingParams, DocumentHighlight, DocumentHighlightParams, DocumentLink,
+        DocumentLinkParams, DocumentRangeFormattingParams, DocumentSymbol, DocumentSymbolParams,
+        DocumentSymbolResponse, FoldingRange, FoldingRangeKind, FoldingRangeParams,
+        GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams, InitializeParams,
+        InitializeResult, InitializedParams, InlayHint, InlayHintParams, Location, Position,
+        PrepareRenameResponse, Range, ReferenceParams, RenameFilesParams, RenameParams,
+        SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult,
+        SemanticTokensResult, ServerInfo, SymbolInformation, SymbolKind,
+        TextDocumentPositionParams, TextEdit, WorkspaceEdit, WorkspaceSymbolParams,
     },
 };
 
 use super::{MaestroServer, server_capabilities};
 use crate::ide::{
     CodeActionService, CodeLensService, CompletionService, DefinitionService,
-    DocumentHighlightService, DocumentLinkService, FileRenameService, HoverService, IdeContext,
-    InlayHintService, ReferencesService, RenameService, SemanticTokensService,
-    WorkspaceSymbolsService, position_to_offset,
+    DocumentHighlightService, DocumentLinkService, HoverService, IdeContext, InlayHintService,
+    ReferencesService, RenameService, SemanticTokensService, WorkspaceSymbolsService,
+    position_to_offset,
 };
 
 #[tower_lsp::async_trait]
 impl LanguageServer for MaestroServer {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+        super::workspace_files::record_watcher_support(&self.state, &params.capabilities);
         // Resolve workspace root
         let workspace_path = params
             .root_uri
@@ -73,9 +74,7 @@ impl LanguageServer for MaestroServer {
     }
 
     async fn initialized(&self, _params: InitializedParams) {
-        self.client
-            .log_message(MessageType::INFO, "vize_maestro LSP server initialized")
-            .await;
+        super::workspace_files::initialized(self).await;
     }
 
     async fn did_change_configuration(&self, _params: DidChangeConfigurationParams) {
@@ -791,24 +790,23 @@ impl LanguageServer for MaestroServer {
     }
 
     async fn will_rename_files(&self, params: RenameFilesParams) -> Result<Option<WorkspaceEdit>> {
-        if !self.state.lsp_features().file_rename {
-            return Ok(None);
-        }
+        Ok(super::workspace_files::will_rename_files(&self.state, &params).await)
+    }
 
-        Ok(FileRenameService::will_rename_files(&self.state, &params).await)
+    async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
+        super::workspace_files::did_change_watched_files(&self.state, &params);
+    }
+
+    async fn did_create_files(&self, params: CreateFilesParams) {
+        super::workspace_files::did_create_files(&self.state, &params);
+    }
+
+    async fn did_delete_files(&self, params: DeleteFilesParams) {
+        super::workspace_files::did_delete_files(&self.state, &params);
     }
 
     async fn did_rename_files(&self, params: RenameFilesParams) {
-        if !self.state.lsp_features().file_rename {
-            return;
-        }
-
-        let renamed = FileRenameService::did_rename_files(&self.state, &params).await;
-
-        for (old_uri, new_uri) in renamed {
-            self.client.publish_diagnostics(old_uri, vec![], None).await;
-            self.publish_diagnostics(&new_uri).await;
-        }
+        super::workspace_files::did_rename_files(self, &params).await;
     }
 
     async fn document_link(&self, params: DocumentLinkParams) -> Result<Option<Vec<DocumentLink>>> {

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -107,9 +107,9 @@ pub struct ServerState {
     /// Workspace root path
     #[cfg(feature = "native")]
     workspace_root: RwLock<Option<PathBuf>>,
-    /// Project declaration files that augment Vue's global components.
+    /// Cached project declarations that augment Vue's global components.
     #[cfg(feature = "native")]
-    global_component_reference_paths: RwLock<Option<Vec<PathBuf>>>,
+    global_component_references: global_components::GlobalComponentReferences,
     /// Batch type checker (lazy initialized, sync)
     #[cfg(feature = "native")]
     batch_checker: OnceLock<Arc<RwLock<BatchTypeChecker>>>,
@@ -162,7 +162,7 @@ impl ServerState {
             #[cfg(feature = "native")]
             workspace_root: RwLock::new(None),
             #[cfg(feature = "native")]
-            global_component_reference_paths: RwLock::new(None),
+            global_component_references: global_components::GlobalComponentReferences::new(),
             #[cfg(feature = "native")]
             batch_checker: OnceLock::new(),
             #[cfg(feature = "native")]
@@ -174,7 +174,7 @@ impl ServerState {
     #[cfg(feature = "native")]
     pub fn set_workspace_root(&self, path: PathBuf) {
         *self.workspace_root.write() = Some(path);
-        *self.global_component_reference_paths.write() = None;
+        self.global_component_references.invalidate();
         // Invalidate batch cache when workspace changes
         self.batch_cache.invalidate();
     }

--- a/crates/vize_maestro/src/server/state/global_components.rs
+++ b/crates/vize_maestro/src/server/state/global_components.rs
@@ -1,23 +1,168 @@
-//! Discovery of project declarations that augment Vue global components.
+//! Discovery and caching of declarations that augment Vue global components.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
+use futures::{channel::oneshot, lock::Mutex as AsyncMutex};
 use ignore::{DirEntry, WalkBuilder};
+use parking_lot::RwLock;
+use tower_lsp::lsp_types::Url;
+
+#[cfg(test)]
+use parking_lot::Mutex;
+#[cfg(test)]
+use std::sync::atomic::AtomicUsize;
 
 use super::ServerState;
 
-impl ServerState {
-    pub(crate) fn global_component_reference_paths(&self) -> Vec<PathBuf> {
-        if let Some(paths) = self.global_component_reference_paths.read().as_ref() {
-            return paths.clone();
-        }
+struct CachedPaths {
+    generation: u64,
+    paths: Vec<PathBuf>,
+}
 
-        let paths = self.get_workspace_root().map_or_else(Vec::new, |root| {
-            collect_global_component_declarations(&root)
-        });
-        *self.global_component_reference_paths.write() = Some(paths.clone());
-        paths
+pub(super) struct GlobalComponentReferences {
+    paths: RwLock<Option<CachedPaths>>,
+    scan_lock: AsyncMutex<()>,
+    generation: AtomicU64,
+    watcher_supported: AtomicBool,
+    #[cfg(test)]
+    scan_count: AtomicUsize,
+    #[cfg(test)]
+    last_scan_thread: Mutex<Option<std::thread::ThreadId>>,
+}
+
+impl GlobalComponentReferences {
+    pub(super) fn new() -> Self {
+        Self {
+            paths: RwLock::new(None),
+            scan_lock: AsyncMutex::new(()),
+            generation: AtomicU64::new(0),
+            watcher_supported: AtomicBool::new(false),
+            #[cfg(test)]
+            scan_count: AtomicUsize::new(0),
+            #[cfg(test)]
+            last_scan_thread: Mutex::new(None),
+        }
     }
+
+    pub(super) fn invalidate(&self) {
+        self.generation.fetch_add(1, Ordering::AcqRel);
+        *self.paths.write() = None;
+    }
+
+    fn cached_paths(&self) -> Option<Vec<PathBuf>> {
+        let generation = self.generation.load(Ordering::Acquire);
+        self.paths
+            .read()
+            .as_ref()
+            .filter(|cached| cached.generation == generation)
+            .map(|cached| cached.paths.clone())
+    }
+
+    async fn paths<F>(&self, mut workspace_root: F) -> Vec<PathBuf>
+    where
+        F: FnMut() -> Option<PathBuf>,
+    {
+        loop {
+            if let Some(paths) = self.cached_paths() {
+                return paths;
+            }
+
+            let _scan = self.scan_lock.lock().await;
+            if let Some(paths) = self.cached_paths() {
+                return paths;
+            }
+            let generation = self.generation.load(Ordering::Acquire);
+            let paths = match workspace_root() {
+                Some(root) => {
+                    #[cfg(test)]
+                    self.scan_count.fetch_add(1, Ordering::AcqRel);
+                    let discovery = discover_in_background(root).await;
+                    #[cfg(test)]
+                    if let Some(thread_id) = discovery.thread_id {
+                        *self.last_scan_thread.lock() = Some(thread_id);
+                    }
+                    discovery.paths
+                }
+                None => Vec::new(),
+            };
+
+            if self.generation.load(Ordering::Acquire) != generation {
+                continue;
+            }
+            *self.paths.write() = Some(CachedPaths {
+                generation,
+                paths: paths.clone(),
+            });
+            return paths;
+        }
+    }
+}
+
+impl ServerState {
+    pub(crate) async fn global_component_reference_paths(&self) -> Vec<PathBuf> {
+        self.global_component_references
+            .paths(|| self.get_workspace_root())
+            .await
+    }
+
+    pub(crate) fn invalidate_global_component_references<I, U>(&self, uris: I) -> bool
+    where
+        I: IntoIterator<Item = U>,
+        U: AsRef<str>,
+    {
+        if !uris.into_iter().any(|uri| is_declaration_uri(uri.as_ref())) {
+            return false;
+        }
+        self.global_component_references.invalidate();
+        self.batch_cache.invalidate();
+        true
+    }
+
+    pub(crate) fn set_global_component_watcher_supported(&self, supported: bool) {
+        self.global_component_references
+            .watcher_supported
+            .store(supported, Ordering::Release);
+    }
+
+    pub(crate) fn global_component_watcher_supported(&self) -> bool {
+        self.global_component_references
+            .watcher_supported
+            .load(Ordering::Acquire)
+    }
+}
+
+struct DiscoveryResult {
+    paths: Vec<PathBuf>,
+    #[cfg(test)]
+    thread_id: Option<std::thread::ThreadId>,
+}
+
+async fn discover_in_background(root: PathBuf) -> DiscoveryResult {
+    let (sender, receiver) = oneshot::channel();
+    let spawned = std::thread::Builder::new()
+        .name("vize-global-components".to_string())
+        .spawn(move || {
+            let paths = collect_global_component_declarations(&root);
+            let _ = sender.send(DiscoveryResult {
+                paths,
+                #[cfg(test)]
+                thread_id: Some(std::thread::current().id()),
+            });
+        });
+    if let Err(error) = spawned {
+        tracing::warn!("failed to spawn global component discovery: {error}");
+        return DiscoveryResult {
+            paths: Vec::new(),
+            #[cfg(test)]
+            thread_id: None,
+        };
+    }
+    receiver.await.unwrap_or_else(|_| DiscoveryResult {
+        paths: Vec::new(),
+        #[cfg(test)]
+        thread_id: None,
+    })
 }
 
 fn collect_global_component_declarations(root: &Path) -> Vec<PathBuf> {
@@ -66,6 +211,14 @@ fn should_visit(entry: &DirEntry) -> bool {
     )
 }
 
+fn is_declaration_uri(uri: &str) -> bool {
+    Url::parse(uri)
+        .ok()
+        .and_then(|url| url.to_file_path().ok())
+        .is_some_and(|path| is_declaration_file(&path))
+        || is_declaration_file(Path::new(uri))
+}
+
 fn is_declaration_file(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
@@ -76,26 +229,26 @@ fn is_declaration_file(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::collect_global_component_declarations;
+    use std::sync::atomic::Ordering;
+    use std::sync::{Arc, Barrier};
+
+    use tower_lsp::lsp_types::Url;
+
+    use super::{ServerState, collect_global_component_declarations};
+
+    const DECLARATION: &str =
+        "declare module 'vue' { interface GlobalComponents { NuxtCard: unknown } }";
 
     #[test]
     fn finds_hidden_project_augmentations_without_scanning_dependencies() {
         let root = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(root.path().join(".nuxt")).unwrap();
         std::fs::create_dir_all(root.path().join("node_modules/pkg")).unwrap();
-        std::fs::write(
-            root.path().join("components.d.ts"),
-            "declare module 'vue' { interface GlobalComponents { RootCard: unknown } }",
-        )
-        .unwrap();
-        std::fs::write(
-            root.path().join(".nuxt/components.d.ts"),
-            "declare module 'vue' { interface GlobalComponents { NuxtCard: unknown } }",
-        )
-        .unwrap();
+        std::fs::write(root.path().join("components.d.ts"), DECLARATION).unwrap();
+        std::fs::write(root.path().join(".nuxt/components.d.ts"), DECLARATION).unwrap();
         std::fs::write(
             root.path().join("node_modules/pkg/global.d.ts"),
-            "declare module 'vue' { interface GlobalComponents { DependencyCard: unknown } }",
+            DECLARATION,
         )
         .unwrap();
         std::fs::write(root.path().join("unrelated.d.ts"), "interface Plain {}\n").unwrap();
@@ -112,6 +265,85 @@ mod tests {
             paths
                 .iter()
                 .all(|path| !path.starts_with(root.path().join("node_modules")))
+        );
+    }
+
+    #[test]
+    fn concurrent_cold_lookups_share_one_background_scan() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("components.d.ts"), DECLARATION).unwrap();
+        let state = Arc::new(ServerState::new());
+        state.set_workspace_root(root.path().to_path_buf());
+        let barrier = Arc::new(Barrier::new(3));
+        let callers = (0..2)
+            .map(|_| {
+                let state = state.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    crate::runtime::block_on(state.global_component_reference_paths())
+                })
+            })
+            .collect::<Vec<_>>();
+        barrier.wait();
+
+        for caller in callers {
+            assert_eq!(caller.join().unwrap().len(), 1);
+        }
+        assert_eq!(
+            state
+                .global_component_references
+                .scan_count
+                .load(Ordering::Acquire),
+            1
+        );
+        assert_ne!(
+            *state.global_component_references.last_scan_thread.lock(),
+            Some(std::thread::current().id())
+        );
+    }
+
+    #[test]
+    fn declaration_file_events_refresh_created_renamed_and_deleted_paths() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join(".nuxt")).unwrap();
+        let state = ServerState::new();
+        state.set_workspace_root(root.path().to_path_buf());
+        assert!(crate::runtime::block_on(state.global_component_reference_paths()).is_empty());
+
+        let created = root.path().join(".nuxt/components.d.ts");
+        std::fs::write(&created, DECLARATION).unwrap();
+        let created_uri = Url::from_file_path(&created).unwrap();
+        assert!(state.invalidate_global_component_references([created_uri.as_str()]));
+        assert_eq!(
+            crate::runtime::block_on(state.global_component_reference_paths()),
+            [std::fs::canonicalize(&created).unwrap()]
+        );
+
+        let renamed = root.path().join(".nuxt/components.d.mts");
+        std::fs::rename(&created, &renamed).unwrap();
+        let renamed_uri = Url::from_file_path(&renamed).unwrap();
+        assert!(
+            state.invalidate_global_component_references([
+                created_uri.as_str(),
+                renamed_uri.as_str(),
+            ])
+        );
+        assert_eq!(
+            crate::runtime::block_on(state.global_component_reference_paths()),
+            [std::fs::canonicalize(&renamed).unwrap()]
+        );
+
+        std::fs::remove_file(&renamed).unwrap();
+        assert!(state.invalidate_global_component_references([renamed_uri.as_str()]));
+        assert!(crate::runtime::block_on(state.global_component_reference_paths()).is_empty());
+        assert!(!state.invalidate_global_component_references(["file:///workspace/App.vue"]));
+        assert_eq!(
+            state
+                .global_component_references
+                .scan_count
+                .load(Ordering::Acquire),
+            4
         );
     }
 }

--- a/crates/vize_maestro/src/server/workspace_files.rs
+++ b/crates/vize_maestro/src/server/workspace_files.rs
@@ -1,0 +1,160 @@
+//! Workspace file-event handling used by LSP diagnostics and rename support.
+
+use tower_lsp::lsp_types::{
+    ClientCapabilities, CreateFilesParams, DeleteFilesParams, DidChangeWatchedFilesParams,
+    MessageType, RenameFilesParams, WorkspaceEdit,
+};
+
+use super::{MaestroServer, ServerState};
+use crate::ide::FileRenameService;
+
+#[cfg(feature = "native")]
+use tower_lsp::lsp_types::{
+    DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern, Registration,
+};
+
+pub(super) fn record_watcher_support(state: &ServerState, capabilities: &ClientCapabilities) {
+    #[cfg(feature = "native")]
+    state.set_global_component_watcher_supported(
+        capabilities
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.did_change_watched_files.as_ref())
+            .and_then(|watched| watched.dynamic_registration)
+            .unwrap_or(false),
+    );
+    #[cfg(not(feature = "native"))]
+    let _ = (state, capabilities);
+}
+
+pub(super) async fn initialized(server: &MaestroServer) {
+    register_global_component_watcher(server).await;
+    server
+        .client
+        .log_message(MessageType::INFO, "vize_maestro LSP server initialized")
+        .await;
+}
+
+async fn register_global_component_watcher(server: &MaestroServer) {
+    #[cfg(feature = "native")]
+    {
+        if !server.state.is_lsp_typecheck_enabled()
+            || !server.state.global_component_watcher_supported()
+        {
+            return;
+        }
+        if let Err(error) = server
+            .client
+            .register_capability(vec![global_component_watcher_registration()])
+            .await
+        {
+            tracing::warn!("failed to register global component declaration watcher: {error}");
+        }
+    }
+    #[cfg(not(feature = "native"))]
+    let _ = server;
+}
+
+#[cfg(feature = "native")]
+fn global_component_watcher_registration() -> Registration {
+    let options = DidChangeWatchedFilesRegistrationOptions {
+        watchers: vec![FileSystemWatcher {
+            glob_pattern: GlobPattern::String("**/*.d.{ts,mts,cts}".into()),
+            kind: None,
+        }],
+    };
+    Registration {
+        id: "vize-global-component-declarations".into(),
+        method: "workspace/didChangeWatchedFiles".into(),
+        register_options: serde_json::to_value(options).ok(),
+    }
+}
+
+pub(super) fn did_change_watched_files(state: &ServerState, params: &DidChangeWatchedFilesParams) {
+    #[cfg(feature = "native")]
+    state.invalidate_global_component_references(
+        params.changes.iter().map(|change| change.uri.as_str()),
+    );
+    #[cfg(not(feature = "native"))]
+    let _ = (state, params);
+}
+
+pub(super) fn did_create_files(state: &ServerState, params: &CreateFilesParams) {
+    #[cfg(feature = "native")]
+    state.invalidate_global_component_references(params.files.iter().map(|file| file.uri.as_str()));
+    #[cfg(not(feature = "native"))]
+    let _ = (state, params);
+}
+
+pub(super) fn did_delete_files(state: &ServerState, params: &DeleteFilesParams) {
+    #[cfg(feature = "native")]
+    state.invalidate_global_component_references(params.files.iter().map(|file| file.uri.as_str()));
+    #[cfg(not(feature = "native"))]
+    let _ = (state, params);
+}
+
+pub(super) async fn will_rename_files(
+    state: &ServerState,
+    params: &RenameFilesParams,
+) -> Option<WorkspaceEdit> {
+    if !state.lsp_features().file_rename {
+        return None;
+    }
+    FileRenameService::will_rename_files(state, params).await
+}
+
+pub(super) async fn did_rename_files(server: &MaestroServer, params: &RenameFilesParams) {
+    #[cfg(feature = "native")]
+    server.state.invalidate_global_component_references(
+        params
+            .files
+            .iter()
+            .flat_map(|file| [file.old_uri.as_str(), file.new_uri.as_str()]),
+    );
+    if !server.state.lsp_features().file_rename {
+        return;
+    }
+
+    let renamed = FileRenameService::did_rename_files(&server.state, params).await;
+    for (old_uri, new_uri) in renamed {
+        server
+            .client
+            .publish_diagnostics(old_uri, vec![], None)
+            .await;
+        server.publish_diagnostics(&new_uri).await;
+    }
+}
+
+#[cfg(all(test, feature = "native"))]
+mod tests {
+    use tower_lsp::lsp_types::ClientCapabilities;
+
+    use super::{ServerState, global_component_watcher_registration, record_watcher_support};
+
+    #[test]
+    fn declaration_watcher_tracks_create_change_and_delete_recursively() {
+        let registration = global_component_watcher_registration();
+        assert_eq!(registration.method, "workspace/didChangeWatchedFiles");
+        let options = registration.register_options.unwrap();
+        assert_eq!(options["watchers"][0]["globPattern"], "**/*.d.{ts,mts,cts}");
+        assert!(
+            options["watchers"][0].get("kind").is_none(),
+            "omitted kind must request create, change, and delete events: {options}"
+        );
+    }
+
+    #[test]
+    fn client_watcher_support_is_recorded_from_initialize_capabilities() {
+        let capabilities: ClientCapabilities = serde_json::from_value(serde_json::json!({
+            "workspace": {
+                "didChangeWatchedFiles": { "dynamicRegistration": true }
+            }
+        }))
+        .unwrap();
+        let state = ServerState::new();
+
+        record_watcher_support(&state, &capabilities);
+
+        assert!(state.global_component_watcher_supported());
+    }
+}


### PR DESCRIPTION
## Summary
- discover Vue global-component declarations off the async diagnostics path
- coalesce concurrent cold lookups behind a single background scan
- invalidate generation-tagged cache entries for watched declaration create/change/delete and workspace rename events
- advertise declaration file operations and dynamically register recursive declaration watchers when supported

## Tests
- concurrent cold lookups perform exactly one background scan
- scan executes outside the requesting thread
- hidden Nuxt declarations are included while dependency/build trees are skipped
- create, rename, and delete events refresh exact canonical declaration paths
- declaration file operation capability coverage
- watcher registration and initialize capability negotiation coverage
- `cargo test -p vize_canon -p vize_maestro`
- `cargo clippy -p vize_canon -p vize_maestro --lib -- -D warnings`
- `cargo fmt --all -- --check`
- Element Plus badge slot clean/broken/repaired editor oracle

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace file tracking for declaration files, including creation, deletion, and renaming.
  * Improved handling of file renames, refreshing diagnostics for affected files.
  * Added support for client file watchers to keep component references current.

* **Bug Fixes**
  * Updated reference discovery to refresh correctly after declaration-file changes.
  * Improved concurrent reference lookups to avoid redundant scans.

* **Tests**
  * Added coverage for watcher registration, file operations, cache refreshes, and concurrent lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->