### PR TITLE
docs(readme): add crate logos

### DIFF
--- a/assets/crates/vize.svg
+++ b/assets/crates/vize.svg
@@ -1,0 +1,14 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize logo">
+  <title>vize</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <g transform="translate(52 74) scale(0.62)">
+      <g transform="skewX(-15)">
+        <path d="M200 0 120 180 210 60 200 0Z" fill="#e6e2d6"/>
+        <path d="M60 0 120 180 160 40 60 0Z" fill="#e6e2d6"/>
+      </g>
+    </g>
+</svg>

--- a/assets/crates/vize_armature.svg
+++ b/assets/crates/vize_armature.svg
@@ -1,0 +1,18 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_armature logo">
+  <title>vize_armature</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <g stroke="#e6e2d6" stroke-width="9" stroke-linecap="round" fill="none">
+      <circle cx="120" cy="80" r="14"/>
+      <path d="M120 94v52"/>
+      <path d="M120 108 86 140M120 108l34 32"/>
+      <path d="M120 146 98 184m22-38 22 38"/>
+    </g>
+    <g fill="#e6e2d6">
+      <circle cx="120" cy="108" r="5"/>
+      <circle cx="120" cy="146" r="5"/>
+    </g>
+</svg>

--- a/assets/crates/vize_atelier_core.svg
+++ b/assets/crates/vize_atelier_core.svg
@@ -1,0 +1,13 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_atelier_core logo">
+  <title>vize_atelier_core</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <g stroke="#e6e2d6" stroke-width="9" stroke-linecap="round" fill="none">
+      <path d="M120 66 78 190M120 66l42 124M120 148v42"/>
+      <rect x="82" y="84" width="76" height="56" rx="6"/>
+      <path d="M74 148h92"/>
+    </g>
+</svg>

--- a/assets/crates/vize_atelier_dom.svg
+++ b/assets/crates/vize_atelier_dom.svg
@@ -1,0 +1,14 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_atelier_dom logo">
+  <title>vize_atelier_dom</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <g stroke="#e6e2d6" stroke-width="9" fill="none">
+      <circle cx="120" cy="86" r="14"/>
+      <circle cx="84" cy="168" r="14"/>
+      <circle cx="156" cy="168" r="14"/>
+      <path d="M113 98 90 156m37-58 23 58" stroke-linecap="round"/>
+    </g>
+</svg>

--- a/assets/crates/vize_atelier_jsx.svg
+++ b/assets/crates/vize_atelier_jsx.svg
@@ -1,0 +1,13 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_atelier_jsx logo">
+  <title>vize_atelier_jsx</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <g stroke="#e6e2d6" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" fill="none">
+      <path d="M90 100 60 131l30 31"/>
+      <path d="M150 100l30 31-30 31"/>
+      <path d="M129 90l-18 82"/>
+    </g>
+</svg>

--- a/assets/crates/vize_atelier_sfc.svg
+++ b/assets/crates/vize_atelier_sfc.svg
@@ -1,0 +1,15 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_atelier_sfc logo">
+  <title>vize_atelier_sfc</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <rect x="76" y="70" width="88" height="120" rx="10" stroke="#e6e2d6" stroke-width="9" fill="none"/>
+    <path d="M76 110h88M76 150h88" stroke="#e6e2d6" stroke-width="7"/>
+    <g fill="#e6e2d6">
+      <rect x="90" y="86" width="30" height="7" rx="3.5"/>
+      <rect x="90" y="126" width="44" height="7" rx="3.5"/>
+      <rect x="90" y="166" width="36" height="7" rx="3.5"/>
+    </g>
+</svg>

--- a/assets/crates/vize_atelier_ssr.svg
+++ b/assets/crates/vize_atelier_ssr.svg
@@ -1,0 +1,15 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_atelier_ssr logo">
+  <title>vize_atelier_ssr</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <rect x="102" y="70" width="76" height="120" rx="10" stroke="#e6e2d6" stroke-width="9" fill="none"/>
+    <path d="M118 100h44m-44 26h44m-44 26h28" stroke="#e6e2d6" stroke-width="7" stroke-linecap="round"/>
+    <g transform="translate(46 96) skewX(-20)" fill="#e6e2d6">
+      <rect width="40" height="8" rx="4"/>
+      <rect x="10" y="26" width="30" height="7" rx="3.5"/>
+      <rect x="4" y="52" width="24" height="6" rx="3"/>
+    </g>
+</svg>

