### PR TITLE
test(typecheck): require divergence budgets

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -28,7 +28,8 @@
         "enabled": true,
         "compareTo": "vue-tsc",
         "hangTimeoutMs": 300000,
-        "maxFalsePositiveRatio": 0.05
+        "maxFalsePositiveRatio": 0.05,
+        "maxFalseNegativeRatio": 0.05
       }
     },
     {
@@ -57,7 +58,8 @@
         "enabled": true,
         "compareTo": "vue-tsc",
         "hangTimeoutMs": 300000,
-        "maxFalsePositiveRatio": 0.05
+        "maxFalsePositiveRatio": 0.05,
+        "maxFalseNegativeRatio": 0.05
       }
     },
     {
@@ -86,7 +88,8 @@
         "enabled": true,
         "compareTo": "vue-tsc",
         "hangTimeoutMs": 300000,
-        "maxFalsePositiveRatio": 0.05
+        "maxFalsePositiveRatio": 0.05,
+        "maxFalseNegativeRatio": 0.05
       }
     },
     {
@@ -115,7 +118,8 @@
         "enabled": true,
         "compareTo": "vue-tsc",
         "hangTimeoutMs": 300000,
-        "maxFalsePositiveRatio": 0.05
+        "maxFalsePositiveRatio": 0.05,
+        "maxFalseNegativeRatio": 0.05
       }
     },
     {
@@ -144,7 +148,8 @@
         "enabled": true,
         "compareTo": "vue-tsc",
         "hangTimeoutMs": 300000,
-        "maxFalsePositiveRatio": 0.05
+        "maxFalsePositiveRatio": 0.05,
+        "maxFalseNegativeRatio": 0.05
       }
     },
     {
@@ -179,7 +184,8 @@
         "enabled": true,
         "compareTo": "vue-tsc",
         "hangTimeoutMs": 300000,
-        "maxFalsePositiveRatio": 0.05
+        "maxFalsePositiveRatio": 0.05,
+        "maxFalseNegativeRatio": 0.05
       }
     },
     {
@@ -208,7 +214,8 @@
         "enabled": true,
         "compareTo": "vue-tsc",
         "hangTimeoutMs": 300000,
-        "maxFalsePositiveRatio": 0.05
+        "maxFalsePositiveRatio": 0.05,
+        "maxFalseNegativeRatio": 0.05
       }
     },
     {
@@ -237,21 +244,9 @@
         "enabled": true,
         "compareTo": "vue-tsc",
         "hangTimeoutMs": 300000,
-        "maxFalsePositiveRatio": 0.05
+        "maxFalsePositiveRatio": 0.05,
+        "maxFalseNegativeRatio": 0.05
       }
-    },
-    {
-      "id": "directus",
-      "displayName": "Directus",
-      "kind": "application",
-      "fixturePath": "tests/_fixtures/_git/directus",
-      "repository": "https://github.com/directus/directus",
-      "revision": "e0444f46909d530c4af243313a5320571992a30c",
-      "license": { "spdx": "LicenseRef-MSCL-1.0-GPL", "files": ["license", "app/license"] },
-      "vueGlobs": ["app/src/**/*.vue"],
-      "tsconfig": "app/tsconfig.json",
-      "coverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
-      "diff": "e2e-vrt"
     },
     {
       "id": "voicevox",
@@ -280,6 +275,7 @@
         "compareTo": "vue-tsc",
         "hangTimeoutMs": 300000,
         "maxFalsePositiveRatio": 0.02,
+        "maxFalseNegativeRatio": 0.02,
         "largeProjectRegressionTarget": true
       }
     },
@@ -310,6 +306,7 @@
         "compareTo": "vue-tsc",
         "hangTimeoutMs": 300000,
         "maxFalsePositiveRatio": 0.02,
+        "maxFalseNegativeRatio": 0.02,
         "largeProjectRegressionTarget": true
       }
     },
@@ -340,8 +337,22 @@
         "compareTo": "vue-tsc",
         "hangTimeoutMs": 300000,
         "maxFalsePositiveRatio": 0.02,
+        "maxFalseNegativeRatio": 0.02,
         "largeProjectRegressionTarget": true
       }
+    },
+    {
+      "id": "directus",
+      "displayName": "Directus",
+      "kind": "application",
+      "fixturePath": "tests/_fixtures/_git/directus",
+      "repository": "https://github.com/directus/directus",
+      "revision": "e0444f46909d530c4af243313a5320571992a30c",
+      "license": { "spdx": "LicenseRef-MSCL-1.0-GPL", "files": ["license", "app/license"] },
+      "vueGlobs": ["app/src/**/*.vue"],
+      "tsconfig": "app/tsconfig.json",
+      "coverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
+      "diff": "e2e-vrt"
     },
     {
       "id": "motion-vue",

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -196,18 +196,15 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
   }
 });
 
