### PR TITLE
test(canon): refresh real-project snapshots for prop-canon fixes

### DIFF
--- a/tests/snapshots/check/__snapshots__/elk-check.snap
+++ b/tests/snapshots/check/__snapshots__/elk-check.snap
@@ -224,7 +224,7 @@
         "error:56:29 [TS2554] Expected 2 arguments, but got 1.",
         "error:69:39 [TS7006] Parameter 'i' implicitly has an 'any' type.",
         "error:75:36 [TS7006] Parameter 'i' implicitly has an 'any' type.",
-        "error:90:21 [TS2322] Type 'string | number | symbol' is not assignable to type 'KeyFieldValue<any> | undefined'.\nType 'number' is not assignable to type 'KeyFieldValue<any> | undefined'."
+        "error:90:23 [TS2322] Type 'string | number | symbol' is not assignable to type 'KeyFieldValue<any> | undefined'.\nType 'number' is not assignable to type 'KeyFieldValue<any> | undefined'."
       ]
     },
     {
@@ -1056,6 +1056,7 @@
     {
       "file": "app/components/timeline/TimelineScheduledPostsPaginator.vue",
       "diagnostics": [
+        "error:2:15 [TS2440] Import declaration conflicts with local declaration of 'CommonPaginator'.",
         "error:3:31 [TS2307] Cannot find module 'masto' or its corresponding type declarations.",
         "error:4:39 [TS2307] Cannot find module 'vue-component-type-helpers' or its corresponding type declarations.",
         "error:5:1 [TS2578] Unused '@ts-expect-error' directive."
@@ -1426,7 +1427,7 @@
       "diagnostics": []
     }
   ],
-  "errorCount": 279,
+  "errorCount": 280,
   "warningCount": 0,
   "fileCount": 253
 }

