### PR TITLE
fix(patina): avoid treating template root fragments as custom blocks

### DIFF
--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -76,6 +76,7 @@ const SHARED_SFC_DESCRIPTOR_RULES: &[&str] = &[
     "vue/sfc-element-order",
     "vue/require-scoped-style",
     "vue/single-style-block",
+    "vue/warn-custom-block",
     "ecosystem/void-link-require-href",
     "ecosystem/void-link-valid-method",
 ];
@@ -121,10 +122,9 @@ impl Linter {
         ctx.set_config_rule_severities(self.severity_overrides.clone());
         ctx.set_help_level(self.help_level);
 
-        // SFC-level rules are uncommon but expensive when each one reparses the
-        // file. Reuse the descriptor produced by the main lint pipeline whenever
-        // available, and only parse lazily when a caller enters this path without
-        // a shared descriptor.
+        // SFC-level rules are uncommon but expensive when each one reparses the file.
+        // Reuse the descriptor produced by the main lint pipeline whenever available,
+        // and only parse lazily when a caller enters this path without one.
         let owned_descriptor;
         let shared_descriptor = if !self.has_active_shared_sfc_descriptor_rules() {
             None

--- a/crates/vize_patina/src/rules/opinionated/vue/warn_custom_block.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/warn_custom_block.rs
@@ -27,6 +27,15 @@
 //! </docs>
 //! ```
 //!
+//! ## Detection
+//!
+//! Custom blocks are *top-level* SFC blocks (siblings of `<template>`,
+//! `<script>`, and `<style>`), so detection relies on the SFC parser's block
+//! boundaries rather than any raw-text or indentation heuristic. Elements
+//! inside the `<template>` block — including unindented multi-root fragment
+//! children starting at column 0 — are template content, never custom blocks
+//! (issue #3210).
+//!
 //! ## Note
 //!
 //! This rule is informational. Custom blocks are valid and useful when
@@ -35,7 +44,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::{LintDiagnostic, Severity};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::RootNode;
+use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
+use vize_carton::profile;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/warn-custom-block",
@@ -44,9 +54,6 @@ static META: RuleMeta = RuleMeta {
     fixable: false,
     default_severity: Severity::Warning,
 };
-
-/// Standard SFC block names
-const STANDARD_BLOCKS: &[&str] = &["script", "template", "style"];
 
 /// Warn about custom blocks
 #[derive(Default)]
@@ -57,7 +64,7 @@ impl Rule for WarnCustomBlock {
         &META
     }
 
-    fn run_on_template<'a>(&self, ctx: &mut LintContext<'a>, _root: &RootNode<'a>) {
+    fn run_on_sfc<'a>(&self, ctx: &mut LintContext<'a>) {
         // Custom blocks are an SFC concept (`<i18n>`, `<docs>`, etc.).
         // Standalone HTML files (e.g. `index.html`, `.storybook/preview-head.html`)
         // are not Vue SFCs, so every top-level non-`script`/`template`/`style`
@@ -67,67 +74,58 @@ impl Rule for WarnCustomBlock {
             return;
         }
 
-        let source = ctx.source;
+        // The engine shares one parsed descriptor across SFC-level rules; parse
+        // lazily only when a host drives this rule without preparing one. A
+        // source that fails to parse as an SFC has no trustworthy block
+        // boundaries — parse errors are reported elsewhere, so stay silent
+        // instead of guessing.
+        let owned_descriptor;
+        let descriptor = if let Some(descriptor) = ctx.sfc_descriptor() {
+            descriptor
+        } else {
+            owned_descriptor = match profile!(
+                "patina.rule.warn_custom_block.parse_sfc",
+                parse_sfc(
+                    ctx.source,
+                    SfcParseOptions {
+                        filename: ctx.filename.into(),
+                        ..Default::default()
+                    },
+                )
+            ) {
+                Ok(descriptor) => descriptor,
+                Err(_) => return,
+            };
+            &owned_descriptor
+        };
 
-        // Find all top-level blocks by looking for < at start of line or after >
-        let mut pos = 0;
-        while pos < source.len() {
-            // Find next < that could be a block start
-            if let Some(tag_start) = source[pos..].find('<') {
-                let abs_pos = pos + tag_start;
+        if descriptor.custom_blocks.is_empty() {
+            return;
+        }
 
-                // Skip if this is a closing tag
-                if source[abs_pos..].starts_with("</") {
-                    pos = abs_pos + 2;
-                    continue;
-                }
+        // `loc.tag_start` is the `<` of the opening tag and `loc.start` is the
+        // first content byte right past its `>` (past `/>` for self-closing
+        // blocks), so this span covers exactly the opening tag. Collected
+        // before reporting because the descriptor borrow must end before
+        // `ctx.report` takes `ctx` mutably.
+        let spans: Vec<(u32, u32)> = descriptor
+            .custom_blocks
+            .iter()
+            .map(|block| (block.loc.tag_start as u32, block.loc.start as u32))
+            .collect();
 
-                // Get the tag name
-                let rest = &source[abs_pos + 1..];
-                let tag_end = rest
-                    .find(|c: char| c.is_whitespace() || c == '>' || c == '/')
-                    .unwrap_or(rest.len());
-                let tag_name = &rest[..tag_end];
-
-                // Check if this is a non-standard block at root level
-                // Only check if we're likely at root level (check for preceding whitespace/newline)
-                let before = &source[..abs_pos];
-                let is_root_level = before.is_empty()
-                    || before.ends_with('\n')
-                    || before.trim_end().ends_with('>') && !before.contains('<');
-
-                if is_root_level
-                    && !tag_name.is_empty()
-                    && !STANDARD_BLOCKS.contains(&tag_name)
-                    && tag_name
-                        .chars()
-                        .next()
-                        .map(|c| c.is_lowercase())
-                        .unwrap_or(false)
-                {
-                    // Find the closing >
-                    let close_pos = source[abs_pos..]
-                        .find('>')
-                        .map(|p| abs_pos + p + 1)
-                        .unwrap_or(abs_pos + tag_end + 1);
-
-                    ctx.report(
-                        LintDiagnostic::warn(
-                            META.name,
-                            "Custom block detected. Ensure proper plugin configuration.",
-                            abs_pos as u32,
-                            close_pos as u32,
-                        )
-                        .with_help(
-                            "Custom blocks require corresponding Vite/Webpack plugins to be processed",
-                        ),
-                    );
-                }
-
-                pos = abs_pos + 1;
-            } else {
-                break;
-            }
+        for (start, end) in spans {
+            ctx.report(
+                LintDiagnostic::warn(
+                    META.name,
+                    "Custom block detected. Ensure proper plugin configuration.",
+                    start,
+                    end,
+                )
+                .with_help(
+                    "Custom blocks require corresponding Vite/Webpack plugins to be processed",
+                ),
+            );
         }
     }
 }
@@ -140,7 +138,15 @@ fn is_sfc_filename(filename: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_sfc_filename;
+    use super::{WarnCustomBlock, is_sfc_filename};
+    use crate::linter::Linter;
+    use crate::rule::RuleRegistry;
+
+    fn create_linter() -> Linter {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(WarnCustomBlock));
+        Linter::with_registry(registry)
+    }
 
     #[test]
     fn detects_vue_sfc_filenames() {
@@ -156,5 +162,158 @@ mod tests {
         assert!(!is_sfc_filename("page.htm"));
         assert!(!is_sfc_filename("script.ts"));
         assert!(!is_sfc_filename("noext"));
+    }
+
+    #[test]
+    fn test_template_root_fragment_is_not_custom_block() {
+        // Exact reproduction of issue #3210: `vize fmt --write` may leave
+        // multi-root fragment children at column 0, which the old raw-text
+        // scan mistook for top-level custom blocks.
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            "<template>\n  <fieldset />\n<hr />\n<fieldset />\n</template>\n",
+            "Component.vue",
+        );
+        assert_eq!(result.warning_count, 0, "got: {:?}", result.diagnostics);
+    }
+
+    #[test]
+    fn test_multi_root_template_with_mixed_indentation_is_valid() {
+        // Multi-root fragments are valid regardless of indentation; children
+        // at column 0, indented children, and nested unindented elements are
+        // all inside the `<template>` block span.
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            "<template>\n<header />\n    <main>\n<article />\n    </main>\n<custom-footer />\n</template>\n",
+            "Component.vue",
+        );
+        assert_eq!(result.warning_count, 0, "got: {:?}", result.diagnostics);
+    }
+
+    #[test]
+    fn test_top_level_docs_block_warns() {
+        let linter = create_linter();
+        let source = "<template>\n  <div />\n</template>\n\n<docs>\n# MyComponent\n</docs>\n";
+        let result = linter.lint_sfc(source, "Component.vue");
+        assert_eq!(result.warning_count, 1, "got: {:?}", result.diagnostics);
+        let diagnostic = &result.diagnostics[0];
+        assert_eq!(diagnostic.rule_name, "vue/warn-custom-block");
+        // The diagnostic must cover exactly the `<docs>` opening tag.
+        let tag_start = source.find("<docs>").unwrap() as u32;
+        assert_eq!(diagnostic.start, tag_start);
+        assert_eq!(diagnostic.end, tag_start + "<docs>".len() as u32);
+    }
+
+    #[test]
+    fn test_top_level_i18n_block_warns() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            "<template>\n  <div />\n</template>\n<i18n>\n{ \"en\": { \"hello\": \"Hello\" } }\n</i18n>\n",
+            "Component.vue",
+        );
+        assert_eq!(result.warning_count, 1, "got: {:?}", result.diagnostics);
+        assert_eq!(result.diagnostics[0].rule_name, "vue/warn-custom-block");
+    }
+
+    #[test]
+    fn test_multiple_custom_blocks_warn_each() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            "<template>\n  <div />\n</template>\n<docs>\ntext\n</docs>\n<i18n>\n{}\n</i18n>\n",
+            "Component.vue",
+        );
+        assert_eq!(result.warning_count, 2, "got: {:?}", result.diagnostics);
+    }
+
+    #[test]
+    fn test_self_closing_custom_block_with_src_warns() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            "<template>\n  <div />\n</template>\n<i18n src=\"./locales.json\" />\n",
+            "Component.vue",
+        );
+        assert_eq!(result.warning_count, 1, "got: {:?}", result.diagnostics);
+        assert_eq!(result.diagnostics[0].rule_name, "vue/warn-custom-block");
+    }
+
+    #[test]
+    fn test_custom_block_content_at_column_zero_warns_once() {
+        // Only the block itself is a custom block; markup inside its content
+        // must not produce additional warnings even at column 0.
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            "<template>\n  <div />\n</template>\n<docs>\n<hr />\ntext\n</docs>\n",
+            "Component.vue",
+        );
+        assert_eq!(result.warning_count, 1, "got: {:?}", result.diagnostics);
+    }
+
+    #[test]
+    fn test_standard_blocks_only_do_not_warn() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            "<template>\n  <div />\n</template>\n<script setup>\nconst n = 1\n</script>\n<style scoped>\n.a { color: red; }\n</style>\n",
+            "Component.vue",
+        );
+        assert_eq!(result.warning_count, 0, "got: {:?}", result.diagnostics);
+    }
+
+    #[test]
+    fn test_custom_block_in_script_only_sfc_warns() {
+        // `run_on_sfc` fires without a template block, so custom blocks in
+        // script-only components are still detected.
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            "<script setup>\nconst n = 1\n</script>\n<story>\nDefault\n</story>\n",
+            "Component.vue",
+        );
+        assert_eq!(result.warning_count, 1, "got: {:?}", result.diagnostics);
+        assert_eq!(result.diagnostics[0].rule_name, "vue/warn-custom-block");
+    }
+}
+
+#[cfg(test)]
+mod preset_tests {
+    use crate::{LintPreset, Linter};
+
+    fn warn_custom_block_count(result: &crate::LintResult) -> usize {
+        result
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.rule_name == "vue/warn-custom-block")
+            .count()
+    }
+
+    #[test]
+    fn test_opinionated_preset_allows_root_fragment_issue_3210() {
+        // The full preset exercises the shared-descriptor pipeline
+        // (`lint_with_descriptor`), where template rules only ever see the
+        // template inner content; the custom-block scan must not run there.
+        let linter = Linter::with_preset(LintPreset::Opinionated);
+        let result = linter.lint_sfc(
+            "<template>\n  <fieldset />\n<hr />\n<fieldset />\n</template>\n",
+            "FormLayout.vue",
+        );
+        assert_eq!(
+            warn_custom_block_count(&result),
+            0,
+            "got: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn test_opinionated_preset_reports_top_level_custom_block() {
+        let linter = Linter::with_preset(LintPreset::Opinionated);
+        let result = linter.lint_sfc(
+            "<template>\n  <div />\n</template>\n<docs>\n# Docs\n</docs>\n",
+            "FormLayout.vue",
+        );
+        assert_eq!(
+            warn_custom_block_count(&result),
+            1,
+            "got: {:?}",
+            result.diagnostics
+        );
     }
 }


