### PR TITLE
feat(ui): add controllable state primitive

### DIFF
--- a/npm/ui/core/src/controllable-state.test.ts
+++ b/npm/ui/core/src/controllable-state.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { effectScope, ref } from "vue";
+
+import { useControllableState } from "./controllable-state.ts";
+
+void test("updates and resets uncontrolled state", () => {
+  const changes: [number, number][] = [];
+  const state = useControllableState({
+    defaultValue: 1,
+    onChange: (value, previous) => changes.push([value, previous]),
+  });
+
+  assert.equal(state.controlled.value, false);
+  assert.equal(
+    state.set((value) => value + 1),
+    true,
+  );
+  assert.equal(state.value.value, 2);
+  assert.equal(state.reset(), true);
+  assert.deepEqual(changes, [
+    [2, 1],
+    [1, 2],
+  ]);
+});
+
+void test("requests controlled updates without mutating the source", () => {
+  const source = ref<boolean | undefined>(false);
+  let requested: boolean | undefined;
+  const state = useControllableState({
+    value: source,
+    defaultValue: true,
+    onChange: (value) => (requested = value),
+  });
+
+  assert.equal(state.controlled.value, true);
+  assert.equal(state.set(true), true);
+  assert.equal(source.value, false);
+  assert.equal(state.value.value, false);
+  assert.equal(requested, true);
+  source.value = true;
+  assert.equal(state.value.value, true);
+});
+
+void test("retains the last value when control is released", () => {
+  const scope = effectScope();
+  const source = ref<string | undefined>("controlled");
+  const state = scope.run(() => useControllableState({ value: source, defaultValue: "initial" }));
+  assert.ok(state);
+
+  source.value = "latest";
+  source.value = undefined;
+  assert.equal(state.controlled.value, false);
+  assert.equal(state.value.value, "latest");
+  scope.stop();
+});
+
+void test("supports domain-specific equality and reports redundant updates", () => {
+  const state = useControllableState({
+    defaultValue: { id: 1, label: "first" },
+    equals: (left, right) => left.id === right.id,
+  });
+
+  assert.equal(state.set({ id: 1, label: "equivalent" }), false);
+  assert.equal(state.value.value.label, "first");
+});

--- a/npm/ui/core/src/controllable-state.ts
+++ b/npm/ui/core/src/controllable-state.ts
@@ -1,0 +1,87 @@
+import { computed, shallowRef, toValue, watch } from "vue";
+import type { ComputedRef, MaybeRefOrGetter } from "vue";
+
+/** Direct value or updater accepted by {@link ControllableState.set}. */
+export type StateUpdate<Value> = Value | ((previous: Value) => Value);
+
+/** Options for {@link useControllableState}. */
+export interface ControllableStateOptions<Value> {
+  /**
+   * Reactive controlled value. `undefined` selects uncontrolled behavior.
+   *
+   * @default undefined
+   */
+  readonly value?: MaybeRefOrGetter<Value | undefined>;
+
+  /** Initial value and the value restored by {@link ControllableState.reset}. */
+  readonly defaultValue: MaybeRefOrGetter<Value>;
+
+  /**
+   * Equality comparison used to suppress redundant updates.
+   *
+   * @default Object.is
+   */
+  readonly equals?: (left: Value, right: Value) => boolean;
+
+  /**
+   * Called after a distinct state change is requested.
+   *
+   * @default undefined
+   */
+  readonly onChange?: (value: Value, previous: Value) => void;
+}
+
+/** Reactive state that can move safely between controlled and uncontrolled use. */
+export interface ControllableState<Value> {
+  /** Current controlled or internal value. */
+  readonly value: ComputedRef<Value>;
+
+  /** Whether the reactive source currently controls the value. */
+  readonly controlled: ComputedRef<boolean>;
+
+  /** Request an update and report whether it differs from the current value. */
+  readonly set: (update: StateUpdate<Value>) => boolean;
+
+  /** Request the current default value and report whether it changed. */
+  readonly reset: () => boolean;
+}
+
+/**
+ * Create one state contract for controlled props and internal state.
+ *
+ * The last controlled value is retained if the source becomes uncontrolled,
+ * preventing an abrupt jump back to the initial default.
+ */
+export function useControllableState<Value>(
+  options: ControllableStateOptions<Value>,
+): ControllableState<Value> {
+  const internal = shallowRef(toValue(options.defaultValue));
+  const controlledValue = () => (options.value === undefined ? undefined : toValue(options.value));
+  const controlled = computed(() => controlledValue() !== undefined);
+  const value = computed<Value>(() => controlledValue() ?? internal.value);
+
+  watch(
+    controlledValue,
+    (next) => {
+      if (next !== undefined) internal.value = next;
+    },
+    { flush: "sync", immediate: true },
+  );
+
+  const set = (update: StateUpdate<Value>) => {
+    const previous = value.value;
+    const next =
+      typeof update === "function" ? (update as (current: Value) => Value)(previous) : update;
+    if ((options.equals ?? Object.is)(previous, next)) return false;
+    if (!controlled.value) internal.value = next;
+    options.onChange?.(next, previous);
+    return true;
+  };
+
+  return {
+    value,
+    controlled,
+    set,
+    reset: () => set(toValue(options.defaultValue)),
+  };
+}

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./controllable-state.ts";
 /** Visually hidden content exposed to assistive technology. */
 export * from "./primitive.ts";
 export { default as VisuallyHidden } from "./VisuallyHidden.vue";


### PR DESCRIPTION
## Summary

- add one typed state contract for controlled props and internal state
- support value updaters, reset, custom equality, and previous-value change callbacks
- retain the last controlled value when ownership moves back to internal state
- report whether update requests are distinct for predictable event emission
- document every optional behavior directly in hover information

## Validation

- package source, formatting, type, and configuration checks
- nine focused controlled, uncontrolled, transition, equality, SFC contract, and accessibility tests
- production entry at 1.24 kB compressed, within the 3 kB budget
- frozen dependency graph validation
- patch whitespace checks
