### PR TITLE
test(typecheck): classify baseline divergences

### DIFF
--- a/tests/tooling/typecheck-divergence.test.ts
+++ b/tests/tooling/typecheck-divergence.test.ts
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { compareTypecheckDiagnostics } from "../../tools/fixtures/typecheck-divergence.mjs";
+
+const cwd = path.join(os.tmpdir(), "vize-divergence-workspace");
+
+function compare(files: Array<{ file: string; diagnostics: string[] }>, vueTscOutput: string) {
+  return compareTypecheckDiagnostics({
+    projectId: "fixture",
+    cwd,
+    vizeReport: { files },
+    vueTscOutput,
+  });
+}
+
+test("typecheck divergence classifies exact diagnostics deterministically", () => {
+  const files = [
+    {
+      file: "src/a.vue",
+      diagnostics: ["warning:9:4 [TS6133] unused   value"],
+    },
+    {
+      file: "src/B.vue",
+      diagnostics: ["error:2:3 [TS2322] Type  string  is not assignable"],
+    },
+  ];
+  const baseline = [
+    `./src/a.vue(9,4): warning TS6133: unused value`,
+    `${path.join(cwd, "src/B.vue")}(2,3): error TS2322: Type string is not assignable`,
+    "",
+  ].join("\r\n");
+  const result = compare(files, baseline);
+
+  assert.deepEqual(Object.keys(result), [
+    "schema",
+    "version",
+    "project",
+    "summary",
+    "shared",
+    "falsePositives",
+    "falseNegatives",
+    "sha256",
+  ]);
+  assert.equal(result.schema, "vize.fixtureTypecheckDivergence");
+  assert.equal(result.version, 1);
+  assert.deepEqual(result.summary, {
+    vizeDiagnosticCount: 2,
+    baselineDiagnosticCount: 2,
+    sharedCount: 2,
+    falsePositiveCount: 0,
+    falseNegativeCount: 0,
+    falsePositiveRatio: 0,
+    falseNegativeRatio: 0,
+    vizeExcludedNonVueCount: 0,
+    baselineExcludedNonVueCount: 0,
+  });
+  assert.deepEqual(
+    result.shared.map((diagnostic: { file: string }) => diagnostic.file),
+    ["src/B.vue", "src/a.vue"],
+  );
+  assert.match(result.sha256, /^[0-9a-f]{64}$/);
+
+  const reversed = compare([...files].reverse(), baseline.split("\r\n").reverse().join("\n"));
+  assert.deepEqual(reversed, result);
+});
+
+test("typecheck divergence separates false positives and false negatives", () => {
+  const result = compare(
+    [
+      {
+        file: "src/App.vue",
+        diagnostics: [
+          "error:3:5 [TS2322] shared",
+          "error:4:7 [TS2339] vize only",
+          "warning:8:2 [TS6133] severity differs",
+        ],
+      },
+    ],
+    [
+      "src/App.vue(3,5): error TS2322: shared",
+      "src/App.vue(6,9): error TS2345: baseline only",
+      "src/App.vue(8,2): error TS6133: severity differs",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(result.summary, {
+    vizeDiagnosticCount: 3,
+    baselineDiagnosticCount: 3,
+    sharedCount: 1,
+    falsePositiveCount: 2,
+    falseNegativeCount: 2,
+    falsePositiveRatio: 2 / 3,
+    falseNegativeRatio: 2 / 3,
+    vizeExcludedNonVueCount: 0,
+    baselineExcludedNonVueCount: 0,
+  });
+  assert.deepEqual(
+    result.falsePositives.map((entry: { code: number }) => entry.code),
+    [2339, 6133],
+  );
+  assert.deepEqual(
+    result.falseNegatives.map((entry: { code: number }) => entry.code),
+    [2345, 6133],
+  );
+});
+
+test("typecheck divergence retains duplicate diagnostics as a multiset", () => {
+  const result = compare(
+    [
+      {
+        file: "src/App.vue",
+        diagnostics: ["error:1:1 [TS2307] z message", "error:1:1 [TS2307] a message"],
+      },
+    ],
+    "src/App.vue(1,1): error TS2307: baseline message\n",
+  );
+
+  assert.equal(result.summary.sharedCount, 1);
+  assert.equal(result.summary.falsePositiveCount, 1);
+  assert.equal(result.shared[0].vizeMessage, "a message");
+  assert.equal(result.falsePositives[0].message, "z message");
+});
+
+test("typecheck divergence accepts a diagnostic-free baseline without NaN ratios", () => {
+  const result = compare([{ file: "src/App.vue", diagnostics: [] }], "");
+  assert.equal(result.summary.falsePositiveRatio, 0);
+  assert.equal(result.summary.falseNegativeRatio, 0);
+  assert.deepEqual(result.shared, []);
+  assert.deepEqual(result.falsePositives, []);
+  assert.deepEqual(result.falseNegatives, []);
+});
+
+test("typecheck divergence records non-Vue diagnostics outside the comparison surface", () => {
+  const result = compare(
+    [
+      { file: "src/App.vue", diagnostics: [] },
+      { file: "src/helper.ts", diagnostics: ["error:1:1 [TS2322] Vize TypeScript"] },
+    ],
+    [
+      "src/helper.ts(1,1): error TS2322: baseline TypeScript",
+      "src/other.ts(2,3): error TS2339: baseline only TypeScript",
+    ].join("\n"),
+  );
+  assert.equal(result.summary.vizeDiagnosticCount, 0);
+  assert.equal(result.summary.baselineDiagnosticCount, 0);
+  assert.equal(result.summary.vizeExcludedNonVueCount, 1);
+  assert.equal(result.summary.baselineExcludedNonVueCount, 2);
+  assert.deepEqual(result.falsePositives, []);
+  assert.deepEqual(result.falseNegatives, []);
+});
+
+test("typecheck divergence uses UTF-8 byte order for Unicode paths", () => {
+  const paths = ["src/😀.vue", "src/é.vue", "src/z.vue", "src/Ω.vue"];
+  const result = compare(
+    paths.map((file, index) => ({
+      file,
+      diagnostics: [`error:1:1 [TS${2000 + index}] message`],
+    })),
+    "",
+  );
+  const expected = [...paths].sort((left, right) =>
+    Buffer.compare(Buffer.from(left), Buffer.from(right)),
+  );
+  assert.deepEqual(
+    result.falsePositives.map((entry: { file: string }) => entry.file),
+    expected,
+  );
+});
+
+test("typecheck divergence rejects ambiguous diagnostics and escaping paths", () => {
+  const validFiles = [{ file: "src/App.vue", diagnostics: [] }];
+  for (const [files, output, message] of [
+    [
+      [{ file: "src/App.vue", diagnostics: ["error:1:1 missing-code"] }],
+      "",
+      /unparseable Vize diagnostic/,
+    ],
+    [
+      [{ file: "src/App.vue", diagnostics: ["error:0:1 [TS2322] invalid range"] }],
+      "",
+      /positive safe integers/,
+    ],
+    [[{ file: "../App.vue", diagnostics: [] }], "", /stay inside/],
+    [validFiles, "error TS5058: missing config\n", /unparseable vue-tsc diagnostic/],
+    [validFiles, "../App.vue(1,1): error TS2322: escaped\n", /stay inside/],
+  ] as const) {
+    assert.throws(() => compare(files as never, output), message);
+  }
+});
+
+test("typecheck divergence rejects invalid envelopes", () => {
+  assert.throws(
+    () =>
+      compareTypecheckDiagnostics({
+        projectId: "",
+        cwd,
+        vizeReport: { files: [] },
+        vueTscOutput: "",
+      }),
+    /project id is required/,
+  );
+  assert.throws(
+    () =>
+      compareTypecheckDiagnostics({
+        projectId: "fixture",
+        cwd: "relative",
+        vizeReport: { files: [] },
+        vueTscOutput: "",
+      }),
+    /cwd must be absolute/,
+  );
+  assert.throws(() =>
+    compareTypecheckDiagnostics({
+      projectId: "fixture",
+      cwd,
+      vizeReport: {},
+      vueTscOutput: "",
+    }),
+  );
+});

--- a/tools/fixtures/typecheck-divergence.mjs
+++ b/tools/fixtures/typecheck-divergence.mjs
@@ -1,0 +1,194 @@
+import { createHash } from "node:crypto";
+import { isAbsolute, relative } from "node:path";
+
+export function compareTypecheckDiagnostics({ projectId, cwd, vizeReport, vueTscOutput }) {
+  if (typeof projectId !== "string" || projectId.length === 0) invalid("project id is required");
+  if (typeof cwd !== "string" || !isAbsolute(cwd)) invalid("cwd must be absolute");
+  const vizeInput = collectVizeDiagnostics(vizeReport, cwd);
+  const baselineInput = collectVueTscDiagnostics(vueTscOutput, cwd);
+  const vize = vizeInput.diagnostics;
+  const baseline = baselineInput.diagnostics;
+  const vizeGroups = groupByIdentity(vize);
+  const baselineGroups = groupByIdentity(baseline);
+  const identities = [...new Set([...vizeGroups.keys(), ...baselineGroups.keys()])].sort(byteOrder);
+  const shared = [];
+  const falsePositives = [];
+  const falseNegatives = [];
+
+  for (const identity of identities) {
+    const candidates = vizeGroups.get(identity) ?? [];
+    const expected = baselineGroups.get(identity) ?? [];
+    const commonCount = Math.min(candidates.length, expected.length);
+    for (let index = 0; index < commonCount; index += 1) {
+      const candidate = candidates[index];
+      shared.push({
+        file: candidate.file,
+        severity: candidate.severity,
+        line: candidate.line,
+        column: candidate.column,
+        code: candidate.code,
+        vizeMessage: candidate.message,
+        baselineMessage: expected[index].message,
+      });
+    }
+    falsePositives.push(...candidates.slice(commonCount));
+    falseNegatives.push(...expected.slice(commonCount));
+  }
+
+  shared.sort(compareShared);
+  falsePositives.sort(compareRecords);
+  falseNegatives.sort(compareRecords);
+  const classified = { shared, falsePositives, falseNegatives };
+  return {
+    schema: "vize.fixtureTypecheckDivergence",
+    version: 1,
+    project: projectId,
+    summary: {
+      vizeDiagnosticCount: vize.length,
+      baselineDiagnosticCount: baseline.length,
+      sharedCount: shared.length,
+      falsePositiveCount: falsePositives.length,
+      falseNegativeCount: falseNegatives.length,
+      falsePositiveRatio: ratio(falsePositives.length, vize.length),
+      falseNegativeRatio: ratio(falseNegatives.length, baseline.length),
+      vizeExcludedNonVueCount: vizeInput.excludedNonVueCount,
+      baselineExcludedNonVueCount: baselineInput.excludedNonVueCount,
+    },
+    ...classified,
+    sha256: createHash("sha256").update(JSON.stringify(classified)).digest("hex"),
+  };
+}
+
+function collectVizeDiagnostics(report, cwd) {
+  if (report == null || typeof report !== "object" || !Array.isArray(report.files)) {
+    invalid("Vize report must contain files");
+  }
+  const diagnostics = [];
+  for (const [fileIndex, file] of report.files.entries()) {
+    if (file == null || typeof file !== "object" || !Array.isArray(file.diagnostics)) {
+      invalid(`Vize files[${fileIndex}] must contain diagnostics`);
+    }
+    const normalizedFile = normalizePath(file.file, cwd, `Vize files[${fileIndex}].file`);
+    for (const [diagnosticIndex, diagnostic] of file.diagnostics.entries()) {
+      if (typeof diagnostic !== "string") {
+        invalid(`Vize diagnostic ${fileIndex}:${diagnosticIndex} must be a string`);
+      }
+      const match = /^(error|warning):(\d+):(\d+) \[TS(\d+)\] ([\s\S]+)$/.exec(diagnostic);
+      if (match == null) invalid(`unparseable Vize diagnostic ${normalizedFile}`);
+      diagnostics.push(record(normalizedFile, match[1], match[2], match[3], match[4], match[5]));
+    }
+  }
+  return partitionVueDiagnostics(diagnostics);
+}
+
+function collectVueTscDiagnostics(output, cwd) {
+  if (typeof output !== "string") invalid("vue-tsc output must be a string");
+  const diagnostics = [];
+  for (const line of output.replaceAll("\r\n", "\n").split("\n")) {
+    const match = /^(.+)\((\d+),(\d+)\): (error|warning) TS(\d+): (.+)$/.exec(line);
+    if (match != null) {
+      const file = normalizePath(match[1], cwd, "vue-tsc diagnostic file");
+      diagnostics.push(record(file, match[4], match[2], match[3], match[5], match[6]));
+    } else if (/\b(?:error|warning) TS\d+:/.test(line)) {
+      invalid(`unparseable vue-tsc diagnostic: ${line}`);
+    }
+  }
+  return partitionVueDiagnostics(diagnostics);
+}
+
+function partitionVueDiagnostics(diagnostics) {
+  const included = diagnostics.filter((diagnostic) => diagnostic.file.endsWith(".vue"));
+  return {
+    diagnostics: included,
+    excludedNonVueCount: diagnostics.length - included.length,
+  };
+}
+
+function normalizePath(value, cwd, label) {
+  if (typeof value !== "string" || value.length === 0) invalid(`${label} must be non-empty`);
+  let normalized = value.replaceAll("\\", "/");
+  if (isAbsolute(normalized)) normalized = relative(cwd, normalized).replaceAll("\\", "/");
+  if (normalized.startsWith("./")) normalized = normalized.slice(2);
+  if (
+    normalized.length === 0 ||
+    isAbsolute(normalized) ||
+    /^[A-Za-z]:\//.test(normalized) ||
+    normalized.split("/").some((segment) => segment === "" || segment === "." || segment === "..")
+  ) {
+    invalid(`${label} must stay inside the fixture workspace`);
+  }
+  return normalized;
+}
+
+function record(file, severity, line, column, code, message) {
+  const values = [line, column, code].map(Number);
+  if (values.some((value) => !Number.isSafeInteger(value) || value < 1)) {
+    invalid(`diagnostic range and code must be positive safe integers: ${file}`);
+  }
+  const normalizedMessage = message.replace(/\s+/g, " ").trim();
+  if (normalizedMessage.length === 0) invalid(`diagnostic message must be non-empty: ${file}`);
+  return {
+    file,
+    severity,
+    line: values[0],
+    column: values[1],
+    code: values[2],
+    message: normalizedMessage,
+  };
+}
+
+function groupByIdentity(records) {
+  const groups = new Map();
+  for (const value of records) {
+    const identity = [value.file, value.severity, value.line, value.column, value.code].join("\0");
+    const group = groups.get(identity) ?? [];
+    group.push(value);
+    groups.set(identity, group);
+  }
+  for (const group of groups.values()) group.sort(compareRecords);
+  return groups;
+}
+
+function compareRecords(left, right) {
+  return (
+    byteOrder(left.file, right.file) ||
+    byteOrder(left.severity, right.severity) ||
+    left.line - right.line ||
+    left.column - right.column ||
+    left.code - right.code ||
+    byteOrder(left.message, right.message)
+  );
+}
+
+function compareShared(left, right) {
+  return (
+    byteOrder(left.file, right.file) ||
+    byteOrder(left.severity, right.severity) ||
+    left.line - right.line ||
+    left.column - right.column ||
+    left.code - right.code ||
+    byteOrder(left.vizeMessage, right.vizeMessage) ||
+    byteOrder(left.baselineMessage, right.baselineMessage)
+  );
+}
+
+function byteOrder(left, right) {
+  if (left === right) return 0;
+  const leftCodePoints = left[Symbol.iterator]();
+  const rightCodePoints = right[Symbol.iterator]();
+  while (true) {
+    const leftPoint = leftCodePoints.next();
+    const rightPoint = rightCodePoints.next();
+    if (leftPoint.done || rightPoint.done) return leftPoint.done ? -1 : 1;
+    const difference = leftPoint.value.codePointAt(0) - rightPoint.value.codePointAt(0);
+    if (difference !== 0) return difference;
+  }
+}
+
+function ratio(count, total) {
+  return total === 0 ? 0 : count / total;
+}
+
+function invalid(message) {
+  throw new Error(`Invalid typecheck divergence input: ${message}`);
+}


### PR DESCRIPTION
## Summary

- normalize Vize and `vue-tsc` Vue diagnostics onto authored file/code/start/severity identities
- classify shared, false-positive, and false-negative multisets with UTF-8 byte ordering and a stable digest
- record excluded non-Vue diagnostics explicitly instead of mixing them into the SFC comparison surface
- reject malformed envelopes, diagnostics, ranges, and escaping paths

Advances #2971.

## Validation

- `node --test tests/tooling/typecheck-divergence.test.ts` (8/8)
- targeted `oxlint --deny-warnings`
- real Reka UI replay: 770 Vize Vue diagnostics / 805 baseline Vue diagnostics / deterministic digest
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->