### PR TITLE
test(fresco): bootstrap the JS component test baseline

### DIFF
--- a/npm/fresco/CONTRIBUTING-tests.md
+++ b/npm/fresco/CONTRIBUTING-tests.md
@@ -1,0 +1,54 @@
+# Fresco JS test baseline
+
+`pnpm test` runs `node:test` suites (via `vp exec tsx --test 'src/**/*.test.ts'`).
+`pnpm check` includes `tsgo --noEmit`, which gates the compile-only type tests.
+
+## The three-part standard
+
+Every suite in `npm/fresco/src` follows three rules (see #3228):
+
+1. **Render-snapshot tests assert the mounted output tree.** Mount through the
+   real renderer and compare `FrescoNode` trees (or `treeToRenderNodes` /
+   `renderToString` output) against inline expected structures with
+   `assert.deepEqual`. Never assert on source text, and avoid giant snapshots:
+   keep expected trees small enough to read inline.
+2. **Type-level tests cover public props/emits.** Compile-only `*.test-d.ts`
+   files (see `src/components/types.test-d.ts`) pair positive cases with
+   `@ts-expect-error` negatives; `tsgo` fails when either direction regresses.
+3. **Behavior tests cover keyboard/focus ownership.** Drive keys through
+   `dispatchKey`/`typeChars` (the same `lastKeyEvent` ref the interactive event
+   loop writes) and assert focus against the `FocusManager` contract.
+
+## The native seam
+
+There is no mock of `@vizejs/fresco-native`. The JS layer is pure up to the
+byte boundary that crosses into Rust: `renderer.ts` imports only types from the
+native package, and `app.ts` loads it lazily and only in interactive mode.
+Tests therefore run the shipped code end-to-end:
+
+- `mountFresco` (in `src/testing/mount.ts`) mounts components with the same
+  provide set `createApp` installs (app context, focus manager, screen reader
+  flag, streams, cursor) and exposes the live mounted tree.
+- `treeToRenderNodes(root)` returns the exact flat payload the native
+  `renderTree` call would paint; assert on it for style/appearance mapping.
+- `renderToString(root)` covers the plain-text output path.
+
+If a future test needs a runtime native API, add a typed seam instead of
+importing the binding: keep the fake at the narrowest boundary possible.
+
+## Adding a component test
+
+1. Create `src/components/YourComponent.test.ts` (colocated, `node:test`).
+2. Mount with `mountComponent(YourComponent, props, slot?, options?)`.
+3. Assert the tree with `toTreeSnapshot(firstChild(mounted))` against an
+   inline expected object, or read targeted props off `firstChild(mounted)`.
+   Note: Boolean-declared props default to `false` and appear on emitted host
+   nodes; assert them explicitly.
+4. For interaction, pass `focused: true` (or use `useFocus` ids) and drive
+   `await dispatchKey({ key: "enter" })` / `await typeChars("abc")`; reactive
+   updates need `await nextTick()` before re-reading the tree.
+5. Always `mounted.unmount()` so composable lifecycles (focus unregister,
+   watcher disposal) are exercised.
+6. Extend `src/components/types.test-d.ts` with the component's public
+   props/emits, including at least one `@ts-expect-error` negative per prop
+   group.

--- a/npm/fresco/package.json
+++ b/npm/fresco/package.json
@@ -47,16 +47,20 @@
   "scripts": {
     "build": "vp pack",
     "dev": "vp pack --watch",
-    "check": "vp check src vite.config.ts",
+    "check": "vp check src vite.config.ts && tsgo --noEmit -p tsconfig.json",
     "check:fix": "vp check --fix src vite.config.ts",
-    "fmt": "vp fmt --write src vite.config.ts"
+    "check:types": "tsgo --noEmit -p tsconfig.json",
+    "fmt": "vp fmt --write src vite.config.ts",
+    "test": "vp exec tsx --test 'src/**/*.test.ts'"
   },
   "dependencies": {
     "@vizejs/fresco-native": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "catalog:typescript",
+    "@typescript/native-preview": "catalog:typescript",
     "@vue/runtime-core": "catalog:vue-stable",
+    "tsx": "catalog:typescript",
     "typescript": "catalog:typescript",
     "vite-plus": "catalog:vite-stack"
   },

--- a/npm/fresco/src/app.ts
+++ b/npm/fresco/src/app.ts
@@ -13,7 +13,7 @@ import {
   type Ref,
   type VNode,
 } from "@vue/runtime-core";
-import type { InputEventNapi } from "@vizejs/fresco-native";
+import type { InputEventNapi, ModifiersNapi } from "@vizejs/fresco-native";
 import {
   SCREEN_READER_KEY,
   isScreenReaderEnabledByDefault,
@@ -824,7 +824,7 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
     }
 
     if (event.eventType === "key") {
-      const modifiers = event.modifiers ?? {};
+      const modifiers: Partial<ModifiersNapi> = event.modifiers ?? {};
       lastKeyEvent.value = {
         type: "key",
         key: event.key ?? undefined,

--- a/npm/fresco/src/components/Box.test.ts
+++ b/npm/fresco/src/components/Box.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { h } from "@vue/runtime-core";
+
+import { firstChild, mountComponent, toTreeSnapshot } from "../testing/mount.js";
+import { Box } from "./Box.js";
+
+// Box declares Boolean props, so Vue defaults them to false and the render
+// function forwards them onto the host node; they are inert downstream
+// (treeToRenderNodes drops falsy appearance) but part of the output tree.
+const boxDefaults = { borderDimColor: false, "aria-hidden": false };
+
+void test("renders a box node and forwards children", () => {
+  const mounted = mountComponent(Box, {}, () => h("text", { text: "inside" }));
+
+  assert.deepEqual(toTreeSnapshot(firstChild(mounted)), {
+    type: "box",
+    props: { style: {}, ...boxDefaults },
+    children: [{ type: "text", props: { text: "inside" } }],
+  });
+  mounted.unmount();
+});
+
+void test("maps layout props onto the style object", () => {
+  const mounted = mountComponent(Box, {
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "flex-end",
+    flexGrow: 1,
+    flexShrink: 0,
+    width: 40,
+    height: "50%",
+    minWidth: 5,
+    gap: 2,
+    overflow: "hidden",
+  });
+
+  assert.deepEqual(firstChild(mounted).props.style, {
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "flex-end",
+    flexGrow: 1,
+    flexShrink: 0,
+    width: "40",
+    height: "50%",
+    minWidth: "5",
+    gap: 2,
+    overflow: "hidden",
+  });
+  mounted.unmount();
+});
+
+void test("expands padding and margin axis shorthands per side", () => {
+  const mounted = mountComponent(Box, {
+    padding: 1,
+    paddingX: 2,
+    paddingTop: 3,
+    marginY: 4,
+    marginLeft: 5,
+  });
+
+  assert.deepEqual(firstChild(mounted).props.style, {
+    padding: 1,
+    paddingTop: 3,
+    paddingRight: 2,
+    // paddingBottom stays unset: per-side keys materialize only when that
+    // side or its axis shorthand is given; the base padding covers the rest.
+    paddingLeft: 2,
+    marginTop: 4,
+    marginBottom: 4,
+    marginLeft: 5,
+  });
+  mounted.unmount();
+});
+
+void test("normalizes border style names and prefers the Ink alias", () => {
+  const withBorder = (props: Record<string, unknown>) => {
+    const mounted = mountComponent(Box, props);
+    const border = firstChild(mounted).props.border;
+    mounted.unmount();
+    return border;
+  };
+
+  assert.equal(withBorder({ border: "single" }), "single");
+  assert.equal(withBorder({ border: "round" }), "rounded");
+  assert.equal(withBorder({ border: "bold" }), "heavy");
+  assert.equal(withBorder({ borderStyle: "double", border: "single" }), "double");
+  assert.equal(withBorder({}), undefined);
+});
+
+void test("resolves color aliases with Fresco names winning", () => {
+  const mounted = mountComponent(Box, {
+    fg: "cyan",
+    color: "red",
+    backgroundColor: "blue",
+    borderColor: "green",
+  });
+
+  const props = firstChild(mounted).props;
+  assert.equal(props.fg, "cyan");
+  assert.equal(props.bg, "blue");
+  assert.equal(props.borderColor, "green");
+  mounted.unmount();
+});
+
+void test("hides aria-hidden subtrees only in screen reader mode", () => {
+  const visible = mountComponent(Box, { "aria-hidden": true }, () => h("text", { text: "x" }));
+  assert.equal(firstChild(visible).type, "box");
+  assert.equal(firstChild(visible).props["aria-hidden"], true);
+  visible.unmount();
+
+  const hidden = mountComponent(Box, { "aria-hidden": true }, () => h("text", { text: "x" }), {
+    screenReader: true,
+  });
+  assert.deepEqual(toTreeSnapshot(firstChild(hidden)), { type: "text" });
+  hidden.unmount();
+});
+
+void test("replaces children with the aria-label in screen reader mode", () => {
+  const mounted = mountComponent(
+    Box,
+    { "aria-label": "status panel" },
+    () => h("text", { text: "42%" }),
+    { screenReader: true },
+  );
+
+  assert.deepEqual(toTreeSnapshot(firstChild(mounted)), {
+    type: "box",
+    props: { style: {}, "aria-label": "status panel", ...boxDefaults },
+    children: [{ type: "text", props: { text: "status panel" } }],
+  });
+  mounted.unmount();
+});

--- a/npm/fresco/src/components/Box.ts
+++ b/npm/fresco/src/components/Box.ts
@@ -228,16 +228,18 @@ export const Box = defineComponent({
     color: String,
     bg: String,
     backgroundColor: String,
-    "aria-label": String,
-    "aria-hidden": Boolean,
-    "aria-role": String as PropType<BoxProps["aria-role"]>,
-    "aria-state": Object as PropType<BoxProps["aria-state"]>,
+    // Declared camelCase so the runtime props object (which Vue camelizes)
+    // matches these keys; templates and h() may still pass "aria-label" etc.
+    ariaLabel: String,
+    ariaHidden: Boolean,
+    ariaRole: String as PropType<BoxProps["aria-role"]>,
+    ariaState: Object as PropType<BoxProps["aria-state"]>,
   },
   setup(props, { slots }) {
     const isScreenReaderEnabled = useIsScreenReaderEnabled();
 
     return () => {
-      if (isScreenReaderEnabled && props["aria-hidden"]) return null;
+      if (isScreenReaderEnabled && props.ariaHidden) return null;
 
       const style: Record<string, unknown> = {};
 
@@ -302,8 +304,8 @@ export const Box = defineComponent({
       if (props.overflowY) style.overflowY = props.overflowY;
 
       const children =
-        isScreenReaderEnabled && props["aria-label"]
-          ? [h("text", { text: props["aria-label"] })]
+        isScreenReaderEnabled && props.ariaLabel
+          ? [h("text", { text: props.ariaLabel })]
           : slots.default?.();
 
       return h(
@@ -320,10 +322,10 @@ export const Box = defineComponent({
           borderBackgroundColor: props.borderBackgroundColor,
           fg: props.fg ?? props.color,
           bg: props.bg ?? props.backgroundColor,
-          "aria-label": props["aria-label"],
-          "aria-hidden": props["aria-hidden"],
-          "aria-role": props["aria-role"],
-          "aria-state": props["aria-state"],
+          "aria-label": props.ariaLabel,
+          "aria-hidden": props.ariaHidden,
+          "aria-role": props.ariaRole,
+          "aria-state": props.ariaState,
         },
         children,
       );

--- a/npm/fresco/src/components/Text.test.ts
+++ b/npm/fresco/src/components/Text.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { firstChild, mountComponent, toTreeSnapshot } from "../testing/mount.js";
+import { ErrorText, InfoText, MutedText, SuccessText, Text, WarningText } from "./Text.js";
+
+// Text declares Boolean props, so Vue defaults them to false and the render
+// function forwards them onto the host node; they are inert downstream
+// (treeToRenderNodes drops falsy appearance) but part of the output tree.
+const textDefaults = {
+  wrap: false,
+  bold: false,
+  dim: false,
+  italic: false,
+  underline: false,
+  strikethrough: false,
+  inverse: false,
+  "aria-hidden": false,
+};
+
+void test("renders the content prop as a single text node", () => {
+  const mounted = mountComponent(Text, { content: "hello" });
+
+  assert.deepEqual(toTreeSnapshot(firstChild(mounted)), {
+    type: "text",
+    props: { text: "hello", ...textDefaults },
+  });
+  mounted.unmount();
+});
+
+void test("stringifies slot children and prefers content over the slot", () => {
+  const slotted = mountComponent(Text, {}, () => ["count: ", 42]);
+  assert.equal(firstChild(slotted).props.text, "count: 42");
+  slotted.unmount();
+
+  const both = mountComponent(Text, { content: "wins" }, () => "loses");
+  assert.equal(firstChild(both).props.text, "wins");
+  both.unmount();
+});
+
+void test("passes styling flags and wrap mode through to the node", () => {
+  const mounted = mountComponent(Text, {
+    content: "styled",
+    bold: true,
+    italic: true,
+    underline: true,
+    strikethrough: true,
+    inverse: true,
+    wrap: "truncate-middle",
+  });
+
+  assert.deepEqual(toTreeSnapshot(firstChild(mounted)), {
+    type: "text",
+    props: {
+      ...textDefaults,
+      text: "styled",
+      bold: true,
+      italic: true,
+      underline: true,
+      strikethrough: true,
+      inverse: true,
+      wrap: "truncate-middle",
+    },
+  });
+  mounted.unmount();
+});
+
+void test("resolves color and dim aliases", () => {
+  const propsOf = (props: Record<string, unknown>) => {
+    const mounted = mountComponent(Text, { content: "x", ...props });
+    const node = firstChild(mounted).props;
+    mounted.unmount();
+    return { fg: node.fg, bg: node.bg, dim: node.dim };
+  };
+
+  assert.deepEqual(propsOf({ color: "red", backgroundColor: "blue" }), {
+    fg: "red",
+    bg: "blue",
+    dim: false,
+  });
+  assert.deepEqual(propsOf({ fg: "cyan", color: "red", bg: "black", backgroundColor: "blue" }), {
+    fg: "cyan",
+    bg: "black",
+    dim: false,
+  });
+  assert.deepEqual(propsOf({ dimColor: true }), { fg: undefined, bg: undefined, dim: true });
+});
+
+void test("honors aria props in screen reader mode", () => {
+  const hidden = mountComponent(Text, { content: "x", "aria-hidden": true }, undefined, {
+    screenReader: true,
+  });
+  assert.deepEqual(toTreeSnapshot(firstChild(hidden)), { type: "text" });
+  hidden.unmount();
+
+  const labeled = mountComponent(Text, { content: "42%", "aria-label": "progress" }, undefined, {
+    screenReader: true,
+  });
+  assert.equal(firstChild(labeled).props.text, "progress");
+  labeled.unmount();
+
+  const plain = mountComponent(Text, { content: "42%", "aria-label": "progress" });
+  assert.equal(firstChild(plain).props.text, "42%");
+  plain.unmount();
+});
+
+void test("convenience variants preset color and dim styling", () => {
+  const nodeFor = (component: typeof ErrorText) => {
+    const mounted = mountComponent(component, { content: "msg" });
+    const { fg, dim, text } = firstChild(mounted).props;
+    mounted.unmount();
+    return { fg, dim, text };
+  };
+
+  assert.deepEqual(nodeFor(ErrorText), { fg: "red", dim: false, text: "msg" });
+  assert.deepEqual(nodeFor(WarningText), { fg: "yellow", dim: false, text: "msg" });
+  assert.deepEqual(nodeFor(SuccessText), { fg: "green", dim: false, text: "msg" });
+  assert.deepEqual(nodeFor(InfoText), { fg: "blue", dim: false, text: "msg" });
+  assert.deepEqual(nodeFor(MutedText), { fg: undefined, dim: true, text: "msg" });
+});

--- a/npm/fresco/src/components/Text.ts
+++ b/npm/fresco/src/components/Text.ts
@@ -66,18 +66,20 @@ export const Text = defineComponent({
     underline: Boolean,
     strikethrough: Boolean,
     inverse: Boolean,
-    "aria-label": String,
-    "aria-hidden": Boolean,
+    // Declared camelCase so the runtime props object (which Vue camelizes)
+    // matches these keys; templates and h() may still pass "aria-label" etc.
+    ariaLabel: String,
+    ariaHidden: Boolean,
   },
   setup(props, { slots }) {
     const isScreenReaderEnabled = useIsScreenReaderEnabled();
 
     return () => {
-      if (isScreenReaderEnabled && props["aria-hidden"]) return null;
+      if (isScreenReaderEnabled && props.ariaHidden) return null;
 
       const text =
-        isScreenReaderEnabled && props["aria-label"]
-          ? props["aria-label"]
+        isScreenReaderEnabled && props.ariaLabel
+          ? props.ariaLabel
           : (props.content ?? stringifyChildren(slots.default?.()));
 
       return h("text", {
@@ -91,8 +93,8 @@ export const Text = defineComponent({
         underline: props.underline,
         strikethrough: props.strikethrough,
         inverse: props.inverse,
-        "aria-label": props["aria-label"],
-        "aria-hidden": props["aria-hidden"],
+        "aria-label": props.ariaLabel,
+        "aria-hidden": props.ariaHidden,
       });
     };
   },

--- a/npm/fresco/src/components/TextInput.test.ts
+++ b/npm/fresco/src/components/TextInput.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { h, nextTick, ref } from "@vue/runtime-core";
+
+import { dispatchKey, firstChild, mountFresco, typeChars } from "../testing/mount.js";
+import { PasswordInput, TextInput } from "./TextInput.js";
+
+/** Mount TextInput with v-model wiring and emit capture. */
+function mountInput(initial = "", props: Record<string, unknown> = {}) {
+  const value = ref(initial);
+  const emitted: Array<[string, unknown]> = [];
+  const mounted = mountFresco(() =>
+    h(TextInput, {
+      modelValue: value.value,
+      focused: true,
+      ...props,
+      "onUpdate:modelValue": (next: string) => {
+        value.value = next;
+      },
+      onSubmit: (submitted: string) => emitted.push(["submit", submitted]),
+      onCancel: () => emitted.push(["cancel", undefined]),
+    }),
+  );
+  return { mounted, value, emitted, node: () => firstChild(mounted) };
+}
+
+void test("renders value, cursor, and placeholder state onto the input node", () => {
+  const { mounted, node } = mountInput("hi", { placeholder: "name..." });
+
+  const props = node().props;
+  assert.equal(node().type, "input");
+  assert.equal(props.value, "hi");
+  assert.equal(props.cursor, 2, "cursor starts after the last grapheme");
+  assert.equal(props.placeholder, "name...");
+  assert.equal(props.focused, true);
+  assert.equal(props.mask, false);
+  assert.equal(props.maskChar, "*");
+  mounted.unmount();
+});
+
+void test("typed characters update the model and the mounted node", async () => {
+  const { mounted, value, node } = mountInput();
+
+  await typeChars("abc");
+  assert.equal(value.value, "abc");
+  assert.equal(node().props.value, "abc");
+  assert.equal(node().props.cursor, 3);
+  mounted.unmount();
+});
+
+void test("ignores keyboard input while unfocused", async () => {
+  const { mounted, value } = mountInput("keep", { focused: false });
+
+  await typeChars("x");
+  await dispatchKey({ key: "backspace" });
+  assert.equal(value.value, "keep");
+  mounted.unmount();
+});
+
+void test("moves the cursor with arrows, home, and end before editing", async () => {
+  const { mounted, value, node } = mountInput("ac");
+
+  await dispatchKey({ key: "left" });
+  assert.equal(node().props.cursor, 1);
+  await typeChars("b");
+  assert.equal(value.value, "abc");
+
+  await dispatchKey({ key: "home" });
+  assert.equal(node().props.cursor, 0);
+  await typeChars("_");
+  assert.equal(value.value, "_abc");
+
+  await dispatchKey({ key: "end" });
+  assert.equal(node().props.cursor, 4);
+  mounted.unmount();
+});
+
+void test("backspace and delete edit by grapheme cluster", async () => {
+  const { mounted, value, node } = mountInput("a👋🏽b");
+
+  assert.equal(node().props.cursor, 3, "emoji with modifier counts as one grapheme");
+  await dispatchKey({ key: "backspace" });
+  assert.equal(value.value, "a👋🏽");
+  await dispatchKey({ key: "backspace" });
+  assert.equal(value.value, "a");
+
+  await dispatchKey({ key: "home" });
+  await dispatchKey({ key: "delete" });
+  assert.equal(value.value, "");
+  await dispatchKey({ key: "delete" });
+  assert.equal(value.value, "", "delete at the end is a no-op");
+  mounted.unmount();
+});
+
+void test("emits submit with the current value and cancel on escape", async () => {
+  const { mounted, emitted } = mountInput("ok");
+
+  await dispatchKey({ key: "enter" });
+  await dispatchKey({ key: "escape" });
+  assert.deepEqual(emitted, [
+    ["submit", "ok"],
+    ["cancel", undefined],
+  ]);
+  mounted.unmount();
+});
+
+void test("external model updates clamp the cursor into range", async () => {
+  const value = ref("longer");
+  const mounted = mountFresco(() => h(TextInput, { modelValue: value.value, focused: true }));
+
+  assert.equal(firstChild(mounted).props.cursor, 6);
+  value.value = "ab";
+  await nextTick();
+  assert.equal(firstChild(mounted).props.value, "ab");
+  assert.equal(firstChild(mounted).props.cursor, 2, "cursor clamps to the shorter value");
+
+  await dispatchKey({ key: "left" });
+  assert.equal(firstChild(mounted).props.cursor, 1, "clamped cursor keeps moving normally");
+  mounted.unmount();
+});
+
+void test("PasswordInput masks by default and forwards its model", async () => {
+  const value = ref("");
+  const mounted = mountFresco(() =>
+    h(PasswordInput, {
+      modelValue: value.value,
+      focus: true,
+      "onUpdate:modelValue": (next: string) => {
+        value.value = next;
+      },
+    }),
+  );
+
+  const node = firstChild(mounted);
+  assert.equal(node.type, "input");
+  assert.equal(node.props.mask, true);
+  assert.equal(node.props.placeholder, "Enter password...");
+
+  await typeChars("pw");
+  assert.equal(value.value, "pw");
+  mounted.unmount();
+});

--- a/npm/fresco/src/components/types.test-d.ts
+++ b/npm/fresco/src/components/types.test-d.ts
@@ -1,0 +1,133 @@
+/**
+ * Compile-only tests for the public props/emits of the baseline components.
+ *
+ * Not executed by the test runner; `tsgo --noEmit -p tsconfig.json` (wired
+ * into `pnpm check` / `pnpm check:types`) fails the build when a positive
+ * case stops typechecking or a `@ts-expect-error` negative starts passing.
+ */
+
+import { h } from "@vue/runtime-core";
+
+import { Box, type BoxProps } from "./Box.js";
+import { Text, type TextProps, type TextWrap } from "./Text.js";
+import { TextInput, type TextInputProps } from "./TextInput.js";
+
+// --- Public prop interfaces ------------------------------------------------
+
+export const boxAcceptsDocumentedProps: BoxProps = {
+  display: "flex",
+  position: "relative",
+  flexDirection: "column",
+  justifyContent: "space-between",
+  alignItems: "center",
+  flexGrow: 1,
+  width: "50%",
+  height: 10,
+  padding: 1,
+  paddingX: 2,
+  marginY: 1,
+  gap: 1,
+  overflow: "hidden",
+  border: "round",
+  borderStyle: "double",
+  borderColor: "cyan",
+  fg: "white",
+  bg: "black",
+  "aria-label": "panel",
+  "aria-hidden": false,
+  "aria-role": "list",
+  "aria-state": { expanded: true },
+};
+
+// @ts-expect-error - "grid" is not a BoxProps flexDirection
+export const boxRejectsUnknownFlexDirection: BoxProps = { flexDirection: "grid" };
+
+// @ts-expect-error - "dotted" is not a supported border style name
+export const boxRejectsUnknownBorderStyle: BoxProps = { borderStyle: "dotted" };
+
+// @ts-expect-error - padding shorthands are numbers, not strings
+export const boxRejectsStringPadding: BoxProps = { padding: "2" };
+
+export const textAcceptsDocumentedProps: TextProps = {
+  content: "hello",
+  wrap: "truncate-middle",
+  fg: "red",
+  color: "red",
+  bg: "blue",
+  backgroundColor: "blue",
+  bold: true,
+  dim: false,
+  dimColor: false,
+  italic: true,
+  underline: true,
+  strikethrough: false,
+  inverse: false,
+  "aria-label": "greeting",
+  "aria-hidden": false,
+};
+
+export const wrapAcceptsBooleans: TextWrap = true;
+
+// @ts-expect-error - "ellipsis" is not a TextWrap mode
+export const textRejectsUnknownWrap: TextProps = { wrap: "ellipsis" };
+
+// @ts-expect-error - content is a string, not a number
+export const textRejectsNumberContent: TextProps = { content: 42 };
+
+export const textInputAcceptsDocumentedProps: TextInputProps = {
+  modelValue: "value",
+  placeholder: "type...",
+  focus: true,
+  focused: true,
+  mask: false,
+  maskChar: "#",
+  width: 20,
+  fg: "white",
+  bg: "black",
+  "onUpdate:modelValue": (value: string) => value,
+  onSubmit: (value: string) => value,
+  onCancel: () => {},
+};
+
+// @ts-expect-error - modelValue is a string, not a number
+export const textInputRejectsNumberModel: TextInputProps = { modelValue: 42 };
+
+export const textInputRejectsBadSubmitHandler: TextInputProps = {
+  // @ts-expect-error - onSubmit receives the submitted string, not a number
+  onSubmit: (value: number) => value,
+};
+
+// --- Component prop contracts through h() ----------------------------------
+
+export function componentsRenderWithTypedProps() {
+  return [
+    h(Box, { flexDirection: "column", borderStyle: "round", ariaRole: "list" }),
+    h(Text, { content: "hi", wrap: "truncate-middle", bold: true }),
+    h(TextInput, { modelValue: "v", focused: true, maskChar: "#" }),
+  ];
+}
+
+export function boxRejectsMistypedRenderProps() {
+  // @ts-expect-error - flexGrow is a number, not a string
+  return h(Box, { flexGrow: "1" });
+}
+
+export function textRejectsMistypedRenderProps() {
+  // @ts-expect-error - bold is a boolean, not a string
+  return h(Text, { bold: "yes" });
+}
+
+// --- Emits -----------------------------------------------------------------
+
+type TextInputEmit = InstanceType<typeof TextInput>["$emit"];
+
+export function textInputEmitsDocumentedEvents(emit: TextInputEmit) {
+  emit("update:modelValue", "next");
+  emit("submit", "value");
+  emit("cancel");
+  emit("compositionstart");
+  emit("compositionupdate", "text", 1);
+  emit("compositionend", "text");
+  // @ts-expect-error - "change" is not a declared TextInput event
+  emit("change");
+}

--- a/npm/fresco/src/composables/useFocus.test.ts
+++ b/npm/fresco/src/composables/useFocus.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { defineComponent, h, nextTick, ref, type Ref } from "@vue/runtime-core";
+
+import { mountFresco } from "../testing/mount.js";
+import { createFocusManager, useFocus, type FocusManager } from "./useFocus.js";
+
+void test("focusNext and focusPrevious traverse registration order and wrap", () => {
+  const manager = createFocusManager();
+  manager.register("a");
+  manager.register("b");
+  manager.register("c");
+
+  assert.equal(manager.focusedId.value, null);
+  manager.focusNext();
+  assert.equal(manager.focusedId.value, "a");
+  manager.focusNext();
+  assert.equal(manager.focusedId.value, "b");
+  manager.focusNext();
+  manager.focusNext();
+  assert.equal(manager.focusedId.value, "a", "traversal wraps past the end");
+
+  manager.focusPrevious();
+  assert.equal(manager.focusedId.value, "c", "backwards traversal wraps to the end");
+});
+
+void test("inactive focusables are skipped and lose focus when deactivated", () => {
+  const manager = createFocusManager();
+  manager.register("a");
+  manager.register("b");
+  manager.register("c");
+
+  manager.setActive("b", false);
+  assert.deepEqual(manager.focusableIds.value, ["a", "c"]);
+
+  manager.focus("b");
+  assert.equal(manager.focusedId.value, null, "inactive targets cannot be focused");
+
+  manager.focus("a");
+  manager.focusNext();
+  assert.equal(manager.focusedId.value, "c", "traversal skips inactive entries");
+
+  manager.setActive("c", false);
+  assert.equal(manager.focusedId.value, null, "deactivation releases focus");
+});
+
+void test("disableFocus clears and blocks focus until re-enabled", () => {
+  const manager = createFocusManager();
+  manager.register("a", { autoFocus: true });
+  assert.equal(manager.focusedId.value, "a");
+
+  manager.disableFocus();
+  assert.equal(manager.focusedId.value, null);
+  manager.focus("a");
+  manager.focusNext();
+  assert.equal(manager.focusedId.value, null, "focus is inert while disabled");
+
+  manager.enableFocus();
+  manager.focus("a");
+  assert.equal(manager.focusedId.value, "a");
+});
+
+interface FocusProbe {
+  id: string;
+  isFocused: Ref<boolean>;
+  focus: (targetId?: string) => void;
+  blur: () => void;
+}
+
+function focusableStub(id: string, probes: Map<string, FocusProbe>, isActive?: Ref<boolean>) {
+  return defineComponent({
+    name: `Focusable${id}`,
+    setup() {
+      probes.set(id, useFocus(isActive === undefined ? { id } : { id, isActive }));
+      return () => h("text", { text: id });
+    },
+  });
+}
+
+void test("mounted components register with the app focus manager and unregister on unmount", async () => {
+  const probes = new Map<string, FocusProbe>();
+  const showSecond = ref(true);
+  const First = focusableStub("first", probes);
+  const Second = focusableStub("second", probes);
+
+  const mounted = mountFresco(() => h("box", [h(First), showSecond.value ? h(Second) : undefined]));
+  const manager: FocusManager = mounted.focusManager;
+
+  assert.deepEqual(manager.focusableIds.value, ["first", "second"]);
+
+  manager.focusNext();
+  manager.focusNext();
+  assert.equal(manager.focusedId.value, "second");
+  assert.equal(probes.get("second")?.isFocused.value, true);
+  assert.equal(probes.get("first")?.isFocused.value, false);
+
+  showSecond.value = false;
+  await nextTick();
+  assert.deepEqual(manager.focusableIds.value, ["first"], "unmount unregisters the target");
+  assert.equal(manager.focusedId.value, null, "focus is released with the unmounted target");
+
+  mounted.unmount();
+  assert.deepEqual(manager.focusableIds.value, []);
+});
+
+void test("focus and blur from useFocus move ownership through the manager", () => {
+  const probes = new Map<string, FocusProbe>();
+  const First = focusableStub("first", probes);
+  const Second = focusableStub("second", probes);
+  const mounted = mountFresco(() => h("box", [h(First), h(Second)]));
+
+  probes.get("first")?.focus();
+  assert.equal(mounted.focusManager.focusedId.value, "first");
+
+  probes.get("first")?.focus("second");
+  assert.equal(mounted.focusManager.focusedId.value, "second", "focus() can target another id");
+
+  probes.get("second")?.blur();
+  assert.equal(mounted.focusManager.focusedId.value, null);
+
+  probes.get("first")?.blur();
+  assert.equal(mounted.focusManager.focusedId.value, null, "blurring unfocused ids is a no-op");
+  mounted.unmount();
+});
+
+void test("autoFocus focuses the first mounted target only", () => {
+  const probes = new Map<string, FocusProbe>();
+  const First = defineComponent({
+    setup() {
+      probes.set("first", useFocus({ id: "first", autoFocus: true }));
+      return () => h("text", { text: "first" });
+    },
+  });
+  const Second = defineComponent({
+    setup() {
+      probes.set("second", useFocus({ id: "second", autoFocus: true }));
+      return () => h("text", { text: "second" });
+    },
+  });
+
+  const mounted = mountFresco(() => h("box", [h(First), h(Second)]));
+  assert.equal(mounted.focusManager.focusedId.value, "first");
+  assert.equal(probes.get("first")?.isFocused.value, true);
+  mounted.unmount();
+});
+
+void test("a reactive isActive toggles traversal membership from inside the tree", async () => {
+  const probes = new Map<string, FocusProbe>();
+  const active = ref(false);
+  const First = focusableStub("first", probes);
+  const Toggle = focusableStub("toggle", probes, active);
+  const mounted = mountFresco(() => h("box", [h(First), h(Toggle)]));
+
+  assert.deepEqual(mounted.focusManager.focusableIds.value, ["first"]);
+
+  active.value = true;
+  await nextTick();
+  assert.deepEqual(mounted.focusManager.focusableIds.value, ["first", "toggle"]);
+
+  mounted.focusManager.focus("toggle");
+  active.value = false;
+  await nextTick();
+  assert.equal(mounted.focusManager.focusedId.value, null, "deactivation releases focus");
+  assert.deepEqual(mounted.focusManager.focusableIds.value, ["first"]);
+  mounted.unmount();
+});

--- a/npm/fresco/src/renderer.test.ts
+++ b/npm/fresco/src/renderer.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { h, nextTick, ref } from "@vue/runtime-core";
+
+import { renderToString } from "./app.js";
+import { treeToRenderNodes } from "./renderer.js";
+import { firstChild, mountFresco, toTreeSnapshot } from "./testing/mount.js";
+
+void test("maps host element tags onto Fresco node types", () => {
+  const mounted = mountFresco(() =>
+    h("box", [h("div"), h("view"), h("text"), h("span"), h("input"), h("custom-tag")]),
+  );
+
+  const root = firstChild(mounted);
+  assert.equal(root.type, "box");
+  assert.deepEqual(
+    root.children.map((child) => child.type),
+    ["box", "box", "text", "text", "input", "box"],
+  );
+  mounted.unmount();
+});
+
+void test("mounts a component tree as the expected output tree", () => {
+  const mounted = mountFresco(() =>
+    h("box", { style: { flexDirection: "column" } }, [
+      h("text", { text: "title", bold: true }),
+      h("box", { style: { gap: 1 } }, [h("text", { text: "body" })]),
+    ]),
+  );
+
+  assert.deepEqual(toTreeSnapshot(firstChild(mounted)), {
+    type: "box",
+    props: { style: { flexDirection: "column" } },
+    children: [
+      { type: "text", props: { text: "title", bold: true } },
+      {
+        type: "box",
+        props: { style: { gap: 1 } },
+        children: [{ type: "text", props: { text: "body" } }],
+      },
+    ],
+  });
+
+  const [title] = firstChild(mounted).children;
+  assert.equal(title?.parent, firstChild(mounted));
+  mounted.unmount();
+});
+
+void test("patches props and text reactively without remounting", async () => {
+  const label = ref<string | undefined>("first");
+  const message = ref("hello");
+  const mounted = mountFresco(() => h("text", { text: message.value, label: label.value }));
+
+  const node = firstChild(mounted);
+  assert.deepEqual(node.props, { text: "hello", label: "first" });
+
+  message.value = "goodbye";
+  label.value = undefined;
+  await nextTick();
+
+  assert.equal(firstChild(mounted), node, "the node is patched in place");
+  assert.deepEqual(node.props, { text: "goodbye" }, "nullish props are removed");
+  mounted.unmount();
+});
+
+void test("inserts, reorders, and removes list children through anchors", async () => {
+  const items = ref(["a", "b"]);
+  const mounted = mountFresco(() =>
+    h(
+      "box",
+      items.value.map((item) => h("text", { key: item, text: item })),
+    ),
+  );
+
+  const texts = () => firstChild(mounted).children.map((child) => child.props.text);
+  assert.deepEqual(texts(), ["a", "b"]);
+
+  items.value = ["c", "a", "b"];
+  await nextTick();
+  assert.deepEqual(texts(), ["c", "a", "b"], "prepend inserts before the anchor");
+
+  items.value = ["c", "b"];
+  await nextTick();
+  assert.deepEqual(texts(), ["c", "b"], "removal detaches the middle child");
+  mounted.unmount();
+});
+
+void test("flattens the mounted tree into native render nodes", () => {
+  const mounted = mountFresco(() =>
+    h("box", { style: { flexDirection: "row", width: "100%", padding: 1 } }, [
+      h("text", { text: "hi", fg: "cyan", bold: true }),
+      h("input", { value: "abc", placeholder: "type...", focused: true, cursor: 3 }),
+    ]),
+  );
+
+  const box = firstChild(mounted);
+  const nodes = treeToRenderNodes(box);
+
+  assert.equal(nodes.length, 3);
+  const [boxNode, textNode, inputNode] = nodes;
+  assert.deepEqual(boxNode, {
+    id: box.id,
+    nodeType: "box",
+    style: { flexDirection: "row", width: "100%", padding: 1 },
+    children: [textNode?.id, inputNode?.id],
+  });
+  assert.deepEqual(textNode, {
+    id: box.children[0]?.id,
+    nodeType: "text",
+    text: "hi",
+    appearance: { fg: "cyan", bold: true },
+  });
+  assert.deepEqual(inputNode, {
+    id: box.children[1]?.id,
+    nodeType: "input",
+    value: "abc",
+    placeholder: "type...",
+    focused: true,
+    cursor: 3,
+  });
+  mounted.unmount();
+});
+
+void test("normalizes wrap props into native wrap modes", () => {
+  const wrapOf = (wrap: unknown) => {
+    const mounted = mountFresco(() => h("text", { text: "x", wrap }));
+    const [node] = treeToRenderNodes(firstChild(mounted));
+    mounted.unmount();
+    return { wrap: node?.wrap, wrapMode: node?.wrapMode };
+  };
+
+  assert.deepEqual(wrapOf(true), { wrap: true, wrapMode: "wrap" });
+  assert.deepEqual(wrapOf(false), { wrap: false, wrapMode: "none" });
+  assert.deepEqual(wrapOf("end"), { wrap: true, wrapMode: "truncate-end" });
+  assert.deepEqual(wrapOf("middle"), { wrap: true, wrapMode: "truncate-middle" });
+  assert.deepEqual(wrapOf("truncate-start"), { wrap: false, wrapMode: "truncate-start" });
+  assert.deepEqual(wrapOf(undefined), { wrap: undefined, wrapMode: undefined });
+});
+
+void test("keeps appearance aliases and drops empty style objects", () => {
+  const mounted = mountFresco(() =>
+    h("text", { text: "x", color: "red", backgroundColor: "blue", dimColor: true, style: {} }),
+  );
+
+  const [node] = treeToRenderNodes(firstChild(mounted));
+  assert.deepEqual(node, {
+    id: firstChild(mounted).id,
+    nodeType: "text",
+    text: "x",
+    appearance: { fg: "red", bg: "blue", dim: true },
+  });
+  mounted.unmount();
+});
+
+void test("renderToString renders column and row layouts deterministically", () => {
+  const column = renderToString(() =>
+    h("box", { style: { flexDirection: "column" } }, [
+      h("text", { text: "hello" }),
+      h("text", { text: "world" }),
+    ]),
+  );
+  assert.equal(column, "hello\nworld");
+
+  const row = renderToString(() =>
+    h("box", { style: { flexDirection: "row" } }, [
+      h("text", { text: "hello " }),
+      h("text", { text: "world" }),
+    ]),
+  );
+  assert.equal(row, "hello world");
+});
+
+void test("renderToString shows input values and falls back to placeholders", () => {
+  assert.equal(
+    renderToString(() => h("input", { value: "typed", placeholder: "type here" })),
+    "typed",
+  );
+  assert.equal(
+    renderToString(() => h("input", { placeholder: "type here" })),
+    "type here",
+  );
+});

--- a/npm/fresco/src/testing/mount.ts
+++ b/npm/fresco/src/testing/mount.ts
@@ -1,0 +1,208 @@
+/**
+ * Test-only mount harness for the Fresco JS layer.
+ *
+ * Fresco's renderer is pure JS up to the byte boundary that crosses into the
+ * native module: `renderer.ts` imports only types from `@vizejs/fresco-native`,
+ * and `app.ts` loads the native binding lazily and only in interactive mode.
+ * This harness mounts components through the real custom renderer with the
+ * same provide set `createApp`/`renderToString` install, so tests assert the
+ * mounted `FrescoNode` output tree without a native build and without mocks.
+ *
+ * Not exported from the package entry points; `vp pack` does not ship it.
+ */
+
+import {
+  h,
+  ref,
+  nextTick,
+  type App as VueApp,
+  type Component,
+  type Ref,
+  type VNodeChild,
+} from "@vue/runtime-core";
+import { SCREEN_READER_KEY } from "../accessibility.js";
+import { lastKeyEvent, type KeyEvent } from "../app.js";
+import { APP_KEY, createAppContext } from "../composables/useApp.js";
+import { createCursorContext, CURSOR_KEY } from "../composables/useCursor.js";
+import { createFocusManager, FOCUS_KEY, type FocusManager } from "../composables/useFocus.js";
+import { createStreamsContext, STREAMS_KEY } from "../composables/useStreams.js";
+import { createRenderer, type FrescoElement, type FrescoNode } from "../renderer.js";
+
+/** Options for {@link mountFresco}. */
+export interface MountFrescoOptions {
+  /** Terminal width provided through the app context. Defaults to 80. */
+  width?: number;
+  /** Terminal height provided through the app context. Defaults to 24. */
+  height?: number;
+  /** Initial screen reader mode. Defaults to false. */
+  screenReader?: boolean;
+}
+
+/** A mounted Fresco component tree under test. */
+export interface MountedFresco {
+  /** Root element the Vue app mounted into; children form the output tree. */
+  root: FrescoElement;
+  /** The Vue app instance (for `provide`-level introspection if needed). */
+  app: VueApp<FrescoElement>;
+  /** Focus manager provided to the tree, as the real app would. */
+  focusManager: FocusManager;
+  /** Screen reader flag provided to the tree; writable to flip modes. */
+  screenReaderEnabled: Ref<boolean>;
+  /** Unmount the tree and dispose all component watchers. */
+  unmount(): void;
+}
+
+/**
+ * Mount a component (or a plain render function) through the Fresco renderer.
+ *
+ * The returned {@link MountedFresco.root} is live: re-read it after reactive
+ * updates plus `await nextTick()` to observe the patched output tree.
+ */
+export function mountFresco(
+  root: Component | (() => VNodeChild),
+  options: MountFrescoOptions = {},
+): MountedFresco {
+  const { createApp } = createRenderer();
+  const component: Component = typeof root === "function" ? { setup: () => root } : root;
+  const app = createApp(component);
+
+  const focusManager = createFocusManager();
+  const screenReaderEnabled = ref(options.screenReader ?? false);
+  const noopWrite = () => {};
+  const width = options.width ?? 80;
+  const height = options.height ?? 24;
+  // A detached stdout stand-in keeps createAppContext from attaching resize
+  // listeners to the real process.stdout on every mounted test tree.
+  const stdout = {
+    isTTY: false,
+    columns: width,
+    rows: height,
+    write: () => true,
+  } as unknown as NodeJS.WriteStream;
+
+  app.provide(APP_KEY, createAppContext({ width, height, stdout }));
+  app.provide(FOCUS_KEY, focusManager);
+  app.provide(SCREEN_READER_KEY, screenReaderEnabled);
+  app.provide(CURSOR_KEY, createCursorContext(noopWrite));
+  app.provide(
+    STREAMS_KEY,
+    createStreamsContext({
+      interactive: false,
+      writeToStdout: noopWrite,
+      writeToStderr: noopWrite,
+    }),
+  );
+
+  const rootElement: FrescoElement = {
+    id: -1,
+    type: "root",
+    props: {},
+    children: [],
+    parent: null,
+  };
+  app.mount(rootElement);
+
+  return {
+    root: rootElement,
+    app,
+    focusManager,
+    screenReaderEnabled,
+    unmount: () => app.unmount(),
+  };
+}
+
+/**
+ * Dispatch a key event through the same `lastKeyEvent` ref the interactive
+ * event loop writes, then wait for watchers to flush.
+ *
+ * Pass `char` for printable input or `key` for named keys ("left", "enter",
+ * "backspace", ...). Modifiers default to false.
+ */
+export function dispatchKey(event: Partial<Omit<KeyEvent, "type">>): Promise<void> {
+  lastKeyEvent.value = {
+    type: "key",
+    ctrl: false,
+    alt: false,
+    shift: false,
+    meta: false,
+    super: false,
+    hyper: false,
+    capsLock: false,
+    numLock: false,
+    ...event,
+  };
+  return nextTick();
+}
+
+/** Dispatch a sequence of printable characters via {@link dispatchKey}. */
+export async function typeChars(text: string): Promise<void> {
+  for (const char of text) {
+    await dispatchKey({ char });
+  }
+}
+
+/**
+ * Serializable snapshot of a mounted output tree.
+ *
+ * Node ids come from a module-global counter and depend on mount order, and
+ * `parent` back-references make trees cyclic, so both are omitted. Props are
+ * kept only when defined, so snapshots stay inline-sized and deterministic.
+ */
+export interface FrescoNodeSnapshot {
+  type: FrescoNode["type"];
+  text?: string;
+  props?: Record<string, unknown>;
+  children?: FrescoNodeSnapshot[];
+}
+
+function definedProps(props: Record<string, unknown>): Record<string, unknown> | undefined {
+  const entries = Object.entries(props).filter(([, value]) => value !== undefined);
+  if (entries.length === 0) return undefined;
+  return Object.fromEntries(entries);
+}
+
+/**
+ * Convert a mounted node (or the harness root) into a plain snapshot object
+ * suitable for `assert.deepEqual` against an inline expected structure.
+ */
+export function toTreeSnapshot(node: FrescoNode): FrescoNodeSnapshot {
+  const snapshot: FrescoNodeSnapshot = { type: node.type };
+  if (node.text !== undefined) snapshot.text = node.text;
+  const props = definedProps(node.props);
+  if (props) snapshot.props = props;
+  if (node.children.length > 0) {
+    snapshot.children = node.children.map((child) => toTreeSnapshot(child));
+  }
+  return snapshot;
+}
+
+/** Depth-first list of nodes matching a predicate, starting at `node`. */
+export function findNodes(
+  node: FrescoNode,
+  predicate: (candidate: FrescoNode) => boolean,
+): FrescoNode[] {
+  const matches: FrescoNode[] = [];
+  const visit = (current: FrescoNode) => {
+    if (predicate(current)) matches.push(current);
+    for (const child of current.children) visit(child);
+  };
+  visit(node);
+  return matches;
+}
+
+/** First mounted child under the harness root, asserting it exists. */
+export function firstChild(mounted: MountedFresco): FrescoNode {
+  const child = mounted.root.children[0];
+  if (!child) throw new Error("expected the mounted tree to have a root child");
+  return child;
+}
+
+/** Convenience wrapper that renders `component` with `h` and mounts it. */
+export function mountComponent(
+  component: Component,
+  props: Record<string, unknown> = {},
+  slot?: () => VNodeChild,
+  options: MountFrescoOptions = {},
+): MountedFresco {
+  return mountFresco(() => h(component, props, slot), options);
+}

--- a/npm/fresco/tsconfig.json
+++ b/npm/fresco/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "lib": ["ES2023"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "declaration": true,
@@ -13,7 +14,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -708,9 +708,15 @@ importers:
       '@types/node':
         specifier: catalog:typescript
         version: 25.9.2
+      '@typescript/native-preview':
+        specifier: catalog:typescript
+        version: 7.0.0-dev.20260602.1
       '@vue/runtime-core':
         specifier: catalog:vue-stable
         version: 3.5.35
+      tsx:
+        specifier: catalog:typescript
+        version: 4.22.4
       typescript:
         specifier: catalog:typescript
         version: 6.0.3


### PR DESCRIPTION
## What

Bootstraps the missing JS-side test baseline for `npm/fresco` (WS-D slice 1 of the Fresco campaign). 37 `node:test` cases plus a compile-only type suite, all green locally via `pnpm test` / `pnpm check` / `pnpm build`.

### Native-boundary seam

No mock and no test-double. The JS layer is already pure up to the byte boundary into Rust: `renderer.ts` imports only types from `@vizejs/fresco-native`, and `app.ts` dynamic-imports it strictly in interactive mode. The new `src/testing/mount.ts` harness (not exported, not shipped) mounts components through the real renderer with the same provide set `createApp` installs, and drives keys through the same `lastKeyEvent` ref the interactive event loop writes. `treeToRenderNodes` — the exact payload the native `renderTree` call paints — is asserted directly.

### Suites

- `src/renderer.test.ts` — node-tree construction (tag mapping, reactive patch/insert/remove with anchors), `treeToRenderNodes` flattening (style/appearance extraction, wrap-mode normalization), `renderToString` output.
- `src/components/Box.test.ts` / `Text.test.ts` — props-to-tree behavior: style mapping, axis shorthand expansion, border normalization, color/dim aliases, screen-reader aria handling, convenience text variants.
- `src/components/TextInput.test.ts` — keyboard behavior: grapheme-cluster editing (emoji-safe backspace/delete), cursor movement, focus gating, submit/cancel emits, external model clamping, `PasswordInput` masking.
- `src/composables/useFocus.test.ts` — manager traversal/wrap/activation plus mounted lifecycle: register on setup, unregister on unmount, autoFocus, reactive `isActive`.
- `src/components/types.test-d.ts` — public props/emits with `@ts-expect-error` negatives, gated by `tsgo --noEmit` newly wired into `check` (marquette pattern).
- `CONTRIBUTING-tests.md` — the three-part standard (mounted-tree snapshots, type tests, keyboard/focus behavior; never regex-on-source) for later slices.

### Bugs surfaced and fixed by the baseline

- **Box/Text screen-reader props were dead code**: props were declared kebab-case (`"aria-label"`) and read back kebab-case, but Vue camelizes runtime prop keys, so the reads always returned `undefined` and `aria-hidden`/`aria-label` handling never fired. Declarations and reads are now camelCase; templates/`h()` still accept kebab via Vue's own normalization, and host nodes still emit kebab keys so `accessibility.ts` is unchanged.
- Two latent type errors caught by the new `tsgo` gate: the untyped `modifiers` fallback in `app.ts` and `findLast` without an ES2023 lib.

Infra: `test` script follows the marquette convention (`vp exec tsx --test`), `tsx`/`@typescript/native-preview` added as catalog devDependencies; the lockfile diff is exactly those two importer entries (`vp install --frozen-lockfile` and the `tests/tooling` guards verified green locally).

Fixes #3228

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility handling for `Box` and `Text` in screen-reader mode (support for `ariaLabel`/`ariaHidden`, including hiding and label substitution).
  * Expanded component and renderer testing utilities (mount harness, keyboard/input driving, deterministic tree snapshots, focus simulation).

* **Bug Fixes**
  * Improved TypeScript typing for keyboard modifier handling.

* **Documentation**
  * Added testing guidelines for render snapshots, focus/keyboard behavior, and type-level prop/emit conventions.

* **Tests**
  * Added/expanded suites for `Box`, `Text`, `TextInput`/`PasswordInput`, focus management, and renderer update/diff semantics.
  * Updated test and type-check scripts to better gate quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
