### PR TITLE
fix(atelier): enable Vue 2 compatibility pipeline

### DIFF
--- a/.github/actions/check-vue-parity/action.yml
+++ b/.github/actions/check-vue-parity/action.yml
@@ -20,10 +20,12 @@ runs:
 
     - name: Build vize CLI
       shell: bash
-      run: cargo build --profile ci -p vize
+      run: cargo build --profile ci -p vize --features legacy
 
     - name: Check Vue compiler and typecheck parity
       shell: bash
+      env:
+        VIZE_TEST_BIN: target/ci/vize
       run: vp run --filter './tests' test:check:fixtures
 
     - name: Check incremental LSP against Misskey

--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -23,7 +23,11 @@ maestro = ["dep:vize_maestro"]
 profiling = []
 # Opt-in legacy Vue (v0 / v1 / v2) support. Off by default so the Vue 3 binary
 # never activates or compiles it; turns on the legacy feature across the stack.
-legacy = ["vize_canon/legacy", "vize_maestro?/legacy"]
+legacy = [
+  "vize_atelier_core/legacy",
+  "vize_canon/legacy",
+  "vize_maestro?/legacy",
+]
 
 [dependencies]
 # Vize crates (re-exported for unified documentation)

--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -23,11 +23,7 @@ maestro = ["dep:vize_maestro"]
 profiling = []
 # Opt-in legacy Vue (v0 / v1 / v2) support. Off by default so the Vue 3 binary
 # never activates or compiles it; turns on the legacy feature across the stack.
-legacy = [
-  "vize_atelier_core/legacy",
-  "vize_canon/legacy",
-  "vize_maestro?/legacy",
-]
+legacy = ["vize_atelier_core/legacy", "vize_canon/legacy", "vize_maestro?/legacy"]
 
 [dependencies]
 # Vize crates (re-exported for unified documentation)

--- a/tests/_helpers/realworld-typecheck.ts
+++ b/tests/_helpers/realworld-typecheck.ts
@@ -110,7 +110,7 @@ function runCommand(command: string, args: string[], cwd: string): CommandResult
   return { status: result.status, stderr: result.stderr, stdout: result.stdout };
 }
 
