### PR TITLE
fix(fixtures): ignore dependency sources

### DIFF
--- a/tests/tooling/fixture-tool-matrix-compiler.test.ts
+++ b/tests/tooling/fixture-tool-matrix-compiler.test.ts
@@ -136,6 +136,10 @@ test("fixture tool matrix mirrors compiler roots when validating artifact paths"
       vueGlobs: ["**/*.vue"],
       source: "src/nested/App.vue",
       extraDirectories: ["src/nested/component-library.vue"],
+      ignoredSources: [
+        ".yarn/unplugged/dependency/Hidden.vue",
+        "node_modules/dependency/Hidden.vue",
+      ],
       output: "src/nested/App.json",
     },
     {
@@ -143,6 +147,7 @@ test("fixture tool matrix mirrors compiler roots when validating artifact paths"
       vueGlobs: ["apps/**/*.vue", "packages/**/*.vue"],
       source: "apps/admin/App.vue",
       extraDirectories: ["packages"],
+      ignoredSources: [],
       output: "apps/admin/App.json",
     },
     {
@@ -150,6 +155,7 @@ test("fixture tool matrix mirrors compiler roots when validating artifact paths"
       vueGlobs: ["apps/**/*.vue", "missing/**/*.vue"],
       source: "apps/admin/App.vue",
       extraDirectories: [],
+      ignoredSources: [],
       output: "admin/App.json",
     },
   ] as const;
@@ -167,6 +173,11 @@ test("fixture tool matrix mirrors compiler roots when validating artifact paths"
       const sourcePath = path.join(fixtureDir, fixtureCase.source);
       fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
       fs.writeFileSync(sourcePath, "<template><main /></template>\n");
+      for (const ignoredSource of fixtureCase.ignoredSources) {
+        const ignoredPath = path.join(fixtureDir, ignoredSource);
+        fs.mkdirSync(path.dirname(ignoredPath), { recursive: true });
+        fs.writeFileSync(ignoredPath, "<template><aside /></template>\n");
+      }
 
       const executable = writeFakeVize(
         fakeDir,

--- a/tools/fixtures/tool-matrix-formatter.mjs
+++ b/tools/fixtures/tool-matrix-formatter.mjs
@@ -7,9 +7,13 @@ const noFilesMessage =
   "No .vue, .js, .mjs, .cjs, .ts, .mts, .cts, .jsx, .tsx, .json, .jsonc, .yaml, .yml, .md, or .markdown files found matching the patterns";
 
 export function snapshotFormatterInputs(cwd, patterns) {
-  const inputPaths = [...new Set(patterns.flatMap((pattern) => globSync(pattern, { cwd })))].sort(
-    (left, right) => left.localeCompare(right),
-  );
+  const inputPaths = [
+    ...new Set(
+      patterns.flatMap((pattern) =>
+        globSync(pattern, { cwd, exclude: [".yarn/**", "**/node_modules/**"] }),
+      ),
+    ),
+  ].sort((left, right) => left.localeCompare(right));
   const digest = createHash("sha256");
   for (const inputPath of inputPaths) {
     const absolute = resolve(cwd, inputPath);

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -151,7 +151,7 @@ function inspectCompilerArtifacts(cwd, patterns, expectedFileCount, outputDir) {
   const inputPaths = [
     ...new Set(
       patterns.flatMap((pattern) =>
-        globSync(pattern, { cwd })
+        globSync(pattern, { cwd, exclude: [".yarn/**", "**/node_modules/**"] })
           .filter((entry) => statSync(resolve(cwd, entry)).isFile())
           .map((entry) => entry.replaceAll("\\", "/")),
       ),


### PR DESCRIPTION
## Summary

- exclude `.yarn` and `node_modules` dependency trees from compiler artifact validation
- apply the same source boundary to formatter immutability snapshots
- cover hidden Yarn unplugged and node_modules Vue files in the compiler oracle

## Failure evidence

- Real Project Matrix run 29641328170: dependency installation passed 11/11; shard 7 counted 108 inputs although Vize correctly compiled 99 fixture sources

## Validation

- `node --test tests/tooling/fixture-tool-matrix-compiler.test.ts tests/tooling/fixture-tool-matrix-formatter.test.ts tests/tooling/fixture-tool-matrix-report.test.ts` (20 passed)
- `oxlint tools/fixtures/tool-matrix-run.mjs tools/fixtures/tool-matrix-formatter.mjs tests/tooling/fixture-tool-matrix-compiler.test.ts`
- installed Vuestic fixture with current 0.296.1 CLI: 99 inputs, 99 JSON artifacts, failedRuns 0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fixture validation by excluding dependency and package-manager directories from compiler scans and snapshot inputs.
  * Ensured ignored source files are correctly excluded from compilation and artifact expectations.
* **Tests**
  * Strengthened fixture coverage for compiler root and artifact path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->