### PR TITLE
fix(sfc): bound CSS bracket nesting before LightningCSS parsing

### DIFF
--- a/crates/vize_atelier_sfc/src/css/parser.rs
+++ b/crates/vize_atelier_sfc/src/css/parser.rs
@@ -13,6 +13,9 @@ use serde_json::Value;
 use std::path::Path;
 use vize_carton::{FxHashMap, String, ToCompactString};
 
+mod nesting;
+mod normalize;
+
 /// Convert major version to LightningCSS format (major << 16)
 pub(crate) fn version_to_u32(major: u32) -> u32 {
     major << 16
@@ -39,6 +42,14 @@ pub(crate) fn parse_css_ast_internal(
     custom_media: bool,
     css_modules: bool,
 ) -> CssAstInternalResult {
+    if nesting::css_nesting_exceeds_max_depth(css) {
+        return CssAstInternalResult {
+            ast: None,
+            errors: vec![String::from(nesting::NESTING_DEPTH_ERROR)],
+            warnings: vec![],
+        };
+    }
+
     let mut flags = ParserFlags::NESTING | ParserFlags::DEEP_SELECTOR_COMBINATOR;
     if custom_media {
         flags |= ParserFlags::CUSTOM_MEDIA;
@@ -97,7 +108,7 @@ pub(crate) fn print_css_ast_internal(
     minify: bool,
     targets: Targets,
 ) -> CssInternalResult {
-    normalize_image_set_file_types(&mut ast);
+    normalize::normalize_image_set_file_types(&mut ast);
 
     let mut stylesheet: StyleSheet = match StyleSheet::deserialize(ast.into_deserializer()) {
         Ok(stylesheet) => stylesheet,
@@ -171,26 +182,6 @@ pub(crate) fn print_css_ast_internal(
     }
 }
 
-fn normalize_image_set_file_types(value: &mut Value) {
-    match value {
-        Value::Object(map) => {
-            if map.get("fileType") == Some(&Value::Null) {
-                map.remove("fileType");
-            }
-
-            for child in map.values_mut() {
-                normalize_image_set_file_types(child);
-            }
-        }
-        Value::Array(items) => {
-            for child in items {
-                normalize_image_set_file_types(child);
-            }
-        }
-        _ => {}
-    }
-}
-
 /// Internal CSS compilation with owned strings to avoid borrow issues
 pub(crate) fn compile_css_internal(
     css: &str,
@@ -200,6 +191,14 @@ pub(crate) fn compile_css_internal(
     custom_media: bool,
     css_modules: bool,
 ) -> CssInternalResult {
+    if nesting::css_nesting_exceeds_max_depth(css) {
+        return CssInternalResult {
+            code: css.to_compact_string(),
+            errors: vec![String::from(nesting::NESTING_DEPTH_ERROR)],
+            exports: None,
+        };
+    }
+
     let mut flags = ParserFlags::NESTING | ParserFlags::DEEP_SELECTOR_COMBINATOR;
     if custom_media {
         flags |= ParserFlags::CUSTOM_MEDIA;

--- a/crates/vize_atelier_sfc/src/css/parser/nesting.rs
+++ b/crates/vize_atelier_sfc/src/css/parser/nesting.rs
@@ -1,0 +1,231 @@
+//! Pre-parse bracket nesting guard for the LightningCSS integration.
+//!
+//! Malformed style sources with deeply nested unclosed function tokens make
+//! LightningCSS backtrack exponentially: every declaration whose typed value
+//! parse fails is re-parsed as a raw token stream, so each extra nesting
+//! level roughly doubles the work. The css_parse fuzz reproducer (#3105)
+//! nested brackets 192 deep and needed seconds of CPU (well past the fuzz
+//! timeout under instrumentation) only to report a parse error, while depth
+//! 32 of the same shape stays in the microsecond range. Real stylesheets
+//! never approach this depth, so parsing rejects such sources up front with
+//! a regular parse error instead of timing out.
+
+/// Maximum `(`/`[`/`{` nesting depth accepted before invoking LightningCSS.
+pub(crate) const MAX_CSS_NESTING_DEPTH: usize = 32;
+
+/// Error reported when [`css_nesting_exceeds_max_depth`] rejects a source.
+pub(crate) const NESTING_DEPTH_ERROR: &str =
+    "CSS parse error: bracket nesting exceeds the supported depth of 32";
+
+/// Returns whether block nesting is deeper than [`MAX_CSS_NESTING_DEPTH`].
+///
+/// The scan follows CSS tokenizer rules so only brackets that open real
+/// blocks are counted: strings (with the bad-string newline rule), comments,
+/// escape sequences, and `url()`/bad-url tokens cannot contain blocks, and
+/// brackets inside them are ignored. `url(` spelled with escapes (`\75rl(`)
+/// is decoded so a quote inside a bad-url can never hide later brackets from
+/// the count.
+pub(crate) fn css_nesting_exceeds_max_depth(css: &str) -> bool {
+    let bytes = css.as_bytes();
+    let mut depth = 0usize;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' | b'\'' => i = skip_string(bytes, i + 1, bytes[i]),
+            b'/' if bytes.get(i + 1) == Some(&b'*') => i = skip_comment(bytes, i + 2),
+            b'(' | b'[' | b'{' => {
+                depth += 1;
+                if depth > MAX_CSS_NESTING_DEPTH {
+                    return true;
+                }
+                i += 1;
+            }
+            b')' | b']' | b'}' => {
+                depth = depth.saturating_sub(1);
+                i += 1;
+            }
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b'-' | b'\\' | 0x80.. => {
+                let (next, is_url) = scan_ident(bytes, i);
+                i = next;
+                if is_url && bytes.get(i) == Some(&b'(') && !url_argument_is_string(bytes, i + 1) {
+                    // A url-token (or bad-url) is atomic: it never opens a
+                    // block and always ends at the first unescaped `)`.
+                    i = skip_url(bytes, i + 1);
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    false
+}
+
+/// Scans one ident-ish token run and reports whether it decodes to `url`.
+///
+/// Number and dimension prefixes are consumed by the same run (`0url` is a
+/// dimension, not the `url` ident), which keeps the decision independent of
+/// scan position without look-behind.
+fn scan_ident(bytes: &[u8], start: usize) -> (usize, bool) {
+    let mut i = start;
+    let mut decoded = [0u8; 3];
+    let mut len = 0usize;
+    while i < bytes.len() {
+        let ch = match bytes[i] {
+            b @ (b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b'-') => {
+                i += 1;
+                b.to_ascii_lowercase()
+            }
+            0x80.. => {
+                i += 1;
+                0
+            }
+            b'\\' => {
+                let (next, ch) = scan_escape(bytes, i + 1);
+                if next == i + 1 {
+                    // `\` before a newline or EOF is a lone delim token.
+                    i = next;
+                    break;
+                }
+                i = next;
+                ch.to_ascii_lowercase()
+            }
+            _ => break,
+        };
+        if len < 3 {
+            decoded[len] = ch;
+        }
+        len += 1;
+    }
+    (i, len == 3 && decoded == *b"url")
+}
+
+/// Consumes one escape sequence (the `\` already consumed) and returns the
+/// decoded byte for ASCII code points, `0` otherwise.
+fn scan_escape(bytes: &[u8], mut i: usize) -> (usize, u8) {
+    match bytes.get(i) {
+        None | Some(b'\n' | b'\r' | b'\x0C') => (i, 0),
+        Some(b) if b.is_ascii_hexdigit() => {
+            let mut value = 0u32;
+            let mut digits = 0;
+            while digits < 6
+                && let Some(b) = bytes.get(i)
+                && b.is_ascii_hexdigit()
+            {
+                value = value * 16 + (*b as char).to_digit(16).unwrap_or(0);
+                i += 1;
+                digits += 1;
+            }
+            // One optional whitespace terminates a hex escape.
+            if matches!(bytes.get(i), Some(b' ' | b'\t' | b'\n' | b'\r' | b'\x0C')) {
+                i += 1;
+            }
+            (i, u8::try_from(value).unwrap_or(0))
+        }
+        Some(&b) => (i + 1, b),
+    }
+}
+
+/// Returns whether `url(` is followed by a quoted argument, which makes it a
+/// regular function token instead of a url-token.
+fn url_argument_is_string(bytes: &[u8], mut i: usize) -> bool {
+    while matches!(bytes.get(i), Some(b' ' | b'\t' | b'\n' | b'\r' | b'\x0C')) {
+        i += 1;
+    }
+    matches!(bytes.get(i), Some(b'"' | b'\''))
+}
+
+fn skip_string(bytes: &[u8], mut i: usize, quote: u8) -> usize {
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => i = i.saturating_add(2),
+            // Bad-string: an unescaped newline ends the token.
+            b'\n' | b'\r' | b'\x0C' => return i,
+            b if b == quote => return i + 1,
+            _ => i += 1,
+        }
+    }
+    i
+}
+
+fn skip_comment(bytes: &[u8], mut i: usize) -> usize {
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+            return i + 2;
+        }
+        i += 1;
+    }
+    bytes.len()
+}
+
+/// Consumes url-token or bad-url content up to and including the closing `)`.
+fn skip_url(bytes: &[u8], mut i: usize) -> usize {
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => i = i.saturating_add(2),
+            b')' => return i + 1,
+            _ => i += 1,
+        }
+    }
+    i
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_CSS_NESTING_DEPTH, css_nesting_exceeds_max_depth};
+
+    #[test]
+    fn accepts_the_documented_boundary_and_rejects_one_past_it() {
+        let allowed = "(".repeat(MAX_CSS_NESTING_DEPTH);
+        let rejected = "(".repeat(MAX_CSS_NESTING_DEPTH + 1);
+        assert!(!css_nesting_exceeds_max_depth(&allowed));
+        assert!(css_nesting_exceeds_max_depth(&rejected));
+    }
+
+    #[test]
+    fn sequential_blocks_do_not_accumulate_depth() {
+        let css = ".a { --x: f(1); }".repeat(MAX_CSS_NESTING_DEPTH);
+        assert!(!css_nesting_exceeds_max_depth(&css));
+    }
+
+    #[test]
+    fn brackets_inside_strings_and_comments_do_not_count() {
+        let brackets = "(".repeat(MAX_CSS_NESTING_DEPTH + 1);
+        assert!(!css_nesting_exceeds_max_depth(&format!(
+            ".a {{ content: \"{brackets}\"; }}"
+        )));
+        assert!(!css_nesting_exceeds_max_depth(&format!(
+            "/* {brackets} */ .a {{ color: red; }}"
+        )));
+    }
+
+    #[test]
+    fn a_bad_string_newline_reenables_counting() {
+        let css = format!("\" \n{}", "(".repeat(MAX_CSS_NESTING_DEPTH + 1));
+        assert!(css_nesting_exceeds_max_depth(&css));
+    }
+
+    #[test]
+    fn url_tokens_are_atomic() {
+        let brackets = "(".repeat(MAX_CSS_NESTING_DEPTH + 1);
+        // url-token and bad-url content never opens blocks.
+        assert!(!css_nesting_exceeds_max_depth(&format!("url({brackets}")));
+        assert!(!css_nesting_exceeds_max_depth(&format!(
+            "\\75rl({brackets}"
+        )));
+        // A quote inside a bad-url must not hide brackets after the `)`.
+        assert!(css_nesting_exceeds_max_depth(&format!(
+            ".a {{ x: url(a\") ; y: {brackets}"
+        )));
+        // `url(` with a quoted argument is a plain function token.
+        assert!(!css_nesting_exceeds_max_depth(
+            ".a { background: url(\"a.png\"); }"
+        ));
+        // A dimension unit spelled `url` is not a url-token.
+        assert!(css_nesting_exceeds_max_depth(&format!("0url({brackets}")));
+    }
+
+    #[test]
+    fn escaped_brackets_do_not_count() {
+        let css = "\\(".repeat(MAX_CSS_NESTING_DEPTH + 1);
+        assert!(!css_nesting_exceeds_max_depth(&css));
+    }
+}

--- a/crates/vize_atelier_sfc/src/css/parser/normalize.rs
+++ b/crates/vize_atelier_sfc/src/css/parser/normalize.rs
@@ -1,0 +1,25 @@
+//! Serialized AST normalization applied before printing.
+
+use serde_json::Value;
+
+/// Drops null `fileType` entries so serialized `image-set()` ASTs deserialize
+/// with LightningCSS' optional file-type representation.
+pub(crate) fn normalize_image_set_file_types(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            if map.get("fileType") == Some(&Value::Null) {
+                map.remove("fileType");
+            }
+
+            for child in map.values_mut() {
+                normalize_image_set_file_types(child);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                normalize_image_set_file_types(child);
+            }
+        }
+        _ => {}
+    }
+}

