### PR TITLE
fix(sfc): reject setup-local macro references

### DIFF
--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -15,7 +15,7 @@ mod tests;
 
 use crate::compile_script::artifacts::{erase_artifact_macro_statements, extract_macro_artifacts};
 use crate::compile_script::lazy_hydration::transform_lazy_hydration_macros;
-use crate::compile_script::props::is_valid_identifier;
+use crate::compile_script::props::{is_valid_identifier, validate_macro_scope_for_descriptor};
 use crate::compile_script::{TemplateParts, compile_script_setup_inline_with_context};
 use crate::compile_template::{
     TemplateBlockCompileContext, compile_template_block, compile_template_block_vapor,
@@ -34,6 +34,7 @@ use self::bindings::{
 };
 use self::helpers::{
     demote_v_model_reactive_const_bindings, extract_component_name, generate_scope_id,
+    trim_trailing_newlines,
 };
 use self::normal_script::extract_normal_script_content;
 use self::output_module::{
@@ -92,12 +93,6 @@ fn extract_descriptor_macro_artifacts(descriptor: &SfcDescriptor) -> Vec<SfcMacr
 
     artifacts.sort_by_key(|artifact| artifact.start);
     artifacts
-}
-
-fn trim_trailing_newlines(code: &mut String) {
-    while code.ends_with('\n') {
-        code.pop();
-    }
 }
 
 /// Compile an SFC descriptor into JavaScript and CSS
@@ -661,6 +656,7 @@ fn compile_sfc_inner(
             None => ctx.analyze(),
         }
     );
+    validate_macro_scope_for_descriptor(&ctx, setup_program.as_ref(), descriptor)?;
 
     // 3. Merge Props bindings from ScriptCompileContext (type resolution fallback)
     //    Croquis can't resolve interface references, so we take Props from the legacy analyzer

--- a/crates/vize_atelier_sfc/src/compile/helpers.rs
+++ b/crates/vize_atelier_sfc/src/compile/helpers.rs
@@ -34,6 +34,12 @@ pub(super) fn extract_component_name(filename: &str) -> String {
         .to_compact_string()
 }
 
+pub(super) fn trim_trailing_newlines(code: &mut String) {
+    while code.ends_with('\n') {
+        code.pop();
+    }
+}
+
 /// Rewrite selected `const reactive(...)` bindings to `let` only when `v-model`
 /// can actually assign to them from the template.
 ///

--- a/crates/vize_atelier_sfc/src/compile/tests/define_props_regressions.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests/define_props_regressions.rs
@@ -138,3 +138,30 @@ const to = "/login"
         result.code
     );
 }
+
+#[test]
+fn test_with_defaults_rejects_setup_local_default_reference() {
+    let source = r#"<script setup lang="ts">
+const items = []
+
+withDefaults(defineProps<{
+  items?: string[]
+}>(), { items })
+</script>
+
+<template>{{ items.join() }}</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("parse reported SFC");
+    let error = compile_sfc(&descriptor, SfcCompileOptions::default())
+        .expect_err("compiler must reject a setup-local withDefaults reference");
+
+    assert_eq!(error.code.as_deref(), Some("SCRIPT_SETUP_MACRO_SCOPE"));
+    assert!(error.message.contains("`withDefaults()`"), "{error:?}");
+    assert!(error.message.contains("`items`"), "{error:?}");
+    let loc = error
+        .loc
+        .expect("compiler error should point at the reference");
+    assert_eq!(&source[loc.start..loc.end], "items");
+    assert_eq!((loc.start_line, loc.start_column), (6, 9));
+    assert_eq!((loc.end_line, loc.end_column), (6, 14));
+}

--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -21,7 +21,7 @@ use super::super::lazy_hydration::transform_lazy_hydration_macros;
 use super::super::props::{
     PropTypeInfo, add_null_to_runtime_type, extract_emit_names_from_type,
     extract_prop_types_from_type_with_context, normalize_destructure_default_value,
-    resolve_prop_js_type, runtime_prop_key, validate_props_destructure_default_types,
+    resolve_prop_js_type, runtime_prop_key, validate_macro_scope_and_props,
 };
 use super::super::statement_sections::extract_script_sections;
 use super::super::typescript::transform_typescript_to_js;
