### PR TITLE
fix(fixtures): pin Reka typecheck target

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -130,7 +130,7 @@
         "files": ["LICENSE"]
       },
       "vueGlobs": ["packages/**/*.vue"],
-      "tsconfig": "tsconfig.json",
+      "tsconfig": "packages/core/tsconfig.check.json",
       "coverage": [
         "compiler",
         "linter",

--- a/tests/tooling/fixture-tool-matrix-typecheck-target.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typecheck-target.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { validateTypecheckPerformanceTarget } from "../../tools/fixtures/tool-matrix-typecheck-target.mjs";
+
+test("fixture tool matrix requires an exact baseline tsconfig for performance targets", () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-typecheck-target-"));
+  const project = {
+    id: "performance-fixture",
+    tsconfig: "configs/tsconfig.check.json",
+    typecheckPerformance: { enabled: true, compareTo: "vue-tsc" },
+  };
+  try {
+    fs.mkdirSync(path.join(fixtureRoot, "configs"));
+    fs.writeFileSync(path.join(fixtureRoot, project.tsconfig), "{}\n");
+    assert.doesNotThrow(() => validateTypecheckPerformanceTarget(project, fixtureRoot));
+    assert.doesNotThrow(() =>
+      validateTypecheckPerformanceTarget(
+        { ...project, tsconfig: undefined, typecheckPerformance: { enabled: false } },
+        fixtureRoot,
+      ),
+    );
+
+    for (const [candidate, message] of [
+      [{ ...project, typecheckPerformance: { enabled: true, compareTo: "tsc" } }, /compareTo/],
+      [{ ...project, tsconfig: undefined }, /normalized relative path/],
+      [{ ...project, tsconfig: "../tsconfig.json" }, /normalized relative path/],
+      [{ ...project, tsconfig: "./tsconfig.json" }, /normalized relative path/],
+      [{ ...project, tsconfig: "/tmp/tsconfig.json" }, /normalized relative path/],
+      [{ ...project, tsconfig: "configs/missing.json" }, /does not exist/],
+      [{ ...project, tsconfig: "configs" }, /is not a file/],
+    ] as const) {
+      assert.throws(() => validateTypecheckPerformanceTarget(candidate, fixtureRoot), message);
+    }
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/tool-matrix-report.mjs
+++ b/tools/fixtures/tool-matrix-report.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { cpus, totalmem } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { resolveVizeLaunch, runTool } from "./tool-matrix-run.mjs";
+import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..", "..");
@@ -25,6 +26,12 @@ function main() {
   if (args.listFixturePaths) {
     process.stdout.write(`${projects.map((project) => project.fixturePath).join("\n")}\n`);
     return;
+  }
+  if (!args.dryRun && tools.includes("typechecker")) {
+    for (const project of projects) {
+      const fixtureRoot = resolve(repoRoot, project.fixturePath);
+      if (existsSync(fixtureRoot)) validateTypecheckPerformanceTarget(project, fixtureRoot);
+    }
   }
 
   const outputDir = resolve(

--- a/tools/fixtures/tool-matrix-typecheck-target.mjs
+++ b/tools/fixtures/tool-matrix-typecheck-target.mjs
@@ -1,0 +1,33 @@
+import { statSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+
+export function validateTypecheckPerformanceTarget(project, fixtureRoot) {
+  if (project.typecheckPerformance?.enabled !== true) return;
+  if (project.typecheckPerformance.compareTo !== "vue-tsc") {
+    invalid(project, "compareTo must be vue-tsc");
+  }
+  const target = project.tsconfig;
+  if (
+    typeof target !== "string" ||
+    target.length === 0 ||
+    isAbsolute(target) ||
+    /^[A-Za-z]:[\\/]/.test(target) ||
+    target.includes("\\") ||
+    target.startsWith("./") ||
+    target.split("/").some((segment) => segment === "" || segment === "." || segment === "..")
+  ) {
+    invalid(project, "tsconfig must be a normalized relative path");
+  }
+  const resolved = resolve(fixtureRoot, target);
+  let metadata;
+  try {
+    metadata = statSync(resolved);
+  } catch {
+    invalid(project, `tsconfig does not exist: ${target}`);
+  }
+  if (!metadata.isFile()) invalid(project, `tsconfig is not a file: ${target}`);
+}
+
+function invalid(project, message) {
+  throw new Error(`Invalid typecheck performance target for ${project.id}: ${message}`);
+}


### PR DESCRIPTION
## Summary

- point Reka UI at its upstream `packages/core/tsconfig.check.json` type-check target
- fail closed when an enabled baseline target is missing, non-file, non-normalized, or not configured for `vue-tsc`
- cover valid, disabled, wrong-baseline, traversal, absolute, missing, and directory cases

Advances #2971.

## Validation

- `node --test tests/tooling/fixture-tool-matrix-*.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts` (36/36)
- targeted `oxlint --deny-warnings`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of typecheck performance targets, including configuration paths and baseline files.
  * Added clearer handling for invalid, missing, absolute, or improperly formatted TypeScript configuration paths.

* **Tests**
  * Added coverage for valid and invalid typecheck performance configurations.
  * Updated the Reka UI fixture to use its dedicated typecheck configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->