### PR TITLE
feat(compose): add async resource controls

### DIFF
--- a/npm/compose/core/src/async-resource.test.ts
+++ b/npm/compose/core/src/async-resource.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { effectScope } from "vue";
+
+import { useAsyncResource } from "./async-resource.ts";
+
+void test("commits only the newest execution result", async () => {
+  const pending = new Map<number, (value: number) => void>();
+  const signals: AbortSignal[] = [];
+  const resource = useAsyncResource<number, readonly [number]>((context, value) => {
+    signals.push(context.signal);
+    return new Promise((resolve) => pending.set(value, resolve));
+  });
+
+  const first = resource.execute(1);
+  const second = resource.execute(2);
+  assert.equal(signals[0]?.aborted, true);
+  pending.get(2)?.(20);
+  assert.deepEqual(await second, { status: "success", data: 20 });
+  pending.get(1)?.(10);
+  assert.deepEqual(await first, { status: "superseded" });
+  assert.equal(resource.data.value, 20);
+});
+
+void test("leaves superseded work running when cancellation is disabled", async () => {
+  const pending = new Map<number, (value: number) => void>();
+  const signals: AbortSignal[] = [];
+  const resource = useAsyncResource<number, readonly [number]>(
+    (context, value) => {
+      signals.push(context.signal);
+      return new Promise((resolve) => pending.set(value, resolve));
+    },
+    { cancelPrevious: false },
+  );
+
+  const first = resource.execute(1);
+  const second = resource.execute(2);
+  assert.equal(signals[0]?.aborted, false);
+  pending.get(1)?.(10);
+  assert.deepEqual(await first, { status: "superseded" });
+  pending.get(2)?.(20);
+  assert.deepEqual(await second, { status: "success", data: 20 });
+});
+
+void test("reports idempotent manual cancellation without an error state", async () => {
+  const resource = useAsyncResource<never, readonly []>(
+    ({ signal }) =>
+      new Promise((_, reject) =>
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true }),
+      ),
+  );
+  const execution = resource.execute();
+
+  assert.equal(resource.cancel("manual"), true);
+  assert.equal(resource.cancel("again"), false);
+  assert.deepEqual(await execution, { status: "cancelled", reason: "manual" });
+  assert.equal(resource.status.value, "cancelled");
+  assert.equal(resource.pending.value, false);
+  assert.equal(resource.error.value, undefined);
+});
+
+void test("returns typed loader failures as explicit results", async () => {
+  const failure = { code: "unavailable" } as const;
+  const resource = useAsyncResource<never, readonly [], typeof failure>(async () => {
+    throw failure;
+  });
+
+  assert.deepEqual(await resource.execute(), { status: "error", error: failure });
+  assert.equal(resource.error.value, failure);
+  assert.equal(resource.status.value, "error");
+});
+
+void test("clears refresh data and restores the documented initial value", async () => {
+  let resolve: ((value: number) => void) | undefined;
+  const resource = useAsyncResource<number, readonly []>(
+    () => new Promise((complete) => (resolve = complete)),
+    { initialData: 1, keepData: false },
+  );
+  const execution = resource.execute();
+
+  assert.equal(resource.data.value, undefined);
+  resolve?.(2);
+  assert.equal((await execution).status, "success");
+  resource.reset();
+  assert.equal(resource.data.value, 1);
+  assert.equal(resource.status.value, "idle");
+});
+
+void test("cancels active work when its reactive scope stops", async () => {
+  const scope = effectScope();
+  const resource = scope.run(() =>
+    useAsyncResource<never, readonly []>(
+      ({ signal }) =>
+        new Promise((_, reject) =>
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true }),
+        ),
+    ),
+  );
+  assert.ok(resource);
+  const execution = resource.execute();
+
+  scope.stop();
+  assert.equal((await execution).status, "cancelled");
+  assert.equal(resource.status.value, "cancelled");
+});