--- a/assets/crates/vize_atelier_vapor.svg
+++ b/assets/crates/vize_atelier_vapor.svg
@@ -1,0 +1,13 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_atelier_vapor logo">
+  <title>vize_atelier_vapor</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <g stroke="#e6e2d6" stroke-width="9" stroke-linecap="round" fill="none">
+      <path d="M92 184c-16-26 14-40-2-66-14-24 12-32 4-50"/>
+      <path d="M124 184c-16-26 14-40-2-66-14-24 12-32 4-50" opacity="0.72"/>
+      <path d="M156 184c-16-26 14-40-2-66-14-24 12-32 4-50" opacity="0.45"/>
+    </g>
+</svg>

--- a/assets/crates/vize_canon.svg
+++ b/assets/crates/vize_canon.svg
@@ -1,0 +1,10 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_canon logo">
+  <title>vize_canon</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <circle cx="120" cy="130" r="52" stroke="#e6e2d6" stroke-width="9" fill="none"/>
+    <path d="m96 132 18 18 40-42" stroke="#e6e2d6" stroke-width="11" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/assets/crates/vize_carton.svg
+++ b/assets/crates/vize_carton.svg
@@ -1,0 +1,14 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_carton logo">
+  <title>vize_carton</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <g stroke="#e6e2d6" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" fill="none">
+      <rect x="72" y="108" width="96" height="76" rx="10"/>
+      <path d="M72 134h96"/>
+      <path d="M100 108V96a20 20 0 0 1 40 0v12"/>
+    </g>
+    <rect x="113" y="126" width="14" height="16" rx="4" fill="#e6e2d6"/>
+</svg>

--- a/assets/crates/vize_croquis.svg
+++ b/assets/crates/vize_croquis.svg
@@ -1,0 +1,10 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_croquis logo">
+  <title>vize_croquis</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <path d="M90 150l6-25 52-51 18 18-51 52Z" stroke="#e6e2d6" stroke-width="8" stroke-linejoin="round" fill="none"/>
+    <path d="M58 174c20-18 36 10 56-8 14-13 28 2 44-6" stroke="#e6e2d6" stroke-width="8" stroke-linecap="round" fill="none"/>
+</svg>

--- a/assets/crates/vize_croquis_cf.svg
+++ b/assets/crates/vize_croquis_cf.svg
@@ -1,0 +1,14 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_croquis_cf logo">
+  <title>vize_croquis_cf</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <g stroke="#e6e2d6" stroke-width="8" fill="none">
+      <rect x="64" y="74" width="66" height="86" rx="8"/>
+      <rect x="110" y="102" width="66" height="86" rx="8" fill="#000"/>
+      <path d="M78 108c8-8 14 6 24-2" stroke-linecap="round"/>
+      <path d="M124 150c8-8 14 6 24-2m-24 22c8-8 14 6 24-2" stroke-linecap="round"/>
+    </g>
+</svg>

--- a/assets/crates/vize_curator.svg
+++ b/assets/crates/vize_curator.svg
@@ -1,0 +1,10 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_curator logo">
+  <title>vize_curator</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <circle cx="106" cy="114" r="40" stroke="#e6e2d6" stroke-width="9" fill="none"/>
+    <path d="m136 144 34 34" stroke="#e6e2d6" stroke-width="12" stroke-linecap="round"/>
+</svg>

--- a/assets/crates/vize_fresco.svg
+++ b/assets/crates/vize_fresco.svg
@@ -1,0 +1,11 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_fresco logo">
+  <title>vize_fresco</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <rect x="62" y="82" width="116" height="92" rx="10" stroke="#e6e2d6" stroke-width="9" fill="none"/>
+    <path d="m84 112 20 16-20 16" stroke="#e6e2d6" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <rect x="116" y="140" width="30" height="9" rx="4.5" fill="#e6e2d6"/>
+</svg>

