### PR TITLE
test(sfc): add Vue Router atelier oracle

### DIFF
--- a/tests/snapshots/check/vue-router-patch-oracle.ts
+++ b/tests/snapshots/check/vue-router-patch-oracle.ts
@@ -1,10 +1,16 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 import { test } from "node:test";
 import { pathToFileURL } from "node:url";
 
+import { assertParsesAsModule } from "../../_helpers/assertions.ts";
 import { symlinkDirectory, withPinnedFixtureWorkspace } from "../../_helpers/realworld-patch.ts";
 import {
   type CommandResult,
+  resolveVizeCommand,
   resolveTsgoBinary,
   resolveVueTscBinary,
   runVizeCheck,
@@ -27,6 +33,124 @@ import { LspSession } from "../../tooling/support/lsp/session.ts";
 const appPath = "packages/playground/src/AppLink.vue";
 const routerManifestPath = "packages/router/package.json";
 const symbol = "packageBoundary";
+const sourceSha256 = "f5c888da7bae9c61151c7fbfde578ccdb768e75fbe2e69637d8298ca4f702c96";
+const cleanOutputSha256 = "baa6667f47df3663c55e938e7f93f0e12eb2f0bd931cc1b3de43b0dbbc110883";
+const cleanCodeSha256 = "d305d39f63d298418bb52dc4bd1d6c02d73a3f5a52205c6166a8811dbec7c3b9";
+const brokenOutputSha256 = "15e571e43307b3ac025db3929f4f11029f1b7f5991d11b405433b6a31c5bc90e";
+const brokenCodeSha256 = "eed24c03d97029fca5d3d13f81ac416099d3876e7f36572d113acc0768872679";
+const cleanHref = ':href="String(to)"';
+const brokenHref = ':href="String(to"';
+
+type CompilerOutput = {
+  code: string;
+  css: string | null;
+  errors: string[];
+  filename: string;
+  macro_artifacts: unknown[];
+  script_lang: string;
+  warnings: string[];
+};
+
+type BuildResult = {
+  files: string[];
+  output: CompilerOutput;
+  outputText: string;
+  status: number | null;
+  stderr: string;
+  stdout: string;
+};
+
+test("Vue Router compiler is deterministic and recovers from an exact expression error", async () => {
+  await withPinnedFixtureWorkspace(
+    { fixtureId: "vue-router", includePaths: [appPath] },
+    async (fixture) => {
+      const source = fixture.read(appPath);
+      const sourceMode = fs.statSync(fixture.resolve(appPath)).mode & 0o777;
+      assert.equal(sha256(source), sourceSha256, "pinned Vue Router source changed");
+      assert.equal(count(source, cleanHref), 1, "compiler patch anchor must stay unique");
+
+      const cleanFirst = runBuild(fixture.workspaceDir, ".vize-compiler-clean-first");
+      const cleanSecond = runBuild(fixture.workspaceDir, ".vize-compiler-clean-second");
+      assertSuccessfulBuild(cleanFirst);
+      assertSuccessfulBuild(cleanSecond);
+      assert.equal(sha256(cleanFirst.outputText), cleanOutputSha256);
+      assert.equal(
+        cleanSecond.outputText,
+        cleanFirst.outputText,
+        "clean output must be byte-stable",
+      );
+      assert.equal(fixture.read(appPath), source, "compiler must not mutate the source");
+      assert.equal(fs.statSync(fixture.resolve(appPath)).mode & 0o777, sourceMode);
+
+      const output = cleanFirst.output;
+      assert.deepEqual(
+        {
+          css: output.css,
+          errors: output.errors,
+          filename: output.filename,
+          macro_artifacts: output.macro_artifacts,
+          script_lang: output.script_lang,
+          warnings: output.warnings,
+        },
+        {
+          css: null,
+          errors: [],
+          filename: "AppLink.vue",
+          macro_artifacts: [],
+          script_lang: "ts",
+          warnings: [],
+        },
+      );
+      assert.equal(sha256(output.code), cleanCodeSha256, output.code);
+      assertParsesAsModule(output.code, "vue-router AppLink.json#code");
+      for (const expected of [
+        "renderSlot as _renderSlot, mergeProps as _mergeProps",
+        '__name: "AppLink"',
+        "props: { disabled: {",
+        "href: String(__props.to)",
+        "href: _unref(href)",
+        "onClick: _cache[0] || (_cache[0] = (...args) => navigate && navigate(...args))",
+      ]) {
+        assert.equal(count(output.code, expected), 1, `${expected}\n${output.code}`);
+      }
+      assert.equal(count(output.code, "key: 0"), 1, output.code);
+      assert.equal(count(output.code, "key: 1"), 1, output.code);
+      assert.equal(
+        count(output.code, '_createElementBlock("a", _mergeProps(_unref(attrs), {'),
+        2,
+        output.code,
+      );
+      assert.equal(
+        count(output.code, 'class: _normalizeClass(["router-link", classes.value])'),
+        2,
+        output.code,
+      );
+      assert.equal(count(output.code, '_renderSlot(_ctx.$slots, "default")'), 2, output.code);
+      assert.equal(output.code.includes("RouterLinkProps"), false, output.code);
+
+      const brokenSource = fixture.applyExactPatch(appPath, cleanHref, brokenHref);
+      const brokenFirst = runBuild(fixture.workspaceDir, ".vize-compiler-broken-first");
+      const brokenSecond = runBuild(fixture.workspaceDir, ".vize-compiler-broken-second");
+      assertBrokenBuild(brokenFirst);
+      assertBrokenBuild(brokenSecond);
+      assert.equal(
+        brokenSecond.outputText,
+        brokenFirst.outputText,
+        "broken output must be byte-stable",
+      );
+      assert.equal(fixture.read(appPath), brokenSource, "compiler must preserve the broken source");
+      assert.equal(fs.statSync(fixture.resolve(appPath)).mode & 0o777, sourceMode);
+
+      const repairedSource = fixture.applyExactPatch(appPath, brokenHref, cleanHref);
+      assert.equal(repairedSource, source);
+      const repaired = runBuild(fixture.workspaceDir, ".vize-compiler-repaired");
+      assertSuccessfulBuild(repaired);
+      assert.equal(repaired.outputText, cleanFirst.outputText, "repair must restore exact output");
+      assert.equal(fixture.read(appPath), source);
+      assert.equal(fs.statSync(fixture.resolve(appPath)).mode & 0o777, sourceMode);
+    },
+  );
+});
 
 test("Vue Router package exports stay exact across clean, broken, and repaired edits", async () => {
   const corsaPath = resolveTsgoBinary();
@@ -181,6 +305,86 @@ test("Vue Router package exports stay exact across clean, broken, and repaired e
     },
   );
 });