-test("typecheck divergence report records an unconfigured false-negative budget", () => {
+test("typecheck divergence report requires a false-negative budget", () => {
   const fixture = setup();
   try {
     const registry = readJson(fixture.registryPath);
     delete registry.projects[0].typecheckPerformance.maxFalseNegativeRatio;
     writeJson(fixture.registryPath, registry);
     const result = run(fixture);
-    assert.equal(result.status, 0, result.stderr);
-    const artifact = readJson(path.join(fixture.reportDir, "fixture-typecheck-divergence.json"));
-    assert.equal(artifact.budget.maxFalseNegativeRatio, null);
-    assert.equal(artifact.budget.falseNegativePassed, null);
-    assert.equal(artifact.budget.passed, null);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /maxFalseNegativeRatio must be a finite number/);
   } finally {
     cleanup(fixture);
   }

--- a/tests/tooling/vue-ecosystem-fixtures.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures.test.ts
@@ -32,6 +32,7 @@ interface FixtureProject {
     compareTo: string;
     hangTimeoutMs: number;
     maxFalsePositiveRatio: number;
+    maxFalseNegativeRatio: number;
     largeProjectRegressionTarget?: boolean;
   };
 }
@@ -295,6 +296,30 @@ test("Directus fixture is wired into Vize-wide check and lint lanes", () => {
   assert.match(pkg.scripts["test:lint"], /snapshots\/lint\/directus\.ts/);
 });
 
+test("typecheck baselines have complete budgets and one target per matrix shard", () => {
+  const registry = readRegistry();
+  const shardCounts = Array.from({ length: 11 }, () => 0);
+  const targets = registry.projects.filter((project, index) => {
+    if (project.typecheckPerformance?.enabled !== true) return false;
+    shardCounts[index % shardCounts.length] += 1;
+    return true;
+  });
+
+  assert.equal(targets.length, shardCounts.length);
+  assert.deepEqual(
+    shardCounts,
+    Array.from({ length: 11 }, () => 1),
+  );
+  for (const project of targets) {
+    const performance = project.typecheckPerformance!;
+    assert.equal(performance.compareTo, "vue-tsc", `${project.id} baseline`);
+    assert.ok(Number.isSafeInteger(performance.hangTimeoutMs));
+    assert.ok(performance.hangTimeoutMs > 0 && performance.hangTimeoutMs <= 300_000);
+    assert.ok(performance.maxFalsePositiveRatio >= 0 && performance.maxFalsePositiveRatio <= 1);
+    assert.equal(performance.maxFalseNegativeRatio, performance.maxFalsePositiveRatio);
+  }
+});
+
 test("large typechecker fixtures have performance safeguards and bench wiring", () => {
   const registry = readRegistry();
   const benchCheck = fs.readFileSync(path.join(root, "bench", "check.ts"), "utf8");
@@ -306,6 +331,7 @@ test("large typechecker fixtures have performance safeguards and bench wiring", 
     assert.equal(project?.typecheckPerformance?.largeProjectRegressionTarget, true);
     assert.ok((project?.typecheckPerformance?.hangTimeoutMs ?? Infinity) <= 300_000);
     assert.ok((project?.typecheckPerformance?.maxFalsePositiveRatio ?? Infinity) <= 0.02);
+    assert.ok((project?.typecheckPerformance?.maxFalseNegativeRatio ?? Infinity) <= 0.02);
     assert.match(benchCheck, new RegExp(`name:\\s*"${id}"`), `${id} should be in bench/check.ts`);
   }
 });

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -176,22 +176,19 @@ function validatePerformanceConfig(performance) {
     throw new Error("typecheckPerformance.hangTimeoutMs must be a positive safe integer");
   }
   ratio(performance.maxFalsePositiveRatio, "maxFalsePositiveRatio");
-  if (performance.maxFalseNegativeRatio != null) {
-    ratio(performance.maxFalseNegativeRatio, "maxFalseNegativeRatio");
-  }
+  ratio(performance.maxFalseNegativeRatio, "maxFalseNegativeRatio");
 }
 
 function evaluateBudget(performance, summary) {
-  const falseNegativeLimit = performance.maxFalseNegativeRatio ?? null;
+  const falseNegativeLimit = performance.maxFalseNegativeRatio;
   const falsePositivePassed = summary.falsePositiveRatio <= performance.maxFalsePositiveRatio;
-  const falseNegativePassed =
-    falseNegativeLimit == null ? null : summary.falseNegativeRatio <= falseNegativeLimit;
+  const falseNegativePassed = summary.falseNegativeRatio <= falseNegativeLimit;
   return {
     maxFalsePositiveRatio: performance.maxFalsePositiveRatio,
     maxFalseNegativeRatio: falseNegativeLimit,
     falsePositivePassed,
     falseNegativePassed,
-    passed: falseNegativePassed == null ? null : falsePositivePassed && falseNegativePassed,
+    passed: falsePositivePassed && falseNegativePassed,
   };
 }
 


### PR DESCRIPTION
## Summary
- require both false-positive and false-negative ratios for every configured baseline
- keep all 11 existing performance targets while placing exactly one in each matrix shard
- fail closed when a false-negative budget is absent
- enforce complete, bounded, matched budgets and shard coverage in registry tests

## Tests
- 41 focused fixture, matrix, and divergence tests
- JSON parse validation
- oxfmt and oxlint with warnings denied
- diff and 350-line source guards

Advances #2971

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->