### PR TITLE
test(canon): add the Vue Vben Admin LSP and scale oracle

### DIFF
--- a/.github/actions/check-vue-parity/action.yml
+++ b/.github/actions/check-vue-parity/action.yml
@@ -15,6 +15,7 @@ runs:
           tests/_fixtures/_git/pinia \
           tests/_fixtures/_git/vue-router \
           tests/_fixtures/_git/vue-element-admin \
+          tests/_fixtures/_git/vue-vben-admin \
           tests/_fixtures/_git/vitepress
         vp install --frozen-lockfile --prefer-offline
 
@@ -28,25 +29,36 @@ runs:
         VIZE_TEST_BIN: target/ci/vize
       run: vp run --filter './tests' test:check:fixtures
 
-    - name: Check incremental LSP against Misskey
+    - name: Check incremental LSP against Misskey and Vue Vben Admin
       shell: bash
       env:
         VIZE_LSP_BIN: target/ci/vize
       run: vp run --filter './tests' test:performance:lsp-incremental
 
-    - name: Publish incremental LSP summary
+    - name: Publish incremental LSP summaries
       if: ${{ always() }}
       shell: bash
       run: |
-        if [ -s target/vize-tests/metrics/misskey-lsp-incremental/summary.md ]; then
-          cat target/vize-tests/metrics/misskey-lsp-incremental/summary.md >> "$GITHUB_STEP_SUMMARY"
-        fi
+        for suite in misskey-lsp-incremental vben-lsp-incremental; do
+          if [ -s "target/vize-tests/metrics/$suite/summary.md" ]; then
+            cat "target/vize-tests/metrics/$suite/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+        done
 
