### PR TITLE
test(fixtures): compile every real project

### DIFF
--- a/tests/tooling/fixture-tool-matrix-compiler.test.ts
+++ b/tests/tooling/fixture-tool-matrix-compiler.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const toolPath = path.join(root, "tools", "fixtures", "tool-matrix-report.mjs");
+
+function run(args: string[]) {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-fixture-tool-compiler-"));
+  const result = spawnSync(process.execPath, [toolPath, ...args, "--output-dir", outputDir], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  return { outputDir, result };
+}
+
+function writeFakeVize(directory: string, body: string) {
+  const executable = path.join(directory, "fake-vize.mjs");
+  fs.writeFileSync(executable, `#!/usr/bin/env node\n${body}\n`);
+  fs.chmodSync(executable, 0o755);
+  return executable;
+}
+
+function withSyntheticFixture(runTest: () => void) {
+  const fixtureDir = path.join(root, "tests", "_fixtures", "_git", "vue-vben-admin");
+  const fixtureExisted = fs.existsSync(fixtureDir);
+  const syntheticDir = path.join(fixtureDir, "apps");
+  const syntheticDirExisted = fs.existsSync(syntheticDir);
+  const fixtureFile = path.join(syntheticDir, "vize-tool-matrix-test.vue");
+  fs.mkdirSync(syntheticDir, { recursive: true });
+  assert.equal(fs.existsSync(fixtureFile), false, fixtureFile);
+  fs.writeFileSync(fixtureFile, "<template><main /></template>\n");
+  try {
+    runTest();
+  } finally {
+    fs.rmSync(fixtureFile, { force: true });
+    if (!syntheticDirExisted) fs.rmdirSync(syntheticDir);
+    if (!fixtureExisted) fs.rmdirSync(fixtureDir);
+  }
+}
+
+test("fixture tool matrix compiles every matched Vue file into validated JSON artifacts", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-fixture-tool-compiler-"));
+  const executable = writeFakeVize(
+    fakeDir,
+    `import fs from "node:fs"; import path from "node:path";
+if (process.argv[2] === "--version") process.exit(0);
+const output = process.argv[process.argv.indexOf("--output") + 1];
+fs.mkdirSync(output, { recursive: true });
+fs.writeFileSync(path.join(output, "synthetic.json"), JSON.stringify({ filename: "vize-tool-matrix-test.vue", code: "export default {}", css: null, errors: [], warnings: ["synthetic warning"], script_lang: "js", macro_artifacts: [] }) + "\\n");
+process.stdout.write("Built: vize-tool-matrix-test.vue\\n");`,
+  );
+  try {
+    withSyntheticFixture(() => {
+      const { outputDir, result } = run([
+        "--project",
+        "vue-vben-admin",
+        "--tool",
+        "compiler",
+        "--vize-bin",
+        executable,
+      ]);
+      try {
+        assert.equal(result.status, 0, result.stderr);
+        const report = JSON.parse(fs.readFileSync(path.join(outputDir, "summary.json"), "utf8"));
+        assert.deepEqual(
+          {
+            failedRuns: report.summary.failedRuns,
+            okRuns: report.summary.okRuns,
+            runStatus: report.projects[0].runs[0].status,
+          },
+          { failedRuns: 0, okRuns: 1, runStatus: "ok" },
+        );
+        const rawPath = path.resolve(root, report.projects[0].runs[0].outputPath);
+        const raw = JSON.parse(fs.readFileSync(rawPath, "utf8"));
+        assert.deepEqual(
+          {
+            inputFileCount: raw.compilerArtifacts.inputFileCount,
+            outputFileCount: raw.compilerArtifacts.outputFileCount,
+            errorCount: raw.compilerArtifacts.errorCount,
+            warningCount: raw.compilerArtifacts.warningCount,
+          },
+          { inputFileCount: 1, outputFileCount: 1, errorCount: 0, warningCount: 1 },
+        );
+        assert.match(raw.compilerArtifacts.sha256, /^[0-9a-f]{64}$/);
+        assert.equal("parsed" in raw, false);
+      } finally {
+        fs.rmSync(outputDir, { recursive: true, force: true });
+      }
+    });
+  } finally {
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
+});
+
+test("fixture tool matrix rejects incomplete and malformed compiler artifacts", () => {
+  const cases = [
+    {
+      name: "missing",
+      body: `if (process.argv[2] === "--version") process.exit(0);`,
+      message: /compiler artifact count mismatch: 1 inputs, 0 outputs/,
+    },
+    {
+      name: "malformed",
+      body: `import fs from "node:fs"; import path from "node:path";
+if (process.argv[2] === "--version") process.exit(0);
+const output = process.argv[process.argv.indexOf("--output") + 1];
+fs.mkdirSync(output, { recursive: true });
+fs.writeFileSync(path.join(output, "synthetic.json"), "{}\\n");`,
+      message: /invalid compiler artifact keys in synthetic\.json/,
+    },
+  ] as const;
+
+  for (const fixtureCase of cases) {
+    const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), `vize-compiler-${fixtureCase.name}-`));
+    const executable = writeFakeVize(fakeDir, fixtureCase.body);
+    try {
+      withSyntheticFixture(() => {
+        const { outputDir, result } = run([
+          "--project",
+          "vue-vben-admin",
+          "--tool",
+          "compiler",
+          "--vize-bin",
+          executable,
+        ]);
+        try {
+          assert.equal(result.status, 1, fixtureCase.name);
+          const report = JSON.parse(fs.readFileSync(path.join(outputDir, "summary.json"), "utf8"));
+          assert.equal(report.summary.failedRuns, 1);
+          assert.match(report.projects[0].runs[0].failure, fixtureCase.message);
+          const rawPath = path.resolve(root, report.projects[0].runs[0].outputPath);
+          const raw = JSON.parse(fs.readFileSync(rawPath, "utf8"));
+          assert.match(raw.validationError, fixtureCase.message);
+        } finally {
+          fs.rmSync(outputDir, { recursive: true, force: true });
+        }
+      });
+    } finally {
+      fs.rmSync(fakeDir, { recursive: true, force: true });
+    }
+  }
+});

