### PR TITLE
fix(canon): preserve reserved enum members

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -489,6 +489,8 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             // causing src_byte_offset drift that incorrectly skips user code.
             let mut src_byte_offset: usize = 0; // offset within script content
             let mut module_span_index = 0usize;
+            let named_value_export_starts =
+                self::script_module::collect_named_value_export_starts(script);
             let mut props_const_assertions = PropsConstAssertions::new(script, options_api);
             // Script-absolute offset right after the wrapped options object.
             let mut pending_wrap_close: Option<usize> = None;
@@ -496,12 +498,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             let mut pending_class_alias: Option<(usize, &str)> = None;
             let mut emitted_default_alias = false;
 
-            // Check if script uses import.meta and add a polyfill variable.
-            // This avoids TS1343 when module is not set to es2020+.
-            let uses_import_meta = script.contains("import.meta");
-            if uses_import_meta {
-                ts.push_str("  const __import_meta: any = {};\n");
-            }
+            let uses_import_meta = self::script_module::emit_import_meta_polyfill(&mut ts, script);
 
             for raw_line in script.split('\n') {
                 // Strip trailing \r for output (normalize CRLF to LF)
@@ -512,6 +509,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                 // Skip lines that overlap with module-level spans (imports, re-exports, type decls)
                 let line_start = src_byte_offset;
                 let line_end = line_start + raw_line.len(); // use raw length for span check
+                let source_token_start = line_start + line.len() - line.trim_start().len();
                 while module_span_index < module_spans.len()
                     && module_spans[module_span_index].1 as usize <= line_start
                 {
@@ -649,7 +647,8 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                             cstr!("{leading_ws}const __default__ ={}", default_expr).into(),
                         );
                     }
-                } else if trimmed_line.starts_with("export ")
+                } else if named_value_export_starts.contains(&(source_token_start as u32))
+                    && trimmed_line.starts_with("export ")
                     && !trimmed_line.starts_with("export type ")
                     && !trimmed_line.starts_with("export interface ")
                 {

--- a/crates/vize_canon/src/virtual_ts/generator/script_module.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module.rs
@@ -43,6 +43,53 @@ pub(super) fn collect_line_module_import_spans(script: &str) -> Vec<(u32, u32)> 
     include_leading_ts_directive_comments(script, spans)
 }
 
+pub(super) fn collect_named_value_export_starts(script: &str) -> FxHashSet<u32> {
+    if !script.lines().any(|line| {
+        let line = line.trim_start();
+        line.starts_with("export ")
+            && !line.starts_with("export default")
+            && !line.starts_with("export type ")
+            && !line.starts_with("export interface ")
+    }) {
+        return FxHashSet::default();
+    }
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script, SourceType::ts().with_module(true)).parse();
+    let parsed = if parsed.panicked || !parsed.errors.is_empty() {
+        Parser::new(&allocator, script, SourceType::tsx().with_module(true)).parse()
+    } else {
+        parsed
+    };
+    if parsed.panicked {
+        return FxHashSet::default();
+    }
+
+    parsed
+        .program
+        .body
+        .iter()
+        .filter_map(|statement| {
+            let Statement::ExportNamedDeclaration(export) = statement else {
+                return None;
+            };
+            export
+                .declaration
+                .as_ref()
+                .is_some_and(declaration_has_runtime_value)
+                .then_some(export.span.start)
+        })
+        .collect()
+}
+
+/// Emit the setup-scoped polyfill that avoids TS1343 under older module targets.
+pub(super) fn emit_import_meta_polyfill(ts: &mut VizeString, script: &str) -> bool {
+    let uses_import_meta = script.contains("import.meta");
+    if uses_import_meta {
+        ts.push_str("  const __import_meta: any = {};\n");
+    }
+    uses_import_meta
+}
+
 pub(super) fn push_setup_return_fields(names: &[CompactString], fields: &mut Vec<CompactString>) {
     fields.extend(names.iter().cloned());
 }
@@ -153,6 +200,16 @@ fn collect_declaration_exports(
     }
 }
 
