### PR TITLE
fix(canon): preserve narrowing in template loops

### DIFF
--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_component_props_source_nested_in_vif_is_wrapped_for_narrowing.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_component_props_source_nested_in_vif_is_wrapped_for_narrowing.snap
@@ -107,11 +107,13 @@ function __setup() {
 
     // v-for scope: value in elems[key]
     __vForList(elems[key]).forEach(([value]) => {
-      void value;
-      void (value); // VBind
-      // @vize-map: expr -> 69:74
-      void (value); // VBind
-      // @vize-map: expr -> 96:101
+      if ((key === 'b')) {
+        void value;
+        void (value); // VBind
+        // @vize-map: expr -> 69:74
+        void (value); // VBind
+        // @vize-map: expr -> 96:101
+      }
     });
   }
 

--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_source_nested_in_vif_is_wrapped_for_narrowing.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_source_nested_in_vif_is_wrapped_for_narrowing.snap
@@ -106,11 +106,13 @@ function __setup() {
 
     // v-for scope: value in elems[key]
     __vForList(elems[key]).forEach(([value]) => {
-      void value;
-      void (value); // VBind
-      // @vize-map: expr -> 69:74
-      void (value); // Interpolation
-      // @vize-map: expr -> 79:84
+      if ((key === 'b')) {
+        void value;
+        void (value); // VBind
+        // @vize-map: expr -> 69:74
+        void (value); // Interpolation
+        // @vize-map: expr -> 79:84
+      }
     });
   }
 

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -27,7 +27,7 @@ use super::emit::{
 };
 use super::event_handler::generate_event_handler_expressions;
 use super::globals::{generate_instance_global_refs, generate_undefined_refs};
-use super::vif_guard::common_vif_guard_prefix_outside_v_for_scope;
+use super::vif_guard::{callback_vif_guard, common_vif_guard_prefix_outside_v_for_scope};
 
 /// Generate scope closures from Croquis scope chain.
 /// Uses recursive tree-based generation so nested v-for/v-slot scopes
@@ -265,15 +265,26 @@ fn generate_scope_node(
                 data.source.as_str(),
             );
 
+            // A positive narrowing established outside a callback is not
+            // retained for captured object properties. Recheck those terms in
+            // the generated callback so discriminated unions stay narrowed.
+            let callback_guard = enclosing_guard.and_then(callback_vif_guard);
+            let callback_indent = if let Some(guard) = callback_guard.as_deref() {
+                append!(*ts, "{vfor_inner_indent}if ({guard}) {{\n");
+                cstr!("{vfor_inner_indent}  ")
+            } else {
+                vfor_inner_indent.clone()
+            };
+
             // Mark v-for variables as used to avoid TS6133
             for value in &data.value_bindings {
-                append!(*ts, "{vfor_inner_indent}void {value};\n");
+                append!(*ts, "{callback_indent}void {value};\n");
             }
             if let Some(ref key) = data.key_alias {
-                append!(*ts, "{vfor_inner_indent}void {key};\n");
+                append!(*ts, "{callback_indent}void {key};\n");
             }
             if let Some(ref index) = data.index_alias {
-                append!(*ts, "{vfor_inner_indent}void {index};\n");
+                append!(*ts, "{callback_indent}void {index};\n");
             }
 
             // Generate expressions in this scope
@@ -287,15 +298,19 @@ fn generate_scope_node(
                     ctx.template_prop_names,
                     ctx.skipped_expression_ranges,
                     ctx.template_offset,
-                    (&vfor_inner_indent, enclosing_guard),
+                    (&callback_indent, enclosing_guard),
                 );
             }
 
             // Recursively generate child scopes inside this closure
             profile!(
                 "canon.virtual_ts.child_scopes",
-                generate_child_scopes(ts, mappings, ctx, scope_id, &vfor_inner_indent)
+                generate_child_scopes(ts, mappings, ctx, scope_id, &callback_indent)
             );
+
+            if callback_guard.is_some() {
+                append!(*ts, "{vfor_inner_indent}}}\n");
+            }
 
             ts.push_str(&loop_indent);
             ts.push_str("});\n");

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -97,8 +97,7 @@ pub(crate) fn generate_scope_closures(
             }
         });
 