--- a/tests/tooling/fixture-tool-matrix-report.test.ts
+++ b/tests/tooling/fixture-tool-matrix-report.test.ts
@@ -62,7 +62,10 @@ test("fixture tool matrix emits read-only commands with machine-readable diagnos
     const runs = Object.fromEntries(
       report.projects[0].runs.map((entry: { tool: string }) => [entry.tool, entry]),
     ) as Record<string, { command: string }>;
-    assert.match(runs.compiler.command, /inspector .*--format json --template-syntax quirks/);
+    assert.match(
+      runs.compiler.command,
+      /build .*--format json --output '<compiler-output>' --template-syntax quirks --continue-on-error --no-config/,
+    );
     assert.match(
       runs.typechecker.command,
       /check .*--format json --no-config --tsconfig playground\/tsconfig\.json/,
@@ -175,7 +178,7 @@ test("fixture tool matrix preserves raw output for invalid JSON and spawn errors
       "--project",
       "vue-vben-admin",
       "--tool",
-      "compiler",
+      "linter",
       "--vize-bin",
       executable,
     ]);

--- a/tools/fixtures/tool-matrix-report.mjs
+++ b/tools/fixtures/tool-matrix-report.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { resolveVizeLaunch, runTool } from "./tool-matrix-run.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..", "..");
@@ -149,94 +150,6 @@ function printHelpAndExit() {
   process.exit(0);
 }
 