@@ -50,7 +50,7 @@ pub fn compile_script_setup(
 
     let mut ctx = ScriptCompileContext::new(content);
     ctx.analyze();
-    validate_props_destructure_default_types(&ctx, 0, content)?;
+    validate_macro_scope_and_props(&ctx, 0, content)?;
 
     // Use arena-allocated Vec for better performance
     let bump = vize_carton::Bump::new();

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
@@ -24,7 +24,9 @@ use crate::types::{CssModuleMapping, SfcError};
 use super::super::artifacts::erase_artifact_macro_statements;
 use super::super::function_mode::contains_top_level_await;
 use super::super::lazy_hydration::transform_lazy_hydration_macros;
-use super::super::props::validate_props_destructure_default_types;
+use super::super::props::{
+    validate_macro_scope_references, validate_props_destructure_default_types,
+};
 use super::super::statement_sections::extract_script_sections_from_program_with_options;
 use super::super::{ScriptCompileResult, TemplateParts};
 use body::compile_script_setup_inline_body;
@@ -145,6 +147,9 @@ pub(crate) fn compile_script_setup_inline_with_context(
             .map(|d| d.bindings.values().any(|b| b.default.is_some()))
             .unwrap_or(false);
 
+    if setup_program.is_none() {
+        validate_macro_scope_references(&ctx, 0, content)?;
+    }
     validate_props_destructure_default_types(&ctx, 0, content)?;
 
     let has_define_model = !ctx.macros.define_models.is_empty();

--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -18,12 +18,16 @@ pub use runtime_type::{
 };
 pub use text_resolve::extract_prop_types_from_type;
 pub use types::PropTypeInfo;
+pub use validation::script_setup_has_semantic_validator_candidates;
 pub use validation::{validate_script_setup_semantics, validate_script_setup_semantics_located};
 
 pub(crate) use defaults::normalize_destructure_default_value;
 pub(crate) use runtime_type::{runtime_prop_key, ts_type_to_js_type};
 pub(crate) use text_resolve::extract_prop_types_from_type_with_context;
-pub(crate) use validation::validate_props_destructure_default_types;
+pub(crate) use validation::{
+    validate_macro_scope_and_props, validate_macro_scope_for_descriptor,
+    validate_macro_scope_references, validate_props_destructure_default_types,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/vize_atelier_sfc/src/compile_script/props/validation.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props/validation.rs
@@ -12,6 +12,13 @@ use crate::types::SfcError;
 use super::runtime_type::resolve_prop_js_type;
 use super::text_resolve::extract_prop_types_from_type_with_context;
 
+mod macro_scope;
+pub use macro_scope::script_setup_has_semantic_validator_candidates;
+pub(crate) use macro_scope::{
+    validate_macro_scope_and_props, validate_macro_scope_for_descriptor,
+    validate_macro_scope_references, validate_macro_scope_references_in_program,
+};
+
 /// Validate Vue-specific script-setup semantics that the TypeScript checker
 /// cannot derive on its own (currently: prop destructure defaults whose value
 /// disagrees with the declared prop type).
@@ -42,8 +49,11 @@ pub fn validate_script_setup_semantics_located(
     if script_setup_content.is_empty() {
         return Ok(());
     }
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script_setup_content, SourceType::ts()).parse();
     let mut ctx = ScriptCompileContext::new(script_setup_content);
-    ctx.analyze();
+    ctx.analyze_program(&parsed.program, script_setup_content);
+    validate_macro_scope_references_in_program(&ctx, &parsed.program, block_start, sfc_source)?;
     validate_props_destructure_default_types(&ctx, block_start, sfc_source)
 }
 

--- a/crates/vize_atelier_sfc/src/compile_script/props/validation/macro_scope.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props/validation/macro_scope.rs
@@ -1,0 +1,237 @@
+//! Scope validation for runtime arguments of hoisted script-setup macros.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Program;
+use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
+use oxc_span::SourceType;
+use oxc_syntax::symbol::SymbolFlags;
+use vize_carton::cstr;
+
+use crate::script::ScriptCompileContext;
+use crate::types::{BindingType, SfcDescriptor, SfcError};
+
+use super::block_location_for_span;
+
+#[cfg(test)]
+mod tests;
+
+/// Cheap strict-superset filter for the script-setup semantic validators.
+/// Callers may skip parsing only when this returns false.
+pub fn script_setup_has_semantic_validator_candidates(content: &str) -> bool {
+    let has_local_declaration = [
+        "const",
+        "let",
+        "var",
+        "using",
+        "function",
+        "class",
+        "enum",
+        "namespace",
+        "module",
+    ]
+    .iter()
+    .any(|keyword| content.contains(keyword));
+    let has_hoisted_macro = [
+        "withDefaults",
+        "defineProps",
+        "defineEmits",
+        "defineOptions",
+        "defineSlots",
+        "defineModel",
+    ]
+    .iter()
+    .any(|macro_name| content.contains(macro_name));
+    has_local_declaration && has_hoisted_macro
+}
+
+#[derive(Clone, Copy)]
+struct HoistedMacroSpan {
+    name: &'static str,
+    start: usize,
+    end: usize,
+}
+
+fn hoisted_macro_spans(ctx: &ScriptCompileContext) -> Vec<HoistedMacroSpan> {
+    let mut spans = Vec::with_capacity(6 + ctx.macros.define_models.len());
+    if let Some(call) = &ctx.macros.with_defaults {
+        spans.push(HoistedMacroSpan {
+            name: "withDefaults",
+            start: call.start,
+            end: call.end,
+        });
+    }
+    for (name, call) in [
+        ("defineProps", ctx.macros.define_props.as_ref()),
+        ("defineEmits", ctx.macros.define_emits.as_ref()),
+        ("defineOptions", ctx.macros.define_options.as_ref()),
+        ("defineSlots", ctx.macros.define_slots.as_ref()),
+    ] {
+        if let Some(call) = call {
+            spans.push(HoistedMacroSpan {
+                name,
+                start: call.start,
+                end: call.end,
+            });
+        }
+    }
+    spans.extend(
+        ctx.macros
+            .define_models
+            .iter()
+            .map(|call| HoistedMacroSpan {
+                name: "defineModel",
+                start: call.start,
+                end: call.end,
+            }),
+    );
+    spans
+}
+
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$')
+}
+
+fn contains_identifier(source: &str, name: &str) -> bool {
+    source.match_indices(name).any(|(start, _)| {
+        let bytes = source.as_bytes();
+        let end = start + name.len();
+        (start == 0 || !is_identifier_byte(bytes[start - 1]))
+            && (end == bytes.len() || !is_identifier_byte(bytes[end]))
+    })
+}
+
+/// Reject setup-local runtime values used by macros whose arguments are
+/// hoisted to module scope. Imports and literal constants remain valid.
+pub(crate) fn validate_macro_scope_references(
+    ctx: &ScriptCompileContext,
+    block_start: usize,
+    sfc_source: &str,
+) -> Result<(), SfcError> {
+    let spans = hoisted_macro_spans(ctx);
+    if !has_possible_local_macro_reference(ctx, &spans) {
+        return Ok(());
+    }
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, &ctx.source, SourceType::ts()).parse();
+    validate_macro_scope_references_in_program(ctx, &parsed.program, block_start, sfc_source)
+}
+
+pub(crate) fn validate_macro_scope_and_props(
+    ctx: &ScriptCompileContext,
+    block_start: usize,
+    sfc_source: &str,
+) -> Result<(), SfcError> {
+    validate_macro_scope_references(ctx, block_start, sfc_source)?;
+    super::validate_props_destructure_default_types(ctx, block_start, sfc_source)
+}
+
+pub(crate) fn validate_macro_scope_for_descriptor(
+    ctx: &ScriptCompileContext,
+    program: Option<&Program<'_>>,
+    descriptor: &SfcDescriptor<'_>,
+) -> Result<(), SfcError> {
+    let setup = descriptor
+        .script_setup
+        .as_ref()
+        .expect("script setup exists while compiling its context");
+    match program {
+        Some(program) => validate_macro_scope_references_in_program(
+            ctx,
+            program,
+            setup.loc.start,
+            &descriptor.source,
+        ),
+        None => validate_macro_scope_references(ctx, setup.loc.start, &descriptor.source),
+    }
+}
+
+fn has_possible_local_macro_reference(
+    ctx: &ScriptCompileContext,
+    spans: &[HoistedMacroSpan],
+) -> bool {
+    // The legacy classifier omits enum/namespace and `using`. A false positive
+    // here only costs one semantic pass and can never suppress a diagnostic.
+    if ["enum", "namespace", "module", "using"]
+        .iter()
+        .any(|keyword| ctx.source.contains(keyword))
+    {
+        return true;
+    }
+    ctx.bindings.bindings.iter().any(|(name, binding_type)| {
+        !matches!(binding_type, BindingType::LiteralConst)
+            && spans.iter().any(|span| {
+                ctx.source
+                    .get(span.start..span.end)
+                    .is_some_and(|source| contains_identifier(source, name))
+            })
+    })
+}
+
+pub(crate) fn validate_macro_scope_references_in_program(
+    ctx: &ScriptCompileContext,
+    program: &Program<'_>,
+    block_start: usize,
+    sfc_source: &str,
+) -> Result<(), SfcError> {
+    let spans = hoisted_macro_spans(ctx);
+    if !has_possible_local_macro_reference(ctx, &spans) {
+        return Ok(());
+    }
+    let semantic = SemanticBuilder::new().build(program).semantic;
+    let scoping = semantic.scoping();
+    let root_bindings = scoping.get_bindings(scoping.root_scope_id());
+    let mut invalid = None;
+
+    for (name, symbol_id) in root_bindings {
+        let flags = scoping.symbol_flags(*symbol_id);
+        if flags.intersects(SymbolFlags::Import | SymbolFlags::TypeImport | SymbolFlags::Ambient)
+            || (flags.is_type() && !flags.intersects(SymbolFlags::Value))
+            || matches!(
+                ctx.bindings.bindings.get(name.as_str()),
+                Some(BindingType::LiteralConst)
+            )
+        {
+            continue;
+        }
+        for reference in semantic.symbol_references(*symbol_id) {
+            let reference_flags = reference.flags();
+            if reference_flags.is_type() || reference_flags.is_value_as_type() {
+                continue;
+            }
+            let reference_span = semantic.reference_span(reference);
+            for macro_span in &spans {
+                if reference_span.start as usize >= macro_span.start
+                    && reference_span.end as usize <= macro_span.end
+                {
+                    let candidate = (
+                        reference_span.start as usize,
+                        reference_span.end as usize,
+                        name.as_str(),
+                        macro_span.name,
+                    );
+                    if invalid
+                        .is_none_or(|current: (usize, usize, &str, &str)| candidate.0 < current.0)
+                    {
+                        invalid = Some(candidate);
+                    }
+                }
+            }
+        }
+    }
+
+    let Some((start, end, name, macro_name)) = invalid else {
+        return Ok(());
+    };
+    Err(SfcError {
+        message: cstr!(
+            "`{macro_name}()` in <script setup> cannot reference locally declared variable `{name}` because its arguments are hoisted outside setup(). Move the initialization to a normal <script> block or import it from another module."
+        ),
+        code: Some("SCRIPT_SETUP_MACRO_SCOPE".into()),
+        loc: Some(block_location_for_span(
+            sfc_source,
+            block_start + start,
+            block_start + end,
+        )),
+    })
+}