-    // Determine which scopes are nested inside a closure scope (VFor/VSlot).
-    // These will be generated recursively inside their parent, not at top level.
+    // Scopes nested inside a VFor/VSlot closure are generated inside their parent.
     let nested_scope_ids: FxHashSet<ScopeId> =
         profile!("canon.virtual_ts.collect_nested_scope_ids", {
             summary
@@ -106,9 +105,7 @@ pub(crate) fn generate_scope_closures(
                 .iter()
                 .filter(|scope| {
                     scope.parent().is_some_and(|pid| {
-                        // Scope ids are arena indices, so resolve the parent
-                        // with the O(1) indexed lookup instead of rescanning
-                        // every scope (was O(n^2) over the scope arena).
+                        // Resolve the parent via O(1) indexed lookup (was O(n^2)).
                         summary.scopes.get_scope(pid).is_some_and(|parent| {
                             matches!(parent.kind, ScopeKind::VFor | ScopeKind::VSlot)
                         })
@@ -222,17 +219,10 @@ fn generate_scope_node(
 
     match scope.data() {
         ScopeData::VFor(data) => {
-            // For a v-for nested in `v-if`, wrap the whole loop in `if (guard) {}`
-            // so TypeScript narrows identifiers used in the v-for source
-            // expression (e.g. `elems[key]` with `key` narrowed by the parent
-            // `v-if="key === 'b'"`). Without this the source is evaluated outside
-            // the narrowing scope and yields the unnarrowed (wider) type (#1511).
-            //
-            // The v-for element's own bindings (`:key`, etc.) and interpolations
-            // are recorded as expressions in this scope carrying that enclosing
-            // guard; any deeper `v-if` nested *inside* the loop body extends the
-            // guard with extra `&& (...)` terms. The enclosing guard is therefore
-            // the longest common `&&`-separated prefix of direct expressions.
+            // For a v-for nested in `v-if`, wrap the loop in `if (guard) {}` so
+            // TypeScript narrows identifiers in the v-for source (e.g. `elems[key]`
+            // narrowed by the parent `v-if`); otherwise it widens (#1511). The guard
+            // is the longest common `&&`-separated prefix of this scope's expressions.
             let enclosing_guard: Option<String> = ctx
                 .expressions_by_scope
                 .get(&scope_id)
@@ -265,9 +255,8 @@ fn generate_scope_node(
                 data.source.as_str(),
             );
 
-            // A positive narrowing established outside a callback is not
-            // retained for captured object properties. Recheck those terms in
-            // the generated callback so discriminated unions stay narrowed.
+            // A positive narrowing outside a callback is not retained for captured
+            // object properties. Recheck those terms so discriminated unions narrow.
             let callback_guard = enclosing_guard.and_then(callback_vif_guard);
             let callback_indent = if let Some(guard) = callback_guard.as_deref() {
                 append!(*ts, "{vfor_inner_indent}if ({guard}) {{\n");
@@ -387,19 +376,14 @@ fn generate_scope_node(
                 let event_type = event_types.event_type;
                 let listener_type = event_types.listener_type;
                 let listener_type_expr = event_types.listener_type_expr;
-                // Type the listener against the FULL emit argument tuple so
-                // multi-arg emits keep every parameter (#1512). When the emit
-                // signature stays unresolved (`unknown[]`, e.g. a fallthrough
-                // DOM event on a component), it stays variadic because custom
-                // components may emit any number of arguments.
+                // Type the listener against the FULL emit tuple so multi-arg emits
+                // keep every parameter (#1512); unresolved sigs stay variadic.
                 append!(
                     *ts,
                     "{indent}type {listener_type} = {listener_type_expr};\n",
                 );
-                // Receive every listener argument via a rest parameter typed by
-                // `Parameters<listener>` (always a tuple, so the spread targets a
-                // rest parameter and avoids TS2556). `$event` stays bound to the
-                // first element for handlers/expressions that reference it.
+                // Receive listener args via a rest parameter typed by
+                // `Parameters<listener>` to avoid TS2556; `$event` is element 0.
                 append!(
                     *ts,
                     "{indent}((...__vize_args: Parameters<{listener_type}>) => {{\n",

--- a/crates/vize_canon/src/virtual_ts/scope/vif_guard.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/vif_guard.rs
@@ -28,7 +28,7 @@ pub(super) fn common_vif_guard_prefix_for_guards(guards: &[&str]) -> Option<Stri
 pub(super) fn callback_vif_guard(guard: &str) -> Option<String> {
     let positive_terms: Vec<_> = split_guard_terms(guard)
         .into_iter()
-        .filter(|term| !term.trim_start().starts_with('!'))
+        .filter(|term| !term.starts_with('!'))
         .collect();
 
     (!positive_terms.is_empty()).then(|| String::from(positive_terms.join(" && ").as_str()))

--- a/crates/vize_canon/src/virtual_ts/scope/vif_guard.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/vif_guard.rs
@@ -19,6 +19,21 @@ pub(super) fn common_vif_guard_prefix_for_guards(guards: &[&str]) -> Option<Stri
     common_guard_prefix_from_terms(first, rest.iter().copied())
 }
 
+/// Return the positive guard terms that must be repeated inside a generated
+/// callback to restore narrowing for captured object properties.
+///
+/// Negated branch terms are intentionally omitted. Rechecking an exclusion
+/// after the surrounding control flow has already narrowed the discriminant
+/// can itself produce an impossible-comparison diagnostic.
+pub(super) fn callback_vif_guard(guard: &str) -> Option<String> {
+    let positive_terms: Vec<_> = split_guard_terms(guard)
+        .into_iter()
+        .filter(|term| !term.trim_start().starts_with('!'))
+        .collect();
+
+    (!positive_terms.is_empty()).then(|| String::from(positive_terms.join(" && ").as_str()))
+}
+
 /// Remove a guard prefix that is already active in the surrounding generated
 /// control flow.
 ///
@@ -158,7 +173,21 @@ fn references_any_alias(term: &str, aliases: &[&str]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::remove_enclosing_vif_guard_prefix;
+    use super::{callback_vif_guard, remove_enclosing_vif_guard_prefix};
+
+    #[test]
+    fn callback_guard_keeps_positive_narrowing_terms() {
+        assert_eq!(
+            callback_vif_guard("!(item.type === 'text') && ready && (item.type === 'container')")
+                .as_deref(),
+            Some("ready && (item.type === 'container')")
+        );
+    }
+
+    #[test]
+    fn callback_guard_omits_negated_branch_terms() {
+        assert_eq!(callback_vif_guard("!(item.type === 'text')"), None);
+    }
 
     #[test]
     fn removes_an_exact_enclosing_guard() {

--- a/crates/vize_canon/tests/nested_vif_narrowing.rs
+++ b/crates/vize_canon/tests/nested_vif_narrowing.rs
@@ -5,6 +5,81 @@ use vize_carton::cstr;
 
 #[test]
 fn nested_else_v_for_keeps_the_outer_discriminant_narrowing() {
+    let project = create_project();
+    let source = cstr!(
+        "{NESTED_VIF_SFC}\n<style>\n{}</style>\n",
+        ".pad {}\n".repeat(400)
+    );
+    write_project_file(project.path(), "src/App.vue", source.as_str());
+
+    let mut checker = BatchTypeChecker::new(project.path()).expect("Corsa should be available");
+    checker.scan_project().expect("project should scan");
+    let result = checker.check_project().expect("project should type check");
+    let discriminant_errors: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == Some(2367))
+        .collect();
+
+    assert!(
+        discriminant_errors.is_empty(),
+        "the nested v-for must not compare an already narrowed discriminant: {discriminant_errors:#?}"
+    );
+}
+
+#[test]
+fn v_for_callback_rechecks_the_outer_discriminant() {
+    let project = create_project();
+    write_project_file(
+        project.path(),
+        "src/Child.vue",
+        r#"<script setup lang="ts">
+defineProps<{ align: "left" | "right" }>();
+</script>
+<template><div /></template>
+"#,
+    );
+    write_project_file(
+        project.path(),
+        "src/App.vue",
+        r#"<script setup lang="ts">
+import Child from "./Child.vue";
+
+type Item =
+  | { type: "text"; text: string }
+  | { type: "container"; children: string[]; align: "left" | "right" };
+
+const item = {} as Item;
+</script>
+
+<template>
+  <div v-if="item.type === 'container'">
+    <Child
+      v-for="child in item.children"
+      :key="child"
+      :align="item.align"
+    />
+  </div>
+</template>
+"#,
+    );
+
+    let mut checker = BatchTypeChecker::new(project.path()).expect("Corsa should be available");
+    checker.scan_project().expect("project should scan");
+    let result = checker.check_project().expect("project should type check");
+    let property_errors: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == Some(2339))
+        .collect();
+
+    assert!(
+        property_errors.is_empty(),
+        "the v-for callback must restore the outer discriminant narrowing: {property_errors:#?}"
+    );
+}
+
+fn create_project() -> tempfile::TempDir {
     let project = tempfile::tempdir().expect("temp project should be created");
     write_project_file(
         project.path(),
@@ -33,26 +108,7 @@ export function ref<T>(value: T): Ref<T>;
 export function computed<T>(getter: () => T): Readonly<Ref<T>>;
 "#,
     );
-
-    let source = cstr!(
-        "{NESTED_VIF_SFC}\n<style>\n{}</style>\n",
-        ".pad {}\n".repeat(400)
-    );
-    write_project_file(project.path(), "src/App.vue", source.as_str());
-
-    let mut checker = BatchTypeChecker::new(project.path()).expect("Corsa should be available");
-    checker.scan_project().expect("project should scan");
-    let result = checker.check_project().expect("project should type check");
-    let discriminant_errors: Vec<_> = result
-        .diagnostics
-        .iter()
-        .filter(|diagnostic| diagnostic.code == Some(2367))
-        .collect();
-
-    assert!(
-        discriminant_errors.is_empty(),
-        "the nested v-for must not compare an already narrowed discriminant: {discriminant_errors:#?}"
-    );
+    project
 }
 
 fn write_project_file(project_root: &Path, path: &str, source: &str) {


### PR DESCRIPTION
## Summary\n\n- restore positive discriminant guards inside generated loop callbacks\n- keep exclusion-only branches from being rechecked after control-flow narrowing\n- add a type-checking regression fixture and update focused virtual output snapshots\n\n## Validation\n\n- cargo fmt --check -p vize_canon\n- cargo clippy -p vize_canon --lib -- -D warnings\n- all 577 vize_canon library tests\n- both nested narrowing integration tests\n- rebuilt the CLI and checked the reported large application component: the remaining property diagnostic is removed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript type narrowing for nested Vue `v-if` and `v-for` templates.
  * Prevented incorrect type errors when accessing narrowed properties inside loop callbacks.
  * Preserved discriminant narrowing across nested conditional and looping scopes.

* **Tests**
  * Added regression coverage for nested narrowing scenarios and related TypeScript diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->