### PR TITLE
feat(doctor): add whole-application CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,6 +3423,7 @@ dependencies = [
  "vize_croquis",
  "vize_croquis_cf",
  "vize_curator",
+ "vize_doctor",
  "vize_glyph",
  "vize_maestro",
  "vize_musea",

--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -39,6 +39,7 @@ vize_patina = { workspace = true }
 vize_canon = { workspace = true, features = ["native"] }
 vize_croquis = { workspace = true }
 vize_croquis_cf = { workspace = true }
+vize_doctor = { workspace = true, features = ["application-analysis"] }
 vize_musea = { workspace = true }
 vize_curator = { workspace = true }
 vize_maestro = { workspace = true, optional = true }

--- a/crates/vize/src/cli.rs
+++ b/crates/vize/src/cli.rs
@@ -39,6 +39,9 @@ enum Commands {
     /// Curator utilities for diagnostics and reports
     Curator(crate::commands::curator::CuratorArgs),
 
+    /// Analyze whole-application health
+    Doctor(crate::commands::doctor::DoctorArgs),
+
     /// Remove Vize-generated cache artifacts
     Clean(crate::commands::clean::CleanArgs),
 
@@ -86,6 +89,7 @@ fn run(cli: Cli) {
         Some(Commands::Check(args)) => crate::commands::check::run(args),
         Some(Commands::Inspector(args)) => crate::commands::inspector::run(args),
         Some(Commands::Curator(args)) => crate::commands::curator::run(args),
+        Some(Commands::Doctor(args)) => crate::commands::doctor::run(args),
         Some(Commands::Clean(args)) => crate::commands::clean::run(args),
         #[cfg(unix)]
         Some(Commands::CheckServer(args)) => crate::commands::check_server::run(args),
@@ -156,6 +160,11 @@ mod tests {
     #[test]
     fn curator_help_snapshot() {
         insta::assert_snapshot!("cli_curator_help", command_help("curator"));
+    }
+
+    #[test]
+    fn doctor_help_snapshot() {
+        insta::assert_snapshot!("cli_doctor_help", command_help("doctor"));
     }
 
     #[test]

--- a/crates/vize/src/commands.rs
+++ b/crates/vize/src/commands.rs
@@ -5,6 +5,7 @@ pub mod check;
 pub mod check_server;
 pub mod clean;
 pub mod curator;
+pub mod doctor;
 pub mod env_info;
 #[cfg(feature = "glyph")]
 pub mod fmt;

--- a/crates/vize/src/commands/doctor.rs
+++ b/crates/vize/src/commands/doctor.rs
@@ -1,0 +1,151 @@
+//! Whole-application health analysis command.
+
+mod analysis;
+mod discovery;
+mod output;
+
+#[cfg(test)]
+mod tests;
+
+use clap::{Args, ValueEnum};
+use std::{fmt, io, path::PathBuf};
+use vize_carton::String;
+use vize_doctor::{DoctorReport, application_analysis::ApplicationAnalysisError};
+
+use self::{
+    analysis::analyze_application,
+    discovery::{DoctorSource, discover_sources},
+    output::write_report,
+};
+
+/// Output representation for `vize doctor`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum DoctorFormat {
+    /// Concise terminal-oriented health report.
+    Text,
+    /// Stable, versioned JSON report for automation and AI consumers.
+    Json,
+}
+
+/// Arguments for whole-application health analysis.
+#[derive(Args, Debug)]
+#[allow(clippy::disallowed_types)]
+pub struct DoctorArgs {
+    /// Files or directories to analyze. Defaults to the workspace root.
+    #[arg(default_value = ".")]
+    pub paths: Vec<String>,
+
+    /// Workspace boundary used for discovery and report paths. Defaults to `.`.
+    #[arg(long, default_value = ".")]
+    pub root: PathBuf,
+
+    /// Output format. Defaults to `text`.
+    #[arg(short, long, value_enum, default_value = "text")]
+    pub format: DoctorFormat,
+
+    /// Return success even when the report contains blocking findings. Defaults to false.
+    #[arg(long)]
+    pub exit_zero: bool,
+}
+
+#[derive(Debug)]
+enum DoctorError {
+    CurrentDirectory(io::Error),
+    InvalidRoot { path: PathBuf, source: io::Error },
+    InvalidInput { path: PathBuf, reason: &'static str },
+    ReadSource { path: PathBuf, source: io::Error },
+    ParseSfc { path: PathBuf, message: String },
+    Analysis(ApplicationAnalysisError),
+    Serialize(serde_json::Error),
+    Write(io::Error),
+}
+
+impl fmt::Display for DoctorError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CurrentDirectory(error) => {
+                write!(formatter, "cannot read current directory: {error}")
+            }
+            Self::InvalidRoot { path, source } => {
+                write!(
+                    formatter,
+                    "cannot resolve workspace root {}: {source}",
+                    path.display()
+                )
+            }
+            Self::InvalidInput { path, reason } => {
+                write!(
+                    formatter,
+                    "invalid doctor input {}: {reason}",
+                    path.display()
+                )
+            }
+            Self::ReadSource { path, source } => {
+                write!(formatter, "cannot read source {}: {source}", path.display())
+            }
+            Self::ParseSfc { path, message } => {
+                write!(
+                    formatter,
+                    "cannot parse component {}: {message}",
+                    path.display()
+                )
+            }
+            Self::Analysis(error) => write!(formatter, "cannot build health report: {error}"),
+            Self::Serialize(error) => write!(formatter, "cannot serialize health report: {error}"),
+            Self::Write(error) => write!(formatter, "cannot write health report: {error}"),
+        }
+    }
+}
+
+impl From<ApplicationAnalysisError> for DoctorError {
+    fn from(error: ApplicationAnalysisError) -> Self {
+        Self::Analysis(error)
+    }
+}
+
+struct DoctorOutcome {
+    report: DoctorReport,
+    format: DoctorFormat,
+    exit_zero: bool,
+}
+
+pub fn run(args: DoctorArgs) {
+    match execute(args) {
+        Ok(outcome) => {
+            let blocking = outcome.report.summary().has_blocking_errors;
+            if let Err(error) = write_report(&outcome.report, outcome.format) {
+                eprintln!("vize doctor: {error}");
+                std::process::exit(2);
+            }
+            if blocking && !outcome.exit_zero {
+                std::process::exit(1);
+            }
+        }
+        Err(error) => {
+            eprintln!("vize doctor: {error}");
+            std::process::exit(2);
+        }
+    }
+}
+
+fn execute(args: DoctorArgs) -> Result<DoctorOutcome, DoctorError> {
+    let cwd = std::env::current_dir().map_err(DoctorError::CurrentDirectory)?;
+    let requested_root = if args.root.is_absolute() {
+        args.root
+    } else {
+        cwd.join(args.root)
+    };
+    let root = requested_root
+        .canonicalize()
+        .map_err(|source| DoctorError::InvalidRoot {
+            path: requested_root,
+            source,
+        })?;
+    let sources = discover_sources(&root, &args.paths)?;
+    let report = analyze_application(&root, &sources)?;
+    Ok(DoctorOutcome {
+        report,
+        format: args.format,
+        exit_zero: args.exit_zero,
+    })
+}

--- a/crates/vize/src/commands/doctor.rs
+++ b/crates/vize/src/commands/doctor.rs
@@ -53,6 +53,7 @@ enum DoctorError {
     CurrentDirectory(io::Error),
     InvalidRoot { path: PathBuf, source: io::Error },
     InvalidInput { path: PathBuf, reason: &'static str },
+    WalkDirectory { path: PathBuf, source: ignore::Error },
     ReadSource { path: PathBuf, source: io::Error },
     ParseSfc { path: PathBuf, message: String },
     Analysis(ApplicationAnalysisError),
@@ -77,6 +78,13 @@ impl fmt::Display for DoctorError {
                 write!(
                     formatter,
                     "invalid doctor input {}: {reason}",
+                    path.display()
+                )
+            }
+            Self::WalkDirectory { path, source } => {
+                write!(
+                    formatter,
+                    "cannot traverse directory {}: {source}",
                     path.display()
                 )
             }

--- a/crates/vize/src/commands/doctor.rs
+++ b/crates/vize/src/commands/doctor.rs
@@ -51,11 +51,26 @@ pub struct DoctorArgs {
 #[derive(Debug)]
 enum DoctorError {
     CurrentDirectory(io::Error),
-    InvalidRoot { path: PathBuf, source: io::Error },
-    InvalidInput { path: PathBuf, reason: &'static str },
-    WalkDirectory { path: PathBuf, source: ignore::Error },
-    ReadSource { path: PathBuf, source: io::Error },
-    ParseSfc { path: PathBuf, message: String },
+    InvalidRoot {
+        path: PathBuf,
+        source: io::Error,
+    },
+    InvalidInput {
+        path: PathBuf,
+        reason: &'static str,
+    },
+    WalkDirectory {
+        path: PathBuf,
+        source: ignore::Error,
+    },
+    ReadSource {
+        path: PathBuf,
+        source: io::Error,
+    },
+    ParseSfc {
+        path: PathBuf,
+        message: String,
+    },
     Analysis(ApplicationAnalysisError),
     Serialize(serde_json::Error),
     Write(io::Error),

--- a/crates/vize/src/commands/doctor/analysis.rs
+++ b/crates/vize/src/commands/doctor/analysis.rs
@@ -1,0 +1,194 @@
+//! Whole-project graph construction with authored SFC coordinate recovery.
+
+use std::path::Path;
+use vize_armature::Parser;
+use vize_atelier_sfc::{
+    SfcParseOptions,
+    croquis::{SfcCroquisOptions, analyze_sfc_descriptor_with_context},
+    parse_sfc,
+};
+use vize_carton::{Allocator, FxHashMap};
+use vize_croquis::{EffectGraphScript, build_effect_graph_from_sfc_scripts};
+use vize_croquis_cf::{CrossFileAnalyzer, CrossFileDiagnosticKind, CrossFileOptions, FileId};
+use vize_doctor::{DoctorReport, application_analysis::report_from_application_graph};
+
+use super::{DoctorError, DoctorSource};
+
+#[derive(Clone, Copy, Debug, Default)]
+struct SourceBlock {
+    authored_start: u32,
+    length: u32,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct SfcSourceMap {
+    source_length: u32,
+    script: Option<SourceBlock>,
+    setup: Option<SourceBlock>,
+    template: Option<SourceBlock>,
+}
+
+pub(super) fn analyze_application(
+    root: &Path,
+    sources: &[DoctorSource],
+) -> Result<DoctorReport, DoctorError> {
+    let mut analyzer = CrossFileAnalyzer::with_project_root(doctor_options(), root);
+    let mut source_maps = FxHashMap::default();
+    let mut ordered_sources = sources.iter().collect::<Vec<_>>();
+    ordered_sources.sort_unstable_by(|left, right| left.path.cmp(&right.path));
+
+    for source in ordered_sources {
+        if source
+            .path
+            .extension()
+            .is_some_and(|extension| extension == "vue")
+        {
+            add_sfc(&mut analyzer, &mut source_maps, source)?;
+        } else {
+            analyzer.add_file(&source.path, source.source.as_str());
+        }
+    }
+
+    analyzer.rebuild_import_edges();
+    analyzer.rebuild_component_edges();
+    let mut result = analyzer.analyze();
+    normalize_sfc_diagnostics(&mut result.diagnostics, &source_maps);
+    report_from_application_graph(".", &analyzer, &result).map_err(DoctorError::from)
+}
+
+fn add_sfc(
+    analyzer: &mut CrossFileAnalyzer,
+    source_maps: &mut FxHashMap<FileId, SfcSourceMap>,
+    source: &DoctorSource,
+) -> Result<(), DoctorError> {
+    let filename = source.path.to_string_lossy();
+    let descriptor = parse_sfc(
+        source.source.as_str(),
+        SfcParseOptions {
+            filename: filename.as_ref().into(),
+            ..Default::default()
+        },
+    )
+    .map_err(|error| DoctorError::ParseSfc {
+        path: source.path.clone(),
+        message: error.message,
+    })?;
+    let analysis = if let Some(template) = descriptor.template.as_ref() {
+        let allocator = Allocator::with_capacity((template.content.len() * 4).max(64 * 1024));
+        let parser = Parser::new(allocator.as_bump(), template.content.as_ref());
+        let (root, errors) = parser.parse();
+        if let Some(error) = errors.iter().find(|error| !error.is_recoverable()) {
+            return Err(DoctorError::ParseSfc {
+                path: source.path.clone(),
+                message: error.message.clone(),
+            });
+        }
+        analyze_sfc_descriptor_with_context(&descriptor, Some(&root), SfcCroquisOptions::full())
+    } else {
+        analyze_sfc_descriptor_with_context(&descriptor, None, SfcCroquisOptions::full())
+    };
+    let effect_summary = build_effect_graph_from_sfc_scripts(
+        descriptor
+            .script
+            .as_ref()
+            .map(|block| EffectGraphScript::new(block.content.as_ref(), block.lang.as_deref())),
+        descriptor
+            .script_setup
+            .as_ref()
+            .map(|block| EffectGraphScript::new(block.content.as_ref(), block.lang.as_deref())),
+    )
+    .summary();
+    let file_id = analyzer.add_file_with_analysis_and_effect_summary(
+        &source.path,
+        source.source.as_str(),
+        analysis.croquis,
+        effect_summary,
+    );
+    source_maps.insert(file_id, SfcSourceMap::from_descriptor(&descriptor));
+    Ok(())
+}
+
+impl SfcSourceMap {
+    fn from_descriptor(descriptor: &vize_atelier_sfc::SfcDescriptor<'_>) -> Self {
+        Self {
+            source_length: descriptor.source.len() as u32,
+            script: descriptor.script.as_ref().map(|block| SourceBlock {
+                authored_start: block.loc.start as u32,
+                length: block.content.len() as u32,
+            }),
+            setup: descriptor.script_setup.as_ref().map(|block| SourceBlock {
+                authored_start: block.loc.start as u32,
+                length: block.content.len() as u32,
+            }),
+            template: descriptor.template.as_ref().map(|block| SourceBlock {
+                authored_start: block.loc.start as u32,
+                length: block.content.len() as u32,
+            }),
+        }
+    }
+
+    fn map(self, kind: &CrossFileDiagnosticKind, offset: u32) -> u32 {
+        let mapped = if uses_template_coordinates(kind) {
+            self.template.map_or(offset, |block| {
+                block.authored_start + offset.min(block.length)
+            })
+        } else {
+            self.map_script(offset)
+        };
+        mapped.min(self.source_length)
+    }
+
+    fn map_script(self, offset: u32) -> u32 {
+        match (self.script, self.setup) {
+            (Some(script), Some(setup)) => {
+                let setup_virtual_start = script.length.saturating_add(1);
+                if offset >= setup_virtual_start {
+                    setup.authored_start + (offset - setup_virtual_start).min(setup.length)
+                } else {
+                    script.authored_start + offset.min(script.length)
+                }
+            }
+            (Some(script), None) => script.authored_start + offset.min(script.length),
+            (_, Some(setup)) => setup.authored_start + offset.min(setup.length),
+            (None, None) => offset,
+        }
+    }
+}
+
+fn normalize_sfc_diagnostics(
+    diagnostics: &mut [vize_croquis_cf::CrossFileDiagnostic],
+    source_maps: &FxHashMap<FileId, SfcSourceMap>,
+) {
+    for diagnostic in diagnostics {
+        if let Some(source_map) = source_maps.get(&diagnostic.primary_file).copied() {
+            diagnostic.primary_offset = source_map.map(&diagnostic.kind, diagnostic.primary_offset);
+            diagnostic.primary_end_offset =
+                source_map.map(&diagnostic.kind, diagnostic.primary_end_offset);
+        }
+        for (file_id, offset, _) in &mut diagnostic.related_files {
+            if let Some(source_map) = source_maps.get(file_id).copied() {
+                *offset = source_map.map(&diagnostic.kind, *offset);
+            }
+        }
+    }
+}
+
+fn uses_template_coordinates(kind: &CrossFileDiagnosticKind) -> bool {
+    matches!(
+        kind,
+        CrossFileDiagnosticKind::DuplicateElementId { .. }
+            | CrossFileDiagnosticKind::NonUniqueIdInLoop { .. }
+            | CrossFileDiagnosticKind::BrowserApiInSsr { .. }
+    )
+}
+
+fn doctor_options() -> CrossFileOptions {
+    CrossFileOptions::minimal()
+        .with_provide_inject(true)
+        .with_unique_ids(true)
+        .with_server_client_boundary(true)
+        .with_reactivity_tracking(true)
+        .with_race_conditions(true)
+        .with_setup_context(true)
+        .with_circular_dependencies(true)
+}

--- a/crates/vize/src/commands/doctor/discovery.rs
+++ b/crates/vize/src/commands/doctor/discovery.rs
@@ -1,0 +1,132 @@
+//! Deterministic, workspace-bounded source discovery.
+
+use ignore::WalkBuilder;
+use rayon::prelude::*;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+use vize_carton::{FxHashSet, String};
+
+use super::DoctorError;
+
+pub(super) struct DoctorSource {
+    pub(super) path: PathBuf,
+    pub(super) source: String,
+}
+
+pub(super) fn discover_sources(
+    root: &Path,
+    inputs: &[String],
+) -> Result<Vec<DoctorSource>, DoctorError> {
+    let root = root.canonicalize().map_err(|_| DoctorError::InvalidInput {
+        path: root.to_path_buf(),
+        reason: "the workspace root does not exist or cannot be resolved",
+    })?;
+    let mut paths = Vec::new();
+    let mut seen = FxHashSet::default();
+
+    for input in inputs {
+        let requested = Path::new(input.as_str());
+        let candidate = if requested.is_absolute() {
+            requested.to_path_buf()
+        } else {
+            root.join(requested)
+        };
+        let resolved = candidate
+            .canonicalize()
+            .map_err(|_| DoctorError::InvalidInput {
+                path: candidate.clone(),
+                reason: "the path does not exist or cannot be resolved",
+            })?;
+        if !resolved.starts_with(&root) {
+            return Err(DoctorError::InvalidInput {
+                path: resolved,
+                reason: "the path is outside the workspace root",
+            });
+        }
+        if resolved.is_file() {
+            if !is_supported_source(&resolved) {
+                return Err(DoctorError::InvalidInput {
+                    path: resolved,
+                    reason: "the file type is not supported by whole-application analysis",
+                });
+            }
+            add_source_path(&root, &resolved, &mut paths, &mut seen)?;
+        } else if resolved.is_dir() {
+            discover_directory(&root, &resolved, &mut paths, &mut seen)?;
+        } else {
+            return Err(DoctorError::InvalidInput {
+                path: resolved,
+                reason: "the path is not a regular file or directory",
+            });
+        }
+    }
+
+    paths.sort();
+    let reads = paths
+        .into_par_iter()
+        .map(|path| {
+            let source = fs::read_to_string(root.join(&path))
+                .map(String::from)
+                .map_err(|source| DoctorError::ReadSource {
+                    path: path.clone(),
+                    source,
+                })?;
+            Ok(DoctorSource { path, source })
+        })
+        .collect::<Vec<_>>();
+    reads.into_iter().collect()
+}
+
+fn discover_directory(
+    root: &Path,
+    directory: &Path,
+    paths: &mut Vec<PathBuf>,
+    seen: &mut FxHashSet<PathBuf>,
+) -> Result<(), DoctorError> {
+    for entry in WalkBuilder::new(directory)
+        .standard_filters(true)
+        .hidden(true)
+        .follow_links(false)
+        .build()
+    {
+        let entry = entry.map_err(|_| DoctorError::InvalidInput {
+            path: directory.to_path_buf(),
+            reason: "the directory cannot be traversed",
+        })?;
+        if entry.file_type().is_some_and(|kind| kind.is_file()) {
+            add_source_path(root, entry.path(), paths, seen)?;
+        }
+    }
+    Ok(())
+}
+
+fn add_source_path(
+    root: &Path,
+    absolute: &Path,
+    paths: &mut Vec<PathBuf>,
+    seen: &mut FxHashSet<PathBuf>,
+) -> Result<(), DoctorError> {
+    if !is_supported_source(absolute) {
+        return Ok(());
+    }
+    let relative = absolute
+        .strip_prefix(root)
+        .map_err(|_| DoctorError::InvalidInput {
+            path: absolute.to_path_buf(),
+            reason: "the source is outside the workspace root",
+        })?
+        .to_path_buf();
+    if seen.insert(relative.clone()) {
+        paths.push(relative);
+    }
+    Ok(())
+}
+
+fn is_supported_source(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|extension| extension.to_str()),
+        Some("vue" | "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" | "mts" | "cts")
+    )
+}

--- a/crates/vize/src/commands/doctor/discovery.rs
+++ b/crates/vize/src/commands/doctor/discovery.rs
@@ -91,9 +91,9 @@ fn discover_directory(
         .follow_links(false)
         .build()
     {
-        let entry = entry.map_err(|_| DoctorError::InvalidInput {
+        let entry = entry.map_err(|source| DoctorError::WalkDirectory {
             path: directory.to_path_buf(),
-            reason: "the directory cannot be traversed",
+            source,
         })?;
         if entry.file_type().is_some_and(|kind| kind.is_file()) {
             add_source_path(root, entry.path(), paths, seen)?;

--- a/crates/vize/src/commands/doctor/output.rs
+++ b/crates/vize/src/commands/doctor/output.rs
@@ -1,0 +1,65 @@
+//! Deterministic terminal and automation output.
+
+use std::io::{self, Write};
+use vize_doctor::{DoctorFinding, DoctorReport, FindingSeverity};
+
+use super::{DoctorError, DoctorFormat};
+
+pub(super) fn write_report(report: &DoctorReport, format: DoctorFormat) -> Result<(), DoctorError> {
+    let stdout = io::stdout();
+    let mut output = stdout.lock();
+    match format {
+        DoctorFormat::Text => write_text(&mut output, report).map_err(DoctorError::Write),
+        DoctorFormat::Json => {
+            let serialized =
+                serde_json::to_string_pretty(report).map_err(DoctorError::Serialize)?;
+            writeln!(output, "{serialized}").map_err(DoctorError::Write)
+        }
+    }
+}
+
+fn write_text(output: &mut impl Write, report: &DoctorReport) -> io::Result<()> {
+    let summary = report.summary();
+    writeln!(output, "Vize Doctor")?;
+    writeln!(output, "Workspace: {}", report.workspace())?;
+    writeln!(output, "Health: {}/100", summary.overall_score)?;
+    writeln!(
+        output,
+        "Findings: {} error(s), {} warning(s), {} notice(s)",
+        summary.counts.errors, summary.counts.warnings, summary.counts.notices
+    )?;
+
+    for finding in report.findings() {
+        write_finding(output, finding)?;
+    }
+    if report.findings().is_empty() {
+        writeln!(
+            output,
+            "\nNo health findings in the analyzed application graph."
+        )?;
+    }
+    Ok(())
+}
+
+fn write_finding(output: &mut impl Write, finding: &DoctorFinding) -> io::Result<()> {
+    let severity = match finding.assessment.severity {
+        FindingSeverity::Error => "error",
+        FindingSeverity::Warning => "warning",
+        FindingSeverity::Notice => "notice",
+    };
+    writeln!(
+        output,
+        "\n[{severity}] {} — {}",
+        finding.code, finding.title
+    )?;
+    writeln!(
+        output,
+        "  {}:{}..{}",
+        finding.primary.path, finding.primary.start, finding.primary.end
+    )?;
+    writeln!(output, "  {}", finding.message)?;
+    if let Some(scenario) = &finding.failure_scenario {
+        writeln!(output, "  Failure scenario: {scenario}")?;
+    }
+    Ok(())
+}

--- a/crates/vize/src/commands/doctor/tests.rs
+++ b/crates/vize/src/commands/doctor/tests.rs
@@ -1,0 +1,138 @@
+use super::{DoctorSource, analysis::analyze_application, discovery::discover_sources};
+use std::{fs, path::Path};
+use vize_carton::String;
+
+#[test]
+fn discovery_is_sorted_deduplicated_and_uses_standard_ignores() {
+    let directory = tempfile::tempdir().unwrap();
+    write(
+        directory.path(),
+        "src/Z.vue",
+        "<template><div /></template>",
+    );
+    write(directory.path(), "src/a.ts", "export const value = 1");
+    write(directory.path(), "src/readme.md", "ignored");
+    write(
+        directory.path(),
+        "node_modules/ignored.ts",
+        "export const ignored = true",
+    );
+
+    let sources = discover_sources(directory.path(), &["src".into(), "src/a.ts".into()]).unwrap();
+    let paths = sources
+        .iter()
+        .map(|source| source.path.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+
+    assert_eq!(paths, ["src/Z.vue", "src/a.ts"]);
+}
+
+#[test]
+fn duplicate_ids_use_authored_template_offsets() {
+    let directory = tempfile::tempdir().unwrap();
+    let first = r#"<script setup lang="ts">
+const label = 'Email'
+</script>
+<template>
+  <label for="email">{{ label }}</label>
+  <input id="email" />
+</template>
+"#;
+    let second = r#"<template>
+  <input id="email" />
+</template>
+"#;
+    let sources = vec![
+        doctor_source("src/First.vue", first),
+        doctor_source("src/Second.vue", second),
+    ];
+
+    let report = analyze_application(directory.path(), &sources).unwrap();
+    let finding = report
+        .findings()
+        .iter()
+        .find(|finding| finding.code == "VIZE_DOCTOR_CF_DUPLICATE_ID")
+        .unwrap();
+
+    assert_eq!(finding.primary.path, "src/First.vue");
+    assert_eq!(
+        finding.primary.start as usize,
+        first.find("id=\"email\"").unwrap()
+    );
+    assert!(finding.primary.end > finding.primary.start);
+    assert_eq!(finding.related[0].location.path, "src/Second.vue");
+    assert_eq!(
+        finding.related[0].location.start as usize,
+        second.find("id=\"email\"").unwrap()
+    );
+}
+
+#[test]
+fn split_script_diagnostics_map_back_to_script_setup() {
+    let directory = tempfile::tempdir().unwrap();
+    let parent = r#"<script setup lang="ts">
+import { reactive } from 'vue'
+import Child from './Child.vue'
+const state = reactive({ count: 0 })
+</script>
+<template><Child :item="state" /></template>
+"#;
+    let child = r#"<script lang="ts">
+export const componentName = 'Child'
+</script>
+<script setup lang="ts">
+const props = defineProps<{ item: { count: number } }>()
+const { item } = props
+</script>
+"#;
+    let sources = vec![
+        doctor_source("src/Child.vue", child),
+        doctor_source("src/Parent.vue", parent),
+    ];
+
+    let report = analyze_application(directory.path(), &sources).unwrap();
+    let finding = report
+        .findings()
+        .iter()
+        .find(|finding| finding.code == "VIZE_DOCTOR_CF_DESTRUCTURING_BREAKS_REACTIVITY")
+        .unwrap();
+    let expected = child.rfind("props").unwrap();
+
+    assert_eq!(finding.primary.path, "src/Child.vue");
+    assert_eq!(finding.primary.start as usize, expected);
+    assert_eq!(&child[expected..finding.primary.end as usize], "props");
+}
+
+#[test]
+fn serialized_report_is_deterministic_for_input_order() {
+    let directory = tempfile::tempdir().unwrap();
+    let a = doctor_source("src/A.vue", "<template><div id=\"shared\" /></template>");
+    let b = doctor_source("src/B.vue", "<template><div id=\"shared\" /></template>");
+    let first = analyze_application(directory.path(), &[a, b]).unwrap();
+    let second = analyze_application(
+        directory.path(),
+        &[
+            doctor_source("src/B.vue", "<template><div id=\"shared\" /></template>"),
+            doctor_source("src/A.vue", "<template><div id=\"shared\" /></template>"),
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(
+        serde_json::to_string(&first).unwrap(),
+        serde_json::to_string(&second).unwrap()
+    );
+}
+
+fn doctor_source(path: &str, source: &str) -> DoctorSource {
+    DoctorSource {
+        path: path.into(),
+        source: String::from(source),
+    }
+}
+
+fn write(root: &Path, relative: &str, source: &str) {
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, source).unwrap();
+}

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_doctor_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_doctor_help.snap
@@ -1,0 +1,34 @@
+---
+source: crates/vize/src/cli.rs
+expression: "command_help(\"doctor\")"
+---
+Analyze whole-application health
+
+Usage: doctor [OPTIONS] [PATHS]...
+
+Arguments:
+  [PATHS]...
+          Files or directories to analyze. Defaults to the workspace root
+
+          [default: .]
+
+Options:
+      --root <ROOT>
+          Workspace boundary used for discovery and report paths. Defaults to `.`
+
+          [default: .]
+
+  -f, --format <FORMAT>
+          Output format. Defaults to `text`
+
+          Possible values:
+          - text: Concise terminal-oriented health report
+          - json: Stable, versioned JSON report for automation and AI consumers
+
+          [default: text]
+
+      --exit-zero
+          Return success even when the report contains blocking findings. Defaults to false
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_long_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_long_help.snap
@@ -13,6 +13,7 @@ Commands:
   check         Type check Vue, JSX, and TSX files
   inspector     Create playground compiler inspector payloads and agent reports
   curator       Curator utilities for diagnostics and reports
+  doctor        Analyze whole-application health
   clean         Remove Vize-generated cache artifacts
   check-server  Start type check JSON-RPC server (Unix only)
   musea         Start component gallery server

--- a/crates/vize/tests/doctor_cli.rs
+++ b/crates/vize/tests/doctor_cli.rs
@@ -1,0 +1,104 @@
+use std::{fs, path::Path, process::Command};
+use vize_doctor::DoctorReport;
+
+#[test]
+fn json_output_is_versioned_and_uses_workspace_relative_paths() {
+    let directory = tempfile::tempdir().unwrap();
+    write(
+        directory.path(),
+        "src/A.vue",
+        "<template><input id=\"email\" /></template>",
+    );
+    write(
+        directory.path(),
+        "src/B.vue",
+        "<template><input id=\"email\" /></template>",
+    );
+
+    let output = doctor(directory.path(), &["src", "--format", "json"]);
+    let report: DoctorReport = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(report.format_version(), 1);
+    assert_eq!(report.workspace(), ".");
+    assert_eq!(report.findings()[0].primary.path, "src/A.vue");
+    assert_eq!(report.summary().counts.warnings, 1);
+}
+
+#[test]
+fn proven_errors_fail_unless_exit_zero_is_requested() {
+    let directory = tempfile::tempdir().unwrap();
+    write(
+        directory.path(),
+        "src/Parent.vue",
+        r#"<script setup lang="ts">
+import { reactive } from 'vue'
+import Child from './Child.vue'
+const state = reactive({ count: 0 })
+</script>
+<template><Child :item="state" /></template>"#,
+    );
+    write(
+        directory.path(),
+        "src/Child.vue",
+        r#"<script setup lang="ts">
+const props = defineProps<{ item: { count: number } }>()
+const { item } = props
+</script>"#,
+    );
+
+    let blocked = doctor(directory.path(), &["src", "--format", "json"]);
+    let allowed = doctor(
+        directory.path(),
+        &["src", "--format", "json", "--exit-zero"],
+    );
+    let report: DoctorReport = serde_json::from_slice(&blocked.stdout).unwrap();
+
+    assert_eq!(blocked.status.code(), Some(1));
+    assert!(report.summary().has_blocking_errors);
+    assert!(allowed.status.success());
+}
+
+#[test]
+fn inputs_outside_the_workspace_fail_closed() {
+    let workspace = tempfile::tempdir().unwrap();
+    let outside = tempfile::NamedTempFile::new().unwrap();
+    let outside_path = outside.path().to_string_lossy();
+
+    let output = doctor(workspace.path(), &[outside_path.as_ref()]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("outside the workspace root"));
+}
+
+#[test]
+fn malformed_components_cannot_produce_a_healthy_report() {
+    let directory = tempfile::tempdir().unwrap();
+    write(
+        directory.path(),
+        "src/Broken.vue",
+        "<template><section><span></template>",
+    );
+
+    let output = doctor(directory.path(), &["src", "--format", "json"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("cannot parse component"));
+    assert!(output.stdout.is_empty());
+}
+
+fn doctor(root: &Path, arguments: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_vize"))
+        .arg("doctor")
+        .args(arguments)
+        .arg("--root")
+        .arg(root)
+        .output()
+        .unwrap()
+}
+
+fn write(root: &Path, relative: &str, source: &str) {
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, source).unwrap();
+}

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -83,6 +83,7 @@ When invoked without a command, `vize` defaults to `build`.
 | `fmt`          | Format Vue SFC files                            |
 | `lint`         | Lint Vue SFC files                              |
 | `check`        | Type check Vue SFC, TS, TSX, and `.d.ts` inputs |
+| `doctor`       | Analyze whole-application health                |
 | `inspector`    | Create playground compiler inspector payloads   |
 | `clean`        | Remove Vize-generated cache artifacts           |
 | `ready`        | Run `fmt`, `lint`, `check`, and `build`         |
@@ -249,6 +250,43 @@ declare module "vue" {
     $t: (key: string) => string;
   }
 }
+```
+
+## Doctor
+
+```bash
+vize doctor
+vize doctor src
+vize doctor src packages/shared --format json
+```
+
+`vize doctor` builds one deterministic application graph across Vue SFCs and script modules. The
+initial analyzer family covers dependency injection, unique element IDs, server/client boundaries,
+reactivity flow, asynchronous mutation risks, setup-context ownership, and circular imports. Vue
+diagnostics are mapped back to byte offsets in the authored `.vue` file, including components with
+both `<script>` and `<script setup>` blocks.
+
+Discovery follows standard source-control ignore files, rejects inputs outside the declared
+workspace, and fails closed when a component cannot be parsed. The command does not write source
+files.
+
+Key options:
+
+| Option         | Description                                                                     |
+| -------------- | ------------------------------------------------------------------------------- |
+| `--root`       | Workspace boundary and base for report paths; defaults to the current directory |
+| `-f, --format` | Output format: `text` (default) or versioned `json`                             |
+| `--exit-zero`  | Return success even when a proven error would normally block                    |
+
+Exit status `0` means the configured gate passed, `1` means the report contains a certain or
+high-confidence error, and `2` means discovery, parsing, analysis, serialization, or output failed.
+Warnings and lower-confidence findings affect the health score but do not block by default.
+
+The JSON representation is deterministic and contains explicit format and scoring versions. It is
+the preferred interface for CI policies, editor integrations, dashboards, and AI tooling:
+
+```bash
+vize doctor src --format json > doctor-report.json
 ```
 
 ## Inspector

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -39,8 +39,7 @@ vp run vize:check
 vp run vize:ready
 ```
 
-Use `vp exec vize ...` for one-off local debugging, but prefer named scripts for documented
-workflows and CI.
+Use `vp exec vize ...` for one-off debugging; prefer named scripts for documented workflows and CI.
 
 ## Rust Binary Installation
 
@@ -92,10 +91,6 @@ When invoked without a command, `vize` defaults to `build`.
 | `musea`        | Musea subcommands and scaffolding               |
 | `lsp`          | Start the language server                       |
 | `ide`          | Install or manage editor integrations           |
-
-All `--profile` terminal reports are rendered by the local-only `vize_curator` crate. The
-instrumentation hooks remain in `vize_carton`, while curator owns the CLI report shape alongside
-inspector and agent-facing artifacts.
 
 ## Build
 
@@ -184,10 +179,7 @@ vize lint --preset essential --max-warnings 0 src
 vize lint --preset opinionated --help-level short src
 vize lint --cross-file --cross-file-tree src
 vize lint --strict-reactivity src
-vize lint --format ansi src
-vize lint --format plain src
 vize lint --format agent src
-vize lint --format markdown src
 ```
 
 ## Check
@@ -220,35 +212,18 @@ Key options:
 | `--declaration`     | Emit `.d.ts` output                                |
 | `--declaration-dir` | Output directory for emitted declarations          |
 
-Use `--corsa-path` when you want to pin a custom Corsa executable while developing Vize or testing a
-local `corsa-bind` checkout. The shared config key is `typeChecker.corsaPath`; `typeChecker.tsgoPath`
-is kept only as a compatibility alias.
-
-Useful patterns:
-
-```bash
-vize check --tsconfig tsconfig.app.json src
-vize check --show-virtual-ts src/components/App.vue
-vize check --profile src
-vize check --declaration --declaration-dir dist/types
-```
+Use `--corsa-path` to pin a custom Corsa executable while developing Vize or a local `corsa-bind`
+checkout. The shared config key is `typeChecker.corsaPath`; `typeChecker.tsgoPath` remains only as a
+compatibility alias.
 
 Project-wide template values and Vue ambient types should be visible through TypeScript project
 configuration. Include generated files such as `auto-imports.d.ts`, `components.d.ts`, or your own
-Vue declarations in `tsconfig.json`, then select that project with `--tsconfig` when needed:
+`declare module "vue"` augmentations in the `tsconfig.json` `include` globs, then select that project
+with `--tsconfig` when needed:
 
 ```json
 {
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "src/**/*.d.ts"]
-}
-```
-
-```ts
-// src/types/vue-app.d.ts
-declare module "vue" {
-  interface ComponentCustomProperties {
-    $t: (key: string) => string;
-  }
 }
 ```
 
@@ -261,14 +236,12 @@ vize doctor src packages/shared --format json
 ```
 
 `vize doctor` builds one deterministic application graph across Vue SFCs and script modules. The
-initial analyzer family covers dependency injection, unique element IDs, server/client boundaries,
-reactivity flow, asynchronous mutation risks, setup-context ownership, and circular imports. Vue
-diagnostics are mapped back to byte offsets in the authored `.vue` file, including components with
-both `<script>` and `<script setup>` blocks.
-
-Discovery follows standard source-control ignore files, rejects inputs outside the declared
-workspace, and fails closed when a component cannot be parsed. The command does not write source
-files.
+initial analyzers cover dependency injection, unique element IDs, server/client boundaries,
+reactivity flow, asynchronous mutation risks, setup-context ownership, and circular imports; Vue
+diagnostics map back to byte offsets in the authored `.vue` file, including components with both
+`<script>` and `<script setup>`. Discovery follows source-control ignore files, rejects inputs
+outside the declared workspace, fails closed when a component cannot be parsed, and never writes
+source files.
 
 Key options:
 
@@ -278,12 +251,11 @@ Key options:
 | `-f, --format` | Output format: `text` (default) or versioned `json`                             |
 | `--exit-zero`  | Return success even when a proven error would normally block                    |
 
-Exit status `0` means the configured gate passed, `1` means the report contains a certain or
-high-confidence error, and `2` means discovery, parsing, analysis, serialization, or output failed.
-Warnings and lower-confidence findings affect the health score but do not block by default.
-
-The JSON representation is deterministic and contains explicit format and scoring versions. It is
-the preferred interface for CI policies, editor integrations, dashboards, and AI tooling:
+Exit status `0` means the gate passed, `1` means a certain or high-confidence error, and `2` means
+discovery, parsing, analysis, serialization, or output failed. Warnings and lower-confidence findings
+affect the health score but do not block by default. The deterministic `--format json` report carries
+explicit format and scoring versions and is the preferred interface for CI, editors, dashboards, and
+AI tooling:
 
 ```bash
 vize doctor src --format json > doctor-report.json
@@ -304,8 +276,6 @@ cross-file graph, then produces a permalink plus a prefilled pull request link.
 
 Use `--format agent` when another local tool or AI agent needs the same repro without opening the
 browser. The report contains the exact payload, playground URL, summary metrics, and import graph.
-Payload, graph, and line diff metadata are built by the local-only `vize_curator` crate so CLI and
-playground inspection stay aligned.
 
 Key options:
 
@@ -332,13 +302,12 @@ vize clean --force
 vize clean path/to/project
 ```
 
-`vize clean` removes known Vize-owned local artifacts for the selected project root, then removes
-empty `.vize` and `node_modules/.vize` parents. The managed artifact list covers profile outputs,
-Musea reports/snapshots/tokens, Patina sessions, config schemas, LSP logs, socket leftovers, OXC
-dumps, Oxlint workaround files, and materialized Corsa project files. Unknown entries under `.vize`
-are preserved by default; use `--force` only when the selected artifact root should be removed
-wholesale. `--dry-run` prints the artifact paths that would be removed. Use `--scope node-modules`
-or `--scope project` when only one artifact root should be cleaned.
+`vize clean` removes known Vize-owned local artifacts (profile outputs, Musea
+reports/snapshots/tokens, Patina sessions, config schemas, LSP logs, socket leftovers, OXC dumps,
+Oxlint workaround files, and materialized Corsa project files) for the selected project root, then
+removes empty `.vize` and `node_modules/.vize` parents. Unknown entries under `.vize` are preserved
+unless `--force` removes the artifact root wholesale. `--dry-run` prints the paths that would be
+removed; `--scope node-modules` or `--scope project` limits cleanup to one artifact root.
 
 ## Ready
 
@@ -347,8 +316,8 @@ vize ready src
 vize ready --output dist src
 ```
 
-`vize ready` runs `fmt --write`, `lint`, `check`, and `build` in order. The command stops at the
-first failing step.
+`vize ready` runs `fmt --write`, `lint`, `check`, and `build` in order, stopping at the first failing
+step.
 
 Key options:
 
@@ -381,17 +350,10 @@ vize musea serve --port 6006
 vize musea new
 ```
 
-The `musea` subcommand currently focuses on scaffolding and experimental entry points.
-For day-to-day gallery development, the recommended workflow today is
-`@vizejs/vite-plugin-musea`.
-
-The npm package also exposes a convenience `vize musea` command that runs Vite with the Musea
-plugin installed in your project:
-
-```bash
-vp exec vize musea
-vp exec vize musea --build
-```
+The `musea` subcommand currently focuses on scaffolding and experimental entry points. For
+day-to-day gallery development, prefer `@vizejs/vite-plugin-musea`. The npm package also exposes a
+convenience `vize musea` command that runs Vite with the Musea plugin installed (`vp exec vize
+musea`, or add `--build` for a production build).
 
 ## LSP and IDE
 
@@ -402,9 +364,8 @@ vize ide vscode
 vize ide zed
 ```
 
-`vize lsp` starts the language server directly.
-`vize ide` adds editor-specific install and management commands for the VS Code and Zed
-integrations.
+`vize lsp` starts the language server directly. `vize ide` adds editor-specific install and
+management commands for the VS Code and Zed integrations.
 
 ## Global Options
 


### PR DESCRIPTION
Part of #3138

## Summary

- add `vize doctor` with deterministic text and versioned JSON reports
- build one workspace-bounded application graph and recover authored SFC spans
- fail closed for invalid input, malformed components, and proven blocking errors
- document output and exit contracts for CI, editors, dashboards, and AI consumers

## Verification

- checked the command library with its application-analysis feature
- passed focused discovery, span-recovery, and deterministic-output unit tests
- passed CLI integration tests for output, exit, boundary, and parse contracts
- passed targeted lint checks with warnings denied
- passed formatting and patch-integrity checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `vize doctor` for whole-workspace health analysis with selectable **Text** or **JSON** output.
  - Lets you analyze specific paths with a configurable workspace root and `--exit-zero` for CI-friendly exit behavior.
  - Produces deterministic results including overall health scoring, severity counts, and detailed finding locations/messages.
- **Documentation**
  - Updated the CLI guide to include the new `doctor` command and usage examples/options.
- **Tests**
  - Added CLI and command tests covering discovery rules, deterministic JSON output, Vue parsing failure handling, and exit/status semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->