### PR TITLE
feat(doctor): add deterministic health reports

### DIFF
--- a/crates/vize_doctor/README.md
+++ b/crates/vize_doctor/README.md
@@ -3,7 +3,7 @@
 `vize_doctor` defines the versioned contracts for Vize whole-application health
 analysis. It gives analyzers, the CLI, editors, CI, Musea, and automated tooling
 one deterministic representation for findings, evidence, fixes, provenance,
-and health assessments.
+scores, and health gates.
 
 Support and deprecation guarantees are defined in the
 [Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
@@ -12,16 +12,18 @@ Support and deprecation guarantees are defined in the
 
 - authored source spans remain attached to primary and related evidence;
 - severity, confidence, impact, fix safety, and analysis cost are explicit;
-- contracts use language-neutral serialization;
-- findings contain no timestamps or process-specific values.
+- findings and nested evidence are normalized into deterministic order;
+- reports use versioned, language-neutral serialization;
+- default health gates never block on low-confidence findings;
+- report output contains no timestamps or process-specific values.
 
 ## Example
 
 ```rust
 use vize_doctor::{
-    AnalysisProvenance, DoctorCategory, DoctorFinding, FindingAssessment,
-    FindingConfidence, FindingImpact, FindingSeverity, HealthPenalty,
-    RuleCost, SourceLocation,
+    AnalysisProvenance, DoctorCategory, DoctorFinding, DoctorReport,
+    FindingAssessment, FindingConfidence, FindingImpact, FindingSeverity,
+    HealthPenalty, RuleCost, SourceLocation,
 };
 
 let finding = DoctorFinding::new(
@@ -39,8 +41,8 @@ let finding = DoctorFinding::new(
     AnalysisProvenance::new("reactivity-graph", RuleCost::Low),
 );
 
-assert_eq!(finding.code, "VIZE_DOCTOR_REACTIVITY_001");
-assert_eq!(finding.primary.path, "src/Counter.vue");
+let report = DoctorReport::new("example", [finding]);
+assert!(report.summary().has_blocking_errors);
 ```
 
 ## License

--- a/crates/vize_doctor/src/lib.rs
+++ b/crates/vize_doctor/src/lib.rs
@@ -14,16 +14,18 @@
 //!
 //! - Findings preserve primary and related authored source spans.
 //! - Severity, confidence, impact, fix safety, and analysis cost are explicit.
+//! - Reports are deterministically ranked and scored.
 //! - Serialized property and enum names are language-neutral and versioned.
-//! - Findings contain no timestamps or process-specific values.
+//! - Reports contain no timestamps or process-specific values.
+//! - A blocking proven error remains blocking regardless of its health score.
 //!
 //! # Example
 //!
 //! ```
 //! use vize_doctor::{
-//!     AnalysisProvenance, DoctorCategory, DoctorFinding, FindingAssessment,
-//!     FindingConfidence, FindingImpact, FindingSeverity, HealthPenalty,
-//!     RuleCost, SourceLocation,
+//!     AnalysisProvenance, DoctorCategory, DoctorFinding, DoctorReport,
+//!     FindingAssessment, FindingConfidence, FindingImpact, FindingSeverity,
+//!     HealthPenalty, RuleCost, SourceLocation,
 //! };
 //!
 //! let finding = DoctorFinding::new(
@@ -40,15 +42,22 @@
 //!     "Move the read into the derived computation that owns the dependency.",
 //!     AnalysisProvenance::new("reactivity-graph", RuleCost::Low),
 //! );
-//! assert_eq!(finding.code, "VIZE_DOCTOR_REACTIVITY_001");
-//! assert_eq!(finding.primary.path, "src/Counter.vue");
+//! let report = DoctorReport::new("example", [finding]);
+//!
+//! assert!(report.summary().has_blocking_errors);
+//! assert_eq!(report.findings().len(), 1);
 //! ```
 
 mod model;
+mod report;
 
 pub use model::{
     AnalysisProvenance, DoctorCategory, DoctorFinding, EvidenceKind, FindingAssessment,
     FindingConfidence, FindingContext, FindingEvidence, FindingFix, FindingImpact, FindingSeverity,
     FixSafety, HealthPenalty, RelatedLocation, RuleCost, SourceLocation, SuppressionPolicy,
     TextEdit,
+};
+pub use report::{
+    CategoryHealth, DOCTOR_REPORT_FORMAT_VERSION, DOCTOR_SCORING_VERSION, DoctorReport,
+    DoctorSummary, FindingCounts,
 };

--- a/crates/vize_doctor/src/report.rs
+++ b/crates/vize_doctor/src/report.rs
@@ -1,0 +1,253 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Deserializer, Serialize, de};
+use vize_carton::String;
+
+use crate::{DoctorCategory, DoctorFinding, FindingConfidence, FindingSeverity};
+
+/// Current serialized doctor report format.
+pub const DOCTOR_REPORT_FORMAT_VERSION: u32 = 1;
+
+/// Current explainable health-scoring model.
+pub const DOCTOR_SCORING_VERSION: u32 = 1;
+
+/// Score and deduction summary for one doctor category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CategoryHealth {
+    /// Health score in the inclusive range `0..=100`.
+    pub score: u8,
+    /// Total uncapped penalty points supplied by findings.
+    pub penalty: u32,
+    /// Number of findings assigned to this category.
+    pub findings: u32,
+}
+
+impl Default for CategoryHealth {
+    fn default() -> Self {
+        Self {
+            score: 100,
+            penalty: 0,
+            findings: 0,
+        }
+    }
+}
+
+/// Finding counts grouped by gate severity.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FindingCounts {
+    /// Findings classified with error severity.
+    pub errors: u32,
+    /// Significant non-error risks.
+    pub warnings: u32,
+    /// Non-blocking evidence-backed opportunities.
+    pub notices: u32,
+}
+
+impl FindingCounts {
+    /// Returns the total finding count with saturating arithmetic.
+    pub const fn total(self) -> u32 {
+        self.errors
+            .saturating_add(self.warnings)
+            .saturating_add(self.notices)
+    }
+}
+
+/// Explainable report-level health and gate summary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DoctorSummary {
+    /// Equal-weight average of all category scores.
+    pub overall_score: u8,
+    /// Stable per-category scores and penalties.
+    pub categories: BTreeMap<DoctorCategory, CategoryHealth>,
+    /// Counts grouped by severity.
+    pub counts: FindingCounts,
+    /// Whether a certain or high-confidence error blocks default success.
+    pub has_blocking_errors: bool,
+}
+
+impl DoctorSummary {
+    fn from_findings(findings: &[DoctorFinding]) -> Self {
+        let mut categories = DoctorCategory::ALL
+            .into_iter()
+            .map(|category| (category, CategoryHealth::default()))
+            .collect::<BTreeMap<_, _>>();
+        let mut counts = FindingCounts::default();
+        let mut has_blocking_errors = false;
+
+        for finding in findings {
+            let health = categories
+                .get_mut(&finding.category)
+                .expect("every doctor category has a score entry");
+            health.penalty = health
+                .penalty
+                .saturating_add(u32::from(finding.assessment.penalty.points));
+            health.findings = health.findings.saturating_add(1);
+
+            match finding.assessment.severity {
+                FindingSeverity::Error => {
+                    counts.errors = counts.errors.saturating_add(1);
+                    has_blocking_errors |= matches!(
+                        finding.assessment.confidence,
+                        FindingConfidence::Certain | FindingConfidence::High
+                    );
+                }
+                FindingSeverity::Warning => {
+                    counts.warnings = counts.warnings.saturating_add(1);
+                }
+                FindingSeverity::Notice => {
+                    counts.notices = counts.notices.saturating_add(1);
+                }
+            }
+        }
+
+        for health in categories.values_mut() {
+            health.score = 100_u8.saturating_sub(health.penalty.min(100) as u8);
+        }
+        let score_total = categories
+            .values()
+            .fold(0_u32, |total, health| total + u32::from(health.score));
+        let overall_score = (score_total / DoctorCategory::ALL.len() as u32) as u8;
+
+        Self {
+            overall_score,
+            categories,
+            counts,
+            has_blocking_errors,
+        }
+    }
+}
+
+/// Deterministically ranked, versioned whole-application health report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DoctorReport {
+    /// Serialized report format.
+    format_version: u32,
+    /// Explainable scoring model version.
+    scoring_version: u32,
+    /// Stable workspace or application identifier.
+    workspace: String,
+    /// Findings ranked by severity, impact, confidence, category, and source.
+    findings: Vec<DoctorFinding>,
+    /// Health and gate summary derived from findings.
+    summary: DoctorSummary,
+}
+
+impl DoctorReport {
+    /// Creates a deterministic report from findings in any input order.
+    pub fn new(
+        workspace: impl Into<String>,
+        findings: impl IntoIterator<Item = DoctorFinding>,
+    ) -> Self {
+        let mut findings = findings.into_iter().collect::<Vec<_>>();
+        for finding in &mut findings {
+            finding.related.sort();
+            finding.evidence.sort();
+            finding.provenance.invalidation_inputs.sort();
+            finding.provenance.invalidation_inputs.dedup();
+            if let Some(fix) = &mut finding.fix {
+                fix.edits.sort();
+                fix.verification.sort();
+                fix.verification.dedup();
+            }
+        }
+        findings.sort_by(compare_findings);
+        let summary = DoctorSummary::from_findings(&findings);
+        Self {
+            format_version: DOCTOR_REPORT_FORMAT_VERSION,
+            scoring_version: DOCTOR_SCORING_VERSION,
+            workspace: workspace.into(),
+            findings,
+            summary,
+        }
+    }
+
+    /// Returns the serialized report format.
+    pub const fn format_version(&self) -> u32 {
+        self.format_version
+    }
+
+    /// Returns the explainable scoring model version.
+    pub const fn scoring_version(&self) -> u32 {
+        self.scoring_version
+    }
+
+    /// Returns the stable workspace or application identifier.
+    pub fn workspace(&self) -> &str {
+        &self.workspace
+    }
+
+    /// Returns deterministically ranked findings.
+    pub fn findings(&self) -> &[DoctorFinding] {
+        &self.findings
+    }
+
+    /// Returns the health and gate summary derived from findings.
+    pub const fn summary(&self) -> &DoctorSummary {
+        &self.summary
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DoctorReportWire {
+    format_version: u32,
+    scoring_version: u32,
+    workspace: String,
+    findings: Vec<DoctorFinding>,
+    summary: DoctorSummary,
+}
+
+impl<'de> Deserialize<'de> for DoctorReport {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = DoctorReportWire::deserialize(deserializer)?;
+        if wire.format_version != DOCTOR_REPORT_FORMAT_VERSION {
+            return Err(de::Error::custom(
+                "unsupported doctor report format version",
+            ));
+        }
+        if wire.scoring_version != DOCTOR_SCORING_VERSION {
+            return Err(de::Error::custom("unsupported doctor scoring version"));
+        }
+
+        let report = Self::new(wire.workspace, wire.findings);
+        if wire.summary != report.summary {
+            return Err(de::Error::custom(
+                "doctor report summary does not match its findings",
+            ));
+        }
+        Ok(report)
+    }
+}
+
+fn compare_findings(left: &DoctorFinding, right: &DoctorFinding) -> std::cmp::Ordering {
+    (
+        left.assessment.severity,
+        left.assessment.impact,
+        left.assessment.confidence,
+        left.category,
+        &left.primary.path,
+        left.primary.start,
+        left.primary.end,
+        &left.code,
+        &left.message,
+    )
+        .cmp(&(
+            right.assessment.severity,
+            right.assessment.impact,
+            right.assessment.confidence,
+            right.category,
+            &right.primary.path,
+            right.primary.start,
+            right.primary.end,
+            &right.code,
+            &right.message,
+        ))
+        .then_with(|| left.cmp(right))
+}

--- a/crates/vize_doctor/tests/report.rs
+++ b/crates/vize_doctor/tests/report.rs
@@ -1,0 +1,206 @@
+use vize_doctor::{
+    AnalysisProvenance, DOCTOR_REPORT_FORMAT_VERSION, DOCTOR_SCORING_VERSION, DoctorCategory,
+    DoctorFinding, DoctorReport, EvidenceKind, FindingAssessment, FindingConfidence,
+    FindingEvidence, FindingImpact, FindingSeverity, HealthPenalty, RuleCost, SourceLocation,
+};
+
+fn finding(
+    code: &str,
+    category: DoctorCategory,
+    severity: FindingSeverity,
+    confidence: FindingConfidence,
+    impact: FindingImpact,
+    path: &str,
+    penalty: u8,
+) -> DoctorFinding {
+    DoctorFinding::new(
+        code,
+        category,
+        FindingAssessment::new(
+            severity,
+            confidence,
+            impact,
+            HealthPenalty::new(penalty, "Test penalty"),
+        ),
+        SourceLocation::new(path, 10, 20),
+        "Test finding",
+        "Test message",
+        AnalysisProvenance::new("test-analysis", RuleCost::Low),
+    )
+}
+
+#[test]
+fn ranks_findings_independently_of_input_order() {
+    let error = finding(
+        "VIZE_DOCTOR_001",
+        DoctorCategory::Correctness,
+        FindingSeverity::Error,
+        FindingConfidence::Certain,
+        FindingImpact::High,
+        "src/a.vue",
+        30,
+    );
+    let warning = finding(
+        "VIZE_DOCTOR_002",
+        DoctorCategory::Performance,
+        FindingSeverity::Warning,
+        FindingConfidence::High,
+        FindingImpact::Medium,
+        "src/b.vue",
+        10,
+    );
+
+    let first = DoctorReport::new("app", [warning.clone(), error.clone()]);
+    let second = DoctorReport::new("app", [error, warning]);
+
+    assert_eq!(first, second);
+    assert_eq!(first.findings()[0].code, "VIZE_DOCTOR_001");
+}
+
+#[test]
+fn normalizes_nested_evidence_and_invalidation_order() {
+    let mut forward = finding(
+        "VIZE_DOCTOR_001",
+        DoctorCategory::Correctness,
+        FindingSeverity::Warning,
+        FindingConfidence::High,
+        FindingImpact::Medium,
+        "src/a.vue",
+        10,
+    );
+    forward.evidence = vec![
+        FindingEvidence::new(EvidenceKind::Type, "second"),
+        FindingEvidence::new(EvidenceKind::Source, "first"),
+    ];
+    forward.provenance.invalidation_inputs =
+        vec!["src/b.ts".into(), "src/a.ts".into(), "src/b.ts".into()];
+    let mut reversed = forward.clone();
+    reversed.evidence.reverse();
+    reversed.provenance.invalidation_inputs.reverse();
+
+    assert_eq!(
+        DoctorReport::new("app", [forward]),
+        DoctorReport::new("app", [reversed])
+    );
+}
+
+#[test]
+fn scores_categories_and_preserves_blocking_errors() {
+    let report = DoctorReport::new(
+        "app",
+        [
+            finding(
+                "VIZE_DOCTOR_001",
+                DoctorCategory::Correctness,
+                FindingSeverity::Error,
+                FindingConfidence::Certain,
+                FindingImpact::Critical,
+                "src/a.vue",
+                35,
+            ),
+            finding(
+                "VIZE_DOCTOR_002",
+                DoctorCategory::Correctness,
+                FindingSeverity::Warning,
+                FindingConfidence::High,
+                FindingImpact::Medium,
+                "src/b.vue",
+                15,
+            ),
+            finding(
+                "VIZE_DOCTOR_003",
+                DoctorCategory::Performance,
+                FindingSeverity::Notice,
+                FindingConfidence::Medium,
+                FindingImpact::Low,
+                "src/c.vue",
+                10,
+            ),
+        ],
+    );
+
+    assert_eq!(report.summary().counts.total(), 3);
+    assert_eq!(report.summary().counts.errors, 1);
+    assert!(report.summary().has_blocking_errors);
+    assert_eq!(
+        report.summary().categories[&DoctorCategory::Correctness].score,
+        50
+    );
+    assert_eq!(
+        report.summary().categories[&DoctorCategory::Performance].score,
+        90
+    );
+    assert_eq!(report.summary().overall_score, 90);
+}
+
+#[test]
+fn low_confidence_errors_never_block_by_default() {
+    let report = DoctorReport::new(
+        "app",
+        [finding(
+            "VIZE_DOCTOR_001",
+            DoctorCategory::Maintainability,
+            FindingSeverity::Error,
+            FindingConfidence::Low,
+            FindingImpact::Low,
+            "src/a.vue",
+            5,
+        )],
+    );
+
+    assert_eq!(report.summary().counts.errors, 1);
+    assert!(!report.summary().has_blocking_errors);
+}
+
+#[test]
+fn serializes_language_neutral_versioned_properties() {
+    let report = DoctorReport::new(
+        "app",
+        [finding(
+            "VIZE_DOCTOR_001",
+            DoctorCategory::ProductionReadiness,
+            FindingSeverity::Warning,
+            FindingConfidence::High,
+            FindingImpact::Medium,
+            "src/server.ts",
+            12,
+        )],
+    );
+    let value = serde_json::to_value(report).unwrap();
+
+    assert_eq!(value["formatVersion"], DOCTOR_REPORT_FORMAT_VERSION);
+    assert_eq!(value["scoringVersion"], DOCTOR_SCORING_VERSION);
+    assert_eq!(value["workspace"], "app");
+    assert_eq!(value["findings"][0]["category"], "production-readiness");
+    assert_eq!(value["findings"][0]["provenance"]["cost"], "low");
+    assert_eq!(value["summary"]["hasBlockingErrors"], false);
+}
+
+#[test]
+fn validates_versions_and_derived_summary_when_deserializing() {
+    let report = DoctorReport::new(
+        "app",
+        [finding(
+            "VIZE_DOCTOR_001",
+            DoctorCategory::Security,
+            FindingSeverity::Warning,
+            FindingConfidence::High,
+            FindingImpact::High,
+            "src/server.ts",
+            20,
+        )],
+    );
+    let value = serde_json::to_value(&report).unwrap();
+    assert_eq!(
+        serde_json::from_value::<DoctorReport>(value.clone()).unwrap(),
+        report
+    );
+
+    let mut wrong_version = value.clone();
+    wrong_version["formatVersion"] = 2.into();
+    assert!(serde_json::from_value::<DoctorReport>(wrong_version).is_err());
+
+    let mut wrong_summary = value;
+    wrong_summary["summary"]["overallScore"] = 100.into();
+    assert!(serde_json::from_value::<DoctorReport>(wrong_summary).is_err());
+}


### PR DESCRIPTION
## Summary

- add deterministic whole-application report ranking across severity, impact, confidence, category, and authored source
- compute equal-weight category health scores from explicit, explainable penalties
- keep low-confidence findings non-blocking by default while preserving proven error gates
- normalize nested evidence, invalidation inputs, edits, and verification steps for stable output
- version the language-neutral report and scoring formats, rejecting unsupported or inconsistent serialized reports
- keep implementation and integration tests below the repository source-length ceiling

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p vize_doctor --all-targets -- -D warnings`
- `cargo test -p vize_doctor`
- `cargo doc -p vize_doctor --no-deps`
- 9 tests plus the crate doctest

Part of #3138

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added versioned doctor reports with deterministic findings, scoring, category health, and blocking-error summaries.
  * Added JSON serialization with language-neutral field names and report version metadata.
  * Added validation to reject unsupported report versions or inconsistent summary data.
* **Documentation**
  * Updated usage examples and contract documentation to describe scores, health gates, normalization, and report summaries.
* **Tests**
  * Added coverage for scoring, ordering, serialization, confidence handling, and report validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->