### PR TITLE
perf(lsp): deduplicate diagnostics in linear time

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
@@ -1,6 +1,7 @@
 //! Mapping Corsa virtual-document diagnostics back to the host SFC.
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url};
+use vize_carton::FxHashSet;
 
 use super::super::{VirtualTsResult, sources};
 use super::mapping::{map_diagnostic_with_source_mappings, source_offset_to_position};
@@ -197,14 +198,16 @@ pub(super) async fn collect_synced_virtual_result_diagnostics(
     deduplicate_diagnostics(mapped_diagnostics)
 }
 
-fn deduplicate_diagnostics(diagnostics: Vec<Diagnostic>) -> Vec<Diagnostic> {
-    let mut unique = Vec::with_capacity(diagnostics.len());
-    for diagnostic in diagnostics {
-        if !unique.contains(&diagnostic) {
-            unique.push(diagnostic);
+fn deduplicate_diagnostics(mut diagnostics: Vec<Diagnostic>) -> Vec<Diagnostic> {
+    let mut seen = FxHashSet::default();
+    diagnostics.retain(|diagnostic| match serde_json::to_vec(diagnostic) {
+        Ok(key) => seen.insert(key),
+        Err(error) => {
+            tracing::warn!("failed to serialize diagnostic deduplication key: {error}");
+            true
         }
-    }
-    unique
+    });
+    diagnostics
 }
 
 fn is_inferred_implicit_any_suggestion(
@@ -318,6 +321,10 @@ mod tests {
             message: "Cannot find name 'anotherBinding'.".into(),
             ..original.clone()
         };
+        let distinct_data = Diagnostic {
+            data: Some(serde_json::json!({ "origin": "second-pass" })),
+            ..original.clone()
+        };
 
         assert_eq!(
             deduplicate_diagnostics(vec![
@@ -325,8 +332,10 @@ mod tests {
                 distinct.clone(),
                 original.clone(),
                 distinct.clone(),
+                distinct_data.clone(),
+                distinct_data.clone(),
             ]),
-            vec![original, distinct],
+            vec![original, distinct, distinct_data],
         );
     }
 }


### PR DESCRIPTION
## Summary

- replace quadratic exact-diagnostic lookup with an order-preserving hash set
- serialize the full LSP diagnostic as the key so differences in optional fields remain distinct
- cover non-adjacent duplicates plus message-only and data-only distinctions

## Validation

- `cargo test -p vize_maestro exact_diagnostics_are_stably_deduplicated`
- `cargo clippy -p vize_maestro --lib -- -D warnings`
- `cargo build -p vize --features legacy`
- `node --test tests/snapshots/check/vue-element-admin-legacy-oracle.ts`
- `cargo fmt --all --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic deduplication so distinct diagnostics—including those with different additional data—are preserved.
  * Prevented diagnostics from being lost when internal processing encounters a serialization issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->