--- a/crates/vize_atelier_sfc/src/compile_script/props/validation/macro_scope/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props/validation/macro_scope/tests.rs
@@ -1,0 +1,157 @@
+use super::super::validate_script_setup_semantics;
+use super::script_setup_has_semantic_validator_candidates;
+
+#[test]
+fn semantic_validator_prefilter_is_a_strict_superset() {
+    for source in [
+        "const local = makeDefault()\nwithDefaults(defineProps(), { value: local })",
+        "const\tlocal = makeDefault()\nwithDefaults(defineProps(), { value: local })",
+        "function local() {}\ndefineOptions({ setup: local })",
+        "const { value = 0 } = defineProps<{ value?: string }>()",
+    ] {
+        assert!(
+            script_setup_has_semantic_validator_candidates(source),
+            "validator candidate must not be skipped: {source}"
+        );
+    }
+    for source in [
+        "const value = compute()",
+        "defineProps<{ value: string }>()",
+        "import { fallback } from './defaults'\nwithDefaults(defineProps(), { value: fallback })",
+    ] {
+        assert!(
+            !script_setup_has_semantic_validator_candidates(source),
+            "obviously irrelevant source should keep the fast path: {source}"
+        );
+    }
+}
+
+#[test]
+fn rejects_setup_local_values_in_every_hoisted_runtime_macro() {
+    let cases = [
+        (
+            "withDefaults direct default",
+            "const local = makeDefault()\nwithDefaults(defineProps<{ value?: string }>(), { value: local })",
+            "withDefaults",
+        ),
+        (
+            "withDefaults factory closure",
+            "const local = makeDefault()\nwithDefaults(defineProps<{ value?: string }>(), { value: () => local })",
+            "withDefaults",
+        ),
+        (
+            "defineProps runtime validator",
+            "const local = makeValidator()\ndefineProps({ value: { validator: local } })",
+            "defineProps",
+        ),
+        (
+            "defineProps runtime constructor",
+            "class local {}\ndefineProps({ value: { type: local } })",
+            "defineProps",
+        ),
+        (
+            "defineEmits runtime validator",
+            "const local = makeValidator()\ndefineEmits({ change: local })",
+            "defineEmits",
+        ),
+        (
+            "defineOptions component option",
+            "const local = makeName()\ndefineOptions({ name: local })",
+            "defineOptions",
+        ),
+        (
+            "function declaration",
+            "function local() {}\ndefineOptions({ setup: local })",
+            "defineOptions",
+        ),
+        (
+            "enum runtime value",
+            "enum local { Ready }\ndefineOptions({ ready: local.Ready })",
+            "defineOptions",
+        ),
+        (
+            "namespace runtime value",
+            "namespace local { export const value = 1 }\ndefineOptions({ value: local.value })",
+            "defineOptions",
+        ),
+        (
+            "defineModel runtime option",
+            "const local = makeValidator()\ndefineModel<string>({ validator: local })",
+            "defineModel",
+        ),
+    ];
+
+    for (label, source, macro_name) in cases {
+        let Err(error) = validate_script_setup_semantics(source) else {
+            panic!("{label} should reject a setup-local reference");
+        };
+        assert_eq!(
+            error.code.as_deref(),
+            Some("SCRIPT_SETUP_MACRO_SCOPE"),
+            "{label}"
+        );
+        assert!(error.message.contains(macro_name), "{label}: {error:?}");
+        assert!(error.message.contains("`local`"), "{label}: {error:?}");
+        let loc = error.loc.expect("invalid reference should have a location");
+        assert_eq!(
+            &source[loc.start..loc.end],
+            "local",
+            "{label} should highlight only the invalid identifier"
+        );
+    }
+}
+
+#[test]
+fn allows_values_that_remain_valid_after_macro_hoisting() {
+    let cases = [
+        (
+            "imported binding",
+            "import { fallback } from './defaults'\nwithDefaults(defineProps<{ value?: string }>(), { value: fallback })",
+        ),
+        (
+            "literal setup constant",
+            "const fallback = 'ready'\nwithDefaults(defineProps<{ value?: string }>(), { value: fallback })",
+        ),
+        (
+            "global binding",
+            "defineProps({ value: { default: Math.random() } })",
+        ),
+        (
+            "shadowed callback parameter",
+            "const fallback = makeDefault()\nwithDefaults(defineProps<{ value?: string }>(), { value: (fallback) => fallback })",
+        ),
+        (
+            "defineExpose setup local",
+            "const exposed = makeValue()\ndefineExpose({ exposed })",
+        ),
+        (
+            "local enum in a type argument",
+            "enum LocalEnum { Ready }\ndefineProps<{ value?: LocalEnum }>()",
+        ),
+        (
+            "local class in a type argument",
+            "class LocalClass {}\ndefineProps<{ value?: LocalClass }>()",
+        ),
+        (
+            "local value in a type query",
+            "const runtime = { ready: true }\ndefineProps<{ value?: typeof runtime }>()",
+        ),
+    ];
+
+    for (label, source) in cases {
+        validate_script_setup_semantics(source)
+            .unwrap_or_else(|error| panic!("{label} should remain valid: {error:?}"));
+    }
+}
+
+#[test]
+fn reports_the_exact_authored_identifier_range() {
+    let source =
+        "const items = []\n\nwithDefaults(defineProps<{\n  items?: string[]\n}>(), { items })";
+    let error = validate_script_setup_semantics(source).expect_err("local default must fail");
+    let loc = error.loc.expect("scope error should be located");
+
+    assert_eq!(&source[loc.start..loc.end], "items");
+    assert_eq!((loc.start_line, loc.start_column), (5, 9));
+    assert_eq!((loc.end_line, loc.end_column), (5, 14));
+}

