### PR TITLE
feat(marquette): validate test-run evidence records

### DIFF
--- a/crates/vize_marquette/src/lib.rs
+++ b/crates/vize_marquette/src/lib.rs
@@ -62,10 +62,11 @@ pub use model::{
 };
 pub use test_run::{
     CanonicalTestRunError, TEST_RUN_EVIDENCE_FORMAT, TEST_RUN_EVIDENCE_FORMAT_VERSION,
-    TestRunArtifact, TestRunEvidence, TestRunIsolation, TestRunRetainedEvidence, TestRunRunner,
-    TestRunSelection, TestRunSuiteExecution, TestRunSuiteKind, TestRunSuiteOutcome,
-    TestRunTargetExecution, TestRunTargetKind, TestRunVerification, TestRunVerificationOutcome,
-    canonical_test_run_json, test_run_fingerprint,
+    TEST_RUN_MAX_SHARDS, TEST_RUN_MAX_SUITES, TEST_RUN_MAX_TARGETS, TestRunArtifact,
+    TestRunEvidence, TestRunIsolation, TestRunRetainedEvidence, TestRunRunner, TestRunSelection,
+    TestRunSuiteExecution, TestRunSuiteKind, TestRunSuiteOutcome, TestRunTargetExecution,
+    TestRunTargetKind, TestRunVerification, TestRunVerificationOutcome, canonical_test_run_json,
+    test_run_fingerprint, validate_test_run,
 };
 pub use validate::{ContractDiagnostic, DiagnosticSeverity, validate_contract};
 

--- a/crates/vize_marquette/src/test_run.rs
+++ b/crates/vize_marquette/src/test_run.rs
@@ -13,6 +13,7 @@
 
 mod canonical;
 mod model;
+mod validate;
 
 #[cfg(test)]
 pub(crate) mod model_tests;
@@ -23,4 +24,7 @@ pub use model::{
     TestRunIsolation, TestRunRetainedEvidence, TestRunRunner, TestRunSelection,
     TestRunSuiteExecution, TestRunSuiteKind, TestRunSuiteOutcome, TestRunTargetExecution,
     TestRunTargetKind, TestRunVerification, TestRunVerificationOutcome,
+};
+pub use validate::{
+    TEST_RUN_MAX_SHARDS, TEST_RUN_MAX_SUITES, TEST_RUN_MAX_TARGETS, validate_test_run,
 };

