### PR TITLE
fix(croquis): limit setup context diagnostics to module scope

### DIFF
--- a/crates/vize_croquis/src/script_parser.rs
+++ b/crates/vize_croquis/src/script_parser.rs
@@ -51,3 +51,6 @@ mod runtime_props_tests;
 
 #[cfg(test)]
 mod options_api_emits_tests;
+
+#[cfg(test)]
+mod setup_context_scope_tests;

--- a/crates/vize_croquis/src/script_parser/extract/reactivity.rs
+++ b/crates/vize_croquis/src/script_parser/extract/reactivity.rs
@@ -1,6 +1,7 @@
 use oxc_ast::ast::{CallExpression, Expression};
 
 use crate::reactivity::ReactiveKind;
+use crate::scope::ScopeKind;
 use crate::setup_context::SetupContextViolationKind;
 use vize_carton::{CompactString, FxHashMap};
 use vize_relief::BindingType;
@@ -52,8 +53,10 @@ pub fn detect_setup_context_violation(
     result: &mut ScriptParseResult,
     call: &CallExpression<'_>,
 ) -> bool {
-    // Only detect in non-setup scripts
-    if !result.is_non_setup_script {
+    // Only record calls made directly in a plain script's module scope.
+    if !result.is_non_setup_script
+        || result.scopes.current_scope().kind != ScopeKind::NonScriptSetup
+    {
         return false;
     }
 

--- a/crates/vize_croquis/src/script_parser/setup_context_scope_tests.rs
+++ b/crates/vize_croquis/src/script_parser/setup_context_scope_tests.rs
@@ -1,0 +1,21 @@
+use super::parse_script;
+
+#[test]
+fn test_plain_script_setup_context_violations_stay_at_module_scope() {
+    let source = r#"
+const shared = ref(0)
+
+export function installState() {
+    provide("state", shared)
+}
+"#;
+    let result = parse_script(source);
+    let violations = result.setup_context.violations();
+
+    assert_eq!(violations.len(), 1, "unexpected violations: {violations:?}");
+    assert_eq!(violations[0].api_name, "ref");
+    assert_eq!(
+        violations[0].start as usize,
+        source.find("ref(0)").expect("module-level ref call")
+    );
+}

--- a/crates/vize_croquis/src/script_parser/tests.rs
+++ b/crates/vize_croquis/src/script_parser/tests.rs
@@ -1040,6 +1040,26 @@ fn test_parse_non_class_components_keep_unspecified_shape() {
 }
 
 #[test]
+fn test_plain_script_setup_context_violations_stay_at_module_scope() {
+    let source = r#"
+const shared = ref(0)
+
+export function installState() {
+    provide("state", shared)
+}
+"#;
+    let result = parse_script(source);
+    let violations = result.setup_context.violations();
+
+    assert_eq!(violations.len(), 1, "unexpected violations: {violations:?}");
+    assert_eq!(violations[0].api_name, "ref");
+    assert_eq!(
+        violations[0].start as usize,
+        source.find("ref(0)").expect("module-level ref call")
+    );
+}
+
+#[test]
 fn test_deeply_nested_callbacks() {
     let result = parse_script_setup(
         r#"

--- a/crates/vize_croquis/src/script_parser/tests.rs
+++ b/crates/vize_croquis/src/script_parser/tests.rs
@@ -1040,26 +1040,6 @@ fn test_parse_non_class_components_keep_unspecified_shape() {
 }
 
 #[test]
-fn test_plain_script_setup_context_violations_stay_at_module_scope() {
-    let source = r#"
-const shared = ref(0)
-
-export function installState() {
-    provide("state", shared)
-}
-"#;
-    let result = parse_script(source);
-    let violations = result.setup_context.violations();
-
-    assert_eq!(violations.len(), 1, "unexpected violations: {violations:?}");
-    assert_eq!(violations[0].api_name, "ref");
-    assert_eq!(
-        violations[0].start as usize,
-        source.find("ref(0)").expect("module-level ref call")
-    );
-}
-
-#[test]
 fn test_deeply_nested_callbacks() {
     let result = parse_script_setup(
         r#"


### PR DESCRIPTION
## Summary

- constrain plain-script setup-context diagnostics to the actual module scope
- preserve module-level state findings while excluding calls inside exported functions
- cover the scope boundary with a focused regression test

## Validation

- `cargo test -p vize_croquis`
- `cargo clippy -p vize_croquis --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->