### PR TITLE
fix(typecheck): register ambient type imports

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -39,7 +39,8 @@ mod socket;
 mod tests;
 use collect::collect_check_files_with_ignores;
 use default_imports::{
-    canonical_file_set, collect_default_run_files, register_transitive_local_imports,
+    canonical_file_set, collect_default_run_files, collect_transitive_local_imports_from,
+    register_transitive_local_imports,
 };
 use diagnostics::{
     emit_json_output, is_reported, is_suppressed_false_positive, render_diagnostics,
@@ -223,15 +224,29 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     // back in so global types stay in scope without widening package checks.
     if !args.patterns.is_empty() && program_tsconfig_path.is_some() {
         let keep_package_local = resolve::project_root_has_package_boundary(&project_root);
-        for path in collect_ambient_declaration_files(
+        let ambient_declarations = collect_ambient_declaration_files(
             &project_root,
             program_tsconfig_path.as_deref(),
             &mut tsconfig_input_cache,
-        ) {
-            if (!keep_package_local || path.starts_with(&project_root)) && !files.contains(&path) {
-                files.push(path);
+        );
+        let ambient_declarations = ambient_declarations
+            .into_iter()
+            .filter(|path| !keep_package_local || path.starts_with(&project_root))
+            .collect::<Vec<_>>();
+        for path in &ambient_declarations {
+            if !files.contains(path) {
+                files.push(path.clone());
             }
         }
+        files.extend(collect_transitive_local_imports_from(
+            &ambient_declarations,
+            &cwd,
+            program_tsconfig_path.as_deref(),
+            jsx_typecheck,
+            &mut canonical_paths,
+            Some(&explicit_input_root),
+            validate_inputs,
+        ));
         files.sort();
         files.dedup();
     }

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -37,8 +37,8 @@ mod socket;
 mod tests;
 use collect::collect_check_files_with_ignores;
 use default_imports::{
-    canonical_file_set, collect_default_run_files, register_explicit_ambient_support,
-    register_transitive_local_imports,
+    ExplicitAmbientImportContext, canonical_file_set, collect_default_run_files,
+    register_explicit_ambient_imports, register_transitive_local_imports,
 };
 use diagnostics::{
     emit_json_output, is_reported, is_suppressed_false_positive, render_diagnostics,
@@ -218,19 +218,21 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             &mut tsconfig_input_cache,
         )
     };
-    // Explicit subsets omit ambient roots; pull package-local `.d.ts` files
-    // back in so global types stay in scope without widening package checks.
-    if !args.patterns.is_empty() && program_tsconfig_path.is_some() {
-        register_explicit_ambient_support(
+    // Explicit subsets need package-local ambient roots and their imported types.
+    if !args.patterns.is_empty()
+        && let Some(program_tsconfig_path) = program_tsconfig_path.as_deref()
+    {
+        register_explicit_ambient_imports(
             &mut files,
-            &project_root,
-            &cwd,
-            program_tsconfig_path.as_deref(),
-            jsx_typecheck,
+            ExplicitAmbientImportContext::new(
+                &project_root,
+                &cwd,
+                program_tsconfig_path,
+                &explicit_input_root,
+                jsx_typecheck,
+            ),
             &mut tsconfig_input_cache,
             &mut canonical_paths,
-            &explicit_input_root,
-            validate_inputs,
         );
     }
     let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &files);

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -22,9 +22,7 @@ use super::{
     path_cache::CanonicalPathCache,
     patterns::CHECK_INPUTS_DISPLAY,
     reporting::{JsonFileResult, JsonOutput},
-    tsconfig_inputs::{
-        TsconfigInputCache, collect_ambient_declaration_files, resolve_tsconfig_for_files,
-    },
+    tsconfig_inputs::{TsconfigInputCache, resolve_tsconfig_for_files},
 };
 mod collect;
 mod default_imports;
@@ -39,7 +37,7 @@ mod socket;
 mod tests;
 use collect::collect_check_files_with_ignores;
 use default_imports::{
-    canonical_file_set, collect_default_run_files, collect_transitive_local_imports_from,
+    canonical_file_set, collect_default_run_files, register_explicit_ambient_support,
     register_transitive_local_imports,
 };
 use diagnostics::{
@@ -223,32 +221,17 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     // Explicit subsets omit ambient roots; pull package-local `.d.ts` files
     // back in so global types stay in scope without widening package checks.
     if !args.patterns.is_empty() && program_tsconfig_path.is_some() {
-        let keep_package_local = resolve::project_root_has_package_boundary(&project_root);
-        let ambient_declarations = collect_ambient_declaration_files(
+        register_explicit_ambient_support(
+            &mut files,
             &project_root,
-            program_tsconfig_path.as_deref(),
-            &mut tsconfig_input_cache,
-        );
-        let ambient_declarations = ambient_declarations
-            .into_iter()
-            .filter(|path| !keep_package_local || path.starts_with(&project_root))
-            .collect::<Vec<_>>();
-        for path in &ambient_declarations {
-            if !files.contains(path) {
-                files.push(path.clone());
-            }
-        }
-        files.extend(collect_transitive_local_imports_from(
-            &ambient_declarations,
             &cwd,
             program_tsconfig_path.as_deref(),
             jsx_typecheck,
+            &mut tsconfig_input_cache,
             &mut canonical_paths,
-            Some(&explicit_input_root),
+            &explicit_input_root,
             validate_inputs,
-        ));
-        files.sort();
-        files.dedup();
+        );
     }
     let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &files);
     let tsconfig_path =

--- a/crates/vize/src/commands/check/runner/default_imports.rs
+++ b/crates/vize/src/commands/check/runner/default_imports.rs
@@ -11,7 +11,8 @@ use crate::commands::check::{
     imports_aliases::PathAliasResolver,
     path_cache::CanonicalPathCache,
     tsconfig_inputs::{
-        TsconfigInputCache, collect_default_check_files, collect_hidden_ambient_declaration_files,
+        TsconfigInputCache, collect_ambient_declaration_files, collect_default_check_files,
+        collect_hidden_ambient_declaration_files,
     },
 };
 
@@ -64,6 +65,45 @@ fn register_ambient_declaration_files(
             files.push(path);
         }
     }
+}
+
+/// Explicit subsets omit ambient roots; pull package-local declarations back in
+/// (plus the local types they import) so global types stay in scope without
+/// widening package checks.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn register_explicit_ambient_support(
+    files: &mut Vec<PathBuf>,
+    project_root: &Path,
+    cwd: &Path,
+    tsconfig_path: Option<&Path>,
+    include_jsx: bool,
+    tsconfig_input_cache: &mut TsconfigInputCache,
+    canonical_paths: &mut CanonicalPathCache,
+    explicit_input_root: &Path,
+    validate_inputs: bool,
+) {
+    let keep_package_local = super::resolve::project_root_has_package_boundary(project_root);
+    let ambient_declarations =
+        collect_ambient_declaration_files(project_root, tsconfig_path, tsconfig_input_cache)
+            .into_iter()
+            .filter(|path| !keep_package_local || path.starts_with(project_root))
+            .collect::<Vec<_>>();
+    for path in &ambient_declarations {
+        if !files.contains(path) {
+            files.push(path.clone());
+        }
+    }
+    files.extend(collect_transitive_local_imports_from(
+        &ambient_declarations,
+        cwd,
+        tsconfig_path,
+        include_jsx,
+        canonical_paths,
+        Some(explicit_input_root),
+        validate_inputs,
+    ));
+    files.sort();
+    files.dedup();
 }
 
 pub(super) fn canonical_file_set(

--- a/crates/vize/src/commands/check/runner/default_imports.rs
+++ b/crates/vize/src/commands/check/runner/default_imports.rs
@@ -85,18 +85,59 @@ pub(super) fn register_transitive_local_imports(
     explicit_input_root: Option<&Path>,
     validate_inputs: bool,
 ) {
+    let discovered = collect_local_imports(files, cwd, tsconfig_path, include_jsx, canonical_paths);
+    append_local_imports(files, discovered, explicit_input_root, validate_inputs);
+}
+
+pub(super) fn collect_transitive_local_imports_from(
+    roots: &[PathBuf],
+    cwd: &Path,
+    tsconfig_path: Option<&Path>,
+    include_jsx: bool,
+    canonical_paths: &mut CanonicalPathCache,
+    explicit_input_root: Option<&Path>,
+    validate_inputs: bool,
+) -> Vec<PathBuf> {
+    collect_local_imports(roots, cwd, tsconfig_path, include_jsx, canonical_paths)
+        .into_iter()
+        .filter(|path| local_import_is_allowed(path, explicit_input_root, validate_inputs))
+        .collect()
+}
+
+fn collect_local_imports(
+    roots: &[PathBuf],
+    cwd: &Path,
+    tsconfig_path: Option<&Path>,
+    include_jsx: bool,
+    canonical_paths: &mut CanonicalPathCache,
+) -> Vec<PathBuf> {
     let aliases = PathAliasResolver::from_tsconfig(tsconfig_path);
-    for path in
-        collect_transitive_local_imports(files, cwd, canonical_paths, include_jsx, Some(&aliases))
-    {
-        let inside_allowed = !validate_inputs
-            || explicit_input_root.is_none_or(|root| path_is_inside_root(root, &path));
-        if inside_allowed && !files.contains(&path) {
+    collect_transitive_local_imports(roots, cwd, canonical_paths, include_jsx, Some(&aliases))
+}
+
+fn append_local_imports(
+    files: &mut Vec<PathBuf>,
+    discovered: Vec<PathBuf>,
+    explicit_input_root: Option<&Path>,
+    validate_inputs: bool,
+) {
+    for path in discovered {
+        if local_import_is_allowed(&path, explicit_input_root, validate_inputs)
+            && !files.contains(&path)
+        {
             files.push(path);
         }
     }
     files.sort();
     files.dedup();
+}
+
+fn local_import_is_allowed(
+    path: &Path,
+    explicit_input_root: Option<&Path>,
+    validate_inputs: bool,
+) -> bool {
+    !validate_inputs || explicit_input_root.is_none_or(|root| path_is_inside_root(root, path))
 }
 
 #[cfg(test)]

--- a/crates/vize/src/commands/check/runner/default_imports.rs
+++ b/crates/vize/src/commands/check/runner/default_imports.rs
@@ -16,6 +16,32 @@ use crate::commands::check::{
     },
 };
 
+pub(super) struct ExplicitAmbientImportContext<'a> {
+    project_root: &'a Path,
+    cwd: &'a Path,
+    tsconfig_path: &'a Path,
+    explicit_input_root: &'a Path,
+    include_jsx: bool,
+}
+
+impl<'a> ExplicitAmbientImportContext<'a> {
+    pub(super) fn new(
+        project_root: &'a Path,
+        cwd: &'a Path,
+        tsconfig_path: &'a Path,
+        explicit_input_root: &'a Path,
+        include_jsx: bool,
+    ) -> Self {
+        Self {
+            project_root,
+            cwd,
+            tsconfig_path,
+            explicit_input_root,
+            include_jsx,
+        }
+    }
+}
+
 pub(super) fn collect_default_run_files(
     project_root: &Path,
     cwd: &Path,
@@ -67,40 +93,31 @@ fn register_ambient_declaration_files(
     }
 }
 
-/// Explicit subsets omit ambient roots; pull package-local declarations back in
-/// (plus the local types they import) so global types stay in scope without
-/// widening package checks.
-#[allow(clippy::too_many_arguments)]
-pub(super) fn register_explicit_ambient_support(
+pub(super) fn register_explicit_ambient_imports(
     files: &mut Vec<PathBuf>,
-    project_root: &Path,
-    cwd: &Path,
-    tsconfig_path: Option<&Path>,
-    include_jsx: bool,
+    context: ExplicitAmbientImportContext<'_>,
     tsconfig_input_cache: &mut TsconfigInputCache,
     canonical_paths: &mut CanonicalPathCache,
-    explicit_input_root: &Path,
-    validate_inputs: bool,
 ) {
-    let keep_package_local = super::resolve::project_root_has_package_boundary(project_root);
-    let ambient_declarations =
-        collect_ambient_declaration_files(project_root, tsconfig_path, tsconfig_input_cache)
-            .into_iter()
-            .filter(|path| !keep_package_local || path.starts_with(project_root))
-            .collect::<Vec<_>>();
-    for path in &ambient_declarations {
-        if !files.contains(path) {
-            files.push(path.clone());
-        }
-    }
+    let keep_package_local =
+        super::resolve::project_root_has_package_boundary(context.project_root);
+    let ambient_declarations = collect_ambient_declaration_files(
+        context.project_root,
+        Some(context.tsconfig_path),
+        tsconfig_input_cache,
+    )
+    .into_iter()
+    .filter(|path| !keep_package_local || path.starts_with(context.project_root))
+    .collect::<Vec<_>>();
+    files.extend(ambient_declarations.iter().cloned());
     files.extend(collect_transitive_local_imports_from(
         &ambient_declarations,
-        cwd,
-        tsconfig_path,
-        include_jsx,
+        context.cwd,
+        Some(context.tsconfig_path),
+        context.include_jsx,
         canonical_paths,
-        Some(explicit_input_root),
-        validate_inputs,
+        Some(context.explicit_input_root),
+        true,
     ));
     files.sort();
     files.dedup();

--- a/crates/vize/tests/check_ambient_imports_cli.rs
+++ b/crates/vize/tests/check_ambient_imports_cli.rs
@@ -1,0 +1,158 @@
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use std::{path::Path, process::Command};
+
+#[path = "support/vue_stub.rs"]
+mod vue_stub;
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn unique_case_dir() -> std::path::PathBuf {
+    workspace_root()
+        .join("target/vize-tests/tests")
+        .join(format!("ambient-imports-{}", std::process::id()))
+}
+
+fn write_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(file_path, content).unwrap();
+}
+
+fn resolve_test_corsa_path() -> Option<std::path::PathBuf> {
+    let sibling_cache = workspace_root().parent()?.join("corsa-bind/.cache/tsgo");
+    if sibling_cache.exists() {
+        return Some(sibling_cache);
+    }
+    let workspace_bin = workspace_root().join("node_modules/.bin/tsgo");
+    workspace_bin.exists().then_some(workspace_bin)
+}
+
+#[test]
+fn explicit_check_registers_types_imported_by_ambient_declarations() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir();
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    vue_stub::install_vue_jsx_type_stub(&project_root);
+
+    write_file(
+        &project_root,
+        "package.json",
+        r#"{ "name": "ambient-imports", "private": true, "type": "module" }"#,
+    );
+    write_file(
+        &project_root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue"]
+}"#,
+    );
+    write_file(
+        &project_root,
+        "src/type/globals.d.ts",
+        r#"import type { WelcomeRuntime, welcomeRuntimeKey } from "../welcome/preloadType";
+
+declare global {
+  interface Window {
+    readonly [welcomeRuntimeKey]: WelcomeRuntime;
+  }
+}
+"#,
+    );
+    write_file(
+        &project_root,
+        "src/welcome/preloadType.ts",
+        r#"import type { RuntimeContract } from "./runtimeContract";
+
+export const welcomeRuntimeKey = "welcomeRuntime";
+export type WelcomeRuntime = RuntimeContract;
+"#,
+    );
+    write_file(
+        &project_root,
+        "src/welcome/runtimeContract.ts",
+        "export type RuntimeContract = { ping(): string };\n",
+    );
+    write_file(
+        &project_root,
+        "src/App.vue",
+        r#"<script setup lang="ts">
+const result: string = window.welcomeRuntime.ping();
+</script>
+
+<template>
+  <div>{{ result }}</div>
+</template>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src/App.vue",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "ambient import check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], 0, "{stdout}\n{stderr}");
+    assert_eq!(json["warningCount"], 0, "{stdout}\n{stderr}");
+    assert_eq!(
+        json["fileCount"], 1,
+        "supporting types must not be reported"
+    );
+
+    let generated: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(project_root.join("node_modules/.vize/canon/tsconfig.json"))
+            .unwrap(),
+    )
+    .unwrap();
+    let includes = generated["include"].as_array().unwrap();
+    for expected in [
+        "src/type/globals.d.cts",
+        "src/welcome/preloadType.ts",
+        "src/welcome/runtimeContract.ts",
+    ] {
+        assert!(
+            includes.iter().any(|value| value == expected),
+            "missing {expected} from generated project: {includes:?}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
## Summary

- register local TypeScript imports referenced by ambient declarations during explicit checks
- preserve explicit report boundaries while materializing transitive type support
- cover computed global keys and two-hop imports end to end

## Verification

- cargo test -p vize --lib commands::check::
- cargo test -p vize --test check_ambient_imports_cli
- cargo test -p vize --test check_cli check_explicit_file_loads_ambient_declare_global_types -- --exact
- cargo clippy -p vize --lib --bin vize -- -D warnings
- Voicevox comparison: affected diagnostics 6 to 0 on 128 SFCs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved explicit subset checks to properly register ambient type declarations and include any allowed transitive local types they reference.
  * Updated boundary-aware ambient handling to reduce missing declaration scenarios.
  * Ensured generated TypeScript config includes the required declaration files, preventing false errors and warnings.
* **Tests**
  * Added a CLI integration test that builds an isolated Vue/TypeScript workspace, runs `check`, asserts zero errors/warnings, and verifies expected `.d.ts` entries are present in the generated canonical config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->