### PR TITLE
feat(compose): add reactive event listeners

### DIFF
--- a/npm/compose/core/src/event-listener.test.ts
+++ b/npm/compose/core/src/event-listener.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { effectScope, ref } from "vue";
+
+import { useEventListener } from "./event-listener.ts";
+
+void test("moves a listener between reactive targets and disposes it with the scope", () => {
+  const first = new EventTarget();
+  const second = new EventTarget();
+  const target = ref<EventTarget | null>(first);
+  const scope = effectScope();
+  let calls = 0;
+  const controls = scope.run(() =>
+    useEventListener(target, "change", () => (calls += 1), { flush: "sync" }),
+  );
+
+  assert.ok(controls);
+  assert.equal(controls.isListening.value, true);
+  first.dispatchEvent(new Event("change"));
+  target.value = second;
+  first.dispatchEvent(new Event("change"));
+  second.dispatchEvent(new Event("change"));
+  assert.equal(calls, 2);
+
+  scope.stop();
+  second.dispatchEvent(new Event("change"));
+  assert.equal(controls.isListening.value, false);
+  assert.equal(calls, 2);
+});
+
+void test("supports idempotent manual and one-shot listener controls", () => {
+  const target = new EventTarget();
+  const scope = effectScope();
+  let calls = 0;
+  const controls = scope.run(() =>
+    useEventListener(target, "submit", () => (calls += 1), {
+      flush: "sync",
+      immediate: false,
+      once: true,
+    }),
+  );
+
+  assert.ok(controls);
+  target.dispatchEvent(new Event("submit"));
+  assert.equal(calls, 0);
+  assert.equal(controls.start(), true);
+  assert.equal(controls.start(), false);
+  target.dispatchEvent(new Event("submit"));
+  assert.equal(calls, 1);
+  assert.equal(controls.isListening.value, false);
+  assert.equal(controls.start(), true);
+  target.dispatchEvent(new Event("submit"));
+  assert.equal(calls, 2);
+
+  controls.stop();
+  controls.stop();
+  scope.stop();
+});
+
+void test("stops when the supplied signal aborts", () => {
+  const target = new EventTarget();
+  const signal = new AbortController();
+  let calls = 0;
+  const controls = useEventListener(target, "update", () => (calls += 1), {
+    flush: "sync",
+    signal: signal.signal,
+  });
+
+  target.dispatchEvent(new Event("update"));
+  signal.abort();
+  target.dispatchEvent(new Event("update"));
+
+  assert.equal(calls, 1);
+  assert.equal(controls.isListening.value, false);
+  assert.equal(controls.start(), false);
+});