--- a/assets/crates/vize_glyph.svg
+++ b/assets/crates/vize_glyph.svg
@@ -1,0 +1,14 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_glyph logo">
+  <title>vize_glyph</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <g fill="#e6e2d6">
+      <path d="M130 68a32 32 0 0 0 0 64Z"/>
+      <rect x="121" y="68" width="10" height="118" rx="4"/>
+      <rect x="146" y="68" width="10" height="118" rx="4"/>
+      <rect x="121" y="68" width="35" height="10" rx="4"/>
+    </g>
+</svg>

--- a/assets/crates/vize_maestro.svg
+++ b/assets/crates/vize_maestro.svg
@@ -1,0 +1,14 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_maestro logo">
+  <title>vize_maestro</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <path d="M82 172 158 82" stroke="#e6e2d6" stroke-width="8" stroke-linecap="round"/>
+    <path d="m78 178 18-21" stroke="#e6e2d6" stroke-width="15" stroke-linecap="round"/>
+    <g stroke="#e6e2d6" stroke-linecap="round" fill="none">
+      <path d="M146 52c14 6 24 16 30 30" stroke-width="7" opacity="0.6"/>
+      <path d="M118 44c24 8 40 24 48 48" stroke-width="6" opacity="0.35"/>
+    </g>
+</svg>

--- a/assets/crates/vize_musea.svg
+++ b/assets/crates/vize_musea.svg
@@ -1,0 +1,13 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_musea logo">
+  <title>vize_musea</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <g stroke="#e6e2d6" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" fill="none">
+      <path d="M62 102 120 66l58 36Z"/>
+      <path d="M78 120v48m28-48v48m28-48v48m28-48v48"/>
+      <path d="M64 184h112"/>
+    </g>
+</svg>

--- a/assets/crates/vize_patina.svg
+++ b/assets/crates/vize_patina.svg
@@ -1,0 +1,14 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_patina logo">
+  <title>vize_patina</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <rect x="64" y="118" width="112" height="54" rx="12" stroke="#e6e2d6" stroke-width="9" fill="none"/>
+    <path d="m88 162 34-32" stroke="#e6e2d6" stroke-width="8" stroke-linecap="round" opacity="0.6"/>
+    <g fill="#e6e2d6">
+      <path d="m148 60 6 16 16 6-16 6-6 16-6-16-16-6 16-6Z"/>
+      <path d="m102 76 4 10 10 4-10 4-4 10-4-10-10-4 10-4Z" opacity="0.7"/>
+    </g>
+</svg>

--- a/assets/crates/vize_relief.svg
+++ b/assets/crates/vize_relief.svg
@@ -1,0 +1,10 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_relief logo">
+  <title>vize_relief</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <rect x="66" y="76" width="108" height="108" rx="10" stroke="#e6e2d6" stroke-width="9" fill="none"/>
+    <path d="M80 180 106 118l18 28 22-42 14 76Z" fill="#e6e2d6"/>
+</svg>

--- a/assets/crates/vize_vitrine.svg
+++ b/assets/crates/vize_vitrine.svg
@@ -1,0 +1,11 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vize_vitrine logo">
+  <title>vize_vitrine</title>
+  <rect x="4" y="4" width="232" height="232" rx="44" fill="#000000" stroke="#e6e2d6" stroke-opacity="0.25" stroke-width="2"/>
+  <g transform="translate(148 42) skewX(-20)" fill="#e6e2d6">
+    <rect width="44" height="4" rx="2" opacity="0.5"/>
+    <rect x="10" y="11" width="28" height="3" rx="1.5" opacity="0.32"/>
+  </g>
+  <path d="M78 158v-36a42 42 0 0 1 84 0v36" stroke="#e6e2d6" stroke-width="9" stroke-linecap="round" fill="none"/>
+    <rect x="64" y="158" width="112" height="10" rx="5" fill="#e6e2d6"/>
+    <path d="m120 100 20 22-20 22-20-22Z" stroke="#e6e2d6" stroke-width="7" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/crates/vize/README.md
+++ b/crates/vize/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize.svg" alt="vize logo" width="120" height="120" />
+</p>
+
 # vize
 
 `vize` is the Rust-native entry point for the Vize workspace.

