### PR TITLE
fix(croquis): preserve escaped regex literals

### DIFF
--- a/crates/vize_canon/tests/escaped_regex_template_expression.rs
+++ b/crates/vize_canon/tests/escaped_regex_template_expression.rs
@@ -1,0 +1,54 @@
+use vize_canon::{SfcTypeCheckOptions, type_check_sfc_with_options_api};
+use vize_carton::String;
+
+const SOURCE: &str = r#"<script setup lang="ts">
+const baseUrl = 'http://example.test'
+function translate(key: string, args: { url: string }) {
+  return `${key}: ${args.url}`
+}
+</script>
+
+<template>
+  <p>
+    {{
+      translate('description', {
+        url: baseUrl.replace(/^http:\/\//, ''),
+      })
+    }}
+  </p>
+</template>
+"#;
+
+#[test]
+fn escaped_slashes_in_template_regex_survive_comment_stripping() {
+    let virtual_ts = generate_virtual_ts(SOURCE);
+
+    assert!(
+        virtual_ts.contains("url: baseUrl.replace(/^http:\\/\\//, ''),"),
+        "the regular expression must remain byte-complete:\n{virtual_ts}"
+    );
+}
+
+#[test]
+fn generated_typescript_with_escaped_regex_is_parseable() {
+    let virtual_ts = generate_virtual_ts(SOURCE);
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed =
+        oxc_parser::Parser::new(&allocator, virtual_ts.as_str(), oxc_span::SourceType::ts())
+            .parse();
+
+    assert!(
+        !parsed.panicked && parsed.errors.is_empty(),
+        "generated TypeScript must parse after preserving escaped regex slashes: {:#?}\n{virtual_ts}",
+        parsed.errors
+    );
+}
+
+fn generate_virtual_ts(source: &str) -> String {
+    type_check_sfc_with_options_api(
+        source,
+        &SfcTypeCheckOptions::new("CraterModule.vue").with_virtual_ts(),
+    )
+    .virtual_ts
+    .expect("virtual TypeScript should be generated")
+}

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/comments.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/comments.rs
@@ -42,7 +42,7 @@ pub fn strip_js_comments(expr: &str) -> Cow<'_, str> {
             continue;
         }
 
-        if c == b'/' && i + 1 < len {
+        if c == b'/' && i + 1 < len && !is_escaped(bytes, i) {
             let next = bytes[i + 1];
 
             if next == b'/' {
@@ -101,4 +101,12 @@ pub fn strip_js_comments(expr: &str) -> Cow<'_, str> {
     } else {
         Cow::Borrowed(expr)
     }
+}
+
+fn is_escaped(bytes: &[u8], index: usize) -> bool {
+    let mut cursor = index;
+    while cursor > 0 && bytes[cursor - 1] == b'\\' {
+        cursor -= 1;
+    }
+    (index - cursor) % 2 == 1
 }

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
@@ -76,6 +76,24 @@ fn test_strip_js_comments_preserves_non_ascii_literals_after_comments() {
 }
 
 #[test]
+fn test_strip_js_comments_preserves_regex_with_escaped_slashes() {
+    let expression = r#"url.replace(/^http:\/\//, '') // remove this comment
++ suffix"#;
+    let stripped = strip_js_comments(expression);
+
+    assert_eq!(
+        stripped.as_ref(),
+        concat!(r#"url.replace(/^http:\/\//, '') "#, "\n+ suffix")
+    );
+
+    let block_like = r#"value.match(/\/\*literal/) /* remove this comment */"#;
+    assert_eq!(
+        strip_js_comments(block_like).as_ref(),
+        r#"value.match(/\/\*literal/)  "#
+    );
+}
+
+#[test]
 fn test_extract_identifiers_ignores_regex_literals() {
     fn to_strings(ids: Vec<CompactString>) -> Vec<CompactString> {
         ids


### PR DESCRIPTION
## Summary
- keep escaped `/` bytes inside template-expression regex literals during comment stripping
- retain removal of real line and block comments
- cover the Crater multiline interpolation through generated TypeScript and OXC parsing

## Real-project evidence
- Crater: exercised Compiler, TypeChecker, Linter, and Formatter across 311 Vue files
- `resources/scripts/admin/views/modules/Index.vue`: TS1161/TS1005 reduced from 2 findings to 0
- all four runs produced classified evidence with no runner failure

## Validation
- `cargo test -p vize_croquis --all-features`
- `cargo test -p vize_canon --all-features`
- `cargo clippy -p vize_croquis --lib --all-features -- -D warnings`
- `cargo clippy -p vize_canon --test escaped_regex_template_expression --all-features -- -D warnings`
- `cargo build -p vize`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed comment stripping to preserve regular expressions containing escaped slashes and comment-like sequences.
  * Prevented escaped `//` and `/*` patterns in Vue template expressions from being incorrectly removed.
  * Improved virtual TypeScript generation and parsing for expressions containing escaped regular-expression literals.

* **Tests**
  * Added coverage verifying regex content remains intact and generated TypeScript parses without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->