### PR TITLE
test(fixtures): validate typechecker reports

### DIFF
--- a/tests/tooling/fixture-tool-matrix-typechecker.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typechecker.test.ts
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { runTool } from "../../tools/fixtures/tool-matrix-run.mjs";
+import { validateTypecheckerOutput } from "../../tools/fixtures/tool-matrix-typechecker.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function validOutput() {
+  return {
+    files: [
+      {
+        file: "src/App.vue",
+        diagnostics: ["error:1:1 [TS1] synthetic error"],
+      },
+    ],
+    errorCount: 1,
+    warningCount: 0,
+    fileCount: 1,
+  };
+}
+
+test("typechecker oracle accepts exact error, warning, project, and zero-file reports", () => {
+  const errorOutput = validOutput();
+  const before = structuredClone(errorOutput);
+  validateTypecheckerOutput({ id: "errors" }, errorOutput, 1);
+  assert.deepEqual(errorOutput, before, "validation must not mutate the report");
+
+  const warningOutput = validOutput();
+  warningOutput.files[0].diagnostics = ["warning:1:1 [TS2] synthetic warning"];
+  warningOutput.errorCount = 0;
+  warningOutput.warningCount = 1;
+  validateTypecheckerOutput({ id: "warnings" }, warningOutput, 0);
+
+  const projectOutput = validOutput();
+  projectOutput.files.push({
+    file: "tsconfig.json",
+    diagnostics: ["error:1:1 [TS3] synthetic project error"],
+  });
+  projectOutput.errorCount = 2;
+  validateTypecheckerOutput({ id: "project-error" }, projectOutput, 1);
+
+  validateTypecheckerOutput(
+    { id: "no-sfc", expectedVueFileCount: 0 },
+    { files: [], errorCount: 0, warningCount: 0, fileCount: 0 },
+    0,
+  );
+});
+
+test("typechecker oracle rejects malformed or internally inconsistent reports", () => {
+  const cases = [
+    {
+      name: "null envelope",
+      output: null,
+      message: /envelope must be an object/,
+    },
+    {
+      name: "extra envelope key",
+      mutate: (output: any) => (output.extra = true),
+      message: /envelope keys must be/,
+    },
+    {
+      name: "negative counter",
+      mutate: (output: any) => (output.errorCount = -1),
+      message: /errorCount must be a non-negative safe integer/,
+    },
+    {
+      name: "fractional counter",
+      mutate: (output: any) => (output.fileCount = 0.5),
+      message: /fileCount must be a non-negative safe integer/,
+    },
+    {
+      name: "non-array files",
+      mutate: (output: any) => (output.files = {}),
+      message: /files must be an array/,
+    },
+    {
+      name: "excess file count",
+      mutate: (output: any) => (output.fileCount = 2),
+      message: /fileCount 2 exceeds 1 file entries/,
+    },
+    {
+      name: "non-empty fixture with no checked files",
+      output: { files: [], errorCount: 0, warningCount: 0, fileCount: 0 },
+      exitCode: 0,
+      message: /non-empty fixture checked zero Vue files/,
+    },
+    {
+      name: "declared zero fixture with a checked file",
+      project: { id: "zero", expectedVueFileCount: 0 },
+      message: /expected zero checked files, received 1/,
+    },
+    {
+      name: "extra file key",
+      mutate: (output: any) => (output.files[0].extra = true),
+      message: /files\[0\] keys must be/,
+    },
+    {
+      name: "absolute Unix path",
+      mutate: (output: any) => (output.files[0].file = "/src/App.vue"),
+      message: /must be a normalized relative path/,
+    },
+    {
+      name: "absolute Windows path",
+      mutate: (output: any) => (output.files[0].file = "C:\\src\\App.vue"),
+      message: /must be a normalized relative path/,
+    },
+    {
+      name: "parent traversal",
+      mutate: (output: any) => (output.files[0].file = "../src/App.vue"),
+      message: /must be a normalized relative path/,
+    },
+    {
+      name: "duplicate file",
+      mutate: (output: any) => {
+        output.files.push(structuredClone(output.files[0]));
+        output.fileCount = 2;
+        output.errorCount = 2;
+      },
+      message: /duplicate file entry/,
+    },
+    {
+      name: "non-Vue checked file",
+      mutate: (output: any) => (output.files[0].file = "src/App.ts"),
+      message: /checked file is not a Vue SFC/,
+    },
+    {
+      name: "unsorted checked files",
+      mutate: (output: any) => {
+        output.files = [
+          { file: "src/B.vue", diagnostics: ["error:1:1 [TS1] B"] },
+          { file: "src/A.vue", diagnostics: ["error:1:1 [TS1] A"] },
+        ];
+        output.fileCount = 2;
+        output.errorCount = 2;
+      },
+      message: /checked file entries are not sorted/,
+    },
+    {
+      name: "non-array diagnostics",
+      mutate: (output: any) => (output.files[0].diagnostics = {}),
+      message: /diagnostics must be an array/,
+    },
+    {
+      name: "empty diagnostic",
+      mutate: (output: any) => (output.files[0].diagnostics = [""]),
+      message: /must be a non-empty string/,
+    },
+    {
+      name: "unknown diagnostic prefix",
+      mutate: (output: any) => (output.files[0].diagnostics = ["info: synthetic"]),
+      message: /has no error or warning prefix/,
+    },
+    {
+      name: "empty project-level entry",
+      mutate: (output: any) => output.files.push({ file: "tsconfig.json", diagnostics: [] }),
+      message: /project-level file entry has no diagnostics/,
+    },
+    {
+      name: "error count mismatch",
+      mutate: (output: any) => (output.errorCount = 0),
+      message: /errorCount 0 does not match 1 diagnostics/,
+    },
+    {
+      name: "warning count mismatch",
+      mutate: (output: any) => {
+        output.files[0].diagnostics = ["warning:1:1 [TS2] warning"];
+        output.errorCount = 0;
+      },
+      message: /warningCount 0 does not match 1 diagnostics/,
+    },
+    {
+      name: "exit code mismatch",
+      exitCode: 0,
+      message: /exit code 0 does not match expected 1/,
+    },
+  ];
+
+  for (const fixtureCase of cases) {
+    const output = "output" in fixtureCase ? fixtureCase.output : validOutput();
+    fixtureCase.mutate?.(output);
+    assert.throws(
+      () =>
+        validateTypecheckerOutput(
+          fixtureCase.project ?? { id: "fixture" },
+          output,
+          fixtureCase.exitCode ?? 1,
+        ),
+      fixtureCase.message,
+      fixtureCase.name,
+    );
+  }
+});
+
+test("fixture tool matrix records typechecker schema failures", () => {
+  const fixtureDir = fs.mkdtempSync(
+    path.join(root, "tests", "_fixtures", "tool-matrix-typechecker-"),
+  );
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-typechecker-"));
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-typechecker-report-"));
+  const executable = path.join(fakeDir, "fake-vize.mjs");
+  fs.mkdirSync(path.join(fixtureDir, "src"), { recursive: true });
+  fs.writeFileSync(path.join(fixtureDir, "src", "App.vue"), "<template />\n");
+  fs.writeFileSync(
+    executable,
+    `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({ files: [], errorCount: 0, warningCount: 0, fileCount: 0 }));\n`,
+  );
+  fs.chmodSync(executable, 0o755);
+
+  try {
+    const run = runTool(
+      {
+        id: "typechecker-schema-fixture",
+        fixturePath: path.relative(root, fixtureDir),
+        vueGlobs: ["**/*.vue"],
+      },
+      "typechecker",
+      { dryRun: false, timeoutMs: 5_000 },
+      { command: executable, prefix: [], label: executable },
+      reportDir,
+    );
+    assert.equal(run.status, "failed");
+    assert.match(run.failure, /non-empty fixture checked zero Vue files/);
+    const raw = JSON.parse(fs.readFileSync(path.resolve(root, run.outputPath as string), "utf8"));
+    assert.match(raw.validationError, /non-empty fixture checked zero Vue files/);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -15,6 +15,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { expectedCompilerOutputs } from "./tool-matrix-compiler-paths.mjs";
+import { validateTypecheckerOutput } from "./tool-matrix-typechecker.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
@@ -83,6 +84,13 @@ export function runTool(project, tool, args, launch, outputDir) {
         payload.parsed = JSON.parse(result.stdout);
       } catch (error) {
         payload.parseError = errorMessage(error);
+      }
+      if (tool === "typechecker" && payload.parseError == null) {
+        try {
+          validateTypecheckerOutput(project, payload.parsed, result.status);
+        } catch (error) {
+          payload.validationError = errorMessage(error);
+        }
       }
     }
     writeFileSync(rawPath, `${JSON.stringify(payload, null, 2)}\n`);

--- a/tools/fixtures/tool-matrix-typechecker.mjs
+++ b/tools/fixtures/tool-matrix-typechecker.mjs
@@ -1,0 +1,99 @@
+import { isAbsolute } from "node:path";
+
+const outputKeys = ["errorCount", "fileCount", "files", "warningCount"];
+const fileKeys = ["diagnostics", "file"];
+
+export function validateTypecheckerOutput(project, output, exitCode) {
+  requireRecord(output, "envelope");
+  requireExactKeys(output, outputKeys, "envelope");
+  for (const field of ["errorCount", "warningCount", "fileCount"]) {
+    if (!Number.isSafeInteger(output[field]) || output[field] < 0) {
+      invalid(`${field} must be a non-negative safe integer`);
+    }
+  }
+  if (!Array.isArray(output.files)) invalid("files must be an array");
+  if (output.fileCount > output.files.length) {
+    invalid(`fileCount ${output.fileCount} exceeds ${output.files.length} file entries`);
+  }
+  if (project.expectedVueFileCount === 0 && output.fileCount !== 0) {
+    invalid(`expected zero checked files, received ${output.fileCount}`);
+  }
+  if (project.expectedVueFileCount !== 0 && output.fileCount === 0) {
+    invalid("non-empty fixture checked zero Vue files");
+  }
+
+  const seenFiles = new Set();
+  let errorCount = 0;
+  let warningCount = 0;
+  for (const [index, file] of output.files.entries()) {
+    requireRecord(file, `files[${index}]`);
+    requireExactKeys(file, fileKeys, `files[${index}]`);
+    requireRelativePath(file.file, `files[${index}].file`);
+    if (seenFiles.has(file.file)) invalid(`duplicate file entry: ${file.file}`);
+    seenFiles.add(file.file);
+    if (!Array.isArray(file.diagnostics)) {
+      invalid(`files[${index}].diagnostics must be an array`);
+    }
+    if (index < output.fileCount && !file.file.endsWith(".vue")) {
+      invalid(`checked file is not a Vue SFC: ${file.file}`);
+    }
+    if (index >= output.fileCount && file.diagnostics.length === 0) {
+      invalid(`project-level file entry has no diagnostics: ${file.file}`);
+    }
+    for (const [diagnosticIndex, diagnostic] of file.diagnostics.entries()) {
+      if (typeof diagnostic !== "string" || diagnostic.length === 0) {
+        invalid(`files[${index}].diagnostics[${diagnosticIndex}] must be a non-empty string`);
+      }
+      if (diagnostic.startsWith("error:")) errorCount += 1;
+      else if (diagnostic.startsWith("warning:")) warningCount += 1;
+      else invalid(`diagnostic has no error or warning prefix: ${file.file}`);
+    }
+  }
+
+  const checkedFiles = output.files.slice(0, output.fileCount).map((file) => file.file);
+  const sortedFiles = [...checkedFiles].sort((left, right) => left.localeCompare(right));
+  if (JSON.stringify(checkedFiles) !== JSON.stringify(sortedFiles)) {
+    invalid("checked file entries are not sorted");
+  }
+  if (output.errorCount !== errorCount) {
+    invalid(`errorCount ${output.errorCount} does not match ${errorCount} diagnostics`);
+  }
+  if (output.warningCount !== warningCount) {
+    invalid(`warningCount ${output.warningCount} does not match ${warningCount} diagnostics`);
+  }
+  const expectedExitCode = errorCount > 0 ? 1 : 0;
+  if (exitCode !== expectedExitCode) {
+    invalid(`exit code ${exitCode} does not match expected ${expectedExitCode}`);
+  }
+}
+
+function requireRecord(value, label) {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    invalid(`${label} must be an object`);
+  }
+}
+
+function requireExactKeys(value, expected, label) {
+  const actual = Object.keys(value).sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    invalid(`${label} keys must be ${expected.join(", ")}; received ${actual.join(", ")}`);
+  }
+}
+
+function requireRelativePath(value, label) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    isAbsolute(value) ||
+    /^[A-Za-z]:[\\/]/.test(value) ||
+    value.includes("\\") ||
+    value.startsWith("./") ||
+    value.split("/").some((segment) => segment === "" || segment === "." || segment === "..")
+  ) {
+    invalid(`${label} must be a normalized relative path`);
+  }
+}
+
+function invalid(message) {
+  throw new Error(`invalid typechecker JSON output: ${message}`);
+}


### PR DESCRIPTION
## Summary

- validate the exact typechecker JSON envelope and per-file schema
- reconcile checked-file counts, normalized unique paths, ordering, diagnostic severities, aggregate counts, and exit codes
- require non-empty fixtures to check Vue files while honoring the two exact-zero declarations
- cover valid error, warning, project-level, and zero-file reports plus 22 malformed cases

## Testing

- node --test --test-concurrency=1 tests/tooling/fixture-tool-matrix-typechecker.test.ts tests/tooling/fixture-tool-matrix-compiler.test.ts tests/tooling/fixture-tool-matrix-report.test.ts tests/tooling/real-project-matrix-workflow.test.ts
- oxlint on changed fixture tooling with warnings denied
- validated all 131 typechecker artifacts from Real Project Matrix run 29634541442

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->