### PR TITLE
fix(atelier): end regex at line terminator after backslash in nesting guard

### DIFF
--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
@@ -247,7 +247,7 @@ fn skip_regex(bytes: &[u8], mut i: usize) -> usize {
             // its 0xE2 lead byte (LS/PS), hiding the following source from the
             // guard, so bail before consuming it.
             b'\\' => match bytes.get(i + 1) {
-                Some(b'\n' | b'\r') => return i,
+                Some(&b'\n' | &b'\r') => return i,
                 Some(&0xe2)
                     if bytes.get(i + 2) == Some(&0x80)
                         && matches!(bytes.get(i + 3), Some(&0xa8) | Some(&0xa9)) =>

--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
@@ -241,7 +241,21 @@ fn skip_regex(bytes: &[u8], mut i: usize) -> usize {
     let mut in_character_class = false;
     while i < bytes.len() {
         match bytes[i] {
-            b'\\' => i = i.saturating_add(2),
+            // A regex literal cannot span a line terminator, and `\` before one
+            // is not a valid escape: the lexer ends the regex at the terminator.
+            // Blindly skipping two bytes would swallow the terminator (LF/CR) or
+            // its 0xE2 lead byte (LS/PS), hiding the following source from the
+            // guard, so bail before consuming it.
+            b'\\' => match bytes.get(i + 1) {
+                Some(b'\n' | b'\r') => return i,
+                Some(&0xe2)
+                    if bytes.get(i + 2) == Some(&0x80)
+                        && matches!(bytes.get(i + 3), Some(&0xa8) | Some(&0xa9)) =>
+                {
+                    return i;
+                }
+                _ => i = i.saturating_add(2),
+            },
             b'[' => {
                 in_character_class = true;
                 i += 1;

--- a/crates/vize_atelier_core/tests/expression_nesting_guard.rs
+++ b/crates/vize_atelier_core/tests/expression_nesting_guard.rs
@@ -234,3 +234,29 @@ fn expression_guard_ends_line_comments_at_every_line_terminator() {
     assert!(expression_exceeds_max_depth(&regex_hidden));
     assert!(!expression_is_safe_to_parse(&regex_hidden));
 }
+
+#[test]
+fn expression_guard_ends_regex_at_line_terminator_after_backslash() {
+    // A regex literal cannot span a line terminator, and `\` immediately before
+    // one is not a valid escape: the lexer ends the regex there. The guard's
+    // 2-byte escape skip used to swallow the terminator (LF/CR) or its 0xE2 lead
+    // byte (LS/PS), hiding the trailing brackets from the depth budget.
+    for terminator in ["\n", "\r", "\u{2028}", "\u{2029}"] {
+        let hidden = [
+            "a = /x\\",
+            terminator,
+            &"[".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1),
+        ]
+        .concat();
+        assert!(
+            expression_exceeds_max_depth(&hidden),
+            "terminator {:?}",
+            terminator.escape_unicode()
+        );
+        assert!(
+            !expression_is_safe_to_parse(&hidden),
+            "terminator {:?}",
+            terminator.escape_unicode()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #3188. That PR made the expression nesting guard's `skip_regex` terminate an unterminated regex literal at LS/PS as well as LF/CR, but the backslash escape path was left able to swallow a line terminator: `b'\\' => i = i.saturating_add(2)` advances two bytes unconditionally, so a `\` immediately before a line terminator skips the terminator (LF/CR) or its `0xE2` lead byte (LS/PS), and the terminator check never runs. Everything after the terminator then stays hidden inside the regex scan and escapes the depth budget, which is exactly the hiding vector #3188 set out to close (caught by CodeRabbit on #3188).

A regex literal cannot span a line terminator, and `\` before one is not a valid `RegularExpressionBackslashSequence`, so the lexer ends the regex at the terminator. The guard now bails at the backslash for all four line terminators instead of skipping past them.

```rust
b'\\' => match bytes.get(i + 1) {
    Some(b'
' | b'\r') => return i,
    Some(&0xe2)
        if bytes.get(i + 2) == Some(&0x80)
            && matches!(bytes.get(i + 3), Some(&0xa8) | Some(&0xa9)) =>
    {
        return i;
    }
    _ => i = i.saturating_add(2),
},
```

This only lets the guard see more of what the parser sees, so it cannot reject previously-safe expressions. A valid escape (`\/`, `
` as the two chars backslash+`n`, etc.) is unaffected because the next byte is not a line terminator.

## Verification

- New regression `expression_guard_ends_regex_at_line_terminator_after_backslash` covers `\`+LF, `\`+CR, `\`+LS, and `\`+PS inside a regex literal.
- `cargo test -p vize_atelier_core --test expression_nesting_guard` passes (13/13), including the existing `\/`-sequence test; fmt clean; no new clippy warnings in the changed files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of regular expressions containing backslashes before line terminators.
  - Prevented hidden source after line breaks from bypassing expression nesting-depth protection.
  - Added coverage for LF, CR, line separator, and paragraph separator cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->