### PR TITLE
fix(patina): preserve analyzed source file paths

### DIFF
--- a/crates/vize_patina/src/linter/native_type_aware.rs
+++ b/crates/vize_patina/src/linter/native_type_aware.rs
@@ -15,6 +15,7 @@ mod parsing;
 mod reactivity_loss;
 mod rule_queries;
 mod script_options;
+mod source_path;
 mod template_queries;
 
 #[cfg(test)]

--- a/crates/vize_patina/src/linter/native_type_aware/driver.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/driver.rs
@@ -4,7 +4,7 @@ use super::{
     RULE_NO_UNSAFE_TEMPLATE_BINDING, RULE_REQUIRE_TYPED_EMITS, RULE_REQUIRE_TYPED_PROPS,
     has_promise_like_return, has_unsafe_template_type, push_warning,
     should_warn_for_emit_validator, should_warn_for_prop_access, should_warn_for_reactivity_loss,
-    with_corsa_session,
+    source_path::absolute_source_file, with_corsa_session,
 };
 use super::{
     markers::{QueryKind, push_promise_marker},
@@ -14,7 +14,6 @@ use super::{
     template_queries::{TemplateQueryKind, collect_template_query_sets},
 };
 use crate::diagnostic::LintDiagnostic;
-use std::path::Path;
 use vize_armature::Parser as TemplateParser;
 use vize_carton::{FxHashSet, profile};
 use vize_croquis::{
@@ -126,7 +125,7 @@ pub(super) fn lint_with_descriptor<'a>(
         .as_ref()
         .map(|(_, offset, _, _)| *offset)
         .unwrap_or(0);
-    let from_file = Path::new(filename).parent();
+    let from_file = absolute_source_file(filename);
     let parse_result = profile!("patina.type_aware.script_parse", {
         if let Some(script_setup) = descriptor.script_setup.as_ref() {
             let generic = script_setup
@@ -155,7 +154,7 @@ pub(super) fn lint_with_descriptor<'a>(
                 .and_then(|(root, _, _, has_fatal)| (!*has_fatal).then_some(root)),
             &config,
             None,
-            from_file,
+            Some(from_file.as_path()),
         )
     );
 

--- a/crates/vize_patina/src/linter/native_type_aware/source_path.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/source_path.rs
@@ -1,0 +1,42 @@
+//! Source-file path preparation for virtual type analysis.
+
+use std::path::{Path, PathBuf};
+
+/// Resolve the analyzed SFC filename to a complete source-file path.
+///
+/// Virtual TypeScript generation resolves relative imports against the parent
+/// of this path, so callers must provide the file itself rather than its parent
+/// directory.
+pub(super) fn absolute_source_file(filename: &str) -> PathBuf {
+    let path = Path::new(filename);
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+
+    std::env::current_dir().map_or_else(|_| path.to_path_buf(), |current| current.join(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::absolute_source_file;
+    use std::path::Path;
+
+    #[test]
+    fn relative_source_files_are_rooted_without_losing_the_filename() {
+        let relative = Path::new("src/components/Button.vue");
+        let resolved = absolute_source_file(relative.to_str().expect("UTF-8 fixture path"));
+
+        assert!(resolved.is_absolute());
+        assert!(resolved.ends_with(relative));
+        assert_eq!(resolved.file_name(), relative.file_name());
+    }
+
+    #[test]
+    fn absolute_source_files_are_preserved() {
+        let absolute = std::env::current_dir()
+            .expect("current directory")
+            .join("src/components/Button.vue");
+
+        assert_eq!(absolute_source_file(absolute.to_str().unwrap()), absolute);
+    }
+}


### PR DESCRIPTION
## Summary\n\n- pass the complete analyzed source file to virtual type generation\n- root relative filenames without dropping their final path segment\n- cover relative and absolute source-file contracts directly\n- keep the oversized analysis driver from growing\n\n## Validation\n\n- cargo test -p vize_patina\n- cargo clippy -p vize_patina --lib -- -D warnings\n- cargo fmt --all -- --check\n- git diff --check\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->