### PR TITLE
test(typecheck): record matrix divergence

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -90,6 +90,14 @@ jobs:
             --timeout-ms 600000 \
             --output-dir "$FIXTURE_REPORT_DIR"
 
+      - name: Record typechecker baseline divergence
+        run: |
+          node tools/fixtures/typecheck-divergence-report.mjs \
+            --report-dir "$FIXTURE_REPORT_DIR" \
+            --shard-index "$FIXTURE_SHARD_INDEX" \
+            --shard-count "$FIXTURE_SHARD_COUNT" \
+            --vue-tsc-bin tests/node_modules/.bin/vue-tsc
+
       - name: Publish shard summary
         if: ${{ always() }}
         shell: bash
@@ -98,6 +106,15 @@ jobs:
             cat "$FIXTURE_REPORT_DIR/summary.md" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "No fixture tool report was produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          mapfile -t divergence_reports < <(
+            find "$FIXTURE_REPORT_DIR" -maxdepth 1 -type f \
+              -name '*-typecheck-divergence.md' -print | sort
+          )
+          if (( ${#divergence_reports[@]} == 1 )); then
+            cat "${divergence_reports[0]}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No unique typecheck divergence report was produced." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload shard report

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -59,7 +59,11 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   );
   const hydration = steps.find((step) => step.name === "Select and hydrate fixture shard");
   const run = steps.find((step) => step.name === "Exercise real projects with every core tool");
+  const runIndex = steps.indexOf(run!);
+  const divergence = steps.find((step) => step.name === "Record typechecker baseline divergence");
+  const divergenceIndex = steps.indexOf(divergence!);
   const summary = steps.find((step) => step.name === "Publish shard summary");
+  const summaryIndex = steps.indexOf(summary!);
   const upload = steps.find((step) => step.name === "Upload shard report");
 
   assert.notEqual(nodeSetupIndex, -1);
@@ -85,8 +89,16 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(run?.run ?? "", /--vize-bin target\/ci\/vize/);
   assert.match(run?.run ?? "", /--timeout-ms 600000/);
   assert.match(run?.run ?? "", /--output-dir "\$FIXTURE_REPORT_DIR"/);
+  assert.ok(runIndex < divergenceIndex && divergenceIndex < summaryIndex);
+  assert.match(divergence?.run ?? "", /tools\/fixtures\/typecheck-divergence-report\.mjs/);
+  assert.match(divergence?.run ?? "", /--report-dir "\$FIXTURE_REPORT_DIR"/);
+  assert.match(divergence?.run ?? "", /--shard-index "\$FIXTURE_SHARD_INDEX"/);
+  assert.match(divergence?.run ?? "", /--shard-count "\$FIXTURE_SHARD_COUNT"/);
+  assert.match(divergence?.run ?? "", /--vue-tsc-bin tests\/node_modules\/\.bin\/vue-tsc/);
   assert.equal(summary?.if, "${{ always() }}");
   assert.match(summary?.run ?? "", /summary\.md/);
+  assert.match(summary?.run ?? "", /\*-typecheck-divergence\.md/);
+  assert.match(summary?.run ?? "", /divergence_reports\[@\]/);
   assert.equal(upload?.if, "${{ always() }}");
   assert.match(upload?.uses ?? "", /^actions\/upload-artifact@[0-9a-f]{40}$/);
   assert.deepEqual(upload?.with, {


### PR DESCRIPTION
## Summary
- run the exact vue-tsc baseline after every real-project core-tool shard
- bind divergence evidence to the shard report and upload it with existing artifacts
- append the unique divergence Markdown report to the Actions step summary
- verify ordering, shard arguments, baseline binary, summary publication, and upload coverage

## Tests
- 40 workflow, release-gate, fixture-registry, and divergence tests
- YAML parse validation
- oxfmt and oxlint with warnings denied
- diff and source-size guards

Budget outcomes are recorded for diagnosis; enforcement follows after measured divergences are corrected.

Advances #2971

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->