### PR TITLE
feat(marquette): stable admission denial codes across host families

### DIFF
--- a/crates/vize_marquette/schema/test-run-admission.schema.json
+++ b/crates/vize_marquette/schema/test-run-admission.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vizejs.dev/schemas/marquette/test-run-admission.schema.json",
+  "title": "Vize Test Run Admission Decision",
+  "description": "Language-neutral allow-or-deny decision that one test-run evidence record produces for one exact release candidate at one instant. Every backend family (JavaScript, Rust, Go, JVM) must produce byte-equivalent decisions for the same evidence, candidate, admission id, and admission time; the shared tests/fixtures/test-run-evidence admission-decision fixtures are the conformance source of truth for new host implementations.",
+  "$ref": "#/$defs/decision",
+  "$defs": {
+    "denialCode": {
+      "description": "Stable machine-readable cause class of one admission denial. The vocabulary is append-only: codes are never renamed, renumbered, reused, or removed, and every new distinguishable rejection cause ships with a new code appended to this enum. Hosts must map every diagnostic to exactly one code: VIZE_MARQUETTE_141 to admission-id-malformed; VIZE_MARQUETTE_142 to admission-id-mismatch; VIZE_MARQUETTE_144 to the candidate-*-mismatch code named by its diagnostic path (application, artifact.fingerprint, contractFingerprint, environment, release, sourceRevision); VIZE_MARQUETTE_145 to record-expired; VIZE_MARQUETTE_146 to verification-not-accepted; VIZE_MARQUETTE_147 to skipped-tests-recorded; VIZE_MARQUETTE_148 to admission-time-malformed; and every other diagnostic, including every record-validation code, to record-invalid.",
+      "enum": [
+        "admission-id-malformed",
+        "admission-id-mismatch",
+        "admission-time-malformed",
+        "candidate-application-mismatch",
+        "candidate-artifact-fingerprint-mismatch",
+        "candidate-contract-fingerprint-mismatch",
+        "candidate-environment-mismatch",
+        "candidate-release-mismatch",
+        "candidate-source-revision-mismatch",
+        "record-expired",
+        "record-invalid",
+        "skipped-tests-recorded",
+        "verification-not-accepted"
+      ]
+    },
+    "diagnostic": {
+      "description": "One stable, source-addressable diagnostic explaining a denial cause. Codes, severities, paths, messages, and ordering are identical across host families.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "severity", "path", "message"],
+      "properties": {
+        "code": {
+          "description": "Stable machine-readable diagnostic code.",
+          "type": "string",
+          "pattern": "^VIZE_MARQUETTE_[0-9]{3}$"
+        },
+        "severity": {
+          "description": "Diagnostic severity; any diagnostic denies admission.",
+          "enum": ["error", "warning"]
+        },
+        "path": {
+          "description": "JSON-style path into the record or the admission input.",
+          "type": "string",
+          "minLength": 1
+        },
+        "message": {
+          "description": "Human-readable explanation and next action.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "decision": {
+      "description": "Structured admission decision. allowed is true only when denialCodes and diagnostics are both empty. denialCodes maps every diagnostic to its denial code, deduplicated and sorted lexicographically by Unicode code point. diagnostics keeps the stable path, code, message order shared by every implementation.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowed", "denialCodes", "diagnostics"],
+      "properties": {
+        "allowed": {
+          "description": "Whether the record admits the candidate.",
+          "type": "boolean"
+        },
+        "denialCodes": {
+          "description": "Deduplicated denial causes in lexicographic order; empty when allowed.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/denialCode" }
+        },
+        "diagnostics": {
+          "description": "Complete denial diagnostics; empty when allowed.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/diagnostic" }
+        }
+      }
+    }
+  }
+}

--- a/crates/vize_marquette/src/lib.rs
+++ b/crates/vize_marquette/src/lib.rs
@@ -61,13 +61,15 @@ pub use model::{
     RuntimeFamily, Target,
 };
 pub use test_run::{
-    CanonicalTestRunError, TEST_RUN_ADMISSION_PREFIX, TEST_RUN_EVIDENCE_FORMAT,
-    TEST_RUN_EVIDENCE_FORMAT_VERSION, TEST_RUN_MAX_SHARDS, TEST_RUN_MAX_SUITES,
-    TEST_RUN_MAX_TARGETS, TestRunArtifact, TestRunCandidate, TestRunEvidence, TestRunIsolation,
+    CanonicalTestRunError, TEST_RUN_ADMISSION_PREFIX, TEST_RUN_DENIAL_CODES,
+    TEST_RUN_EVIDENCE_FORMAT, TEST_RUN_EVIDENCE_FORMAT_VERSION, TEST_RUN_MAX_SHARDS,
+    TEST_RUN_MAX_SUITES, TEST_RUN_MAX_TARGETS, TestRunAdmissionDecision, TestRunArtifact,
+    TestRunCandidate, TestRunDenialCode, TestRunEvidence, TestRunIsolation,
     TestRunRetainedEvidence, TestRunRunner, TestRunSelection, TestRunSuiteExecution,
     TestRunSuiteKind, TestRunSuiteOutcome, TestRunTargetExecution, TestRunTargetKind,
     TestRunVerification, TestRunVerificationOutcome, admit_test_run, canonical_test_run_json,
-    parse_test_run_admission_id, test_run_admission_id, test_run_fingerprint, validate_test_run,
+    decide_test_run_admission, parse_test_run_admission_id, test_run_admission_id,
+    test_run_denial_code, test_run_fingerprint, validate_test_run,
 };
 pub use validate::{ContractDiagnostic, DiagnosticSeverity, validate_contract};
 
@@ -84,6 +86,15 @@ pub const APPLICATION_CONTRACT_JSON_SCHEMA: &str =
 /// expose the exact record contract without resolving a filesystem path.
 pub const TEST_RUN_EVIDENCE_JSON_SCHEMA: &str =
     include_str!("../schema/test-run-evidence.schema.json");
+
+/// Canonical JSON Schema for test-run admission decisions.
+///
+/// The schema declares the append-only denial-code vocabulary and the
+/// structured decision shape every backend family must produce identically.
+/// It is embedded so deployment gates and tooling can expose the exact
+/// contract without resolving a filesystem path.
+pub const TEST_RUN_ADMISSION_JSON_SCHEMA: &str =
+    include_str!("../schema/test-run-admission.schema.json");
 
 #[cfg(test)]
 mod schema_tests {
@@ -107,5 +118,16 @@ mod schema_tests {
             evidence["formatVersion"]["const"],
             super::TEST_RUN_EVIDENCE_FORMAT_VERSION
         );
+    }
+
+    #[test]
+    fn embedded_admission_schema_declares_the_exact_denial_vocabulary() {
+        let schema: serde_json::Value =
+            serde_json::from_str(super::TEST_RUN_ADMISSION_JSON_SCHEMA).unwrap();
+        let declared = schema["$defs"]["denialCode"]["enum"].as_array().unwrap();
+        let implemented = super::TEST_RUN_DENIAL_CODES
+            .map(|code| serde_json::to_value(code).unwrap())
+            .to_vec();
+        assert_eq!(declared, &implemented);
     }
 }

--- a/crates/vize_marquette/src/test_run.rs
+++ b/crates/vize_marquette/src/test_run.rs
@@ -13,6 +13,7 @@
 
 mod admission;
 mod canonical;
+mod decision;
 mod model;
 mod validate;
 
