### PR TITLE
fix(fixtures): count only atelier input files

### DIFF
--- a/tests/tooling/fixture-tool-matrix-compiler.test.ts
+++ b/tests/tooling/fixture-tool-matrix-compiler.test.ts
@@ -73,7 +73,7 @@ test("fixture tool matrix mirrors compiler roots when validating artifact paths"
       name: "root-wide glob",
       vueGlobs: ["**/*.vue"],
       source: "src/nested/App.vue",
-      extraDirectories: [],
+      extraDirectories: ["src/nested/component-library.vue"],
       output: "src/nested/App.json",
     },
     {

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -7,6 +7,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -111,7 +112,9 @@ function inspectCompilerArtifacts(cwd, patterns, outputDir) {
   const inputPaths = [
     ...new Set(
       patterns.flatMap((pattern) =>
-        globSync(pattern, { cwd }).map((entry) => entry.replaceAll("\\", "/")),
+        globSync(pattern, { cwd })
+          .filter((entry) => statSync(resolve(cwd, entry)).isFile())
+          .map((entry) => entry.replaceAll("\\", "/")),
       ),
     ),
   ].sort((left, right) => left.localeCompare(right));


### PR DESCRIPTION
## Summary

- exclude directories whose names end in .vue from compiler input reconciliation
- match the build command's regular-file collection semantics
- cover the directory edge case in the compiler artifact layout oracle

## Testing

- node --test --test-concurrency=1 tests/tooling/fixture-tool-matrix-compiler.test.ts tests/tooling/fixture-tool-matrix-report.test.ts tests/tooling/real-project-matrix-workflow.test.ts
- oxlint on changed fixture tooling with warnings denied
- real Vue Data UI compiler run: 400 inputs and 400 outputs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler artifact validation to ignore directories and process only actual Vue files.
  * Updated fixture coverage to correctly validate nested component paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->