### PR TITLE
test(patina): cover namespace exports in no-export-in-script-setup

### DIFF
--- a/crates/vize_patina/src/rules/script/no_export_in_script_setup_tests.rs
+++ b/crates/vize_patina/src/rules/script/no_export_in_script_setup_tests.rs
@@ -109,6 +109,17 @@ export {}
     assert_eq!(result.error_count, 1);
 }
 
+#[test]
+fn test_invalid_export_namespace_with_macro() {
+    // A non-ambient namespace emits a runtime object, so it must be flagged.
+    let source = r#"
+defineProps<{ count: number }>()
+export namespace Config { export const value = 1 }
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+}
+
 // --- Valid: type-only exports are erased and stay legal in <script setup> ---
 
 #[test]
@@ -172,6 +183,18 @@ fn test_valid_export_ambient_declare() {
     let source = r#"
 defineProps<{ count: number }>()
 export declare const version: string
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_export_declare_namespace() {
+    // An ambient namespace is erased at compile time; only non-ambient
+    // `export namespace` emits a runtime object.
+    let source = r#"
+defineProps<{ count: number }>()
+export declare namespace Config { const value: number }
 "#;
     let result = create_linter().lint(source, 0);
     assert_eq!(result.error_count, 0);


### PR DESCRIPTION
Follow-up to the merged #3215 addressing CodeRabbit's review note on `no_export_in_script_setup`.

The rule already treats `TSModuleDeclaration` correctly: `is_type_only_named_export` returns `declaration.declare`, so a non-ambient `export namespace Config {}` (which emits a runtime object) is flagged while `export declare namespace` is erased and allowed. That behavior had no test coverage, so this adds two regression cases to lock in the boundary CodeRabbit was worried about.

```rust
Some(Declaration::TSModuleDeclaration(declaration)) => declaration.declare,
```

- `test_invalid_export_namespace_with_macro`: `export namespace Config { export const value = 1 }` is reported.
- `test_valid_export_declare_namespace`: `export declare namespace Config { const value: number }` is allowed.

`cargo test -p vize_patina no_export_in_script_setup`: 24 passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring runtime namespace exports in `<script setup>` are flagged as invalid.
  * Confirmed ambient namespace declarations are accepted without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->