@@ -24,6 +25,10 @@ pub use admission::{
     test_run_admission_id,
 };
 pub use canonical::{CanonicalTestRunError, canonical_test_run_json, test_run_fingerprint};
+pub use decision::{
+    TEST_RUN_DENIAL_CODES, TestRunAdmissionDecision, TestRunDenialCode, decide_test_run_admission,
+    test_run_denial_code,
+};
 pub use model::{
     TEST_RUN_EVIDENCE_FORMAT, TEST_RUN_EVIDENCE_FORMAT_VERSION, TestRunArtifact, TestRunEvidence,
     TestRunIsolation, TestRunRetainedEvidence, TestRunRunner, TestRunSelection,

--- a/crates/vize_marquette/src/test_run/admission.rs
+++ b/crates/vize_marquette/src/test_run/admission.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use vize_carton::{String, cstr};
 
 use crate::ContractDiagnostic;
@@ -13,7 +14,8 @@ pub const TEST_RUN_ADMISSION_PREFIX: &str = "test-run:";
 ///
 /// Every field must match the record exactly; admission never falls back to
 /// a newer, older, or partially matching record.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TestRunCandidate {
     /// Application the gate is deploying.
     pub application: String,

--- a/crates/vize_marquette/src/test_run/decision.rs
+++ b/crates/vize_marquette/src/test_run/decision.rs
@@ -1,0 +1,240 @@
+use serde::{Deserialize, Serialize};
+
+use crate::ContractDiagnostic;
+
+use super::admission::{TestRunCandidate, admit_test_run};
+use super::model::TestRunEvidence;
+
+/// Stable machine-readable cause class of one admission denial.
+///
+/// The vocabulary is shared by every backend family: a JavaScript, Rust, Go,
+/// or JVM host must derive the same codes from the same diagnostics, as
+/// pinned by the shared `tests/fixtures/test-run-evidence` decision fixtures.
+/// Codes are append-only: they are never renamed, renumbered, reused, or
+/// removed, and a new rejection cause always ships with a new code. Variants
+/// are declared in the lexicographic order of their serialized names, so the
+/// derived ordering matches the documented decision ordering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TestRunDenialCode {
+    /// The admission id fails the `test-run:<64 lowercase hex>` grammar.
+    AdmissionIdMalformed,
+    /// The admission id does not name the record's canonical fingerprint.
+    AdmissionIdMismatch,
+    /// The admission time is not a millisecond-precision UTC instant.
+    AdmissionTimeMalformed,
+    /// The record does not bind the candidate application.
+    CandidateApplicationMismatch,
+    /// The record does not bind the candidate artifact fingerprint.
+    CandidateArtifactFingerprintMismatch,
+    /// The record does not bind the candidate contract fingerprint.
+    CandidateContractFingerprintMismatch,
+    /// The record does not bind the candidate environment.
+    CandidateEnvironmentMismatch,
+    /// The record does not bind the candidate release.
+    CandidateReleaseMismatch,
+    /// The record does not bind the candidate source revision.
+    CandidateSourceRevisionMismatch,
+    /// The record is expired at the admission time.
+    RecordExpired,
+    /// The record failed structural or consistency validation.
+    RecordInvalid,
+    /// The record accounts skipped tests, which admission never approves.
+    SkippedTestsRecorded,
+    /// The independent verification did not accept the run.
+    VerificationNotAccepted,
+}
+
+/// Every denial code, in the stable lexicographic decision order.
+pub const TEST_RUN_DENIAL_CODES: [TestRunDenialCode; 13] = [
+    TestRunDenialCode::AdmissionIdMalformed,
+    TestRunDenialCode::AdmissionIdMismatch,
+    TestRunDenialCode::AdmissionTimeMalformed,
+    TestRunDenialCode::CandidateApplicationMismatch,
+    TestRunDenialCode::CandidateArtifactFingerprintMismatch,
+    TestRunDenialCode::CandidateContractFingerprintMismatch,
+    TestRunDenialCode::CandidateEnvironmentMismatch,
+    TestRunDenialCode::CandidateReleaseMismatch,
+    TestRunDenialCode::CandidateSourceRevisionMismatch,
+    TestRunDenialCode::RecordExpired,
+    TestRunDenialCode::RecordInvalid,
+    TestRunDenialCode::SkippedTestsRecorded,
+    TestRunDenialCode::VerificationNotAccepted,
+];
+
+/// Structured allow-or-deny admission decision for one exact candidate.
+///
+/// The decision carries the machine-readable cause classes next to the exact
+/// diagnostics, so a deployment gate in any language can act on one bounded
+/// vocabulary while operators keep the full explanation. Serialization
+/// follows `schema/test-run-admission.schema.json`; decisions are outputs,
+/// so no deserializer is provided and a gate must never trust a decision it
+/// did not compute itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestRunAdmissionDecision {
+    /// Whether the record admits the candidate; true only with no diagnostics.
+    pub allowed: bool,
+    /// Deduplicated denial causes sorted lexicographically; empty when allowed.
+    pub denial_codes: Vec<TestRunDenialCode>,
+    /// Complete diagnostics in the stable path, code, message order.
+    pub diagnostics: Vec<ContractDiagnostic>,
+}
+
+/// Returns the stable denial code one admission diagnostic maps to.
+///
+/// The mapping is total and identical in every host family: admission codes
+/// `VIZE_MARQUETTE_141` through `VIZE_MARQUETTE_148` map to their exact
+/// cause, `VIZE_MARQUETTE_144` distinguishes the mismatched candidate
+/// binding by its diagnostic path, and every other diagnostic is a
+/// [`TestRunDenialCode::RecordInvalid`] record-validation failure.
+pub fn test_run_denial_code(diagnostic: &ContractDiagnostic) -> TestRunDenialCode {
+    match (diagnostic.code, diagnostic.path.as_str()) {
+        ("VIZE_MARQUETTE_141", _) => TestRunDenialCode::AdmissionIdMalformed,
+        ("VIZE_MARQUETTE_142", _) => TestRunDenialCode::AdmissionIdMismatch,
+        ("VIZE_MARQUETTE_144", "application") => TestRunDenialCode::CandidateApplicationMismatch,
+        ("VIZE_MARQUETTE_144", "artifact.fingerprint") => {
+            TestRunDenialCode::CandidateArtifactFingerprintMismatch
+        }
+        ("VIZE_MARQUETTE_144", "contractFingerprint") => {
+            TestRunDenialCode::CandidateContractFingerprintMismatch
+        }
+        ("VIZE_MARQUETTE_144", "environment") => TestRunDenialCode::CandidateEnvironmentMismatch,
+        ("VIZE_MARQUETTE_144", "release") => TestRunDenialCode::CandidateReleaseMismatch,
+        ("VIZE_MARQUETTE_144", "sourceRevision") => {
+            TestRunDenialCode::CandidateSourceRevisionMismatch
+        }
+        ("VIZE_MARQUETTE_145", _) => TestRunDenialCode::RecordExpired,
+        ("VIZE_MARQUETTE_146", _) => TestRunDenialCode::VerificationNotAccepted,
+        ("VIZE_MARQUETTE_147", _) => TestRunDenialCode::SkippedTestsRecorded,
+        ("VIZE_MARQUETTE_148", _) => TestRunDenialCode::AdmissionTimeMalformed,
+        _ => TestRunDenialCode::RecordInvalid,
+    }
+}
+
+/// Decides one candidate and returns the structured admission decision.
+///
+/// The decision wraps [`admit_test_run`]: `diagnostics` is exactly its
+/// result, `denial_codes` maps every diagnostic through
+/// [`test_run_denial_code`] and then deduplicates and sorts the codes
+/// lexicographically, and `allowed` is true only when both are empty. Inputs
+/// carry the same obligations as [`admit_test_run`].
+pub fn decide_test_run_admission(
+    evidence: &TestRunEvidence,
+    candidate: &TestRunCandidate,
+    admission_id: &str,
+    now: &str,
+) -> TestRunAdmissionDecision {
+    let diagnostics = admit_test_run(evidence, candidate, admission_id, now);
+    let mut denial_codes: Vec<TestRunDenialCode> =
+        diagnostics.iter().map(test_run_denial_code).collect();
+    denial_codes.sort_unstable();
+    denial_codes.dedup();
+    TestRunAdmissionDecision {
+        allowed: diagnostics.is_empty(),
+        denial_codes,
+        diagnostics,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_run::admission::test_run_admission_id;
+    use crate::test_run::model_tests::example_evidence;
+
+    use super::*;
+
+    fn example_candidate() -> TestRunCandidate {
+        let evidence = example_evidence();
+        TestRunCandidate {
+            application: evidence.application,
+            environment: evidence.environment,
+            contract_fingerprint: evidence.contract_fingerprint,
+            source_revision: evidence.source_revision,
+            release: evidence.release,
+            artifact_fingerprint: evidence.artifact.fingerprint,
+        }
+    }
+
+    const NOW: &str = "2026-07-22T00:00:00.000Z";
+
+    #[test]
+    fn the_vocabulary_is_sorted_and_serializes_kebab_case() {
+        let serialized: [vize_carton::String; 13] = TEST_RUN_DENIAL_CODES
+            .map(|code| serde_json::to_value(code).unwrap().as_str().unwrap().into());
+        let mut sorted = serialized.clone();
+        sorted.sort();
+        assert_eq!(serialized, sorted);
+        assert_eq!(serialized[0], "admission-id-malformed");
+        assert_eq!(serialized[10], "record-invalid");
+
+        let mut ordered = TEST_RUN_DENIAL_CODES;
+        ordered.sort_unstable();
+        assert_eq!(ordered, TEST_RUN_DENIAL_CODES);
+    }
+
+    #[test]
+    fn an_admitted_candidate_has_no_denial_codes() {
+        let evidence = example_evidence();
+        let id = test_run_admission_id(&evidence).unwrap();
+        let decision = decide_test_run_admission(&evidence, &example_candidate(), &id, NOW);
+        assert!(decision.allowed);
+        assert_eq!(decision.denial_codes, Vec::new());
+        assert_eq!(decision.diagnostics, Vec::new());
+    }
+
+    #[test]
+    fn every_binding_mismatch_has_a_distinct_code() {
+        let evidence = example_evidence();
+        let id = test_run_admission_id(&evidence).unwrap();
+        let candidate = TestRunCandidate {
+            application: "other".into(),
+            environment: "other".into(),
+            contract_fingerprint: "other".into(),
+            source_revision: "other".into(),
+            release: "other".into(),
+            artifact_fingerprint: "other".into(),
+        };
+        let decision = decide_test_run_admission(&evidence, &candidate, &id, NOW);
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.denial_codes,
+            [
+                TestRunDenialCode::CandidateApplicationMismatch,
+                TestRunDenialCode::CandidateArtifactFingerprintMismatch,
+                TestRunDenialCode::CandidateContractFingerprintMismatch,
+                TestRunDenialCode::CandidateEnvironmentMismatch,
+                TestRunDenialCode::CandidateReleaseMismatch,
+                TestRunDenialCode::CandidateSourceRevisionMismatch,
+            ]
+        );
+        assert_eq!(decision.diagnostics.len(), 6);
+    }
+
+    #[test]
+    fn repeated_causes_deduplicate_into_sorted_codes() {
+        let mut evidence = example_evidence();
+        evidence.application = "not-the-candidate".into();
+        evidence.artifact.fingerprint = "tampered".into();
+        evidence.contract_fingerprint = "also-tampered".into();
+        let decision = decide_test_run_admission(
+            &evidence,
+            &example_candidate(),
+            "test-run:junk",
+            "2099-01-01T00:00:00.000+0",
+        );
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.denial_codes,
+            [
+                TestRunDenialCode::AdmissionIdMalformed,
+                TestRunDenialCode::AdmissionTimeMalformed,
+                TestRunDenialCode::CandidateApplicationMismatch,
+                TestRunDenialCode::CandidateArtifactFingerprintMismatch,
+                TestRunDenialCode::CandidateContractFingerprintMismatch,
+                TestRunDenialCode::RecordInvalid,
+            ]
+        );
+        assert!(decision.diagnostics.len() > decision.denial_codes.len());
+    }
+}