--- a/tests/snapshots/check/__snapshots__/misskey-check.snap
+++ b/tests/snapshots/check/__snapshots__/misskey-check.snap
@@ -38,15 +38,7 @@
     },
     {
       "file": "src/components/MkAsUi.vue",
-      "diagnostics": [
-        "error:14:285 [TS2345] Argument of type '((evId: string) => Promise<void>) | undefined' is not assignable to parameter of type '($event: any) => unknown'.\nType 'undefined' is not assignable to type '($event: any) => unknown'.\nProperty 'primary' does not exist on type 'AsUiButtons'.\nProperty 'rounded' does not exist on type 'AsUiButtons'.\nProperty 'disabled' does not exist on type 'AsUiButtons'.",
-        "error:15:150 [TS2345] Argument of type '(() => Promise<void>) | undefined' is not assignable to parameter of type '(payload: PointerEvent) => unknown'.\nType 'undefined' is not assignable to type '(payload: PointerEvent) => unknown'.",
-        "error:17:162 [TS2345] Argument of type '(() => Promise<void>) | undefined' is not assignable to parameter of type '(payload: PointerEvent) => unknown'.\nType 'undefined' is not assignable to type '(payload: PointerEvent) => unknown'.\nProperty 'default' does not exist on type 'AsUiButton'.",
-        "error:23:100 [TS2345] Argument of type '((v: string) => Promise<void>) | undefined' is not assignable to parameter of type '(value: string) => unknown'.\nType 'undefined' is not assignable to type '(value: string) => unknown'.\nProperty 'default' does not exist on type 'AsUiButton'.",
-        "error:27:124 [TS2345] Argument of type '((v: string) => Promise<void>) | undefined' is not assignable to parameter of type '(value: string) => unknown'.\nType 'undefined' is not assignable to type '(value: string) => unknown'.\nProperty 'default' does not exist on type 'AsUiButton'.",
-        "error:31:140 [TS2345] Argument of type '((v: number) => Promise<void>) | undefined' is not assignable to parameter of type '(value: number) => unknown'.\nType 'undefined' is not assignable to type '(value: number) => unknown'.\nProperty 'primary' does not exist on type 'AsUiButtons'.\nProperty 'rounded' does not exist on type 'AsUiButtons'.",
-        "error:58:112 [TS2339] Property 'align' does not exist on type 'AsUiComponent'.\nProperty 'align' does not exist on type 'AsUiButton'."
-      ]
+      "diagnostics": []
     },
     {
       "file": "src/components/MkAuthConfirm.vue",
@@ -66,9 +58,7 @@
     },
     {
       "file": "src/components/MkCaptcha.vue",
-      "diagnostics": [
-        "error:57:1 [TS1234] An ambient module declaration is only allowed at the top level in a file."
-      ]
+      "diagnostics": []
     },
     {
       "file": "src/components/MkChannelFollowButton.vue",
@@ -129,10 +119,10 @@
     {
       "file": "src/components/MkContainer.vue",
       "diagnostics": [
-        "error:26:11 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
-        "error:27:16 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
-        "error:28:11 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
-        "error:29:16 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more."
+        "error:26:11 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
+        "error:27:16 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
+        "error:28:11 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
+        "error:29:16 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more."
       ]
     },
     {
@@ -252,19 +242,19 @@
     {
       "file": "src/components/MkFoldableSection.vue",
       "diagnostics": [
-        "error:21:11 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
-        "error:22:16 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
-        "error:23:11 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
-        "error:24:16 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more."
+        "error:21:11 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
+        "error:22:16 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
+        "error:23:11 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
+        "error:24:16 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more."
       ]
     },
     {
       "file": "src/components/MkFolder.vue",
       "diagnostics": [
-        "error:63:13 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
-        "error:64:18 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
-        "error:65:13 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
-        "error:66:18 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.\nProperty 'step' does not exist on type 'ArrayFormItem'.\nProperty 'manualSave' does not exist on type 'ArrayFormItem'.\nProperty 'treatAsMfm' does not exist on type 'ArrayFormItem'.\nProperty 'manualSave' does not exist on type 'ArrayFormItem'.\nProperty 'treatAsMfm' does not exist on type 'ArrayFormItem'.\nProperty 'treatAsMfm' does not exist on type 'ArrayFormItem'.\nProperty 'manualSave' does not exist on type 'ArrayFormItem'.\nProperty 'defaultFileId' does not exist on type 'ArrayFormItem'.\nProperty 'validate' does not exist on type 'ArrayFormItem'.\nProperty 'validate' does not exist on type 'ArrayFormItem'."
+        "error:63:13 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
+        "error:64:18 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
+        "error:65:13 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
+        "error:66:18 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.\nProperty 'step' does not exist on type 'ArrayFormItem'.\nProperty 'manualSave' does not exist on type 'ArrayFormItem'.\nProperty 'treatAsMfm' does not exist on type 'ArrayFormItem'.\nProperty 'manualSave' does not exist on type 'ArrayFormItem'.\nProperty 'treatAsMfm' does not exist on type 'ArrayFormItem'.\nProperty 'treatAsMfm' does not exist on type 'ArrayFormItem'.\nProperty 'manualSave' does not exist on type 'ArrayFormItem'.\nProperty 'defaultFileId' does not exist on type 'ArrayFormItem'.\nProperty 'validate' does not exist on type 'ArrayFormItem'.\nProperty 'validate' does not exist on type 'ArrayFormItem'."
       ]
     },
     {
@@ -746,10 +736,10 @@
       "file": "src/components/MkTabs.vue",
       "diagnostics": [
         "error:11:11 [TS7006] Parameter 'el' implicitly has an 'any' type.",
-        "error:33:14 [TS2345] Argument of type '(el: Element) => Promise<void>' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
-        "error:34:19 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
-        "error:35:14 [TS2345] Argument of type '(el: Element) => Promise<void>' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
-        "error:36:19 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.\nProperty 'align' does not exist on type '{ id: string; type: \"stripe\"; angle: number; frequency: number; threshold: number; color: [r: number, g: number, b: number]; opacity: number; }'.\nProperty 'align' does not exist on type '{ id: string; type: \"stripe\"; angle: number; frequency: number; threshold: number; color: [r: number, g: number, b: number]; opacity: number; }'.\nProperty 'align' does not exist on type '{ id: string; type: \"stripe\"; angle: number; frequency: number; threshold: number; color: [r: number, g: number, b: number]; opacity: number; }'."
+        "error:33:14 [TS2345] Argument of type '(el: Element) => Promise<void>' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
+        "error:34:19 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
+        "error:35:14 [TS2345] Argument of type '(el: Element) => Promise<void>' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
+        "error:36:19 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.\nProperty 'align' does not exist on type '{ id: string; type: \"stripe\"; angle: number; frequency: number; threshold: number; color: [r: number, g: number, b: number]; opacity: number; }'.\nProperty 'align' does not exist on type '{ id: string; type: \"stripe\"; angle: number; frequency: number; threshold: number; color: [r: number, g: number, b: number]; opacity: number; }'.\nProperty 'align' does not exist on type '{ id: string; type: \"stripe\"; angle: number; frequency: number; threshold: number; color: [r: number, g: number, b: number]; opacity: number; }'."
       ]
     },
     {
@@ -984,10 +974,10 @@
       "file": "src/components/global/MkPageHeader.tabs.vue",
       "diagnostics": [
         "error:11:11 [TS7006] Parameter 'el' implicitly has an 'any' type.",
-        "error:31:35 [TS2345] Argument of type '(el: Element) => Promise<void>' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
-        "error:31:55 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
-        "error:31:75 [TS2345] Argument of type '(el: Element) => Promise<void>' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
-        "error:32:19 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'el' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more."
+        "error:31:35 [TS2345] Argument of type '(el: Element) => Promise<void>' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
+        "error:31:55 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
+        "error:31:75 [TS2345] Argument of type '(el: Element) => Promise<void>' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
+        "error:32:19 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more."
       ]
     },
     {
@@ -1169,15 +1159,13 @@
     {
       "file": "src/pages/admin-user.vue",
       "diagnostics": [
-        "error:190:39 [TS2322] Type 'string' is not assignable to type '\"active-users\" | \"ap-request\" | \"drive\" | \"drive-files\" | \"federation\" | \"instance-drive-files\" | \"instance-drive-files-total\" | \"instance-drive-usage\" | \"instance-drive-usage-total\" | ... 17 more ... | \"users-total\"'.",
-        "error:192:39 [TS2322] Type 'string' is not assignable to type '\"active-users\" | \"ap-request\" | \"drive\" | \"drive-files\" | \"federation\" | \"instance-drive-files\" | \"instance-drive-files-total\" | \"instance-drive-usage\" | \"instance-drive-usage-total\" | ... 17 more ... | \"users-total\"'."
+        "error:190:35 [TS2322] Type 'string' is not assignable to type '\"active-users\" | \"ap-request\" | \"drive\" | \"drive-files\" | \"federation\" | \"instance-drive-files\" | \"instance-drive-files-total\" | \"instance-drive-usage\" | \"instance-drive-usage-total\" | ... 17 more ... | \"users-total\"'.",
+        "error:192:35 [TS2322] Type 'string' is not assignable to type '\"active-users\" | \"ap-request\" | \"drive\" | \"drive-files\" | \"federation\" | \"instance-drive-files\" | \"instance-drive-files-total\" | \"instance-drive-usage\" | \"instance-drive-usage-total\" | ... 17 more ... | \"users-total\"'."
       ]
     },
     {
       "file": "src/pages/admin/RolesEditorFormula.vue",
-      "diagnostics": [
-        "error:11:106 [TS2345] Argument of type '((ev: DragEvent) => void) | undefined' is not assignable to parameter of type '($event: DragEvent) => unknown'.\nType 'undefined' is not assignable to type '($event: DragEvent) => unknown'."
-      ]
+      "diagnostics": []
     },
     {
       "file": "src/pages/admin/abuse-report/notification-recipient.editor.vue",
@@ -1598,7 +1586,7 @@
       "diagnostics": [
         "error:9:29 [TS2454] Variable 'paginator' is used before being assigned.",
         "error:9:30 [TS2454] Variable 'paginator' is used before being assigned.",
-        "error:9:38 [TS2454] Variable 'paginator' is used before being assigned."
+        "error:9:39 [TS2454] Variable 'paginator' is used before being assigned."
       ]
     },
     {
@@ -1704,7 +1692,7 @@
     {
       "file": "src/pages/page-editor/page-editor.blocks.vue",
       "diagnostics": [
-        "error:18:91 [TS2345] Argument of type '(v: { id: string; type: \"text\"; text: string; } | { id: string; type: \"section\"; title: string; children: ({ id: string; type: \"text\"; text: string; } | ... | { id: string; type: \"image\"; fileId: string | null; } | { ...; })[]; } | { ...; } | { ...; }) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'v' and '$event' are incompatible.\nType 'Event' is not assignable to type '{ id: string; type: \"text\"; text: string; } | { id: string; type: \"section\"; title: string; children: ({ id: string; type: \"text\"; text: string; } | ... | { id: string; type: \"image\"; fileId: string | null; } | { ...; })[]; } | { ...; } | { ...; }'.\nType 'Event' is missing the following properties from type '{ id: string; type: \"note\"; detailed: boolean; note: string | null; }': id, detailed, note"
+        "error:18:91 [TS2345] Argument of type '(v: { id: string; type: \"text\"; text: string; } | { id: string; type: \"section\"; title: string; children: ({ id: string; type: \"text\"; text: string; } | ... | { id: string; type: \"image\"; fileId: string | null; } | { ...; })[]; } | { ...; } | { ...; }) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'v' and '_e' are incompatible.\nType 'Event' is not assignable to type '{ id: string; type: \"text\"; text: string; } | { id: string; type: \"section\"; title: string; children: ({ id: string; type: \"text\"; text: string; } | ... | { id: string; type: \"image\"; fileId: string | null; } | { ...; })[]; } | { ...; } | { ...; }'.\nType 'Event' is missing the following properties from type '{ id: string; type: \"note\"; detailed: boolean; note: string | null; }': id, detailed, note"
       ]
     },
     {
@@ -1778,7 +1766,7 @@
     {
       "file": "src/pages/role.vue",
       "diagnostics": [
-        "error:14:90 [TS7006] Parameter 'item' implicitly has an 'any' type."
+        "error:14:91 [TS7006] Parameter 'item' implicitly has an 'any' type."
       ]
     },
     {
@@ -1899,7 +1887,9 @@
     },
     {
       "file": "src/pages/settings/notifications.notification-config.vue",
-      "diagnostics": []
+      "diagnostics": [
+        "error:32:13 [TS2300] Duplicate identifier 'NotificationConfig'."
+      ]
     },
     {
       "file": "src/pages/settings/notifications.vue",
@@ -2180,7 +2170,7 @@
     {
       "file": "src/ui/deck.vue",
       "diagnostics": [
-        "error:38:22 [TS2345] Argument of type '(ev: WheelEvent) => void' is not assignable to parameter of type '($event: Event) => unknown'.\nTypes of parameters 'ev' and '$event' are incompatible.\nType 'Event' is missing the following properties from type 'WheelEvent': deltaMode, deltaX, deltaY, deltaZ, and 30 more."
+        "error:38:22 [TS2345] Argument of type '(ev: WheelEvent) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'ev' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'WheelEvent': deltaMode, deltaX, deltaY, deltaZ, and 30 more."
       ]
     },
     {
@@ -2402,7 +2392,7 @@
       "diagnostics": []
     }
   ],
-  "errorCount": 48,
+  "errorCount": 40,
   "warningCount": 0,
   "fileCount": 583
 }

--- a/tests/snapshots/check/__snapshots__/nuxt-ui-check.snap
+++ b/tests/snapshots/check/__snapshots__/nuxt-ui-check.snap
@@ -25,8 +25,7 @@
       "diagnostics": [
         "error:4:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:5:19 [TS2307] Cannot find module '#build/ui/auth-form' or its corresponding type declarations.",
-        "error:107:38 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:248:18 [TS2345] Argument of type '((event: FormSubmitEvent<InferOutput<T>>) => void | Promise<void>) | (() => void | Promise<void>) | undefined' is not assignable to parameter of type '(event: FormSubmitEvent<InferOutput<T>>) => unknown'.\nType 'undefined' is not assignable to type '(event: FormSubmitEvent<InferOutput<T>>) => unknown'."
+        "error:107:38 [TS2307] Cannot find module '#imports' or its corresponding type declarations."
       ]
     },
     {
@@ -70,8 +69,7 @@
         "error:3:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:4:19 [TS2307] Cannot find module '#build/ui/blog-post' or its corresponding type declarations.",
         "error:62:7 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:62:45 [TS2307] Cannot find module '#build/ui-image-component' or its corresponding type declarations.",
-        "error:122:137 [TS2345] Argument of type '((event: MouseEvent) => void | Promise<void>) | undefined' is not assignable to parameter of type '($event: any) => unknown'.\nType 'undefined' is not assignable to type '($event: any) => unknown'."
+        "error:62:45 [TS2307] Cannot find module '#build/ui-image-component' or its corresponding type declarations."
       ]
     },
     {
@@ -145,8 +143,7 @@
         "error:3:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:4:19 [TS2307] Cannot find module '#build/ui/changelog-version' or its corresponding type declarations.",
         "error:62:7 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:62:45 [TS2307] Cannot find module '#build/ui-image-component' or its corresponding type declarations.",
-        "error:147:105 [TS2345] Argument of type '((event: MouseEvent) => void | Promise<void>) | undefined' is not assignable to parameter of type '($event: any) => unknown'.\nType 'undefined' is not assignable to type '($event: any) => unknown'."
+        "error:62:45 [TS2307] Cannot find module '#build/ui-image-component' or its corresponding type declarations."
       ]
     },
     {
@@ -213,7 +210,7 @@
         "error:66:40 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
         "error:116:54 [TS2304] Cannot find name 'as'.",
         "error:116:55 [TS2304] Cannot find name 'as'.",
-        "error:116:64 [TS2304] Cannot find name 'as'."
+        "error:116:65 [TS2304] Cannot find name 'as'."
       ]
     },
     {
@@ -265,7 +262,7 @@
         "error:338:33 [TS7006] Parameter 'result' implicitly has an 'any' type.",
         "error:378:48 [TS2345] Argument of type 'unknown' is not assignable to parameter of type '(T & { matches?: any; })[]'.",
         "error:585:38 [TS2345] Argument of type 'AcceptableValue' is not assignable to parameter of type 'Record<string, any> | undefined'.\nType 'null' is not assignable to type 'Record<string, any> | undefined'.",
-        "error:585:69 [TS2345] Argument of type 'AcceptableValue' is not assignable to parameter of type 'Record<string, any> | undefined'.\nType 'null' is not assignable to type 'Record<string, any> | undefined'."
+        "error:585:70 [TS2345] Argument of type 'AcceptableValue' is not assignable to parameter of type 'Record<string, any> | undefined'.\nType 'null' is not assignable to type 'Record<string, any> | undefined'."
       ]
     },
     {
@@ -289,10 +286,7 @@
       "diagnostics": [
         "error:3:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:4:24 [TS2307] Cannot find module '#build/ui/context-menu' or its corresponding type declarations.",
-        "error:41:13 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:167:36 [TS2345] Argument of type '((checked: boolean) => void) | undefined' is not assignable to parameter of type '(payload: boolean) => unknown'.\nType 'undefined' is not assignable to type '(payload: boolean) => unknown'.",
-        "error:168:24 [TS2345] Argument of type '((e: Event) => void) | undefined' is not assignable to parameter of type '(event: Event) => unknown'.\nType 'undefined' is not assignable to type '(event: Event) => unknown'.",
-        "error:177:26 [TS2345] Argument of type '((e: Event) => void) | undefined' is not assignable to parameter of type '(event: Event) => unknown'.\nType 'undefined' is not assignable to type '(event: Event) => unknown'."
+        "error:41:13 [TS2307] Cannot find module '#imports' or its corresponding type declarations."
       ]
     },
     {
@@ -343,8 +337,7 @@
         "error:2:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:3:19 [TS2307] Cannot find module '#build/ui/dashboard-search-button' or its corresponding type declarations.",
         "error:54:30 [TS2307] Cannot find module 'defu' or its corresponding type declarations.",
-        "error:56:64 [TS2307] Cannot find module '#imports' or its corresponding type declarations.\nProperty 'active' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'activeClass' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'ariaCurrentValue' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'exact' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'exactHash' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'exactQuery' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'external' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'href' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'inactiveClass' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'noPrefetch' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'noRel' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'prefetch' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'prefetchOn' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'prefetchedClass' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'rel' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'replace' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'target' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'to' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'trailingSlash' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.",
-        "error:110:15 [TS2345] Argument of type '(() => void) | undefined' is not assignable to parameter of type '($event: any) => unknown'.\nType 'undefined' is not assignable to type '($event: any) => unknown'."
+        "error:56:64 [TS2307] Cannot find module '#imports' or its corresponding type declarations.\nProperty 'active' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'activeClass' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'ariaCurrentValue' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'exact' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'exactHash' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'exactQuery' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'external' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'href' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'inactiveClass' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'noPrefetch' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'noRel' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'prefetch' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'prefetchOn' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'prefetchedClass' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'rel' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'replace' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'target' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'to' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'.\nProperty 'trailingSlash' does not exist on type 'Omit<__LooseRequired<DashboardSearchButtonProps>, \"collapsed\" | \"color\" | \"kbds\" | \"tooltip\"> & { collapsed: boolean; color: string | ... 1 more ... | symbol; kbds: KbdProps[] | (string | undefined)[]; tooltip: boolean | TooltipProps; }'."
       ]
     },
     {
@@ -369,8 +362,7 @@
       "diagnostics": [
         "error:2:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:3:19 [TS2307] Cannot find module '#build/ui/dashboard-sidebar-toggle' or its corresponding type declarations.",
-        "error:30:40 [TS2307] Cannot find module '#imports' or its corresponding type declarations.\nProperty 'active' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'activeClass' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'ariaCurrentValue' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'exact' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'exactHash' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'exactQuery' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'external' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'href' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'inactiveClass' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'noPrefetch' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'noRel' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'prefetch' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'prefetchOn' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'prefetchedClass' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'rel' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'replace' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'target' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'to' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'trailingSlash' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.",
-        "error:66:13 [TS2345] Argument of type '(() => void) | undefined' is not assignable to parameter of type '($event: any) => unknown'.\nType 'undefined' is not assignable to type '($event: any) => unknown'."
+        "error:30:40 [TS2307] Cannot find module '#imports' or its corresponding type declarations.\nProperty 'active' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'activeClass' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'ariaCurrentValue' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'exact' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'exactHash' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'exactQuery' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'external' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'href' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'inactiveClass' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'noPrefetch' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'noRel' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'prefetch' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'prefetchOn' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'prefetchedClass' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'rel' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'replace' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'target' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'to' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'.\nProperty 'trailingSlash' does not exist on type 'Omit<__LooseRequired<DashboardSidebarToggleProps>, \"color\" | \"side\" | \"variant\"> & { color: string | number | symbol; side: \"left\" | \"right\"; variant: string | ... 1 more ... | symbol; }'."
       ]
     },
     {
@@ -406,10 +398,7 @@
       "diagnostics": [
         "error:5:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:6:24 [TS2307] Cannot find module '#build/ui/dropdown-menu' or its corresponding type declarations.",
-        "error:53:12 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:181:36 [TS2345] Argument of type '((checked: boolean) => void) | undefined' is not assignable to parameter of type '(payload: boolean) => unknown'.\nType 'undefined' is not assignable to type '(payload: boolean) => unknown'.",
-        "error:182:24 [TS2345] Argument of type '((e: Event) => void) | undefined' is not assignable to parameter of type '(event: Event) => unknown'.\nType 'undefined' is not assignable to type '(event: Event) => unknown'.",
-        "error:191:26 [TS2345] Argument of type '((e: Event) => void) | undefined' is not assignable to parameter of type '(event: Event) => unknown'.\nType 'undefined' is not assignable to type '(event: Event) => unknown'."
+        "error:53:12 [TS2307] Cannot find module '#imports' or its corresponding type declarations."
       ]
     },
     {
@@ -670,8 +659,7 @@
         "error:5:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:6:19 [TS2307] Cannot find module '#build/ui/navigation-menu' or its corresponding type declarations.",
         "error:229:130 [TS2307] Cannot find module 'defu' or its corresponding type declarations.",
-        "error:229:234 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:408:20 [TS2345] Argument of type '((e: Event) => void) | undefined' is not assignable to parameter of type '($event: Event) => unknown'.\nType 'undefined' is not assignable to type '($event: Event) => unknown'."
+        "error:229:234 [TS2307] Cannot find module '#imports' or its corresponding type declarations."
       ]
     },
     {
@@ -723,8 +711,7 @@
       "diagnostics": [
         "error:3:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:4:19 [TS2307] Cannot find module '#build/ui/page-card' or its corresponding type declarations.",
-        "error:74:61 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:134:13 [TS2345] Argument of type '((event: MouseEvent) => void | Promise<void>) | undefined' is not assignable to parameter of type '($event: any) => unknown'.\nType 'undefined' is not assignable to type '($event: any) => unknown'."
+        "error:74:61 [TS2307] Cannot find module '#imports' or its corresponding type declarations."
       ]
     },
     {
@@ -740,8 +727,7 @@
       "diagnostics": [
         "error:3:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:4:19 [TS2307] Cannot find module '#build/ui/page-feature' or its corresponding type declarations.",
-        "error:45:32 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:76:137 [TS2345] Argument of type '((event: MouseEvent) => void | Promise<void>) | undefined' is not assignable to parameter of type '($event: any) => unknown'.\nType 'undefined' is not assignable to type '($event: any) => unknown'."
+        "error:45:32 [TS2307] Cannot find module '#imports' or its corresponding type declarations."
       ]
     },
     {
@@ -814,8 +800,8 @@
         "error:5:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:6:19 [TS2307] Cannot find module '#build/ui/pin-input' or its corresponding type declarations.",
         "error:56:7 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:130:13 [TS2322] Type 'PinInputValue<T>' is not assignable to type 'string[] | null | undefined'.\nType 'string[] | number[]' is not assignable to type 'string[] | null | undefined'.\nType 'number[]' is not assignable to type 'string[]'.\nType 'number' is not assignable to type 'string'.\nType 'PinInputValue<T>' is not assignable to type 'string[]'.\nType 'string[] | number[]' is not assignable to type 'string[]'.\nType 'number[]' is not assignable to type 'string[]'.\nType 'number' is not assignable to type 'string'.",
-        "error:131:13 [TS2322] Type 'PinInputValue<T>' is not assignable to type 'string[] | undefined'.\nType 'string[] | number[]' is not assignable to type 'string[] | undefined'.\nType 'number[]' is not assignable to type 'string[]'.\nType 'number' is not assignable to type 'string'.\nType 'PinInputValue<T>' is not assignable to type 'string[]'.\nType 'string[] | number[]' is not assignable to type 'string[]'.\nType 'number[]' is not assignable to type 'string[]'.\nType 'number' is not assignable to type 'string'."
+        "error:130:19 [TS2322] Type 'PinInputValue<T>' is not assignable to type 'string[] | null | undefined'.\nType 'string[] | number[]' is not assignable to type 'string[] | null | undefined'.\nType 'number[]' is not assignable to type 'string[]'.\nType 'number' is not assignable to type 'string'.\nType 'PinInputValue<T>' is not assignable to type 'string[]'.\nType 'string[] | number[]' is not assignable to type 'string[]'.\nType 'number[]' is not assignable to type 'string[]'.\nType 'number' is not assignable to type 'string'.",
+        "error:131:21 [TS2322] Type 'PinInputValue<T>' is not assignable to type 'string[] | undefined'.\nType 'string[] | number[]' is not assignable to type 'string[] | undefined'.\nType 'number[]' is not assignable to type 'string[]'.\nType 'number' is not assignable to type 'string'.\nType 'PinInputValue<T>' is not assignable to type 'string[]'.\nType 'string[] | number[]' is not assignable to type 'string[]'.\nType 'number[]' is not assignable to type 'string[]'.\nType 'number' is not assignable to type 'string'."
       ]
     },
     {
@@ -833,7 +819,7 @@
         "error:3:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:4:19 [TS2307] Cannot find module '#build/ui/pricing-plan' or its corresponding type declarations.",
         "error:115:50 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:231:155 [TS2345] Argument of type '((event: MouseEvent) => void | Promise<void>)[] | ((event: MouseEvent) => void | Promise<void>) | undefined' is not assignable to parameter of type '($event: any) => unknown'.\nType 'undefined' is not assignable to type '($event: any) => unknown'."
+        "error:231:155 [TS2345] Argument of type '((event: MouseEvent) => void | Promise<void>)[] | ((event: MouseEvent) => void | Promise<void>) | undefined' is not assignable to parameter of type '((...args: any[]) => unknown) | null | undefined'.\nType '((event: MouseEvent) => void | Promise<void>)[]' is not assignable to type '(...args: any[]) => unknown'.\nType '((event: MouseEvent) => void | Promise<void>)[]' provides no match for the signature '(...args: any[]): unknown'."
       ]
     },
     {
@@ -849,7 +835,7 @@
       "diagnostics": [
         "error:4:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:5:19 [TS2307] Cannot find module '#build/ui/pricing-table' or its corresponding type declarations.",
-        "error:106:13 [TS2307] Cannot find module '#imports' or its corresponding type declarations.\nType 'unknown' is not assignable to type 'Pick<PricingPlanProps, \"badge\" | \"billingCycle\" | \"billingPeriod\" | \"button\" | \"description\" | \"discount\" | \"highlight\" | \"price\" | \"title\">'."
+        "error:106:13 [TS2307] Cannot find module '#imports' or its corresponding type declarations."
       ]
     },
     {
@@ -866,7 +852,7 @@
         "error:4:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:5:19 [TS2307] Cannot find module '#build/ui/radio-group' or its corresponding type declarations.",
         "error:93:92 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:181:13 [TS2322] Type 'string | number | symbol' is not assignable to type 'DataOrientation | undefined'.\nType 'string' is not assignable to type 'DataOrientation | undefined'."
+        "error:181:19 [TS2322] Type 'string | number | symbol' is not assignable to type 'DataOrientation | undefined'.\nType 'string' is not assignable to type 'DataOrientation | undefined'."
       ]
     },
     {
@@ -937,7 +923,7 @@
         "error:5:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:6:19 [TS2307] Cannot find module '#build/ui/stepper' or its corresponding type declarations.",
         "error:83:8 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:147:70 [TS2322] Type 'string | number | symbol' is not assignable to type 'DataOrientation | undefined'.\nType 'string' is not assignable to type 'DataOrientation | undefined'."
+        "error:147:76 [TS2322] Type 'string | number | symbol' is not assignable to type 'DataOrientation | undefined'.\nType 'string' is not assignable to type 'DataOrientation | undefined'."
       ]
     },
     {
@@ -971,7 +957,7 @@
         "error:5:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:6:19 [TS2307] Cannot find module '#build/ui/tabs' or its corresponding type declarations.",
         "error:96:11 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:145:13 [TS2322] Type 'string | number | symbol' is not assignable to type 'DataOrientation | undefined'.\nType 'string' is not assignable to type 'DataOrientation | undefined'."
+        "error:145:19 [TS2322] Type 'string | number | symbol' is not assignable to type 'DataOrientation | undefined'.\nType 'string' is not assignable to type 'DataOrientation | undefined'."
       ]
     },
     {
@@ -992,7 +978,7 @@
         "error:4:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:5:19 [TS2307] Cannot find module '#build/ui/timeline' or its corresponding type declarations.",
         "error:74:10 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:156:23 [TS2322] Type 'string | number | symbol' is not assignable to type 'DataOrientation | undefined'.\nType 'string' is not assignable to type 'DataOrientation | undefined'."
+        "error:156:25 [TS2322] Type 'string | number | symbol' is not assignable to type 'DataOrientation | undefined'.\nType 'string' is not assignable to type 'DataOrientation | undefined'."
       ]
     },
     {
@@ -1042,8 +1028,7 @@
       "diagnostics": [
         "error:3:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:4:19 [TS2307] Cannot find module '#build/ui/user' or its corresponding type declarations.",
-        "error:46:32 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:72:137 [TS2345] Argument of type '((event: MouseEvent) => void | Promise<void>) | undefined' is not assignable to parameter of type '($event: any) => unknown'.\nType 'undefined' is not assignable to type '($event: any) => unknown'."
+        "error:46:32 [TS2307] Cannot find module '#imports' or its corresponding type declarations."
       ]
     },
     {
@@ -1086,8 +1071,8 @@
         "error:175:24 [TS2339] Property 'title' does not exist on type 'ContentNavigationLink'.",
         "error:175:92 [TS2339] Property 'title' does not exist on type 'ContentNavigationLink'.",
         "error:176:46 [TS2339] Property 'title' does not exist on type 'ContentNavigationLink'.",
-        "error:176:67 [TS2339] Property 'title' does not exist on type 'ContentNavigationLink'.",
-        "error:176:76 [TS2339] Property 'title' does not exist on type 'ContentNavigationLink'.",
+        "error:176:68 [TS2339] Property 'title' does not exist on type 'ContentNavigationLink'.",
+        "error:176:77 [TS2339] Property 'title' does not exist on type 'ContentNavigationLink'.",
         "error:177:19 [TS2339] Property 'title' does not exist on type 'ContentNavigationLink'.",
         "error:177:20 [TS2339] Property 'title' does not exist on type 'ContentNavigationLink'.",
         "error:180:61 [TS2339] Property 'title' does not exist on type 'ContentNavigationLink'.",
@@ -1124,7 +1109,7 @@
         "error:57:10 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
         "error:86:34 [TS2339] Property 'path' does not exist on type 'ContentSurroundLink'.",
         "error:86:35 [TS2339] Property 'path' does not exist on type 'ContentSurroundLink'.",
-        "error:86:38 [TS2339] Property 'path' does not exist on type 'ContentSurroundLink'.",
+        "error:86:39 [TS2339] Property 'path' does not exist on type 'ContentSurroundLink'.",
         "error:96:21 [TS2339] Property 'title' does not exist on type 'ContentSurroundLink'."
       ]
     },
