### PR TITLE
fix(patina): repair HTML quote diagnostics

### DIFF
--- a/crates/vize_patina/src/rules/vue/html_quotes.rs
+++ b/crates/vize_patina/src/rules/vue/html_quotes.rs
@@ -20,7 +20,7 @@
 //! ```
 
 use crate::context::LintContext;
-use crate::diagnostic::Severity;
+use crate::diagnostic::{Fix, LintDiagnostic, Severity, TextEdit};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::{ElementNode, ElementType, PropNode};
 
@@ -81,26 +81,87 @@ impl Rule for HtmlQuotes {
                 match self.style {
                     HtmlQuotesOption::Double => {
                         if quote_char == Some(b'\'') {
-                            ctx.warn_with_help(
-                                ctx.t("vue/html-quotes.message_double"),
-                                &value.loc,
-                                ctx.t("vue/html-quotes.help"),
-                            );
+                            let message = ctx.t("vue/html-quotes.message_double");
+                            let help = ctx.t("vue/html-quotes.help");
+                            let mut diagnostic = LintDiagnostic::warn(
+                                META.name,
+                                message,
+                                value.loc.start.offset,
+                                value.loc.end.offset,
+                            )
+                            .with_help(help);
+                            if let Some(fix) = quote_fix(
+                                ctx.source,
+                                value.loc.start.offset,
+                                value.loc.end.offset,
+                                b'"',
+                                "Use double quotes",
+                            ) {
+                                diagnostic = diagnostic.with_fix(fix);
+                            }
+                            ctx.report(diagnostic);
                         }
                     }
                     HtmlQuotesOption::Single => {
                         if quote_char == Some(b'"') {
-                            ctx.warn_with_help(
-                                ctx.t("vue/html-quotes.message_single"),
-                                &value.loc,
-                                ctx.t("vue/html-quotes.help"),
-                            );
+                            let message = ctx.t("vue/html-quotes.message_single");
+                            let help = ctx.t("vue/html-quotes.help");
+                            let mut diagnostic = LintDiagnostic::warn(
+                                META.name,
+                                message,
+                                value.loc.start.offset,
+                                value.loc.end.offset,
+                            )
+                            .with_help(help);
+                            if let Some(fix) = quote_fix(
+                                ctx.source,
+                                value.loc.start.offset,
+                                value.loc.end.offset,
+                                b'\'',
+                                "Use single quotes",
+                            ) {
+                                diagnostic = diagnostic.with_fix(fix);
+                            }
+                            ctx.report(diagnostic);
                         }
                     }
                 }
             }
         }
     }
+}
+
+fn quote_fix(
+    source: &str,
+    start: u32,
+    end: u32,
+    expected_quote: u8,
+    message: &'static str,
+) -> Option<Fix> {
+    let opening = start.checked_sub(1)?;
+    let closing_end = end.checked_add(1)?;
+    let start_index = usize::try_from(start).ok()?;
+    let end_index = usize::try_from(end).ok()?;
+    let opening_index = usize::try_from(opening).ok()?;
+    let actual_quote = *source.as_bytes().get(opening_index)?;
+    if !matches!(actual_quote, b'\'' | b'"')
+        || source.as_bytes().get(end_index).copied() != Some(actual_quote)
+        || source
+            .as_bytes()
+            .get(start_index..end_index)?
+            .contains(&expected_quote)
+    {
+        return None;
+    }
+
+    let replacement = if expected_quote == b'"' { "\"" } else { "'" };
+    Some(Fix::with_edits(
+        message,
+        vec![
+            TextEdit::replace(opening, start, replacement),
+            TextEdit::replace(end, closing_end, replacement),
+        ],
+    ))
 }
 
 #[cfg(test)]
@@ -123,6 +184,29 @@ mod tests {
     }
 
     #[test]
+    fn test_double_quotes_fix_replaces_both_delimiters() {
+        let linter = create_linter();
+        let source = r#"<div class='foo'></div>"#;
+        let result = linter.lint_template(source, "test.vue");
+        assert_eq!(result.warning_count, 1);
+        let fix = result.diagnostics[0]
+            .fix
+            .as_ref()
+            .expect("expected quote fix");
+        assert_eq!(fix.message, "Use double quotes");
+        assert_eq!(fix.edits.len(), 2);
+        assert_eq!(fix.apply(source), r#"<div class="foo"></div>"#);
+    }
+
+    #[test]
+    fn test_double_quotes_fix_is_omitted_when_value_contains_double_quote() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div title='say "hi"'></div>"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
+        assert!(!result.diagnostics[0].has_fix());
+    }
+
+    #[test]
     fn test_valid_no_value() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<input disabled />"#, "test.vue");
