### PR TITLE
feat(marquette): add test-run evidence model and canonical fingerprints

### DIFF
--- a/crates/vize_marquette/src/lib.rs
+++ b/crates/vize_marquette/src/lib.rs
@@ -45,6 +45,7 @@
 mod canonical;
 mod compatibility;
 mod model;
+mod test_run;
 mod validate;
 
 #[cfg(test)]
@@ -59,6 +60,13 @@ pub use model::{
     Environment, EnvironmentConsumer, Protocol, ProtocolFamily, RenderingMode, Route,
     RuntimeFamily, Target,
 };
+pub use test_run::{
+    CanonicalTestRunError, TEST_RUN_EVIDENCE_FORMAT, TEST_RUN_EVIDENCE_FORMAT_VERSION,
+    TestRunArtifact, TestRunEvidence, TestRunIsolation, TestRunRetainedEvidence, TestRunRunner,
+    TestRunSelection, TestRunSuiteExecution, TestRunSuiteKind, TestRunSuiteOutcome,
+    TestRunTargetExecution, TestRunTargetKind, TestRunVerification, TestRunVerificationOutcome,
+    canonical_test_run_json, test_run_fingerprint,
+};
 pub use validate::{ContractDiagnostic, DiagnosticSeverity, validate_contract};
 
 /// Canonical JSON Schema for serialized application contracts.
@@ -67,6 +75,13 @@ pub use validate::{ContractDiagnostic, DiagnosticSeverity, validate_contract};
 /// consumers can expose the exact contract without resolving a filesystem path.
 pub const APPLICATION_CONTRACT_JSON_SCHEMA: &str =
     include_str!("../schema/application-contract.schema.json");
+
+/// Canonical JSON Schema for serialized test-run evidence records.
+///
+/// The schema is embedded so CLI, promotion, and AI tooling consumers can
+/// expose the exact record contract without resolving a filesystem path.
+pub const TEST_RUN_EVIDENCE_JSON_SCHEMA: &str =
+    include_str!("../schema/test-run-evidence.schema.json");
 
 #[cfg(test)]
 mod schema_tests {
@@ -77,6 +92,18 @@ mod schema_tests {
         assert_eq!(
             schema["$defs"]["contract"]["properties"]["formatVersion"]["const"],
             1
+        );
+    }
+
+    #[test]
+    fn embedded_test_run_schema_tracks_the_current_format() {
+        let schema: serde_json::Value =
+            serde_json::from_str(super::TEST_RUN_EVIDENCE_JSON_SCHEMA).unwrap();
+        let evidence = &schema["$defs"]["evidence"]["properties"];
+        assert_eq!(evidence["format"]["const"], super::TEST_RUN_EVIDENCE_FORMAT);
+        assert_eq!(
+            evidence["formatVersion"]["const"],
+            super::TEST_RUN_EVIDENCE_FORMAT_VERSION
         );
     }
 }

--- a/crates/vize_marquette/src/test_run.rs
+++ b/crates/vize_marquette/src/test_run.rs
@@ -1,0 +1,26 @@
+//! Release-bound test-run evidence.
+//!
+//! A `tests` deployment check is only trustworthy when its retained evidence
+//! is immutable and bound to the exact candidate it verified. This module
+//! defines the strict record, its canonical serialization, and the SHA-256
+//! fingerprint admitted as `test-run:<sha256>` by deployment gates.
+//!
+//! The contract validates and binds retained facts. It does not operate a
+//! runner, authenticate an external worker, guarantee production topology
+//! equivalence, or prove that unreported tests ran; promotion infrastructure
+//! must collect these facts from protected runner and report stores and
+//! retain them immutably.
+
+mod canonical;
+mod model;
+
+#[cfg(test)]
+pub(crate) mod model_tests;
+
+pub use canonical::{CanonicalTestRunError, canonical_test_run_json, test_run_fingerprint};
+pub use model::{
+    TEST_RUN_EVIDENCE_FORMAT, TEST_RUN_EVIDENCE_FORMAT_VERSION, TestRunArtifact, TestRunEvidence,
+    TestRunIsolation, TestRunRetainedEvidence, TestRunRunner, TestRunSelection,
+    TestRunSuiteExecution, TestRunSuiteKind, TestRunSuiteOutcome, TestRunTargetExecution,
+    TestRunTargetKind, TestRunVerification, TestRunVerificationOutcome,
+};

