### PR TITLE
feat(doctor): add health finding contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3685,6 +3685,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vize_doctor"
+version = "0.298.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "vize_carton",
+]
+
+[[package]]
 name = "vize_fresco"
 version = "0.298.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   "crates/vize_curator",
   "crates/vize_fresco",
   "crates/vize_marquette",
+  "crates/vize_doctor",
   "tests/vize_test_runner",
 ]
 
@@ -50,6 +51,7 @@ vize_patina = { path = "crates/vize_patina", version = "=0.298.0" }
 vize_canon = { path = "crates/vize_canon", version = "=0.298.0", default-features = false }
 vize_fresco = { path = "crates/vize_fresco", version = "=0.298.0", default-features = false }
 vize_marquette = { path = "crates/vize_marquette", version = "=0.298.0" }
+vize_doctor = { path = "crates/vize_doctor", version = "=0.298.0" }
 
 # Workspace-only internal crates (always use the local path)
 vize_vitrine = { path = "crates/vize_vitrine", default-features = false }

--- a/crates/vize_doctor/Cargo.toml
+++ b/crates/vize_doctor/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "vize_doctor"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Whole-application health analysis contracts for Vize"
+metadata.vize.stability = "experimental"
+
+[dependencies]
+serde.workspace = true
+vize_carton.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/vize_doctor/README.md
+++ b/crates/vize_doctor/README.md
@@ -1,0 +1,48 @@
+# vize_doctor
+
+`vize_doctor` defines the versioned contracts for Vize whole-application health
+analysis. It gives analyzers, the CLI, editors, CI, Musea, and automated tooling
+one deterministic representation for findings, evidence, fixes, provenance,
+and health assessments.
+
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
+## Guarantees
+
+- authored source spans remain attached to primary and related evidence;
+- severity, confidence, impact, fix safety, and analysis cost are explicit;
+- contracts use language-neutral serialization;
+- findings contain no timestamps or process-specific values.
+
+## Example
+
+```rust
+use vize_doctor::{
+    AnalysisProvenance, DoctorCategory, DoctorFinding, FindingAssessment,
+    FindingConfidence, FindingImpact, FindingSeverity, HealthPenalty,
+    RuleCost, SourceLocation,
+};
+
+let finding = DoctorFinding::new(
+    "VIZE_DOCTOR_REACTIVITY_001",
+    DoctorCategory::Correctness,
+    FindingAssessment::new(
+        FindingSeverity::Error,
+        FindingConfidence::Certain,
+        FindingImpact::High,
+        HealthPenalty::new(30, "Proven stale state read"),
+    ),
+    SourceLocation::new("src/Counter.vue", 120, 132),
+    "State is read outside its reactive owner",
+    "Move the read into the derived computation that owns the dependency.",
+    AnalysisProvenance::new("reactivity-graph", RuleCost::Low),
+);
+
+assert_eq!(finding.code, "VIZE_DOCTOR_REACTIVITY_001");
+assert_eq!(finding.primary.path, "src/Counter.vue");
+```
+
+## License
+
+MIT

