### PR TITLE
fix(canon): keep repeated component prop names from redeclaring checks

### DIFF
--- a/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
@@ -8,6 +8,7 @@
 use super::super::helpers::{to_camel_case, to_safe_identifier_fragment};
 use super::super::types::{VizeMapping, VizeSubSpan};
 use super::reserved_props::rewrite_reserved_template_prop;
+use vize_carton::FxHashMap;
 use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::append;
@@ -132,6 +133,7 @@ pub(crate) fn generate_component_prop_checks(
     indent: &str,
 ) {
     let component_type_name = to_safe_identifier_fragment(usage.name.as_str());
+    let mut name_occurrences: FxHashMap<String, u32> = FxHashMap::default();
     for prop in &usage.props {
         if !is_checkable_prop(prop) {
             continue;
@@ -163,7 +165,18 @@ pub(crate) fn generate_component_prop_checks(
                 append!(*ts, "{indent}if ({guard}) {{\n");
             }
 
-            let check_name = cstr!("__vize_prop_check_{idx}_{safe_prop_name}");
+            // A repeated attribute name (static class next to :class) still
+            // checks every authored value, but each check constant needs a
+            // unique name or the virtual TS redeclares it (TS2451).
+            let occurrence = name_occurrences
+                .entry(String::from(safe_prop_name.as_str()))
+                .and_modify(|count| *count += 1)
+                .or_insert(1);
+            let check_name = if *occurrence == 1 {
+                cstr!("__vize_prop_check_{idx}_{safe_prop_name}")
+            } else {
+                cstr!("__vize_prop_check_{idx}_{safe_prop_name}_{occurrence}")
+            };
             let gen_stmt_start = ts.len();
             append!(*ts, "{expr_indent}const ");
             let check_name_start = ts.len();

--- a/crates/vize_canon/src/virtual_ts/expressions/component_props_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/component_props_tests.rs
@@ -157,3 +157,53 @@ fn valueless_static_attributes_stay_out_of_per_prop_checks() {
         output.code
     );
 }
+
+#[test]
+fn repeated_prop_names_keep_unique_checks_and_one_type_alias() {
+    let script = r#"import Child from "./Child.vue"
+const isLoading = false
+"#;
+    let template = r#"<Child class="static-card" :class="{ loading: isLoading }" />"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+
+    assert_eq!(
+        output
+            .code
+            .matches("type __Child_0_prop_class = __VizePropValue<__Child_Props_0, 'class'>;")
+            .count(),
+        1,
+        "the child prop type alias must be declared exactly once:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("const __vize_prop_check_0_class: __Child_0_prop_class = \"static-card\";"),
+        "the static class value keeps the base check name:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains(
+            "const __vize_prop_check_0_class_2: __Child_0_prop_class = { loading: isLoading };"
+        ),
+        "the bound class value gets a unique check name:\n{}",
+        output.code
+    );
+    assert_eq!(
+        output
+            .code
+            .matches("const __vize_prop_check_0_class")
+            .count(),
+        2,
+        "both authored values stay checked:\n{}",
+        output.code
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -104,6 +104,10 @@ pub(super) fn generate_component_props(
             "  type __{component_type_name}_Props_{idx} = typeof {component_ref} extends {{ __vizeCheck: any }} ? Record<string, unknown> : (typeof {component_ref} extends {{ new (): {{ $props: infer __P }} }} ? __P : (typeof {component_ref} extends (props: infer __P) => any ? __P : {{}}));\n",
         );
 
+        // One alias per distinct prop name: a repeated attribute (for example
+        // a static class next to a bound :class) reuses the same child prop
+        // type, and a duplicate alias would be a TS2300 in the virtual TS.
+        let mut declared_aliases = FxHashSet::default();
         for prop in &usage.props {
             if prop.name_is_dynamic || prop.name.as_str() == "key" || prop.name.as_str() == "ref" {
                 continue;
@@ -111,6 +115,9 @@ pub(super) fn generate_component_props(
             if prop.value.is_some() {
                 let camel_prop_name = to_camel_case(prop.name.as_str());
                 let safe_prop_name = to_safe_identifier_fragment(prop.name.as_str());
+                if !declared_aliases.insert(safe_prop_name.clone()) {
+                    continue;
+                }
                 append!(
                     *ts,
                     "  type __{component_type_name}_{idx}_prop_{safe_prop_name} = __VizePropValue<__{component_type_name}_Props_{idx}, '{camel_prop_name}'>;\n",

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -313,24 +313,7 @@ fn generate_closure_component_props_recursive(
             }
 
             // Recursively handle child closure scopes (v-for and v-slot)
-            if let Some(child_ids) = ctx.children_map.get(&scope_id) {
-                for &child_id in child_ids {
-                    if let Some(child_scope) = ctx.summary.scopes.get_scope(child_id)
-                        && matches!(child_scope.kind, ScopeKind::VFor | ScopeKind::VSlot)
-                    {
-                        profile!(
-                            "canon.virtual_ts.closure_component_props",
-                            generate_closure_component_props_recursive(
-                                ts,
-                                mappings,
-                                ctx,
-                                child_scope,
-                                &vfor_inner_indent,
-                            )
-                        );
-                    }
-                }
-            }
+            recurse_child_closure_scopes(ts, mappings, ctx, scope_id, &vfor_inner_indent);
 
             ts.push_str(&loop_indent);
             ts.push_str("});\n");
@@ -387,28 +370,35 @@ fn generate_closure_component_props_recursive(
             }
 
             // Recursively handle child closure scopes (v-for and v-slot)
-            if let Some(child_ids) = ctx.children_map.get(&scope_id) {
-                for &child_id in child_ids {
-                    if let Some(child_scope) = ctx.summary.scopes.get_scope(child_id)
-                        && matches!(child_scope.kind, ScopeKind::VFor | ScopeKind::VSlot)
-                    {
-                        profile!(
-                            "canon.virtual_ts.closure_component_props",
-                            generate_closure_component_props_recursive(
-                                ts,
-                                mappings,
-                                ctx,
-                                child_scope,
-                                &inner_indent,
-                            )
-                        );
-                    }
-                }
-            }
+            recurse_child_closure_scopes(ts, mappings, ctx, scope_id, &inner_indent);
 
             ts.push_str(indent);
             ts.push_str("};\n");
         }
         _ => {}
+    }
+}
+
+/// Recurse into a scope's direct v-for/v-slot child scopes, emitting their
+/// component prop checks at the given indent.
+fn recurse_child_closure_scopes(
+    ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    ctx: &VForPropsContext<'_>,
+    scope_id: u32,
+    indent: &str,
+) {
+    let Some(child_ids) = ctx.children_map.get(&scope_id) else {
+        return;
+    };
+    for &child_id in child_ids {
+        if let Some(child_scope) = ctx.summary.scopes.get_scope(child_id)
+            && matches!(child_scope.kind, ScopeKind::VFor | ScopeKind::VSlot)
+        {
+            profile!(
+                "canon.virtual_ts.closure_component_props",
+                generate_closure_component_props_recursive(ts, mappings, ctx, child_scope, indent)
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by #3197 (static attribute prop checks): a static attribute next to a bound attribute of the same name — most commonly `class="card"` beside `:class="expr"` — emitted the same `__vize_prop_check_{idx}_{name}` constant and the same `__{Component}_{idx}_prop_{name}` type alias twice, so the virtual TS failed with `TS2451`/`TS2300` redeclarations and masked surrounding diagnostics.

Not caught earlier because the ecosystem lane's fixtures never combine a static and a bound occurrence of the same prop on one element, and the real-project matrix (misskey, reka-ui, nuxt-ui show exactly these collisions against their stale snapshots) has not run since #3197 merged — this would have turned the release-preflight matrix red on its next run.

## Fix

- The child prop type alias is declared once per distinct prop name.
- Every additional occurrence of a name gets an occurrence-suffixed check constant (`__vize_prop_check_0_class`, `__vize_prop_check_0_class_2`), so each authored value still checks against the child's prop type — both the static string and the bound expression remain covered.

## Verification

- New unit test pins: exactly one alias declaration, the base name on the first value, the suffixed name on the second, and both values checked.
- End-to-end on a minimal repro (`<HelloWorld :msg="count" class="card" :class="{ active: count > 0 }" />`): the pre-fix binary reports two `TS2451` redeclarations; the fixed binary reports only the two legitimate `TS2322`s.
- `vize_canon` suite green (629 tests), fmt/clippy clean.

Part of #2971

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed TypeScript redeclaration errors when a component defines the same prop name multiple times.
  - Ensured each authored repeated prop value keeps its own generated type-check identifier (including static + dynamic cases).
  - Avoided duplicate emitted prop type aliases while still validating all component property values correctly.
- **Tests**
  - Added a new test covering repeated prop names to confirm unique checks are generated and alias types are emitted only once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->