### PR TITLE
fix(canon): map batch diagnostics through exact-expression sub-spans

### DIFF
--- a/crates/vize_canon/src/batch/source_map.rs
+++ b/crates/vize_canon/src/batch/source_map.rs
@@ -44,15 +44,21 @@ impl SfcSourceMap {
     }
 
     /// Get the original SFC position from a virtual TS offset.
+    ///
+    /// Shares the language server's arithmetic: the narrowest mapping wins,
+    /// an exact-expression sub-span beats the enclosing statement mapping,
+    /// and synthetic generated text can never push a position past the
+    /// authored bytes. A diagnostic on a synthetic prop-check identifier
+    /// therefore lands on the authored expression instead of a
+    /// content-independent generated column.
     pub fn get_original_position(&self, virtual_offset: u32) -> Option<(u32, u32, SfcBlockType)> {
         let virtual_offset = virtual_offset as usize;
-        let mapping = self
-            .mappings
-            .iter()
-            .find(|mapping| mapping.gen_range.contains(&virtual_offset))?;
-        let delta = virtual_offset.saturating_sub(mapping.gen_range.start);
-        let src_offset = mapping.src_range.start.saturating_add(delta);
-        let src_offset = src_offset.min(mapping.src_range.end.saturating_sub(1));
+        let mapping = crate::virtual_ts::mapping::mapping_for_generated_offset(
+            &self.mappings,
+            virtual_offset,
+        )?;
+        let src_offset =
+            crate::virtual_ts::mapping::map_generated_offset_to_source(mapping, virtual_offset);
         let src_offset = u32::try_from(src_offset).ok()?;
         let block = self
             .blocks
@@ -251,6 +257,79 @@ mod tests {
         let (offset, _, block) = result.unwrap();
         assert_eq!(offset, 100);
         assert_eq!(block, SfcBlockType::ScriptSetup);
+    }
+
+    #[test]
+    fn sub_spans_map_synthetic_identifiers_to_authored_expressions() {
+        use crate::virtual_ts::VizeSubSpan;
+        let map = SfcSourceMap::new(
+            vec![VizeMapping {
+                // const __vize_prop_check_0_msg: __T = 42;
+                gen_range: Range {
+                    start: 100,
+                    end: 145,
+                },
+                // :msg="42"
+                src_range: Range { start: 16, end: 25 },
+                sub_spans: vec![VizeSubSpan {
+                    // the synthetic check identifier
+                    gen_range: Range {
+                        start: 106,
+                        end: 129,
+                    },
+                    // the authored bound expression
+                    src_range: Range { start: 22, end: 24 },
+                }],
+            }],
+            vec![SfcBlockRange {
+                start: 0,
+                end: 200,
+                block_type: SfcBlockType::Template,
+            }],
+        );
+
+        // A diagnostic on the identifier resolves to the authored expression.
+        assert_eq!(
+            map.get_original_position(106),
+            Some((22, 0, SfcBlockType::Template))
+        );
+        // Offsets outside the sub-span clamp to the authored prop range
+        // instead of drifting to a content-independent generated column.
+        assert_eq!(
+            map.get_original_position(144),
+            Some((25, 0, SfcBlockType::Template))
+        );
+    }
+
+    #[test]
+    fn the_narrowest_mapping_wins_for_nested_generated_ranges() {
+        let map = SfcSourceMap::new(
+            vec![
+                VizeMapping {
+                    gen_range: Range { start: 0, end: 300 },
+                    src_range: Range { start: 0, end: 100 },
+                    sub_spans: Vec::new(),
+                },
+                VizeMapping {
+                    gen_range: Range {
+                        start: 120,
+                        end: 140,
+                    },
+                    src_range: Range { start: 40, end: 60 },
+                    sub_spans: Vec::new(),
+                },
+            ],
+            vec![SfcBlockRange {
+                start: 0,
+                end: 100,
+                block_type: SfcBlockType::Template,
+            }],
+        );
+
+        assert_eq!(
+            map.get_original_position(125),
+            Some((45, 0, SfcBlockType::Template))
+        );
     }
 
     #[test]

--- a/crates/vize_canon/src/typecheck_service.rs
+++ b/crates/vize_canon/src/typecheck_service.rs
@@ -385,6 +385,12 @@ fn add_script_parse_diagnostics(
 }
 
 /// Map position from virtual TypeScript to original SFC.
+///
+/// Shares the language server's sub-span-aware arithmetic so a diagnostic on
+/// a synthetic identifier (for example a component prop check) lands on the
+/// exact authored expression instead of a content-independent generated
+/// column, and generated punctuation can never push a position past the
+/// authored bytes.
 fn map_position_to_sfc(
     virtual_ts: &VirtualTsOutput,
     start_line: u32,
@@ -398,20 +404,12 @@ fn map_position_to_sfc(
     let gen_start_offset = line_col_to_offset(&virtual_ts.code, start_line, start_char) as usize;
     let gen_end_offset = line_col_to_offset(&virtual_ts.code, end_line, end_char) as usize;
 
-    // Try to find source mapping
-    if let Some(mapping) = virtual_ts
-        .mappings
-        .iter()
-        .find(|mapping| mapping.gen_range.contains(&gen_start_offset))
-    {
-        let src_start =
-            mapping.src_range.start as u32 + (gen_start_offset - mapping.gen_range.start) as u32;
-        let src_end = if mapping.gen_range.contains(&gen_end_offset) {
-            mapping.src_range.start as u32 + (gen_end_offset - mapping.gen_range.start) as u32
-        } else {
-            mapping.src_range.end as u32
-        };
-        return (src_start, src_end);
+    if let Some((src_start, src_end)) = crate::virtual_ts::mapping::map_generated_range_to_source(
+        &virtual_ts.mappings,
+        gen_start_offset,
+        gen_end_offset,
+    ) {
+        return (src_start as u32, src_end as u32);
     }
 
     // Fallback: estimate based on line numbers

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -17,6 +17,7 @@ pub mod incremental;
 mod interface_extends_tests;
 #[cfg(test)]
 mod legacy_vue2_vuetify_tests;
+pub mod mapping;
 mod props;
 mod scope;
 #[cfg(test)]

--- a/crates/vize_canon/src/virtual_ts/mapping.rs
+++ b/crates/vize_canon/src/virtual_ts/mapping.rs
@@ -1,0 +1,160 @@
+//! Shared translation of generated virtual-TS offsets back to SFC source.
+//!
+//! Both the language server and the batch type checker must place a
+//! diagnostic on the same authored bytes, so the sub-span-aware offset
+//! arithmetic lives here and is consumed by both paths.
+
+use super::types::VizeMapping;
+
+/// Returns the narrowest mapping whose generated range contains `offset`.
+pub fn mapping_for_generated_offset(
+    mappings: &[VizeMapping],
+    offset: usize,
+) -> Option<&VizeMapping> {
+    mappings
+        .iter()
+        .filter(|mapping| mapping.gen_range.contains(&offset))
+        .min_by_key(|mapping| {
+            mapping
+                .gen_range
+                .end
+                .saturating_sub(mapping.gen_range.start)
+        })
+}
+
+/// Returns the mapping that should resolve a diagnostic end offset.
+///
+/// Reuses the start mapping while the end stays inside it so one diagnostic
+/// cannot straddle two unrelated source ranges.
+pub fn mapping_for_end_offset<'a>(
+    mappings: &'a [VizeMapping],
+    start_mapping: &'a VizeMapping,
+    end_offset: usize,
+) -> Option<&'a VizeMapping> {
+    if end_offset > start_mapping.gen_range.start && end_offset <= start_mapping.gen_range.end {
+        Some(start_mapping)
+    } else {
+        mapping_for_generated_offset(mappings, end_offset)
+    }
+}
+
+/// Maps one generated offset into authored source through `mapping`.
+///
+/// An exact-expression sub-span wins over the enclosing mapping, and both
+/// paths clamp to the authored range so synthetic generated text (helper
+/// names, punctuation) can never push a diagnostic past the authored bytes.
+pub fn map_generated_offset_to_source(mapping: &VizeMapping, generated_offset: usize) -> usize {
+    if let Some(span) = mapping.sub_spans.iter().find(|span| {
+        generated_offset >= span.gen_range.start && generated_offset <= span.gen_range.end
+    }) {
+        let generated_relative = generated_offset.saturating_sub(span.gen_range.start);
+        let source_len = span.src_range.end.saturating_sub(span.src_range.start);
+        return span
+            .src_range
+            .start
+            .saturating_add(generated_relative.min(source_len));
+    }
+
+    let generated_relative = generated_offset.saturating_sub(mapping.gen_range.start);
+    let source_len = mapping
+        .src_range
+        .end
+        .saturating_sub(mapping.src_range.start);
+    mapping
+        .src_range
+        .start
+        .saturating_add(generated_relative.min(source_len))
+}
+
+/// Maps a generated diagnostic range into authored source offsets.
+///
+/// Returns `None` when no mapping covers the start offset; the end offset is
+/// resolved through [`mapping_for_end_offset`] and never collapses below one
+/// authored byte.
+pub fn map_generated_range_to_source(
+    mappings: &[VizeMapping],
+    start_offset: usize,
+    end_offset: usize,
+) -> Option<(usize, usize)> {
+    let start_mapping = mapping_for_generated_offset(mappings, start_offset)?;
+    let src_start = map_generated_offset_to_source(start_mapping, start_offset);
+    let src_end = mapping_for_end_offset(mappings, start_mapping, end_offset)
+        .map(|mapping| map_generated_offset_to_source(mapping, end_offset))
+        .unwrap_or_else(|| {
+            let generated_len = end_offset.saturating_sub(start_offset);
+            src_start
+                .saturating_add(generated_len)
+                .min(start_mapping.src_range.end)
+        })
+        .max(src_start.saturating_add(1));
+    Some((src_start, src_end))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::types::{VizeMapping, VizeSubSpan};
+    use super::*;
+
+    #[test]
+    fn prefers_exact_expression_sub_spans() {
+        let mapping = VizeMapping {
+            gen_range: 10..80,
+            src_range: 100..140,
+            sub_spans: vec![VizeSubSpan {
+                gen_range: 20..43,
+                src_range: 107..130,
+            }],
+        };
+        assert_eq!(map_generated_offset_to_source(&mapping, 20), 107);
+        assert_eq!(map_generated_offset_to_source(&mapping, 43), 130);
+    }
+
+    #[test]
+    fn clamps_generated_overflow_to_the_authored_range() {
+        let mapping = VizeMapping {
+            gen_range: 0..100,
+            src_range: 10..20,
+            sub_spans: Vec::new(),
+        };
+        assert_eq!(map_generated_offset_to_source(&mapping, 95), 20);
+    }
+
+    #[test]
+    fn selects_the_narrowest_mapping_for_an_offset() {
+        let mappings = [
+            VizeMapping {
+                gen_range: 0..100,
+                src_range: 0..100,
+                sub_spans: Vec::new(),
+            },
+            VizeMapping {
+                gen_range: 40..60,
+                src_range: 200..220,
+                sub_spans: Vec::new(),
+            },
+        ];
+        let mapping = mapping_for_generated_offset(&mappings, 45).expect("mapping");
+        assert_eq!(mapping.src_range, 200..220);
+    }
+
+    #[test]
+    fn maps_ranges_and_keeps_at_least_one_authored_byte() {
+        let mappings = [VizeMapping {
+            gen_range: 10..80,
+            src_range: 100..140,
+            sub_spans: vec![VizeSubSpan {
+                gen_range: 20..43,
+                src_range: 107..130,
+            }],
+        }];
+        assert_eq!(
+            map_generated_range_to_source(&mappings, 20, 43),
+            Some((107, 130))
+        );
+        assert_eq!(
+            map_generated_range_to_source(&mappings, 20, 20),
+            Some((107, 108))
+        );
+        assert_eq!(map_generated_range_to_source(&mappings, 5, 20), None);
+    }
+}

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/mapping.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/mapping.rs
@@ -23,74 +23,15 @@ pub(super) fn map_diagnostic_with_source_mappings(
         .unwrap_or(start_offset_post.saturating_add(1));
     let start_offset = import_source_map.get_original_offset(start_offset_post as u32) as usize;
     let end_offset = import_source_map.get_original_offset(end_offset_post as u32) as usize;
-    let start_mapping = mapping_for_generated_offset(mappings, start_offset)?;
-    let src_start = map_generated_offset_to_source(start_mapping, start_offset);
-    let src_end = mapping_for_diagnostic_end_offset(mappings, start_mapping, end_offset)
-        .map(|mapping| map_generated_offset_to_source(mapping, end_offset))
-        .unwrap_or_else(|| {
-            let generated_len = end_offset.saturating_sub(start_offset);
-            src_start
-                .saturating_add(generated_len)
-                .min(start_mapping.src_range.end)
-        })
-        .max(src_start.saturating_add(1));
+    let (src_start, src_end) = vize_canon::virtual_ts::mapping::map_generated_range_to_source(
+        mappings,
+        start_offset,
+        end_offset,
+    )?;
 
     let (start_line, start_char) = source_offset_to_position(source, src_start);
     let (end_line, end_char) = source_offset_to_position(source, src_end.min(source.len()));
     Some((start_line, end_line, start_char, end_char))
-}
-
-fn mapping_for_generated_offset(
-    mappings: &[vize_canon::virtual_ts::VizeMapping],
-    offset: usize,
-) -> Option<&vize_canon::virtual_ts::VizeMapping> {
-    mappings
-        .iter()
-        .filter(|mapping| mapping.gen_range.contains(&offset))
-        .min_by_key(|mapping| {
-            mapping
-                .gen_range
-                .end
-                .saturating_sub(mapping.gen_range.start)
-        })
-}
-
-fn mapping_for_diagnostic_end_offset<'a>(
-    mappings: &'a [vize_canon::virtual_ts::VizeMapping],
-    start_mapping: &'a vize_canon::virtual_ts::VizeMapping,
-    end_offset: usize,
-) -> Option<&'a vize_canon::virtual_ts::VizeMapping> {
-    if end_offset > start_mapping.gen_range.start && end_offset <= start_mapping.gen_range.end {
-        Some(start_mapping)
-    } else {
-        mapping_for_generated_offset(mappings, end_offset)
-    }
-}
-
-fn map_generated_offset_to_source(
-    mapping: &vize_canon::virtual_ts::VizeMapping,
-    generated_offset: usize,
-) -> usize {
-    if let Some(span) = mapping.sub_spans.iter().find(|span| {
-        generated_offset >= span.gen_range.start && generated_offset <= span.gen_range.end
-    }) {
-        let generated_relative = generated_offset.saturating_sub(span.gen_range.start);
-        let source_len = span.src_range.end.saturating_sub(span.src_range.start);
-        return span
-            .src_range
-            .start
-            .saturating_add(generated_relative.min(source_len));
-    }
-
-    let generated_relative = generated_offset.saturating_sub(mapping.gen_range.start);
-    let source_len = mapping
-        .src_range
-        .end
-        .saturating_sub(mapping.src_range.start);
-    mapping
-        .src_range
-        .start
-        .saturating_add(generated_relative.min(source_len))
 }
 
 pub(super) fn line_character_to_byte_offset(
@@ -157,9 +98,8 @@ pub(super) fn source_offset_to_position(source: &str, offset: usize) -> (u32, u3
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        map_generated_offset_to_source, mapping_for_diagnostic_end_offset,
-        mapping_for_generated_offset,
+    use vize_canon::virtual_ts::mapping::{
+        map_generated_offset_to_source, mapping_for_end_offset, mapping_for_generated_offset,
     };
     use vize_canon::virtual_ts::{VizeMapping, VizeSubSpan};
 
@@ -207,7 +147,7 @@ mod tests {
             0..100
         );
         assert_eq!(
-            mapping_for_diagnostic_end_offset(&mappings, &mappings[1], 40)
+            mapping_for_end_offset(&mappings, &mappings[1], 40)
                 .expect("end mapping present")
                 .src_range,
             200..220


### PR DESCRIPTION
## Summary

Fixes the mapper half of divergence 2 in #2971: `vize check --format json` reported TS2322 for `:msg="42"` at a content-independent generated column (the same column for `:msg="count"`), because `SfcSourceMap::get_original_position` used first-match lookup plus a linear delta clamped to `src_range.end - 1` and never consulted the exact-expression sub-spans from #2975.

## Change

- New shared `vize_canon::virtual_ts::mapping` module: narrowest-mapping selection, sub-span-aware offset arithmetic with clamping, and range resolution that keeps at least one authored byte.
- The batch `SfcSourceMap`, the corsa-bridge `TypeCheckService`, and the language server (`vize_maestro`) now share it verbatim — the maestro copies are deleted and its tests import the shared functions.

Measured on a minimal repro (`defineProps<{ msg: string }>` + `<HelloWorld :msg="42" />`): `vize check` moves from the content-independent `11:25` to the authored expression `11:23`; absurd columns past the authored line (e.g. `14:285` in stale real-project snapshots) can no longer be produced because synthetic text clamps into the authored range.

vue-tsc anchors the same diagnostic at the attribute name (`11:18`); retargeting the check identifier's sub-span to the attribute name is the follow-up PR so both engines agree byte-for-byte.

## Tests

- New unit suites for the shared module (sub-span preference, overflow clamping, narrowest-mapping selection, range floors) and for `SfcSourceMap` (synthetic identifier → authored expression; nested-range narrowest wins).
- `vize_canon` 634 tests and the `vize_maestro` suite green; fmt/clippy clean.

Part of #2971

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic locations so they point to the precise authored expressions in source files.
  * Fixed mapping for nested generated ranges, overlapping mappings, and generated punctuation.
  * Prevented diagnostics from extending beyond the relevant authored source range.
* **Tests**
  * Added coverage for sub-span mapping, range clamping, nested mappings, and minimum-range preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->