### PR TITLE
test(fixtures): require complete patina coverage

### DIFF
--- a/tests/tooling/fixture-tool-matrix-linter.test.ts
+++ b/tests/tooling/fixture-tool-matrix-linter.test.ts
@@ -51,7 +51,30 @@ test("linter oracle accepts exact error, warning, clean, and zero-file reports",
   clean[0].warningCount = 0;
   validateLinterOutput({ id: "clean" }, clean, 0);
 
-  validateLinterOutput({ id: "no-sfc", expectedVueFileCount: 0 }, [], 0);
+  validateLinterOutput({ id: "no-sfc", expectedVueFileCount: 0 }, [], 0, []);
+});
+
+test("linter oracle requires every fixture input and rejects substitutions", () => {
+  const output = validOutput();
+  output.push({
+    file: "src/Card.vue",
+    messages: [],
+    errorCount: 0,
+    warningCount: 0,
+  });
+
+  validateLinterOutput({ id: "complete" }, output, 1, ["src/App.vue", "src/Card.vue"]);
+
+  assert.throws(
+    () =>
+      validateLinterOutput({ id: "partial" }, validOutput(), 1, ["src/App.vue", "src/Card.vue"]),
+    /checked file count 1 does not match 2 inputs/,
+  );
+
+  assert.throws(
+    () => validateLinterOutput({ id: "substituted" }, validOutput(), 1, ["src/Other.vue"]),
+    /checked files do not match inputs: missing \[src\/Other\.vue\], unexpected \[src\/App\.vue\]/,
+  );
 });
 
 test("linter oracle rejects malformed or internally inconsistent reports", () => {
@@ -242,6 +265,46 @@ test("fixture tool matrix records linter schema failures", () => {
     assert.match(run.failure, /non-empty fixture linted zero Vue files/);
     const raw = JSON.parse(fs.readFileSync(path.resolve(root, run.outputPath as string), "utf8"));
     assert.match(raw.validationError, /non-empty fixture linted zero Vue files/);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
+});
+
+test("fixture tool matrix rejects partial linter coverage", () => {
+  const fixtureDir = fs.mkdtempSync(
+    path.join(root, "tests", "_fixtures", "tool-matrix-linter-partial-"),
+  );
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-linter-partial-"));
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-linter-partial-report-"));
+  const executable = path.join(fakeDir, "fake-vize.mjs");
+  fs.mkdirSync(path.join(fixtureDir, "src"), { recursive: true });
+  fs.writeFileSync(path.join(fixtureDir, "src", "App.vue"), "<template />\n");
+  fs.writeFileSync(path.join(fixtureDir, "src", "Card.vue"), "<template />\n");
+  fs.writeFileSync(
+    executable,
+    `#!/usr/bin/env node
+process.stdout.write(JSON.stringify([{ file: "src/App.vue", messages: [], errorCount: 0, warningCount: 0 }]));\n`,
+  );
+  fs.chmodSync(executable, 0o755);
+
+  try {
+    const run = runTool(
+      {
+        id: "linter-partial-fixture",
+        fixturePath: path.relative(root, fixtureDir),
+        vueGlobs: ["**/*.vue"],
+      },
+      "linter",
+      { dryRun: false, timeoutMs: 5_000 },
+      { command: executable, prefix: [], label: executable },
+      reportDir,
+    );
+    assert.equal(run.status, "failed");
+    assert.match(run.failure, /checked file count 1 does not match 2 inputs/);
+    const raw = JSON.parse(fs.readFileSync(path.resolve(root, run.outputPath as string), "utf8"));
+    assert.match(raw.validationError, /checked file count 1 does not match 2 inputs/);
   } finally {
     fs.rmSync(fixtureDir, { recursive: true, force: true });
     fs.rmSync(fakeDir, { recursive: true, force: true });

--- a/tools/fixtures/tool-matrix-linter.mjs
+++ b/tools/fixtures/tool-matrix-linter.mjs
@@ -23,13 +23,16 @@ const messageKeysWithHelp = [
   "severity",
 ];
 
-export function validateLinterOutput(project, output, exitCode) {
+export function validateLinterOutput(project, output, exitCode, expectedFiles = null) {
   if (!Array.isArray(output)) invalid("envelope must be an array");
   if (project.expectedVueFileCount === 0 && output.length !== 0) {
     invalid(`expected zero checked files, received ${output.length}`);
   }
   if (project.expectedVueFileCount !== 0 && output.length === 0) {
     invalid("non-empty fixture linted zero Vue files");
+  }
+  if (expectedFiles != null && output.length !== expectedFiles.length) {
+    invalid(`checked file count ${output.length} does not match ${expectedFiles.length} inputs`);
   }
 
   const seenFiles = new Set();
@@ -80,6 +83,19 @@ export function validateLinterOutput(project, output, exitCode) {
       );
     }
     totalErrors += errorCount;
+  }
+
+  const checkedFiles = output.map((file) => file.file);
+  if (expectedFiles != null) {
+    const checkedSet = new Set(checkedFiles);
+    const expectedSet = new Set(expectedFiles);
+    const missing = expectedFiles.filter((file) => !checkedSet.has(file));
+    const unexpected = checkedFiles.filter((file) => !expectedSet.has(file));
+    if (missing.length > 0 || unexpected.length > 0) {
+      invalid(
+        `checked files do not match inputs: missing [${missing.join(", ")}], unexpected [${unexpected.join(", ")}]`,
+      );
+    }
   }
 
   const expectedExitCode = totalErrors > 0 ? 1 : 0;

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -46,8 +46,10 @@ export function runTool(project, tool, args, launch, outputDir) {
   if (!fixtureExists) return { ...base, status: "missing-fixture" };
   const formatterStateBefore =
     tool === "formatter" ? snapshotFormatterInputs(cwd, project.vueGlobs) : null;
-  const expectedTypecheckerFiles =
-    tool === "typechecker" ? collectVueInputPaths(cwd, project.vueGlobs) : null;
+  const expectedToolFiles =
+    tool === "typechecker" || tool === "linter"
+      ? collectVueInputPaths(cwd, project.vueGlobs)
+      : null;
 
   try {
     const startedAt = Date.now();
@@ -95,19 +97,14 @@ export function runTool(project, tool, args, launch, outputDir) {
       }
       if (tool === "typechecker" && payload.parseError == null) {
         try {
-          validateTypecheckerOutput(
-            project,
-            payload.parsed,
-            result.status,
-            expectedTypecheckerFiles,
-          );
+          validateTypecheckerOutput(project, payload.parsed, result.status, expectedToolFiles);
         } catch (error) {
           payload.validationError = errorMessage(error);
         }
       }
       if (tool === "linter" && payload.parseError == null) {
         try {
-          validateLinterOutput(project, payload.parsed, result.status);
+          validateLinterOutput(project, payload.parsed, result.status, expectedToolFiles);
         } catch (error) {
           payload.validationError = errorMessage(error);
         }


### PR DESCRIPTION
## What changed

- derive the exact Vue input manifest for each real-project linter run
- require linter JSON to cover every matched path exactly once, independent of report ordering
- add oracle and end-to-end regressions for partial and substituted coverage

## Why

The matrix previously accepted any non-empty linter report. A regression could silently skip most files while all shards remained green.

The first matrix run showed that 43 projects emit a stable but non-global path order. Exact set equality is the coverage contract; output ordering is intentionally left for a separate determinism change.

## Validation

- `vp check` on all changed files
- compiler/typechecker/linter/formatter harness suites: 19/19 tests
- Real Project Matrix rerun in progress on the amended branch
