### PR TITLE
test(fixtures): record matrix provenance

### DIFF
--- a/tests/tooling/fixture-tool-matrix-compiler.test.ts
+++ b/tests/tooling/fixture-tool-matrix-compiler.test.ts
@@ -94,6 +94,7 @@ test("fixture tool matrix requires an explicit zero-file compiler expectation", 
       reportDir,
     );
     assert.equal(declared.status, "findings", JSON.stringify(declared));
+    assert.equal(declared.fileCount, 0);
     const raw = JSON.parse(
       fs.readFileSync(path.resolve(root, declared.outputPath as string), "utf8"),
     );
@@ -187,6 +188,7 @@ fs.writeFileSync(artifact, JSON.stringify({ filename: ${JSON.stringify(path.base
         reportDir,
       );
       assert.equal(run.status, "ok", `${fixtureCase.name}: ${JSON.stringify(run)}`);
+      assert.equal(run.fileCount, 1, fixtureCase.name);
     } finally {
       fs.rmSync(fixtureDir, { recursive: true, force: true });
       fs.rmSync(fakeDir, { recursive: true, force: true });

--- a/tests/tooling/fixture-tool-matrix-report.test.ts
+++ b/tests/tooling/fixture-tool-matrix-report.test.ts
@@ -6,6 +6,8 @@ import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { validatedFileCount } from "../../tools/fixtures/tool-matrix-metrics.mjs";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const toolPath = path.join(root, "tools", "fixtures", "tool-matrix-report.mjs");
 
@@ -31,6 +33,29 @@ test("fixture tool matrix plans every registered project across all four require
     assert.equal(result.status, 0, result.stderr);
     const report = JSON.parse(fs.readFileSync(path.join(outputDir, "summary.json"), "utf8"));
     assert.equal(report.schema, "vize.fixtureToolMatrixReport");
+    assert.equal(report.version, 2);
+    assert.match(report.evidence.commitSha, /^[0-9a-f]{40}$/);
+    assert.deepEqual(Object.keys(report.evidence).sort(), ["commitSha", "machine", "runtime"]);
+    assert.deepEqual(Object.keys(report.evidence.runtime).sort(), ["name", "version"]);
+    assert.equal(report.evidence.runtime.name, "node");
+    assert.equal(report.evidence.runtime.version, process.versions.node);
+    assert.deepEqual(Object.keys(report.evidence.machine).sort(), [
+      "arch",
+      "cpuModel",
+      "logicalCpuCount",
+      "platform",
+      "totalMemoryBytes",
+    ]);
+    assert.equal(report.evidence.machine.platform, process.platform);
+    assert.equal(report.evidence.machine.arch, process.arch);
+    assert.ok(report.evidence.machine.cpuModel.length > 0);
+    assert.ok(report.evidence.machine.logicalCpuCount > 0);
+    assert.ok(report.evidence.machine.totalMemoryBytes > 0);
+    const markdown = fs.readFileSync(path.join(outputDir, "summary.md"), "utf8");
+    assert.match(markdown, new RegExp(`Commit: ${report.evidence.commitSha}`));
+    assert.match(markdown, /Runtime: node \d+\.\d+\.\d+/);
+    assert.match(markdown, /Machine: [^/]+\/[^,]+, \d+ logical CPUs, \d+ bytes memory/);
+    assert.match(markdown, /\| Project \| Tool \| Status \| Exit \| Files \| Duration \(ms\) \|/);
     assert.equal(report.summary.projectCount, 131);
     assert.equal(report.summary.toolCount, 4);
     assert.equal(report.summary.runCount, 524);
@@ -42,10 +67,38 @@ test("fixture tool matrix plans every registered project across all four require
         ["compiler", "typechecker", "linter", "formatter"],
         `${project.id} should exercise every requested tool`,
       );
+      for (const entry of project.runs) assert.equal(entry.fileCount, null);
     }
   } finally {
     fs.rmSync(outputDir, { recursive: true, force: true });
   }
+});
+
+test("fixture tool matrix rejects malformed commit evidence", () => {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-fixture-tool-matrix-sha-"));
+  try {
+    const result = spawnSync(process.execPath, [toolPath, "--dry-run", "--output-dir", outputDir], {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...process.env, GITHUB_SHA: "not-a-full-sha" },
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /GITHUB_SHA must be a full lowercase commit SHA/);
+    assert.equal(fs.existsSync(path.join(outputDir, "summary.json")), false);
+  } finally {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+test("fixture tool matrix derives checked file evidence from validated tool payloads", () => {
+  assert.equal(validatedFileCount("compiler", { compilerArtifacts: { inputFileCount: 7 } }), 7);
+  assert.equal(validatedFileCount("typechecker", { parsed: { fileCount: 5 } }), 5);
+  assert.equal(validatedFileCount("linter", { parsed: [{}, {}, {}] }), 3);
+  assert.equal(validatedFileCount("formatter", { formatterCheck: { checkedFileCount: 11 } }), 11);
+  assert.throws(
+    () => validatedFileCount("unknown", {}),
+    /Unsupported fixture matrix tool: unknown/,
+  );
 });
 
 test("fixture tool matrix emits read-only commands with machine-readable diagnostics", () => {

--- a/tools/fixtures/tool-matrix-metrics.mjs
+++ b/tools/fixtures/tool-matrix-metrics.mjs
@@ -1,0 +1,7 @@
+export function validatedFileCount(tool, payload) {
+  if (tool === "compiler") return payload.compilerArtifacts.inputFileCount;
+  if (tool === "typechecker") return payload.parsed.fileCount;
+  if (tool === "linter") return payload.parsed.length;
+  if (tool === "formatter") return payload.formatterCheck.checkedFileCount;
+  throw new Error(`Unsupported fixture matrix tool: ${tool}`);
+}

--- a/tools/fixtures/tool-matrix-report.mjs
+++ b/tools/fixtures/tool-matrix-report.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
+import { spawnSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { cpus, totalmem } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -34,8 +36,9 @@ function main() {
 
   const report = {
     schema,
-    version: 1,
+    version: 2,
     generatedAt: new Date().toISOString(),
+    evidence: collectEvidence(),
     registryPath: relative(repoRoot, registryPath),
     command: {
       vize: launch.label,
@@ -172,14 +175,17 @@ function renderMarkdown(report) {
     `Projects: ${report.summary.projectCount}`,
     `Tools: ${report.command.tools.join(", ")}`,
     `Runs: ${report.summary.runCount}`,
+    `Commit: ${report.evidence.commitSha}`,
+    `Runtime: ${report.evidence.runtime.name} ${report.evidence.runtime.version}`,
+    `Machine: ${report.evidence.machine.platform}/${report.evidence.machine.arch}, ${report.evidence.machine.logicalCpuCount} logical CPUs, ${report.evidence.machine.totalMemoryBytes} bytes memory`,
     "",
-    "| Project | Tool | Status | Exit | Duration (ms) | Output |",
-    "| --- | --- | --- | ---: | ---: | --- |",
+    "| Project | Tool | Status | Exit | Files | Duration (ms) | Output |",
+    "| --- | --- | --- | ---: | ---: | ---: | --- |",
   ];
   for (const project of report.projects) {
     for (const run of project.runs) {
       lines.push(
-        `| ${project.id} | ${run.tool} | ${run.status} | ${run.exitCode ?? "-"} | ${run.durationMs} | ${run.outputPath == null ? "-" : `\`${run.outputPath}\``} |`,
+        `| ${project.id} | ${run.tool} | ${run.status} | ${run.exitCode ?? "-"} | ${run.fileCount ?? "-"} | ${run.durationMs} | ${run.outputPath == null ? "-" : `\`${run.outputPath}\``} |`,
       );
     }
   }
@@ -211,6 +217,47 @@ function selectShard(projects, shardIndex, shardCount) {
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
+}
+function collectEvidence() {
+  const machineCpus = cpus();
+  const logicalCpuCount = machineCpus.length;
+  const totalMemoryBytes = totalmem();
+  if (!Number.isSafeInteger(logicalCpuCount) || logicalCpuCount < 1) {
+    throw new Error("Machine evidence requires at least one logical CPU");
+  }
+  if (!Number.isSafeInteger(totalMemoryBytes) || totalMemoryBytes < 1) {
+    throw new Error("Machine evidence requires positive total memory");
+  }
+  return {
+    commitSha: resolveCommitSha(),
+    runtime: { name: "node", version: process.versions.node },
+    machine: {
+      platform: process.platform,
+      arch: process.arch,
+      cpuModel: machineCpus[0]?.model.trim() || "unknown",
+      logicalCpuCount,
+      totalMemoryBytes,
+    },
+  };
+}
+function resolveCommitSha() {
+  const environmentSha = process.env.GITHUB_SHA;
+  if (environmentSha != null) return requireCommitSha(environmentSha, "GITHUB_SHA");
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+  if (result.error != null || result.status !== 0) {
+    throw new Error("Unable to resolve fixture matrix commit SHA");
+  }
+  return requireCommitSha(result.stdout.trim(), "git rev-parse HEAD");
+}
+function requireCommitSha(value, source) {
+  if (!/^[0-9a-f]{40}$/.test(value)) {
+    throw new Error(`${source} must be a full lowercase commit SHA`);
+  }
+  return value;
 }
 function splitCsv(value) {
   return value

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -17,10 +17,10 @@ import { fileURLToPath } from "node:url";
 import { expectedCompilerOutputs } from "./tool-matrix-compiler-paths.mjs";
 import { snapshotFormatterInputs, validateFormatterOutput } from "./tool-matrix-formatter.mjs";
 import { validateLinterOutput } from "./tool-matrix-linter.mjs";
+import { validatedFileCount } from "./tool-matrix-metrics.mjs";
 import { validateTypecheckerOutput } from "./tool-matrix-typechecker.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
-
 export function runTool(project, tool, args, launch, outputDir) {
   const cwd = resolve(repoRoot, project.fixturePath);
   const fixtureExists = existsSync(cwd);
@@ -37,6 +37,7 @@ export function runTool(project, tool, args, launch, outputDir) {
     command: displayCommand(launch.command, commandArgs),
     cwd: relative(repoRoot, cwd),
     durationMs: 0,
+    fileCount: null,
     exitCode: null,
     outputPath: null,
   };
@@ -136,7 +137,11 @@ export function runTool(project, tool, args, launch, outputDir) {
         failure: `invalid JSON output: ${payload.parseError}`,
       };
     }
-    return { ...completed, status: result.status === 0 ? "ok" : "findings" };
+    return {
+      ...completed,
+      fileCount: validatedFileCount(tool, payload),
+      status: result.status === 0 ? "ok" : "findings",
+    };
   } finally {
     if (compilerOutputDir != null) rmSync(compilerOutputDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- record exact commit, runtime, and machine evidence in every real-project matrix summary
- attach validated file counts to each core-tool run and surface them in Markdown artifacts
- reject malformed commit evidence and cover all count mappings with strict tests

Advances #2971.

## Validation

- `node --test tests/tooling/fixture-tool-matrix-*.test.ts` (26/26)
- targeted `oxlint --deny-warnings`
- `git diff --check`
- 350-line source limit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fixture tool-matrix reports now include validated file counts for each tool run.
  * Reports now include execution evidence such as commit, runtime, and machine details.
  * Markdown reports display file counts and execution durations.

* **Bug Fixes**
  * Reports now reject malformed commit identifiers and invalid execution metrics with clear errors.
  * Improved validation for file counts across supported tooling results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->