### PR TITLE
fix(patina): allow v-html on dynamic native elements

### DIFF
--- a/crates/vize_patina/src/rules/vue/no_v_text_v_html_on_component.rs
+++ b/crates/vize_patina/src/rules/vue/no_v_text_v_html_on_component.rs
@@ -17,14 +17,15 @@
 //! ### Valid
 //! ```vue
 //! <div v-html="content"></div>
+//! <component is="div" v-html="content" />
 //! <MyComponent>{{ content }}</MyComponent>
 //! ```
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::is_html_tag;
-use vize_relief::{DirectiveNode, ElementNode, ElementType};
+use vize_carton::{is_html_tag, is_native_tag};
+use vize_relief::{DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-v-text-v-html-on-component",
@@ -71,12 +72,76 @@ impl Rule for NoVTextVHtmlOnComponent {
 }
 
 fn is_component_like_tag(element: &ElementNode<'_>) -> bool {
+    // The dynamic-component element renders whatever its `is` prop resolves
+    // to, so it must be classified by that prop instead of its tag name (and
+    // before the `tag_type` check: parser options decide whether `<component>`
+    // itself is typed `Element` or `Component`). A static `is` naming a known
+    // native tag renders that native element, where v-text / v-html are as
+    // safe as on the literal tag (#3211).
+    if is_dynamic_component(element) {
+        return !resolves_to_static_native_tag(element);
+    }
+
     if element.tag_type == ElementType::Component {
         return true;
     }
 
     let tag = element.tag.as_str();
-    tag == "component" || (tag.contains('-') && !is_html_tag(tag))
+    tag.contains('-') && !is_html_tag(tag)
+}
+
+/// Whether the element compiles through `resolveDynamicComponent`.
+///
+/// Mirrors the compiler's `is_dynamic_component` helper in `vize_atelier_core`:
+/// lowercase `<component>` is always Vue's reserved dynamic-component element,
+/// while `<Component>` is only dynamic when it actually carries an `is` prop —
+/// without one it is a user component named `Component` and stays subject to
+/// the plain component classification.
+fn is_dynamic_component(element: &ElementNode<'_>) -> bool {
+    element.tag == "component"
+        || (element.tag == "Component" && element.props.iter().any(is_is_prop))
+}
+
+/// Whether a prop is the `is` attribute or a `:is` binding.
+fn is_is_prop(prop: &PropNode<'_>) -> bool {
+    match prop {
+        PropNode::Attribute(attr) => attr.name == "is",
+        PropNode::Directive(dir) => is_bind_is(dir),
+    }
+}
+
+/// Whether a directive is a static-argument `:is` / `v-bind:is` binding.
+fn is_bind_is(dir: &DirectiveNode<'_>) -> bool {
+    dir.name == "bind"
+        && matches!(&dir.arg, Some(ExpressionNode::Simple(arg)) if arg.content == "is")
+}
+
+/// Whether a dynamic component statically resolves to a native element.
+///
+/// `resolveDynamicComponent` looks the string up in the component registry
+/// first and only falls back to rendering the literal tag, so only values
+/// Vue could never register — known native HTML/SVG/MathML tags — are
+/// accepted. Anything else may still produce a component and stays flagged:
+/// a `:is` binding (which wins over a static `is` attribute in codegen, in
+/// any prop order), a missing/valueless `is`, or a non-native value such as
+/// `is="MyComponent"`. The `vue:` prefix is deliberately NOT stripped: Vue
+/// honours it only on literal native tags (`<button is="vue:x">`), while on
+/// the dynamic-component element the raw value reaches
+/// `resolveDynamicComponent` verbatim, so `is="vue:div"` does not render a
+/// native `<div>`.
+fn resolves_to_static_native_tag(element: &ElementNode<'_>) -> bool {
+    let mut static_is: Option<&str> = None;
+    for prop in element.props.iter() {
+        match prop {
+            PropNode::Directive(dir) if is_bind_is(dir) => return false,
+            // Duplicate `is` attributes: codegen keeps the first.
+            PropNode::Attribute(attr) if attr.name == "is" && static_is.is_none() => {
+                static_is = attr.value.as_ref().map(|v| v.content.as_str());
+            }
+            _ => {}
+        }
+    }
+    static_is.is_some_and(is_native_tag)
 }
 
 #[cfg(test)]
@@ -141,6 +206,112 @@ mod tests {
         let linter = create_linter();
         let result =
             linter.lint_template(r#"<MyComponent>{{ content }}</MyComponent>"#, "test.vue");
+        assert_eq!(result.error_count, 0);
+    }
+
+    /// Exact reproduction of #3211: a static `is="div"` resolves to a native
+    /// `<div>`, so `v-html` must be allowed exactly as on a literal `<div>`.
+    #[test]
+    fn test_valid_v_html_on_component_with_static_native_is_sfc() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            r#"<script setup lang="ts">
+defineProps<{ html: string }>();
+</script>
+
+<template>
+  <component is="div" v-html="html" />
+</template>"#,
+            "App.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_valid_v_text_on_component_with_static_is_span() {
+        let linter = create_linter();
+        let result =
+            linter.lint_template(r#"<component is="span" v-text="content" />"#, "test.vue");
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_valid_v_html_on_component_with_static_is_svg_tag() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<component is="svg" v-html="content" />"#, "test.vue");
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_valid_v_html_on_uppercase_component_tag_with_static_native_is() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<Component is="div" v-html="content" />"#, "test.vue");
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_invalid_v_html_on_component_with_static_component_is() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<component is="MyComponent" v-html="content" />"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_html_on_component_with_unknown_is() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<component is="unknown-thing" v-html="content" />"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_html_on_component_without_is() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<component v-html="content" />"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    /// Vue strips the `vue:` prefix only on literal native tags; on
+    /// `<component>` the value reaches `resolveDynamicComponent` verbatim and
+    /// does not render a native `<div>`, so the directive stays flagged.
+    #[test]
+    fn test_invalid_v_html_on_component_with_vue_prefixed_is() {
+        let linter = create_linter();
+        let result =
+            linter.lint_template(r#"<component is="vue:div" v-html="content" />"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    /// A `:is` binding wins over a static `is` attribute in codegen, so the
+    /// element may still resolve to a component at runtime.
+    #[test]
+    fn test_invalid_v_html_when_bind_is_shadows_static_native_is() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<component is="div" :is="tagName" v-html="content" />"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_v_html_on_uppercase_component_tag_without_is() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<Component v-html="content" />"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    /// On a literal native element `is` means customized built-in elements,
+    /// not component substitution — behavior there must not change.
+    #[test]
+    fn test_valid_v_html_on_native_element_with_is_attribute() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div is="my-thing" v-html="content" />"#, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 }


### PR DESCRIPTION
## Root cause

`vue/no-v-text-v-html-on-component` classified elements as "component-like" purely by tag name: any `<component>` was treated as a component, so `v-html` / `v-text` were rejected even when a static `is` attribute pins the dynamic component to a native tag. But `<component is="div">` compiles to `resolveDynamicComponent("div")`, which falls back to rendering a literal native `<div>` — where `v-html` is exactly as safe as on a written-out `<div>`.

## Fix

Classification of the dynamic-component element (`<component>`, and `<Component>` when it carries an `is` prop, mirroring the compiler's `is_dynamic_component` helper in `vize_atelier_core`) now resolves the static `is` target:

- `is="div"` / `is="span"` / any known native HTML/SVG/MathML tag (via the existing `vize_carton::is_native_tag`) → treated as that native element, no diagnostic.
- Still flagged: dynamic `:is="expr"` (which also wins over a static `is` attribute in codegen, in any prop order), a missing or valueless `is`, `is="MyComponent"`, and any other non-native value.
- `is="vue:div"` stays flagged: Vue strips the `vue:` prefix only on literal native tags (`<button is="vue:x">`); on the dynamic-component element the raw value reaches `resolveDynamicComponent` verbatim and does not render a native `<div>`.
- Behavior for non-`<component>` tags is unchanged — on a literal native element (`<div is="my-thing">`) the `is` attribute means customized built-in elements and is not component substitution.

## Verification

- `cargo test -p vize_patina` — 2178 passed, 0 failed (18 tests for this rule, including the exact issue reproduction as an SFC and the `is="span"` v-text variant).
- `cargo clippy -p vize_patina --all-targets` — no warnings in touched files.
- `cargo fmt --check` — clean.

Fixes #3211

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of `v-text` and `v-html` on dynamic components.
  * These directives are now allowed when a dynamic component resolves to a native HTML, SVG, or MathML element.
  * Improved handling of dynamic and static `is` attributes, casing, prefixes, duplicates, and missing values.
  * Native elements using the `is` attribute are no longer incorrectly flagged.

* **Documentation**
  * Updated rule examples to reflect the corrected validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->