### PR TITLE
feat(compose): add reactive media queries

### DIFF
--- a/npm/compose/core/src/index.ts
+++ b/npm/compose/core/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./event-listener.ts";
+export * from "./media-query.ts";
 export * from "./scope.ts";

--- a/npm/compose/core/src/media-query.test.ts
+++ b/npm/compose/core/src/media-query.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { effectScope, nextTick, ref } from "vue";
+
+import { useMediaQuery, useReducedMotion } from "./media-query.ts";
+import type { MediaQueryHost } from "./media-query.ts";
+
+class ObservableMediaQuery extends EventTarget {
+  readonly media: string;
+  matches: boolean;
+
+  constructor(media: string, matches = false) {
+    super();
+    this.media = media;
+    this.matches = matches;
+  }
+
+  setMatches(matches: boolean): void {
+    this.matches = matches;
+    this.dispatchEvent(new Event("change"));
+  }
+
+  asMediaQueryList(): MediaQueryList {
+    return this as unknown as MediaQueryList;
+  }
+}
+
+function createHost(initialMatches = false): {
+  readonly host: MediaQueryHost;
+  readonly results: Map<string, ObservableMediaQuery>;
+} {
+  const results = new Map<string, ObservableMediaQuery>();
+  return {
+    host: {
+      matchMedia: (query) => {
+        let result = results.get(query);
+        if (!result) {
+          result = new ObservableMediaQuery(query, initialMatches);
+          results.set(query, result);
+        }
+        return result.asMediaQueryList();
+      },
+    },
+    results,
+  };
+}
+
+void test("uses an explicit server value without a media-query capability", () => {
+  const matches = useMediaQuery("(width > 40rem)", {
+    host: () => undefined,
+    ssrValue: true,
+  });
+
+  assert.equal(matches.value, true);
+});
+
+void test("rebinds reactive queries and removes obsolete listeners", async () => {
+  const { host, results } = createHost();
+  const query = ref("(width > 40rem)");
+  const scope = effectScope();
+  const matches = scope.run(() => useMediaQuery(query, { host }));
+
+  assert.ok(matches);
+  const first = results.get("(width > 40rem)");
+  assert.ok(first);
+  first.setMatches(true);
+  assert.equal(matches.value, true);
+
+  query.value = "(orientation: portrait)";
+  await nextTick();
+  const second = results.get("(orientation: portrait)");
+  assert.ok(second);
+  assert.equal(matches.value, false);
+  first.setMatches(false);
+  assert.equal(matches.value, false);
+  second.setMatches(true);
+  assert.equal(matches.value, true);
+
+  scope.stop();
+  second.setMatches(false);
+  assert.equal(matches.value, true);
+});
+
+void test("maps the motion query to a closed preference type", () => {
+  const { host, results } = createHost(true);
+  const preference = useReducedMotion({ host });
+  const motion = results.get("(prefers-reduced-motion: reduce)");
+
+  assert.ok(motion);
+  assert.equal(preference.value, "reduce");
+  motion.setMatches(false);
+  assert.equal(preference.value, "no-preference");
+});

--- a/npm/compose/core/src/media-query.ts
+++ b/npm/compose/core/src/media-query.ts
@@ -1,0 +1,79 @@
+import { computed, readonly, ref, toValue, watchEffect } from "vue";
+import type { ComputedRef, MaybeRefOrGetter, Ref } from "vue";
+
+/** Capability required to evaluate media queries. */
+export interface MediaQueryHost {
+  /** Create an observable result for a media query. */
+  readonly matchMedia: (query: string) => MediaQueryList;
+}
+
+/** Options for {@link useMediaQuery}. */
+export interface UseMediaQueryOptions {
+  /**
+   * Value exposed when no media-query capability is available.
+   *
+   * @default false
+   */
+  readonly ssrValue?: boolean;
+
+  /**
+   * Reactive media-query capability for alternate runtimes and tests.
+   *
+   * @default globalThis.window when available
+   */
+  readonly host?: MaybeRefOrGetter<MediaQueryHost | null | undefined>;
+}
+
+/**
+ * Evaluate a reactive media query without requiring browser globals.
+ *
+ * @param query Reactive media-query source.
+ * @param options Runtime capability and server-rendered fallback.
+ * @default options {}
+ */
+export function useMediaQuery(
+  query: MaybeRefOrGetter<string>,
+  options: UseMediaQueryOptions = {},
+): Readonly<Ref<boolean>> {
+  const matches = ref(options.ssrValue ?? false);
+
+  watchEffect((onCleanup) => {
+    const host = options.host === undefined ? browserMediaQueryHost() : toValue(options.host);
+    if (!host) {
+      matches.value = options.ssrValue ?? false;
+      return;
+    }
+
+    const media = host.matchMedia(toValue(query));
+    const update = (): void => {
+      matches.value = media.matches;
+    };
+    update();
+    media.addEventListener("change", update);
+    onCleanup(() => media.removeEventListener("change", update));
+  });
+
+  return readonly(matches);
+}
+
+/** User motion preference exposed by {@link useReducedMotion}. */
+export type MotionPreference = "reduce" | "no-preference";
+
+/**
+ * Return the reactive user motion preference.
+ *
+ * @param options Runtime capability and server-rendered fallback.
+ * @default options {}
+ */
+export function useReducedMotion(
+  options: UseMediaQueryOptions = {},
+): ComputedRef<MotionPreference> {
+  const reduced = useMediaQuery("(prefers-reduced-motion: reduce)", options);
+  return computed(() => (reduced.value ? "reduce" : "no-preference"));
+}
+
+function browserMediaQueryHost(): MediaQueryHost | undefined {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window
+    : undefined;
+}


### PR DESCRIPTION
## Summary

- add an SSR-safe reactive media-query composable with explicit capability injection
- rebind listeners when the query changes and dispose obsolete subscriptions deterministically
- expose a closed reduced-motion preference type
- document every public option default directly in the API
- export the composables from the public core entry point

## Validation

- package source, formatting, type, and configuration checks
- eight focused lifecycle, listener, media-query, and reduced-motion tests
- production build and compressed-size budget
- repository-wide formatting checks
- patch whitespace checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->