+
+function runBuild(workspaceDir: string, outputDirectory: string): BuildResult {
+  const [command, ...prefixArgs] = resolveVizeCommand();
+  const result = spawnSync(
+    command,
+    [...prefixArgs, "build", appPath, "--format", "json", "--output", outputDirectory],
+    {
+      cwd: workspaceDir,
+      encoding: "utf8",
+      env: { ...process.env, LANG: "C", LC_ALL: "C" },
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: 120_000,
+    },
+  );
+  if (result.error != null) throw result.error;
+
+  const outputRoot = path.join(workspaceDir, outputDirectory);
+  const files = fs.existsSync(outputRoot)
+    ? fs
+        .readdirSync(outputRoot, { recursive: true })
+        .map(String)
+        .filter((entry) => entry.endsWith(".json"))
+        .sort()
+    : [];
+  const outputText =
+    files.length === 1 ? fs.readFileSync(path.join(outputRoot, files[0]), "utf8") : "";
+  return {
+    files,
+    output: outputText === "" ? ({} as CompilerOutput) : (JSON.parse(outputText) as CompilerOutput),
+    outputText,
+    status: result.status,
+    stderr: result.stderr,
+    stdout: result.stdout,
+  };
+}
+
+function assertSuccessfulBuild(result: BuildResult): void {
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.deepEqual(result.files, ["AppLink.json"]);
+  assert.deepEqual(result.output.errors, []);
+  assert.deepEqual(result.output.warnings, []);
+}
+
+function assertBrokenBuild(result: BuildResult): void {
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.deepEqual(result.files, ["AppLink.json"]);
+  assert.equal(sha256(result.outputText), brokenOutputSha256);
+  assert.deepEqual(
+    {
+      css: result.output.css,
+      errors: result.output.errors,
+      filename: result.output.filename,
+      macro_artifacts: result.output.macro_artifacts,
+      script_lang: result.output.script_lang,
+      warnings: result.output.warnings,
+    },
+    {
+      css: null,
+      errors: [
+        'Template compilation errors: [CompilerError { code: InvalidExpression, message: "Error parsing JavaScript expression: Expected `)` but found `EOF`", loc: Some(SourceLocation { start: Position { offset: 157, line: 1, column: 158 }, end: Position { offset: 166, line: 1, column: 167 }, source: "String(to" }) }]',
+      ],
+      filename: "AppLink.vue",
+      macro_artifacts: [],
+      script_lang: "ts",
+      warnings: [],
+    },
+  );
+  assert.equal(sha256(result.output.code), brokenCodeSha256, result.output.code);
+  assertParsesAsModule(result.output.code, "broken vue-router AppLink.json#code");
+  assert.equal(result.output.code.includes("_createElementBlock"), false, result.output.code);
+  assert.equal(count(result.output.code, "return {"), 1, result.output.code);
+}
+
+function sha256(source: string | Buffer): string {
+  return createHash("sha256").update(source).digest("hex");
+}
+
+function count(source: string, needle: string): number {
+  return source.split(needle).length - 1;
+}
 
 async function definitionLocations(
   session: LspSession,


### PR DESCRIPTION
## Summary
- pin Vue Router AppLink compiler source and generated output hashes
- assert deterministic clean and broken compilation with exact diagnostics
- prove exact source repair restores byte-identical output

## Validation
- node --test --test-concurrency=1 tests/snapshots/check/vue-router-patch-oracle.ts
- vp run --filter ./tests test:check:fixtures (46 passed)
- fixture registry and wiring tests (10 passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->