### PR TITLE
fix(glyph): honor ignores for relative globs

### DIFF
--- a/crates/vize/src/commands/fmt/files.rs
+++ b/crates/vize/src/commands/fmt/files.rs
@@ -316,31 +316,6 @@ mod tests {
         assert!(!pattern.matches(Path::new("./examples/cli/src/App.vue")));
     }
 
-    #[test]
-    fn explicit_relative_glob_respects_nested_gitignore() {
-        let cwd = std::env::current_dir().unwrap();
-        let relative_root = PathBuf::from("tests")
-            .join(unique_case_dir("explicit-glob-ignore").file_name().unwrap());
-        let root = cwd.join(&relative_root);
-        let source = root.join("apps/web/src/App.vue");
-        let dependency = root.join("apps/web/node_modules/dependency/Hidden.vue");
-        let _ = fs::remove_dir_all(&root);
-        fs::create_dir_all(source.parent().unwrap()).unwrap();
-        fs::create_dir_all(dependency.parent().unwrap()).unwrap();
-        fs::write(&source, "<template><main /></template>").unwrap();
-        fs::write(&dependency, "<template><aside /></template>").unwrap();
-        fs::write(root.join("apps/web/.gitignore"), "node_modules/\n").unwrap();
-
-        let pattern = relative_root
-            .join("apps/**/*.vue")
-            .to_string_lossy()
-            .into_owned();
-        let files = collect_files(&[pattern], None);
-        let _ = fs::remove_dir_all(&root);
-
-        assert_eq!(files, vec![relative_root.join("apps/web/src/App.vue")]);
-    }
-
     fn unique_case_dir(name: &str) -> PathBuf {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/vize/src/commands/fmt/files.rs
+++ b/crates/vize/src/commands/fmt/files.rs
@@ -1,6 +1,6 @@
 use glob::{MatchOptions, Pattern, glob};
 use ignore::WalkBuilder;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use super::ignores::FmtIgnoreSet;
 use super::patterns::is_format_extension;
@@ -79,7 +79,12 @@ fn should_include_format_file(path: &Path, ignore_set: Option<&FmtIgnoreSet>) ->
 fn should_walk_with_gitignore(pattern: &str) -> bool {
     // `normalize_fmt_pattern` strips leading `./`, but accept it defensively.
     let bare = pattern.strip_prefix("./").unwrap_or(pattern);
-    bare == "**/*" || bare.strip_prefix("**/*.").is_some_and(is_format_extension)
+    let path = Path::new(bare);
+    contains_glob_char(bare)
+        && !path.is_absolute()
+        && !path
+            .components()
+            .any(|component| component == Component::ParentDir)
 }
 
 pub(super) struct FmtPattern {
@@ -309,6 +314,34 @@ mod tests {
 
         assert!(pattern.matches(Path::new("./bench/__in__/Component0000.vue")));
         assert!(!pattern.matches(Path::new("./examples/cli/src/App.vue")));
+    }
+
+    #[test]
+    fn explicit_relative_glob_respects_nested_gitignore() {
+        let cwd = std::env::current_dir().unwrap();
+        let relative_root = PathBuf::from("tests")
+            .join(unique_case_dir("explicit-glob-ignore").file_name().unwrap());
+        let root = cwd.join(&relative_root);
+        let source = root.join("apps/web/src/App.vue");
+        let dependency = root.join("apps/web/node_modules/dependency/Hidden.vue");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        fs::create_dir_all(dependency.parent().unwrap()).unwrap();
+        fs::write(&source, "<template><main /></template>").unwrap();
+        fs::write(&dependency, "<template><aside /></template>").unwrap();
+        fs::write(root.join("apps/web/.gitignore"), "node_modules/\n").unwrap();
+
+        let pattern = relative_root
+            .join("apps/**/*.vue")
+            .to_string_lossy()
+            .into_owned();
+        let files = collect_files(&[pattern], None);
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(
+            files,
+            vec![PathBuf::from(".").join(relative_root.join("apps/web/src/App.vue"))]
+        );
     }
 
     fn unique_case_dir(name: &str) -> PathBuf {

--- a/crates/vize/src/commands/fmt/files.rs
+++ b/crates/vize/src/commands/fmt/files.rs
@@ -63,7 +63,7 @@ fn collect_walked_files(
     for entry in walker.filter_map(Result::ok) {
         let path = entry.path();
         if pattern.matches(path) && should_include_format_file(path, ignore_set) {
-            files.push(path.to_path_buf());
+            files.push(path.strip_prefix(".").unwrap_or(path).to_path_buf());
         }
     }
 }
@@ -338,10 +338,7 @@ mod tests {
         let files = collect_files(&[pattern], None);
         let _ = fs::remove_dir_all(&root);
 
-        assert_eq!(
-            files,
-            vec![PathBuf::from(".").join(relative_root.join("apps/web/src/App.vue"))]
-        );
+        assert_eq!(files, vec![relative_root.join("apps/web/src/App.vue")]);
     }
 
     fn unique_case_dir(name: &str) -> PathBuf {

--- a/crates/vize/src/commands/fmt/files_tests.rs
+++ b/crates/vize/src/commands/fmt/files_tests.rs
@@ -32,6 +32,31 @@ fn collect_files_ignores_supported_extension_directories() {
     assert_eq!(files_from_glob, expected);
 }
 
+#[test]
+fn explicit_relative_glob_respects_nested_gitignore() {
+    let cwd = std::env::current_dir().unwrap();
+    let relative_root =
+        PathBuf::from("tests").join(unique_case_dir("explicit-glob-ignore").file_name().unwrap());
+    let root = cwd.join(&relative_root);
+    let source = root.join("apps/web/src/App.vue");
+    let dependency = root.join("apps/web/node_modules/dependency/Hidden.vue");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(source.parent().unwrap()).unwrap();
+    fs::create_dir_all(dependency.parent().unwrap()).unwrap();
+    fs::write(&source, "<template><main /></template>").unwrap();
+    fs::write(&dependency, "<template><aside /></template>").unwrap();
+    fs::write(root.join("apps/web/.gitignore"), "node_modules/\n").unwrap();
+
+    let pattern = relative_root
+        .join("apps/**/*.vue")
+        .to_string_lossy()
+        .into_owned();
+    let files = collect_files(&[pattern], None);
+    let _ = fs::remove_dir_all(&root);
+
+    assert_eq!(files, vec![relative_root.join("apps/web/src/App.vue")]);
+}
+
 fn unique_case_dir(name: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
## Summary

- send relative formatter globs through the gitignore-aware file walker
- preserve the existing raw glob path for absolute and parent-relative requests
- cover narrow monorepo globs with a nested ignored dependency fixture

## Root cause

Broad `**/*.vue` patterns already used the ignore-aware walker, but narrower real-project patterns such as `apps/**/*.vue` used raw glob expansion. Installed dependency trees under those roots were therefore treated as project source.

## Impact

On the hydrated vue-vben-admin fixture, the formatter matrix target now checks exactly 613 source SFCs instead of 136,117 source-plus-dependency SFCs.

## Validation

- `cargo test -p vize --lib` (351 passed)
- `cargo clippy -p vize --lib -- -D warnings`
- `node --test tests/tooling/fixture-tool-matrix-formatter.test.ts` (4 passed)
- `cargo fmt --all -- --check`
- hydrated vue-vben-admin formatter count: 613; dependency-excluding source count: 613
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file matching for formatting patterns with absolute paths or parent-directory references.
  * Fixed explicit relative glob patterns so nested ignore rules are respected, preventing excluded files from being formatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->