### PR TITLE
fix(sfc): preserve defineModel runtime options

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_script/function_mode.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode.rs
@@ -10,6 +10,10 @@
 mod compiler;
 pub(crate) mod helpers;
 pub(crate) mod imports;
+mod model;
+
+#[cfg(test)]
+mod tests;
 
 pub use compiler::compile_script_setup;
 pub use helpers::contains_top_level_await;

--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -9,8 +9,7 @@ use vize_croquis::macros::runtime_erased_macro_names;
 
 use crate::script::{
     PropsDestructuredBindings, ScriptCompileContext, TemplateUsedIdentifiers, define_model_name,
-    model_modifiers_binding_name, resolve_template_used_identifiers, resolve_type_args,
-    transform_destructured_props,
+    resolve_template_used_identifiers, resolve_type_args, transform_destructured_props,
 };
 use crate::types::{BindingType, SfcError};
 
@@ -27,6 +26,7 @@ use super::super::statement_sections::extract_script_sections;
 use super::super::typescript::transform_typescript_to_js;
 use super::helpers::{collect_runtime_identifier_references, is_reserved_word};
 use super::imports::dedupe_imports;
+use super::model::emit_model_bindings;
 
 /// Compile script setup content following Vue.js core format
 #[allow(dead_code)]
@@ -574,37 +574,6 @@ fn emit_expose(output: &mut vize_carton::Vec<u8>, ctx: &ScriptCompileContext) {
         // No defineExpose, but still need to call __expose() for Vue runtime
         output.extend_from_slice(b"  __expose();\n");
     }
-}
-
-/// Emit defineModel bindings and return the binding names.
-fn emit_model_bindings(
-    output: &mut vize_carton::Vec<u8>,
-    ctx: &ScriptCompileContext,
-) -> Vec<String> {
-    let mut model_binding_names: Vec<String> = Vec::new();
-    for model_call in &ctx.macros.define_models {
-        if let Some(ref binding_name) = model_call.binding_name {
-            let model_name = define_model_name(ctx.source.as_str(), model_call);
-
-            output.extend_from_slice(b"  const ");
-            if let Some(ref modifiers_binding_name) =
-                model_modifiers_binding_name(ctx.source.as_str(), model_call)
-            {
-                output.push(b'[');
-                output.extend_from_slice(binding_name.as_bytes());
-                output.extend_from_slice(b", ");
-                output.extend_from_slice(modifiers_binding_name.as_bytes());
-                output.extend_from_slice(b"]");
-            } else {
-                output.extend_from_slice(binding_name.as_bytes());
-            }
-            output.extend_from_slice(b" = _useModel(__props, \"");
-            output.extend_from_slice(model_name.as_bytes());
-            output.extend_from_slice(b"\")\n");
-            model_binding_names.push(String::from(binding_name.as_str()));
-        }
-    }
-    model_binding_names
 }
 
 /// Build the list of bindings to include in `__returned__`.

--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/model.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/model.rs
@@ -1,0 +1,40 @@
+//! `defineModel` code generation for function mode.
+
+use vize_carton::String;
+
+use crate::script::{ScriptCompileContext, define_model_metadata, model_modifiers_binding_name};
+
+/// Emit `defineModel` bindings and return their binding names.
+pub(super) fn emit_model_bindings(
+    output: &mut vize_carton::Vec<u8>,
+    ctx: &ScriptCompileContext,
+) -> Vec<String> {
+    let mut binding_names = Vec::new();
+    for model_call in &ctx.macros.define_models {
+        if let Some(ref binding_name) = model_call.binding_name {
+            let metadata = define_model_metadata(ctx.source.as_str(), model_call);
+            output.extend_from_slice(b"  const ");
+            if let Some(ref modifiers) =
+                model_modifiers_binding_name(ctx.source.as_str(), model_call)
+            {
+                output.push(b'[');
+                output.extend_from_slice(binding_name.as_bytes());
+                output.extend_from_slice(b", ");
+                output.extend_from_slice(modifiers.as_bytes());
+                output.push(b']');
+            } else {
+                output.extend_from_slice(binding_name.as_bytes());
+            }
+            output.extend_from_slice(b" = _useModel(__props, \"");
+            output.extend_from_slice(metadata.name.as_bytes());
+            output.push(b'"');
+            if let Some(options) = metadata.runtime_options {
+                output.extend_from_slice(b", ");
+                output.extend_from_slice(options.as_bytes());
+            }
+            output.extend_from_slice(b")\n");
+            binding_names.push(String::from(binding_name.as_str()));
+        }
+    }
+    binding_names
+}

