### PR TITLE
fix(atelier): end unterminated strings at line terminators in the expression guard

### DIFF
--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
@@ -18,10 +18,13 @@ fn analyze_expression_nesting(content: &str) -> (usize, bool) {
     let mut can_start_regex = true;
     let mut template_interpolation_depths = Vec::new();
     // Plain `foo < bar` is indistinguishable from a type argument to a byte
-    // scanner. Enter angle-tracking mode only for the repeated structural type
-    // prefixes present in the parser-timeout class (`<{`, `<[`), discovered
-    // while scanning so strings and comments cannot activate the mode.
-    let mut structural_type_angle_opens = 0usize;
+    // scanner. Enter angle-tracking mode only for repeated speculative type
+    // prefixes: the structural shapes of the parser-timeout class (`<{`, `<[`,
+    // #2944) and the JSDoc non-nullable shape (`<!`, #3213), where OXC's type
+    // speculation recurses once per `!` and per nested `<` until the Rust
+    // stack overflows. Both are discovered while scanning so strings and
+    // comments cannot activate the mode.
+    let mut speculative_type_angle_opens = 0usize;
     let mut track_type_angles = false;
     let mut i = 0;
 
@@ -111,9 +114,9 @@ fn analyze_expression_nesting(content: &str) -> (usize, bool) {
             }
             b'<' => {
                 angle_depth += 1;
-                if is_structural_type_angle_open(bytes, i) {
-                    structural_type_angle_opens += 1;
-                    track_type_angles = structural_type_angle_opens >= 2;
+                if is_speculative_type_angle_open(bytes, i) {
+                    speculative_type_angle_opens += 1;
+                    track_type_angles = speculative_type_angle_opens >= 2;
                 }
                 can_start_regex = true;
             }
@@ -175,12 +178,26 @@ pub fn expression_exceeds_max_depth(content: &str) -> bool {
 
 fn skip_quoted(bytes: &[u8], mut i: usize, quote: u8) -> usize {
     while i < bytes.len() {
-        if bytes[i] == b'\\' {
-            i = i.saturating_add(2);
-        } else if bytes[i] == quote {
-            return i + 1;
-        } else {
-            i += 1;
+        match bytes[i] {
+            b'\\' => {
+                // `\` + CRLF is a single LineContinuation sequence; every other
+                // escape is two bytes. (`\` + LS/PS also continues the line: the
+                // two-byte skip consumes the E2 lead byte and the remaining
+                // bytes are ordinary string content.)
+                if bytes.get(i + 1) == Some(&b'\r') && bytes.get(i + 2) == Some(&b'\n') {
+                    i = i.saturating_add(3);
+                } else {
+                    i = i.saturating_add(2);
+                }
+            }
+            // An unescaped LF or CR ends a (mal)formed string literal for the
+            // lexer. Scanning past it to a later quote swallowed real source,
+            // hiding brackets and type angles from the depth guard (#3213).
+            // Unescaped LS/PS stay legal inside string literals (ES2019), so
+            // only LF and CR terminate.
+            b'\n' | b'\r' => return i,
+            b if b == quote => return i + 1,
+            _ => i += 1,
         }
     }
     i
@@ -201,12 +218,15 @@ fn skip_template_text(bytes: &[u8], mut i: usize) -> (usize, bool) {
     (i, false)
 }
 
-fn is_structural_type_angle_open(bytes: &[u8], i: usize) -> bool {
+fn is_speculative_type_angle_open(bytes: &[u8], i: usize) -> bool {
     let mut next = i + 1;
     while matches!(bytes.get(next), Some(b' ' | b'\t' | b'\r' | b'\n')) {
         next += 1;
     }
-    matches!(bytes.get(next), Some(b'{' | b'['))
+    // `{`/`[` start structural types (#2944); `!` starts a JSDoc non-nullable
+    // type (#3213). Each keeps OXC inside type-argument speculation, so
+    // repeated occurrences make unclosed angles count toward the depth budget.
+    matches!(bytes.get(next), Some(b'{' | b'[' | b'!'))
 }
 
 fn skip_line_comment(bytes: &[u8], mut i: usize) -> usize {

--- a/crates/vize_atelier_core/tests/expression_nesting_guard.rs
+++ b/crates/vize_atelier_core/tests/expression_nesting_guard.rs
@@ -184,6 +184,83 @@ fn expression_guard_treats_slash_after_private_names_as_division() {
 }
 
 #[test]
+fn expression_guard_ends_unterminated_strings_at_line_terminators() {
+    // The 4 KiB js_ts_expression reproducer (#3213) hid its pathological
+    // bracket and type-angle runs behind an unterminated `'` literal: the
+    // scanner ran through newlines to a quote hundreds of bytes later while
+    // the lexer ends a (mal)formed string literal at the first unescaped LF or
+    // CR and resumes lexing the junk the guard never saw.
+    for terminator in ["\n", "\r"] {
+        let hidden = [
+            "'x",
+            terminator,
+            &"(".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1),
+        ]
+        .concat();
+        assert_eq!(
+            expression_nesting_depth(&hidden),
+            MAX_EXPRESSION_NESTING_DEPTH + 1,
+            "terminator {:?}",
+            terminator.escape_unicode()
+        );
+        assert!(expression_exceeds_max_depth(&hidden));
+        assert!(!expression_is_safe_to_parse(&hidden));
+    }
+
+    // Unescaped LS/PS are legal string content (ES2019), and `\` + LF as well
+    // as `\` + CRLF are LineContinuation sequences: none of them end the
+    // literal, so none of them expose the quoted brackets to the guard.
+    for continued in [
+        "'a\u{2028}b(' + c",
+        "'a\u{2029}b(' + c",
+        "'a\\\nb(' + c",
+        "'a\\\r\nb(' + c",
+    ] {
+        assert_eq!(expression_nesting_depth(continued), 0, "{continued:?}");
+        assert!(expression_has_balanced_delimiters(continued));
+        assert!(expression_is_safe_to_parse(continued));
+    }
+}
+
+#[test]
+fn expression_guard_rejects_jsdoc_non_nullable_type_angle_chains() {
+    // Minimized from the js_ts_expression stack-overflow reproducer (#3213):
+    // in `a<!!a<!!a<...`, OXC's type-argument speculation parses every `!` as
+    // a JSDoc non-nullable type and every following `<` as nested type
+    // arguments, recursing once per token until the parser overflows the Rust
+    // stack. `<` followed by `!` therefore joins the speculative type-angle
+    // class, making the unclosed angle run count toward the depth budget.
+    let rejected = "a<!!".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1);
+    assert!(expression_nesting_depth(&rejected) > MAX_EXPRESSION_NESTING_DEPTH);
+    assert!(expression_exceeds_max_depth(&rejected));
+    assert!(!expression_is_safe_to_parse(&rejected));
+    assert_eq!(
+        prefix_identifiers_in_expression(&rejected).as_str(),
+        rejected
+    );
+    assert_eq!(
+        strip_typescript_from_expression(&rejected).as_str(),
+        rejected
+    );
+
+    // Whitespace between `<` and `!` reaches the same speculation path.
+    let spaced = "a< !!".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1);
+    assert!(!expression_is_safe_to_parse(&spaced));
+
+    // The fuzzer's stack-overflow shape: hundreds of interleaved `<!!` units.
+    let overflow = "a<!!".repeat(500);
+    assert!(!expression_is_safe_to_parse(&overflow));
+
+    // Real comparisons against negated operands stay below the activation
+    // threshold and inside the depth budget.
+    let legitimate = "x < !a && y < !b && z < !!c";
+    assert_eq!(expression_nesting_depth(legitimate), 3);
+    assert!(expression_is_safe_to_parse(legitimate));
+    let rewritten = prefix_identifiers_in_expression(legitimate);
+    assert!(rewritten.contains("_ctx.x < !_ctx.a"), "{rewritten}");
+}
+
+#[test]
 fn expression_guard_does_not_treat_relational_operators_as_type_angles() {
     let expression = std::iter::repeat_n("value < limit", MAX_EXPRESSION_NESTING_DEPTH + 1)
         .collect::<Vec<_>>()


### PR DESCRIPTION
Fixes #3213.

The 4 KiB `js_ts_expression` slow-unit hid its pathological bracket and type-angle runs behind an unterminated `'` literal: `skip_quoted` scanned through newlines to a quote hundreds of bytes later, while the real lexer ends a (mal)formed string literal at the first unescaped LF/CR and resumes lexing the junk the guard never saw (same visibility-hole genus as #3107 and #3185). OXC then spent ~10 s in type-argument speculation over the hidden `<{`/`[` runs — and past the 25 s CI budget on slower runners.

Two guard hardenings:
- `skip_quoted` now ends at unescaped LF/CR exactly like the lexer, while preserving `\` + LF, `\` + CRLF line continuations and ES2019 unescaped LS/PS string content.
- `<` followed by `!` joins the speculative type-angle class (with `<{`, `<[`): OXC parses each `!` as a JSDoc non-nullable type and recurses per token, so `a<!!a<!!…` chains overflow the parser stack (AddressSanitizer confirmed at ~500 units) unless the unclosed angle run counts toward the depth budget.

Verified: the artifact now executes in 0 ms (guard rejects before parse; was 9.6 s), `a<!!`×500 no longer overflows, and `cargo test -p vize_atelier_core -p vize_atelier_sfc -p vize_atelier_dom -p vize_atelier_vapor -p vize_atelier_ssr` passes. Regression tests cover the terminator hole (LF/CR reject; LS/PS + line continuations stay accepted) and the JSDoc-angle chains with the legitimate-comparison boundary.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of TypeScript expressions containing speculative type syntax and JSDoc non-nullable markers.
  * Fixed nesting-depth protection for unterminated strings, including line breaks and escaped line continuations.
  * Improved detection of deeply nested or ambiguous expressions, preventing unsafe parsing while preserving valid comparisons and string content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->