### PR TITLE
fix(fuzz): guard mismatched expression delimiters

### DIFF
--- a/crates/vize_atelier_core/src/codegen/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/helpers.rs
@@ -413,7 +413,7 @@ pub fn is_constant_simple_expression(
 
     // Expressions that already reference runtime context/setup/props are dynamic.
     let content = exp.content.as_str();
-    if crate::steps::expression::expression_exceeds_max_depth(content) {
+    if !crate::steps::expression::expression_is_safe_to_parse(content) {
         return false;
     }
     if content.contains("_ctx.")

--- a/crates/vize_atelier_core/src/codegen/patch_flag.rs
+++ b/crates/vize_atelier_core/src/codegen/patch_flag.rs
@@ -75,7 +75,7 @@ fn is_string_literal(content: &str) -> bool {
 }
 
 fn is_static_object_or_array_literal(content: &str) -> bool {
-    if crate::steps::expression::expression_exceeds_max_depth(content) {
+    if !crate::steps::expression::expression_is_safe_to_parse(content) {
         return false;
     }
     let mut wrapped = String::with_capacity(content.len() + 2);

--- a/crates/vize_atelier_core/src/codegen/slots/params.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/params.rs
@@ -24,7 +24,7 @@ pub(super) fn get_slot_props(dir: &DirectiveNode<'_>) -> Option<vize_carton::Str
 /// e.g., "{ item = defaultItem }" -> "{ item = _ctx.defaultItem }"
 /// Only processes default value expressions, not the param names.
 pub(super) fn prefix_slot_defaults(source: &str) -> String {
-    if crate::steps::expression::expression_exceeds_max_depth(source) {
+    if !crate::steps::expression::expression_is_safe_to_parse(source) {
         return String::new(source);
     }
 

--- a/crates/vize_atelier_core/src/transforms/transform_expression.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression.rs
@@ -22,17 +22,17 @@ use crate::{ConstantType, ExpressionNode, SimpleExpressionNode, lane::TransformC
 
 pub use inline_handler::process_inline_handler;
 pub use nesting::{
-    MAX_EXPRESSION_NESTING_DEPTH, expression_exceeds_max_depth, expression_nesting_depth,
+    MAX_EXPRESSION_NESTING_DEPTH, expression_exceeds_max_depth, expression_has_balanced_delimiters,
+    expression_is_safe_to_parse, expression_nesting_depth,
 };
 pub use prefix::{is_simple_identifier, prefix_identifiers_in_expression};
-pub use typescript::strip_typescript_from_expression;
-
 use rewrite::rewrite_expression;
+pub use typescript::strip_typescript_from_expression;
 
 /// Returns true if an expression is a callable reference that should be passed
 /// through directly as an event handler, not wrapped as `$event => (...)`.
 pub fn is_event_handler_reference_expression(content: &str) -> bool {
-    if expression_exceeds_max_depth(content) {
+    if !expression_is_safe_to_parse(content) {
         return false;
     }
     let allocator = oxc_allocator::Allocator::default();
@@ -56,7 +56,7 @@ pub fn is_event_handler_reference_expression(content: &str) -> bool {
 
 /// Returns true if the whole expression is a function / arrow function expression.
 pub fn is_function_expression(content: &str) -> bool {
-    if expression_exceeds_max_depth(content) {
+    if !expression_is_safe_to_parse(content) {
         return false;
     }
     let allocator = oxc_allocator::Allocator::default();

--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
@@ -9,10 +9,12 @@ pub const MAX_EXPRESSION_NESTING_DEPTH: usize = 31;
 /// Brackets and unambiguous TypeScript angles are paired, while decorator markers
 /// accumulate for OXC's recursive parser. Strings, template text, comments, and
 /// regexes are skipped; `${...}` template interpolations are scanned.
-pub fn expression_nesting_depth(content: &str) -> usize {
+fn analyze_expression_nesting(content: &str) -> (usize, bool) {
     let bytes = content.as_bytes();
-    let (mut bracket_depth, mut angle_depth, mut decorator_depth) = (0usize, 0usize, 0usize);
+    let (mut angle_depth, mut decorator_depth) = (0usize, 0usize);
     let mut max_depth = 0usize;
+    let mut delimiters = Vec::new();
+    let mut delimiters_balanced = true;
     let mut can_start_regex = true;
     let mut template_interpolation_depths = Vec::new();
     // Plain `foo < bar` is indistinguishable from a type argument to a byte
@@ -39,11 +41,11 @@ pub fn expression_nesting_depth(content: &str) -> usize {
                 let (next, has_interpolation) = skip_template_text(bytes, i + 1);
                 i = next;
                 if has_interpolation {
-                    bracket_depth += 1;
-                    template_interpolation_depths.push(bracket_depth);
+                    delimiters.push(b'}');
+                    template_interpolation_depths.push(delimiters.len());
                     let effective_angle_depth = if track_type_angles { angle_depth } else { 0 };
                     max_depth =
-                        max_depth.max(bracket_depth + effective_angle_depth + decorator_depth);
+                        max_depth.max(delimiters.len() + effective_angle_depth + decorator_depth);
                     can_start_regex = true;
                 } else {
                     can_start_regex = false;
@@ -75,24 +77,28 @@ pub fn expression_nesting_depth(content: &str) -> usize {
                 continue;
             }
             b'(' | b'[' | b'{' => {
-                bracket_depth += 1;
+                delimiters.push(match b {
+                    b'(' => b')',
+                    b'[' => b']',
+                    _ => b'}',
+                });
                 can_start_regex = true;
             }
             b')' | b']' => {
-                bracket_depth = bracket_depth.saturating_sub(1);
+                delimiters_balanced &= delimiters.pop() == Some(b);
                 can_start_regex = false;
             }
-            b'}' if template_interpolation_depths.last() == Some(&bracket_depth) => {
-                bracket_depth = bracket_depth.saturating_sub(1);
+            b'}' if template_interpolation_depths.last() == Some(&delimiters.len()) => {
+                delimiters_balanced &= delimiters.pop() == Some(b'}');
                 template_interpolation_depths.pop();
                 let (next, has_interpolation) = skip_template_text(bytes, i + 1);
                 i = next;
                 if has_interpolation {
-                    bracket_depth += 1;
-                    template_interpolation_depths.push(bracket_depth);
+                    delimiters.push(b'}');
+                    template_interpolation_depths.push(delimiters.len());
                     let effective_angle_depth = if track_type_angles { angle_depth } else { 0 };
                     max_depth =
-                        max_depth.max(bracket_depth + effective_angle_depth + decorator_depth);
+                        max_depth.max(delimiters.len() + effective_angle_depth + decorator_depth);
                     can_start_regex = true;
                 } else {
                     can_start_regex = false;
@@ -100,7 +106,7 @@ pub fn expression_nesting_depth(content: &str) -> usize {
                 continue;
             }
             b'}' => {
-                bracket_depth = bracket_depth.saturating_sub(1);
+                delimiters_balanced &= delimiters.pop() == Some(b'}');
                 can_start_regex = false;
             }
             b'<' => {
@@ -130,11 +136,29 @@ pub fn expression_nesting_depth(content: &str) -> usize {
         }
 
         let effective_angle_depth = if track_type_angles { angle_depth } else { 0 };
-        max_depth = max_depth.max(bracket_depth + effective_angle_depth + decorator_depth);
+        max_depth = max_depth.max(delimiters.len() + effective_angle_depth + decorator_depth);
         i += 1;
     }
 
-    max_depth
+    (
+        max_depth,
+        delimiters_balanced && delimiters.is_empty() && template_interpolation_depths.is_empty(),
+    )
+}
+
+pub fn expression_nesting_depth(content: &str) -> usize {
+    analyze_expression_nesting(content).0
+}
+
+/// Returns whether parentheses, brackets, and braces are correctly paired.
+pub fn expression_has_balanced_delimiters(content: &str) -> bool {
+    analyze_expression_nesting(content).1
+}
+
+/// Returns whether an expression can be handed to OXC's recursive parser safely.
+pub fn expression_is_safe_to_parse(content: &str) -> bool {
+    let (depth, balanced) = analyze_expression_nesting(content);
+    balanced && depth <= MAX_EXPRESSION_NESTING_DEPTH
 }
 
 /// Returns true if `content` exceeds [`MAX_EXPRESSION_NESTING_DEPTH`].

--- a/crates/vize_atelier_core/src/transforms/transform_expression/prefix.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/prefix.rs
@@ -106,7 +106,7 @@ pub fn prefix_identifiers_in_expression(content: &str) -> String {
     // Skip parsing for inputs that would overflow the parser stack — return
     // the original content unchanged so the compile lane emits a normal
     // diagnostic for the surrounding directive instead of aborting. (#956)
-    if super::expression_exceeds_max_depth(content) {
+    if !super::expression_is_safe_to_parse(content) {
         return String::new(content);
     }
     let allocator = OxcAllocator::default();

--- a/crates/vize_atelier_core/src/transforms/transform_expression/rewrite.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/rewrite.rs
@@ -167,21 +167,14 @@ pub(crate) fn rewrite_expression(
     ctx: &TransformContext<'_>,
     as_params: bool,
 ) -> RewriteResult {
-    // Skip parsing for inputs that would overflow the parser stack — return
-    // the original content unchanged so the compile lane emits a normal
-    // diagnostic for the surrounding directive instead of aborting. (#956)
-    if super::expression_exceeds_max_depth(content) {
+    // Pass raw content through instead of aborting: depth overflow keeps the
+    // silent passthrough (#956); mismatched delimiters surface a diagnostic.
+    let overflows = super::expression_exceeds_max_depth(content);
+    if overflows || !super::expression_has_balanced_delimiters(content) {
         return RewriteResult {
             code: String::new(content),
             used_unref: false,
-            parse_error: None,
-        };
-    }
-    if !super::expression_has_balanced_delimiters(content) {
-        return RewriteResult {
-            code: String::new(content),
-            used_unref: false,
-            parse_error: Some(String::new("mismatched expression delimiters")),
+            parse_error: (!overflows).then(|| String::new("mismatched expression delimiters")),
         };
     }
     // First, if this is TypeScript, strip type annotations

--- a/crates/vize_atelier_core/src/transforms/transform_expression/rewrite.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/rewrite.rs
@@ -177,6 +177,13 @@ pub(crate) fn rewrite_expression(
             parse_error: None,
         };
     }
+    if !super::expression_has_balanced_delimiters(content) {
+        return RewriteResult {
+            code: String::new(content),
+            used_unref: false,
+            parse_error: Some(String::new("mismatched expression delimiters")),
+        };
+    }
     // First, if this is TypeScript, strip type annotations
     let js_content = if ctx.options.is_ts {
         strip_typescript_from_expression(content)

--- a/crates/vize_atelier_core/src/transforms/transform_expression/typescript.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/typescript.rs
@@ -212,7 +212,7 @@ pub fn strip_typescript_from_expression(content: &str) -> String {
     // Skip parsing for inputs that would overflow the parser stack — return
     // the original content unchanged so the surrounding lane emits a
     // normal diagnostic instead of aborting. (#956)
-    if super::expression_exceeds_max_depth(content) {
+    if !super::expression_is_safe_to_parse(content) {
         return String::new(content);
     }
     // Only process if TypeScript syntax is detected

--- a/crates/vize_atelier_core/tests/expression_nesting_guard.rs
+++ b/crates/vize_atelier_core/tests/expression_nesting_guard.rs
@@ -1,12 +1,13 @@
 use vize_atelier_core::steps::expression::{
-    MAX_EXPRESSION_NESTING_DEPTH, expression_exceeds_max_depth, expression_nesting_depth,
-    is_event_handler_reference_expression, is_function_expression,
-    prefix_identifiers_in_expression, strip_typescript_from_expression,
+    MAX_EXPRESSION_NESTING_DEPTH, expression_exceeds_max_depth, expression_has_balanced_delimiters,
+    expression_is_safe_to_parse, expression_nesting_depth, is_event_handler_reference_expression,
+    is_function_expression, prefix_identifiers_in_expression, strip_typescript_from_expression,
 };
 
 const TIMEOUT_REPRODUCER: &str = "\nd=\nd=efnuiProps<{[dnuiProps<{[d=efnuiProps<{[dnuiProps<{[defnuiProps<{[  cts<{[  oefnuiProps<{[dnuiProps<{[defnuiProps<{[  cts<{[  oo>>efnuiProps<{[  cts<{[  oefnuiProps<{[dnuiProps<{[defnuiProps<{[  cts<{[  oo>>> \x1a\x1a\x1a\x1a\x1atr";
 const SLOW_TYPE_ARGUMENT_REPRODUCER: &str = "eu.tfpS<{[ erntro-Coro-Couo<tidon<cttnS<{[ erntro-rntro-Coro-Couo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tuo<tidon<cttnS<{[ erntro-Coro-Coug<tidon<cttn<tidon<cttopti<nn<ctstrCoro[Couo<tidon<cttn<tuo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tidon<cttopti<nn<ctstrin<n<<on<ta<ts";
 const TIMEOUT_TYPE_ARGUMENT_REPRODUCER: &str = "eu.tfpS<{[ erntro-Coro-Couo<tidon<cttnS<{[ erntro-rntro-Coro-Couo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tuo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tidottn<tuo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tidon<cttopti<nn<ctsttro-Coro-Couo<tidon<cttnS<{[ erntro-rntro-Coro-Couo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tuo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tidottn<tuo<tidon<cttnS<{[ erntro-Coro-Couo<tidon<cttn<tidon<cttoptrin<n<<on<ta<ts";
+const MISMATCHED_DELIMITER_REPRODUCER: &str = "\ndennProps<[\n  ao?: stri,\t\n);\n";
 
 #[test]
 fn expression_guard_rejects_the_js_ts_timeout_reproducer() {
@@ -32,6 +33,42 @@ fn expression_guard_preserves_the_documented_boundary() {
 
     assert!(!expression_exceeds_max_depth(&allowed));
     assert!(expression_exceeds_max_depth(&rejected));
+}
+
+#[test]
+fn expression_guard_rejects_the_mismatched_delimiter_reproducer() {
+    assert_eq!(MISMATCHED_DELIMITER_REPRODUCER.len(), 30);
+    assert_eq!(expression_nesting_depth(MISMATCHED_DELIMITER_REPRODUCER), 1);
+    assert!(!expression_has_balanced_delimiters(
+        MISMATCHED_DELIMITER_REPRODUCER
+    ));
+    assert!(!expression_is_safe_to_parse(
+        MISMATCHED_DELIMITER_REPRODUCER
+    ));
+    assert!(!is_event_handler_reference_expression(
+        MISMATCHED_DELIMITER_REPRODUCER
+    ));
+    assert!(!is_function_expression(MISMATCHED_DELIMITER_REPRODUCER));
+    assert_eq!(
+        prefix_identifiers_in_expression(MISMATCHED_DELIMITER_REPRODUCER).as_str(),
+        MISMATCHED_DELIMITER_REPRODUCER
+    );
+    assert_eq!(
+        strip_typescript_from_expression(MISMATCHED_DELIMITER_REPRODUCER).as_str(),
+        MISMATCHED_DELIMITER_REPRODUCER
+    );
+}
+
+#[test]
+fn expression_guard_tracks_delimiter_kinds_without_scanning_literals() {
+    let balanced = r#"foo("]") + /[})]/u.test(value) + `] ${items.map((item) => ({ item }))}`"#;
+    assert!(expression_has_balanced_delimiters(balanced));
+    assert!(expression_is_safe_to_parse(balanced));
+
+    for mismatched in ["(]", "([)]", "foo(", "foo)", "`text ${foo)`"] {
+        assert!(!expression_has_balanced_delimiters(mismatched));
+        assert!(!expression_is_safe_to_parse(mismatched));
+    }
 }
 
 #[test]

--- a/tests/fuzz/fuzz_targets/js_ts_expression.rs
+++ b/tests/fuzz/fuzz_targets/js_ts_expression.rs
@@ -9,13 +9,13 @@ use libfuzzer_sys::fuzz_target;
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_atelier_core::steps::expression::expression_exceeds_max_depth;
+use vize_atelier_core::steps::expression::expression_is_safe_to_parse;
 
 fuzz_target!(|data: &[u8]| {
     let Ok(source) = std::str::from_utf8(data) else {
         return;
     };
-    if expression_exceeds_max_depth(source) {
+    if !expression_is_safe_to_parse(source) {
         return;
     }
 
@@ -23,7 +23,9 @@ fuzz_target!(|data: &[u8]| {
     let parser = Parser::new(
         &allocator,
         source,
-        SourceType::default().with_module(true).with_typescript(true),
+        SourceType::default()
+            .with_module(true)
+            .with_typescript(true),
     );
     let _ = parser.parse_expression();
 });

--- a/tests/snapshots/check/vue-router-patch-oracle.ts
+++ b/tests/snapshots/check/vue-router-patch-oracle.ts
@@ -36,7 +36,7 @@ const symbol = "packageBoundary";
 const sourceSha256 = "f5c888da7bae9c61151c7fbfde578ccdb768e75fbe2e69637d8298ca4f702c96";
 const cleanOutputSha256 = "84e9feaa14017c1c0e27a6b8955bd4a591b3b61e8708f3ead335aaa0c7c96013";
 const cleanCodeSha256 = "2e99ba339b7fb47f5788a990245b0292ede267d6bdfcb6c80cbe4c76da9cdebc";
-const brokenOutputSha256 = "15e571e43307b3ac025db3929f4f11029f1b7f5991d11b405433b6a31c5bc90e";
+const brokenOutputSha256 = "f71d3b39b2481594dc6ee9bf43911aaeca29194f95dd45e5f8c999d960ab04c1";
 const brokenCodeSha256 = "eed24c03d97029fca5d3d13f81ac416099d3876e7f36572d113acc0768872679";
 const cleanHref = ':href="String(to)"';
 const brokenHref = ':href="String(to"';
@@ -444,7 +444,7 @@ function assertBrokenBuild(result: BuildResult): void {
     {
       css: null,
       errors: [
-        'Template compilation errors: [CompilerError { code: InvalidExpression, message: "Error parsing JavaScript expression: Expected `)` but found `EOF`", loc: Some(SourceLocation { start: Position { offset: 157, line: 1, column: 158 }, end: Position { offset: 166, line: 1, column: 167 }, source: "String(to" }) }]',
+        'Template compilation errors: [CompilerError { code: InvalidExpression, message: "Error parsing JavaScript expression: mismatched expression delimiters", loc: Some(SourceLocation { start: Position { offset: 157, line: 1, column: 158 }, end: Position { offset: 166, line: 1, column: 167 }, source: "String(to" }) }]',
       ],
       filename: "AppLink.vue",
       macro_artifacts: [],


### PR DESCRIPTION
## Summary

- reject mismatched or unclosed expression delimiters before invoking Oxc
- share one lexical guard across compiler entry points and the JS/TS fuzz target
- preserve compiler diagnostics for invalid expressions while keeping depth-overflow inputs on the existing safe passthrough path
- pin the exact 30-byte artifact plus nested, literal, regex, and template-literal boundary cases

## Root cause

Oxc constructs an inverted diagnostic span while recovering from a malformed TypeScript tuple inside an unclosed bracket. Converting that span to a diagnostic source span panics before the parser can return an error. The same validation boundary now protects production compilation and fuzzing.

## Validation

- `cargo test -p vize_atelier_core --lib` (205 passed)
- `cargo test -p vize_atelier_core --test expression_nesting_guard` (9 passed)
- `cargo clippy -p vize_atelier_core --lib -- -D warnings`
- `cargo fmt --all -- --check`
- exact uploaded artifact replayed with `cargo +nightly fuzz run --fuzz-dir tests/fuzz js_ts_expression`; exit 0
- `cargo +nightly fuzz run --fuzz-dir tests/fuzz js_ts_expression -- -runs=10000 -max_len=4096 -timeout=10`; exit 0

Fixes #3041.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved expression parse-safety by validating both nesting depth and delimiter balance (including template interpolation delimiters).
  - Added clearer handling for mismatched delimiters, ensuring such inputs are rejected and left unchanged during transformations.
  - Tightened guards across identifier prefixing, TypeScript stripping, slot defaults, and directive-bound expressions to avoid unsafe parsing.

- **Tests**
  - Added new test cases covering mismatched delimiters, template substitutions, and complex balanced expressions.
  - Updated fuzz inputs to use the enhanced parse-safety validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->