### PR TITLE
fix(atelier): preserve v-if spread order

### DIFF
--- a/crates/vize_atelier_core/src/codegen/v_if.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if.rs
@@ -6,6 +6,7 @@
 
 mod branch;
 mod generate;
+mod props;
 
 use crate::{IfBranchNode, IfNode, PropNode, RuntimeHelper};
 

--- a/crates/vize_atelier_core/src/codegen/v_if/branch.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch.rs
@@ -32,11 +32,8 @@ use super::{
             has_dynamic_slots_flag, has_forwarded_slot_outlet, has_slot_children,
         },
     },
-    generate::{
-        extract_static_class_style, generate_if_branch_props_object, has_dynamic_class,
-        has_dynamic_style, has_vbind_spread, has_von_spread,
-    },
     generate_if_branch_key,
+    props::generate_if_branch_props,
 };
 
 /// Generate a single if branch.
@@ -248,82 +245,8 @@ fn generate_if_branch_component(
 
     let has_patch_info = patch_flag.is_some() || dynamic_props.is_some();
 
-    // Extract static class/style for merging with dynamic bindings
-    let static_merge = extract_static_class_style(el);
-    let has_dyn_class = has_dynamic_class(el);
-    let has_dyn_style = has_dynamic_style(el);
-
-    // Check if component has v-bind spread or v-on spread
-    let has_vbind = has_vbind_spread(el);
-    let has_von = has_von_spread(el);
-    if has_vbind || has_von {
-        ctx.use_helper(RuntimeHelper::MergeProps);
-        ctx.push(", ");
-        ctx.push(ctx.helper(RuntimeHelper::MergeProps));
-        ctx.push("(");
-
-        let mut first_merge_arg = true;
-        // Add v-bind spreads
-        for prop in el.props.iter() {
-            if let PropNode::Directive(dir) = prop
-                && dir.name == "bind"
-                && dir.arg.is_none()
-                && let Some(exp) = &dir.exp
-            {
-                if !first_merge_arg {
-                    ctx.push(", ");
-                }
-                generate_expression(ctx, exp);
-                first_merge_arg = false;
-            }
-        }
-
-        // Add v-on spreads wrapped with _toHandlers
-        for prop in el.props.iter() {
-            if let PropNode::Directive(dir) = prop
-                && dir.name == "on"
-                && dir.arg.is_none()
-                && let Some(exp) = &dir.exp
-            {
-                if !first_merge_arg {
-                    ctx.push(", ");
-                }
-                ctx.use_helper(RuntimeHelper::ToHandlers);
-                ctx.push(ctx.helper(RuntimeHelper::ToHandlers));
-                ctx.push("(");
-                generate_expression(ctx, exp);
-                ctx.push(", true)");
-                first_merge_arg = false;
-            }
-        }
-
-        if !first_merge_arg {
-            ctx.push(", ");
-        }
-        generate_if_branch_props_object(
-            ctx,
-            el,
-            branch,
-            branch_index,
-            static_merge,
-            has_dyn_class,
-            has_dyn_style,
-            is_dynamic,
-        );
-        ctx.push(")");
-    } else {
-        ctx.push(", ");
-        generate_if_branch_props_object(
-            ctx,
-            el,
-            branch,
-            branch_index,
-            static_merge,
-            has_dyn_class,
-            has_dyn_style,
-            is_dynamic,
-        );
-    }
+    ctx.push(", ");
+    generate_if_branch_props(ctx, el, branch, branch_index, is_dynamic);
 
     ctx.skip_scope_id = prev_skip_scope_id;
 
@@ -425,82 +348,8 @@ fn generate_if_branch_element(
     ctx.push(el.tag.as_str());
     ctx.push("\"");
 
-    // Extract static class/style for merging with dynamic bindings
-    let static_merge = extract_static_class_style(el);
-    let has_dyn_class = has_dynamic_class(el);
-    let has_dyn_style = has_dynamic_style(el);
-
-    // Generate props with key and all other props (handle v-bind/v-on spreads)
-    let has_vbind = has_vbind_spread(el);
-    let has_von = has_von_spread(el);
-    if has_vbind || has_von {
-        ctx.use_helper(RuntimeHelper::MergeProps);
-        ctx.push(", ");
-        ctx.push(ctx.helper(RuntimeHelper::MergeProps));
-        ctx.push("(");
-
-        // Add all v-bind spreads
-        let mut first_merge_arg = true;
-        for prop in el.props.iter() {
-            if let PropNode::Directive(dir) = prop
-                && dir.name == "bind"
-                && dir.arg.is_none()
-                && let Some(exp) = &dir.exp
-            {
-                if !first_merge_arg {
-                    ctx.push(", ");
-                }
-                generate_expression(ctx, exp);
-                first_merge_arg = false;
-            }
-        }
-
-        // Add all v-on spreads wrapped with _toHandlers
-        for prop in el.props.iter() {
-            if let PropNode::Directive(dir) = prop
-                && dir.name == "on"
-                && dir.arg.is_none()
-                && let Some(exp) = &dir.exp
-            {
-                if !first_merge_arg {
-                    ctx.push(", ");
-                }
-                ctx.use_helper(RuntimeHelper::ToHandlers);
-                ctx.push(ctx.helper(RuntimeHelper::ToHandlers));
-                ctx.push("(");
-                generate_expression(ctx, exp);
-                ctx.push(", true)");
-                first_merge_arg = false;
-            }
-        }
-
-        if !first_merge_arg {
-            ctx.push(", ");
-        }
-        generate_if_branch_props_object(
-            ctx,
-            el,
-            branch,
-            branch_index,
-            static_merge,
-            has_dyn_class,
-            has_dyn_style,
-            false,
-        );
-        ctx.push(")");
-    } else {
-        ctx.push(", ");
-        generate_if_branch_props_object(
-            ctx,
-            el,
-            branch,
-            branch_index,
-            static_merge,
-            has_dyn_class,
-            has_dyn_style,
-            false,
-        );
-    }
+    ctx.push(", ");
+    generate_if_branch_props(ctx, el, branch, branch_index, false);
 
     // Generate children if any
     if !el.children.is_empty() {

--- a/crates/vize_atelier_core/src/codegen/v_if/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/generate.rs
@@ -1,18 +1,14 @@
 //! Props and helper utilities for v-if branch code generation.
 //!
-//! Contains prop object generation, static class/style extraction,
-//! dynamic binding checks, event key deduplication, and spread detection.
+//! Contains single-prop generation, event key deduplication, and spread detection.
 
-use crate::{DirectiveNode, ElementNode, ExpressionNode, IfBranchNode, PropNode};
+use crate::{DirectiveNode, ExpressionNode, PropNode};
 
 use super::super::{
     context::CodegenContext,
-    element::helpers::is_is_prop,
     helpers::{camelize, capitalize_first, escape_js_string, is_valid_js_identifier},
-    props::{StaticMerge, generate_directive_prop_with_static, is_supported_directive},
+    props::{StaticMerge, generate_directive_prop_with_static},
 };
-use super::generate_if_branch_key;
-use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::ToCompactString;
 
@@ -48,37 +44,6 @@ pub(super) fn should_skip_prop_for_if(
             false
         }
     }
-}
-
-/// Extract static class/style values and their source ordering from props.
-pub(super) fn extract_static_class_style<'a>(el: &'a ElementNode<'_>) -> StaticMerge<'a> {
-    StaticMerge::from_props(&el.props)
-}
-
-/// Check if element has dynamic `:class` binding.
-pub(super) fn has_dynamic_class(el: &ElementNode<'_>) -> bool {
-    el.props.iter().any(|p| {
-        if let PropNode::Directive(dir) = p
-            && dir.name == "bind"
-            && let Some(ExpressionNode::Simple(arg)) = &dir.arg
-        {
-            return arg.content == "class";
-        }
-        false
-    })
-}
-
-/// Check if element has dynamic `:style` binding.
-pub(super) fn has_dynamic_style(el: &ElementNode<'_>) -> bool {
-    el.props.iter().any(|p| {
-        if let PropNode::Directive(dir) = p
-            && dir.name == "bind"
-            && let Some(ExpressionNode::Simple(arg)) = &dir.arg
-        {
-            return arg.content == "style";
-        }
-        false
-    })
 }
 
 /// Generate a single prop for v-if branch element.
@@ -152,119 +117,12 @@ pub(super) fn generate_single_prop_for_if(
     }
 }
 
