### PR TITLE
fix(lsp): harden global component cache invalidation

### DIFF
--- a/crates/vize_maestro/src/server/state/global_components.rs
+++ b/crates/vize_maestro/src/server/state/global_components.rs
@@ -1,6 +1,7 @@
 //! Discovery and caching of declarations that augment Vue global components.
 
-use std::path::{Path, PathBuf};
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use futures::{channel::oneshot, lock::Mutex as AsyncMutex};
@@ -87,10 +88,12 @@ impl GlobalComponentReferences {
                 None => Vec::new(),
             };
 
+            let mut cached = self.paths.write();
             if self.generation.load(Ordering::Acquire) != generation {
+                drop(cached);
                 continue;
             }
-            *self.paths.write() = Some(CachedPaths {
+            *cached = Some(CachedPaths {
                 generation,
                 paths: paths.clone(),
             });
@@ -111,7 +114,13 @@ impl ServerState {
         I: IntoIterator<Item = U>,
         U: AsRef<str>,
     {
-        if !uris.into_iter().any(|uri| is_declaration_uri(uri.as_ref())) {
+        let Some(root) = self.get_workspace_root() else {
+            return false;
+        };
+        if !uris
+            .into_iter()
+            .any(|uri| is_discoverable_declaration_uri(&root, uri.as_ref()))
+        {
             return false;
         }
         self.global_component_references.invalidate();
@@ -205,18 +214,28 @@ fn should_visit(entry: &DirEntry) -> bool {
     if entry.depth() == 0 || !entry.file_type().is_some_and(|kind| kind.is_dir()) {
         return true;
     }
-    !matches!(
-        entry.file_name().to_str(),
-        Some(".git" | "node_modules" | "target" | "coverage" | "dist")
-    )
+    !is_excluded_directory(entry.file_name())
 }
 
-fn is_declaration_uri(uri: &str) -> bool {
-    Url::parse(uri)
+fn is_discoverable_declaration_uri(root: &Path, uri: &str) -> bool {
+    let uri_path = Url::parse(uri)
         .ok()
         .and_then(|url| url.to_file_path().ok())
-        .is_some_and(|path| is_declaration_file(&path))
-        || is_declaration_file(Path::new(uri))
+        .unwrap_or_else(|| PathBuf::from(uri));
+    let Ok(relative) = uri_path.strip_prefix(root) else {
+        return false;
+    };
+    is_declaration_file(relative)
+        && relative.components().all(|component| {
+            !matches!(component, Component::Normal(name) if is_excluded_directory(name))
+        })
+}
+
+fn is_excluded_directory(name: &OsStr) -> bool {
+    matches!(
+        name.to_str(),
+        Some(".git" | "node_modules" | "target" | "coverage" | "dist")
+    )
 }
 
 fn is_declaration_file(path: &Path) -> bool {
@@ -231,8 +250,6 @@ fn is_declaration_file(path: &Path) -> bool {
 mod tests {
     use std::sync::atomic::Ordering;
     use std::sync::{Arc, Barrier};
-
-    use tower_lsp::lsp_types::Url;
 
     use super::{ServerState, collect_global_component_declarations};
 
@@ -281,14 +298,28 @@ mod tests {
                 let barrier = barrier.clone();
                 std::thread::spawn(move || {
                     barrier.wait();
-                    crate::runtime::block_on(state.global_component_reference_paths())
+                    let caller_thread = std::thread::current().id();
+                    let paths = crate::runtime::block_on(state.global_component_reference_paths());
+                    (caller_thread, paths)
                 })
             })
             .collect::<Vec<_>>();
         barrier.wait();
 
-        for caller in callers {
-            assert_eq!(caller.join().unwrap().len(), 1);
+        let caller_results = callers
+            .into_iter()
+            .map(|caller| caller.join().unwrap())
+            .collect::<Vec<_>>();
+        let scan_thread = state
+            .global_component_references
+            .last_scan_thread
+            .lock()
+            .as_ref()
+            .copied()
+            .expect("background scan thread should be recorded");
+        for (caller_thread, paths) in caller_results {
+            assert_eq!(paths.len(), 1);
+            assert_ne!(scan_thread, caller_thread);
         }
         assert_eq!(
             state
@@ -297,53 +328,8 @@ mod tests {
                 .load(Ordering::Acquire),
             1
         );
-        assert_ne!(
-            *state.global_component_references.last_scan_thread.lock(),
-            Some(std::thread::current().id())
-        );
-    }
-
-    #[test]
-    fn declaration_file_events_refresh_created_renamed_and_deleted_paths() {
-        let root = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(root.path().join(".nuxt")).unwrap();
-        let state = ServerState::new();
-        state.set_workspace_root(root.path().to_path_buf());
-        assert!(crate::runtime::block_on(state.global_component_reference_paths()).is_empty());
-
-        let created = root.path().join(".nuxt/components.d.ts");
-        std::fs::write(&created, DECLARATION).unwrap();
-        let created_uri = Url::from_file_path(&created).unwrap();
-        assert!(state.invalidate_global_component_references([created_uri.as_str()]));
-        assert_eq!(
-            crate::runtime::block_on(state.global_component_reference_paths()),
-            [std::fs::canonicalize(&created).unwrap()]
-        );
-
-        let renamed = root.path().join(".nuxt/components.d.mts");
-        std::fs::rename(&created, &renamed).unwrap();
-        let renamed_uri = Url::from_file_path(&renamed).unwrap();
-        assert!(
-            state.invalidate_global_component_references([
-                created_uri.as_str(),
-                renamed_uri.as_str(),
-            ])
-        );
-        assert_eq!(
-            crate::runtime::block_on(state.global_component_reference_paths()),
-            [std::fs::canonicalize(&renamed).unwrap()]
-        );
-
-        std::fs::remove_file(&renamed).unwrap();
-        assert!(state.invalidate_global_component_references([renamed_uri.as_str()]));
-        assert!(crate::runtime::block_on(state.global_component_reference_paths()).is_empty());
-        assert!(!state.invalidate_global_component_references(["file:///workspace/App.vue"]));
-        assert_eq!(
-            state
-                .global_component_references
-                .scan_count
-                .load(Ordering::Acquire),
-            4
-        );
     }
 }
+
+#[cfg(test)]
+mod event_tests;

--- a/crates/vize_maestro/src/server/state/global_components/event_tests.rs
+++ b/crates/vize_maestro/src/server/state/global_components/event_tests.rs
@@ -1,0 +1,92 @@
+use std::sync::atomic::Ordering;
+
+use tower_lsp::lsp_types::Url;
+
+use super::ServerState;
+
+const DECLARATION: &str =
+    "declare module 'vue' { interface GlobalComponents { NuxtCard: unknown } }";
+
+#[test]
+fn declaration_file_events_refresh_created_renamed_and_deleted_paths() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(root.path().join(".nuxt")).unwrap();
+    let state = ServerState::new();
+    state.set_workspace_root(root.path().to_path_buf());
+    assert!(crate::runtime::block_on(state.global_component_reference_paths()).is_empty());
+
+    let created = root.path().join(".nuxt/components.d.ts");
+    std::fs::write(&created, DECLARATION).unwrap();
+    let created_uri = Url::from_file_path(&created).unwrap();
+    assert!(state.invalidate_global_component_references([created_uri.as_str()]));
+    assert_eq!(
+        crate::runtime::block_on(state.global_component_reference_paths()),
+        [std::fs::canonicalize(&created).unwrap()]
+    );
+
+    let renamed = root.path().join(".nuxt/components.d.mts");
+    std::fs::rename(&created, &renamed).unwrap();
+    let renamed_uri = Url::from_file_path(&renamed).unwrap();
+    assert!(
+        state.invalidate_global_component_references([created_uri.as_str(), renamed_uri.as_str(),])
+    );
+    assert_eq!(
+        crate::runtime::block_on(state.global_component_reference_paths()),
+        [std::fs::canonicalize(&renamed).unwrap()]
+    );
+
+    std::fs::remove_file(&renamed).unwrap();
+    assert!(state.invalidate_global_component_references([renamed_uri.as_str()]));
+    assert!(crate::runtime::block_on(state.global_component_reference_paths()).is_empty());
+    assert!(!state.invalidate_global_component_references(["file:///workspace/App.vue"]));
+    assert_eq!(
+        state
+            .global_component_references
+            .scan_count
+            .load(Ordering::Acquire),
+        4
+    );
+}
+
+#[test]
+fn excluded_tree_events_do_not_restart_discovery_but_nuxt_events_do() {
+    let root = tempfile::tempdir().unwrap();
+    let state = ServerState::new();
+    state.set_workspace_root(root.path().to_path_buf());
+    assert!(crate::runtime::block_on(state.global_component_reference_paths()).is_empty());
+
+    for directory in [".git", "node_modules", "target", "coverage", "dist"] {
+        let uri = Url::from_file_path(root.path().join(directory).join("components.d.ts")).unwrap();
+        assert!(
+            !state.invalidate_global_component_references([uri.as_str()]),
+            "{directory} events must not invalidate discovery"
+        );
+    }
+    let outside = Url::from_file_path(root.path().parent().unwrap().join("outside.d.ts")).unwrap();
+    assert!(!state.invalidate_global_component_references([outside.as_str()]));
+    assert!(crate::runtime::block_on(state.global_component_reference_paths()).is_empty());
+    assert_eq!(
+        state
+            .global_component_references
+            .scan_count
+            .load(Ordering::Acquire),
+        1
+    );
+
+    let nuxt = root.path().join(".nuxt/components.d.cts");
+    std::fs::create_dir_all(nuxt.parent().unwrap()).unwrap();
+    std::fs::write(&nuxt, DECLARATION).unwrap();
+    let nuxt_uri = Url::from_file_path(&nuxt).unwrap();
+    assert!(state.invalidate_global_component_references([nuxt_uri.as_str()]));
+    assert_eq!(
+        crate::runtime::block_on(state.global_component_reference_paths()),
+        [std::fs::canonicalize(nuxt).unwrap()]
+    );
+    assert_eq!(
+        state
+            .global_component_references
+            .scan_count
+            .load(Ordering::Acquire),
+        2
+    );
+}


### PR DESCRIPTION
## Summary\n\n- serialize cache publication with the final generation check\n- ignore declaration events outside discovery-eligible workspace trees while preserving generated framework declarations\n- verify discovery always runs off every request thread\n- split event coverage into a focused test module to keep source files within the length guard\n\n## Tests\n\n- 
running 544 tests
test document::store::tests::test_document_line_count ... ok
test document::store::tests::test_document_creation ... ok
test document::store::tests::test_document_store_rename_missing_source_returns_false ... ok
test document::store::tests::test_document_get_line ... ok
test document::store::tests::test_document_store_ignores_changes_for_closed_document ... ok
test document::store::tests::test_document_store_rename_same_uri_is_noop_for_open_document ... ok
test document::store::tests::test_document_store_rename_does_not_overwrite_open_target ... ok
test document::store::tests::test_document_store ... ok
test document::store::tests::test_full_content_change ... ok
test document::store::tests::test_document_store_rename ... ok
test document::store::tests::test_incremental_change_rejects_utf16_surrogate_pair_interior ... ok
test document::store::tests::test_incremental_change ... ok
test document::store::tests::test_incremental_change_uses_utf16_positions ... ok
test document::store::tests::test_out_of_bounds_incremental_change_is_ignored ... ok
test document::store::tests::test_multiline_incremental_change_replaces_cross_line_range ... ok
test document::store::tests::test_reversed_incremental_change_is_ignored ... ok
test document::store::tests::test_petite_vue_detection_is_memoized_and_reset_on_change ... ok
test ide::code_action::tests::offset_to_line_col_counts_utf16_code_units ... ok
test document::store::tests::test_multiple_document_store_changes_apply_in_order_with_final_version ... ok
test ide::code_action::tests::template_position_maps_content_lines_to_lsp_lines ... ok
test ide::code_action::tests::test_ranges_overlap ... ok
test ide::code_action::tests::test_get_line_indent ... ok
test ide::code_lens::tests::test_count_identifier_occurrences ... ok
test ide::code_action::tests::test_offset_to_line_col ... ok
test ide::code_lens::tests::test_extract_first_identifier ... ok
test ide::code_lens::tests::test_count_vbind_occurrences ... ok
test ide::code_lens::tests::test_find_declarations ... ok
test ide::completion::items::tests::directive_completion_docs_include_highlightable_example ... ok
test ide::completion::items::tests::attribute_completion_docs_include_template_syntax_link ... ok
test ide::completion::script::tests::pins_negative_and_non_inferrable_cases ... ok
test ide::auto_import::tests::empty_directory_yields_empty_index ... ok
test ide::completion::script::tests::pins_angle_and_paren_inference_behavior ... ok
test ide::completion::script::tests::receiver_extractor_matches_cursor_context_on_chains ... ok
test ide::code_action::tests::test_diff_paths_relative_specifier ... ok
test ide::completion::template::bindings::options_api_tests::class_component_members_completed_without_flag ... ok
test ide::auto_import::tests::find_in_directory_matches_lookup_first ... ok
test ide::completion::template::component_docs::tests::prop_docs_are_markdown_with_vue_examples ... ok
test ide::auto_import::tests::indexes_vue_components_and_composables ... ok
test ide::completion::template::bindings::options_api_tests::options_api_data_binding_completed_when_enabled ... ok
test ide::completion::template::component_cache::tests::disk_metadata_cache_hits_then_invalidates_on_change ... ok
test ide::completion::template::bindings::options_api_tests::options_api_data_binding_absent_when_opted_out ... ok
test ide::completion::component_props_tests::template_component_prop_completion_resolves_imported_script_setup_props ... ok
test ide::completion::template::component_meta::slot_prop_name_tests::extracts_slot_prop_names_with_ts_ast ... ok
test ide::completion::dedup_tests::script_completion_lists_reactive_binding_once ... ok
test ide::completion::template::component_meta::slot_prop_name_tests::returns_none_for_non_object_slot_props ... ok
test ide::completion::component_props_tests::template_component_prop_completion_replaces_dynamic_prefix ... ok
test ide::completion::dedup_tests::template_completion_lists_reactive_binding_once ... ok
test ide::completion::template::slot_outlets::tests::extracts_slot_outlets_from_template_ast ... ok
test ide::completion::template::slot_outlets::tests::extracts_slots_nested_in_control_flow ... ok
test ide::completion::template::slot_outlets::tests::ignores_slot_like_text_in_comments_and_attribute_values ... ok
test ide::completion::template_event_tests::event_completion_replaces_typed_shorthand_prefix ... ok
test ide::completion::component_props_tests::template_component_prop_completion_tracks_open_child_buffer ... ok
test ide::completion::template::native_tests::keeps_bindings_in_multiline_event_handler ... ok
test ide::completion::template::native_tests::offers_event_shorthand_after_prefix ... ok
test ide::completion::tests::test_art_variant_completion_includes_script_setup_state_bindings ... ok
test ide::completion::tests::test_composition_api_completions ... ok
test ide::completion::tests::test_directive_completions ... ok
test ide::completion::template::native_tests::offers_native_attributes_in_opening_tag ... ok
test ide::completion::tests::test_art_variant_completion_uses_art_component_attribute_for_props ... ok
test ide::completion::tests::test_is_inside_html_comment ... ok
test ide::completion::tests::test_macro_completions ... ok
test ide::completion::tests::test_art_variant_completion_infers_imported_component_slots ... ok
test ide::completion::tests::test_art_variant_completion_includes_script_bindings_in_non_default_variant ... ok
test ide::completion::tests::test_petite_vue_directive_completions ... ok
test ide::completion::tests::test_art_variant_completion_uses_define_art_component_for_props ... ok
test ide::completion::tests::test_i18n_key_completion_from_workspace_json_catalog ... ok
test ide::completion::tests::test_script_completion_includes_closure_local_binding ... ok
test ide::completion::tests::test_i18n_key_completion_from_same_file_json_block ... ok
test ide::completion::tests::test_script_completion_excludes_inner_binding_outside_its_scope ... ok
test ide::completion::tests::test_art_variant_completion_infers_imported_component_props ... ok
test ide::completion::tests::test_route_param_completion_from_route_path ... ok
test ide::completion::tests::test_route_name_completion_from_same_file_route_sources ... ok
test ide::completion::tests::test_route_param_completion_from_file_route_name ... ok
test ide::completion::tests::test_define_art_source_completion_suggests_vue_files ... ok
test ide::completion::tests::test_standalone_html_completion_respects_dialect_config ... ok
test ide::completion::tests::test_script_member_access_lists_reactive_object_keys ... ok
test ide::completion::tests::test_standalone_html_completion_ignores_petite_vue_mention_in_comment ... ok
test ide::completion::tests::test_script_member_access_on_non_ref_returns_empty_in_sync_fallback ... ok
test ide::completion::tests::test_standalone_html_completion_includes_v_scope_bindings_in_expression ... ok
test ide::completion::tests::test_script_member_access_after_decimal_literal_is_not_member_access ... ok
test ide::completion::tests::test_standalone_html_completion_includes_petite_vue_directives ... ok
test ide::completion::tests::test_script_ref_member_completion_includes_value ... ok
test ide::completion::tests::test_trigger_characters ... ok
test ide::completion::tests::test_script_completion_infers_computed_ref_type ... ok
test ide::completion::tests::test_vue_css_completions ... ok
test ide::completion::tests::test_vize_directive_completions ... ok
test ide::completion::tests::test_standalone_html_completion_v_scope_bindings_do_not_leak_to_sibling ... ok
test ide::completion::tests::test_template_completion_includes_v_for_binding ... ok
test ide::completion::tests::test_template_completion_excludes_v_for_binding_outside ... ok
test ide::completion::tests::test_template_completion_skips_bindings_in_static_attribute_value ... ok
test ide::completion::tests::test_template_completion_keeps_bindings_in_dynamic_attribute_value ... ok
test ide::completion::tests::test_template_completion_skips_bindings_in_plain_text_node ... ok
test ide::corsa_support::html_attribute_tests::html_attribute_virtual_document_queries_dom_property ... ok
test ide::corsa_support::html_attribute_tests::native_dom_attribute_info_preserves_svg_dom_property_names ... ok
test ide::corsa_support::canonical_tests::canonical_source_offset_maps_bare_event_handler_to_handler_identifier ... ok
test ide::corsa_support::canonical_tests::canonical_source_offset_maps_script_ts_usage_to_generated_position ... ok
test ide::corsa_support::html_attribute_tests::native_dom_attribute_info_maps_html_attributes_to_dom_properties ... ok
test ide::corsa_support::canonical_tests::canonical_source_offset_accounts_for_vue_import_rewrite_before_script_body ... ok
test ide::corsa_support::canonical_tests::canonical_source_offset_maps_inline_event_handler_body_expression ... ok
test ide::corsa_support::canonical_tests::canonical_source_offset_maps_template_expression_to_generated_position ... ok
test ide::corsa_support::html_attribute_tests::native_dom_attribute_info_rejects_unknown_and_component_attributes ... ok
test ide::corsa_support::html_tag::tests::html_tag_virtual_document_queries_lib_dom_types ... ok
test ide::corsa_support::html_tag::tests::html_tag_virtual_document_supports_svg_tags ... ok
test ide::corsa_support::html_tag::tests::html_tag_virtual_document_supports_mathml_tag_map_entries ... ok
test ide::corsa_support::html_tag::tests::html_tag_virtual_document_uses_mathml_fallback_for_unmapped_tags ... ok
test ide::corsa_support::html_tag::tests::native_dom_tag_info_rejects_custom_elements ... ok
test ide::corsa_support::html_tag::tests::native_dom_tag_info_rejects_html_tags_missing_dom_map_entries ... ok
test ide::corsa_support::html_tag::tests::native_dom_tag_info_rejects_vue_builtins ... ok
test ide::cursor_context::tests::cursor_at_zero_is_other ... ok
test ide::cursor_context::tests::detects_html_comment ... ok
test ide::cursor_context::tests::closed_comment_is_not_html_comment ... ok
test ide::cursor_context::tests::detects_identifier_prefix ... ok
test ide::corsa_support::html_tag::tests::native_dom_tag_info_rejects_svg_tags_missing_dom_map_entries ... ok
test ide::cursor_context::tests::detects_member_access_on_chained_receiver ... ok
test ide::cursor_context::tests::detects_member_access_on_simple_receiver ... ok
test ide::cursor_context::tests::empty_prefix_after_operator_is_other ... ok
test ide::cursor_context::tests::member_access_with_whitespace_between_dot_and_cursor ... ok
test ide::cursor_context::tests::ignores_floating_point_literal ... ok
test ide::definition::html_tests::definition_resolves_native_html_tag_to_mdn_reference ... ok
test ide::definition::html_tests::definition_resolves_multiline_native_html_attribute_to_mdn_reference ... ok
test ide::definition::module_specifier::tests::finds_only_module_specifier_strings_at_the_cursor ... ok
test ide::definition::html_tests::definition_resolves_native_html_attribute_to_mdn_reference ... ok
test ide::definition::html_tests::multiline_bound_attribute_ignores_gt_inside_previous_attribute_value ... ok
test ide::definition::html_tests::static_boolean_attribute_is_detected_at_identifier_end_boundary ... ok
test ide::definition::tests::definition_options_api_data_absent_when_opted_out ... ok
test ide::definition::html_tests::multiline_bound_attribute_is_detected_at_identifier_end_boundary ... ok
test ide::definition::module_specifier::tests::definition_service_navigates_module_specifier_to_types_export ... ok
test ide::definition::tests::test_definition_in_style_resolves_inside_v_bind_argument ... ok
test ide::definition::tests::test_definition_does_not_panic_on_non_ascii_before_identifier ... ok
test ide::definition::tests::test_definition_in_style_ignores_same_word_after_closed_v_bind ... ok
test ide::definition::tests::test_definition_ignores_static_attribute_value ... ok
test ide::definition::tests::test_definition_resolves_art_variant_binding_at_identifier_boundary ... ok
test ide::definition::module_specifier::tests::resolves_relative_declarations_and_rejects_package_escape ... ok
test ide::definition::module_specifier::tests::resolves_scoped_wildcard_declaration_subpath ... ok
test ide::definition::module_specifier::tests::resolves_hoisted_package_types_export ... ok
test ide::definition::tests::test_find_binding_location_const ... ok
test ide::definition::tests::test_definition_resolves_standalone_html_create_app_property ... ok
test ide::definition::tests::test_find_binding_location_destructure ... ok
test ide::definition::tests::test_definition_resolves_define_art_source ... ok
test ide::definition::tests::test_definition_resolves_standalone_html_v_scope_property ... ok
test ide::definition::tests::test_find_binding_location_function ... ok
test ide::definition::tests::definition_resolves_class_component_member_in_template_without_flag ... ok
test ide::definition::tests::test_find_binding_location_raw_destructure ... ok
test ide::definition::tests::test_get_word_at_offset ... ok
test ide::definition::tests::test_find_prop_in_define_props ... ok
test ide::definition::tests::test_find_binding_location_raw_const ... ok
test ide::definition::tests::test_definition_prefers_component_prop_on_attribute_name_only ... ok
test ide::definition::tests::test_find_binding_location_raw_import ... ok
test ide::definition::tests::test_get_tag_at_offset_only_matches_tag_name ... ok
test ide::definition::tests::test_is_in_vue_directive_expression_detection ... ok
test ide::definition::tests::test_is_valid_identifier ... ok
test ide::definition::tests::test_offset_to_position ... ok
test ide::definition::tests::test_definition_with_corsa_fallback_resolves_template_binding_at_boundary ... ok
test ide::diagnostics::corsa::collect_virtual::tests::corsa_diagnostic_codes_preserve_lsp_number_and_string_shapes ... ok
test ide::diagnostics::corsa::mapping::tests::diagnostic_mapping_prefers_exact_expression_sub_span ... ok
test ide::definition::tests::test_definition_resolves_component_tag_at_identifier_boundary ... ok
test ide::definition::tests::test_get_attribute_and_component_at_offset_only_matches_attribute_name ... ok
test ide::diagnostics::corsa::mapping::tests::diagnostic_mapping_prefers_the_narrowest_generated_range ... ok
test ide::diagnostics::corsa::mapping::tests::diagnostic_mapping_preserves_exclusive_range_end ... ok
test ide::diagnostics::corsa::message::hint_tests::leaves_known_property_value_alone ... ok
test ide::diagnostics::corsa::message::hint_tests::rewrites_internal_vue_tsx_imports_back_to_vue ... ok
test ide::diagnostics::corsa::message::hint_tests::property_extractor_returns_name ... ok
test ide::diagnostics::component_props_tests::reports_missing_required_component_props_on_template_tag ... ok
test ide::diagnostics::corsa::message::hint_tests::passes_through_unrelated_messages ... ok
test ide::diagnostics::corsa::message::hint_tests::rewrites_every_internal_vue_virtual_suffix_in_message ... ok
test ide::diagnostics::corsa::message::hint_tests::rewrites_internal_vue_suffix_before_adding_value_hint ... ok
test ide::diagnostics::corsa::message::hint_tests::rewrites_internal_vue_ts_imports_back_to_vue ... ok
test ide::diagnostics::corsa::message::hint_tests::rewrites_property_does_not_exist_with_value_hint ... ok
test ide::diagnostics::component_props_tests::skips_required_component_prop_diagnostic_when_spread_attrs_are_present ... ok
test ide::diagnostics::corsa::message::hint_tests::rewrites_ref_assignment_with_unwrap_hint ... ok
test ide::diagnostics::corsa::tests::source_offset_to_position_counts_utf16_code_units ... ok
test ide::diagnostics::component_props_tests::skips_required_component_prop_diagnostic_for_runtime_prop_name ... ok
test ide::diagnostics::corsa::tests::line_character_to_byte_offset_counts_utf16_code_units ... ok
test ide::diagnostics::corsa::tests::line_character_to_byte_offset_rejects_surrogate_pair_interior ... ok
test ide::diagnostics::corsa::tests::editor_virtual_ts_for_inline_art_binds_self_to_host_props ... ok
test ide::diagnostics::corsa::tests::editor_virtual_ts_rewrites_dot_vue_imports ... ok
test ide::diagnostics::tests::collect_accepts_jsx_render_fn_in_tsx_script_block ... ok
test ide::diagnostics::editor_typecheck_tests::virtual_ts_generates_template_less_sfc_mirror ... ok
test ide::diagnostics::tests::collect_accepts_jsx_script_without_false_parse_diagnostic ... ok
test ide::diagnostics::tests::collect_accepts_tsx_script_without_false_parse_diagnostic ... ok
test ide::diagnostics::tests::collect_does_not_misdiagnose_valid_vapor_mode_tsx ... ok
test ide::diagnostics::tests::collect_async_skips_jsx_type_diagnostics_when_flag_off ... ok
test ide::diagnostics::corsa::tests::editor_virtual_ts_for_art_imports_define_art_target_component ... ok
test ide::diagnostics::editor_typecheck_tests::sync_collect_does_not_surface_legacy_type_false_positives ... ok
test ide::diagnostics::tests::collect_does_not_report_sfc_compile_diagnostic_for_valid_default ... ok
test ide::diagnostics::tests::collect_lint_only_is_empty_when_lint_disabled ... ok
test ide::diagnostics::tests::collect_keeps_type_diagnostics_for_parseable_sfc ... ok
test ide::diagnostics::tests::collect_lint_only_equals_lint_subset_of_collect ... ok
test ide::diagnostics::tests::collect_lints_standalone_html_with_configured_rule ... ok
test ide::diagnostics::tests::collect_lint_only_short_circuits_on_parse_error ... ok
test ide::diagnostics::tests::collect_produces_no_error_for_valid_tsx ... ok
test ide::diagnostics::tests::collect_produces_no_error_for_valid_jsx ... ok
test ide::diagnostics::tests::collect_reports_missing_define_art_source_file ... ok
test ide::diagnostics::tests::collect_reports_props_destructure_default_type_mismatch_for_lsp ... ok
test ide::diagnostics::tests::collect_reports_unknown_route_path_params ... ok
test ide::diagnostics::tests::collect_reports_unknown_file_route_params ... ok
test ide::diagnostics::tests::collect_short_circuits_dependent_diagnostics_after_script_parse_error ... ok
test ide::diagnostics::tests::collect_short_circuits_dependent_diagnostics_after_sfc_parse_error ... ok
test ide::diagnostics::tests::collect_reports_workspace_i18n_missing_key ... ok
test ide::diagnostics::tests::collect_short_circuits_dependent_diagnostics_after_template_parse_error ... ok
test ide::diagnostics::tests::collect_skips_unsupported_script_language ... ok
test ide::diagnostics::tests::collect_still_rejects_jsx_in_plain_ts_script_block ... ok
test ide::diagnostics::tests::collect_surfaces_conflicting_mode_directives_on_tsx ... ok
test ide::diagnostics::tests::collect_surfaces_jsx_compiler_error_for_broken_tsx ... ok
test ide::diagnostics::tests::collect_surfaces_malformed_mode_directive_on_tsx ... ok
test ide::diagnostics::tests::collect_surfaces_sfc_level_lint_diagnostics ... ok
test ide::diagnostics::tests::offset_to_line_col_counts_utf16_code_units ... ok
test ide::diagnostics::tests::test_diagnostic_builder ... ok
test ide::diagnostics::tests::test_severity_conversion ... ok
test ide::document_highlight::tests::highlights_identifier_occurrences_in_art_variant ... ok
test ide::document_highlight::tests::highlights_matching_component_tags_in_art_variant ... ok
test ide::document_highlight::tests::position_walker_matches_offset_to_position_str ... ok
test ide::document_link::tests::test_extract_import_path ... ok
test ide::document_link::tests::test_define_art_source_link ... ok
test ide::document_link::tests::test_extract_string_literal ... ok
test ide::ecosystem::context::tests::detects_string_literal_before_cursor ... ok
test ide::ecosystem::context::tests::ignores_content_outside_string_literals ... ok
test ide::diagnostics::tests::collect_keeps_dependent_diagnostics_after_recoverable_template_repair ... ok
test ide::diagnostics::tests::collect_lint_only_keeps_lint_after_recoverable_template_repair ... ok
test ide::completion::tests::test_binding_type_to_completion_info ... ok
test ide::ecosystem::i18n::tests::detects_i18n_call_strings ... ok
test ide::ecosystem::i18n::tests::collects_locale_stripped_json_catalog_keys ... ok
test ide::ecosystem::router::tests::detects_router_push_and_router_link_name_contexts ... ok
test ide::ecosystem::i18n::tests::keeps_direct_message_root_keys ... ok
test ide::ecosystem::router::tests::extracts_route_names_from_route_block_and_define_page ... ok
test ide::ecosystem::router::tests::infers_params_from_vue_router_paths ... ok
test ide::ecosystem::router::tests::infers_params_from_vue_router_file_names ... ok
test ide::ecosystem::void::tests::detects_void_link_and_use_form_route_contexts ... ok
test ide::ecosystem::router_extension_tests::infers_params_from_module_route_file_names ... ok
test ide::ecosystem::void::tests::maps_void_page_files_to_route_paths ... ok
test ide::file_rename::merge_tests::inserts_manual_edits_before_resource_operations ... ok
test ide::file_rename::manual_tests::renames_open_documents_inside_renamed_folder ... ok
test ide::file_rename::merge_tests::merges_changes_into_document_changes ... ok
test ide::file_rename::merge_tests::prefers_overlay_document_changes_over_base_changes ... ok
test ide::file_rename::resources::tests::css_import_ranges_cover_only_the_specifier_text ... ok
test ide::file_rename::resources::tests::src_attribute_ranges_cover_quoted_values_only ... ok
test ide::hover::component_tag::items::tests::formats_runtime_directive_names_without_presenting_them_as_static ... ok
test ide::hover::component_tag::items::tests::runtime_key_and_ref_names_are_not_filtered_as_reserved_props ... ok
test ide::completion::component_props_tests::template_component_prop_completion_is_preserved_with_corsa ... ok
test ide::hover::component_tag::tests::hover_component_tag_does_not_overstate_missing_props_with_spread_attrs ... ok
test ide::hover::component_prop::tests::hover_component_prop_uses_croquis_metadata ... ok
test ide::hover::component_tag::tests::hover_component_tag_uses_croquis_usage ... ok
test ide::hover::html::tests::test_hover_template_describes_native_html_attribute ... ok
test ide::hover::html::tests::test_hover_template_describes_multiline_native_html_bound_attribute_name ... ok
test ide::hover::html::tests::test_hover_template_describes_native_html_bound_attribute_name ... ok
test ide::hover::html::tests::test_hover_template_describes_native_html_element ... ok
test ide::file_rename::manual_tests::rewrites_extensionless_ts_imports_without_corsa ... ok
test ide::hover::html::tests::test_hover_template_does_not_describe_unknown_native_attribute ... ok
test ide::hover::tests::test_binding_type_to_ts_display ... ok
test ide::hover::html::tests::test_hover_template_does_not_describe_custom_element_as_native_dom ... ok
test ide::hover::tests::test_corsa_hover_is_decorated_for_editor_clients ... ok
test ide::hover::tests::test_get_word_at_offset ... ok
test ide::hover::tests::test_binding_type_to_description ... ok
test ide::file_rename::manual_tests::rewrites_vue_imports_for_component_rename ... ok
test ide::hover::tests::test_hover_builder ... ok
test ide::hover::tests::test_hover_directive ... ok
test ide::file_rename::declaration_index_tests::renaming_module_declaration_index_directory_keeps_directory_specifier ... ok
test ide::hover::tests::test_hover_petite_vue_v_scope_binding_does_not_leak_to_sibling ... ok
test ide::hover::tests::test_hover_infers_computed_getter_return_type ... ok
test ide::hover::tests::test_hover_petite_vue_v_scope_binding_in_expression ... ok
test ide::hover::tests::test_hover_supports_art_variant_binding_at_identifier_boundary ... ok
test ide::hover::tests::test_hover_template_keeps_binding_hover_in_interpolation ... ok
test ide::hover::tests::test_hover_template_returns_none_for_plain_text_node ... ok
test ide::hover::tests::test_hover_template_keeps_binding_hover_in_dynamic_attribute ... ok
test ide::hover::tests::test_hover_vue_api ... ok
test ide::hover::tests::test_hover_with_corsa_fallback_supports_directive_boundaries ... ok
test ide::inlay_hint::tests::test_is_in_string ... ok
test ide::inlay_hint::tests::test_i18n_message_preview_without_script_setup ... ok
test ide::hover::tests::test_hover_template_returns_none_for_static_attribute_value ... ok
test ide::inlay_hint::tests::test_no_hints_in_define_props_type ... ok
test ide::inlay_hint::tests::test_no_hints_in_event_name_pattern ... ok
test ide::hover::tests::test_hover_with_corsa_fallback_supports_identifier_boundaries ... ok
test ide::inlay_hint::tests::test_props_destructure_analysis ... ok
test ide::inlay_hint::tests::test_i18n_message_preview_from_workspace_json_catalog ... ok
test ide::inlay_hint::tests::test_props_destructure_with_alias ... ok
test ide::inlay_hint::tests::test_props_without_destructure_in_template ... ok
test ide::inlay_hint::tests::test_reactive_binding_inlay_hint_resolves_inner_type ... ok
test ide::inlay_hint::tests::test_reactive_binding_inlay_hint ... ok
test ide::jsx::code_action::tests::no_actions_for_clean_component ... ok
test ide::jsx::document_symbols::tests::falls_back_to_placeholder_for_anonymous ... ok
test ide::jsx::code_action::tests::surfaces_quickfix_for_fixable_jsx_diagnostic ... ok
test ide::jsx::code_action::tests::quickfix_carries_a_workspace_edit ... ok
test ide::jsx::document_symbols::tests::lists_multiple_components_in_order ... ok
test ide::jsx::document_symbols::tests::lists_named_component ... ok
test ide::jsx::position::tests::maps_member_access_trigger_in_setup_body ... ok
test ide::jsx::position::tests::maps_props_access_inside_jsx_expr ... ok
test ide::jsx::document_symbols::tests::no_symbols_for_non_component_module ... ok
test ide::jsx::position::tests::maps_setup_scope_identifier ... ok
test ide::jsx::references::tests::references_without_bridge_returns_none ... ok
test ide::jsx::rename::tests::prepare_rename_without_bridge_returns_none ... ok
test ide::jsx::rename::tests::rejects_invalid_new_name ... ok
test ide::jsx::rename::tests::rename_with_invalid_identifier_returns_none ... ok
test ide::jsx::code_action::tests::no_actions_when_range_misses_diagnostic ... ok
test ide::jsx::scoped_style::tests::extracts_string_literal_scoped_css ... ok
test ide::jsx::scoped_style::tests::extracts_template_literal_scoped_css ... ok
test ide::jsx::scoped_style::tests::ignores_component_without_style ... ok
test ide::jsx::scoped_style::tests::no_virtual_documents_without_scoped_style ... ok
test ide::jsx::scoped_style::tests::ignores_non_scoped_style ... ok
test ide::jsx::scoped_style::tests::virtual_document_has_one_to_one_source_map ... ok
test ide::jsx::semantic_tokens::tests::tokenizes_bound_attribute_expression ... ok
test ide::jsx::service::tests::completion_without_bridge_returns_none ... ok
test ide::jsx::service::tests::definition_without_bridge_returns_none ... ok
test ide::jsx::service::tests::diagnostics_without_bridge_is_empty ... ok
test ide::jsx::semantic_tokens::tests::tokenizes_interpolation_expression ... ok
test ide::jsx::semantic_tokens::tests::no_tokens_for_static_only_component ... ok
test ide::jsx::semantic_tokens::tests::tokens_land_at_source_columns ... ok
test ide::jsx::service::tests::same_uri_matches_across_file_scheme ... ok
test ide::jsx::service::tests::request_path_is_distinct_from_sfc_virtual_docs ... ok
test ide::jsx::service::tests::hover_without_bridge_returns_none ... ok
test ide::jsx::virtual_ts::tests::collect_jsx_expressions_includes_for_body_model_and_style_exprs ... ok
test ide::markup::tests::markdown_builder_emits_fenced_examples_and_docs ... ok
test ide::definition::corsa_tests::definition_with_corsa_resolves_component_prop_attribute_to_child_prop ... ok
test ide::jsx::virtual_ts::tests::jsx_file_mode_is_exact ... ok
test ide::markup::tests::snippet_for_docs_keeps_examples_readable ... ok
test ide::references::tests::test_find_binding_in_script ... ok
test ide::jsx::virtual_ts::tests::multiple_roots_and_static_style_are_exact ... ok
test ide::references::tests::test_find_identifier_references_in_script ... ok
test ide::references::tests::test_find_vbind_references_in_style ... ok
test ide::references::tests::test_get_word_at_offset ... ok
test ide::references::tests::test_is_in_binding_context ... ok
test ide::rename::tests::test_find_identifier_occurrences ... ok
test ide::rename::tests::test_find_vbind_occurrences ... ok
test ide::rename::tests::test_get_word_at_offset ... ok
test ide::rename::tests::test_is_keyword ... ok
test ide::rename::tests::test_is_valid_identifier ... ok
test ide::rename::tests::test_offset_range_to_lsp_counts_utf16_code_units ... ok
test ide::semantic_tokens::tests::test_art_attribute_tokens ... ok
test ide::semantic_tokens::tests::test_art_block_tokens ... ok
test ide::semantic_tokens::tests::test_art_script_tokens ... ok
test ide::semantic_tokens::tests::test_art_tokens_basic ... ok
test ide::jsx::virtual_ts::tests::typed_component_with_jsx_control_flow_directives_and_styles_is_exact ... ok
test ide::references::tests::test_find_word_occurrences ... ok
test ide::semantic_tokens::tests::test_directive_expression_does_not_steal_next_attribute_value ... ok
test ide::semantic_tokens::tests::test_directive_expression_tokenization ... ok
test ide::semantic_tokens::tests::test_art_variant_template_tokens ... ok
test ide::semantic_tokens::tests::test_extract_identifiers ... ok
test ide::semantic_tokens::tests::test_full_sfc_semantic_tokens ... ok
test ide::semantic_tokens::tests::test_full_sfc_semantic_tokens_use_lsp_coordinates ... ok
test ide::semantic_tokens::tests::test_interpolation_string_token_uses_utf16_length ... ok
test ide::semantic_tokens::tests::test_interpolation_tokens ... ok
test ide::semantic_tokens::tests::test_inline_art_tokens_in_vue ... ok
test ide::semantic_tokens::tests::test_looks_like_function_call ... ok
test ide::semantic_tokens::tests::test_offset_to_line_col ... ok
test ide::semantic_tokens::tests::test_offset_to_line_col_counts_utf16_code_units ... ok
test ide::semantic_tokens::tests::test_template_semantic_tokens_collect_dynamic_shorthand_args ... ok
test ide::semantic_tokens::tests::test_template_semantic_tokens_collect_unquoted_directive_values ... ok
test ide::semantic_tokens::tests::test_template_semantic_tokens_ignore_plain_text_lookalikes ... ok
test ide::semantic_tokens::tests::test_range_semantic_tokens_return_only_requested_lines ... ok
test ide::semantic_tokens::tests::test_template_semantic_tokens_ignore_static_attribute_text ... ok
test ide::semantic_tokens::tests::test_template_semantic_tokens_still_collect_attribute_tokens ... ok
test ide::semantic_tokens::tests::test_variant_block_tokens ... ok
test ide::tests::standalone_html_block_detection_finds_template_script_and_style_regions ... ok
test ide::tests::standalone_html_block_detection_ignores_raw_tags_inside_comments ... ok
test ide::semantic_tokens::tests::test_token_modifier_encode ... ok
test ide::semantic_tokens::tests::test_tokenize_expression ... ok
test ide::tests::standalone_html_block_detection_resumes_after_comment_closes ... ok
test ide::tests::test_kebab_to_pascal ... ok
test ide::tests::test_offset_to_position ... ok
test ide::tests::test_is_component_tag ... ok
test ide::tests::test_offset_to_position_counts_utf16_code_units ... ok
test ide::tests::test_pascal_to_kebab ... ok
test ide::tests::test_position_to_offset ... ok
test ide::tests::test_position_to_offset_counts_utf16_code_units ... ok
test ide::tests::test_position_to_offset_rejects_utf16_surrogate_pair_interior ... ok
test ide::tests::test_token_at_offset_supports_end_of_file_boundaries ... ok
test ide::tests::test_token_span_at_offset_allows_identifier_boundaries ... ok
test ide::type_service::diagnostics::diagnostics_tests::offset_to_line_col_counts_utf16_code_units ... ok
test ide::type_service::tests::test_infer_binding_type ... ok
test ide::type_service::diagnostics::diagnostics_tests::offset_to_line_col_is_zero_indexed_for_lsp ... ok
test ide::type_service::tests::test_extract_identifier ... ok
test ide::workspace_symbols::tests::test_extract_css_classes ... ok
test ide::type_service::diagnostics::diagnostics_tests::collect_diagnostics_uses_zero_indexed_lsp_lines ... ok
test ide::workspace_symbols::tests::test_extract_css_ids ... ok
test runtime::tests::threaded_writer_waits_for_pending_flush_before_accepting_more_writes ... ok
test ide::workspace_symbols::tests::test_extract_identifier ... ok
test ide::workspace_symbols::tests::test_parse_declaration ... ok
test ide::workspace_symbols::tests::test_to_pascal_case ... ok
test server::capabilities::tests::code_actions_require_both_lint_and_code_action_features ... ok
test server::capabilities::tests::all_features_skip_unimplemented_providers_and_keep_implemented_ones ... ok
test server::capabilities::tests::declaration_events_remain_registered_when_file_rename_is_disabled ... ok
test server::capabilities::tests::completion_triggers_match_completion_service_contract ... ok
test ide::type_service::diagnostics::diagnostics_tests::collect_diagnostics_does_not_report_regex_literals_as_undefined_bindings ... ok
test server::capabilities::tests::declaration_file_operations_cover_create_delete_and_rename ... ok
test server::capabilities::tests::default_features_advertise_non_opinionated_providers ... ok
test server::capabilities::tests::file_rename_registration_mentions_declaration_files ... ok
test server::capabilities::tests::text_document_sync_uses_incremental_open_close_and_save_without_text ... ok
test server::capabilities::tests::individual_feature_flags_gate_matching_providers ... ok
test server::format::tests::format_document_edit_covers_full_range ... ok
test server::format::tests::format_document_edit_uses_real_eof_for_trailing_newline ... ok
test server::format::tests::format_document_edit_uses_utf16_columns ... ok
test server::format::tests::format_document_is_idempotent ... ok
test server::format::tests::format_document_returns_edit_for_unformatted ... ok
test server::format::tests::format_document_respects_options ... ok
test server::format::tests::format_document_with_single_quote ... ok
test server::handlers::tests::code_action_surfaces_tsx_quickfix ... ok
test server::handlers::tests::document_symbol_lists_tsx_components ... ok
test server::format::tests::format_document_with_config_loaded_from_state ... ok
test server::handlers::tests::directive_edit_reinvalidates_jsx_diagnostics_and_virtual_docs ... ok
test server::handlers::tests::document_symbol_still_parses_sfc_after_jsx_routing ... ok
test server::handlers::tests::lifecycle::did_change_full_content_replaces_document_and_rebuilds_virtual_docs ... ok
test server::handlers::tests::formatting_returns_no_edits_for_standalone_html ... ok
test server::handlers::tests::embedded_scoped_style_produces_css_virtual_document ... ok
test server::handlers::tests::lifecycle::did_change_unopened_document_does_not_create_document_or_virtual_docs ... ok
test server::handlers::tests::lifecycle::did_close_removes_document_and_virtual_docs ... ok
test server::handlers::tests::lifecycle::did_save_unopened_document_does_not_create_document ... ok
test server::handlers::tests::references_gated_off_returns_none_for_tsx ... ok
test server::handlers::tests::rename_gated_off_returns_none_for_tsx ... ok
test server::handlers::tests::lifecycle::did_open_stores_document_and_generates_virtual_docs ... ok
test server::handlers::tests::lifecycle::did_change_incremental_content_updates_document_and_virtual_docs ... ok
test server::handlers::tests::requests::code_lens_disabled_returns_none ... ok
test server::handlers::tests::requests::completion_missing_document_returns_none ... ok
test server::handlers::tests::requests::code_action_disabled_when_code_actions_are_off ... ok
test server::handlers::tests::requests::code_action_disabled_when_lint_is_off ... ok
test server::handlers::tests::requests::completion_disabled_returns_none ... ok
test server::handlers::tests::requests::definition_disabled_returns_none ... ok
test server::handlers::tests::requests::definition_missing_document_returns_none ... ok
test server::handlers::tests::requests::document_highlight_disabled_returns_none ... ok
test server::handlers::tests::requests::file_rename_disabled_returns_none ... ok
test server::handlers::tests::requests::document_symbol_disabled_returns_none ... ok
test server::handlers::tests::requests::folding_range_disabled_returns_none ... ok
test server::handlers::tests::requests::formatting_disabled_returns_none ... ok
test server::handlers::tests::requests::guards_extra::code_action_missing_document_returns_none ... ok
test server::handlers::tests::requests::guards_extra::code_lens_missing_document_returns_none ... ok
test server::handlers::tests::requests::guards_extra::code_action_out_of_range_returns_none ... ok
test server::handlers::tests::requests::document_link_disabled_returns_none ... ok
test server::handlers::tests::requests::guards_extra::document_highlight_missing_document_returns_none ... ok
test server::handlers::tests::requests::guards_extra::document_link_missing_document_returns_none ... ok
test server::handlers::tests::requests::guards_extra::document_highlight_out_of_range_returns_none ... ok
test server::handlers::tests::requests::guards_extra::completion_out_of_range_returns_none ... ok
test server::handlers::tests::requests::guards_extra::folding_range_missing_document_returns_none ... ok
test server::handlers::tests::requests::guards_extra::formatting_missing_document_returns_none ... ok
test server::handlers::tests::requests::guards_extra::document_symbol_missing_document_returns_none ... ok
test server::handlers::tests::requests::guards_extra::definition_out_of_range_returns_none ... ok
test server::handlers::tests::requests::guards_extra::hover_out_of_range_returns_none ... ok
test server::handlers::tests::requests::guards_extra::inlay_hint_missing_document_returns_none ... ok
test server::handlers::tests::requests::guards_extra::prepare_rename_missing_document_returns_none ... ok
test server::handlers::tests::requests::guards_extra::range_formatting_missing_document_returns_none ... ok
test server::handlers::tests::requests::guards_extra::prepare_rename_out_of_range_returns_none ... ok
test server::handlers::tests::requests::guards_extra::range_formatting_out_of_range_returns_none ... ok
test server::handlers::tests::requests::guards_extra::rename_missing_document_returns_none ... ok
test server::handlers::tests::requests::guards_extra::references_missing_document_returns_none ... ok
test server::handlers::tests::requests::guards_extra::semantic_tokens_full_missing_document_returns_none ... ok
test server::handlers::tests::requests::guards_extra::semantic_tokens_range_missing_document_returns_none ... ok
test server::handlers::tests::requests::guards_extra::rename_out_of_range_returns_none ... ok
test server::handlers::tests::requests::hover_disabled_returns_none ... ok
test server::handlers::tests::requests::hover_missing_document_returns_none ... ok
test server::handlers::tests::requests::guards_extra::references_out_of_range_returns_none ... ok
test server::handlers::tests::requests::prepare_rename_disabled_returns_none ... ok
test ide::diagnostics::corsa::tests::editor_virtual_ts_preserves_computed_map_value_types ... ok
test server::handlers::tests::requests::range_formatting_disabled_returns_none ... ok
test server::handlers::tests::requests::inlay_hint_disabled_returns_none ... ok
test server::handlers::tests::requests::responses::document_symbols_list_sfc_blocks_with_editor_labels ... ok
test server::handlers::tests::requests::references_disabled_returns_none ... ok
test server::handlers::tests::requests::responses::folding_ranges_cover_multiline_sfc_blocks ... ok
test server::handlers::tests::requests::responses::root_completion_returns_block_snippet_labels ... ok
test server::handlers::tests::requests::rename_disabled_returns_none ... ok
test server::handlers::tests::requests::workspace_symbols_disabled_returns_none ... ok
test server::handlers::tests::requests::semantic_tokens_range_disabled_returns_none ... ok
test server::handlers::tests::requests::semantic_tokens_full_disabled_returns_none ... ok
test server::importers::package::tests::package_exports_select_types_without_guessing_a_root_subpath ... ok
test server::importers::package::tests::package_specifiers_preserve_scopes_and_subpaths ... ok
test server::handlers::tests::semantic_tokens_full_highlights_tsx_expressions ... ok
test server::importers::tests::index_resolves_explicit_script_dependencies_and_query_suffixes ... ok
test server::importers::package::tests::package_export_arrays_fall_back_without_escaping_the_package ... ok
test server::importers::tests::exact_directory_specifiers_resolve_index_files ... ok
test server::importers::package::tests::package_export_patterns_prefer_the_longest_prefix_before_total_length ... ok
test server::importers::package::tests::package_export_conditions_block_empty_and_unknown_targets ... ok
test server::importers::package::tests::package_runtime_exports_prefer_declaration_sidecars ... ok
test server::importers::package::tests::package_exports_are_authoritative_and_support_nested_wildcards ... ok
test server::importers::tests::index_tracks_and_removes_open_vue_imports ... ok
test server::state::config_tests::disabled_language_server_clears_logged_legacy_vue2_feature ... ok
test server::state::config_tests::language_server_legacy_vue2_reaches_logged_lsp_feature_payload ... ok
test server::state::tests::corsa_init_failure_is_recorded ... ok
test server::state::tests::apply_lsp_initialization_options ... ok
test server::state::tests::default_format_options ... ok
test server::importers::tests::index_resolves_package_export_declaration_variants ... ok
test server::state::tests::jsx_typecheck_defaults_off ... ok
test server::state::tests::jsx_typecheck_config_opts_in ... ok
test server::state::tests::legacy_vue2_config_implies_options_api ... ok
test server::state::global_components::tests::concurrent_cold_lookups_share_one_background_scan ... ok
test server::state::tests::load_format_config_from_file ... ok
test server::state::tests::load_format_config_invalid_json ... ok
test server::state::global_components::event_tests::excluded_tree_events_do_not_restart_discovery_but_nuxt_events_do ... ok
test server::state::tests::load_lsp_config_from_pkl ... ignored, requires pkl runtime installed
test server::state::tests::load_format_config_no_file ... ok
test server::state::tests::load_format_config_partial ... ok
test server::state::tests::load_format_config_no_fmt_section ... ok
test server::state::tests::load_lsp_config_from_json ... ok
test server::state::global_components::event_tests::declaration_file_events_refresh_created_renamed_and_deleted_paths ... ok
test server::state::tests::lsp_features_enable_non_opinionated_defaults ... ok
test server::state::tests::options_api_enabled_by_default ... ok
test server::state::global_components::tests::finds_hidden_project_augmentations_without_scanning_dependencies ... ok
test server::state::tests::load_lsp_config_updates_linter_config ... ok
test server::state::tests::load_lsp_config_invalid_json_keeps_default ... ok
test server::state::tests::update_art_virtual_docs_keeps_script_setup_shared_when_isolate_false ... ok
test server::state::tests::update_art_virtual_docs_tracks_non_default_variants_separately ... ok
test server::state::tests::type_checker_options_api_explicit_opt_in_from_config ... ok
test server::state::tests::load_lsp_config_updates_type_checker_config ... ok
test server::state::tests::update_art_virtual_docs_isolates_script_setup_per_variant ... ok
test server::state::tests::type_checker_options_api_opt_out_from_config ... ok
test server::state::tests::update_virtual_docs_generates_standalone_html_template_doc ... ok
test server::state::tests::update_virtual_docs_removes_cache_after_art_parse_failure ... ok
test server::state::tests::update_virtual_docs_removes_cache_after_sfc_parse_failure ... ok
test server::workspace_files::tests::client_watcher_support_is_recorded_from_initialize_capabilities ... ok
test server::workspace_files::tests::declaration_watcher_tracks_create_change_and_delete_recursively ... ok
test utils::position::tests::test_internal_to_lsp_position ... ok
test utils::position::tests::test_offset_to_position ... ok
test utils::position::tests::test_offset_to_position_counts_utf16_code_units ... ok
test utils::position::tests::test_offset_to_position_str_counts_utf16_code_units ... ok
test utils::position::tests::test_position_to_offset ... ok
test utils::position::tests::test_position_to_offset_str_counts_utf16_code_units ... ok
test utils::position::tests::test_position_to_offset_rejects_utf16_surrogate_pair_interior ... ok
test utils::position::tests::test_position_to_offset_counts_utf16_code_units ... ok
test virtual_code::generator::tests::test_block_type_art_language ... ok
test virtual_code::generator::tests::test_batch_generator ... ok
test virtual_code::generator::tests::test_find_art_block_at_offset ... ok
test virtual_code::generator::tests::test_find_art_block_at_offset_treats_variant_body_as_template ... ok
test virtual_code::generator::tests::test_find_art_block_at_offset_treats_variant_body_whitespace_as_template ... ok
test virtual_code::generator::tests::test_find_block_at_offset ... ok
test virtual_code::generator::tests::test_find_block_at_offset_detects_inline_art_variant_template ... ok
test virtual_code::generator::tests::test_find_block_at_offset_inline_art ... ok
test virtual_code::generator::tests::test_script_setup_exports_template_used_bindings ... ok
test virtual_code::script_code::tests::non_setup_compatibility_path_remains_empty ... ok
test virtual_code::generator::tests::test_virtual_code_generator ... ok
test virtual_code::source_map::tests::test_mapping_generated_to_source ... ok
test virtual_code::generator::tests_semantic_bindings::generator_exports_semantic_script_bindings_used_by_template ... ok
test virtual_code::source_map::tests::test_mapping_source_to_generated ... ok
test virtual_code::source_map::tests::test_source_map_to_generated ... ok
test virtual_code::generator::tests_semantic_bindings::allocator_and_owned_generation_keep_semantic_exports_in_sync ... ok
test virtual_code::source_map::tests::test_source_map_to_source ... ok
test virtual_code::script_code::tests::semantic_binding_extraction_handles_complete_binding_patterns ... ok
test virtual_code::source_map::tests::test_source_map_with_block_offset ... ok
test virtual_code::source_map::tests::test_source_range_contains ... ok
test virtual_code::style_code::tests::test_style_code_generator ... ok
test virtual_code::style_code::tests::test_style_metadata ... ok
test virtual_code::template_code::tests::test_event_arrow_expression_is_not_prefixed_as_member ... ok
test virtual_code::template_code::tests::test_generator_with_directives ... ok
test virtual_code::template_code::tests::test_multiline_event_arrow_expression_is_not_prefixed_as_member ... ok
test virtual_code::template_code::tests::test_template_code_generator ... ok
test ide::hover::corsa_tests::hover_with_corsa_resolves_component_prop_attribute ... ok
test ide::diagnostics::editor_typecheck_tests::async_collect_resolves_define_art_target_vue_imports ... ok
test ide::diagnostics::editor_typecheck_tests::async_collect_resolves_relative_vue_imports_in_script_setup ... ok
test ide::diagnostics::editor_typecheck_tests::async_collect_preserves_imported_computed_callback_types ... ok
test ide::diagnostics::corsa::relative_import_tests::editor_relative_vue_imports_resolve_existing_siblings ... ok

test result: ok. 543 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.27s


running 3 tests
test rewrites_extensionless_declaration_imports_for_renamed_dmts ... ok
test rewrites_extensionless_declaration_imports_for_renamed_dcts ... ok
test rewrites_extensionless_declaration_imports_for_renamed_dts ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 1 test
test crates/vize_maestro/src/lib.rs - (line 58) - compile ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

all doctests ran in 0.95s; merged doctests compilation took 0.54s\n- \n- \n-

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->