### PR TITLE
test(fixtures): require complete formatter coverage

### DIFF
--- a/tests/tooling/fixture-tool-matrix-formatter.test.ts
+++ b/tests/tooling/fixture-tool-matrix-formatter.test.ts
@@ -29,12 +29,15 @@ function changedReport() {
 
 test("formatter oracle accepts changed, mixed, clean, and zero-file reports", () => {
   assert.deepEqual(
-    validateFormatterOutput({ id: "changed" }, "", changedReport(), 1, "same", "same"),
+    validateFormatterOutput({ id: "changed" }, "", changedReport(), 1, "same", "same", [
+      "src/App.vue",
+      "src/Card.vue",
+    ]),
     {
       checkedFileCount: 2,
       changedFileCount: 2,
       unchangedFileCount: 0,
-      changedPathsSha256: "51d272a067976b5d31b5a538d475d04fe9c917837d342781ced092794acc5e2c",
+      changedPathsSha256: "60e7f3109278640e86d41597937d4032f96264285f92113a525cd05c56456913",
     },
   );
   assert.deepEqual(
@@ -53,6 +56,7 @@ test("formatter oracle accepts changed, mixed, clean, and zero-file reports", ()
       1,
       "same",
       "same",
+      ["src/App.vue", "src/Card.vue"],
     ),
     {
       checkedFileCount: 2,
@@ -69,6 +73,7 @@ test("formatter oracle accepts changed, mixed, clean, and zero-file reports", ()
       0,
       "same",
       "same",
+      ["src/App.vue"],
     ),
     {
       checkedFileCount: 1,
@@ -85,6 +90,7 @@ test("formatter oracle accepts changed, mixed, clean, and zero-file reports", ()
       1,
       "same",
       "same",
+      [],
     ),
     {
       checkedFileCount: 0,
@@ -140,6 +146,16 @@ test("formatter oracle rejects malformed, inconsistent, or mutating checks", () 
       stderr: "Found 0 file(s)\n\nChecked 0 file(s)\n",
       exitCode: 0,
       message: /non-empty fixture formatted zero files/,
+    },
+    {
+      name: "partial fixture coverage",
+      expectedFiles: ["src/App.vue", "src/Card.vue", "src/Other.vue"],
+      message: /found count 2 does not match 3 inputs/,
+    },
+    {
+      name: "changed path outside fixture inputs",
+      expectedFiles: ["src/Card.vue", "src/Other.vue"],
+      message: /changed files are not fixture inputs: src\/App\.vue/,
     },
     {
       name: "absolute Unix path",
@@ -217,6 +233,7 @@ test("formatter oracle rejects malformed, inconsistent, or mutating checks", () 
           fixtureCase.exitCode ?? 1,
           "same",
           fixtureCase.after ?? "same",
+          fixtureCase.expectedFiles ?? null,
         ),
       fixtureCase.message,
       fixtureCase.name,
@@ -277,6 +294,46 @@ process.exit(1);\n`,
     assert.match(run.failure, /modified its working tree or input metadata/);
     const raw = JSON.parse(fs.readFileSync(path.resolve(root, run.outputPath as string), "utf8"));
     assert.match(raw.validationError, /modified its working tree or input metadata/);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
+});
+
+test("fixture tool matrix rejects partial formatter coverage", () => {
+  const fixtureDir = fs.mkdtempSync(
+    path.join(root, "tests", "_fixtures", "tool-matrix-formatter-partial-"),
+  );
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-formatter-partial-"));
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-formatter-partial-report-"));
+  const executable = path.join(fakeDir, "fake-vize.mjs");
+  fs.mkdirSync(path.join(fixtureDir, "src"), { recursive: true });
+  fs.writeFileSync(path.join(fixtureDir, "src", "App.vue"), "<template />\n");
+  fs.writeFileSync(path.join(fixtureDir, "src", "Card.vue"), "<template />\n");
+  fs.writeFileSync(
+    executable,
+    `#!/usr/bin/env node
+process.stderr.write("Found 1 file(s)\\n\\nChecked 1 file(s)\\n  1 file(s) already formatted\\n");\n`,
+  );
+  fs.chmodSync(executable, 0o755);
+
+  try {
+    const run = runTool(
+      {
+        id: "formatter-partial-fixture",
+        fixturePath: path.relative(root, fixtureDir),
+        vueGlobs: ["**/*.vue"],
+      },
+      "formatter",
+      { dryRun: false, timeoutMs: 5_000 },
+      { command: executable, prefix: [], label: executable },
+      reportDir,
+    );
+    assert.equal(run.status, "failed");
+    assert.match(run.failure, /found count 1 does not match 2 inputs/);
+    const raw = JSON.parse(fs.readFileSync(path.resolve(root, run.outputPath as string), "utf8"));
+    assert.match(raw.validationError, /found count 1 does not match 2 inputs/);
   } finally {
     fs.rmSync(fixtureDir, { recursive: true, force: true });
     fs.rmSync(fakeDir, { recursive: true, force: true });

--- a/tools/fixtures/tool-matrix-formatter.mjs
+++ b/tools/fixtures/tool-matrix-formatter.mjs
@@ -40,7 +40,15 @@ export function snapshotFormatterInputs(cwd, patterns) {
   return digest.digest("hex");
 }
 
-export function validateFormatterOutput(project, stdout, stderr, exitCode, before, after) {
+export function validateFormatterOutput(
+  project,
+  stdout,
+  stderr,
+  exitCode,
+  before,
+  after,
+  expectedFiles = null,
+) {
   if (stdout !== "") invalid("stdout must be empty");
   if (before !== after) invalid("formatter check modified its working tree or input metadata");
   const normalizedStderr = stderr.replaceAll("\r\n", "\n");
@@ -57,12 +65,14 @@ export function validateFormatterOutput(project, stdout, stderr, exitCode, befor
   const lines = normalizedStderr.slice(0, -1).split("\n");
   const found = parseCount(lines[0], /^Found (\d+) file\(s\)$/, "found count");
   if (found === 0) invalid("non-empty fixture formatted zero files");
+  if (expectedFiles != null && found !== expectedFiles.length) {
+    invalid(`found count ${found} does not match ${expectedFiles.length} inputs`);
+  }
   const changedPaths = [];
   let index = 1;
   while (lines[index]?.startsWith("Would reformat: ")) {
     const candidate = lines[index].slice("Would reformat: ".length);
-    requireFormatterPath(candidate);
-    changedPaths.push(candidate);
+    changedPaths.push(normalizeFormatterPath(candidate));
     index += 1;
   }
   if (lines[index] !== "") invalid("missing blank line before formatter summary");
@@ -85,6 +95,13 @@ export function validateFormatterOutput(project, stdout, stderr, exitCode, befor
   if (index !== lines.length) invalid("formatter report contains unexpected lines");
   if (new Set(changedPaths).size !== changedPaths.length) {
     invalid("formatter report contains duplicate changed paths");
+  }
+  if (expectedFiles != null) {
+    const expectedSet = new Set(expectedFiles);
+    const unexpected = changedPaths.filter((file) => !expectedSet.has(file));
+    if (unexpected.length > 0) {
+      invalid(`changed files are not fixture inputs: ${unexpected.join(", ")}`);
+    }
   }
   if (changed !== changedPaths.length) {
     invalid(`changed count ${changed} does not match ${changedPaths.length} paths`);
@@ -127,7 +144,7 @@ function safeCount(value, label) {
   return count;
 }
 
-function requireFormatterPath(value) {
+function normalizeFormatterPath(value) {
   const bare = value.startsWith("./") ? value.slice(2) : value;
   if (
     bare.length === 0 ||
@@ -139,6 +156,7 @@ function requireFormatterPath(value) {
     invalid("changed file must be a normalized relative path");
   }
   if (!bare.endsWith(".vue")) invalid(`changed file is not a Vue SFC: ${value}`);
+  return bare;
 }
 
 function invalid(message) {

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -47,7 +47,7 @@ export function runTool(project, tool, args, launch, outputDir) {
   const formatterStateBefore =
     tool === "formatter" ? snapshotFormatterInputs(cwd, project.vueGlobs) : null;
   const expectedToolFiles =
-    tool === "typechecker" || tool === "linter"
+    tool === "typechecker" || tool === "linter" || tool === "formatter"
       ? collectVueInputPaths(cwd, project.vueGlobs)
       : null;
 
@@ -119,6 +119,7 @@ export function runTool(project, tool, args, launch, outputDir) {
           result.status,
           formatterStateBefore,
           formatterStateAfter,
+          expectedToolFiles,
         );
       } catch (error) {
         payload.validationError = errorMessage(error);


### PR DESCRIPTION
## Summary

- snapshot the exact formatter input manifest before execution
- require formatter reports to account for every fixture Vue file
- reject partial, substituted, and mutating formatter checks

## Verification

- vp check
- node --test --test-concurrency=1 tests/tooling/fixture-tool-matrix-formatter.test.ts tests/tooling/fixture-tool-matrix-linter.test.ts tests/tooling/fixture-tool-matrix-typechecker.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->