### PR TITLE
test(fixtures): add AIRI real project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -664,3 +664,7 @@
 	path = tests/_fixtures/_git/vue-cal-v4
 	url = https://github.com/antoniandre/vue-cal-v4
 	shallow = true
+[submodule "tests/_fixtures/_git/airi"]
+	path = tests/_fixtures/_git/airi
+	url = https://github.com/moeru-ai/airi
+	shallow = true

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2903,6 +2903,36 @@
         "lsp"
       ],
       "diff": "curator-compare"
+    },
+    {
+      "id": "airi",
+      "displayName": "Project AIRI",
+      "kind": "application",
+      "fixturePath": "tests/_fixtures/_git/airi",
+      "repository": "https://github.com/moeru-ai/airi",
+      "revision": "b43b8944bfba4113233ccfc090f373a6e869dff6",
+      "license": {
+        "spdx": "MIT",
+        "files": [
+          "LICENSE"
+        ]
+      },
+      "vueGlobs": [
+        "apps/**/*.vue",
+        "docs/**/*.vue",
+        "packages/**/*.vue",
+        "plugins/**/*.vue"
+      ],
+      "tsconfig": "tsconfig.json",
+      "coverage": [
+        "compiler",
+        "linter",
+        "typechecker",
+        "formatter",
+        "syntax-highlighter",
+        "lsp"
+      ],
+      "diff": "e2e-vrt"
     }
   ]
 }

--- a/tests/tooling/airi-fixture.test.ts
+++ b/tests/tooling/airi-fixture.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const registry = JSON.parse(
+  fs.readFileSync(path.join(root, "tests/_fixtures/vue-ecosystem-fixtures.json"), "utf8"),
+) as {
+  projects: Array<{ id: string; revision: string; tsconfig?: string; vueGlobs: string[] }>;
+};
+
+test("AIRI fixture pins its complete Vue monorepo surface", () => {
+  const project = registry.projects.find((candidate) => candidate.id === "airi");
+
+  assert.ok(project);
+  assert.equal(project.revision, "b43b8944bfba4113233ccfc090f373a6e869dff6");
+  assert.equal(project.tsconfig, "tsconfig.json");
+  assert.deepEqual(project.vueGlobs, [
+    "apps/**/*.vue",
+    "docs/**/*.vue",
+    "packages/**/*.vue",
+    "plugins/**/*.vue",
+  ]);
+});

--- a/tests/tooling/fixture-tool-matrix-report.test.ts
+++ b/tests/tooling/fixture-tool-matrix-report.test.ts
@@ -56,11 +56,11 @@ test("fixture tool matrix plans every registered project across all four require
     assert.match(markdown, /Runtime: node \d+\.\d+\.\d+/);
     assert.match(markdown, /Machine: [^/]+\/[^,]+, \d+ logical CPUs, \d+ bytes memory/);
     assert.match(markdown, /\| Project \| Tool \| Status \| Exit \| Files \| Duration \(ms\) \|/);
-    assert.equal(report.summary.projectCount, 131);
+    assert.equal(report.summary.projectCount, 132);
     assert.equal(report.summary.toolCount, 4);
-    assert.equal(report.summary.runCount, 524);
-    assert.equal(report.summary.plannedRuns, 524);
-    assert.equal(report.projects.length, 131);
+    assert.equal(report.summary.runCount, 528);
+    assert.equal(report.summary.plannedRuns, 528);
+    assert.equal(report.projects.length, 132);
     for (const project of report.projects) {
       assert.deepEqual(
         project.runs.map((entry: { tool: string }) => entry.tool),
@@ -285,14 +285,14 @@ test("fixture tool matrix shards every project exactly once with balanced sizes"
       fs.rmSync(outputDir, { recursive: true, force: true });
     }
   }
-  assert.equal(projectIds.size, 131);
+  assert.equal(projectIds.size, 132);
   assert.deepEqual(
     [...new Set(shardSizes)].sort((a, b) => a - b),
-    [11, 12],
+    [12],
   );
   assert.equal(
     shardSizes.reduce((sum, size) => sum + size, 0),
-    131,
+    132,
   );
 });
 

--- a/tests/tooling/vue-ecosystem-fixtures.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures.test.ts
@@ -53,6 +53,7 @@ interface SubmoduleEntry {
 }
 
 const requestedFixtures = [
+  "airi",
   "vue-vben-admin",
   "hoppscotch",
   "element-plus",
@@ -76,6 +77,7 @@ const requestedFixtures = [
 ] as const;
 const requiredTypecheckProjects = ["voicevox", "elk", "misskey"] as const;
 const newlyAddedSubmodules = new Set([
+  "airi",
   "vue-vben-admin",
   "hoppscotch",
   "element-plus",
@@ -97,6 +99,7 @@ const newlyAddedSubmodules = new Set([
   "vue-termui",
 ]);
 const requestedFixtureLicenses = new Map<string, string>([
+  ["airi", "MIT"],
   ["motion-vue", "MIT"],
   ["shadcn-vue", "MIT"],
   ["inspira-ui", "MIT"],


### PR DESCRIPTION
## Summary

- pin moeru-ai/airi v0.11.2 as a shallow real-project fixture
- cover all 611 tracked Vue SFCs across apps, docs, packages, and plugins
- register AIRI for Compiler, TypeChecker, Linter, Formatter, syntax highlighter, and LSP coverage
- add a dedicated contract test for the pinned revision, tsconfig, and Vue roots

## Validation

- registry and AIRI contract tests: 16 passed
- AIRI tool matrix: 4 runs, 0 failed, 0 missing
- Compiler: 573 files, exit 0
- TypeChecker: 573 files, expected findings
- Linter: 573 files, expected findings
- Formatter: 611 files, expected findings
- fixture checkout remained unmodified
- `git diff --check`

The 38-file tool count difference is isolated to `docs/.vitepress` and is tracked as the next formatter glob-alignment fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AIRi as a supported Vue ecosystem fixture for tooling and visual regression coverage.
  * Included AIRi’s repository metadata, license information, TypeScript configuration, and Vue file coverage.

* **Tests**
  * Added validation for AIRi’s fixture configuration and repository revision.
  * Updated fixture planning and sharding checks to include the new project.
  * Added coverage for AIRi’s shallow checkout and license metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->