### PR TITLE
fix(canon): preserve setup-scoped type exports

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -12,6 +12,7 @@ mod props_anchors;
 mod script_module;
 mod setup_helpers;
 mod setup_props;
+mod setup_type_exports;
 mod spans;
 mod template_refs;
 use self::anchors::emit_setup_binding_anchors;
@@ -33,6 +34,7 @@ use self::options_api_props_identifiers::PropsConstAssertions;
 use self::props_anchors::emit_setup_scope_prop_anchors;
 use self::setup_helpers::emit_setup_helpers;
 use self::setup_props::SetupPropsPlan;
+use self::setup_type_exports::SetupTypeExportsPlan;
 use self::spans::{
     DEFINE_COMPONENT_REF, merge_overlapping_spans, rewrite_export_default_for_module_scope,
     template_usage,
@@ -213,6 +215,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         has_script_setup,
         has_plain_script_scope,
     );
+    let setup_type_exports = SetupTypeExportsPlan::new(summary, script_content);
 
     // Classify the main `<script>` default export in one parse. A plain
     // `export default { ... }` (Options API shape) gets wrapped with Vue's
@@ -527,9 +530,8 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                 ts.push_str("  "); // indentation (not in source)
                 let gen_content_start = ts.len();
 
-                // Process the line: strip `export` keyword (invalid inside function),
-                // replace import.meta with polyfill variable
                 let mut output_line = std::borrow::Cow::Borrowed(line);
+                setup_type_exports.strip_modifiers(&mut output_line, line_start as u32);
 
                 // Close the `defineComponent(` wrap right after the wrapped
                 // options object's closing brace.
@@ -661,7 +663,6 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                         }
                     }
                 }
-
                 // Replace import.meta with polyfill variable to avoid TS1343
                 if uses_import_meta && output_line.contains("import.meta") {
                     #[allow(clippy::disallowed_types)]
@@ -882,11 +883,9 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         }
     });
 
-    // Return runtime-derived type artifacts from __setup() so their types can be
-    // extracted at module level while keeping each runtime expression in setup
-    // scope, where script-setup bindings are defined.
     let mut setup_return_fields: Vec<String> = Vec::new();
     self::script_module::push_setup_return_fields(&named_value_exports, &mut setup_return_fields);
+    setup_type_exports.emit_setup_artifacts(&mut ts, &mut setup_return_fields);
     let mut setup_artifact_return_fields = Vec::new();
     setup_props_plan.push_return_field(&mut setup_artifact_return_fields);
     setup_return_fields.extend(setup_artifact_return_fields.into_iter().map(String::from));
@@ -916,6 +915,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     // Invoke setup to keep diagnostics inside the generated setup body.
     ts.push_str("// Invoke setup to verify types\n");
     self::script_module::emit_setup_invocation_and_exports(&mut ts, &named_value_exports);
+    setup_type_exports.emit_module_exports(&mut ts);
 
     setup_props_plan.emit_module_export(&mut ts, options_api_props.as_ref());
 