--- a/crates/vize_marquette/tests/test_run_conformance.rs
+++ b/crates/vize_marquette/tests/test_run_conformance.rs
@@ -6,8 +6,8 @@
 use std::{fs, path::PathBuf};
 
 use vize_marquette::{
-    TestRunEvidence, canonical_test_run_json, parse_test_run_admission_id, test_run_admission_id,
-    test_run_fingerprint,
+    TestRunCandidate, TestRunEvidence, canonical_test_run_json, decide_test_run_admission,
+    parse_test_run_admission_id, test_run_admission_id, test_run_fingerprint,
 };
 
 fn fixture(name: &str) -> PathBuf {
@@ -51,4 +51,33 @@ fn returns_the_shared_invalid_diagnostic_codes() {
     let expected: Vec<vize_carton::String> =
         serde_json::from_slice(&fs::read(fixture("invalid.expected.json")).unwrap()).unwrap();
     assert_eq!(actual, expected);
+}
+
+#[test]
+fn reproduces_every_shared_admission_decision() {
+    let document: serde_json::Value =
+        serde_json::from_slice(&fs::read(fixture("admission-decisions.json")).unwrap()).unwrap();
+    let cases = document["cases"].as_array().unwrap();
+    assert!(!cases.is_empty());
+
+    for case in cases {
+        let name = case["name"].as_str().unwrap();
+        let evidence: TestRunEvidence =
+            serde_json::from_slice(&fs::read(fixture(case["evidence"].as_str().unwrap())).unwrap())
+                .unwrap();
+        let candidate: TestRunCandidate =
+            serde_json::from_value(case["candidate"].clone()).unwrap();
+        let decision = decide_test_run_admission(
+            &evidence,
+            &candidate,
+            case["admissionId"].as_str().unwrap(),
+            case["now"].as_str().unwrap(),
+        );
+        assert!(case["decision"].is_object(), "{name} must pin a decision");
+        assert_eq!(
+            serde_json::to_value(&decision).unwrap(),
+            case["decision"],
+            "decision mismatch for case {name}",
+        );
+    }
 }

--- a/crates/vize_marquette/tests/test_run_schema.rs
+++ b/crates/vize_marquette/tests/test_run_schema.rs
@@ -57,3 +57,38 @@ fn test_run_schema_is_strict_and_versioned() {
         "every object schema must reject unknown properties"
     );
 }
