### PR TITLE
fix(release): download new package artifacts in the smoke job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,8 +176,7 @@ jobs:
     needs: [build-editor-extensions, release-preflight]
     timeout-minutes: 15
     environment: vscode-marketplace
-    permissions:
-      contents: read
+    permissions: { contents: read }
     env:
       VSCE_PAT: ${{ secrets.VSCE_PAT }}
     steps:
@@ -192,8 +191,7 @@ jobs:
         with:
           path: ~/.local/share/pnpm/store
           key: ${{ runner.os }}-pnpm-vscode-release-${{ hashFiles('.node-version') }}-v1
-          restore-keys: |
-            ${{ runner.os }}-pnpm-vscode-release-
+          restore-keys: ${{ runner.os }}-pnpm-vscode-release-
       - name: Download editor extension artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: editor-extensions, path: editor-extension-artifacts }
@@ -548,15 +546,11 @@ jobs:
 
       - name: Download vize native artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: bindings-*
-          path: npm/native/artifacts
+        with: { pattern: bindings-*, path: npm/native/artifacts }
 
       - name: Download fresco native artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: fresco-bindings-*
-          path: npm/fresco-native/artifacts
+        with: { pattern: fresco-bindings-*, path: npm/fresco-native/artifacts }
 
       - name: Apply slow platform release cadence
         run: node tools/github/release-platforms.mjs apply-cadence "${{ github.ref_name }}" npm/native/package.json npm/oxint/package.json
@@ -593,10 +587,7 @@ jobs:
             npm/ui/core
 
   release-preflight:
-    permissions:
-      actions: write
-      contents: read
-      issues: read
+    permissions: { actions: write, contents: read, issues: read }
     uses: ./.github/workflows/release-preflight.yml
   # npm Trusted Publishing/provenance currently rejects self-hosted runners.
   # Keep the publish edge on GitHub-hosted runners; build and smoke jobs stay on Blacksmith.
@@ -729,8 +720,7 @@ jobs:
     permissions: { contents: read, id-token: write }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
+        with: { persist-credentials: false }
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }
@@ -759,8 +749,7 @@ jobs:
     permissions: { contents: read, id-token: write }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
+        with: { persist-credentials: false }
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }
@@ -789,8 +778,7 @@ jobs:
     permissions: { contents: read, id-token: write }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
+        with: { persist-credentials: false }
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }
@@ -813,8 +801,7 @@ jobs:
     permissions: { contents: read, id-token: write }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
+        with: { persist-credentials: false }
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }
@@ -837,8 +824,7 @@ jobs:
     permissions: { contents: read, id-token: write }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
+        with: { persist-credentials: false }
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }
@@ -861,8 +847,7 @@ jobs:
     permissions: { contents: read, id-token: write }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
+        with: { persist-credentials: false }
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }
@@ -886,8 +871,7 @@ jobs:
     permissions: { contents: read, id-token: write }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
+        with: { persist-credentials: false }
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }
@@ -910,8 +894,7 @@ jobs:
     permissions: { contents: read, id-token: write }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
+        with: { persist-credentials: false }
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }
@@ -934,8 +917,7 @@ jobs:
     permissions: { contents: read, id-token: write }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
+        with: { persist-credentials: false }
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }
@@ -958,8 +940,7 @@ jobs:
     permissions: { contents: read, id-token: write }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
+        with: { persist-credentials: false }
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }
@@ -982,8 +963,7 @@ jobs:
     permissions: { contents: read, id-token: write }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
+        with: { persist-credentials: false }
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }
@@ -1015,8 +995,7 @@ jobs:
     permissions: { contents: read, id-token: write }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
+        with: { persist-credentials: false }
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }
@@ -1210,8 +1189,7 @@ jobs:
     permissions: { contents: read, id-token: write }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
+        with: { persist-credentials: false }
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -534,6 +534,18 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: release-package-nuxt, path: npm/framework/nuxt }
 
+      - name: Download marquette package artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with: { name: release-package-marquette, path: npm/marquette }
+
+      - name: Download compose core package artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with: { name: release-package-composable, path: npm/compose/core }
+
+      - name: Download ui core package artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with: { name: release-package-ui, path: npm/ui/core }
+
       - name: Download vize native artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/tests/tooling/github-workflows-release-publish.test.ts
+++ b/tests/tooling/github-workflows-release-publish.test.ts
@@ -188,65 +188,6 @@ test("release workflow publishes npm packages from package-specific artifacts", 
   }
 });
 
