### PR TITLE
fix(sfc): stabilize native css dependency resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3525,6 +3525,7 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "oxc_transformer",
+ "parcel_selectors",
  "pklrust",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ mimalloc = "=0.1.52"
 
 # CSS
 lightningcss = "=1.0.0-alpha.71"
+parcel_selectors = "=0.28.2"
 
 # Terminal / layout
 crossterm = "=0.29.0"

--- a/crates/vize_atelier_sfc/Cargo.toml
+++ b/crates/vize_atelier_sfc/Cargo.toml
@@ -10,7 +10,7 @@ metadata.vize.stability = "alpha-supported"
 
 [features]
 default = ["native"]
-native = ["dep:lightningcss", "lightningcss/serde"]
+native = ["dep:lightningcss", "lightningcss/serde", "dep:parcel_selectors"]
 
 [dependencies]
 vize_carton = { workspace = true }
@@ -36,6 +36,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 lightningcss = { workspace = true, optional = true }
+parcel_selectors = { workspace = true, optional = true }
 regex = { workspace = true }
 sha2 = { workspace = true }
 


### PR DESCRIPTION
## Summary

- constrain the native CSS dependency graph to one parser-compatible selector release
- carry the constraint in the published SFC crate instead of relying only on the workspace lockfile
- keep the dependency behind the existing native feature
- restore reproducible rustdoc and API compatibility checks for fresh downstream resolution

## Validation

- workspace Rust formatting
- SFC crate check with every feature enabled
- dependency-tree verification with a single compatible selector release
- fresh external consumer resolution outside the workspace
- external consumer rustdoc generation without workspace lockfile reuse
- patch whitespace checks
