### PR TITLE
test(fixtures): harden atelier matrix runner and assertions

### DIFF
--- a/tests/tooling/fixture-tool-matrix-compiler.test.ts
+++ b/tests/tooling/fixture-tool-matrix-compiler.test.ts
@@ -86,7 +86,10 @@ process.stdout.write("Built: vize-tool-matrix-test.vue\\n");`,
           },
           { inputFileCount: 1, outputFileCount: 1, errorCount: 0, warningCount: 1 },
         );
-        assert.match(raw.compilerArtifacts.sha256, /^[0-9a-f]{64}$/);
+        assert.equal(
+          raw.compilerArtifacts.sha256,
+          "472e9ac54a4318345412c8fab1f81aa472684be9d7c9791adea885dc5ef19a3f",
+        );
         assert.equal("parsed" in raw, false);
       } finally {
         fs.rmSync(outputDir, { recursive: true, force: true });

--- a/tests/tooling/fixture-tool-matrix-report.test.ts
+++ b/tests/tooling/fixture-tool-matrix-report.test.ts
@@ -62,10 +62,13 @@ test("fixture tool matrix emits read-only commands with machine-readable diagnos
     const runs = Object.fromEntries(
       report.projects[0].runs.map((entry: { tool: string }) => [entry.tool, entry]),
     ) as Record<string, { command: string }>;
-    assert.match(
-      runs.compiler.command,
-      /build .*--format json --output '<compiler-output>' --template-syntax quirks --continue-on-error --no-config/,
-    );
+    const compilerCommand = runs.compiler.command;
+    assert.match(compilerCommand, /(?:^|\s)build(?:\s|$)/);
+    assert.match(compilerCommand, /(?:^|\s)--format json(?:\s|$)/);
+    assert.match(compilerCommand, /(?:^|\s)--output \S*<compiler-output>\S*(?:\s|$)/);
+    assert.match(compilerCommand, /(?:^|\s)--template-syntax quirks(?:\s|$)/);
+    assert.match(compilerCommand, /(?:^|\s)--continue-on-error(?:\s|$)/);
+    assert.match(compilerCommand, /(?:^|\s)--no-config(?:\s|$)/);
     assert.match(
       runs.typechecker.command,
       /check .*--format json --no-config --tsconfig playground\/tsconfig\.json/,

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -17,8 +17,9 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 export function runTool(project, tool, args, launch, outputDir) {
   const cwd = resolve(repoRoot, project.fixturePath);
+  const fixtureExists = existsSync(cwd);
   const compilerOutputDir =
-    tool === "compiler" && !args.dryRun
+    tool === "compiler" && !args.dryRun && fixtureExists
       ? mkdtempSync(join(tmpdir(), "vize-fixture-compiler-"))
       : null;
   const commandArgs = [
@@ -34,7 +35,7 @@ export function runTool(project, tool, args, launch, outputDir) {
     outputPath: null,
   };
   if (args.dryRun) return { ...base, status: "planned" };
-  if (!existsSync(cwd)) return { ...base, status: "missing-fixture" };
+  if (!fixtureExists) return { ...base, status: "missing-fixture" };
 
   try {
     const startedAt = Date.now();


### PR DESCRIPTION
Follow-up to #3034 (already merged) addressing CodeRabbit review feedback on the compiler fixture matrix.

- Stop leaking the compiler temp directory when a fixture is missing. `runTool` now allocates the `mkdtempSync` output dir only when the fixture exists, so the early `missing-fixture` return (which bypasses the `try/finally` cleanup) no longer strands a temp directory.

```js
const fixtureExists = existsSync(cwd);
const compilerOutputDir =
  tool === "compiler" && !args.dryRun && fixtureExists
    ? mkdtempSync(join(tmpdir(), "vize-fixture-compiler-"))
    : null;
// ...
if (!fixtureExists) return { ...base, status: "missing-fixture" };
```

- Decouple the report test from shell-quote formatting: the compiler command is now asserted flag-by-flag, matching the `<compiler-output>` value without requiring literal surrounding quotes.
- Assert the exact deterministic SHA-256 for the fixed synthetic artifact instead of only matching the hex format, so ordering or digest-input regressions are caught.

Not addressed: the suggestion to reconcile artifact `filename` values against the matched input paths. The compiler sets `filename` to the file basename (`path.file_name()` in `crates/vize/src/commands/build/runner/compile.rs`), and real projects have many colliding basenames across directories, while output files are written common-root-relative rather than cwd-relative. Reconciling on those identities would inject false failures into the real matrix, so the existing count + envelope checks are retained.

Validation: `node --test --test-concurrency=1 tests/tooling/fixture-tool-matrix-compiler.test.ts tests/tooling/fixture-tool-matrix-report.test.ts` (11 pass), plus oxlint and oxfmt over the three changed files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->