-test("smoke job downloads every packed artifact directory it smoke-installs", () => {
-  const source = readRepoFile(".github", "workflows", "release.yml");
-  const workflow = parse(source) as { jobs?: Record<string, ReleaseJob> };
-  const jobs = workflow.jobs ?? {};
-
-  // Directory -> artifact name, derived from every release-package-* upload.
-  // Packages assembled in-job from bindings artifacts (native, fresco-native)
-  // never appear here, so they are exempt by construction rather than by list.
-  const uploadedPathToName = new Map<string, string>();
-  for (const job of Object.values(jobs)) {
-    for (const step of job.steps ?? []) {
-      if (!step.uses?.includes("actions/upload-artifact@")) continue;
-      const name = step.with?.name;
-      const path = step.with?.path;
-      if (typeof name !== "string" || !name.startsWith("release-package-")) continue;
-      assert.ok(typeof path === "string", `artifact ${name} must upload a single directory path`);
-      uploadedPathToName.set(path, name);
-    }
-  }
-  assert.ok(uploadedPathToName.size > 0, "expected release-package-* uploads in release.yml");
-
-  const smokeJob = jobs["smoke-release-packages"];
-  assert.ok(smokeJob, "missing smoke-release-packages job");
-  const smokeRun = (smokeJob.steps ?? []).find((step) =>
-    step.run?.includes("smoke-release-install.mjs"),
-  )?.run;
-  assert.ok(smokeRun, "smoke-release-packages must run smoke-release-install.mjs");
-  const smokedDirectories = smokeRun
-    .replace(/\\\n/g, " ")
-    .split(/\s+/)
-    .filter((token) => token.startsWith("npm/"));
-  assert.ok(smokedDirectories.length > 0, "smoke install list must not be empty");
-
-  const smokeDownloads = new Map<string, string>();
-  for (const step of smokeJob.steps ?? []) {
-    if (!step.uses?.includes("actions/download-artifact@")) continue;
-    const name = step.with?.name;
-    const path = step.with?.path;
-    if (typeof name !== "string" || !name.startsWith("release-package-")) continue;
-    assert.ok(typeof path === "string", `smoke download ${name} must target a directory path`);
-    smokeDownloads.set(path, name);
-    assert.equal(
-      uploadedPathToName.get(path),
-      name,
-      `smoke download ${name} -> ${path} must mirror the build upload wiring`,
-    );
-  }
-
-  for (const directory of smokedDirectories) {
-    const artifactName = uploadedPathToName.get(directory);
-    if (artifactName == null) continue;
-    assert.equal(
-      smokeDownloads.get(directory),
-      artifactName,
-      `smoke-release-packages must download ${artifactName} into ${directory} before installing it`,
-    );
-  }
-});
-
 test("release workflow smokes the wasm package wrapper before publishing", () => {
   const workflow = readRepoFile(".github", "workflows", "release.yml");
   const buildJob = workflowJobBody(workflow, "build-wasm-package");

--- a/tests/tooling/github-workflows-release-publish.test.ts
+++ b/tests/tooling/github-workflows-release-publish.test.ts
@@ -188,6 +188,65 @@ test("release workflow publishes npm packages from package-specific artifacts", 
   }
 });
 
