### PR TITLE
fix(core): preserve Vue 2 conditional v-model

### DIFF
--- a/crates/vize_atelier_core/src/transform/element.rs
+++ b/crates/vize_atelier_core/src/transform/element.rs
@@ -4,6 +4,7 @@ use vize_carton::{Box, String, Vec, capitalize, is_builtin_directive, is_native_
 
 use crate::errors::ErrorCode;
 use crate::steps::expression::process_inline_handler;
+use crate::steps::v_model::generate_model_assignment_handler;
 use crate::steps::v_slot::validate_v_slot_usage;
 use crate::{
     ConstantType, DirectiveNode, ElementNode, ElementType, ExpressionNode, InterpolationNode,
@@ -354,11 +355,7 @@ fn process_element_props<'a>(ctx: &mut TransformContext<'a>, el: &mut Box<'a, El
 
             // Build handler expression
             let handler = if is_component {
-                let mut out = String::with_capacity(raw_value_exp.len() + 20);
-                out.push_str("$event => ((");
-                out.push_str(raw_value_exp.as_str());
-                out.push_str(") = $event)");
-                out
+                generate_model_assignment_handler(ctx, raw_value_exp.as_str(), "$event")
             } else {
                 // For native elements, check modifiers
                 let has_number = dir.modifiers.iter().any(|m| m.content == "number");
@@ -375,13 +372,11 @@ fn process_element_props<'a>(ctx: &mut TransformContext<'a>, el: &mut Box<'a, El
                     wrapped.push(')');
                     target_value = wrapped;
                 }
-                let mut out = String::with_capacity(raw_value_exp.len() + target_value.len() + 16);
-                out.push_str("$event => ((");
-                out.push_str(raw_value_exp.as_str());
-                out.push_str(") = ");
-                out.push_str(target_value.as_str());
-                out.push(')');
-                out
+                generate_model_assignment_handler(
+                    ctx,
+                    raw_value_exp.as_str(),
+                    target_value.as_str(),
+                )
             };
 
             let dir_loc = dir.loc.clone();
@@ -571,10 +566,8 @@ fn process_element_props<'a>(ctx: &mut TransformContext<'a>, el: &mut Box<'a, El
         // For native elements: process in reverse order to preserve indices during insertion
         for data in vmodel_data.iter().rev() {
             // Keep v-model directive, insert onUpdate:modelValue handler right after it
-            let mut handler = String::with_capacity(data.raw_value_exp.len() + 20);
-            handler.push_str("$event => ((");
-            handler.push_str(data.raw_value_exp.as_str());
-            handler.push_str(") = $event)");
+            let handler =
+                generate_model_assignment_handler(ctx, data.raw_value_exp.as_str(), "$event");
             let raw_handler_expr = ExpressionNode::Simple(Box::new_in(
                 SimpleExpressionNode::new(handler.as_str(), false, data.dir_loc.clone()),
                 allocator,

--- a/crates/vize_atelier_core/src/transforms/v_model.rs
+++ b/crates/vize_atelier_core/src/transforms/v_model.rs
@@ -2,6 +2,9 @@
 //!
 //! Transforms v-model directives for two-way binding.
 
+use oxc_ast::ast::Expression;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
 use vize_carton::{Box, String, Vec};
 
 use crate::lane::TransformContext;
@@ -16,6 +19,46 @@ pub struct VModelModifiers {
     pub lazy: bool,
     pub number: bool,
     pub trim: bool,
+}
+
+/// Build the assignment callback shared by component and native `v-model`.
+///
+/// Vue 2 emitted an unparenthesized top-level conditional before `=`, making
+/// JavaScript assign only to its alternate branch. Preserve that quirk only in
+/// the explicitly selected compatibility mode; every other expression keeps
+/// the Vue 3 assignment shape and its normal invalid-target diagnostic.
+pub(crate) fn generate_model_assignment_handler(
+    ctx: &TransformContext<'_>,
+    value: &str,
+    assignment: &str,
+) -> String {
+    let is_legacy_conditional =
+        ctx.template_syntax_quirks() && super::expression::expression_is_safe_to_parse(value) && {
+            let allocator = oxc_allocator::Allocator::default();
+            let source_type = if ctx.options.is_ts {
+                SourceType::ts().with_module(true)
+            } else {
+                SourceType::default().with_module(true)
+            };
+            matches!(
+                Parser::new(&allocator, value, source_type).parse_expression(),
+                Ok(Expression::ConditionalExpression(_))
+            )
+        };
+
+    let mut handler = String::with_capacity(value.len() + assignment.len() + 16);
+    handler.push_str("$event => (");
+    if !is_legacy_conditional {
+        handler.push('(');
+    }
+    handler.push_str(value);
+    if !is_legacy_conditional {
+        handler.push(')');
+    }
+    handler.push_str(" = ");
+    handler.push_str(assignment);
+    handler.push(')');
+    handler
 }
 
 /// Parse v-model modifiers from directive modifiers

--- a/crates/vize_atelier_core/src/transforms/v_model.rs
+++ b/crates/vize_atelier_core/src/transforms/v_model.rs
@@ -46,7 +46,7 @@ pub(crate) fn generate_model_assignment_handler(
             )
         };
 
-    let mut handler = String::with_capacity(value.len() + assignment.len() + 16);
+    let mut handler = String::with_capacity(value.len() + assignment.len() + 17);
     handler.push_str("$event => (");
     if !is_legacy_conditional {
         handler.push('(');

--- a/crates/vize_atelier_dom/tests/conditional_v_model_quirks.rs
+++ b/crates/vize_atelier_dom/tests/conditional_v_model_quirks.rs
@@ -1,0 +1,83 @@
+#![allow(clippy::disallowed_types)]
+
+use vize_atelier_core::{ErrorCode, TemplateSyntaxMode};
+use vize_atelier_dom::{DomCompilerOptions, compile_template_with_template_syntax};
+use vize_carton::{Bump, String};
+
+fn compile(source: &str, mode: TemplateSyntaxMode) -> (Vec<ErrorCode>, String) {
+    let allocator = Bump::new();
+    let options = DomCompilerOptions {
+        prefix_identifiers: true,
+        ..DomCompilerOptions::default()
+    };
+    let (_, errors, result) =
+        compile_template_with_template_syntax(&allocator, source, options, mode);
+    (
+        errors.into_iter().map(|error| error.code).collect(),
+        result.code,
+    )
+}
+
+#[test]
+fn quirks_preserves_vue2_conditional_component_model_callback() {
+    let (errors, code) = compile(
+        r#"<el-input v-model="multiple ? presentText : inputValue" />"#,
+        TemplateSyntaxMode::Quirks,
+    );
+
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    assert!(
+        code.contains("$event => (_ctx.multiple ? _ctx.presentText : _ctx.inputValue = $event)"),
+        "Vue 2 callback shape was not preserved:\n{code}"
+    );
+    assert!(
+        !code.contains("((_ctx.multiple ? _ctx.presentText : _ctx.inputValue) = $event)"),
+        "conditional target must not be parenthesized in quirks mode:\n{code}"
+    );
+}
+
+#[test]
+fn quirks_preserves_conditional_native_model_callback() {
+    let (errors, code) = compile(
+        r#"<input v-model="enabled ? primary : fallback.value" />"#,
+        TemplateSyntaxMode::Quirks,
+    );
+
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    assert!(
+        code.contains("$event => (_ctx.enabled ? _ctx.primary : _ctx.fallback.value = $event)"),
+        "native model callback did not assign its alternate branch:\n{code}"
+    );
+}
+
+#[test]
+fn standard_and_strict_reject_conditional_model_targets() {
+    let source = r#"<el-input v-model="multiple ? presentText : inputValue" />"#;
+
+    for mode in [TemplateSyntaxMode::Standard, TemplateSyntaxMode::Strict] {
+        let (errors, _) = compile(source, mode);
+        assert_eq!(
+            errors,
+            [ErrorCode::InvalidExpression],
+            "conditional compatibility leaked into {mode:?}"
+        );
+    }
+}
+
+#[test]
+fn quirks_does_not_accept_parenthesized_or_binary_model_targets() {
+    for (expression, source) in [
+        (
+            "(multiple ? presentText : inputValue)",
+            r#"<el-input v-model="(multiple ? presentText : inputValue)" />"#,
+        ),
+        ("left + right", r#"<el-input v-model="left + right" />"#),
+    ] {
+        let (errors, _) = compile(source, TemplateSyntaxMode::Quirks);
+        assert_eq!(
+            errors,
+            [ErrorCode::InvalidExpression],
+            "non-compatible target {expression:?} was accepted"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- preserve Vue 2's unparenthesized conditional model callback in quirks mode
- share the bounded assignment builder across component and native v-model handlers
- keep standard, strict, parenthesized, and binary invalid targets rejected

## Tests

- cargo test -p vize_atelier_core -p vize_atelier_dom --all-features
- cargo clippy -p vize_atelier_dom --test conditional_v_model_quirks -- -D warnings
- cargo clippy -p vize_atelier_core -p vize_atelier_dom --all-features --lib -- -D warnings
- vp check
- Element compiler fixture: 155 inputs, 155 outputs, 0 errors, 0 warnings, exit 0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `v-model` update handler generation for conditional targets, preserving Vue 2-compatible behavior in Quirks mode.
  * Correctly handles conditional and modifier-driven `v-model` targets (e.g., `trim`, `number`).
  * Standard and Strict modes now properly reject unsupported conditional `v-model` targets with the expected diagnostics.
* **Tests**
  * Added a new DOM test suite covering valid and invalid conditional `v-model` behavior across syntax modes and verifying the generated update callback shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->