### PR TITLE
fix(canon): strip generic setup exports and dedupe merged type artifacts

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -33,7 +33,7 @@ use self::options_api::{
 use self::options_api_props_identifiers::PropsConstAssertions;
 use self::props_anchors::emit_setup_scope_prop_anchors;
 use self::setup_helpers::emit_setup_helpers;
-use self::setup_props::SetupPropsPlan;
+use self::setup_props::generate_setup_props;
 use self::setup_type_exports::SetupTypeExportsPlan;
 use self::spans::{
     DEFINE_COMPONENT_REF, merge_overlapping_spans, rewrite_export_default_for_module_scope,
@@ -454,19 +454,13 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         } else {
             None
         };
-    let setup_props_plan = SetupPropsPlan::new(
+    let setup_props_plan = generate_setup_props(
+        &mut ts,
         summary,
+        generic_param,
         options_api_props.as_ref(),
         setup_type_exports.exports_public_type("Props"),
     );
-    profile!("canon.virtual_ts.generate_props_type", {
-        setup_props_plan.generate_props_type(
-            &mut ts,
-            summary,
-            generic_param,
-            options_api_props.as_ref(),
-        )
-    });
 
     // Setup scope: function that contains setup helpers and script content
     ts.push_str("// ========== Setup Scope ==========\n");

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -454,7 +454,11 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         } else {
             None
         };
-    let setup_props_plan = SetupPropsPlan::new(summary, options_api_props.as_ref());
+    let setup_props_plan = SetupPropsPlan::new(
+        summary,
+        options_api_props.as_ref(),
+        setup_type_exports.exports_public_type("Props"),
+    );
     profile!("canon.virtual_ts.generate_props_type", {
         setup_props_plan.generate_props_type(
             &mut ts,

--- a/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
@@ -1,4 +1,4 @@
-use vize_carton::{String, append, cstr};
+use vize_carton::{String, append, cstr, profile};
 use vize_croquis::Croquis;
 
 use super::generics::{is_ident_byte, references_any_identifier, skip_ascii_ws};
@@ -88,6 +88,23 @@ pub(super) fn define_props_type_requires_setup_scope(summary: &Croquis) -> bool 
         .collect();
     !non_hoisted_type_names.is_empty()
         && references_any_identifier(inner_type, &non_hoisted_type_names)
+}
+
+/// Build the setup props plan and emit the module-level props type in one step.
+/// Keeps `generator.rs` from re-threading `options_api_props` through a second
+/// call site (and from growing past the source-length gate).
+pub(super) fn generate_setup_props(
+    ts: &mut String,
+    summary: &Croquis,
+    generic_param: Option<&str>,
+    options_api_props: Option<&OptionsApiPropsSource>,
+    props_is_public_export: bool,
+) -> SetupPropsPlan {
+    let plan = SetupPropsPlan::new(summary, options_api_props, props_is_public_export);
+    profile!("canon.virtual_ts.generate_props_type", {
+        plan.generate_props_type(ts, summary, generic_param, options_api_props);
+    });
+    plan
 }
 
 pub(super) struct SetupPropsPlan {

--- a/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
@@ -100,11 +100,19 @@ impl SetupPropsPlan {
     pub(super) fn new(
         summary: &Croquis,
         options_api_props: Option<&OptionsApiPropsSource>,
+        props_is_public_export: bool,
     ) -> Self {
-        let module_scope_declares_props = summary
-            .type_exports
-            .iter()
-            .any(|te| te.name.as_str() == "Props");
+        // A `Props` declaration only lands at module scope when it is hoisted
+        // (emitted directly at module level) or when it is a value-dependent
+        // export recaptured through the setup return (`props_is_public_export`).
+        // A private, non-hoisted `type Props` stays inside `__setup`, so it must
+        // NOT be treated as an existing public alias — otherwise the public
+        // `export type Props` consumers need is suppressed.
+        let module_scope_declares_props = props_is_public_export
+            || summary
+                .type_exports
+                .iter()
+                .any(|te| te.hoisted && te.name.as_str() == "Props");
         Self {
             defer: define_props_type_requires_setup_scope(summary),
             defer_options_api_props: !module_scope_declares_props
@@ -160,6 +168,9 @@ impl SetupPropsPlan {
     }
 
     pub(super) fn component_props_type_ref(&self) -> &'static str {
+        // Defer to `__VizeResolvedProps` only when a `Props` already lives at
+        // module scope; otherwise the public `Props` alias emitted from the
+        // setup return is the component prop source.
         if self.defer && self.module_scope_declares_props {
             "__VizeResolvedProps"
         } else {
@@ -247,10 +258,15 @@ impl SetupPropsPlan {
     ) {
         if self.defer {
             if self.module_scope_declares_props {
+                // A `Props` already lives at module scope (hoisted, or restored
+                // by the setup type-export plan); emit an internal alias for the
+                // component instance to avoid a duplicate public declaration.
                 ts.push_str(
                     "type __VizeResolvedProps = Awaited<ReturnType<typeof __setup>>[\"__vize_setup_props\"];\n\n",
                 );
             } else {
+                // No `Props` exists at module scope (inline type args, or a
+                // private setup-scoped `Props`), so restore the public alias.
                 ts.push_str(
                     "export type Props = Awaited<ReturnType<typeof __setup>>[\"__vize_setup_props\"];\n\n",
                 );

--- a/crates/vize_canon/src/virtual_ts/generator/setup_type_exports.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/setup_type_exports.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use vize_carton::{String, append, cstr};
+use vize_carton::{FxHashSet, String, append, cstr};
 use vize_croquis::Croquis;
 
 fn skip_trivia(source: &str, mut at: usize) -> usize {
@@ -68,6 +68,7 @@ impl SetupTypeExportsPlan {
     pub(super) fn new(summary: &Croquis, script: Option<&str>) -> Self {
         let mut export_starts = Vec::new();
         let mut exports = Vec::new();
+        let mut captured_names: FxHashSet<String> = FxHashSet::default();
 
         if let Some(script) = script {
             for declaration in summary.type_exports.iter().filter(|item| !item.hoisted) {
@@ -81,10 +82,27 @@ impl SetupTypeExportsPlan {
                 }
 
                 let name: String = declaration.name.as_str().into();
+                // Every analyzed setup-scoped export must lose its `export`
+                // modifier so the declaration is legal inside `__setup`; a
+                // retained modifier emitted in function scope is TS1184. Record
+                // the span before the guards below, which only decide whether we
+                // additionally capture a re-exportable artifact.
+                export_starts.push(declaration.start);
+                // Generic declarations cannot ride the non-generic
+                // `undefined as unknown as T` capture path: it drops their type
+                // parameters, and a value-dependent generic cannot be
+                // reconstructed at module scope. Strip the modifier (above) but
+                // skip artifact capture.
                 if exported_type_is_generic(source, &name) {
                     continue;
                 }
-                export_starts.push(declaration.start);
+                // Legal declaration merging (e.g. two `export interface
+                // Options`) surfaces the same name twice. Keep every modifier
+                // span, but capture a single artifact per exported name so the
+                // generated module has no duplicate bindings or aliases.
+                if !captured_names.insert(name.clone()) {
+                    continue;
+                }
                 exports.push(SetupTypeExport {
                     artifact: cstr!("__vize_exported_type_{name}"),
                     name,
@@ -97,6 +115,13 @@ impl SetupTypeExportsPlan {
             export_starts,
             exports,
         }
+    }
+
+    /// Whether `name` is captured as an explicit public re-export at module
+    /// scope. Used to distinguish a public `export type Props` from a private
+    /// setup-scoped `type Props`, which is never re-exported.
+    pub(super) fn exports_public_type(&self, name: &str) -> bool {
+        self.exports.iter().any(|export| export.name.as_str() == name)
     }
 
     pub(super) fn strip_modifiers(&self, line: &mut Cow<'_, str>, line_start: u32) {
@@ -231,14 +256,57 @@ mod tests {
             hoisted: false,
         });
         let plan = SetupTypeExportsPlan::new(&summary, Some(source));
+        // The `export` modifier is still stripped: a non-hoisted generic stays
+        // inside `__setup`, where a retained modifier would be TS1184.
         let mut line = std::borrow::Cow::Borrowed(source);
         plan.strip_modifiers(&mut line, 0);
-        assert_eq!(line, source);
+        assert_eq!(line, " /* public */ type Box<T extends typeof value> = { value: T }");
 
+        // But it is never captured through the non-generic artifact path, which
+        // would drop its type parameters.
         let mut fields = Vec::new();
         let mut setup = vize_carton::String::default();
         plan.emit_setup_artifacts(&mut setup, &mut fields);
         assert!(fields.is_empty());
         assert!(setup.is_empty());
+    }
+
+    #[test]
+    fn merged_interface_exports_capture_one_artifact_per_name() {
+        let script = "export interface Options { a: typeof value } export interface Options { b: typeof value }";
+        let first_start = script.find("export").unwrap() as u32;
+        let second_start = script.rfind("export").unwrap() as u32;
+        let mut summary = Croquis::new();
+        for start in [first_start, second_start] {
+            summary.type_exports.push(TypeExport {
+                name: "Options".into(),
+                kind: TypeExportKind::Interface,
+                start,
+                end: script.len() as u32,
+                hoisted: false,
+            });
+        }
+
+        let plan = SetupTypeExportsPlan::new(&summary, Some(script));
+
+        // Both `export` modifiers are stripped so neither merged declaration is
+        // illegal inside `__setup`.
+        let mut line = std::borrow::Cow::Borrowed(script);
+        plan.strip_modifiers(&mut line, 0);
+        assert_eq!(
+            line,
+            " interface Options { a: typeof value }  interface Options { b: typeof value }"
+        );
+
+        // But only one artifact/alias is emitted for the merged name.
+        let mut fields = Vec::new();
+        let mut setup = vize_carton::String::default();
+        plan.emit_setup_artifacts(&mut setup, &mut fields);
+        assert_eq!(fields, ["__vize_exported_type_Options"]);
+        assert_eq!(setup.matches("unknown as Options").count(), 1);
+
+        let mut module = vize_carton::String::default();
+        plan.emit_module_exports(&mut module);
+        assert_eq!(module.matches("export type Options =").count(), 1);
     }
 }

--- a/crates/vize_canon/src/virtual_ts/generator/setup_type_exports.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/setup_type_exports.rs
@@ -121,7 +121,9 @@ impl SetupTypeExportsPlan {
     /// scope. Used to distinguish a public `export type Props` from a private
     /// setup-scoped `type Props`, which is never re-exported.
     pub(super) fn exports_public_type(&self, name: &str) -> bool {
-        self.exports.iter().any(|export| export.name.as_str() == name)
+        self.exports
+            .iter()
+            .any(|export| export.name.as_str() == name)
     }
 
     pub(super) fn strip_modifiers(&self, line: &mut Cow<'_, str>, line_start: u32) {
@@ -260,7 +262,10 @@ mod tests {
         // inside `__setup`, where a retained modifier would be TS1184.
         let mut line = std::borrow::Cow::Borrowed(source);
         plan.strip_modifiers(&mut line, 0);
-        assert_eq!(line, " /* public */ type Box<T extends typeof value> = { value: T }");
+        assert_eq!(
+            line,
+            " /* public */ type Box<T extends typeof value> = { value: T }"
+        );
 
         // But it is never captured through the non-generic artifact path, which
         // would drop its type parameters.

--- a/crates/vize_canon/tests/setup_scoped_type_exports.rs
+++ b/crates/vize_canon/tests/setup_scoped_type_exports.rs
@@ -32,6 +32,18 @@ void props;
 <template><button /></template>
 "#;
 
+const PRIVATE_SETUP_PROPS_COMPONENT: &str = r#"<script setup lang="ts">
+const NATIVE_TYPES = ["button", "submit"] as const;
+type Props = {
+  nativeType: typeof NATIVE_TYPES[number];
+};
+const props = defineProps<Props>();
+void props;
+</script>
+
+<template><button /></template>
+"#;
+
 #[test]
 fn setup_value_dependent_exports_are_captured_and_reexported() {
     let virtual_ts = type_check_sfc(
@@ -143,6 +155,46 @@ fn exported_setup_scoped_props_have_one_public_declaration() {
     assert!(
         parsed.errors.is_empty(),
         "a public setup-scoped Props interface must remain parseable: {:#?}\n{virtual_ts}",
+        parsed.errors
+    );
+}
+
+#[test]
+fn private_setup_scoped_props_still_export_a_public_declaration() {
+    let virtual_ts = type_check_sfc(
+        PRIVATE_SETUP_PROPS_COMPONENT,
+        &SfcTypeCheckOptions::new("PrivateSetupButton.vue").with_virtual_ts(),
+    )
+    .virtual_ts
+    .expect("virtual TypeScript should be generated");
+
+    // The user's `Props` is private and value-dependent, so it stays inside
+    // `__setup` and is never re-exported by the type-export plan. The public
+    // `export type Props` consumers need must still be restored from the setup
+    // return, and there must be exactly one of them.
+    assert_eq!(
+        virtual_ts.match_indices("export type Props =").count(),
+        1,
+        "a private value-dependent Props must still yield one public export:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains(
+            "export type Props = Awaited<ReturnType<typeof __setup>>[\"__vize_setup_props\"]"
+        ),
+        "the public Props alias must resolve from the setup return:\n{virtual_ts}"
+    );
+    assert!(
+        !virtual_ts.contains("__VizeResolvedProps"),
+        "a private Props must not be treated as an existing public alias:\n{virtual_ts}"
+    );
+
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed =
+        oxc_parser::Parser::new(&allocator, virtual_ts.as_str(), oxc_span::SourceType::ts())
+            .parse();
+    assert!(
+        parsed.errors.is_empty(),
+        "a private setup-scoped Props must remain parseable: {:#?}\n{virtual_ts}",
         parsed.errors
     );
 }


### PR DESCRIPTION
Follow-up to #3093 (already merged) addressing CodeRabbit review findings on the setup-scoped type-export path.

### Generic setup exports no longer emit TS1184
A non-hoisted generic export (e.g. `export type Box<T> = { v: typeof value }`) stays inside `__setup`, but the generic check ran *before* the modifier span was recorded, so its `export` keyword survived into function scope (TS1184). The span is now recorded unconditionally; generics are still excluded from the non-generic `undefined as unknown as T` capture (that path drops type parameters and a value-dependent generic cannot be reconstructed at module scope).

```rust
// Record the span before the guards, which only decide whether we
// additionally capture a re-exportable artifact.
export_starts.push(declaration.start);
if exported_type_is_generic(source, &name) {
    continue; // strip the modifier, skip artifact capture
}
```

### Merged interfaces capture one artifact per name
Legal declaration merging (two `export interface Options`) added the same artifact twice, emitting duplicate `const __vize_exported_type_Options` bindings and duplicate module aliases. Every modifier span is still stripped, but only one artifact per exported name is captured.

### Private `Props` is no longer treated as a public alias
`module_scope_declares_props` matched any analyzed declaration named `Props`, including a private, non-hoisted `type Props = typeof value`. Such a `Props` stays inside `__setup` and is never re-exported, so the public `export type Props` consumers need was being suppressed. The predicate now recognizes only a `Props` that actually lands at module scope (hoisted, or a value-dependent export recaptured through the setup return):

```rust
let module_scope_declares_props = props_is_public_export
    || summary.type_exports.iter().any(|te| te.hoisted && te.name.as_str() == "Props");
```

### Tests
- Unit: generic export modifier is stripped (no widening); merged interfaces yield one artifact/alias.
- Integration: a private, value-dependent `Props` used by `defineProps<Props>()` still emits exactly one public `export type Props` and no `__VizeResolvedProps`.

`cargo test -p vize_canon --lib` (570 passing) and `cargo clippy -p vize_canon --lib -- -D warnings` are clean. The `downstream_imports_...` integration test requires the node/tsc toolchain (`corsa`) and only runs in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated TypeScript when setup-defined `Props` is private, ensuring consumers still receive exactly one public `export type Props` via the setup props return.
  * Prevented duplicate artifacts/aliases when multiple non-hoisted exports share the same name, including merged `export interface` declarations.
  * Preserved correct `export`-modifier stripping for generic exported types.
* **Tests**
  * Added coverage for private setup props recovery and merged interface export de-duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->