+
+#[test]
+fn admission_schema_is_strict_and_documents_the_append_only_policy() {
+    let schema: Value = serde_json::from_slice(
+        &fs::read(repository_file(
+            "crates/vize_marquette/schema/test-run-admission.schema.json",
+        ))
+        .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        schema["$schema"],
+        "https://json-schema.org/draft/2020-12/schema"
+    );
+    let description = schema["$defs"]["denialCode"]["description"]
+        .as_str()
+        .unwrap();
+    assert!(description.contains("append-only"));
+    assert!(description.contains("never renamed, renumbered, reused, or removed"));
+
+    let codes = schema["$defs"]["denialCode"]["enum"].as_array().unwrap();
+    let mut sorted = codes.clone();
+    sorted.sort_by_key(|value| value.as_str().unwrap().to_owned());
+    assert_eq!(
+        codes, &sorted,
+        "denial codes must stay in lexicographic order"
+    );
+
+    assert_eq!(
+        count_open_object_schemas(&schema),
+        0,
+        "every object schema must reject unknown properties"
+    );
+}

--- a/npm/marquette/README.md
+++ b/npm/marquette/README.md
@@ -99,18 +99,26 @@ deployment tooling can bind a `tests` check to retained, immutable facts:
 import { defineTestRunEvidence } from "@vizejs/marquette/test-run";
 import { validateTestRunEvidence } from "@vizejs/marquette/test-run/validate";
 import { testRunAdmissionId } from "@vizejs/marquette/test-run/canonical";
-import { admitTestRun } from "@vizejs/marquette/test-run/admission";
+import { admitTestRun, decideTestRunAdmission } from "@vizejs/marquette/test-run/admission";
 
 const diagnostics = validateTestRunEvidence(evidence);
 const admissionId = await testRunAdmissionId(evidence); // test-run:<sha256>
 const rejections = await admitTestRun(evidence, candidate, admissionId, now);