--- a/crates/vize_atelier_sfc/tests/css_nesting_guard.rs
+++ b/crates/vize_atelier_sfc/tests/css_nesting_guard.rs
@@ -1,0 +1,84 @@
+//! Regression tests for the pre-parse CSS bracket nesting guard (#3105).
+//!
+//! The css_parse fuzz target found a 3.7KB stylesheet nesting brackets 192
+//! deep through unclosed color-function chains. LightningCSS backtracks
+//! exponentially on that shape (each nesting level roughly doubles the work),
+//! so the reproducer burned >25s under fuzz instrumentation only to report a
+//! parse error. The guard rejects such sources up front.
+#![cfg(feature = "native")]
+
+use vize_atelier_sfc::{CssCompileOptions, compile_css, parse_css_ast};
+
+/// One repetition of the dominant pattern in the fuzz reproducer; each
+/// repetition opens six brackets that are never closed.
+const REPRODUCER_CHUNK: &str =
+    "height: hwb(-het: hwb(max(60*\\ %\n (light-dark(fieldtext: hwb(-let: hwb(ma\n  ";
+
+const NESTING_DEPTH_ERROR: &str =
+    "CSS parse error: bracket nesting exceeds the supported depth of 32";
+
+fn reproducer(repetitions: usize) -> String {
+    let mut css = String::from(".a {");
+    for _ in 0..repetitions {
+        css.push_str(REPRODUCER_CHUNK);
+    }
+    css
+}
+
+#[test]
+fn parse_css_ast_rejects_the_fuzz_timeout_shape_without_backtracking() {
+    // 32 repetitions nest 193 brackets deep — the depth of the actual fuzz
+    // artifact. Without the guard this exact call takes seconds of CPU.
+    let result = parse_css_ast(&reproducer(32), &CssCompileOptions::default());
+    assert!(result.ast.is_none());
+    assert_eq!(result.errors, [NESTING_DEPTH_ERROR]);
+    assert_eq!(result.warnings, Vec::<vize_carton::String>::new());
+
+    // The smallest reproducer shape past the boundary is rejected the same way.
+    let result = parse_css_ast(&reproducer(6), &CssCompileOptions::default());
+    assert!(result.ast.is_none());
+    assert_eq!(result.errors, [NESTING_DEPTH_ERROR]);
+}
+
+#[test]
+fn parse_css_ast_keeps_accepting_the_documented_depth_boundary() {
+    let nested = |depth: usize| {
+        [
+            ".a { --x: ",
+            &"f(".repeat(depth),
+            "1",
+            &")".repeat(depth),
+            "; }",
+        ]
+        .concat()
+    };
+
+    // `.a {` plus 31 function tokens sits exactly on the depth-32 boundary.
+    let allowed = parse_css_ast(&nested(31), &CssCompileOptions::default());
+    assert!(allowed.ast.is_some());
+    assert_eq!(allowed.errors, Vec::<vize_carton::String>::new());
+
+    let rejected = parse_css_ast(&nested(32), &CssCompileOptions::default());
+    assert!(rejected.ast.is_none());
+    assert_eq!(rejected.errors, [NESTING_DEPTH_ERROR]);
+}
+
+#[test]
+fn compile_css_rejects_over_deep_sources_and_passes_them_through() {
+    let css = reproducer(32);
+    let result = compile_css(&css, &CssCompileOptions::default());
+    assert_eq!(result.code, css);
+    assert!(result.map.is_none());
+    assert_eq!(result.css_vars, Vec::<vize_carton::String>::new());
+    assert_eq!(result.errors, [NESTING_DEPTH_ERROR]);
+    assert_eq!(result.warnings, Vec::<vize_carton::String>::new());
+    assert!(result.exports.is_none());
+}
+
+#[test]
+fn compile_css_still_compiles_realistic_nesting() {
+    let css = ".a { .b { .c { width: calc(1px + min(2px, max(3px, 4px))); } } }";
+    let result = compile_css(css, &CssCompileOptions::default());
+    assert_eq!(result.errors, Vec::<vize_carton::String>::new());
+    assert!(!result.code.is_empty());
+}


