### PR TITLE
fix(fixtures): use byte order for typecheck paths

### DIFF
--- a/tests/tooling/fixture-tool-matrix-typechecker.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typechecker.test.ts
@@ -44,6 +44,15 @@ test("typechecker oracle accepts exact error, warning, project, and zero-file re
   projectOutput.errorCount = 2;
   validateTypecheckerOutput({ id: "project-error" }, projectOutput, 1);
 
+  const byteOrderedOutput = validOutput();
+  byteOrderedOutput.files = [
+    { file: "src/B.vue", diagnostics: ["error:1:1 [TS1] uppercase"] },
+    { file: "src/a.vue", diagnostics: ["error:1:1 [TS1] lowercase"] },
+  ];
+  byteOrderedOutput.fileCount = 2;
+  byteOrderedOutput.errorCount = 2;
+  validateTypecheckerOutput({ id: "byte-order" }, byteOrderedOutput, 1);
+
   validateTypecheckerOutput(
     { id: "no-sfc", expectedVueFileCount: 0 },
     { files: [], errorCount: 0, warningCount: 0, fileCount: 0 },
@@ -132,8 +141,8 @@ test("typechecker oracle rejects malformed or internally inconsistent reports", 
       name: "unsorted checked files",
       mutate: (output: any) => {
         output.files = [
-          { file: "src/B.vue", diagnostics: ["error:1:1 [TS1] B"] },
-          { file: "src/A.vue", diagnostics: ["error:1:1 [TS1] A"] },
+          { file: "src/a.vue", diagnostics: ["error:1:1 [TS1] lowercase"] },
+          { file: "src/B.vue", diagnostics: ["error:1:1 [TS1] uppercase"] },
         ];
         output.fileCount = 2;
         output.errorCount = 2;

--- a/tools/fixtures/tool-matrix-typechecker.mjs
+++ b/tools/fixtures/tool-matrix-typechecker.mjs
@@ -52,9 +52,10 @@ export function validateTypecheckerOutput(project, output, exitCode) {
   }
 
   const checkedFiles = output.files.slice(0, output.fileCount).map((file) => file.file);
-  const sortedFiles = [...checkedFiles].sort((left, right) =>
-    Buffer.compare(Buffer.from(left), Buffer.from(right)),
-  );
+  const sortedFiles = checkedFiles
+    .map((file) => ({ file, buf: Buffer.from(file) }))
+    .sort((left, right) => Buffer.compare(left.buf, right.buf))
+    .map(({ file }) => file);
   if (JSON.stringify(checkedFiles) !== JSON.stringify(sortedFiles)) {
     invalid("checked file entries are not sorted");
   }

--- a/tools/fixtures/tool-matrix-typechecker.mjs
+++ b/tools/fixtures/tool-matrix-typechecker.mjs
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { isAbsolute } from "node:path";
 
 const outputKeys = ["errorCount", "fileCount", "files", "warningCount"];
@@ -51,7 +52,9 @@ export function validateTypecheckerOutput(project, output, exitCode) {
   }
 
   const checkedFiles = output.files.slice(0, output.fileCount).map((file) => file.file);
-  const sortedFiles = [...checkedFiles].sort((left, right) => left.localeCompare(right));
+  const sortedFiles = [...checkedFiles].sort((left, right) =>
+    Buffer.compare(Buffer.from(left), Buffer.from(right)),
+  );
   if (JSON.stringify(checkedFiles) !== JSON.stringify(sortedFiles)) {
     invalid("checked file entries are not sorted");
   }


### PR DESCRIPTION
## Summary

- compare reported typechecker paths with the UTF-8 byte ordering used by Rust strings
- avoid locale-dependent false failures for mixed-case real-project paths
- cover the ordering difference with explicit accepted and rejected path sequences

## Testing

- node --test --test-concurrency=1 tests/tooling/fixture-tool-matrix-typechecker.test.ts tests/tooling/fixture-tool-matrix-report.test.ts
- oxlint on changed files with warnings denied
- revalidated all 12 typechecker artifacts from shard 0 of run 29635467350

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when validating checked file ordering by using deterministic byte-wise sorting.
  * Updated typechecker oracle test scenarios so acceptance and “unsorted checked files” cases correctly handle mixed-case paths and updated diagnostic text/counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->