### PR TITLE
feat(ui): add SFC quality tooling

### DIFF
--- a/npm/ui/tooling/lint-sfc.test.ts
+++ b/npm/ui/tooling/lint-sfc.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { formatSfcLintResults, lintSfcFiles } from "./lint-sfc.ts";
+
+void test("discovers overlapping SFC roots once in deterministic order", async (context) => {
+  const root = await mkdtemp(path.join(tmpdir(), "vize-ui-sfc-"));
+  context.after(() => rm(root, { force: true, recursive: true }));
+  await mkdir(path.join(root, "a"));
+  await mkdir(path.join(root, "z"));
+  await writeFile(path.join(root, "z", "Second.vue"), "<template><p>Second</p></template>");
+  await writeFile(path.join(root, "a", "First.vue"), "<template><p>First</p></template>");
+
+  const requestedFiles: string[] = [];
+  const results = await lintSfcFiles(
+    (_, options) => {
+      requestedFiles.push(options.filename);
+      assert.equal(options.preset, "opinionated");
+      assert.equal(options.typeAware, true);
+      assert.equal(options.helpLevel, "short");
+      return { diagnostics: [] };
+    },
+    [root, root],
+  );
+
+  assert.deepEqual(
+    requestedFiles.map((filename) => path.basename(filename)),
+    ["First.vue", "Second.vue"],
+  );
+  assert.equal(results.length, 2);
+});
+
+void test("formats source locations and preserves warning severity", () => {
+  const report = formatSfcLintResults([
+    {
+      filename: "src/Control.vue",
+      diagnostics: [
+        {
+          rule: "a11y/control-name",
+          severity: "warning",
+          message: "Control requires an accessible name",
+          location: { start: { line: 4, column: 7 } },
+        },
+      ],
+    },
+  ]);
+
+  assert.equal(
+    report,
+    "src/Control.vue:4:7 warning a11y/control-name Control requires an accessible name",
+  );
+});

