### PR TITLE
fix(fresco): reposition keyed children instead of duplicating on reorder

### DIFF
--- a/npm/fresco/src/renderer.test.ts
+++ b/npm/fresco/src/renderer.test.ts
@@ -73,7 +73,14 @@ void test("inserts, reorders, and removes list children through anchors", async 
   );
 
   const texts = () => firstChild(mounted).children.map((child) => child.props.text);
+  const [a, b] = firstChild(mounted).children;
   assert.deepEqual(texts(), ["a", "b"]);
+
+  items.value = ["b", "a"];
+  await nextTick();
+  assert.deepEqual(texts(), ["b", "a"], "keyed children swap order");
+  assert.equal(firstChild(mounted).children[0], b, "retained node moves with its key");
+  assert.equal(firstChild(mounted).children[1], a, "retained node moves with its key");
 
   items.value = ["c", "a", "b"];
   await nextTick();

--- a/npm/fresco/src/renderer.ts
+++ b/npm/fresco/src/renderer.ts
@@ -52,6 +52,16 @@ const rendererOptions: RendererOptions<FrescoNode, FrescoElement> = {
   },
 
   insert(child, parent, anchor) {
+    // Vue reuses host nodes for keyed moves and re-inserts them without a
+    // preceding remove, relying on DOM insertBefore move semantics. Detach the
+    // child from its current position first so a reorder repositions the
+    // existing node instead of duplicating it.
+    if (child.parent) {
+      const existing = child.parent.children.indexOf(child);
+      if (existing !== -1) {
+        child.parent.children.splice(existing, 1);
+      }
+    }
     child.parent = parent;
     if (anchor) {
       const index = parent.children.indexOf(anchor);


### PR DESCRIPTION
## What

Addresses the review comment on #3232 (now merged) asking `renderer.test.ts` to actually cover a keyed reorder. Adding that coverage surfaced a real renderer bug, which this PR fixes.

## The bug

Fresco's Vue custom renderer host `insert` spliced the child into the parent without first detaching it from its current position. Vue reuses host nodes for keyed moves and re-inserts them without a preceding `remove`, relying on DOM `insertBefore` move semantics. Because `insert` never detached, a keyed reorder duplicated the moved node. Reproduced against `@vue/runtime-core@3.5.35` with the exact host options: `["a","b"] → ["b","a"]` produced `["b","a","b"]`, and a following `["c","a","b"]` compounded to `["c","a","b","a","b"]`.

The fix detaches the node from its old position before inserting, matching DOM move semantics:

```ts
insert(child, parent, anchor) {
  // Vue reuses host nodes for keyed moves and re-inserts them without a
  // preceding remove, relying on DOM insertBefore move semantics. Detach the
  // child from its current position first so a reorder repositions the
  // existing node instead of duplicating it.
  if (child.parent) {
    const existing = child.parent.children.indexOf(child);
    if (existing !== -1) child.parent.children.splice(existing, 1);
  }
  child.parent = parent;
  // ...anchor insert / push unchanged
}
```

Fresh mounts (`child.parent == null`) are unaffected; only true moves change behavior.

## Test

The `inserts, reorders, and removes list children through anchors` test now performs a `["a","b"] → ["b","a"]` transition and asserts both the resulting order and that each retained node moves with its key (node identity preserved), so keyed-move regressions can no longer pass unnoticed.

Note: opened as a standalone PR because #3232 merged before this fix could land on its branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyed list updates to correctly move existing items without duplicating them.
  * Preserved existing item elements during reordering, improving rendering consistency and efficiency.

* **Tests**
  * Added coverage to verify that keyed items retain their original elements when moved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->