### PR TITLE
fix(canon): strip v-on ASI prefixes

### DIFF
--- a/crates/vize_canon/src/virtual_ts/expressions/statements.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/statements.rs
@@ -251,15 +251,25 @@ pub(super) fn generate_expression_statement(
     if trimmed_expression.is_empty() {
         return;
     }
+    let statement_expression =
+        if expr.kind == TemplateExpressionKind::VOn && trimmed_expression.starts_with(';') {
+            trimmed_expression
+                .trim_start_matches(|character: char| character == ';' || character.is_whitespace())
+        } else {
+            expression.as_ref()
+        };
+    if statement_expression.is_empty() {
+        return;
+    }
     let rewritten_expression =
-        rewrite_reserved_template_prop(trimmed_expression, template_prop_names);
+        rewrite_reserved_template_prop(statement_expression.trim(), template_prop_names);
     let generated_expression = rewritten_expression
         .as_ref()
-        .map_or_else(|| expression.as_ref(), |s| s.as_str());
+        .map_or_else(|| statement_expression, |s| s.as_str());
     let mapping_needle = if rewritten_expression.is_some() {
         generated_expression
     } else {
-        expression.as_ref()
+        statement_expression
     };
 
     let gen_stmt_start = ts.len();

--- a/crates/vize_canon/tests/leading_semicolon_event_handler.rs
+++ b/crates/vize_canon/tests/leading_semicolon_event_handler.rs
@@ -1,0 +1,72 @@
+use vize_canon::{SfcTypeCheckOptions, type_check_sfc_with_options_api};
+use vize_carton::String;
+
+const SOURCE: &str = r#"<script setup lang="ts">
+let currentFocus: object | null = null
+let currentArea = {}
+const area = {}
+const pause = () => {}
+const resume = (_force: boolean) => {}
+</script>
+
+<template>
+  <input
+    @focus=";(currentFocus = { on: 'area', area }), (currentArea = area), pause()"
+    @blur=";(currentFocus = null), resume(true)"
+  >
+</template>
+"#;
+
+#[test]
+fn v_on_asi_prefix_is_not_parenthesized_as_an_expression() {
+    let virtual_ts = generate_virtual_ts(SOURCE);
+
+    assert!(
+        !virtual_ts.contains("void (;"),
+        "a leading empty statement is invalid inside a parenthesized expression:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains(
+            "void ((currentFocus = { on: 'area', area }), (currentArea = area), pause()); // VOn"
+        ),
+        "removing the ASI prefix must preserve the complete focus handler:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("void ((currentFocus = null), resume(true)); // VOn"),
+        "removing the ASI prefix must preserve the complete blur handler:\n{virtual_ts}"
+    );
+}
+
+#[test]
+fn generated_typescript_with_v_on_asi_prefixes_is_parseable() {
+    let virtual_ts = generate_virtual_ts(SOURCE);
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed =
+        oxc_parser::Parser::new(&allocator, virtual_ts.as_str(), oxc_span::SourceType::ts())
+            .parse();
+
+    assert!(
+        !parsed.panicked && parsed.errors.is_empty(),
+        "Vue event handlers with an ASI prefix must generate valid TypeScript: {:#?}\n{virtual_ts}",
+        parsed.errors
+    );
+}
+
+#[test]
+fn v_on_with_only_empty_statements_emits_no_void_expression() {
+    let virtual_ts = generate_virtual_ts("<template><button @click=\"; ;\" /></template>");
+
+    assert!(
+        !virtual_ts.contains("void (); // VOn") && !virtual_ts.contains("void (;"),
+        "empty event-handler statements must not become invalid TypeScript:\n{virtual_ts}"
+    );
+}
+
+fn generate_virtual_ts(source: &str) -> String {
+    type_check_sfc_with_options_api(
+        source,
+        &SfcTypeCheckOptions::new("CssCodeAreaName.vue").with_virtual_ts(),
+    )
+    .virtual_ts
+    .expect("virtual TypeScript should be generated")
+}


### PR DESCRIPTION
## Summary

- strip leading empty statements before wrapping v-on expressions in virtual TypeScript
- preserve every assignment and call in Layoutit Grid-style focus and blur handlers
- cover parse validity and empty-statement-only handlers with strict integration tests

## Verification

- cargo test -p vize_canon --all-features
- cargo clippy -p vize_canon --all-features -- -D warnings
- cargo build -p vize
- cargo fmt --all -- --check
- Layoutit Grid: 112 Vue files through Compiler, TypeChecker, Linter, and Formatter; no runner failures and TS1109 reduced from 2 to 0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->