### PR TITLE
test(fixtures): enforce zero-SFC expectations

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "projects": [
     {
@@ -581,6 +581,7 @@
       "revision": "e6ab47cff0f3d201bb7f2504a5fa46419f4824eb",
       "license": { "spdx": "MIT", "files": ["LICENSE"] },
       "vueGlobs": ["**/*.vue"],
+      "expectedVueFileCount": 0,
       "coverage": ["compiler","linter","typechecker","formatter","syntax-highlighter","lsp"],
       "diff": "curator-compare"
     },
@@ -1133,6 +1134,7 @@
       "vueGlobs": [
         "**/*.vue"
       ],
+      "expectedVueFileCount": 0,
       "coverage": [
         "compiler",
         "linter",

--- a/tests/tooling/fixture-tool-matrix-compiler.test.ts
+++ b/tests/tooling/fixture-tool-matrix-compiler.test.ts
@@ -67,6 +67,67 @@ test("fixture tool matrix does not allocate compiler output for a missing fixtur
   assert.deepEqual(compilerTempEntries(), before);
 });
 
+test("fixture tool matrix requires an explicit zero-file compiler expectation", () => {
+  const fixtureDir = fs.mkdtempSync(
+    path.join(root, "tests", "_fixtures", "tool-matrix-empty-compiler-"),
+  );
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-empty-compiler-"));
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-empty-compiler-report-"));
+  const executable = writeFakeVize(fakeDir, "process.exit(1);");
+  const project = {
+    id: "empty-compiler-fixture",
+    fixturePath: path.relative(root, fixtureDir),
+    vueGlobs: ["**/*.vue"],
+  };
+  const args = { dryRun: false, timeoutMs: 5_000 };
+  const launch = { command: executable, prefix: [], label: executable };
+  try {
+    const undeclared = runTool(project, "compiler", args, launch, reportDir);
+    assert.equal(undeclared.status, "failed");
+    assert.match(undeclared.failure, /compiler matched no Vue files/);
+
+    const declared = runTool(
+      { ...project, expectedVueFileCount: 0 },
+      "compiler",
+      args,
+      launch,
+      reportDir,
+    );
+    assert.equal(declared.status, "findings", JSON.stringify(declared));
+    const raw = JSON.parse(
+      fs.readFileSync(path.resolve(root, declared.outputPath as string), "utf8"),
+    );
+    assert.deepEqual(
+      {
+        inputFileCount: raw.compilerArtifacts.inputFileCount,
+        outputFileCount: raw.compilerArtifacts.outputFileCount,
+        errorCount: raw.compilerArtifacts.errorCount,
+        warningCount: raw.compilerArtifacts.warningCount,
+      },
+      { inputFileCount: 0, outputFileCount: 0, errorCount: 0, warningCount: 0 },
+    );
+    assert.equal(
+      raw.compilerArtifacts.sha256,
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+
+    fs.writeFileSync(path.join(fixtureDir, "unexpected.vue"), "<template />\n");
+    const stale = runTool(
+      { ...project, expectedVueFileCount: 0 },
+      "compiler",
+      args,
+      launch,
+      reportDir,
+    );
+    assert.equal(stale.status, "failed");
+    assert.match(stale.failure, /compiler input count mismatch: expected 0, matched 1/);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
+});
+
 test("fixture tool matrix mirrors compiler roots when validating artifact paths", () => {
   const cases = [
     {

--- a/tests/tooling/vue-ecosystem-fixtures.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures.test.ts
@@ -23,6 +23,7 @@ interface FixtureProject {
     files: string[];
   };
   vueGlobs: string[];
+  expectedVueFileCount?: 0;
   tsconfig?: string;
   coverage: string[];
   diff: FixtureDiff;
@@ -160,13 +161,26 @@ test("Vue ecosystem registry covers the requested projects", () => {
   const registry = readRegistry();
   const ids = new Set(registry.projects.map((project) => project.id));
 
-  assert.equal(registry.schemaVersion, 2);
+  assert.equal(registry.schemaVersion, 3);
   for (const id of requestedFixtures) {
     assert.ok(ids.has(id), `${id} should be registered`);
   }
   for (const id of requiredTypecheckProjects) {
     assert.ok(ids.has(id), `${id} should be registered for typechecker performance`);
   }
+});
+
+test("fixtures without Vue SFCs declare an exact zero-file expectation", () => {
+  const registry = readRegistry();
+  const projects = registry.projects.filter((project) => "expectedVueFileCount" in project);
+
+  assert.deepEqual(
+    projects.map((project) => ({ id: project.id, count: project.expectedVueFileCount })),
+    [
+      { id: "docsify", count: 0 },
+      { id: "vue-native-core", count: 0 },
+    ],
+  );
 });
 
 test("registered fixtures are pinned submodules with declared licenses", () => {

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -72,6 +72,7 @@ export function runTool(project, tool, args, launch, outputDir) {
         payload.compilerArtifacts = inspectCompilerArtifacts(
           cwd,
           project.vueGlobs,
+          project.expectedVueFileCount,
           compilerOutputDir,
         );
       } catch (error) {
@@ -108,7 +109,7 @@ export function runTool(project, tool, args, launch, outputDir) {
   }
 }
 
-function inspectCompilerArtifacts(cwd, patterns, outputDir) {
+function inspectCompilerArtifacts(cwd, patterns, expectedFileCount, outputDir) {
   const inputPaths = [
     ...new Set(
       patterns.flatMap((pattern) =>
@@ -118,7 +119,14 @@ function inspectCompilerArtifacts(cwd, patterns, outputDir) {
       ),
     ),
   ].sort((left, right) => left.localeCompare(right));
-  if (inputPaths.length === 0) throw new Error("compiler matched no Vue files");
+  if (expectedFileCount != null && inputPaths.length !== expectedFileCount) {
+    throw new Error(
+      `compiler input count mismatch: expected ${expectedFileCount}, matched ${inputPaths.length}`,
+    );
+  }
+  if (inputPaths.length === 0 && expectedFileCount !== 0) {
+    throw new Error("compiler matched no Vue files");
+  }
 
   const outputPaths = collectFiles(outputDir);
   const nonJsonPaths = outputPaths.filter((entry) => !entry.endsWith(".json"));


### PR DESCRIPTION
## Summary

- declare the two pinned fixtures that contain exactly zero Vue SFCs
- reject empty compiler inputs unless the registry explicitly expects zero
- reject stale zero-file declarations as soon as a Vue file appears
- retain artifact count and digest validation for the zero-output case

## Testing

- node --test --test-concurrency=1 tests/tooling/fixture-tool-matrix-compiler.test.ts tests/tooling/fixture-tool-matrix-report.test.ts tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts tests/tooling/requested-vue-fixtures.test.ts
- oxlint on changed fixture tooling with warnings denied
- real compiler runs for both zero-SFC fixtures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->