+const decision = await decideTestRunAdmission(evidence, candidate, admissionId, now);
+if (!decision.allowed) {
+  console.error(decision.denialCodes); // e.g. ["record-expired"]
+}
 ```
 
 Validation shares its `VIZE_MARQUETTE_1xx` codes, paths, and ordering with the
 native implementation, and the canonical entry produces byte-identical
 serialization and SHA-256 fingerprints, proven by the shared fixtures in
-`tests/fixtures/test-run-evidence/`. The published record schema is available
-from `@vizejs/marquette/test-run/schema`.
+`tests/fixtures/test-run-evidence/`. Admission decisions carry the stable,
+append-only denial-code vocabulary shared by every backend family; the same
+fixtures pin every decision so a JavaScript, Rust, Go, or JVM gate denies for
+identical machine-readable causes. The published record schema is available
+from `@vizejs/marquette/test-run/schema`, and the decision contract from
+`@vizejs/marquette/test-run/admission/schema`.
 
 ## Guarantees
 

--- a/npm/marquette/package.json
+++ b/npm/marquette/package.json
@@ -57,7 +57,8 @@
       "default": "./dist/test-run-admission.mjs"
     },
     "./schema": "./dist/application-contract.schema.json",
-    "./test-run/schema": "./dist/test-run-evidence.schema.json"
+    "./test-run/schema": "./dist/test-run-evidence.schema.json",
+    "./test-run/admission/schema": "./dist/test-run-admission.schema.json"
   },
   "publishConfig": {
     "access": "public"

--- a/npm/marquette/scripts/check-size.mjs
+++ b/npm/marquette/scripts/check-size.mjs
@@ -25,7 +25,7 @@ const budgets = [
   {
     entry: "@vizejs/marquette/test-run/admission",
     file: "dist/test-run-admission.mjs",
-    maximumGzipBytes: 2048,
+    maximumGzipBytes: 3072,
   },
 ];
 

--- a/npm/marquette/src/test-run-admission.test.ts
+++ b/npm/marquette/src/test-run-admission.test.ts
@@ -3,16 +3,22 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import type { TestRunEvidence } from "./test-run.js";
-import { admitTestRun, type TestRunCandidate } from "./test-run-admission.js";
+import {
+  TEST_RUN_DENIAL_CODES,
+  admitTestRun,
+  decideTestRunAdmission,
+  testRunDenialCode,
+  type TestRunAdmissionDecision,
+  type TestRunCandidate,
+} from "./test-run-admission.js";
 import { testRunAdmissionId } from "./test-run-canonical.js";
 
-function readEvidence(): TestRunEvidence {
-  return JSON.parse(
-    readFileSync(
-      new URL("../../../tests/fixtures/test-run-evidence/valid.json", import.meta.url),
-      "utf8",
-    ),
-  ) as TestRunEvidence;
+function fixture(name: string): URL {
+  return new URL(`../../../tests/fixtures/test-run-evidence/${name}`, import.meta.url);
+}
+
+function readEvidence(name = "valid.json"): TestRunEvidence {
+  return JSON.parse(readFileSync(fixture(name), "utf8")) as TestRunEvidence;
 }
 
 function candidateFor(evidence: TestRunEvidence): TestRunCandidate {
@@ -102,4 +108,65 @@ void test("skipped tests are not admitted", async () => {
   assert.deepEqual(codes(await admitTestRun(skipped, candidateFor(skipped), id, NOW)), [
     "VIZE_MARQUETTE_147",
   ]);
+});
+
+void test("the denial vocabulary is sorted and deduplicates into decisions", async () => {
+  assert.deepEqual([...TEST_RUN_DENIAL_CODES], [...TEST_RUN_DENIAL_CODES].sort());
+
+  const evidence = readEvidence();
+  const decision = await decideTestRunAdmission(
+    {
+      ...evidence,
+      application: "not-the-candidate",
+      contractFingerprint: "tampered",
+      artifact: { ...evidence.artifact, fingerprint: "also-tampered" },
+    },
+    candidateFor(evidence),
+    "test-run:junk",
+    "yesterday",
+  );
+  assert.equal(decision.allowed, false);
+  assert.deepEqual(decision.denialCodes, [
+    "admission-id-malformed",
+    "admission-time-malformed",
+    "candidate-application-mismatch",
+    "candidate-artifact-fingerprint-mismatch",
+    "candidate-contract-fingerprint-mismatch",
+    "record-invalid",
+  ]);
+  assert.ok(decision.diagnostics.length > decision.denialCodes.length);
+  for (const diagnostic of decision.diagnostics) {
+    assert.ok(TEST_RUN_DENIAL_CODES.includes(testRunDenialCode(diagnostic)));
+  }
+});
+
+interface SharedDecisionCase {
+  readonly name: string;
+  readonly family: string;
+  readonly evidence: string;
+  readonly candidate: TestRunCandidate;
+  readonly admissionId: string;
+  readonly now: string;
+  readonly decision: TestRunAdmissionDecision;
+}
+
+void test("reproduces every shared admission decision", async () => {
+  const document = JSON.parse(readFileSync(fixture("admission-decisions.json"), "utf8")) as {
+    cases: SharedDecisionCase[];
+  };
+  assert.ok(document.cases.length > 0);
+
+  for (const sharedCase of document.cases) {
+    const decision = await decideTestRunAdmission(
+      readEvidence(sharedCase.evidence),
+      sharedCase.candidate,
+      sharedCase.admissionId,
+      sharedCase.now,
+    );
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(decision)),
+      sharedCase.decision,
+      `decision mismatch for case ${sharedCase.name}`,
+    );
+  }
 });

--- a/npm/marquette/src/test-run-admission.ts
+++ b/npm/marquette/src/test-run-admission.ts
@@ -141,3 +141,110 @@ export async function admitTestRun(
   );
   return diagnostics;
 }
+
+/**
+ * Every denial code, in the stable lexicographic decision order.
+ *
+ * The vocabulary is shared by every backend family: a JavaScript, Rust, Go,
+ * or JVM host must derive the same codes from the same diagnostics, as
+ * pinned by the shared `tests/fixtures/test-run-evidence` decision fixtures.
+ * Codes are append-only: they are never renamed, renumbered, reused, or
+ * removed, and a new rejection cause always ships with a new code.
+ */
+export const TEST_RUN_DENIAL_CODES = [
+  "admission-id-malformed",
+  "admission-id-mismatch",
+  "admission-time-malformed",
+  "candidate-application-mismatch",
+  "candidate-artifact-fingerprint-mismatch",
+  "candidate-contract-fingerprint-mismatch",
+  "candidate-environment-mismatch",
+  "candidate-release-mismatch",
+  "candidate-source-revision-mismatch",
+  "record-expired",
+  "record-invalid",
+  "skipped-tests-recorded",
+  "verification-not-accepted",
+] as const;
+
+/** Stable machine-readable cause class of one admission denial. */
+export type TestRunDenialCode = (typeof TEST_RUN_DENIAL_CODES)[number];
+
+/**
+ * Structured allow-or-deny admission decision for one exact candidate.
+ *
+ * The decision carries the machine-readable cause classes next to the exact
+ * diagnostics, so a deployment gate in any language can act on one bounded
+ * vocabulary while operators keep the full explanation. Serialization
+ * follows the shared `test-run-admission` schema; decisions are outputs, so
+ * a gate must never trust a decision it did not compute itself.
+ */
+export interface TestRunAdmissionDecision {
+  /** Whether the record admits the candidate; true only with no diagnostics. */
+  readonly allowed: boolean;
+  /** Deduplicated denial causes sorted lexicographically; empty when allowed. */
+  readonly denialCodes: readonly TestRunDenialCode[];
+  /** Complete diagnostics in the stable path, code, message order. */
+  readonly diagnostics: readonly MarquetteDiagnostic[];
+}
+
+const CANDIDATE_MISMATCH_CODES: ReadonlyMap<string, TestRunDenialCode> = new Map([
+  ["application", "candidate-application-mismatch"],
+  ["artifact.fingerprint", "candidate-artifact-fingerprint-mismatch"],
+  ["contractFingerprint", "candidate-contract-fingerprint-mismatch"],
+  ["environment", "candidate-environment-mismatch"],
+  ["release", "candidate-release-mismatch"],
+  ["sourceRevision", "candidate-source-revision-mismatch"],
+]);
+
+/**
+ * Returns the stable denial code one admission diagnostic maps to.
+ *
+ * The mapping is total and identical in every host family: admission codes
+ * `VIZE_MARQUETTE_141` through `VIZE_MARQUETTE_148` map to their exact
+ * cause, `VIZE_MARQUETTE_144` distinguishes the mismatched candidate binding
+ * by its diagnostic path, and every other diagnostic is a `record-invalid`
+ * record-validation failure.
+ */
+export function testRunDenialCode(diagnostic: MarquetteDiagnostic): TestRunDenialCode {
+  switch (diagnostic.code) {
+    case "VIZE_MARQUETTE_141":
+      return "admission-id-malformed";
+    case "VIZE_MARQUETTE_142":
+      return "admission-id-mismatch";
+    case "VIZE_MARQUETTE_144":
+      return CANDIDATE_MISMATCH_CODES.get(diagnostic.path) ?? "record-invalid";
+    case "VIZE_MARQUETTE_145":
+      return "record-expired";
+    case "VIZE_MARQUETTE_146":
+      return "verification-not-accepted";
+    case "VIZE_MARQUETTE_147":
+      return "skipped-tests-recorded";
+    case "VIZE_MARQUETTE_148":
+      return "admission-time-malformed";
+    default:
+      return "record-invalid";
+  }
+}
+
+/**
+ * Decides one candidate and returns the structured admission decision.
+ *
+ * The decision wraps {@link admitTestRun}: `diagnostics` is exactly its
+ * result, `denialCodes` maps every diagnostic through
+ * {@link testRunDenialCode} and then deduplicates and sorts the codes
+ * lexicographically, and `allowed` is true only when both are empty. Codes,
+ * ordering, and diagnostics are identical to the native implementation, as
+ * pinned by the shared decision fixtures. Inputs carry the same obligations
+ * as {@link admitTestRun}.
+ */
+export async function decideTestRunAdmission(
+  evidence: TestRunEvidence,
+  candidate: TestRunCandidate,
+  admissionId: string,
+  now: string,
+): Promise<TestRunAdmissionDecision> {
+  const diagnostics = await admitTestRun(evidence, candidate, admissionId, now);
+  const denialCodes = [...new Set(diagnostics.map(testRunDenialCode))].sort();
+  return { allowed: diagnostics.length === 0, denialCodes, diagnostics };
+}

--- a/npm/marquette/vite.config.ts
+++ b/npm/marquette/vite.config.ts
@@ -7,7 +7,11 @@ import { defineConfig } from "vite-plus";
  * `vp pack` self-contained: a post-pack copy step's outputs would escape the
  * task cache, so a cache hit could restore `dist/` without the schemas.
  */
-const contractSchemas = ["application-contract.schema.json", "test-run-evidence.schema.json"];
+const contractSchemas = [
+  "application-contract.schema.json",
+  "test-run-evidence.schema.json",
+  "test-run-admission.schema.json",
+];
 
 export default defineConfig({
   lint: {

--- a/tests/fixtures/test-run-evidence/admission-anonymous.json
+++ b/tests/fixtures/test-run-evidence/admission-anonymous.json
@@ -1,0 +1,131 @@
+{
+  "format": "vize.test-run.evidence",
+  "formatVersion": 1,
+  "id": "run-2026-07-21.005",
+  "application": "example",
+  "environment": "production",
+  "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+  "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "release": "0.298.0",
+  "artifact": {
+    "id": "web-bundle",
+    "fingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+    "sizeBytes": 4096
+  },
+  "startedAt": "2026-07-21T00:00:00.000Z",
+  "completedAt": "2026-07-21T00:10:00.000Z",
+  "validUntil": "2026-07-28T00:10:00.000Z",
+  "runner": {
+    "identity": "Anonymous Runner!",
+    "authenticationEvidence": {
+      "reference": "trust-me",
+      "fingerprint": "3333333333333333333333333333333333333333333333333333333333333333"
+    },
+    "isolation": "ephemeral",
+    "invocationFingerprint": "4444444444444444444444444444444444444444444444444444444444444444",
+    "environmentEvidence": {
+      "reference": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+      "fingerprint": "5555555555555555555555555555555555555555555555555555555555555555"
+    },
+    "environmentFingerprint": "6666666666666666666666666666666666666666666666666666666666666666"
+  },
+  "selection": {
+    "targetIds": ["server", "web"],
+    "suiteIds": ["contract", "unit"]
+  },
+  "targets": [
+    {
+      "id": "web",
+      "kind": "web",
+      "environment": "production"
+    },
+    {
+      "id": "server",
+      "kind": "server",
+      "environment": "production"
+    }
+  ],
+  "suites": [
+    {
+      "id": "unit",
+      "targetId": "web",
+      "kind": "unit",
+      "shardIndex": 2,
+      "shardCount": 2,
+      "outcome": "passed",
+      "passed": 64,
+      "failed": 0,
+      "skipped": 0,
+      "retries": 0,
+      "durationMs": 30500,
+      "invocationFingerprint": "7777777777777777777777777777777777777777777777777777777777777777",
+      "report": {
+        "reference": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+        "fingerprint": "8888888888888888888888888888888888888888888888888888888888888888"
+      },
+      "log": {
+        "reference": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+        "fingerprint": "9999999999999999999999999999999999999999999999999999999999999999"
+      }
+    },
+    {
+      "id": "contract",
+      "targetId": "server",
+      "kind": "contract",
+      "shardIndex": 1,
+      "shardCount": 1,
+      "outcome": "passed",
+      "passed": 18,
+      "failed": 0,
+      "skipped": 0,
+      "retries": 0,
+      "durationMs": 42000,
+      "invocationFingerprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "report": {
+        "reference": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "fingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "log": {
+        "reference": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "fingerprint": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      }
+    },
+    {
+      "id": "unit",
+      "targetId": "web",
+      "kind": "unit",
+      "shardIndex": 1,
+      "shardCount": 2,
+      "outcome": "passed",
+      "passed": 56,
+      "failed": 0,
+      "skipped": 0,
+      "retries": 0,
+      "durationMs": 31000,
+      "invocationFingerprint": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "report": {
+        "reference": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "fingerprint": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      },
+      "log": {
+        "reference": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      }
+    }
+  ],
+  "verification": {
+    "verifier": "release.verifier",
+    "completedAt": "2026-07-21T00:11:00.000Z",
+    "outcome": "accepted",
+    "targetCount": 2,
+    "suiteCount": 3,
+    "passed": 138,
+    "failed": 0,
+    "skipped": 0,
+    "retries": 0,
+    "evidence": {
+      "reference": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "fingerprint": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  }
+}

--- a/tests/fixtures/test-run-evidence/admission-decisions.json
+++ b/tests/fixtures/test-run-evidence/admission-decisions.json
@@ -1,0 +1,521 @@
+{
+  "cases": [
+    {
+      "admissionId": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": true,
+        "denialCodes": [],
+        "diagnostics": []
+      },
+      "evidence": "valid.json",
+      "family": "admitted",
+      "name": "admitted-exact-candidate",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "admissionId": "test-run:junk",
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["admission-id-malformed"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_141",
+            "message": "admission id must be test-run: followed by 64 lowercase hexadecimal characters",
+            "path": "admission.id",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "admission-id",
+      "name": "admission-id-malformed",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "admissionId": "test-run:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["admission-id-mismatch"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_142",
+            "message": "admission id does not name this record's canonical fingerprint",
+            "path": "admission.id",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "admission-id",
+      "name": "admission-id-mismatch",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "admissionId": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+      "candidate": {
+        "application": "intruder",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["candidate-application-mismatch"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_144",
+            "message": "record does not bind the candidate application",
+            "path": "application",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "cross-scope",
+      "name": "cross-scope-application",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "admissionId": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "staging",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["candidate-environment-mismatch"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_144",
+            "message": "record does not bind the candidate environment",
+            "path": "environment",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "cross-scope",
+      "name": "cross-scope-environment",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "admissionId": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "9999999999999999999999999999999999999999999999999999999999999999",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["candidate-contract-fingerprint-mismatch"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_144",
+            "message": "record does not bind the candidate contractFingerprint",
+            "path": "contractFingerprint",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "cross-scope",
+      "name": "cross-scope-contract-fingerprint",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "admissionId": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["candidate-source-revision-mismatch"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_144",
+            "message": "record does not bind the candidate sourceRevision",
+            "path": "sourceRevision",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "cross-scope",
+      "name": "cross-scope-source-revision",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "admissionId": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.299.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["candidate-release-mismatch"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_144",
+            "message": "record does not bind the candidate release",
+            "path": "release",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "cross-scope",
+      "name": "cross-scope-release",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "admissionId": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "8888888888888888888888888888888888888888888888888888888888888888",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["candidate-artifact-fingerprint-mismatch"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_144",
+            "message": "record does not bind the candidate artifact.fingerprint",
+            "path": "artifact.fingerprint",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "cross-scope",
+      "name": "cross-scope-artifact-fingerprint",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "admissionId": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["record-expired"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_145",
+            "message": "record is expired at the admission time",
+            "path": "validUntil",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "late",
+      "name": "late-expired-record",
+      "now": "2026-07-28T00:10:00.000Z"
+    },
+    {
+      "admissionId": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["admission-time-malformed"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_148",
+            "message": "admission time must be a millisecond-precision UTC instant",
+            "path": "admission.now",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "late",
+      "name": "late-malformed-admission-time",
+      "now": "yesterday"
+    },
+    {
+      "admissionId": "test-run:151c16edbe166ccb54cd0a424ff6f725c82d2c67e9945ec7133a48e87bdbba52",
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["verification-not-accepted"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_146",
+            "message": "only an accepted verification can admit a deployment",
+            "path": "verification.outcome",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "admission-rejected.json",
+      "family": "denied",
+      "name": "denied-verification",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "admissionId": "test-run:d47ac1c117d5e81af4207211bd8d245b5f592eea1e388b43b1464442b535d68e",
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["verification-not-accepted"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_146",
+            "message": "only an accepted verification can admit a deployment",
+            "path": "verification.outcome",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "admission-failed.json",
+      "family": "failed",
+      "name": "failed-suite-execution",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "admissionId": "test-run:3aed54f89e1870148007327bda26ed05fe0d29d2fc0e075bf3afa48a246efcf6",
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["skipped-tests-recorded"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_147",
+            "message": "skipped tests are not approved for deployment admission",
+            "path": "verification.skipped",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "admission-skipped.json",
+      "family": "skipped",
+      "name": "skipped-tests-recorded",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "admissionId": "test-run:e7a95206a2fa60e570bbe27be7c84d831b6bc3ffaebbeb06384b273252a042e1",
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["record-invalid"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_108",
+            "message": "evidence reference must be sha256: followed by 64 lowercase hexadecimal characters",
+            "path": "runner.authenticationEvidence.reference",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_103",
+            "message": "identifier must use lowercase ASCII letters, digits, dash, underscore, or dot",
+            "path": "runner.identity",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "admission-anonymous.json",
+      "family": "anonymous",
+      "name": "anonymous-runner",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "admissionId": "test-run:30c6e60d92ec245d874a0e39b25edaa8588168a8869f9df8291a79b58ee8c222",
+      "candidate": {
+        "application": "Example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["record-expired", "record-invalid"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_103",
+            "message": "identifier must use lowercase ASCII letters, digits, dash, underscore, or dot",
+            "path": "application",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_108",
+            "message": "evidence reference must be sha256: followed by 64 lowercase hexadecimal characters",
+            "path": "suites.contract.report.reference",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_125",
+            "message": "suite must record every shard from 1 to 2",
+            "path": "suites.unit",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_113",
+            "message": "record expiry must come after run completion",
+            "path": "validUntil",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_145",
+            "message": "record is expired at the admission time",
+            "path": "validUntil",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_128",
+            "message": "verified passed total must equal the sum over suite executions",
+            "path": "verification.passed",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_128",
+            "message": "verified retried total must equal the sum over suite executions",
+            "path": "verification.retries",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_127",
+            "message": "verified suite count must equal the recorded suite executions",
+            "path": "verification.suiteCount",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "invalid.json",
+      "family": "malformed",
+      "name": "malformed-expired-record",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "admissionId": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "staging",
+        "release": "0.299.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": [
+          "candidate-environment-mismatch",
+          "candidate-release-mismatch",
+          "record-expired"
+        ],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_144",
+            "message": "record does not bind the candidate environment",
+            "path": "environment",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_144",
+            "message": "record does not bind the candidate release",
+            "path": "release",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_145",
+            "message": "record is expired at the admission time",
+            "path": "validUntil",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "multi-cause",
+      "name": "multi-cause-cross-scope-late",
+      "now": "2026-07-28T00:10:00.000Z"
+    }
+  ],
+  "description": "Shared host-side admission-decision conformance cases. Each case feeds one evidence record, one candidate, one admission id, and one instant to the admission gate; every backend family must produce exactly the pinned decision. See crates/vize_marquette/schema/test-run-admission.schema.json for the decision contract and the append-only denial-code policy."
+}

--- a/tests/fixtures/test-run-evidence/admission-failed.json
+++ b/tests/fixtures/test-run-evidence/admission-failed.json
@@ -1,0 +1,131 @@
+{
+  "format": "vize.test-run.evidence",
+  "formatVersion": 1,
+  "id": "run-2026-07-21.003",
+  "application": "example",
+  "environment": "production",
+  "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+  "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "release": "0.298.0",
+  "artifact": {
+    "id": "web-bundle",
+    "fingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+    "sizeBytes": 4096
+  },
+  "startedAt": "2026-07-21T00:00:00.000Z",
+  "completedAt": "2026-07-21T00:10:00.000Z",
+  "validUntil": "2026-07-28T00:10:00.000Z",
+  "runner": {
+    "identity": "ci.runner-1",
+    "authenticationEvidence": {
+      "reference": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+      "fingerprint": "3333333333333333333333333333333333333333333333333333333333333333"
+    },
+    "isolation": "ephemeral",
+    "invocationFingerprint": "4444444444444444444444444444444444444444444444444444444444444444",
+    "environmentEvidence": {
+      "reference": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+      "fingerprint": "5555555555555555555555555555555555555555555555555555555555555555"
+    },
+    "environmentFingerprint": "6666666666666666666666666666666666666666666666666666666666666666"
+  },
+  "selection": {
+    "targetIds": ["server", "web"],
+    "suiteIds": ["contract", "unit"]
+  },
+  "targets": [
+    {
+      "id": "web",
+      "kind": "web",
+      "environment": "production"
+    },
+    {
+      "id": "server",
+      "kind": "server",
+      "environment": "production"
+    }
+  ],
+  "suites": [
+    {
+      "id": "unit",
+      "targetId": "web",
+      "kind": "unit",
+      "shardIndex": 2,
+      "shardCount": 2,
+      "outcome": "passed",
+      "passed": 64,
+      "failed": 0,
+      "skipped": 0,
+      "retries": 0,
+      "durationMs": 30500,
+      "invocationFingerprint": "7777777777777777777777777777777777777777777777777777777777777777",
+      "report": {
+        "reference": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+        "fingerprint": "8888888888888888888888888888888888888888888888888888888888888888"
+      },
+      "log": {
+        "reference": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+        "fingerprint": "9999999999999999999999999999999999999999999999999999999999999999"
+      }
+    },
+    {
+      "id": "contract",
+      "targetId": "server",
+      "kind": "contract",
+      "shardIndex": 1,
+      "shardCount": 1,
+      "outcome": "failed",
+      "passed": 16,
+      "failed": 2,
+      "skipped": 0,
+      "retries": 0,
+      "durationMs": 42000,
+      "invocationFingerprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "report": {
+        "reference": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "fingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "log": {
+        "reference": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "fingerprint": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      }
+    },
+    {
+      "id": "unit",
+      "targetId": "web",
+      "kind": "unit",
+      "shardIndex": 1,
+      "shardCount": 2,
+      "outcome": "passed",
+      "passed": 56,
+      "failed": 0,
+      "skipped": 0,
+      "retries": 0,
+      "durationMs": 31000,
+      "invocationFingerprint": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "report": {
+        "reference": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "fingerprint": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      },
+      "log": {
+        "reference": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      }
+    }
+  ],
+  "verification": {
+    "verifier": "release.verifier",
+    "completedAt": "2026-07-21T00:11:00.000Z",
+    "outcome": "rejected",
+    "targetCount": 2,
+    "suiteCount": 3,
+    "passed": 136,
+    "failed": 2,
+    "skipped": 0,
+    "retries": 0,
+    "evidence": {
+      "reference": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "fingerprint": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  }
+}

--- a/tests/fixtures/test-run-evidence/admission-rejected.json
+++ b/tests/fixtures/test-run-evidence/admission-rejected.json
@@ -1,0 +1,131 @@
+{
+  "format": "vize.test-run.evidence",
+  "formatVersion": 1,
+  "id": "run-2026-07-21.002",
+  "application": "example",
+  "environment": "production",
+  "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+  "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "release": "0.298.0",
+  "artifact": {
+    "id": "web-bundle",
+    "fingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+    "sizeBytes": 4096
+  },
+  "startedAt": "2026-07-21T00:00:00.000Z",
+  "completedAt": "2026-07-21T00:10:00.000Z",
+  "validUntil": "2026-07-28T00:10:00.000Z",
+  "runner": {
+    "identity": "ci.runner-1",
+    "authenticationEvidence": {
+      "reference": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+      "fingerprint": "3333333333333333333333333333333333333333333333333333333333333333"
+    },
+    "isolation": "ephemeral",
+    "invocationFingerprint": "4444444444444444444444444444444444444444444444444444444444444444",
+    "environmentEvidence": {
+      "reference": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+      "fingerprint": "5555555555555555555555555555555555555555555555555555555555555555"
+    },
+    "environmentFingerprint": "6666666666666666666666666666666666666666666666666666666666666666"
+  },
+  "selection": {
+    "targetIds": ["server", "web"],
+    "suiteIds": ["contract", "unit"]
+  },
+  "targets": [
+    {
+      "id": "web",
+      "kind": "web",
+      "environment": "production"
+    },
+    {
+      "id": "server",
+      "kind": "server",
+      "environment": "production"
+    }
+  ],
+  "suites": [
+    {
+      "id": "unit",
+      "targetId": "web",
+      "kind": "unit",
+      "shardIndex": 2,
+      "shardCount": 2,
+      "outcome": "passed",
+      "passed": 64,
+      "failed": 0,
+      "skipped": 0,
+      "retries": 0,
+      "durationMs": 30500,
+      "invocationFingerprint": "7777777777777777777777777777777777777777777777777777777777777777",
+      "report": {
+        "reference": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+        "fingerprint": "8888888888888888888888888888888888888888888888888888888888888888"
+      },
+      "log": {
+        "reference": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+        "fingerprint": "9999999999999999999999999999999999999999999999999999999999999999"
+      }
+    },
+    {
+      "id": "contract",
+      "targetId": "server",
+      "kind": "contract",
+      "shardIndex": 1,
+      "shardCount": 1,
+      "outcome": "passed",
+      "passed": 18,
+      "failed": 0,
+      "skipped": 0,
+      "retries": 0,
+      "durationMs": 42000,
+      "invocationFingerprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "report": {
+        "reference": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "fingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "log": {
+        "reference": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "fingerprint": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      }
+    },
+    {
+      "id": "unit",
+      "targetId": "web",
+      "kind": "unit",
+      "shardIndex": 1,
+      "shardCount": 2,
+      "outcome": "passed",
+      "passed": 56,
+      "failed": 0,
+      "skipped": 0,
+      "retries": 0,
+      "durationMs": 31000,
+      "invocationFingerprint": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "report": {
+        "reference": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "fingerprint": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      },
+      "log": {
+        "reference": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      }
+    }
+  ],
+  "verification": {
+    "verifier": "release.verifier",
+    "completedAt": "2026-07-21T00:11:00.000Z",
+    "outcome": "rejected",
+    "targetCount": 2,
+    "suiteCount": 3,
+    "passed": 138,
+    "failed": 0,
+    "skipped": 0,
+    "retries": 0,
+    "evidence": {
+      "reference": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "fingerprint": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  }
+}

--- a/tests/fixtures/test-run-evidence/admission-skipped.json
+++ b/tests/fixtures/test-run-evidence/admission-skipped.json
@@ -1,0 +1,131 @@
+{
+  "format": "vize.test-run.evidence",
+  "formatVersion": 1,
+  "id": "run-2026-07-21.004",
+  "application": "example",
+  "environment": "production",
+  "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+  "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "release": "0.298.0",
+  "artifact": {
+    "id": "web-bundle",
+    "fingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+    "sizeBytes": 4096
+  },
+  "startedAt": "2026-07-21T00:00:00.000Z",
+  "completedAt": "2026-07-21T00:10:00.000Z",
+  "validUntil": "2026-07-28T00:10:00.000Z",
+  "runner": {
+    "identity": "ci.runner-1",
+    "authenticationEvidence": {
+      "reference": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+      "fingerprint": "3333333333333333333333333333333333333333333333333333333333333333"
+    },
+    "isolation": "ephemeral",
+    "invocationFingerprint": "4444444444444444444444444444444444444444444444444444444444444444",
+    "environmentEvidence": {
+      "reference": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+      "fingerprint": "5555555555555555555555555555555555555555555555555555555555555555"
+    },
+    "environmentFingerprint": "6666666666666666666666666666666666666666666666666666666666666666"
+  },
+  "selection": {
+    "targetIds": ["server", "web"],
+    "suiteIds": ["contract", "unit"]
+  },
+  "targets": [
+    {
+      "id": "web",
+      "kind": "web",
+      "environment": "production"
+    },
+    {
+      "id": "server",
+      "kind": "server",
+      "environment": "production"
+    }
+  ],
+  "suites": [
+    {
+      "id": "unit",
+      "targetId": "web",
+      "kind": "unit",
+      "shardIndex": 2,
+      "shardCount": 2,
+      "outcome": "passed",
+      "passed": 64,
+      "failed": 0,
+      "skipped": 0,
+      "retries": 0,
+      "durationMs": 30500,
+      "invocationFingerprint": "7777777777777777777777777777777777777777777777777777777777777777",
+      "report": {
+        "reference": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+        "fingerprint": "8888888888888888888888888888888888888888888888888888888888888888"
+      },
+      "log": {
+        "reference": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+        "fingerprint": "9999999999999999999999999999999999999999999999999999999999999999"
+      }
+    },
+    {
+      "id": "contract",
+      "targetId": "server",
+      "kind": "contract",
+      "shardIndex": 1,
+      "shardCount": 1,
+      "outcome": "passed",
+      "passed": 15,
+      "failed": 0,
+      "skipped": 3,
+      "retries": 0,
+      "durationMs": 42000,
+      "invocationFingerprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "report": {
+        "reference": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "fingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "log": {
+        "reference": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "fingerprint": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      }
+    },
+    {
+      "id": "unit",
+      "targetId": "web",
+      "kind": "unit",
+      "shardIndex": 1,
+      "shardCount": 2,
+      "outcome": "passed",
+      "passed": 56,
+      "failed": 0,
+      "skipped": 0,
+      "retries": 0,
+      "durationMs": 31000,
+      "invocationFingerprint": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "report": {
+        "reference": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "fingerprint": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      },
+      "log": {
+        "reference": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      }
+    }
+  ],
+  "verification": {
+    "verifier": "release.verifier",
+    "completedAt": "2026-07-21T00:11:00.000Z",
+    "outcome": "accepted",
+    "targetCount": 2,
+    "suiteCount": 3,
+    "passed": 135,
+    "failed": 0,
+    "skipped": 3,
+    "retries": 0,
+    "evidence": {
+      "reference": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "fingerprint": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  }
+}


### PR DESCRIPTION
## Design

The admission gate already denies with stable `VIZE_MARQUETTE_1xx` diagnostics, but the causes were not published as a machine-readable vocabulary, the decision had no structured shape, and no shared fixture pinned a full decision, so a Go or JVM host had to reverse-engineer the taxonomy from two source trees.

- **`TestRunDenialCode`** — 13 kebab-case codes, one per distinguishable rejection cause: `record-invalid`, `admission-id-malformed`, `admission-id-mismatch`, one `candidate-*-mismatch` per bound candidate field (application, environment, contract fingerprint, source revision, release, artifact fingerprint), `record-expired`, `verification-not-accepted`, `skipped-tests-recorded`, `admission-time-malformed`. Append-only: codes are never renamed, renumbered, reused, or removed.
- **`TestRunAdmissionDecision`** — `{ allowed, denialCodes, diagnostics }`. `denialCodes` maps every diagnostic through the total mapping (`test_run_denial_code` / `testRunDenialCode`), deduplicated and sorted lexicographically; `diagnostics` keeps the existing path/code/message order; `allowed` is true only when both are empty. `admit_test_run` / `admitTestRun` are unchanged; `decide_test_run_admission` / `decideTestRunAdmission` layer on top.
- **Schema** — new `crates/vize_marquette/schema/test-run-admission.schema.json` carries the enum with per-cause mapping rules, the decision shape, the append-only policy, and the host-implementation contract. Embedded as `TEST_RUN_ADMISSION_JSON_SCHEMA` and published as `@vizejs/marquette/test-run/admission/schema` through the existing vite schema emission.

## Fixture coverage

`tests/fixtures/test-run-evidence/admission-decisions.json` pins 17 cases (`evidence + candidate + admissionId + now -> full decision`, diagnostics included), executed byte-equivalently by `crates/vize_marquette/tests/test_run_conformance.rs` and `npm/marquette/src/test-run-admission.test.ts`:

- admitted exact candidate; malformed and mismatched admission ids;
- cross-scope: one case per candidate binding (all six codes);
- late: expired record and malformed admission instant;
- denied (verifier rejected), failed (failing suite), skipped, anonymous (unauthenticated runner), malformed (shared invalid record);
- multi-cause with deterministic ordering: `[candidate-environment-mismatch, candidate-release-mismatch, record-expired]` and `[record-expired, record-invalid]`, plus deduplication of repeated causes.

Four new evidence records (`admission-rejected/failed/skipped/anonymous.json`) back the families the shared valid record cannot express; all 13 codes appear across the corpus.

## Verification

- `cargo test -p vize_marquette` (48 tests incl. doctest), `cargo fmt --all -- --check`, `cargo clippy -p vize_marquette --all-targets -- -D warnings`, `cargo doc` warning-free.
- `vp run --filter './npm/marquette' test check build`: 29 tests, lint/format/typecheck clean, schemas emitted into `dist/`.
- The admission entry grew from 2,048 to 2,312 gzip bytes carrying the documented vocabulary; its budget moves one step up the existing ladder to 3,072 (`scripts/check-size.mjs`).

Part of #3145.
Fixes #3230

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->