--- a/npm/compose/core/src/async-resource.ts
+++ b/npm/compose/core/src/async-resource.ts
@@ -1,0 +1,153 @@
+import { computed, shallowRef } from "vue";
+import type { ComputedRef, Ref, ShallowRef } from "vue";
+
+import { tryOnScopeDispose } from "./scope.ts";
+
+/** Lifecycle state of an asynchronous resource. */
+export type AsyncResourceStatus = "idle" | "pending" | "success" | "error" | "cancelled";
+
+/** Context supplied to an asynchronous resource loader. */
+export interface AsyncResourceContext {
+  /** Signal aborted by cancellation, reset, scope disposal, or a newer execution. */
+  readonly signal: AbortSignal;
+}
+
+/** Explicit result of one asynchronous resource execution. */
+export type AsyncResourceExecution<Data, Failure> =
+  | { readonly status: "success"; readonly data: Data }
+  | { readonly status: "error"; readonly error: Failure }
+  | { readonly status: "cancelled"; readonly reason: unknown }
+  | { readonly status: "superseded" };
+
+/** Options for {@link useAsyncResource}. */
+export interface UseAsyncResourceOptions<Data> {
+  /**
+   * Initial data restored by {@link AsyncResource.reset}.
+   *
+   * @default undefined
+   */
+  readonly initialData?: Data;
+
+  /**
+   * Abort the active execution when a newer execution starts.
+   *
+   * @default true
+   */
+  readonly cancelPrevious?: boolean;
+
+  /**
+   * Retain the current data while a new execution is pending.
+   *
+   * @default true
+   */
+  readonly keepData?: boolean;
+
+  /**
+   * Cancel an active execution when the current reactive scope is disposed.
+   *
+   * @default true
+   */
+  readonly scope?: boolean;
+}
+
+/** Reactive state and controls for an asynchronous loader. */
+export interface AsyncResource<Data, Arguments extends readonly unknown[], Failure> {
+  readonly data: Readonly<ShallowRef<Data | undefined>>;
+  readonly error: Readonly<ShallowRef<Failure | undefined>>;
+  readonly status: Readonly<Ref<AsyncResourceStatus>>;
+  readonly pending: ComputedRef<boolean>;
+  readonly execute: (...arguments_: Arguments) => Promise<AsyncResourceExecution<Data, Failure>>;
+  readonly cancel: (reason?: unknown) => boolean;
+  readonly reset: () => void;
+}
+
+interface ActiveExecution {
+  readonly generation: number;
+  readonly controller: AbortController;
+  superseded: boolean;
+}
+
+/**
+ * Create a scoped, abortable asynchronous resource with latest-result-wins
+ * state. Every execution returns a discriminated result, so cancellation,
+ * supersession, loader failure, and successful `undefined` data stay distinct.
+ */
+export function useAsyncResource<Data, Arguments extends readonly unknown[], Failure = unknown>(
+  loader: (context: AsyncResourceContext, ...arguments_: Arguments) => Promise<Data>,
+  options: UseAsyncResourceOptions<Data> = {},
+): AsyncResource<Data, Arguments, Failure> {
+  const data = shallowRef<Data | undefined>(options.initialData);
+  const error = shallowRef<Failure | undefined>(undefined);
+  const status = shallowRef<AsyncResourceStatus>("idle");
+  const pending = computed(() => status.value === "pending");
+  let generation = 0;
+  let active: ActiveExecution | undefined;
+
+  const cancel = (reason: unknown = createAbortReason("The execution was cancelled.")) => {
+    if (active === undefined) return false;
+    generation += 1;
+    active.controller.abort(reason);
+    active = undefined;
+    status.value = "cancelled";
+    return true;
+  };
+
+  const execute = async (...arguments_: Arguments) => {
+    if ((options.cancelPrevious ?? true) && active !== undefined) {
+      active.superseded = true;
+      active.controller.abort(createAbortReason("A newer execution started."));
+    }
+    const record: ActiveExecution = {
+      generation: ++generation,
+      controller: new AbortController(),
+      superseded: false,
+    };
+    active = record;
+    error.value = undefined;
+    status.value = "pending";
+    if (!(options.keepData ?? true)) data.value = undefined;
+
+    try {
+      const result = await loader({ signal: record.controller.signal }, ...arguments_);
+      if (record.generation !== generation) return executionAfterInvalidation(record);
+      data.value = result;
+      status.value = "success";
+      return { status: "success", data: result } as const;
+    } catch (cause) {
+      if (record.generation !== generation || record.controller.signal.aborted) {
+        return executionAfterInvalidation(record);
+      }
+      error.value = cause as Failure;
+      status.value = "error";
+      return { status: "error", error: cause as Failure } as const;
+    } finally {
+      if (active === record) active = undefined;
+    }
+  };
+
+  const reset = () => {
+    cancel(createAbortReason("The resource was reset."));
+    data.value = options.initialData;
+    error.value = undefined;
+    status.value = "idle";
+  };
+
+  if (options.scope ?? true) {
+    tryOnScopeDispose(() => cancel(createAbortReason("The reactive scope was disposed.")));
+  }
+
+  return { data, error, status, pending, execute, cancel, reset };
+}
+
+function executionAfterInvalidation<Data, Failure>(
+  execution: ActiveExecution,
+): AsyncResourceExecution<Data, Failure> {
+  if (execution.superseded || !execution.controller.signal.aborted) {
+    return { status: "superseded" };
+  }
+  return { status: "cancelled", reason: execution.controller.signal.reason };
+}
+
+function createAbortReason(message: string): DOMException {
+  return new DOMException(message, "AbortError");
+}

--- a/npm/compose/core/src/index.ts
+++ b/npm/compose/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./async-resource.ts";
 export * from "./event-listener.ts";
 export * from "./locale.ts";
 export * from "./media-query.ts";


### PR DESCRIPTION
## Summary

- add a scoped asynchronous resource with deterministic latest-result-wins state
- return discriminated success, error, cancellation, and supersession outcomes
- support explicit cancellation, optional concurrent work, reset, retained refresh data, and initial data
- cancel active work automatically with its reactive scope by default
- document every option default and keep pending state derived from the lifecycle state

## Validation

- package source, formatting, type, and configuration checks
- eighteen focused lifecycle, concurrency, cancellation, failure, reset, locale, media, and listener tests
- production build at 2.64 kB compressed, within the 4 kB budget
- frozen dependency graph validation
- patch whitespace checks
