### PR TITLE
feat(marquette): add typed contract authoring

### DIFF
--- a/npm/marquette/README.md
+++ b/npm/marquette/README.md
@@ -1,0 +1,87 @@
+# `@vizejs/marquette`
+
+Typed application marquettes for every Vize target.
+
+> Experimental: serialized contracts are versioned, but the TypeScript API may
+> evolve while target adapters are being validated.
+
+Marquette is the small, language-neutral description shared by web, native,
+desktop, terminal, backend, transport, testing, and gallery tooling. This
+package provides literal-preserving TypeScript authoring. Runtime validation,
+canonicalization, and compatibility analysis are delivered as separate,
+focused layers.
+
+## Author a marquette
+
+```ts
+import { defineApplicationMarquette } from "@vizejs/marquette";
+
+export default defineApplicationMarquette({
+  application: "shop",
+  targets: ["web", "native"],
+  environments: [
+    {
+      id: "web",
+      target: "web",
+      consumer: "client",
+      runtime: "browser",
+    },
+    {
+      id: "native",
+      target: "native",
+      consumer: "client",
+      runtime: "native",
+    },
+    {
+      id: "server",
+      target: "web",
+      consumer: "server",
+      runtime: "rust",
+    },
+  ],
+  backends: [
+    {
+      id: "api",
+      family: "rust",
+      environment: "server",
+    },
+  ],
+  protocols: [
+    {
+      id: "api.query",
+      family: "schema-query",
+      backend: "api",
+    },
+  ],
+  routes: [
+    {
+      id: "home",
+      path: "/",
+      environment: "web",
+      rendering: "hybrid",
+      backend: "api",
+      protocol: "api.query",
+    },
+  ],
+});
+```
+
+Environment dependencies, backend owners, protocol owners, and route
+references are checked against identifiers declared in the same object. A
+misspelled reference is therefore an authoring error rather than a runtime
+surprise.
+
+## Guarantees
+
+- Exact identifiers remain available as `EnvironmentId`, `BackendId`,
+  `ProtocolId`, and `RouteId` unions.
+- `defineApplicationMarquette` returns its input without allocation or
+  normalization.
+- The published application-contract schema is available from
+  `@vizejs/marquette/schema`.
+- Every optional contract field documents its default in JSDoc.
+- Package builds enforce a 1 KiB gzip budget for the runtime entry.
+
+Marquette describes components and environments; it does not author UI
+components. Public Vize UI components use real `.vue` SFC files as their
+canonical source, never authored `h()` calls or handwritten render functions.

--- a/npm/marquette/package.json
+++ b/npm/marquette/package.json
@@ -21,8 +21,8 @@
   "files": [
     "dist"
   ],