@@ -1560,7 +1545,7 @@
       ]
     }
   ],
-  "errorCount": 666,
+  "errorCount": 651,
   "warningCount": 0,
   "fileCount": 180
 }

--- a/tests/snapshots/check/__snapshots__/reka-ui-check.snap
+++ b/tests/snapshots/check/__snapshots__/reka-ui-check.snap
@@ -469,7 +469,7 @@
       "diagnostics": [
         "error:24:12 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type '__DefineProps<ComboboxAnchorProps, never>'.\nProperty 'as' does not exist on type '__DefineProps<ComboboxAnchorProps, never>'.",
         "error:24:13 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type '__DefineProps<ComboboxAnchorProps, never>'.\nProperty 'as' does not exist on type '__DefineProps<ComboboxAnchorProps, never>'.\nType '\"as\"' is not assignable to type 'never'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<ComboboxArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'asChild' does not exist on type 'Omit<__LooseRequired<ComboboxArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'height' does not exist on type 'Omit<__LooseRequired<ComboboxArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'rounded' does not exist on type 'Omit<__LooseRequired<ComboboxArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'width' does not exist on type 'Omit<__LooseRequired<ComboboxArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'align' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'alignFlip' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'alignOffset' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'arrowPadding' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'avoidCollisions' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'collisionBoundary' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'collisionPadding' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'disableUpdateOnLayoutShift' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'hideShiftedArrow' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'hideWhenDetached' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'positionStrategy' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'prioritizePosition' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'reference' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'side' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'sideFlip' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'sideOffset' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'sticky' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'updatePositionStrategy' does not exist on type '__DefineProps<ComboboxContentProps, \"asChild\" | \"bodyLock\" | \"disableOutsidePointerEvents\" | \"forceMount\" | \"hideWhenEmpty\">'.\nProperty 'align' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'alignFlip' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'alignOffset' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'arrowPadding' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'avoidCollisions' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'collisionBoundary' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'collisionPadding' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'disableUpdateOnLayoutShift' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'hideShiftedArrow' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'hideWhenDetached' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'positionStrategy' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'prioritizePosition' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'reference' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'side' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'sideFlip' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'sideOffset' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'sticky' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'updatePositionStrategy' does not exist on type 'Omit<__LooseRequired<ComboboxContentImplProps>, \"position\"> & { position: \"inline\" | \"popper\"; }'.\nProperty 'defer' does not exist on type '__DefineProps<ComboboxPortalProps, never>'.\nProperty 'disabled' does not exist on type '__DefineProps<ComboboxPortalProps, never>'.\nProperty 'forceMount' does not exist on type '__DefineProps<ComboboxPortalProps, never>'.\nProperty 'to' does not exist on type '__DefineProps<ComboboxPortalProps, never>'.",
-        "error:24:14 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type '__DefineProps<ComboboxAnchorProps, never>'.\nProperty 'as' does not exist on type '__DefineProps<ComboboxAnchorProps, never>'."
+        "error:24:15 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type '__DefineProps<ComboboxAnchorProps, never>'.\nProperty 'as' does not exist on type '__DefineProps<ComboboxAnchorProps, never>'."
       ]
     },
     {
@@ -565,19 +565,19 @@
     {
       "file": "packages/core/src/Combobox/story/ComboboxCancel.story.vue",
       "diagnostics": [
-        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.\nType '\"as\"' is not assignable to type 'never'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'asChild' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'height' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'rounded' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'width' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'defer' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'disabled' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'forceMount' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'to' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'."
+        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations."
       ]
     },
     {
       "file": "packages/core/src/Combobox/story/ComboboxCustom.story.vue",
       "diagnostics": [
-        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.\nType '\"as\"' is not assignable to type 'never'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'asChild' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'height' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'rounded' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'width' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'defer' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'disabled' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'forceMount' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'to' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'."
+        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations."
       ]
     },
     {
       "file": "packages/core/src/Combobox/story/ComboboxMultiple.story.vue",
       "diagnostics": [
-        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations."
+        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.\nType '\"as\"' is not assignable to type 'never'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'asChild' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'height' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'rounded' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'width' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'defer' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'disabled' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'forceMount' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'to' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'."
       ]
     },
     {
@@ -595,7 +595,7 @@
     {
       "file": "packages/core/src/Combobox/story/ComboboxScrolling.story.vue",
       "diagnostics": [
-        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations."
+        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.\nType '\"as\"' is not assignable to type 'never'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'asChild' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'height' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'rounded' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'width' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'defer' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'disabled' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'forceMount' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'to' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'."
       ]
     },
     {
@@ -608,7 +608,9 @@
       "file": "packages/core/src/Combobox/story/ComboboxVirtual.story.vue",
       "diagnostics": [
         "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.",
-        "error:50:50 [TS7006] Parameter 'opt' implicitly has an 'any' type."
+        "error:50:51 [TS7006] Parameter 'opt' implicitly has an 'any' type.",
+        "error:62:24 [TS18047] 'option' is possibly 'null'.",
+        "error:62:31 [TS2339] Property 'label' does not exist on type 'string | number | bigint | Record<string, any>'.\nProperty 'label' does not exist on type 'string'."
       ]
     },
     {
@@ -1343,7 +1345,7 @@
       "diagnostics": [
         "error:38:12 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<HoverCardTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<HoverCardTriggerProps>, \"as\"> & {}'.",
         "error:38:13 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<HoverCardTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<HoverCardTriggerProps>, \"as\"> & {}'.",
-        "error:38:14 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<HoverCardTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<HoverCardTriggerProps>, \"as\"> & {}'."
+        "error:38:15 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<HoverCardTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<HoverCardTriggerProps>, \"as\"> & {}'."
       ]
     },
     {
@@ -1425,12 +1427,24 @@
     {
       "file": "packages/core/src/Listbox/story/ListboxVirtual.story.vue",
       "diagnostics": [
-        "error:24:46 [TS7006] Parameter 'opt' implicitly has an 'any' type.",
-        "error:48:54 [TS7006] Parameter 'option' implicitly has an 'any' type.",
-        "error:69:54 [TS7006] Parameter 'option' implicitly has an 'any' type.",
-        "error:90:54 [TS7006] Parameter 'option' implicitly has an 'any' type.",
-        "error:111:54 [TS7006] Parameter 'option' implicitly has an 'any' type.",
-        "error:135:54 [TS7006] Parameter 'option' implicitly has an 'any' type."
+        "error:24:47 [TS7006] Parameter 'opt' implicitly has an 'any' type.",
+        "error:30:18 [TS18047] 'option' is possibly 'null'.",
+        "error:30:25 [TS2339] Property 'label' does not exist on type 'string | number | bigint | Record<string, any>'.\nProperty 'label' does not exist on type 'string'.",
+        "error:48:55 [TS7006] Parameter 'option' implicitly has an 'any' type.",
+        "error:55:20 [TS18047] 'option' is possibly 'null'.",
+        "error:55:27 [TS2339] Property 'label' does not exist on type 'string | number | bigint | Record<string, any>'.\nProperty 'label' does not exist on type 'string'.",
+        "error:69:55 [TS7006] Parameter 'option' implicitly has an 'any' type.",
+        "error:76:20 [TS18047] 'option' is possibly 'null'.",
+        "error:76:27 [TS2339] Property 'label' does not exist on type 'string | number | bigint | Record<string, any>'.\nProperty 'label' does not exist on type 'string'.",
+        "error:90:55 [TS7006] Parameter 'option' implicitly has an 'any' type.",
+        "error:97:20 [TS18047] 'option' is possibly 'null'.",
+        "error:97:27 [TS2339] Property 'label' does not exist on type 'string | number | bigint | Record<string, any>'.\nProperty 'label' does not exist on type 'string'.",
+        "error:111:55 [TS7006] Parameter 'option' implicitly has an 'any' type.",
+        "error:118:20 [TS18047] 'option' is possibly 'null'.",
+        "error:118:27 [TS2339] Property 'label' does not exist on type 'string | number | bigint | Record<string, any>'.\nProperty 'label' does not exist on type 'string'.",
+        "error:135:55 [TS7006] Parameter 'option' implicitly has an 'any' type.",
+        "error:142:20 [TS18047] 'option' is possibly 'null'.",
+        "error:142:27 [TS2339] Property 'label' does not exist on type 'string | number | bigint | Record<string, any>'.\nProperty 'label' does not exist on type 'string'."
       ]
     },
     {
@@ -2499,10 +2513,10 @@
         "error:20:33 [TS2353] Object literal may only specify known properties, and 'as' does not exist in type '__WithDefaultsArgs<SelectTriggerProps>'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.\nProperty 'asChild' does not exist on type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.\nProperty 'reference' does not exist on type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.",
         "error:60:14 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.",
         "error:60:15 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.",
-        "error:60:52 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.",
+        "error:60:53 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.",
         "error:71:12 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.",
         "error:71:13 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.",
-        "error:71:14 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'."
+        "error:71:15 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<SelectTriggerProps>, \"as\"> & {}'."
       ]
     },
     {
@@ -2978,9 +2992,7 @@
     },
     {
       "file": "packages/core/src/Toast/story/ToastMultiple.story.vue",
-      "diagnostics": [
-        "error:29:23 [TS2345] Argument of type '((value: boolean) => void) | undefined' is not assignable to parameter of type '(value: boolean) => unknown'.\nType 'undefined' is not assignable to type '(value: boolean) => unknown'."
-      ]
+      "diagnostics": []
     },
     {
       "file": "packages/core/src/Toast/story/_Toast.vue",
@@ -3092,9 +3104,9 @@
       "diagnostics": [
         "error:114:12 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<TooltipTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<TooltipTriggerProps>, \"as\"> & {}'.",
         "error:114:13 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<TooltipTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<TooltipTriggerProps>, \"as\"> & {}'.",
-        "error:114:14 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<TooltipTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<TooltipTriggerProps>, \"as\"> & {}'.",
+        "error:114:15 [TS7053] Element implicitly has an 'any' type because expression of type '\"as\"' can't be used to index type 'Omit<__LooseRequired<TooltipTriggerProps>, \"as\"> & {}'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<TooltipTriggerProps>, \"as\"> & {}'.",
         "error:115:24 [TS2339] Property 'asChild' does not exist on type 'Omit<__LooseRequired<TooltipTriggerProps>, \"as\"> & {}'.",
-        "error:115:31 [TS2339] Property 'asChild' does not exist on type 'Omit<__LooseRequired<TooltipTriggerProps>, \"as\"> & {}'."
+        "error:115:32 [TS2339] Property 'asChild' does not exist on type 'Omit<__LooseRequired<TooltipTriggerProps>, \"as\"> & {}'."
       ]
     },
     {
@@ -3142,41 +3154,41 @@
       "file": "packages/core/src/Tree/story/TreeAsync.story.vue",
       "diagnostics": [
         "error:3:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.",
-        "error:77:41 [TS7006] Parameter 'item' implicitly has an 'any' type."
+        "error:77:42 [TS7006] Parameter 'item' implicitly has an 'any' type."
       ]
     },
     {
       "file": "packages/core/src/Tree/story/TreeBasic.story.vue",
       "diagnostics": [
         "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.",
-        "error:17:39 [TS7006] Parameter 'item' implicitly has an 'any' type."
+        "error:17:40 [TS7006] Parameter 'item' implicitly has an 'any' type."
       ]
     },
     {
       "file": "packages/core/src/Tree/story/TreeCheckbox.story.vue",
       "diagnostics": [
         "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.",
-        "error:21:39 [TS7006] Parameter 'item' implicitly has an 'any' type."
+        "error:21:40 [TS7006] Parameter 'item' implicitly has an 'any' type."
       ]
     },
     {
       "file": "packages/core/src/Tree/story/TreeNested.story.vue",
       "diagnostics": [
-        "error:16:39 [TS7006] Parameter 'item' implicitly has an 'any' type."
+        "error:16:40 [TS7006] Parameter 'item' implicitly has an 'any' type."
       ]
     },
     {
       "file": "packages/core/src/Tree/story/TreeVirtual.story.vue",
       "diagnostics": [
         "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.",
-        "error:30:39 [TS7006] Parameter 'item' implicitly has an 'any' type."
+        "error:30:40 [TS7006] Parameter 'item' implicitly has an 'any' type."
       ]
     },
     {
       "file": "packages/core/src/Tree/story/_Tree.vue",
       "diagnostics": [
         "error:3:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.",
-        "error:75:35 [TS7006] Parameter 'item' implicitly has an 'any' type."
+        "error:75:36 [TS7006] Parameter 'item' implicitly has an 'any' type."
       ]
     },
     {
@@ -3332,7 +3344,7 @@
       "diagnostics": []
     }
   ],
-  "errorCount": 322,
+  "errorCount": 335,
   "warningCount": 0,
   "fileCount": 700
 }


### PR DESCRIPTION
## Summary

The misskey, reka-ui, nuxt-ui, and elk check snapshots were last regenerated on 2026-07-16 — before the static-prop checks (#3197), the repeated-prop-name hotfix (#3202), and the sub-span batch mapping (#3201). This refresh re-baselines them against the current checker so the next Real Project Matrix run stays green.

Reviewed diff-by-diff before committing:

- **Zero `TS2451`/`TS2300` prop-check redeclarations** anywhere (the #3202 regression class is gone), and the diagnostics those redeclarations masked are restored.
- Positions move onto authored expressions (sub-span mapping) instead of clamped generated columns; past-end-of-line columns disappear.
- Message-level churn is dedup differentiation: duplicates that previously collapsed onto one clamped column are now distinct, and vice versa.

**Deliberately excluded:** `npmx.dev-check.snap`. Regenerating it requires the pinned fixture's own dependency install (its `@vueuse/core` resolution), which only the matrix environment has — refreshing it locally would bake ten bogus `TS2307`s into the snapshot. If the next matrix run flags npmx.dev, it needs one in-environment regeneration.

Part of #2971

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->