### PR TITLE
fix(glyph): require explicit hidden glob components

### DIFF
--- a/crates/vize/src/commands/fmt/files.rs
+++ b/crates/vize/src/commands/fmt/files.rs
@@ -179,7 +179,7 @@ fn fmt_glob_match_options() -> MatchOptions {
     MatchOptions {
         case_sensitive: !cfg!(windows),
         require_literal_separator: true,
-        require_literal_leading_dot: false,
+        require_literal_leading_dot: true,
     }
 }
 

--- a/crates/vize/src/commands/fmt/files_tests.rs
+++ b/crates/vize/src/commands/fmt/files_tests.rs
@@ -57,6 +57,36 @@ fn explicit_relative_glob_respects_nested_gitignore() {
     assert_eq!(files, vec![relative_root.join("apps/web/src/App.vue")]);
 }
 
+#[test]
+fn relative_globs_require_explicit_hidden_components() {
+    let cwd = std::env::current_dir().unwrap();
+    let relative_root =
+        PathBuf::from("tests").join(unique_case_dir("hidden-glob").file_name().unwrap());
+    let root = cwd.join(&relative_root);
+    let source = root.join("src/App.vue");
+    let hidden = root.join("docs/.vitepress/Theme.vue");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(source.parent().unwrap()).unwrap();
+    fs::create_dir_all(hidden.parent().unwrap()).unwrap();
+    fs::write(&source, "<template><main /></template>").unwrap();
+    fs::write(&hidden, "<template><aside /></template>").unwrap();
+
+    let implicit = collect_files(&[relative_root.join("**/*.vue").to_string_lossy()], None);
+    let explicit = collect_files(
+        &[relative_root
+            .join("docs/.vitepress/**/*.vue")
+            .to_string_lossy()],
+        None,
+    );
+    let _ = fs::remove_dir_all(&root);
+
+    assert_eq!(implicit, vec![relative_root.join("src/App.vue")]);
+    assert_eq!(
+        explicit,
+        vec![relative_root.join("docs/.vitepress/Theme.vue")]
+    );
+}
+
 fn unique_case_dir(name: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
## Summary

- require wildcard path components to match hidden directories explicitly
- keep explicit hidden-directory patterns such as `docs/.vitepress/**/*.vue` working
- cover both implicit exclusion and explicit inclusion in one filesystem regression test

## Root cause

The formatter glob matcher allowed wildcards to consume leading-dot path components. Compiler, TypeChecker, and Linter use literal-dot semantics, so Formatter widened the input set in 24 real projects.

## Impact

- AIRI default formatter inputs: 611 → 573, matching the other three core tools
- AIRI explicit `.vitepress` input: 38 files remain selectable
- Element Plus formatter inputs: 1,002 → 823, matching the other three core tools

## Validation

- regression test demonstrated the implicit hidden match before the fix
- `cargo test -p vize --lib` (352 passed)
- `cargo test -p vize --test fmt_config_cli` (10 passed)
- `cargo clippy -p vize --lib -- -D warnings`
- formatter matrix oracle tests (4 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->