### PR TITLE
feat(ui): publish independent primitive entries

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -34,6 +34,31 @@
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
     },
+    "./button": {
+      "types": "./dist/button.d.mts",
+      "import": "./dist/button.mjs",
+      "default": "./dist/button.mjs"
+    },
+    "./checkbox": {
+      "types": "./dist/checkbox.d.mts",
+      "import": "./dist/checkbox.mjs",
+      "default": "./dist/checkbox.mjs"
+    },
+    "./controllable-state": {
+      "types": "./dist/controllable-state.d.mts",
+      "import": "./dist/controllable-state.mjs",
+      "default": "./dist/controllable-state.mjs"
+    },
+    "./primitive": {
+      "types": "./dist/primitive.d.mts",
+      "import": "./dist/primitive.mjs",
+      "default": "./dist/primitive.mjs"
+    },
+    "./visually-hidden": {
+      "types": "./dist/visually-hidden.d.mts",
+      "import": "./dist/visually-hidden.mjs",
+      "default": "./dist/visually-hidden.mjs"
+    },
     "./style.css": "./dist/style.css"
   },
   "publishConfig": {

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -1,10 +1,52 @@
 import { readFile } from "node:fs/promises";
+import { posix } from "node:path";
 import { gzipSync } from "node:zlib";
 
-const maximumGzipBytes = 3 * 1024;
-const gzipBytes = gzipSync(
-  await readFile(new URL("../dist/index.mjs", import.meta.url)),
-).byteLength;
+const distributionDirectory = new URL("../dist/", import.meta.url);
+const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
+const budgets = new Map([
+  ["index.mjs", 3_200],
+  ["button.mjs", 1_600],
+  ["checkbox.mjs", 1_900],
+  ["controllable-state.mjs", 600],
+  ["primitive.mjs", 800],
+  ["visually-hidden.mjs", 800],
+]);
 
-console.log(JSON.stringify({ entry: "@vizeui/core", gzipBytes, maximumGzipBytes }));
-if (gzipBytes > maximumGzipBytes) process.exitCode = 1;
+async function collectStaticDependencies(file, collected = new Map()) {
+  if (collected.has(file)) return collected;
+
+  const source = await readFile(new URL(file, distributionDirectory));
+  collected.set(file, source);
+
+  for (const match of source.toString().matchAll(staticImportPattern)) {
+    const dependency = posix.normalize(posix.join(posix.dirname(file), match[1]));
+    if (dependency === ".." || dependency.startsWith("../")) {
+      throw new Error(`Output dependency escapes dist: ${dependency}`);
+    }
+    await collectStaticDependencies(dependency, collected);
+  }
+
+  return collected;
+}
+
+for (const [entry, maximumGzipBytes] of budgets) {
+  const files = await collectStaticDependencies(entry);
+  const gzipBytes = gzipSync(
+    [...files.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([file, source]) => `/* ${file} */\n${source}`)
+      .join("\n"),
+  ).byteLength;
+
+  console.log(
+    JSON.stringify({
+      entry: `@vizeui/core/${entry.replace(/\.mjs$/, "")}`,
+      files: files.size,
+      gzipBytes,
+      maximumGzipBytes,
+    }),
+  );
+
+  if (gzipBytes > maximumGzipBytes) process.exitCode = 1;
+}

--- a/npm/ui/core/src/distribution.test.ts
+++ b/npm/ui/core/src/distribution.test.ts
@@ -4,7 +4,16 @@ import { test } from "node:test";
 
 const packageDirectory = new URL("../", import.meta.url);
 
-void test("preserves required accessibility CSS in the public entry", async () => {
+const publicEntries = [
+  ".",
+  "./button",
+  "./checkbox",
+  "./controllable-state",
+  "./primitive",
+  "./visually-hidden",
+] as const;
+
+void test("every public entry exposes generated JavaScript and declarations", async () => {
   const manifest = JSON.parse(
     await readFile(new URL("package.json", packageDirectory), "utf8"),
   ) as {
@@ -15,8 +24,31 @@ void test("preserves required accessibility CSS in the public entry", async () =
   assert.deepEqual(manifest.sideEffects, ["./dist/*.css"]);
   assert.equal(manifest.exports["./style.css"], "./dist/style.css");
 
-  const entry = await readFile(new URL("dist/index.mjs", packageDirectory), "utf8");
-  assert.match(entry, /import\s*["']\.\/style\.css["'];?/);
+  for (const entry of publicEntries) {
+    const target = manifest.exports[entry];
+    assert.equal(typeof target, "object", `${entry} must be a conditional export`);
+    if (typeof target !== "object") continue;
+
+    assert.equal(target.import, target.default);
+    await assert.doesNotReject(
+      readFile(new URL(target.import.replace(/^\.\//, ""), packageDirectory)),
+    );
+    await assert.doesNotReject(
+      readFile(new URL(target.types.replace(/^\.\//, ""), packageDirectory)),
+    );
+  }
+});
+
+void test("required accessibility CSS follows its component entry", async () => {
+  const entry = await readFile(new URL("dist/visually-hidden.mjs", packageDirectory), "utf8");
+  const componentPath = entry.match(/from ["'](\.\/visually-hidden-[^"']+)["']/)?.[1];
+  assert.ok(componentPath, "component chunk must be reachable from its public entry");
+
+  const component = await readFile(
+    new URL(`dist/${componentPath.replace(/^\.\//, "")}`, packageDirectory),
+    "utf8",
+  );
+  assert.match(component, /import\s*["']\.\/style\.css["'];?/);
 
   const style = await readFile(new URL("dist/style.css", packageDirectory), "utf8");
   assert.match(style, /data-vize-ui=["']?visually-hidden["']?/);

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -2,5 +2,4 @@ export * from "./checkbox.ts";
 export * from "./controllable-state.ts";
 export * from "./button.ts";
 export * from "./primitive.ts";
-/** Visually hidden content exposed to assistive technology. */
-export { default as VisuallyHidden } from "./VisuallyHidden.vue";
+export * from "./visually-hidden.ts";

--- a/npm/ui/core/src/visually-hidden.ts
+++ b/npm/ui/core/src/visually-hidden.ts
@@ -1,0 +1,2 @@
+/** Content that is visually hidden while remaining available to assistive technology. */
+export { default as VisuallyHidden } from "./VisuallyHidden.vue";

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -8,7 +8,14 @@ export default defineConfig({
   },
   fmt: { ignorePatterns: ["dist/**"] },
   pack: {
-    entry: ["src/index.ts"],
+    entry: {
+      index: "src/index.ts",
+      button: "src/button.ts",
+      checkbox: "src/checkbox.ts",
+      "controllable-state": "src/controllable-state.ts",
+      primitive: "src/primitive.ts",
+      "visually-hidden": "src/visually-hidden.ts",
+    },
     format: "esm",
     dts: { vue: true },
     plugins: [vue()],


### PR DESCRIPTION
## Summary

- expose each public primitive and state helper through an explicit package subpath
- keep accessibility CSS attached to the entry that requires it
- enforce dependency-graph gzip budgets for every public entry
- verify generated JavaScript and declaration targets in the package contract

## Validation

- `pnpm --filter @vizeui/core check`
- `pnpm --filter @vizeui/core test`
- `pnpm --filter @vizeui/core lint:sfc`
- `pnpm install --offline --frozen-lockfile`
- package dry run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added public entry points for Button, Checkbox, Controllable State, Primitive, and Visually Hidden components.
  - Added generated JavaScript and TypeScript declarations for each entry point.
  - Improved access to Visually Hidden functionality through the public package API.

- **Bug Fixes**
  - Improved accessibility style verification for the Visually Hidden component.

- **Tests**
  - Added validation that all public entry points expose usable modules and type declarations.
  - Added per-entry bundle size checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->