### PR TITLE
fix(atelier): guard nested slot destructuring

### DIFF
--- a/crates/vize_atelier_core/src/transforms/v_slot.rs
+++ b/crates/vize_atelier_core/src/transforms/v_slot.rs
@@ -2,10 +2,6 @@
 //!
 //! Transforms v-slot (# shorthand) directives for slot content.
 
-use oxc_allocator::Allocator;
-use oxc_ast::ast::BindingPattern;
-use oxc_parser::Parser;
-use oxc_span::SourceType;
 use vize_carton::{String, is_builtin_directive};
 
 use crate::errors::ErrorCode;
@@ -14,6 +10,11 @@ use crate::{
     DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper,
     SourceLocation, TemplateChildNode,
 };
+
+#[path = "v_slot/params.rs"]
+mod params;
+
+pub use params::extract_slot_prop_names;
 
 /// Check if element has v-slot directive
 pub fn has_v_slot(el: &ElementNode<'_>) -> bool {
@@ -60,63 +61,6 @@ pub fn get_slot_prop_names(dir: &DirectiveNode<'_>) -> Vec<String> {
     get_slot_props_string(dir)
         .map(|pattern| extract_slot_prop_names(pattern.as_str()))
         .unwrap_or_default()
-}
-
-/// Extract binding names from a slot props pattern.
-pub fn extract_slot_prop_names(pattern: &str) -> Vec<String> {
-    let trimmed = pattern.trim();
-    if trimmed.is_empty() {
-        return Vec::new();
-    }
-
-    let mut source = String::with_capacity(trimmed.len() + 18);
-    source.push_str("let ");
-    source.push_str(trimmed);
-    source.push_str(" = __slotProps");
-
-    let allocator = Allocator::default();
-    let source_type = SourceType::default().with_typescript(true);
-    let parsed = Parser::new(&allocator, source.as_str(), source_type).parse();
-
-    let Some(oxc_ast::ast::Statement::VariableDeclaration(var_decl)) = parsed.program.body.first()
-    else {
-        return Vec::new();
-    };
-
-    let Some(declarator) = var_decl.declarations.first() else {
-        return Vec::new();
-    };
-
-    let mut names = Vec::new();
-    collect_slot_binding_names(&declarator.id, &mut names);
-    names
-}
-
-fn collect_slot_binding_names(pattern: &BindingPattern<'_>, names: &mut Vec<String>) {
-    match pattern {
-        BindingPattern::BindingIdentifier(id) => {
-            names.push(String::new(id.name.as_str()));
-        }
-        BindingPattern::ObjectPattern(obj) => {
-            for prop in obj.properties.iter() {
-                collect_slot_binding_names(&prop.value, names);
-            }
-            if let Some(rest) = &obj.rest {
-                collect_slot_binding_names(&rest.argument, names);
-            }
-        }
-        BindingPattern::ArrayPattern(arr) => {
-            for elem in arr.elements.iter().flatten() {
-                collect_slot_binding_names(elem, names);
-            }
-            if let Some(rest) = &arr.rest {
-                collect_slot_binding_names(&rest.argument, names);
-            }
-        }
-        BindingPattern::AssignmentPattern(assign) => {
-            collect_slot_binding_names(&assign.left, names);
-        }
-    }
 }
 
 /// Check if slot is dynamic (has dynamic name)
@@ -503,20 +447,6 @@ mod tests {
             errors[0].code,
             ErrorCode::VSlotUnexpectedDirectiveOnSlotOutlet
         );
-    }
-
-    #[test]
-    fn test_extract_slot_prop_names_simple_destructure() {
-        let names = extract_slot_prop_names("{ item, index }");
-        let names: Vec<_> = names.iter().map(|name| name.as_str()).collect();
-        assert_eq!(names, vec!["item", "index"]);
-    }
-
-    #[test]
-    fn test_extract_slot_prop_names_nested_defaults_and_rest() {
-        let names = extract_slot_prop_names("{ item: { id }, index = 0, ...rest }");
-        let names: Vec<_> = names.iter().map(|name| name.as_str()).collect();
-        assert_eq!(names, vec!["id", "index", "rest"]);
     }
 
     #[test]

