### PR TITLE
fix(typecheck): unwrap typed mixin arrays

### DIFF
--- a/crates/vize_croquis/src/script_parser/legacy_vue2_tests.rs
+++ b/crates/vize_croquis/src/script_parser/legacy_vue2_tests.rs
@@ -118,6 +118,19 @@ export default { mixins: ([LocalMixin] satisfies readonly object[]) }
 }
 
 #[test]
+fn mixins_unwrap_angle_bracket_asserted_arrays() {
+    assert_typed_mixin_array(
+        r#"
+const LocalMixin = {
+  methods: { inheritedMethod() {} },
+  filters: { inheritedFilter(value) { return value } }
+}
+export default { mixins: (<const>[LocalMixin]) }
+"#,
+    );
+}
+
+#[test]
 fn class_component_decorator_filters_are_legacy_only() {
     let source = r#"
 import Vue from 'vue'

--- a/crates/vize_croquis/src/script_parser/legacy_vue2_tests.rs
+++ b/crates/vize_croquis/src/script_parser/legacy_vue2_tests.rs
@@ -72,6 +72,51 @@ export default {
     }
 }
 
+fn assert_typed_mixin_array(source: &str) {
+    let legacy = parse_legacy(source);
+    let vue3 = parse_vue3_options(source);
+
+    assert_eq!(
+        legacy.bindings.get("inheritedMethod"),
+        Some(BindingType::Options)
+    );
+    assert_eq!(
+        vue3.bindings.get("inheritedMethod"),
+        Some(BindingType::Options)
+    );
+    assert_eq!(
+        legacy.bindings.get("inheritedFilter"),
+        Some(BindingType::Options)
+    );
+    assert!(!vue3.bindings.contains("inheritedFilter"));
+}
+
+#[test]
+fn mixins_unwrap_as_const_arrays() {
+    assert_typed_mixin_array(
+        r#"
+const LocalMixin = {
+  methods: { inheritedMethod() {} },
+  filters: { inheritedFilter(value) { return value } }
+}
+export default { mixins: ([LocalMixin] as const) }
+"#,
+    );
+}
+
+#[test]
+fn mixins_unwrap_satisfies_arrays() {
+    assert_typed_mixin_array(
+        r#"
+const LocalMixin = {
+  methods: { inheritedMethod() {} },
+  filters: { inheritedFilter(value) { return value } }
+}
+export default { mixins: ([LocalMixin] satisfies readonly object[]) }
+"#,
+    );
+}
+
 #[test]
 fn class_component_decorator_filters_are_legacy_only() {
     let source = r#"

--- a/crates/vize_croquis/src/script_parser/process/options_api/inheritance.rs
+++ b/crates/vize_croquis/src/script_parser/process/options_api/inheritance.rs
@@ -47,6 +47,9 @@ fn unwrap_array_expression<'a>(expression: &'a Expression<'a>) -> Option<&'a Arr
             unwrap_array_expression(&parenthesized.expression)
         }
         Expression::TSAsExpression(ts_as) => unwrap_array_expression(&ts_as.expression),
+        Expression::TSTypeAssertion(ts_assertion) => {
+            unwrap_array_expression(&ts_assertion.expression)
+        }
         Expression::TSSatisfiesExpression(ts_satisfies) => {
             unwrap_array_expression(&ts_satisfies.expression)
         }

--- a/crates/vize_croquis/src/script_parser/process/options_api/inheritance.rs
+++ b/crates/vize_croquis/src/script_parser/process/options_api/inheritance.rs
@@ -1,6 +1,6 @@
 //! Same-file Options API mixin and extends resolution.
 
-use oxc_ast::ast::{Expression, ObjectExpression};
+use oxc_ast::ast::{ArrayExpression, Expression, ObjectExpression};
 use vize_carton::{FxHashMap, FxHashSet};
 
 use super::{
@@ -19,8 +19,10 @@ pub(super) fn collect_mixins_bindings<'a>(
     seen_mixins: &mut FxHashSet<&'a str>,
     legacy_vue2: bool,
 ) {
-    let Some(Expression::ArrayExpression(array)) = option_expression_property(options, "mixins")
-    else {
+    let Some(expression) = option_expression_property(options, "mixins") else {
+        return;
+    };
+    let Some(array) = unwrap_array_expression(expression) else {
         return;
     };
 
@@ -35,6 +37,23 @@ pub(super) fn collect_mixins_bindings<'a>(
             seen_mixins,
             legacy_vue2,
         );
+    }
+}
+
+fn unwrap_array_expression<'a>(expression: &'a Expression<'a>) -> Option<&'a ArrayExpression<'a>> {
+    match expression {
+        Expression::ArrayExpression(array) => Some(array),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            unwrap_array_expression(&parenthesized.expression)
+        }
+        Expression::TSAsExpression(ts_as) => unwrap_array_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            unwrap_array_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            unwrap_array_expression(&ts_non_null.expression)
+        }
+        _ => None,
     }
 }
 


### PR DESCRIPTION
## Summary

- unwrap transparent TypeScript wrappers around same-file Options API `mixins` arrays
- preserve inherited methods in Vue 3 and inherited filters in legacy Vue 2
- add isolated regression coverage for `as const` and `satisfies` array forms

Follow-up to #3018.

## Validation

- `cargo test -p vize_croquis --lib` (259 passed)
- `cargo clippy -p vize_croquis --lib -- -D warnings`
- `cargo build -p vize --features legacy`
- `node --test --test-concurrency=1 tests/snapshots/check/vue-element-admin-legacy-oracle.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of `mixins` defined with TypeScript constructs (e.g., `as const` and `satisfies`) in Vue Options API parsing.
  * Correctly distinguishes inherited option bindings between legacy Vue 2 and Vue 3 modes, including methods vs. filters.
* **Tests**
  * Added new test cases to validate typed `mixins` arrays and the expected inherited bindings in both modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->