### PR TITLE
fix(atelier): avoid recursive destructuring extraction

### DIFF
--- a/crates/vize_atelier_core/src/codegen/v_for/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/helpers.rs
@@ -4,8 +4,7 @@
 //! and utility predicates for v-for rendering.
 
 use crate::{ElementNode, ExpressionNode, PropNode};
-use vize_carton::String;
-use vize_carton::ToCompactString;
+use vize_carton::{SmallVec, String, ToCompactString};
 
 /// Extract parameter names from a v-for callback expression.
 /// Handles simple identifiers ("item"), destructuring patterns ("{ id, name }"),
@@ -19,74 +18,73 @@ pub(crate) fn extract_for_params(expr: &ExpressionNode<'_>, params: &mut Vec<Str
     extract_destructure_params(content.trim(), params);
 }
 
-/// Recursively extract parameter names from a destructuring pattern string.
+/// Extract parameter names from a destructuring pattern string.
+///
+/// Template aliases are untrusted, so nested patterns are processed on an
+/// explicit work stack instead of consuming the process stack.
 pub(crate) fn extract_destructure_params(trimmed: &str, params: &mut Vec<String>) {
-    if trimmed.contains(',') && !trimmed.starts_with('{') && !trimmed.starts_with('[') {
-        for part in split_top_level(trimmed)
-            .into_iter()
-            .filter(|part| *part != trimmed)
-        {
-            let part = part.trim();
-            if !part.is_empty() {
-                extract_destructure_params(part, params);
-            }
-        }
-        return;
-    }
+    let mut pending = SmallVec::<[&str; 8]>::new();
+    pending.push(trimmed);
 
-    if trimmed.starts_with('{') && trimmed.ends_with('}') {
-        let inner = &trimmed[1..trimmed.len() - 1];
-        // Split by commas at the top level (respecting nested braces/brackets)
-        for part in split_top_level(inner) {
-            let part = part.trim();
-            // Handle rest element: ...rest
-            if let Some(rest) = part.strip_prefix("...") {
-                let rest = rest.trim();
-                if !rest.is_empty() && is_valid_ident(rest) {
-                    params.push(rest.to_compact_string());
+    while let Some(trimmed) = pending.pop() {
+        if trimmed.contains(',') && !trimmed.starts_with('{') && !trimmed.starts_with('[') {
+            for part in split_top_level(trimmed).into_iter().rev() {
+                if part == trimmed {
+                    continue;
                 }
-                continue;
-            }
-            // Handle renaming/nested: "original: value"
-            if let Some(colon_pos) = find_top_level_char(part, ':') {
-                let value = strip_default_value(part[colon_pos + 1..].trim());
-                // Value might be another destructure pattern or a simple identifier
-                if value.starts_with('{') || value.starts_with('[') {
-                    extract_destructure_params(value, params);
-                } else if is_valid_ident(value) {
-                    params.push(value.to_compact_string());
+                let part = part.trim();
+                if !part.is_empty() {
+                    pending.push(part);
                 }
-                continue;
             }
-
-            // Handle default values: "item = default" -- take name before =
-            let part = strip_default_value(part);
-            // Simple identifier
-            if !part.is_empty() && is_valid_ident(part) {
-                params.push(part.to_compact_string());
-            }
+            continue;
         }
-    } else if trimmed.starts_with('[') && trimmed.ends_with(']') {
-        let inner = &trimmed[1..trimmed.len() - 1];
-        for part in split_top_level(inner) {
-            let part = part.trim();
-            if let Some(rest) = part.strip_prefix("...") {
-                let rest = rest.trim();
-                if !rest.is_empty() && is_valid_ident(rest) {
-                    params.push(rest.to_compact_string());
-                }
-                continue;
-            }
 
-            let part = strip_default_value(part);
-            if part.starts_with('{') || part.starts_with('[') {
-                extract_destructure_params(part, params);
-            } else if !part.is_empty() && is_valid_ident(part) {
-                params.push(part.to_compact_string());
+        if trimmed.starts_with('{') && trimmed.ends_with('}') {
+            let inner = &trimmed[1..trimmed.len() - 1];
+            for part in split_top_level(inner).into_iter().rev() {
+                let part = part.trim();
+                if let Some(rest) = part.strip_prefix("...") {
+                    let rest = rest.trim();
+                    if !rest.is_empty() {
+                        pending.push(rest);
+                    }
+                    continue;
+                }
+
+                if let Some(colon_pos) = find_top_level_char(part, ':') {
+                    let value = strip_default_value(part[colon_pos + 1..].trim());
+                    if !value.is_empty() {
+                        pending.push(value);
+                    }
+                    continue;
+                }
+
+                let part = strip_default_value(part);
+                if !part.is_empty() {
+                    pending.push(part);
+                }
             }
+        } else if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            let inner = &trimmed[1..trimmed.len() - 1];
+            for part in split_top_level(inner).into_iter().rev() {
+                let part = part.trim();
+                if let Some(rest) = part.strip_prefix("...") {
+                    let rest = rest.trim();
+                    if !rest.is_empty() {
+                        pending.push(rest);
+                    }
+                    continue;
+                }
+
+                let part = strip_default_value(part);
+                if !part.is_empty() {
+                    pending.push(part);
+                }
+            }
+        } else if is_valid_ident(trimmed) {
+            params.push(trimmed.to_compact_string());
         }
-    } else if is_valid_ident(trimmed) {
-        params.push(trimmed.to_compact_string());
     }
 }
 
@@ -248,6 +246,7 @@ pub(crate) fn should_skip_prop(p: &PropNode<'_>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{extract_destructure_params, is_numeric_content, split_top_level};
+    use vize_carton::String;
 
     /// Test numeric source detection for v-for range expressions.
     #[test]
@@ -306,6 +305,32 @@ mod tests {
         let mut params = Vec::new();
         extract_destructure_params("item, index", &mut params);
         assert_eq!(params, ["item", "index"]);
+    }
+
+    #[test]
+    fn extract_destructure_params_handles_deep_nesting_on_a_small_stack() {
+        let depth = 512;
+        let mut pattern = String::with_capacity(depth * 4 + 5);
+        for _ in 0..depth {
+            pattern.push_str("{x:");
+        }
+        pattern.push_str("value");
+        for _ in 0..depth {
+            pattern.push('}');
+        }
+
+        let params = std::thread::Builder::new()
+            .stack_size(64 * 1024)
+            .spawn(move || {
+                let mut params = Vec::new();
+                extract_destructure_params(&pattern, &mut params);
+                params
+            })
+            .expect("spawn extraction thread")
+            .join()
+            .expect("extract parameters without overflowing the stack");
+
+        assert_eq!(params, ["value"]);
     }
 
     #[test]

--- a/crates/vize_atelier_ssr/src/codegen/helpers.rs
+++ b/crates/vize_atelier_ssr/src/codegen/helpers.rs
@@ -1,12 +1,15 @@
 //! HTML escaping utilities and child/control-flow processing for SSR codegen.
 
+mod destructure;
+
 use vize_atelier_core::{
     CommentNode, ElementType, ForNode, IfNode, InterpolationNode, PropNode, RuntimeHelper,
     TemplateChildNode, TextNode,
 };
 
 use super::SsrCodegenContext;
-use vize_carton::{FxHashSet, String, ToCompactString, cstr};
+pub(crate) use destructure::{collect_for_scoped_params, extract_destructure_params};
+use vize_carton::{String, ToCompactString, cstr};
 
 impl<'a> SsrCodegenContext<'a> {
     /// Process a list of children nodes
@@ -304,128 +307,6 @@ impl<'a> SsrCodegenContext<'a> {
             }
         }
     }
-}
-
-pub(crate) fn collect_for_scoped_params(for_node: &ForNode) -> FxHashSet<String> {
-    let mut params = FxHashSet::default();
-
-    if let Some(value) = &for_node.value_alias {
-        collect_expression_params(value, &mut params);
-    }
-    if let Some(key) = &for_node.key_alias {
-        collect_expression_params(key, &mut params);
-    }
-    if let Some(index) = &for_node.object_index_alias {
-        collect_expression_params(index, &mut params);
-    }
-
-    params
-}
-
-pub(crate) fn collect_expression_params(
-    expr: &vize_atelier_core::ExpressionNode,
-    params: &mut FxHashSet<String>,
-) {
-    let content = match expr {
-        vize_atelier_core::ExpressionNode::Simple(simple) => simple.content.clone(),
-        vize_atelier_core::ExpressionNode::Compound(compound) => {
-            let mut content = String::default();
-            for child in &compound.children {
-                use vize_atelier_core::CompoundExpressionChild;
-                match child {
-                    CompoundExpressionChild::Simple(simple) => content.push_str(&simple.content),
-                    CompoundExpressionChild::String(value) => content.push_str(value),
-                    _ => {}
-                }
-            }
-            if content.is_empty() {
-                compound.loc.source.clone()
-            } else {
-                content
-            }
-        }
-    };
-    extract_destructure_params(content.trim(), params);
-}
-
-pub(crate) fn extract_destructure_params(value: &str, params: &mut FxHashSet<String>) {
-    if value.starts_with('(') && value.ends_with(')') {
-        extract_destructure_params(value[1..value.len() - 1].trim(), params);
-        return;
-    }
-    if value.contains(',') && !value.starts_with('{') && !value.starts_with('[') {
-        for part in split_top_level(value)
-            .into_iter()
-            .filter(|part| *part != value)
-        {
-            extract_destructure_params(part.trim(), params);
-        }
-        return;
-    }
-    if value.starts_with('{') && value.ends_with('}') {
-        for part in split_top_level(&value[1..value.len() - 1]) {
-            let part = part.trim();
-            if let Some(rest) = part.strip_prefix("...") {
-                collect_identifier_param(rest.trim(), params);
-                continue;
-            }
-            if let Some(eq_pos) = part.find('=') {
-                extract_destructure_params(part[..eq_pos].trim(), params);
-                continue;
-            }
-            if let Some(colon_pos) = part.find(':') {
-                extract_destructure_params(part[colon_pos + 1..].trim(), params);
-                continue;
-            }
-            extract_destructure_params(part, params);
-        }
-    } else if value.starts_with('[') && value.ends_with(']') {
-        for part in split_top_level(&value[1..value.len() - 1]) {
-            let part = part.trim();
-            if let Some(rest) = part.strip_prefix("...") {
-                collect_identifier_param(rest.trim(), params);
-            } else {
-                extract_destructure_params(part, params);
-            }
-        }
-    } else {
-        collect_identifier_param(value, params);
-    }
-}
-fn collect_identifier_param(value: &str, params: &mut FxHashSet<String>) {
-    if is_valid_identifier(value) {
-        params.insert(value.to_compact_string());
-    }
-}
-
-fn split_top_level(value: &str) -> std::vec::Vec<&str> {
-    let mut parts = std::vec::Vec::new();
-    let mut depth = 0i32;
-    let mut start = 0;
-
-    for (index, byte) in value.bytes().enumerate() {
-        match byte {
-            b'{' | b'[' | b'(' => depth += 1,
-            b'}' | b']' | b')' => depth -= 1,
-            b',' if depth == 0 => {
-                parts.push(&value[start..index]);
-                start = index + 1;
-            }
-            _ => {}
-        }
-    }
-
-    parts.push(&value[start..]);
-    parts
-}
-
-fn is_valid_identifier(value: &str) -> bool {
-    let mut chars = value.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_alphabetic() || c == '_' || c == '$' => {}
-        _ => return false,
-    }
-    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
 }
 
 /// Escape HTML special characters

--- a/crates/vize_atelier_ssr/src/codegen/helpers/destructure.rs
+++ b/crates/vize_atelier_ssr/src/codegen/helpers/destructure.rs
@@ -1,0 +1,181 @@
+//! Destructuring-pattern parameter extraction for SSR codegen scopes.
+
+use vize_atelier_core::{CompoundExpressionChild, ExpressionNode, ForNode};
+use vize_carton::{FxHashSet, SmallVec, String, ToCompactString};
+
+pub(crate) fn collect_for_scoped_params(for_node: &ForNode) -> FxHashSet<String> {
+    let mut params = FxHashSet::default();
+
+    if let Some(value) = &for_node.value_alias {
+        collect_expression_params(value, &mut params);
+    }
+    if let Some(key) = &for_node.key_alias {
+        collect_expression_params(key, &mut params);
+    }
+    if let Some(index) = &for_node.object_index_alias {
+        collect_expression_params(index, &mut params);
+    }
+
+    params
+}
+
+fn collect_expression_params(expr: &ExpressionNode, params: &mut FxHashSet<String>) {
+    let content = match expr {
+        ExpressionNode::Simple(simple) => simple.content.clone(),
+        ExpressionNode::Compound(compound) => {
+            let mut content = String::default();
+            for child in &compound.children {
+                match child {
+                    CompoundExpressionChild::Simple(simple) => content.push_str(&simple.content),
+                    CompoundExpressionChild::String(value) => content.push_str(value),
+                    _ => {}
+                }
+            }
+            if content.is_empty() {
+                compound.loc.source.clone()
+            } else {
+                content
+            }
+        }
+    };
+    extract_destructure_params(content.trim(), params);
+}
+
+pub(crate) fn extract_destructure_params(value: &str, params: &mut FxHashSet<String>) {
+    let mut pending = SmallVec::<[&str; 8]>::new();
+    pending.push(value);
+
+    while let Some(value) = pending.pop() {
+        if value.starts_with('(') && value.ends_with(')') {
+            pending.push(value[1..value.len() - 1].trim());
+            continue;
+        }
+        if value.contains(',') && !value.starts_with('{') && !value.starts_with('[') {
+            for part in split_top_level(value).into_iter().rev() {
+                if part != value {
+                    pending.push(part.trim());
+                }
+            }
+            continue;
+        }
+        if value.starts_with('{') && value.ends_with('}') {
+            for part in split_top_level(&value[1..value.len() - 1])
+                .into_iter()
+                .rev()
+            {
+                let part = part.trim();
+                if let Some(rest) = part.strip_prefix("...") {
+                    pending.push(rest.trim());
+                    continue;
+                }
+                if let Some(eq_pos) = part.find('=') {
+                    pending.push(part[..eq_pos].trim());
+                    continue;
+                }
+                if let Some(colon_pos) = part.find(':') {
+                    pending.push(part[colon_pos + 1..].trim());
+                    continue;
+                }
+                pending.push(part);
+            }
+        } else if value.starts_with('[') && value.ends_with(']') {
+            for part in split_top_level(&value[1..value.len() - 1])
+                .into_iter()
+                .rev()
+            {
+                let part = part.trim();
+                if let Some(rest) = part.strip_prefix("...") {
+                    pending.push(rest.trim());
+                } else {
+                    pending.push(part);
+                }
+            }
+        } else if is_valid_identifier(value) {
+            params.insert(value.to_compact_string());
+        }
+    }
+}
+
+fn split_top_level(value: &str) -> std::vec::Vec<&str> {
+    let mut parts = std::vec::Vec::new();
+    let mut depth = 0i32;
+    let mut start = 0;
+
+    for (index, byte) in value.bytes().enumerate() {
+        match byte {
+            b'{' | b'[' | b'(' => depth += 1,
+            b'}' | b']' | b')' => depth -= 1,
+            b',' if depth == 0 => {
+                parts.push(&value[start..index]);
+                start = index + 1;
+            }
+            _ => {}
+        }
+    }
+
+    parts.push(&value[start..]);
+    parts
+}
+
+fn is_valid_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' || c == '$' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_destructure_params;
+    use vize_carton::{FxHashSet, String};
+
+    #[test]
+    fn extracts_nested_params_and_rejects_unsplit_malformed_aliases() {
+        let mut params = FxHashSet::default();
+        extract_destructure_params(
+            "{ id: itemId, nested: [first, ...rest], count = fallback }",
+            &mut params,
+        );
+        extract_destructure_params("(index)", &mut params);
+
+        for expected in ["itemId", "first", "rest", "count", "index"] {
+            assert!(params.contains(expected), "missing {expected:?}");
+        }
+        assert_eq!(params.len(), 5);
+
+        for malformed in ["$data.[label, value]", "(dep(, file)"] {
+            let mut params = FxHashSet::default();
+            extract_destructure_params(malformed, &mut params);
+            assert!(params.is_empty(), "unexpected params for {malformed:?}");
+        }
+    }
+
+    #[test]
+    fn extract_destructure_params_handles_deep_nesting_on_a_small_stack() {
+        let depth = 512;
+        let mut pattern = String::with_capacity(depth * 4 + 5);
+        for _ in 0..depth {
+            pattern.push_str("{x:");
+        }
+        pattern.push_str("value");
+        for _ in 0..depth {
+            pattern.push('}');
+        }
+
+        let params = std::thread::Builder::new()
+            .stack_size(64 * 1024)
+            .spawn(move || {
+                let mut params = FxHashSet::default();
+                extract_destructure_params(&pattern, &mut params);
+                params
+            })
+            .expect("spawn extraction thread")
+            .join()
+            .expect("extract parameters without overflowing the stack");
+
+        assert_eq!(params.len(), 1);
+        assert!(params.contains("value"));
+    }
+}

--- a/crates/vize_atelier_vapor/src/generate/destructure.rs
+++ b/crates/vize_atelier_vapor/src/generate/destructure.rs
@@ -1,5 +1,5 @@
 use vize_atelier_core::options::{BindingMetadata, BindingType};
-use vize_carton::{String, ToCompactString, cstr};
+use vize_carton::{SmallVec, String, ToCompactString, cstr};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct DestructureBinding {
@@ -51,64 +51,49 @@ pub(super) fn resolve_props_binding(
 }
 
 fn parse_pattern(pattern: &str, prefix: String, bindings: &mut std::vec::Vec<DestructureBinding>) {
-    let pattern = strip_wrapping_parens(pattern.trim());
+    let mut pending = SmallVec::<[(&str, String); 8]>::new();
+    pending.push((pattern, prefix));
 
-    if pattern.starts_with('{') && pattern.ends_with('}') {
-        parse_object_pattern(pattern, prefix, bindings);
-    } else if pattern.starts_with('[') && pattern.ends_with(']') {
-        parse_array_pattern(pattern, prefix, bindings);
-    } else if is_valid_ident(pattern) {
-        bindings.push(DestructureBinding {
-            local: pattern.to_compact_string(),
-            path: prefix,
-        });
-    }
-}
+    while let Some((pattern, prefix)) = pending.pop() {
+        let pattern = strip_wrapping_parens(strip_default(pattern.trim()));
 
-fn parse_object_pattern(
-    pattern: &str,
-    prefix: String,
-    bindings: &mut std::vec::Vec<DestructureBinding>,
-) {
-    let inner = &pattern[1..pattern.len() - 1];
-    for part in split_top_level(inner) {
-        let part = part.trim();
-        if part.is_empty() || part.starts_with("...") {
-            continue;
-        }
+        if pattern.starts_with('{') && pattern.ends_with('}') {
+            let inner = &pattern[1..pattern.len() - 1];
+            for part in split_top_level(inner).into_iter().rev() {
+                let part = part.trim();
+                if part.is_empty() || part.starts_with("...") {
+                    continue;
+                }
 
-        if let Some(colon) = find_top_level_char(part, ':') {
-            let key = part[..colon].trim();
-            let value = strip_default(part[colon + 1..].trim());
-            let Some(segment) = object_path_segment(key) else {
-                continue;
-            };
-            parse_pattern(value, cstr!("{prefix}{segment}"), bindings);
-            continue;
-        }
+                if let Some(colon) = find_top_level_char(part, ':') {
+                    let key = part[..colon].trim();
+                    let Some(segment) = object_path_segment(key) else {
+                        continue;
+                    };
+                    pending.push((part[colon + 1..].trim(), cstr!("{prefix}{segment}")));
+                    continue;
+                }
 
-        let name = strip_default(part);
-        if is_valid_ident(name) {
+                let name = strip_default(part);
+                if is_valid_ident(name) {
+                    pending.push((name, cstr!("{prefix}.{}", name)));
+                }
+            }
+        } else if pattern.starts_with('[') && pattern.ends_with(']') {
+            let inner = &pattern[1..pattern.len() - 1];
+            for (index, part) in split_top_level(inner).into_iter().enumerate().rev() {
+                let part = part.trim();
+                if part.is_empty() || part.starts_with("...") {
+                    continue;
+                }
+                pending.push((part, cstr!("{prefix}[{index}]")));
+            }
+        } else if is_valid_ident(pattern) {
             bindings.push(DestructureBinding {
-                local: name.to_compact_string(),
-                path: cstr!("{prefix}.{}", name),
+                local: pattern.to_compact_string(),
+                path: prefix,
             });
         }
-    }
-}
-
-fn parse_array_pattern(
-    pattern: &str,
-    prefix: String,
-    bindings: &mut std::vec::Vec<DestructureBinding>,
-) {
-    let inner = &pattern[1..pattern.len() - 1];
-    for (index, part) in split_top_level(inner).into_iter().enumerate() {
-        let part = part.trim();
-        if part.is_empty() || part.starts_with("...") {
-            continue;
-        }
-        parse_pattern(strip_default(part), cstr!("{prefix}[{index}]"), bindings);
     }
 }
 
@@ -274,6 +259,7 @@ fn is_valid_ident(s: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::parse_destructure_bindings;
+    use vize_carton::String;
 
     #[test]
     fn parses_object_aliases_and_nested_paths() {
@@ -311,5 +297,29 @@ mod tests {
             pairs,
             vec![("first", "[0]"), ("secondId", "[1].id"), ("third", "[2]"),]
         );
+    }
+
+    #[test]
+    fn parses_deep_nesting_on_a_small_stack() {
+        let depth = 512;
+        let mut pattern = String::with_capacity(depth * 4 + 5);
+        for _ in 0..depth {
+            pattern.push_str("{x:");
+        }
+        pattern.push_str("value");
+        for _ in 0..depth {
+            pattern.push('}');
+        }
+
+        let bindings = std::thread::Builder::new()
+            .stack_size(64 * 1024)
+            .spawn(move || parse_destructure_bindings(&pattern))
+            .expect("spawn destructure parser thread")
+            .join()
+            .expect("parse bindings without overflowing the stack");
+
+        assert_eq!(bindings.len(), 1);
+        assert_eq!(bindings[0].local, "value");
+        assert_eq!(bindings[0].path, ".x".repeat(depth));
     }
 }


### PR DESCRIPTION
## Summary

- replace recursive destructuring walkers in core, SSR, and Vapor codegen with inline `SmallVec` work stacks
- preserve the non-progress guard for malformed comma-separated aliases from #2951
- move SSR scope extraction into a focused helper module and add direct behavior coverage
- add deterministic 64 KiB stack regressions for all three codegen surfaces

## Root cause

#2951 stopped malformed aliases from recursing forever when top-level splitting made no progress. Valid deeply nested object or array patterns still consumed one process-stack frame per nesting level in the core, SSR, and Vapor walkers. Since template input is untrusted, a sufficiently nested alias could abort the compiler with stack overflow.

## Impact

Deep destructuring aliases now use bounded process stack across DOM/core, SSR, and Vapor codegen. Common shallow patterns stay on the inline work-stack storage, and source-order behavior remains unchanged where ordering is observable.

## Validation

- confirmed each new regression aborts with `SIGABRT: stack overflow` before the implementation change
- `cargo fmt --all -- --check`
- `cargo test -p vize_atelier_core -p vize_atelier_ssr -p vize_atelier_vapor --lib`
- `cargo clippy -p vize_atelier_core -p vize_atelier_ssr -p vize_atelier_vapor --lib -- -D warnings -D clippy::wildcard_imports`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deeply nested destructuring patterns to prevent stack overflows.
  * Preserved support for object, array, rest, default-value, and nested parameter syntax across code generation.
  * Improved SSR and Vapor processing of scoped parameters and destructuring bindings.

* **Tests**
  * Added coverage for deeply nested patterns and constrained-stack execution.
  * Added validation for nested extraction and malformed destructuring aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->