### PR TITLE
fix(canon): skip empty template interpolations

### DIFF
--- a/crates/vize_canon/src/virtual_ts/expressions/statements.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/statements.rs
@@ -248,6 +248,9 @@ pub(super) fn generate_expression_statement(
         strip_js_comments(expr.content.as_str())
     );
     let trimmed_expression = expression.as_ref().trim();
+    if trimmed_expression.is_empty() {
+        return;
+    }
     let rewritten_expression =
         rewrite_reserved_template_prop(trimmed_expression, template_prop_names);
     let generated_expression = rewritten_expression

--- a/crates/vize_canon/tests/empty_template_interpolation.rs
+++ b/crates/vize_canon/tests/empty_template_interpolation.rs
@@ -1,0 +1,52 @@
+use vize_canon::{SfcTypeCheckOptions, type_check_sfc_with_options_api};
+use vize_carton::String;
+
+const SOURCE: &str = r#"<script setup lang="ts">
+const value = 'visible'
+</script>
+
+<template>
+  <SfCollectedProduct>
+    <template #more-actions>{{  }}</template>
+  </SfCollectedProduct>
+  <p>{{ value }}</p>
+</template>
+"#;
+
+#[test]
+fn empty_interpolation_emits_no_typescript_expression() {
+    let virtual_ts = generate_virtual_ts(SOURCE);
+
+    assert!(
+        !virtual_ts.contains("void (); // Interpolation"),
+        "blank Vue interpolations must not become invalid void expressions:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("void (value); // Interpolation"),
+        "skipping a blank interpolation must preserve neighboring expressions:\n{virtual_ts}"
+    );
+}
+
+#[test]
+fn generated_typescript_with_empty_interpolation_is_parseable() {
+    let virtual_ts = generate_virtual_ts(SOURCE);
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed =
+        oxc_parser::Parser::new(&allocator, virtual_ts.as_str(), oxc_span::SourceType::ts())
+            .parse();
+
+    assert!(
+        !parsed.panicked && parsed.errors.is_empty(),
+        "blank Vue interpolations must not corrupt generated TypeScript: {:#?}\n{virtual_ts}",
+        parsed.errors
+    );
+}
+
+fn generate_virtual_ts(source: &str) -> String {
+    type_check_sfc_with_options_api(
+        source,
+        &SfcTypeCheckOptions::new("CartSidebar.vue").with_virtual_ts(),
+    )
+    .virtual_ts
+    .expect("virtual TypeScript should be generated")
+}


### PR DESCRIPTION
## Summary

- skip blank Vue interpolation expressions before emitting virtual TypeScript
- keep neighboring non-empty interpolations intact
- parse the generated TypeScript with OXC in a real-project-style regression test

## Verification

- cargo test -p vize_canon --all-features
- cargo clippy -p vize_canon --all-features -- -D warnings
- cargo build -p vize
- cargo fmt --all -- --check
- 45 Vue Storefront fixture files through Compiler, TypeChecker, Linter, and Formatter

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed empty Vue template interpolations generating invalid TypeScript expressions.
  - Preserved adjacent non-empty interpolations correctly.
  - Improved generated TypeScript syntax validity for templates containing blank interpolations.

- **Tests**
  - Added coverage confirming empty interpolations are skipped and generated output remains parseable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->