### PR TITLE
feat(marquette): add test-run admission and consolidated CLI

### DIFF
--- a/crates/vize_marquette/src/bin/vize-marquette.rs
+++ b/crates/vize_marquette/src/bin/vize-marquette.rs
@@ -1,4 +1,8 @@
 //! Small Rust CLI for contract validation, canonicalization, and fingerprints.
+//!
+//! Application contracts: `vize-marquette schema|validate|canonical|fingerprint [contract.json]`.
+//! Test-run evidence: `vize-marquette test-run schema|validate|canonical|fingerprint [evidence.json]`.
+//! `schema` prints the embedded JSON Schema and takes no path.
 
 use std::{
     env, fs,
@@ -6,7 +10,14 @@ use std::{
     process::ExitCode,
 };
 
-use vize_marquette::{ApplicationContract, canonical_json, contract_fingerprint};
+use vize_marquette::{
+    APPLICATION_CONTRACT_JSON_SCHEMA, ApplicationContract, ContractDiagnostic, DiagnosticSeverity,
+    TEST_RUN_EVIDENCE_JSON_SCHEMA, TestRunEvidence, canonical_json, canonical_test_run_json,
+    contract_fingerprint, test_run_fingerprint,
+};
+
+const USAGE: &str =
+    "usage: vize-marquette [test-run] schema|validate|canonical|fingerprint [<path.json>]";
 
 /// Runs the marquette CLI and renders errors without panicking.
 fn main() -> ExitCode {
@@ -22,41 +33,77 @@ fn main() -> ExitCode {
 /// Parses one command and returns its process-level result.
 fn run() -> Result<ExitCode, Box<dyn std::error::Error>> {
     let mut arguments = env::args().skip(1);
-    let command = arguments
-        .next()
-        .ok_or("usage: vize-marquette validate|canonical|fingerprint <contract.json>")?;
-    let path = arguments.next().ok_or("missing contract path")?;
+    let mut command = arguments.next().ok_or(USAGE)?;
+    let test_run = command == "test-run";
+    if test_run {
+        command = arguments.next().ok_or(USAGE)?;
+    }
+
+    if command == "schema" {
+        if arguments.next().is_some() {
+            return Err("unexpected additional arguments".into());
+        }
+        print!(
+            "{}",
+            if test_run {
+                TEST_RUN_EVIDENCE_JSON_SCHEMA
+            } else {
+                APPLICATION_CONTRACT_JSON_SCHEMA
+            }
+        );
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    let path = arguments.next().ok_or("missing document path")?;
     if arguments.next().is_some() {
         return Err("unexpected additional arguments".into());
     }
-    let contract: ApplicationContract = serde_json::from_slice(&fs::read(path)?)?;
+    let bytes = fs::read(path)?;
 
-    match command.as_str() {
-        "validate" => {
-            let diagnostics = contract.validate();
-            println!("{}", serde_json::to_string_pretty(&diagnostics)?);
-            Ok(
-                if diagnostics
-                    .iter()
-                    .any(|value| value.severity == vize_marquette::DiagnosticSeverity::Error)
-                {
-                    ExitCode::FAILURE
-                } else {
-                    ExitCode::SUCCESS
-                },
-            )
+    if test_run {
+        let evidence: TestRunEvidence = serde_json::from_slice(&bytes)?;
+        match command.as_str() {
+            "validate" => print_diagnostics(&evidence.validate()),
+            "canonical" => {
+                io::stdout().write_all(&canonical_test_run_json(&evidence)?)?;
+                Ok(ExitCode::SUCCESS)
+            }
+            "fingerprint" => {
+                println!("{}", test_run_fingerprint(&evidence)?);
+                Ok(ExitCode::SUCCESS)
+            }
+            _ => Err(USAGE.into()),
         }
-        "canonical" => {
-            io::stdout().write_all(&canonical_json(&contract)?)?;
-            Ok(ExitCode::SUCCESS)
-        }
-        "fingerprint" => {
-            println!("{}", contract_fingerprint(&contract)?);
-            Ok(ExitCode::SUCCESS)
-        }
-        _ => {
-            eprintln!("unknown command {command}");
-            Err("unknown command".into())
+    } else {
+        let contract: ApplicationContract = serde_json::from_slice(&bytes)?;
+        match command.as_str() {
+            "validate" => print_diagnostics(&contract.validate()),
+            "canonical" => {
+                io::stdout().write_all(&canonical_json(&contract)?)?;
+                Ok(ExitCode::SUCCESS)
+            }
+            "fingerprint" => {
+                println!("{}", contract_fingerprint(&contract)?);
+                Ok(ExitCode::SUCCESS)
+            }
+            _ => Err(USAGE.into()),
         }
     }
+}
+
+/// Prints diagnostics as JSON and maps any error to a failing exit code.
+fn print_diagnostics(
+    diagnostics: &[ContractDiagnostic],
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    println!("{}", serde_json::to_string_pretty(diagnostics)?);
+    Ok(
+        if diagnostics
+            .iter()
+            .any(|value| value.severity == DiagnosticSeverity::Error)
+        {
+            ExitCode::FAILURE
+        } else {
+            ExitCode::SUCCESS
+        },
+    )
 }

--- a/crates/vize_marquette/src/lib.rs
+++ b/crates/vize_marquette/src/lib.rs
@@ -61,12 +61,13 @@ pub use model::{
     RuntimeFamily, Target,
 };
 pub use test_run::{
-    CanonicalTestRunError, TEST_RUN_EVIDENCE_FORMAT, TEST_RUN_EVIDENCE_FORMAT_VERSION,
-    TEST_RUN_MAX_SHARDS, TEST_RUN_MAX_SUITES, TEST_RUN_MAX_TARGETS, TestRunArtifact,
-    TestRunEvidence, TestRunIsolation, TestRunRetainedEvidence, TestRunRunner, TestRunSelection,
-    TestRunSuiteExecution, TestRunSuiteKind, TestRunSuiteOutcome, TestRunTargetExecution,
-    TestRunTargetKind, TestRunVerification, TestRunVerificationOutcome, canonical_test_run_json,
-    test_run_fingerprint, validate_test_run,
+    CanonicalTestRunError, TEST_RUN_ADMISSION_PREFIX, TEST_RUN_EVIDENCE_FORMAT,
+    TEST_RUN_EVIDENCE_FORMAT_VERSION, TEST_RUN_MAX_SHARDS, TEST_RUN_MAX_SUITES,
+    TEST_RUN_MAX_TARGETS, TestRunArtifact, TestRunCandidate, TestRunEvidence, TestRunIsolation,
+    TestRunRetainedEvidence, TestRunRunner, TestRunSelection, TestRunSuiteExecution,
+    TestRunSuiteKind, TestRunSuiteOutcome, TestRunTargetExecution, TestRunTargetKind,
+    TestRunVerification, TestRunVerificationOutcome, admit_test_run, canonical_test_run_json,
+    parse_test_run_admission_id, test_run_admission_id, test_run_fingerprint, validate_test_run,
 };
 pub use validate::{ContractDiagnostic, DiagnosticSeverity, validate_contract};
 

--- a/crates/vize_marquette/src/test_run.rs
+++ b/crates/vize_marquette/src/test_run.rs
@@ -11,6 +11,7 @@
 //! must collect these facts from protected runner and report stores and
 //! retain them immutably.
 
+mod admission;
 mod canonical;
 mod model;
 mod validate;
@@ -18,6 +19,10 @@ mod validate;
 #[cfg(test)]
 pub(crate) mod model_tests;
 
+pub use admission::{
+    TEST_RUN_ADMISSION_PREFIX, TestRunCandidate, admit_test_run, parse_test_run_admission_id,
+    test_run_admission_id,
+};
 pub use canonical::{CanonicalTestRunError, canonical_test_run_json, test_run_fingerprint};
 pub use model::{
     TEST_RUN_EVIDENCE_FORMAT, TEST_RUN_EVIDENCE_FORMAT_VERSION, TestRunArtifact, TestRunEvidence,

--- a/crates/vize_marquette/src/test_run/admission.rs
+++ b/crates/vize_marquette/src/test_run/admission.rs
@@ -1,0 +1,280 @@
+use vize_carton::{String, cstr};
+
+use crate::ContractDiagnostic;
+
+use super::canonical::{CanonicalTestRunError, test_run_fingerprint};
+use super::model::{TestRunEvidence, TestRunVerificationOutcome};
+use super::validate::validate_test_run;
+
+/// Prefix of every test-run deployment admission id.
+pub const TEST_RUN_ADMISSION_PREFIX: &str = "test-run:";
+
+/// Exact release candidate a deployment gate wants evidence for.
+///
+/// Every field must match the record exactly; admission never falls back to
+/// a newer, older, or partially matching record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TestRunCandidate {
+    /// Application the gate is deploying.
+    pub application: String,
+    /// Deployment environment the gate is promoting into.
+    pub environment: String,
+    /// Lowercase SHA-256 fingerprint of the application contract.
+    pub contract_fingerprint: String,
+    /// Exact source revision of the candidate.
+    pub source_revision: String,
+    /// Release the candidate belongs to.
+    pub release: String,
+    /// Lowercase SHA-256 fingerprint of the exact artifact being promoted.
+    pub artifact_fingerprint: String,
+}
+
+/// Returns the fingerprint named by a `test-run:<sha256>` admission id.
+///
+/// Returns `None` unless the prefix, length, and lowercase hexadecimal
+/// grammar are all exact.
+pub fn parse_test_run_admission_id(id: &str) -> Option<&str> {
+    let fingerprint = id.strip_prefix(TEST_RUN_ADMISSION_PREFIX)?;
+    (fingerprint.len() == 64
+        && fingerprint
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')))
+    .then_some(fingerprint)
+}
+
+/// Returns the `test-run:<sha256>` admission id for one record.
+pub fn test_run_admission_id(evidence: &TestRunEvidence) -> Result<String, CanonicalTestRunError> {
+    let fingerprint = test_run_fingerprint(evidence)?;
+    let mut id = String::with_capacity(TEST_RUN_ADMISSION_PREFIX.len() + fingerprint.len());
+    id.push_str(TEST_RUN_ADMISSION_PREFIX);
+    id.push_str(&fingerprint);
+    Ok(id)
+}
+
+/// Decides whether one record admits one exact candidate at one instant.
+///
+/// An empty result admits the deployment. Any diagnostic rejects it: the
+/// record must validate cleanly, its canonical fingerprint must be the one
+/// named by `admission_id`, every candidate binding must match exactly, the
+/// record must not be expired at `now`, the independent verification must
+/// have accepted the run, and no skipped test may remain unaccounted for.
+///
+/// `now` must be a millisecond-precision UTC timestamp such as
+/// `2026-01-01T00:00:00.000Z`; the fixed-width format keeps the expiry
+/// comparison exact. Callers own retrieval: fetch the canonical bytes from
+/// an immutable store within their own deadline, refuse oversized content,
+/// and hand the parsed record here.
+pub fn admit_test_run(
+    evidence: &TestRunEvidence,
+    candidate: &TestRunCandidate,
+    admission_id: &str,
+    now: &str,
+) -> Vec<ContractDiagnostic> {
+    let mut diagnostics = validate_test_run(evidence);
+
+    let now_is_exact = super::validate::is_strict_timestamp_value(now);
+    if !now_is_exact {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_148",
+            "admission.now",
+            "admission time must be a millisecond-precision UTC instant",
+        ));
+    }
+
+    match parse_test_run_admission_id(admission_id) {
+        None => diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_141",
+            "admission.id",
+            "admission id must be test-run: followed by 64 lowercase hexadecimal characters",
+        )),
+        Some(expected) => match test_run_fingerprint(evidence) {
+            Ok(actual) if actual.as_str() == expected => {}
+            Ok(_) => diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_142",
+                "admission.id",
+                "admission id does not name this record's canonical fingerprint",
+            )),
+            Err(_) => diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_142",
+                "admission.id",
+                "record could not be canonically fingerprinted",
+            )),
+        },
+    }
+
+    let bindings = [
+        (
+            evidence.application.as_str(),
+            candidate.application.as_str(),
+            "application",
+        ),
+        (
+            evidence.environment.as_str(),
+            candidate.environment.as_str(),
+            "environment",
+        ),
+        (
+            evidence.contract_fingerprint.as_str(),
+            candidate.contract_fingerprint.as_str(),
+            "contractFingerprint",
+        ),
+        (
+            evidence.source_revision.as_str(),
+            candidate.source_revision.as_str(),
+            "sourceRevision",
+        ),
+        (
+            evidence.release.as_str(),
+            candidate.release.as_str(),
+            "release",
+        ),
+        (
+            evidence.artifact.fingerprint.as_str(),
+            candidate.artifact_fingerprint.as_str(),
+            "artifact.fingerprint",
+        ),
+    ];
+    for (recorded, expected, field) in bindings {
+        if recorded != expected {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_144",
+                field,
+                cstr!("record does not bind the candidate {field}"),
+            ));
+        }
+    }
+
+    if now_is_exact && evidence.valid_until.as_str() <= now {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_145",
+            "validUntil",
+            "record is expired at the admission time",
+        ));
+    }
+    if evidence.verification.outcome != TestRunVerificationOutcome::Accepted {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_146",
+            "verification.outcome",
+            "only an accepted verification can admit a deployment",
+        ));
+    }
+    if evidence.verification.skipped > 0 {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_147",
+            "verification.skipped",
+            "skipped tests are not approved for deployment admission",
+        ));
+    }
+
+    diagnostics.sort_by(|left, right| {
+        (&left.path, left.code, &left.message).cmp(&(&right.path, right.code, &right.message))
+    });
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_run::model_tests::example_evidence;
+
+    use super::*;
+
+    fn example_candidate() -> TestRunCandidate {
+        let evidence = example_evidence();
+        TestRunCandidate {
+            application: evidence.application,
+            environment: evidence.environment,
+            contract_fingerprint: evidence.contract_fingerprint,
+            source_revision: evidence.source_revision,
+            release: evidence.release,
+            artifact_fingerprint: evidence.artifact.fingerprint,
+        }
+    }
+
+    const NOW: &str = "2026-07-22T00:00:00.000Z";
+
+    fn codes(diagnostics: &[ContractDiagnostic]) -> Vec<&'static str> {
+        diagnostics.iter().map(|value| value.code).collect()
+    }
+
+    #[test]
+    fn an_exact_candidate_is_admitted() {
+        let evidence = example_evidence();
+        let id = test_run_admission_id(&evidence).unwrap();
+        assert_eq!(parse_test_run_admission_id(&id).unwrap(), &id[9..]);
+        assert_eq!(
+            admit_test_run(&evidence, &example_candidate(), &id, NOW),
+            Vec::new()
+        );
+    }
+
+    #[test]
+    fn admission_ids_must_be_exact() {
+        assert!(parse_test_run_admission_id("test-run:").is_none());
+        assert!(parse_test_run_admission_id("tests:abc").is_none());
+        let mut uppercase = String::from(TEST_RUN_ADMISSION_PREFIX);
+        for _ in 0..64 {
+            uppercase.push('A');
+        }
+        assert!(parse_test_run_admission_id(&uppercase).is_none());
+
+        let evidence = example_evidence();
+        let rejected = admit_test_run(&evidence, &example_candidate(), "test-run:junk", NOW);
+        assert_eq!(codes(&rejected), ["VIZE_MARQUETTE_141"]);
+    }
+
+    #[test]
+    fn a_different_record_cannot_reuse_an_admission_id() {
+        let evidence = example_evidence();
+        let id = test_run_admission_id(&evidence).unwrap();
+        let mut tampered = evidence.clone();
+        tampered.suites[1].passed = 23;
+        tampered.verification.passed = 143;
+        assert_eq!(
+            codes(&admit_test_run(&tampered, &example_candidate(), &id, NOW)),
+            ["VIZE_MARQUETTE_142"]
+        );
+    }
+
+    #[test]
+    fn every_candidate_binding_must_match() {
+        let evidence = example_evidence();
+        let id = test_run_admission_id(&evidence).unwrap();
+        let mut candidate = example_candidate();
+        candidate.release = "0.299.0".into();
+        candidate.environment = "staging".into();
+        assert_eq!(
+            codes(&admit_test_run(&evidence, &candidate, &id, NOW)),
+            ["VIZE_MARQUETTE_144", "VIZE_MARQUETTE_144"]
+        );
+    }
+
+    #[test]
+    fn expired_and_unverified_records_are_rejected() {
+        let evidence = example_evidence();
+        let id = test_run_admission_id(&evidence).unwrap();
+        let expired = admit_test_run(
+            &evidence,
+            &example_candidate(),
+            &id,
+            "2026-07-28T00:10:00.000Z",
+        );
+        assert_eq!(codes(&expired), ["VIZE_MARQUETTE_145"]);
+
+        let malformed_now = admit_test_run(&evidence, &example_candidate(), &id, "yesterday");
+        assert_eq!(codes(&malformed_now), ["VIZE_MARQUETTE_148"]);
+    }
+
+    #[test]
+    fn skipped_tests_are_not_admitted() {
+        let mut evidence = example_evidence();
+        evidence.suites[0].skipped = 1;
+        evidence.suites[0].passed = 119;
+        evidence.verification.skipped = 1;
+        evidence.verification.passed = 143;
+        let id = test_run_admission_id(&evidence).unwrap();
+        assert_eq!(
+            codes(&admit_test_run(&evidence, &example_candidate(), &id, NOW)),
+            ["VIZE_MARQUETTE_147"]
+        );
+    }
+}

