### PR TITLE
fix(marquette): align serialized contract validation

### DIFF
--- a/crates/vize_marquette/src/bin/vize-marquette.rs
+++ b/crates/vize_marquette/src/bin/vize-marquette.rs
@@ -8,6 +8,7 @@ use std::{
 
 use vize_marquette::{ApplicationContract, canonical_json, contract_fingerprint};
 
+/// Runs the marquette CLI and renders errors without panicking.
 fn main() -> ExitCode {
     match run() {
         Ok(code) => code,
@@ -18,6 +19,7 @@ fn main() -> ExitCode {
     }
 }
 
+/// Parses one command and returns its process-level result.
 fn run() -> Result<ExitCode, Box<dyn std::error::Error>> {
     let mut arguments = env::args().skip(1);
     let command = arguments

--- a/crates/vize_marquette/src/compatibility.rs
+++ b/crates/vize_marquette/src/compatibility.rs
@@ -142,6 +142,7 @@ pub fn compare_contracts(
     CompatibilityReport { changes }
 }
 
+/// Compares a named collection by stable identifier.
 fn compare_by_id<T: PartialEq>(
     collection: &str,
     previous: &[T],
@@ -170,10 +171,12 @@ fn compare_by_id<T: PartialEq>(
     }
 }
 
+/// Creates a breaking compatibility change for one collection member.
 fn breaking(collection: &str, id: &str, message: &str) -> CompatibilityChange {
     change(CompatibilityChangeKind::Breaking, collection, id, message)
 }
 
+/// Creates a compatibility change with a deterministic graph path.
 fn change(
     kind: CompatibilityChangeKind,
     collection: &str,

--- a/crates/vize_marquette/src/lib.rs
+++ b/crates/vize_marquette/src/lib.rs
@@ -47,6 +47,9 @@ mod compatibility;
 mod model;
 mod validate;
 
+#[cfg(test)]
+mod model_tests;
+
 pub use canonical::{CanonicalContractError, canonical_json, contract_fingerprint};
 pub use compatibility::{
     CompatibilityChange, CompatibilityChangeKind, CompatibilityReport, compare_contracts,

--- a/crates/vize_marquette/src/model.rs
+++ b/crates/vize_marquette/src/model.rs
@@ -31,6 +31,7 @@ pub enum RuntimeFamily {
     /// Web browser runtime.
     Browser,
     /// JavaScript server or worker runtime.
+    #[serde(rename = "javascript")]
     JavaScript,
     /// Rust executable or library runtime.
     Rust,
@@ -63,6 +64,7 @@ pub enum EnvironmentConsumer {
 #[serde(rename_all = "kebab-case")]
 pub enum BackendFamily {
     /// Backend hosted by the JavaScript application runtime.
+    #[serde(rename = "javascript")]
     JavaScript,
     /// Rust application or service.
     Rust,

--- a/crates/vize_marquette/src/model_tests.rs
+++ b/crates/vize_marquette/src/model_tests.rs
@@ -1,0 +1,18 @@
+use crate::{BackendFamily, RuntimeFamily};
+
+#[test]
+fn javascript_families_match_the_language_neutral_schema_value() {
+    let runtime = serde_json::to_value(RuntimeFamily::JavaScript).unwrap();
+    let backend = serde_json::to_value(BackendFamily::JavaScript).unwrap();
+
+    assert_eq!(runtime, "javascript");
+    assert_eq!(backend, "javascript");
+    assert_eq!(
+        serde_json::from_value::<RuntimeFamily>(runtime).unwrap(),
+        RuntimeFamily::JavaScript
+    );
+    assert_eq!(
+        serde_json::from_value::<BackendFamily>(backend).unwrap(),
+        BackendFamily::JavaScript
+    );
+}

--- a/crates/vize_marquette/src/validate.rs
+++ b/crates/vize_marquette/src/validate.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
-use vize_carton::String;
+use vize_carton::{String, cstr};
 
 use crate::{ApplicationContract, CONTRACT_FORMAT_VERSION, EnvironmentConsumer, RuntimeFamily};
 
@@ -39,6 +39,7 @@ pub struct ContractDiagnostic {
 }
 
 impl ContractDiagnostic {
+    /// Creates an error diagnostic that prevents adapter execution.
     fn error(code: &'static str, path: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
             code,
@@ -48,6 +49,7 @@ impl ContractDiagnostic {
         }
     }
 
+    /// Creates a warning diagnostic for a valid but suspicious contract.
     fn warning(code: &'static str, path: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
             code,
@@ -104,6 +106,13 @@ pub fn validate_contract(contract: &ApplicationContract) -> Vec<ContractDiagnost
                 "VIZE_MARQUETTE_005",
                 contract_path("capabilities", key),
                 "capability version must be greater than zero",
+            ));
+        }
+        if capability.description.trim().is_empty() {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_024",
+                contract_path("capabilities", key),
+                "capability description must not be empty",
             ));
         }
     }
@@ -283,7 +292,7 @@ pub fn validate_contract(contract: &ApplicationContract) -> Vec<ContractDiagnost
             diagnostics.push(ContractDiagnostic::error(
                 "VIZE_MARQUETTE_019",
                 path,
-                previous.clone(),
+                cstr!("route path is already used by route \"{previous}\""),
             ));
         }
     }

--- a/crates/vize_marquette/src/validate/rules.rs
+++ b/crates/vize_marquette/src/validate/rules.rs
@@ -6,6 +6,7 @@ use crate::{ApplicationContract, RenderingMode, Target};
 
 use super::ContractDiagnostic;
 
+/// Validates and collects unique identifiers for one contract collection.
 pub(super) fn collect_unique_ids<'a>(
     collection: &str,
     ids: impl Iterator<Item = &'a String>,
@@ -30,6 +31,7 @@ pub(super) fn collect_unique_ids<'a>(
     unique
 }
 
+/// Validates the portable lowercase identifier grammar used by every adapter.
 pub(super) fn validate_identifier(
     id: &str,
     path: &str,
@@ -52,6 +54,7 @@ pub(super) fn validate_identifier(
     }
 }
 
+/// Reports capability references that are absent from the root declaration.
 pub(super) fn validate_capabilities(
     path: &str,
     required: &BTreeSet<String>,
@@ -69,6 +72,7 @@ pub(super) fn validate_capabilities(
     }
 }
 
+/// Reports cycles in the environment dependency graph.
 pub(super) fn validate_environment_cycles(
     contract: &ApplicationContract,
     diagnostics: &mut Vec<ContractDiagnostic>,
@@ -92,6 +96,7 @@ pub(super) fn validate_environment_cycles(
     }
 }
 
+/// Visits one dependency node and returns whether its path closes a cycle.
 pub(super) fn has_cycle<'a>(
     id: &'a String,
     graph: &BTreeMap<&'a String, &'a BTreeSet<String>>,
@@ -116,6 +121,7 @@ pub(super) fn has_cycle<'a>(
     cyclic
 }
 
