### PR TITLE
fix(vitrine): emit structured empty patina results

### DIFF
--- a/crates/vize_vitrine/src/napi/lint.rs
+++ b/crates/vize_vitrine/src/napi/lint.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use vize_carton::append;
 
 use super::lint_fix::{is_lintable_extension, lint_file_with_optional_fix, lint_source};
+mod empty_result;
 mod lint_options;
 use lint_options::{
     LintOptionsNapi, LintResultNapi, PatinaLintOptionsNapi, configure_type_aware_lint,
@@ -298,6 +299,11 @@ pub fn lint(patterns: Vec<String>, options: Option<LintOptionsNapi>) -> Result<L
 
     let opts = options.unwrap_or_default();
     let start = Instant::now();
+    let format = opts
+        .format
+        .as_deref()
+        .and_then(OutputFormat::parse)
+        .unwrap_or(OutputFormat::Text);
 
     // Collect .vue files using glob patterns or directory walking
     let files: Vec<std::path::PathBuf> = patterns
@@ -335,10 +341,7 @@ pub fn lint(patterns: Vec<String>, options: Option<LintOptionsNapi>) -> Result<L
 
     if files.is_empty() {
         return Ok(LintResultNapi {
-            output: format!(
-                "No .vue or .html files found matching patterns: {:?}",
-                patterns
-            ),
+            output: empty_result::format_empty_lint_output(&patterns, format),
             error_count: 0,
             warning_count: 0,
             file_count: 0,
@@ -374,12 +377,6 @@ pub fn lint(patterns: Vec<String>, options: Option<LintOptionsNapi>) -> Result<L
 
     let total_errors = error_count.load(Ordering::Relaxed);
     let total_warnings = warning_count.load(Ordering::Relaxed);
-
-    let format = opts
-        .format
-        .as_deref()
-        .and_then(OutputFormat::parse)
-        .unwrap_or(OutputFormat::Text);
 
     let quiet = opts.quiet.unwrap_or(false);
 

--- a/crates/vize_vitrine/src/napi/lint/empty_result.rs
+++ b/crates/vize_vitrine/src/napi/lint/empty_result.rs
@@ -1,0 +1,35 @@
+//! Empty lint result formatting for native callers.
+
+use vize_patina::{OutputFormat, format_results};
+
+/// Render a valid response when no files match the requested patterns.
+pub(super) fn format_empty_lint_output(patterns: &[String], format: OutputFormat) -> String {
+    if format == OutputFormat::Text {
+        return format!("No .vue or .html files found matching patterns: {patterns:?}");
+    }
+
+    format_results(&[], &[], format).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_empty_lint_output;
+    use serde_json::Value;
+    use vize_patina::OutputFormat;
+
+    #[test]
+    fn structured_empty_output_remains_valid_json() {
+        let output = format_empty_lint_output(&["missing".to_owned()], OutputFormat::Json);
+        let value: Value = serde_json::from_str(&output).expect("valid JSON output");
+
+        assert_eq!(value, Value::Array(Vec::new()));
+    }
+
+    #[test]
+    fn text_empty_output_explains_the_unmatched_patterns() {
+        let output = format_empty_lint_output(&["missing".to_owned()], OutputFormat::Text);
+
+        assert!(output.contains("No .vue or .html files found"));
+        assert!(output.contains("missing"));
+    }
+}


### PR DESCRIPTION
## Summary

- honor the requested output format when no source files match
- preserve the interactive explanation for text output
- return schema-valid empty reports for structured consumers
- isolate the behavior without growing the native binding module

## Validation

- `cargo check -p vize_vitrine --features napi`
- `cargo fmt --all -- --check`
- `git diff --check`