--- a/crates/vize_doctor/src/lib.rs
+++ b/crates/vize_doctor/src/lib.rs
@@ -1,0 +1,54 @@
+#![deny(missing_docs)]
+
+//! Whole-application health analysis contracts for Vize.
+//!
+//! **Experimental:** report serialization is versioned, but rule and scoring
+//! APIs may evolve while the doctor integrates every Vize analysis graph.
+//!
+//! `vize_doctor` defines the stable finding, evidence, fix, provenance, and
+//! health-assessment contracts shared by the CLI, editor, CI, Musea, framework,
+//! and AI consumers. Analyzer crates produce findings through these types
+//! instead of inventing reporter-specific diagnostics.
+//!
+//! # Design guarantees
+//!
+//! - Findings preserve primary and related authored source spans.
+//! - Severity, confidence, impact, fix safety, and analysis cost are explicit.
+//! - Serialized property and enum names are language-neutral and versioned.
+//! - Findings contain no timestamps or process-specific values.
+//!
+//! # Example
+//!
+//! ```
+//! use vize_doctor::{
+//!     AnalysisProvenance, DoctorCategory, DoctorFinding, FindingAssessment,
+//!     FindingConfidence, FindingImpact, FindingSeverity, HealthPenalty,
+//!     RuleCost, SourceLocation,
+//! };
+//!
+//! let finding = DoctorFinding::new(
+//!     "VIZE_DOCTOR_REACTIVITY_001",
+//!     DoctorCategory::Correctness,
+//!     FindingAssessment::new(
+//!         FindingSeverity::Error,
+//!         FindingConfidence::Certain,
+//!         FindingImpact::High,
+//!         HealthPenalty::new(30, "Proven stale state read"),
+//!     ),
+//!     SourceLocation::new("src/Counter.vue", 120, 132),
+//!     "State is read outside its reactive owner",
+//!     "Move the read into the derived computation that owns the dependency.",
+//!     AnalysisProvenance::new("reactivity-graph", RuleCost::Low),
+//! );
+//! assert_eq!(finding.code, "VIZE_DOCTOR_REACTIVITY_001");
+//! assert_eq!(finding.primary.path, "src/Counter.vue");
+//! ```
+
+mod model;
+
+pub use model::{
+    AnalysisProvenance, DoctorCategory, DoctorFinding, EvidenceKind, FindingAssessment,
+    FindingConfidence, FindingContext, FindingEvidence, FindingFix, FindingImpact, FindingSeverity,
+    FixSafety, HealthPenalty, RelatedLocation, RuleCost, SourceLocation, SuppressionPolicy,
+    TextEdit,
+};

--- a/crates/vize_doctor/src/model.rs
+++ b/crates/vize_doctor/src/model.rs
@@ -1,0 +1,12 @@
+mod assessment;
+mod evidence;
+mod finding;
+
+pub use assessment::{
+    DoctorCategory, EvidenceKind, FindingAssessment, FindingConfidence, FindingImpact,
+    FindingSeverity, FixSafety, HealthPenalty, RuleCost, SuppressionPolicy,
+};
+pub use evidence::{
+    AnalysisProvenance, FindingContext, FindingEvidence, RelatedLocation, SourceLocation, TextEdit,
+};
+pub use finding::{DoctorFinding, FindingFix};