--- a/crates/vize_marquette/src/test_run/validate.rs
+++ b/crates/vize_marquette/src/test_run/validate.rs
@@ -18,6 +18,11 @@ use super::model::{
     TestRunVerificationOutcome,
 };
 
+/// Returns whether `value` is a millisecond-precision UTC instant.
+pub(crate) fn is_strict_timestamp_value(value: &str) -> bool {
+    rules::is_strict_timestamp(value.as_bytes())
+}
+
 /// Maximum recorded target executions and selected target identifiers.
 pub const TEST_RUN_MAX_TARGETS: usize = 32;
 

--- a/crates/vize_marquette/src/test_run/validate/rules.rs
+++ b/crates/vize_marquette/src/test_run/validate/rules.rs
@@ -110,7 +110,7 @@ fn is_lower_hex(value: &str, minimum: usize, maximum: usize) -> bool {
             .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
 }
 
-fn is_strict_timestamp(bytes: &[u8]) -> bool {
+pub(super) fn is_strict_timestamp(bytes: &[u8]) -> bool {
     if bytes.len() != 24 {
         return false;
     }

--- a/crates/vize_marquette/tests/cli.rs
+++ b/crates/vize_marquette/tests/cli.rs
@@ -1,0 +1,181 @@
+//! End-to-end tests for the consolidated vize-marquette CLI.
+
+use std::collections::BTreeSet;
+use std::process::Command;
+
+use vize_marquette::{
+    TEST_RUN_EVIDENCE_FORMAT, TestRunArtifact, TestRunEvidence, TestRunIsolation,
+    TestRunRetainedEvidence, TestRunRunner, TestRunSelection, TestRunSuiteExecution,
+    TestRunSuiteKind, TestRunSuiteOutcome, TestRunTargetExecution, TestRunTargetKind,
+    TestRunVerification, TestRunVerificationOutcome, test_run_fingerprint,
+};
+
+fn digest(fill: char) -> vize_carton::String {
+    let mut output = vize_carton::String::with_capacity(64);
+    for _ in 0..64 {
+        output.push(fill);
+    }
+    output
+}
+
+fn retained(fill: char) -> TestRunRetainedEvidence {
+    let fingerprint = digest(fill);
+    let mut reference = vize_carton::String::from("sha256:");
+    reference.push_str(&fingerprint);
+    TestRunRetainedEvidence::new(reference, fingerprint)
+}
+
+fn example_evidence() -> TestRunEvidence {
+    let mut revision = vize_carton::String::with_capacity(40);
+    for _ in 0..40 {
+        revision.push('a');
+    }
+    TestRunEvidence {
+        format: TEST_RUN_EVIDENCE_FORMAT.into(),
+        format_version: 1,
+        id: "run-1".into(),
+        application: "example".into(),
+        environment: "production".into(),
+        contract_fingerprint: digest('1'),
+        source_revision: revision,
+        release: "0.298.0".into(),
+        artifact: TestRunArtifact {
+            id: "web-bundle".into(),
+            fingerprint: digest('2'),
+            size_bytes: 1024,
+        },
+        started_at: "2026-07-21T00:00:00.000Z".into(),
+        completed_at: "2026-07-21T00:10:00.000Z".into(),
+        valid_until: "2026-07-28T00:10:00.000Z".into(),
+        runner: TestRunRunner {
+            identity: "ci.runner-1".into(),
+            authentication_evidence: retained('3'),
+            isolation: TestRunIsolation::Ephemeral,
+            invocation_fingerprint: digest('4'),
+            environment_evidence: retained('5'),
+            environment_fingerprint: digest('6'),
+        },
+        selection: TestRunSelection {
+            target_ids: BTreeSet::from(["web".into()]),
+            suite_ids: BTreeSet::from(["unit".into()]),
+        },
+        targets: vec![TestRunTargetExecution {
+            id: "web".into(),
+            kind: TestRunTargetKind::Web,
+            environment: "production".into(),
+        }],
+        suites: vec![TestRunSuiteExecution {
+            id: "unit".into(),
+            target_id: "web".into(),
+            kind: TestRunSuiteKind::Unit,
+            shard_index: 1,
+            shard_count: 1,
+            outcome: TestRunSuiteOutcome::Passed,
+            passed: 12,
+            failed: 0,
+            skipped: 0,
+            retries: 0,
+            duration_ms: 61_000,
+            invocation_fingerprint: digest('7'),
+            report: retained('8'),
+            log: retained('9'),
+        }],
+        verification: TestRunVerification {
+            verifier: "release.verifier".into(),
+            completed_at: "2026-07-21T00:11:00.000Z".into(),
+            outcome: TestRunVerificationOutcome::Accepted,
+            target_count: 1,
+            suite_count: 1,
+            passed: 12,
+            failed: 0,
+            skipped: 0,
+            retries: 0,
+            evidence: retained('d'),
+        },
+    }
+}
+
+fn cli() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_vize-marquette"))
+}
+
+fn write_example(name: &str) -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(name);
+    std::fs::write(&path, serde_json::to_vec(&example_evidence()).unwrap()).unwrap();
+    path
+}
+
+#[test]
+fn schema_commands_print_the_embedded_schemas() {
+    let output = cli().args(["test-run", "schema"]).output().unwrap();
+    assert!(output.status.success());
+    assert_eq!(
+        std::str::from_utf8(&output.stdout).unwrap(),
+        vize_marquette::TEST_RUN_EVIDENCE_JSON_SCHEMA
+    );
+
+    let output = cli().arg("schema").output().unwrap();
+    assert!(output.status.success());
+    assert_eq!(
+        std::str::from_utf8(&output.stdout).unwrap(),
+        vize_marquette::APPLICATION_CONTRACT_JSON_SCHEMA
+    );
+}
+
+#[test]
+fn test_run_validate_reports_diagnostics_and_exit_codes() {
+    let path = write_example("vize-marquette-cli-valid.json");
+    let output = cli()
+        .args(["test-run", "validate"])
+        .arg(&path)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(std::str::from_utf8(&output.stdout).unwrap().trim(), "[]");
+
+    let mut broken = example_evidence();
+    broken.verification.passed = 1;
+    let broken_path = std::env::temp_dir().join("vize-marquette-cli-broken.json");
+    std::fs::write(&broken_path, serde_json::to_vec(&broken).unwrap()).unwrap();
+    let output = cli()
+        .args(["test-run", "validate"])
+        .arg(&broken_path)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(
+        std::str::from_utf8(&output.stdout)
+            .unwrap()
+            .contains("VIZE_MARQUETTE_128")
+    );
+}
+
+#[test]
+fn test_run_fingerprint_matches_the_library() {
+    let path = write_example("vize-marquette-cli-fingerprint.json");
+    let output = cli()
+        .args(["test-run", "fingerprint"])
+        .arg(&path)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_eq!(
+        std::str::from_utf8(&output.stdout).unwrap().trim(),
+        test_run_fingerprint(&example_evidence()).unwrap().as_str()
+    );
+}
+
+#[test]
+fn test_run_canonical_streams_sorted_bytes() {
+    let path = write_example("vize-marquette-cli-canonical.json");
+    let output = cli()
+        .args(["test-run", "canonical"])
+        .arg(&path)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_eq!(
+        output.stdout,
+        vize_marquette::canonical_test_run_json(&example_evidence()).unwrap()
+    );
+}


