### PR TITLE
feat(compose): add reactive temporal clock

### DIFF
--- a/npm/compose/temporal/package.json
+++ b/npm/compose/temporal/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@vizecompose/temporal",
+  "version": "0.298.0",
+  "description": "Reactive, standards-based date and time utilities for Vize applications",
+  "keywords": [
+    "composables",
+    "date",
+    "temporal",
+    "time",
+    "vue"
+  ],
+  "homepage": "https://github.com/ubugeeei-prod/vize",
+  "bugs": {
+    "url": "https://github.com/ubugeeei-prod/vize/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ubugeeei-prod/vize.git",
+    "directory": "npm/compose/temporal"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "vp pack",
+    "dev": "vp pack --watch",
+    "pretest": "vp pack && pnpm check:size",
+    "test": "vp exec node --test 'src/**/*.test.ts'",
+    "check": "vp check src scripts vite.config.ts",
+    "check:fix": "vp check --fix src scripts vite.config.ts",
+    "check:size": "node scripts/check-size.mjs",
+    "fmt": "vp fmt --write src scripts vite.config.ts"
+  },
+  "dependencies": {
+    "temporal-polyfill-lite": "0.4.2"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:typescript",
+    "typescript": "catalog:typescript",
+    "vite-plus": "catalog:vite-stack",
+    "vue": "catalog:vue-stable"
+  },
+  "peerDependencies": {
+    "vue": "^3.5.0"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/npm/compose/temporal/scripts/check-size.mjs
+++ b/npm/compose/temporal/scripts/check-size.mjs
@@ -1,0 +1,10 @@
+import { readFile } from "node:fs/promises";
+import { gzipSync } from "node:zlib";
+
+const maximumGzipBytes = 1_200;
+const gzipBytes = gzipSync(
+  await readFile(new URL("../dist/index.mjs", import.meta.url)),
+).byteLength;
+
+console.log(JSON.stringify({ entry: "@vizecompose/temporal", gzipBytes, maximumGzipBytes }));
+if (gzipBytes > maximumGzipBytes) process.exitCode = 1;

--- a/npm/compose/temporal/src/index.ts
+++ b/npm/compose/temporal/src/index.ts
@@ -1,0 +1,162 @@
+import { computed, readonly, shallowRef, toValue, watchEffect } from "vue";
+import type { ComputedRef, MaybeRefOrGetter, Ref } from "vue";
+import { Intl as TemporalIntl, Temporal } from "temporal-polyfill-lite";
+
+/**
+ * Timer host used by {@link useTemporalNow}.
+ *
+ * Implement this interface to integrate a deterministic clock, a native
+ * runtime timer, or an application-owned scheduler.
+ */
+export interface TemporalScheduler {
+  /** Starts a repeating callback and returns its opaque cancellation handle. */
+  readonly setInterval: (callback: () => void, intervalMs: number) => unknown;
+
+  /** Cancels a handle previously returned by {@link TemporalScheduler.setInterval}. */
+  readonly clearInterval: (handle: unknown) => void;
+}
+
+/** Options for {@link useTemporalNow}. */
+export interface UseTemporalNowOptions {
+  /**
+   * Clock update interval in milliseconds.
+   *
+   * Reactive changes replace the active timer. Values must be finite and
+   * greater than zero.
+   *
+   * @default 1000
+   */
+  readonly intervalMs?: MaybeRefOrGetter<number>;
+
+  /**
+   * Pauses periodic updates while preserving the current instant.
+   * Manual calls to {@link TemporalClock.refresh} continue to work.
+   *
+   * @default false
+   */
+  readonly paused?: MaybeRefOrGetter<boolean>;
+
+  /**
+   * Starts the timer when no browser `window` is available.
+   *
+   * Keep this disabled during server rendering. Enable it for native,
+   * desktop, worker, and test runtimes whose scheduler is lifecycle-bound.
+   *
+   * @default false
+   */
+  readonly runOnServer?: MaybeRefOrGetter<boolean>;
+
+  /**
+   * Produces the current instant.
+   *
+   * @default Temporal.Now.instant
+   */
+  readonly now?: () => Temporal.Instant;
+
+  /**
+   * Owns the repeating timer.
+   *
+   * @default globalThis timer functions
+   */
+  readonly scheduler?: TemporalScheduler;
+}
+
+/** Reactive controls returned by {@link useTemporalNow}. */
+export interface TemporalClock {
+  /** The latest instant. This ref is readonly to consumers. */
+  readonly instant: Readonly<Ref<Temporal.Instant>>;
+
+  /** Reads the clock source immediately, stores the value, and returns it. */
+  readonly refresh: () => Temporal.Instant;
+}
+
+/** Options for {@link useTemporalZonedDateTime}. */
+export interface UseTemporalZonedDateTimeOptions extends UseTemporalNowOptions {
+  /**
+   * Time-zone identifier or zoned date-time accepted by Temporal.
+   *
+   * @default Temporal.Now.timeZoneId()
+   */
+  readonly timeZone?: MaybeRefOrGetter<Temporal.TimeZoneLike>;
+}
+
+const defaultScheduler: TemporalScheduler = {
+  setInterval: (callback, intervalMs) => globalThis.setInterval(callback, intervalMs),
+  clearInterval: (handle) => {
+    globalThis.clearInterval(handle as ReturnType<typeof setInterval>);
+  },
+};
+
+function resolveIntervalMs(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new RangeError(
+      `[VIZE_COMPOSE_TEMPORAL_INVALID_INTERVAL] intervalMs must be finite and greater than zero; received ${String(value)}`,
+    );
+  }
+
+  return Math.max(1, Math.trunc(value));
+}
+
+function shouldSchedule(options: UseTemporalNowOptions): boolean {
+  if (toValue(options.paused ?? false)) return false;
+  return typeof window !== "undefined" || toValue(options.runOnServer ?? false);
+}
+
+/**
+ * Creates a pauseable Temporal clock whose timer follows the current Vue
+ * effect scope.
+ *
+ * The timer is replaced when reactive options change and is always cancelled
+ * when the owning scope stops. During server rendering, no timer starts unless
+ * {@link UseTemporalNowOptions.runOnServer} is explicitly enabled.
+ */
+export function useTemporalNow(options: UseTemporalNowOptions = {}): TemporalClock {
+  const readNow = options.now ?? Temporal.Now.instant;
+  const instant = shallowRef(readNow());
+
+  // Fail synchronously for invalid initial input. Reactive updates are still
+  // validated inside the watcher before a replacement timer is created.
+  if (shouldSchedule(options)) resolveIntervalMs(toValue(options.intervalMs ?? 1_000));
+
+  const refresh = (): Temporal.Instant => {
+    const nextInstant = readNow();
+    instant.value = nextInstant;
+    return nextInstant;
+  };
+
+  watchEffect((onCleanup) => {
+    if (!shouldSchedule(options)) return;
+
+    const intervalMs = resolveIntervalMs(toValue(options.intervalMs ?? 1_000));
+    const scheduler = options.scheduler ?? defaultScheduler;
+    const handle = scheduler.setInterval(refresh, intervalMs);
+
+    onCleanup(() => scheduler.clearInterval(handle));
+  });
+
+  return {
+    instant: readonly(instant),
+    refresh,
+  };
+}
+
+/**
+ * Creates a reactive zoned date-time derived from a scoped Temporal clock.
+ *
+ * Changes to {@link UseTemporalZonedDateTimeOptions.timeZone} are reflected
+ * without replacing the underlying timer.
+ */
+export function useTemporalZonedDateTime(
+  options: UseTemporalZonedDateTimeOptions = {},
+): ComputedRef<Temporal.ZonedDateTime> {
+  const clock = useTemporalNow(options);
+
+  return computed(() => {
+    const timeZone =
+      options.timeZone === undefined ? Temporal.Now.timeZoneId() : toValue(options.timeZone);
+
+    return clock.instant.value.toZonedDateTimeISO(timeZone);
+  });
+}
+
+export { Temporal, TemporalIntl };

