### PR TITLE
feat(ui): add accessible button primitive

### DIFF
--- a/npm/ui/core/src/ActionButton.vue
+++ b/npm/ui/core/src/ActionButton.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import { computed, useTemplateRef } from "vue";
+
+import { getButtonKeyboardAction } from "./button-keyboard.ts";
+import type { ButtonKeyboardPhase } from "./button-keyboard.ts";
+import type { PrimitiveAs, PrimitiveElement } from "./primitive.ts";
+
+const {
+  as = "button",
+  native,
+  type = "button",
+  disabled = false,
+  loading = false,
+} = defineProps<{
+  /**
+   * Native element, custom element, or component to render.
+   *
+   * @default "button"
+   */
+  readonly as?: PrimitiveAs;
+
+  /**
+   * Whether the rendered target already implements native button semantics.
+   *
+   * @default true when `as` is "button"; otherwise false
+   */
+  readonly native?: boolean;
+
+  /**
+   * Native button submission behavior.
+   *
+   * @default "button"
+   */
+  readonly type?: "button" | "reset" | "submit";
+
+  /**
+   * Remove the control from activation and sequential keyboard focus.
+   *
+   * @default false
+   */
+  readonly disabled?: boolean;
+
+  /**
+   * Announce in-progress work and prevent repeated activation while preserving focus.
+   *
+   * @default false
+   */
+  readonly loading?: boolean;
+}>();
+
+defineSlots<{
+  default(props: {
+    readonly disabled: boolean;
+    readonly loading: boolean;
+    readonly unavailable: boolean;
+  }): unknown;
+}>();
+
+const emit = defineEmits<{
+  press: [event: MouseEvent];
+}>();
+
+const element = useTemplateRef<PrimitiveElement>("element");
+const isNativeButton = computed(() => native ?? as === "button");
+const unavailable = computed(() => disabled || loading);
+const tabIndex = computed(() => {
+  if (isNativeButton.value) return undefined;
+  return disabled ? -1 : 0;
+});
+
+function onClick(event: MouseEvent): void {
+  if (unavailable.value) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    return;
+  }
+  emit("press", event);
+}
+
+function onKeyboard(event: KeyboardEvent, phase: ButtonKeyboardPhase): void {
+  if (isNativeButton.value) return;
+  const action = getButtonKeyboardAction(event.key, phase);
+  if (action === "ignore") return;
+  event.preventDefault();
+  if (unavailable.value) {
+    event.stopImmediatePropagation();
+    return;
+  }
+  if (action === "activate" && event.currentTarget instanceof HTMLElement) {
+    event.currentTarget.click();
+  }
+}
+
+function onKeydown(event: KeyboardEvent): void {
+  onKeyboard(event, "keydown");
+}
+
+function onKeyup(event: KeyboardEvent): void {
+  onKeyboard(event, "keyup");
+}
+
+/** Move focus to the rendered control when it exposes a focus method. */
+function focus(options?: FocusOptions): void {
+  focusTarget(element.value, options);
+}
+
+function focusTarget(target: unknown, options?: FocusOptions): void {
+  if (
+    typeof target === "object" &&
+    target !== null &&
+    "focus" in target &&
+    typeof target.focus === "function"
+  ) {
+    target.focus(options);
+  }
+}
+
+defineExpose({ element, focus });
+</script>
+
+<template>
+  <component
+    :is="as"
+    ref="element"
+    :type="isNativeButton ? type : undefined"
+    :disabled="isNativeButton ? disabled : undefined"
+    :role="isNativeButton ? undefined : 'button'"
+    :tabindex="tabIndex"
+    :aria-disabled="unavailable && (!isNativeButton || loading) ? 'true' : undefined"
+    :aria-busy="loading ? 'true' : undefined"
+    data-vize-ui="button"
+    :data-state="disabled ? 'disabled' : loading ? 'loading' : 'idle'"
+    @click="onClick"
+    @keydown="onKeydown"
+    @keyup="onKeyup"
+  >
+    <slot :disabled :loading :unavailable />
+  </component>
+</template>
+
+<style scoped>
+/* Headless by design. Native CSS remains entirely consumer-owned. */
+</style>

