### PR TITLE
fix(atelier): harden expression nesting guard against false regex starts

### DIFF
--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
@@ -132,7 +132,13 @@ fn analyze_expression_nesting(content: &str) -> (usize, bool) {
             }
             b',' | b';' | b':' | b'?' | b'!' | b'=' | b'+' | b'-' | b'*' | b'/' | b'%' | b'&'
             | b'|' | b'^' | b'~' => can_start_regex = true,
-            _ => can_start_regex = b < 0x80,
+            // Every byte reaching this arm is identifier-like (`\` starts a
+            // Unicode identifier escape, `#` a private name, non-ASCII bytes
+            // continue multi-byte identifiers) or an invalid control
+            // character. None of them can precede a regex literal, and
+            // claiming they do lets `skip_regex` swallow arbitrary source —
+            // hiding real brackets from the depth guard (#3107).
+            _ => can_start_regex = false,
         }
 
         let effective_angle_depth = if track_type_angles { angle_depth } else { 0 };

--- a/crates/vize_atelier_core/tests/expression_nesting_guard.rs
+++ b/crates/vize_atelier_core/tests/expression_nesting_guard.rs
@@ -142,6 +142,48 @@ fn expression_guard_scans_deep_template_interpolations_without_recursion() {
 }
 
 #[test]
+fn expression_guard_counts_brackets_after_a_backslash_slash_sequence() {
+    // Minimized from the js_ts_expression fuzz crash (#3107): after `v`, the
+    // `\` byte must not enable regex-literal detection, otherwise the
+    // following `/` swallows the rest of the source as a "regex" and the
+    // bracket run is hidden from the depth guard while OXC still recurses
+    // over every real `(`.
+    let reproducer = ["v\\/", &"(".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1)].concat();
+    assert_eq!(reproducer.len(), 35);
+    assert_eq!(
+        expression_nesting_depth(&reproducer),
+        MAX_EXPRESSION_NESTING_DEPTH + 1
+    );
+    assert!(expression_exceeds_max_depth(&reproducer));
+    assert!(!expression_has_balanced_delimiters(&reproducer));
+    assert!(!expression_is_safe_to_parse(&reproducer));
+    assert!(!is_event_handler_reference_expression(&reproducer));
+    assert!(!is_function_expression(&reproducer));
+    assert_eq!(
+        prefix_identifiers_in_expression(&reproducer).as_str(),
+        reproducer
+    );
+    assert_eq!(
+        strip_typescript_from_expression(&reproducer).as_str(),
+        reproducer
+    );
+
+    // The stack-overflow shape found by the fuzzer: tens of thousands of
+    // brackets hidden behind the same two-byte prefix.
+    let overflow = ["v\\/", &"(".repeat(60_000)].concat();
+    assert_eq!(expression_nesting_depth(&overflow), 60_000);
+    assert!(!expression_is_safe_to_parse(&overflow));
+}
+
+#[test]
+fn expression_guard_treats_slash_after_private_names_as_division() {
+    let expression = "a.#b / c / d";
+    assert_eq!(expression_nesting_depth(expression), 0);
+    assert!(expression_has_balanced_delimiters(expression));
+    assert!(expression_is_safe_to_parse(expression));
+}
+
+#[test]
 fn expression_guard_does_not_treat_relational_operators_as_type_angles() {
     let expression = std::iter::repeat_n("value < limit", MAX_EXPRESSION_NESTING_DEPTH + 1)
         .collect::<Vec<_>>()


### PR DESCRIPTION
## Fuzz reproducer

The `js_ts_expression` fuzz target found a crash at `5067f2578` (#3107, run 29676928893). The 8358-byte reproducer contains the byte sequence `v\/` followed later by runs of ~1700 raw `(` bytes. Minimized:

```
"v\\/" + "(".repeat(60000)
```

(the two-byte prefix `\` `/` is the trigger; any bracket run behind it is invisible to the guard).

## Root cause

`analyze_expression_nesting` (`crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs`) drives every `expression_is_safe_to_parse` entry point that protects OXC's recursive parser from deep bracket nesting (#956, #2944). Its catch-all scanner arm set `can_start_regex = b < 0x80`, so an ASCII byte with no dedicated arm — `\`, `#`, or a control character — flipped the scanner into "a regex may start here" even directly after an identifier. In the reproducer, `v` (identifier, regex off) followed by `\` re-enabled regex detection, and the next `/` made `skip_regex` swallow the remaining 8292 bytes — including 1698 open parens — as regex text. The guard reported depth 0/balanced, and OXC then recursed over ~1700 real nested parens: stack overflow (reproduced locally as a SIGABRT `stack overflow` with the 60k-paren minimization; the CI crash is the same shape under sanitizer-inflated frames).

No valid JS/TS places a regex literal after any byte reaching that arm: `\` starts a Unicode identifier escape, `#` a private name, non-ASCII bytes continue identifiers, and the rest are invalid controls. Claiming otherwise only hides source from the depth count.

## Fix

The catch-all arm now sets `can_start_regex = false`, so a `/` after such a byte is scanned as division and everything behind it is counted normally. Strictly conservative: inputs the scanner previously measured correctly are unaffected; pathological inputs are now measured instead of skipped.

## Regression tests

`crates/vize_atelier_core/tests/expression_nesting_guard.rs`:
- `expression_guard_counts_brackets_after_a_backslash_slash_sequence` — the minimized reproducer must report depth 32 (fails on main with depth 0), be rejected as unbalanced/over-depth, and pass through `prefix_identifiers_in_expression` / `strip_typescript_from_expression` unchanged; also pins the 60k-paren overflow shape.
- `expression_guard_treats_slash_after_private_names_as_division` — documents the division reading after identifier-like bytes.

Fixes #3107