### PR TITLE
test(compose): enforce side-effect-free imports and tree-shakeability

### DIFF
--- a/npm/compose/core/src/async-resource.ts
+++ b/npm/compose/core/src/async-resource.ts
@@ -52,12 +52,35 @@ export interface UseAsyncResourceOptions<Data> {
 
 /** Reactive state and controls for an asynchronous loader. */
 export interface AsyncResource<Data, Arguments extends readonly unknown[], Failure> {
+  /** Data of the newest successful execution, retained according to `keepData`. */
   readonly data: Readonly<ShallowRef<Data | undefined>>;
+
+  /** Failure of the newest settled execution, cleared when a new one starts. */
   readonly error: Readonly<ShallowRef<Failure | undefined>>;
+
+  /** Current lifecycle status, driven only by the newest execution. */
   readonly status: Readonly<Ref<AsyncResourceStatus>>;
+
+  /** Whether an execution is currently pending. */
   readonly pending: ComputedRef<boolean>;
+
+  /**
+   * Run the loader. The returned promise never rejects: loader failures,
+   * cancellation, and supersession are reported as the discriminated result,
+   * and stale executions leave the reactive state untouched.
+   */
   readonly execute: (...arguments_: Arguments) => Promise<AsyncResourceExecution<Data, Failure>>;
+
+  /**
+   * Abort the active execution and mark the resource cancelled.
+   *
+   * @param reason Abort reason forwarded to the loader's signal.
+   * @default reason DOMException("AbortError")
+   * @returns Whether an active execution was cancelled.
+   */
   readonly cancel: (reason?: unknown) => boolean;
+
+  /** Cancel any active execution and restore the initial idle state. */
   readonly reset: () => void;
 }
 
@@ -71,6 +94,18 @@ interface ActiveExecution {
  * Create a scoped, abortable asynchronous resource with latest-result-wins
  * state. Every execution returns a discriminated result, so cancellation,
  * supersession, loader failure, and successful `undefined` data stay distinct.
+ *
+ * When created inside an active reactive scope (and `scope` is enabled), the
+ * active execution is aborted when that scope stops; outside a scope,
+ * cancellation ownership stays with the caller. The execute promise never
+ * rejects — synchronous and asynchronous loader failures both settle into
+ * the `"error"` result. Safe during server rendering: no browser globals are
+ * read and abort reasons use the runtime-native `DOMException`.
+ *
+ * @param loader Asynchronous loader receiving the abort context first.
+ * @param options Data retention, supersession, and scope behavior.
+ * @default options {}
+ * @returns Reactive state and controls for the loader.
  */
 export function useAsyncResource<Data, Arguments extends readonly unknown[], Failure = unknown>(
   loader: (context: AsyncResourceContext, ...arguments_: Arguments) => Promise<Data>,

--- a/npm/compose/core/src/docs-coverage.test.ts
+++ b/npm/compose/core/src/docs-coverage.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const sourceDirectory = new URL(".", import.meta.url);
+
+/**
+ * Top-level exported declarations that must carry documentation. Re-export
+ * statements (`export {…}`, `export * from`, `export type {…}`) are exempt:
+ * they forward symbols documented at their declaration site.
+ */
+const EXPORT_DECLARATION =
+  /^export\s+(?:abstract\s+)?(?:async\s+)?(?:function|const|let|var|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/;
+
+/** Exported options-bag interfaces whose optional members need `@default`. */
+const OPTIONS_INTERFACE = /^export interface [A-Za-z_$][\w$]*Options\b.*\{$/;
+
+/** An optional property declaration inside an interface body. */
+const OPTIONAL_PROPERTY = /^\s*(?:readonly\s+)?([\w$]+)\?:/;
+
+function listSourceFiles(): readonly string[] {
+  return readdirSync(sourceDirectory)
+    .filter((name) => name.endsWith(".ts") && !name.endsWith(".test.ts"))
+    .sort();
+}
+
+function readSourceLines(file: string): readonly string[] {
+  return readFileSync(new URL(file, sourceDirectory), "utf8").split("\n");
+}
+
+/**
+ * Return the JSDoc block whose closing marker sits directly above the given
+ * line, or `undefined` when the declaration is undocumented or preceded only
+ * by a plain (non-JSDoc) comment.
+ */
+function docBlockAbove(lines: readonly string[], declarationLine: number): string | undefined {
+  let line = declarationLine - 1;
+  const closing = lines[line]?.trim();
+  if (closing === undefined || !closing.endsWith("*/")) return undefined;
+
+  const collected: string[] = [];
+  while (line >= 0) {
+    const text = (lines[line] ?? "").trim();
+    collected.unshift(text);
+    if (text.includes("/**")) return collected.join("\n");
+    if (text.includes("/*") || !text.startsWith("*")) return undefined;
+    line -= 1;
+  }
+  return undefined;
+}
+
+void test("every exported declaration is directly preceded by a JSDoc block", () => {
+  const problems: string[] = [];
+  let declarations = 0;
+
+  for (const file of listSourceFiles()) {
+    const lines = readSourceLines(file);
+    const seenNames = new Set<string>();
+
+    for (const [index, lineText] of lines.entries()) {
+      const match = EXPORT_DECLARATION.exec(lineText);
+      if (!match) continue;
+      const name = match[1] ?? "";
+      // Later declarations of a seen name are overload signatures or the
+      // overload implementation; the group is documented once, on its first
+      // declaration, matching the package style.
+      if (seenNames.has(name)) continue;
+      seenNames.add(name);
+      declarations += 1;
+
+      if (docBlockAbove(lines, index) === undefined) {
+        problems.push(`${file}:${index + 1} export "${name}" has no JSDoc block directly above`);
+      }
+    }
+  }
+
+  // Guard the scanner itself: if the regex rots, the suite must fail loudly
+  // instead of silently checking nothing.
+  assert.ok(declarations >= 20, `expected >= 20 exported declarations, found ${declarations}`);
+  assert.deepEqual(problems, []);
+});
+
+void test("optional members of exported options interfaces document their @default", () => {
+  const problems: string[] = [];
+  let optionalMembers = 0;
+
+  for (const file of listSourceFiles()) {
+    const lines = readSourceLines(file);
+    let insideOptionsInterface = false;
+
+    for (const [index, lineText] of lines.entries()) {
+      if (OPTIONS_INTERFACE.test(lineText)) {
+        insideOptionsInterface = true;
+        continue;
+      }
+      if (insideOptionsInterface && lineText === "}") {
+        insideOptionsInterface = false;
+        continue;
+      }
+      if (!insideOptionsInterface) continue;
+
+      const property = OPTIONAL_PROPERTY.exec(lineText);
+      if (!property) continue;
+      optionalMembers += 1;
+
+      const documentation = docBlockAbove(lines, index);
+      if (documentation === undefined || !documentation.includes("@default")) {
+        problems.push(
+          `${file}:${index + 1} optional option "${property[1] ?? ""}" must document @default`,
+        );
+      }
+    }
+  }
+
+  assert.ok(optionalMembers >= 15, `expected >= 15 optional options, found ${optionalMembers}`);
+  assert.deepEqual(problems, []);
+});

--- a/npm/compose/core/src/event-listener.ts
+++ b/npm/compose/core/src/event-listener.ts
@@ -27,7 +27,8 @@ export interface UseEventListenerOptions {
   readonly passive?: boolean;
 
   /**
-   * Stop listening when this signal is aborted.
+   * Stop listening when this signal is aborted. An already-aborted signal
+   * prevents listening from ever starting.
    *
    * @default undefined
    */
@@ -56,7 +57,8 @@ export interface EventListenerControls {
   /**
    * Begin listening.
    *
-   * @returns Whether a new reactive listener was started.
+   * @returns Whether a new reactive listener was started. `false` while
+   * already listening and after the abort signal has fired.
    */
   readonly start: () => boolean;
 
@@ -66,13 +68,23 @@ export interface EventListenerControls {
 
 /**
  * Attach an event listener to a reactive target and clean it up with the
- * current reactive scope. Missing targets are valid during server rendering.
+ * current reactive scope. Missing targets are valid during server rendering:
+ * a `null`/`undefined` target keeps the listener detached until a concrete
+ * target appears, so no browser globals are required.
+ *
+ * The listener is re-attached whenever the reactive target changes and is
+ * removed when the owning reactive scope stops, when
+ * {@link EventListenerControls.stop} is called, or when the abort signal
+ * fires. Outside an active scope, teardown ownership stays with the caller,
+ * who must call `stop` explicitly. Errors thrown by a custom target's
+ * add/remove methods propagate to the active watcher run.
  *
  * @param target Reactive event target.
  * @param event Event name.
  * @param listener Typed event listener.
  * @param options Listener lifecycle and scheduling options.
  * @default options {}
+ * @returns Controls to observe and change the listening state.
  */
 export function useEventListener<Key extends keyof WindowEventMap>(
   target: MaybeRefOrGetter<Window | null | undefined>,

--- a/npm/compose/core/src/event-listener.ts
+++ b/npm/compose/core/src/event-listener.ts
@@ -57,8 +57,9 @@ export interface EventListenerControls {
   /**
    * Begin listening.
    *
-   * @returns Whether a new reactive listener was started. `false` while
-   * already listening and after the abort signal has fired.
+   * @returns Whether a new reactive watcher was started. `false` while the
+   * watcher is already active (including a null-target watcher with no
+   * listener attached) and after the abort signal has fired.
    */
   readonly start: () => boolean;
 

--- a/npm/compose/core/src/locale.ts
+++ b/npm/compose/core/src/locale.ts
@@ -21,7 +21,12 @@ export interface UseLocaleOptions {
   readonly fallback?: Intl.Locale | string;
 }
 
-/** Reactive locale metadata and cached formatter factories. */
+/**
+ * Reactive locale metadata and cached formatter factories.
+ *
+ * Formatter factories propagate `TypeError` and `RangeError` from the
+ * platform `Intl` constructors when the supplied options are invalid.
+ */
 export interface LocaleControls {
   /** Canonical Unicode locale identifier. */
   readonly locale: ComputedRef<string>;
@@ -53,6 +58,19 @@ const FORMATTER_CACHE_LIMIT = 32;
  * Equivalent formatter options reuse instances. The bounded cache follows the
  * active locale automatically and prevents repeated constructor overhead in
  * reactive render paths.
+ *
+ * Detection is lazy and guarded: the default detector reads
+ * `navigator.language` behind a `typeof` check at call time, so importing and
+ * calling this during server rendering is safe, and runtimes without a
+ * `navigator` resolve to the fallback locale. The composable owns no timers
+ * or listeners, so no scope cleanup is required.
+ *
+ * @param source Reactive locale source. Empty values defer to the detector.
+ * @param options Detection and fallback behavior.
+ * @default options {}
+ * @throws `RangeError` on first read of the reactive values when the winning
+ * candidate is not a structurally valid locale identifier.
+ * @returns Reactive locale metadata and cached formatter factories.
  */
 export function useLocale(
   source?: MaybeRefOrGetter<Intl.Locale | string | null | undefined>,

--- a/npm/compose/core/src/media-query.ts
+++ b/npm/compose/core/src/media-query.ts
@@ -27,9 +27,18 @@ export interface UseMediaQueryOptions {
 /**
  * Evaluate a reactive media query without requiring browser globals.
  *
+ * During server rendering (or whenever no capability host resolves) the ref
+ * holds the configured server value and no subscription is created. The
+ * change subscription follows the reactive query and host: each
+ * re-evaluation removes the previous listener, and the final listener is
+ * removed when the owning reactive scope stops. Call inside an active scope
+ * so the subscription is released. A host whose matcher throws propagates
+ * the error to the active effect run; the browser default never throws.
+ *
  * @param query Reactive media-query source.
  * @param options Runtime capability and server-rendered fallback.
  * @default options {}
+ * @returns Readonly ref that is `true` while the query matches.
  */
 export function useMediaQuery(
   query: MaybeRefOrGetter<string>,
@@ -62,8 +71,13 @@ export type MotionPreference = "reduce" | "no-preference";
 /**
  * Return the reactive user motion preference.
  *
+ * Shares {@link useMediaQuery} semantics: during server rendering the
+ * preference is `"no-preference"` unless `ssrValue` is `true`, and the
+ * underlying subscription is removed when the owning reactive scope stops.
+ *
  * @param options Runtime capability and server-rendered fallback.
  * @default options {}
+ * @returns Computed preference for `(prefers-reduced-motion: reduce)`.
  */
 export function useReducedMotion(
   options: UseMediaQueryOptions = {},

--- a/npm/compose/core/src/scope.ts
+++ b/npm/compose/core/src/scope.ts
@@ -3,6 +3,14 @@ import { getCurrentScope, onScopeDispose } from "vue";
 /**
  * Register cleanup in the active reactive scope when one exists.
  *
+ * This is the shared lifecycle primitive of the package: composables hand
+ * their teardown here so owned resources are released when the surrounding
+ * scope stops.
+ *
+ * Never throws and is safe during server rendering; no browser globals are
+ * read. When no scope is active the cleanup is not registered and disposal
+ * ownership stays with the caller.
+ *
  * @param cleanup Cleanup invoked exactly once when the scope is disposed.
  * @returns Whether the cleanup was registered.
  */

--- a/npm/compose/core/src/temporal.ts
+++ b/npm/compose/core/src/temporal.ts
@@ -108,7 +108,7 @@ function shouldSchedule(options: UseTemporalNowOptions): boolean {
  *
  * The timer is replaced when reactive options change and is always cancelled
  * when the owning scope stops. Call inside an active effect scope; without
- * one, the interval keeps running until the clock is unreachable. During
+ * one, there is no automatic timer cleanup. During
  * server rendering, no timer starts unless
  * {@link UseTemporalNowOptions.runOnServer} is explicitly enabled.
  *

--- a/npm/compose/core/src/temporal.ts
+++ b/npm/compose/core/src/temporal.ts
@@ -107,8 +107,17 @@ function shouldSchedule(options: UseTemporalNowOptions): boolean {
  * effect scope.
  *
  * The timer is replaced when reactive options change and is always cancelled
- * when the owning scope stops. During server rendering, no timer starts unless
+ * when the owning scope stops. Call inside an active effect scope; without
+ * one, the interval keeps running until the clock is unreachable. During
+ * server rendering, no timer starts unless
  * {@link UseTemporalNowOptions.runOnServer} is explicitly enabled.
+ *
+ * @param options Clock scheduling, pause, and runtime overrides.
+ * @default options {}
+ * @throws `RangeError` tagged `VIZE_COMPOSE_TEMPORAL_INVALID_INTERVAL` when
+ * the resolved interval is not finite or not greater than zero, both
+ * synchronously at creation and on invalid reactive updates.
+ * @returns Reactive clock controls.
  */
 export function useTemporalNow(options: UseTemporalNowOptions = {}): TemporalClock {
   const readNow = options.now ?? Temporal.Now.instant;
@@ -144,7 +153,14 @@ export function useTemporalNow(options: UseTemporalNowOptions = {}): TemporalClo
  * Creates a reactive zoned date-time derived from a scoped Temporal clock.
  *
  * Changes to {@link UseTemporalZonedDateTimeOptions.timeZone} are reflected
- * without replacing the underlying timer.
+ * without replacing the underlying timer. Scheduling, server rendering, and
+ * scope-cleanup rules are shared with {@link useTemporalNow}.
+ *
+ * @param options Clock scheduling plus the reactive time zone.
+ * @default options {}
+ * @throws `RangeError` for invalid intervals (see {@link useTemporalNow}),
+ * and on read when the reactive time zone cannot be resolved by Temporal.
+ * @returns Computed zoned date-time in the reactive time zone.
  */
 export function useTemporalZonedDateTime(
   options: UseTemporalZonedDateTimeOptions = {},
@@ -159,4 +175,8 @@ export function useTemporalZonedDateTime(
   });
 }
 
+/**
+ * Temporal API namespaces re-exported from the underlying polyfill so hosts
+ * can construct instants and time zones without a direct dependency.
+ */
 export { Temporal, TemporalIntl };

--- a/npm/compose/core/src/treeshake.test.ts
+++ b/npm/compose/core/src/treeshake.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { build } from "vite-plus";
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+const sourceDirectory = fileURLToPath(new URL(".", import.meta.url));
+const entries = {
+  index: fileURLToPath(new URL("index.ts", import.meta.url)),
+  temporal: fileURLToPath(new URL("temporal.ts", import.meta.url)),
+} as const;
+
+/**
+ * Fingerprints that identify each source module inside an unminified
+ * production bundle. Comments are stripped before matching, so identifiers
+ * and string literals are reliable module markers: none of them appears in
+ * another module or in the retained external `vue` import specifiers.
+ */
+const sentinels = {
+  scope: ["tryOnScopeDispose"],
+  "event-listener": ["useEventListener", "isListening"],
+  "media-query": ["useMediaQuery", "matchMedia"],
+  locale: ["useLocale", "getTextInfo"],
+  "async-resource": ["useAsyncResource", "A newer execution started."],
+  temporal: ["useTemporalNow", "VIZE_COMPOSE_TEMPORAL_INVALID_INTERVAL"],
+} as const;
+
+type ModuleName = keyof typeof sentinels;
+
+interface UtilityCase {
+  readonly binding: string;
+  readonly entry: keyof typeof entries;
+  readonly module: ModuleName;
+  /** Documented shared infrastructure allowed alongside the module itself. */
+  readonly shared: readonly ModuleName[];
+}
+
+const utilities: readonly UtilityCase[] = [
+  { binding: "tryOnScopeDispose", entry: "index", module: "scope", shared: [] },
+  { binding: "useEventListener", entry: "index", module: "event-listener", shared: ["scope"] },
+  { binding: "useMediaQuery", entry: "index", module: "media-query", shared: [] },
+  { binding: "useReducedMotion", entry: "index", module: "media-query", shared: [] },
+  { binding: "useLocale", entry: "index", module: "locale", shared: [] },
+  { binding: "useAsyncResource", entry: "index", module: "async-resource", shared: ["scope"] },
+  { binding: "useTemporalNow", entry: "temporal", module: "temporal", shared: [] },
+  { binding: "useTemporalZonedDateTime", entry: "temporal", module: "temporal", shared: [] },
+];
+
+const VIRTUAL_ID = "virtual:compose-treeshake-entry";
+const RESOLVED_ID = `\0${VIRTUAL_ID}`;
+
+/**
+ * Bundle a scratch entry in production mode, exactly like a consumer build.
+ *
+ * By default the package's own `"sideEffects": false` manifest hint is
+ * neutralized: every `src` module is resolved with `moduleSideEffects: true`,
+ * so statements survive on honest per-statement analysis alone. Without this,
+ * the manifest lets the bundler drop a genuinely side-effectful module
+ * wholesale and the emptiness assertions below would be vacuous.
+ * `trustManifest` restores the consumer-visible semantics.
+ */
+async function bundleEntry(entryCode: string, trustManifest = false): Promise<string> {
+  const result = await build({
+    configFile: false,
+    logLevel: "error",
+    root: packageRoot,
+    plugins: [
+      {
+        name: "compose-treeshake-entry",
+        enforce: "pre",
+        resolveId(id: string, importer: string | undefined) {
+          if (id === VIRTUAL_ID) return RESOLVED_ID;
+          if (trustManifest) return undefined;
+          const importedFrom = importer === RESOLVED_ID ? packageRoot : dirname(importer ?? "/");
+          const target = id.startsWith("./") ? resolve(importedFrom, id) : id;
+          if (target.startsWith(sourceDirectory) && target.endsWith(".ts")) {
+            return { id: target, moduleSideEffects: true };
+          }
+          return undefined;
+        },
+        load(id: string) {
+          return id === RESOLVED_ID ? entryCode : undefined;
+        },
+      },
+    ],
+    build: {
+      write: false,
+      minify: false,
+      target: "es2022",
+      reportCompressedSize: false,
+      rollupOptions: {
+        input: VIRTUAL_ID,
+        preserveEntrySignatures: "strict",
+        // The peer and the runtime dependency stay external, matching how
+        // `vp pack` builds the published entries.
+        external: ["vue", "temporal-polyfill-lite"],
+        // Both externals declare side-effect freedom in their own manifests;
+        // unresolved externals would otherwise be conservatively retained.
+        treeshake: { moduleSideEffects: "no-external" },
+        output: { format: "es" },
+      },
+    },
+  });
+  assert.ok(!Array.isArray(result), "expected a single-environment build result");
+  assert.ok("output" in result, "expected an in-memory rollup output");
+  return result.output.map((item) => (item.type === "chunk" ? item.code : "")).join("\n");
+}
+
+/** Remove block comments and comment-only lines before sentinel matching. */
+function stripComments(code: string): string {
+  return code.replaceAll(/\/\*[^]*?\*\//g, "").replaceAll(/^[\t ]*\/\/.*$/gm, "");
+}
+
+void test("the package manifest declares side-effect freedom", () => {
+  const manifest = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  ) as { sideEffects?: unknown };
+
+  assert.equal(manifest.sideEffects, false);
+});
+
+void test("module-level code performs no work: a bare import bundles to nothing", async () => {
+  for (const [name, entry] of Object.entries(entries)) {
+    const code = stripComments(await bundleEntry(`import ${JSON.stringify(entry)};`));
+    assert.equal(
+      code.trim(),
+      "",
+      `entry "${name}" retained module-level side effects:\n${code.trim()}`,
+    );
+  }
+});
+
+void test("consumers honoring the manifest can drop the unused package wholesale", async () => {
+  for (const [name, entry] of Object.entries(entries)) {
+    const code = stripComments(await bundleEntry(`import ${JSON.stringify(entry)};`, true));
+    assert.equal(code.trim(), "", `entry "${name}" must be fully removable when unused`);
+  }
+});
+
+for (const { binding, entry, module, shared } of utilities) {
+  void test(`bundling only ${binding} excludes every unrelated utility`, async () => {
+    const code = stripComments(
+      await bundleEntry(`export { ${binding} } from ${JSON.stringify(entries[entry])};`),
+    );
+
+    for (const sentinel of sentinels[module]) {
+      assert.ok(code.includes(sentinel), `${binding} bundle lost its own marker "${sentinel}"`);
+    }
+
+    const allowed = new Set<ModuleName>([module, ...shared]);
+    for (const other of Object.keys(sentinels) as ModuleName[]) {
+      if (allowed.has(other)) continue;
+      for (const sentinel of sentinels[other]) {
+        assert.ok(
+          !code.includes(sentinel),
+          `${binding} bundle must not pull "${sentinel}" from ${other}`,
+        );
+      }
+    }
+  });
+}
+
+void test("unused sibling exports of the same module are eliminated", async () => {
+  const media = stripComments(
+    await bundleEntry(`export { useMediaQuery } from ${JSON.stringify(entries.index)};`),
+  );
+  assert.ok(!media.includes("useReducedMotion"), "useReducedMotion should be dropped");
+  assert.ok(!media.includes("prefers-reduced-motion"), "the motion query should be dropped");
+
+  const temporal = stripComments(
+    await bundleEntry(`export { useTemporalNow } from ${JSON.stringify(entries.temporal)};`),
+  );
+  assert.ok(
+    !temporal.includes("useTemporalZonedDateTime"),
+    "useTemporalZonedDateTime should be dropped",
+  );
+});
+
+void test("importing an entry executes no module-level browser-global access", () => {
+  for (const [name, entry] of Object.entries(entries)) {
+    // The peer dependency is imported before the traps are installed, so the
+    // probe measures this package (plus its bundled dependencies) only. The
+    // throwing getters fail even a `typeof window` guard hoisted to module
+    // scope, keeping capability detection lazy by construction. The probe
+    // runs `src/*.ts` through the same type-stripping runtime as this suite.
+    const probe = [
+      'import "vue";',
+      'for (const name of ["window", "document", "navigator"]) {',
+      "  Object.defineProperty(globalThis, name, {",
+      "    configurable: true,",
+      "    get() {",
+      "      throw new Error(`[import-side-effect] module-level access to globalThis.${name}`);",
+      "    },",
+      "  });",
+      "}",
+      `await import(${JSON.stringify(pathToFileURL(entry).href)});`,
+    ].join("\n");
+
+    const result = spawnSync(process.execPath, ["--input-type=module", "--eval", probe], {
+      cwd: packageRoot,
+      encoding: "utf8",
+    });
+    assert.equal(
+      result.status,
+      0,
+      `entry "${name}" ran a module-level side effect:\n${result.stderr}`,
+    );
+  }
+});


### PR DESCRIPTION
## What is enforced

Two new package-local gates in `npm/compose/core` (plain `node:test`, picked up by the existing `test` script) make the #3136 packaging principles fail CI instead of relying on review:

1. **`src/treeshake.test.ts`** — bundles scratch entries with the workspace bundler (`vite-plus` programmatic `build()`, production mode, `minify: false`, `vue`/`temporal-polyfill-lite` external):
   - `"sideEffects": false` must stay declared in the manifest.
   - **Code purity**: a bare `import` of `index.ts`/`temporal.ts` must bundle to nothing under forced per-statement analysis. The package's own `sideEffects` manifest hint is neutralized (a pre-enforced `resolveId` returns `moduleSideEffects: true` for `src` modules), because otherwise the bundler trusts the manifest, drops even a genuinely side-effectful module wholesale, and the assertion is vacuous — this is exactly the "manifest lies" hazard the gate must catch.
   - **Consumer contract**: the same bare imports also bundle to nothing with the manifest honored, documenting what downstream bundlers do.
   - **Per-utility isolation**: bundling a single named export (`tryOnScopeDispose`, `useEventListener`, `useMediaQuery`, `useReducedMotion`, `useLocale`, `useAsyncResource`, `useTemporalNow`, `useTemporalZonedDateTime`) must contain that module's sentinel identifiers/strings and none of the other modules' (comments stripped before matching). `scope.ts` is allowed only where it is documented shared infrastructure (event-listener, async-resource).
   - **Sibling elimination**: importing `useMediaQuery` drops `useReducedMotion` (and the motion query literal); importing `useTemporalNow` drops `useTemporalZonedDateTime`.
   - **Import-time probe**: a subprocess imports `vue`, installs throwing getters for `window`/`document`/`navigator` on `globalThis`, then imports each entry — any module-level browser-global access fails, including a hoisted `typeof window` guard.
2. **`src/docs-coverage.test.ts`** — zero-dependency line scan: every top-level exported declaration in `src/*.ts` must be directly preceded by a JSDoc block (overload groups documented once; re-export statements exempt), and every optional member of an exported `*Options` interface must document its `@default`. Scanner self-guards assert it keeps finding ≥20 declarations / ≥15 optional members so regex rot cannot silently pass.

The six modules also get a shared-contract documentation pass to that bar: SSR behavior, `@throws`/failure modes, cleanup and ownership rules (notably the previously undocumented `AsyncResource` members, `useAsyncResource`'s never-rejecting execute, `useTemporalNow`'s `RangeError` code, and `useLocale`'s lazy guarded detection).

No `package.json` change was needed: `"sideEffects": false` was already declared, and reading all six modules confirmed no module-level side effects exist (the probe and purity bundles now prove it continuously).

## Verification

- `vp run --filter './npm/compose/core' test` — 38/38 pass (existing 23 + 15 new; includes `vp pack` + size budget via `pretest`).
- `vp run --filter './npm/compose/core' check` — format and type-aware lint clean.
- Negative controls exercised locally, each tripping the intended gate and then reverted:
  - hoisted `const HOISTED_GUARD = typeof window !== "undefined"` → probe fails;
  - `useLocale` calling into `scope.ts` → isolation fails (`useLocale bundle must not pull "tryOnScopeDispose" from scope`);
  - module-level `console.warn` → code-purity emptiness fails (and demonstrated the manifest-trusting variant alone would not catch it);
  - undocumented `export const` → docs coverage fails with file:line.
- New files are 213 and 117 lines, within the new-file budget.

Fixes #3229

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified behavior for asynchronous resources, including cancellation, superseded requests, retained data, and result handling.
  - Expanded guidance for event listeners, locale detection, media queries, reduced-motion preferences, temporal utilities, and lifecycle cleanup.
  - Added details on server-rendering behavior, browser capability detection, validation errors, and timer management.

- **Tests**
  - Added automated checks for API documentation coverage, option defaults, tree-shaking, and safe imports without browser globals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->