### PR TITLE
fix(patina): accept bound media accessible names

### DIFF
--- a/crates/vize_patina/src/rules/a11y/helpers.rs
+++ b/crates/vize_patina/src/rules/a11y/helpers.rs
@@ -105,7 +105,7 @@ pub fn is_focusable_element(element: &ElementNode) -> bool {
     false
 }
 
-fn has_named_prop(element: &ElementNode, name: &str) -> bool {
+pub(super) fn has_named_prop(element: &ElementNode, name: &str) -> bool {
     element.props.iter().any(|prop| match prop {
         PropNode::Attribute(attr) => attr.name == name,
         PropNode::Directive(dir) if dir.name == "bind" => {

--- a/crates/vize_patina/src/rules/a11y/media_has_caption.rs
+++ b/crates/vize_patina/src/rules/a11y/media_has_caption.rs
@@ -26,7 +26,7 @@ use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::{ElementNode, ElementType, TemplateChildNode};
 
-use super::helpers::get_static_attribute_value;
+use super::helpers::{get_static_attribute_value, has_named_prop};
 use vize_relief::PropNode;
 
 static META: RuleMeta = RuleMeta {
@@ -80,13 +80,12 @@ impl Rule for MediaHasCaption {
             return;
         }
 
-        // aria-label satisfies the requirement
-        if get_static_attribute_value(element, "aria-label").is_some() {
+        // Static and bound accessible names satisfy the requirement.
+        if has_named_prop(element, "aria-label") {
             return;
         }
 
-        // aria-labelledby satisfies the requirement
-        if get_static_attribute_value(element, "aria-labelledby").is_some() {
+        if has_named_prop(element, "aria-labelledby") {
             return;
         }
 
@@ -140,6 +139,26 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(
             r#"<video src="movie.mp4" aria-label="Movie clip"></video>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_valid_video_with_bound_aria_label() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<video src="movie.mp4" :aria-label="label"></video>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_valid_audio_with_bound_aria_labelledby() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<audio src="podcast.mp3" :aria-labelledby="labelId"></audio>"#,
             "test.vue",
         );
         assert_eq!(result.warning_count, 0);


### PR DESCRIPTION
## Summary

- recognize bound accessible names on media elements
- reuse the directive-aware named-property check
- cover bound label and labelled-by forms

## Validation

- cargo fmt --all -- --check
- cargo test -p vize_patina
- cargo clippy -p vize_patina --lib -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->