### PR TITLE
fix(croquis): emit valid macro type aliases

### DIFF
--- a/crates/vize_croquis/src/snapshots/vize_croquis__virtual_ts__tests__generate_with_croquis.snap
+++ b/crates/vize_croquis/src/snapshots/vize_croquis__virtual_ts__tests__generate_with_croquis.snap
@@ -41,7 +41,7 @@ function __setup<T extends string>() {
   function withDefaults<T, D extends __WithDefaultsArgs<T>>(props: T, defaults: D): __WithDefaultsResult<T, D> { return undefined as unknown as __WithDefaultsResult<T, D>; }
   const $event: Event = undefined as unknown as Event;
   function useTemplateRef<T = any>(key: string): $Vue['ShallowRef']<T | null> { return undefined as unknown as $Vue['ShallowRef']<T | null>; }
-  type __Props = <{ name: string }>;
+  type __Props = { name: string };
   
   // User setup code
   

--- a/crates/vize_croquis/src/snapshots/vize_croquis__virtual_ts__tests__snapshot_generic_setup.snap
+++ b/crates/vize_croquis/src/snapshots/vize_croquis__virtual_ts__tests__snapshot_generic_setup.snap
@@ -40,13 +40,13 @@ function __setup<T extends { id: string }>() {
   function withDefaults<T, D extends __WithDefaultsArgs<T>>(props: T, defaults: D): __WithDefaultsResult<T, D> { return undefined as unknown as __WithDefaultsResult<T, D>; }
   const $event: Event = undefined as unknown as Event;
   function useTemplateRef<T = any>(key: string): $Vue['ShallowRef']<T | null> { return undefined as unknown as $Vue['ShallowRef']<T | null>; }
-  type __Props = <{
+  type __Props = {
   items: T[]
   selected?: T
-}>;
-  type __Emits = <{
+};
+  type __Emits = {
   (e: 'select', item: T): void
-}>;
+};
   
   // User setup code
   

--- a/crates/vize_croquis/src/snapshots/vize_croquis__virtual_ts__tests__snapshot_script_setup_output.snap
+++ b/crates/vize_croquis/src/snapshots/vize_croquis__virtual_ts__tests__snapshot_script_setup_output.snap
@@ -41,14 +41,14 @@ function __setup() {
   function withDefaults<T, D extends __WithDefaultsArgs<T>>(props: T, defaults: D): __WithDefaultsResult<T, D> { return undefined as unknown as __WithDefaultsResult<T, D>; }
   const $event: Event = undefined as unknown as Event;
   function useTemplateRef<T = any>(key: string): $Vue['ShallowRef']<T | null> { return undefined as unknown as $Vue['ShallowRef']<T | null>; }
-  type __Props = <{
+  type __Props = {
   title: string
   count?: number
-}>;
-  type __Emits = <{
+};
+  type __Emits = {
   (e: 'update', value: number): void
   (e: 'close'): void
-}>;
+};
   
   // User setup code
   

--- a/crates/vize_croquis/src/virtual_ts/generator.rs
+++ b/crates/vize_croquis/src/virtual_ts/generator.rs
@@ -4,6 +4,7 @@
 //! - `script`: Script setup generation, imports, compiler macros
 //! - `template`: Template AST traversal and expression emission
 
+mod macro_type_arguments;
 mod options_api;
 mod script;
 mod template;

--- a/crates/vize_croquis/src/virtual_ts/generator/macro_type_arguments.rs
+++ b/crates/vize_croquis/src/virtual_ts/generator/macro_type_arguments.rs
@@ -1,0 +1,49 @@
+use vize_carton::String;
+
+use super::VirtualTsGenerator;
+
+impl VirtualTsGenerator {
+    /// Emit an internal alias from the type arguments captured for a macro call.
+    pub(super) fn emit_macro_type_alias(&mut self, name: &str, type_arguments: &str) {
+        let body = type_argument_body(type_arguments);
+        let mut alias = String::with_capacity(8 + name.len() + body.len());
+        alias.push_str("type ");
+        alias.push_str(name);
+        alias.push_str(" = ");
+        alias.push_str(body);
+        alias.push(';');
+        self.emit_line(&alias);
+    }
+}
+
+/// Return the type expression inside a macro call's outer `<...>` delimiters.
+///
+/// The parser stores the complete type-argument span so source locations remain
+/// exact. Generated aliases need only its body because `<Type>` is not a valid
+/// type expression on the right-hand side of an alias.
+fn type_argument_body(type_arguments: &str) -> &str {
+    let trimmed = type_arguments.trim();
+
+    trimmed
+        .strip_prefix('<')
+        .and_then(|value| value.strip_suffix('>'))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(trimmed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::type_argument_body;
+
+    #[test]
+    fn removes_only_complete_outer_delimiters() {
+        assert_eq!(type_argument_body("<Props>"), "Props");
+        assert_eq!(
+            type_argument_body(" <Record<string, Value>> "),
+            "Record<string, Value>"
+        );
+        assert_eq!(type_argument_body("Props"), "Props");
+        assert_eq!(type_argument_body("<>"), "<>");
+    }
+}

--- a/crates/vize_croquis/src/virtual_ts/generator/script.rs
+++ b/crates/vize_croquis/src/virtual_ts/generator/script.rs
@@ -282,21 +282,20 @@ impl VirtualTsGenerator {
         // useTemplateRef (Vue 3.5+)
         self.emit_line("function useTemplateRef<T = any>(key: string): $Vue['ShallowRef']<T | null> { return undefined as unknown as $Vue['ShallowRef']<T | null>; }");
 
-        // If macros were actually used, emit type aliases based on their type arguments
         if let Some(props) = macros.define_props()
             && let Some(ref type_args) = props.type_args
         {
-            self.emit_line(&format!("type __Props = {};", type_args));
+            self.emit_macro_type_alias("__Props", type_args);
         }
         if let Some(emits) = macros.define_emits()
             && let Some(ref type_args) = emits.type_args
         {
-            self.emit_line(&format!("type __Emits = {};", type_args));
+            self.emit_macro_type_alias("__Emits", type_args);
         }
         if let Some(expose) = macros.define_expose() {
             // Generate exposed interface type for InstanceType and useTemplateRef
             if let Some(ref type_args) = expose.type_args {
-                self.emit_line(&format!("type __Exposed = {};", type_args));
+                self.emit_macro_type_alias("__Exposed", type_args);
             } else if let Some(ref runtime_args) = expose.runtime_args {
                 // If runtime args are provided, infer type from the object
                 self.emit_line(&format!("type __Exposed = typeof ({});", runtime_args));
@@ -309,7 +308,7 @@ impl VirtualTsGenerator {
         if let Some(slots) = macros.define_slots()
             && let Some(ref type_args) = slots.type_args
         {
-            self.emit_line(&format!("type __Slots = {};", type_args));
+            self.emit_macro_type_alias("__Slots", type_args);
         }
 
         self.emit_line("");

--- a/crates/vize_croquis/tests/macro_type_arguments.rs
+++ b/crates/vize_croquis/tests/macro_type_arguments.rs
@@ -1,0 +1,34 @@
+use vize_croquis::script_parser::parse_script_setup;
+use vize_croquis::virtual_ts::{VirtualTsConfig, VirtualTsGenerator};
+
+#[test]
+fn compiler_macro_aliases_use_the_type_argument_body() {
+    let script = r#"
+const props = defineProps<Record<string, { value: string }>>()
+const emit = defineEmits<{ save: [value: string] }>()
+defineExpose<{ focus(): void }>()
+defineSlots<{ default(props: { value: string }): unknown }>()
+"#;
+    let parse_result = parse_script_setup(script);
+    let mut generator = VirtualTsGenerator::new();
+    let output = generator.generate_from_croquis(
+        script,
+        &parse_result,
+        None,
+        &VirtualTsConfig::default(),
+        None,
+    );
+
+    for expected in [
+        "type __Props = Record<string, { value: string }>;",
+        "type __Emits = { save: [value: string] };",
+        "type __Exposed = { focus(): void };",
+        "type __Slots = { default(props: { value: string }): unknown };",
+    ] {
+        assert!(
+            output.content.contains(expected),
+            "missing `{expected}` from generated output:\n{}",
+            output.content
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- remove only the outer type-argument delimiters before emitting internal aliases
- cover props, emits, exposed members, and slots with an integration regression
- refresh the three affected generator snapshots without growing the existing oversized source file

## Validation

- `cargo test -p vize_croquis`
- `cargo clippy -p vize_croquis --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->