### PR TITLE
feat(marquette): add deterministic runtime validation

### DIFF
--- a/npm/marquette/README.md
+++ b/npm/marquette/README.md
@@ -99,7 +99,8 @@ code.
 - The published application-contract schema is available from
   `@vizejs/marquette/schema`.
 - Every optional contract field documents its default in JSDoc.
-- Package builds enforce a 1 KiB gzip budget for the runtime entry.
+- Package builds enforce a 1 KiB gzip budget for authoring and a 3 KiB budget
+  for runtime validation.
 
 Marquette describes components and environments; it does not author UI
 components. Public Vize UI components use real `.vue` SFC files as their

--- a/npm/marquette/README.md
+++ b/npm/marquette/README.md
@@ -7,9 +7,9 @@ Typed application marquettes for every Vize target.
 
 Marquette is the small, language-neutral description shared by web, native,
 desktop, terminal, backend, transport, testing, and gallery tooling. This
-package provides literal-preserving TypeScript authoring. Runtime validation,
-canonicalization, and compatibility analysis are delivered as separate,
-focused layers.
+package provides literal-preserving TypeScript authoring. Runtime validation is
+available through a separate entry, while canonicalization and compatibility
+analysis remain focused layers.
 
 ## Author a marquette
 
@@ -70,6 +70,25 @@ Environment dependencies, backend owners, protocol owners, and route
 references are checked against identifiers declared in the same object. A
 misspelled reference is therefore an authoring error rather than a runtime
 surprise.
+
+## Runtime validation
+
+Use the dedicated validation entry when contracts cross file, process, or
+language boundaries:
+
+```ts
+import { validateApplicationMarquette } from "@vizejs/marquette/validate";
+
+const diagnostics = validateApplicationMarquette(shop);
+for (const diagnostic of diagnostics) {
+  console.error(diagnostic.code, diagnostic.path, diagnostic.message);
+}
+```
+
+Validation is deterministic, does not mutate the authored object, and reports
+stable codes shared with the native contract implementation. Keeping it in a
+separate entry means authoring-only applications do not include validation
+code.
 
 ## Guarantees
 

--- a/npm/marquette/package.json
+++ b/npm/marquette/package.json
@@ -31,6 +31,11 @@
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
     },
