### PR TITLE
fix(marquette): reject impossible dates and dedupe suite-id diagnostics

### DIFF
--- a/crates/vize_marquette/src/test_run/validate/executions.rs
+++ b/crates/vize_marquette/src/test_run/validate/executions.rs
@@ -69,9 +69,9 @@ pub(super) fn validate_suites(
     }
 
     let mut shards = std::collections::BTreeMap::new();
+    let mut checked_ids = std::collections::BTreeSet::new();
     for suite in &evidence.suites {
         let path = contract_path("suites", &suite.id);
-        check_identifier(&suite.id, &path, diagnostics);
         if !seen_shard(&mut shards, suite) {
             diagnostics.push(ContractDiagnostic::error(
                 "VIZE_MARQUETTE_120",
@@ -79,23 +79,29 @@ pub(super) fn validate_suites(
                 "suite shard is recorded more than once",
             ));
         }
-        if !evidence.selection.suite_ids.contains(&suite.id) {
-            diagnostics.push(ContractDiagnostic::error(
-                "VIZE_MARQUETTE_121",
-                path.clone(),
-                "suite execution was not selected for this candidate",
-            ));
-        }
-        if !evidence
-            .targets
-            .iter()
-            .any(|target| target.id == suite.target_id)
-        {
-            diagnostics.push(ContractDiagnostic::error(
-                "VIZE_MARQUETTE_123",
-                contract_path(&path, "targetId"),
-                "suite target has no recorded target execution",
-            ));
+        // Suite-id-scoped invariants are shard-independent, so evaluate them
+        // once per unique suite id. Running them per shard would emit the same
+        // code/path/message diagnostic once for every shard of the suite.
+        if checked_ids.insert(suite.id.as_str()) {
+            check_identifier(&suite.id, &path, diagnostics);
+            if !evidence.selection.suite_ids.contains(&suite.id) {
+                diagnostics.push(ContractDiagnostic::error(
+                    "VIZE_MARQUETTE_121",
+                    path.clone(),
+                    "suite execution was not selected for this candidate",
+                ));
+            }
+            if !evidence
+                .targets
+                .iter()
+                .any(|target| target.id == suite.target_id)
+            {
+                diagnostics.push(ContractDiagnostic::error(
+                    "VIZE_MARQUETTE_123",
+                    contract_path(&path, "targetId"),
+                    "suite target has no recorded target execution",
+                ));
+            }
         }
         if suite.shard_count == 0
             || suite.shard_count > TEST_RUN_MAX_SHARDS

--- a/crates/vize_marquette/src/test_run/validate/rules.rs
+++ b/crates/vize_marquette/src/test_run/validate/rules.rs
@@ -132,10 +132,19 @@ fn is_strict_timestamp(bytes: &[u8]) -> bool {
             .iter()
             .fold(0, |value, byte| value * 10 + u32::from(byte - b'0'))
     };
+    let year = digits(0, 4);
     let month = digits(5, 7);
     let day = digits(8, 10);
-    (1..=12).contains(&month)
-        && (1..=31).contains(&day)
+    if !(1..=12).contains(&month) {
+        return false;
+    }
+    let max_day = match month {
+        4 | 6 | 9 | 11 => 30,
+        2 if year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) => 29,
+        2 => 28,
+        _ => 31,
+    };
+    (1..=max_day).contains(&day)
         && digits(11, 13) <= 23
         && digits(14, 16) <= 59
         && digits(17, 19) <= 59

--- a/crates/vize_marquette/src/test_run/validate/tests.rs
+++ b/crates/vize_marquette/src/test_run/validate/tests.rs
@@ -184,6 +184,32 @@ fn acceptance_requires_a_fully_passing_run() {
 }
 
 #[test]
+fn impossible_calendar_dates_are_rejected() {
+    let mut evidence = example_evidence();
+    evidence.started_at = "2026-02-30T00:00:00.000Z".into();
+    assert_eq!(codes(&evidence), ["VIZE_MARQUETTE_107"]);
+}
+
+#[test]
+fn suite_id_scoped_diagnostics_appear_once_across_shards() {
+    let mut evidence = example_evidence();
+    let mut shard = evidence.suites[0].clone();
+    shard.shard_index = 2;
+    shard.shard_count = 2;
+    let added_passed = shard.passed;
+    evidence.suites[0].shard_count = 2;
+    evidence.suites.push(shard);
+    evidence.verification.suite_count += 1;
+    evidence.verification.passed += added_passed;
+
+    let suite_id = evidence.suites[0].id.clone();
+    evidence.selection.suite_ids.remove(suite_id.as_str());
+
+    // The membership error surfaces once for the suite, not once per shard.
+    assert_eq!(codes(&evidence), ["VIZE_MARQUETTE_121"]);
+}
+
+#[test]
 fn diagnostics_are_sorted_and_stable() {
     let mut evidence = example_evidence();
     evidence.format = "zzz".into();


### PR DESCRIPTION
Follow-up to #3191, which merged before these two review comments were addressed. Both are contained to the test-run evidence validator.

**Reject calendar-impossible timestamps.** `is_strict_timestamp` only bounded the day to `1..=31`, so instants like `2026-02-30T00:00:00.000Z` or `2026-04-31T00:00:00.000Z` passed the "strict millisecond-UTC" grammar and became valid evidence timestamps. Since this validator is the deterministic gate for evidence records, it now checks the day against the actual month and year (leap-year aware):

```rust
let year = digits(0, 4);
let month = digits(5, 7);
let day = digits(8, 10);
if !(1..=12).contains(&month) {
    return false;
}
let max_day = match month {
    4 | 6 | 9 | 11 => 30,
    2 if year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) => 29,
    2 => 28,
    _ => 31,
};
(1..=max_day).contains(&day) && /* time components unchanged */
```

**Emit suite-id-scoped diagnostics once per suite.** In `validate_suites`, the checks that depend only on the suite `id` (identifier grammar `103`, selection membership `121`, target existence `123`) ran inside the per-shard loop, so a multi-shard suite emitted the same code/path/message diagnostic once per shard. They now run once per unique suite id via a `checked_ids` set; per-shard checks (shard index, counts, fingerprints, outcome) are unchanged.

Added regression tests: a Feb 30 timestamp is rejected with `VIZE_MARQUETTE_107`, and a two-shard suite dropped from the selection reports `VIZE_MARQUETTE_121` exactly once.

Part of #3146

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->