--- a/crates/vize_marquette/src/test_run/validate.rs
+++ b/crates/vize_marquette/src/test_run/validate.rs
@@ -1,0 +1,247 @@
+use vize_carton::cstr;
+
+use crate::validate::rules::contract_path;
+use crate::{ContractDiagnostic, TestRunEvidence};
+
+mod executions;
+mod rules;
+#[cfg(test)]
+mod tests;
+
+use executions::{validate_suites, validate_targets};
+use rules::{
+    check_digest, check_identifier, check_retained_evidence, check_safe_integer, check_timestamp,
+};
+
+use super::model::{
+    TEST_RUN_EVIDENCE_FORMAT, TEST_RUN_EVIDENCE_FORMAT_VERSION, TestRunSuiteOutcome,
+    TestRunVerificationOutcome,
+};
+
+/// Maximum recorded target executions and selected target identifiers.
+pub const TEST_RUN_MAX_TARGETS: usize = 32;
+
+/// Maximum recorded suite executions and selected suite identifiers.
+pub const TEST_RUN_MAX_SUITES: usize = 512;
+
+/// Maximum shard index and shard count for one suite execution.
+pub const TEST_RUN_MAX_SHARDS: u32 = 1024;
+
+/// Validates a complete test-run evidence record.
+///
+/// Diagnostics are deterministic and sorted by path, code, and message so the
+/// same record produces stable CLI, promotion, test, and CI output. A record
+/// with any error diagnostic must never satisfy a deployment check.
+pub fn validate_test_run(evidence: &TestRunEvidence) -> Vec<ContractDiagnostic> {
+    let mut diagnostics = Vec::new();
+
+    if evidence.format.as_str() != TEST_RUN_EVIDENCE_FORMAT {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_101",
+            "format",
+            "unsupported test-run evidence format marker",
+        ));
+    }
+    if evidence.format_version != TEST_RUN_EVIDENCE_FORMAT_VERSION {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_102",
+            "formatVersion",
+            "unsupported test-run evidence format version",
+        ));
+    }
+
+    check_identifier(&evidence.id, "id", &mut diagnostics);
+    check_identifier(&evidence.application, "application", &mut diagnostics);
+    check_identifier(&evidence.environment, "environment", &mut diagnostics);
+    check_digest(
+        &evidence.contract_fingerprint,
+        "contractFingerprint",
+        &mut diagnostics,
+    );
+    rules::check_source_revision(&evidence.source_revision, &mut diagnostics);
+    if evidence.release.is_empty() || evidence.release.len() > 256 {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_106",
+            "release",
+            "release must be between 1 and 256 characters",
+        ));
+    }
+
+    check_identifier(&evidence.artifact.id, "artifact.id", &mut diagnostics);
+    check_digest(
+        &evidence.artifact.fingerprint,
+        "artifact.fingerprint",
+        &mut diagnostics,
+    );
+    if evidence.artifact.size_bytes == 0 {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_110",
+            "artifact.sizeBytes",
+            "artifact size must be at least one byte",
+        ));
+    }
+    check_safe_integer(
+        evidence.artifact.size_bytes,
+        "artifact.sizeBytes",
+        &mut diagnostics,
+    );
+
+    check_timestamp(&evidence.started_at, "startedAt", &mut diagnostics);
+    check_timestamp(&evidence.completed_at, "completedAt", &mut diagnostics);
+    check_timestamp(&evidence.valid_until, "validUntil", &mut diagnostics);
+    if evidence.completed_at < evidence.started_at {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_112",
+            "completedAt",
+            "run completion must not precede its start",
+        ));
+    }
+    if evidence.valid_until <= evidence.completed_at {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_113",
+            "validUntil",
+            "record expiry must come after run completion",
+        ));
+    }
+
+    validate_runner(evidence, &mut diagnostics);
+    validate_selection(evidence, &mut diagnostics);
+    validate_targets(evidence, &mut diagnostics);
+    validate_suites(evidence, &mut diagnostics);
+    validate_verification(evidence, &mut diagnostics);
+
+    diagnostics.sort_by(|left, right| {
+        (&left.path, left.code, &left.message).cmp(&(&right.path, right.code, &right.message))
+    });
+    diagnostics
+}
+
+fn validate_runner(evidence: &TestRunEvidence, diagnostics: &mut Vec<ContractDiagnostic>) {
+    let runner = &evidence.runner;
+    check_identifier(&runner.identity, "runner.identity", diagnostics);
+    check_retained_evidence(
+        &runner.authentication_evidence,
+        "runner.authenticationEvidence",
+        diagnostics,
+    );
+    check_digest(
+        &runner.invocation_fingerprint,
+        "runner.invocationFingerprint",
+        diagnostics,
+    );
+    check_retained_evidence(
+        &runner.environment_evidence,
+        "runner.environmentEvidence",
+        diagnostics,
+    );
+    check_digest(
+        &runner.environment_fingerprint,
+        "runner.environmentFingerprint",
+        diagnostics,
+    );
+}
+
+fn validate_selection(evidence: &TestRunEvidence, diagnostics: &mut Vec<ContractDiagnostic>) {
+    let selection = &evidence.selection;
+    if selection.target_ids.is_empty() || selection.target_ids.len() > TEST_RUN_MAX_TARGETS {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_115",
+            "selection.targetIds",
+            "selection must include between 1 and 32 targets",
+        ));
+    }
+    if selection.suite_ids.is_empty() || selection.suite_ids.len() > TEST_RUN_MAX_SUITES {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_115",
+            "selection.suiteIds",
+            "selection must include between 1 and 512 suites",
+        ));
+    }
+    for id in &selection.target_ids {
+        check_identifier(id, &contract_path("selection.targetIds", id), diagnostics);
+    }
+    for id in &selection.suite_ids {
+        check_identifier(id, &contract_path("selection.suiteIds", id), diagnostics);
+    }
+}
+
+fn validate_verification(evidence: &TestRunEvidence, diagnostics: &mut Vec<ContractDiagnostic>) {
+    let verification = &evidence.verification;
+    check_identifier(&verification.verifier, "verification.verifier", diagnostics);
+    check_timestamp(
+        &verification.completed_at,
+        "verification.completedAt",
+        diagnostics,
+    );
+    check_retained_evidence(&verification.evidence, "verification.evidence", diagnostics);
+    if verification.completed_at < evidence.completed_at {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_114",
+            "verification.completedAt",
+            "verification must complete after the run completes",
+        ));
+    }
+
+    if verification.target_count as usize != evidence.targets.len() {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_127",
+            "verification.targetCount",
+            "verified target count must equal the recorded target executions",
+        ));
+    }
+    if verification.suite_count as usize != evidence.suites.len() {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_127",
+            "verification.suiteCount",
+            "verified suite count must equal the recorded suite executions",
+        ));
+    }
+
+    let mut totals = [0u64; 4];
+    for suite in &evidence.suites {
+        totals[0] += u64::from(suite.passed);
+        totals[1] += u64::from(suite.failed);
+        totals[2] += u64::from(suite.skipped);
+        totals[3] += u64::from(suite.retries);
+    }
+    let recorded = [
+        (u64::from(verification.passed), "verification.passed"),
+        (u64::from(verification.failed), "verification.failed"),
+        (u64::from(verification.skipped), "verification.skipped"),
+        (u64::from(verification.retries), "verification.retries"),
+    ];
+    for ((total, (value, path)), name) in totals
+        .iter()
+        .zip(recorded)
+        .zip(["passed", "failed", "skipped", "retried"])
+    {
+        if *total != value {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_128",
+                path,
+                cstr!("verified {name} total must equal the sum over suite executions"),
+            ));
+        }
+    }
+
+    if verification.outcome == TestRunVerificationOutcome::Accepted {
+        let clean = evidence
+            .suites
+            .iter()
+            .all(|suite| suite.outcome == TestRunSuiteOutcome::Passed && suite.failed == 0);
+        if !clean || verification.failed > 0 {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_129",
+                "verification.outcome",
+                "verification cannot accept a run with failed or cancelled executions",
+            ));
+        }
+    }
+}
+
+impl TestRunEvidence {
+    /// Returns all structural and consistency diagnostics in stable order.
+    pub fn validate(&self) -> Vec<ContractDiagnostic> {
+        validate_test_run(self)
+    }
+}