--- a/crates/vize_doctor/src/model/assessment.rs
+++ b/crates/vize_doctor/src/model/assessment.rs
@@ -1,0 +1,188 @@
+use serde::{Deserialize, Serialize};
+use vize_carton::String;
+
+/// Health category used for reporting, scoring, ownership, and policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DoctorCategory {
+    /// SFC, type, control-flow, reactivity, and contract correctness.
+    Correctness,
+    /// Semantic, keyboard, focus, assistive, locale, and modality support.
+    Accessibility,
+    /// Build, output, startup, rendering, memory, and interaction performance.
+    Performance,
+    /// Architecture, ownership, documentation, complexity, and extension health.
+    Maintainability,
+    /// Trust boundaries, unsafe data flow, permissions, and exploitable behavior.
+    Security,
+    /// Deployment, observability, lifecycle, resilience, and operational health.
+    ProductionReadiness,
+}
+
+impl DoctorCategory {
+    /// All score categories in stable serialized order.
+    pub const ALL: [Self; 6] = [
+        Self::Correctness,
+        Self::Accessibility,
+        Self::Performance,
+        Self::Maintainability,
+        Self::Security,
+        Self::ProductionReadiness,
+    ];
+}
+
+/// Whether a finding prevents success or guides a non-blocking improvement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FindingSeverity {
+    /// Failure-severity finding; default blocking still requires high confidence.
+    Error,
+    /// Likely defect or significant risk that requires attention.
+    Warning,
+    /// Non-blocking opportunity with concrete supporting evidence.
+    Notice,
+}
+
+/// Strength of the evidence supporting a finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FindingConfidence {
+    /// The analyzer proved the finding from complete semantic information.
+    Certain,
+    /// Evidence is strong but one bounded runtime condition remains unknown.
+    High,
+    /// Evidence is useful but depends on several explicit assumptions.
+    Medium,
+    /// The finding is exploratory and must never block by default.
+    Low,
+}
+
+/// User and production consequence if a finding occurs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FindingImpact {
+    /// Application safety, data, or core operation is at immediate risk.
+    Critical,
+    /// A primary workflow or production invariant is affected.
+    High,
+    /// A bounded workflow, target, or maintainability invariant is affected.
+    Medium,
+    /// The consequence is narrow and has a reliable fallback.
+    Low,
+}
+
+/// Whether an automatic fix can be applied without human judgment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FixSafety {
+    /// The edit is semantics-preserving and may be applied automatically.
+    Safe,
+    /// The edit is concrete but requires review of product behavior.
+    ReviewRequired,
+    /// No generally correct source edit is available.
+    Unavailable,
+}
+
+/// Policy governing source-level suppression of a finding.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum SuppressionPolicy {
+    /// Suppression is accepted without additional text.
+    Allowed,
+    /// Suppression requires an authored justification.
+    #[default]
+    ReasonRequired,
+    /// Suppression is rejected because the invariant is mandatory.
+    Forbidden,
+}
+
+/// Expected cost of producing one rule's analysis capability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RuleCost {
+    /// Constant-time lookup over an existing analysis product.
+    Trivial,
+    /// Local file or node analysis with bounded traversal.
+    Low,
+    /// Affected-graph analysis across a bounded dependency region.
+    Moderate,
+    /// Workspace-wide or measurement-backed analysis.
+    High,
+}
+
+/// Analysis product that provides one piece of supporting evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum EvidenceKind {
+    /// Authored or generated source evidence.
+    Source,
+    /// Type-system evidence.
+    Type,
+    /// Control-flow evidence.
+    ControlFlow,
+    /// Reactivity or effect-graph evidence.
+    Reactivity,
+    /// Component, slot, prop, event, or semantic-tree evidence.
+    Component,
+    /// CSS cascade, selector, token, layout, or style evidence.
+    Css,
+    /// Module, route, environment, or build-graph evidence.
+    BuildGraph,
+    /// Contract, capability, backend, or transport evidence.
+    Contract,
+    /// Measured build or runtime evidence.
+    Measurement,
+}
+
+/// Explicit deduction applied to one category's health score.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HealthPenalty {
+    /// Deduction from the category score, clamped to `0..=100`.
+    pub points: u8,
+    /// Human-readable explanation of the scoring consequence.
+    pub reason: String,
+}
+
+impl HealthPenalty {
+    /// Creates an explainable score penalty.
+    pub fn new(points: u8, reason: impl Into<String>) -> Self {
+        Self {
+            points: points.min(100),
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Required severity, confidence, impact, and scoring assessment.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FindingAssessment {
+    /// Gate severity.
+    pub severity: FindingSeverity,
+    /// Strength of supporting evidence.
+    pub confidence: FindingConfidence,
+    /// Consequence if the issue occurs.
+    pub impact: FindingImpact,
+    /// Explainable category-score deduction.
+    pub penalty: HealthPenalty,
+}
+
+impl FindingAssessment {
+    /// Creates a complete finding assessment without inferred policy.
+    pub const fn new(
+        severity: FindingSeverity,
+        confidence: FindingConfidence,
+        impact: FindingImpact,
+        penalty: HealthPenalty,
+    ) -> Self {
+        Self {
+            severity,
+            confidence,
+            impact,
+            penalty,
+        }
+    }
+}

--- a/crates/vize_doctor/src/model/evidence.rs
+++ b/crates/vize_doctor/src/model/evidence.rs
@@ -1,0 +1,178 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use vize_carton::String;
+
+use super::assessment::{EvidenceKind, RuleCost};
+
+/// Authored byte span used by diagnostics, editors, fixes, and reports.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SourceLocation {
+    /// Workspace-relative, slash-normalized source path.
+    pub path: String,
+    /// Inclusive UTF-8 byte offset.
+    pub start: u32,
+    /// Exclusive UTF-8 byte offset.
+    pub end: u32,
+}
+
+impl SourceLocation {
+    /// Creates a source location and clamps an inverted end to the start.
+    pub fn new(path: impl Into<String>, start: u32, end: u32) -> Self {
+        Self {
+            path: path.into(),
+            start,
+            end: end.max(start),
+        }
+    }
+
+    /// Returns the byte length of the span.
+    pub const fn len(&self) -> u32 {
+        self.end.saturating_sub(self.start)
+    }
+
+    /// Returns whether the source span is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.start >= self.end
+    }
+}
+
+/// Related source span that explains a cross-file or cross-node relationship.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RelatedLocation {
+    /// Related authored location.
+    pub location: SourceLocation,
+    /// Explanation of how the related location contributes to the finding.
+    pub message: String,
+}
+
+impl RelatedLocation {
+    /// Creates related source information.
+    pub fn new(location: SourceLocation, message: impl Into<String>) -> Self {
+        Self {
+            location,
+            message: message.into(),
+        }
+    }
+}
+
+/// Application graph context attached to a finding.
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FindingContext {
+    /// User-visible target identifier. Defaults to absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    /// Execution environment identifier. Defaults to absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment: Option<String>,
+    /// Route identifier. Defaults to absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub route: Option<String>,
+    /// Component identifier. Defaults to absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component: Option<String>,
+    /// Capability identifier. Defaults to absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capability: Option<String>,
+    /// Build-graph node identifier. Defaults to absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_node: Option<String>,
+}
+
+/// Provenance and invalidation contract for one rule result.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AnalysisProvenance {
+    /// Stable analysis capability identifier.
+    pub capability: String,
+    /// Expected analysis cost.
+    pub cost: RuleCost,
+    /// Inputs whose fingerprints invalidate this result. Defaults to empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub invalidation_inputs: Vec<String>,
+}
+
+impl AnalysisProvenance {
+    /// Creates provenance with no additional invalidation inputs.
+    pub fn new(capability: impl Into<String>, cost: RuleCost) -> Self {
+        Self {
+            capability: capability.into(),
+            cost,
+            invalidation_inputs: Vec::new(),
+        }
+    }
+
+    /// Adds stable input identifiers used by incremental analysis.
+    pub fn with_invalidation_inputs(
+        mut self,
+        inputs: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.invalidation_inputs = inputs.into_iter().map(Into::into).collect();
+        self.invalidation_inputs.sort();
+        self.invalidation_inputs.dedup();
+        self
+    }
+}
+
+/// One source, graph, contract, or measurement fact supporting a finding.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FindingEvidence {
+    /// Analysis domain that produced the evidence.
+    pub kind: EvidenceKind,
+    /// Concise factual summary.
+    pub summary: String,
+    /// Supporting authored location. Defaults to absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<SourceLocation>,
+    /// Deterministically ordered structured details. Defaults to empty.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub details: BTreeMap<String, String>,
+}
+
+impl FindingEvidence {
+    /// Creates evidence without a source location or structured details.
+    pub fn new(kind: EvidenceKind, summary: impl Into<String>) -> Self {
+        Self {
+            kind,
+            summary: summary.into(),
+            location: None,
+            details: BTreeMap::new(),
+        }
+    }
+
+    /// Attaches the authored location that supports this evidence.
+    pub fn with_location(mut self, location: SourceLocation) -> Self {
+        self.location = Some(location);
+        self
+    }
+
+    /// Adds one stable structured detail.
+    pub fn with_detail(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.details.insert(key.into(), value.into());
+        self
+    }
+}
+
+/// One source replacement proposed by a doctor fix.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TextEdit {
+    /// Authored span to replace.
+    pub location: SourceLocation,
+    /// UTF-8 replacement source.
+    pub replacement: String,
+}
+
+impl TextEdit {
+    /// Creates a source replacement.
+    pub fn new(location: SourceLocation, replacement: impl Into<String>) -> Self {
+        Self {
+            location,
+            replacement: replacement.into(),
+        }
+    }
+}