-  "sideEffects": false,
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "exports": {

--- a/npm/marquette/package.json
+++ b/npm/marquette/package.json
@@ -36,7 +36,7 @@
   "publishConfig": {
     "access": "public"
   },
-    "scripts": {
+  "scripts": {
     "build": "vp pack && node scripts/copy-schema.mjs && node scripts/check-size.mjs",
     "check": "vp check README.md package.json tsconfig.json src scripts vite.config.ts && tsgo --noEmit -p tsconfig.json",
     "check:fix": "vp check --fix README.md package.json tsconfig.json src scripts vite.config.ts",

--- a/npm/marquette/package.json
+++ b/npm/marquette/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@vizejs/marquette",
+  "version": "0.298.0",
+  "description": "Typed application marquettes for every Vize target",
+  "keywords": [
+    "application-contract",
+    "marquette",
+    "type-safe",
+    "vize"
+  ],
+  "homepage": "https://github.com/ubugeeei-prod/vize",
+  "bugs": {
+    "url": "https://github.com/ubugeeei-prod/vize/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ubugeeei-prod/vize.git",
+    "directory": "npm/marquette"
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "type": "module",
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    },
+    "./schema": "./dist/application-contract.schema.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "vp pack && node scripts/copy-schema.mjs",
+    "check": "vp check README.md src scripts vite.config.ts && tsgo --noEmit -p tsconfig.json",
+    "check:fix": "vp check --fix README.md src scripts vite.config.ts",
+    "check:size": "node scripts/check-size.mjs",
+    "check:types": "tsgo --noEmit -p tsconfig.json",
+    "dev": "vp pack --watch",
+    "fmt": "vp fmt --write README.md src scripts vite.config.ts",
+    "test": "vp exec tsx --test src/**/*.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:typescript",
+    "@typescript/native-preview": "catalog:typescript",
+    "tsx": "catalog:typescript",
+    "typescript": "catalog:typescript",
+    "vite-plus": "catalog:vite-stack"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/npm/marquette/package.json
+++ b/npm/marquette/package.json
@@ -36,8 +36,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "build": "vp pack && node scripts/copy-schema.mjs",
+    "scripts": {
+    "build": "vp pack && node scripts/copy-schema.mjs && node scripts/check-size.mjs",
     "check": "vp check README.md package.json tsconfig.json src scripts vite.config.ts && tsgo --noEmit -p tsconfig.json",
     "check:fix": "vp check --fix README.md package.json tsconfig.json src scripts vite.config.ts",
     "check:size": "node scripts/check-size.mjs",

--- a/npm/marquette/package.json
+++ b/npm/marquette/package.json
@@ -38,12 +38,12 @@
   },
   "scripts": {
     "build": "vp pack && node scripts/copy-schema.mjs",
-    "check": "vp check README.md src scripts vite.config.ts && tsgo --noEmit -p tsconfig.json",
-    "check:fix": "vp check --fix README.md src scripts vite.config.ts",
+    "check": "vp check README.md package.json tsconfig.json src scripts vite.config.ts && tsgo --noEmit -p tsconfig.json",
+    "check:fix": "vp check --fix README.md package.json tsconfig.json src scripts vite.config.ts",
     "check:size": "node scripts/check-size.mjs",
     "check:types": "tsgo --noEmit -p tsconfig.json",
     "dev": "vp pack --watch",
-    "fmt": "vp fmt --write README.md src scripts vite.config.ts",
+    "fmt": "vp fmt --write README.md package.json tsconfig.json src scripts vite.config.ts",
     "test": "vp exec tsx --test src/**/*.test.ts"
   },
   "devDependencies": {

--- a/npm/marquette/scripts/check-size.mjs
+++ b/npm/marquette/scripts/check-size.mjs
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const entryPath = path.join(packageRoot, "dist/index.mjs");
+const maximumGzipBytes = 1024;
+const gzipBytes = gzipSync(fs.readFileSync(entryPath), { level: 9 }).byteLength;
+
+if (gzipBytes > maximumGzipBytes) {
+  throw new Error(
+    `@vizejs/marquette gzip size ${gzipBytes} bytes exceeds ${maximumGzipBytes} byte budget`,
+  );
+}
+
+console.log(
+  JSON.stringify({
+    entry: "@vizejs/marquette",
+    gzipBytes,
+    maximumGzipBytes,
+  }),
+);

--- a/npm/marquette/scripts/copy-schema.mjs
+++ b/npm/marquette/scripts/copy-schema.mjs
@@ -1,0 +1,12 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const schemaSource = path.resolve(
+  packageRoot,
+  "../../crates/vize_marquette/schema/application-contract.schema.json",
+);
+const schemaOutput = path.join(packageRoot, "dist/application-contract.schema.json");
+
+fs.copyFileSync(schemaSource, schemaOutput);

--- a/npm/marquette/src/author.test.ts
+++ b/npm/marquette/src/author.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  defineApplicationMarquette,
+  type BackendId,
+  type CapabilityId,
+  type EnvironmentId,
+  type ProtocolId,
+  type RouteId,
+  type ServerEnvironmentId,
+  type TargetId,
+} from "./index.js";
+
+const marquette = defineApplicationMarquette({
+  application: "shop",
+  targets: ["web"],
+  capabilities: {
+    "auth.session": {
+      id: "auth.session",
+      description: "Authenticated application session",
+    },
+  },
+  environments: [
+    { id: "web", target: "web", consumer: "client", runtime: "browser" },
+    { id: "server", target: "web", consumer: "server", runtime: "rust" },
+  ],
+  backends: [{ id: "api", family: "rust", environment: "server" }],
+  protocols: [{ id: "api.query", family: "schema-query", backend: "api" }],
+  routes: [
+    {
+      id: "home",
+      path: "/",
+      environment: "web",
+      rendering: "hybrid",
+      backend: "api",
+      protocol: "api.query",
+      capabilities: ["auth.session"],
+    },
+  ],
+} as const);
+
+void test("preserves exact identifier unions without runtime allocation", () => {
+  const environment: EnvironmentId<typeof marquette> = "web";
+  const backend: BackendId<typeof marquette> = "api";
+  const protocol: ProtocolId<typeof marquette> = "api.query";
+  const route: RouteId<typeof marquette> = "home";
+  const server: ServerEnvironmentId<typeof marquette> = "server";
+  const target: TargetId<typeof marquette> = "web";
+  const capability: CapabilityId<typeof marquette> = "auth.session";
+
+  assert.equal(environment, "web");
+  assert.equal(backend, "api");
+  assert.equal(protocol, "api.query");
+  assert.equal(route, "home");
+  assert.equal(server, "server");
+  assert.equal(target, "web");
+  assert.equal(capability, "auth.session");
+  assert.equal(marquette.application, "shop");
+});
+
+void test("accepts self-contained environment dependency references", () => {
+  const dependent = defineApplicationMarquette({
+    application: "docs",
+    targets: ["web"],
+    environments: [
+      { id: "server", target: "web", consumer: "server", runtime: "rust" },
+      {
+        id: "web",
+        target: "web",
+        consumer: "client",
+        runtime: "browser",
+        dependsOn: ["server"],
+      },
+    ],
+  } as const);
+
+  assert.deepEqual(dependent.environments[1].dependsOn, ["server"]);
+});
+
+defineApplicationMarquette({
+  application: "invalid",
+  // @ts-expect-error Backend environments must reference an authored environment.
+  backends: [{ id: "api", family: "rust", environment: "missing" }],
+} as const);
+
+defineApplicationMarquette({
+  application: "invalid",
+  // @ts-expect-error Protocols must reference an authored backend.
+  protocols: [{ id: "api.query", family: "schema-query", backend: "missing" }],
+} as const);
+
+defineApplicationMarquette({
+  application: "invalid",
+  // @ts-expect-error Routes must reference an authored environment.
+  routes: [{ id: "home", path: "/", environment: "missing", rendering: "client" }],
+} as const);
+
+defineApplicationMarquette({
+  application: "invalid",
+  targets: ["web"],
+  // @ts-expect-error Environment targets must appear in the authored target list.
+  environments: [{ id: "native", target: "native", consumer: "client", runtime: "native" }],
+} as const);
+
+defineApplicationMarquette({
+  application: "invalid",
+  targets: ["web"],
+  capabilities: {
+    session: { id: "session", description: "Session" },
+  },
+  // @ts-expect-error Required capabilities must be declared by key.
+  environments: [
+    {
+      id: "web",
+      target: "web",
+      consumer: "client",
+      runtime: "browser",
+      capabilities: ["missing"],
+    },
+  ],
+} as const);
+
+defineApplicationMarquette({
+  application: "invalid",
+  targets: ["web"],
+  environments: [{ id: "web", target: "web", consumer: "client", runtime: "browser" }],
+  // @ts-expect-error Locally owned backends must reference a server environment.
+  backends: [{ id: "api", family: "rust", environment: "web" }],
+} as const);

--- a/npm/marquette/src/author.ts
+++ b/npm/marquette/src/author.ts
@@ -1,0 +1,69 @@
+import type {
+  ApplicationMarquette,
+  BackendId,
+  CapabilityDefinition,
+  CapabilityId,
+  EnvironmentId,
+  MarquetteBackend,
+  MarquetteEnvironment,
+  MarquetteProtocol,
+  MarquetteRoute,
+  ProtocolId,
+  ServerEnvironmentId,
+  TargetId,
+} from "./model.js";
+
+/**
+ * Cross-reference constraints derived from the literals in one marquette.
+ *
+ * Keeping this type separate makes editor diagnostics point at the authored
+ * reference instead of widening every identifier to `string`.
+ */
+export type MarquetteReferenceConstraints<Marquette extends ApplicationMarquette> = {
+  readonly capabilities?: {
+    readonly [Id in CapabilityId<Marquette>]: CapabilityDefinition & { readonly id: Id };
+  };
+  readonly environments?: readonly (MarquetteEnvironment<string, EnvironmentId<Marquette>> & {
+    readonly capabilities?: readonly CapabilityId<Marquette>[];
+    readonly target: TargetId<Marquette>;
+  })[];
+  readonly backends?: readonly (MarquetteBackend<string, ServerEnvironmentId<Marquette>> & {
+    readonly capabilities?: readonly CapabilityId<Marquette>[];
+  })[];
+  readonly protocols?: readonly (MarquetteProtocol<string, BackendId<Marquette>> & {
+    readonly capabilities?: readonly CapabilityId<Marquette>[];
+  })[];
+  readonly routes?: readonly (MarquetteRoute<
+    string,
+    EnvironmentId<Marquette>,
+    BackendId<Marquette>,
+    ProtocolId<Marquette>
+  > & { readonly capabilities?: readonly CapabilityId<Marquette>[] })[];
+};
+
+/**
+ * Defines an application marquette while preserving every authored literal.
+ *
+ * Environment dependencies, backend owners, protocol owners, and route
+ * references are checked against identifiers declared in the same object.
+ * The function returns its input without allocation or runtime work.
+ *
+ * @example
+ * ```ts
+ * const app = defineApplicationMarquette({
+ *   application: "shop",
+ *   targets: ["web"],
+ *   environments: [
+ *     { id: "web", target: "web", consumer: "client", runtime: "browser" },
+ *   ],
+ *   routes: [
+ *     { id: "home", path: "/", environment: "web", rendering: "client" },
+ *   ],
+ * });
+ * ```
+ */
+export function defineApplicationMarquette<const Marquette extends ApplicationMarquette>(
+  marquette: Marquette & MarquetteReferenceConstraints<NoInfer<Marquette>>,
+): Marquette {
+  return marquette;
+}

--- a/npm/marquette/src/index.ts
+++ b/npm/marquette/src/index.ts
@@ -1,0 +1,23 @@
+export { defineApplicationMarquette, type MarquetteReferenceConstraints } from "./author.js";
+export {
+  MARQUETTE_FORMAT_VERSION,
+  type ApplicationMarquette,
+  type BackendFamily,
+  type BackendId,
+  type CapabilityDefinition,
+  type CapabilityId,
+  type EnvironmentConsumer,
+  type EnvironmentId,
+  type MarquetteBackend,
+  type MarquetteEnvironment,
+  type MarquetteProtocol,
+  type MarquetteRoute,
+  type MarquetteTarget,
+  type ProtocolFamily,
+  type ProtocolId,
+  type RenderingMode,
+  type RouteId,
+  type RuntimeFamily,
+  type ServerEnvironmentId,
+  type TargetId,
+} from "./model.js";

--- a/npm/marquette/src/model.ts
+++ b/npm/marquette/src/model.ts
@@ -1,0 +1,260 @@
+/** Current serialized application-marquette format. */
+export const MARQUETTE_FORMAT_VERSION = 1 as const;
+
+/** User-visible target produced by an application marquette. */
+export type MarquetteTarget = "web" | "native" | "desktop" | "terminal";
+
+/** Runtime family that executes one environment. */
+export type RuntimeFamily =
+  | "browser"
+  | "javascript"
+  | "rust"
+  | "go"
+  | "jvm"
+  | "native"
+  | "desktop"
+  | "terminal"
+  | "external";
+
+/** Side of the application graph that consumes an environment. */
+export type EnvironmentConsumer = "client" | "server";
+
+/** Backend implementation family selected by an application. */
+export type BackendFamily = "javascript" | "rust" | "go" | "jvm" | "external";
+
+/** Semantic family used by one data or procedure endpoint. */
+export type ProtocolFamily = "schema-query" | "typed-rpc" | "binary-rpc";
+
+/** Rendering strategy selected for one route or target view. */
+export type RenderingMode =
+  | "client"
+  | "static"
+  | "server"
+  | "stream"
+  | "partial"
+  | "hybrid"
+  | "native"
+  | "desktop"
+  | "terminal";
+
+/** Versioned capability understood by adapters and developer tools. */
+export interface CapabilityDefinition {
+  /** Stable lowercase capability identifier. */
+  readonly id: string;
+  /** Summary shown by diagnostics, documentation, and AI tooling. */
+  readonly description: string;
+  /**
+   * Capability contract version.
+   *
+   * @default 1
+   */
+  readonly version?: number;
+}
+
+/** Independently transformed and cached application environment. */
+export interface MarquetteEnvironment<
+  Id extends string = string,
+  DependencyId extends string = string,
+> {
+  /** Stable identifier, unique within the application. */
+  readonly id: Id;
+  /** User-visible target served by this environment. */
+  readonly target: MarquetteTarget;
+  /** Whether output is consumed by an end user or a trusted runtime. */
+  readonly consumer: EnvironmentConsumer;
+  /** Runtime family that executes the output. */
+  readonly runtime: RuntimeFamily;
+  /**
+   * Authored entry module.
+   *
+   * @default undefined
+   */
+  readonly entry?: string;
+  /**
+   * Environments that must build first.
+   *
+   * @default []
+   */
+  readonly dependsOn?: readonly DependencyId[];
+  /**
+   * Capabilities required from the environment adapter.
+   *
+   * @default []
+   */
+  readonly capabilities?: readonly string[];
+}
+
+/** Backend application or independently deployed service. */
+export interface MarquetteBackend<
+  Id extends string = string,
+  EnvironmentId extends string = string,
+> {
+  /** Stable backend identifier. */
+  readonly id: Id;
+  /** Backend implementation family. */
+  readonly family: BackendFamily;
+  /**
+   * Server environment that owns local execution.
+   *
+   * @default undefined
+   */
+  readonly environment?: EnvironmentId;
+  /**
+   * Capabilities required from the backend adapter.
+   *
+   * @default []
+   */
+  readonly capabilities?: readonly string[];
+}
+
+/** Protocol endpoint exposed by a backend. */
+export interface MarquetteProtocol<Id extends string = string, BackendId extends string = string> {
+  /** Stable endpoint identifier. */
+  readonly id: Id;
+  /** Protocol semantic family. */
+  readonly family: ProtocolFamily;
+  /** Backend that owns the endpoint. */
+  readonly backend: BackendId;
+  /**
+   * Capabilities required from the protocol adapter.
+   *
+   * @default []
+   */
+  readonly capabilities?: readonly string[];
+}
+
+/** Typed application route or target view. */
+export interface MarquetteRoute<
+  Id extends string = string,
+  EnvironmentId extends string = string,
+  BackendId extends string = string,
+  ProtocolId extends string = string,
+> {
+  /** Stable identifier used by generated navigation APIs. */
+  readonly id: Id;
+  /** Logical path, always beginning with `/`. */
+  readonly path: `/${string}`;
+  /** Environment that owns the rendered route. */
+  readonly environment: EnvironmentId;
+  /** Rendering strategy used by the route. */
+  readonly rendering: RenderingMode;
+  /**
+   * Backend used by data loading, mutations, or server rendering.
+   *
+   * @default undefined
+   */
+  readonly backend?: BackendId;
+  /**
+   * Protocol endpoint used as the route data contract.
+   *
+   * @default undefined
+   */
+  readonly protocol?: ProtocolId;
+  /**
+   * Capabilities required by the route.
+   *
+   * @default []
+   */
+  readonly capabilities?: readonly string[];
+}
+
+/** Complete, versioned application marquette. */
+export interface ApplicationMarquette<
+  Environments extends readonly MarquetteEnvironment[] = readonly MarquetteEnvironment[],
+  Backends extends readonly MarquetteBackend[] = readonly MarquetteBackend[],
+  Protocols extends readonly MarquetteProtocol[] = readonly MarquetteProtocol[],
+  Routes extends readonly MarquetteRoute[] = readonly MarquetteRoute[],
+> {
+  /**
+   * Serialized contract format.
+   *
+   * @default 1
+   */
+  readonly formatVersion?: typeof MARQUETTE_FORMAT_VERSION;
+  /** Stable lowercase application identifier. */
+  readonly application: string;
+  /**
+   * User-visible application targets.
+   *
+   * @default []
+   */
+  readonly targets?: readonly MarquetteTarget[];
+  /**
+   * Versioned capability definitions keyed by identifier.
+   *
+   * @default {}
+   */
+  readonly capabilities?: Readonly<Record<string, CapabilityDefinition>>;
+  /**
+   * Independently transformed application environments.
+   *
+   * @default []
+   */
+  readonly environments?: Environments;
+  /**
+   * Backend applications and services.
+   *
+   * @default []
+   */
+  readonly backends?: Backends;
+  /**
+   * Protocol endpoints.
+   *
+   * @default []
+   */
+  readonly protocols?: Protocols;
+  /**
+   * Typed routes and target views.
+   *
+   * @default []
+   */
+  readonly routes?: Routes;
+}
+
+/** Extracts identifiers only when a collection is present in the authored object. */
+type DeclaredId<Marquette, Collection extends PropertyKey> = Marquette extends {
+  readonly [Key in Collection]: readonly { readonly id: infer Id extends string }[];
+}
+  ? Id
+  : never;
+
+/** Exact environment identifier union inferred from a marquette. */
+export type EnvironmentId<Marquette extends ApplicationMarquette> = DeclaredId<
+  Marquette,
+  "environments"
+>;
+
+/** Exact server-owned environment identifier union inferred from a marquette. */
+export type ServerEnvironmentId<Marquette extends ApplicationMarquette> = Marquette extends {
+  readonly environments: readonly (infer Environment)[];
+}
+  ? Environment extends {
+      readonly consumer: "server";
+      readonly id: infer Id extends string;
+    }
+    ? Id
+    : never
+  : never;
+
+/** Exact backend identifier union inferred from a marquette. */
+export type BackendId<Marquette extends ApplicationMarquette> = DeclaredId<Marquette, "backends">;
+
+/** Exact protocol identifier union inferred from a marquette. */
+export type ProtocolId<Marquette extends ApplicationMarquette> = DeclaredId<Marquette, "protocols">;
+
+/** Exact route identifier union inferred from a marquette. */
+export type RouteId<Marquette extends ApplicationMarquette> = DeclaredId<Marquette, "routes">;
+
+/** Exact target union inferred from the authored target list. */
+export type TargetId<Marquette extends ApplicationMarquette> = Marquette extends {
+  readonly targets: readonly (infer Target extends MarquetteTarget)[];
+}
+  ? Target
+  : never;
+
+/** Exact capability identifier union inferred from authored capability keys. */
+export type CapabilityId<Marquette extends ApplicationMarquette> = Marquette extends {
+  readonly capabilities: Readonly<Record<infer Id extends string, CapabilityDefinition>>;
+}
+  ? Id
+  : never;

--- a/npm/marquette/tsconfig.json
+++ b/npm/marquette/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noUncheckedIndexedAccess": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node"],
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/npm/marquette/vite.config.ts
+++ b/npm/marquette/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  lint: {
+    ignorePatterns: ["dist/**"],
+    options: {
+      typeAware: true,
+    },
+  },
+  fmt: {
+    ignorePatterns: ["dist/**"],
+  },
+  pack: {
+    entry: ["src/index.ts"],
+    format: "esm",
+    dts: true,
+    clean: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,6 +423,24 @@ importers:
         specifier: catalog:vue-stable
         version: 3.5.35(typescript@6.0.3)
 
+  npm/marquette:
+    devDependencies:
+      '@types/node':
+        specifier: catalog:typescript
+        version: 25.9.2
+      '@typescript/native-preview':
+        specifier: catalog:typescript
+        version: 7.0.0-dev.20260602.1
+      tsx:
+        specifier: catalog:typescript
+        version: 4.22.4
+      typescript:
+        specifier: catalog:typescript
+        version: 6.0.3
+      vite-plus:
+        specifier: catalog:vite-stack
+        version: 0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)
+
   npm/mcp-musea:
     dependencies:
       '@modelcontextprotocol/sdk':

--- a/tests/tooling/release-package-versions.test.ts
+++ b/tests/tooling/release-package-versions.test.ts
@@ -15,6 +15,7 @@ const releasePackageJsonPaths = [
   "npm/fresco-native/package.json",
   "npm/framework/musea-nuxt/package.json",
   "npm/framework/nuxt/package.json",
+  "npm/marquette/package.json",
   "npm/mcp-musea/package.json",
   "npm/native/package.json",
   "npm/oxint/package.json",

--- a/tests/tooling/release-preflight-runner.test.ts
+++ b/tests/tooling/release-preflight-runner.test.ts
@@ -103,6 +103,7 @@ test("release metadata inventory discovers every non-private npm and editor pack
       "npm/framework/nuxt/package.json",
       "npm/fresco-native/package.json",
       "npm/fresco/package.json",
+      "npm/marquette/package.json",
       "npm/mcp-musea/package.json",
       "npm/native/package.json",
       "npm/oxint/package.json",

--- a/tools/vite-plus/task-inputs.ts
+++ b/tools/vite-plus/task-inputs.ts
@@ -21,6 +21,7 @@ export const checkedPackages = [
   "./npm/framework/musea-nuxt",
   "./npm/mcp-musea",
   "./npm/fresco",
+  "./npm/marquette",
   "./npm/builder/vite/example",
   "./npm/builder/rspack/example",
   "./examples/vite-musea",
@@ -63,6 +64,7 @@ export const packedPackages = [
   "./npm/framework/musea-nuxt",
   "./npm/mcp-musea",
   "./npm/fresco",
+  "./npm/marquette",
 ] satisfies PackagePath[];
 
 export const testedPackages = [
@@ -73,6 +75,7 @@ export const testedPackages = [
   "./npm/builder/rspack",
   "./npm/framework/nuxt",
   "./npm/mcp-musea",
+  "./npm/marquette",
 ] satisfies PackagePath[];
 
 export const floatingPromiseTestPatterns = ["tests/**/*.ts"];


### PR DESCRIPTION
## Summary

- add the `@vizejs/marquette` package with literal-preserving application authoring
- infer and validate target, capability, environment, backend, protocol, and route references at compile time
- publish the shared application schema and document every optional-field default
- wire package checks, tests, builds, and a 1 KiB gzip budget into workspace quality gates

Part of #3131.

## Verification

- package type check
- package runtime tests
- package lint and format check
- package production build
- package gzip budget: 523 bytes / 1,024 bytes
- workspace manifest policy tests
- workspace task wiring tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `@vizejs/marquette` package for defining typed application contracts.
  - Added support for describing environments, backends, protocols, routes, targets, and capabilities.
  - Added compile-time validation for references and identifier values.
  - Added a schema export for application contract validation.

- **Documentation**
  - Added package documentation with usage examples, guarantees, and format guidance.

- **Tests**
  - Added coverage for valid definitions and invalid cross-references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->