### PR TITLE
test(patina): cover typed dynamic targets

### DIFF
--- a/crates/vize_patina/src/linter/native_type_aware.rs
+++ b/crates/vize_patina/src/linter/native_type_aware.rs
@@ -16,6 +16,8 @@ mod reactivity_loss;
 mod rule_queries;
 mod script_options;
 mod source_path;
+#[cfg(test)]
+mod template_component_tests;
 mod template_queries;
 
 #[cfg(test)]

--- a/crates/vize_patina/src/linter/native_type_aware/template_component_tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_component_tests.rs
@@ -1,0 +1,35 @@
+use super::{RULE_NO_UNSAFE_TEMPLATE_BINDING, lint_sfc_with_corsa, tests::corsa_available};
+use crate::{LintPreset, Linter};
+
+#[test]
+fn typed_dynamic_component_target_is_a_safe_template_binding() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+type RenderTarget =
+  | keyof HTMLElementTagNameMap
+  | object
+  | ((...args: never[]) => unknown)
+
+const props = defineProps<{
+  readonly as: RenderTarget
+}>()
+</script>
+
+<template>
+  <component :is="props.as"></component>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "DynamicFixture.vue");
+
+    assert!(
+        !result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.rule_name == RULE_NO_UNSAFE_TEMPLATE_BINDING),
+        "a typed render target should retain a safe template type: {:?}",
+        result.diagnostics
+    );
+}


### PR DESCRIPTION
## Summary

- cover typed dynamic component targets through the native type-aware lint path
- verify structural target unions remain safe template bindings
- keep the SFC fixture aligned with the opinionated source conventions
- isolate the regression without growing the oversized native test module

## Validation

- `cargo test -p vize_patina typed_dynamic_component_target_is_a_safe_template_binding`
- `cargo test -p vize_patina`
- `cargo clippy -p vize_patina --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`