--- a/crates/vize_marquette/src/test_run/validate/executions.rs
+++ b/crates/vize_marquette/src/test_run/validate/executions.rs
@@ -1,0 +1,200 @@
+use vize_carton::cstr;
+
+use crate::ContractDiagnostic;
+use crate::validate::rules::contract_path;
+
+use super::super::model::{
+    TestRunEvidence, TestRunSuiteExecution, TestRunSuiteKind, TestRunSuiteOutcome,
+};
+use super::rules::{check_digest, check_identifier, check_retained_evidence, check_safe_integer};
+use super::{TEST_RUN_MAX_SHARDS, TEST_RUN_MAX_SUITES, TEST_RUN_MAX_TARGETS};
+
+pub(super) fn validate_targets(
+    evidence: &TestRunEvidence,
+    diagnostics: &mut Vec<ContractDiagnostic>,
+) {
+    if evidence.targets.is_empty() || evidence.targets.len() > TEST_RUN_MAX_TARGETS {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_131",
+            "targets",
+            "record must include between 1 and 32 target executions",
+        ));
+    }
+
+    let mut seen = std::collections::BTreeSet::new();
+    for target in &evidence.targets {
+        let path = contract_path("targets", &target.id);
+        check_identifier(&target.id, &path, diagnostics);
+        check_identifier(
+            &target.environment,
+            &contract_path(&path, "environment"),
+            diagnostics,
+        );
+        if !seen.insert(&target.id) {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_117",
+                path.clone(),
+                "target execution is recorded more than once",
+            ));
+        }
+        if !evidence.selection.target_ids.contains(&target.id) {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_118",
+                path,
+                "target execution was not selected for this candidate",
+            ));
+        }
+    }
+    for selected in &evidence.selection.target_ids {
+        if !evidence.targets.iter().any(|target| target.id == *selected) {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_119",
+                contract_path("selection.targetIds", selected),
+                "selected target has no recorded execution",
+            ));
+        }
+    }
+}
+
+pub(super) fn validate_suites(
+    evidence: &TestRunEvidence,
+    diagnostics: &mut Vec<ContractDiagnostic>,
+) {
+    if evidence.suites.is_empty() || evidence.suites.len() > TEST_RUN_MAX_SUITES {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_131",
+            "suites",
+            "record must include between 1 and 512 suite executions",
+        ));
+    }
+
+    let mut shards = std::collections::BTreeMap::new();
+    for suite in &evidence.suites {
+        let path = contract_path("suites", &suite.id);
+        check_identifier(&suite.id, &path, diagnostics);
+        if !seen_shard(&mut shards, suite) {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_120",
+                path.clone(),
+                "suite shard is recorded more than once",
+            ));
+        }
+        if !evidence.selection.suite_ids.contains(&suite.id) {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_121",
+                path.clone(),
+                "suite execution was not selected for this candidate",
+            ));
+        }
+        if !evidence
+            .targets
+            .iter()
+            .any(|target| target.id == suite.target_id)
+        {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_123",
+                contract_path(&path, "targetId"),
+                "suite target has no recorded target execution",
+            ));
+        }
+        if suite.shard_count == 0
+            || suite.shard_count > TEST_RUN_MAX_SHARDS
+            || suite.shard_index == 0
+            || suite.shard_index > suite.shard_count
+        {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_124",
+                contract_path(&path, "shardIndex"),
+                "shard index must fall within a shard count between 1 and 1024",
+            ));
+        }
+        check_safe_integer(
+            suite.duration_ms,
+            &contract_path(&path, "durationMs"),
+            diagnostics,
+        );
+        check_digest(
+            &suite.invocation_fingerprint,
+            &contract_path(&path, "invocationFingerprint"),
+            diagnostics,
+        );
+        check_retained_evidence(&suite.report, &contract_path(&path, "report"), diagnostics);
+        check_retained_evidence(&suite.log, &contract_path(&path, "log"), diagnostics);
+
+        let executed = u64::from(suite.passed) + u64::from(suite.failed) + u64::from(suite.skipped);
+        let consistent = match suite.outcome {
+            TestRunSuiteOutcome::Passed => suite.failed == 0 && executed > 0,
+            TestRunSuiteOutcome::Failed => suite.failed > 0,
+            TestRunSuiteOutcome::Cancelled => true,
+        };
+        if !consistent {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_130",
+                contract_path(&path, "outcome"),
+                "suite outcome does not match its recorded counts",
+            ));
+        }
+    }
+
+    for selected in &evidence.selection.suite_ids {
+        if !evidence.suites.iter().any(|suite| suite.id == *selected) {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_122",
+                contract_path("selection.suiteIds", selected),
+                "selected suite has no recorded execution",
+            ));
+        }
+    }
+
+    for (id, group) in &shards {
+        let path = contract_path("suites", id);
+        let expected = group.shard_count;
+        if group.kinds_disagree || group.targets_disagree || group.counts_disagree {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_126",
+                path.clone(),
+                "every shard of one suite must share its kind, target, and shard count",
+            ));
+        } else if expected != 0
+            && expected <= TEST_RUN_MAX_SHARDS
+            && group.indexes.len() != expected as usize
+        {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_125",
+                path,
+                cstr!("suite must record every shard from 1 to {expected}"),
+            ));
+        }
+    }
+}
+
+struct ShardGroup<'a> {
+    shard_count: u32,
+    kind: TestRunSuiteKind,
+    target_id: &'a str,
+    indexes: std::collections::BTreeSet<u32>,
+    kinds_disagree: bool,
+    targets_disagree: bool,
+    counts_disagree: bool,
+}
+
+fn seen_shard<'a>(
+    shards: &mut std::collections::BTreeMap<&'a str, ShardGroup<'a>>,
+    suite: &'a TestRunSuiteExecution,
+) -> bool {
+    let group = shards
+        .entry(suite.id.as_str())
+        .or_insert_with(|| ShardGroup {
+            shard_count: suite.shard_count,
+            kind: suite.kind,
+            target_id: suite.target_id.as_str(),
+            indexes: std::collections::BTreeSet::new(),
+            kinds_disagree: false,
+            targets_disagree: false,
+            counts_disagree: false,
+        });
+    group.kinds_disagree |= group.kind != suite.kind;
+    group.targets_disagree |= group.target_id != suite.target_id.as_str();
+    group.counts_disagree |= group.shard_count != suite.shard_count;
+    group.indexes.insert(suite.shard_index)
+}