+fn declaration_has_runtime_value(declaration: &Declaration<'_>) -> bool {
+    matches!(
+        declaration,
+        Declaration::VariableDeclaration(_)
+            | Declaration::FunctionDeclaration(_)
+            | Declaration::ClassDeclaration(_)
+            | Declaration::TSEnumDeclaration(_)
+    )
+}
+
 fn collect_binding_names(
     pattern: &BindingPattern<'_>,
     seen: &mut FxHashSet<CompactString>,
@@ -236,7 +293,10 @@ fn contains_ts_suppression_directive(comment: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{CompactString, collect_line_module_import_spans, collect_named_value_exports};
+    use super::{
+        CompactString, collect_line_module_import_spans, collect_named_value_export_starts,
+        collect_named_value_exports,
+    };
 
     #[test]
     fn collect_import_span_includes_adjacent_ts_ignore_comment_group() {
@@ -269,5 +329,16 @@ mod tests {
         );
 
         assert_eq!(names, vec![CompactString::new("DiffDisplayMode")]);
+    }
+
+    #[test]
+    fn named_value_export_starts_exclude_nested_enum_members() {
+        let script =
+            "enum Modes {\n  export = 'export',\n}\nexport const selected = Modes.export;\n";
+        let starts = collect_named_value_export_starts(script);
+
+        assert_eq!(starts.len(), 1);
+        assert!(starts.contains(&(script.find("export const").unwrap() as u32)));
+        assert!(!starts.contains(&(script.find("export =").unwrap() as u32)));
     }
 }

--- a/crates/vize_canon/tests/reserved_enum_member.rs
+++ b/crates/vize_canon/tests/reserved_enum_member.rs
@@ -1,0 +1,60 @@
+use vize_canon::{SfcTypeCheckOptions, type_check_sfc_with_options_api};
+use vize_carton::String;
+
+const SOURCE: &str = r#"<template>
+  <p v-if="mode === MODES.export">{{ mode }}</p>
+</template>
+
+<script setup lang="ts">
+enum MODES {
+  tag = "tag",
+  category = "category",
+  export = "export",
+  delete = "delete",
+}
+
+const mode = MODES.export
+</script>
+"#;
+
+#[test]
+fn reserved_enum_members_survive_setup_script_rewriting() {
+    let virtual_ts = generate_virtual_ts(SOURCE);
+
+    assert!(
+        virtual_ts.contains("export = \"export\","),
+        "an enum member named export must not be mistaken for a declaration modifier:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("delete = \"delete\","),
+        "preserving export must not disturb neighboring reserved enum members:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("const mode = MODES.export"),
+        "the enum member reference must remain available to setup and template code:\n{virtual_ts}"
+    );
+}
+
+#[test]
+fn generated_typescript_with_reserved_enum_members_is_parseable() {
+    let virtual_ts = generate_virtual_ts(SOURCE);
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed =
+        oxc_parser::Parser::new(&allocator, virtual_ts.as_str(), oxc_span::SourceType::ts())
+            .parse();
+
+    assert!(
+        !parsed.panicked && parsed.errors.is_empty(),
+        "reserved enum members must generate valid TypeScript: {:#?}\n{virtual_ts}",
+        parsed.errors
+    );
+}
+
+fn generate_virtual_ts(source: &str) -> String {
+    type_check_sfc_with_options_api(
+        source,
+        &SfcTypeCheckOptions::new("recipes.vue").with_virtual_ts(),
+    )
+    .virtual_ts
+    .expect("virtual TypeScript should be generated")
+}


### PR DESCRIPTION
## Summary

- identify runtime export declarations from top-level AST spans before removing their export modifier
- preserve nested enum members named export and neighboring reserved members
- retain normal-script named value exports and validate generated TypeScript with OXC

## Verification

- cargo test -p vize_canon --all-features
- cargo clippy -p vize_canon --all-features -- -D warnings
- cargo build -p vize
- cargo fmt --all -- --check
- Mealie: 201 Vue files through Compiler, TypeChecker, Linter, and Formatter; no runner failures and TS1132 reduced from 1 to 0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rewriting of `export` in Vue `<script setup>` so `export` prefixes are stripped only when they correspond to actual top-level runtime exports (while preserving `export type`/`interface` patterns).
  * Enhanced handling of `import.meta` polyfill emission for more consistent virtual TypeScript generation.
* **Tests**
  * Added regression coverage ensuring enum members named like reserved keywords (e.g., `export`, `delete`) aren’t misinterpreted, and that generated virtual TypeScript parses cleanly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->