### PR TITLE
fix(ci): set up Node before fixture selection

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -36,6 +36,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: false
+
       - name: Select and hydrate fixture shard
         shell: bash
         run: |
@@ -52,12 +58,6 @@ jobs:
           mkdir -p "$FIXTURE_REPORT_DIR"
           printf '%s\n' "${fixture_paths[@]}" > "$FIXTURE_REPORT_DIR/selected-fixtures.txt"
           git submodule update --init --depth 1 -- "${fixture_paths[@]}"
-
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
-        with:
-          node-version-file: ".node-version"
-          cache: true
-          run-install: false
 
       - uses: ./.github/actions/setup-moonbit
 

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -53,11 +53,26 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
     jobs?: Record<string, WorkflowJob>;
   };
   const steps = workflow.jobs?.["real-project-matrix"]?.steps ?? [];
+  const nodeSetupIndex = steps.findIndex((step) => step.uses?.startsWith("voidzero-dev/setup-vp@"));
+  const hydrationIndex = steps.findIndex(
+    (step) => step.name === "Select and hydrate fixture shard",
+  );
   const hydration = steps.find((step) => step.name === "Select and hydrate fixture shard");
   const run = steps.find((step) => step.name === "Exercise real projects with every core tool");
   const summary = steps.find((step) => step.name === "Publish shard summary");
   const upload = steps.find((step) => step.name === "Upload shard report");
 
+  assert.notEqual(nodeSetupIndex, -1);
+  assert.notEqual(hydrationIndex, -1);
+  assert.ok(
+    nodeSetupIndex < hydrationIndex,
+    "Node 24 must be active before loading matrix scripts",
+  );
+  assert.deepEqual(steps[nodeSetupIndex].with, {
+    "node-version-file": ".node-version",
+    cache: true,
+    "run-install": false,
+  });
   assert.match(hydration?.run ?? "", /--list-fixture-paths/);
   assert.match(hydration?.run ?? "", /--shard-index "\$FIXTURE_SHARD_INDEX"/);
   assert.match(hydration?.run ?? "", /--shard-count "\$FIXTURE_SHARD_COUNT"/);


### PR DESCRIPTION
## Summary
- activate the pinned Node runtime before loading the real-project matrix scripts
- keep fixture hydration sharded and dependency installation deferred
- assert the Node setup ordering and exact setup contract in the workflow test

## Failure evidence
- run 29633088384 failed all 11 shards before hydration under runner Node 20 because `node:fs` did not expose `globSync`

## Validation
- `node --test --test-concurrency=1 tests/tooling/real-project-matrix-workflow.test.ts`
- workflow/test formatter, lint, and diff checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the real-project workflow so the required JavaScript runtime is configured before fixture shard hydration.
  * Ensured workflow caching and Node version settings are applied consistently.

* **Tests**
  * Added validation for setup-step ordering and runtime configuration to help prevent workflow regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->