--- a/npm/compose/core/src/event-listener.ts
+++ b/npm/compose/core/src/event-listener.ts
@@ -1,0 +1,161 @@
+import { readonly, ref, toValue, watch } from "vue";
+import type { MaybeRefOrGetter, Ref, WatchHandle } from "vue";
+
+import { tryOnScopeDispose } from "./scope.ts";
+
+/** Options for {@link useEventListener}. */
+export interface UseEventListenerOptions {
+  /**
+   * Invoke the listener during the capture phase.
+   *
+   * @default false
+   */
+  readonly capture?: boolean;
+
+  /**
+   * Stop listening after the first event.
+   *
+   * @default false
+   */
+  readonly once?: boolean;
+
+  /**
+   * Declare that the listener does not cancel the event's default action.
+   *
+   * @default false
+   */
+  readonly passive?: boolean;
+
+  /**
+   * Stop listening when this signal is aborted.
+   *
+   * @default undefined
+   */
+  readonly signal?: AbortSignal;
+
+  /**
+   * Start listening during composable creation.
+   *
+   * @default true
+   */
+  readonly immediate?: boolean;
+
+  /**
+   * Reactive target update timing.
+   *
+   * @default "pre"
+   */
+  readonly flush?: "pre" | "post" | "sync";
+}
+
+/** Reactive controls returned by {@link useEventListener}. */
+export interface EventListenerControls {
+  /** Whether a concrete target currently owns the listener. */
+  readonly isListening: Readonly<Ref<boolean>>;
+
+  /**
+   * Begin listening.
+   *
+   * @returns Whether a new reactive listener was started.
+   */
+  readonly start: () => boolean;
+
+  /** Stop listening. Repeated calls are safe. */
+  readonly stop: () => void;
+}
+
+/**
+ * Attach an event listener to a reactive target and clean it up with the
+ * current reactive scope. Missing targets are valid during server rendering.
+ *
+ * @param target Reactive event target.
+ * @param event Event name.
+ * @param listener Typed event listener.
+ * @param options Listener lifecycle and scheduling options.
+ * @default options {}
+ */
+export function useEventListener<Key extends keyof WindowEventMap>(
+  target: MaybeRefOrGetter<Window | null | undefined>,
+  event: Key,
+  listener: (event: WindowEventMap[Key]) => void,
+  options?: UseEventListenerOptions,
+): EventListenerControls;
+export function useEventListener<Key extends keyof DocumentEventMap>(
+  target: MaybeRefOrGetter<Document | null | undefined>,
+  event: Key,
+  listener: (event: DocumentEventMap[Key]) => void,
+  options?: UseEventListenerOptions,
+): EventListenerControls;
+export function useEventListener<Key extends keyof HTMLElementEventMap>(
+  target: MaybeRefOrGetter<HTMLElement | null | undefined>,
+  event: Key,
+  listener: (event: HTMLElementEventMap[Key]) => void,
+  options?: UseEventListenerOptions,
+): EventListenerControls;
+export function useEventListener(
+  target: MaybeRefOrGetter<EventTarget | null | undefined>,
+  event: string,
+  listener: EventListener,
+  options?: UseEventListenerOptions,
+): EventListenerControls;
+export function useEventListener(
+  target: MaybeRefOrGetter<EventTarget | null | undefined>,
+  event: string,
+  listener: EventListener,
+  options: UseEventListenerOptions = {},
+): EventListenerControls {
+  const {
+    capture = false,
+    once = false,
+    passive = false,
+    signal,
+    immediate = true,
+    flush = "pre",
+  } = options;
+  const isListening = ref(false);
+  const eventOptions: AddEventListenerOptions = {
+    capture,
+    passive,
+    ...(signal ? { signal } : {}),
+  };
+  let stopWatch: WatchHandle | undefined;
+
+  const stop = (): void => {
+    stopWatch?.stop();
+    stopWatch = undefined;
+    isListening.value = false;
+  };
+  const start = (): boolean => {
+    if (stopWatch || signal?.aborted) return false;
+
+    stopWatch = watch(
+      () => toValue(target),
+      (next, _previous, onCleanup) => {
+        isListening.value = false;
+        if (!next || signal?.aborted) return;
+
+        const invoke: EventListener = (nativeEvent) => {
+          if (once) stop();
+          listener(nativeEvent);
+        };
+        const onAbort = (): void => stop();
+        next.addEventListener(event, invoke, eventOptions);
+        signal?.addEventListener("abort", onAbort, { once: true });
+        isListening.value = true;
+
+        onCleanup(() => {
+          next.removeEventListener(event, invoke, capture);
+          signal?.removeEventListener("abort", onAbort);
+          isListening.value = false;
+        });
+      },
+      { flush, immediate: true },
+    );
+    return true;
+  };
+
+  tryOnScopeDispose(stop);
+  if (immediate) start();
+
+  return { isListening: readonly(isListening), start, stop };
+}

--- a/npm/compose/core/src/index.ts
+++ b/npm/compose/core/src/index.ts
@@ -1,1 +1,2 @@
+export * from "./event-listener.ts";
 export * from "./scope.ts";


### PR DESCRIPTION
## Summary

- add typed event-listener overloads for common browser targets and general event targets
- support reactive target rebinding, explicit lifecycle controls, scope cleanup, and external cancellation
- document every option default directly on the public API
- keep one-shot listeners restartable through explicit controls
- export the composable from the public core entry point

## Validation

- package source, formatting, type, and configuration checks
- focused lifecycle and event-listener tests
- production build and compressed-size budget
- repository-wide formatting checks
- patch whitespace checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a composable for managing typed event listeners on reactive browser targets.
  * Supports manual start/stop controls, listening status tracking, one-time handlers, passive and capture options, abort signals, and server-rendering-safe behavior.
  * Exported the event listener utility through the core package.

* **Tests**
  * Added coverage for reactive target changes, lifecycle cleanup, manual controls, one-time activation, and abort behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->