### PR TITLE
fix(canon): keep runtime props in value scope

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/options_api_required_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/options_api_required_props.rs
@@ -274,3 +274,59 @@ function onSelect(id: number) {
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn reports_cross_file_mismatch_for_runtime_constructor_props() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case(
+        "options-runtime-constructor-props",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script>
+export default {
+  props: { count: Number },
+}
+</script>
+<template><span>{{ count }}</span></template>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+<template><Child :count="'wrong'" /></template>
+"#,
+            ),
+        ],
+    );
+
+    let mut checker = match BatchTypeChecker::new(&project_root) {
+        Ok(checker) => checker,
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        }
+    };
+    checker.enable_options_api();
+    checker.scan_project().unwrap();
+    let result = checker.check_project().unwrap();
+    let mismatch = result.diagnostics.iter().any(|diagnostic| {
+        relative_path(&project_root, &diagnostic.file) == "src/Parent.vue"
+            && diagnostic
+                .message
+                .contains("not assignable to type 'number'")
+    });
+
+    assert!(
+        mismatch,
+        "runtime Number props must reject string bindings across SFCs: {:#?}",
+        result.diagnostics
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/virtual_ts/generator/options_api.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api.rs
@@ -702,7 +702,7 @@ fn options_api_props_from_expression(
     match expression {
         Expression::ObjectExpression(object) => {
             let source = source_slice(script, object.span())?;
-            Some(props_source_from_object(object, source))
+            Some(props_source_from_object(source))
         }
         Expression::ArrayExpression(array) => {
             let mut names = Vec::new();

--- a/crates/vize_canon/src/virtual_ts/generator/options_api_support.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api_support.rs
@@ -1,4 +1,3 @@
-use oxc_ast::ast::{ArrayExpressionElement, Expression, ObjectExpression, ObjectPropertyKind};
 use oxc_syntax::identifier::is_identifier_part;
 use vize_carton::String;
 use vize_croquis::{Croquis, OptionGroup};
@@ -34,50 +33,8 @@ pub(super) fn extend_options_api_descriptor_names<'a>(
     }));
 }
 
-pub(super) fn props_source_from_object(
-    object: &ObjectExpression<'_>,
-    source: &str,
-) -> OptionsApiPropsSource {
-    let source = String::from(source);
-    if object_props_must_stay_in_value_scope(object) {
-        OptionsApiPropsSource::DeferredObject(source)
-    } else {
-        OptionsApiPropsSource::Object(source)
-    }
-}
-
-fn object_props_must_stay_in_value_scope(object: &ObjectExpression<'_>) -> bool {
-    object.properties.iter().any(|property| match property {
-        ObjectPropertyKind::SpreadProperty(_) => true,
-        ObjectPropertyKind::ObjectProperty(property) => {
-            property.method || expression_must_stay_in_value_scope(&property.value)
-        }
-    })
-}
-
-fn expression_must_stay_in_value_scope(expression: &Expression<'_>) -> bool {
-    match expression {
-        Expression::ArrowFunctionExpression(_)
-        | Expression::CallExpression(_)
-        | Expression::FunctionExpression(_)
-        | Expression::NewExpression(_)
-        | Expression::TSAsExpression(_)
-        | Expression::TSInstantiationExpression(_)
-        | Expression::TSNonNullExpression(_)
-        | Expression::TSSatisfiesExpression(_)
-        | Expression::TSTypeAssertion(_) => true,
-        Expression::ArrayExpression(array) => array.elements.iter().any(|element| {
-            matches!(element, ArrayExpressionElement::SpreadElement(_))
-                || element
-                    .as_expression()
-                    .is_some_and(expression_must_stay_in_value_scope)
-        }),
-        Expression::ObjectExpression(object) => object_props_must_stay_in_value_scope(object),
-        Expression::ParenthesizedExpression(parenthesized) => {
-            expression_must_stay_in_value_scope(&parenthesized.expression)
-        }
-        _ => false,
-    }
+pub(super) fn props_source_from_object(source: &str) -> OptionsApiPropsSource {
+    OptionsApiPropsSource::DeferredObject(String::from(source))
 }
 
 #[cfg(test)]

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -195,9 +195,9 @@ fn append_model_props_type_literal(ts: &mut String, models: &[ModelDefinition]) 
 }
 
 /// Runtime `props:` source for Options API `export type Props` emission.
-/// `DeferredObject` is routed through setup scope for value-only object syntax.
+/// Objects are routed through setup scope so JavaScript values never leak into
+/// TypeScript type position.
 pub(crate) enum OptionsApiPropsSource {
-    Object(String),
     DeferredObject(String),
     Names(Vec<String>),
 }