-function resolveVizeCommand(): string[] {
+export function resolveVizeCommand(): string[] {
   const candidates = [
     process.env.VIZE_TEST_BIN,
     path.join(repoRoot, "target/debug/vize"),

--- a/tests/snapshots/check/vue-element-admin-legacy-oracle.ts
+++ b/tests/snapshots/check/vue-element-admin-legacy-oracle.ts
@@ -1,9 +1,14 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import { test } from "node:test";
 import { pathToFileURL } from "node:url";
 
+import { assertParsesAsModule } from "../../_helpers/assertions.ts";
 import { withPinnedFixtureWorkspace } from "../../_helpers/realworld-patch.ts";
 import {
+  resolveVizeCommand,
   resolveTsgoBinary,
   runVizeCheck,
   symlinkVueTypes,
@@ -17,6 +22,16 @@ const sourcePath = "src/views/dashboard/admin/components/TransactionTable.vue";
 const cleanBinding = ':data="list"';
 const brokenBinding = ':data="missingList"';
 
+type CompilerOutput = {
+  code: string;
+  css: string | null;
+  errors: string[];
+  filename: string;
+  macro_artifacts: unknown[];
+  script_lang: string;
+  warnings: string[];
+};
+
 const missingListDiagnostic = {
   range: {
     start: { line: 1, character: 19 },
@@ -27,6 +42,81 @@ const missingListDiagnostic = {
   source: "vize/types",
   message: "Cannot find name 'missingList'.",
 };
+
+test("vue-element-admin compiler lowers legacy slot scopes and filters deterministically", async () => {
+  await withPinnedFixtureWorkspace(
+    { fixtureId: "vue-element-admin", includePaths: [sourcePath] },
+    async (fixture) => {
+      fixture.write("vize.config.json", json({ compiler: { compatibility: { vueVersion: "2" } } }));
+
+      const source = fixture.read(sourcePath);
+      const first = runVizeBuild(fixture.workspaceDir, sourcePath, ".vize-compiler-first");
+      const second = runVizeBuild(fixture.workspaceDir, sourcePath, ".vize-compiler-second");
+
+      assert.equal(first.status, 0, first.stderr || first.stdout);
+      assert.equal(second.status, 0, second.stderr || second.stdout);
+      assert.deepEqual(first.files, ["TransactionTable.json"]);
+      assert.deepEqual(second.files, first.files);
+      assert.equal(second.outputText, first.outputText, "compiler output must be byte-stable");
+      assert.equal(fixture.read(sourcePath), source, "compiler must not mutate the Vue source");
+
+      const output = first.output;
+      assert.deepEqual(
+        {
+          css: output.css,
+          errors: output.errors,
+          filename: output.filename,
+          macro_artifacts: output.macro_artifacts,
+          script_lang: output.script_lang,
+          warnings: output.warnings,
+        },
+        {
+          css: null,
+          errors: [],
+          filename: "TransactionTable.vue",
+          macro_artifacts: [],
+          script_lang: "js",
+          warnings: [],
+        },
+      );
+      assertParsesAsModule(output.code, "TransactionTable.json#code");
+
+      assert.equal(count(output.code, "resolveFilter as _resolveFilter"), 1, output.code);
+      assert.equal(count(output.code, "_resolveFilter("), 3, output.code);
+      for (const filter of ["orderNoFilter", "toThousandFilter", "statusFilter"]) {
+        assert.equal(
+          count(output.code, `const _filter_${filter} = _resolveFilter("${filter}")`),
+          1,
+          output.code,
+        );
+        assert.equal(count(output.code, `_filter_${filter}(`), 1, output.code);
+      }
+
+      assert.equal(count(output.code, "default: _withCtx((scope) => ["), 2, output.code);
+      assert.equal(count(output.code, "default: _withCtx(({row}) => ["), 1, output.code);
+      for (const expected of [
+        "_toDisplayString(_filter_orderNoFilter(scope.row.order_no))",
+        "_toDisplayString(_filter_toThousandFilter(scope.row.price))",
+        "type: _filter_statusFilter(row.status)",
+        "_toDisplayString(row.status)",
+      ]) {
+        assert.equal(count(output.code, expected), 1, `${expected}\n${output.code}`);
+      }
+
+      for (const forbidden of [
+        "slot-scope",
+        '_createElementVNode("template"',
+        "scope.row.order_no | orderNoFilter",
+        "scope.row.price | toThousandFilter",
+        "row.status | statusFilter",
+        "_ctx.scope",
+        "_ctx.row",
+      ]) {
+        assert.equal(output.code.includes(forbidden), false, `${forbidden}\n${output.code}`);
+      }
+    },
+  );
+});
 
 test("vue-element-admin legacy slot scopes recover exact CLI diagnostics", async () => {
   const corsaPath = resolveTsgoBinary();
@@ -140,6 +230,56 @@ function assertBrokenCheck(result: VizeCheckResult): void {
     warningCount: 0,
     fileCount: 1,
   });
+}
+
+function runVizeBuild(
+  workspaceDir: string,
+  input: string,
+  outputDirectory: string,
+): {
+  files: string[];
+  output: CompilerOutput;
+  outputText: string;
+  status: number | null;
+  stderr: string;
+  stdout: string;
+} {
+  const [command, ...prefixArgs] = resolveVizeCommand();
+  const result = spawnSync(
+    command,
+    [...prefixArgs, "build", input, "--format", "json", "--output", outputDirectory],
+    {
+      cwd: workspaceDir,
+      encoding: "utf8",
+      env: { ...process.env, LANG: "C", LC_ALL: "C" },
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: 120_000,
+    },
+  );
+  if (result.error != null) throw result.error;
+
+  const outputRoot = path.join(workspaceDir, outputDirectory);
+  const files = fs.existsSync(outputRoot)
+    ? fs
+        .readdirSync(outputRoot, { recursive: true })
+        .map(String)
+        .filter((entry) => entry.endsWith(".json"))
+        .sort()
+    : [];
+  const outputText =
+    files.length === 1 ? fs.readFileSync(path.join(outputRoot, files[0]), "utf8") : "";
+  return {
+    files,
+    output: outputText === "" ? ({} as CompilerOutput) : (JSON.parse(outputText) as CompilerOutput),
+    outputText,
+    status: result.status,
+    stderr: result.stderr,
+    stdout: result.stdout,
+  };
+}
+
+function count(source: string, needle: string): number {
+  return source.split(needle).length - 1;
 }
 
 function json(value: unknown): string {

--- a/tests/tooling/github-workflows-vue-parity.test.ts
+++ b/tests/tooling/github-workflows-vue-parity.test.ts
@@ -38,12 +38,11 @@ test("Vue parity structurally gates compiler fixtures and incremental LSP behavi
   assert.match(hydration?.run ?? "", /vp install --frozen-lockfile --prefer-offline/);
   assert.equal(
     steps.find((step) => step.name === "Build vize CLI")?.run,
-    "cargo build --profile ci -p vize",
+    "cargo build --profile ci -p vize --features legacy",
   );
-  assert.equal(
-    steps.find((step) => step.name === "Check Vue compiler and typecheck parity")?.run,
-    "vp run --filter './tests' test:check:fixtures",
-  );
+  const parity = steps.find((step) => step.name === "Check Vue compiler and typecheck parity");
+  assert.deepEqual(parity?.env, { VIZE_TEST_BIN: "target/ci/vize" });
+  assert.equal(parity?.run, "vp run --filter './tests' test:check:fixtures");
 
   const incremental = steps.find((step) => step.name === "Check incremental LSP against Misskey");
   assert.deepEqual(incremental?.env, { VIZE_LSP_BIN: "target/ci/vize" });


### PR DESCRIPTION
## Summary

- Forward the CLI `legacy` feature into compiler core so Vue 2 scoped-slot and pipe-filter transforms are compiled.
- Build and select the legacy-enabled CLI in the Vue parity action.
- Extend the pinned vue-element-admin oracle with exact, deterministic compiler-output assertions.

## Change Class

- [ ] Parser or AST
- [x] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

- Related to #2971.
- Pinned `vue-element-admin` `TransactionTable.vue` exercises Vue 2 `slot-scope` and all three pipe filters under `compiler.compatibility.vueVersion: "2"`.

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — no snapshot files changed
- [x] Parity or real-world fixture coverage considered — pinned vue-element-admin oracle plus the complete 40-test fixture parity suite
- [x] Security/audit impact considered — feature wiring and read-only compiler execution only
- [x] Performance status or PR benchmark impact considered — default builds remain feature-gated; PR benchmark will report CI impact
- [x] Fuzzing target or crash-reproducer coverage considered — no parser surface changed
- [x] Editor/LSP scenario coverage considered — the existing clean/broken/repaired LSP oracle remains in the same fixture test
- [x] Ecosystem or broad app compatibility impact considered — all hydrated parity fixtures passed
- [x] Docs, release, or stability notes updated when public behavior changed — no documentation change needed for restoring an existing opt-in compatibility feature

Commands:

- `VIZE_TEST_BIN=target/debug/vize vp run --filter './tests' test:check:fixtures` — 40 passed
- `cargo test -p vize_atelier_core --features legacy` — 279 passed, 2 doc tests ignored
- `cargo test -p vize --features legacy --test build_cli --test build_output_paths_cli` — 11 passed
- `cargo clippy -p vize --features legacy --lib --bins -- -D warnings`
- `vp exec oxlint tests/_helpers/realworld-typecheck.ts tests/snapshots/check/vue-element-admin-legacy-oracle.ts`
- `cargo fmt --all -- --check`
- `git diff --check`

## Risk

Low and bounded to the opt-in `legacy` feature. The Vue 3 default feature set is unchanged. CI explicitly selects the legacy-enabled binary only for the parity action that contains the Vue 2 fixture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved Vue compatibility checks by validating both modern and legacy support paths.
  - Ensured parity checks run against the CLI build produced specifically for the test environment.
  - Strengthened automated type-checking coverage to help detect compatibility issues earlier.

- **Chores**
  - Updated legacy support configuration across the build and validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->