--- a/crates/vize_marquette/src/test_run/canonical.rs
+++ b/crates/vize_marquette/src/test_run/canonical.rs
@@ -1,0 +1,96 @@
+use sha2::{Digest, Sha256};
+use vize_carton::String;
+
+use super::model::TestRunEvidence;
+
+/// Failure to serialize a test-run evidence record canonically.
+#[derive(Debug)]
+pub struct CanonicalTestRunError(serde_json::Error);
+
+impl std::fmt::Display for CanonicalTestRunError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("failed to serialize the test-run evidence")
+    }
+}
+
+impl std::error::Error for CanonicalTestRunError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+/// Serializes a test-run evidence record after sorting recorded executions.
+///
+/// Targets sort by id and suites by id then shard index, so equivalent records
+/// produce identical bytes for cache keys, fixtures, and fingerprints. Call
+/// validation before trusting the record; canonicalization does not make an
+/// invalid record valid.
+pub fn canonical_test_run_json(
+    evidence: &TestRunEvidence,
+) -> Result<Vec<u8>, CanonicalTestRunError> {
+    let mut canonical = evidence.clone();
+    canonical
+        .targets
+        .sort_by(|left, right| left.id.cmp(&right.id));
+    canonical
+        .suites
+        .sort_by(|left, right| (&left.id, left.shard_index).cmp(&(&right.id, right.shard_index)));
+    serde_json::to_vec(&canonical).map_err(CanonicalTestRunError)
+}
+
+/// Returns a lowercase SHA-256 fingerprint of the canonical record.
+///
+/// The fingerprint is the exact value admitted as `test-run:<sha256>` by
+/// deployment gates.
+pub fn test_run_fingerprint(evidence: &TestRunEvidence) -> Result<String, CanonicalTestRunError> {
+    let bytes = canonical_test_run_json(evidence)?;
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(64);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for byte in digest {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_run::model_tests::{example_evidence, filled};
+
+    use super::*;
+
+    #[test]
+    fn execution_order_does_not_change_the_fingerprint() {
+        let left = example_evidence();
+        let mut right = left.clone();
+        right.targets.reverse();
+        right.suites.reverse();
+
+        assert_eq!(
+            canonical_test_run_json(&left).unwrap(),
+            canonical_test_run_json(&right).unwrap()
+        );
+        assert_eq!(
+            test_run_fingerprint(&left).unwrap(),
+            test_run_fingerprint(&right).unwrap()
+        );
+    }
+
+    #[test]
+    fn any_bound_fact_changes_the_fingerprint() {
+        let base = example_evidence();
+        let baseline = test_run_fingerprint(&base).unwrap();
+
+        let mut artifact = base.clone();
+        artifact.artifact.fingerprint = filled('9', 64);
+        let mut revision = base.clone();
+        revision.source_revision = filled('b', 40);
+        let mut counts = base;
+        counts.suites[0].passed += 1;
+
+        for changed in [&artifact, &revision, &counts] {
+            assert_ne!(baseline, test_run_fingerprint(changed).unwrap());
+        }
+    }
+}

--- a/crates/vize_marquette/src/test_run/model.rs
+++ b/crates/vize_marquette/src/test_run/model.rs
@@ -1,0 +1,280 @@
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use vize_carton::String;
+
+/// Serialized `format` marker for test-run evidence records.
+///
+/// Readers must reject any other value before trusting the record.
+pub const TEST_RUN_EVIDENCE_FORMAT: &str = "vize.test-run.evidence";
+
+/// Current serialized test-run evidence format.
+///
+/// Readers must reject a higher value until they explicitly support it.
+pub const TEST_RUN_EVIDENCE_FORMAT_VERSION: u32 = 1;
+
+/// Immutable, content-addressed reference to retained evidence.
+///
+/// The reference names the retained content by SHA-256 so a green label can
+/// never drift away from the bytes that were verified.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TestRunRetainedEvidence {
+    /// Content-addressed retrieval reference in `sha256:<64 hex>` form.
+    pub reference: String,
+    /// Lowercase SHA-256 fingerprint of the retained content.
+    pub fingerprint: String,
+}
+
+impl TestRunRetainedEvidence {
+    /// Creates a retained-evidence binding.
+    pub fn new(reference: impl Into<String>, fingerprint: impl Into<String>) -> Self {
+        Self {
+            reference: reference.into(),
+            fingerprint: fingerprint.into(),
+        }
+    }
+}
+
+/// Exact release artifact that the recorded test executions exercised.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TestRunArtifact {
+    /// Stable artifact identifier.
+    pub id: String,
+    /// Lowercase SHA-256 fingerprint of the artifact bytes.
+    pub fingerprint: String,
+    /// Exact artifact size in bytes; must be at least one byte.
+    pub size_bytes: u64,
+}
+
+/// Isolation level of the runner that executed the tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TestRunIsolation {
+    /// Runner reserved for one verified workload at a time.
+    Dedicated,
+    /// Runner created for this invocation and destroyed afterwards.
+    Ephemeral,
+}
+
+/// Authenticated runner that executed the recorded test run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TestRunRunner {
+    /// Stable runner identity.
+    pub identity: String,
+    /// Retained evidence for the runner's authentication.
+    pub authentication_evidence: TestRunRetainedEvidence,
+    /// Isolation level the runner guaranteed for this invocation.
+    pub isolation: TestRunIsolation,
+    /// Lowercase SHA-256 fingerprint of the exact invocation.
+    pub invocation_fingerprint: String,
+    /// Retained evidence describing the execution environment.
+    pub environment_evidence: TestRunRetainedEvidence,
+    /// Lowercase SHA-256 fingerprint of the execution environment.
+    pub environment_fingerprint: String,
+}
+
+/// Complete candidate-selected target and suite coverage for the run.
+///
+/// Recorded executions must cover exactly these identifiers; anything less is
+/// an undeclared omission and anything more is an undeclared execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TestRunSelection {
+    /// Selected target identifiers, sorted and unique.
+    pub target_ids: BTreeSet<String>,
+    /// Selected suite identifiers, sorted and unique.
+    pub suite_ids: BTreeSet<String>,
+}
+
+/// Kind of user-visible target a test execution ran against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TestRunTargetKind {
+    /// Standards-based web output.
+    Web,
+    /// Native mobile or device application output.
+    Native,
+    /// Desktop application output.
+    Desktop,
+    /// Terminal application output.
+    Terminal,
+    /// Server or backend output.
+    Server,
+}
+
+/// One executed target of the release candidate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TestRunTargetExecution {
+    /// Stable target identifier from the candidate selection.
+    pub id: String,
+    /// Kind of target that was exercised.
+    pub kind: TestRunTargetKind,
+    /// Environment identifier the target executed in.
+    pub environment: String,
+}
+
+/// Semantic kind of one executed suite.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TestRunSuiteKind {
+    /// Isolated unit tests.
+    Unit,
+    /// Cross-component integration tests.
+    Integration,
+    /// Contract and conformance tests.
+    Contract,
+    /// Full end-to-end tests.
+    EndToEnd,
+    /// Accessibility tests.
+    Accessibility,
+    /// Visual regression tests.
+    Visual,
+    /// Performance and budget tests.
+    Performance,
+    /// Fault-injection and resilience tests.
+    Resilience,
+    /// Installation tests.
+    Installation,
+    /// Upgrade tests.
+    Upgrade,
+    /// Data or schema migration tests.
+    Migration,
+}
+
+/// Final result of one executed suite shard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TestRunSuiteOutcome {
+    /// Every selected test passed.
+    Passed,
+    /// At least one test failed.
+    Failed,
+    /// Execution stopped before completion.
+    Cancelled,
+}
+
+/// One executed suite shard with its exact recorded results.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TestRunSuiteExecution {
+    /// Stable suite identifier from the candidate selection.
+    pub id: String,
+    /// Target this shard executed against.
+    pub target_id: String,
+    /// Semantic suite kind.
+    pub kind: TestRunSuiteKind,
+    /// One-based shard index within `shard_count`.
+    pub shard_index: u32,
+    /// Total number of shards the suite was split into.
+    pub shard_count: u32,
+    /// Final shard outcome.
+    pub outcome: TestRunSuiteOutcome,
+    /// Number of passed tests.
+    pub passed: u32,
+    /// Number of failed tests.
+    pub failed: u32,
+    /// Number of skipped tests.
+    pub skipped: u32,
+    /// Number of retried tests; retries must always be declared.
+    pub retries: u32,
+    /// Wall-clock shard duration in milliseconds.
+    pub duration_ms: u64,
+    /// Lowercase SHA-256 fingerprint of the exact shard invocation.
+    pub invocation_fingerprint: String,
+    /// Retained machine-readable report evidence.
+    pub report: TestRunRetainedEvidence,
+    /// Retained execution log evidence.
+    pub log: TestRunRetainedEvidence,
+}
+
+/// Final result of the independent verification pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TestRunVerificationOutcome {
+    /// The verifier accepted the complete run.
+    Accepted,
+    /// The verifier rejected the run.
+    Rejected,
+}
+
+/// Independent verification summary over every recorded execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TestRunVerification {
+    /// Stable identity of the independent verifier.
+    pub verifier: String,
+    /// Millisecond-precision UTC time the verification completed.
+    pub completed_at: String,
+    /// Final verification outcome.
+    pub outcome: TestRunVerificationOutcome,
+    /// Exact number of recorded target executions.
+    pub target_count: u32,
+    /// Exact number of recorded suite executions.
+    pub suite_count: u32,
+    /// Total passed tests across every recorded suite execution.
+    pub passed: u32,
+    /// Total failed tests across every recorded suite execution.
+    pub failed: u32,
+    /// Total skipped tests across every recorded suite execution.
+    pub skipped: u32,
+    /// Total retried tests across every recorded suite execution.
+    pub retries: u32,
+    /// Retained evidence produced by the verification pass.
+    pub evidence: TestRunRetainedEvidence,
+}
+
+/// Complete, versioned test-run evidence for one release candidate.
+///
+/// The record binds application, environment, application contract, source
+/// revision, release, and exact artifact fingerprint to bounded target and
+/// suite executions, so a `tests` check can only be satisfied by retained,
+/// immutable facts instead of a mutable label or path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TestRunEvidence {
+    /// Serialized format marker; always [`TEST_RUN_EVIDENCE_FORMAT`].
+    pub format: String,
+    /// Serialized format version.
+    ///
+    /// Defaults to [`TEST_RUN_EVIDENCE_FORMAT_VERSION`].
+    #[serde(default = "default_test_run_format_version")]
+    pub format_version: u32,
+    /// Stable record identifier.
+    pub id: String,
+    /// Application the run verified.
+    pub application: String,
+    /// Deployment environment the run verified the candidate for.
+    pub environment: String,
+    /// Lowercase SHA-256 fingerprint of the application contract.
+    pub contract_fingerprint: String,
+    /// Exact source revision the candidate was built from.
+    pub source_revision: String,
+    /// Release the candidate belongs to.
+    pub release: String,
+    /// Exact artifact the recorded executions exercised.
+    pub artifact: TestRunArtifact,
+    /// Millisecond-precision UTC time the run started.
+    pub started_at: String,
+    /// Millisecond-precision UTC time the run completed.
+    pub completed_at: String,
+    /// Millisecond-precision UTC time the record expires.
+    pub valid_until: String,
+    /// Authenticated runner that executed the run.
+    pub runner: TestRunRunner,
+    /// Complete candidate-selected target and suite coverage.
+    pub selection: TestRunSelection,
+    /// Recorded target executions.
+    pub targets: Vec<TestRunTargetExecution>,
+    /// Recorded suite executions.
+    pub suites: Vec<TestRunSuiteExecution>,
+    /// Independent verification summary.
+    pub verification: TestRunVerification,
+}
+
+const fn default_test_run_format_version() -> u32 {
+    TEST_RUN_EVIDENCE_FORMAT_VERSION
+}