--- a/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
@@ -104,7 +104,7 @@ impl SetupPropsPlan {
         let module_scope_declares_props = summary
             .type_exports
             .iter()
-            .any(|te| te.hoisted && te.name.as_str() == "Props");
+            .any(|te| te.name.as_str() == "Props");
         Self {
             defer: define_props_type_requires_setup_scope(summary),
             defer_options_api_props: !module_scope_declares_props

--- a/crates/vize_canon/src/virtual_ts/generator/setup_type_exports.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/setup_type_exports.rs
@@ -1,0 +1,244 @@
+use std::borrow::Cow;
+
+use vize_carton::{String, append, cstr};
+use vize_croquis::Croquis;
+
+fn skip_trivia(source: &str, mut at: usize) -> usize {
+    let bytes = source.as_bytes();
+    loop {
+        while bytes.get(at).is_some_and(u8::is_ascii_whitespace) {
+            at += 1;
+        }
+        if source.get(at..).is_some_and(|rest| rest.starts_with("//")) {
+            at = source[at..]
+                .find('\n')
+                .map_or(source.len(), |end| at + end + 1);
+        } else if source.get(at..).is_some_and(|rest| rest.starts_with("/*")) {
+            at = source[at + 2..]
+                .find("*/")
+                .map_or(source.len(), |end| at + end + 4);
+        } else {
+            return at;
+        }
+    }
+}
+
+fn keyword_end(source: &str, at: usize, keyword: &str) -> Option<usize> {
+    let rest = source.get(at..)?.strip_prefix(keyword)?;
+    (!rest
+        .as_bytes()
+        .first()
+        .is_some_and(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$')))
+    .then_some(at + keyword.len())
+}
+
+fn exported_type_is_generic(source: &str, name: &str) -> bool {
+    let Some(mut at) = keyword_end(source, 0, "export") else {
+        return false;
+    };
+    at = skip_trivia(source, at);
+    if let Some(end) = keyword_end(source, at, "declare") {
+        at = skip_trivia(source, end);
+    }
+    let Some(end) =
+        keyword_end(source, at, "type").or_else(|| keyword_end(source, at, "interface"))
+    else {
+        return false;
+    };
+    at = skip_trivia(source, end);
+    let Some(rest) = source.get(at..).and_then(|rest| rest.strip_prefix(name)) else {
+        return false;
+    };
+    rest.get(skip_trivia(rest, 0)..)
+        .is_some_and(|rest| rest.starts_with('<'))
+}
+
+struct SetupTypeExport {
+    name: String,
+    artifact: String,
+}
+
+/// Preserves public types whose `typeof` dependencies keep them in setup scope.
+pub(super) struct SetupTypeExportsPlan {
+    export_starts: Vec<u32>,
+    exports: Vec<SetupTypeExport>,
+}
+
+impl SetupTypeExportsPlan {
+    pub(super) fn new(summary: &Croquis, script: Option<&str>) -> Self {
+        let mut export_starts = Vec::new();
+        let mut exports = Vec::new();
+
+        if let Some(script) = script {
+            for declaration in summary.type_exports.iter().filter(|item| !item.hoisted) {
+                let start = declaration.start as usize;
+                let end = declaration.end as usize;
+                let Some(source) = script.get(start..end) else {
+                    continue;
+                };
+                if !source.starts_with("export") {
+                    continue;
+                }
+
+                let name: String = declaration.name.as_str().into();
+                if exported_type_is_generic(source, &name) {
+                    continue;
+                }
+                export_starts.push(declaration.start);
+                exports.push(SetupTypeExport {
+                    artifact: cstr!("__vize_exported_type_{name}"),
+                    name,
+                });
+            }
+        }
+
+        export_starts.sort_unstable();
+        Self {
+            export_starts,
+            exports,
+        }
+    }
+
+    pub(super) fn strip_modifiers(&self, line: &mut Cow<'_, str>, line_start: u32) {
+        let line_end = line_start.saturating_add(line.len() as u32);
+        let first = self
+            .export_starts
+            .partition_point(|start| *start < line_start);
+        let last = self
+            .export_starts
+            .partition_point(|start| *start < line_end);
+        if first == last {
+            return;
+        }
+
+        let original = line.as_ref();
+        let mut output = String::with_capacity(original.len());
+        let mut copied_until = 0usize;
+        for start in &self.export_starts[first..last] {
+            let column = (*start - line_start) as usize;
+            if original.get(column..column + "export".len()) == Some("export") {
+                output.push_str(&original[copied_until..column]);
+                copied_until = column + "export".len();
+            }
+        }
+        output.push_str(&original[copied_until..]);
+        *line = Cow::Owned(output.into());
+    }
+
+    pub(super) fn emit_setup_artifacts(&self, ts: &mut String, fields: &mut Vec<String>) {
+        for exported in &self.exports {
+            let name = &exported.name;
+            let artifact = &exported.artifact;
+            append!(
+                *ts,
+                "\n  const {artifact} = undefined as unknown as {name};\n"
+            );
+            fields.push(artifact.clone());
+        }
+    }
+
+    pub(super) fn emit_module_exports(&self, ts: &mut String) {
+        for exported in &self.exports {
+            let name = &exported.name;
+            let artifact = &exported.artifact;
+            append!(
+                *ts,
+                "export type {name} = Awaited<ReturnType<typeof __setup>>[\"{artifact}\"];\n"
+            );
+        }
+        if !self.exports.is_empty() {
+            ts.push('\n');
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SetupTypeExportsPlan, exported_type_is_generic};
+    use vize_croquis::{Croquis, TypeExport, TypeExportKind};
+
+    #[test]
+    fn only_explicit_non_hoisted_exports_are_planned() {
+        let script = "type Local = typeof value;\nexport type Public = typeof value;";
+        let public_start = script.find("export").unwrap() as u32;
+        let mut summary = Croquis::new();
+        summary.type_exports.push(TypeExport {
+            name: "Local".into(),
+            kind: TypeExportKind::Type,
+            start: 0,
+            end: 26,
+            hoisted: false,
+        });
+        summary.type_exports.push(TypeExport {
+            name: "Public".into(),
+            kind: TypeExportKind::Type,
+            start: public_start,
+            end: script.len() as u32,
+            hoisted: false,
+        });
+
+        let plan = SetupTypeExportsPlan::new(&summary, Some(script));
+        let mut line = std::borrow::Cow::Borrowed("export type Public = typeof value;");
+        plan.strip_modifiers(&mut line, public_start);
+        assert_eq!(line, " type Public = typeof value;");
+
+        let mut fields = Vec::new();
+        let mut setup = vize_carton::String::default();
+        plan.emit_setup_artifacts(&mut setup, &mut fields);
+        assert!(setup.contains("unknown as Public"));
+        assert_eq!(fields, ["__vize_exported_type_Public"]);
+    }
+
+    #[test]
+    fn every_export_modifier_on_a_shared_line_is_removed_by_exact_span() {
+        let script = "const value = 1; export type Public = typeof value; export interface Shape { value: typeof value }";
+        let public_start = script.find("export").unwrap() as u32;
+        let shape_start = script.rfind("export").unwrap() as u32;
+        let mut summary = Croquis::new();
+        for (name, kind, start) in [
+            ("Public", TypeExportKind::Type, public_start),
+            ("Shape", TypeExportKind::Interface, shape_start),
+        ] {
+            summary.type_exports.push(TypeExport {
+                name: name.into(),
+                kind,
+                start,
+                end: script.len() as u32,
+                hoisted: false,
+            });
+        }
+
+        let plan = SetupTypeExportsPlan::new(&summary, Some(script));
+        let mut line = std::borrow::Cow::Borrowed(script);
+        plan.strip_modifiers(&mut line, 0);
+        assert_eq!(
+            line,
+            "const value = 1;  type Public = typeof value;  interface Shape { value: typeof value }"
+        );
+    }
+
+    #[test]
+    fn generic_exports_are_not_widened_by_a_non_generic_capture() {
+        let source = "export /* public */ type Box<T extends typeof value> = { value: T }";
+        assert!(exported_type_is_generic(source, "Box"));
+
+        let mut summary = Croquis::new();
+        summary.type_exports.push(TypeExport {
+            name: "Box".into(),
+            kind: TypeExportKind::Type,
+            start: 0,
+            end: source.len() as u32,
+            hoisted: false,
+        });
+        let plan = SetupTypeExportsPlan::new(&summary, Some(source));
+        let mut line = std::borrow::Cow::Borrowed(source);
+        plan.strip_modifiers(&mut line, 0);
+        assert_eq!(line, source);
+
+        let mut fields = Vec::new();
+        let mut setup = vize_carton::String::default();
+        plan.emit_setup_artifacts(&mut setup, &mut fields);
+        assert!(fields.is_empty());
+        assert!(setup.is_empty());
+    }
+}

--- a/crates/vize_canon/tests/setup_scoped_type_exports.rs
+++ b/crates/vize_canon/tests/setup_scoped_type_exports.rs
@@ -1,0 +1,206 @@
+use std::path::Path;
+
+use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait, SfcTypeCheckOptions, type_check_sfc};
+
+const COMPONENT: &str = r#"<script lang="ts">
+const NATIVE_TYPES = ["button", "submit", "reset"] as const;
+export type ButtonNativeType = typeof NATIVE_TYPES[number];
+
+const COLORS = ["red", "blue"] as const;
+export interface BadgeOptions {
+  color: typeof COLORS[number];
+}
+
+const selected: ButtonNativeType = "button";
+const options: BadgeOptions = { color: "red" };
+void selected;
+void options;
+</script>
+
+<template><button /></template>
+"#;
+
+const SETUP_PROPS_COMPONENT: &str = r#"<script setup lang="ts">
+const NATIVE_TYPES = ["button", "submit"] as const;
+export interface Props {
+  nativeType: typeof NATIVE_TYPES[number];
+}
+const props = defineProps<Props>();
+void props;
+</script>
+
+<template><button /></template>
+"#;
+
+#[test]
+fn setup_value_dependent_exports_are_captured_and_reexported() {
+    let virtual_ts = type_check_sfc(
+        COMPONENT,
+        &SfcTypeCheckOptions::new("Button.vue").with_virtual_ts(),
+    )
+    .virtual_ts
+    .expect("virtual TypeScript should be generated");
+
+    assert!(
+        !virtual_ts.contains("  export type ButtonNativeType"),
+        "an export modifier must not remain inside __setup:\n{virtual_ts}"
+    );
+    assert!(
+        !virtual_ts.contains("  export interface BadgeOptions"),
+        "an interface export modifier must not remain inside __setup:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("type ButtonNativeType = typeof NATIVE_TYPES[number]"),
+        "the setup-scoped alias must retain its value dependency:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("color: typeof COLORS[number]"),
+        "the setup-scoped interface body must remain byte-complete:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains(
+            "export type ButtonNativeType = Awaited<ReturnType<typeof __setup>>[\"__vize_exported_type_ButtonNativeType\"]"
+        ),
+        "the public alias must be restored at module scope:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains(
+            "export type BadgeOptions = Awaited<ReturnType<typeof __setup>>[\"__vize_exported_type_BadgeOptions\"]"
+        ),
+        "the public interface shape must be restored at module scope:\n{virtual_ts}"
+    );
+
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed =
+        oxc_parser::Parser::new(&allocator, virtual_ts.as_str(), oxc_span::SourceType::ts())
+            .parse();
+    assert!(
+        !parsed.panicked && parsed.errors.is_empty(),
+        "captured type exports must produce parseable TypeScript: {:#?}\n{virtual_ts}",
+        parsed.errors
+    );
+}
+
+#[test]
+fn downstream_imports_accept_exact_types_and_reject_invalid_values() {
+    let project = tempfile::tempdir().expect("temporary project should be created");
+    write_project(project.path());
+
+    let mut checker = BatchTypeChecker::new(project.path()).expect("type checker should start");
+    checker.scan_project().expect("project should scan");
+    let diagnostics = checker
+        .check_project()
+        .expect("project should type check")
+        .diagnostics;
+
+    let structural_failures: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            matches!(diagnostic.code, Some(1184 | 2305 | 2300 | 2614))
+                || (diagnostic.file.ends_with("consumer.ts") && diagnostic.code != Some(2322))
+        })
+        .collect();
+    assert!(
+        structural_failures.is_empty(),
+        "valid public type imports must remain diagnostic-free: {structural_failures:#?}"
+    );
+
+    let rejected_assignments = diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.file.ends_with("consumer.ts") && diagnostic.code == Some(2322)
+        })
+        .count();
+    assert_eq!(
+        rejected_assignments, 2,
+        "both invalid literal assignments must be rejected without widening: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn exported_setup_scoped_props_have_one_public_declaration() {
+    let virtual_ts = type_check_sfc(
+        SETUP_PROPS_COMPONENT,
+        &SfcTypeCheckOptions::new("SetupButton.vue").with_virtual_ts(),
+    )
+    .virtual_ts
+    .expect("virtual TypeScript should be generated");
+
+    assert_eq!(
+        virtual_ts.match_indices("export type Props =").count(),
+        1,
+        "the setup artifact and the public source type must not emit duplicate Props aliases:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("type __VizeResolvedProps = Awaited<ReturnType<typeof __setup>>"),
+        "component prop checking must still resolve the setup-scoped Props shape:\n{virtual_ts}"
+    );
+
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed =
+        oxc_parser::Parser::new(&allocator, virtual_ts.as_str(), oxc_span::SourceType::ts())
+            .parse();
+    assert!(
+        parsed.errors.is_empty(),
+        "a public setup-scoped Props interface must remain parseable: {:#?}\n{virtual_ts}",
+        parsed.errors
+    );
+}
+
+fn write_project(root: &Path) {
+    write_file(
+        root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write_file(
+        root,
+        "node_modules/vue/package.json",
+        r#"{ "name": "vue", "types": "index.d.ts" }"#,
+    );
+    write_file(
+        root,
+        "node_modules/vue/index.d.ts",
+        r#"export interface ComponentPublicInstance {
+  $attrs: Record<string, unknown>;
+  $slots: Record<string, unknown>;
+  $refs: Record<string, unknown>;
+  $emit: (...args: unknown[]) => void;
+}
+"#,
+    );
+    write_file(root, "src/Button.vue", COMPONENT);
+    write_file(
+        root,
+        "src/consumer.ts",
+        r#"import type { BadgeOptions, ButtonNativeType } from "./Button.vue";
+
+const acceptedButton: ButtonNativeType = "submit";
+const rejectedButton: ButtonNativeType = "anchor";
+const acceptedBadge: BadgeOptions = { color: "blue" };
+const rejectedBadge: BadgeOptions = { color: "green" };
+
+void acceptedButton;
+void rejectedButton;
+void acceptedBadge;
+void rejectedBadge;
+"#,
+    );
+}
+
+fn write_file(root: &Path, path: &str, source: &str) {
+    let path = root.join(path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("parent directory should be created");
+    }
+    std::fs::write(path, source).expect("fixture should be written");
+}


### PR DESCRIPTION
## Summary

- remove public type/interface modifiers only at analyzed setup-scoped declaration spans
- capture non-generic value-dependent public types through the setup return and re-export their exact inferred shape at module scope
- keep generic declarations out of the non-generic capture path and avoid duplicate public `Props` aliases

## Verification

- `cargo test -p vize_canon --all-features`
- `cargo clippy -p vize_canon --all-features --lib -- -D warnings`
- `cargo build -p vize`
- strict parse plus downstream positive/negative type import tests
- Buefy, Directus, Inspira UI, and Scalar: 3,531 SFCs through compiler, typechecker, linter, and formatter; TS1184 reduced from 20 to 0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - TypeScript types and interfaces exported from `<script setup>` are now available to consumers at the module level.
  - Setup-scoped exported types retain their dependencies and accurate type relationships.
  - Generic type exports continue to preserve their intended type behavior.
  - `Props` types derived from `defineProps` are exposed consistently without duplicate declarations.

- **Bug Fixes**
  - Improved generated TypeScript output to prevent setup-scoped exports from being incorrectly nested or omitted.
  - Preserved type-checking diagnostics for invalid assignments while avoiding unwanted type widening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->