### PR TITLE
test(fixtures): require complete typechecker coverage

### DIFF
--- a/tests/tooling/fixture-tool-matrix-typechecker.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typechecker.test.ts
@@ -57,6 +57,30 @@ test("typechecker oracle accepts exact error, warning, project, and zero-file re
     { id: "no-sfc", expectedVueFileCount: 0 },
     { files: [], errorCount: 0, warningCount: 0, fileCount: 0 },
     0,
+    [],
+  );
+});
+
+test("typechecker oracle requires every fixture input and rejects substitutions", () => {
+  const output = validOutput();
+  output.files.push({ file: "src/Card.vue", diagnostics: [] });
+  output.fileCount = 2;
+
+  validateTypecheckerOutput({ id: "complete" }, output, 1, ["src/App.vue", "src/Card.vue"]);
+
+  assert.throws(
+    () =>
+      validateTypecheckerOutput({ id: "partial" }, validOutput(), 1, [
+        "src/App.vue",
+        "src/Card.vue",
+      ]),
+    /checked file count 1 does not match 2 fixture inputs/,
+  );
+
+  const substituted = validOutput();
+  assert.throws(
+    () => validateTypecheckerOutput({ id: "substituted" }, substituted, 1, ["src/Other.vue"]),
+    /checked files do not match fixture inputs: missing \[src\/Other\.vue\], unexpected \[src\/App\.vue\]/,
   );
 });
 