--- a/crates/vize/README.md
+++ b/crates/vize/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize.svg" alt="vize logo" width="120" height="120" />
-</p>
-
-# vize
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize.svg" alt="vize logo" width="120" height="120" /><br>
+  vize
+</h1>
 
 `vize` is the Rust-native entry point for the Vize workspace.
 

--- a/crates/vize_armature/README.md
+++ b/crates/vize_armature/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_armature.svg" alt="vize_armature logo" width="120" height="120" />
+</p>
+
 # vize_armature
 
 Support and deprecation guarantees are defined in the

--- a/crates/vize_armature/README.md
+++ b/crates/vize_armature/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_armature.svg" alt="vize_armature logo" width="120" height="120" />
-</p>
-
-# vize_armature
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_armature.svg" alt="vize_armature logo" width="120" height="120" /><br>
+  vize_armature
+</h1>
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).

--- a/crates/vize_atelier_core/README.md
+++ b/crates/vize_atelier_core/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_core.svg" alt="vize_atelier_core logo" width="120" height="120" />
+</p>
+
 # vize_atelier_core
 
 Support and deprecation guarantees are defined in the

--- a/crates/vize_atelier_core/README.md
+++ b/crates/vize_atelier_core/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_core.svg" alt="vize_atelier_core logo" width="120" height="120" />
-</p>
-
-# vize_atelier_core
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_core.svg" alt="vize_atelier_core logo" width="120" height="120" /><br>
+  vize_atelier_core
+</h1>
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).

--- a/crates/vize_atelier_dom/README.md
+++ b/crates/vize_atelier_dom/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_dom.svg" alt="vize_atelier_dom logo" width="120" height="120" />
+</p>
+
 # vize_atelier_dom
 
 Support and deprecation guarantees are defined in the

--- a/crates/vize_atelier_dom/README.md
+++ b/crates/vize_atelier_dom/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_dom.svg" alt="vize_atelier_dom logo" width="120" height="120" />
-</p>
-
-# vize_atelier_dom
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_dom.svg" alt="vize_atelier_dom logo" width="120" height="120" /><br>
+  vize_atelier_dom
+</h1>
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).

--- a/crates/vize_atelier_jsx/README.md
+++ b/crates/vize_atelier_jsx/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_jsx.svg" alt="vize_atelier_jsx logo" width="120" height="120" />
-</p>
-
-# vize_atelier_jsx
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_jsx.svg" alt="vize_atelier_jsx logo" width="120" height="120" /><br>
+  vize_atelier_jsx
+</h1>
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).

--- a/crates/vize_atelier_jsx/README.md
+++ b/crates/vize_atelier_jsx/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_jsx.svg" alt="vize_atelier_jsx logo" width="120" height="120" />
+</p>
+
 # vize_atelier_jsx
 
 Support and deprecation guarantees are defined in the

--- a/crates/vize_atelier_sfc/README.md
+++ b/crates/vize_atelier_sfc/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_sfc.svg" alt="vize_atelier_sfc logo" width="120" height="120" />
+</p>
+
 # vize_atelier_sfc
 
 Support and deprecation guarantees are defined in the

--- a/crates/vize_atelier_sfc/README.md
+++ b/crates/vize_atelier_sfc/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_sfc.svg" alt="vize_atelier_sfc logo" width="120" height="120" />
-</p>
-
-# vize_atelier_sfc
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_sfc.svg" alt="vize_atelier_sfc logo" width="120" height="120" /><br>
+  vize_atelier_sfc
+</h1>
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).

--- a/crates/vize_atelier_ssr/README.md
+++ b/crates/vize_atelier_ssr/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_ssr.svg" alt="vize_atelier_ssr logo" width="120" height="120" />
+</p>
+
 # vize_atelier_ssr
 
 Support and deprecation guarantees are defined in the

