### PR TITLE
refactor(croquis-cf): share module path candidates

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/core/paths.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/paths.rs
@@ -1,75 +1,8 @@
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use vize_carton::String;
 
 pub(super) fn import_candidates(specifier: &str, from_dir: Option<&Path>) -> Vec<PathBuf> {
-    let mut bases = Vec::new();
-
-    if let Some(relative) = specifier.strip_prefix("@/") {
-        bases.push(PathBuf::from("src").join(relative));
-    } else if specifier.starts_with('.') {
-        let base = from_dir
-            .filter(|dir| !dir.as_os_str().is_empty())
-            .map_or_else(|| PathBuf::from(specifier), |dir| dir.join(specifier));
-        bases.push(base);
-    } else if let Some(stripped) = specifier.strip_prefix('/') {
-        bases.push(PathBuf::from(stripped));
-        bases.push(PathBuf::from(specifier));
-    } else {
-        bases.push(PathBuf::from(specifier));
-    }
-
-    let mut candidates = Vec::new();
-    for base in bases {
-        let has_extension = base.extension().is_some();
-        candidates.push(normalize_logical_path(base.clone()));
-
-        if !has_extension {
-            for suffix in [
-                ".vue",
-                ".ts",
-                ".tsx",
-                ".js",
-                ".jsx",
-                "/index.vue",
-                "/index.ts",
-                "/index.tsx",
-                "/index.js",
-                "/index.jsx",
-            ] {
-                candidates.push(normalize_logical_path(path_with_suffix(&base, suffix)));
-            }
-        }
-    }
-
-    candidates
-}
-
-fn path_with_suffix(base: &Path, suffix: &str) -> PathBuf {
-    if let Some(index_file) = suffix.strip_prefix('/') {
-        base.join(index_file)
-    } else {
-        let mut value = base.as_os_str().to_os_string();
-        value.push(suffix);
-        PathBuf::from(value)
-    }
-}
-
-fn normalize_logical_path(path: PathBuf) -> PathBuf {
-    let mut normalized = PathBuf::new();
-
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            Component::Normal(part) => normalized.push(part),
-            Component::RootDir => normalized.push(Path::new("/")),
-            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
-        }
-    }
-
-    normalized
+    crate::module_paths::import_candidates(specifier, from_dir)
 }
 
 pub(super) fn component_names_match(left: &str, right: &str) -> bool {

--- a/crates/vize_croquis_cf/src/lib.rs
+++ b/crates/vize_croquis_cf/src/lib.rs
@@ -54,6 +54,7 @@
 mod analyzer;
 mod diagnostics;
 mod graph;
+mod module_paths;
 mod registry;
 mod suppression;
 

--- a/crates/vize_croquis_cf/src/module_paths.rs
+++ b/crates/vize_croquis_cf/src/module_paths.rs
@@ -1,0 +1,98 @@
+//! Deterministic logical module-path resolution shared by cross-file rules.
+
+use std::path::{Component, Path, PathBuf};
+
+/// Build normalized source candidates for an import specifier.
+pub(crate) fn import_candidates(specifier: &str, from_dir: Option<&Path>) -> Vec<PathBuf> {
+    let mut bases = Vec::new();
+
+    if let Some(relative) = specifier.strip_prefix("@/") {
+        bases.push(PathBuf::from("src").join(relative));
+    } else if specifier.starts_with('.') {
+        let base = from_dir
+            .filter(|dir| !dir.as_os_str().is_empty())
+            .map_or_else(|| PathBuf::from(specifier), |dir| dir.join(specifier));
+        bases.push(base);
+    } else if let Some(stripped) = specifier.strip_prefix('/') {
+        bases.push(PathBuf::from(stripped));
+        bases.push(PathBuf::from(specifier));
+    } else {
+        bases.push(PathBuf::from(specifier));
+    }
+
+    let mut candidates = Vec::new();
+    for base in bases {
+        candidates.push(normalize_logical_path(base.clone()));
+
+        if base.extension().is_none() {
+            for suffix in [
+                ".vue",
+                ".ts",
+                ".tsx",
+                ".js",
+                ".jsx",
+                "/index.vue",
+                "/index.ts",
+                "/index.tsx",
+                "/index.js",
+                "/index.jsx",
+            ] {
+                candidates.push(normalize_logical_path(path_with_suffix(&base, suffix)));
+            }
+        }
+    }
+
+    candidates
+}
+
+fn path_with_suffix(base: &Path, suffix: &str) -> PathBuf {
+    if let Some(index_file) = suffix.strip_prefix('/') {
+        base.join(index_file)
+    } else {
+        let mut value = base.as_os_str().to_os_string();
+        value.push(suffix);
+        PathBuf::from(value)
+    }
+}
+
+/// Collapse `.` and `..` segments without accessing the host filesystem.
+pub(crate) fn normalize_logical_path(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Normal(part) => normalized.push(part),
+            Component::RootDir => normalized.push(Path::new("/")),
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+        }
+    }
+
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::import_candidates;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn relative_candidates_preserve_directory_and_extension_order() {
+        let candidates = import_candidates("../primitive", Some(Path::new("src/components")));
+
+        assert_eq!(candidates[0], PathBuf::from("src/primitive"));
+        assert_eq!(candidates[1], PathBuf::from("src/primitive.vue"));
+        assert!(candidates.contains(&PathBuf::from("src/primitive/index.ts")));
+    }
+
+    #[test]
+    fn source_alias_candidates_begin_at_the_source_root() {
+        let candidates = import_candidates("@/components/Button", None);
+
+        assert_eq!(candidates[0], PathBuf::from("src/components/Button"));
+        assert!(candidates.contains(&PathBuf::from("src/components/Button.vue")));
+    }
+}

