### PR TITLE
perf(typecheck): avoid ambient path clones

### DIFF
--- a/crates/vize/src/commands/check/runner/default_imports.rs
+++ b/crates/vize/src/commands/check/runner/default_imports.rs
@@ -109,7 +109,6 @@ pub(super) fn register_explicit_ambient_imports(
     .into_iter()
     .filter(|path| !keep_package_local || path.starts_with(context.project_root))
     .collect::<Vec<_>>();
-    files.extend(ambient_declarations.iter().cloned());
     files.extend(collect_transitive_local_imports_from(
         &ambient_declarations,
         context.cwd,
@@ -119,6 +118,7 @@ pub(super) fn register_explicit_ambient_imports(
         Some(context.explicit_input_root),
         true,
     ));
+    files.extend(ambient_declarations);
     files.sort();
     files.dedup();
 }


### PR DESCRIPTION
## Summary

- collect transitive ambient imports before consuming the declaration vector
- avoid cloning each ambient PathBuf while preserving registration order semantics

## Verification

- cargo fmt --all -- --check
- cargo clippy -p vize --lib --bin vize -- -D warnings
- cargo test -p vize --test check_ambient_imports_cli

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->