### PR TITLE
fix(canon): parenthesize runtime function prop unions

### DIFF
--- a/crates/vize_canon/tests/runtime_function_prop_union.rs
+++ b/crates/vize_canon/tests/runtime_function_prop_union.rs
@@ -1,0 +1,169 @@
+use std::path::Path;
+
+use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait, SfcTypeCheckOptions, type_check_sfc};
+
+const COMPONENT: &str = r#"<script setup lang="ts">
+const props = defineProps({
+  data: { type: [Array, Function], required: true },
+  labelOrPredicate: { type: [String, Function], required: true },
+  formatter: { type: Function, required: true },
+})
+void props
+</script>
+
+<template><div /></template>
+"#;
+
+#[test]
+fn runtime_function_union_members_generate_parseable_typescript() {
+    let virtual_ts = type_check_sfc(
+        COMPONENT,
+        &SfcTypeCheckOptions::new("FlexibleData.vue").with_virtual_ts(),
+    )
+    .virtual_ts
+    .expect("virtual TypeScript should be generated");
+
+    assert!(
+        virtual_ts.contains("data: unknown[] | ((...args: any[]) => any);"),
+        "the Crater-style Array/Function prop must parenthesize its function member:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("labelOrPredicate: string | ((...args: any[]) => any);"),
+        "a scalar/function union must preserve the same precedence:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("formatter: (...args: any[]) => any;"),
+        "a standalone Function constructor must retain its callable shape:\n{virtual_ts}"
+    );
+    assert!(
+        !virtual_ts.contains("unknown[] | (...args: any[]) => any"),
+        "an unparenthesized function union must never be emitted:\n{virtual_ts}"
+    );
+
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed =
+        oxc_parser::Parser::new(&allocator, virtual_ts.as_str(), oxc_span::SourceType::ts())
+            .parse();
+    assert!(
+        !parsed.panicked && parsed.errors.is_empty(),
+        "runtime function unions must produce parseable TypeScript: {:#?}\n{virtual_ts}",
+        parsed.errors
+    );
+}
+
+#[test]
+fn runtime_function_unions_accept_both_members_and_reject_other_types() {
+    let project = tempfile::tempdir().expect("temporary project should be created");
+    write_project(project.path());
+
+    let mut checker = BatchTypeChecker::new(project.path()).expect("type checker should start");
+    checker.scan_project().expect("project should scan");
+    let diagnostics = checker
+        .check_project()
+        .expect("project should type check")
+        .diagnostics;
+
+    let unexpected: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.code == Some(1385)
+                || (diagnostic.file.ends_with("consumer.ts") && diagnostic.code != Some(2322))
+        })
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "valid arrays, strings, and functions must remain diagnostic-free: {unexpected:#?}"
+    );
+
+    let rejected_assignments = diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.file.ends_with("consumer.ts") && diagnostic.code == Some(2322)
+        })
+        .count();
+    assert_eq!(
+        rejected_assignments, 3,
+        "each value outside the declared runtime prop types must be rejected: {diagnostics:#?}"
+    );
+}
+
+fn write_project(root: &Path) {
+    write_file(
+        root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write_file(
+        root,
+        "node_modules/vue/package.json",
+        r#"{ "name": "vue", "types": "index.d.ts" }"#,
+    );
+    write_file(
+        root,
+        "node_modules/vue/index.d.ts",
+        r#"export interface ComponentPublicInstance {
+  $attrs: Record<string, unknown>;
+  $slots: Record<string, unknown>;
+  $refs: Record<string, unknown>;
+  $emit: (...args: unknown[]) => void;
+}
+"#,
+    );
+    write_file(root, "src/FlexibleData.vue", COMPONENT);
+    write_file(
+        root,
+        "src/consumer.ts",
+        r#"import type { Props } from "./FlexibleData.vue";
+
+const acceptedArray: Props = {
+  data: [],
+  labelOrPredicate: "ready",
+  formatter: () => "done",
+};
+const acceptedFunctions: Props = {
+  data: () => ({ id: 1 }),
+  labelOrPredicate: (label: string) => label.length > 0,
+  formatter: (value: unknown) => String(value),
+};
+
+const rejectedData: Props = {
+  data: "not-an-array-or-function",
+  labelOrPredicate: "ready",
+  formatter: () => "done",
+};
+const rejectedPredicate: Props = {
+  data: [],
+  labelOrPredicate: 42,
+  formatter: () => "done",
+};
+const rejectedFormatter: Props = {
+  data: [],
+  labelOrPredicate: "ready",
+  formatter: "not-a-function",
+};
+
+void acceptedArray;
+void acceptedFunctions;
+void rejectedData;
+void rejectedPredicate;
+void rejectedFormatter;
+"#,
+    );
+}
+
+fn write_file(root: &Path, path: &str, source: &str) {
+    let path = root.join(path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("parent directory should be created");
+    }
+    std::fs::write(path, source).expect("fixture should be written");
+}

