### PR TITLE
fix(e2e): align visual artifact output paths

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -319,10 +319,10 @@ jobs:
             tests/app/screenshots/
             tests/app/playwright-report/
             tests/playwright-report/
-            .vize/vrt/elk/artifacts/
-            .vize/vrt/frontend-phpcon/artifacts/
-            .vize/vrt/misskey/artifacts/
-            .vize/vrt/npmx/artifacts/
-            .vize/vrt/vuefes/artifacts/
+            .vize/artifacts/elk-vrt/artifacts/
+            .vize/artifacts/frontend-phpcon-vrt/artifacts/
+            .vize/artifacts/misskey-vrt/artifacts/
+            .vize/artifacts/npmx-vrt/artifacts/
+            .vize/artifacts/vuefes-vrt/artifacts/
           if-no-files-found: ignore
           retention-days: 7

--- a/tests/app/vrt/elk.spec.ts
+++ b/tests/app/vrt/elk.spec.ts
@@ -29,7 +29,7 @@ interface VisualRoute {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR =
   process.env.VIZE_ELK_VRT_OUTPUT_DIR ??
-  path.resolve(__dirname, "../../../.vize/vrt/elk/artifacts");
+  path.resolve(__dirname, "../../../.vize/artifacts/elk-vrt/artifacts");
 const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
 const DEFAULT_MAX_DIFF_RATIO = 0.04;
 const ELK_MIN_CONTENT_TEXT_LENGTH = 40;

--- a/tests/app/vrt/frontend-phpcon.spec.ts
+++ b/tests/app/vrt/frontend-phpcon.spec.ts
@@ -29,7 +29,7 @@ type VisualMode = "dev" | "preview";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR =
   process.env.VIZE_FRONTEND_PHPCON_VRT_OUTPUT_DIR ??
-  path.resolve(__dirname, "../../../.vize/vrt/frontend-phpcon/artifacts");
+  path.resolve(__dirname, "../../../.vize/artifacts/frontend-phpcon-vrt/artifacts");
 const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
 const FRONTEND_PHPCON_VRT_TIMEOUT = 900_000;

--- a/tests/app/vrt/misskey.spec.ts
+++ b/tests/app/vrt/misskey.spec.ts
@@ -30,7 +30,7 @@ interface VisualRoute {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR =
   process.env.VIZE_MISSKEY_VRT_OUTPUT_DIR ??
-  path.resolve(__dirname, "../../../.vize/vrt/misskey/artifacts");
+  path.resolve(__dirname, "../../../.vize/artifacts/misskey-vrt/artifacts");
 const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
 const MISSKEY_VRT_TIMEOUT = 900_000;

--- a/tests/app/vrt/npmx.spec.ts
+++ b/tests/app/vrt/npmx.spec.ts
@@ -34,7 +34,7 @@ type VisualMode = "dev" | "preview";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR =
   process.env.VIZE_NPMX_VRT_OUTPUT_DIR ??
-  path.resolve(__dirname, "../../../.vize/vrt/npmx/artifacts");
+  path.resolve(__dirname, "../../../.vize/artifacts/npmx-vrt/artifacts");
 const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
 const NPMX_VRT_TIMEOUT = 900_000;
 const modes: VisualMode[] = ["dev", "preview"];

--- a/tests/app/vrt/vuefes.spec.ts
+++ b/tests/app/vrt/vuefes.spec.ts
@@ -28,7 +28,7 @@ type VisualMode = "dev" | "preview";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR =
   process.env.VIZE_VUEFES_VRT_OUTPUT_DIR ??
-  path.resolve(__dirname, "../../../.vize/vrt/vuefes/artifacts");
+  path.resolve(__dirname, "../../../.vize/artifacts/vuefes-vrt/artifacts");
 const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
 const VUEFES_VRT_TIMEOUT = 900_000;

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -77,7 +77,7 @@ test("full app e2e workflow remains nightly/on-demand and uploads failure artifa
   assert.match(appJob, /tests\/app\/playwright-report\//);
   assert.match(appJob, /tests\/playwright-report\//);
   for (const fixture of ["elk", "frontend-phpcon", "misskey", "npmx", "vuefes"]) {
-    assert.match(appJob, new RegExp(`\\.vize/vrt/${fixture}/artifacts/`));
+    assert.match(appJob, new RegExp(`\\.vize/artifacts/${fixture}-vrt/artifacts/`));
   }
   assert.match(appJob, /if-no-files-found:\s*ignore/);
 });


### PR DESCRIPTION
## Summary\n\n- write visual regression artifacts under the shared artifact directory\n- collect every visual fixture from the same canonical paths in CI\n- lock the five upload paths with a workflow regression test\n\n## Validation\n\n- node --test tests/tooling/e2e-workflow.test.ts\n- git diff --check\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->