--- a/crates/vize_atelier_core/src/transforms/v_slot/params.rs
+++ b/crates/vize_atelier_core/src/transforms/v_slot/params.rs
@@ -1,0 +1,124 @@
+//! Slot parameter binding extraction.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::BindingPattern;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{SmallVec, String};
+
+use crate::steps::expression::expression_is_safe_to_parse;
+
+/// Extract binding names from a slot props pattern.
+pub fn extract_slot_prop_names(pattern: &str) -> Vec<String> {
+    let trimmed = pattern.trim();
+    if trimmed.is_empty() || !expression_is_safe_to_parse(trimmed) {
+        return Vec::new();
+    }
+
+    let mut source = String::with_capacity(trimmed.len() + 18);
+    source.push_str("let ");
+    source.push_str(trimmed);
+    source.push_str(" = __slotProps");
+
+    let allocator = Allocator::default();
+    let source_type = SourceType::default().with_typescript(true);
+    let parsed = Parser::new(&allocator, source.as_str(), source_type).parse();
+
+    let Some(oxc_ast::ast::Statement::VariableDeclaration(var_decl)) = parsed.program.body.first()
+    else {
+        return Vec::new();
+    };
+
+    let Some(declarator) = var_decl.declarations.first() else {
+        return Vec::new();
+    };
+
+    let mut names = Vec::new();
+    collect_slot_binding_names(&declarator.id, &mut names);
+    names
+}
+
+fn collect_slot_binding_names(pattern: &BindingPattern<'_>, names: &mut Vec<String>) {
+    let mut pending = SmallVec::<[&BindingPattern<'_>; 8]>::new();
+    pending.push(pattern);
+
+    while let Some(pattern) = pending.pop() {
+        match pattern {
+            BindingPattern::BindingIdentifier(id) => {
+                names.push(String::new(id.name.as_str()));
+            }
+            BindingPattern::ObjectPattern(obj) => {
+                if let Some(rest) = &obj.rest {
+                    pending.push(&rest.argument);
+                }
+                for prop in obj.properties.iter().rev() {
+                    pending.push(&prop.value);
+                }
+            }
+            BindingPattern::ArrayPattern(arr) => {
+                if let Some(rest) = &arr.rest {
+                    pending.push(&rest.argument);
+                }
+                for elem in arr.elements.iter().rev().flatten() {
+                    pending.push(elem);
+                }
+            }
+            BindingPattern::AssignmentPattern(assign) => {
+                pending.push(&assign.left);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::steps::expression::MAX_EXPRESSION_NESTING_DEPTH;
+
+    #[test]
+    fn extracts_simple_destructure() {
+        let names = extract_slot_prop_names("{ item, index }");
+        let names: Vec<_> = names.iter().map(|name| name.as_str()).collect();
+        assert_eq!(names, vec!["item", "index"]);
+    }
+
+    #[test]
+    fn extracts_nested_defaults_and_rest_in_source_order() {
+        let names = extract_slot_prop_names("{ item: { id }, index = 0, ...rest }");
+        let names: Vec<_> = names.iter().map(|name| name.as_str()).collect();
+        assert_eq!(names, vec!["id", "index", "rest"]);
+    }
+
+    #[test]
+    fn accepts_patterns_at_the_nesting_limit() {
+        let pattern = nested_pattern(MAX_EXPRESSION_NESTING_DEPTH);
+        let names = extract_slot_prop_names(&pattern);
+        let names: Vec<_> = names.iter().map(|name| name.as_str()).collect();
+        assert_eq!(names, ["value"]);
+    }
+
+    #[test]
+    fn rejects_deep_nesting_on_a_small_stack() {
+        let pattern = nested_pattern(512);
+        let names = std::thread::Builder::new()
+            .stack_size(64 * 1024)
+            .spawn(move || extract_slot_prop_names(&pattern))
+            .expect("spawn slot binding extraction thread")
+            .join()
+            .expect("reject nested slot bindings without overflowing the stack");
+
+        assert!(names.is_empty());
+    }
+
+    fn nested_pattern(depth: usize) -> String {
+        let mut pattern = String::with_capacity(depth * 4 + 5);
+        for _ in 0..depth {
+            pattern.push_str("{x:");
+        }
+        pattern.push_str("value");
+        for _ in 0..depth {
+            pattern.push('}');
+        }
+        pattern
+    }
+}


### PR DESCRIPTION
## Summary

- reject `v-slot` binding patterns that exceed the shared safe parser nesting limit
- collect nested object, array, assignment, and rest bindings with an explicit work stack while preserving source order
- move slot parameter parsing into a focused module and cover the accepted boundary

## Regression

On `origin/main`, extracting a 512-level nested slot binding on a 64 KiB thread stack aborts with a stack overflow (`SIGABRT`). The regression now runs the same input on that stack and verifies it is rejected without invoking the parser.

## Validation

- `cargo test -p vize_atelier_core --lib` (207 passed)
- `cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction of slot prop names from destructured slot bindings.
  * Added support for nested object and array patterns, default values, and rest properties.
  * Improved handling of deeply nested patterns while preventing unsafe parsing.
* **Tests**
  * Expanded coverage for simple, nested, and deeply nested slot prop patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->