--- a/crates/vize_doctor/src/model/finding.rs
+++ b/crates/vize_doctor/src/model/finding.rs
@@ -1,0 +1,263 @@
+use serde::{Deserialize, Serialize};
+use vize_carton::{String, cstr};
+
+use super::{
+    assessment::{DoctorCategory, FindingAssessment, FixSafety, SuppressionPolicy},
+    evidence::{
+        AnalysisProvenance, FindingContext, FindingEvidence, RelatedLocation, SourceLocation,
+        TextEdit,
+    },
+};
+
+/// Optional source fix and its verification plan.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FindingFix {
+    /// Safety classification used by CLI and editor consumers.
+    pub safety: FixSafety,
+    /// User-visible fix title.
+    pub title: String,
+    /// Deterministically applied source edits. Defaults to empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub edits: Vec<TextEdit>,
+    /// Post-fix verification commands or checks. Defaults to empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub verification: Vec<String>,
+}
+
+impl FindingFix {
+    /// Creates a fix without edits or verification steps.
+    pub fn new(safety: FixSafety, title: impl Into<String>) -> Self {
+        Self {
+            safety,
+            title: title.into(),
+            edits: Vec::new(),
+            verification: Vec::new(),
+        }
+    }
+
+    /// Adds a source edit.
+    pub fn with_edit(mut self, edit: TextEdit) -> Self {
+        self.edits.push(edit);
+        self
+    }
+
+    /// Adds a post-fix verification step.
+    pub fn with_verification(mut self, verification: impl Into<String>) -> Self {
+        self.verification.push(verification.into());
+        self
+    }
+}
+
+/// Complete source-aware application health finding.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DoctorFinding {
+    /// Stable machine-readable rule code.
+    pub code: String,
+    /// Health and ownership category.
+    pub category: DoctorCategory,
+    /// Required severity, confidence, impact, and score assessment.
+    pub assessment: FindingAssessment,
+    /// Primary authored source span.
+    pub primary: SourceLocation,
+    /// Concise user-visible title.
+    pub title: String,
+    /// Explanation and next action.
+    pub message: String,
+    /// Concrete failure scenario. Defaults to absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_scenario: Option<String>,
+    /// Stable documentation path or URL. Defaults to absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub documentation: Option<String>,
+    /// Related source locations. Defaults to empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub related: Vec<RelatedLocation>,
+    /// Supporting evidence. Defaults to empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence: Vec<FindingEvidence>,
+    /// Source fix. Defaults to absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fix: Option<FindingFix>,
+    /// Application graph context. Defaults to empty.
+    #[serde(default)]
+    pub context: FindingContext,
+    /// Analysis capability, cost, and invalidation inputs.
+    pub provenance: AnalysisProvenance,
+    /// Suppression behavior. Defaults to reason-required.
+    #[serde(default)]
+    pub suppression: SuppressionPolicy,
+}
+
+impl DoctorFinding {
+    /// Creates a finding with empty optional evidence and reason-required suppression.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        code: impl Into<String>,
+        category: DoctorCategory,
+        assessment: FindingAssessment,
+        primary: SourceLocation,
+        title: impl Into<String>,
+        message: impl Into<String>,
+        provenance: AnalysisProvenance,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            category,
+            assessment,
+            primary,
+            title: title.into(),
+            message: message.into(),
+            failure_scenario: None,
+            documentation: None,
+            related: Vec::new(),
+            evidence: Vec::new(),
+            fix: None,
+            context: FindingContext::default(),
+            provenance,
+            suppression: SuppressionPolicy::ReasonRequired,
+        }
+    }
+
+    /// Adds a concrete failure scenario.
+    pub fn with_failure_scenario(mut self, scenario: impl Into<String>) -> Self {
+        self.failure_scenario = Some(scenario.into());
+        self
+    }
+
+    /// Adds stable rule documentation.
+    pub fn with_documentation(mut self, documentation: impl Into<String>) -> Self {
+        self.documentation = Some(documentation.into());
+        self
+    }
+
+    /// Adds a related source location.
+    pub fn with_related(mut self, related: RelatedLocation) -> Self {
+        self.related.push(related);
+        self
+    }
+
+    /// Adds supporting evidence.
+    pub fn with_evidence(mut self, evidence: FindingEvidence) -> Self {
+        self.evidence.push(evidence);
+        self
+    }
+
+    /// Attaches a source fix.
+    pub fn with_fix(mut self, fix: FindingFix) -> Self {
+        self.fix = Some(fix);
+        self
+    }
+
+    /// Attaches application graph context.
+    pub fn with_context(mut self, context: FindingContext) -> Self {
+        self.context = context;
+        self
+    }
+
+    /// Overrides the source suppression policy.
+    pub const fn with_suppression(mut self, suppression: SuppressionPolicy) -> Self {
+        self.suppression = suppression;
+        self
+    }
+
+    /// Returns a deterministic key for baselines and changed-finding policies.
+    pub fn baseline_key(&self) -> String {
+        cstr!(
+            "{}:{}:{}:{}",
+            self.code,
+            self.primary.path,
+            self.primary.start,
+            self.primary.end
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        EvidenceKind, FindingConfidence, FindingImpact, FindingSeverity, HealthPenalty, RuleCost,
+    };
+
+    fn finding() -> DoctorFinding {
+        DoctorFinding::new(
+            "VIZE_DOCTOR_TEST_001",
+            DoctorCategory::Correctness,
+            FindingAssessment::new(
+                FindingSeverity::Warning,
+                FindingConfidence::High,
+                FindingImpact::Medium,
+                HealthPenalty::new(12, "Test penalty"),
+            ),
+            SourceLocation::new("src/App.vue", 20, 30),
+            "Test finding",
+            "Test message",
+            AnalysisProvenance::new("test-graph", RuleCost::Low),
+        )
+    }
+
+    #[test]
+    fn normalizes_locations_and_incremental_inputs() {
+        let location = SourceLocation::new("src/App.vue", 30, 20);
+        let provenance = AnalysisProvenance::new("reactivity-graph", RuleCost::Moderate)
+            .with_invalidation_inputs(["src/b.ts", "src/a.ts", "src/b.ts"]);
+
+        assert!(location.is_empty());
+        assert_eq!(location.start, 30);
+        assert_eq!(location.end, 30);
+        assert_eq!(provenance.invalidation_inputs, ["src/a.ts", "src/b.ts"]);
+    }
+
+    #[test]
+    fn preserves_evidence_fixes_context_and_baseline_identity() {
+        let finding = finding()
+            .with_failure_scenario("The rendered value stays stale.")
+            .with_documentation("/doctor/test-001")
+            .with_related(RelatedLocation::new(
+                SourceLocation::new("src/state.ts", 4, 9),
+                "Reactive owner",
+            ))
+            .with_evidence(
+                FindingEvidence::new(EvidenceKind::Reactivity, "Dependency edge is absent")
+                    .with_location(SourceLocation::new("src/App.vue", 20, 30))
+                    .with_detail("binding", "count"),
+            )
+            .with_fix(
+                FindingFix::new(FixSafety::Safe, "Move the read")
+                    .with_edit(TextEdit::new(
+                        SourceLocation::new("src/App.vue", 20, 30),
+                        "derived.value",
+                    ))
+                    .with_verification("vize doctor src/App.vue"),
+            )
+            .with_context(FindingContext {
+                target: Some("web".into()),
+                component: Some("App".into()),
+                ..FindingContext::default()
+            })
+            .with_suppression(SuppressionPolicy::Forbidden);
+
+        assert_eq!(
+            finding.baseline_key(),
+            "VIZE_DOCTOR_TEST_001:src/App.vue:20:30"
+        );
+        assert_eq!(finding.related.len(), 1);
+        assert_eq!(finding.evidence[0].details["binding"], "count");
+        assert_eq!(finding.fix.as_ref().unwrap().edits.len(), 1);
+        assert_eq!(finding.context.target.as_deref(), Some("web"));
+        assert_eq!(finding.suppression, SuppressionPolicy::Forbidden);
+    }
+
+    #[test]
+    fn clamps_penalties_and_defaults_missing_suppression_policy() {
+        assert_eq!(HealthPenalty::new(255, "bounded").points, 100);
+
+        let mut value = serde_json::to_value(finding()).unwrap();
+        value.as_object_mut().unwrap().remove("suppression");
+        let decoded: DoctorFinding = serde_json::from_value(value).unwrap();
+
+        assert_eq!(decoded.suppression, SuppressionPolicy::ReasonRequired);
+    }
+}

