### PR TITLE
fix(inspector): standardize report artifact paths

### DIFF
--- a/tests/_helpers/inspector-parity.ts
+++ b/tests/_helpers/inspector-parity.ts
@@ -115,10 +115,7 @@ function writeInspectorReport(
   target: "dom" | "ssr",
   report: InspectorCompareReport,
 ): void {
-  const outputRoot = inspectorReportDirectory(
-    appName,
-    process.env.VIZE_INSPECT_OUTPUT_DIR,
-  );
+  const outputRoot = inspectorReportDirectory(appName, process.env.VIZE_INSPECT_OUTPUT_DIR);
   fs.mkdirSync(outputRoot, { recursive: true });
 
   fs.writeFileSync(path.join(outputRoot, `${target}.json`), JSON.stringify(report, null, 2) + "\n");
@@ -149,13 +146,9 @@ function writeInspectorReport(
  * @param outputDirectory - Explicit directory supplied by the test environment.
  * @default `<repository>/.vize/artifacts/inspect/<application>`
  */
-export function inspectorReportDirectory(
-  appName: string,
-  outputDirectory?: string,
-): string {
+export function inspectorReportDirectory(appName: string, outputDirectory?: string): string {
   return (
-    outputDirectory ??
-    path.join(REPO_ROOT, ".vize", "artifacts", "inspect", sanitizeName(appName))
+    outputDirectory ?? path.join(REPO_ROOT, ".vize", "artifacts", "inspect", sanitizeName(appName))
   );
 }
 

--- a/tests/_helpers/inspector-parity.ts
+++ b/tests/_helpers/inspector-parity.ts
@@ -115,9 +115,10 @@ function writeInspectorReport(
   target: "dom" | "ssr",
   report: InspectorCompareReport,
 ): void {
-  const outputRoot =
-    process.env.VIZE_INSPECT_OUTPUT_DIR ??
-    path.join(REPO_ROOT, ".vize", "inspect", sanitizeName(appName));
+  const outputRoot = inspectorReportDirectory(
+    appName,
+    process.env.VIZE_INSPECT_OUTPUT_DIR,
+  );
   fs.mkdirSync(outputRoot, { recursive: true });
 
   fs.writeFileSync(path.join(outputRoot, `${target}.json`), JSON.stringify(report, null, 2) + "\n");
@@ -139,6 +140,22 @@ function writeInspectorReport(
       null,
       2,
     ) + "\n",
+  );
+}
+
+/**
+ * Resolve the directory used for one application's inspector reports.
+ *
+ * @param outputDirectory - Explicit directory supplied by the test environment.
+ * @default `<repository>/.vize/artifacts/inspect/<application>`
+ */
+export function inspectorReportDirectory(
+  appName: string,
+  outputDirectory?: string,
+): string {
+  return (
+    outputDirectory ??
+    path.join(REPO_ROOT, ".vize", "artifacts", "inspect", sanitizeName(appName))
   );
 }
 

--- a/tests/tooling/inspector-parity.test.ts
+++ b/tests/tooling/inspector-parity.test.ts
@@ -7,11 +7,10 @@ import { inspectorReportDirectory } from "../_helpers/inspector-parity.ts";
 test("inspector reports use the shared artifact directory by default", () => {
   const outputDirectory = inspectorReportDirectory("Example / Application");
 
-  assert.match(
-    outputDirectory,
-    new RegExp(
-      `${escapeRegExp(path.join(".vize", "artifacts", "inspect", "Example-Application"))}$`,
-    ),
+  const expectedSuffix = path.join(".vize", "artifacts", "inspect", "Example-Application");
+  assert.ok(
+    outputDirectory.endsWith(expectedSuffix),
+    `Expected path to end with "${expectedSuffix}", but got "${outputDirectory}"`,
   );
 });
 
@@ -21,7 +20,3 @@ test("inspector reports preserve an explicit output directory", () => {
     "/tmp/inspection-output",
   );
 });
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}

--- a/tests/tooling/inspector-parity.test.ts
+++ b/tests/tooling/inspector-parity.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+
+import { inspectorReportDirectory } from "../_helpers/inspector-parity.ts";
+
+test("inspector reports use the shared artifact directory by default", () => {
+  const outputDirectory = inspectorReportDirectory("Example / Application");
+
+  assert.match(
+    outputDirectory,
+    new RegExp(
+      `${escapeRegExp(path.join(".vize", "artifacts", "inspect", "Example-Application"))}$`,
+    ),
+  );
+});
+
+test("inspector reports preserve an explicit output directory", () => {
+  assert.equal(
+    inspectorReportDirectory("Example", "/tmp/inspection-output"),
+    "/tmp/inspection-output",
+  );
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary\n\n- place inspector reports under the shared artifact directory by default\n- preserve explicit output directory overrides\n- cover default and overridden path resolution with focused tests\n\n## Validation\n\n- node --test tests/tooling/inspector-parity.test.ts\n- git diff --check\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inspector report output now defaults to the standardized `.vize/artifacts/inspect/<app>` directory.
  * Default behavior no longer uses the previous `.vize/inspect/<app>` location.

* **New Features**
  * Added support for providing a custom inspector report output directory.

* **Tests**
  * Added coverage verifying both the default directory and custom output directory behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->