--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/tests.rs
@@ -1,0 +1,21 @@
+use super::compile_script_setup;
+
+#[test]
+fn preserves_define_model_setup_runtime_accessors() {
+    let content = r#"
+const minimum = computed(() => 1)
+const [model, modifiers] = defineModel<number>({
+  get(value) { return value ?? minimum.value },
+  set(value) { return modifiers.number ? Math.max(minimum.value, Number(value)) : value },
+})
+"#;
+    let result = compile_script_setup(content, "Test", false, true, None).unwrap();
+
+    assert!(
+        result.code.contains("_useModel(__props, \"modelValue\", {")
+            && result.code.contains("return value ?? minimum.value"),
+        "{}",
+        result.code
+    );
+    assert!(result.code.contains("modifiers.number"), "{}", result.code);
+}

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/body.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/body.rs
@@ -79,6 +79,7 @@ pub(super) fn compile_script_setup_inline_body(
         Option<String>,
         Option<String>,
         Option<String>,
+        Option<String>,
     )> = profile!(
         "atelier.script_inline.collect_model_infos",
         collect_model_infos(&ctx)

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/model.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/model.rs
@@ -55,6 +55,7 @@ pub(super) fn build_model_props_emits(
         Option<String>,
         Option<String>,
         Option<String>,
+        Option<String>,
     )],
     is_ts: bool,
     needs_prop_type: bool,