--- a/crates/vize_croquis_cf/src/rules/component_resolution/paths.rs
+++ b/crates/vize_croquis_cf/src/rules/component_resolution/paths.rs
@@ -1,5 +1,6 @@
+use crate::module_paths::{import_candidates, normalize_logical_path};
 use crate::registry::ModuleRegistry;
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 
 /// Try to resolve an import specifier to a file in the registry.
 #[allow(clippy::disallowed_macros)]
@@ -33,67 +34,6 @@ pub(super) fn resolve_import(
 
     // For absolute or other paths, check directly
     registry.get_by_path(specifier).is_some()
-}
-
-/// Build the set of canonical candidate paths a relative import specifier may
-/// resolve to, trying the common module extensions and `index` files.
-fn import_candidates(specifier: &str, from_dir: Option<&Path>) -> Vec<PathBuf> {
-    let base = from_dir
-        .filter(|dir| !dir.as_os_str().is_empty())
-        .map_or_else(|| PathBuf::from(specifier), |dir| dir.join(specifier));
-
-    let mut candidates = Vec::new();
-    let has_extension = base.extension().is_some();
-    candidates.push(normalize_logical_path(base.clone()));
-
-    if !has_extension {
-        for suffix in [
-            ".vue",
-            ".ts",
-            ".tsx",
-            ".js",
-            ".jsx",
-            "/index.vue",
-            "/index.ts",
-            "/index.tsx",
-            "/index.js",
-            "/index.jsx",
-        ] {
-            candidates.push(normalize_logical_path(path_with_suffix(&base, suffix)));
-        }
-    }
-
-    candidates
-}
-
-fn path_with_suffix(base: &Path, suffix: &str) -> PathBuf {
-    if let Some(index_file) = suffix.strip_prefix('/') {
-        base.join(index_file)
-    } else {
-        let mut value = base.as_os_str().to_os_string();
-        value.push(suffix);
-        PathBuf::from(value)
-    }
-}
-
-/// Normalize a path by collapsing `.`/`..` segments without touching the
-/// filesystem, yielding a canonical logical path for comparison.
-fn normalize_logical_path(path: PathBuf) -> PathBuf {
-    let mut normalized = PathBuf::new();
-
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            Component::Normal(part) => normalized.push(part),
-            Component::RootDir => normalized.push(Path::new("/")),
-            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
-        }
-    }
-
-    normalized
 }
 
 #[cfg(test)]

