### PR TITLE
test(typecheck): clarify workflow assertion

### DIFF
--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -61,7 +61,8 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   const dependency = steps.find(
     (step) => step.name === "Install pinned typecheck baseline dependencies",
   );
-  const dependencyIndex = steps.indexOf(dependency!);
+  assert.ok(dependency, "Missing 'Install pinned typecheck baseline dependencies' step");
+  const dependencyIndex = steps.indexOf(dependency);
   const run = steps.find((step) => step.name === "Exercise real projects with every core tool");
   const runIndex = steps.indexOf(run!);
   const divergence = steps.find((step) => step.name === "Record typechecker baseline divergence");
@@ -90,11 +91,11 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.doesNotMatch(hydration?.run ?? "", /--recursive/);
   assert.match(hydration?.run ?? "", /"\$\{fixture_paths\[@\]\}"/);
   assert.ok(hydrationIndex < dependencyIndex && dependencyIndex < runIndex);
-  assert.match(dependency?.run ?? "", /tools\/fixtures\/typecheck-dependency-prepare\.mjs/);
-  assert.match(dependency?.run ?? "", /--output-dir "\$FIXTURE_REPORT_DIR"/);
-  assert.match(dependency?.run ?? "", /--shard-index "\$FIXTURE_SHARD_INDEX"/);
-  assert.match(dependency?.run ?? "", /--shard-count "\$FIXTURE_SHARD_COUNT"/);
-  assert.match(dependency?.run ?? "", /--timeout-ms 600000/);
+  assert.match(dependency.run ?? "", /tools\/fixtures\/typecheck-dependency-prepare\.mjs/);
+  assert.match(dependency.run ?? "", /--output-dir "\$FIXTURE_REPORT_DIR"/);
+  assert.match(dependency.run ?? "", /--shard-index "\$FIXTURE_SHARD_INDEX"/);
+  assert.match(dependency.run ?? "", /--shard-count "\$FIXTURE_SHARD_COUNT"/);
+  assert.match(dependency.run ?? "", /--timeout-ms 600000/);
   assert.match(run?.run ?? "", /tools\/fixtures\/tool-matrix-report\.mjs/);
   assert.match(run?.run ?? "", /--vize-bin target\/ci\/vize/);
   assert.match(run?.run ?? "", /--timeout-ms 600000/);


### PR DESCRIPTION
## Summary

- fail explicitly when the pinned dependency workflow step is absent
- narrow the step type before checking its ordering and command contract

## Validation

- `node --test tests/tooling/real-project-matrix-workflow.test.ts` (2 passed)
- `oxlint tests/tooling/real-project-matrix-workflow.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->