### PR TITLE
test(typecheck): bind divergence artifacts

### DIFF
--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -1,0 +1,311 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const script = path.join(root, "tools", "fixtures", "typecheck-divergence-report.mjs");
+const commitSha = "a".repeat(40);
+
+function setup() {
+  const fixtureRoot = fs.mkdtempSync(
+    path.join(root, "tests", "_fixtures", "typecheck-divergence-"),
+  );
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-divergence-report-"));
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-divergence-vue-tsc-"));
+  const fixturePath = path.relative(root, fixtureRoot);
+  const project = {
+    id: "fixture",
+    fixturePath,
+    revision: "b".repeat(40),
+    vueGlobs: ["src/**/*.vue"],
+    tsconfig: "tsconfig.json",
+    typecheckPerformance: {
+      enabled: true,
+      compareTo: "vue-tsc",
+      hangTimeoutMs: 5_000,
+      maxFalsePositiveRatio: 0.05,
+      maxFalseNegativeRatio: 0.05,
+    },
+  };
+  fs.mkdirSync(path.join(fixtureRoot, "src"));
+  fs.writeFileSync(path.join(fixtureRoot, "tsconfig.json"), "{}\n");
+  fs.writeFileSync(path.join(fixtureRoot, "src", "App.vue"), "<template />\n");
+  const registryPath = path.join(fixtureRoot, "registry.json");
+  fs.writeFileSync(registryPath, `${JSON.stringify({ projects: [project] }, null, 2)}\n`);
+  const outputPath = path.join(reportDir, "fixture-typechecker.json");
+  const parsed = {
+    errorCount: 1,
+    warningCount: 0,
+    fileCount: 1,
+    files: [{ file: "src/App.vue", diagnostics: ["error:1:1 [TS2322] shared"] }],
+  };
+  fs.writeFileSync(
+    outputPath,
+    `${JSON.stringify(
+      {
+        schema: "vize.fixtureToolRun",
+        version: 1,
+        project: "fixture",
+        tool: "typechecker",
+        exitCode: 1,
+        stdout: JSON.stringify(parsed),
+        stderr: "",
+        parsed,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  fs.writeFileSync(
+    path.join(reportDir, "summary.json"),
+    `${JSON.stringify(
+      {
+        schema: "vize.fixtureToolMatrixReport",
+        version: 2,
+        evidence: {
+          commitSha,
+          runtime: { name: "node", version: process.versions.node },
+          machine: {
+            platform: process.platform,
+            arch: process.arch,
+            cpuModel: "synthetic",
+            logicalCpuCount: 1,
+            totalMemoryBytes: 1,
+          },
+        },
+        projects: [
+          {
+            id: "fixture",
+            revision: project.revision,
+            runs: [
+              {
+                tool: "typechecker",
+                status: "findings",
+                exitCode: 1,
+                fileCount: 1,
+                outputPath: "nested/fixture-typechecker.json",
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  const vueTsc = path.join(fakeDir, "vue-tsc.mjs");
+  writeVueTsc(
+    vueTsc,
+    'process.stdout.write("src/App.vue(1,1): error TS2322: shared\\n"); process.exit(2);',
+  );
+  return { fixtureRoot, reportDir, fakeDir, registryPath, vueTsc, project };
+}
+
+function writeVueTsc(pathname: string, runBody: string) {
+  fs.writeFileSync(
+    pathname,
+    `#!/usr/bin/env node\nif (process.argv.includes("--version")) { console.log("3.3.4"); process.exit(0); }\n${runBody}\n`,
+  );
+  fs.chmodSync(pathname, 0o755);
+}
+
+function run(fixture: ReturnType<typeof setup>, env: NodeJS.ProcessEnv = {}) {
+  return spawnSync(
+    process.execPath,
+    [
+      script,
+      "--registry",
+      fixture.registryPath,
+      "--report-dir",
+      fixture.reportDir,
+      "--vue-tsc-bin",
+      fixture.vueTsc,
+    ],
+    { cwd: root, encoding: "utf8", env: { ...process.env, GITHUB_SHA: commitSha, ...env } },
+  );
+}
+
+function cleanup(fixture: ReturnType<typeof setup>) {
+  fs.rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+  fs.rmSync(fixture.reportDir, { recursive: true, force: true });
+  fs.rmSync(fixture.fakeDir, { recursive: true, force: true });
+}
+
+test("typecheck divergence report binds baseline evidence to the matrix artifact", () => {
+  const fixture = setup();
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 0, result.stderr);
+    const artifact = JSON.parse(
+      fs.readFileSync(path.join(fixture.reportDir, "fixture-typecheck-divergence.json"), "utf8"),
+    );
+    assert.deepEqual(Object.keys(artifact), [
+      "schema",
+      "version",
+      "project",
+      "revision",
+      "tsconfig",
+      "evidence",
+      "baseline",
+      "budget",
+      "divergence",
+    ]);
+    assert.equal(artifact.schema, "vize.fixtureTypecheckDivergenceRun");
+    assert.equal(artifact.evidence.commitSha, commitSha);
+    assert.equal(artifact.baseline.exitCode, 2);
+    assert.equal(artifact.baseline.version, "3.3.4");
+    assert.ok(artifact.baseline.durationMs >= 0);
+    assert.match(artifact.baseline.stdoutSha256, /^[0-9a-f]{64}$/);
+    assert.match(artifact.baseline.stderrSha256, /^[0-9a-f]{64}$/);
+    assert.deepEqual(artifact.budget, {
+      maxFalsePositiveRatio: 0.05,
+      maxFalseNegativeRatio: 0.05,
+      falsePositivePassed: true,
+      falseNegativePassed: true,
+      passed: true,
+    });
+    assert.equal(artifact.divergence.summary.sharedCount, 1);
+    assert.equal(artifact.divergence.summary.falsePositiveCount, 0);
+    assert.equal(artifact.divergence.summary.falseNegativeCount, 0);
+    const markdown = fs.readFileSync(
+      path.join(fixture.reportDir, "fixture-typecheck-divergence.md"),
+      "utf8",
+    );
+    assert.match(markdown, /Budget passed: true/);
+    assert.match(markdown, new RegExp(`Digest: ${artifact.divergence.sha256}`));
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("typecheck divergence report records an unconfigured false-negative budget", () => {
+  const fixture = setup();
+  try {
+    const registry = JSON.parse(fs.readFileSync(fixture.registryPath, "utf8"));
+    delete registry.projects[0].typecheckPerformance.maxFalseNegativeRatio;
+    fs.writeFileSync(fixture.registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+    const result = run(fixture);
+    assert.equal(result.status, 0, result.stderr);
+    const artifact = JSON.parse(
+      fs.readFileSync(path.join(fixture.reportDir, "fixture-typecheck-divergence.json"), "utf8"),
+    );
+    assert.equal(artifact.budget.maxFalseNegativeRatio, null);
+    assert.equal(artifact.budget.falseNegativePassed, null);
+    assert.equal(artifact.budget.passed, null);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("typecheck divergence report fails closed on mismatched matrix artifacts", () => {
+  const fixture = setup();
+  try {
+    const payloadPath = path.join(fixture.reportDir, "fixture-typechecker.json");
+    const payload = JSON.parse(fs.readFileSync(payloadPath, "utf8"));
+    payload.project = "wrong-project";
+    fs.writeFileSync(payloadPath, `${JSON.stringify(payload, null, 2)}\n`);
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /artifact identity is invalid/);
+    assert.equal(
+      fs.existsSync(path.join(fixture.reportDir, "fixture-typecheck-divergence.json")),
+      false,
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("typecheck divergence report rejects evidence from another commit", () => {
+  const fixture = setup();
+  try {
+    const result = run(fixture, { GITHUB_SHA: "c".repeat(40) });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /commit does not match GITHUB_SHA/);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("typecheck divergence report rejects parsed output that differs from stdout", () => {
+  const fixture = setup();
+  try {
+    const payloadPath = path.join(fixture.reportDir, "fixture-typechecker.json");
+    const payload = JSON.parse(fs.readFileSync(payloadPath, "utf8"));
+    payload.parsed.errorCount = 2;
+    fs.writeFileSync(payloadPath, `${JSON.stringify(payload, null, 2)}\n`);
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /stdout does not match parsed output/);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("typecheck divergence report rejects a mismatched matrix file count", () => {
+  const fixture = setup();
+  try {
+    const summaryPath = path.join(fixture.reportDir, "summary.json");
+    const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+    summary.projects[0].runs[0].fileCount = 2;
+    fs.writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /file count is inconsistent/);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("typecheck divergence report rejects invalid performance budgets", () => {
+  for (const [field, value, message] of [
+    ["hangTimeoutMs", 0, /hangTimeoutMs must be a positive safe integer/],
+    ["maxFalsePositiveRatio", Number.NaN, /maxFalsePositiveRatio must be a finite number/],
+    ["maxFalseNegativeRatio", 1.1, /maxFalseNegativeRatio must be a finite number/],
+  ] as const) {
+    const fixture = setup();
+    try {
+      const registry = JSON.parse(fs.readFileSync(fixture.registryPath, "utf8"));
+      registry.projects[0].typecheckPerformance[field] = value;
+      fs.writeFileSync(fixture.registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+      const result = run(fixture);
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, message);
+    } finally {
+      cleanup(fixture);
+    }
+  }
+});
+
+test("typecheck divergence report rejects unsupported baseline exits and output", () => {
+  for (const [body, message] of [
+    ["process.exit(1);", /unsupported status 1/],
+    ['process.stderr.write("error TS5058: missing config\\n"); process.exit(2);', /unparseable/],
+  ] as const) {
+    const fixture = setup();
+    try {
+      writeVueTsc(fixture.vueTsc, body);
+      const result = run(fixture);
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, message);
+    } finally {
+      cleanup(fixture);
+    }
+  }
+});
+
+test("typecheck divergence report requires one performance project per shard", () => {
+  const fixture = setup();
+  try {
+    fs.writeFileSync(fixture.registryPath, '{"projects":[]}\n');
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Expected exactly one.*found 0/);
+  } finally {
+    cleanup(fixture);
+  }
+});

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { validateTypecheckerOutput } from "./tool-matrix-typechecker.mjs";
+import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
+import { compareTypecheckDiagnostics } from "./typecheck-divergence.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..");
+const defaultRegistry = join(repoRoot, "tests", "_fixtures", "vue-ecosystem-fixtures.json");
+
+export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const registry = readJson(args.registry);
+  const selected = registry.projects
+    .filter((_, index) => index % args.shardCount === args.shardIndex)
+    .filter((project) => project.typecheckPerformance?.enabled === true);
+  if (selected.length !== 1) {
+    throw new Error(
+      `Expected exactly one typecheck performance project in shard ${args.shardIndex}/${args.shardCount}, found ${selected.length}`,
+    );
+  }
+
+  const project = selected[0];
+  validatePerformanceConfig(project.typecheckPerformance);
+  const fixtureRoot = resolve(repoRoot, project.fixturePath);
+  validateTypecheckPerformanceTarget(project, fixtureRoot);
+  const summary = readAndValidateSummary(args.reportDir, project);
+  const vizeRun = readAndValidateVizeRun(args.reportDir, project, summary);
+  const vueTsc = resolveVueTsc(args.vueTscBin);
+  const baselineArgs = ["--noEmit", "--pretty", "false", "-p", project.tsconfig];
+  const startedAt = Date.now();
+  const baseline = spawnSync(vueTsc.path, baselineArgs, {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    env: { ...process.env, LANG: "C", LC_ALL: "C" },
+    maxBuffer: 1024 * 1024 * 1024,
+    timeout: project.typecheckPerformance.hangTimeoutMs,
+  });
+  const durationMs = Date.now() - startedAt;
+  if (baseline.error != null)
+    throw new Error(`vue-tsc failed to run: ${errorMessage(baseline.error)}`);
+  if (baseline.status !== 0 && baseline.status !== 2) {
+    throw new Error(`vue-tsc exited with unsupported status ${baseline.status}`);
+  }
+
+  const divergence = compareTypecheckDiagnostics({
+    projectId: project.id,
+    cwd: fixtureRoot,
+    vizeReport: vizeRun.parsed,
+    vueTscOutput: `${baseline.stdout ?? ""}\n${baseline.stderr ?? ""}`,
+  });
+  const budget = evaluateBudget(project.typecheckPerformance, divergence.summary);
+  const artifact = {
+    schema: "vize.fixtureTypecheckDivergenceRun",
+    version: 1,
+    project: project.id,
+    revision: project.revision,
+    tsconfig: project.tsconfig,
+    evidence: summary.evidence,
+    baseline: {
+      command: displayCommand(vueTsc.path, baselineArgs),
+      version: vueTsc.version,
+      durationMs,
+      exitCode: baseline.status,
+      stdoutSha256: sha256(baseline.stdout ?? ""),
+      stderrSha256: sha256(baseline.stderr ?? ""),
+    },
+    budget,
+    divergence,
+  };
+  const jsonPath = join(args.reportDir, `${project.id}-typecheck-divergence.json`);
+  const markdownPath = join(args.reportDir, `${project.id}-typecheck-divergence.md`);
+  writeFileSync(jsonPath, `${JSON.stringify(artifact, null, 2)}\n`);
+  writeFileSync(markdownPath, renderMarkdown(artifact));
+  process.stdout.write(`Wrote ${relative(repoRoot, jsonPath)}\n`);
+  process.stdout.write(`Wrote ${relative(repoRoot, markdownPath)}\n`);
+  return artifact;
+}
+
+function readAndValidateSummary(reportDir, project) {
+  const summary = readJson(join(reportDir, "summary.json"));
+  if (summary.schema !== "vize.fixtureToolMatrixReport" || summary.version !== 2) {
+    throw new Error("Fixture matrix summary schema is unsupported");
+  }
+  if (!/^[0-9a-f]{40}$/.test(summary.evidence?.commitSha ?? "")) {
+    throw new Error("Fixture matrix summary is missing exact commit evidence");
+  }
+  if (process.env.GITHUB_SHA != null && summary.evidence.commitSha !== process.env.GITHUB_SHA) {
+    throw new Error("Fixture matrix summary commit does not match GITHUB_SHA");
+  }
+  const projectSummary = summary.projects?.filter((entry) => entry.id === project.id) ?? [];
+  if (projectSummary.length !== 1 || projectSummary[0].revision !== project.revision) {
+    throw new Error(`Fixture matrix summary does not contain pinned project ${project.id}`);
+  }
+  return summary;
+}
+
+function readAndValidateVizeRun(reportDir, project, summary) {
+  const projectSummary = summary.projects.find((entry) => entry.id === project.id);
+  const runs = projectSummary.runs.filter((run) => run.tool === "typechecker");
+  if (runs.length !== 1 || !["ok", "findings"].includes(runs[0].status)) {
+    throw new Error(`Fixture matrix summary has no successful typechecker run for ${project.id}`);
+  }
+  const expectedName = `${project.id}-typechecker.json`;
+  if (basename(runs[0].outputPath ?? "") !== expectedName) {
+    throw new Error(`Fixture matrix typechecker output path is invalid for ${project.id}`);
+  }
+  const payload = readJson(join(reportDir, expectedName));
+  const expectedKeys = [
+    "exitCode",
+    "parsed",
+    "project",
+    "schema",
+    "stderr",
+    "stdout",
+    "tool",
+    "version",
+  ];
+  if (JSON.stringify(Object.keys(payload).sort()) !== JSON.stringify(expectedKeys)) {
+    throw new Error(`Fixture matrix typechecker artifact keys are invalid for ${project.id}`);
+  }
+  if (
+    payload.schema !== "vize.fixtureToolRun" ||
+    payload.version !== 1 ||
+    payload.project !== project.id ||
+    payload.tool !== "typechecker" ||
+    payload.exitCode !== runs[0].exitCode
+  ) {
+    throw new Error(`Fixture matrix typechecker artifact identity is invalid for ${project.id}`);
+  }
+  let stdout;
+  try {
+    stdout = JSON.parse(payload.stdout);
+  } catch {
+    throw new Error(`Fixture matrix typechecker stdout is not JSON for ${project.id}`);
+  }
+  if (canonicalJson(stdout) !== canonicalJson(payload.parsed)) {
+    throw new Error(
+      `Fixture matrix typechecker stdout does not match parsed output for ${project.id}`,
+    );
+  }
+  validateTypecheckerOutput(project, payload.parsed, payload.exitCode);
+  if (runs[0].fileCount !== payload.parsed.fileCount) {
+    throw new Error(`Fixture matrix typechecker file count is inconsistent for ${project.id}`);
+  }
+  return payload;
+}
+
+function validatePerformanceConfig(performance) {
+  if (!Number.isSafeInteger(performance.hangTimeoutMs) || performance.hangTimeoutMs <= 0) {
+    throw new Error("typecheckPerformance.hangTimeoutMs must be a positive safe integer");
+  }
+  ratio(performance.maxFalsePositiveRatio, "maxFalsePositiveRatio");
+  if (performance.maxFalseNegativeRatio != null) {
+    ratio(performance.maxFalseNegativeRatio, "maxFalseNegativeRatio");
+  }
+}
+
+function evaluateBudget(performance, summary) {
+  const falseNegativeLimit = performance.maxFalseNegativeRatio ?? null;
+  const falsePositivePassed = summary.falsePositiveRatio <= performance.maxFalsePositiveRatio;
+  const falseNegativePassed =
+    falseNegativeLimit == null ? null : summary.falseNegativeRatio <= falseNegativeLimit;
+  return {
+    maxFalsePositiveRatio: performance.maxFalsePositiveRatio,
+    maxFalseNegativeRatio: falseNegativeLimit,
+    falsePositivePassed,
+    falseNegativePassed,
+    passed: falseNegativePassed == null ? null : falsePositivePassed && falseNegativePassed,
+  };
+}
+
+function renderMarkdown(artifact) {
+  const summary = artifact.divergence.summary;
+  return [
+    `## ${artifact.project} typecheck divergence`,
+    "",
+    `Commit: ${artifact.evidence.commitSha}`,
+    `Vize diagnostics: ${summary.vizeDiagnosticCount}`,
+    `vue-tsc diagnostics: ${summary.baselineDiagnosticCount}`,
+    `Shared: ${summary.sharedCount}`,
+    `False positives: ${summary.falsePositiveCount} (${summary.falsePositiveRatio})`,
+    `False negatives: ${summary.falseNegativeCount} (${summary.falseNegativeRatio})`,
+    `Budget passed: ${artifact.budget.passed ?? "not configured"}`,
+    `Digest: ${artifact.divergence.sha256}`,
+    "",
+  ].join("\n");
+}
+
+function resolveVueTsc(value) {
+  const candidate = isAbsolute(value) ? value : resolve(repoRoot, value);
+  const probe = spawnSync(candidate, ["--version"], { encoding: "utf8", timeout: 10_000 });
+  const version = (probe.stdout ?? "").trim();
+  if (probe.error != null || probe.status !== 0 || version === "")
+    throw new Error(`vue-tsc is not runnable: ${value}`);
+  return { path: candidate, version };
+}
+
+function parseArgs(argv) {
+  const args = {
+    registry: defaultRegistry,
+    reportDir: null,
+    shardCount: 1,
+    shardIndex: 0,
+    vueTscBin: null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = () => {
+      if (argv[index + 1] == null) throw new Error(`${arg} requires a value`);
+      return argv[++index];
+    };
+    if (arg === "--registry") args.registry = resolve(repoRoot, value());
+    else if (arg === "--report-dir") args.reportDir = resolve(repoRoot, value());
+    else if (arg === "--shard-count") args.shardCount = integer(value(), arg, 1);
+    else if (arg === "--shard-index") args.shardIndex = integer(value(), arg, 0);
+    else if (arg === "--vue-tsc-bin") args.vueTscBin = value();
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (args.reportDir == null) throw new Error("--report-dir is required");
+  if (args.vueTscBin == null) throw new Error("--vue-tsc-bin is required");
+  if (args.shardIndex >= args.shardCount) {
+    throw new Error("--shard-index must be less than --shard-count");
+  }
+  return args;
+}
+
+function integer(value, name, minimum) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < minimum) {
+    throw new Error(`${name} must be an integer >= ${minimum}`);
+  }
+  return parsed;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value != null && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function ratio(value, name) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 1) {
+    throw new Error(`typecheckPerformance.${name} must be a finite number between 0 and 1`);
+  }
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function displayCommand(command, args) {
+  return [command, ...args].join(" ");
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+const entrypoint = process.argv[1]
+  ? fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  : false;
+if (entrypoint) {
+  try {
+    runTypecheckDivergenceReport();
+  } catch (error) {
+    process.stderr.write(`${errorMessage(error)}\n`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- run the configured vue-tsc baseline against the exact fixture target
- bind divergence output to the matrix commit, project revision, raw typechecker payload, checked-file count, and baseline version
- record deterministic JSON and Markdown evidence plus explicit false-positive/false-negative budget states
- reject stale, malformed, inconsistent, or incomplete inputs before writing evidence

## Tests
- 29 focused tooling tests
- oxfmt and oxlint with warnings denied
- diff and 350-line source guards

Advances #2971

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typecheck divergence reporting for pinned fixture projects.
  * Reports now include JSON and Markdown summaries comparing typechecker diagnostics.
  * Added configurable performance and diagnostic budgets with pass/fail results.
  * Added validation for report inputs, artifact consistency, tool availability, and shard configuration.

* **Tests**
  * Added comprehensive coverage for valid reports, mismatched artifacts, unsupported results, invalid budgets, and configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->