### PR TITLE
fix(glyph): preserve object directive order

### DIFF
--- a/crates/vize_glyph/src/template/attributes.rs
+++ b/crates/vize_glyph/src/template/attributes.rs
@@ -22,15 +22,12 @@ pub(crate) struct ParsedAttribute {
 
 /// Sort attributes based on the configured options.
 pub(crate) fn sort_attributes(attrs: &mut [ParsedAttribute], options: &FormatOptions) {
-    let mut segment_start = 0;
-    for barrier_index in 0..attrs.len() {
-        if !is_order_sensitive_spread(&attrs[barrier_index].name) {
-            continue;
-        }
-        sort_attribute_segment(&mut attrs[segment_start..barrier_index], options);
-        segment_start = barrier_index + 1;
+    // `split_mut` yields the segments between order-sensitive spreads while
+    // leaving each `v-bind`/`v-on` object directive fixed in place, so merge
+    // precedence cannot change.
+    for segment in attrs.split_mut(|attr| is_order_sensitive_spread(&attr.name)) {
+        sort_attribute_segment(segment, options);
     }
-    sort_attribute_segment(&mut attrs[segment_start..], options);
 }
 
 /// Sort one contiguous group that cannot cross an object directive spread.

--- a/crates/vize_glyph/src/template/attributes.rs
+++ b/crates/vize_glyph/src/template/attributes.rs
@@ -22,6 +22,24 @@ pub(crate) struct ParsedAttribute {
 
 /// Sort attributes based on the configured options.
 pub(crate) fn sort_attributes(attrs: &mut [ParsedAttribute], options: &FormatOptions) {
+    let mut segment_start = 0;
+    for barrier_index in 0..attrs.len() {
+        if !is_order_sensitive_spread(&attrs[barrier_index].name) {
+            continue;
+        }
+
+        sort_attribute_segment(&mut attrs[segment_start..barrier_index], options);
+        segment_start = barrier_index + 1;
+    }
+    sort_attribute_segment(&mut attrs[segment_start..], options);
+}
+
+/// Sort one contiguous group that cannot cross an object directive spread.
+///
+/// Vue applies object `v-bind` and `v-on` directives in source order. Moving
+/// an attribute across either directive changes the order of `mergeProps`
+/// arguments and can therefore change which value wins at runtime.
+fn sort_attribute_segment(attrs: &mut [ParsedAttribute], options: &FormatOptions) {
     match options.attribute_sort_order {
         AttributeSortOrder::Alphabetical => {
             // Decorate-sort-undecorate: `attr_sort_key` lowercases the name,
@@ -48,6 +66,10 @@ pub(crate) fn sort_attributes(attrs: &mut [ParsedAttribute], options: &FormatOpt
             });
         }
     }
+}
+
+fn is_order_sensitive_spread(name: &str) -> bool {
+    name == "v-bind" || name.starts_with("v-bind.") || name == "v-on" || name.starts_with("v-on.")
 }
 
 /// Generate a sort key for alphabetical ordering within a group.

--- a/crates/vize_glyph/src/template/attributes.rs
+++ b/crates/vize_glyph/src/template/attributes.rs
@@ -27,7 +27,6 @@ pub(crate) fn sort_attributes(attrs: &mut [ParsedAttribute], options: &FormatOpt
         if !is_order_sensitive_spread(&attrs[barrier_index].name) {
             continue;
         }
-
         sort_attribute_segment(&mut attrs[segment_start..barrier_index], options);
         segment_start = barrier_index + 1;
     }

--- a/crates/vize_glyph/tests/template_directive_attributes.rs
+++ b/crates/vize_glyph/tests/template_directive_attributes.rs
@@ -1,6 +1,67 @@
 use vize_glyph::{FormatOptions, format_sfc, format_template};
 
 #[test]
+fn object_v_bind_stays_between_independently_sorted_attribute_groups() {
+    let source = r#"<a title="link" class="router-link" v-bind="attrs" target="_blank" rel="noopener" :href="href"></a>"#;
+    let options = FormatOptions {
+        print_width: 200,
+        ..FormatOptions::default()
+    };
+
+    let first = format_template(source, &options).unwrap();
+    let second = format_template(&first, &options).unwrap();
+
+    assert_eq!(
+        first.as_str(),
+        r#"<a class="router-link" title="link" v-bind="attrs" rel="noopener" target="_blank" :href="href"></a>"#
+    );
+    assert_eq!(first, second);
+}
+
+#[test]
+fn object_v_on_stays_between_independently_sorted_event_groups() {
+    let source = r#"<button @keyup="up" @click="click" v-on="listeners" @mouseup="up" @mousedown="down"></button>"#;
+    let options = FormatOptions {
+        print_width: 200,
+        ..FormatOptions::default()
+    };
+
+    let first = format_template(source, &options).unwrap();
+    let second = format_template(&first, &options).unwrap();
+
+    assert_eq!(
+        first.as_str(),
+        r#"<button @click="click" @keyup="up" v-on="listeners" @mousedown="down" @mouseup="up"></button>"#
+    );
+    assert_eq!(first, second);
+}
+
+#[test]
+fn object_directive_modifiers_are_also_ordering_barriers() {
+    let options = FormatOptions {
+        print_width: 200,
+        ..FormatOptions::default()
+    };
+    let cases = [
+        (
+            r#"<div title="x" v-bind.prop="attrs" id="y"></div>"#,
+            r#"<div title="x" v-bind.prop="attrs" id="y"></div>"#,
+        ),
+        (
+            r#"<div @keyup="up" v-on.stop="listeners" @click="click"></div>"#,
+            r#"<div @keyup="up" v-on.stop="listeners" @click="click"></div>"#,
+        ),
+    ];
+
+    for (source, expected) in cases {
+        let first = format_template(source, &options).unwrap();
+        let second = format_template(&first, &options).unwrap();
+        assert_eq!(first.as_str(), expected);
+        assert_eq!(first, second);
+    }
+}
+
+#[test]
 fn multiline_directive_attribute_value_is_indented_from_attribute_depth() {
     let source = r#"<span
   :class='[


### PR DESCRIPTION
## Summary
- keep object v-bind and v-on directives fixed in source order during attribute sorting
- sort attributes independently on each side so merge precedence cannot change
- cover plain and modifier directives plus formatter idempotence

## Validation
- cargo test -p vize_glyph
- cargo test -p vize_glyph --test template_directive_attributes (10 passed)
- cargo clippy -p vize_glyph --lib -- -D warnings
- vp run --filter ./tests test:check:fixtures (47 passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template attribute sorting to preserve Vue `v-bind` and `v-on` spread ordering, preventing reordering across those directives.
  * Ensured directive modifiers (for example, `v-on.stop`) act as ordering boundaries to keep output correct.
  * Improved formatting stability so repeated formatting is idempotent and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->