### PR TITLE
fix(cli): preserve failed atelier artifacts

### DIFF
--- a/crates/vize/src/commands/build/runner.rs
+++ b/crates/vize/src/commands/build/runner.rs
@@ -7,6 +7,7 @@ mod cache;
 mod collect;
 mod compile;
 mod compile_stats;
+mod fallback;
 mod output;
 mod profile_facts;
 mod settings;
@@ -197,12 +198,11 @@ pub(crate) fn run(args: BuildArgs) {
                     }
                     Err(err) => {
                         stats.failed.fetch_add(1, Ordering::Relaxed);
-
-                        if let Ok(mut errs) = errors.lock() {
-                            errs.push(err);
-                        }
-
-                        None
+                        fallback::record_error(&errors, err.clone());
+                        args.continue_on_error.then(|| CompiledBuildOutput {
+                            input,
+                            output: fallback::fallback_output(&input.source, &err),
+                        })
                     }
                 }
             })

--- a/crates/vize/src/commands/build/runner/fallback.rs
+++ b/crates/vize/src/commands/build/runner/fallback.rs
@@ -1,0 +1,54 @@
+use std::{path::Path, sync::Mutex};
+
+use super::super::config::{CompileError, CompileOutput};
+
+pub(super) fn record_error(errors: &Mutex<Vec<CompileError>>, error: CompileError) {
+    if let Ok(mut errors) = errors.lock() {
+        errors.push(error);
+    }
+}
+
+pub(super) fn fallback_output(source: &Path, error: &CompileError) -> CompileOutput {
+    let filename = source
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("anonymous.vue")
+        .into();
+    CompileOutput {
+        filename,
+        code: "".into(),
+        css: None,
+        errors: vec![error.error.clone()],
+        warnings: Vec::new(),
+        script_lang: "js".into(),
+        macro_artifacts: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{CompileError, CompileOutput, fallback_output};
+    use crate::commands::build::config::ErrorPhase;
+
+    #[test]
+    fn fallback_output_preserves_compile_errors_in_json_shape() {
+        let output: CompileOutput = fallback_output(
+            PathBuf::from("src/Broken.vue").as_path(),
+            &CompileError {
+                path: PathBuf::from("src/Broken.vue"),
+                error: "semantic compile failure".into(),
+                phase: ErrorPhase::Compile,
+            },
+        );
+
+        assert_eq!(output.filename, "Broken.vue");
+        assert!(output.code.is_empty());
+        assert!(output.css.is_none());
+        assert_eq!(output.errors, ["semantic compile failure"]);
+        assert!(output.warnings.is_empty());
+        assert_eq!(output.script_lang, "js");
+        assert!(output.macro_artifacts.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- keep one JSON build artifact for every input when `--continue-on-error` is enabled
- preserve the compiler error in the fallback artifact while retaining the failing exit status
- add a strict unit test for the machine-readable output shape

## Validation
- `cargo test -p vize --lib commands::build -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- real-project matrix run on main exposed the three affected projects (`lew-ui`, `gui-for-singbox`, `piclist`) via artifact-count mismatches; the fallback artifact addresses that failure mode

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Builds configured to continue after errors now generate a fallback result for failed files instead of omitting them.
  * The failed-file output preserves the expected output structure and includes compilation error details, so downstream writing and visibility into failures remain consistent.
  * When available, the fallback uses the failed source’s filename (otherwise a default), with errors and other fields populated in a predictable way.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->