### PR DESCRIPTION
## Fuzz reproducer

The `css_parse` fuzz target found a timeout at `5067f2578` (#3105, run 29676928893): a 3742-byte stylesheet built from unclosed color-function chains such as

```
height: hwb(-het: hwb(max(60*\ %
 (light-dark(fieldtext: hwb(-let: hwb(ma
```

nesting brackets 192 deep overall. Replayed locally, `parse_css_ast` burns 2.3s of CPU (optimized build; >25s under fuzz instrumentation) only to return a regular parse error.

## Root cause

LightningCSS backtracks exponentially on this shape: every declaration whose typed value parse fails is re-parsed as a raw token stream, so each additional nesting level roughly doubles the work. Measured with the reproducer chunk above: 24 levels parse in 0.4ms, 48 in 3ms, 72 in 47ms, 96 in 752ms — about 2x per 6-bracket repetition. Closed (sequential) repetitions of the same chunk stay linear, and valid deeply nested input parses fast, so the blowup is keyed purely on open-bracket depth of malformed input. The cost is upstream (`lightningcss 1.0.0-alpha.71`), reachable through `parse_css_ast` / `compile_css` on arbitrary style-block content.

## Fix

`crates/vize_atelier_sfc/src/css/parser/nesting.rs` (new): `css_nesting_exceeds_max_depth` scans the source with CSS tokenizer rules — strings (bad-string newline rule), comments, escape sequences, and `url()`/bad-url tokens (including escape-spelled `\75rl(`) cannot open blocks — and reports whether `(`/`[`/`{` nest deeper than 32. `parse_css_ast_internal` and `compile_css_internal` reject such sources up front with a deterministic parse error (`CSS parse error: bracket nesting exceeds the supported depth of 32`), mirroring the existing `MAX_EXPRESSION_NESTING_DEPTH` guard that protects OXC on the script side (#956/#2944). At depth 32 the worst measured shape stays in the microsecond range; real stylesheets nest nowhere near 32 brackets. The original artifact is now rejected in 64µs.

`normalize_image_set_file_types` moved unchanged to `css/parser/normalize.rs` to keep `css/parser.rs` within its current size under the source-file length gate.

## Regression tests

- `crates/vize_atelier_sfc/tests/css_nesting_guard.rs` — `parse_css_ast` rejects the fuzz-shape at depth 193 and at the minimal over-boundary repetition with exactly the guard error (fails on main: the boundary test accepts 33-deep input and the deep shape backtracks); the depth-32 boundary still parses; `compile_css` passes rejected sources through unchanged with the same error; realistic nesting still compiles.
- Scanner unit tests in `css/parser/nesting.rs` cover the boundary, sequential blocks, strings/comments/escapes, bad-string newline recovery, and url-token atomicity (including the bad-url quote case that must not hide later brackets).

Fixes #3105

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against excessively deep CSS bracket nesting, with a clear error reported when the supported depth is exceeded.
  * Preserved source CSS when compilation is rejected due to excessive nesting.
  * Improved handling of nested CSS syntax, strings, comments, escapes, and `url()` content.
  * Fixed serialization of `image-set()` values with missing file type information.
* **Tests**
  * Added coverage for nesting limits, valid boundary cases, and realistic nested CSS compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->