### PR TITLE
test(fixtures): preserve atelier finding evidence

### DIFF
--- a/tests/tooling/fixture-tool-matrix-compiler.test.ts
+++ b/tests/tooling/fixture-tool-matrix-compiler.test.ts
@@ -248,8 +248,21 @@ process.stdout.write("Built: vize-tool-matrix-test.vue\\n");`,
             outputFileCount: raw.compilerArtifacts.outputFileCount,
             errorCount: raw.compilerArtifacts.errorCount,
             warningCount: raw.compilerArtifacts.warningCount,
+            findings: raw.compilerArtifacts.findings,
           },
-          { inputFileCount: 1, outputFileCount: 1, errorCount: 0, warningCount: 1 },
+          {
+            inputFileCount: 1,
+            outputFileCount: 1,
+            errorCount: 0,
+            warningCount: 1,
+            findings: [
+              {
+                file: "apps/vize-tool-matrix-test.vue",
+                errors: [],
+                warnings: ["synthetic warning"],
+              },
+            ],
+          },
         );
         assert.equal(
           raw.compilerArtifacts.sha256,

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -198,6 +198,7 @@ function inspectCompilerArtifacts(cwd, patterns, expectedFileCount, outputDir) {
   const digest = createHash("sha256");
   let errorCount = 0;
   let warningCount = 0;
+  const findings = [];
   for (const outputPath of outputPaths) {
     const source = readFileSync(join(outputDir, outputPath), "utf8");
     digest.update(outputPath);
@@ -210,9 +211,13 @@ function inspectCompilerArtifacts(cwd, patterns, expectedFileCount, outputDir) {
     } catch (error) {
       throw new Error(`invalid compiler JSON artifact ${outputPath}: ${errorMessage(error)}`);
     }
-    validateCompilerArtifact(outputPath, artifact, inputByOutputPath.get(outputPath));
+    const inputPath = inputByOutputPath.get(outputPath);
+    validateCompilerArtifact(outputPath, artifact, inputPath);
     errorCount += artifact.errors.length;
     warningCount += artifact.warnings.length;
+    if (artifact.errors.length > 0 || artifact.warnings.length > 0) {
+      findings.push({ file: inputPath, errors: artifact.errors, warnings: artifact.warnings });
+    }
   }
 
   return {
@@ -220,6 +225,7 @@ function inspectCompilerArtifacts(cwd, patterns, expectedFileCount, outputDir) {
     outputFileCount: outputPaths.length,
     errorCount,
     warningCount,
+    findings,
     sha256: digest.digest("hex"),
   };
 }


### PR DESCRIPTION
## What changed

- retain per-file compiler errors and warnings in each real-project run artifact
- cover clean, warning, error-count, and zero-input artifact reports

## Why

The latest 132-project sweep found 16 compiler errors in 11 projects, but the matrix deleted the compiler artifacts and retained only aggregate counts. This preserves the minimal path/message evidence needed to turn each real-project failure into a regression.

The first validation run also exposed eight projects where compiler artifacts contain errors while the CLI exits successfully. That exit-code fix is intentionally split into a follow-up `fix(cli)` change.

## Validation

- `vp check` on both changed files
- compiler fixture harness: 5/5 tests
- source file remains below the 350-line growth limit (348 lines)
- Real Project Matrix rerun in progress on the amended branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler artifact validation by reporting errors and warnings on a per-file basis, not just aggregate counts.
  * Updated compiler artifact inspection to correctly match each output back to its corresponding input before validating results.
  * Expanded test coverage to assert detailed per-file findings payload in addition to existing summary metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->