-/// Generate props object for v-if branch (with key and other props).
-#[allow(clippy::too_many_arguments)]
-pub(super) fn generate_if_branch_props_object(
-    ctx: &mut CodegenContext,
-    el: &ElementNode<'_>,
-    branch: &IfBranchNode<'_>,
-    branch_index: usize,
-    static_merge: StaticMerge<'_>,
-    has_dynamic_class: bool,
-    has_dynamic_style: bool,
-    skip_is_prop: bool,
-) {
-    // Check if there are other props besides key (skip excluded ones)
-    let has_other_props = el.props.iter().any(|p| {
-        // Skip unsupported directives (v-slot, v-tooltip, custom directives, etc.)
-        if let PropNode::Directive(dir) = p
-            && !is_supported_directive(dir)
-        {
-            return false;
-        }
-        if skip_is_prop && is_is_prop(p) {
-            return false;
-        }
-        !should_skip_prop_for_if(p, has_dynamic_class, has_dynamic_style)
-            && !is_vbind_spread_prop(p)
-            && !is_von_spread_prop(p)
-    });
-    // skip_scope_id suppresses duplicate scope attrs for synthetic prop objects.
-    let scope_id = if ctx.skip_scope_id {
-        None
-    } else {
-        ctx.options.scope_id.clone()
-    };
-    let has_scope = scope_id.is_some();
-
-    if !has_other_props && !has_scope {
-        // Key-only: use inline format { key: N }
-        ctx.push("{ key: ");
-        generate_if_branch_key(ctx, branch, branch_index);
-        ctx.push(" }");
-        return;
-    }
-
-    // Multiline format for key + other props
-    ctx.push("{");
-    ctx.indent();
-    ctx.newline();
-    ctx.push("key: ");
-    generate_if_branch_key(ctx, branch, branch_index);
-
-    let mut seen_events: FxHashSet<String> = FxHashSet::default();
-
-    for prop in el.props.iter() {
-        // Skip unsupported directives (v-slot, v-tooltip, custom directives, etc.)
-        if let PropNode::Directive(dir) = prop
-            && !is_supported_directive(dir)
-        {
-            continue;
-        }
-        if skip_is_prop && is_is_prop(prop) {
-            continue;
-        }
-        if should_skip_prop_for_if(prop, has_dynamic_class, has_dynamic_style) {
-            continue;
-        }
-        if is_vbind_spread_prop(prop) {
-            continue;
-        }
-        if is_von_spread_prop(prop) {
-            continue;
-        }
-        if let PropNode::Directive(dir) = prop
-            && dir.name == "on"
-            && let Some(key) = get_static_event_key(dir)
-            && !seen_events.insert(key)
-        {
-            continue;
-        }
-        ctx.push(",");
-        ctx.newline();
-        generate_single_prop_for_if(ctx, prop, static_merge);
-    }
-
-    // Add scope_id for scoped CSS
-    if let Some(ref scope_id) = scope_id {
-        ctx.push(",");
-        ctx.newline();
-        ctx.push("\"");
-        ctx.push(scope_id);
-        ctx.push("\": \"\"");
-    }
-
-    ctx.deindent();
-    ctx.newline();
-    ctx.push("}");
-}
-
-/// Check if element has v-bind object spread.
-pub(super) fn has_vbind_spread(el: &ElementNode<'_>) -> bool {
-    el.props.iter().any(|p| is_vbind_spread_prop(p))
-}
-
 /// Check if prop is a v-bind object spread (`v-bind="obj"`).
 pub(super) fn is_vbind_spread_prop(prop: &PropNode<'_>) -> bool {
     if let PropNode::Directive(dir) = prop {
         return dir.name == "bind" && dir.arg.is_none();
     }
     false
-}
-
-/// Check if element has v-on object spread (`v-on="obj"`).
-pub(super) fn has_von_spread(el: &ElementNode<'_>) -> bool {
-    el.props.iter().any(|p| is_von_spread_prop(p))
 }
 
 /// Check if prop is a v-on object spread (`v-on="obj"`).
