### PR TITLE
fix(parser): preserve HTML tree shape in quirks

### DIFF
--- a/crates/vize_armature/src/parser/element/scope.rs
+++ b/crates/vize_armature/src/parser/element/scope.rs
@@ -8,6 +8,10 @@ use super::is_html_tree_element;
 
 impl<'a> Parser<'a> {
     pub(super) fn handle_in_body_start_tag(&mut self, tag: &str, offset: usize) {
+        if self.template_syntax.is_quirks() {
+            return;
+        }
+
         if tag.eq_ignore_ascii_case("html") || tag.eq_ignore_ascii_case("body") {
             return;
         }
@@ -150,7 +154,8 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn should_ignore_start_tag(&self, element: &ElementNode<'a>) -> bool {
-        is_html_tree_element(element)
+        !self.template_syntax.is_quirks()
+            && is_html_tree_element(element)
             && element.tag.eq_ignore_ascii_case("form")
             && self.open_form_count > 0
     }

--- a/crates/vize_armature/src/parser/element/table.rs
+++ b/crates/vize_armature/src/parser/element/table.rs
@@ -19,7 +19,8 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn should_foster_text(&self, content: &str) -> bool {
-        self.open_table_count > 0
+        !self.template_syntax.is_quirks()
+            && self.open_table_count > 0
             && content
                 .chars()
                 .any(|c| !matches!(c, ' ' | '\t' | '\n' | '\r' | '\u{000C}'))
@@ -27,7 +28,8 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn should_foster_start_tag(&self, tag: &str, is_html_element: bool) -> bool {
-        is_html_element
+        !self.template_syntax.is_quirks()
+            && is_html_element
             && self.open_table_count > 0
             && self.is_in_table_insertion_context()
             && !self.is_allowed_in_table_insertion_context(tag)

--- a/crates/vize_armature/tests/template_syntax_quirks.rs
+++ b/crates/vize_armature/tests/template_syntax_quirks.rs
@@ -44,3 +44,47 @@ fn quirks_ignores_closing_tags_for_void_elements() {
     );
     assert!(quirks_errors.is_empty(), "{quirks_errors:?}");
 }
+
+#[test]
+fn quirks_preserves_vue_tree_shape_for_html_recovery_cases() {
+    let cases = [
+        (
+            "nested button",
+            "<button><span><button>share</button></span></button>",
+        ),
+        (
+            "nested anchor",
+            "<a href=\"#outer\"><span><a href=\"#inner\">open</a></span></a>",
+        ),
+        (
+            "nested form",
+            "<form><section><form><input></form></section></form>",
+        ),
+        (
+            "table foster parenting",
+            "<table><div>description</div><tr><td>value</td></tr></table>",
+        ),
+    ];
+
+    for (name, source) in cases {
+        let allocator = Bump::new();
+        let (_, standard_errors) = parse_with_options(&allocator, source, ParserOptions::default());
+        assert!(
+            !standard_errors.is_empty(),
+            "{name} should exercise HTML recovery"
+        );
+
+        let (root, quirks_errors) = parse_with_options_and_template_syntax(
+            &allocator,
+            source,
+            ParserOptions::default(),
+            TemplateSyntaxMode::Quirks,
+        );
+        assert!(quirks_errors.is_empty(), "{name}: {quirks_errors:?}");
+        assert_eq!(
+            root.children.len(),
+            1,
+            "{name} should preserve its lexical root"
+        );
+    }
+}

--- a/crates/vize_atelier_dom/tests/template_syntax_quirks_recovery.rs
+++ b/crates/vize_atelier_dom/tests/template_syntax_quirks_recovery.rs
@@ -1,0 +1,26 @@
+use vize_atelier_core::TemplateSyntaxMode;
+use vize_atelier_dom::{DomCompilerOptions, compile_template_with_template_syntax};
+use vize_carton::Bump;
+
+#[test]
+fn quirks_compiles_html_tree_recovery_cases_without_cascading_errors() {
+    let cases = [
+        "<button><span><button>share</button></span></button>",
+        "<a href=\"#outer\"><span><a href=\"#inner\">open</a></span></a>",
+        "<form><section><form><input></form></section></form>",
+        "<table><div>description</div><tr><td>value</td></tr></table>",
+    ];
+
+    for source in cases {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_template_with_template_syntax(
+            &allocator,
+            source,
+            DomCompilerOptions::default(),
+            TemplateSyntaxMode::Quirks,
+        );
+
+        assert!(errors.is_empty(), "{source}: {errors:?}");
+        assert!(!result.code.is_empty(), "{source}");
+    }
+}


### PR DESCRIPTION
## Summary

- skip browser-only tree recovery for Vue-compatible quirks parsing
- preserve nested buttons, anchors, forms, and table children in lexical order
- cover parser and DOM compiler behavior with strict regression cases

## Verification

- cargo test -p vize_armature
- cargo test -p vize_atelier_dom
- cargo clippy -p vize_armature -p vize_atelier_dom --lib -- -D warnings
- cargo fmt --all -- --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->