--- a/crates/vize_atelier_sfc/src/lib.rs
+++ b/crates/vize_atelier_sfc/src/lib.rs
@@ -1,7 +1,6 @@
 //! Vue Single File Component (.vue) compiler.
 //!
-//! This module provides parsing and compilation of Vue SFCs, following the
-//! Vue.js core structure:
+//! This module follows the Vue.js core structure for parsing and compilation:
 //!
 //! - `parse` - SFC parsing into descriptor blocks
 //! - `compile_script` - Script/script setup compilation
@@ -63,7 +62,8 @@ pub use compile::compile_sfc_with_template_syntax_and_codegen_options;
 pub use compile::compile_sfc_with_vue_parser_quirks;
 pub use compile::{ScriptCompileResult, compile_sfc, compile_sfc_with_template_syntax};
 pub use compile_script::props::{
-    validate_script_setup_semantics, validate_script_setup_semantics_located,
+    script_setup_has_semantic_validator_candidates, validate_script_setup_semantics,
+    validate_script_setup_semantics_located,
 };
 pub use css::{
     CssAstResult, CssCompileOptions, CssCompileResult, CssTargets, bundle_css, compile_css,

--- a/crates/vize_canon/src/batch/virtual_project/diagnostics.rs
+++ b/crates/vize_canon/src/batch/virtual_project/diagnostics.rs
@@ -6,7 +6,10 @@ use std::path::Path;
 
 use vize_carton::{String as CompactString, cstr};
 
-use vize_atelier_sfc::{SfcDescriptor, SfcError, validate_script_setup_semantics_located};
+use vize_atelier_sfc::{
+    SfcDescriptor, SfcError, script_setup_has_semantic_validator_candidates,
+    validate_script_setup_semantics_located,
+};
 
 use crate::batch::source_map::SfcBlockRange;
 use crate::batch::{Diagnostic, SfcBlockType};
@@ -24,10 +27,10 @@ pub(super) fn collect_sfc_compile_diagnostic(
     let script_setup = descriptor.script_setup.as_ref()?;
 
     // Cheap pre-filter: the only validator we currently run targets
-    // `const { ... = ... } = defineProps<...>()`. Skip the OXC parse entirely
-    // when none of those tokens appear, which is the common case for app
-    // components without destructured typed props.
-    if !script_setup_has_validator_candidates(&script_setup.content) {
+    // Skip the OXC parse entirely when neither props-default validation nor
+    // hoisted-macro scope validation can apply. The shared predicate is a
+    // strict superset of every semantic validator pattern.
+    if !script_setup_has_semantic_validator_candidates(&script_setup.content) {
         return None;
     }
 
@@ -39,15 +42,6 @@ pub(super) fn collect_sfc_compile_diagnostic(
         Ok(()) => None,
         Err(error) => Some(sfc_error_to_diagnostic(path, source, descriptor, &error)),
     }
-}
-
-/// Cheap byte-level filter — must be a strict superset of the patterns the
-/// underlying validators actually fire on, so we never miss a real diagnostic.
-fn script_setup_has_validator_candidates(content: &str) -> bool {
-    // Validator needs: typed defineProps (`defineProps<...>`) AND a destructure
-    // pattern (`{ ... = ... } = defineProps`). The combined presence of these
-    // two substrings is a tight enough filter for typical app code.
-    content.contains("defineProps<") && content.contains("= defineProps")
 }
 
 fn sfc_error_to_diagnostic(

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use vize_atelier_core::TemplateSyntaxMode;
 use vize_carton::cstr;
 mod graphql_generated;
+mod macro_scope;
 mod module_augmentations;
 mod ref_arity;
 mod setup_props;
@@ -1114,8 +1115,6 @@ fn test_source_type_for_path() {
     );
     assert_eq!(source_type_for_path(Path::new("foo.vue")), None);
 }
-
-// --- JSX/TSX opt-in type-checking (#1497, #1502) -------------------------
 
 #[test]
 fn jsx_typecheck_off_keeps_tsx_verbatim_passthrough() {

--- a/crates/vize_canon/src/batch/virtual_project/tests/macro_scope.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/macro_scope.rs
@@ -1,0 +1,36 @@
+use std::fs;
+
+use super::{VirtualProject, unique_case_dir};
+
+#[test]
+fn register_vue_file_reports_hoisted_macro_local_scope_reference() {
+    let case_dir = unique_case_dir("macro-local-scope");
+    let _ = fs::remove_dir_all(&case_dir);
+    let src_dir = case_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    let vue_path = src_dir.join("Bad.vue");
+    let vue_content = r#"<script setup lang="ts">
+const items = []
+
+withDefaults(defineProps<{
+  items?: string[]
+}>(), { items })
+</script>
+
+<template>{{ items.join() }}</template>
+"#;
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.register_vue_file(&vue_path, vue_content).unwrap();
+
+    let diagnostics = project.diagnostics();
+    let diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.message.contains("SCRIPT_SETUP_MACRO_SCOPE"))
+        .expect("typechecker should surface the SFC macro scope diagnostic");
+    assert_eq!((diagnostic.line, diagnostic.column), (5, 8));
+    assert!(diagnostic.message.contains("`withDefaults()`"));
+    assert!(diagnostic.message.contains("`items`"));
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize_canon/src/corsa_server.rs
+++ b/crates/vize_canon/src/corsa_server.rs
@@ -403,7 +403,7 @@ fn collect_sfc_compile_diagnostic(
     descriptor: &vize_atelier_sfc::SfcDescriptor<'_>,
 ) -> Option<Diagnostic> {
     let script_setup = descriptor.script_setup.as_ref()?;
-    if !script_setup_has_validator_candidates(&script_setup.content) {
+    if !vize_atelier_sfc::script_setup_has_semantic_validator_candidates(&script_setup.content) {
         return None;
     }
 
@@ -437,12 +437,6 @@ fn collect_sfc_compile_diagnostic(
         column,
         code: error.code.clone(),
     })
-}
-
-/// See the canon batch path for rationale — keep this in sync with
-/// `crates/vize_canon/src/batch/virtual_project.rs`.
-fn script_setup_has_validator_candidates(content: &str) -> bool {
-    content.contains("defineProps<") && content.contains("= defineProps")
 }
 
 fn sfc_block_fallback_offset(descriptor: &vize_atelier_sfc::SfcDescriptor<'_>) -> usize {

--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -376,7 +376,8 @@ impl DiagnosticService {
         let Some(script_setup) = descriptor.script_setup.as_ref() else {
             return Vec::new();
         };
-        if !script_setup_has_validator_candidates(&script_setup.content) {
+        if !vize_atelier_sfc::script_setup_has_semantic_validator_candidates(&script_setup.content)
+        {
             return Vec::new();
         }
 
@@ -675,12 +676,6 @@ fn script_source_type(lang: Option<&str>) -> Option<SourceType> {
     };
 
     SourceType::from_path(format!("script.{extension}")).ok()
-}
-
-/// See the canon batch path for rationale — keep this in sync with
-/// `crates/vize_canon/src/batch/virtual_project.rs`.
-fn script_setup_has_validator_candidates(content: &str) -> bool {
-    content.contains("defineProps<") && content.contains("= defineProps")
 }
 
 fn diagnostic_span(error: &oxc_diagnostics::OxcDiagnostic, source_len: usize) -> (usize, usize) {

--- a/crates/vize_maestro/src/ide/diagnostics/tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/tests.rs
@@ -1,4 +1,5 @@
 //! Tests for the diagnostics aggregation pipeline.
+mod macro_scope;
 mod self_closing_compatibility;
 use std::fs;
 
@@ -630,7 +631,6 @@ fn collect_produces_no_error_for_valid_jsx() {
     );
 }
 
-// ----------------------------------------------------------------------
 // VDOM/Vapor mode directives on JSX/TSX (#1498).
 //
 // `"use vue:vdom"` / `"use vue:vapor"` select a component's output mode. A

--- a/crates/vize_maestro/src/ide/diagnostics/tests/macro_scope.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/tests/macro_scope.rs
@@ -1,0 +1,42 @@
+use super::{DiagnosticService, DiagnosticSeverity, Url, sources, state_with_lsp_diagnostics};
+
+#[test]
+fn collect_reports_hoisted_macro_local_scope_reference_for_lsp() {
+    let state = state_with_lsp_diagnostics(false, false);
+    let uri = Url::parse("file:///MacroScope.vue").unwrap();
+    let source = r#"<script setup lang="ts">
+const items = []
+
+withDefaults(defineProps<{
+  items?: string[]
+}>(), { items })
+</script>
+
+<template>{{ items.join() }}</template>
+"#;
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+
+    let diagnostics = DiagnosticService::collect(&state, &uri);
+    let diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.message.contains("SCRIPT_SETUP_MACRO_SCOPE"))
+        .expect("LSP should surface the SFC macro scope diagnostic");
+    assert_eq!(diagnostic.source.as_deref(), Some(sources::SFC_COMPILER));
+    assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::ERROR));
+    assert_eq!(
+        diagnostic.range,
+        tower_lsp::lsp_types::Range {
+            start: tower_lsp::lsp_types::Position {
+                line: 5,
+                character: 8,
+            },
+            end: tower_lsp::lsp_types::Position {
+                line: 5,
+                character: 13,
+            },
+        }
+    );
+    assert_eq!(&source.lines().nth(5).unwrap()[8..13], "items");
+}


### PR DESCRIPTION
## Summary
- reject setup-local runtime values referenced from hoisted script-setup macros
- preserve imported, literal-constant, global, shadowed, and type-only references
- surface the exact diagnostic through compiler, batch typecheck, and LSP paths

## Validation
- cargo test -p vize_atelier_sfc --lib
- cargo test -p vize_canon test_register_vue_file_reports_hoisted_macro_local_scope_reference --lib
- cargo test -p vize_maestro collect_reports_hoisted_macro_local_scope_reference_for_lsp --lib
- cargo clippy -p vize_atelier_sfc -p vize_canon -p vize_maestro --lib -- -D warnings
- cargo fmt --all -- --check

Fixes #2968

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Vue `<script setup>` macro-scope validation for hoisted macros such as `withDefaults()`, `defineProps()`, and related macros.
  - Compilation and editor diagnostics now reject invalid defaults that reference setup-local variables, including `withDefaults(..., { items })`.
  - Error locations are more precise, highlighting the exact offending identifier; diagnostics are surfaced consistently.
  - Improved diagnostic responsiveness by skipping semantic validation when no relevant `<script setup>` patterns are present.

- **Tests**
  - Added regression and diagnostics coverage for compiler and language-server behavior around macro-scope errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->