### PR TITLE
fix(musea): rewrite gallery base before injecting static globals

### DIFF
--- a/npm/builder/vite-musea/src/static-export.ts
+++ b/npm/builder/vite-musea/src/static-export.ts
@@ -1,22 +1,15 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
-import { generateGalleryBody, generateGalleryScript } from "./gallery/template.js";
-import { generateGalleryGlobalsScript } from "./gallery/globals.js";
 import { serializeScriptValue } from "./security.js";
-import {
-  publicBasePathFromViteBase,
-  rewriteGalleryBase,
-  rewriteGalleryTextAssetBase,
-} from "./static-base.js";
+import { publicBasePathFromViteBase } from "./static-base.js";
+import { emitGalleryShell, joinFileName } from "./static-gallery-shell.js";
 import {
   createStaticGalleryPayload,
   joinUrlPath,
   staticPreviewId,
   type StaticGalleryDataContext,
-  type StaticGalleryPayload,
 } from "./static-data.js";
 import type { ArtFileInfo } from "./types/index.js";
 import type { MuseaTokenPreviewConfig } from "./tokens/preview.js";
@@ -28,7 +21,6 @@ export const VIRTUAL_STATIC_RUNTIME = "virtual:musea-static-runtime";
 const RESOLVED_STATIC_RUNTIME = "\0musea-static-runtime";
 const STATIC_RUNTIME_INPUT_NAME = "musea-static-runtime";
 const STATIC_USER_INPUT_NAME = "musea-static-entry";
-const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
 export type StaticBuildInput = string | readonly string[] | Record<string, string> | undefined;
 type OutputBundle = Record<string, OutputChunk | { type: string; fileName: string }>;
@@ -164,50 +156,6 @@ function findRuntimeFileName(bundle: OutputBundle): string | null {
   return null;
 }
 
-async function emitGalleryShell(
-  emitFile: (asset: { type: "asset"; fileName: string; source: string | Uint8Array }) => void,
-  staticRoot: string,
-  ctx: StaticEmitContext,
-  payload: StaticGalleryPayload,
-): Promise<void> {
-  const galleryDir = resolveGalleryDistDir();
-  if (!galleryDir) {
-    const html = injectStaticGlobals(generateStaticFallbackGalleryHtml(ctx.basePath), ctx, payload);
-    emitFile({ type: "asset", fileName: joinFileName(staticRoot, "index.html"), source: html });
-    return;
-  }
-
-  for (const filePath of await collectFiles(galleryDir)) {
-    const relative = path.relative(galleryDir, filePath).split(path.sep).join("/");
-    const target = joinFileName(staticRoot, relative);
-    const content = await fs.promises.readFile(filePath);
-    if (relative === "index.html") {
-      const html = injectStaticGlobals(content.toString("utf-8"), ctx, payload);
-      emitFile({ type: "asset", fileName: target, source: rewriteGalleryBase(html, ctx.basePath) });
-    } else {
-      const source = rewriteGalleryTextAssetBase(content, relative, ctx.basePath);
-      emitFile({ type: "asset", fileName: target, source });
-    }
-  }
-}
-
-function generateStaticFallbackGalleryHtml(basePath: string): string {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Musea - Component Gallery</title>
-  <style>html,body{min-height:100%;margin:0}body{font-family:system-ui,sans-serif}</style>
-</head>
-<body>${generateGalleryBody(basePath)}
-
-  <script type="module">${generateGalleryScript(basePath)}
-  </script>
-</body>
-</html>`;
-}
-
 function emitPreviewHtml(
   emitFile: (asset: { type: "asset"; fileName: string; source: string }) => void,
   staticRoot: string,
@@ -264,22 +212,6 @@ function generateStaticPreviewHtml(
 </html>`;
 }
 
-function injectStaticGlobals(
-  html: string,
-  ctx: StaticEmitContext,
-  payload: StaticGalleryPayload,
-): string {
-  const script = `<script>${generateGalleryGlobalsScript({
-    basePath: ctx.basePath,
-    staticPreviews: payload.previews,
-    themeConfig: ctx.themeConfig,
-    tokenPreviewConfig: ctx.tokenPreviewConfig,
-  })}</script>`;
-  return html.includes("</head>")
-    ? html.replace("</head>", `${script}</head>`)
-    : `${script}${html}`;
-}
-
 function emitRootRedirect(
   emitFile: (asset: { type: "asset"; fileName: string; source: string }) => void,
   staticRoot: string,
@@ -312,31 +244,8 @@ async function emitAxeVendor(
   }
 }
 
