### PR TITLE
test(fixtures): standardize generated artifact paths

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -319,9 +319,10 @@ jobs:
             tests/app/screenshots/
             tests/app/playwright-report/
             tests/playwright-report/
-            __agent_only/elk-vrt/artifacts/
-            __agent_only/frontend-phpcon-vrt/artifacts/
-            __agent_only/npmx-vrt/artifacts/
-            __agent_only/vuefes-vrt/artifacts/
+            .vize/vrt/elk/artifacts/
+            .vize/vrt/frontend-phpcon/artifacts/
+            .vize/vrt/misskey/artifacts/
+            .vize/vrt/npmx/artifacts/
+            .vize/vrt/vuefes/artifacts/
           if-no-files-found: ignore
           retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,6 @@ tests/_fixtures/_projects/_git-worktrees/
 
 # Vize local data (snapshots, cache, etc.)
 .vize/
-__agent_only/
 *.pending-snap
 
 # cargo-fuzz runtime state — corpora are seeded by tools/fuzz/seed_corpus.mjs

--- a/tests/_helpers/inspector-parity.ts
+++ b/tests/_helpers/inspector-parity.ts
@@ -117,7 +117,7 @@ function writeInspectorReport(
 ): void {
   const outputRoot =
     process.env.VIZE_INSPECT_OUTPUT_DIR ??
-    path.join(REPO_ROOT, "__agent_only", "inspect", sanitizeName(appName));
+    path.join(REPO_ROOT, ".vize", "inspect", sanitizeName(appName));
   fs.mkdirSync(outputRoot, { recursive: true });
 
   fs.writeFileSync(path.join(outputRoot, `${target}.json`), JSON.stringify(report, null, 2) + "\n");

--- a/tests/app/vrt/elk.spec.ts
+++ b/tests/app/vrt/elk.spec.ts
@@ -29,7 +29,7 @@ interface VisualRoute {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR =
   process.env.VIZE_ELK_VRT_OUTPUT_DIR ??
-  path.resolve(__dirname, "../../../__agent_only/elk-vrt/artifacts");
+  path.resolve(__dirname, "../../../.vize/vrt/elk/artifacts");
 const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
 const DEFAULT_MAX_DIFF_RATIO = 0.04;
 const ELK_MIN_CONTENT_TEXT_LENGTH = 40;

--- a/tests/app/vrt/frontend-phpcon.spec.ts
+++ b/tests/app/vrt/frontend-phpcon.spec.ts
@@ -29,7 +29,7 @@ type VisualMode = "dev" | "preview";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR =
   process.env.VIZE_FRONTEND_PHPCON_VRT_OUTPUT_DIR ??
-  path.resolve(__dirname, "../../../__agent_only/frontend-phpcon-vrt/artifacts");
+  path.resolve(__dirname, "../../../.vize/vrt/frontend-phpcon/artifacts");
 const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
 const FRONTEND_PHPCON_VRT_TIMEOUT = 900_000;

--- a/tests/app/vrt/misskey.spec.ts
+++ b/tests/app/vrt/misskey.spec.ts
@@ -30,7 +30,7 @@ interface VisualRoute {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR =
   process.env.VIZE_MISSKEY_VRT_OUTPUT_DIR ??
-  path.resolve(__dirname, "../../../__agent_only/misskey-vrt/artifacts");
+  path.resolve(__dirname, "../../../.vize/vrt/misskey/artifacts");
 const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
 const MISSKEY_VRT_TIMEOUT = 900_000;

--- a/tests/app/vrt/npmx.spec.ts
+++ b/tests/app/vrt/npmx.spec.ts
@@ -34,7 +34,7 @@ type VisualMode = "dev" | "preview";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR =
   process.env.VIZE_NPMX_VRT_OUTPUT_DIR ??
-  path.resolve(__dirname, "../../../__agent_only/npmx-vrt/artifacts");
+  path.resolve(__dirname, "../../../.vize/vrt/npmx/artifacts");
 const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
 const NPMX_VRT_TIMEOUT = 900_000;
 const modes: VisualMode[] = ["dev", "preview"];

--- a/tests/app/vrt/vuefes.spec.ts
+++ b/tests/app/vrt/vuefes.spec.ts
@@ -28,7 +28,7 @@ type VisualMode = "dev" | "preview";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR =
   process.env.VIZE_VUEFES_VRT_OUTPUT_DIR ??
-  path.resolve(__dirname, "../../../__agent_only/vuefes-vrt/artifacts");
+  path.resolve(__dirname, "../../../.vize/vrt/vuefes/artifacts");
 const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
 const VUEFES_VRT_TIMEOUT = 900_000;

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -76,8 +76,8 @@ test("full app e2e workflow remains nightly/on-demand and uploads failure artifa
   assert.match(appJob, /tests\/app\/screenshots\//);
   assert.match(appJob, /tests\/app\/playwright-report\//);
   assert.match(appJob, /tests\/playwright-report\//);
-  for (const fixture of ["elk", "frontend-phpcon", "npmx", "vuefes"]) {
-    assert.match(appJob, new RegExp(`__agent_only/${fixture}-vrt/artifacts/`));
+  for (const fixture of ["elk", "frontend-phpcon", "misskey", "npmx", "vuefes"]) {
+    assert.match(appJob, new RegExp(`\\.vize/vrt/${fixture}/artifacts/`));
   }
   assert.match(appJob, /if-no-files-found:\s*ignore/);
 });

--- a/tools/fixtures/compiler-diff-report.mjs
+++ b/tools/fixtures/compiler-diff-report.mjs
@@ -17,7 +17,7 @@ function main() {
   const targets = args.targets.length === 0 ? defaultTargets : args.targets;
   const outputDir = resolve(
     repoRoot,
-    args.outputDir ?? join("__agent_only", "compiler-diff-report", timestampSlug(new Date())),
+    args.outputDir ?? join(".vize", "compiler-diff-report", timestampSlug(new Date())),
   );
   const launch = resolveVizeLaunch(args.vizeBin);
 
@@ -173,7 +173,7 @@ Options:
   --target <dom|ssr>        Limit target; repeat or comma-separate. Defaults to dom,ssr.
   --max-files <n>           Forward a per-project file limit to vize inspector.
   --template-syntax <mode>  Forward template syntax mode. Defaults to quirks.
-  --output-dir <dir>        Report directory. Defaults under __agent_only/compiler-diff-report.
+  --output-dir <dir>        Report directory. Defaults under .vize/compiler-diff-report.
   --vize-bin <path>         vize binary. Defaults to VIZE_BIN, target/ci, target/debug, or cargo.
   --timeout-ms <n>          Per project/target timeout. Defaults to 300000.
   --dry-run                 Write the planned report without invoking vize.

--- a/tools/fixtures/tool-matrix-report.mjs
+++ b/tools/fixtures/tool-matrix-report.mjs
@@ -36,7 +36,7 @@ function main() {
 
   const outputDir = resolve(
     repoRoot,
-    args.outputDir ?? join("__agent_only", "fixture-tool-matrix", timestampSlug(new Date())),
+    args.outputDir ?? join(".vize", "fixture-tool-matrix", timestampSlug(new Date())),
   );
   const launch = resolveVizeLaunch(args.vizeBin, args.dryRun);
   mkdirSync(outputDir, { recursive: true });


### PR DESCRIPTION
## Summary

- place compiler and four-tool fixture reports under the repository-owned `.vize/` data directory
- use one `.vize/vrt/<fixture>/artifacts` layout for every visual parity fixture
- upload Misskey visual parity artifacts alongside the other real-project fixtures
- keep workflow assertions synchronized with every VRT artifact path

## Why

Generated fixture evidence should use a documented project-owned namespace, stay ignored locally, and remain recoverable from failed Actions runs.

## Validation

- `node --test tests/tooling/compiler-fixture-diff-report.test.ts tests/tooling/fixture-tool-matrix-report.test.ts` (13 passed)
- `node --test tests/tooling/e2e-workflow.test.ts` (5 passed)
- `oxfmt --check` on all changed JavaScript, TypeScript, workflow, and ignore files
- `git diff --check`
- repository-wide scan confirms the retired artifact namespace is absent

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated generated visual testing, inspection, and diagnostic artifacts under the `.vize/` directory.
  * Updated artifact collection and reporting paths to reflect the new locations.

* **Tests**
  * Updated end-to-end and visual comparison checks to validate artifacts from the consolidated directories.
  * Preserved existing test coverage and artifact upload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->