--- a/docs/content/stability.md
+++ b/docs/content/stability.md
@@ -93,6 +93,7 @@ details are not compatibility surfaces.
 | `vize_armature`      | Alpha-supported       | Tools that parse Vue templates            | `vize_armature::{parse, Parser, Tokenizer}`     | One minor with `#[deprecated]`         |
 | `vize_croquis`       | Compatibility preview | Semantic and type-aware tooling authors   | `vize_croquis::{Croquis, Drawer}`               | One minor with `#[deprecated]`         |
 | `vize_croquis_cf`    | Experimental          | Opt-in whole-project analysis experiments | `vize_croquis_cf::CrossFileAnalyzer`            | No minimum; note breaks when practical |
+| `vize_doctor`        | Experimental          | Application health analyzer authors       | `vize_doctor::{DoctorFinding, FindingEvidence}` | No minimum; note breaks when practical |
 | `vize_atelier_core`  | Alpha-supported       | Custom Vue compiler backend authors       | `vize_atelier_core::{transform, generate}`      | One minor with `#[deprecated]`         |
 | `vize_atelier_dom`   | Alpha-supported       | VDOM compiler and bundler integrations    | `vize_atelier_dom::compile_template`            | One minor with `#[deprecated]`         |
 | `vize_atelier_vapor` | Experimental          | Opt-in Vapor compiler integrations        | `vize_atelier_vapor::compile_vapor`             | No minimum; note breaks when practical |

