### PR TITLE
feat(ui): add visually hidden primitive

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -318,10 +318,8 @@ jobs:
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
-      - name: Build native package
-        run: vp run --filter './npm/native' build:ci
-      - name: Lint UI SFC packages
-        run: vp run --filter './npm/ui/core' lint:sfc
+      - name: Build native package and lint UI SFC packages
+        run: vp run --filter './npm/native' build:ci && vp run --filter './npm/ui/core' lint:sfc
       - name: Build JS packages
         run: vp run --workspace-root build:packages
       - name: Stage shared JS build artifacts

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -320,6 +320,8 @@ jobs:
         run: vp install --frozen-lockfile --prefer-offline
       - name: Build native package
         run: vp run --filter './npm/native' build:ci
+      - name: Lint UI SFC packages
+        run: vp run --filter './npm/ui/core' lint:sfc
       - name: Build JS packages
         run: vp run --workspace-root build:packages
       - name: Stage shared JS build artifacts

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -60,7 +60,8 @@ jobs:
             './npm/builder/vite-musea' \
             './npm/builder/rspack' \
             './npm/framework/musea-nuxt' \
-            './npm/framework/nuxt' 2>&1 | tee "$OUTPUT_FILE"; then
+            './npm/framework/nuxt' \
+            './npm/ui/core' 2>&1 | tee "$OUTPUT_FILE"; then
             exit 0
           fi
           if grep -q "The app https://github.com/apps/pkg-pr-new is not installed" "$OUTPUT_FILE"; then

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: ./.github/actions/setup-moonbit
 
       - name: Install package build dependencies
-        run: moon run --target native tools/moon/cmd/github/vp_install -- --filter './npm/cli...' --filter './npm/builder/vite...' --filter './npm/oxint...' --filter './npm/builder/unplugin...' --filter './npm/fresco...' --filter './npm/mcp-musea...' --filter './npm/builder/vite-musea...' --filter './npm/builder/rspack...' --filter './npm/framework/musea-nuxt...' --filter './npm/framework/nuxt...'
+        run: moon run --target native tools/moon/cmd/github/vp_install -- --filter './npm/cli...' --filter './npm/builder/vite...' --filter './npm/oxint...' --filter './npm/builder/unplugin...' --filter './npm/fresco...' --filter './npm/mcp-musea...' --filter './npm/builder/vite-musea...' --filter './npm/builder/rspack...' --filter './npm/framework/musea-nuxt...' --filter './npm/framework/nuxt...' --filter './npm/ui/core...'
 
       - name: Build preview packages
         run: vp run --workspace-root build:packages

--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -37,7 +37,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "pnpm lint:sfc && vp pack",
+    "build": "vp pack",
     "dev": "vp pack --watch",
     "lint:sfc": "vp exec node scripts/lint-sfc.ts src",
     "pretest": "vp pack && pnpm check:size",