@@ -139,5 +223,35 @@ mod tests {
         // Parser preserves double quotes, so single-quote preference should warn
         let result = linter.lint_template(r#"<div class="foo"></div>"#, "test.vue");
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_single_quotes_fix_replaces_both_delimiters() {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(HtmlQuotes {
+            style: HtmlQuotesOption::Single,
+        }));
+        let linter = Linter::with_registry(registry);
+        let source = r#"<div class="foo"></div>"#;
+        let result = linter.lint_template(source, "test.vue");
+        let fix = result.diagnostics[0]
+            .fix
+            .as_ref()
+            .expect("expected quote fix");
+        assert_eq!(fix.message, "Use single quotes");
+        assert_eq!(fix.edits.len(), 2);
+        assert_eq!(fix.apply(source), "<div class='foo'></div>");
+    }
+
+    #[test]
+    fn test_single_quotes_fix_is_omitted_when_value_contains_single_quote() {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(HtmlQuotes {
+            style: HtmlQuotesOption::Single,
+        }));
+        let linter = Linter::with_registry(registry);
+        let result = linter.lint_template(r#"<div title="don't"></div>"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
+        assert!(!result.diagnostics[0].has_fix());
     }
 }

--- a/tests/snapshots/check/create-vue-patch-oracle.ts
+++ b/tests/snapshots/check/create-vue-patch-oracle.ts
@@ -25,6 +25,8 @@ const sourceSha256 = "bdafe70baf73a040d432b574108ce0e11823a3c1c1cc8bdfe01d118d6f
 const compiledCodeSha256 = "1216a548943fe8a09ab349a913c627d4115f93935b75ec89922415511475eff7";
 const cleanHeading = "  <h1>You did it!</h1>";
 const brokenHeading = "  <h1>You did it!</h2>";