-function resolveGalleryDistDir(): string | null {
-  const candidates = [path.join(moduleDir, "gallery"), path.resolve(moduleDir, "../dist/gallery")];
-  return candidates.find((candidate) => fs.existsSync(path.join(candidate, "index.html"))) ?? null;
-}
-
-async function collectFiles(dir: string): Promise<string[]> {
-  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
-  const files: string[] = [];
-  for (const entry of entries) {
-    const filePath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...(await collectFiles(filePath)));
-    } else {
-      files.push(filePath);
-    }
-  }
-  return files;
-}
-
 function staticRootFromBasePath(basePath: string): string {
   return basePath.replace(/^\/+|\/+$/g, "");
-}
-
-function joinFileName(...parts: string[]): string {
-  return parts.filter(Boolean).join("/");
 }
 
 function relativeUrl(fromDir: string, toFile: string): string {

--- a/npm/builder/vite-musea/src/static-gallery-shell.test.ts
+++ b/npm/builder/vite-musea/src/static-gallery-shell.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import vm from "node:vm";
+import type { ResolvedConfig } from "vite";
+
+import { joinUrlPath, staticPreviewId } from "./static-data.js";
+import { emitGalleryShell } from "./static-gallery-shell.js";
+import type { ArtFileInfo } from "./types/index.js";
+
+function createArt(pathname: string): ArtFileInfo {
+  return {
+    path: pathname,
+    metadata: { title: "Button", tags: [], status: "ready" },
+    variants: [{ name: "Default", template: "<Button />", isDefault: true }],
+    hasScriptSetup: false,
+    hasScript: false,
+    styleCount: 0,
+    isInline: false,
+  };
+}
+
+function assetText(assets: Map<string, string>, fileName: string): string {
+  const value = assets.get(fileName);
+  assert.notEqual(value, undefined);
+  return value as string;
+}
+
+function executeStaticGlobals(indexHtml: string): Record<string, unknown> {
+  const script = [...indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(
+    (match) => match[1] ?? "",
+  )[0];
+  assert.notEqual(script, undefined);
+  const context = { window: {} as Record<string, unknown> };
+  vm.runInNewContext(script as string, context);
+  return JSON.parse(JSON.stringify(context.window)) as Record<string, unknown>;
+}
+
+// Regression test for #3109: with a prebuilt gallery shell and a basePath that
+// carries a subpath, the base rewrite must run before the globals are injected —
+// rewriting afterwards expanded the already prefixed preview URLs a second time
+// (`/site/__musea__/preview/…` → `/site/site/__musea__/preview/…`).
+void test("emitGalleryShell keeps subpath base paths single-prefixed in the prebuilt shell", async () => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-gallery-shell-"));
+  try {
+    const galleryDistDir = path.join(tempDir, "gallery");
+    await fs.promises.mkdir(galleryDistDir, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(galleryDistDir, "index.html"),
+      '<html><head><link rel="stylesheet" href="/__musea__/assets/app.css"></head><body></body></html>',
+      "utf8",
+    );
+    await fs.promises.writeFile(
+      path.join(galleryDistDir, "app.js"),
+      'fetch("/__musea__/api/arts");',
+      "utf8",
+    );
+
+    const art = createArt("/repo/src/Button.art.vue");
+    const previewId = staticPreviewId(art.path, "Default");
+    const basePath = "/site/__musea__";
+    const ctx = {
+      config: { root: tempDir } as ResolvedConfig,
+      artFiles: new Map([[art.path, art]]),
+      scanRoots: [tempDir],
+      tokensPath: undefined,
+      basePath,
+      resolvedPreviewCss: [],
+      resolvedPreviewSetup: null,
+      devSessionToken: "static-test",
+      themeConfig: undefined,
+      tokenPreviewConfig: undefined,
+    };
+    const payload = {
+      arts: [],
+      previews: { [art.path]: { Default: joinUrlPath(basePath, "preview", `${previewId}.html`) } },
+    };
+
+    const assets = new Map<string, string>();
+    await emitGalleryShell(
+      (asset) => {
+        assets.set(
+          asset.fileName,
+          typeof asset.source === "string"
+            ? asset.source
+            : Buffer.from(asset.source).toString("utf8"),
+        );
+      },
+      "site/__musea__",
+      ctx,
+      payload,
+      galleryDistDir,
+    );
+
+    const indexHtml = assetText(assets, "site/__musea__/index.html");
+    assert.equal(indexHtml.includes("/site/site/"), false);
+    assert.equal(indexHtml.includes('href="/site/__musea__/assets/app.css"'), true);
+    assert.deepEqual(executeStaticGlobals(indexHtml), {
+      __MUSEA_BASE_PATH__: basePath,
+      __MUSEA_STATIC__: true,
+      __MUSEA_STATIC_PREVIEWS__: {
+        [art.path]: {
+          Default: `/site/__musea__/preview/${previewId}.html`,
+        },
+      },
+    });
+    assert.equal(assetText(assets, "site/__musea__/app.js"), 'fetch("/site/__musea__/api/arts");');
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/npm/builder/vite-musea/src/static-gallery-shell.ts
+++ b/npm/builder/vite-musea/src/static-gallery-shell.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { generateGalleryBody, generateGalleryScript } from "./gallery/template.js";
+import { generateGalleryGlobalsScript } from "./gallery/globals.js";
+import { rewriteGalleryBase, rewriteGalleryTextAssetBase } from "./static-base.js";
+import type { StaticGalleryPayload } from "./static-data.js";
+import type { StaticEmitContext } from "./static-export.js";
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+export function joinFileName(...parts: string[]): string {
+  return parts.filter(Boolean).join("/");
+}
+
+export async function emitGalleryShell(
+  emitFile: (asset: { type: "asset"; fileName: string; source: string | Uint8Array }) => void,
+  staticRoot: string,
+  ctx: StaticEmitContext,
+  payload: StaticGalleryPayload,
+  galleryDistDir: string | null = resolveGalleryDistDir(),
+): Promise<void> {
+  if (!galleryDistDir) {
+    const html = injectStaticGlobals(generateStaticFallbackGalleryHtml(ctx.basePath), ctx, payload);
+    emitFile({ type: "asset", fileName: joinFileName(staticRoot, "index.html"), source: html });
+    return;
+  }
+
+  for (const filePath of await collectFiles(galleryDistDir)) {
+    const relative = path.relative(galleryDistDir, filePath).split(path.sep).join("/");
+    const target = joinFileName(staticRoot, relative);
+    const content = await fs.promises.readFile(filePath);
+    if (relative === "index.html") {
+      // The base rewrite targets the prebuilt, base-agnostic gallery shell;
+      // the injected globals already carry fully prefixed preview URLs, so
+      // rewriting after injection doubled the prefix for subpath base paths
+      // (#3109). Rewrite first, then inject.
+      const html = rewriteGalleryBase(content.toString("utf-8"), ctx.basePath);
+      emitFile({
+        type: "asset",
+        fileName: target,
+        source: injectStaticGlobals(html, ctx, payload),
+      });
+    } else {
+      const source = rewriteGalleryTextAssetBase(content, relative, ctx.basePath);
+      emitFile({ type: "asset", fileName: target, source });
+    }
+  }
+}
+
+export function injectStaticGlobals(
+  html: string,
+  ctx: StaticEmitContext,
+  payload: StaticGalleryPayload,
+): string {
+  const script = `<script>${generateGalleryGlobalsScript({
+    basePath: ctx.basePath,
+    staticPreviews: payload.previews,
+    themeConfig: ctx.themeConfig,
+    tokenPreviewConfig: ctx.tokenPreviewConfig,
+  })}</script>`;
+  return html.includes("</head>")
+    ? html.replace("</head>", `${script}</head>`)
+    : `${script}${html}`;
+}
+
+function generateStaticFallbackGalleryHtml(basePath: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Musea - Component Gallery</title>
+  <style>html,body{min-height:100%;margin:0}body{font-family:system-ui,sans-serif}</style>
+</head>
+<body>${generateGalleryBody(basePath)}
+
+  <script type="module">${generateGalleryScript(basePath)}
+  </script>
+</body>
+</html>`;
+}
+
+function resolveGalleryDistDir(): string | null {
+  const candidates = [path.join(moduleDir, "gallery"), path.resolve(moduleDir, "../dist/gallery")];
+  return candidates.find((candidate) => fs.existsSync(path.join(candidate, "index.html"))) ?? null;
+}
+
+async function collectFiles(dir: string): Promise<string[]> {
+  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const filePath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(filePath)));
+    } else {
+      files.push(filePath);
+    }
+  }
+  return files;
+}


### PR DESCRIPTION
## Problem

Building the static gallery with a `basePath` that carries a subpath (e.g. `/site/__musea__` for GitHub Pages project sites) baked a **doubled** prefix into the gallery HTML: the emitted files land at the correct place, but `staticPreviews` URLs became `/site/site/__musea__/preview/<id>.html`, so every variant iframe 404s — and with the usual SPA fallback each iframe recursively renders the whole gallery.

Root cause (as analyzed in the issue): `emitGalleryShell` injected the static globals (whose preview URLs already carry the full basePath) and **then** ran `rewriteGalleryBase` over the whole document, expanding `/__musea__/` inside the injected payload a second time. With the default `basePath = "/__musea__"` the rewrite is an identity, which is why it survived.

## Fix

Rewrite the prebuilt, base-agnostic shell **first**, then inject the globals. The shell emission moves to `static-gallery-shell.ts` (with the gallery dist dir injectable) so `static-export.ts` stays inside the source-length budget and the prebuilt path is deterministically testable.

## Tests

`static-gallery-shell.test.ts` drives the prebuilt path with `basePath: "/site/__musea__"` and asserts the emitted index.html keeps asset links rewritten to the subpath base, contains no `/site/site/`, and exposes single-prefixed `__MUSEA_STATIC_PREVIEWS__` (full `deepEqual` on the executed globals); text assets keep their existing rewrite. Verified the test fails against the previous injection order. Full vite-musea suite: 98 passed.

This makes the reporter's post-build collapse script unnecessary.

Fixes #3109

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->