### PR TITLE
feat(compose): add lifecycle scope foundation

### DIFF
--- a/npm/compose/core/package.json
+++ b/npm/compose/core/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@vizecompose/core",
+  "version": "0.298.0",
+  "description": "Lifecycle-safe composable foundations for Vize applications",
+  "keywords": [
+    "composables",
+    "lifecycle",
+    "type-safe",
+    "vize",
+    "vue"
+  ],
+  "homepage": "https://github.com/ubugeeei-prod/vize",
+  "bugs": {
+    "url": "https://github.com/ubugeeei-prod/vize/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ubugeeei-prod/vize.git",
+    "directory": "npm/compose/core"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "vp pack",
+    "dev": "vp pack --watch",
+    "test": "vp exec node --test 'src/**/*.test.ts'",
+    "check": "vp check src scripts vite.config.ts",
+    "check:fix": "vp check --fix src scripts vite.config.ts",
+    "check:size": "node scripts/check-size.mjs",
+    "fmt": "vp fmt --write src scripts vite.config.ts"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:typescript",
+    "typescript": "catalog:typescript",
+    "vite-plus": "catalog:vite-stack",
+    "vue": "catalog:vue-stable"
+  },
+  "peerDependencies": {
+    "vue": "^3.5.0"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/npm/compose/core/scripts/check-size.mjs
+++ b/npm/compose/core/scripts/check-size.mjs
@@ -1,0 +1,10 @@
+import { readFile } from "node:fs/promises";
+import { gzipSync } from "node:zlib";
+
+const maximumGzipBytes = 4 * 1024;
+const gzipBytes = gzipSync(
+  await readFile(new URL("../dist/index.mjs", import.meta.url)),
+).byteLength;
+
+console.log(JSON.stringify({ entry: "@vizecompose/core", gzipBytes, maximumGzipBytes }));
+if (gzipBytes > maximumGzipBytes) process.exitCode = 1;

--- a/npm/compose/core/src/index.ts
+++ b/npm/compose/core/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./scope.ts";

--- a/npm/compose/core/src/scope.test.ts
+++ b/npm/compose/core/src/scope.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { effectScope } from "vue";
+
+import { tryOnScopeDispose } from "./scope.ts";
+
+void test("reports that cleanup cannot be registered outside a scope", () => {
+  let cleanupCalls = 0;
+
+  assert.equal(
+    tryOnScopeDispose(() => (cleanupCalls += 1)),
+    false,
+  );
+  assert.equal(cleanupCalls, 0);
+});
+
+void test("runs registered cleanup exactly once when the scope stops", () => {
+  const scope = effectScope();
+  let cleanupCalls = 0;
+  const registered = scope.run(() => tryOnScopeDispose(() => (cleanupCalls += 1)));
+
+  assert.equal(registered, true);
+  assert.equal(cleanupCalls, 0);
+  scope.stop();
+  scope.stop();
+  assert.equal(cleanupCalls, 1);
+});

--- a/npm/compose/core/src/scope.ts
+++ b/npm/compose/core/src/scope.ts
@@ -1,0 +1,13 @@
+import { getCurrentScope, onScopeDispose } from "vue";
+
+/**
+ * Register cleanup in the active reactive scope when one exists.
+ *
+ * @param cleanup Cleanup invoked exactly once when the scope is disposed.
+ * @returns Whether the cleanup was registered.
+ */
+export function tryOnScopeDispose(cleanup: () => void): boolean {
+  if (!getCurrentScope()) return false;
+  onScopeDispose(cleanup);
+  return true;
+}

--- a/npm/compose/core/tsconfig.json
+++ b/npm/compose/core/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "rewriteRelativeImportExtensions": true,
+    "types": ["node"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/npm/compose/core/vite.config.ts
+++ b/npm/compose/core/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  lint: {
+    ignorePatterns: ["dist/**"],
+    options: { typeAware: true },
+  },
+  fmt: { ignorePatterns: ["dist/**"] },
+  pack: {
+    entry: ["src/index.ts"],
+    format: "esm",
+    dts: true,
+    clean: true,
+    deps: {
+      neverBundle: ["vue"],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,6 +379,21 @@ importers:
         specifier: workspace:*
         version: link:../../npm/cli
 
+  npm/compose/core:
+    devDependencies:
+      '@types/node':
+        specifier: catalog:typescript
+        version: 25.9.2
+      typescript:
+        specifier: catalog:typescript
+        version: 6.0.3
+      vite-plus:
+        specifier: catalog:vite-stack
+        version: 0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
+      vue:
+        specifier: catalog:vue-stable
+        version: 3.5.35(typescript@6.0.3)
+
   npm/fresco:
     dependencies:
       '@vizejs/fresco-native':

--- a/tests/tooling/release-preflight-runner.test.ts
+++ b/tests/tooling/release-preflight-runner.test.ts
@@ -99,6 +99,7 @@ test("release metadata inventory discovers every non-private npm and editor pack
       "npm/builder/vite-musea/package.json",
       "npm/builder/vite/package.json",
       "npm/cli/package.json",
+      "npm/compose/core/package.json",
       "npm/framework/musea-nuxt/package.json",
       "npm/framework/nuxt/package.json",
       "npm/fresco-native/package.json",


### PR DESCRIPTION
## Summary

- establish the core composable package with strict source and package contracts
- add lifecycle-aware cleanup registration with an explicit success result
- document the public cleanup behavior and return contract
- enforce a compressed production-size budget
- cover scoped and unscoped cleanup behavior

## Validation

- `pnpm --filter @vizecompose/core check`
- `pnpm --filter @vizecompose/core test`
- `pnpm --filter @vizecompose/core build`
- `pnpm --filter @vizecompose/core check:size`
- repository-wide format and lint inspection
- workspace lockfile policy verification
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable cleanup utility that safely registers callbacks within Vue reactive scopes.
  * Exported the new utility through the core package.
  * Introduced the core package with ESM and TypeScript distribution support.

* **Bug Fixes**
  * Cleanup callbacks now execute once when their associated scope is stopped.

* **Tests**
  * Added coverage for scoped and out-of-scope cleanup behavior.

* **Chores**
  * Added build, validation, formatting, and bundle-size checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->