### PR TITLE
fix(atelier): end line comments at every line terminator in nesting guard

### DIFF
--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
@@ -210,8 +210,19 @@ fn is_structural_type_angle_open(bytes: &[u8], i: usize) -> bool {
 }
 
 fn skip_line_comment(bytes: &[u8], mut i: usize) -> usize {
-    while i < bytes.len() && bytes[i] != b'\n' {
-        i += 1;
+    while i < bytes.len() {
+        // Line comments end at any ECMAScript line terminator: LF, CR, LS
+        // (U+2028), or PS (U+2029). Stopping only at LF let a bare CR hide
+        // parsed code from the guard (#3185).
+        match bytes[i] {
+            b'\n' | b'\r' => break,
+            0xe2 if bytes.get(i + 1) == Some(&0x80)
+                && matches!(bytes.get(i + 2), Some(&0xa8) | Some(&0xa9)) =>
+            {
+                break;
+            }
+            _ => i += 1,
+        }
     }
     i
 }
@@ -241,6 +252,12 @@ fn skip_regex(bytes: &[u8], mut i: usize) -> usize {
             }
             b'/' if !in_character_class => return skip_identifier(bytes, i + 1),
             b'\n' | b'\r' => return i,
+            // LS/PS terminate an (unterminated) regex literal like LF/CR.
+            0xe2 if bytes.get(i + 1) == Some(&0x80)
+                && matches!(bytes.get(i + 2), Some(&0xa8) | Some(&0xa9)) =>
+            {
+                return i;
+            }
             _ => i += 1,
         }
     }

--- a/crates/vize_atelier_core/tests/expression_nesting_guard.rs
+++ b/crates/vize_atelier_core/tests/expression_nesting_guard.rs
@@ -194,3 +194,43 @@ fn expression_guard_does_not_treat_relational_operators_as_type_angles() {
     let rewritten = prefix_identifiers_in_expression(&expression);
     assert!(rewritten.contains("_ctx.value < _ctx.limit"), "{rewritten}");
 }
+
+#[test]
+fn expression_guard_ends_line_comments_at_every_line_terminator() {
+    // The js_ts_expression OOM reproducer (#3185) hid parser-visible source
+    // behind a bare CR inside a line comment: the scanner only ended comments
+    // at LF while the lexer ends them at any ECMAScript line terminator, so
+    // everything between the CR and the next LF escaped the depth guard.
+    for terminator in ["\r", "\u{2028}", "\u{2029}"] {
+        let hidden = [
+            "//x",
+            terminator,
+            &"(".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1),
+        ]
+        .concat();
+        assert_eq!(
+            expression_nesting_depth(&hidden),
+            MAX_EXPRESSION_NESTING_DEPTH + 1,
+            "terminator {:?}",
+            terminator.escape_unicode()
+        );
+        assert!(expression_exceeds_max_depth(&hidden));
+        assert!(!expression_has_balanced_delimiters(&hidden));
+        assert!(!expression_is_safe_to_parse(&hidden));
+    }
+
+    // Without a line terminator the brackets stay inside the comment.
+    let commented = ["//x ", &"(".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1)].concat();
+    assert_eq!(expression_nesting_depth(&commented), 0);
+    assert!(expression_is_safe_to_parse(&commented));
+
+    // A regex literal is likewise terminated by LS/PS, not only LF/CR.
+    let regex_hidden = [
+        "a = /x",
+        "\u{2028}",
+        &"[".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1),
+    ]
+    .concat();
+    assert!(expression_exceeds_max_depth(&regex_hidden));
+    assert!(!expression_is_safe_to_parse(&regex_hidden));
+}


### PR DESCRIPTION
## Summary

The scheduled fuzz run in #3185 found a `js_ts_expression` input that aborts out of memory inside OXC's speculative TypeScript type parsing. Root cause: the expression nesting guard's scanner only ended `//` comments at LF, while the lexer ends them at any ECMAScript line terminator (LF, CR, LS U+2028, PS U+2029). The reproducer carried bare CRs inside line comments, so everything between a CR and the next LF was invisible to the depth guard but fully parsed by OXC — hiding bracket depth and unbounded speculative type-argument chains from the budget. Unterminated regex literals had the same LS/PS gap.

## Fix

- `skip_line_comment` now stops at LF, CR, LS, and PS, matching the lexer.
- `skip_regex` now also terminates at LS/PS (it already handled LF/CR).

Both changes only let the guard see more of what the parser sees, so they cannot reject previously-safe expressions.

## Verification

- Replaying the fuzz artifact (`timeout-4fd10fc1…`, 5304 bytes, 3 bare CRs inside comments) against the previous code reproduces the OOM (exit 71 deep in `parse_union_type_or_intersection_type`); with this fix it completes in milliseconds at `-timeout=20 -rss_limit_mb=2048`.
- New regression tests cover CR/LS/PS comment termination, the still-commented control case, and LS-terminated regex literals.
- `cargo test --release -p vize_atelier_core` passes; fmt clean; clippy warning count unchanged.

Closes #3185

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of ECMAScript line comments and regular expressions containing all supported line terminators.
  * Prevented deeply nested expressions from being incorrectly hidden after Unicode line separators, improving parsing safety.

* **Tests**
  * Added regression coverage for carriage returns and Unicode line separators (U+2028 and U+2029).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->