### PR TITLE
test(patina): cover template attrs spreads

### DIFF
--- a/crates/vize_patina/src/linter/native_type_aware.rs
+++ b/crates/vize_patina/src/linter/native_type_aware.rs
@@ -18,6 +18,8 @@ mod script_options;
 mod template_queries;
 
 #[cfg(test)]
+mod template_globals_tests;
+#[cfg(test)]
 mod tests;
 
 const RULE_REQUIRE_TYPED_PROPS: &str = "type/require-typed-props";

--- a/crates/vize_patina/src/linter/native_type_aware/template_globals_tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_globals_tests.rs
@@ -1,0 +1,28 @@
+use super::{RULE_NO_UNSAFE_TEMPLATE_BINDING, lint_sfc_with_corsa, tests::corsa_available};
+use crate::{LintPreset, Linter};
+
+#[test]
+fn public_instance_attrs_are_a_safe_template_spread() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+const visible = true
+</script>
+
+<template>
+  <div v-if="visible" v-bind="$attrs"></div>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "AttrsFixture.vue");
+
+    assert!(
+        !result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.rule_name == RULE_NO_UNSAFE_TEMPLATE_BINDING),
+        "public instance attributes should retain a safe structural type: {:?}",
+        result.diagnostics
+    );
+}

--- a/crates/vize_patina/src/linter/native_type_aware/tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{LintPreset, Linter};
 
-fn corsa_available() -> bool {
+pub(super) fn corsa_available() -> bool {
     let mut session = match super::CorsaTypeAwareSession::new_with_corsa_path("Component.vue", None)
     {
         Ok(session) => session,


### PR DESCRIPTION
## Summary\n\n- verify public instance attributes remain safe in structural spread bindings\n- exercise the opinionated type-aware lint path with a standard SFC fixture\n- isolate the regression without growing the oversized native test module\n\n## Validation\n\n- cargo test -p vize_patina\n- cargo clippy -p vize_patina --lib -- -D warnings\n- cargo fmt --all -- --check\n- git diff --check\n