@@ -293,12 +293,6 @@ fn emit_options_api_props_type(
     options_api_props: &OptionsApiPropsSource,
 ) {
     match options_api_props {
-        OptionsApiPropsSource::Object(source) => {
-            append!(
-                *ts,
-                "export type Props{generic_decl} = __RuntimePropShape<{source}>;\n"
-            );
-        }
         OptionsApiPropsSource::DeferredObject(_) => {}
         OptionsApiPropsSource::Names(names) => {
             append!(*ts, "export type Props{generic_decl} = {{\n");

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -325,10 +325,8 @@ fn test_options_api_template_bindings_use_default_instance_type() {
 
 #[test]
 fn test_options_api_emits_real_props_type_from_object_option() {
-    // A plain `<script>` Options API component with a runtime `props:` object
-    // must produce a real `export type Props` (via the shared
-    // `__RuntimePropShape<...>` machinery) instead of the historical `{}` no-op,
-    // so cross-file prop checking is no longer silently disabled.
+    // Runtime props are values, so keep the object in setup scope and derive a
+    // real `export type Props` from the captured value.
     let script = r#"export default {
     props: {
         initial: Number,
@@ -348,9 +346,9 @@ fn test_options_api_emits_real_props_type_from_object_option() {
 
     assert!(
         output.code.contains(
-            "export type Props = __RuntimePropShape<{\n        initial: Number,\n        label: { type: String, required: true },\n    }>;"
+            "const __vize_options_props = ({\n        initial: Number,\n        label: { type: String, required: true },\n    });"
         ),
-        "expected a real Props type derived from the runtime props option:\n{}",
+        "expected the runtime props object to remain in value scope:\n{}",
         output.code
     );
     assert!(

--- a/crates/vize_canon/tests/options_api_runtime_props_value_scope.rs
+++ b/crates/vize_canon/tests/options_api_runtime_props_value_scope.rs
@@ -1,0 +1,72 @@
+use vize_canon::{SfcTypeCheckOptions, type_check_sfc_with_options_api};
+use vize_carton::String;
+
+const SOURCE: &str = r#"<script>
+export default {
+  props: {
+    content: {
+      type: String,
+      default: ''
+    },
+    offset: {
+      type: Number,
+      default: Math.PI / 4
+    },
+    direction: {
+      type: String,
+      default: 'lt' // preserve this runtime comment in value scope
+    }
+  }
+}
+</script>
+
+<template><span>{{ direction }}</span></template>
+"#;
+
+#[test]
+fn options_api_runtime_props_stay_in_value_scope() {
+    let virtual_ts = generate_virtual_ts(SOURCE);
+
+    assert!(
+        !virtual_ts.contains("export type Props = __RuntimePropShape<{"),
+        "a runtime object must never be copied into TypeScript type position:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("const __vize_options_props = ({"),
+        "the runtime props object must be captured as a setup-scoped value:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("default: Math.PI / 4"),
+        "runtime default expressions must remain byte-complete:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains(
+            "export type Props = __RuntimePropShape<Awaited<ReturnType<typeof __setup>>[\"__vize_options_props\"]>;"
+        ),
+        "Props must be derived from the captured runtime value:\n{virtual_ts}"
+    );
+}
+
+#[test]
+fn options_api_runtime_props_with_comments_generate_parseable_typescript() {
+    let virtual_ts = generate_virtual_ts(SOURCE);
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed =
+        oxc_parser::Parser::new(&allocator, virtual_ts.as_str(), oxc_span::SourceType::ts())
+            .parse();
+
+    assert!(
+        !parsed.panicked && parsed.errors.is_empty(),
+        "runtime props defaults and comments must not corrupt generated TypeScript: {:#?}\n{virtual_ts}",
+        parsed.errors
+    );
+}
+
+fn generate_virtual_ts(source: &str) -> String {
+    type_check_sfc_with_options_api(
+        source,
+        &SfcTypeCheckOptions::new("MintPaletteButton.vue").with_virtual_ts(),
+    )
+    .virtual_ts
+    .expect("virtual TypeScript should be generated")
+}


### PR DESCRIPTION
## Summary
- keep Options API runtime props objects in setup value scope
- derive exported Props from the captured runtime value instead of copying JavaScript into type position
- preserve constructor types so cross-SFC prop mismatches remain detectable

## Real-project evidence
- Mint UI: exercised Compiler, TypeChecker, Linter, and Formatter across 69 Vue files
- `packages/palette-button/src/palette-button.vue`: generated TypeScript parse diagnostics reduced from 14 to 0
- newly unblocked semantic findings remain classified as typechecker evidence rather than being hidden by parser recovery

## Validation
- `cargo test -p vize_canon --all-features` (567 unit tests plus integration tests)
- strict OXC parse regression for runtime defaults and line comments
- strict cross-SFC false-negative regression for `Number` props
- `cargo clippy -p vize_canon --all-features -- -D warnings`
- `cargo build -p vize`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->