--- a/crates/vize_atelier_ssr/README.md
+++ b/crates/vize_atelier_ssr/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_ssr.svg" alt="vize_atelier_ssr logo" width="120" height="120" />
-</p>
-
-# vize_atelier_ssr
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_ssr.svg" alt="vize_atelier_ssr logo" width="120" height="120" /><br>
+  vize_atelier_ssr
+</h1>
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).

--- a/crates/vize_atelier_vapor/README.md
+++ b/crates/vize_atelier_vapor/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_vapor.svg" alt="vize_atelier_vapor logo" width="120" height="120" />
+</p>
+
 # vize_atelier_vapor
 
 Support and deprecation guarantees are defined in the

--- a/crates/vize_atelier_vapor/README.md
+++ b/crates/vize_atelier_vapor/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_vapor.svg" alt="vize_atelier_vapor logo" width="120" height="120" />
-</p>
-
-# vize_atelier_vapor
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_atelier_vapor.svg" alt="vize_atelier_vapor logo" width="120" height="120" /><br>
+  vize_atelier_vapor
+</h1>
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).

--- a/crates/vize_canon/README.md
+++ b/crates/vize_canon/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_canon.svg" alt="vize_canon logo" width="120" height="120" />
-</p>
-
-# vize_canon
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_canon.svg" alt="vize_canon logo" width="120" height="120" /><br>
+  vize_canon
+</h1>
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).

--- a/crates/vize_canon/README.md
+++ b/crates/vize_canon/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_canon.svg" alt="vize_canon logo" width="120" height="120" />
+</p>
+
 # vize_canon
 
 Support and deprecation guarantees are defined in the

--- a/crates/vize_carton/README.md
+++ b/crates/vize_carton/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_carton.svg" alt="vize_carton logo" width="120" height="120" />
+</p>
+
 # vize_carton
 
 Support and deprecation guarantees are defined in the

--- a/crates/vize_carton/README.md
+++ b/crates/vize_carton/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_carton.svg" alt="vize_carton logo" width="120" height="120" />
-</p>
-
-# vize_carton
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_carton.svg" alt="vize_carton logo" width="120" height="120" /><br>
+  vize_carton
+</h1>
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).

--- a/crates/vize_croquis/README.md
+++ b/crates/vize_croquis/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_croquis.svg" alt="vize_croquis logo" width="120" height="120" />
-</p>
-
-# vize_croquis
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_croquis.svg" alt="vize_croquis logo" width="120" height="120" /><br>
+  vize_croquis
+</h1>
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).

--- a/crates/vize_croquis/README.md
+++ b/crates/vize_croquis/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_croquis.svg" alt="vize_croquis logo" width="120" height="120" />
+</p>
+
 # vize_croquis
 
 Support and deprecation guarantees are defined in the

--- a/crates/vize_croquis_cf/README.md
+++ b/crates/vize_croquis_cf/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_croquis_cf.svg" alt="vize_croquis_cf logo" width="120" height="120" />
-</p>
-
-# vize_croquis_cf
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_croquis_cf.svg" alt="vize_croquis_cf logo" width="120" height="120" /><br>
+  vize_croquis_cf
+</h1>
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).

--- a/crates/vize_croquis_cf/README.md
+++ b/crates/vize_croquis_cf/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_croquis_cf.svg" alt="vize_croquis_cf logo" width="120" height="120" />
+</p>
+
 # vize_croquis_cf
 
 Support and deprecation guarantees are defined in the

--- a/crates/vize_curator/README.md
+++ b/crates/vize_curator/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_curator.svg" alt="vize_curator logo" width="120" height="120" />
-</p>
-
-# vize_curator
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_curator.svg" alt="vize_curator logo" width="120" height="120" /><br>
+  vize_curator
+</h1>
 
 `vize_curator` contains local-only inspection and reporting helpers for Vize.
 

--- a/crates/vize_curator/README.md
+++ b/crates/vize_curator/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_curator.svg" alt="vize_curator logo" width="120" height="120" />
+</p>
+
 # vize_curator
 
 `vize_curator` contains local-only inspection and reporting helpers for Vize.