### PR DESCRIPTION
## Summary

Third step for #3146, on top of #3189 and #3191.

**Admission (`test-run:<sha256>`)**
- `parse_test_run_admission_id` / `test_run_admission_id`: exact prefix + 64-lowercase-hex grammar, built from the canonical fingerprint.
- `admit_test_run(evidence, candidate, admission_id, now)`: empty diagnostics admit the deployment; anything else rejects. Requires a cleanly validated record, a canonical fingerprint matching the admission id (so a tampered record can never reuse an id), exact candidate binding on application / environment / contract fingerprint / source revision / release / artifact fingerprint, an unexpired record at the supplied millisecond-UTC instant (fail-closed on a malformed instant), an accepted independent verification, and zero skipped tests (`VIZE_MARQUETTE_141–148`).
- Retrieval stays with the caller by design: fetch canonical bytes from an immutable store under your own deadline/cancellation and size bound, then hand the parsed record here — the admission id's content addressing closes the loop.

**Consolidated CLI**
- `vize-marquette [test-run] schema|validate|canonical|fingerprint [<path.json>]` — adds the missing `schema` command for both documents and the full test-run command set.
- End-to-end tests run the packaged binary: embedded schema output, diagnostics with exit codes, fingerprint/canonical parity with the library.

Shared fixtures + cross-language conformance and the TypeScript entries follow as the last two small PRs.

Part of #3146

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->