### PR TITLE
test(release): require real project matrix

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -1,4 +1,5 @@
 name: Real Project Matrix
+run-name: Real Project Matrix @ ${{ github.sha }}
 
 on:
   workflow_dispatch:

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -77,6 +77,13 @@ test("release gate plans bind exact SHAs to expected evidence titles", () => {
         expectedRunName: "Native Smoke",
       },
       {
+        workflowName: "Real Project Matrix",
+        workflowId: "real-project-matrix.yml",
+        ref: "v1.2.3",
+        inputs: {},
+        expectedRunName: `Real Project Matrix @ ${releaseSha}`,
+      },
+      {
         workflowName: "Fuzz",
         workflowId: "fuzz.yml",
         ref: "v1.2.3",
@@ -159,6 +166,14 @@ test("Native Smoke uses its stable workflow title as evidence", () => {
   const native = readWorkflow(findReleasePlan("Native Smoke").workflowId);
   assert.equal(native.name, "Native Smoke");
   assert.equal(native["run-name"], undefined);
+});
+
+test("Real Project Matrix dispatch identifies its immutable target", () => {
+  const matrix = readWorkflow(findReleasePlan("Real Project Matrix").workflowId);
+  assert.equal(matrix.name, "Real Project Matrix");
+  assert.deepEqual(Object.keys(matrix.on?.workflow_dispatch?.inputs ?? {}), []);
+  assert.match(matrix["run-name"] ?? "", /^Real Project Matrix @ /);
+  assert.match(matrix["run-name"] ?? "", /github\.sha/);
 });
 
 test("on-demand gates correlate expanded display titles, never workflow names", () => {
@@ -245,7 +260,13 @@ test("release gate bootstrap dispatches only missing gates and waits for exact e
     pollIntervalMs: 1_000,
   });
 
-  assert.deepEqual(dispatched, ["Benchmark", "App E2E", "Native Smoke", "Fuzz"]);
+  assert.deepEqual(dispatched, [
+    "Benchmark",
+    "App E2E",
+    "Native Smoke",
+    "Real Project Matrix",
+    "Fuzz",
+  ]);
   assert.deepEqual([...selected.keys()], requiredReleaseWorkflows);
 });
 
@@ -265,7 +286,13 @@ test("release gate bootstrap attempts every missing dispatch before reporting fa
     }),
     /Failed to dispatch release gates:[\s\S]*Benchmark: dispatch denied[\s\S]*Fuzz: dispatch denied/,
   );
-  assert.deepEqual(attempts, ["Benchmark", "App E2E", "Native Smoke", "Fuzz"]);
+  assert.deepEqual(attempts, [
+    "Benchmark",
+    "App E2E",
+    "Native Smoke",
+    "Real Project Matrix",
+    "Fuzz",
+  ]);
 });
 
 test("release gate bootstrap never retries or hides a red latest run", async () => {

--- a/tests/tooling/release-preflight-evidence.test.ts
+++ b/tests/tooling/release-preflight-evidence.test.ts
@@ -146,4 +146,29 @@ test("matrix-sensitive release gates require every successful job", () => {
     () => assertRequiredWorkflowJobs("Native Smoke", nativeJobs.slice(1)),
     /Native host smoke \(linux-x64-gnu\)/,
   );
+
+  const realProjectJobs = Array.from({ length: 11 }, (_, shard) =>
+    successfulReleaseJob(`real projects (${shard}/11)`),
+  );
+  assert.doesNotThrow(() => assertRequiredWorkflowJobs("Real Project Matrix", realProjectJobs));
+  assert.throws(
+    () => assertRequiredWorkflowJobs("Real Project Matrix", realProjectJobs.slice(1)),
+    /real projects \(0\/11\)/,
+  );
+  assert.throws(
+    () =>
+      assertRequiredWorkflowJobs("Real Project Matrix", [
+        ...realProjectJobs,
+        successfulReleaseJob("real projects (0/11)"),
+      ]),
+    /real projects \(0\/11\).*found 2/,
+  );
+  assert.throws(
+    () =>
+      assertRequiredWorkflowJobs("Real Project Matrix", [
+        { ...realProjectJobs[0], conclusion: "failure" },
+        ...realProjectJobs.slice(1),
+      ]),
+    /real projects \(0\/11\) is completed\/failure/,
+  );
 });

--- a/tools/github/release-preflight-bootstrap.mjs
+++ b/tools/github/release-preflight-bootstrap.mjs
@@ -43,6 +43,13 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
       expectedRunName: "Native Smoke",
     },
     {
+      workflowName: "Real Project Matrix",
+      workflowId: "real-project-matrix.yml",
+      ref,
+      inputs: {},
+      expectedRunName: `Real Project Matrix @ ${headSha}`,
+    },
+    {
       workflowName: "Fuzz",
       workflowId: "fuzz.yml",
       ref,

--- a/tools/github/release-preflight-evidence.mjs
+++ b/tools/github/release-preflight-evidence.mjs
@@ -5,6 +5,7 @@ export const requiredReleaseWorkflows = [
   "Fuzz",
   "Miri",
   "App E2E",
+  "Real Project Matrix",
   "Deploy docs",
 ];
 
@@ -35,6 +36,14 @@ export const requiredReleaseWorkflowEvidence = new Map([
     "App E2E",
     {
       path: ".github/workflows/e2e.yml",
+      events: ["schedule", "workflow_dispatch"],
+      branches: { schedule: ["main"] },
+    },
+  ],
+  [
+    "Real Project Matrix",
+    {
+      path: ".github/workflows/real-project-matrix.yml",
       events: ["schedule", "workflow_dispatch"],
       branches: { schedule: ["main"] },
     },
@@ -91,6 +100,7 @@ const requiredJobNames = new Map([
       ),
     ],
   ],
+  ["Real Project Matrix", Array.from({ length: 11 }, (_, shard) => `real projects (${shard}/11)`)],
 ]);
 
 function compareRuns(left, right) {


### PR DESCRIPTION
## Summary

- require Real Project Matrix as exact-SHA release evidence
- dispatch the matrix automatically from release preflight when evidence is missing
- fail closed unless all 11 real-project shards are present exactly once and successful

Advances #2971.

## Validation

- `node --test tests/tooling/release-preflight-*.test.ts tests/tooling/github-workflows-check.test.ts` (46/46)
- targeted `oxlint --deny-warnings`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->