@@ -68,7 +69,9 @@ pub(super) fn build_model_props_emits(
         // model props declaration: `{\n    "name": <opts>,\n    "nameModifiers": {},\n  }`
         let mut model_decl: Vec<u8> = Vec::new();
         model_decl.push(b'{');
-        for (model_name, _binding_name, _modifiers_binding_name, options, type_arg) in model_infos {
+        for (model_name, _binding_name, _modifiers_binding_name, options, _, type_arg) in
+            model_infos
+        {
             model_decl.extend_from_slice(b"\n    \"");
             model_decl.extend_from_slice(model_name.as_bytes());
             model_decl.extend_from_slice(b"\": ");
@@ -133,7 +136,7 @@ pub(super) fn build_model_props_emits(
     let model_emits: Vec<u8> = {
         let mut v = Vec::new();
         v.push(b'[');
-        for (i, (name, _, _, _, _)) in model_infos.iter().enumerate() {
+        for (i, (name, _, _, _, _, _)) in model_infos.iter().enumerate() {
             if i > 0 {
                 v.extend_from_slice(b", ");
             }
@@ -182,6 +185,7 @@ pub(super) fn collect_model_infos(
     Option<String>,
     Option<String>,
     Option<String>,
+    Option<String>,
 )> {
     ctx.macros
         .define_models
@@ -200,6 +204,7 @@ pub(super) fn collect_model_infos(
                 binding_name,
                 modifiers_binding_name,
                 metadata.options,
+                metadata.runtime_options,
                 m.type_args.clone(),
             )
         })

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/setup_emit.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/setup_emit.rs
@@ -102,6 +102,7 @@ pub(super) fn emit_setup_body(
         Option<String>,
         Option<String>,
         Option<String>,
+        Option<String>,
     )],
     setup_body_lines: &[String],
     source_is_ts: bool,
@@ -141,7 +142,9 @@ pub(super) fn emit_setup_body(
 
     // Model bindings: const model = _useModel<T>(__props, 'modelValue')
     if !model_infos.is_empty() {
-        for (model_name, binding_name, modifiers_binding_name, _, type_arg) in model_infos {
+        for (model_name, binding_name, modifiers_binding_name, _, runtime_options, type_arg) in
+            model_infos
+        {
             output.extend_from_slice(b"const ");
             if let Some(modifiers_binding_name) = modifiers_binding_name {
                 output.push(b'[');
@@ -165,7 +168,12 @@ pub(super) fn emit_setup_body(
             }
             output.extend_from_slice(b"(__props, \"");
             output.extend_from_slice(model_name.as_bytes());
-            output.extend_from_slice(b"\")\n");
+            output.push(b'"');
+            if let Some(runtime_options) = runtime_options {
+                output.extend_from_slice(b", ");
+                output.extend_from_slice(runtime_options.as_bytes());
+            }
+            output.extend_from_slice(b")\n");
         }
     }
 

--- a/crates/vize_atelier_sfc/src/compile_script/inline/define_model_tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/define_model_tests.rs
@@ -57,15 +57,36 @@ const model = defineModel(('label') as const, {
         "expected model emits to use the AST string argument:\n{output}"
     );
     assert!(
-        normalized.contains(r#"const model = _useModel(__props, "label");"#),
-        "expected useModel to use the AST string argument:\n{output}"
+        normalized.contains(r#"const model = _useModel(__props, "label", {"#)
+            && normalized.contains("get(value) { return value; }")
+            && normalized.contains("set(value) { return value.trim(); }"),
+        "expected useModel to preserve runtime accessors:\n{output}"
     );
     assert!(
         !normalized.contains("modelValue"),
         "parenthesized/as string argument should not fall back to modelValue:\n{output}"
     );
+}
+
+#[test]
+fn define_model_runtime_accessors_can_reference_setup_bindings() {
+    let content = r#"
+const minimum = computed(() => 1)
+const [model, modifiers] = defineModel<number>({
+  get(value) {
+    return value ?? minimum.value
+  },
+  set(value) {
+    return modifiers.number ? Math.max(minimum.value, Number(value)) : value
+  },
+})
+"#;
+
+    let output = compile_setup(content);
+    assert!(output.contains("minimum.value"), "{output}");
+    assert!(output.contains("modifiers.number"), "{output}");
     assert!(
-        !normalized.contains("get(value)") && !normalized.contains("set(value)"),
-        "runtime-only model accessors should not be copied into props options:\n{output}"
+        output.contains("_useModel(__props, \"modelValue\", {"),
+        "{output}"
     );
 }

--- a/crates/vize_atelier_sfc/src/compile_script/props/validation/macro_scope.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props/validation/macro_scope.rs
@@ -8,7 +8,7 @@ use oxc_span::SourceType;
 use oxc_syntax::symbol::SymbolFlags;
 use vize_carton::cstr;
 
-use crate::script::ScriptCompileContext;
+use crate::script::{ScriptCompileContext, define_model_prop_option_spans};
 use crate::types::{BindingType, SfcDescriptor, SfcError};
 
 use super::block_location_for_span;
@@ -75,16 +75,15 @@ fn hoisted_macro_spans(ctx: &ScriptCompileContext) -> Vec<HoistedMacroSpan> {
             });
         }
     }
-    spans.extend(
-        ctx.macros
-            .define_models
-            .iter()
-            .map(|call| HoistedMacroSpan {
+    spans.extend(ctx.macros.define_models.iter().flat_map(|call| {
+        define_model_prop_option_spans(ctx.source.as_str(), call)
+            .into_iter()
+            .map(|(start, end)| HoistedMacroSpan {
                 name: "defineModel",
-                start: call.start,
-                end: call.end,
-            }),
-    );
+                start,
+                end,
+            })
+    }));
     spans
 }
 

--- a/crates/vize_atelier_sfc/src/compile_script/props/validation/macro_scope/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props/validation/macro_scope/tests.rs
@@ -79,6 +79,11 @@ fn rejects_setup_local_values_in_every_hoisted_runtime_macro() {
             "const local = makeValidator()\ndefineModel<string>({ validator: local })",
             "defineModel",
         ),
+        (
+            "defineModel prop option beside runtime accessor",
+            "const local = makeValidator()\ndefineModel<string>({ validator: local, get: value => value })",
+            "defineModel",
+        ),
     ];
 
     for (label, source, macro_name) in cases {
@@ -135,6 +140,14 @@ fn allows_values_that_remain_valid_after_macro_hoisting() {
         (
             "local value in a type query",
             "const runtime = { ready: true }\ndefineProps<{ value?: typeof runtime }>()",
+        ),
+        (
+            "defineModel runtime accessors",
+            "const local = computed(() => 1)\ndefineModel<number>({ get(value) { return value ?? local.value }, set(value) { return Math.max(local.value, value) } })",
+        ),
+        (
+            "defineModel modifiers binding in setter",
+            "const [model, modifiers] = defineModel<string>({ set(value) { return modifiers.trim ? value.trim() : value } })",
         ),
     ];
 

--- a/crates/vize_atelier_sfc/src/script.rs
+++ b/crates/vize_atelier_sfc/src/script.rs
@@ -26,7 +26,9 @@ pub use context::{ScriptCompileContext, TypeResolutionBatchGuard, begin_type_res
 pub use define_emits::{
     DefineEmitsResult, extract_runtime_emits, gen_runtime_emits, process_define_emits,
 };
-pub(crate) use define_model_metadata::{define_model_metadata, define_model_name};
+pub(crate) use define_model_metadata::{
+    define_model_metadata, define_model_name, define_model_prop_option_spans,
+};
 pub use define_props_destructure::{
     PropsDestructureBinding, PropsDestructuredBindings, gen_props_access_exp,
     process_props_destructure, transform_destructured_props,

--- a/crates/vize_atelier_sfc/src/script/define_model_metadata.rs
+++ b/crates/vize_atelier_sfc/src/script/define_model_metadata.rs
@@ -12,6 +12,7 @@ use super::MacroCall;
 pub(crate) struct DefineModelMetadata {
     pub(crate) name: String,
     pub(crate) options: Option<String>,
+    pub(crate) runtime_options: Option<String>,
 }
 
 pub(crate) fn define_model_name(source: &str, call: &MacroCall) -> String {
@@ -43,20 +44,67 @@ fn extract_metadata_from_call(call: &CallExpression<'_>, source: &str) -> Define
         .map(|name| name.to_compact_string())
         .unwrap_or_else(|| "modelValue".to_compact_string());
     let options_index = if name_arg.is_some() { 1 } else { 0 };
-    let options = call
+    let (options, runtime_options) = call
         .arguments
         .get(options_index)
         .and_then(argument_object)
-        .and_then(|object| strip_model_runtime_accessors(object, source));
+        .map_or((None, None), |object| split_model_options(object, source));
 
-    DefineModelMetadata { name, options }
+    DefineModelMetadata {
+        name,
+        options,
+        runtime_options,
+    }
 }
 
 fn default_metadata() -> DefineModelMetadata {
     DefineModelMetadata {
         name: "modelValue".into(),
         options: None,
+        runtime_options: None,
     }
+}
+
+pub(crate) fn define_model_prop_option_spans(
+    source: &str,
+    macro_call: &MacroCall,
+) -> Vec<(usize, usize)> {
+    let Some(call_source) = source.get(macro_call.start..macro_call.end) else {
+        return Vec::new();
+    };
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, call_source, SourceType::ts()).parse();
+    let Some(Statement::ExpressionStatement(statement)) = parsed.program.body.first() else {
+        return Vec::new();
+    };
+    let Expression::CallExpression(call) = &statement.expression else {
+        return Vec::new();
+    };
+    let name_arg = call.arguments.first().and_then(argument_string_literal);
+    let options_index = usize::from(name_arg.is_some());
+    let Some(object) = call.arguments.get(options_index).and_then(argument_object) else {
+        return Vec::new();
+    };
+    if has_dynamic_model_options(object) {
+        return Vec::new();
+    }
+
+    object
+        .properties
+        .iter()
+        .filter_map(|property| {
+            let ObjectPropertyKind::ObjectProperty(property) = property else {
+                return None;
+            };
+            if matches!(static_property_name(&property.key), Some("get" | "set")) {
+                return None;
+            }
+            Some((
+                macro_call.start + property.span.start as usize,
+                macro_call.start + property.span.end as usize,
+            ))
+        })
+        .collect()
 }
 
 fn argument_string_literal<'a>(argument: &'a Argument<'a>) -> Option<&'a str> {
@@ -103,20 +151,34 @@ fn expression_object<'a>(expression: &'a Expression<'a>) -> Option<&'a ObjectExp
     }
 }
 
-fn strip_model_runtime_accessors(object: &ObjectExpression<'_>, source: &str) -> Option<String> {
-    if object.properties.iter().any(|property| match property {
+fn has_dynamic_model_options(object: &ObjectExpression<'_>) -> bool {
+    object.properties.iter().any(|property| match property {
         ObjectPropertyKind::ObjectProperty(property) => property.computed,
         ObjectPropertyKind::SpreadProperty(_) => true,
-    }) {
-        return source
-            .get(object.span.start as usize..object.span.end as usize)
-            .map(String::from);
+    })
+}
+
+fn split_model_options(
+    object: &ObjectExpression<'_>,
+    source: &str,
+) -> (Option<String>, Option<String>) {
+    let object_source = source
+        .get(object.span.start as usize..object.span.end as usize)
+        .map(String::from);
+    if has_dynamic_model_options(object) {
+        return (object_source.clone(), object_source);
     }
 
     let object_start = object.span.start as usize;
     let object_end = object.span.end as usize;
-    let object_close = object_end.checked_sub(1)?;
-    let mut result = source.get(object_start..object_end)?.to_compact_string();
+    let Some(object_close) = object_end.checked_sub(1) else {
+        return (object_source, None);
+    };
+    let Some(object_source) = source.get(object_start..object_end) else {
+        return (None, None);
+    };
+    let mut prop_options = object_source.to_compact_string();
+    let mut runtime_options = object_source.to_compact_string();
     let properties: Vec<_> = object
         .properties
         .iter()
@@ -130,17 +192,26 @@ fn strip_model_runtime_accessors(object: &ObjectExpression<'_>, source: &str) ->
             ))
         })
         .collect();
+    let has_runtime_accessors = properties
+        .iter()
+        .any(|(_, key)| matches!(key, Some("get" | "set")));
 
     for (index, (start, key)) in properties.iter().enumerate().rev() {
+        let end = properties
+            .get(index + 1)
+            .map(|(next_start, _)| *next_start)
+            .unwrap_or(object_close);
+        let range = start - object_start..end - object_start;
         if matches!(key, Some("get" | "set")) {
-            let end = properties
-                .get(index + 1)
-                .map(|(next_start, _)| *next_start)
-                .unwrap_or(object_close);
-            result.replace_range(start - object_start..end - object_start, "");
+            prop_options.replace_range(range, "");
+        } else {
+            runtime_options.replace_range(range, "");
         }
     }
-    Some(result)
+    (
+        Some(prop_options),
+        has_runtime_accessors.then_some(runtime_options),
+    )
 }
 
 fn static_property_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {


### PR DESCRIPTION
## Summary

- split defineModel prop options from setup-time get/set accessors
- preserve runtime accessors in both inline and function-mode useModel calls
- validate only the model options that are actually hoisted
- cover setup locals, modifier bindings, and mixed hoisted/runtime options

## Verification

- cargo test -p vize_atelier_sfc
- cargo clippy -p vize_atelier_sfc --lib -- -D warnings
- vp check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->