### PR DESCRIPTION
## Root cause

`vue/warn-custom-block` ran as a `run_on_template` rule and rescanned `ctx.source` with a raw-text heuristic: any lowercase tag right after a newline was treated as a top-level SFC block. In every SFC lint path, template rules receive only the **template inner content**, so unindented template children (valid multi-root fragments, exactly what `vize fmt --write` emits) sat at column 0 and were misreported as custom blocks:

```vue
<template>
  <fieldset />
<hr />
<fieldset />
</template>
```

Worse, real top-level custom blocks (`<docs>`, `<i18n>` siblings of `<template>`) never appear in the template content, so in the `lint_sfc` pipeline the heuristic could only ever produce false positives and never a true positive.

## Fix

Reclassify detection on the SFC parser's actual block boundaries instead of indentation:

- The rule now implements `run_on_sfc` and reports each entry of `SfcDescriptor::custom_blocks`, which the parser only populates for genuine top-level non-`template`/`script`/`style` blocks. Anything inside the `<template>` span can never be flagged, independent of indentation.
- Diagnostic span covers exactly the opening tag (`loc.tag_start..loc.start`), matching the previous diagnostic shape; message, help text, rule name, and severity are unchanged.
- `vue/warn-custom-block` is added to `SHARED_SFC_DESCRIPTOR_RULES` so the engine's shared parsed descriptor is reused (with the same lazy `parse_sfc` fallback pattern as `vue/single-style-block` for hosts that drive the rule without one).
- The `.vue`-filename guard from #2245 (no warnings on standalone HTML) is preserved.

As a side effect the rule now also catches custom blocks in script-only SFCs and self-closing `src` blocks (`<i18n src="./locales.json" />`), which the old template-phase scan could never see.

## Verification

- `cargo test -p vize_patina` — 2176 passed, 0 failed (includes the #2245 standalone-HTML regression test).
- New tests: exact issue repro (no warnings), multi-root template with mixed indentation incl. column-0 children (no warnings), top-level `<docs>`/`<i18n>`/multiple/self-closing-`src`/script-only custom blocks (still warn, with exact opening-tag span asserted), custom-block content at column 0 warns once, standard-blocks-only SFC clean, plus full `Opinionated`-preset repro and positive cases through the shared-descriptor pipeline.
- `cargo clippy -p vize_patina --all-targets` — no new warnings in touched files; `cargo fmt --check` clean.

Fixes #3210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of custom blocks in Vue single-file components.
  * Prevented template root fragments from being incorrectly flagged as custom blocks.
  * Added warnings for each detected custom block with more accurate diagnostic locations.
  * Improved resilience when Vue component parsing fails, avoiding misleading warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->