### PR TITLE
feat(ui): add typed component context

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -44,6 +44,11 @@
       "import": "./dist/checkbox.mjs",
       "default": "./dist/checkbox.mjs"
     },
+    "./context": {
+      "types": "./dist/context.d.mts",
+      "import": "./dist/context.mjs",
+      "default": "./dist/context.mjs"
+    },
     "./controllable-state": {
       "types": "./dist/controllable-state.d.mts",
       "import": "./dist/controllable-state.mjs",

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,9 +5,10 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 3_200],
+  ["index.mjs", 3_600],
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
+  ["context.mjs", 700],
   ["controllable-state.mjs", 600],
   ["primitive.mjs", 800],
   ["visually-hidden.mjs", 800],

--- a/npm/ui/core/src/context.test.ts
+++ b/npm/ui/core/src/context.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createApp } from "vue";
+
+import { createContext } from "./context.ts";
+
+void test("creates an immutable context with an integration key", () => {
+  const context = createContext<{ value: number }>(" Selection ");
+
+  assert.equal(context.name, "Selection");
+  assert.equal(context.key.description, "Selection");
+  assert.equal(Object.isFrozen(context), true);
+});
+
+void test("resolves application-provided values", () => {
+  const context = createContext<{ value: number }>("Selection");
+  const value = { value: 42 };
+  const app = createApp({});
+  app.provide(context.key, value);
+
+  assert.equal(app.runWithContext(context.use), value);
+  assert.equal(app.runWithContext(context.useOptional), value);
+});
+
+void test("distinguishes an explicit undefined value from a missing provider", () => {
+  const context = createContext<string | undefined>("NullableSelection");
+  const provided = createApp({});
+  provided.provide(context.key, undefined);
+
+  assert.equal(provided.runWithContext(context.use), undefined);
+
+  const missing = createApp({});
+  assert.equal(missing.runWithContext(context.useOptional), undefined);
+  assert.throws(
+    () => missing.runWithContext(context.use),
+    /VIZE_UI_CONTEXT_MISSING: NullableSelection requires a matching provider/,
+  );
+});
+
+void test("rejects names that cannot produce actionable diagnostics", () => {
+  assert.throws(() => createContext("   "), /VIZE_UI_CONTEXT_NAME/);
+});

--- a/npm/ui/core/src/context.ts
+++ b/npm/ui/core/src/context.ts
@@ -1,0 +1,55 @@
+import { inject, provide } from "vue";
+import type { InjectionKey } from "vue";
+
+const missingContext = Symbol("missing component context");
+
+/** A typed provider and consumer contract for one component family. */
+export interface ComponentContext<Value> {
+  /** Human-readable context name used by diagnostics and developer tools. */
+  readonly name: string;
+  /** Public injection key for application-level adapters and test harnesses. */
+  readonly key: InjectionKey<Value>;
+  /** Provides a value from component setup and returns that same value. */
+  readonly provide: (value: Value) => Value;
+  /** Reads the nearest value or throws a stable missing-provider diagnostic. */
+  readonly use: () => Value;
+  /** Reads the nearest value when the provider is intentionally optional. */
+  readonly useOptional: () => Value | undefined;
+}
+
+/**
+ * Creates an immutable typed context for a compound component family.
+ *
+ * A private sentinel distinguishes a missing provider from a provider whose
+ * value is explicitly `undefined`.
+ */
+export function createContext<Value>(name: string): ComponentContext<Value> {
+  const contextName = name.trim();
+  if (contextName.length === 0) {
+    throw new Error("VIZE_UI_CONTEXT_NAME: context name must not be empty");
+  }
+
+  const key = Symbol(contextName) as InjectionKey<Value>;
+  const internalKey = key as InjectionKey<Value | typeof missingContext>;
+  const read = () => inject(internalKey, missingContext);
+
+  return Object.freeze({
+    name: contextName,
+    key,
+    provide: (value: Value) => {
+      provide(key, value);
+      return value;
+    },
+    use: () => {
+      const value = read();
+      if (value === missingContext) {
+        throw new Error(`VIZE_UI_CONTEXT_MISSING: ${contextName} requires a matching provider`);
+      }
+      return value;
+    },
+    useOptional: () => {
+      const value = read();
+      return value === missingContext ? undefined : value;
+    },
+  });
+}

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./checkbox.ts";
+export * from "./context.ts";
 export * from "./controllable-state.ts";
 export * from "./button.ts";
 export * from "./primitive.ts";

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       index: "src/index.ts",
       button: "src/button.ts",
       checkbox: "src/checkbox.ts",
+      context: "src/context.ts",
       "controllable-state": "src/controllable-state.ts",
       primitive: "src/primitive.ts",
       "visually-hidden": "src/visually-hidden.ts",


### PR DESCRIPTION
## Summary

- add an immutable typed context contract for compound component families
- distinguish a missing provider from an explicitly undefined value
- expose required and optional consumers plus an integration key
- publish the context as an independent size-budgeted entry

## Validation

- `pnpm --filter @vizeui/core check`
- `pnpm --filter @vizeui/core test`
- `pnpm --filter @vizeui/core lint:sfc`
- `pnpm install --offline --frozen-lockfile`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->