--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@vizeui/core",
+  "version": "0.298.0",
+  "description": "Accessible, headless, Native CSS-first UI primitives",
+  "keywords": [
+    "accessibility",
+    "headless",
+    "type-safe",
+    "vize",
+    "vue"
+  ],
+  "homepage": "https://github.com/ubugeeei-prod/vize",
+  "bugs": {
+    "url": "https://github.com/ubugeeei-prod/vize/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ubugeeei-prod/vize.git",
+    "directory": "npm/ui/core"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "vp pack",
+    "dev": "vp pack --watch",
+    "lint:sfc": "vp exec node scripts/lint-sfc.ts src",
+    "pretest": "pnpm lint:sfc && pnpm build && pnpm check:size",
+    "test": "vp exec node --test 'src/**/*.test.ts'",
+    "check": "pnpm lint:sfc && vp check src scripts vite.config.ts",
+    "check:fix": "vp check --fix src scripts vite.config.ts",
+    "check:size": "node scripts/check-size.mjs",
+    "fmt": "vp fmt --write src scripts vite.config.ts"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:typescript",
+    "@vitejs/plugin-vue": "catalog:vite-stack",
+    "@vizejs/native": "workspace:*",
+    "@vizeui/tooling": "workspace:*",
+    "typescript": "catalog:typescript",
+    "vite": "catalog:vite-stack",
+    "vite-plus": "catalog:vite-stack",
+    "vue": "catalog:vue-stable"
+  },
+  "peerDependencies": {
+    "vue": "^3.5.0"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -42,7 +42,7 @@
     "lint:sfc": "vp exec node scripts/lint-sfc.ts src",
     "pretest": "pnpm lint:sfc && pnpm build && pnpm check:size",
     "test": "vp exec node --test 'src/**/*.test.ts'",
-    "check": "pnpm lint:sfc && vp check src scripts vite.config.ts",
+    "check": "vp check src scripts vite.config.ts",
     "check:fix": "vp check --fix src scripts vite.config.ts",
     "check:size": "node scripts/check-size.mjs",
     "fmt": "vp fmt --write src scripts vite.config.ts"

--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -37,10 +37,10 @@
     "access": "public"
   },
   "scripts": {
-    "build": "vp pack",
+    "build": "pnpm lint:sfc && vp pack",
     "dev": "vp pack --watch",
     "lint:sfc": "vp exec node scripts/lint-sfc.ts src",
-    "pretest": "pnpm lint:sfc && pnpm build && pnpm check:size",
+    "pretest": "vp pack && pnpm check:size",
     "test": "vp exec node --test 'src/**/*.test.ts'",
     "check": "vp check src scripts vite.config.ts",
     "check:fix": "vp check --fix src scripts vite.config.ts",

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -1,0 +1,10 @@
+import { readFile } from "node:fs/promises";
+import { gzipSync } from "node:zlib";
+
+const maximumGzipBytes = 3 * 1024;
+const gzipBytes = gzipSync(
+  await readFile(new URL("../dist/index.mjs", import.meta.url)),
+).byteLength;
+
+console.log(JSON.stringify({ entry: "@vizeui/core", gzipBytes, maximumGzipBytes }));
+if (gzipBytes > maximumGzipBytes) process.exitCode = 1;

--- a/npm/ui/core/scripts/lint-sfc.ts
+++ b/npm/ui/core/scripts/lint-sfc.ts
@@ -1,0 +1,29 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { lintPatinaSfc } from "@vizejs/native";
+import {
+  formatSfcLintResults,
+  lintSfcFiles as lintFiles,
+  runSfcLintCli,
+} from "@vizeui/tooling/lint-sfc";
+
+export { formatSfcLintResults };
+
+/**
+ * Lint the package's SFC sources with Vize's opinionated preset.
+ *
+ * @param sourceRoots Directories containing SFC sources.
+ * @default "src"
+ */
+export async function lintSfcFiles(sourceRoots: string | readonly string[] = "src") {
+  return lintFiles(lintPatinaSfc, sourceRoots);
+}
+
+const invokedAsScript =
+  process.argv[1] != null && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (invokedAsScript) {
+  const sourceRoots = process.argv.slice(2);
+  await runSfcLintCli(lintPatinaSfc, sourceRoots.length > 0 ? sourceRoots : "src");
+}

--- a/npm/ui/core/src/VisuallyHidden.vue
+++ b/npm/ui/core/src/VisuallyHidden.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { useTemplateRef } from "vue";
+
+const element = useTemplateRef<HTMLSpanElement>("element");
+
+defineExpose({ element });
+</script>
+
+<template>
+  <span ref="element" data-vize-ui="visually-hidden">
+    <slot />
+  </span>
+</template>
+
+<style scoped>
+[data-vize-ui="visually-hidden"] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+</style>

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -1,0 +1,2 @@
+/** Visually hidden content exposed to assistive technology. */
+export { default as VisuallyHidden } from "./VisuallyHidden.vue";

--- a/npm/ui/core/src/sfc-lint.test.ts
+++ b/npm/ui/core/src/sfc-lint.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { formatSfcLintResults, lintSfcFiles } from "../scripts/lint-sfc.ts";
+
+void test("keeps every shipped SFC clean under the opinionated Vize preset", async () => {
+  const results = await lintSfcFiles();
+
+  assert.deepEqual(
+    results.map((result) => result.filename),
+    ["src/VisuallyHidden.vue"],
+  );
+  assert.equal(formatSfcLintResults(results), "");
+});

--- a/npm/ui/core/src/sfc-lint.test.ts
+++ b/npm/ui/core/src/sfc-lint.test.ts
@@ -1,14 +1,28 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { formatSfcLintResults, lintSfcFiles } from "../scripts/lint-sfc.ts";
+import { formatSfcLintResults, lintSfcFiles } from "@vizeui/tooling/lint-sfc";
+import type { SfcLintFunction } from "@vizeui/tooling/lint-sfc";
 
-void test("keeps every shipped SFC clean under the opinionated Vize preset", async () => {
-  const results = await lintSfcFiles();
+void test("discovers every SFC with the opinionated Vize contract", async () => {
+  const requests: Parameters<SfcLintFunction>[1][] = [];
+  const lint: SfcLintFunction = (_source, options) => {
+    requests.push(options);
+    return { diagnostics: [] };
+  };
+  const results = await lintSfcFiles(lint);
 
   assert.deepEqual(
     results.map((result) => result.filename),
     ["src/VisuallyHidden.vue"],
   );
+  assert.deepEqual(requests, [
+    {
+      filename: new URL("./VisuallyHidden.vue", import.meta.url).pathname,
+      preset: "opinionated",
+      typeAware: true,
+      helpLevel: "short",
+    },
+  ]);
   assert.equal(formatSfcLintResults(results), "");
 });

--- a/npm/ui/core/src/visually-hidden.test.ts
+++ b/npm/ui/core/src/visually-hidden.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const source = await readFile(new URL("./VisuallyHidden.vue", import.meta.url), "utf8");
+
+void test("ships the primitive as an explicit opinionated SFC", () => {
+  assert.match(source, /<script setup lang="ts">[\s\S]*<\/script>/);
+  assert.match(source, /<template>[\s\S]*<\/template>/);
+  assert.match(source, /<style scoped>[\s\S]*<\/style>/);
+  assert.doesNotMatch(source, /\bh\s*\(/);
+  assert.doesNotMatch(source, /defineOptions|withDefaults|interface (?:Props|Emits)/);
+});
+
+void test("preserves accessibility while removing visual layout", () => {
+  assert.match(source, /<slot \/>/);
+  assert.match(source, /position: absolute/);
+  assert.match(source, /clip-path: inset\(50%\)/);
+  assert.match(source, /white-space: nowrap/);
+  assert.doesNotMatch(source, /display:\s*none|visibility:\s*hidden/);
+});

--- a/npm/ui/core/tsconfig.json
+++ b/npm/ui/core/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "rewriteRelativeImportExtensions": true,
+    "types": ["node"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -1,0 +1,20 @@
+import vue from "@vitejs/plugin-vue";
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  lint: {
+    ignorePatterns: ["dist/**"],
+    options: { typeAware: true },
+  },
+  fmt: { ignorePatterns: ["dist/**"] },
+  pack: {
+    entry: ["src/index.ts"],
+    format: "esm",
+    dts: { vue: true },
+    plugins: [vue()],
+    clean: true,
+    deps: {
+      neverBundle: ["vue"],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -883,6 +883,33 @@ importers:
         specifier: catalog:vite-stack
         version: 0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)
 
+  npm/ui/core:
+    devDependencies:
+      '@types/node':
+        specifier: catalog:typescript
+        version: 25.9.2
+      '@vitejs/plugin-vue':
+        specifier: catalog:vite-stack
+        version: 6.0.7(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+      '@vizejs/native':
+        specifier: workspace:*
+        version: link:../../native
+      '@vizeui/tooling':
+        specifier: workspace:*
+        version: link:../tooling
+      typescript:
+        specifier: catalog:typescript
+        version: 6.0.3
+      vite:
+        specifier: catalog:vite-stack
+        version: '@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)'
+      vite-plus:
+        specifier: catalog:vite-stack
+        version: 0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)
+      vue:
+        specifier: catalog:vue-stable
+        version: 3.5.35(typescript@6.0.3)
+
   npm/wasm: {}
 
   playground:

--- a/tests/tooling/release-preflight-runner.test.ts
+++ b/tests/tooling/release-preflight-runner.test.ts
@@ -108,6 +108,7 @@ test("release metadata inventory discovers every non-private npm and editor pack
       "npm/mcp-musea/package.json",
       "npm/native/package.json",
       "npm/oxint/package.json",
+      "npm/ui/core/package.json",
       "npm/wasm/package.json",
     ],
   );

--- a/tools/vite-plus/task-inputs.ts
+++ b/tools/vite-plus/task-inputs.ts
@@ -21,6 +21,7 @@ export const checkedPackages = [
   "./npm/framework/musea-nuxt",
   "./npm/mcp-musea",
   "./npm/fresco",
+  "./npm/ui/core",
   "./npm/marquette",
   "./npm/builder/vite/example",
   "./npm/builder/rspack/example",
@@ -64,6 +65,7 @@ export const packedPackages = [
   "./npm/framework/musea-nuxt",
   "./npm/mcp-musea",
   "./npm/fresco",
+  "./npm/ui/core",
   "./npm/marquette",
 ] satisfies PackagePath[];
 
@@ -75,6 +77,7 @@ export const testedPackages = [
   "./npm/builder/rspack",
   "./npm/framework/nuxt",
   "./npm/mcp-musea",
+  "./npm/ui/core",
   "./npm/marquette",
 ] satisfies PackagePath[];
 


### PR DESCRIPTION
## Summary

- establish a public headless UI package with strict source and build contracts
- add an SFC-only visually hidden primitive that preserves accessible content
- expose the rendered element deliberately and provide a Native CSS customization hook
- enforce opinionated SFC linting and a compressed production-size budget
- register package checks, builds, and tests in workspace CI

## Validation

- frozen lockfile installation and supply-chain policy
- package type, lint, formatting, and configuration checks
- package tests
- production build and compressed-size check
- repository-wide formatting and linting
- JavaScript task wiring tests
- patch whitespace checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `@vizeui/core` ESM package (v0.298.0) for distributing reusable Vue UI components.
  * Introduced a new `VisuallyHidden` component that visually hides content while keeping it accessible to assistive technologies.

* **Testing**
  * Added linting validation for shipped SFCs and automated tests for `VisuallyHidden`.
  * Added bundle size and packaging checks to CI for the core package.

* **Chores**
  * Expanded monorepo package inclusion so core is covered by build/test task selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->