--- a/npm/ui/core/src/button-keyboard.ts
+++ b/npm/ui/core/src/button-keyboard.ts
@@ -1,0 +1,20 @@
+/** Keyboard event phase used by button activation semantics. */
+export type ButtonKeyboardPhase = "keydown" | "keyup";
+
+/** Action required to emulate a native button for one keyboard event. */
+export type ButtonKeyboardAction = "activate" | "prevent" | "ignore";
+
+/**
+ * Resolve native-equivalent activation timing for a non-native button.
+ *
+ * Enter activates on keydown. Space prevents scrolling on keydown and
+ * activates on keyup, matching the interaction users expect from a button.
+ */
+export function getButtonKeyboardAction(
+  key: string,
+  phase: ButtonKeyboardPhase,
+): ButtonKeyboardAction {
+  if (key === "Enter") return phase === "keydown" ? "activate" : "ignore";
+  if (key === " ") return phase === "keydown" ? "prevent" : "activate";
+  return "ignore";
+}

--- a/npm/ui/core/src/button.test.ts
+++ b/npm/ui/core/src/button.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+import { getButtonKeyboardAction } from "./button-keyboard.ts";
+
+const source = await readFile(new URL("./ActionButton.vue", import.meta.url), "utf8");
+
+void test("matches native keyboard activation timing", () => {
+  assert.equal(getButtonKeyboardAction("Enter", "keydown"), "activate");
+  assert.equal(getButtonKeyboardAction("Enter", "keyup"), "ignore");
+  assert.equal(getButtonKeyboardAction(" ", "keydown"), "prevent");
+  assert.equal(getButtonKeyboardAction(" ", "keyup"), "activate");
+  assert.equal(getButtonKeyboardAction("Escape", "keydown"), "ignore");
+});
+
+void test("ships typed disabled and loading semantics in an explicit SFC", () => {
+  assert.match(source, /defineEmits<\{[\s\S]*press: \[event: MouseEvent\]/);
+  assert.match(source, /:disabled="isNativeButton \? disabled : undefined"/);
+  assert.match(source, /:aria-disabled=/);
+  assert.match(source, /:aria-busy=/);
+  assert.match(source, /:tabindex="tabIndex"/);
+  assert.doesNotMatch(source, /\bh\s*\(/);
+  assert.doesNotMatch(source, /defineOptions|withDefaults|interface (?:Props|Emits)/);
+});
+
+void test("exposes focus deliberately and provides programmable slot state", () => {
+  assert.match(source, /defineExpose\(\{ element, focus \}\)/);
+  assert.match(source, /<slot :disabled :loading :unavailable \/>/);
+  assert.match(source, /data-vize-ui="button"/);
+  assert.match(source, /:data-state=/);
+});

--- a/npm/ui/core/src/button.ts
+++ b/npm/ui/core/src/button.ts
@@ -1,0 +1,4 @@
+export * from "./button-keyboard.ts";
+
+/** Accessible, unstyled button with polymorphic rendering. */
+export { default as Button } from "./ActionButton.vue";

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -1,3 +1,4 @@
 /** Visually hidden content exposed to assistive technology. */
+export * from "./button.ts";
 export * from "./primitive.ts";
 export { default as VisuallyHidden } from "./VisuallyHidden.vue";

--- a/npm/ui/core/src/sfc-lint.test.ts
+++ b/npm/ui/core/src/sfc-lint.test.ts
@@ -14,9 +14,15 @@ void test("discovers every SFC with the opinionated Vize contract", async () => 
 
   assert.deepEqual(
     results.map((result) => result.filename),
-    ["src/PrimitiveElement.vue", "src/VisuallyHidden.vue"],
+    ["src/ActionButton.vue", "src/PrimitiveElement.vue", "src/VisuallyHidden.vue"],
   );
   assert.deepEqual(requests, [
+    {
+      filename: new URL("./ActionButton.vue", import.meta.url).pathname,
+      preset: "opinionated",
+      typeAware: true,
+      helpLevel: "short",
+    },
     {
       filename: new URL("./PrimitiveElement.vue", import.meta.url).pathname,
       preset: "opinionated",


### PR DESCRIPTION
## Summary

- add an SFC-only polymorphic Button with a typed `press` event
- match native Enter and Space activation timing for non-native render targets
- distinguish disabled and loading behavior so in-progress actions preserve focus
- provide native, role, focus-order, busy, disabled, and state attributes declaratively
- expose focus deliberately and provide disabled, loading, and unavailable slot state

## Validation

- package source, formatting, type, and configuration checks
- real opinionated Vize SFC lint across every shipped component
- eight focused keyboard, semantic, event, exposure, slot, discovery, and accessibility tests
- production entry at 1.74 kB compressed, within the 3 kB budget
- patch whitespace checks