--- a/npm/compose/temporal/src/temporal.test.ts
+++ b/npm/compose/temporal/src/temporal.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { effectScope, nextTick, ref } from "vue";
+import type { EffectScope } from "vue";
+import {
+  Temporal,
+  useTemporalNow,
+  useTemporalZonedDateTime,
+  type TemporalScheduler,
+} from "./index.ts";
+
+interface ScheduledTimer {
+  readonly callback: () => void;
+  readonly intervalMs: number;
+}
+
+class TestScheduler implements TemporalScheduler {
+  readonly active = new Set<ScheduledTimer>();
+  readonly cleared: ScheduledTimer[] = [];
+
+  setInterval(callback: () => void, intervalMs: number): ScheduledTimer {
+    const timer = { callback, intervalMs };
+    this.active.add(timer);
+    return timer;
+  }
+
+  clearInterval(handle: unknown): void {
+    const timer = handle as ScheduledTimer;
+    this.active.delete(timer);
+    this.cleared.push(timer);
+  }
+
+  tick(): void {
+    for (const timer of this.active) timer.callback();
+  }
+}
+
+function runInScope<T>(callback: () => T): [EffectScope, T] {
+  const scope = effectScope();
+  const value = scope.run(callback);
+  assert.notEqual(value, undefined);
+  return [scope, value as T];
+}
+
+void test("provides a deterministic clock without starting a server timer", () => {
+  const scheduler = new TestScheduler();
+  const expected = Temporal.Instant.from("2026-07-19T00:00:00Z");
+  const [scope, clock] = runInScope(() =>
+    useTemporalNow({
+      now: () => expected,
+      scheduler,
+    }),
+  );
+
+  assert.equal(clock.instant.value.toString(), "2026-07-19T00:00:00Z");
+  assert.equal(clock.refresh(), expected);
+  assert.equal(scheduler.active.size, 0);
+  scope.stop();
+});
+
+void test("replaces, pauses, resumes, and disposes the active timer", async () => {
+  const scheduler = new TestScheduler();
+  const intervalMs = ref(250);
+  const paused = ref(false);
+  let epochNanoseconds = 0n;
+  const [scope, clock] = runInScope(() =>
+    useTemporalNow({
+      intervalMs,
+      paused,
+      runOnServer: true,
+      scheduler,
+      now: () => Temporal.Instant.fromEpochNanoseconds(epochNanoseconds++),
+    }),
+  );
+
+  assert.deepEqual(
+    [...scheduler.active].map((timer) => timer.intervalMs),
+    [250],
+  );
+  scheduler.tick();
+  assert.equal(clock.instant.value.epochNanoseconds, 1n);
+
+  intervalMs.value = 400.9;
+  await nextTick();
+  assert.deepEqual(
+    [...scheduler.active].map((timer) => timer.intervalMs),
+    [400],
+  );
+  assert.equal(scheduler.cleared.length, 1);
+
+  paused.value = true;
+  await nextTick();
+  assert.equal(scheduler.active.size, 0);
+  assert.equal(scheduler.cleared.length, 2);
+
+  paused.value = false;
+  await nextTick();
+  assert.equal(scheduler.active.size, 1);
+
+  scope.stop();
+  assert.equal(scheduler.active.size, 0);
+  assert.equal(scheduler.cleared.length, 3);
+});
+
+void test("rejects intervals that cannot create a predictable timer", () => {
+  for (const intervalMs of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.throws(
+      () =>
+        runInScope(() =>
+          useTemporalNow({
+            intervalMs,
+            runOnServer: true,
+            scheduler: new TestScheduler(),
+          }),
+        ),
+      (error: unknown) =>
+        error instanceof RangeError &&
+        error.message.startsWith("[VIZE_COMPOSE_TEMPORAL_INVALID_INTERVAL]"),
+    );
+  }
+});
+
+void test("reacts to time-zone changes", () => {
+  const timeZone = ref<Temporal.TimeZoneLike>("UTC");
+  const instant = Temporal.Instant.from("2026-07-19T00:00:00Z");
+  const [scope, zoned] = runInScope(() =>
+    useTemporalZonedDateTime({
+      now: () => instant,
+      timeZone,
+    }),
+  );
+
+  assert.equal(zoned.value.hour, 0);
+  timeZone.value = "Asia/Tokyo";
+  assert.equal(zoned.value.hour, 9);
+  scope.stop();
+});
+
+void test("publishes an importable ESM distribution with declarations", async () => {
+  const packageJson = JSON.parse(
+    await readFile(new URL("../package.json", import.meta.url), "utf8"),
+  ) as {
+    readonly exports: {
+      readonly ".": { readonly import: string; readonly types: string };
+    };
+  };
+
+  assert.equal(packageJson.exports["."].import, "./dist/index.mjs");
+  assert.equal(packageJson.exports["."].types, "./dist/index.d.mts");
+
+  const distribution = await import("../dist/index.mjs");
+  assert.equal(typeof distribution.useTemporalNow, "function");
+  assert.equal(typeof distribution.Temporal.Instant.from, "function");
+});