--- a/crates/vize_fresco/README.md
+++ b/crates/vize_fresco/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_fresco.svg" alt="vize_fresco logo" width="120" height="120" />
+</p>
+
 # vize_fresco
 
 Support and deprecation guarantees are defined in the

--- a/crates/vize_fresco/README.md
+++ b/crates/vize_fresco/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_fresco.svg" alt="vize_fresco logo" width="120" height="120" />
-</p>
-
-# vize_fresco
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_fresco.svg" alt="vize_fresco logo" width="120" height="120" /><br>
+  vize_fresco
+</h1>
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).

--- a/crates/vize_glyph/README.md
+++ b/crates/vize_glyph/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_glyph.svg" alt="vize_glyph logo" width="120" height="120" />
-</p>
-
-# vize_glyph
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_glyph.svg" alt="vize_glyph logo" width="120" height="120" /><br>
+  vize_glyph
+</h1>
 
 `vize_glyph` formats Vue Single File Components.
 

--- a/crates/vize_glyph/README.md
+++ b/crates/vize_glyph/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_glyph.svg" alt="vize_glyph logo" width="120" height="120" />
+</p>
+
 # vize_glyph
 
 `vize_glyph` formats Vue Single File Components.

--- a/crates/vize_maestro/README.md
+++ b/crates/vize_maestro/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_maestro.svg" alt="vize_maestro logo" width="120" height="120" />
-</p>
-
-# vize_maestro
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_maestro.svg" alt="vize_maestro logo" width="120" height="120" /><br>
+  vize_maestro
+</h1>
 
 `vize_maestro` is the Language Server Protocol implementation for Vize.
 

--- a/crates/vize_maestro/README.md
+++ b/crates/vize_maestro/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_maestro.svg" alt="vize_maestro logo" width="120" height="120" />
+</p>
+
 # vize_maestro
 
 `vize_maestro` is the Language Server Protocol implementation for Vize.

--- a/crates/vize_musea/README.md
+++ b/crates/vize_musea/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_musea.svg" alt="vize_musea logo" width="120" height="120" />
+</p>
+
 # vize_musea
 
 Support and deprecation guarantees are defined in the

--- a/crates/vize_musea/README.md
+++ b/crates/vize_musea/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_musea.svg" alt="vize_musea logo" width="120" height="120" />
-</p>
-
-# vize_musea
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_musea.svg" alt="vize_musea logo" width="120" height="120" /><br>
+  vize_musea
+</h1>
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).

--- a/crates/vize_patina/README.md
+++ b/crates/vize_patina/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_patina.svg" alt="vize_patina logo" width="120" height="120" />
-</p>
-
-# vize_patina
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_patina.svg" alt="vize_patina logo" width="120" height="120" /><br>
+  vize_patina
+</h1>
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).

--- a/crates/vize_patina/README.md
+++ b/crates/vize_patina/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_patina.svg" alt="vize_patina logo" width="120" height="120" />
+</p>
+
 # vize_patina
 
 Support and deprecation guarantees are defined in the

--- a/crates/vize_relief/README.md
+++ b/crates/vize_relief/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_relief.svg" alt="vize_relief logo" width="120" height="120" />
+</p>
+
 # vize_relief
 
 Support and deprecation guarantees are defined in the

--- a/crates/vize_relief/README.md
+++ b/crates/vize_relief/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_relief.svg" alt="vize_relief logo" width="120" height="120" />
-</p>
-
-# vize_relief
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_relief.svg" alt="vize_relief logo" width="120" height="120" /><br>
+  vize_relief
+</h1>
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).

--- a/crates/vize_vitrine/README.md
+++ b/crates/vize_vitrine/README.md
@@ -1,8 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_vitrine.svg" alt="vize_vitrine logo" width="120" height="120" />
-</p>
-
-# vize_vitrine
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_vitrine.svg" alt="vize_vitrine logo" width="120" height="120" /><br>
+  vize_vitrine
+</h1>
 
 `vize_vitrine` exposes Vize functionality to JavaScript through NAPI and WASM bindings.
 