--- a/crates/vize_croquis_cf/src/rules/cross_file_reactivity/path_helpers.rs
+++ b/crates/vize_croquis_cf/src/rules/cross_file_reactivity/path_helpers.rs
@@ -1,4 +1,5 @@
-use std::path::{Component, Path, PathBuf};
+use crate::module_paths::{import_candidates, normalize_logical_path};
+use std::path::Path;
 pub(super) fn import_targets_path(specifier: &str, from_dir: Option<&Path>, target: &Path) -> bool {
     let normalized_target = normalize_logical_path(target.to_path_buf());
     // The component-suffix fallback (`target` ends with the candidate path) lets
@@ -22,77 +23,6 @@ fn is_relative_specifier(specifier: &str) -> bool {
         || specifier.starts_with("../")
         || specifier == "."
         || specifier == ".."
-}
-
-fn import_candidates(specifier: &str, from_dir: Option<&Path>) -> Vec<PathBuf> {
-    let mut bases = Vec::new();
-
-    if let Some(relative) = specifier.strip_prefix("@/") {
-        bases.push(PathBuf::from("src").join(relative));
-    } else if specifier.starts_with('.') {
-        let base = from_dir
-            .filter(|dir| !dir.as_os_str().is_empty())
-            .map_or_else(|| PathBuf::from(specifier), |dir| dir.join(specifier));
-        bases.push(base);
-    } else if let Some(stripped) = specifier.strip_prefix('/') {
-        bases.push(PathBuf::from(stripped));
-        bases.push(PathBuf::from(specifier));
-    } else {
-        bases.push(PathBuf::from(specifier));
-    }
-
-    let mut candidates = Vec::new();
-    for base in bases {
-        let has_extension = base.extension().is_some();
-        candidates.push(normalize_logical_path(base.clone()));
-
-        if !has_extension {
-            for suffix in [
-                ".vue",
-                ".ts",
-                ".tsx",
-                ".js",
-                ".jsx",
-                "/index.vue",
-                "/index.ts",
-                "/index.tsx",
-                "/index.js",
-                "/index.jsx",
-            ] {
-                candidates.push(normalize_logical_path(path_with_suffix(&base, suffix)));
-            }
-        }
-    }
-
-    candidates
-}
-
-fn path_with_suffix(base: &Path, suffix: &str) -> PathBuf {
-    if let Some(index_file) = suffix.strip_prefix('/') {
-        base.join(index_file)
-    } else {
-        let mut value = base.as_os_str().to_os_string();
-        value.push(suffix);
-        PathBuf::from(value)
-    }
-}
-
-fn normalize_logical_path(path: PathBuf) -> PathBuf {
-    let mut normalized = PathBuf::new();
-
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            Component::Normal(part) => normalized.push(part),
-            Component::RootDir => normalized.push(Path::new("/")),
-            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
-        }
-    }
-
-    normalized
 }
 
 #[cfg(test)]

--- a/crates/vize_croquis_cf/src/rules/props_validation/helpers.rs
+++ b/crates/vize_croquis_cf/src/rules/props_validation/helpers.rs
@@ -1,6 +1,7 @@
 use super::PropInfo;
+use crate::module_paths::{import_candidates, normalize_logical_path};
 use crate::registry::ModuleEntry;
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 use vize_carton::{CompactString, FxHashMap, String, camelize};
 use vize_croquis::macros::MacroKind;
 
@@ -196,77 +197,6 @@ fn is_relative_specifier(specifier: &str) -> bool {
         || specifier.starts_with("../")
         || specifier == "."
         || specifier == ".."
-}
-
-fn import_candidates(specifier: &str, from_dir: Option<&Path>) -> Vec<PathBuf> {
-    let mut bases = Vec::new();
-
-    if let Some(relative) = specifier.strip_prefix("@/") {
-        bases.push(PathBuf::from("src").join(relative));
-    } else if specifier.starts_with('.') {
-        let base = from_dir
-            .filter(|dir| !dir.as_os_str().is_empty())
-            .map_or_else(|| PathBuf::from(specifier), |dir| dir.join(specifier));
-        bases.push(base);
-    } else if let Some(stripped) = specifier.strip_prefix('/') {
-        bases.push(PathBuf::from(stripped));
-        bases.push(PathBuf::from(specifier));
-    } else {
-        bases.push(PathBuf::from(specifier));
-    }
-
-    let mut candidates = Vec::new();
-    for base in bases {
-        let has_extension = base.extension().is_some();
-        candidates.push(normalize_logical_path(base.clone()));
-
-        if !has_extension {
-            for suffix in [
-                ".vue",
-                ".ts",
-                ".tsx",
-                ".js",
-                ".jsx",
-                "/index.vue",
-                "/index.ts",
-                "/index.tsx",
-                "/index.js",
-                "/index.jsx",
-            ] {
-                candidates.push(normalize_logical_path(path_with_suffix(&base, suffix)));
-            }
-        }
-    }
-
-    candidates
-}
-
-fn path_with_suffix(base: &Path, suffix: &str) -> PathBuf {
-    if let Some(index_file) = suffix.strip_prefix('/') {
-        base.join(index_file)
-    } else {
-        let mut value = base.as_os_str().to_os_string();
-        value.push(suffix);
-        PathBuf::from(value)
-    }
-}
-
-fn normalize_logical_path(path: PathBuf) -> PathBuf {
-    let mut normalized = PathBuf::new();
-
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            Component::Normal(part) => normalized.push(part),
-            Component::RootDir => normalized.push(Path::new("/")),
-            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
-        }
-    }
-
-    normalized
 }
 
 fn component_names_match(left: &str, right: &str) -> bool {


### PR DESCRIPTION
## Summary\n\n- centralize deterministic logical module path normalization\n- preserve each rule caller existing resolution boundaries\n- cover relative and source-root candidate ordering directly\n- remove repeated candidate expansion from four analyzers\n\n## Validation\n\n- cargo test -p vize_croquis_cf\n- cargo clippy -p vize_croquis_cf --lib -- -D warnings\n- cargo fmt --all -- --check\n- git diff --check\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->