--- a/tests/tooling/moonbit-publish-crates.test.ts
+++ b/tests/tooling/moonbit-publish-crates.test.ts
@@ -1,10 +1,9 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import fs from "node:fs";
+import fs, { mkdtempSync, rmSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
 import { test } from "node:test";
-import { mkdtempSync, rmSync } from "node:fs";
 
 import { repoRoot, runMoonScript } from "./_helpers/moonbit.ts";
 import { writeFakeCommand } from "./support/fake-command.ts";
@@ -100,6 +99,7 @@ test("publish_crates only defers crates that have not been created on crates.io"
     "vize_croquis_cf",
     "vize_atelier_jsx",
     "vize_marquette",
+    "vize_doctor",
   ]);
 });
 

--- a/tools/moon/cmd/publish_crates/main.mbt
+++ b/tools/moon/cmd/publish_crates/main.mbt
@@ -32,6 +32,7 @@ let pending_first_publish_crates : Array[String] = [
   "vize_croquis_cf",
   "vize_atelier_jsx",
   "vize_marquette",
+  "vize_doctor",
 ]
 
 /// Existing crates whose current version depends on a crate that still needs


### PR DESCRIPTION
## Summary

- add the publishable native `vize_doctor` crate for whole-application health findings
- model source spans, related evidence, application context, fixes, suppression, analysis cost, and incremental invalidation explicitly
- separate severity, confidence, impact, and explainable health penalties so policy remains programmable
- document every public contract and default, with deterministic serialization and baseline identity tests
- register the crate in the workspace and first-publication release plan

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p vize_doctor --all-targets -- -D warnings`
- `cargo test -p vize_doctor`
- `cargo doc -p vize_doctor --no-deps`
- release-plan ordering and partition tests

Part of #3138