### PR TITLE
test(fixtures): validate formatter checks

### DIFF
--- a/tests/tooling/fixture-tool-matrix-formatter.test.ts
+++ b/tests/tooling/fixture-tool-matrix-formatter.test.ts
@@ -1,0 +1,285 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  snapshotFormatterInputs,
+  validateFormatterOutput,
+} from "../../tools/fixtures/tool-matrix-formatter.mjs";
+import { runTool } from "../../tools/fixtures/tool-matrix-run.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const noFilesReport =
+  "No .vue, .js, .mjs, .cjs, .ts, .mts, .cts, .jsx, .tsx, .json, .jsonc, .yaml, .yml, .md, or .markdown files found matching the patterns\n";
+
+function changedReport() {
+  return [
+    "Found 2 file(s)",
+    "Would reformat: src/App.vue",
+    "Would reformat: ./src/Card.vue",
+    "",
+    "Checked 2 file(s)",
+    "  2 file(s) would be reformatted",
+    "",
+  ].join("\n");
+}
+
+test("formatter oracle accepts changed, mixed, clean, and zero-file reports", () => {
+  assert.deepEqual(
+    validateFormatterOutput({ id: "changed" }, "", changedReport(), 1, "same", "same"),
+    {
+      checkedFileCount: 2,
+      changedFileCount: 2,
+      unchangedFileCount: 0,
+      changedPathsSha256: "51d272a067976b5d31b5a538d475d04fe9c917837d342781ced092794acc5e2c",
+    },
+  );
+  assert.deepEqual(
+    validateFormatterOutput(
+      { id: "mixed" },
+      "",
+      [
+        "Found 2 file(s)",
+        "Would reformat: src/App.vue",
+        "",
+        "Checked 2 file(s)",
+        "  1 file(s) would be reformatted",
+        "  1 file(s) already formatted",
+        "",
+      ].join("\n"),
+      1,
+      "same",
+      "same",
+    ),
+    {
+      checkedFileCount: 2,
+      changedFileCount: 1,
+      unchangedFileCount: 1,
+      changedPathsSha256: "6b96ff4f4fad70570fff95f5a53de5486ef276e93fbc672e245f832afa8902c4",
+    },
+  );
+  assert.deepEqual(
+    validateFormatterOutput(
+      { id: "clean" },
+      "",
+      "Found 1 file(s)\n\nChecked 1 file(s)\n  1 file(s) already formatted\n",
+      0,
+      "same",
+      "same",
+    ),
+    {
+      checkedFileCount: 1,
+      changedFileCount: 0,
+      unchangedFileCount: 1,
+      changedPathsSha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    },
+  );
+  assert.deepEqual(
+    validateFormatterOutput(
+      { id: "no-sfc", expectedVueFileCount: 0 },
+      "",
+      noFilesReport,
+      1,
+      "same",
+      "same",
+    ),
+    {
+      checkedFileCount: 0,
+      changedFileCount: 0,
+      unchangedFileCount: 0,
+      changedPathsSha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    },
+  );
+});
+
+test("formatter oracle rejects malformed, inconsistent, or mutating checks", () => {
+  const cases = [
+    {
+      name: "stdout output",
+      stdout: "unexpected",
+      message: /stdout must be empty/,
+    },
+    {
+      name: "working tree mutation",
+      after: "changed",
+      message: /modified its working tree or input metadata/,
+    },
+    {
+      name: "missing final newline",
+      stderr: changedReport().slice(0, -1),
+      message: /stderr must end with a newline/,
+    },
+    {
+      name: "zero fixture unexpected report",
+      project: { id: "zero", expectedVueFileCount: 0 },
+      stderr: changedReport(),
+      message: /zero-file fixture emitted an unexpected report/,
+    },
+    {
+      name: "zero fixture exit mismatch",
+      project: { id: "zero", expectedVueFileCount: 0 },
+      stderr: noFilesReport,
+      exitCode: 0,
+      message: /zero-file exit code 0 does not match expected 1/,
+    },
+    {
+      name: "missing found count",
+      stderr: changedReport().replace("Found 2 file(s)", "Found files"),
+      message: /missing found count/,
+    },
+    {
+      name: "unsafe found count",
+      stderr: changedReport().replace("Found 2 file(s)", "Found 9007199254740992 file(s)"),
+      message: /found count is not a safe integer/,
+    },
+    {
+      name: "zero found count",
+      stderr: "Found 0 file(s)\n\nChecked 0 file(s)\n",
+      exitCode: 0,
+      message: /non-empty fixture formatted zero files/,
+    },
+    {
+      name: "absolute Unix path",
+      stderr: changedReport().replace("src/App.vue", "/src/App.vue"),
+      message: /changed file must be a normalized relative path/,
+    },
+    {
+      name: "absolute Windows path",
+      stderr: changedReport().replace("src/App.vue", "C:\\src\\App.vue"),
+      message: /changed file must be a normalized relative path/,
+    },
+    {
+      name: "parent traversal",
+      stderr: changedReport().replace("src/App.vue", "../src/App.vue"),
+      message: /changed file must be a normalized relative path/,
+    },
+    {
+      name: "non-Vue path",
+      stderr: changedReport().replace("src/App.vue", "src/App.ts"),
+      message: /changed file is not a Vue SFC/,
+    },
+    {
+      name: "missing summary separator",
+      stderr: changedReport().replace("./src/Card.vue\n\nChecked", "./src/Card.vue\nChecked"),
+      message: /missing blank line before formatter summary/,
+    },
+    {
+      name: "missing checked count",
+      stderr: changedReport().replace("Checked 2 file(s)", "Checked files"),
+      message: /missing checked count/,
+    },
+    {
+      name: "unexpected report line",
+      stderr: changedReport().replace("\n", "\nextra\n"),
+      message: /missing blank line before formatter summary/,
+    },
+    {
+      name: "duplicate changed path",
+      stderr: changedReport().replace("./src/Card.vue", "src/App.vue"),
+      message: /duplicate changed paths/,
+    },
+    {
+      name: "changed count mismatch",
+      stderr: changedReport().replace(
+        "2 file(s) would be reformatted",
+        "1 file(s) would be reformatted",
+      ),
+      message: /changed count 1 does not match 2 paths/,
+    },
+    {
+      name: "found and checked mismatch",
+      stderr: changedReport().replace("Checked 2 file(s)", "Checked 3 file(s)"),
+      message: /file counts do not reconcile/,
+    },
+    {
+      name: "missing unchanged summary",
+      stderr: "Found 1 file(s)\n\nChecked 1 file(s)\n",
+      exitCode: 0,
+      message: /file counts do not reconcile/,
+    },
+    {
+      name: "exit code mismatch",
+      exitCode: 0,
+      message: /exit code 0 does not match expected 1/,
+    },
+  ];
+
+  for (const fixtureCase of cases) {
+    assert.throws(
+      () =>
+        validateFormatterOutput(
+          fixtureCase.project ?? { id: "fixture" },
+          fixtureCase.stdout ?? "",
+          fixtureCase.stderr ?? changedReport(),
+          fixtureCase.exitCode ?? 1,
+          "same",
+          fixtureCase.after ?? "same",
+        ),
+      fixtureCase.message,
+      fixtureCase.name,
+    );
+  }
+});
+
+test("formatter input snapshot detects source and metadata changes", () => {
+  const fixtureDir = fs.mkdtempSync(path.join(root, "tests", "_fixtures", "formatter-snapshot-"));
+  const sourcePath = path.join(fixtureDir, "App.vue");
+  fs.writeFileSync(sourcePath, "<template />\n");
+  try {
+    const before = snapshotFormatterInputs(fixtureDir, ["**/*.vue"]);
+    fs.writeFileSync(sourcePath, "<template><main /></template>\n");
+    const afterContent = snapshotFormatterInputs(fixtureDir, ["**/*.vue"]);
+    assert.notEqual(afterContent, before);
+    fs.writeFileSync(sourcePath, "<template />\n");
+    fs.chmodSync(sourcePath, 0o744);
+    const afterMetadata = snapshotFormatterInputs(fixtureDir, ["**/*.vue"]);
+    assert.notEqual(afterMetadata, before);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test("fixture tool matrix records formatter mutations", () => {
+  const fixtureDir = fs.mkdtempSync(
+    path.join(root, "tests", "_fixtures", "tool-matrix-formatter-"),
+  );
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-formatter-"));
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-formatter-report-"));
+  const executable = path.join(fakeDir, "fake-vize.mjs");
+  fs.mkdirSync(path.join(fixtureDir, "src"), { recursive: true });
+  fs.writeFileSync(path.join(fixtureDir, "src", "App.vue"), "<template />\n");
+  fs.writeFileSync(
+    executable,
+    `#!/usr/bin/env node
+import fs from "node:fs";
+fs.writeFileSync("src/App.vue", "<template><main /></template>\\n");
+process.stderr.write("Found 1 file(s)\\nWould reformat: src/App.vue\\n\\nChecked 1 file(s)\\n  1 file(s) would be reformatted\\n");
+process.exit(1);\n`,
+  );
+  fs.chmodSync(executable, 0o755);
+
+  try {
+    const run = runTool(
+      {
+        id: "formatter-mutation-fixture",
+        fixturePath: path.relative(root, fixtureDir),
+        vueGlobs: ["**/*.vue"],
+      },
+      "formatter",
+      { dryRun: false, timeoutMs: 5_000 },
+      { command: executable, prefix: [], label: executable },
+      reportDir,
+    );
+    assert.equal(run.status, "failed");
+    assert.match(run.failure, /modified its working tree or input metadata/);
+    const raw = JSON.parse(fs.readFileSync(path.resolve(root, run.outputPath as string), "utf8"));
+    assert.match(raw.validationError, /modified its working tree or input metadata/);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/tool-matrix-formatter.mjs
+++ b/tools/fixtures/tool-matrix-formatter.mjs
@@ -1,0 +1,142 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { globSync, readFileSync, statSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+
+const noFilesMessage =
+  "No .vue, .js, .mjs, .cjs, .ts, .mts, .cts, .jsx, .tsx, .json, .jsonc, .yaml, .yml, .md, or .markdown files found matching the patterns";
+
+export function snapshotFormatterInputs(cwd, patterns) {
+  const inputPaths = [...new Set(patterns.flatMap((pattern) => globSync(pattern, { cwd })))].sort(
+    (left, right) => left.localeCompare(right),
+  );
+  const digest = createHash("sha256");
+  for (const inputPath of inputPaths) {
+    const absolute = resolve(cwd, inputPath);
+    const metadata = statSync(absolute, { bigint: true });
+    if (!metadata.isFile()) continue;
+    digest.update(inputPath.replaceAll("\\", "/"));
+    digest.update("\0");
+    digest.update(String(metadata.mode));
+    digest.update("\0");
+    digest.update(String(metadata.mtimeNs));
+    digest.update("\0");
+    digest.update(readFileSync(absolute));
+    digest.update("\0");
+  }
+  const status = spawnSync(
+    "git",
+    ["status", "--porcelain=v1", "-z", "--untracked-files=all", "--ignore-submodules=none"],
+    { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  if (status.error != null || status.status !== 0) {
+    throw new Error("failed to snapshot formatter working tree");
+  }
+  digest.update(status.stdout);
+  return digest.digest("hex");
+}
+
+export function validateFormatterOutput(project, stdout, stderr, exitCode, before, after) {
+  if (stdout !== "") invalid("stdout must be empty");
+  if (before !== after) invalid("formatter check modified its working tree or input metadata");
+  const normalizedStderr = stderr.replaceAll("\r\n", "\n");
+  if (!normalizedStderr.endsWith("\n")) invalid("stderr must end with a newline");
+
+  if (project.expectedVueFileCount === 0) {
+    if (normalizedStderr !== `${noFilesMessage}\n`) {
+      invalid("zero-file fixture emitted an unexpected report");
+    }
+    if (exitCode !== 1) invalid(`zero-file exit code ${exitCode} does not match expected 1`);
+    return formatterSummary(0, [], 0);
+  }
+
+  const lines = normalizedStderr.slice(0, -1).split("\n");
+  const found = parseCount(lines[0], /^Found (\d+) file\(s\)$/, "found count");
+  if (found === 0) invalid("non-empty fixture formatted zero files");
+  const changedPaths = [];
+  let index = 1;
+  while (lines[index]?.startsWith("Would reformat: ")) {
+    const candidate = lines[index].slice("Would reformat: ".length);
+    requireFormatterPath(candidate);
+    changedPaths.push(candidate);
+    index += 1;
+  }
+  if (lines[index] !== "") invalid("missing blank line before formatter summary");
+  index += 1;
+  const checked = parseCount(lines[index], /^Checked (\d+) file\(s\)$/, "checked count");
+  index += 1;
+
+  let changed = 0;
+  const changedMatch = /^  (\d+) file\(s\) would be reformatted$/.exec(lines[index] ?? "");
+  if (changedMatch != null) {
+    changed = safeCount(changedMatch[1], "changed count");
+    index += 1;
+  }
+  let unchanged = 0;
+  const unchangedMatch = /^  (\d+) file\(s\) already formatted$/.exec(lines[index] ?? "");
+  if (unchangedMatch != null) {
+    unchanged = safeCount(unchangedMatch[1], "unchanged count");
+    index += 1;
+  }
+  if (index !== lines.length) invalid("formatter report contains unexpected lines");
+  if (new Set(changedPaths).size !== changedPaths.length) {
+    invalid("formatter report contains duplicate changed paths");
+  }
+  if (changed !== changedPaths.length) {
+    invalid(`changed count ${changed} does not match ${changedPaths.length} paths`);
+  }
+  if (found !== checked || checked !== changed + unchanged) {
+    invalid(
+      `file counts do not reconcile: found ${found}, checked ${checked}, changed ${changed}, unchanged ${unchanged}`,
+    );
+  }
+  const expectedExitCode = changed > 0 ? 1 : 0;
+  if (exitCode !== expectedExitCode) {
+    invalid(`exit code ${exitCode} does not match expected ${expectedExitCode}`);
+  }
+  return formatterSummary(checked, changedPaths, unchanged);
+}
+
+function formatterSummary(checkedFileCount, changedPaths, unchangedFileCount) {
+  const digest = createHash("sha256");
+  for (const inputPath of [...changedPaths].sort((left, right) => left.localeCompare(right))) {
+    digest.update(inputPath);
+    digest.update("\0");
+  }
+  return {
+    checkedFileCount,
+    changedFileCount: changedPaths.length,
+    unchangedFileCount,
+    changedPathsSha256: digest.digest("hex"),
+  };
+}
+
+function parseCount(line, pattern, label) {
+  const match = pattern.exec(line ?? "");
+  if (match == null) invalid(`missing ${label}`);
+  return safeCount(match[1], label);
+}
+
+function safeCount(value, label) {
+  const count = Number(value);
+  if (!Number.isSafeInteger(count) || count < 0) invalid(`${label} is not a safe integer`);
+  return count;
+}
+
+function requireFormatterPath(value) {
+  const bare = value.startsWith("./") ? value.slice(2) : value;
+  if (
+    bare.length === 0 ||
+    isAbsolute(bare) ||
+    /^[A-Za-z]:[\\/]/.test(bare) ||
+    bare.includes("\\") ||
+    bare.split("/").some((segment) => segment === "" || segment === "." || segment === "..")
+  ) {
+    invalid("changed file must be a normalized relative path");
+  }
+  if (!bare.endsWith(".vue")) invalid(`changed file is not a Vue SFC: ${value}`);
+}
+
+function invalid(message) {
+  throw new Error(`invalid formatter check output: ${message}`);
+}

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -15,6 +15,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { expectedCompilerOutputs } from "./tool-matrix-compiler-paths.mjs";
+import { snapshotFormatterInputs, validateFormatterOutput } from "./tool-matrix-formatter.mjs";
 import { validateLinterOutput } from "./tool-matrix-linter.mjs";
 import { validateTypecheckerOutput } from "./tool-matrix-typechecker.mjs";
 
@@ -41,6 +42,8 @@ export function runTool(project, tool, args, launch, outputDir) {
   };
   if (args.dryRun) return { ...base, status: "planned" };
   if (!fixtureExists) return { ...base, status: "missing-fixture" };
+  const formatterStateBefore =
+    tool === "formatter" ? snapshotFormatterInputs(cwd, project.vueGlobs) : null;
 
   try {
     const startedAt = Date.now();
@@ -99,6 +102,20 @@ export function runTool(project, tool, args, launch, outputDir) {
         } catch (error) {
           payload.validationError = errorMessage(error);
         }
+      }
+    } else if (tool === "formatter" && (result.status === 0 || result.status === 1)) {
+      try {
+        const formatterStateAfter = snapshotFormatterInputs(cwd, project.vueGlobs);
+        payload.formatterCheck = validateFormatterOutput(
+          project,
+          payload.stdout,
+          payload.stderr,
+          result.status,
+          formatterStateBefore,
+          formatterStateAfter,
+        );
+      } catch (error) {
+        payload.validationError = errorMessage(error);
       }
     }
     writeFileSync(rawPath, `${JSON.stringify(payload, null, 2)}\n`);


### PR DESCRIPTION
## Summary

- parse and reconcile formatter check discovery, changed paths, checked counts, unchanged counts, and exit codes
- record a deterministic digest of sorted changed paths
- snapshot matched inputs plus Git state before and after every formatter run to detect content, mode, timestamp, or working-tree mutation
- cover changed, mixed, clean, and exact-zero reports plus 20 malformed or mutating cases

## Testing

- node --test --test-concurrency=1 tests/tooling/fixture-tool-matrix-formatter.test.ts tests/tooling/fixture-tool-matrix-linter.test.ts tests/tooling/fixture-tool-matrix-typechecker.test.ts tests/tooling/fixture-tool-matrix-compiler.test.ts tests/tooling/fixture-tool-matrix-report.test.ts tests/tooling/real-project-matrix-workflow.test.ts
- oxlint on changed fixture tooling with warnings denied
- validated all 131 formatter artifacts from Real Project Matrix run 29634541442

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->