### PR TITLE
fix(tooling): standardize atelier report artifacts

### DIFF
--- a/tests/tooling/compiler-fixture-diff-report.test.ts
+++ b/tests/tooling/compiler-fixture-diff-report.test.ts
@@ -16,7 +16,7 @@ test("compiler fixture diff reporter documents the shared artifact directory", (
   });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /Defaults under \.vize\/artifacts\/compiler-diff-report\./);
+  assert.match(result.stdout, /\.vize\/artifacts\/compiler-diff-report/);
 });
 
 test("compiler fixture diff reporter dry-runs selected registry projects", () => {

--- a/tests/tooling/compiler-fixture-diff-report.test.ts
+++ b/tests/tooling/compiler-fixture-diff-report.test.ts
@@ -9,6 +9,16 @@ import { fileURLToPath } from "node:url";
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const toolPath = path.join(root, "tools", "fixtures", "compiler-diff-report.mjs");
 
+test("compiler fixture diff reporter documents the shared artifact directory", () => {
+  const result = spawnSync(process.execPath, [toolPath, "--help"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Defaults under \.vize\/artifacts\/compiler-diff-report\./);
+});
+
 test("compiler fixture diff reporter dry-runs selected registry projects", () => {
   const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-compiler-diff-report-"));
   try {

--- a/tools/fixtures/compiler-diff-report.mjs
+++ b/tools/fixtures/compiler-diff-report.mjs
@@ -17,8 +17,7 @@ function main() {
   const targets = args.targets.length === 0 ? defaultTargets : args.targets;
   const outputDir = resolve(
     repoRoot,
-    args.outputDir ??
-      join(".vize", "artifacts", "compiler-diff-report", timestampSlug(new Date())),
+    args.outputDir ?? join(".vize", "artifacts", "compiler-diff-report", timestampSlug(new Date())),
   );
   const launch = resolveVizeLaunch(args.vizeBin);
 

--- a/tools/fixtures/compiler-diff-report.mjs
+++ b/tools/fixtures/compiler-diff-report.mjs
@@ -17,7 +17,8 @@ function main() {
   const targets = args.targets.length === 0 ? defaultTargets : args.targets;
   const outputDir = resolve(
     repoRoot,
-    args.outputDir ?? join(".vize", "compiler-diff-report", timestampSlug(new Date())),
+    args.outputDir ??
+      join(".vize", "artifacts", "compiler-diff-report", timestampSlug(new Date())),
   );
   const launch = resolveVizeLaunch(args.vizeBin);
 
@@ -173,7 +174,7 @@ Options:
   --target <dom|ssr>        Limit target; repeat or comma-separate. Defaults to dom,ssr.
   --max-files <n>           Forward a per-project file limit to vize inspector.
   --template-syntax <mode>  Forward template syntax mode. Defaults to quirks.
-  --output-dir <dir>        Report directory. Defaults under .vize/compiler-diff-report.
+  --output-dir <dir>        Report directory. Defaults under .vize/artifacts/compiler-diff-report.
   --vize-bin <path>         vize binary. Defaults to VIZE_BIN, target/ci, target/debug, or cargo.
   --timeout-ms <n>          Per project/target timeout. Defaults to 300000.
   --dry-run                 Write the planned report without invoking vize.


### PR DESCRIPTION
## Summary\n\n- place compiler comparison reports under the shared artifact directory by default\n- keep the command help aligned with the effective default\n- cover the documented default alongside existing dry-run behavior\n\n## Validation\n\n- node --test tests/tooling/compiler-fixture-diff-report.test.ts\n- git diff --check\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compiler difference reports now default to a shared `.vize/artifacts/compiler-diff-report` directory.
  * Updated command-line help text documents the new report location.

* **Tests**
  * Added coverage verifying the documented default report directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->