### PR TITLE
feat(compose): add reactive locale controls

### DIFF
--- a/npm/compose/core/src/index.ts
+++ b/npm/compose/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./event-listener.ts";
+export * from "./locale.ts";
 export * from "./media-query.ts";
 export * from "./scope.ts";

--- a/npm/compose/core/src/locale.test.ts
+++ b/npm/compose/core/src/locale.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { ref } from "vue";
+
+import { useLocale } from "./locale.ts";
+
+void test("canonicalizes reactive locales and reads native text direction", () => {
+  const source = ref<Intl.Locale | string>("EN-us");
+  const locale = useLocale(source);
+
+  assert.equal(locale.locale.value, "en-US");
+  assert.equal(locale.direction.value, "ltr");
+  source.value = new Intl.Locale("ar-EG");
+  assert.equal(locale.direction.value, "rtl");
+});
+
+void test("uses an injected detector before the documented fallback", () => {
+  assert.equal(useLocale(undefined, { detect: () => "fr-FR" }).locale.value, "fr-FR");
+  assert.equal(
+    useLocale(undefined, { detect: () => undefined, fallback: "ja-JP" }).locale.value,
+    "ja-JP",
+  );
+});
+
+void test("reuses equivalent formatter options until the locale changes", () => {
+  const source = ref("en-US");
+  const locale = useLocale(source);
+  const first = locale.number({ style: "unit", unit: "meter" });
+  const equivalent = locale.number({ unit: "meter", style: "unit" });
+
+  assert.equal(first, equivalent);
+  source.value = "de-DE";
+  assert.notEqual(locale.number({ style: "unit", unit: "meter" }), first);
+});
+
+void test("creates native list, date, and relative-time formatters", () => {
+  const locale = useLocale("en-US");
+
+  assert.ok(locale.list() instanceof Intl.ListFormat);
+  assert.ok(locale.dateTime() instanceof Intl.DateTimeFormat);
+  assert.ok(locale.relativeTime() instanceof Intl.RelativeTimeFormat);
+});

