### PR TITLE
fix(canon): hoist ambient declarations

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -252,9 +252,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             module_spans.push((imp.start, imp.end));
         }
         if let Some(script) = script_content {
-            module_spans.extend(self::script_module::collect_line_module_import_spans(
-                script,
-            ));
+            module_spans.extend(self::script_module::collect_line_module_spans(script));
         }
         for re in &summary.re_exports {
             module_spans.push((re.start, re.end));

--- a/crates/vize_canon/src/virtual_ts/generator/script_module.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module.rs
@@ -4,7 +4,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::{BindingPattern, Declaration, Statement, TSEnumDeclaration};
 use oxc_ast_visit::Visit;
 use oxc_parser::Parser;
-use oxc_span::SourceType;
+use oxc_span::{GetSpan, SourceType};
 use vize_carton::{CompactString, FxHashSet, String as VizeString, append};
 
 pub(super) fn collect_normal_script_named_value_exports(
@@ -18,23 +18,29 @@ pub(super) fn collect_normal_script_named_value_exports(
     script.map(collect_named_value_exports).unwrap_or_default()
 }
 
-pub(super) fn collect_line_module_import_spans(script: &str) -> Vec<(u32, u32)> {
+pub(super) fn collect_line_module_spans(script: &str) -> Vec<(u32, u32)> {
     let mut spans = Vec::new();
     let allocator = Allocator::default();
-    let parsed = Parser::new(&allocator, script, SourceType::tsx().with_module(true)).parse();
+    let parsed = Parser::new(&allocator, script, SourceType::ts().with_module(true)).parse();
+    let parsed = if parsed.panicked {
+        Parser::new(&allocator, script, SourceType::tsx().with_module(true)).parse()
+    } else {
+        parsed
+    };
     if parsed.panicked {
         return spans;
     }
 
     for statement in &parsed.program.body {
         match statement {
-            Statement::ImportDeclaration(decl) => {
-                spans.push((decl.span.start, decl.span.end));
+            Statement::ImportDeclaration(_)
+            | Statement::ExportAllDeclaration(_)
+            | Statement::TSModuleDeclaration(_)
+            | Statement::TSGlobalDeclaration(_) => {
+                let span = statement.span();
+                spans.push((span.start, span.end));
             }
             Statement::ExportNamedDeclaration(decl) if decl.source.is_some() => {
-                spans.push((decl.span.start, decl.span.end));
-            }
-            Statement::ExportAllDeclaration(decl) => {
                 spans.push((decl.span.start, decl.span.end));
             }
             _ => {}
@@ -294,14 +300,14 @@ fn contains_ts_suppression_directive(comment: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        CompactString, collect_line_module_import_spans, collect_named_value_export_starts,
+        CompactString, collect_line_module_spans, collect_named_value_export_starts,
         collect_named_value_exports,
     };
 
     #[test]
     fn collect_import_span_includes_adjacent_ts_ignore_comment_group() {
         let script = "const before = 1;\n// FIXME: types\n// @ts-ignore\nimport Chart from \"chart.js/auto/auto\";\nconst after = 2;\n";
-        let spans = collect_line_module_import_spans(script);
+        let spans = collect_line_module_spans(script);
 
         assert_eq!(spans.len(), 1);
         assert_eq!(
@@ -313,7 +319,7 @@ mod tests {
     #[test]
     fn collect_import_span_leaves_regular_comments_in_script_body() {
         let script = "// import note\nimport Chart from \"chart.js/auto/auto\";\n";
-        let spans = collect_line_module_import_spans(script);
+        let spans = collect_line_module_spans(script);
 
         assert_eq!(spans.len(), 1);
         assert_eq!(

--- a/crates/vize_canon/tests/ambient_declarations.rs
+++ b/crates/vize_canon/tests/ambient_declarations.rs
@@ -1,0 +1,179 @@
+use std::path::Path;
+
+use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait, SfcTypeCheckOptions, type_check_sfc};
+
+const COMPONENT: &str = r#"<script setup lang="ts">
+import type { Payload } from "virtual-service";
+
+declare global {
+  interface Window {
+    refreshLivePreview: (url: string | null) => void;
+  }
+}
+
+declare module "virtual-service" {
+  interface Payload {
+    label: string;
+  }
+}
+
+const payload: Payload = { id: "one", label: "ready" };
+window.refreshLivePreview("/preview");
+void payload;
+</script>
+
+<template><div /></template>
+"#;
+
+#[test]
+fn ambient_declarations_are_emitted_once_at_module_scope() {
+    let virtual_ts = type_check_sfc(
+        COMPONENT,
+        &SfcTypeCheckOptions::new("LivePreview.vue").with_virtual_ts(),
+    )
+    .virtual_ts
+    .expect("virtual TypeScript should be generated");
+
+    let setup_start = virtual_ts
+        .find("function __setup")
+        .expect("setup function should be generated");
+    let global_declaration = "declare global {\n  interface Window";
+    let global_start = virtual_ts
+        .find(global_declaration)
+        .expect("global augmentation should be preserved");
+    let module_start = virtual_ts
+        .find("declare module \"virtual-service\"")
+        .expect("module augmentation should be preserved");
+    assert!(
+        global_start < setup_start && module_start < setup_start,
+        "ambient declarations must precede the setup function:\n{virtual_ts}"
+    );
+    assert_eq!(virtual_ts.match_indices(global_declaration).count(), 1);
+    assert_eq!(
+        virtual_ts
+            .match_indices("declare module \"virtual-service\"")
+            .count(),
+        1
+    );
+    assert!(
+        virtual_ts.contains("refreshLivePreview: (url: string | null) => void;"),
+        "the global declaration body must remain byte-complete:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("interface Payload {\n    label: string;\n  }"),
+        "the module augmentation body must remain byte-complete:\n{virtual_ts}"
+    );
+
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed =
+        oxc_parser::Parser::new(&allocator, virtual_ts.as_str(), oxc_span::SourceType::ts())
+            .parse();
+    assert!(
+        !parsed.panicked && parsed.errors.is_empty(),
+        "hoisted ambient declarations must produce parseable TypeScript: {:#?}\n{virtual_ts}",
+        parsed.errors
+    );
+}
+
+#[test]
+fn ambient_augmentations_accept_valid_uses_and_reject_invalid_ones() {
+    let project = tempfile::tempdir().expect("temporary project should be created");
+    write_project(project.path());
+
+    let mut checker = BatchTypeChecker::new(project.path()).expect("type checker should start");
+    checker.scan_project().expect("project should scan");
+    let diagnostics = checker
+        .check_project()
+        .expect("project should type check")
+        .diagnostics;
+
+    let structural_failures: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            matches!(diagnostic.code, Some(1234 | 2307 | 2339 | 2664))
+                || (diagnostic.file.ends_with("consumer.ts")
+                    && !matches!(diagnostic.code, Some(2345 | 2741)))
+        })
+        .collect();
+    assert!(
+        structural_failures.is_empty(),
+        "valid global and module augmentations must remain diagnostic-free: {structural_failures:#?}"
+    );
+
+    let rejected_uses: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.file.ends_with("consumer.ts") && matches!(diagnostic.code, Some(2345 | 2741))
+        })
+        .collect();
+    assert_eq!(
+        rejected_uses.len(),
+        2,
+        "both invalid uses must be rejected without widening the augmentations: {diagnostics:#?}"
+    );
+}
+
+fn write_project(root: &Path) {
+    write_file(
+        root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write_file(
+        root,
+        "node_modules/vue/package.json",
+        r#"{ "name": "vue", "types": "index.d.ts" }"#,
+    );
+    write_file(
+        root,
+        "node_modules/vue/index.d.ts",
+        r#"export interface ComponentPublicInstance {
+  $attrs: Record<string, unknown>;
+  $slots: Record<string, unknown>;
+  $refs: Record<string, unknown>;
+  $emit: (...args: unknown[]) => void;
+}
+"#,
+    );
+    write_file(
+        root,
+        "node_modules/virtual-service/package.json",
+        r#"{ "name": "virtual-service", "types": "index.d.ts" }"#,
+    );
+    write_file(
+        root,
+        "node_modules/virtual-service/index.d.ts",
+        "export interface Payload { id: string; }\n",
+    );
+    write_file(root, "src/LivePreview.vue", COMPONENT);
+    write_file(
+        root,
+        "src/consumer.ts",
+        r#"import type { Payload } from "virtual-service";
+
+const accepted: Payload = { id: "one", label: "ready" };
+const rejected: Payload = { id: "two" };
+window.refreshLivePreview("/ready");
+window.refreshLivePreview(42);
+void accepted;
+void rejected;
+"#,
+    );
+}
+
+fn write_file(root: &Path, path: &str, source: &str) {
+    let path = root.join(path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("parent directory should be created");
+    }
+    std::fs::write(path, source).expect("fixture should be written");
+}


### PR DESCRIPTION
## Summary

- collect top-level TypeScript global and module declaration spans with imports and re-exports
- emit ambient declarations once at virtual module scope instead of inside `__setup`
- parse TypeScript first and fall back to TSX so long non-TSX setup files retain early ambient declarations

## Verification

- `cargo test -p vize_canon --all-features`
- `cargo clippy -p vize_canon --all-features --lib -- -D warnings`
- `cargo build -p vize`
- strict parse plus downstream positive/negative global and module augmentation tests
- Airi, Alexandrie, Directus, Frappe Builder, Inertia, and Misskey: 3,037 SFCs through compiler, typechecker, linter, and formatter; TS1234 reduced from 19 to 0 with no diagnostic additions in the same local environment

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->