--- a/crates/vize_marquette/src/test_run/validate/rules.rs
+++ b/crates/vize_marquette/src/test_run/validate/rules.rs
@@ -1,0 +1,142 @@
+use crate::ContractDiagnostic;
+use crate::test_run::model::TestRunRetainedEvidence;
+use crate::validate::rules::{contract_path, validate_identifier};
+
+/// Largest integer every consuming language can represent exactly.
+const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+
+/// Validates the shared identifier grammar and the schema length bound.
+pub(super) fn check_identifier(id: &str, path: &str, diagnostics: &mut Vec<ContractDiagnostic>) {
+    validate_identifier(id, path, "VIZE_MARQUETTE_103", diagnostics);
+    if id.is_empty() || id.len() > 128 {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_103",
+            path,
+            "identifier must be between 1 and 128 characters",
+        ));
+    }
+}
+
+/// Validates a lowercase 64-character SHA-256 fingerprint.
+pub(super) fn check_digest(value: &str, path: &str, diagnostics: &mut Vec<ContractDiagnostic>) {
+    if !is_lower_hex(value, 64, 64) {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_104",
+            path,
+            "fingerprint must be 64 lowercase hexadecimal characters",
+        ));
+    }
+}
+
+/// Validates an exact source revision digest.
+pub(super) fn check_source_revision(value: &str, diagnostics: &mut Vec<ContractDiagnostic>) {
+    if !is_lower_hex(value, 40, 128) {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_105",
+            "sourceRevision",
+            "source revision must be 40 to 128 lowercase hexadecimal characters",
+        ));
+    }
+}
+
+/// Validates a millisecond-precision UTC timestamp such as
+/// `2026-07-21T00:00:00.000Z`.
+///
+/// The fixed-width format keeps lexicographic and chronological order
+/// identical, which the ordering rules rely on.
+pub(super) fn check_timestamp(value: &str, path: &str, diagnostics: &mut Vec<ContractDiagnostic>) {
+    if !is_strict_timestamp(value.as_bytes()) {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_107",
+            path,
+            "timestamp must be a millisecond-precision UTC instant like 2026-01-01T00:00:00.000Z",
+        ));
+    }
+}
+
+/// Rejects integers that lose precision in a consuming language.
+pub(super) fn check_safe_integer(
+    value: u64,
+    path: &str,
+    diagnostics: &mut Vec<ContractDiagnostic>,
+) {
+    if value > MAX_SAFE_INTEGER {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_111",
+            path,
+            "value must not exceed the largest exactly-representable integer",
+        ));
+    }
+}
+
+/// Validates an immutable retained-evidence binding.
+///
+/// The retrieval reference must be content-addressed and name exactly the
+/// fingerprinted bytes; anything else would let retained evidence mutate
+/// behind a stable-looking record.
+pub(super) fn check_retained_evidence(
+    retained: &TestRunRetainedEvidence,
+    path: &str,
+    diagnostics: &mut Vec<ContractDiagnostic>,
+) {
+    check_digest(
+        &retained.fingerprint,
+        &contract_path(path, "fingerprint"),
+        diagnostics,
+    );
+    match retained.reference.strip_prefix("sha256:") {
+        Some(suffix) if is_lower_hex(suffix, 64, 64) => {
+            if suffix != retained.fingerprint.as_str() {
+                diagnostics.push(ContractDiagnostic::error(
+                    "VIZE_MARQUETTE_109",
+                    contract_path(path, "reference"),
+                    "content-addressed reference must name the fingerprinted content",
+                ));
+            }
+        }
+        _ => diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_108",
+            contract_path(path, "reference"),
+            "evidence reference must be sha256: followed by 64 lowercase hexadecimal characters",
+        )),
+    }
+}
+
+fn is_lower_hex(value: &str, minimum: usize, maximum: usize) -> bool {
+    value.len() >= minimum
+        && value.len() <= maximum
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+fn is_strict_timestamp(bytes: &[u8]) -> bool {
+    if bytes.len() != 24 {
+        return false;
+    }
+    for (index, byte) in bytes.iter().enumerate() {
+        let valid = match index {
+            4 | 7 => *byte == b'-',
+            10 => *byte == b'T',
+            13 | 16 => *byte == b':',
+            19 => *byte == b'.',
+            23 => *byte == b'Z',
+            _ => byte.is_ascii_digit(),
+        };
+        if !valid {
+            return false;
+        }
+    }
+    let digits = |start: usize, end: usize| -> u32 {
+        bytes[start..end]
+            .iter()
+            .fold(0, |value, byte| value * 10 + u32::from(byte - b'0'))
+    };
+    let month = digits(5, 7);
+    let day = digits(8, 10);
+    (1..=12).contains(&month)
+        && (1..=31).contains(&day)
+        && digits(11, 13) <= 23
+        && digits(14, 16) <= 59
+        && digits(17, 19) <= 59
+}

--- a/crates/vize_marquette/src/test_run/validate/tests.rs
+++ b/crates/vize_marquette/src/test_run/validate/tests.rs
@@ -1,0 +1,197 @@
+use crate::test_run::model_tests::{example_evidence, filled};
+use crate::{TestRunEvidence, TestRunSuiteOutcome, TestRunVerificationOutcome, validate_test_run};
+
+fn codes(evidence: &TestRunEvidence) -> Vec<&'static str> {
+    validate_test_run(evidence)
+        .iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+#[test]
+fn a_complete_record_validates_cleanly() {
+    assert_eq!(validate_test_run(&example_evidence()), Vec::new());
+}
+
+#[test]
+fn format_marker_and_version_are_pinned() {
+    let mut evidence = example_evidence();
+    evidence.format = "vize.other.evidence".into();
+    evidence.format_version = 2;
+    assert_eq!(
+        codes(&evidence),
+        ["VIZE_MARQUETTE_101", "VIZE_MARQUETTE_102"]
+    );
+}
+
+#[test]
+fn bound_facts_must_use_exact_grammars() {
+    let mut evidence = example_evidence();
+    evidence.application = "Mixed.Case".into();
+    evidence.contract_fingerprint = filled('x', 64);
+    evidence.source_revision = filled('a', 12);
+    evidence.release = "".into();
+    evidence.artifact.size_bytes = 0;
+    evidence.started_at = "2026-07-21T00:00:00Z".into();
+
+    let reported = codes(&evidence);
+    for expected in [
+        "VIZE_MARQUETTE_103",
+        "VIZE_MARQUETTE_104",
+        "VIZE_MARQUETTE_105",
+        "VIZE_MARQUETTE_106",
+        "VIZE_MARQUETTE_110",
+        "VIZE_MARQUETTE_107",
+    ] {
+        assert!(reported.contains(&expected), "{expected} in {reported:?}");
+    }
+}
+
+#[test]
+fn record_times_must_be_ordered() {
+    let mut evidence = example_evidence();
+    evidence.completed_at = "2026-07-20T00:00:00.000Z".into();
+    let reported = codes(&evidence);
+    assert!(reported.contains(&"VIZE_MARQUETTE_112"), "{reported:?}");
+
+    let mut expired = example_evidence();
+    expired.valid_until = expired.completed_at.clone();
+    assert_eq!(codes(&expired), ["VIZE_MARQUETTE_113"]);
+
+    let mut early_verification = example_evidence();
+    early_verification.verification.completed_at = "2026-07-21T00:09:00.000Z".into();
+    assert_eq!(codes(&early_verification), ["VIZE_MARQUETTE_114"]);
+}
+
+#[test]
+fn mutable_evidence_references_are_rejected() {
+    let mut unbound = example_evidence();
+    unbound.runner.authentication_evidence.reference = {
+        let mut reference = vize_carton::String::from("sha256:");
+        reference.push_str(&filled('0', 64));
+        reference
+    };
+    assert_eq!(codes(&unbound), ["VIZE_MARQUETTE_109"]);
+
+    let mut mutable = example_evidence();
+    mutable.suites[0].report.reference = "https://reports.example/latest".into();
+    assert_eq!(codes(&mutable), ["VIZE_MARQUETTE_108"]);
+}
+
+#[test]
+fn coverage_must_match_the_candidate_selection_exactly() {
+    let mut undeclared = example_evidence();
+    undeclared.selection.suite_ids.remove("e2e");
+    assert_eq!(codes(&undeclared), ["VIZE_MARQUETTE_121"]);
+
+    let mut omitted = example_evidence();
+    omitted.suites.pop();
+    omitted.verification.suite_count = 1;
+    omitted.verification.passed = 120;
+    assert_eq!(codes(&omitted), ["VIZE_MARQUETTE_122"]);
+
+    let mut unknown_target = example_evidence();
+    unknown_target.suites[0].target_id = "missing".into();
+    assert_eq!(codes(&unknown_target), ["VIZE_MARQUETTE_123"]);
+}
+
+#[test]
+fn duplicate_executions_are_rejected() {
+    let mut duplicate_target = example_evidence();
+    let target = duplicate_target.targets[0].clone();
+    duplicate_target.targets.push(target);
+    duplicate_target.verification.target_count = 2;
+    assert_eq!(codes(&duplicate_target), ["VIZE_MARQUETTE_117"]);
+
+    let mut duplicate_shard = example_evidence();
+    let shard = duplicate_shard.suites[0].clone();
+    duplicate_shard.suites.push(shard);
+    duplicate_shard.verification.suite_count = 3;
+    duplicate_shard.verification.passed += 120;
+    assert_eq!(codes(&duplicate_shard), ["VIZE_MARQUETTE_120"]);
+}
+
+#[test]
+fn shard_records_must_be_complete_and_consistent() {
+    let mut sharded = example_evidence();
+    sharded.suites[0].shard_count = 2;
+    sharded.verification.suite_count = 2;
+    assert_eq!(codes(&sharded), ["VIZE_MARQUETTE_125"]);
+
+    let mut second = example_evidence();
+    let mut shard = second.suites[0].clone();
+    shard.shard_index = 2;
+    shard.shard_count = 2;
+    second.suites[0].shard_count = 2;
+    second.suites.push(shard.clone());
+    second.verification.suite_count = 3;
+    second.verification.passed += shard.passed;
+    assert_eq!(codes(&second), Vec::<&str>::new());
+
+    let mut disagreeing = second.clone();
+    disagreeing.suites[2].kind = crate::TestRunSuiteKind::Integration;
+    assert_eq!(codes(&disagreeing), ["VIZE_MARQUETTE_126"]);
+
+    let mut out_of_range = example_evidence();
+    out_of_range.suites[0].shard_index = 2;
+    assert_eq!(codes(&out_of_range), ["VIZE_MARQUETTE_124"]);
+}
+
+#[test]
+fn hidden_retries_and_totals_are_rejected() {
+    let mut hidden = example_evidence();
+    hidden.suites[0].retries = 3;
+    assert_eq!(codes(&hidden), ["VIZE_MARQUETTE_128"]);
+
+    let mut declared = example_evidence();
+    declared.suites[0].retries = 3;
+    declared.verification.retries = 3;
+    assert_eq!(codes(&declared), Vec::<&str>::new());
+
+    let mut counts = example_evidence();
+    counts.verification.passed = 1;
+    assert_eq!(codes(&counts), ["VIZE_MARQUETTE_128"]);
+
+    let mut sizes = example_evidence();
+    sizes.verification.target_count = 3;
+    assert_eq!(codes(&sizes), ["VIZE_MARQUETTE_127"]);
+}
+
+#[test]
+fn acceptance_requires_a_fully_passing_run() {
+    let mut failed = example_evidence();
+    failed.suites[0].outcome = TestRunSuiteOutcome::Failed;
+    failed.suites[0].failed = 2;
+    failed.suites[0].passed = 118;
+    failed.verification.failed = 2;
+    failed.verification.passed = 142;
+    assert_eq!(codes(&failed), ["VIZE_MARQUETTE_129"]);
+
+    failed.verification.outcome = TestRunVerificationOutcome::Rejected;
+    assert_eq!(codes(&failed), Vec::<&str>::new());
+
+    let mut lying = example_evidence();
+    lying.suites[0].failed = 1;
+    lying.verification.failed = 1;
+    let reported = codes(&lying);
+    assert!(reported.contains(&"VIZE_MARQUETTE_129"), "{reported:?}");
+    assert!(reported.contains(&"VIZE_MARQUETTE_130"), "{reported:?}");
+
+    let mut empty = example_evidence();
+    empty.suites[0].passed = 0;
+    empty.verification.passed = 24;
+    assert_eq!(codes(&empty), ["VIZE_MARQUETTE_130"]);
+}
+
+#[test]
+fn diagnostics_are_sorted_and_stable() {
+    let mut evidence = example_evidence();
+    evidence.format = "zzz".into();
+    evidence.application = "Broken".into();
+    let diagnostics = validate_test_run(&evidence);
+    let mut sorted = diagnostics.clone();
+    sorted.sort_by(|left, right| {
+        (&left.path, left.code, &left.message).cmp(&(&right.path, right.code, &right.message))
+    });
+    assert_eq!(diagnostics, sorted);
+}

--- a/crates/vize_marquette/src/validate.rs
+++ b/crates/vize_marquette/src/validate.rs
@@ -5,7 +5,7 @@ use vize_carton::{String, cstr};
 
 use crate::{ApplicationContract, CONTRACT_FORMAT_VERSION, EnvironmentConsumer, RuntimeFamily};
 
-mod rules;
+pub(crate) mod rules;
 #[cfg(test)]
 mod tests;
 
@@ -40,7 +40,11 @@ pub struct ContractDiagnostic {
 
 impl ContractDiagnostic {
     /// Creates an error diagnostic that prevents adapter execution.
-    fn error(code: &'static str, path: impl Into<String>, message: impl Into<String>) -> Self {
+    pub(crate) fn error(
+        code: &'static str,
+        path: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
         Self {
             code,
             severity: DiagnosticSeverity::Error,
@@ -50,7 +54,11 @@ impl ContractDiagnostic {
     }
 
     /// Creates a warning diagnostic for a valid but suspicious contract.
-    fn warning(code: &'static str, path: impl Into<String>, message: impl Into<String>) -> Self {
+    pub(crate) fn warning(
+        code: &'static str,
+        path: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
         Self {
             code,
             severity: DiagnosticSeverity::Warning,

--- a/crates/vize_marquette/src/validate/rules.rs
+++ b/crates/vize_marquette/src/validate/rules.rs
@@ -32,7 +32,7 @@ pub(super) fn collect_unique_ids<'a>(
 }
 
 /// Validates the portable lowercase identifier grammar used by every adapter.
-pub(super) fn validate_identifier(
+pub(crate) fn validate_identifier(
     id: &str,
     path: &str,
     code: &'static str,
@@ -156,7 +156,7 @@ pub(super) fn validate_rendering_target(
 }
 
 /// Builds the stable diagnostic path for a named collection member.
-pub(super) fn contract_path(collection: &str, id: &str) -> String {
+pub(crate) fn contract_path(collection: &str, id: &str) -> String {
     let mut path = collection.to_compact_string();
     path.push('.');
     path.push_str(id);


### PR DESCRIPTION
## Summary

Second step for #3146, on top of the model from #3189: deterministic validation with stable `VIZE_MARQUETTE_1xx` codes, mirroring the application-contract validator's shape (sorted path/code/message output, error-only admission posture).

Rules cover the issue's adversarial list:

- pinned `format` marker and `formatVersion` (101/102)
- identifier, digest, source-revision, release, and strict millisecond-UTC timestamp grammars (103–107)
- ordered start → completion → expiry and verification-after-completion times (112–114)
- content-addressed retained evidence: `sha256:<64 hex>` references that must name exactly the fingerprinted content, so no mutable reference can hide behind a stable-looking record (108/109)
- exact candidate coverage in both directions — no undeclared executions, no undeclared omissions — plus duplicate target/shard rejection and per-suite shard completeness and consistency (115–126, 131)
- verified totals that must equal per-suite sums (no hidden retries or skips) and counts that must equal recorded executions (127/128)
- an `accepted` verification outcome that is impossible for runs with failed or cancelled executions, plus suite outcome/count consistency (129/130)

Shared identifier/path helpers are reused from the application-contract validator (visibility widened to `pub(crate)`; no behavior change).

Admission (`test-run:<sha256>`), CLI, shared fixtures, and the TypeScript side follow in separate small PRs.

Part of #3146

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive validation for complete test-run evidence records.
  * Validation checks required format metadata, identifiers, digests, timestamps, retained evidence, limits, executions, suites, targets, shards, and verification results.
  * Added a convenient validation method and standalone validation function.
  * Added documented limits for targets, suites, and shards.
  * Validation returns consistently ordered diagnostics for predictable results.

* **Tests**
  * Added coverage for invalid evidence, execution consistency, shard completeness, timing rules, and deterministic diagnostic ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->