### PR TITLE
fix(lsp): honor configured template globals

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
@@ -46,10 +46,19 @@ impl DiagnosticService {
         let is_art_file = uri.path().ends_with(".art.vue");
         let options_api = state.options_api_enabled();
         let legacy_vue2 = state.legacy_vue2_enabled();
+        let mut virtual_ts_options = state.virtual_ts_options();
+        virtual_ts_options.reference_paths = state
+            .global_component_reference_paths()
+            .await
+            .iter()
+            .map(|path| path.to_string_lossy().as_ref().into())
+            .collect();
         let mut diagnostics = if is_art_file {
-            let Some(art_virtual) =
-                Self::generate_virtual_ts_for_art_with_dependencies(uri, &content)
-            else {
+            let Some(art_virtual) = Self::generate_virtual_ts_for_art_with_dependencies(
+                uri,
+                &content,
+                &virtual_ts_options,
+            ) else {
                 tracing::warn!("failed to generate virtual ts for {}", uri);
                 return vec![];
             };
@@ -85,15 +94,6 @@ impl DiagnosticService {
                     ))
                 })
                 .collect::<Vec<(std::path::PathBuf, vize_carton::String)>>();
-            let virtual_ts_options = vize_canon::virtual_ts::VirtualTsOptions {
-                reference_paths: state
-                    .global_component_reference_paths()
-                    .await
-                    .iter()
-                    .map(|path| path.to_string_lossy().as_ref().into())
-                    .collect(),
-                ..Default::default()
-            };
             let opened = match bridge
                 .open_vue_virtual_document_with_overlays_and_options(
                     &source_path,
@@ -135,6 +135,7 @@ impl DiagnosticService {
                 &content,
                 options_api,
                 legacy_vue2,
+                &virtual_ts_options,
             ) {
                 diagnostics.extend(
                     collect_virtual_result_diagnostics(

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
@@ -81,9 +81,14 @@ pub(super) async fn collect_synced_virtual_result_diagnostics(
         );
     }
 
-    corsa_diags
+    let mapped_diagnostics = corsa_diags
         .into_iter()
         .filter_map(|diag| {
+            if is_inferred_implicit_any_suggestion(&diag) {
+                tracing::debug!("skipping TS7044 inference suggestion");
+                return None;
+            }
+
             let is_unused_warning = diag.message.contains("is declared but")
                 && (diag.message.contains("never read") || diag.message.contains("never used"));
             let is_internal_var = diag.message.contains("'__")
@@ -187,7 +192,30 @@ pub(super) async fn collect_synced_virtual_result_diagnostics(
                 ..Default::default()
             })
         })
-        .collect()
+        .collect::<Vec<_>>();
+
+    deduplicate_diagnostics(mapped_diagnostics)
+}
+
+fn deduplicate_diagnostics(diagnostics: Vec<Diagnostic>) -> Vec<Diagnostic> {
+    let mut unique = Vec::with_capacity(diagnostics.len());
+    for diagnostic in diagnostics {
+        if !unique.contains(&diagnostic) {
+            unique.push(diagnostic);
+        }
+    }
+    unique
+}
+
+fn is_inferred_implicit_any_suggestion(
+    diagnostic: &vize_canon::corsa_bridge::LspDiagnostic,
+) -> bool {
+    diagnostic.severity == Some(4)
+        && diagnostic.code.as_ref().is_some_and(|code| match code {
+            serde_json::Value::Number(number) => number.as_i64() == Some(7044),
+            serde_json::Value::String(code) => matches!(code.as_str(), "7044" | "TS7044"),
+            _ => false,
+        })
 }
 
 fn corsa_diagnostic_code(code: serde_json::Value) -> NumberOrString {
@@ -208,8 +236,11 @@ fn corsa_diagnostic_code(code: serde_json::Value) -> NumberOrString {
 
 #[cfg(test)]
 mod tests {
-    use super::corsa_diagnostic_code;
-    use tower_lsp::lsp_types::NumberOrString;
+    use super::{
+        corsa_diagnostic_code, deduplicate_diagnostics, is_inferred_implicit_any_suggestion,
+    };
+    use tower_lsp::lsp_types::{Diagnostic, NumberOrString, Position, Range};
+    use vize_canon::corsa_bridge::{LspDiagnostic, LspPosition, LspRange};
 
     #[test]
     fn corsa_diagnostic_codes_preserve_lsp_number_and_string_shapes() {
@@ -220,6 +251,82 @@ mod tests {
         assert_eq!(
             corsa_diagnostic_code(serde_json::json!("TS2322")),
             NumberOrString::String("TS2322".to_string()),
+        );
+    }
+
+    #[test]
+    fn only_ts7044_hints_are_suppressed() {
+        let diagnostic = |severity, code| LspDiagnostic {
+            range: LspRange {
+                start: LspPosition {
+                    line: 0,
+                    character: 0,
+                },
+                end: LspPosition {
+                    line: 0,
+                    character: 1,
+                },
+            },
+            severity,
+            code,
+            source: Some("ts".into()),
+            message: "diagnostic".into(),
+            related_information: None,
+        };
+
+        assert!(is_inferred_implicit_any_suggestion(&diagnostic(
+            Some(4),
+            Some(serde_json::json!(7044)),
+        )));
+        assert!(is_inferred_implicit_any_suggestion(&diagnostic(
+            Some(4),
+            Some(serde_json::json!("TS7044")),
+        )));
+        assert!(!is_inferred_implicit_any_suggestion(&diagnostic(
+            Some(1),
+            Some(serde_json::json!(7044)),
+        )));
+        assert!(!is_inferred_implicit_any_suggestion(&diagnostic(
+            Some(4),
+            Some(serde_json::json!(7043)),
+        )));
+        assert!(!is_inferred_implicit_any_suggestion(&diagnostic(
+            None, None,
+        )));
+    }
+
+    #[test]
+    fn exact_diagnostics_are_stably_deduplicated() {
+        let original = Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 19,
+                },
+                end: Position {
+                    line: 1,
+                    character: 30,
+                },
+            },
+            severity: Some(tower_lsp::lsp_types::DiagnosticSeverity::ERROR),
+            code: Some(NumberOrString::Number(2304)),
+            source: Some("vize/types".into()),
+            message: "Cannot find name 'missingList'.".into(),
+            ..Default::default()
+        };
+        let distinct = Diagnostic {
+            message: "Cannot find name 'anotherBinding'.".into(),
+            ..original.clone()
+        };
+
+        assert_eq!(
+            deduplicate_diagnostics(vec![
+                original.clone(),
+                distinct.clone(),
+                original.clone(),
+                distinct.clone(),
+            ]),
+            vec![original, distinct],
         );
     }
 }

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs
@@ -94,8 +94,13 @@ defineProps<{ variant?: "primary" | "secondary" }>();
   </variant>
 </art>"#;
 
-    let results =
-        DiagnosticService::generate_virtual_ts_for_inline_art_variants(&uri, content, false, false);
+    let results = DiagnosticService::generate_virtual_ts_for_inline_art_variants(
+        &uri,
+        content,
+        false,
+        false,
+        &vize_canon::virtual_ts::VirtualTsOptions::default(),
+    );
 
     assert_eq!(results.len(), 1);
     let (_, result) = &results[0];
@@ -129,9 +134,13 @@ defineArt("./Button.vue", { title: "Button" });
   </variant>
 </art>"#;
 
-    let result = DiagnosticService::generate_virtual_ts_for_art_with_dependencies(&uri, content)
-        .expect("virtual TS generated")
-        .virtual_result;
+    let result = DiagnosticService::generate_virtual_ts_for_art_with_dependencies(
+        &uri,
+        content,
+        &vize_canon::virtual_ts::VirtualTsOptions::default(),
+    )
+    .expect("virtual TS generated")
+    .virtual_result;
 
     assert!(
         result

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs
@@ -20,6 +20,7 @@ impl DiagnosticService {
     pub(in crate::ide::diagnostics) fn generate_virtual_ts_for_art_with_dependencies(
         uri: &Url,
         content: &str,
+        base_options: &VirtualTsOptions,
     ) -> Option<ArtVirtualTsResult> {
         let art_allocator = vize_carton::Bump::new();
         let art_desc = vize_musea::parse_art(
@@ -113,7 +114,7 @@ impl DiagnosticService {
         analyzer.analyze_template(&template_ast);
 
         let summary = analyzer.finish();
-        let mut virtual_ts_options = VirtualTsOptions::default();
+        let mut virtual_ts_options = base_options.clone();
         if let Some(target) = target_component.as_ref() {
             add_art_target_component_bindings(&mut virtual_ts_options, &summary, target);
         }

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs
@@ -31,6 +31,7 @@ impl DiagnosticService {
         content: &str,
         options_api: bool,
         legacy_vue2: bool,
+        base_options: &VirtualTsOptions,
     ) -> Vec<(usize, VirtualTsResult)> {
         if uri.path().ends_with(".art.vue") || !content.contains("<art") {
             return Vec::new();
@@ -93,7 +94,7 @@ impl DiagnosticService {
                     crate::ide::offset_to_position(content, script_offset as usize).0 + 1
                 };
 
-                let mut virtual_ts_options = VirtualTsOptions::default();
+                let mut virtual_ts_options = base_options.clone();
                 add_inline_self_component_binding(&mut virtual_ts_options, &analysis.croquis);
 
                 let generate_virtual_ts = if legacy_vue2 {

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -23,7 +23,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use dashmap::DashMap;
 use parking_lot::RwLock;
 use tower_lsp::lsp_types::Url;
-use vize_carton::config::{LinterConfig, TypeCheckerConfig};
+use vize_carton::config::{GlobalTypesConfig, LinterConfig, TypeCheckerConfig};
 use vize_carton::dialect::VueDialect;
 
 #[cfg(feature = "native")]
@@ -66,6 +66,8 @@ pub struct ServerState {
     lsp_typecheck_enabled: AtomicBool,
     /// Type checker options shared by LSP diagnostics.
     type_checker_config: RwLock<TypeCheckerConfig>,
+    /// User-declared template globals shared by every virtual TypeScript path.
+    global_types: RwLock<GlobalTypesConfig>,
     /// Vue 3 Options API binding-resolution opt-in from config.
     type_checker_options_api: RwLock<bool>,
     /// Vue 2.7 / Nuxt 2 type checker compatibility flag from config.
@@ -137,6 +139,7 @@ impl ServerState {
             lsp_features: RwLock::new(default_features),
             lsp_typecheck_enabled: AtomicBool::new(default_features.typecheck),
             type_checker_config: RwLock::new(TypeCheckerConfig::default()),
+            global_types: RwLock::new(GlobalTypesConfig::default()),
             // Options API resolution is default-on (matches vue-tsc); config can
             // opt out with `typeChecker.optionsApi: false`.
             type_checker_options_api: RwLock::new(true),

--- a/crates/vize_maestro/src/server/state/batch_cache.rs
+++ b/crates/vize_maestro/src/server/state/batch_cache.rs
@@ -82,7 +82,7 @@ impl ServerState {
         let corsa_path = config.runtime_path().map(PathBuf::from);
         let options = BatchTypeCheckerOptions {
             tsconfig_path: config.tsconfig.as_ref().map(PathBuf::from),
-            virtual_ts_options: vize_canon::virtual_ts::VirtualTsOptions::default(),
+            virtual_ts_options: self.virtual_ts_options(),
         };
 
         match BatchTypeChecker::with_options_and_corsa_path(

--- a/crates/vize_maestro/src/server/state/config.rs
+++ b/crates/vize_maestro/src/server/state/config.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 use std::sync::atomic::Ordering;
 
-use vize_carton::config::{LinterConfig, TypeCheckerConfig};
+use vize_carton::config::{GlobalTypesConfig, LinterConfig, TypeCheckerConfig};
 
 #[cfg(feature = "glyph")]
 use vize_carton::config::FormatterConfig;
@@ -35,6 +35,22 @@ impl ServerState {
         self.type_checker_config.read().clone()
     }
 
+    /// Build the shared virtual TypeScript options from workspace config.
+    #[cfg(feature = "native")]
+    pub(crate) fn virtual_ts_options(&self) -> vize_canon::virtual_ts::VirtualTsOptions {
+        let mut options = vize_canon::virtual_ts::VirtualTsOptions::default();
+        options
+            .template_globals
+            .extend(self.global_types.read().iter().map(|(name, declaration)| {
+                vize_canon::virtual_ts::TemplateGlobal {
+                    name: name.clone(),
+                    type_annotation: declaration.type_annotation.clone(),
+                    default_value: declaration.template_default_value(),
+                }
+            }));
+        options
+    }
+
     /// Get a clone of the current linter config.
     #[inline]
     pub fn get_linter_config(&self) -> LinterConfig {
@@ -62,6 +78,13 @@ impl ServerState {
     fn apply_type_checker_config(&self, config: TypeCheckerConfig, source: &str) {
         *self.type_checker_config.write() = config;
         tracing::info!("Loaded type checker config from {}", source);
+    }
+
+    fn apply_global_types_config(&self, config: GlobalTypesConfig, source: &str) {
+        *self.global_types.write() = config;
+        #[cfg(feature = "native")]
+        self.batch_cache.invalidate();
+        tracing::info!("Loaded global types config from {}", source);
     }
 
     fn apply_config_features(&self, features: vize_carton::config::ConfigFeatureFlags) {
@@ -106,6 +129,7 @@ impl ServerState {
             self.apply_linter_config(linter_config, &source);
             *self.linter_rule_options.write() =
                 vize_carton::config::load_linter_rule_options(Some(dir));
+            self.apply_global_types_config(config.global_types, &source);
             self.apply_type_checker_config(config.type_checker, &source);
             self.apply_config_features(loaded.features);
             self.apply_lsp_config(config.language_server.into(), &source);
@@ -119,13 +143,15 @@ impl ServerState {
             vize_carton::config::load_config_and_linter_with_features_and_source(Some(dir));
         if let Some(source_path) = loaded.source_path {
             let source = source_path.display().to_string();
+            let config = loaded.config;
             self.apply_linter_config(linter_config, &source);
             *self.linter_rule_options.write() =
                 vize_carton::config::load_linter_rule_options(Some(dir));
-            self.apply_type_checker_config(loaded.config.type_checker, &source);
+            self.apply_global_types_config(config.global_types, &source);
+            self.apply_type_checker_config(config.type_checker, &source);
             self.apply_config_features(loaded.features);
-            self.apply_lsp_config(loaded.config.language_server.into(), &source);
-            self.set_dialect_config(loaded.config.dialect);
+            self.apply_lsp_config(config.language_server.into(), &source);
+            self.set_dialect_config(config.dialect);
         }
     }
 

--- a/crates/vize_maestro/src/server/state/config_tests.rs
+++ b/crates/vize_maestro/src/server/state/config_tests.rs
@@ -73,3 +73,53 @@ fn disabled_language_server_clears_logged_legacy_vue2_feature() {
     assert!(logged_payload.contains("legacy_vue2: false"));
     assert!(logged_payload.contains("options_api: false"));
 }
+
+#[test]
+fn both_config_loaders_preserve_exact_template_globals() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("vize.config.json"),
+        r#"{
+          "globalTypes": {
+            "currentRoute": {
+              "type": "{ path: string }",
+              "defaultValue": "{ path: '/' }"
+            },
+            "toThousandFilter": "(value: number) => string"
+          }
+        }"#,
+    )
+    .unwrap();
+
+    for load_workspace in [true, false] {
+        let state = ServerState::new();
+        if load_workspace {
+            state.load_workspace_config(dir.path());
+        } else {
+            state.load_lsp_config(dir.path());
+        }
+
+        let globals = state
+            .virtual_ts_options()
+            .template_globals
+            .into_iter()
+            .map(|global| (global.name, global.type_annotation, global.default_value))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            globals,
+            vec![
+                (
+                    "currentRoute".into(),
+                    "{ path: string }".into(),
+                    "{ path: '/' }".into(),
+                ),
+                (
+                    "toThousandFilter".into(),
+                    "(value: number) => string".into(),
+                    "{} as any".into(),
+                ),
+            ],
+            "load_workspace={load_workspace}",
+        );
+    }
+}

--- a/tests/snapshots/check/vue-element-admin-legacy-oracle.ts
+++ b/tests/snapshots/check/vue-element-admin-legacy-oracle.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { pathToFileURL } from "node:url";
 
 import { withPinnedFixtureWorkspace } from "../../_helpers/realworld-patch.ts";
 import {
@@ -8,10 +9,24 @@ import {
   symlinkVueTypes,
   type VizeCheckResult,
 } from "../../_helpers/realworld-typecheck.ts";
+import { isDiagnosticsForUri } from "../../tooling/support/lsp/assertions.ts";
+import type { PublishDiagnosticsParams } from "../../tooling/support/lsp/protocol.ts";
+import { LspSession } from "../../tooling/support/lsp/session.ts";
 
 const sourcePath = "src/views/dashboard/admin/components/TransactionTable.vue";
 const cleanBinding = ':data="list"';
 const brokenBinding = ':data="missingList"';
+
+const missingListDiagnostic = {
+  range: {
+    start: { line: 1, character: 19 },
+    end: { line: 1, character: 30 },
+  },
+  severity: 1,
+  code: 2304,
+  source: "vize/types",
+  message: "Cannot find name 'missingList'.",
+};
 
 test("vue-element-admin legacy slot scopes recover exact CLI diagnostics", async () => {
   const corsaPath = resolveTsgoBinary();
@@ -32,18 +47,75 @@ test("vue-element-admin legacy slot scopes recover exact CLI diagnostics", async
       );
 
       const source = fixture.read(sourcePath);
+      const sourceUri = pathToFileURL(fixture.resolve(sourcePath)).href;
       assertCleanCheck(runVizeCheck(fixture.workspaceDir, corsaPath, [sourcePath]));
 
-      const brokenSource = fixture.applyExactPatch(sourcePath, cleanBinding, brokenBinding);
-      assert.notEqual(source, brokenSource);
-      assertBrokenCheck(runVizeCheck(fixture.workspaceDir, corsaPath, [sourcePath]));
+      const session = new LspSession();
+      try {
+        await session.initialize(fixture.workspaceDir, {
+          editor: true,
+          legacyVue2: true,
+          lint: false,
+          typecheck: true,
+        });
+        session.notify("textDocument/didOpen", {
+          textDocument: { uri: sourceUri, languageId: "vue", version: 1, text: source },
+        });
+        const cleanPublish = await waitForDiagnostics(session, sourceUri, 1, false);
+        assert.deepEqual(cleanPublish.diagnostics, [], JSON.stringify(cleanPublish.diagnostics));
 
-      const repairedSource = fixture.applyExactPatch(sourcePath, brokenBinding, cleanBinding);
-      assert.equal(repairedSource, source);
-      assertCleanCheck(runVizeCheck(fixture.workspaceDir, corsaPath, [sourcePath]));
+        const brokenSource = fixture.applyExactPatch(sourcePath, cleanBinding, brokenBinding);
+        assert.notEqual(source, brokenSource);
+        session.notify("textDocument/didChange", {
+          textDocument: { uri: sourceUri, version: 2 },
+          contentChanges: [{ text: brokenSource }],
+        });
+        const brokenPublish = await waitForDiagnostics(session, sourceUri, 2, true);
+        assert.deepEqual(brokenPublish.diagnostics, [missingListDiagnostic]);
+        assertBrokenCheck(runVizeCheck(fixture.workspaceDir, corsaPath, [sourcePath]));
+
+        const repairedSource = fixture.applyExactPatch(sourcePath, brokenBinding, cleanBinding);
+        assert.equal(repairedSource, source);
+        session.notify("textDocument/didChange", {
+          textDocument: { uri: sourceUri, version: 3 },
+          contentChanges: [{ text: repairedSource }],
+        });
+        const repairedPublish = await waitForDiagnostics(session, sourceUri, 3, false);
+        assert.deepEqual(
+          repairedPublish.diagnostics,
+          [],
+          JSON.stringify(repairedPublish.diagnostics),
+        );
+        assertCleanCheck(runVizeCheck(fixture.workspaceDir, corsaPath, [sourcePath]));
+      } finally {
+        await session.shutdown();
+      }
     },
   );
 });
+
+async function waitForDiagnostics(
+  session: LspSession,
+  uri: string,
+  version: number,
+  expectMissingList: boolean,
+): Promise<PublishDiagnosticsParams> {
+  return (await session.waitForNotification(
+    "textDocument/publishDiagnostics",
+    (params) =>
+      isDiagnosticsForUri(params, uri) &&
+      params.version === version &&
+      params.diagnostics.some(isMissingListDiagnostic) === expectMissingList,
+    120_000,
+  )) as PublishDiagnosticsParams;
+}
+
+function isMissingListDiagnostic(diagnostic: PublishDiagnosticsParams["diagnostics"][number]) {
+  return (
+    String(diagnostic.code).replace(/^TS/, "") === "2304" &&
+    diagnostic.message === "Cannot find name 'missingList'."
+  );
+}
 
 function assertCleanCheck(result: VizeCheckResult): void {
   assert.equal(result.status, 0, result.stderr || result.stdout);


### PR DESCRIPTION
## Summary

- carry workspace `globalTypes` into normal SFC, Art, and batch virtual TypeScript options
- suppress the non-actionable TS7044 inference hint while preserving real implicit-any errors, and stably remove exact duplicate diagnostics
- exercise vue-element-admin through exact clean, broken TS2304, and byte-identical repaired LSP/CLI states

## Validation

- `cargo test -p vize_maestro`
- `cargo clippy -p vize_maestro --lib -- -D warnings`
- `cargo build -p vize --features legacy`
- `node --test tests/snapshots/check/vue-element-admin-legacy-oracle.ts`
- `vp exec oxlint tests/snapshots/check/vue-element-admin-legacy-oracle.ts --deny-warnings`
- `vp exec oxfmt --check tests/snapshots/check/vue-element-admin-legacy-oracle.ts`
- `cargo fmt --all --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy editor diagnostics by hiding inferred implicit-`any` hints.
  * Removed duplicate diagnostics while preserving their original order.
  * Improved diagnostic accuracy for components with dependencies and inline variants.

* **New Features**
  * Global template types configured through workspace or language-server settings are now recognized consistently during type checking.
  * Configuration changes are applied reliably to subsequent diagnostics and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->