### PR TITLE
fix(canon): exclude template literals from bindings

### DIFF
--- a/crates/vize_canon/src/options_api_setup_spread.rs
+++ b/crates/vize_canon/src/options_api_setup_spread.rs
@@ -283,7 +283,13 @@ fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
     }
 }
 
-fn is_safe_value_identifier(name: &str) -> bool {
+pub(crate) fn is_safe_value_identifier(name: &str) -> bool {
+    // Literal tokens can surface from expression identifier extraction, but
+    // can never be Options API bindings. Keep contextual names such as `as`:
+    // existing component APIs legitimately expose those in templates.
+    if matches!(name, "false" | "true" | "null") {
+        return false;
+    }
     let mut chars = name.chars();
     let Some(first) = chars.next() else {
         return false;

--- a/crates/vize_canon/src/virtual_ts/generator/options_api_support.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api_support.rs
@@ -2,6 +2,7 @@ use oxc_ast::ast::{ArrayExpressionElement, Expression, ObjectExpression, ObjectP
 use vize_carton::String;
 use vize_croquis::{Croquis, OptionGroup};
 
+pub(super) use crate::options_api_setup_spread::is_safe_value_identifier;
 use crate::virtual_ts::props::OptionsApiPropsSource;
 
 pub(super) fn extend_options_api_descriptor_names<'a>(
@@ -70,15 +71,4 @@ fn expression_must_stay_in_value_scope(expression: &Expression<'_>) -> bool {
         }
         _ => false,
     }
-}
-
-pub(super) fn is_safe_value_identifier(name: &str) -> bool {
-    let mut chars = name.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
-        return false;
-    }
-    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$')
 }

--- a/crates/vize_canon/tests/reserved_template_literals.rs
+++ b/crates/vize_canon/tests/reserved_template_literals.rs
@@ -1,0 +1,115 @@
+use vize_canon::{SfcTypeCheckOptions, type_check_sfc_with_options_api};
+use vize_carton::{String, cstr};
+
+const EXTENDS_SOURCE: &str = r#"<script lang="ts">
+import Base from './Base'
+
+export default {
+  extends: Base,
+}
+</script>
+
+<template>
+  <button
+    :disabled="false"
+    :aria-hidden="true"
+    :data-empty="null"
+    :data-state="falsey ? trueValue : nullish"
+    @click="inheritedHandler(false)"
+  />
+</template>
+"#;
+
+const SETUP_SPREAD_SOURCE: &str = r#"<script lang="ts">
+export default {
+  setup() {
+    const known = {}
+    return { ...known }
+  },
+}
+</script>
+
+<template>
+  <button
+    :disabled="false"
+    :aria-hidden="true"
+    :data-empty="null"
+    :data-state="falsey ? trueValue : nullish"
+  />
+</template>
+"#;
+
+#[test]
+fn unresolved_options_extends_never_declares_template_literals() {
+    let virtual_ts = generate_virtual_ts(EXTENDS_SOURCE);
+
+    for reserved in ["false", "true", "null"] {
+        assert!(
+            !virtual_ts.contains(cstr!("const {reserved}: any").as_str()),
+            "a template literal must not become an inherited binding `{reserved}`:\n{virtual_ts}"
+        );
+        assert!(
+            !virtual_ts.contains(cstr!("void {reserved};").as_str()),
+            "a template literal must not become a generated identifier `{reserved}`:\n{virtual_ts}"
+        );
+    }
+}
+
+#[test]
+fn unresolved_options_extends_keeps_legal_inherited_names() {
+    let virtual_ts = generate_virtual_ts(EXTENDS_SOURCE);
+
+    for name in ["falsey", "trueValue", "nullish", "inheritedHandler"] {
+        assert!(
+            virtual_ts.contains(cstr!("const {name}: any = undefined as any;").as_str()),
+            "legal inherited template binding `{name}` must remain available:\n{virtual_ts}"
+        );
+    }
+}
+
+#[test]
+fn options_setup_spread_never_captures_template_literals() {
+    let virtual_ts = generate_virtual_ts(SETUP_SPREAD_SOURCE);
+
+    for literal in ["false", "true", "null"] {
+        assert!(
+            !virtual_ts.contains(cstr!("type __R_{literal} =").as_str())
+                && !virtual_ts.contains(cstr!("var {literal}:").as_str()),
+            "a template literal must not become a setup-return binding `{literal}`:\n{virtual_ts}"
+        );
+    }
+    for name in ["falsey", "trueValue", "nullish"] {
+        assert!(
+            virtual_ts.contains(
+                cstr!("type __R_{name} = __VizeOptionsSetupBinding<\"{name}\">;").as_str()
+            ),
+            "legal spread-backed template binding `{name}` must remain available:\n{virtual_ts}"
+        );
+    }
+}
+
+#[test]
+fn generated_typescript_with_template_literals_is_parseable() {
+    for source in [EXTENDS_SOURCE, SETUP_SPREAD_SOURCE] {
+        let virtual_ts = generate_virtual_ts(source);
+        let allocator = oxc_allocator::Allocator::default();
+        let parsed =
+            oxc_parser::Parser::new(&allocator, virtual_ts.as_str(), oxc_span::SourceType::ts())
+                .parse();
+
+        assert!(
+            !parsed.panicked && parsed.errors.is_empty(),
+            "generated TypeScript must parse without literal declarations: {:#?}\n{virtual_ts}",
+            parsed.errors
+        );
+    }
+}
+
+fn generate_virtual_ts(source: &str) -> String {
+    type_check_sfc_with_options_api(
+        source,
+        &SfcTypeCheckOptions::new("App.vue").with_virtual_ts(),
+    )
+    .virtual_ts
+    .expect("virtual TypeScript should be generated")
+}


### PR DESCRIPTION
## Summary

- prevent false, true, and null template literals from becoming generated Options API bindings
- share the identifier safety filter across unresolved extends and spread-backed setup returns
- preserve legal contextual binding names such as as and keyword-prefixed identifiers

## Real project evidence

Focused Vize TypeChecker checks no longer report TS1389 or the paired TS1005 for:
- douyin src/pages/login/OtherLogin.vue
- v-viewer example/views/example/ComponentExample.vue
- Element Plus select and select-v2 component implementations
- vue-netcore ViewGrid.vue
- vue-storefront Category.vue

## Tests

- cargo test -p vize_canon --all-features
- cargo clippy -p vize_canon --lib --all-features -- -D warnings
- cargo clippy -p vize_canon --test reserved_template_literals --all-features -- -D warnings
- cargo fmt --all -- --check