### PR TITLE
fix(vitrine): deduplicate patina inputs

### DIFF
--- a/crates/vize_vitrine/src/napi/lint.rs
+++ b/crates/vize_vitrine/src/napi/lint.rs
@@ -10,7 +10,6 @@
     clippy::disallowed_macros
 )]
 
-use glob::glob;
 use napi::bindgen_prelude::{Error, Result, Status};
 use napi_derive::napi;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
@@ -18,8 +17,9 @@ use serde_json::{Value, json};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use vize_carton::append;
 
-use super::lint_fix::{is_lintable_extension, lint_file_with_optional_fix, lint_source};
+use super::lint_fix::{lint_file_with_optional_fix, lint_source};
 mod empty_result;
+mod file_collection;
 mod lint_options;
 use lint_options::{
     LintOptionsNapi, LintResultNapi, PatinaLintOptionsNapi, configure_type_aware_lint,
@@ -293,7 +293,6 @@ pub fn get_patina_rules() -> Result<Value> {
 /// Lint Vue SFC files matching patterns (native multithreading, .gitignore-aware)
 #[napi]
 pub fn lint(patterns: Vec<String>, options: Option<LintOptionsNapi>) -> Result<LintResultNapi> {
-    use ignore::Walk;
     use std::time::Instant;
     use vize_patina::{HelpLevel, OutputFormat, format_results, format_summary};
 
@@ -305,39 +304,7 @@ pub fn lint(patterns: Vec<String>, options: Option<LintOptionsNapi>) -> Result<L
         .and_then(OutputFormat::parse)
         .unwrap_or(OutputFormat::Text);
 
-    // Collect .vue files using glob patterns or directory walking
-    let files: Vec<std::path::PathBuf> = patterns
-        .iter()
-        .flat_map(|pattern| {
-            if pattern.contains('*') || pattern.contains('?') || pattern.contains('[') {
-                // Use glob for pattern matching
-                glob(pattern)
-                    .ok()
-                    .into_iter()
-                    .flatten()
-                    .filter_map(|r| r.ok())
-                    .filter(|p| {
-                        p.extension()
-                            .and_then(|ext| ext.to_str())
-                            .is_some_and(is_lintable_extension)
-                            && !p.components().any(|c| c.as_os_str() == "node_modules")
-                    })
-                    .collect::<Vec<_>>()
-            } else {
-                // Use directory walking for paths (respects .gitignore)
-                Walk::new(pattern)
-                    .filter_map(|e| e.ok())
-                    .filter(|e| {
-                        e.path()
-                            .extension()
-                            .and_then(|ext| ext.to_str())
-                            .is_some_and(is_lintable_extension)
-                    })
-                    .map(|e| e.path().to_path_buf())
-                    .collect::<Vec<_>>()
-            }
-        })
-        .collect();
+    let files = file_collection::collect_lint_files(&patterns);
 
     if files.is_empty() {
         return Ok(LintResultNapi {

--- a/crates/vize_vitrine/src/napi/lint/file_collection.rs
+++ b/crates/vize_vitrine/src/napi/lint/file_collection.rs
@@ -1,0 +1,75 @@
+//! Deterministic file discovery for native lint requests.
+
+use super::super::lint_fix::is_lintable_extension;
+use glob::glob;
+use ignore::Walk;
+use std::path::PathBuf;
+
+/// Discover lintable paths, then sort and deduplicate overlapping inputs.
+pub(super) fn collect_lint_files(patterns: &[String]) -> Vec<PathBuf> {
+    let mut files = patterns
+        .iter()
+        .flat_map(|pattern| {
+            if pattern.contains('*') || pattern.contains('?') || pattern.contains('[') {
+                glob(pattern)
+                    .ok()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(Result::ok)
+                    .filter(|path| {
+                        path.extension()
+                            .and_then(|extension| extension.to_str())
+                            .is_some_and(is_lintable_extension)
+                            && !path
+                                .components()
+                                .any(|component| component.as_os_str() == "node_modules")
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                Walk::new(pattern)
+                    .filter_map(Result::ok)
+                    .filter(|entry| {
+                        entry
+                            .path()
+                            .extension()
+                            .and_then(|extension| extension.to_str())
+                            .is_some_and(is_lintable_extension)
+                    })
+                    .map(|entry| entry.path().to_path_buf())
+                    .collect::<Vec<_>>()
+            }
+        })
+        .collect::<Vec<_>>();
+    sort_unique_file_paths(&mut files);
+    files
+}
+
+fn sort_unique_file_paths(files: &mut Vec<PathBuf>) {
+    files.sort_unstable();
+    files.dedup();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sort_unique_file_paths;
+    use std::path::PathBuf;
+
+    #[test]
+    fn overlapping_inputs_are_linted_once_in_stable_order() {
+        let mut files = vec![
+            PathBuf::from("src/Zeta.vue"),
+            PathBuf::from("src/Alpha.vue"),
+            PathBuf::from("src/Zeta.vue"),
+        ];
+
+        sort_unique_file_paths(&mut files);
+
+        assert_eq!(
+            files,
+            vec![
+                PathBuf::from("src/Alpha.vue"),
+                PathBuf::from("src/Zeta.vue")
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- lint each exact source path once when input patterns overlap
- make native lint file ordering deterministic
- keep collection normalization isolated from the binding entry point
- cover both ordering and duplicate removal

## Validation

- `cargo check -p vize_vitrine --features napi --tests`
- `cargo fmt --all -- --check`
- `git diff --check`