--- a/crates/vize_croquis/src/script_parser.rs
+++ b/crates/vize_croquis/src/script_parser.rs
@@ -47,4 +47,7 @@ mod legacy_vue2_tests;
 mod props_destructure_tests;
 
 #[cfg(test)]
+mod runtime_props_tests;
+
+#[cfg(test)]
 mod options_api_emits_tests;

--- a/crates/vize_croquis/src/script_parser/extract/props.rs
+++ b/crates/vize_croquis/src/script_parser/extract/props.rs
@@ -178,7 +178,13 @@ pub(super) fn extract_runtime_prop_type(
                 if has_type {
                     union.push_str(" | ");
                 }
-                union.push_str(prop_type.as_str());
+                if arr.elements.len() > 1 && prop_type.contains("=>") {
+                    union.push('(');
+                    union.push_str(prop_type.as_str());
+                    union.push(')');
+                } else {
+                    union.push_str(prop_type.as_str());
+                }
                 has_type = true;
             }
             has_type.then(|| CompactString::new(union.as_str()))

--- a/crates/vize_croquis/src/script_parser/runtime_props_tests.rs
+++ b/crates/vize_croquis/src/script_parser/runtime_props_tests.rs
@@ -1,0 +1,43 @@
+use super::parse_script_setup;
+
+#[test]
+fn parenthesizes_function_union_members() {
+    let result = parse_script_setup(
+        r#"
+            const props = defineProps({
+                data: { type: [Array, Function], required: true },
+                formatter: Function,
+                labelOrPredicate: [
+                    String,
+                    Function as PropType<(value: string) => boolean>,
+                ],
+            })
+        "#,
+    );
+
+    let props = result.macros.props();
+    assert_eq!(props.len(), 3);
+    assert_eq!(
+        props
+            .iter()
+            .find(|prop| prop.name == "data")
+            .and_then(|prop| prop.prop_type.as_deref()),
+        Some("unknown[] | ((...args: any[]) => any)")
+    );
+    assert_eq!(
+        props
+            .iter()
+            .find(|prop| prop.name == "formatter")
+            .and_then(|prop| prop.prop_type.as_deref()),
+        Some("(...args: any[]) => any"),
+        "a standalone function type does not need an extra pair of parentheses"
+    );
+    assert_eq!(
+        props
+            .iter()
+            .find(|prop| prop.name == "labelOrPredicate")
+            .and_then(|prop| prop.prop_type.as_deref()),
+        Some("string | ((value: string) => boolean)"),
+        "PropType function members need the same union precedence protection"
+    );
+}


### PR DESCRIPTION
## Summary
- parenthesize callable members when runtime constructor arrays become TypeScript unions
- preserve standalone Function constructor output and cover PropType callable members
- add parse, positive, and negative typechecking contracts

## Real-project evidence
- Crater, Frappe CRM, and Vuestic UI: 1,667 SFCs exercised with compiler, typechecker, linter, and formatter
- TS1385: 3 to 0
- compiler, linter, and formatter parsed output unchanged

## Validation
- cargo test -p vize_croquis
- cargo test -p vize_canon
- cargo clippy -p vize_croquis -p vize_canon --lib -- -D warnings
- cargo fmt --all -- --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated TypeScript types for Vue props that combine function types with other union members.
  * Added required parentheses to preserve correct type precedence and prevent parsing or type-checking errors.
  * Improved validation of runtime prop declarations, including clearer detection of invalid assignments.

* **Tests**
  * Added coverage for generated prop types and expected TypeScript diagnostics across valid and invalid usage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->