+const cleanHref = 'href="https://vuejs.org/"';
+const brokenHref = "href='https://vuejs.org/'";
 
 type CompilerOutput = {
   code: string;
@@ -35,6 +37,23 @@ type CompilerOutput = {
   script_lang: string;
   warnings: string[];
 };
+
+type LintReport = Array<{
+  errorCount: number;
+  file: string;
+  messages: Array<{
+    column: number;
+    endColumn: number;
+    endLine: number;
+    help: string;
+    line: number;
+    message: string;
+    ruleDocsPath: string;
+    ruleId: string;
+    severity: number;
+  }>;
+  warningCount: number;
+}>;
 
 test("create-vue compiler is deterministic and recovers from an exact template parse error", async () => {
   await withPinnedFixtureWorkspace(
@@ -107,6 +126,63 @@ test("create-vue compiler is deterministic and recovers from an exact template p
       const repaired = runBuild(fixture.workspaceDir, ".vize-compiler-repaired");
       assertSuccessfulBuild(repaired);
       assert.equal(repaired.outputText, cleanFirst.outputText, "repair must restore exact output");
+      assert.equal(fixture.read(appPath), source);
+      assert.equal(fs.statSync(fixture.resolve(appPath)).mode & 0o777, sourceMode);
+    },
+  );
+});
+
+test("create-vue linter reports and repairs one exact HTML quote edit", async () => {
+  await withPinnedFixtureWorkspace(
+    { fixtureId: "create-vue", includePaths: [appPath] },
+    async (fixture) => {
+      fixture.write(
+        "vize.config.json",
+        `${JSON.stringify(
+          {
+            linter: {
+              preset: "incremental",
+              rules: { "vue/html-quotes": "error" },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      const source = fixture.read(appPath);
+      const sourceMode = fs.statSync(fixture.resolve(appPath)).mode & 0o777;
+      assert.equal(sha256(source), sourceSha256, "pinned create-vue source changed");
+
+      const cleanFirst = runLint(fixture.workspaceDir);
+      const cleanSecond = runLint(fixture.workspaceDir);
+      assertCleanLint(cleanFirst);
+      assertCleanLint(cleanSecond);
+      assert.equal(cleanSecond.stdout, cleanFirst.stdout, "clean lint JSON must be byte-stable");
+      assert.equal(fixture.read(appPath), source, "read-only lint must preserve the source");
+      assert.equal(fs.statSync(fixture.resolve(appPath)).mode & 0o777, sourceMode);
+
+      const brokenSource = fixture.applyExactPatch(appPath, cleanHref, brokenHref);
+      const brokenFirst = runLint(fixture.workspaceDir);
+      const brokenSecond = runLint(fixture.workspaceDir);
+      assertBrokenLint(brokenFirst);
+      assertBrokenLint(brokenSecond);
+      assert.equal(brokenSecond.stdout, brokenFirst.stdout, "broken lint JSON must be byte-stable");
+      assert.equal(fixture.read(appPath), brokenSource, "read-only lint must preserve the edit");
+      assert.equal(fs.statSync(fixture.resolve(appPath)).mode & 0o777, sourceMode);
+
+      const fixed = runLint(fixture.workspaceDir, true);
+      assertCleanLint(fixed);
+      assert.equal(fixed.stdout, cleanFirst.stdout, "fixed lint JSON must match clean JSON");
+      assert.equal(fixture.read(appPath), source, "--fix must restore the exact pinned source");
+      assert.equal(fs.statSync(fixture.resolve(appPath)).mode & 0o777, sourceMode);
+
+      const repaired = runLint(fixture.workspaceDir);
+      const idempotentFix = runLint(fixture.workspaceDir, true);
+      assertCleanLint(repaired);
+      assertCleanLint(idempotentFix);
+      assert.equal(repaired.stdout, cleanFirst.stdout);
+      assert.equal(idempotentFix.stdout, cleanFirst.stdout);
       assert.equal(fixture.read(appPath), source);
       assert.equal(fs.statSync(fixture.resolve(appPath)).mode & 0o777, sourceMode);
     },
@@ -406,6 +482,73 @@ function assertBrokenBuild(result: BuildResult): void {
     script_lang: "ts",
     macro_artifacts: [],
   });
+}
+
+type LintResult = {
+  report: LintReport;
+  status: number | null;
+  stderr: string;
+  stdout: string;
+};
+
+function runLint(workspaceDir: string, fix = false): LintResult {
+  const [command, ...prefixArgs] = resolveVizeCommand();
+  const result = spawnSync(
+    command,
+    [...prefixArgs, "lint", appPath, "--format", "json", ...(fix ? ["--fix"] : [])],
+    {
+      cwd: workspaceDir,
+      encoding: "utf8",
+      env: { ...process.env, LANG: "C", LC_ALL: "C" },
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: 120_000,
+    },
+  );
+  if (result.error != null) throw result.error;
+  return {
+    report: JSON.parse(result.stdout) as LintReport,
+    status: result.status,
+    stderr: result.stderr,
+    stdout: result.stdout,
+  };
+}
+
+function assertCleanLint(result: LintResult): void {
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(result.stderr, "");
+  assert.deepEqual(result.report, [
+    {
+      file: appPath,
+      messages: [],
+      errorCount: 0,
+      warningCount: 0,
+    },
+  ]);
+}
+
+function assertBrokenLint(result: LintResult): void {
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  assert.equal(result.stderr, "");
+  assert.deepEqual(result.report, [
+    {
+      file: appPath,
+      messages: [
+        {
+          ruleId: "vue/html-quotes",
+          ruleDocsPath: "docs/content/rules/vue.md",
+          severity: 2,
+          message: "[vize:vue/html-quotes] Expected double quotes but found single quotes",
+          line: 6,
+          column: 20,
+          endLine: 6,
+          endColumn: 38,
+          help: "Use consistent quote style for HTML attribute values.",
+        },
+      ],
+      errorCount: 1,
+      warningCount: 0,
+    },
+  ]);
 }
 
 function sha256(source: string | Buffer): string {


### PR DESCRIPTION
## Summary
- attach safe two-delimiter fixes to `vue/html-quotes` diagnostics
- omit fixes when the target quote occurs inside the attribute value
- add strict double- and single-quote unit coverage
- prove create-vue clean, broken, fixed, repaired, deterministic, and non-mutating behavior

## Verification
- `cargo test -p vize_patina` (2,151 passed)
- `cargo clippy -p vize_patina --lib -- -D warnings`
- `node --test --test-concurrency=1 tests/snapshots/check/create-vue-patch-oracle.ts` (3/3)
- `vp run --filter './tests' test:check:fixtures` (44/44)
- `node --test tests/tooling/snapshot-baselines.test.ts tests/tooling/realworld-snapshot-scripts.test.ts`
- `cargo fmt -p vize_patina -- --check`
- `./node_modules/.bin/oxfmt --check tests/snapshots/check/create-vue-patch-oracle.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML attribute quote-style diagnostics with clearer guidance.
  * Added safe automated fixes that update mismatched quote delimiters.
  * Prevented fixes when changing quotes could alter attribute value content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->