### PR TITLE
fix(typecheck): enable manager shims

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -43,6 +43,9 @@ jobs:
           cache: true
           run-install: false
 
+      - name: Enable package manager shims
+        run: corepack enable
+
       - name: Select and hydrate fixture shard
         shell: bash
         run: |

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -54,6 +54,9 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   };
   const steps = workflow.jobs?.["real-project-matrix"]?.steps ?? [];
   const nodeSetupIndex = steps.findIndex((step) => step.uses?.startsWith("voidzero-dev/setup-vp@"));
+  const shims = steps.find((step) => step.name === "Enable package manager shims");
+  assert.ok(shims, "Missing 'Enable package manager shims' step");
+  const shimsIndex = steps.indexOf(shims);
   const hydrationIndex = steps.findIndex(
     (step) => step.name === "Select and hydrate fixture shard",
   );
@@ -74,14 +77,15 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.notEqual(nodeSetupIndex, -1);
   assert.notEqual(hydrationIndex, -1);
   assert.ok(
-    nodeSetupIndex < hydrationIndex,
-    "Node 24 must be active before loading matrix scripts",
+    nodeSetupIndex < shimsIndex && shimsIndex < hydrationIndex,
+    "Node 24 and package manager shims must be active before loading matrix scripts",
   );
   assert.deepEqual(steps[nodeSetupIndex].with, {
     "node-version-file": ".node-version",
     cache: true,
     "run-install": false,
   });
+  assert.equal(shims.run, "corepack enable");
   assert.match(hydration?.run ?? "", /--list-fixture-paths/);
   assert.match(hydration?.run ?? "", /--shard-index "\$FIXTURE_SHARD_INDEX"/);
   assert.match(hydration?.run ?? "", /--shard-count "\$FIXTURE_SHARD_COUNT"/);


### PR DESCRIPTION
## Summary

- enable Corepack package-manager launchers after setup-vp in the real-project matrix
- ensure pnpm and Yarn resolve the pinned version declared by each hydrated fixture
- require the shim step to run before fixture loading and dependency installation

## Failure evidence

- Real Project Matrix run 29641056750: npm shard succeeded; all pnpm shards had no executable and the Yarn shard resolved 1.22.22 instead of 4.9.2

## Validation

- `node --test tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/typecheck-dependency-prepare.test.ts` (9 passed)
- `oxlint tests/tooling/real-project-matrix-workflow.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->