--- a/crates/vize_marquette/src/test_run/model_tests.rs
+++ b/crates/vize_marquette/src/test_run/model_tests.rs
@@ -1,0 +1,144 @@
+use std::collections::BTreeSet;
+
+use super::model::*;
+
+pub(crate) fn filled(fill: char, length: usize) -> vize_carton::String {
+    let mut output = vize_carton::String::with_capacity(length);
+    for _ in 0..length {
+        output.push(fill);
+    }
+    output
+}
+
+fn digest(fill: char) -> vize_carton::String {
+    filled(fill, 64)
+}
+
+fn retained(fill: char) -> TestRunRetainedEvidence {
+    let fingerprint = digest(fill);
+    let mut reference = vize_carton::String::from("sha256:");
+    reference.push_str(&fingerprint);
+    TestRunRetainedEvidence::new(reference, fingerprint)
+}
+
+/// Returns a fully-populated record that satisfies every schema bound.
+pub(crate) fn example_evidence() -> TestRunEvidence {
+    TestRunEvidence {
+        format: TEST_RUN_EVIDENCE_FORMAT.into(),
+        format_version: TEST_RUN_EVIDENCE_FORMAT_VERSION,
+        id: "run-2026-07-21.001".into(),
+        application: "example".into(),
+        environment: "production".into(),
+        contract_fingerprint: digest('1'),
+        source_revision: filled('a', 40),
+        release: "0.298.0".into(),
+        artifact: TestRunArtifact {
+            id: "web-bundle".into(),
+            fingerprint: digest('2'),
+            size_bytes: 1024,
+        },
+        started_at: "2026-07-21T00:00:00.000Z".into(),
+        completed_at: "2026-07-21T00:10:00.000Z".into(),
+        valid_until: "2026-07-28T00:10:00.000Z".into(),
+        runner: TestRunRunner {
+            identity: "ci.runner-1".into(),
+            authentication_evidence: retained('3'),
+            isolation: TestRunIsolation::Ephemeral,
+            invocation_fingerprint: digest('4'),
+            environment_evidence: retained('5'),
+            environment_fingerprint: digest('6'),
+        },
+        selection: TestRunSelection {
+            target_ids: BTreeSet::from(["web".into()]),
+            suite_ids: BTreeSet::from(["e2e".into(), "unit".into()]),
+        },
+        targets: vec![TestRunTargetExecution {
+            id: "web".into(),
+            kind: TestRunTargetKind::Web,
+            environment: "production".into(),
+        }],
+        suites: vec![
+            TestRunSuiteExecution {
+                id: "unit".into(),
+                target_id: "web".into(),
+                kind: TestRunSuiteKind::Unit,
+                shard_index: 1,
+                shard_count: 1,
+                outcome: TestRunSuiteOutcome::Passed,
+                passed: 120,
+                failed: 0,
+                skipped: 0,
+                retries: 0,
+                duration_ms: 61_000,
+                invocation_fingerprint: digest('7'),
+                report: retained('8'),
+                log: retained('9'),
+            },
+            TestRunSuiteExecution {
+                id: "e2e".into(),
+                target_id: "web".into(),
+                kind: TestRunSuiteKind::EndToEnd,
+                shard_index: 1,
+                shard_count: 1,
+                outcome: TestRunSuiteOutcome::Passed,
+                passed: 24,
+                failed: 0,
+                skipped: 0,
+                retries: 0,
+                duration_ms: 180_000,
+                invocation_fingerprint: digest('a'),
+                report: retained('b'),
+                log: retained('c'),
+            },
+        ],
+        verification: TestRunVerification {
+            verifier: "release.verifier".into(),
+            completed_at: "2026-07-21T00:11:00.000Z".into(),
+            outcome: TestRunVerificationOutcome::Accepted,
+            target_count: 1,
+            suite_count: 2,
+            passed: 144,
+            failed: 0,
+            skipped: 0,
+            retries: 0,
+            evidence: retained('d'),
+        },
+    }
+}
+
+#[test]
+fn serialization_round_trips_with_schema_field_names() {
+    let evidence = example_evidence();
+    let json = serde_json::to_value(&evidence).unwrap();
+
+    assert_eq!(json["format"], TEST_RUN_EVIDENCE_FORMAT);
+    assert_eq!(json["formatVersion"], 1);
+    assert_eq!(json["artifact"]["sizeBytes"], 1024);
+    assert_eq!(json["runner"]["isolation"], "ephemeral");
+    assert_eq!(json["selection"]["targetIds"][0], "web");
+    assert_eq!(json["suites"][1]["kind"], "end-to-end");
+    assert_eq!(json["verification"]["outcome"], "accepted");
+
+    let restored: TestRunEvidence = serde_json::from_value(json).unwrap();
+    assert_eq!(restored, evidence);
+}
+
+#[test]
+fn format_version_defaults_and_unknown_properties_are_rejected() {
+    let mut json = serde_json::to_value(example_evidence()).unwrap();
+    json.as_object_mut().unwrap().remove("formatVersion");
+    let restored: TestRunEvidence = serde_json::from_value(json.clone()).unwrap();
+    assert_eq!(restored.format_version, TEST_RUN_EVIDENCE_FORMAT_VERSION);
+
+    json.as_object_mut()
+        .unwrap()
+        .insert("unexpected".into(), serde_json::Value::Bool(true));
+    assert!(serde_json::from_value::<TestRunEvidence>(json).is_err());
+
+    let mut nested = serde_json::to_value(example_evidence()).unwrap();
+    nested["runner"]
+        .as_object_mut()
+        .unwrap()
+        .insert("unexpected".into(), serde_json::Value::Bool(true));
+    assert!(serde_json::from_value::<TestRunEvidence>(nested).is_err());
+}


