### PR TITLE
test(fixtures): validate patina reports

### DIFF
--- a/tests/tooling/fixture-tool-matrix-linter.test.ts
+++ b/tests/tooling/fixture-tool-matrix-linter.test.ts
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { runTool } from "../../tools/fixtures/tool-matrix-run.mjs";
+import { validateLinterOutput } from "../../tools/fixtures/tool-matrix-linter.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function diagnostic(severity = 2) {
+  return {
+    ruleId: "vue/synthetic-rule",
+    ruleDocsPath: "rules/vue/synthetic-rule.md",
+    severity,
+    message: "synthetic diagnostic",
+    line: 1,
+    column: 2,
+    endLine: 1,
+    endColumn: 3,
+  };
+}
+
+function validOutput() {
+  return [
+    {
+      file: "src/App.vue",
+      messages: [diagnostic(2), { ...diagnostic(1), help: "synthetic help" }],
+      errorCount: 1,
+      warningCount: 1,
+    },
+  ];
+}
+
+test("linter oracle accepts exact error, warning, clean, and zero-file reports", () => {
+  const output = validOutput();
+  const before = structuredClone(output);
+  validateLinterOutput({ id: "mixed" }, output, 1);
+  assert.deepEqual(output, before, "validation must not mutate the report");
+
+  const warningOnly = validOutput();
+  warningOnly[0].messages = [diagnostic(1)];
+  warningOnly[0].errorCount = 0;
+  validateLinterOutput({ id: "warnings" }, warningOnly, 0);
+
+  const clean = validOutput();
+  clean[0].messages = [];
+  clean[0].errorCount = 0;
+  clean[0].warningCount = 0;
+  validateLinterOutput({ id: "clean" }, clean, 0);
+
+  validateLinterOutput({ id: "no-sfc", expectedVueFileCount: 0 }, [], 0);
+});
+
+test("linter oracle rejects malformed or internally inconsistent reports", () => {
+  const cases = [
+    {
+      name: "non-array envelope",
+      output: {},
+      message: /envelope must be an array/,
+    },
+    {
+      name: "non-empty fixture with no files",
+      output: [],
+      exitCode: 0,
+      message: /non-empty fixture linted zero Vue files/,
+    },
+    {
+      name: "declared zero fixture with a file",
+      project: { id: "zero", expectedVueFileCount: 0 },
+      message: /expected zero checked files, received 1/,
+    },
+    {
+      name: "non-object file entry",
+      mutate: (output: any) => (output[0] = null),
+      message: /files\[0\] must be an object/,
+    },
+    {
+      name: "extra file key",
+      mutate: (output: any) => (output[0].extra = true),
+      message: /files\[0\] keys must be/,
+    },
+    {
+      name: "absolute Unix file path",
+      mutate: (output: any) => (output[0].file = "/src/App.vue"),
+      message: /must be a normalized relative path/,
+    },
+    {
+      name: "absolute Windows file path",
+      mutate: (output: any) => (output[0].file = "C:\\src\\App.vue"),
+      message: /must be a normalized relative path/,
+    },
+    {
+      name: "file parent traversal",
+      mutate: (output: any) => (output[0].file = "../src/App.vue"),
+      message: /must be a normalized relative path/,
+    },
+    {
+      name: "non-Vue checked file",
+      mutate: (output: any) => (output[0].file = "src/App.ts"),
+      message: /checked file is not a Vue SFC/,
+    },
+    {
+      name: "duplicate file",
+      mutate: (output: any) => output.push(structuredClone(output[0])),
+      message: /duplicate file entry/,
+    },
+    {
+      name: "negative file counter",
+      mutate: (output: any) => (output[0].errorCount = -1),
+      message: /errorCount must be a non-negative safe integer/,
+    },
+    {
+      name: "fractional file counter",
+      mutate: (output: any) => (output[0].warningCount = 0.5),
+      message: /warningCount must be a non-negative safe integer/,
+    },
+    {
+      name: "non-array messages",
+      mutate: (output: any) => (output[0].messages = {}),
+      message: /messages must be an array/,
+    },
+    {
+      name: "non-object message",
+      mutate: (output: any) => (output[0].messages[0] = null),
+      message: /messages\[0\] must be an object/,
+    },
+    {
+      name: "extra message key",
+      mutate: (output: any) => (output[0].messages[0].extra = true),
+      message: /messages\[0\] keys must be/,
+    },
+    {
+      name: "empty rule id",
+      mutate: (output: any) => (output[0].messages[0].ruleId = ""),
+      message: /ruleId must be non-empty/,
+    },
+    {
+      name: "invalid docs path",
+      mutate: (output: any) => (output[0].messages[0].ruleDocsPath = "../rule.md"),
+      message: /ruleDocsPath must be a normalized relative path/,
+    },
+    {
+      name: "empty message",
+      mutate: (output: any) => (output[0].messages[0].message = ""),
+      message: /message must be non-empty/,
+    },
+    {
+      name: "empty help",
+      mutate: (output: any) => (output[0].messages[1].help = ""),
+      message: /help must be non-empty/,
+    },
+    {
+      name: "invalid severity",
+      mutate: (output: any) => (output[0].messages[0].severity = 3),
+      message: /severity must be 1 or 2/,
+    },
+    {
+      name: "zero location",
+      mutate: (output: any) => (output[0].messages[0].line = 0),
+      message: /line must be a positive safe integer/,
+    },
+    {
+      name: "fractional location",
+      mutate: (output: any) => (output[0].messages[0].column = 1.5),
+      message: /column must be a positive safe integer/,
+    },
+    {
+      name: "inverted line range",
+      mutate: (output: any) => {
+        output[0].messages[0].line = 2;
+        output[0].messages[0].endLine = 1;
+      },
+      message: /inverted source range/,
+    },
+    {
+      name: "inverted column range",
+      mutate: (output: any) => {
+        output[0].messages[0].column = 4;
+        output[0].messages[0].endColumn = 3;
+      },
+      message: /inverted source range/,
+    },
+    {
+      name: "error count mismatch",
+      mutate: (output: any) => (output[0].errorCount = 0),
+      message: /errorCount 0 does not match 1 messages/,
+    },
+    {
+      name: "warning count mismatch",
+      mutate: (output: any) => (output[0].warningCount = 0),
+      message: /warningCount 0 does not match 1 messages/,
+    },
+    {
+      name: "exit code mismatch",
+      exitCode: 0,
+      message: /exit code 0 does not match expected 1/,
+    },
+  ];
+
+  for (const fixtureCase of cases) {
+    const output = "output" in fixtureCase ? fixtureCase.output : validOutput();
+    fixtureCase.mutate?.(output);
+    assert.throws(
+      () =>
+        validateLinterOutput(
+          fixtureCase.project ?? { id: "fixture" },
+          output,
+          fixtureCase.exitCode ?? 1,
+        ),
+      fixtureCase.message,
+      fixtureCase.name,
+    );
+  }
+});
+
+test("fixture tool matrix records linter schema failures", () => {
+  const fixtureDir = fs.mkdtempSync(path.join(root, "tests", "_fixtures", "tool-matrix-linter-"));
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-linter-"));
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-linter-report-"));
+  const executable = path.join(fakeDir, "fake-vize.mjs");
+  fs.mkdirSync(path.join(fixtureDir, "src"), { recursive: true });
+  fs.writeFileSync(path.join(fixtureDir, "src", "App.vue"), "<template />\n");
+  fs.writeFileSync(executable, '#!/usr/bin/env node\nprocess.stdout.write("[]");\n');
+  fs.chmodSync(executable, 0o755);
+
+  try {
+    const run = runTool(
+      {
+        id: "linter-schema-fixture",
+        fixturePath: path.relative(root, fixtureDir),
+        vueGlobs: ["**/*.vue"],
+      },
+      "linter",
+      { dryRun: false, timeoutMs: 5_000 },
+      { command: executable, prefix: [], label: executable },
+      reportDir,
+    );
+    assert.equal(run.status, "failed");
+    assert.match(run.failure, /non-empty fixture linted zero Vue files/);
+    const raw = JSON.parse(fs.readFileSync(path.resolve(root, run.outputPath as string), "utf8"));
+    assert.match(raw.validationError, /non-empty fixture linted zero Vue files/);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/tool-matrix-linter.mjs
+++ b/tools/fixtures/tool-matrix-linter.mjs
@@ -1,0 +1,136 @@
+import { isAbsolute } from "node:path";
+
+const fileKeys = ["errorCount", "file", "messages", "warningCount"];
+const messageKeys = [
+  "column",
+  "endColumn",
+  "endLine",
+  "line",
+  "message",
+  "ruleDocsPath",
+  "ruleId",
+  "severity",
+];
+const messageKeysWithHelp = [
+  "column",
+  "endColumn",
+  "endLine",
+  "help",
+  "line",
+  "message",
+  "ruleDocsPath",
+  "ruleId",
+  "severity",
+];
+
+export function validateLinterOutput(project, output, exitCode) {
+  if (!Array.isArray(output)) invalid("envelope must be an array");
+  if (project.expectedVueFileCount === 0 && output.length !== 0) {
+    invalid(`expected zero checked files, received ${output.length}`);
+  }
+  if (project.expectedVueFileCount !== 0 && output.length === 0) {
+    invalid("non-empty fixture linted zero Vue files");
+  }
+
+  const seenFiles = new Set();
+  let totalErrors = 0;
+  for (const [fileIndex, file] of output.entries()) {
+    requireRecord(file, `files[${fileIndex}]`);
+    requireExactKeys(file, fileKeys, `files[${fileIndex}]`);
+    requireNormalizedPath(file.file, `files[${fileIndex}].file`);
+    if (!file.file.endsWith(".vue")) invalid(`checked file is not a Vue SFC: ${file.file}`);
+    if (seenFiles.has(file.file)) invalid(`duplicate file entry: ${file.file}`);
+    seenFiles.add(file.file);
+    for (const field of ["errorCount", "warningCount"]) {
+      requireNonNegativeInteger(file[field], `files[${fileIndex}].${field}`);
+    }
+    if (!Array.isArray(file.messages)) invalid(`files[${fileIndex}].messages must be an array`);
+
+    let errorCount = 0;
+    let warningCount = 0;
+    for (const [messageIndex, message] of file.messages.entries()) {
+      const label = `files[${fileIndex}].messages[${messageIndex}]`;
+      requireRecord(message, label);
+      const expectedKeys = "help" in message ? messageKeysWithHelp : messageKeys;
+      requireExactKeys(message, expectedKeys, label);
+      for (const field of ["ruleId", "ruleDocsPath", "message"]) {
+        requireNonEmptyString(message[field], `${label}.${field}`);
+      }
+      requireNormalizedPath(message.ruleDocsPath, `${label}.ruleDocsPath`);
+      if ("help" in message) requireNonEmptyString(message.help, `${label}.help`);
+      if (message.severity === 2) errorCount += 1;
+      else if (message.severity === 1) warningCount += 1;
+      else invalid(`${label}.severity must be 1 or 2`);
+      for (const field of ["line", "column", "endLine", "endColumn"]) {
+        requirePositiveInteger(message[field], `${label}.${field}`);
+      }
+      if (
+        message.endLine < message.line ||
+        (message.endLine === message.line && message.endColumn < message.column)
+      ) {
+        invalid(`${label} has an inverted source range`);
+      }
+    }
+    if (file.errorCount !== errorCount) {
+      invalid(`${file.file} errorCount ${file.errorCount} does not match ${errorCount} messages`);
+    }
+    if (file.warningCount !== warningCount) {
+      invalid(
+        `${file.file} warningCount ${file.warningCount} does not match ${warningCount} messages`,
+      );
+    }
+    totalErrors += errorCount;
+  }
+
+  const expectedExitCode = totalErrors > 0 ? 1 : 0;
+  if (exitCode !== expectedExitCode) {
+    invalid(`exit code ${exitCode} does not match expected ${expectedExitCode}`);
+  }
+}
+
+function requireRecord(value, label) {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    invalid(`${label} must be an object`);
+  }
+}
+
+function requireExactKeys(value, expected, label) {
+  const actual = Object.keys(value).sort((left, right) => left.localeCompare(right));
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    invalid(`${label} keys must be ${expected.join(", ")}; received ${actual.join(", ")}`);
+  }
+}
+
+function requireNormalizedPath(value, label) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    isAbsolute(value) ||
+    /^[A-Za-z]:[\\/]/.test(value) ||
+    value.includes("\\") ||
+    value.startsWith("./") ||
+    value.split("/").some((segment) => segment === "" || segment === "." || segment === "..")
+  ) {
+    invalid(`${label} must be a normalized relative path`);
+  }
+}
+
+function requireNonEmptyString(value, label) {
+  if (typeof value !== "string" || value.length === 0) invalid(`${label} must be non-empty`);
+}
+
+function requireNonNegativeInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    invalid(`${label} must be a non-negative safe integer`);
+  }
+}
+
+function requirePositiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    invalid(`${label} must be a positive safe integer`);
+  }
+}
+
+function invalid(message) {
+  throw new Error(`invalid linter JSON output: ${message}`);
+}

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -15,6 +15,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { expectedCompilerOutputs } from "./tool-matrix-compiler-paths.mjs";
+import { validateLinterOutput } from "./tool-matrix-linter.mjs";
 import { validateTypecheckerOutput } from "./tool-matrix-typechecker.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -88,6 +89,13 @@ export function runTool(project, tool, args, launch, outputDir) {
       if (tool === "typechecker" && payload.parseError == null) {
         try {
           validateTypecheckerOutput(project, payload.parsed, result.status);
+        } catch (error) {
+          payload.validationError = errorMessage(error);
+        }
+      }
+      if (tool === "linter" && payload.parseError == null) {
+        try {
+          validateLinterOutput(project, payload.parsed, result.status);
         } catch (error) {
           payload.validationError = errorMessage(error);
         }


### PR DESCRIPTION
## Summary

- validate the exact linter JSON envelope, file entries, and optional-help message schema
- reject invalid counters, paths, duplicate files, severities, source ranges, aggregates, and exit codes
- require non-empty fixtures to lint Vue files while honoring exact-zero declarations
- cover valid mixed, warning-only, clean, and zero-file reports plus 27 malformed cases

## Testing

- node --test --test-concurrency=1 tests/tooling/fixture-tool-matrix-linter.test.ts tests/tooling/fixture-tool-matrix-typechecker.test.ts tests/tooling/fixture-tool-matrix-compiler.test.ts tests/tooling/fixture-tool-matrix-report.test.ts tests/tooling/real-project-matrix-workflow.test.ts
- oxlint on changed fixture tooling with warnings denied
- validated all 131 linter artifacts from Real Project Matrix run 29634541442

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict validation for linter output, including file entries, messages, paths, ranges, severity counts, and exit codes.
  * Linter runs now report schema validation errors when output is malformed or inconsistent.

* **Tests**
  * Added comprehensive coverage for valid and invalid linter reports.
  * Added integration coverage confirming validation errors are persisted for invalid tool output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->