-function runTool(project, tool, args, launch, outputDir) {
-  const cwd = resolve(repoRoot, project.fixturePath);
-  const commandArgs = [...launch.prefix, ...toolArgs(project, tool)];
-  const base = {
-    tool,
-    command: displayCommand(launch.command, commandArgs),
-    cwd: relative(repoRoot, cwd),
-    durationMs: 0,
-    exitCode: null,
-    outputPath: null,
-  };
-  if (args.dryRun) return { ...base, status: "planned" };
-  if (!existsSync(cwd)) return { ...base, status: "missing-fixture" };
-
-  const startedAt = Date.now();
-  const result = spawnSync(launch.command, commandArgs, {
-    cwd,
-    encoding: "utf8",
-    env: { ...process.env, LANG: "C", LC_ALL: "C" },
-    maxBuffer: 1024 * 1024 * 1024,
-    timeout: args.timeoutMs,
-  });
-  const rawPath = join(outputDir, `${project.id}-${tool}.json`);
-  const completed = {
-    ...base,
-    durationMs: Date.now() - startedAt,
-    exitCode: result.status,
-    outputPath: relative(repoRoot, rawPath),
-  };
-  const payload = {
-    schema: "vize.fixtureToolRun",
-    version: 1,
-    project: project.id,
-    tool,
-    exitCode: result.status,
-    stdout: result.stdout ?? "",
-    stderr: result.stderr ?? "",
-  };
-  if (result.error != null) {
-    payload.spawnError = errorMessage(result.error);
-  } else if (tool !== "formatter" && (result.status === 0 || result.status === 1)) {
-    try {
-      payload.parsed = JSON.parse(result.stdout);
-    } catch (error) {
-      payload.parseError = errorMessage(error);
-    }
-  }
-  writeFileSync(rawPath, `${JSON.stringify(payload, null, 2)}\n`);
-
-  if (result.error != null) {
-    return { ...completed, status: "failed", failure: errorMessage(result.error) };
-  }
-  if (result.status !== 0 && result.status !== 1) {
-    return { ...completed, status: "failed", failure: failureOutput(result) };
-  }
-  if (payload.parseError != null) {
-    return {
-      ...completed,
-      status: "failed",
-      failure: `invalid JSON output: ${payload.parseError}`,
-    };
-  }
-  return { ...completed, status: result.status === 0 ? "ok" : "findings" };
-}
-
-function toolArgs(project, tool) {
-  if (tool === "compiler") {
-    return ["inspector", ...project.vueGlobs, "--format", "json", "--template-syntax", "quirks"];
-  }
-  if (tool === "linter") {
-    return [
-      "lint",
-      ...project.vueGlobs,
-      "--format",
-      "json",
-      "--preset",
-      "ecosystem",
-      "--no-config",
-    ];
-  }
-  if (tool === "typechecker") {
-    const args = ["check", ...project.vueGlobs, "--format", "json", "--no-config"];
-    if (project.tsconfig != null) args.push("--tsconfig", project.tsconfig);
-    return args;
-  }
-  return ["fmt", ...project.vueGlobs, "--check", "--no-config"];
-}
-
 function assertRegistryCoverage(registry, projects, tools) {
   for (const tool of tools) {
     if (!registry.requiredToolCoverage.includes(tool)) {
@@ -250,33 +163,6 @@ function assertRegistryCoverage(registry, projects, tools) {
       }
     }
   }
-}
-
-function resolveVizeLaunch(vizeBin, dryRun) {
-  const candidates = [
-    vizeBin,
-    process.env.VIZE_BIN,
-    join(repoRoot, "target", "ci", executableName("vize")),
-    join(repoRoot, "target", "debug", executableName("vize")),
-    join(repoRoot, "target", "release", executableName("vize")),
-  ]
-    .filter(Boolean)
-    .map((candidate) => resolve(candidate));
-  for (const candidate of candidates) {
-    if (!existsSync(candidate)) continue;
-    if (dryRun) return { command: candidate, prefix: [], label: candidate };
-    const probe = spawnSync(candidate, ["--version"], {
-      encoding: "utf8",
-      timeout: 10_000,
-    });
-    if (probe.status === 0) return { command: candidate, prefix: [], label: candidate };
-  }
-  if (vizeBin != null && !dryRun) throw new Error(`Vize executable is not runnable: ${vizeBin}`);
-  return {
-    command: "cargo",
-    prefix: ["run", "-q", "-p", "vize", "--"],
-    label: "cargo run -q -p vize --",
-  };
 }
 
 function renderMarkdown(report) {
@@ -350,23 +236,8 @@ function timestampSlug(date) {
     .replace(/\.\d{3}Z$/, "Z")
     .replace(/[:.]/g, "-");
 }
-function executableName(name) {
-  return process.platform === "win32" ? `${name}.exe` : name;
-}
 function errorMessage(error) {
   return error instanceof Error ? error.message : String(error);
-}
-function failureOutput(result) {
-  return { stdout: truncate(result.stdout), stderr: truncate(result.stderr) };
-}
-function truncate(value) {
-  return value.length <= 4000 ? value : `${value.slice(0, 4000)}\n...<truncated>`;
-}
-function displayCommand(command, args) {
-  return [command, ...args].map(shellQuote).join(" ");
-}
-function shellQuote(value) {
-  return /^[A-Za-z0-9_./:=@*-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 try {

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -1,0 +1,285 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  globSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+export function runTool(project, tool, args, launch, outputDir) {
+  const cwd = resolve(repoRoot, project.fixturePath);
+  const compilerOutputDir =
+    tool === "compiler" && !args.dryRun
+      ? mkdtempSync(join(tmpdir(), "vize-fixture-compiler-"))
+      : null;
+  const commandArgs = [
+    ...launch.prefix,
+    ...toolArgs(project, tool, compilerOutputDir ?? "<compiler-output>"),
+  ];
+  const base = {
+    tool,
+    command: displayCommand(launch.command, commandArgs),
+    cwd: relative(repoRoot, cwd),
+    durationMs: 0,
+    exitCode: null,
+    outputPath: null,
+  };
+  if (args.dryRun) return { ...base, status: "planned" };
+  if (!existsSync(cwd)) return { ...base, status: "missing-fixture" };
+
+  try {
+    const startedAt = Date.now();
+    const result = spawnSync(launch.command, commandArgs, {
+      cwd,
+      encoding: "utf8",
+      env: { ...process.env, LANG: "C", LC_ALL: "C" },
+      maxBuffer: 1024 * 1024 * 1024,
+      timeout: args.timeoutMs,
+    });
+    const rawPath = join(outputDir, `${project.id}-${tool}.json`);
+    const completed = {
+      ...base,
+      durationMs: Date.now() - startedAt,
+      exitCode: result.status,
+      outputPath: relative(repoRoot, rawPath),
+    };
+    const payload = {
+      schema: "vize.fixtureToolRun",
+      version: 1,
+      project: project.id,
+      tool,
+      exitCode: result.status,
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+    };
+    if (result.error != null) {
+      payload.spawnError = errorMessage(result.error);
+    } else if (tool === "compiler" && (result.status === 0 || result.status === 1)) {
+      try {
+        payload.compilerArtifacts = inspectCompilerArtifacts(
+          cwd,
+          project.vueGlobs,
+          compilerOutputDir,
+        );
+      } catch (error) {
+        payload.validationError = errorMessage(error);
+      }
+    } else if (tool !== "formatter" && (result.status === 0 || result.status === 1)) {
+      try {
+        payload.parsed = JSON.parse(result.stdout);
+      } catch (error) {
+        payload.parseError = errorMessage(error);
+      }
+    }
+    writeFileSync(rawPath, `${JSON.stringify(payload, null, 2)}\n`);
+
+    if (result.error != null) {
+      return { ...completed, status: "failed", failure: errorMessage(result.error) };
+    }
+    if (result.status !== 0 && result.status !== 1) {
+      return { ...completed, status: "failed", failure: failureOutput(result) };
+    }
+    if (payload.validationError != null) {
+      return { ...completed, status: "failed", failure: payload.validationError };
+    }
+    if (payload.parseError != null) {
+      return {
+        ...completed,
+        status: "failed",
+        failure: `invalid JSON output: ${payload.parseError}`,
+      };
+    }
+    return { ...completed, status: result.status === 0 ? "ok" : "findings" };
+  } finally {
+    if (compilerOutputDir != null) rmSync(compilerOutputDir, { recursive: true, force: true });
+  }
+}
+
+function inspectCompilerArtifacts(cwd, patterns, outputDir) {
+  const inputPaths = [
+    ...new Set(
+      patterns.flatMap((pattern) =>
+        globSync(pattern, { cwd }).map((entry) => entry.replaceAll("\\", "/")),
+      ),
+    ),
+  ].sort((left, right) => left.localeCompare(right));
+  if (inputPaths.length === 0) throw new Error("compiler matched no Vue files");
+
+  const outputPaths = collectFiles(outputDir);
+  const unexpected = outputPaths.filter((entry) => !entry.endsWith(".json"));
+  if (unexpected.length > 0) {
+    throw new Error(`compiler emitted non-JSON artifacts: ${unexpected.join(", ")}`);
+  }
+  if (outputPaths.length !== inputPaths.length) {
+    throw new Error(
+      `compiler artifact count mismatch: ${inputPaths.length} inputs, ${outputPaths.length} outputs`,
+    );
+  }
+
+  const digest = createHash("sha256");
+  let errorCount = 0;
+  let warningCount = 0;
+  for (const outputPath of outputPaths) {
+    const source = readFileSync(join(outputDir, outputPath), "utf8");
+    digest.update(outputPath);
+    digest.update("\0");
+    digest.update(source);
+    digest.update("\0");
+    let artifact;
+    try {
+      artifact = JSON.parse(source);
+    } catch (error) {
+      throw new Error(`invalid compiler JSON artifact ${outputPath}: ${errorMessage(error)}`);
+    }
+    validateCompilerArtifact(outputPath, artifact);
+    errorCount += artifact.errors.length;
+    warningCount += artifact.warnings.length;
+  }
+
+  return {
+    inputFileCount: inputPaths.length,
+    outputFileCount: outputPaths.length,
+    errorCount,
+    warningCount,
+    sha256: digest.digest("hex"),
+  };
+}
+
+function collectFiles(root, directory = root, files = []) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const absolute = join(directory, entry.name);
+    if (entry.isDirectory()) collectFiles(root, absolute, files);
+    else if (entry.isFile()) files.push(relative(root, absolute).replaceAll("\\", "/"));
+    else throw new Error(`compiler emitted unsupported artifact: ${entry.name}`);
+  }
+  return files.sort((left, right) => left.localeCompare(right));
+}
+
+function validateCompilerArtifact(outputPath, artifact) {
+  if (artifact == null || typeof artifact !== "object" || Array.isArray(artifact)) {
+    throw new Error(`invalid compiler artifact envelope: ${outputPath}`);
+  }
+  const expectedKeys = [
+    "code",
+    "css",
+    "errors",
+    "filename",
+    "macro_artifacts",
+    "script_lang",
+    "warnings",
+  ];
+  const actualKeys = Object.keys(artifact).sort();
+  if (JSON.stringify(actualKeys) !== JSON.stringify(expectedKeys)) {
+    throw new Error(`invalid compiler artifact keys in ${outputPath}: ${actualKeys.join(", ")}`);
+  }
+  if (typeof artifact.filename !== "string" || !artifact.filename.endsWith(".vue")) {
+    throw new Error(`invalid compiler filename in ${outputPath}`);
+  }
+  if (typeof artifact.code !== "string") throw new Error(`invalid compiler code in ${outputPath}`);
+  if (artifact.css !== null && typeof artifact.css !== "string") {
+    throw new Error(`invalid compiler css in ${outputPath}`);
+  }
+  if (typeof artifact.script_lang !== "string") {
+    throw new Error(`invalid compiler script_lang in ${outputPath}`);
+  }
+  for (const field of ["errors", "warnings"]) {
+    if (
+      !Array.isArray(artifact[field]) ||
+      artifact[field].some((entry) => typeof entry !== "string")
+    ) {
+      throw new Error(`invalid compiler ${field} in ${outputPath}`);
+    }
+  }
+  if (!Array.isArray(artifact.macro_artifacts)) {
+    throw new Error(`invalid compiler macro_artifacts in ${outputPath}`);
+  }
+}
+
+function toolArgs(project, tool, compilerOutputDir) {
+  if (tool === "compiler") {
+    return [
+      "build",
+      ...project.vueGlobs,
+      "--format",
+      "json",
+      "--output",
+      compilerOutputDir,
+      "--template-syntax",
+      "quirks",
+      "--continue-on-error",
+      "--no-config",
+    ];
+  }
+  if (tool === "linter") {
+    return [
+      "lint",
+      ...project.vueGlobs,
+      "--format",
+      "json",
+      "--preset",
+      "ecosystem",
+      "--no-config",
+    ];
+  }
+  if (tool === "typechecker") {
+    const args = ["check", ...project.vueGlobs, "--format", "json", "--no-config"];
+    if (project.tsconfig != null) args.push("--tsconfig", project.tsconfig);
+    return args;
+  }
+  return ["fmt", ...project.vueGlobs, "--check", "--no-config"];
+}
+
+export function resolveVizeLaunch(vizeBin, dryRun) {
+  const candidates = [
+    vizeBin,
+    process.env.VIZE_BIN,
+    join(repoRoot, "target", "ci", executableName("vize")),
+    join(repoRoot, "target", "debug", executableName("vize")),
+    join(repoRoot, "target", "release", executableName("vize")),
+  ]
+    .filter(Boolean)
+    .map((candidate) => resolve(candidate));
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    if (dryRun) return { command: candidate, prefix: [], label: candidate };
+    const probe = spawnSync(candidate, ["--version"], {
+      encoding: "utf8",
+      timeout: 10_000,
+    });
+    if (probe.status === 0) return { command: candidate, prefix: [], label: candidate };
+  }
+  if (vizeBin != null && !dryRun) throw new Error(`Vize executable is not runnable: ${vizeBin}`);
+  return {
+    command: "cargo",
+    prefix: ["run", "-q", "-p", "vize", "--"],
+    label: "cargo run -q -p vize --",
+  };
+}
+
+function executableName(name) {
+  return process.platform === "win32" ? `${name}.exe` : name;
+}
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+function failureOutput(result) {
+  return { stdout: truncate(result.stdout), stderr: truncate(result.stderr) };
+}
+function truncate(value) {
+  return value.length <= 4000 ? value : `${value.slice(0, 4000)}\n...<truncated>`;
+}
+function displayCommand(command, args) {
+  return [command, ...args].map(shellQuote).join(" ");
+}
+function shellQuote(value) {
+  return /^[A-Za-z0-9_./:=@*-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}


### PR DESCRIPTION
## Summary
- replace the Compiler matrix probe with a real `vize build` over every registered Vue glob
- require one validated JSON artifact per matched SFC and record exact aggregate counts plus a deterministic digest
- fail on empty input, missing/extra/non-JSON output, malformed JSON, or compiler envelope drift
- split the runner and tests so every changed source remains below the 350-line guard

## Validation
- `node --test --test-concurrency=1 tests/tooling/fixture-tool-matrix-compiler.test.ts tests/tooling/fixture-tool-matrix-report.test.ts`
- formatter and lint checks over all four changed source files
- changed-file 350-line guard and `git diff --check origin/main`
- pinned Pinia Compiler run: 24 inputs, 24 outputs, 0 errors, 0 warnings, deterministic SHA-256

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fixture tool matrix reporting for compiler runs by validating generated artifacts, counting inputs/outputs/errors/warnings, and adding integrity checks (including SHA-256).
  * Enhanced failure handling for invalid or malformed tool output, preserving clearer validation error details and consistent exit behavior.
  * Updated diagnostic command expectations and ensured failure scenarios capture the correct tool output.

* **Tests**
  * Added/expanded automated coverage for the fixture tool matrix, verifying both `summary.json` results and per-run raw artifacts across success and failure paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->