+    "./validate": {
+      "types": "./dist/validate.d.mts",
+      "import": "./dist/validate.mjs",
+      "default": "./dist/validate.mjs"
+    },
     "./schema": "./dist/application-contract.schema.json"
   },
   "publishConfig": {

--- a/npm/marquette/scripts/check-size.mjs
+++ b/npm/marquette/scripts/check-size.mjs
@@ -4,20 +4,25 @@ import { fileURLToPath } from "node:url";
 import { gzipSync } from "node:zlib";
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const entryPath = path.join(packageRoot, "dist/index.mjs");
-const maximumGzipBytes = 1024;
-const gzipBytes = gzipSync(fs.readFileSync(entryPath), { level: 9 }).byteLength;
+const budgets = [
+  { entry: "@vizejs/marquette", file: "dist/index.mjs", maximumGzipBytes: 1024 },
+  {
+    entry: "@vizejs/marquette/validate",
+    file: "dist/validate.mjs",
+    maximumGzipBytes: 3072,
+  },
+];
 
-if (gzipBytes > maximumGzipBytes) {
-  throw new Error(
-    `@vizejs/marquette gzip size ${gzipBytes} bytes exceeds ${maximumGzipBytes} byte budget`,
-  );
+for (const { entry, file, maximumGzipBytes } of budgets) {
+  const gzipBytes = gzipSync(fs.readFileSync(path.join(packageRoot, file)), {
+    level: 9,
+  }).byteLength;
+
+  if (gzipBytes > maximumGzipBytes) {
+    throw new Error(
+      `${entry} gzip size ${gzipBytes} bytes exceeds ${maximumGzipBytes} byte budget`,
+    );
+  }
+
+  console.log(JSON.stringify({ entry, gzipBytes, maximumGzipBytes }));
 }
-
-console.log(
-  JSON.stringify({
-    entry: "@vizejs/marquette",
-    gzipBytes,
-    maximumGzipBytes,
-  }),
-);

--- a/npm/marquette/src/validate.test.ts
+++ b/npm/marquette/src/validate.test.ts
@@ -147,6 +147,26 @@ void test("returns diagnostics in stable path, code, and message order", () => {
   );
 });
 
+void test("normalizes set-backed references before producing diagnostics", () => {
+  const diagnostics = validateApplicationMarquette({
+    application: "deduplicated",
+    targets: ["web"],
+    environments: [
+      {
+        id: "server",
+        target: "web",
+        consumer: "server",
+        runtime: "javascript",
+        dependsOn: ["missing", "missing"],
+        capabilities: ["missing", "missing"],
+      },
+    ],
+  });
+
+  assert.equal(diagnostics.filter(({ code }) => code === "VIZE_MARQUETTE_009").length, 1);
+  assert.equal(diagnostics.filter(({ code }) => code === "VIZE_MARQUETTE_021").length, 1);
+});
+
 void test("covers every stable validation diagnostic", () => {
   const marquette = {
     formatVersion: 2,

--- a/npm/marquette/src/validate.test.ts
+++ b/npm/marquette/src/validate.test.ts
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+import type { ApplicationMarquette } from "./model.js";
+import { validateApplicationMarquette } from "./validate.js";
+
+const fixture = (name: string) =>
+  new URL(`../../../tests/fixtures/marquette/${name}`, import.meta.url);
+
+void test("accepts the shared cross-language marquette fixture", async () => {
+  const marquette = JSON.parse(
+    await readFile(fixture("valid.json"), "utf8"),
+  ) as ApplicationMarquette;
+
+  assert.deepEqual(validateApplicationMarquette(marquette), []);
+});
+
+void test("matches shared invalid diagnostic-code fixtures", async () => {
+  const marquette = JSON.parse(
+    await readFile(fixture("invalid.json"), "utf8"),
+  ) as ApplicationMarquette;
+  const expected = JSON.parse(await readFile(fixture("invalid.expected.json"), "utf8")) as string[];
+
+  assert.deepEqual(
+    validateApplicationMarquette(marquette).map((diagnostic) => diagnostic.code),
+    expected,
+  );
+});
+
+void test("reports empty descriptions and identifies the previous duplicate route", () => {
+  const diagnostics = validateApplicationMarquette({
+    application: "shop",
+    targets: ["web"],
+    capabilities: {
+      "auth.session": {
+        id: "auth.session",
+        description: "   ",
+      },
+    },
+    environments: [
+      {
+        id: "browser",
+        target: "web",
+        consumer: "client",
+        runtime: "browser",
+      },
+    ],
+    routes: [
+      {
+        id: "home",
+        path: "/",
+        environment: "browser",
+        rendering: "client",
+      },
+      {
+        id: "landing",
+        path: "/",
+        environment: "browser",
+        rendering: "client",
+      },
+    ],
+  });
+
+  assert.ok(
+    diagnostics.some(
+      (diagnostic) =>
+        diagnostic.code === "VIZE_MARQUETTE_024" &&
+        diagnostic.message === "capability description must not be empty",
+    ),
+  );
+  assert.ok(
+    diagnostics.some(
+      (diagnostic) =>
+        diagnostic.code === "VIZE_MARQUETTE_019" &&
+        diagnostic.message === 'route path is already used by route "home"',
+    ),
+  );
+});
+
+void test("reports cycles, incompatible rendering, capabilities, and suspicious runtimes", () => {
+  const diagnostics = validateApplicationMarquette({
+    application: "workbench",
+    targets: ["web", "native"],
+    environments: [
+      {
+        id: "first",
+        target: "web",
+        consumer: "client",
+        runtime: "rust",
+        dependsOn: ["second"],
+        capabilities: ["missing"],
+      },
+      {
+        id: "second",
+        target: "web",
+        consumer: "server",
+        runtime: "javascript",
+        dependsOn: ["first"],
+      },
+    ],
+    routes: [
+      {
+        id: "home",
+        path: "/",
+        environment: "first",
+        rendering: "native",
+      },
+    ],
+  });
+  const codes = new Set(diagnostics.map((diagnostic) => diagnostic.code));
+
+  assert.ok(codes.has("VIZE_MARQUETTE_010"));
+  assert.ok(codes.has("VIZE_MARQUETTE_020"));
+  assert.ok(codes.has("VIZE_MARQUETTE_021"));
+  assert.ok(codes.has("VIZE_MARQUETTE_022"));
+  assert.ok(codes.has("VIZE_MARQUETTE_023"));
+});
+
+void test("returns diagnostics in stable path, code, and message order", () => {
+  const marquette: ApplicationMarquette = {
+    application: "Broken App",
+    targets: ["web"],
+    environments: [
+      {
+        id: "client",
+        target: "native",
+        consumer: "client",
+        runtime: "browser",
+        dependsOn: ["missing"],
+      },
+    ],
+  };
+
+  assert.deepEqual(
+    validateApplicationMarquette(marquette),
+    validateApplicationMarquette(structuredClone(marquette)),
+  );
+  assert.deepEqual(
+    validateApplicationMarquette(marquette).map(({ path, code }) => [path, code]),
+    [
+      ["application", "VIZE_MARQUETTE_002"],
+      ["environments.client", "VIZE_MARQUETTE_007"],
+      ["environments.client", "VIZE_MARQUETTE_009"],
+      ["targets", "VIZE_MARQUETTE_020"],
+    ],
+  );
+});
+
+void test("covers every stable validation diagnostic", () => {
+  const marquette = {
+    formatVersion: 2,
+    application: "Broken App",
+    targets: ["native"],
+    capabilities: {
+      "Bad Key": {
+        id: "different",
+        description: "",
+        version: 0,
+      },
+    },
+    environments: [
+      {
+        id: "client",
+        target: "web",
+        consumer: "client",
+        runtime: "rust",
+        dependsOn: ["server", "missing"],
+        capabilities: ["missing"],
+      },
+      {
+        id: "server",
+        target: "web",
+        consumer: "server",
+        runtime: "javascript",
+        dependsOn: ["client"],
+      },
+      {
+        id: "self",
+        target: "web",
+        consumer: "server",
+        runtime: "javascript",
+        dependsOn: ["self"],
+      },
+    ],
+    backends: [
+      {
+        id: "missing-owner",
+        family: "external",
+        environment: "missing",
+        capabilities: ["missing"],
+      },
+      { id: "client-owner", family: "external", environment: "client" },
+      { id: "api-a", family: "external" },
+      { id: "api-b", family: "external" },
+    ],
+    protocols: [
+      { id: "orphan", family: "schema-query", backend: "missing" },
+      { id: "api.query", family: "schema-query", backend: "api-a" },
+    ],
+    routes: [
+      {
+        id: "broken",
+        path: "broken",
+        environment: "missing",
+        rendering: "native",
+        backend: "missing",
+        protocol: "missing",
+        capabilities: ["missing"],
+      },
+      {
+        id: "mismatch",
+        path: "/",
+        environment: "client",
+        rendering: "native",
+        backend: "api-b",
+        protocol: "api.query",
+      },
+      {
+        id: "mismatch",
+        path: "/",
+        environment: "client",
+        rendering: "client",
+      },
+    ],
+  } as unknown as ApplicationMarquette;
+
+  assert.deepEqual(
+    [...new Set(validateApplicationMarquette(marquette).map(({ code }) => code))].sort(),
+    Array.from(
+      { length: 24 },
+      (_, index) => `VIZE_MARQUETTE_${String(index + 1).padStart(3, "0")}`,
+    ),
+  );
+});

--- a/npm/marquette/src/validate.ts
+++ b/npm/marquette/src/validate.ts
@@ -1,0 +1,326 @@
+import type {
+  ApplicationMarquette,
+  MARQUETTE_FORMAT_VERSION,
+  MarquetteEnvironment,
+  MarquetteRoute,
+  MarquetteTarget,
+  RenderingMode,
+} from "./model.js";
+
+/** Severity of an application-marquette diagnostic. */
+export type MarquetteDiagnosticSeverity = "error" | "warning";
+
+/** Stable, source-addressable application-marquette diagnostic. */
+export interface MarquetteDiagnostic {
+  /** Stable machine-readable diagnostic code. */
+  readonly code: `VIZE_MARQUETTE_${string}`;
+  /** Severity used by CLI, editor, test, and CI consumers. */
+  readonly severity: MarquetteDiagnosticSeverity;
+  /** JSON-style path into the authored marquette. */
+  readonly path: string;
+  /** Human-readable explanation and next action. */
+  readonly message: string;
+}
+
+const IDENTIFIER = /^[a-z0-9][a-z0-9._-]*$/;
+const SUPPORTED_FORMAT_VERSION: typeof MARQUETTE_FORMAT_VERSION = 1;
+
+/**
+ * Validates a complete application marquette.
+ *
+ * Diagnostics cover structural, reference, capability, target, and dependency
+ * invariants. Results are sorted by path, code, and message so identical input
+ * produces stable editor, CLI, test, and CI output.
+ *
+ * This function does not mutate the authored object and does not throw.
+ */
+export function validateApplicationMarquette(
+  marquette: ApplicationMarquette,
+): MarquetteDiagnostic[] {
+  const diagnostics: MarquetteDiagnostic[] = [];
+  const environments = marquette.environments ?? [];
+  const backends = marquette.backends ?? [];
+  const protocols = marquette.protocols ?? [];
+  const routes = marquette.routes ?? [];
+  const targets = new Set(marquette.targets ?? []);
+  const capabilityIds = new Set(Object.keys(marquette.capabilities ?? {}));
+
+  if ((marquette.formatVersion ?? SUPPORTED_FORMAT_VERSION) !== SUPPORTED_FORMAT_VERSION) {
+    diagnostics.push(
+      error("VIZE_MARQUETTE_001", "formatVersion", "unsupported marquette format version"),
+    );
+  }
+
+  validateIdentifier(marquette.application, "application", "VIZE_MARQUETTE_002", diagnostics);
+
+  for (const [key, capability] of Object.entries(marquette.capabilities ?? {})) {
+    const path = contractPath("capabilities", key);
+    validateIdentifier(key, path, "VIZE_MARQUETTE_003", diagnostics);
+    if (key !== capability.id) {
+      diagnostics.push(
+        error("VIZE_MARQUETTE_004", path, "capability map key must equal capability.id"),
+      );
+    }
+    const version = capability.version ?? 1;
+    if (!Number.isInteger(version) || version < 1) {
+      diagnostics.push(
+        error("VIZE_MARQUETTE_005", path, "capability version must be greater than zero"),
+      );
+    }
+    if (capability.description.trim().length === 0) {
+      diagnostics.push(
+        error("VIZE_MARQUETTE_024", path, "capability description must not be empty"),
+      );
+    }
+  }
+
+  const environmentIds = collectUniqueIds("environments", environments, diagnostics);
+  const backendIds = collectUniqueIds("backends", backends, diagnostics);
+  const protocolIds = collectUniqueIds("protocols", protocols, diagnostics);
+  collectUniqueIds("routes", routes, diagnostics);
+
+  for (const environment of environments) {
+    const path = contractPath("environments", environment.id);
+    if (!targets.has(environment.target)) {
+      diagnostics.push(
+        error("VIZE_MARQUETTE_007", path, "environment target must be declared in targets"),
+      );
+    }
+    for (const dependency of environment.dependsOn ?? []) {
+      if (dependency === environment.id) {
+        diagnostics.push(error("VIZE_MARQUETTE_008", path, "environment cannot depend on itself"));
+      } else if (!environmentIds.has(dependency)) {
+        diagnostics.push(
+          error("VIZE_MARQUETTE_009", path, "environment dependency does not exist"),
+        );
+      }
+    }
+    validateCapabilities(path, environment.capabilities, capabilityIds, diagnostics);
+
+    if (
+      environment.consumer === "client" &&
+      (environment.runtime === "rust" ||
+        environment.runtime === "go" ||
+        environment.runtime === "jvm")
+    ) {
+      diagnostics.push(
+        warning(
+          "VIZE_MARQUETTE_010",
+          path,
+          "client environment uses a server-oriented runtime; declare an adapter capability if this is intentional",
+        ),
+      );
+    }
+  }
+
+  validateEnvironmentCycles(environments, diagnostics);
+
+  for (const backend of backends) {
+    const path = contractPath("backends", backend.id);
+    if (backend.environment != null) {
+      const environment = environments.find((candidate) => candidate.id === backend.environment);
+      if (environment == null) {
+        diagnostics.push(error("VIZE_MARQUETTE_011", path, "backend environment does not exist"));
+      } else if (environment.consumer !== "server") {
+        diagnostics.push(
+          error("VIZE_MARQUETTE_012", path, "backend environment must be a server consumer"),
+        );
+      }
+    }
+    validateCapabilities(path, backend.capabilities, capabilityIds, diagnostics);
+  }
+
+  for (const protocol of protocols) {
+    const path = contractPath("protocols", protocol.id);
+    if (!backendIds.has(protocol.backend)) {
+      diagnostics.push(error("VIZE_MARQUETTE_013", path, "protocol backend does not exist"));
+    }
+    validateCapabilities(path, protocol.capabilities, capabilityIds, diagnostics);
+  }
+
+  const routePaths = new Map<string, string>();
+  for (const route of routes) {
+    const path = contractPath("routes", route.id);
+    if (!route.path.startsWith("/")) {
+      diagnostics.push(error("VIZE_MARQUETTE_014", path, "route path must start with /"));
+    }
+    const environment = environments.find((candidate) => candidate.id === route.environment);
+    if (environment == null) {
+      diagnostics.push(error("VIZE_MARQUETTE_015", path, "route environment does not exist"));
+    }
+    if (route.backend != null && !backendIds.has(route.backend)) {
+      diagnostics.push(error("VIZE_MARQUETTE_016", path, "route backend does not exist"));
+    }
+    if (route.protocol != null) {
+      const protocol = protocols.find((candidate) => candidate.id === route.protocol);
+      if (!protocolIds.has(route.protocol) || protocol == null) {
+        diagnostics.push(error("VIZE_MARQUETTE_017", path, "route protocol does not exist"));
+      } else if (route.backend != null && protocol.backend !== route.backend) {
+        diagnostics.push(
+          error(
+            "VIZE_MARQUETTE_018",
+            path,
+            "route protocol and backend must refer to the same service",
+          ),
+        );
+      }
+    }
+    if (environment != null && !renderingMatchesTarget(route, environment.target)) {
+      diagnostics.push(
+        error(
+          "VIZE_MARQUETTE_023",
+          path,
+          "rendering mode is not compatible with the route environment target",
+        ),
+      );
+    }
+    validateCapabilities(path, route.capabilities, capabilityIds, diagnostics);
+
+    const routeKey = `${route.environment}\u0000${route.path}`;
+    const previous = routePaths.get(routeKey);
+    if (previous != null) {
+      diagnostics.push(
+        error("VIZE_MARQUETTE_019", path, `route path is already used by route "${previous}"`),
+      );
+    }
+    routePaths.set(routeKey, route.id);
+  }
+
+  for (const target of targets) {
+    if (!environments.some((environment) => environment.target === target)) {
+      diagnostics.push(
+        warning("VIZE_MARQUETTE_020", "targets", "declared target has no environment"),
+      );
+    }
+  }
+
+  return diagnostics.sort(compareDiagnostics);
+}
+
+function collectUniqueIds(
+  collection: string,
+  values: readonly { readonly id: string }[],
+  diagnostics: MarquetteDiagnostic[],
+): Set<string> {
+  const ids = new Set<string>();
+  for (const value of values) {
+    const path = contractPath(collection, value.id);
+    validateIdentifier(value.id, path, "VIZE_MARQUETTE_006", diagnostics);
+    if (ids.has(value.id)) {
+      diagnostics.push(
+        error("VIZE_MARQUETTE_006", path, "identifier must be unique within its collection"),
+      );
+    }
+    ids.add(value.id);
+  }
+  return ids;
+}
+
+function validateIdentifier(
+  id: string,
+  path: string,
+  code: `VIZE_MARQUETTE_${string}`,
+  diagnostics: MarquetteDiagnostic[],
+): void {
+  if (!IDENTIFIER.test(id)) {
+    diagnostics.push(
+      error(
+        code,
+        path,
+        "identifier must use lowercase ASCII letters, digits, dash, underscore, or dot",
+      ),
+    );
+  }
+}
+
+function validateCapabilities(
+  path: string,
+  capabilities: readonly string[] | undefined,
+  declared: ReadonlySet<string>,
+  diagnostics: MarquetteDiagnostic[],
+): void {
+  for (const capability of capabilities ?? []) {
+    if (!declared.has(capability)) {
+      diagnostics.push(error("VIZE_MARQUETTE_021", path, "referenced capability is not declared"));
+    }
+  }
+}
+
+function validateEnvironmentCycles(
+  environments: readonly MarquetteEnvironment[],
+  diagnostics: MarquetteDiagnostic[],
+): void {
+  const graph = new Map(environments.map((value) => [value.id, value.dependsOn ?? []]));
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+
+  for (const id of [...graph.keys()].sort()) {
+    if (hasCycle(id, graph, visiting, visited)) {
+      diagnostics.push(
+        error(
+          "VIZE_MARQUETTE_022",
+          contractPath("environments", id),
+          "environment dependency graph must be acyclic",
+        ),
+      );
+    }
+  }
+}
+
+function hasCycle(
+  id: string,
+  graph: ReadonlyMap<string, readonly string[]>,
+  visiting: Set<string>,
+  visited: Set<string>,
+): boolean {
+  if (visited.has(id)) return false;
+  if (visiting.has(id)) return true;
+  visiting.add(id);
+  const cyclic = [...(graph.get(id) ?? [])]
+    .sort()
+    .some((dependency) => graph.has(dependency) && hasCycle(dependency, graph, visiting, visited));
+  visiting.delete(id);
+  visited.add(id);
+  return cyclic;
+}
+
+function renderingMatchesTarget(route: MarquetteRoute, target: MarquetteTarget): boolean {
+  const targetRendering: Partial<Record<RenderingMode, MarquetteTarget>> = {
+    native: "native",
+    desktop: "desktop",
+    terminal: "terminal",
+  };
+  return (targetRendering[route.rendering] ?? "web") === target;
+}
+
+function compareDiagnostics(left: MarquetteDiagnostic, right: MarquetteDiagnostic): number {
+  return (
+    compareText(left.path, right.path) ||
+    compareText(left.code, right.code) ||
+    compareText(left.message, right.message)
+  );
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function contractPath(collection: string, id: string): string {
+  return `${collection}.${id}`;
+}
+
+function error(
+  code: `VIZE_MARQUETTE_${string}`,
+  path: string,
+  message: string,
+): MarquetteDiagnostic {
+  return { code, severity: "error", path, message };
+}
+
+function warning(
+  code: `VIZE_MARQUETTE_${string}`,
+  path: string,
+  message: string,
+): MarquetteDiagnostic {
+  return { code, severity: "warning", path, message };
+}

--- a/npm/marquette/src/validate.ts
+++ b/npm/marquette/src/validate.ts
@@ -86,7 +86,7 @@ export function validateApplicationMarquette(
         error("VIZE_MARQUETTE_007", path, "environment target must be declared in targets"),
       );
     }
-    for (const dependency of environment.dependsOn ?? []) {
+    for (const dependency of [...new Set(environment.dependsOn ?? [])].sort()) {
       if (dependency === environment.id) {
         diagnostics.push(error("VIZE_MARQUETTE_008", path, "environment cannot depend on itself"));
       } else if (!environmentIds.has(dependency)) {
@@ -239,7 +239,7 @@ function validateCapabilities(
   declared: ReadonlySet<string>,
   diagnostics: MarquetteDiagnostic[],
 ): void {
-  for (const capability of capabilities ?? []) {
+  for (const capability of [...new Set(capabilities ?? [])].sort()) {
     if (!declared.has(capability)) {
       diagnostics.push(error("VIZE_MARQUETTE_021", path, "referenced capability is not declared"));
     }

--- a/npm/marquette/vite.config.ts
+++ b/npm/marquette/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     ignorePatterns: ["dist/**"],
   },
   pack: {
-    entry: ["src/index.ts"],
+    entry: ["src/index.ts", "src/validate.ts"],
     format: "esm",
     dts: true,
     clean: true,


### PR DESCRIPTION
## Summary

- add deterministic runtime validation for structural, reference, capability, target, rendering, and dependency invariants
- publish validation through a dedicated subpath so authoring-only applications retain the zero-allocation 523-byte gzip entry
- keep all 24 stable diagnostic codes aligned with the native contract implementation
- identify the previous route in duplicate-path diagnostics
- document validation behavior and its production-size isolation

## Verification

- package formatting, linting, and declaration checks
- 8 package tests, including shared cross-language fixtures and complete diagnostic-code coverage
- package build and 1 KiB authoring-entry budget
- built validation-subpath smoke test
- 26 repository package, task, and release metadata tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->