@@ -237,6 +261,46 @@ process.stdout.write(JSON.stringify({ files: [], errorCount: 0, warningCount: 0,
     assert.match(run.failure, /non-empty fixture checked zero Vue files/);
     const raw = JSON.parse(fs.readFileSync(path.resolve(root, run.outputPath as string), "utf8"));
     assert.match(raw.validationError, /non-empty fixture checked zero Vue files/);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
+});
+
+test("fixture tool matrix rejects partial typechecker coverage", () => {
+  const fixtureDir = fs.mkdtempSync(
+    path.join(root, "tests", "_fixtures", "tool-matrix-typechecker-partial-"),
+  );
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-typechecker-partial-"));
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-typechecker-partial-report-"));
+  const executable = path.join(fakeDir, "fake-vize.mjs");
+  fs.mkdirSync(path.join(fixtureDir, "src"), { recursive: true });
+  fs.writeFileSync(path.join(fixtureDir, "src", "App.vue"), "<template />\n");
+  fs.writeFileSync(path.join(fixtureDir, "src", "Card.vue"), "<template />\n");
+  fs.writeFileSync(
+    executable,
+    `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({ files: [{ file: "src/App.vue", diagnostics: [] }], errorCount: 0, warningCount: 0, fileCount: 1 }));\n`,
+  );
+  fs.chmodSync(executable, 0o755);
+
+  try {
+    const run = runTool(
+      {
+        id: "typechecker-partial-fixture",
+        fixturePath: path.relative(root, fixtureDir),
+        vueGlobs: ["**/*.vue"],
+      },
+      "typechecker",
+      { dryRun: false, timeoutMs: 5_000 },
+      { command: executable, prefix: [], label: executable },
+      reportDir,
+    );
+    assert.equal(run.status, "failed");
+    assert.match(run.failure, /checked file count 1 does not match 2 fixture inputs/);
+    const raw = JSON.parse(fs.readFileSync(path.resolve(root, run.outputPath as string), "utf8"));
+    assert.match(raw.validationError, /checked file count 1 does not match 2 fixture inputs/);
   } finally {
     fs.rmSync(fixtureDir, { recursive: true, force: true });
     fs.rmSync(fakeDir, { recursive: true, force: true });

--- a/tools/fixtures/tool-matrix-inputs.mjs
+++ b/tools/fixtures/tool-matrix-inputs.mjs
@@ -1,0 +1,18 @@
+import { Buffer } from "node:buffer";
+import { globSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+export function collectVueInputPaths(cwd, patterns) {
+  return [
+    ...new Set(
+      patterns.flatMap((pattern) =>
+        globSync(pattern, { cwd, exclude: [".yarn/**", "**/node_modules/**"] })
+          .filter((entry) => statSync(resolve(cwd, entry)).isFile())
+          .map((entry) => entry.replaceAll("\\", "/")),
+      ),
+    ),
+  ]
+    .map((file) => ({ file, bytes: Buffer.from(file) }))
+    .sort((left, right) => Buffer.compare(left.bytes, right.bytes))
+    .map(({ file }) => file);
+}

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -16,6 +16,7 @@ import { fileURLToPath } from "node:url";
 
 import { expectedCompilerOutputs } from "./tool-matrix-compiler-paths.mjs";
 import { snapshotFormatterInputs, validateFormatterOutput } from "./tool-matrix-formatter.mjs";
+import { collectVueInputPaths } from "./tool-matrix-inputs.mjs";
 import { validateLinterOutput } from "./tool-matrix-linter.mjs";
 import { validatedFileCount } from "./tool-matrix-metrics.mjs";
 import { validateTypecheckerOutput } from "./tool-matrix-typechecker.mjs";
@@ -45,6 +46,8 @@ export function runTool(project, tool, args, launch, outputDir) {
   if (!fixtureExists) return { ...base, status: "missing-fixture" };
   const formatterStateBefore =
     tool === "formatter" ? snapshotFormatterInputs(cwd, project.vueGlobs) : null;
+  const expectedTypecheckerFiles =
+    tool === "typechecker" ? collectVueInputPaths(cwd, project.vueGlobs) : null;
 
   try {
     const startedAt = Date.now();
@@ -92,7 +95,12 @@ export function runTool(project, tool, args, launch, outputDir) {
       }
       if (tool === "typechecker" && payload.parseError == null) {
         try {
-          validateTypecheckerOutput(project, payload.parsed, result.status);
+          validateTypecheckerOutput(
+            project,
+            payload.parsed,
+            result.status,
+            expectedTypecheckerFiles,
+          );
         } catch (error) {
           payload.validationError = errorMessage(error);
         }

--- a/tools/fixtures/tool-matrix-typechecker.mjs
+++ b/tools/fixtures/tool-matrix-typechecker.mjs
@@ -4,7 +4,7 @@ import { isAbsolute } from "node:path";
 const outputKeys = ["errorCount", "fileCount", "files", "warningCount"];
 const fileKeys = ["diagnostics", "file"];
 
-export function validateTypecheckerOutput(project, output, exitCode) {
+export function validateTypecheckerOutput(project, output, exitCode, expectedFiles = null) {
   requireRecord(output, "envelope");
   requireExactKeys(output, outputKeys, "envelope");
   for (const field of ["errorCount", "warningCount", "fileCount"]) {
@@ -21,6 +21,11 @@ export function validateTypecheckerOutput(project, output, exitCode) {
   }
   if (project.expectedVueFileCount !== 0 && output.fileCount === 0) {
     invalid("non-empty fixture checked zero Vue files");
+  }
+  if (expectedFiles != null && output.fileCount !== expectedFiles.length) {
+    invalid(
+      `checked file count ${output.fileCount} does not match ${expectedFiles.length} fixture inputs`,
+    );
   }
 
   const seenFiles = new Set();
@@ -58,6 +63,15 @@ export function validateTypecheckerOutput(project, output, exitCode) {
     .map(({ file }) => file);
   if (JSON.stringify(checkedFiles) !== JSON.stringify(sortedFiles)) {
     invalid("checked file entries are not sorted");
+  }
+  if (expectedFiles != null && JSON.stringify(checkedFiles) !== JSON.stringify(expectedFiles)) {
+    const checkedSet = new Set(checkedFiles);
+    const expectedSet = new Set(expectedFiles);
+    const missing = expectedFiles.filter((file) => !checkedSet.has(file));
+    const unexpected = checkedFiles.filter((file) => !expectedSet.has(file));
+    invalid(
+      `checked files do not match fixture inputs: missing [${missing.join(", ")}], unexpected [${unexpected.join(", ")}]`,
+    );
   }
   if (output.errorCount !== errorCount) {
     invalid(`errorCount ${output.errorCount} does not match ${errorCount} diagnostics`);


### PR DESCRIPTION
## What changed

- derive the exact byte-sorted Vue input manifest from each registered real-project glob
- require typechecker JSON to cover every matched input path exactly once
- add oracle and end-to-end harness regressions for partial and substituted coverage

## Why

The real-project matrix previously accepted any non-zero checked file count, so a typechecker regression could silently skip most files while the shard remained green.

## Validation

- `vp check` on all changed files
- `node --test` across compiler, typechecker, linter, and formatter matrix harness suites (17 tests)
- latest main Real Project Matrix: 11/11 shards, 528 runs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved typechecker fixture validation to ensure all expected Vue files are checked.
  * Added clear errors when files are missing, unexpected, or substituted.
  * Ensured typechecker runs fail when output covers only part of the fixture set.

* **Tests**
  * Added coverage for complete, partial, and mismatched typechecker file results.
  * Added integration coverage for checked-file count validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->