--- a/npm/ui/tooling/lint-sfc.ts
+++ b/npm/ui/tooling/lint-sfc.ts
@@ -1,0 +1,140 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+interface SfcDiagnostic {
+  readonly rule?: unknown;
+  readonly severity?: unknown;
+  readonly message?: unknown;
+  readonly location?: {
+    readonly start?: {
+      readonly line?: unknown;
+      readonly column?: unknown;
+    };
+  };
+}
+
+interface SfcLintResult {
+  readonly diagnostics?: unknown;
+}
+
+/** One SFC and the diagnostics produced for it. */
+export interface LintedFile {
+  readonly filename: string;
+  readonly diagnostics: readonly SfcDiagnostic[];
+}
+
+/** Native SFC lint entry point supplied by the consuming workspace package. */
+export interface SfcLintFunction {
+  (
+    source: string,
+    options: {
+      readonly filename: string;
+      readonly preset: "opinionated";
+      readonly typeAware: true;
+      readonly helpLevel: "short";
+    },
+  ): unknown;
+}
+
+/**
+ * Lint SFC sources with Vize's strict opinionated preset.
+ *
+ * Diagnostics are reported in stable path order so CI logs and automated
+ * tooling can compare results without depending on filesystem traversal order.
+ *
+ * @param lint Native Vize SFC lint function.
+ * @param sourceRoots Directories containing SFC sources.
+ * @default "src"
+ */
+export async function lintSfcFiles(
+  lint: SfcLintFunction,
+  sourceRoots: string | readonly string[] = "src",
+): Promise<readonly LintedFile[]> {
+  const roots = typeof sourceRoots === "string" ? [sourceRoots] : sourceRoots;
+  const discovered = await Promise.all(roots.map((root) => collectVueFiles(path.resolve(root))));
+  const files = [...new Set(discovered.flat())].sort();
+  const results: LintedFile[] = [];
+
+  for (const filename of files) {
+    const source = await readFile(filename, "utf8");
+    const raw = lint(source, {
+      filename,
+      preset: "opinionated",
+      typeAware: true,
+      helpLevel: "short",
+    }) as SfcLintResult;
+    const diagnostics = Array.isArray(raw.diagnostics)
+      ? raw.diagnostics.filter(isSfcDiagnostic)
+      : [];
+    results.push({
+      filename: path.relative(process.cwd(), filename),
+      diagnostics,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Render Vize diagnostics for terminals and continuous integration.
+ *
+ * @param results Results returned by {@link lintSfcFiles}.
+ * @returns A newline-delimited report; an empty string means a clean run.
+ */
+export function formatSfcLintResults(results: readonly LintedFile[]): string {
+  return results
+    .flatMap(({ filename, diagnostics }) =>
+      diagnostics.map((diagnostic) => {
+        const line = numberOrFallback(diagnostic.location?.start?.line, 1);
+        const column = numberOrFallback(diagnostic.location?.start?.column, 1);
+        const severity = diagnostic.severity === "warning" ? "warning" : "error";
+        const rule = stringOrFallback(diagnostic.rule, "vize/sfc");
+        const message = stringOrFallback(diagnostic.message, "Vize SFC lint diagnostic");
+        return `${filename}:${line}:${column} ${severity} ${rule} ${message}`;
+      }),
+    )
+    .join("\n");
+}
+
+/**
+ * Run the shared SFC gate and set a failing process status for any diagnostic.
+ *
+ * @param lint Native Vize SFC lint function.
+ * @param sourceRoots Directories containing SFC sources.
+ * @default "src"
+ */
+export async function runSfcLintCli(
+  lint: SfcLintFunction,
+  sourceRoots: string | readonly string[] = "src",
+): Promise<void> {
+  const results = await lintSfcFiles(lint, sourceRoots);
+  const report = formatSfcLintResults(results);
+  if (report) process.stderr.write(`${report}\n`);
+  if (results.some((result) => result.diagnostics.length > 0)) process.exitCode = 1;
+}
+
+async function collectVueFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const filename = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectVueFiles(filename)));
+    } else if (entry.isFile() && entry.name.endsWith(".vue")) {
+      files.push(filename);
+    }
+  }
+  return files;
+}
+
+function isSfcDiagnostic(value: unknown): value is SfcDiagnostic {
+  return typeof value === "object" && value !== null;
+}
+
+function numberOrFallback(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function stringOrFallback(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}

--- a/npm/ui/tooling/package.json
+++ b/npm/ui/tooling/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@vizeui/tooling",
+  "version": "0.298.0",
+  "private": true,
+  "description": "Internal source-quality tooling for Vize UI packages",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./lint-sfc": "./lint-sfc.ts"
+  },
+  "scripts": {
+    "check": "vp check lint-sfc.ts lint-sfc.test.ts",
+    "fmt": "vp fmt --write lint-sfc.ts lint-sfc.test.ts",
+    "test": "vp exec node --test lint-sfc.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:typescript",
+    "vite-plus": "catalog:vite-stack"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/npm/ui/tooling/tsconfig.json
+++ b/npm/ui/tooling/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -859,6 +859,15 @@ importers:
         specifier: catalog:native-binaries
         version: 0.108.0
 
+  npm/ui/tooling:
+    devDependencies:
+      '@types/node':
+        specifier: catalog:typescript
+        version: 25.9.2
+      vite-plus:
+        specifier: catalog:vite-stack
+        version: 0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)
+
   npm/wasm: {}
 
   playground:


### PR DESCRIPTION
## Summary

- add a shared opinionated SFC quality gate for UI packages
- discover overlapping source roots once in deterministic order
- render stable source-addressed diagnostics for terminals and CI
- document every public option and default
- cover discovery, deduplication, lint options, locations, and severity

## Validation

- `pnpm --filter @vizeui/tooling check`
- `pnpm --filter @vizeui/tooling test`
- workspace lockfile policy verification
- `git diff --check`