### PR TITLE
fix(ui): preserve required styles in package output

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -23,7 +23,9 @@
     "dist"
   ],
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/*.css"
+  ],
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "exports": {
@@ -31,7 +33,8 @@
       "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
-    }
+    },
+    "./style.css": "./dist/style.css"
   },
   "publishConfig": {
     "access": "public"
@@ -48,6 +51,7 @@
     "fmt": "vp fmt --write src scripts vite.config.ts"
   },
   "devDependencies": {
+    "@tsdown/css": "catalog:content",
     "@types/node": "catalog:typescript",
     "@vitejs/plugin-vue": "catalog:vite-stack",
     "@vizejs/native": "workspace:*",

--- a/npm/ui/core/src/distribution.test.ts
+++ b/npm/ui/core/src/distribution.test.ts
@@ -16,8 +16,8 @@ void test("preserves required accessibility CSS in the public entry", async () =
   assert.equal(manifest.exports["./style.css"], "./dist/style.css");
 
   const entry = await readFile(new URL("dist/index.mjs", packageDirectory), "utf8");
-  assert.match(entry, /import ["']\.\/style\.css["'];/);
+  assert.match(entry, /import\s*["']\.\/style\.css["'];?/);
 
   const style = await readFile(new URL("dist/style.css", packageDirectory), "utf8");
-  assert.match(style, /data-vize-ui=visually-hidden/);
+  assert.match(style, /data-vize-ui=["']?visually-hidden["']?/);
 });

--- a/npm/ui/core/src/distribution.test.ts
+++ b/npm/ui/core/src/distribution.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const packageDirectory = new URL("../", import.meta.url);
+
+void test("preserves required accessibility CSS in the public entry", async () => {
+  const manifest = JSON.parse(
+    await readFile(new URL("package.json", packageDirectory), "utf8"),
+  ) as {
+    exports: Record<string, string | { default: string; import: string; types: string }>;
+    sideEffects: string[];
+  };
+
+  assert.deepEqual(manifest.sideEffects, ["./dist/*.css"]);
+  assert.equal(manifest.exports["./style.css"], "./dist/style.css");
+
+  const entry = await readFile(new URL("dist/index.mjs", packageDirectory), "utf8");
+  assert.match(entry, /import ["']\.\/style\.css["'];/);
+
+  const style = await readFile(new URL("dist/style.css", packageDirectory), "utf8");
+  assert.match(style, /data-vize-ui=visually-hidden/);
+});

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -1,6 +1,6 @@
 export * from "./checkbox.ts";
 export * from "./controllable-state.ts";
-/** Visually hidden content exposed to assistive technology. */
 export * from "./button.ts";
 export * from "./primitive.ts";
+/** Visually hidden content exposed to assistive technology. */
 export { default as VisuallyHidden } from "./VisuallyHidden.vue";

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
     format: "esm",
     dts: { vue: true },
     plugins: [vue()],
+    css: {
+      inject: true,
+      minify: true,
+    },
     clean: true,
     deps: {
       neverBundle: ["vue"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -885,6 +885,9 @@ importers:
 
   npm/ui/core:
     devDependencies:
+      '@tsdown/css':
+        specifier: catalog:content
+        version: 0.22.0(jiti@2.7.0)(postcss@8.5.15)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
       '@types/node':
         specifier: catalog:typescript
         version: 25.9.2


### PR DESCRIPTION
## Summary

- keep required accessibility styles reachable from the public JavaScript entry
- expose the emitted stylesheet and preserve its side effects during consumer builds
- verify the published manifest, JavaScript import, and compiled selector

## Validation

- `pnpm --filter @vizeui/core check`
- `pnpm --filter @vizeui/core test`
- `pnpm --filter @vizeui/core lint:sfc`
- `pnpm install --offline --frozen-lockfile`
- package dry run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated stylesheet export (`style.css`) for easier access to the UI package’s styles.
  - Build now injects and minifies CSS for improved stylesheet handling.

- **Bug Fixes**
  - Improved reliability of accessibility-related styling by ensuring the visually-hidden stylesheet is preserved in published output.

- **Tests**
  - Added distribution checks to verify stylesheet export mappings, CSS inclusion rules, and the required accessibility marker in the built stylesheet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->