### PR TITLE
fix(fixtures): mirror atelier output roots

### DIFF
--- a/tests/tooling/fixture-tool-matrix-compiler.test.ts
+++ b/tests/tooling/fixture-tool-matrix-compiler.test.ts
@@ -67,6 +67,73 @@ test("fixture tool matrix does not allocate compiler output for a missing fixtur
   assert.deepEqual(compilerTempEntries(), before);
 });
 
+test("fixture tool matrix mirrors compiler roots when validating artifact paths", () => {
+  const cases = [
+    {
+      name: "root-wide glob",
+      vueGlobs: ["**/*.vue"],
+      source: "src/nested/App.vue",
+      extraDirectories: [],
+      output: "src/nested/App.json",
+    },
+    {
+      name: "multiple existing roots",
+      vueGlobs: ["apps/**/*.vue", "packages/**/*.vue"],
+      source: "apps/admin/App.vue",
+      extraDirectories: ["packages"],
+      output: "apps/admin/App.json",
+    },
+    {
+      name: "missing roots are excluded",
+      vueGlobs: ["apps/**/*.vue", "missing/**/*.vue"],
+      source: "apps/admin/App.vue",
+      extraDirectories: [],
+      output: "admin/App.json",
+    },
+  ] as const;
+
+  for (const fixtureCase of cases) {
+    const fixtureDir = fs.mkdtempSync(
+      path.join(root, "tests", "_fixtures", "tool-matrix-compiler-layout-"),
+    );
+    const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-compiler-layout-"));
+    const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-compiler-report-"));
+    try {
+      for (const directory of fixtureCase.extraDirectories) {
+        fs.mkdirSync(path.join(fixtureDir, directory), { recursive: true });
+      }
+      const sourcePath = path.join(fixtureDir, fixtureCase.source);
+      fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+      fs.writeFileSync(sourcePath, "<template><main /></template>\n");
+
+      const executable = writeFakeVize(
+        fakeDir,
+        `import fs from "node:fs"; import path from "node:path";
+const output = process.argv[process.argv.indexOf("--output") + 1];
+const artifact = path.join(output, ${JSON.stringify(fixtureCase.output)});
+fs.mkdirSync(path.dirname(artifact), { recursive: true });
+fs.writeFileSync(artifact, JSON.stringify({ filename: ${JSON.stringify(path.basename(fixtureCase.source))}, code: "export default {}", css: null, errors: [], warnings: [], script_lang: "js", macro_artifacts: [] }) + "\\n");`,
+      );
+      const run = runTool(
+        {
+          id: `compiler-layout-${fixtureCase.name}`,
+          fixturePath: path.relative(root, fixtureDir),
+          vueGlobs: [...fixtureCase.vueGlobs],
+        },
+        "compiler",
+        { dryRun: false, timeoutMs: 5_000 },
+        { command: executable, prefix: [], label: executable },
+        reportDir,
+      );
+      assert.equal(run.status, "ok", `${fixtureCase.name}: ${JSON.stringify(run)}`);
+    } finally {
+      fs.rmSync(fixtureDir, { recursive: true, force: true });
+      fs.rmSync(fakeDir, { recursive: true, force: true });
+      fs.rmSync(reportDir, { recursive: true, force: true });
+    }
+  }
+});
+
 test("fixture tool matrix compiles every matched Vue file into validated JSON artifacts", () => {
   const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-fixture-tool-compiler-"));
   const executable = writeFakeVize(

--- a/tools/fixtures/tool-matrix-compiler-paths.mjs
+++ b/tools/fixtures/tool-matrix-compiler-paths.mjs
@@ -1,0 +1,62 @@
+import { existsSync, statSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+
+export function expectedCompilerOutputs(cwd, patterns, inputPaths) {
+  // Build plans layout from existing input roots, including roots that match no files.
+  const patternRoots = patterns.map((pattern) => compilerInputRoot(cwd, pattern)).filter(Boolean);
+  const roots =
+    patternRoots.length > 0
+      ? patternRoots
+      : inputPaths.map((entry) => dirname(resolve(cwd, entry)));
+  const root = commonPathRoot(roots);
+  const outputs = new Map(
+    inputPaths.map((inputPath) => {
+      const relativeInput = relative(root, resolve(cwd, inputPath));
+      if (
+        relativeInput === ".." ||
+        relativeInput.startsWith(`..${sep}`) ||
+        isAbsolute(relativeInput)
+      ) {
+        throw new Error(`compiler input is outside its output root: ${inputPath}`);
+      }
+      return [relativeInput.replaceAll("\\", "/").replace(/\.vue$/, ".json"), inputPath];
+    }),
+  );
+  if (outputs.size !== inputPaths.length) {
+    throw new Error("compiler inputs map to duplicate output paths");
+  }
+  return outputs;
+}
+
+function compilerInputRoot(cwd, pattern) {
+  const literal = resolve(cwd, pattern);
+  if (existsSync(literal)) {
+    const metadata = statSync(literal);
+    if (metadata.isFile()) return dirname(literal);
+    if (metadata.isDirectory()) return literal;
+    return null;
+  }
+
+  const normalized = pattern.replaceAll("\\", "/");
+  const metacharacter = normalized.search(/[*?[]/);
+  if (metacharacter < 0) return null;
+  const prefix = normalized.slice(0, metacharacter);
+  const separator = prefix.lastIndexOf("/");
+  const root = resolve(cwd, separator < 0 ? "." : prefix.slice(0, separator));
+  return existsSync(root) && statSync(root).isDirectory() ? root : null;
+}
+
+function commonPathRoot(paths) {
+  let root = paths[0];
+  while (
+    paths.some((entry) => {
+      const nested = relative(root, entry);
+      return nested === ".." || nested.startsWith(`..${sep}`) || isAbsolute(nested);
+    })
+  ) {
+    const parent = dirname(root);
+    if (parent === root) throw new Error("compiler inputs have no common output root");
+    root = parent;
+  }
+  return root;
+}

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -13,6 +13,8 @@ import { tmpdir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { expectedCompilerOutputs } from "./tool-matrix-compiler-paths.mjs";
+
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 export function runTool(project, tool, args, launch, outputDir) {
@@ -125,7 +127,7 @@ function inspectCompilerArtifacts(cwd, patterns, outputDir) {
       `compiler artifact count mismatch: ${inputPaths.length} inputs, ${outputPaths.length} outputs`,
     );
   }
-  const inputByOutputPath = expectedCompilerOutputs(inputPaths);
+  const inputByOutputPath = expectedCompilerOutputs(cwd, patterns, inputPaths);
   const missingPaths = [...inputByOutputPath.keys()].filter(
     (entry) => !outputPaths.includes(entry),
   );
@@ -163,27 +165,6 @@ function inspectCompilerArtifacts(cwd, patterns, outputDir) {
     warningCount,
     sha256: digest.digest("hex"),
   };
-}
-
-function expectedCompilerOutputs(inputPaths) {
-  const parentSegments = inputPaths.map((entry) => entry.split("/").slice(0, -1));
-  const commonSegments = [];
-  for (let index = 0; parentSegments.every((segments) => segments[index] != null); index += 1) {
-    const segment = parentSegments[0][index];
-    if (!parentSegments.every((segments) => segments[index] === segment)) break;
-    commonSegments.push(segment);
-  }
-  const commonPrefix = commonSegments.length === 0 ? "" : `${commonSegments.join("/")}/`;
-  const outputs = new Map(
-    inputPaths.map((inputPath) => [
-      inputPath.slice(commonPrefix.length).replace(/\.vue$/, ".json"),
-      inputPath,
-    ]),
-  );
-  if (outputs.size !== inputPaths.length) {
-    throw new Error("compiler inputs map to duplicate output paths");
-  }
-  return outputs;
 }
 
 function collectFiles(root, directory = root, files = []) {


### PR DESCRIPTION
## Summary

- derive expected compiler artifact paths from the existing literal and glob roots used by the build planner
- keep path reconciliation isolated in a focused helper
- cover root-wide globs, multiple existing roots, and missing roots

## Testing

- node --test --test-concurrency=1 tests/tooling/fixture-tool-matrix-compiler.test.ts tests/tooling/fixture-tool-matrix-report.test.ts tests/tooling/real-project-matrix-workflow.test.ts
- oxlint on changed JavaScript and TypeScript files with warnings denied
- real Muse UI compiler matrix run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of compiler-generated artifact paths across fixture configurations.
  * Added checks for invalid paths, duplicate output mappings, and inconsistent directory layouts.
  * Standardized expected output paths, including path separator normalization and `.vue` to `.json` conversion.

* **Tests**
  * Added integration coverage for compiler output path validation across multiple fixture layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->