--- a/crates/vize_vitrine/README.md
+++ b/crates/vize_vitrine/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ubugeeei-prod/vize/main/assets/crates/vize_vitrine.svg" alt="vize_vitrine logo" width="120" height="120" />
+</p>
+
 # vize_vitrine
 
 `vize_vitrine` exposes Vize functionality to JavaScript through NAPI and WASM bindings.


### PR DESCRIPTION
## Summary

Adds an original logo badge for every workspace crate and surfaces it at the top of each crate README, per the issue TODO list.

## Visual language

- One shared frame for all 20 badges: 240x240 rounded black tile in the brand palette (`#000000` / `#e6e2d6`, the exact colors of `assets/logo.svg` / `assets/logo-light.svg`), with the brand's skewed speed-line motif in the corner.
- One hand-drawn geometric glyph per crate reflecting its role, leaning into the workspace's atelier/museum naming theme.
- Self-contained contrast (light ink on its own dark tile), so a single asset renders identically on GitHub light and dark themes — no `<picture>` duplication needed.

## Inventory

| Crate | Glyph motif | Asset |
| --- | --- | --- |
| `vize` | the brand V mark | `assets/crates/vize.svg` |
| `vize_armature` | sculptor's wire armature | `assets/crates/vize_armature.svg` |
| `vize_atelier_core` | easel | `assets/crates/vize_atelier_core.svg` |
| `vize_atelier_dom` | document tree | `assets/crates/vize_atelier_dom.svg` |
| `vize_atelier_jsx` | closing tag `</>` | `assets/crates/vize_atelier_jsx.svg` |
| `vize_atelier_sfc` | one file, three blocks | `assets/crates/vize_atelier_sfc.svg` |
| `vize_atelier_ssr` | document served at speed | `assets/crates/vize_atelier_ssr.svg` |
| `vize_atelier_vapor` | rising vapor wisps | `assets/crates/vize_atelier_vapor.svg` |
| `vize_canon` | seal of correctness | `assets/crates/vize_canon.svg` |
| `vize_carton` | artist's toolbox | `assets/crates/vize_carton.svg` |
| `vize_croquis` | pencil and sketch stroke | `assets/crates/vize_croquis.svg` |
| `vize_croquis_cf` | two linked sketch sheets | `assets/crates/vize_croquis_cf.svg` |
| `vize_curator` | inspector's loupe | `assets/crates/vize_curator.svg` |
| `vize_fresco` | terminal panel | `assets/crates/vize_fresco.svg` |
| `vize_glyph` | pilcrow | `assets/crates/vize_glyph.svg` |
| `vize_maestro` | conductor's baton | `assets/crates/vize_maestro.svg` |
| `vize_musea` | gallery facade | `assets/crates/vize_musea.svg` |
| `vize_patina` | burnished surface | `assets/crates/vize_patina.svg` |
| `vize_relief` | carved relief slab | `assets/crates/vize_relief.svg` |
| `vize_vitrine` | display case | `assets/crates/vize_vitrine.svg` |

Every `crates/*/README.md` gets a centered `<img>` (120x120) above its title, matching the root README's centered-header style.

## License

All badges are original SVGs authored for this PR from basic primitives (rects, circles, paths) plus the project's own existing logo shapes. No third-party artwork, icon sets, or fonts (badges contain no text), so there are no external license obligations.

## Package artifacts

- Assets live at repo root (`assets/crates/`), outside every crate directory, and no crate defines `include`/`readme`/`license-file` paths that could pull them in; `cargo package --list -p vize_carton` / `-p vize_relief` confirm zero `assets/`/`.svg` entries.
- READMEs reference the badges via absolute `raw.githubusercontent.com/.../main/...` URLs, so crates.io/docs.rs render them too. The images 404 in this PR's file view and resolve once merged to `main`.
- Each SVG is 0.7–1.0 KB (20 files, ~16 KB total); all validate with `xmllint` and were render-checked with `rsvg-convert`.

Fixes #1600

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated multiple crate README files to use a centered header featuring the crate’s SVG logo and name at the top of each page.
  * Replaced the previous plain top-level headings with consistent branded logo blocks, keeping the rest of the README content unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->