@@ -276,7 +134,7 @@ pub(super) fn is_von_spread_prop(prop: &PropNode<'_>) -> bool {
 }
 
 /// Compute static event prop key for dedupe (e.g., `onClick`, `onUpdate:modelValue`).
-fn get_static_event_key(dir: &DirectiveNode<'_>) -> Option<String> {
+pub(super) fn get_static_event_key(dir: &DirectiveNode<'_>) -> Option<String> {
     let arg = dir.arg.as_ref()?;
     let ExpressionNode::Simple(exp) = arg else {
         return None;

--- a/crates/vize_atelier_core/src/codegen/v_if/props.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/props.rs
@@ -1,0 +1,261 @@
+//! Source-ordered props generation for v-if branches.
+
+use crate::{ElementNode, ExpressionNode, IfBranchNode, PropNode, RuntimeHelper};
+use vize_carton::{FxHashSet, String};
+
+use super::{
+    super::{
+        context::CodegenContext,
+        element::helpers::is_is_prop,
+        expression::generate_expression,
+        props::{StaticMerge, is_supported_directive},
+    },
+    generate::{
+        generate_single_prop_for_if, get_static_event_key, is_vbind_spread_prop,
+        is_von_spread_prop, should_skip_prop_for_if,
+    },
+    generate_if_branch_key,
+};
+
+pub(super) fn generate_if_branch_props(
+    ctx: &mut CodegenContext,
+    el: &ElementNode<'_>,
+    branch: &IfBranchNode<'_>,
+    branch_index: usize,
+    skip_is_prop: bool,
+) {
+    let scope_id = if ctx.skip_scope_id {
+        None
+    } else {
+        ctx.options.scope_id.clone()
+    };
+    let has_spread = el.props.iter().any(is_usable_spread);
+
+    if !has_spread {
+        generate_segment_object(
+            ctx,
+            &el.props,
+            branch,
+            branch_index,
+            true,
+            scope_id.as_deref(),
+            skip_is_prop,
+            false,
+        );
+        return;
+    }
+
+    ctx.use_helper(RuntimeHelper::MergeProps);
+    ctx.push(ctx.helper(RuntimeHelper::MergeProps));
+    ctx.push("(");
+
+    let mut first_arg = true;
+    let mut key_pending = true;
+    let mut segment_start = 0;
+
+    for (index, prop) in el.props.iter().enumerate() {
+        let Some(dir) = usable_spread(prop) else {
+            continue;
+        };
+        let Some(expression) = &dir.exp else { continue };
+
+        flush_segment(
+            ctx,
+            &el.props[segment_start..index],
+            branch,
+            branch_index,
+            key_pending,
+            None,
+            skip_is_prop,
+            &mut first_arg,
+        );
+        key_pending = false;
+        segment_start = index + 1;
+
+        push_separator(ctx, &mut first_arg);
+        if dir.name == "bind" {
+            generate_expression(ctx, expression);
+        } else {
+            ctx.use_helper(RuntimeHelper::ToHandlers);
+            ctx.push(ctx.helper(RuntimeHelper::ToHandlers));
+            ctx.push("(");
+            generate_expression(ctx, expression);
+            ctx.push(", true)");
+        }
+    }
+
+    flush_segment(
+        ctx,
+        &el.props[segment_start..],
+        branch,
+        branch_index,
+        key_pending,
+        scope_id.as_deref(),
+        skip_is_prop,
+        &mut first_arg,
+    );
+    ctx.push(")");
+}
+
+#[allow(clippy::too_many_arguments)]
+fn flush_segment(
+    ctx: &mut CodegenContext,
+    props: &[PropNode<'_>],
+    branch: &IfBranchNode<'_>,
+    branch_index: usize,
+    include_key: bool,
+    scope_id: Option<&str>,
+    skip_is_prop: bool,
+    first_arg: &mut bool,
+) {
+    if !include_key && scope_id.is_none() && !has_renderable_prop(props, skip_is_prop) {
+        return;
+    }
+    push_separator(ctx, first_arg);
+    generate_segment_object(
+        ctx,
+        props,
+        branch,
+        branch_index,
+        include_key,
+        scope_id,
+        skip_is_prop,
+        true,
+    );
+}
+
+fn push_separator(ctx: &mut CodegenContext, first_arg: &mut bool) {
+    if !*first_arg {
+        ctx.push(", ");
+    }
+    *first_arg = false;
+}
+
+#[allow(clippy::too_many_arguments)]
+fn generate_segment_object(
+    ctx: &mut CodegenContext,
+    props: &[PropNode<'_>],
+    branch: &IfBranchNode<'_>,
+    branch_index: usize,
+    include_key: bool,
+    scope_id: Option<&str>,
+    skip_is_prop: bool,
+    inside_merge_props: bool,
+) {
+    let has_dynamic_class = has_dynamic_binding(props, "class");
+    let has_dynamic_style = has_dynamic_binding(props, "style");
+    let has_other = props
+        .iter()
+        .any(|prop| is_renderable_prop(prop, skip_is_prop, has_dynamic_class, has_dynamic_style));
+
+    if include_key && !has_other && scope_id.is_none() {
+        ctx.push("{ key: ");
+        generate_if_branch_key(ctx, branch, branch_index);
+        ctx.push(" }");
+        return;
+    }
+
+    let static_merge = StaticMerge::from_props(props);
+    let mut seen_events: FxHashSet<String> = FxHashSet::default();
+    let previous_skip_normalize = ctx.skip_normalize;
+    if inside_merge_props {
+        ctx.skip_normalize = true;
+    }
+
+    ctx.push("{");
+    ctx.indent();
+    let mut first_prop = true;
+    if include_key {
+        ctx.newline();
+        ctx.push("key: ");
+        generate_if_branch_key(ctx, branch, branch_index);
+        first_prop = false;
+    }
+
+    for prop in props {
+        if !is_renderable_prop(prop, skip_is_prop, has_dynamic_class, has_dynamic_style) {
+            continue;
+        }
+        if let PropNode::Directive(dir) = prop
+            && dir.name == "on"
+            && let Some(key) = get_static_event_key(dir)
+            && !seen_events.insert(key)
+        {
+            continue;
+        }
+        if !first_prop {
+            ctx.push(",");
+        }
+        ctx.newline();
+        generate_single_prop_for_if(ctx, prop, static_merge);
+        first_prop = false;
+    }
+
+    if let Some(scope_id) = scope_id {
+        if !first_prop {
+            ctx.push(",");
+        }
+        ctx.newline();
+        ctx.push("\"");
+        ctx.push(scope_id);
+        ctx.push("\": \"\"");
+    }
+
+    ctx.deindent();
+    ctx.newline();
+    ctx.push("}");
+    ctx.skip_normalize = previous_skip_normalize;
+}
+
+fn has_renderable_prop(props: &[PropNode<'_>], skip_is_prop: bool) -> bool {
+    let has_dynamic_class = has_dynamic_binding(props, "class");
+    let has_dynamic_style = has_dynamic_binding(props, "style");
+    props
+        .iter()
+        .any(|prop| is_renderable_prop(prop, skip_is_prop, has_dynamic_class, has_dynamic_style))
+}
+
+fn is_renderable_prop(
+    prop: &PropNode<'_>,
+    skip_is_prop: bool,
+    has_dynamic_class: bool,
+    has_dynamic_style: bool,
+) -> bool {
+    if let PropNode::Directive(dir) = prop
+        && !is_supported_directive(dir)
+    {
+        return false;
+    }
+    if skip_is_prop && is_is_prop(prop) {
+        return false;
+    }
+    !should_skip_prop_for_if(prop, has_dynamic_class, has_dynamic_style)
+        && !is_vbind_spread_prop(prop)
+        && !is_von_spread_prop(prop)
+}
+
+fn has_dynamic_binding(props: &[PropNode<'_>], name: &str) -> bool {
+    props.iter().any(|prop| {
+        matches!(
+            prop,
+            PropNode::Directive(dir)
+                if dir.name == "bind"
+                    && matches!(&dir.arg, Some(ExpressionNode::Simple(arg)) if arg.content == name)
+        )
+    })
+}
+
+fn is_usable_spread(prop: &PropNode<'_>) -> bool {
+    usable_spread(prop).is_some()
+}
+
+fn usable_spread<'a, 'b>(prop: &'a PropNode<'b>) -> Option<&'a crate::DirectiveNode<'b>> {
+    let PropNode::Directive(dir) = prop else {
+        return None;
+    };
+    if dir.exp.is_some() && (is_vbind_spread_prop(prop) || is_von_spread_prop(prop)) {
+        Some(dir)
+    } else {
+        None
+    }
+}

--- a/crates/vize_atelier_core/tests/v_if_spread_order.rs
+++ b/crates/vize_atelier_core/tests/v_if_spread_order.rs
@@ -1,0 +1,195 @@
+use vize_atelier_core::{
+    CodegenOptions, CodegenResult, TransformOptions, generate, parse, transform,
+};
+use vize_carton::String;
+
+fn result_output(result: &CodegenResult) -> String {
+    let mut output = String::with_capacity(result.preamble.len() + result.code.len() + 1);
+    output.push_str(&result.preamble);
+    output.push('\n');
+    output.push_str(&result.code);
+    output
+}
+
+fn compile(source: &str) -> String {
+    compile_with_options(source, CodegenOptions::default())
+}
+
+fn compile_with_options(source: &str, mut codegen_options: CodegenOptions) -> String {
+    let allocator = bumpalo::Bump::new();
+    let (mut root, errors) = parse(&allocator, source);
+    assert!(errors.is_empty(), "Parse errors: {errors:?}");
+    transform(
+        &allocator,
+        &mut root,
+        TransformOptions {
+            prefix_identifiers: true,
+            ..Default::default()
+        },
+        None,
+    );
+    codegen_options.prefix_identifiers = true;
+    result_output(&generate(&root, codegen_options))
+}
+
+#[test]
+fn v_if_key_and_props_stay_before_and_after_object_v_bind() {
+    let output = compile(r#"<a v-if="show" target="_blank" v-bind="attrs" :href="href"></a>"#);
+
+    assert!(
+        output.contains(
+            "_mergeProps({\n      key: 0,\n      target: \"_blank\"\n    }, _ctx.attrs, {\n      href: _ctx.href\n    })",
+        ),
+        "v-if props must be flushed around v-bind in source order:\n{output}",
+    );
+}
+
+#[test]
+fn v_if_key_precedes_a_leading_object_v_bind() {
+    let output = compile(r#"<a v-if="show" v-bind="attrs" target="_blank"></a>"#);
+
+    assert!(
+        output.contains("_mergeProps({ key: 0 }, _ctx.attrs, {\n      target: \"_blank\"\n    })",),
+        "the generated branch key must precede a leading v-bind:\n{output}",
+    );
+}
+
+#[test]
+fn component_v_if_keeps_interleaved_object_spreads_in_source_order() {
+    let output = compile(
+        r#"<Widget v-if="show" id="before" v-on="listeners" title="middle" v-bind="attrs" @click="after" />"#,
+    );
+
+    assert!(
+        output.contains(
+            "_mergeProps({\n      key: 0,\n      id: \"before\"\n    }, _toHandlers(_ctx.listeners, true), {\n      title: \"middle\"\n    }, _ctx.attrs, {\n      onClick: _ctx.after\n    })",
+        ),
+        "component spreads and prop segments must keep source order:\n{output}",
+    );
+}
+
+#[test]
+fn v_if_class_bindings_do_not_merge_across_object_spreads() {
+    let output = compile(r#"<div v-if="show" class="base" v-bind="attrs" :class="classes"></div>"#);
+
+    assert!(
+        output.contains(
+            "_mergeProps({\n      key: 0,\n      class: \"base\"\n    }, _ctx.attrs, {\n      class: _ctx.classes\n    })",
+        ),
+        "class bindings on opposite sides of v-bind must stay separate:\n{output}",
+    );
+    assert!(
+        !output.contains("class: [\"base\", _ctx.classes]"),
+        "{output}"
+    );
+}
+
+#[test]
+fn v_if_style_bindings_do_not_merge_or_normalize_across_spreads() {
+    let output =
+        compile(r#"<div v-if="show" style="color: red" v-bind="attrs" :style="styles"></div>"#);
+
+    assert!(
+        output.contains(
+            "_mergeProps({\n      key: 0,\n      style: \"color: red\"\n    }, _ctx.attrs, {\n      style: _ctx.styles\n    })",
+        ),
+        "style bindings on opposite sides of v-bind must stay separate:\n{output}",
+    );
+    assert!(!output.contains("_normalizeStyle"), "{output}");
+    assert!(!output.contains("style: ["), "{output}");
+}
+
+#[test]
+fn v_if_class_bindings_still_merge_within_one_segment() {
+    let output = compile(r#"<div v-if="show" class="base" :class="classes" v-bind="attrs"></div>"#);
+
+    assert!(
+        output.contains(
+            "_mergeProps({\n      key: 0,\n      class: [\"base\", _ctx.classes]\n    }, _ctx.attrs)",
+        ),
+        "class bindings in one segment must retain Vue's array merge:\n{output}",
+    );
+    assert!(!output.contains("_normalizeClass"), "{output}");
+}
+
+#[test]
+fn v_if_user_key_is_hoisted_before_a_leading_spread() {
+    let output = compile(r#"<div v-if="show" v-bind="attrs" :key="identity"></div>"#);
+
+    assert!(
+        output.contains("_mergeProps({ key: _ctx.identity }, _ctx.attrs)"),
+        "the user key is the generated branch key and must win before spreads:\n{output}",
+    );
+    assert_eq!(output.matches("key: _ctx.identity").count(), 1, "{output}");
+}
+
+#[test]
+fn v_if_consecutive_v_bind_and_v_on_spreads_do_not_emit_empty_objects() {
+    let output = compile(r#"<div v-if="show" v-bind="attrs" v-on="listeners"></div>"#);
+
+    assert!(
+        output.contains("_mergeProps({ key: 0 }, _ctx.attrs, _toHandlers(_ctx.listeners, true))",),
+        "consecutive spreads must remain adjacent after the branch key:\n{output}",
+    );
+    assert!(!output.contains("{\n    }"), "{output}");
+}
+
+#[test]
+fn dynamic_component_is_prop_is_skipped_in_every_segment() {
+    let output = compile(
+        r#"<component v-if="show" :is="view" id="before" v-bind="attrs" title="after"></component>"#,
+    );
+
+    assert!(
+        output.contains(
+            "_mergeProps({\n      key: 0,\n      id: \"before\"\n    }, _ctx.attrs, {\n      title: \"after\"\n    })",
+        ),
+        "dynamic component props must keep order while consuming :is:\n{output}",
+    );
+    assert!(!output.contains("\n      is:"), "{output}");
+}
+
+#[test]
+fn event_deduplication_is_scoped_to_each_merge_segment() {
+    let output = compile(
+        r#"<button v-if="show" @click="before" v-bind="attrs" v-on:click="after"></button>"#,
+    );
+
+    assert!(
+        output.contains(
+            "_mergeProps({\n      key: 0,\n      onClick: _ctx.before\n    }, _ctx.attrs, {\n      onClick: _ctx.after\n    })",
+        ),
+        "handlers separated by a spread must both survive for mergeProps:\n{output}",
+    );
+    assert_eq!(output.matches("onClick:").count(), 2, "{output}");
+}
+
+#[test]
+fn scoped_css_marker_is_emitted_only_after_the_final_spread() {
+    let output = compile_with_options(
+        r#"<div v-if="show" id="before" v-bind="attrs" title="after"></div>"#,
+        CodegenOptions {
+            scope_id: Some(String::from("data-v-order")),
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        output.contains(
+            "_mergeProps({\n      key: 0,\n      id: \"before\"\n    }, _ctx.attrs, {\n      title: \"after\",\n      \"data-v-order\": \"\"\n    })",
+        ),
+        "scope marker must be appended to the trailing props segment:\n{output}",
+    );
+    assert_eq!(output.matches("data-v-order").count(), 1, "{output}");
+}
+
+#[test]
+fn no_spread_v_if_keeps_the_key_and_props_object_shape() {
+    let output = compile(r#"<div v-if="show" id="stable"></div>"#);
+
+    assert!(
+        output.contains("{\n      key: 0,\n      id: \"stable\"\n    }"),
+        "non-spread v-if props must retain their established shape:\n{output}",
+    );
+    assert!(!output.contains("_mergeProps"), "{output}");
+}

--- a/tests/expected/sfc/patches.snap
+++ b/tests/expected/sfc/patches.snap
@@ -450,8 +450,7 @@ const buttonProps = computed(() => ({ disabled: false, type: 'primary' }))
 
 return (_ctx, _cache) => {
   return (isActive.value)
-      ? (_openBlock(), _createBlock(Button, _mergeProps(buttonProps.value, {
-        key: 0,
+      ? (_openBlock(), _createBlock(Button, _mergeProps({ key: 0 }, buttonProps.value, {
         onClick: _cache[0] || (_cache[0] = (...args) => (_ctx.handleClick && _ctx.handleClick(...args)))
       }), {
         default: _withCtx(() => [
@@ -500,8 +499,7 @@ return (_ctx, _cache) => {
         name: "eye"
       }))
       : (mode.value === 'edit')
-        ? (_openBlock(), _createBlock(Icon, _mergeProps(iconProps, {
-          key: 1,
+        ? (_openBlock(), _createBlock(Icon, _mergeProps({ key: 1 }, iconProps, {
           name: "pencil"
         }), null, 16 /* FULL_PROPS */))
       : (_openBlock(), _createBlock(Icon, {

--- a/tests/snapshots/check/vue-router-patch-oracle.ts
+++ b/tests/snapshots/check/vue-router-patch-oracle.ts
@@ -145,11 +145,7 @@ test("Vue Router compiler is deterministic and recovers from an exact expression
         );
       }
       assert.equal(output.code.includes("_mergeProps(_unref(attrs), {"), false, output.code);
-      assert.equal(
-        count(output.code, 'class: ["router-link", classes.value]'),
-        2,
-        output.code,
-      );
+      assert.equal(count(output.code, 'class: ["router-link", classes.value]'), 2, output.code);
       assert.equal(output.code.includes("_normalizeClass"), false, output.code);
       assert.equal(count(output.code, '_renderSlot(_ctx.$slots, "default")'), 2, output.code);
       assert.equal(output.code.includes("RouterLinkProps"), false, output.code);

--- a/tests/snapshots/check/vue-router-patch-oracle.ts
+++ b/tests/snapshots/check/vue-router-patch-oracle.ts
@@ -34,8 +34,8 @@ const appPath = "packages/playground/src/AppLink.vue";
 const routerManifestPath = "packages/router/package.json";
 const symbol = "packageBoundary";
 const sourceSha256 = "f5c888da7bae9c61151c7fbfde578ccdb768e75fbe2e69637d8298ca4f702c96";
-const cleanOutputSha256 = "baa6667f47df3663c55e938e7f93f0e12eb2f0bd931cc1b3de43b0dbbc110883";
-const cleanCodeSha256 = "d305d39f63d298418bb52dc4bd1d6c02d73a3f5a52205c6166a8811dbec7c3b9";
+const cleanOutputSha256 = "84e9feaa14017c1c0e27a6b8955bd4a591b3b61e8708f3ead335aaa0c7c96013";
+const cleanCodeSha256 = "2e99ba339b7fb47f5788a990245b0292ede267d6bdfcb6c80cbe4c76da9cdebc";
 const brokenOutputSha256 = "15e571e43307b3ac025db3929f4f11029f1b7f5991d11b405433b6a31c5bc90e";
 const brokenCodeSha256 = "eed24c03d97029fca5d3d13f81ac416099d3876e7f36572d113acc0768872679";
 const cleanHref = ':href="String(to)"';
@@ -134,16 +134,23 @@ test("Vue Router compiler is deterministic and recovers from an exact expression
       }
       assert.equal(count(output.code, "key: 0"), 1, output.code);
       assert.equal(count(output.code, "key: 1"), 1, output.code);
+      for (const branchKey of [0, 1]) {
+        assert.equal(
+          count(
+            output.code,
+            `_createElementBlock("a", _mergeProps({ key: ${branchKey} }, _unref(attrs), {`,
+          ),
+          1,
+          output.code,
+        );
+      }
+      assert.equal(output.code.includes("_mergeProps(_unref(attrs), {"), false, output.code);
       assert.equal(
-        count(output.code, '_createElementBlock("a", _mergeProps(_unref(attrs), {'),
+        count(output.code, 'class: ["router-link", classes.value]'),
         2,
         output.code,
       );
-      assert.equal(
-        count(output.code, 'class: _normalizeClass(["router-link", classes.value])'),
-        2,
-        output.code,
-      );
+      assert.equal(output.code.includes("_normalizeClass"), false, output.code);
       assert.equal(count(output.code, '_renderSlot(_ctx.$slots, "default")'), 2, output.code);
       assert.equal(output.code.includes("RouterLinkProps"), false, output.code);
 

--- a/tests/snapshots/sfc/js/patches__v_else_if_with_v_bind_object_spread.snap
+++ b/tests/snapshots/sfc/js/patches__v_else_if_with_v_bind_object_spread.snap
@@ -22,8 +22,7 @@ return (_ctx, _cache) => {
       name: "eye"
     }))
     : (mode.value === 'edit')
-      ? (_openBlock(), _createBlock(Icon, _mergeProps(iconProps, {
-        key: 1,
+      ? (_openBlock(), _createBlock(Icon, _mergeProps({ key: 1 }, iconProps, {
         name: "pencil"
       }), null, 16 /* FULL_PROPS */))
     : (_openBlock(), _createBlock(Icon, {

--- a/tests/snapshots/sfc/js/patches__v_if_with_v_bind_object_spread.snap
+++ b/tests/snapshots/sfc/js/patches__v_if_with_v_bind_object_spread.snap
@@ -18,8 +18,7 @@ const buttonProps = computed(() => ({ disabled: false, type: 'primary' }))
 
 return (_ctx, _cache) => {
   return (isActive.value)
-    ? (_openBlock(), _createBlock(Button, _mergeProps(buttonProps.value, {
-      key: 0,
+    ? (_openBlock(), _createBlock(Button, _mergeProps({ key: 0 }, buttonProps.value, {
       onClick: _cache[0] || (_cache[0] = (...args) => (_ctx.handleClick && _ctx.handleClick(...args)))
     }), {
       default: _withCtx(() => [

--- a/tests/snapshots/sfc/ts/patches__v_else_if_with_v_bind_object_spread.snap
+++ b/tests/snapshots/sfc/ts/patches__v_else_if_with_v_bind_object_spread.snap
@@ -23,8 +23,7 @@ return (_ctx: any,_cache: any) => {
       name: "eye"
     }))
     : (mode.value === 'edit')
-      ? (_openBlock(), _createBlock(Icon, _mergeProps(iconProps, {
-        key: 1,
+      ? (_openBlock(), _createBlock(Icon, _mergeProps({ key: 1 }, iconProps, {
         name: "pencil"
       }), null, 16 /* FULL_PROPS */))
     : (_openBlock(), _createBlock(Icon, {

--- a/tests/snapshots/sfc/ts/patches__v_if_with_v_bind_object_spread.snap
+++ b/tests/snapshots/sfc/ts/patches__v_if_with_v_bind_object_spread.snap
@@ -19,8 +19,7 @@ const buttonProps = computed(() => ({ disabled: false, type: 'primary' }))
 
 return (_ctx: any,_cache: any) => {
   return (isActive.value)
-    ? (_openBlock(), _createBlock(Button, _mergeProps(buttonProps.value, {
-      key: 0,
+    ? (_openBlock(), _createBlock(Button, _mergeProps({ key: 0 }, buttonProps.value, {
       onClick: _cache[0] || (_cache[0] = (...args) => (_ctx.handleClick && _ctx.handleClick(...args)))
     }), {
       default: _withCtx(() => [


### PR DESCRIPTION
## Summary

- preserve v-if branch props and object spreads in template source order
- place generated and user branch keys before leading spreads
- keep class, style, event, scope, and dynamic-component behavior segment-local
- refresh the strict Vue Router compiler oracle for the corrected output

## Validation

- cargo test -p vize_atelier_core
- cargo test -p vize_atelier_core --test v_if_spread_order
- cargo clippy -p vize_atelier_core --lib -- -D warnings
- 12 exact v-if spread-order regression tests
- real-project fixture suite: 46 unchanged cases passed; corrected Vue Router compiler clean/broken/repaired oracle passed independently

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `v-if` prop and event handling when templates use object spreads, dynamic classes, styles, or handlers.
  * Preserved source order and correct merging across multiple `v-bind` and `v-on` segments.
  * Improved handling of keys, scoped styles, dynamic components, and duplicate static event handlers.

* **Tests**
  * Added coverage for `v-if` spread ordering, prop merging, handler deduplication, and no-spread scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->