### PR TITLE
fix(fixtures): reconcile atelier artifacts

### DIFF
--- a/tests/tooling/fixture-tool-matrix-compiler.test.ts
+++ b/tests/tooling/fixture-tool-matrix-compiler.test.ts
@@ -6,6 +6,8 @@ import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { runTool } from "../../tools/fixtures/tool-matrix-run.mjs";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const toolPath = path.join(root, "tools", "fixtures", "tool-matrix-report.mjs");
 
@@ -43,6 +45,28 @@ function withSyntheticFixture(runTest: () => void) {
   }
 }
 
+test("fixture tool matrix does not allocate compiler output for a missing fixture", () => {
+  const compilerTempEntries = () =>
+    fs
+      .readdirSync(os.tmpdir())
+      .filter((entry) => entry.startsWith("vize-fixture-compiler-"))
+      .sort((left, right) => left.localeCompare(right));
+  const before = compilerTempEntries();
+  const run = runTool(
+    {
+      id: "missing-compiler-fixture",
+      fixturePath: "tests/_fixtures/_git/missing-compiler-fixture",
+      vueGlobs: ["**/*.vue"],
+    },
+    "compiler",
+    { dryRun: false, timeoutMs: 1_000 },
+    { command: process.execPath, prefix: [], label: process.execPath },
+    os.tmpdir(),
+  );
+  assert.equal(run.status, "missing-fixture");
+  assert.deepEqual(compilerTempEntries(), before);
+});
+
 test("fixture tool matrix compiles every matched Vue file into validated JSON artifacts", () => {
   const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-fixture-tool-compiler-"));
   const executable = writeFakeVize(
@@ -51,7 +75,7 @@ test("fixture tool matrix compiles every matched Vue file into validated JSON ar
 if (process.argv[2] === "--version") process.exit(0);
 const output = process.argv[process.argv.indexOf("--output") + 1];
 fs.mkdirSync(output, { recursive: true });
-fs.writeFileSync(path.join(output, "synthetic.json"), JSON.stringify({ filename: "vize-tool-matrix-test.vue", code: "export default {}", css: null, errors: [], warnings: ["synthetic warning"], script_lang: "js", macro_artifacts: [] }) + "\\n");
+fs.writeFileSync(path.join(output, "vize-tool-matrix-test.json"), JSON.stringify({ filename: "vize-tool-matrix-test.vue", code: "export default {}", css: null, errors: [], warnings: ["synthetic warning"], script_lang: "js", macro_artifacts: [] }) + "\\n");
 process.stdout.write("Built: vize-tool-matrix-test.vue\\n");`,
   );
   try {
@@ -86,7 +110,10 @@ process.stdout.write("Built: vize-tool-matrix-test.vue\\n");`,
           },
           { inputFileCount: 1, outputFileCount: 1, errorCount: 0, warningCount: 1 },
         );
-        assert.match(raw.compilerArtifacts.sha256, /^[0-9a-f]{64}$/);
+        assert.equal(
+          raw.compilerArtifacts.sha256,
+          "706ebeac28056a83af4a93074d352014f1f80d8427a5d9dd135ffc6c6473a796",
+        );
         assert.equal("parsed" in raw, false);
       } finally {
         fs.rmSync(outputDir, { recursive: true, force: true });
@@ -110,8 +137,28 @@ test("fixture tool matrix rejects incomplete and malformed compiler artifacts", 
 if (process.argv[2] === "--version") process.exit(0);
 const output = process.argv[process.argv.indexOf("--output") + 1];
 fs.mkdirSync(output, { recursive: true });
-fs.writeFileSync(path.join(output, "synthetic.json"), "{}\\n");`,
-      message: /invalid compiler artifact keys in synthetic\.json/,
+fs.writeFileSync(path.join(output, "vize-tool-matrix-test.json"), "{}\\n");`,
+      message: /invalid compiler artifact keys in vize-tool-matrix-test\.json/,
+    },
+    {
+      name: "unexpected-path",
+      body: `import fs from "node:fs"; import path from "node:path";
+if (process.argv[2] === "--version") process.exit(0);
+const output = process.argv[process.argv.indexOf("--output") + 1];
+fs.mkdirSync(output, { recursive: true });
+fs.writeFileSync(path.join(output, "unrelated.json"), JSON.stringify({ filename: "vize-tool-matrix-test.vue", code: "export default {}", css: null, errors: [], warnings: [], script_lang: "js", macro_artifacts: [] }));`,
+      message:
+        /compiler artifact path mismatch: missing \[vize-tool-matrix-test\.json\], unexpected \[unrelated\.json\]/,
+    },
+    {
+      name: "filename-mismatch",
+      body: `import fs from "node:fs"; import path from "node:path";
+if (process.argv[2] === "--version") process.exit(0);
+const output = process.argv[process.argv.indexOf("--output") + 1];
+fs.mkdirSync(output, { recursive: true });
+fs.writeFileSync(path.join(output, "vize-tool-matrix-test.json"), JSON.stringify({ filename: "other.vue", code: "export default {}", css: null, errors: [], warnings: [], script_lang: "js", macro_artifacts: [] }));`,
+      message:
+        /compiler filename mismatch in vize-tool-matrix-test\.json: expected vize-tool-matrix-test\.vue, received other\.vue/,
     },
   ] as const;
 

--- a/tests/tooling/fixture-tool-matrix-report.test.ts
+++ b/tests/tooling/fixture-tool-matrix-report.test.ts
@@ -62,10 +62,14 @@ test("fixture tool matrix emits read-only commands with machine-readable diagnos
     const runs = Object.fromEntries(
       report.projects[0].runs.map((entry: { tool: string }) => [entry.tool, entry]),
     ) as Record<string, { command: string }>;
-    assert.match(
-      runs.compiler.command,
-      /build .*--format json --output '<compiler-output>' --template-syntax quirks --continue-on-error --no-config/,
-    );
+    const compilerCommand = runs.compiler.command;
+    assert.match(compilerCommand, /(?:^|\s)build(?:\s|$)/);
+    assert.match(compilerCommand, /--format json(?:\s|$)/);
+    assert.match(compilerCommand, /--output(?:\s|$)/);
+    assert.equal(compilerCommand.includes("<compiler-output>"), true);
+    assert.match(compilerCommand, /--template-syntax quirks(?:\s|$)/);
+    assert.match(compilerCommand, /--continue-on-error(?:\s|$)/);
+    assert.match(compilerCommand, /--no-config(?:\s|$)/);
     assert.match(
       runs.typechecker.command,
       /check .*--format json --no-config --tsconfig playground\/tsconfig\.json/,

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -17,8 +17,9 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 export function runTool(project, tool, args, launch, outputDir) {
   const cwd = resolve(repoRoot, project.fixturePath);
+  const fixtureExists = existsSync(cwd);
   const compilerOutputDir =
-    tool === "compiler" && !args.dryRun
+    tool === "compiler" && !args.dryRun && fixtureExists
       ? mkdtempSync(join(tmpdir(), "vize-fixture-compiler-"))
       : null;
   const commandArgs = [
@@ -34,7 +35,7 @@ export function runTool(project, tool, args, launch, outputDir) {
     outputPath: null,
   };
   if (args.dryRun) return { ...base, status: "planned" };
-  if (!existsSync(cwd)) return { ...base, status: "missing-fixture" };
+  if (!fixtureExists) return { ...base, status: "missing-fixture" };
 
   try {
     const startedAt = Date.now();
@@ -115,13 +116,23 @@ function inspectCompilerArtifacts(cwd, patterns, outputDir) {
   if (inputPaths.length === 0) throw new Error("compiler matched no Vue files");
 
   const outputPaths = collectFiles(outputDir);
-  const unexpected = outputPaths.filter((entry) => !entry.endsWith(".json"));
-  if (unexpected.length > 0) {
-    throw new Error(`compiler emitted non-JSON artifacts: ${unexpected.join(", ")}`);
+  const nonJsonPaths = outputPaths.filter((entry) => !entry.endsWith(".json"));
+  if (nonJsonPaths.length > 0) {
+    throw new Error(`compiler emitted non-JSON artifacts: ${nonJsonPaths.join(", ")}`);
   }
   if (outputPaths.length !== inputPaths.length) {
     throw new Error(
       `compiler artifact count mismatch: ${inputPaths.length} inputs, ${outputPaths.length} outputs`,
+    );
+  }
+  const inputByOutputPath = expectedCompilerOutputs(inputPaths);
+  const missingPaths = [...inputByOutputPath.keys()].filter(
+    (entry) => !outputPaths.includes(entry),
+  );
+  const unexpectedPaths = outputPaths.filter((entry) => !inputByOutputPath.has(entry));
+  if (missingPaths.length > 0 || unexpectedPaths.length > 0) {
+    throw new Error(
+      `compiler artifact path mismatch: missing [${missingPaths.join(", ")}], unexpected [${unexpectedPaths.join(", ")}]`,
     );
   }
 
@@ -140,7 +151,7 @@ function inspectCompilerArtifacts(cwd, patterns, outputDir) {
     } catch (error) {
       throw new Error(`invalid compiler JSON artifact ${outputPath}: ${errorMessage(error)}`);
     }
-    validateCompilerArtifact(outputPath, artifact);
+    validateCompilerArtifact(outputPath, artifact, inputByOutputPath.get(outputPath));
     errorCount += artifact.errors.length;
     warningCount += artifact.warnings.length;
   }
@@ -154,6 +165,27 @@ function inspectCompilerArtifacts(cwd, patterns, outputDir) {
   };
 }
 
+function expectedCompilerOutputs(inputPaths) {
+  const parentSegments = inputPaths.map((entry) => entry.split("/").slice(0, -1));
+  const commonSegments = [];
+  for (let index = 0; parentSegments.every((segments) => segments[index] != null); index += 1) {
+    const segment = parentSegments[0][index];
+    if (!parentSegments.every((segments) => segments[index] === segment)) break;
+    commonSegments.push(segment);
+  }
+  const commonPrefix = commonSegments.length === 0 ? "" : `${commonSegments.join("/")}/`;
+  const outputs = new Map(
+    inputPaths.map((inputPath) => [
+      inputPath.slice(commonPrefix.length).replace(/\.vue$/, ".json"),
+      inputPath,
+    ]),
+  );
+  if (outputs.size !== inputPaths.length) {
+    throw new Error("compiler inputs map to duplicate output paths");
+  }
+  return outputs;
+}
+
 function collectFiles(root, directory = root, files = []) {
   for (const entry of readdirSync(directory, { withFileTypes: true })) {
     const absolute = join(directory, entry.name);
@@ -164,7 +196,7 @@ function collectFiles(root, directory = root, files = []) {
   return files.sort((left, right) => left.localeCompare(right));
 }
 
-function validateCompilerArtifact(outputPath, artifact) {
+function validateCompilerArtifact(outputPath, artifact, inputPath) {
   if (artifact == null || typeof artifact !== "object" || Array.isArray(artifact)) {
     throw new Error(`invalid compiler artifact envelope: ${outputPath}`);
   }
@@ -181,8 +213,11 @@ function validateCompilerArtifact(outputPath, artifact) {
   if (JSON.stringify(actualKeys) !== JSON.stringify(expectedKeys)) {
     throw new Error(`invalid compiler artifact keys in ${outputPath}: ${actualKeys.join(", ")}`);
   }
-  if (typeof artifact.filename !== "string" || !artifact.filename.endsWith(".vue")) {
-    throw new Error(`invalid compiler filename in ${outputPath}`);
+  const expectedFilename = inputPath.slice(inputPath.lastIndexOf("/") + 1);
+  if (artifact.filename !== expectedFilename) {
+    throw new Error(
+      `compiler filename mismatch in ${outputPath}: expected ${expectedFilename}, received ${artifact.filename}`,
+    );
   }
   if (typeof artifact.code !== "string") throw new Error(`invalid compiler code in ${outputPath}`);
   if (artifact.css !== null && typeof artifact.css !== "string") {


### PR DESCRIPTION
## Summary
- map every matched SFC to its exact expected relative JSON artifact path
- reject missing, unrelated, duplicate-path, and mismatched-filename compiler artifacts
- avoid allocating a compiler output directory when the fixture is missing
- pin the synthetic artifact digest exactly and decouple command assertions from shell quoting

## Validation
- 12/12 fixture matrix contract tests
- formatter, lint, changed-file line limit, and diff checks
- pinned create-vue, Vue Router, and Pinia run: 181 inputs, 181 exact output paths, 0 errors, 0 warnings