### PR DESCRIPTION
## Summary

First implementation step for #3146, building on the schema landed in #3147.

- Strict serde model for `vize.test-run.evidence` records: every object rejects unknown properties, field names and enum spellings match the schema exactly, and `formatVersion` defaults to 1 with the default documented.
- Canonical serialization sorts targets by id and suites by (id, shardIndex) so equivalent records produce identical bytes; selection id sets are ordered by construction.
- `test_run_fingerprint` returns the lowercase SHA-256 admitted later as `test-run:<sha256>`.
- `TEST_RUN_EVIDENCE_JSON_SCHEMA` embeds the schema next to the application-contract schema, with a format-tracking test.
- Tests: schema-name round-trip, formatVersion defaulting, nested unknown-property rejection, order-independence of the fingerprint, and fingerprint sensitivity to bound facts (artifact fingerprint, source revision, suite counts).

Validation rules, admission, CLI, shared fixtures, and the TypeScript side follow in separate small PRs per the issue's delivery contract.

Part of #3146

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standardized test-run evidence format for recording artifacts, execution results, verification details, and retained evidence.
  * Added a published JSON schema and versioning support for test-run evidence records.
  * Added deterministic JSON serialization and SHA-256 fingerprints that remain stable regardless of execution ordering.

* **Tests**
  * Added coverage for schema consistency, serialization round trips, default versions, unknown-field rejection, and fingerprint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->