### PR TITLE
feat(ui): add polymorphic primitive

### DIFF
--- a/npm/ui/core/src/PrimitiveElement.vue
+++ b/npm/ui/core/src/PrimitiveElement.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { useSlots, useTemplateRef } from "vue";
+
+import type { PrimitiveAs, PrimitiveElement } from "./primitive.ts";
+
+const { as = "div" } = defineProps<{
+  /**
+   * Native element, custom element, or component to render.
+   *
+   * @default "div"
+   */
+  readonly as?: PrimitiveAs;
+}>();
+
+const slots = useSlots();
+const element = useTemplateRef<PrimitiveElement>("element");
+
+function getSlotNames(): string[] {
+  return Object.keys(slots);
+}
+
+defineExpose({ element });
+</script>
+
+<template>
+  <component :is="as" ref="element" data-vize-ui="primitive">
+    <template v-for="name in getSlotNames()" #[name]>
+      <slot :name="name" />
+    </template>
+  </component>
+</template>
+
+<style scoped>
+/* Headless by design. Native CSS remains entirely consumer-owned. */
+</style>

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -1,2 +1,3 @@
 /** Visually hidden content exposed to assistive technology. */
+export * from "./primitive.ts";
 export { default as VisuallyHidden } from "./VisuallyHidden.vue";

--- a/npm/ui/core/src/primitive.test.ts
+++ b/npm/ui/core/src/primitive.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const source = await readFile(new URL("./PrimitiveElement.vue", import.meta.url), "utf8");
+
+void test("ships a polymorphic SFC without render-function escape hatches", () => {
+  assert.match(source, /<component :is="as"/);
+  assert.match(source, /readonly as\?: PrimitiveAs/);
+  assert.match(source, /@default "div"/);
+  assert.doesNotMatch(source, /\bh\s*\(/);
+  assert.doesNotMatch(source, /defineOptions|withDefaults|interface (?:Props|Emits)/);
+});
+
+void test("forwards every slot and exposes the rendered value deliberately", () => {
+  assert.match(source, /v-for="name in getSlotNames\(\)"/);
+  assert.match(source, /<slot :name="name" \/>/);
+  assert.match(source, /defineExpose\(\{ element \}\)/);
+  assert.match(source, /data-vize-ui="primitive"/);
+});

--- a/npm/ui/core/src/primitive.ts
+++ b/npm/ui/core/src/primitive.ts
@@ -1,0 +1,10 @@
+import type { Component, ComponentPublicInstance } from "vue";
+
+/** Native element, custom element, or component accepted by {@link Primitive}. */
+export type PrimitiveAs = string | Component;
+
+/** Rendered value exposed by {@link Primitive}. */
+export type PrimitiveElement = Element | ComponentPublicInstance;
+
+/** Unstyled polymorphic foundation with attribute and slot forwarding. */
+export { default as Primitive } from "./PrimitiveElement.vue";

--- a/npm/ui/core/src/sfc-lint.test.ts
+++ b/npm/ui/core/src/sfc-lint.test.ts
@@ -14,9 +14,15 @@ void test("discovers every SFC with the opinionated Vize contract", async () => 
 
   assert.deepEqual(
     results.map((result) => result.filename),
-    ["src/VisuallyHidden.vue"],
+    ["src/PrimitiveElement.vue", "src/VisuallyHidden.vue"],
   );
   assert.deepEqual(requests, [
+    {
+      filename: new URL("./PrimitiveElement.vue", import.meta.url).pathname,
+      preset: "opinionated",
+      typeAware: true,
+      helpLevel: "short",
+    },
     {
       filename: new URL("./VisuallyHidden.vue", import.meta.url).pathname,
       preset: "opinionated",


### PR DESCRIPTION
## Summary

- add an SFC-only polymorphic primitive for native elements, custom elements, and components
- forward attributes and named slots while retaining a stable Native CSS hook
- expose the rendered element or component instance through a deliberate template ref contract
- keep the public component name concise without a project prefix
- extend opinionated SFC discovery and option-contract coverage

## Validation

- package source, formatting, type, and configuration checks
- real opinionated Vize SFC lint across every shipped component
- five focused source, forwarding, exposure, discovery, and accessibility tests
- production entry at 812 bytes compressed, within the 3 kB budget
- patch whitespace checks
