### PR TITLE
fix(croquis): scope template attrs binding

### DIFF
--- a/crates/vize_croquis/src/snapshots/vize_croquis__virtual_ts__tests__generate_template.snap
+++ b/crates/vize_croquis/src/snapshots/vize_croquis__virtual_ts__tests__generate_template.snap
@@ -9,5 +9,6 @@ expression: output.content.as_str()
 declare const __ctx: { message: any };
 const { message } = __ctx;
 
+const $attrs: Readonly<Record<string, unknown>> = {};
 // Template expressions
 const __expr_0 = message;

--- a/crates/vize_croquis/src/snapshots/vize_croquis__virtual_ts__tests__snapshot_full_sfc.snap
+++ b/crates/vize_croquis/src/snapshots/vize_croquis__virtual_ts__tests__snapshot_full_sfc.snap
@@ -52,6 +52,7 @@ function __setup() {
     // Template refs (auto-unwrapped)
     const __unwrapped_count = count.value;
     
+    const $attrs: Readonly<Record<string, unknown>> = {};
     // Template expressions
     const __expr_0 = increment;
     const __expr_1 = count;

--- a/crates/vize_croquis/src/snapshots/vize_croquis__virtual_ts__tests__snapshot_template_with_v_for.snap
+++ b/crates/vize_croquis/src/snapshots/vize_croquis__virtual_ts__tests__snapshot_template_with_v_for.snap
@@ -9,6 +9,7 @@ expression: output.content
 declare const __ctx: { items: any };
 const { items } = __ctx;
 
+const $attrs: Readonly<Record<string, unknown>> = {};
 // Template expressions
 // v-for scope
 {

--- a/crates/vize_croquis/src/snapshots/vize_croquis__virtual_ts__tests__snapshot_template_with_v_if.snap
+++ b/crates/vize_croquis/src/snapshots/vize_croquis__virtual_ts__tests__snapshot_template_with_v_if.snap
@@ -9,6 +9,7 @@ expression: output.content
 declare const __ctx: { isVisible: any, isAlternate: any };
 const { isVisible, isAlternate } = __ctx;
 
+const $attrs: Readonly<Record<string, unknown>> = {};
 // Template expressions
 if (isVisible) {
 }

--- a/crates/vize_croquis/src/virtual_ts/generator.rs
+++ b/crates/vize_croquis/src/virtual_ts/generator.rs
@@ -8,6 +8,7 @@ mod macro_type_arguments;
 mod options_api;
 mod script;
 mod template;
+mod template_globals;
 
 use std::path::Path;
 

--- a/crates/vize_croquis/src/virtual_ts/generator/template.rs
+++ b/crates/vize_croquis/src/virtual_ts/generator/template.rs
@@ -56,6 +56,7 @@ impl VirtualTsGenerator {
             self.write_line("");
         }
 
+        self.emit_template_globals();
         // Profile the full child walk as one span. This keeps virtual TS
         // generation observable without wrapping every recursive template node
         // and paying guard overhead proportional to AST size.
@@ -76,12 +77,11 @@ impl VirtualTsGenerator {
         self.emit_line(";(function __template() {");
         self.indent_level += 1;
 
-        // Declare refs for template ref access
         profile!(
             "croquis.virtual_ts.template.emit_ref_declarations",
             self.emit_template_ref_declarations(bindings)
         );
-
+        self.emit_template_globals();
         // Same coarse span as the standalone path: the emitted code is built by
         // the recursive walk, but profiling each child would dominate small
         // templates and add noise to large ones.

--- a/crates/vize_croquis/src/virtual_ts/generator/template_globals.rs
+++ b/crates/vize_croquis/src/virtual_ts/generator/template_globals.rs
@@ -1,0 +1,10 @@
+//! Template-only public instance bindings.
+
+use super::VirtualTsGenerator;
+
+impl VirtualTsGenerator {
+    /// Emit public instance attributes in the template's lexical scope.
+    pub(crate) fn emit_template_globals(&mut self) {
+        self.emit_line("const $attrs: Readonly<Record<string, unknown>> = {};");
+    }
+}

--- a/crates/vize_croquis/tests/template_globals.rs
+++ b/crates/vize_croquis/tests/template_globals.rs
@@ -1,0 +1,58 @@
+use vize_armature::parse;
+use vize_carton::Bump;
+use vize_croquis::croquis::BindingMetadata;
+use vize_croquis::script_parser::parse_script_setup;
+use vize_croquis::virtual_ts::{VirtualTsConfig, VirtualTsGenerator};
+
+const ATTRS_DECLARATION: &str = "const $attrs: Readonly<Record<string, unknown>> = {};";
+
+#[test]
+fn full_sfc_declares_attrs_only_inside_template_scope() {
+    let script = "const visible = true";
+    let template = r#"<div v-if="visible" v-bind="$attrs">{{ $attrs.id }}</div>"#;
+    let parse_result = parse_script_setup(script);
+    let allocator = Bump::new();
+    let (template_ast, errors) = parse(&allocator, template);
+    assert!(errors.is_empty(), "template should parse without errors");
+
+    let mut generator = VirtualTsGenerator::new();
+    let output = generator.generate_from_croquis(
+        script,
+        &parse_result,
+        Some(&template_ast),
+        &VirtualTsConfig::default(),
+        None,
+    );
+    let (setup_scope, template_scope) = output
+        .content
+        .split_once(";(function __template() {")
+        .expect("generated output should contain a template scope");
+
+    assert!(!setup_scope.contains(ATTRS_DECLARATION));
+    assert!(template_scope.contains(ATTRS_DECLARATION));
+    assert!(
+        template_scope.contains(" = $attrs;"),
+        "generated output should check the attribute expression:\n{}",
+        output.content
+    );
+}
+
+#[test]
+fn standalone_template_declares_attrs_before_expressions() {
+    let allocator = Bump::new();
+    let (template_ast, errors) = parse(&allocator, r#"<main v-bind="$attrs"></main>"#);
+    assert!(errors.is_empty(), "template should parse without errors");
+
+    let mut generator = VirtualTsGenerator::new();
+    let output = generator.generate_template(&template_ast, &BindingMetadata::default(), 0, false);
+    let declaration = output
+        .content
+        .find(ATTRS_DECLARATION)
+        .expect("generated output should declare template attributes");
+    let expression = output
+        .content
+        .find(" = $attrs;")
+        .expect("generated output should check the attribute expression");
+
+    assert!(declaration < expression);
+}


### PR DESCRIPTION
## Summary\n\n- declare public instance attributes in template lexical scopes\n- keep the binding unavailable to user setup code\n- cover full-component and standalone template generation\n- refresh only the four template-bearing snapshots\n\n## Validation\n\n- cargo test -p vize_croquis\n- cargo clippy -p vize_croquis --all-targets -- -D warnings\n- cargo fmt --all -- --check\n- git diff --check\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->