--- a/npm/compose/core/src/locale.ts
+++ b/npm/compose/core/src/locale.ts
@@ -1,0 +1,130 @@
+import { computed, toValue } from "vue";
+import type { ComputedRef, MaybeRefOrGetter } from "vue";
+
+/** Text flow reported by the internationalization runtime. */
+export type TextDirection = "ltr" | "rtl";
+
+/** Locale selection options for {@link useLocale}. */
+export interface UseLocaleOptions {
+  /**
+   * Locale detector used when the reactive source has no value.
+   *
+   * @default navigator.language when available; otherwise undefined
+   */
+  readonly detect?: () => Intl.Locale | string | null | undefined;
+
+  /**
+   * Locale used when neither the source nor detector provides one.
+   *
+   * @default "en"
+   */
+  readonly fallback?: Intl.Locale | string;
+}
+
+/** Reactive locale metadata and cached formatter factories. */
+export interface LocaleControls {
+  /** Canonical Unicode locale identifier. */
+  readonly locale: ComputedRef<string>;
+
+  /** Parsed locale details supplied by the internationalization runtime. */
+  readonly details: ComputedRef<Intl.Locale>;
+
+  /** Native writing direction for the active locale. */
+  readonly direction: ComputedRef<TextDirection>;
+
+  /** Return a cached number formatter for the active locale and options. */
+  readonly number: (options?: Intl.NumberFormatOptions) => Intl.NumberFormat;
+
+  /** Return a cached date and time formatter for the active locale and options. */
+  readonly dateTime: (options?: Intl.DateTimeFormatOptions) => Intl.DateTimeFormat;
+
+  /** Return a cached list formatter for the active locale and options. */
+  readonly list: (options?: Intl.ListFormatOptions) => Intl.ListFormat;
+
+  /** Return a cached relative-time formatter for the active locale and options. */
+  readonly relativeTime: (options?: Intl.RelativeTimeFormatOptions) => Intl.RelativeTimeFormat;
+}
+
+const FORMATTER_CACHE_LIMIT = 32;
+
+/**
+ * Create reactive locale metadata and platform-native formatter factories.
+ *
+ * Equivalent formatter options reuse instances. The bounded cache follows the
+ * active locale automatically and prevents repeated constructor overhead in
+ * reactive render paths.
+ */
+export function useLocale(
+  source?: MaybeRefOrGetter<Intl.Locale | string | null | undefined>,
+  options: UseLocaleOptions = {},
+): LocaleControls {
+  const locale = computed(() => {
+    const candidate =
+      (source === undefined ? undefined : toValue(source)) ??
+      (options.detect ?? detectBrowserLocale)() ??
+      options.fallback ??
+      "en";
+    return candidate instanceof Intl.Locale
+      ? candidate.toString()
+      : new Intl.Locale(candidate).toString();
+  });
+  const details = computed(() => new Intl.Locale(locale.value));
+  const direction = computed<TextDirection>(() => details.value.getTextInfo().direction);
+
+  const number = createFormatterCache<Intl.NumberFormatOptions, Intl.NumberFormat>(
+    (activeLocale, formatOptions) => new Intl.NumberFormat(activeLocale, formatOptions),
+  );
+  const dateTime = createFormatterCache<Intl.DateTimeFormatOptions, Intl.DateTimeFormat>(
+    (activeLocale, formatOptions) => new Intl.DateTimeFormat(activeLocale, formatOptions),
+  );
+  const list = createFormatterCache<Intl.ListFormatOptions, Intl.ListFormat>(
+    (activeLocale, formatOptions) => new Intl.ListFormat(activeLocale, formatOptions),
+  );
+  const relativeTime = createFormatterCache<
+    Intl.RelativeTimeFormatOptions,
+    Intl.RelativeTimeFormat
+  >((activeLocale, formatOptions) => new Intl.RelativeTimeFormat(activeLocale, formatOptions));
+
+  return {
+    locale,
+    details,
+    direction,
+    number: (formatOptions) => number(locale.value, formatOptions),
+    dateTime: (formatOptions) => dateTime(locale.value, formatOptions),
+    list: (formatOptions) => list(locale.value, formatOptions),
+    relativeTime: (formatOptions) => relativeTime(locale.value, formatOptions),
+  };
+}
+
+function detectBrowserLocale(): string | undefined {
+  return typeof navigator === "undefined" ? undefined : navigator.language;
+}
+
+function createFormatterCache<Options extends object, Formatter>(
+  create: (locale: string, options?: Options) => Formatter,
+): (locale: string, options?: Options) => Formatter {
+  const cache = new Map<string, Formatter>();
+  return (locale, options) => {
+    const key = `${locale}\u0000${serializeOptions(options)}`;
+    const cached = cache.get(key);
+    if (cached !== undefined) {
+      cache.delete(key);
+      cache.set(key, cached);
+      return cached;
+    }
+    const formatter = create(locale, options);
+    if (cache.size >= FORMATTER_CACHE_LIMIT) {
+      const oldest = cache.keys().next().value;
+      if (oldest !== undefined) cache.delete(oldest);
+    }
+    cache.set(key, formatter);
+    return formatter;
+  };
+}
+
+function serializeOptions(options: object | undefined): string {
+  if (options === undefined) return "";
+  return JSON.stringify(
+    Object.entries(options).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}

--- a/npm/compose/core/tsconfig.json
+++ b/npm/compose/core/tsconfig.json
@@ -7,7 +7,7 @@
     "erasableSyntaxOnly": true,
     "rewriteRelativeImportExtensions": true,
     "types": ["node"],
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "ESNext.Intl", "DOM", "DOM.Iterable"],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,


### PR DESCRIPTION
## Summary

- add reactive canonical locale metadata with modern runtime text-direction discovery
- support browser detection, deterministic server fallback, and explicit detector injection
- expose cached number, date-time, list, and relative-time formatter factories
- bound formatter retention while reusing equivalent option sets across render paths
- document every public option default and export the API from the core entry point

## Validation

- package source, formatting, type, and configuration checks
- twelve focused lifecycle, media, locale, direction, detection, and formatter tests
- production build at 1.90 kB compressed, within the 4 kB budget
- frozen dependency graph validation
- patch whitespace checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->