+/// Ensures a route's rendering mode can execute on its target environment.
 pub(super) fn validate_rendering_target(
     contract: &ApplicationContract,
     route: &crate::Route,
@@ -149,6 +155,7 @@ pub(super) fn validate_rendering_target(
     }
 }
 
+/// Builds the stable diagnostic path for a named collection member.
 pub(super) fn contract_path(collection: &str, id: &str) -> String {
     let mut path = collection.to_compact_string();
     path.push('.');

--- a/crates/vize_marquette/src/validate/tests.rs
+++ b/crates/vize_marquette/src/validate/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
-    Backend, BackendFamily, Environment, Protocol, ProtocolFamily, RenderingMode, Route,
-    RuntimeFamily, Target,
+    Backend, BackendFamily, CapabilityDefinition, Environment, Protocol, ProtocolFamily,
+    RenderingMode, Route, RuntimeFamily, Target,
 };
 
 #[test]
@@ -70,4 +70,34 @@ fn reports_cycles_and_cross_reference_errors() {
     assert!(codes.contains("VIZE_MARQUETTE_014"));
     assert!(codes.contains("VIZE_MARQUETTE_015"));
     assert!(codes.contains("VIZE_MARQUETTE_022"));
+}
+
+#[test]
+fn rejects_empty_capability_descriptions_and_explains_duplicate_routes() {
+    let mut contract = ApplicationContract::new("shop");
+    contract.targets.insert(Target::Web);
+    contract.environments.push(Environment::new(
+        "browser",
+        Target::Web,
+        EnvironmentConsumer::Client,
+        RuntimeFamily::Browser,
+    ));
+    contract.capabilities.insert(
+        "auth.session".into(),
+        CapabilityDefinition::new("auth.session", "   "),
+    );
+    contract.routes.extend([
+        Route::new("home", "/", "browser", RenderingMode::Client),
+        Route::new("landing", "/", "browser", RenderingMode::Client),
+    ]);
+
+    let diagnostics = validate_contract(&contract);
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "VIZE_MARQUETTE_024"
+            && diagnostic.message == "capability description must not be empty"
+    }));
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "VIZE_MARQUETTE_019"
+            && diagnostic.message == "route path is already used by route \"home\""
+    }));
 }


### PR DESCRIPTION
## Summary

- align script-runtime serialization with the language-neutral contract schema
- reject blank capability descriptions and provide actionable duplicate-route diagnostics
- add round-trip and validation regression coverage
- expand documentation comments for contract internals and CLI entry points

Follow-up to #3128.

## Verification

- `cargo test -p vize_marquette`
- `cargo clippy -p vize_marquette --all-targets -- -D warnings`
- `cargo fmt --package vize_marquette -- --check`
- `vp check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->