+test("smoke job downloads every packed artifact directory it smoke-installs", () => {
+  const source = readRepoFile(".github", "workflows", "release.yml");
+  const workflow = parse(source) as { jobs?: Record<string, ReleaseJob> };
+  const jobs = workflow.jobs ?? {};
+
+  // Directory -> artifact name, derived from every release-package-* upload.
+  // Packages assembled in-job from bindings artifacts (native, fresco-native)
+  // never appear here, so they are exempt by construction rather than by list.
+  const uploadedPathToName = new Map<string, string>();
+  for (const job of Object.values(jobs)) {
+    for (const step of job.steps ?? []) {
+      if (!step.uses?.includes("actions/upload-artifact@")) continue;
+      const name = step.with?.name;
+      const path = step.with?.path;
+      if (typeof name !== "string" || !name.startsWith("release-package-")) continue;
+      assert.ok(typeof path === "string", `artifact ${name} must upload a single directory path`);
+      uploadedPathToName.set(path, name);
+    }
+  }
+  assert.ok(uploadedPathToName.size > 0, "expected release-package-* uploads in release.yml");
+
+  const smokeJob = jobs["smoke-release-packages"];
+  assert.ok(smokeJob, "missing smoke-release-packages job");
+  const smokeRun = (smokeJob.steps ?? []).find((step) =>
+    step.run?.includes("smoke-release-install.mjs"),
+  )?.run;
+  assert.ok(smokeRun, "smoke-release-packages must run smoke-release-install.mjs");
+  const smokedDirectories = smokeRun
+    .replace(/\\\n/g, " ")
+    .split(/\s+/)
+    .filter((token) => token.startsWith("npm/"));
+  assert.ok(smokedDirectories.length > 0, "smoke install list must not be empty");
+
+  const smokeDownloads = new Map<string, string>();
+  for (const step of smokeJob.steps ?? []) {
+    if (!step.uses?.includes("actions/download-artifact@")) continue;
+    const name = step.with?.name;
+    const path = step.with?.path;
+    if (typeof name !== "string" || !name.startsWith("release-package-")) continue;
+    assert.ok(typeof path === "string", `smoke download ${name} must target a directory path`);
+    smokeDownloads.set(path, name);
+    assert.equal(
+      uploadedPathToName.get(path),
+      name,
+      `smoke download ${name} -> ${path} must mirror the build upload wiring`,
+    );
+  }
+
+  for (const directory of smokedDirectories) {
+    const artifactName = uploadedPathToName.get(directory);
+    if (artifactName == null) continue;
+    assert.equal(
+      smokeDownloads.get(directory),
+      artifactName,
+      `smoke-release-packages must download ${artifactName} into ${directory} before installing it`,
+    );
+  }
+});
+
 test("release workflow smokes the wasm package wrapper before publishing", () => {
   const workflow = readRepoFile(".github", "workflows", "release.yml");
   const buildJob = workflowJobBody(workflow, "build-wasm-package");

--- a/tests/tooling/github-workflows-release-smoke.test.ts
+++ b/tests/tooling/github-workflows-release-smoke.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parse } from "yaml";
+
+import { readRepoFile } from "./support/github-workflows.ts";
+
+type ReleaseJob = {
+  steps?: Array<{
+    run?: string;
+    uses?: string;
+    with?: Record<string, unknown>;
+  }>;
+};
+
+test("smoke job downloads every packed artifact directory it smoke-installs", () => {
+  const source = readRepoFile(".github", "workflows", "release.yml");
+  const workflow = parse(source) as { jobs?: Record<string, ReleaseJob> };
+  const jobs = workflow.jobs ?? {};
+
+  // Directory -> artifact name, derived from every release-package-* upload.
+  // Packages assembled in-job from bindings artifacts (native, fresco-native)
+  // never appear here, so they are exempt by construction rather than by list.
+  const uploadedPathToName = new Map<string, string>();
+  for (const job of Object.values(jobs)) {
+    for (const step of job.steps ?? []) {
+      if (!step.uses?.includes("actions/upload-artifact@")) continue;
+      const name = step.with?.name;
+      const path = step.with?.path;
+      if (typeof name !== "string" || !name.startsWith("release-package-")) continue;
+      assert.ok(typeof path === "string", `artifact ${name} must upload a single directory path`);
+      uploadedPathToName.set(path, name);
+    }
+  }
+  assert.ok(uploadedPathToName.size > 0, "expected release-package-* uploads in release.yml");
+
+  const smokeJob = jobs["smoke-release-packages"];
+  assert.ok(smokeJob, "missing smoke-release-packages job");
+  const smokeRun = (smokeJob.steps ?? []).find((step) =>
+    step.run?.includes("smoke-release-install.mjs"),
+  )?.run;
+  assert.ok(smokeRun, "smoke-release-packages must run smoke-release-install.mjs");
+  const smokedDirectories = smokeRun
+    .replace(/\\\n/g, " ")
+    .split(/\s+/)
+    .filter((token) => token.startsWith("npm/"));
+  assert.ok(smokedDirectories.length > 0, "smoke install list must not be empty");
+
+  const smokeDownloads = new Map<string, string>();
+  for (const step of smokeJob.steps ?? []) {
+    if (!step.uses?.includes("actions/download-artifact@")) continue;
+    const name = step.with?.name;
+    const path = step.with?.path;
+    if (typeof name !== "string" || !name.startsWith("release-package-")) continue;
+    assert.ok(typeof path === "string", `smoke download ${name} must target a directory path`);
+    smokeDownloads.set(path, name);
+    assert.equal(
+      uploadedPathToName.get(path),
+      name,
+      `smoke download ${name} -> ${path} must mirror the build upload wiring`,
+    );
+  }
+
+  for (const directory of smokedDirectories) {
+    const artifactName = uploadedPathToName.get(directory);
+    if (artifactName == null) continue;
+    assert.equal(
+      smokeDownloads.get(directory),
+      artifactName,
+      `smoke-release-packages must download ${artifactName} into ${directory} before installing it`,
+    );
+  }
+});


### PR DESCRIPTION
## Why

v0.300.0's Release run failed in **Smoke release npm package installs**: the smoke list gained `npm/marquette`, `npm/compose/core`, and `npm/ui/core` (#3206), but the job never downloaded their `release-package-*` artifacts, so `assertPublishEntrypointsExist` saw an empty `dist/` and failed before anything was published. Build artifacts themselves are complete (verified by downloading `release-package-marquette` from the failed run — schema JSONs included).

## What

- Add the three missing `download-artifact` steps to `smoke-release-packages`, mirroring the build-job upload wiring.
- Add a derived invariant test: every directory in the smoke install list that is covered by a `release-package-*` upload must be downloaded into that exact directory by the smoke job, and every smoke download must mirror the build upload's name→path pair. Packages assembled in-job from bindings artifacts (native, fresco-native) are exempt by construction, not by list.

## Verification

- New test fails on the unfixed workflow with `smoke-release-packages must download release-package-marquette into npm/marquette before installing it`, passes with the fix.
- `node tools/npm/smoke-release-install.mjs --prepare-manifests --runtime-checks npm/marquette npm/compose/core npm/ui/core` → `smoked 3/3 package tarballs` locally with CI-equivalent builds.
- `vp check` clean, source-length gate green, all 10 workflow tooling tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release smoke checks now include all required npm package artifacts, improving validation of release packages before publishing.

* **Tests**
  * Added automated workflow checks to verify that uploaded release artifacts are downloaded into the correct directories during smoke testing.

* **Chores**
  * Simplified workflow formatting without changing release behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->