--- a/npm/compose/temporal/tsconfig.json
+++ b/npm/compose/temporal/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "rewriteRelativeImportExtensions": true,
+    "types": ["node"],
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/npm/compose/temporal/vite.config.ts
+++ b/npm/compose/temporal/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  lint: {
+    ignorePatterns: ["dist/**"],
+    options: { typeAware: true },
+  },
+  fmt: { ignorePatterns: ["dist/**"] },
+  pack: {
+    entry: ["src/index.ts"],
+    format: "esm",
+    dts: true,
+    clean: true,
+    deps: {
+      neverBundle: ["vue", "temporal-polyfill-lite"],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,6 +394,25 @@ importers:
         specifier: catalog:vue-stable
         version: 3.5.35(typescript@6.0.3)
 
+  npm/compose/temporal:
+    dependencies:
+      temporal-polyfill-lite:
+        specifier: 0.4.2
+        version: 0.4.2
+    devDependencies:
+      '@types/node':
+        specifier: catalog:typescript
+        version: 25.9.2
+      typescript:
+        specifier: catalog:typescript
+        version: 6.0.3
+      vite-plus:
+        specifier: catalog:vite-stack
+        version: 0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
+      vue:
+        specifier: catalog:vue-stable
+        version: 3.5.35(typescript@6.0.3)
+
   npm/fresco:
     dependencies:
       '@vizejs/fresco-native':
@@ -9568,6 +9587,9 @@ packages:
         optional: true
       uglify-js:
         optional: true
+
+  temporal-polyfill-lite@0.4.2:
+    resolution: {integrity: sha512-AguA4sTLtAnpoJ62dk/kjssR5Tt1JmodrjS4r1o9IDkmxWJsqLJNsyicAZTpMY/Dt5AKF1tbkL9P84wGsXPhAQ==}
 
   terser@5.47.1:
     resolution: {integrity: sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==}
@@ -19419,6 +19441,8 @@ snapshots:
     optionalDependencies:
       esbuild: 0.28.1
       postcss: 8.5.15
+
+  temporal-polyfill-lite@0.4.2: {}
 
   terser@5.47.1:
     dependencies:

--- a/tests/tooling/release-preflight-runner.test.ts
+++ b/tests/tooling/release-preflight-runner.test.ts
@@ -100,6 +100,7 @@ test("release metadata inventory discovers every non-private npm and editor pack
       "npm/builder/vite/package.json",
       "npm/cli/package.json",
       "npm/compose/core/package.json",
+      "npm/compose/temporal/package.json",
       "npm/framework/musea-nuxt/package.json",
       "npm/framework/nuxt/package.json",
       "npm/fresco-native/package.json",


### PR DESCRIPTION
## Summary

- add a standards-based reactive clock with scoped timer ownership
- support deterministic clock and scheduler injection across runtime targets
- add zoned date-time derivation, documented defaults, distribution checks, and a strict size budget

## Validation

- Vize check: 84 files, no type errors
- package check: no warnings or errors
- package tests: 5 passed
- frozen workspace install
- package dry run
- gzip: 1,033 bytes / 1,200-byte budget

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->