### PR TITLE
test(typecheck): prepare pinned dependencies

### DIFF
--- a/tests/tooling/typecheck-dependency-prepare.test.ts
+++ b/tests/tooling/typecheck-dependency-prepare.test.ts
@@ -1,0 +1,299 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const script = path.join(root, "tools", "fixtures", "typecheck-dependency-prepare.mjs");
+const commitSha = "a".repeat(40);
+const packageManagers = [
+  {
+    name: "npm",
+    version: "11.9.0",
+    lockfile: "package-lock.json",
+    lockfileContents: '{"lockfileVersion":3}\n',
+    installArgs: ["ci", "--ignore-scripts", "--prefer-offline", "--no-audit", "--no-fund"],
+  },
+  {
+    name: "pnpm",
+    version: "10.0.0",
+    lockfile: "pnpm-lock.yaml",
+    lockfileContents: "lockfileVersion: '9.0'\n",
+    installArgs: ["install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"],
+  },
+  {
+    name: "yarn",
+    version: "4.9.2",
+    lockfile: "yarn.lock",
+    lockfileContents: "__metadata:\n  version: 8\n",
+    installArgs: ["install", "--immutable", "--mode=skip-build"],
+  },
+] as const;
+
+function setup(packageManager: (typeof packageManagers)[number] = packageManagers[1]) {
+  const fixtureRoot = fs.mkdtempSync(
+    path.join(root, "tests", "_fixtures", "typecheck-dependencies-"),
+  );
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-typecheck-dependencies-out-"));
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-typecheck-dependencies-manager-"));
+  const fixturePath = path.relative(root, fixtureRoot);
+  const project = {
+    id: "fixture",
+    fixturePath,
+    revision: "b".repeat(40),
+    vueGlobs: ["src/**/*.vue"],
+    tsconfig: "tsconfig.json",
+    typecheckPerformance: {
+      enabled: true,
+      compareTo: "vue-tsc",
+      packageManager: packageManager.name,
+      packageManagerVersion: packageManager.version,
+      lockfile: packageManager.lockfile,
+      hangTimeoutMs: 5_000,
+      maxFalsePositiveRatio: 0.05,
+      maxFalseNegativeRatio: 0.05,
+    },
+  };
+  fs.mkdirSync(path.join(fixtureRoot, "src"));
+  fs.writeFileSync(path.join(fixtureRoot, "src", "App.vue"), "<template />\n");
+  fs.writeFileSync(path.join(fixtureRoot, "tsconfig.json"), "{}\n");
+  fs.writeFileSync(path.join(fixtureRoot, "package.json"), '{"name":"fixture"}\n');
+  fs.writeFileSync(
+    path.join(fixtureRoot, packageManager.lockfile),
+    packageManager.lockfileContents,
+  );
+  const registryPath = path.join(fixtureRoot, "registry.json");
+  writeJson(registryPath, { projects: [project] });
+  git(fixtureRoot, ["init", "-q"]);
+  git(fixtureRoot, ["add", "."]);
+  git(fixtureRoot, [
+    "-c",
+    "user.name=Fixture",
+    "-c",
+    "user.email=fixture@example.com",
+    "commit",
+    "-qm",
+    "fixture",
+  ]);
+  const invocationPath = path.join(fakeDir, "invocation.json");
+  const manager = path.join(fakeDir, packageManager.name);
+  writeManager(manager, invocationPath, packageManager.version, successBody);
+  return {
+    fixtureRoot,
+    outputDir,
+    fakeDir,
+    registryPath,
+    invocationPath,
+    manager,
+    packageManager,
+    project,
+  };
+}
+
+const successBody = `fs.mkdirSync("node_modules", { recursive: true }); fs.writeFileSync("node_modules/installed", "yes"); process.stdout.write("installed");`;
+
+function writeManager(
+  pathname: string,
+  invocationPath: string,
+  version: string,
+  installBody: string,
+) {
+  fs.writeFileSync(
+    pathname,
+    `#!/usr/bin/env node\nimport fs from "node:fs";\nif (process.argv.includes("--version")) { console.log(${JSON.stringify(version)}); process.exit(0); }\nfs.writeFileSync(${JSON.stringify(invocationPath)}, JSON.stringify({ cwd: process.cwd(), args: process.argv.slice(2), env: { CI: process.env.CI, npm: process.env.npm_config_ignore_scripts, yarn: process.env.YARN_ENABLE_SCRIPTS } }));\n${installBody}\n`,
+  );
+  fs.chmodSync(pathname, 0o755);
+}
+
+function run(fixture: ReturnType<typeof setup>, extraArgs: string[] = []) {
+  return spawnSync(
+    process.execPath,
+    [script, "--registry", fixture.registryPath, "--output-dir", fixture.outputDir, ...extraArgs],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_SHA: commitSha,
+        PATH: `${fixture.fakeDir}${path.delimiter}${process.env.PATH}`,
+      },
+    },
+  );
+}
+
+function git(cwd: string, args: string[]) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function artifactPath(fixture: ReturnType<typeof setup>) {
+  return path.join(fixture.outputDir, "fixture-typecheck-dependencies.json");
+}
+
+function writeJson(pathname: string, value: unknown) {
+  fs.writeFileSync(pathname, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function cleanup(fixture: ReturnType<typeof setup>) {
+  fs.rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+  fs.rmSync(fixture.outputDir, { recursive: true, force: true });
+  fs.rmSync(fixture.fakeDir, { recursive: true, force: true });
+}
+
+test("dependency prepare uses each pinned manager's immutable install command", () => {
+  for (const packageManager of packageManagers) {
+    const fixture = setup(packageManager);
+    try {
+      const lockfile = fs.readFileSync(path.join(fixture.fixtureRoot, packageManager.lockfile));
+      const result = run(fixture);
+      assert.equal(result.status, 0, result.stderr);
+      const artifact = JSON.parse(fs.readFileSync(artifactPath(fixture), "utf8"));
+      assert.deepEqual(Object.keys(artifact).sort(), [
+        "evidence",
+        "install",
+        "lockfile",
+        "packageManager",
+        "project",
+        "revision",
+        "schema",
+        "version",
+      ]);
+      assert.equal(artifact.schema, "vize.fixtureTypecheckDependencyInstall");
+      assert.equal(artifact.evidence.commitSha, commitSha);
+      assert.deepEqual(artifact.packageManager, {
+        name: packageManager.name,
+        version: packageManager.version,
+      });
+      assert.deepEqual(artifact.lockfile, {
+        path: packageManager.lockfile,
+        sizeBytes: lockfile.byteLength,
+        sha256: createHash("sha256").update(lockfile).digest("hex"),
+      });
+      assert.deepEqual(artifact.install.command, [
+        packageManager.name,
+        ...packageManager.installArgs,
+      ]);
+      assert.equal(artifact.install.exitCode, 0);
+      assert.match(artifact.install.stdoutSha256, /^[0-9a-f]{64}$/);
+      assert.match(artifact.install.stderrSha256, /^[0-9a-f]{64}$/);
+      assert.deepEqual(JSON.parse(fs.readFileSync(fixture.invocationPath, "utf8")), {
+        cwd: fixture.fixtureRoot,
+        args: packageManager.installArgs,
+        env: { CI: "true", npm: "true", yarn: "false" },
+      });
+    } finally {
+      cleanup(fixture);
+    }
+  }
+});
+
+test("dependency prepare rejects a mismatched detected package manager version", () => {
+  const fixture = setup();
+  try {
+    writeManager(fixture.manager, fixture.invocationPath, "9.0.0", successBody);
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Detected pnpm version 9.0.0 does not match 10.0.0/);
+    assert.equal(fs.existsSync(fixture.invocationPath), false);
+    assert.equal(fs.existsSync(artifactPath(fixture)), false);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("dependency prepare rejects an unavailable pinned package manager", () => {
+  const fixture = setup();
+  try {
+    fs.writeFileSync(fixture.manager, "#!/bin/sh\nexit 12\n");
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /pnpm is not runnable/);
+    assert.equal(fs.existsSync(artifactPath(fixture)), false);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("dependency prepare rejects lockfile and tracked-source mutations", () => {
+  for (const [body, message] of [
+    [`fs.appendFileSync("pnpm-lock.yaml", "changed");`, /modified frozen lockfile/],
+    [`fs.appendFileSync("package.json", " ");`, /tracked source changed/],
+  ] as const) {
+    const fixture = setup();
+    try {
+      writeManager(fixture.manager, fixture.invocationPath, "10.0.0", body);
+      const result = run(fixture);
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, message);
+      assert.equal(fs.existsSync(artifactPath(fixture)), false);
+    } finally {
+      cleanup(fixture);
+    }
+  }
+});
+
+test("dependency prepare rejects pre-existing tracked-source changes", () => {
+  const fixture = setup();
+  try {
+    fs.appendFileSync(path.join(fixture.fixtureRoot, "package.json"), " ");
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /tracked source changed before dependency installation/);
+    assert.equal(fs.existsSync(fixture.invocationPath), false);
+    assert.equal(fs.existsSync(artifactPath(fixture)), false);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("dependency prepare rejects failed and timed-out installs", () => {
+  for (const [body, args, message] of [
+    ["process.exit(9);", [], /exited with status 9/],
+    [
+      "Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);",
+      ["--timeout-ms", "50"],
+      /failed to run/,
+    ],
+  ] as const) {
+    const fixture = setup();
+    try {
+      writeManager(fixture.manager, fixture.invocationPath, "10.0.0", body);
+      const result = run(fixture, [...args]);
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, message);
+      assert.equal(fs.existsSync(artifactPath(fixture)), false);
+    } finally {
+      cleanup(fixture);
+    }
+  }
+});
+
+test("dependency prepare requires one performance project and exact SHA evidence", () => {
+  const fixture = setup();
+  try {
+    writeJson(fixture.registryPath, { projects: [] });
+    const missing = run(fixture);
+    assert.equal(missing.status, 1);
+    assert.match(missing.stderr, /Expected exactly one.*found 0/);
+    writeJson(fixture.registryPath, {
+      projects: [fixture.project, { ...fixture.project, id: "duplicate" }],
+    });
+    const duplicate = run(fixture);
+    assert.equal(duplicate.status, 1);
+    assert.match(duplicate.stderr, /Expected exactly one.*found 2/);
+    writeJson(fixture.registryPath, { projects: [fixture.project] });
+    const malformedSha = spawnSync(
+      process.execPath,
+      [script, "--registry", fixture.registryPath, "--output-dir", fixture.outputDir],
+      { cwd: root, encoding: "utf8", env: { ...process.env, GITHUB_SHA: "main" } },
+    );
+    assert.equal(malformedSha.status, 1);
+    assert.match(malformedSha.stderr, /GITHUB_SHA must be a full lowercase commit SHA/);
+  } finally {
+    cleanup(fixture);
+  }
+});

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..");
+const defaultRegistry = join(repoRoot, "tests", "_fixtures", "vue-ecosystem-fixtures.json");
+
+export function runTypecheckDependencyPrepare(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const registry = readJson(args.registry);
+  const selected = registry.projects
+    .filter((_, index) => index % args.shardCount === args.shardIndex)
+    .filter((project) => project.typecheckPerformance?.enabled === true);
+  if (selected.length !== 1) {
+    throw new Error(
+      `Expected exactly one typecheck performance project in shard ${args.shardIndex}/${args.shardCount}, found ${selected.length}`,
+    );
+  }
+
+  const project = selected[0];
+  const fixtureRoot = resolve(repoRoot, project.fixturePath);
+  validateTypecheckPerformanceTarget(project, fixtureRoot);
+  requireDirectory(args.outputDir);
+  const commitSha = requireCommitSha(process.env.GITHUB_SHA);
+  const performance = project.typecheckPerformance;
+  const lockfilePath = resolve(fixtureRoot, performance.lockfile);
+  const lockfileBefore = readFileSync(lockfilePath);
+  requireCleanFixture(fixtureRoot, "before dependency installation");
+
+  const manager = performance.packageManager;
+  const probe = spawnSync(manager, ["--version"], {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  if (probe.error != null || probe.status !== 0) {
+    throw new Error(`${manager} is not runnable: ${errorMessage(probe.error ?? probe.status)}`);
+  }
+  const detectedVersion = (probe.stdout ?? "").trim();
+  if (detectedVersion !== performance.packageManagerVersion) {
+    throw new Error(
+      `Detected ${manager} version ${detectedVersion} does not match ${performance.packageManagerVersion}`,
+    );
+  }
+
+  const installArgs = installArguments(manager);
+  const startedAt = Date.now();
+  const install = spawnSync(manager, installArgs, {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CI: "true",
+      npm_config_ignore_scripts: "true",
+      YARN_ENABLE_SCRIPTS: "false",
+    },
+    maxBuffer: 1024 * 1024 * 1024,
+    timeout: args.timeoutMs,
+  });
+  const durationMs = Date.now() - startedAt;
+  if (install.error != null) {
+    throw new Error(`${manager} install failed to run: ${errorMessage(install.error)}`);
+  }
+  if (install.status !== 0) {
+    throw new Error(`${manager} install exited with status ${install.status}`);
+  }
+
+  const lockfileAfter = readFileSync(lockfilePath);
+  if (!lockfileBefore.equals(lockfileAfter)) {
+    throw new Error(`${manager} install modified frozen lockfile ${performance.lockfile}`);
+  }
+  requireCleanFixture(fixtureRoot, "after dependency installation");
+  const artifact = {
+    schema: "vize.fixtureTypecheckDependencyInstall",
+    version: 1,
+    project: project.id,
+    revision: project.revision,
+    evidence: {
+      commitSha,
+      runtime: { name: "node", version: process.versions.node },
+    },
+    packageManager: { name: manager, version: detectedVersion },
+    lockfile: {
+      path: performance.lockfile,
+      sizeBytes: lockfileAfter.byteLength,
+      sha256: sha256(lockfileAfter),
+    },
+    install: {
+      command: [manager, ...installArgs],
+      durationMs,
+      exitCode: install.status,
+      stdoutSha256: sha256(install.stdout ?? ""),
+      stderrSha256: sha256(install.stderr ?? ""),
+    },
+  };
+  const artifactPath = join(args.outputDir, `${project.id}-typecheck-dependencies.json`);
+  writeFileSync(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`);
+  process.stdout.write(`Wrote ${relative(repoRoot, artifactPath)}\n`);
+  return artifact;
+}
+
+function installArguments(manager) {
+  return {
+    npm: ["ci", "--ignore-scripts", "--prefer-offline", "--no-audit", "--no-fund"],
+    pnpm: ["install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"],
+    yarn: ["install", "--immutable", "--mode=skip-build"],
+  }[manager];
+}
+
+function requireCleanFixture(fixtureRoot, phase) {
+  const status = spawnSync("git", ["status", "--porcelain=v1", "--untracked-files=no"], {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  if (status.error != null || status.status !== 0) {
+    throw new Error(`Unable to inspect fixture source ${phase}`);
+  }
+  if (status.stdout !== "") throw new Error(`Fixture tracked source changed ${phase}`);
+}
+
+function parseArgs(argv) {
+  const args = {
+    outputDir: null,
+    registry: defaultRegistry,
+    shardCount: 1,
+    shardIndex: 0,
+    timeoutMs: 600_000,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = () => {
+      if (argv[index + 1] == null) throw new Error(`${arg} requires a value`);
+      return argv[++index];
+    };
+    if (arg === "--output-dir") args.outputDir = resolve(repoRoot, value());
+    else if (arg === "--registry") args.registry = resolve(repoRoot, value());
+    else if (arg === "--shard-count") args.shardCount = integer(value(), arg, 1);
+    else if (arg === "--shard-index") args.shardIndex = integer(value(), arg, 0);
+    else if (arg === "--timeout-ms") args.timeoutMs = integer(value(), arg, 1);
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (args.outputDir == null) throw new Error("--output-dir is required");
+  if (args.shardIndex >= args.shardCount) {
+    throw new Error("--shard-index must be less than --shard-count");
+  }
+  return args;
+}
+
+function requireDirectory(path) {
+  let metadata;
+  try {
+    metadata = statSync(path);
+  } catch {
+    throw new Error(`Output directory does not exist: ${path}`);
+  }
+  if (!metadata.isDirectory()) throw new Error(`Output path is not a directory: ${path}`);
+}
+
+function requireCommitSha(value) {
+  if (!/^[0-9a-f]{40}$/.test(value ?? "")) {
+    throw new Error("GITHUB_SHA must be a full lowercase commit SHA");
+  }
+  return value;
+}
+
+function integer(value, name, minimum) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) {
+    throw new Error(`${name} must be a safe integer >= ${minimum}`);
+  }
+  return parsed;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+const entrypoint = process.argv[1]
+  ? fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  : false;
+if (entrypoint) {
+  try {
+    runTypecheckDependencyPrepare();
+  } catch (error) {
+    process.stderr.write(`${errorMessage(error)}\n`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

- install exactly one typecheck baseline target per shard with its declared package manager and version
- require immutable lockfiles, disabled lifecycle scripts, clean tracked sources, and SHA-bound install evidence
- cover npm, pnpm, and Yarn commands plus version, mutation, failure, timeout, shard, and provenance rejection paths

## Validation

- `node --test tests/tooling/typecheck-dependency-prepare.test.ts tests/tooling/fixture-tool-matrix-typecheck-target.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts tests/tooling/typecheck-divergence-report.test.ts` (29 passed)
- `oxlint tools/fixtures/typecheck-dependency-prepare.mjs tests/tooling/typecheck-dependency-prepare.test.ts`
- real immutable installs: lx-music-desktop (npm 11.9.0), reka-ui (pnpm 10.13.1), vuestic-admin (Yarn 4.9.2)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tooling to prepare dependency installations for type-check performance benchmarking across npm, pnpm, and Yarn.
  - Generates detailed installation artifacts containing project, revision, environment, lockfile, and command execution metadata.
  - Validates package manager versions, frozen lockfiles, registry configuration, and project selection before and after installation.

- **Tests**
  - Added coverage for successful installations and validation failures, including version mismatches, unavailable tools, lockfile changes, failed installs, timeouts, and invalid configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->