-    - name: Upload incremental LSP metrics
+    - name: Upload Misskey incremental LSP metrics
       if: ${{ always() }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: misskey-lsp-incremental-metrics
         path: target/vize-tests/metrics/misskey-lsp-incremental/
+        if-no-files-found: warn
+        retention-days: 14
+
+    - name: Upload Vue Vben Admin incremental LSP metrics
+      if: ${{ always() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: vben-lsp-incremental-metrics
+        path: target/vize-tests/metrics/vben-lsp-incremental/
         if-no-files-found: warn
         retention-days: 14

--- a/tests/package.json
+++ b/tests/package.json
@@ -17,7 +17,7 @@
     "test:readiness:build": "node --test --test-concurrency=1 snapshots/build/generic.ts snapshots/build/elk.ts",
     "test:readiness:dev": "VIZE_TEST_WORKTREE_ID=${VIZE_TEST_WORKTREE_ID:-ci-readiness} playwright test --config app/playwright.config.ts app/dev/misskey.spec.ts",
     "test:check:fixtures": "node --test --test-concurrency=1 snapshots/check/typecheck-errors.ts snapshots/check/typecheck-vue-imports.ts snapshots/check/compiler-macros.ts snapshots/check/style-preprocessors.ts snapshots/check/ecosystem-products.ts snapshots/check/generic-build.ts snapshots/check/nuxt-parity.ts snapshots/check/toolchain-parity.ts snapshots/check/options-api.ts snapshots/check/class-component.ts snapshots/check/create-vue-patch-oracle.ts snapshots/check/create-vue-generated-template-oracle.ts snapshots/check/vue-router-patch-oracle.ts snapshots/check/vue-router-formatter-oracle.ts snapshots/check/pinia-generic-store-oracle.ts snapshots/check/typescript-project-references-oracle.ts snapshots/check/vue-router-dmts-oracle.ts snapshots/check/element-plus-slot-oracle.ts snapshots/check/nuxt-ui-ambient-oracle.ts snapshots/check/vitepress-theme-oracle.ts snapshots/check/vue-element-admin-legacy-oracle.ts snapshots/check/zz-intentional-errors-fixtures.ts",
-    "test:performance:lsp-incremental": "node --test --test-concurrency=1 performance/misskey-lsp-incremental.test.ts"
+    "test:performance:lsp-incremental": "node --test --test-concurrency=1 performance/misskey-lsp-incremental.test.ts performance/vben-lsp-incremental.test.ts"
   },
   "devDependencies": {
     "@apollo/client": "3.14.1",

--- a/tests/performance/misskey-lsp-incremental.test.ts
+++ b/tests/performance/misskey-lsp-incremental.test.ts
@@ -4,20 +4,22 @@ import { test } from "node:test";
 import { pathToFileURL } from "node:url";
 
 import { withPinnedFixtureWorkspace } from "../_helpers/realworld-patch.ts";
-import {
-  completionLabels,
-  hoverToText,
-  isDiagnosticsForUri,
-  offsetToPosition,
-} from "../tooling/support/lsp/assertions.ts";
-import type { LspDiagnostic, PublishDiagnosticsParams } from "../tooling/support/lsp/protocol.ts";
+import { completionLabels, hoverToText } from "../tooling/support/lsp/assertions.ts";
 import { LspSession } from "../tooling/support/lsp/session.ts";
 import { countFiles, IncrementalMetrics } from "./support/incremental-metrics.ts";
+import {
+  assertSingleInjectedMismatch,
+  changeVue,
+  diagnosticsTimeoutMs,
+  normalizeDiagnostics,
+  positionInsideTemplateSymbol,
+  replaceExactly,
+  waitForDiagnostics,
+} from "./support/lsp-oracle.ts";
 
 const componentPath = "packages/frontend/src/components/MkDivider.vue";
 const dependencyPath = "packages/frontend/src/components/MkCodeInline.vue";
 const symbol = "benchmarkMirror";
-const waitTimeoutMs = 120_000;
 
 test(
   "Misskey LSP clean, leaf, and shared edits stay exact in one production session",
@@ -49,7 +51,10 @@ test(
         assert.ok(vueFiles >= 500, `expected a monorepo-scale fixture, got ${vueFiles} Vue files`);
 
         const session = new LspSession();
-        const metrics = new IncrementalMetrics(session.processId);
+        const metrics = new IncrementalMetrics(session.processId, {
+          id: "misskey-lsp-incremental",
+          title: "Misskey LSP Incremental Oracle",
+        });
         let baseline: string[] = [];
         let failure: unknown;
 
@@ -95,9 +100,9 @@ test(
               "textDocument/completion",
               {
                 textDocument: { uri: componentUri },
-                position: positionInsideTemplateSymbol(cleanSource, "benchmarkM"),
+                position: positionInsideTemplateSymbol(cleanSource, symbol, "benchmarkM"),
               },
-              waitTimeoutMs,
+              diagnosticsTimeoutMs,
             ),
           );
           assert.ok(
@@ -110,9 +115,9 @@ test(
               "textDocument/hover",
               {
                 textDocument: { uri: componentUri },
-                position: positionInsideTemplateSymbol(cleanSource, symbol),
+                position: positionInsideTemplateSymbol(cleanSource, symbol, symbol),
               },
-              waitTimeoutMs,
+              diagnosticsTimeoutMs,
             ),
           )) as { contents?: unknown } | null;
           const hoverText = hoverToText(hover);
@@ -134,7 +139,7 @@ test(
             source: leafBrokenSource,
             expectError: true,
           });
-          assertSingleInjectedMismatch(leafBroken.diagnostics, baseline, leafBrokenSource);
+          assertSingleInjectedMismatch(leafBroken.diagnostics, baseline, leafBrokenSource, symbol);
 
           const leafRepaired = await changeVue(session, metrics, {
             name: "leafRepaired",
@@ -151,12 +156,9 @@ test(
             });
             return waitForDiagnostics(session, componentUri, 4, true);
           });
-          assertSingleInjectedMismatch(
-            sharedBroken.diagnostics,
-            baseline,
-            cleanSource,
-            "attribute-name",
-          );
+          assertSingleInjectedMismatch(sharedBroken.diagnostics, baseline, cleanSource, symbol, {
+            attributeName: "code",
+          });
 
           const sharedRepaired = await metrics.measure("sharedRepaired", async () => {
             session.notify("textDocument/didChange", {
@@ -204,114 +206,4 @@ function prepareComponent(source: string): string {
     "</div>\n</template>",
     `\t<MkCodeInline :code="String(${symbol})" /><span>{{ ${symbol} }}</span>\n</div>\n</template>`,
   );
-}
-
-function replaceExactly(source: string, expected: string, replacement: string): string {
-  const first = source.indexOf(expected);
-  assert.notEqual(first, -1, `missing patch anchor: ${expected}`);
-  assert.equal(
-    source.indexOf(expected, first + expected.length),
-    -1,
-    "patch anchor must be unique",
-  );
-  return `${source.slice(0, first)}${replacement}${source.slice(first + expected.length)}`;
-}
-
-async function changeVue(
-  session: LspSession,
-  metrics: IncrementalMetrics,
-  change: { name: string; uri: string; version: number; source: string; expectError?: boolean },
-): Promise<PublishDiagnosticsParams> {
-  return metrics.measure(change.name, async () => {
-    session.notify("textDocument/didChange", {
-      textDocument: { uri: change.uri, version: change.version },
-      contentChanges: [{ text: change.source }],
-    });
-    return waitForDiagnostics(session, change.uri, change.version, change.expectError);
-  });
-}
-
-async function waitForDiagnostics(
-  session: LspSession,
-  uri: string,
-  version: number,
-  expectError?: boolean,
-): Promise<PublishDiagnosticsParams> {
-  return (await session.waitForNotification(
-    "textDocument/publishDiagnostics",
-    (params) => {
-      if (!isDiagnosticsForUri(params, uri) || params.version !== version) return false;
-      return expectError == null || hasInjectedMismatch(params.diagnostics) === expectError;
-    },
-    waitTimeoutMs,
-  )) as PublishDiagnosticsParams;
-}
-
-function hasInjectedMismatch(diagnostics: LspDiagnostic[]): boolean {
-  return diagnostics.some(
-    (diagnostic) =>
-      String(diagnostic.code).replace(/^TS/, "") === "2322" &&
-      /string.*not assignable.*number/i.test(diagnostic.message ?? ""),
-  );
-}
-
-function assertSingleInjectedMismatch(
-  diagnostics: LspDiagnostic[],
-  baseline: string[],
-  source: string,
-  expectedRange: "declaration" | "attribute-name" = "declaration",
-): void {
-  const injected = diagnostics.filter(
-    (diagnostic) =>
-      String(diagnostic.code).replace(/^TS/, "") === "2322" &&
-      /string.*not assignable.*number/i.test(diagnostic.message ?? ""),
-  );
-  assert.equal(injected.length, 1, JSON.stringify(diagnostics));
-  const [diagnostic] = injected;
-  assert.equal(diagnostic.source, "vize/types");
-  assert.equal(diagnostic.severity, 1);
-  if (expectedRange === "declaration") {
-    const declarationOffset = source.indexOf(`const ${symbol}`);
-    assert.notEqual(declarationOffset, -1);
-    const start = offsetToPosition(source, declarationOffset + "const ".length);
-    const end = { line: start.line, character: start.character + symbol.length };
-    assert.deepEqual(diagnostic.range?.start, start);
-    assert.deepEqual(diagnostic.range?.end, end);
-  } else {
-    // The child prop-type mismatch anchors at the attribute name, exactly
-    // where vue-tsc reports it.
-    const attributeOffset = source.indexOf(`:code="String(${symbol})"`);
-    assert.notEqual(attributeOffset, -1);
-    const start = offsetToPosition(source, attributeOffset + ":".length);
-    const end = { line: start.line, character: start.character + "code".length };
-    assert.deepEqual(diagnostic.range?.start, start);
-    assert.deepEqual(diagnostic.range?.end, end);
-  }
-  assert.deepEqual(
-    normalizeDiagnostics(diagnostics.filter((item) => item !== diagnostic)),
-    baseline,
-  );
-}
-
-function normalizeDiagnostics(diagnostics: LspDiagnostic[]): string[] {
-  return diagnostics
-    .map((diagnostic) =>
-      JSON.stringify({
-        code: diagnostic.code,
-        message: diagnostic.message,
-        range: diagnostic.range,
-        severity: diagnostic.severity,
-        source: diagnostic.source,
-      }),
-    )
-    .sort();
-}
-
-function positionInsideTemplateSymbol(
-  source: string,
-  prefix: string,
-): { line: number; character: number } {
-  const templateOffset = source.indexOf(`{{ ${symbol} }}`);
-  assert.notEqual(templateOffset, -1);
-  return offsetToPosition(source, templateOffset + "{{ ".length + prefix.length);
 }

--- a/tests/performance/support/incremental-metrics.ts
+++ b/tests/performance/support/incremental-metrics.ts
@@ -7,10 +7,16 @@ import { performance } from "node:perf_hooks";
 
 import { repoRoot } from "../../_helpers/realworld-patch.ts";
 
-export const incrementalMetricsDir = path.join(
-  repoRoot,
-  "target/vize-tests/metrics/misskey-lsp-incremental",
-);
+export type IncrementalSuite = {
+  /** Metrics directory name under `target/vize-tests/metrics/`. */
+  id: string;
+  /** Markdown summary heading, e.g. `Misskey LSP Incremental Oracle`. */
+  title: string;
+};
+
+export function incrementalMetricsDir(suiteId: string): string {
+  return path.join(repoRoot, "target/vize-tests/metrics", suiteId);
+}
 
 type MetricContext = {
   fixture: string;
@@ -24,9 +30,11 @@ export class IncrementalMetrics {
   private readonly timingsMs: Record<string, number> = {};
   private readonly rssSamplesKiB: Record<string, number> = {};
   private readonly processId: number;
+  private readonly suite: IncrementalSuite;
 
-  constructor(processId: number) {
+  constructor(processId: number, suite: IncrementalSuite) {
     this.processId = processId;
+    this.suite = suite;
   }
 
   async measure<T>(name: string, operation: () => Promise<T>): Promise<T> {
@@ -45,7 +53,8 @@ export class IncrementalMetrics {
   }
 
   write(context: MetricContext, failure?: unknown): void {
-    fs.mkdirSync(incrementalMetricsDir, { recursive: true });
+    const outputDir = incrementalMetricsDir(this.suite.id);
+    fs.mkdirSync(outputDir, { recursive: true });
     const sampledPeakRssKiB = Math.max(0, ...Object.values(this.rssSamplesKiB));
     const data = {
       schemaVersion: 1,
@@ -72,20 +81,22 @@ export class IncrementalMetrics {
       sampledPeakRssKiB,
       note: "Latency and RSS are report-only; diagnostic, completion, hover, and repair oracles are gated.",
     };
-    fs.writeFileSync(
-      path.join(incrementalMetricsDir, "metrics.json"),
-      `${JSON.stringify(data, null, 2)}\n`,
-    );
-    fs.writeFileSync(path.join(incrementalMetricsDir, "summary.md"), renderMarkdown(data));
+    fs.writeFileSync(path.join(outputDir, "metrics.json"), `${JSON.stringify(data, null, 2)}\n`);
+    fs.writeFileSync(path.join(outputDir, "summary.md"), renderMarkdown(this.suite.title, data));
   }
 }
 
-export function countFiles(root: string, extensions: ReadonlySet<string>): number {
+export function countFiles(
+  root: string,
+  extensions: ReadonlySet<string>,
+  ignoreDirectories?: ReadonlySet<string>,
+): number {
   let count = 0;
   for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
     const filePath = path.join(root, entry.name);
     if (entry.isDirectory()) {
-      count += countFiles(filePath, extensions);
+      if (ignoreDirectories?.has(entry.name)) continue;
+      count += countFiles(filePath, extensions, ignoreDirectories);
     } else if (extensions.has(path.extname(entry.name))) {
       count += 1;
     }
@@ -106,16 +117,19 @@ function gitHead(): string {
   return result.status === 0 ? result.stdout.trim() : "unknown";
 }
 
-function renderMarkdown(data: {
-  status: string;
-  fixture: string;
-  fixtureRevision: string;
-  corpus: { vueFiles: number; vueAndTypeScriptFiles: number; baselineDiagnostics: number };
-  timingsMs: Record<string, number>;
-  sampledPeakRssKiB: number;
-}): string {
+function renderMarkdown(
+  title: string,
+  data: {
+    status: string;
+    fixture: string;
+    fixtureRevision: string;
+    corpus: { vueFiles: number; vueAndTypeScriptFiles: number; baselineDiagnostics: number };
+    timingsMs: Record<string, number>;
+    sampledPeakRssKiB: number;
+  },
+): string {
   const lines = [
-    "## Misskey LSP Incremental Oracle",
+    `## ${title}`,
     "",
     `Status: **${data.status}**. Fixture: \`${data.fixture}@${data.fixtureRevision}\`.`,
     "",

--- a/tests/performance/support/lsp-oracle.ts
+++ b/tests/performance/support/lsp-oracle.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+
+import { isDiagnosticsForUri, offsetToPosition } from "../../tooling/support/lsp/assertions.ts";
+import type {
+  LspDiagnostic,
+  PublishDiagnosticsParams,
+} from "../../tooling/support/lsp/protocol.ts";
+import type { LspSession } from "../../tooling/support/lsp/session.ts";
+import type { IncrementalMetrics } from "./incremental-metrics.ts";
+
+export const diagnosticsTimeoutMs = 120_000;
+
+/**
+ * Where an injected `string`-into-`number` mismatch must be reported:
+ * `"declaration"` anchors at the injected `const <symbol>` name, while
+ * `{ attributeName }` anchors at a component prop attribute, exactly where
+ * vue-tsc reports child prop-type mismatches.
+ */
+export type MismatchAnchor = "declaration" | { attributeName: string };
+
+export function replaceExactly(source: string, expected: string, replacement: string): string {
+  const first = source.indexOf(expected);
+  assert.notEqual(first, -1, `missing patch anchor: ${expected}`);
+  assert.equal(
+    source.indexOf(expected, first + expected.length),
+    -1,
+    "patch anchor must be unique",
+  );
+  return `${source.slice(0, first)}${replacement}${source.slice(first + expected.length)}`;
+}
+
+export async function changeVue(
+  session: LspSession,
+  metrics: IncrementalMetrics,
+  change: { name: string; uri: string; version: number; source: string; expectError?: boolean },
+): Promise<PublishDiagnosticsParams> {
+  return metrics.measure(change.name, async () => {
+    session.notify("textDocument/didChange", {
+      textDocument: { uri: change.uri, version: change.version },
+      contentChanges: [{ text: change.source }],
+    });
+    return waitForDiagnostics(session, change.uri, change.version, change.expectError);
+  });
+}
+
+export async function waitForDiagnostics(
+  session: LspSession,
+  uri: string,
+  version: number,
+  expectError?: boolean,
+): Promise<PublishDiagnosticsParams> {
+  return (await session.waitForNotification(
+    "textDocument/publishDiagnostics",
+    (params) => {
+      if (!isDiagnosticsForUri(params, uri) || params.version !== version) return false;
+      return expectError == null || hasInjectedMismatch(params.diagnostics) === expectError;
+    },
+    diagnosticsTimeoutMs,
+  )) as PublishDiagnosticsParams;
+}
+
+export function hasInjectedMismatch(diagnostics: LspDiagnostic[]): boolean {
+  return diagnostics.some(
+    (diagnostic) =>
+      String(diagnostic.code).replace(/^TS/, "") === "2322" &&
+      /string.*not assignable.*number/i.test(diagnostic.message ?? ""),
+  );
+}
+
+export function assertSingleInjectedMismatch(
+  diagnostics: LspDiagnostic[],
+  baseline: string[],
+  source: string,
+  symbol: string,
+  anchor: MismatchAnchor = "declaration",
+): void {
+  const injected = diagnostics.filter(
+    (diagnostic) =>
+      String(diagnostic.code).replace(/^TS/, "") === "2322" &&
+      /string.*not assignable.*number/i.test(diagnostic.message ?? ""),
+  );
+  assert.equal(injected.length, 1, JSON.stringify(diagnostics));
+  const [diagnostic] = injected;
+  assert.equal(diagnostic.source, "vize/types");
+  assert.equal(diagnostic.severity, 1);
+  if (anchor === "declaration") {
+    const declarationOffset = source.indexOf(`const ${symbol}`);
+    assert.notEqual(declarationOffset, -1);
+    const start = offsetToPosition(source, declarationOffset + "const ".length);
+    const end = { line: start.line, character: start.character + symbol.length };
+    assert.deepEqual(diagnostic.range?.start, start);
+    assert.deepEqual(diagnostic.range?.end, end);
+  } else {
+    const attributeOffset = source.indexOf(`:${anchor.attributeName}="String(${symbol})"`);
+    assert.notEqual(attributeOffset, -1);
+    const start = offsetToPosition(source, attributeOffset + ":".length);
+    const end = { line: start.line, character: start.character + anchor.attributeName.length };
+    assert.deepEqual(diagnostic.range?.start, start);
+    assert.deepEqual(diagnostic.range?.end, end);
+  }
+  assert.deepEqual(
+    normalizeDiagnostics(diagnostics.filter((item) => item !== diagnostic)),
+    baseline,
+  );
+}
+
+export function normalizeDiagnostics(diagnostics: LspDiagnostic[]): string[] {
+  return diagnostics
+    .map((diagnostic) =>
+      JSON.stringify({
+        code: diagnostic.code,
+        message: diagnostic.message,
+        range: diagnostic.range,
+        severity: diagnostic.severity,
+        source: diagnostic.source,
+      }),
+    )
+    .sort();
+}
+
+export function positionInsideTemplateSymbol(
+  source: string,
+  symbol: string,
+  prefix: string,
+): { line: number; character: number } {
+  const templateOffset = source.indexOf(`{{ ${symbol} }}`);
+  assert.notEqual(templateOffset, -1);
+  return offsetToPosition(source, templateOffset + "{{ ".length + prefix.length);
+}

--- a/tests/performance/vben-lsp-incremental.test.ts
+++ b/tests/performance/vben-lsp-incremental.test.ts
@@ -1,0 +1,298 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { withPinnedFixtureWorkspace } from "../_helpers/realworld-patch.ts";
+import { completionLabels, hoverToText } from "../tooling/support/lsp/assertions.ts";
+import { LspSession } from "../tooling/support/lsp/session.ts";
+import { countFiles, IncrementalMetrics } from "./support/incremental-metrics.ts";
+import {
+  assertSingleInjectedMismatch,
+  changeVue,
+  diagnosticsTimeoutMs,
+  normalizeDiagnostics,
+  positionInsideTemplateSymbol,
+  replaceExactly,
+  waitForDiagnostics,
+} from "./support/lsp-oracle.ts";
+
+// A shared `packages/` component that every Vben app renders through the basic
+// layout, plus one real view in each of two different `apps/` workspace
+// packages. Editing the shared component must refresh diagnostics in both apps.
+const sharedComponentPath = "packages/effects/layouts/src/basic/copyright/copyright.vue";
+const firstLeafPath = "apps/web-antd/src/views/_core/fallback/offline.vue";
+const secondLeafPath = "apps/web-ele/src/views/_core/fallback/offline.vue";
+const sharedComponentImport =
+  "../../../../../../packages/effects/layouts/src/basic/copyright/copyright.vue";
+const symbol = "monorepoMirror";
+const ignoredDirectories = new Set(["node_modules"]);
+
+test(
+  "Vben LSP cross-package edits stay exact across two apps in one production session",
+  { timeout: 300_000 },
+  async () => {
+    await withPinnedFixtureWorkspace(
+      {
+        fixtureId: "vue-vben-admin",
+        includePaths: ["apps", "packages", "playground", "package.json", "pnpm-workspace.yaml"],
+      },
+      async (fixture) => {
+        const workspaceDir = fixture.workspaceDir;
+        const sharedUri = pathToFileURL(fixture.resolve(sharedComponentPath)).href;
+        const firstLeafUri = pathToFileURL(fixture.resolve(firstLeafPath)).href;
+        const secondLeafUri = pathToFileURL(fixture.resolve(secondLeafPath)).href;
+        const cleanShared = prepareSharedComponent(fixture.read(sharedComponentPath));
+        const brokenShared = replaceExactly(cleanShared, "  date?: string;", "  date?: number;");
+        const firstLeafSource = prepareLeaf(fixture.read(firstLeafPath));
+        const secondLeafSource = prepareLeaf(fixture.read(secondLeafPath));
+        const leafBrokenSource = replaceExactly(
+          firstLeafSource,
+          `const ${symbol}: number = 1;`,
+          `const ${symbol}: number = 'leaf-broken';`,
+        );
+        const vueExtension = new Set([".vue"]);
+        const vueFiles = countFiles(workspaceDir, vueExtension, ignoredDirectories);
+        const sourceFiles = countFiles(
+          workspaceDir,
+          new Set([".vue", ".ts", ".tsx"]),
+          ignoredDirectories,
+        );
+        const appVueFiles = countFiles(
+          path.join(workspaceDir, "apps"),
+          vueExtension,
+          ignoredDirectories,
+        );
+        const packageVueFiles = countFiles(
+          path.join(workspaceDir, "packages"),
+          vueExtension,
+          ignoredDirectories,
+        );
+        assert.ok(vueFiles >= 500, `expected a monorepo-scale fixture, got ${vueFiles} Vue files`);
+        assert.ok(appVueFiles >= 100, `expected app-side scale, got ${appVueFiles} Vue files`);
+        assert.ok(
+          packageVueFiles >= 250,
+          `expected package-side scale, got ${packageVueFiles} Vue files`,
+        );
+
+        const session = new LspSession();
+        const metrics = new IncrementalMetrics(session.processId, {
+          id: "vben-lsp-incremental",
+          title: "Vue Vben Admin LSP Incremental Oracle",
+        });
+        let baseline: string[] = [];
+        let secondBaseline: string[] = [];
+        let failure: unknown;
+
+        try {
+          await metrics.measure("initialize", () =>
+            session.initialize(workspaceDir, {
+              completion: true,
+              editor: true,
+              hover: true,
+              lint: false,
+              typecheck: true,
+            }),
+          );
+          session.notify("textDocument/didOpen", {
+            textDocument: {
+              uri: sharedUri,
+              languageId: "vue",
+              version: 1,
+              text: cleanShared,
+            },
+          });
+
+          const cleanPublish = await metrics.measure("coldOpen", async () => {
+            session.notify("textDocument/didOpen", {
+              textDocument: {
+                uri: firstLeafUri,
+                languageId: "vue",
+                version: 1,
+                text: firstLeafSource,
+              },
+            });
+            return waitForDiagnostics(session, firstLeafUri, 1);
+          });
+          assert.equal(
+            cleanPublish.diagnostics.length,
+            0,
+            `expected no clean diagnostics: ${JSON.stringify(cleanPublish.diagnostics)}`,
+          );
+          baseline = normalizeDiagnostics(cleanPublish.diagnostics);
+
+          const secondPublish = await metrics.measure("coldOpenSecondApp", async () => {
+            session.notify("textDocument/didOpen", {
+              textDocument: {
+                uri: secondLeafUri,
+                languageId: "vue",
+                version: 1,
+                text: secondLeafSource,
+              },
+            });
+            return waitForDiagnostics(session, secondLeafUri, 1);
+          });
+          assert.equal(
+            secondPublish.diagnostics.length,
+            0,
+            `expected no clean diagnostics: ${JSON.stringify(secondPublish.diagnostics)}`,
+          );
+          secondBaseline = normalizeDiagnostics(secondPublish.diagnostics);
+
+          const completion = await metrics.measure("completion", () =>
+            session.request(
+              "textDocument/completion",
+              {
+                textDocument: { uri: firstLeafUri },
+                position: positionInsideTemplateSymbol(firstLeafSource, symbol, "monorepoM"),
+              },
+              diagnosticsTimeoutMs,
+            ),
+          );
+          assert.ok(
+            completionLabels(completion as never).includes(symbol),
+            JSON.stringify(completion),
+          );
+
+          const hover = (await metrics.measure("hover", () =>
+            session.request(
+              "textDocument/hover",
+              {
+                textDocument: { uri: firstLeafUri },
+                position: positionInsideTemplateSymbol(firstLeafSource, symbol, symbol),
+              },
+              diagnosticsTimeoutMs,
+            ),
+          )) as { contents?: unknown } | null;
+          const hoverText = hoverToText(hover);
+          assert.match(hoverText, new RegExp(symbol));
+          assert.match(hoverText, /number/i);
+
+          const warmPublish = await changeVue(session, metrics, {
+            name: "warmNoop",
+            uri: firstLeafUri,
+            version: 2,
+            source: firstLeafSource,
+          });
+          assert.deepEqual(normalizeDiagnostics(warmPublish.diagnostics), baseline);
+
+          const leafBroken = await changeVue(session, metrics, {
+            name: "leafBroken",
+            uri: firstLeafUri,
+            version: 3,
+            source: leafBrokenSource,
+            expectError: true,
+          });
+          assertSingleInjectedMismatch(leafBroken.diagnostics, baseline, leafBrokenSource, symbol);
+
+          const leafRepaired = await changeVue(session, metrics, {
+            name: "leafRepaired",
+            uri: firstLeafUri,
+            version: 4,
+            source: firstLeafSource,
+          });
+          assert.deepEqual(normalizeDiagnostics(leafRepaired.diagnostics), baseline);
+
+          const sharedBroken = await metrics.measure("sharedBroken", async () => {
+            session.notify("textDocument/didChange", {
+              textDocument: { uri: sharedUri, version: 2 },
+              contentChanges: [{ text: brokenShared }],
+            });
+            return waitForDiagnostics(session, firstLeafUri, 4, true);
+          });
+          assertSingleInjectedMismatch(
+            sharedBroken.diagnostics,
+            baseline,
+            firstLeafSource,
+            symbol,
+            {
+              attributeName: "date",
+            },
+          );
+          const sharedBrokenSecond = await metrics.measure("sharedBrokenSecondApp", () =>
+            waitForDiagnostics(session, secondLeafUri, 1, true),
+          );
+          assertSingleInjectedMismatch(
+            sharedBrokenSecond.diagnostics,
+            secondBaseline,
+            secondLeafSource,
+            symbol,
+            { attributeName: "date" },
+          );
+
+          const sharedRepaired = await metrics.measure("sharedRepaired", async () => {
+            session.notify("textDocument/didChange", {
+              textDocument: { uri: sharedUri, version: 3 },
+              contentChanges: [{ text: cleanShared }],
+            });
+            return waitForDiagnostics(session, firstLeafUri, 4, false);
+          });
+          assert.deepEqual(normalizeDiagnostics(sharedRepaired.diagnostics), baseline);
+          const sharedRepairedSecond = await metrics.measure("sharedRepairedSecondApp", () =>
+            waitForDiagnostics(session, secondLeafUri, 1, false),
+          );
+          assert.deepEqual(normalizeDiagnostics(sharedRepairedSecond.diagnostics), secondBaseline);
+
+          // A fresh-version no-op edit cannot match any stale publish, so it
+          // proves the second app converged after the whole shared cycle.
+          const secondWarm = await changeVue(session, metrics, {
+            name: "warmNoopSecondApp",
+            uri: secondLeafUri,
+            version: 2,
+            source: secondLeafSource,
+          });
+          assert.deepEqual(normalizeDiagnostics(secondWarm.diagnostics), secondBaseline);
+
+          session.notify("textDocument/didClose", { textDocument: { uri: firstLeafUri } });
+          session.notify("textDocument/didClose", { textDocument: { uri: secondLeafUri } });
+          session.notify("textDocument/didClose", { textDocument: { uri: sharedUri } });
+        } catch (error) {
+          failure = error;
+        }
+        try {
+          await session.shutdown();
+        } catch (error) {
+          failure ??= error;
+        }
+        metrics.write(
+          {
+            fixture: "vue-vben-admin/apps+packages+playground",
+            revision: fixture.entry.revision,
+            vueFiles,
+            sourceFiles,
+            baselineDiagnostics: baseline.length,
+          },
+          failure,
+        );
+        if (failure != null) throw failure;
+      },
+    );
+  },
+);
+
+// The pinned fixture is hydrated without a pnpm install, so `vue` type
+// declarations are unavailable and `defineOptions`/`withDefaults` cannot be
+// resolved. The patch keeps both views on the props-typed SFC shape the
+// Misskey oracle exercises while wiring them to the shared `packages/`
+// component through an explicit cross-package import.
+function prepareLeaf(source: string): string {
+  const patched = replaceExactly(
+    source,
+    "import { Fallback } from '@vben/common-ui';\n\ndefineOptions({ name: 'FallbackOfflineDemo' });",
+    `import VbenCopyright from '${sharedComponentImport}';\n\nconst ${symbol}: number = 1;\n\ndefineProps<{ mirrorTone?: string }>();`,
+  );
+  return replaceExactly(
+    patched,
+    '<Fallback status="offline" />',
+    `<div>\n    <VbenCopyright :date="String(${symbol})" />\n    <span>{{ ${symbol} }}</span>\n  </div>`,
+  );
+}
+
+function prepareSharedComponent(source: string): string {
+  const patched = replaceExactly(source, "defineOptions({\n  name: 'Copyright',\n});\n\n", "");
+  return replaceExactly(
+    patched,
+    "withDefaults(defineProps<Props>(), {\n  companyName: 'Vben Admin',\n  companySiteLink: '',\n  date: '2024',\n  icp: '',\n  icpLink: '',\n});",
+    "defineProps<Props>();",
+  );
+}

--- a/tests/tooling/github-workflows-vue-parity.test.ts
+++ b/tests/tooling/github-workflows-vue-parity.test.ts
@@ -34,6 +34,7 @@ test("Vue parity structurally gates compiler fixtures and incremental LSP behavi
   assert.match(hydration?.run ?? "", /tests\/_fixtures\/_git\/pinia/);
   assert.match(hydration?.run ?? "", /tests\/_fixtures\/_git\/vue-router/);
   assert.match(hydration?.run ?? "", /tests\/_fixtures\/_git\/vue-element-admin/);
+  assert.match(hydration?.run ?? "", /tests\/_fixtures\/_git\/vue-vben-admin/);
   assert.match(hydration?.run ?? "", /tests\/_fixtures\/_git\/vitepress/);
   assert.match(hydration?.run ?? "", /vp install --frozen-lockfile --prefer-offline/);
   assert.equal(
@@ -44,26 +45,34 @@ test("Vue parity structurally gates compiler fixtures and incremental LSP behavi
   assert.deepEqual(parity?.env, { VIZE_TEST_BIN: "target/ci/vize" });
   assert.equal(parity?.run, "vp run --filter './tests' test:check:fixtures");
 
-  const incremental = steps.find((step) => step.name === "Check incremental LSP against Misskey");
+  const incremental = steps.find(
+    (step) => step.name === "Check incremental LSP against Misskey and Vue Vben Admin",
+  );
   assert.deepEqual(incremental?.env, { VIZE_LSP_BIN: "target/ci/vize" });
   assert.equal(incremental?.run, "vp run --filter './tests' test:performance:lsp-incremental");
 
-  const summary = steps.find((step) => step.name === "Publish incremental LSP summary");
+  const summary = steps.find((step) => step.name === "Publish incremental LSP summaries");
   assert.equal(summary?.if, "${{ always() }}");
-  assert.match(summary?.run ?? "", /misskey-lsp-incremental\/summary\.md/);
+  assert.match(summary?.run ?? "", /misskey-lsp-incremental vben-lsp-incremental/);
+  assert.match(summary?.run ?? "", /summary\.md/);
   assert.match(summary?.run ?? "", /GITHUB_STEP_SUMMARY/);
 
-  const upload = steps.find((step) => step.name === "Upload incremental LSP metrics");
-  assert.equal(upload?.if, "${{ always() }}");
-  assert.match(upload?.uses ?? "", /^actions\/upload-artifact@[0-9a-f]{40}$/);
-  assert.deepEqual(upload?.with, {
-    name: "misskey-lsp-incremental-metrics",
-    path: "target/vize-tests/metrics/misskey-lsp-incremental/",
-    "if-no-files-found": "warn",
-    "retention-days": 14,
-  });
+  for (const suite of ["misskey", "vben"]) {
+    const displayName = suite === "misskey" ? "Misskey" : "Vue Vben Admin";
+    const upload = steps.find(
+      (step) => step.name === `Upload ${displayName} incremental LSP metrics`,
+    );
+    assert.equal(upload?.if, "${{ always() }}");
+    assert.match(upload?.uses ?? "", /^actions\/upload-artifact@[0-9a-f]{40}$/);
+    assert.deepEqual(upload?.with, {
+      name: `${suite}-lsp-incremental-metrics`,
+      path: `target/vize-tests/metrics/${suite}-lsp-incremental/`,
+      "if-no-files-found": "warn",
+      "retention-days": 14,
+    });
+  }
   assert.equal(
     testsPackage.scripts["test:performance:lsp-incremental"],
-    "node --test --test-concurrency=1 performance/misskey-lsp-incremental.test.ts",
+    "node --test --test-concurrency=1 performance/misskey-lsp-incremental.test.ts performance/vben-lsp-incremental.test.ts",
   );
 });


### PR DESCRIPTION
## What

Adds the second half of the #2971 audit item 2 scale lane: a Vue Vben Admin LSP + scale oracle that runs per PR next to the Misskey one, exercising the pnpm-monorepo shape Misskey cannot — a shared `packages/` component edit must refresh diagnostics in dependent views of two different `apps/` workspace packages.

- `tests/performance/vben-lsp-incremental.test.ts`: one production `vize lsp` session over the pinned `vue-vben-admin` fixture (full `apps` + `packages` + `playground` corpus, 613 Vue / 1206 Vue+TS files, guarded `>= 500` total, `>= 100` app-side, `>= 250` package-side). Lanes: initialize, cold open in each app, completion, hover, warm no-op, single-leaf break/repair (`apps/web-antd` view), shared-component break/repair (`packages/effects/layouts/.../copyright.vue`) asserted exactly in both apps at the attribute-name anchor, and a fresh-version no-op on the second app so convergence can never be satisfied by a stale publish.\n- `tests/performance/support/lsp-oracle.ts`: the diagnostics-oracle helpers previously private to the Misskey suite, now shared verbatim by both suites (`assertSingleInjectedMismatch` gains the symbol/attribute parameters).\n- `tests/performance/support/incremental-metrics.ts`: suite id/title parameterized so each oracle writes its own `metrics.json`/`summary.md`; `countFiles` learns an ignore set for `node_modules` inside dev-machine fixtures.\n- Wiring: `test:performance:lsp-incremental` runs both files; `check-vue-parity` hydrates `vue-vben-admin`, publishes both step summaries, and uploads a `vben-lsp-incremental-metrics` artifact; the workflow-shape test pins all of it.

## Measured locally (Apple M5 Pro, release binary via `VIZE_LSP_BIN`)

Vben suite 7.3s, Misskey suite 4.6s, script total 12.2s — the full-corpus copy is ~7 MB, so no subset gating is needed; the only meaningful CI cost is the one-time `--depth 1` hydration of the vben submodule.

| Lane | Time |
| --- | ---: |
| initialize | 22.6 ms |
| coldOpen | 687.5 ms |
| coldOpenSecondApp | 250.6 ms |
| completion | 5.0 ms |
| hover | 6.8 ms |
| warmNoop | 263.8 ms |
| leafBroken / leafRepaired | 275.0 / 281.3 ms |
| sharedBroken / sharedBrokenSecondApp | 613.0 / 257.5 ms |
| sharedRepaired / sharedRepairedSecondApp | 569.8 / 272.1 ms |
| warmNoopSecondApp | 287.0 ms |

Sampled peak LSP RSS 15.5 MiB; baseline diagnostics 0 in both opened views.

Latency and RSS stay report-only exactly like the Misskey suite today; making both suites enforce budgets is a separate slice. The fixture is hydrated without a pnpm install, so the injected view patches keep the props-typed SFC shape (`defineOptions`/`withDefaults` need `vue` type declarations that are not present in a hydration-only checkout — same constraint the Misskey file choices already encode).

Fixes #3234

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->