### PR TITLE
feat(marquette): bind deployment evidence to release-bound test runs

### DIFF
--- a/crates/vize_marquette/schema/test-run-admission.schema.json
+++ b/crates/vize_marquette/schema/test-run-admission.schema.json
@@ -6,7 +6,7 @@
   "$ref": "#/$defs/decision",
   "$defs": {
     "denialCode": {
-      "description": "Stable machine-readable cause class of one admission denial. The vocabulary is append-only: codes are never renamed, renumbered, reused, or removed, and every new distinguishable rejection cause ships with a new code appended to this enum. Hosts must map every diagnostic to exactly one code: VIZE_MARQUETTE_141 to admission-id-malformed; VIZE_MARQUETTE_142 to admission-id-mismatch; VIZE_MARQUETTE_144 to the candidate-*-mismatch code named by its diagnostic path (application, artifact.fingerprint, contractFingerprint, environment, release, sourceRevision); VIZE_MARQUETTE_145 to record-expired; VIZE_MARQUETTE_146 to verification-not-accepted; VIZE_MARQUETTE_147 to skipped-tests-recorded; VIZE_MARQUETTE_148 to admission-time-malformed; and every other diagnostic, including every record-validation code, to record-invalid.",
+      "description": "Stable machine-readable cause class of one admission denial. The vocabulary is append-only: codes are never renamed, renumbered, reused, or removed, and every new distinguishable rejection cause ships with a new code added to this enum in lexicographic position. Hosts must map every diagnostic to exactly one code: VIZE_MARQUETTE_141 to admission-id-malformed; VIZE_MARQUETTE_142 to admission-id-mismatch; VIZE_MARQUETTE_144 to the candidate-*-mismatch code named by its diagnostic path (application, artifact.fingerprint, contractFingerprint, environment, release, sourceRevision); VIZE_MARQUETTE_145 to record-expired; VIZE_MARQUETTE_146 to verification-not-accepted; VIZE_MARQUETTE_147 to skipped-tests-recorded; VIZE_MARQUETTE_148 to admission-time-malformed; VIZE_MARQUETTE_149 to check-candidate-mismatch; VIZE_MARQUETTE_150 to check-invalid; VIZE_MARQUETTE_151 to check-observer-not-independent; every other diagnostic whose path starts with check. to check-invalid; and every remaining diagnostic, including every record-validation code, to record-invalid.",
       "enum": [
         "admission-id-malformed",
         "admission-id-mismatch",
@@ -17,6 +17,9 @@
         "candidate-environment-mismatch",
         "candidate-release-mismatch",
         "candidate-source-revision-mismatch",
+        "check-candidate-mismatch",
+        "check-invalid",
+        "check-observer-not-independent",
         "record-expired",
         "record-invalid",
         "skipped-tests-recorded",

--- a/crates/vize_marquette/schema/test-run-check.schema.json
+++ b/crates/vize_marquette/schema/test-run-check.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vizejs.dev/schemas/marquette/test-run-check.schema.json",
+  "title": "Vize Test Run Check",
+  "description": "Retained, release-bound tests check for one deployment decision. This record replaces every generic test-result reference: a release decision may only satisfy its tests evidence with the exact test-run:<sha256> admission id of an independently verified run, bound to the six exact candidate facts and to the independent observer that recorded the admission. Verification is fail-closed and identical across JavaScript, Rust, Go, and JVM hosts; the shared tests/fixtures/test-run-evidence check-decision fixtures are the conformance source of truth for new host implementations.",
+  "$ref": "#/$defs/check",
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[a-z0-9][a-z0-9._-]*$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "admissionId": {
+      "description": "Exact test-run:<sha256> admission id. Summary blobs, report paths, run URLs, and green workflow labels are not admissible test evidence.",
+      "type": "string",
+      "pattern": "^test-run:[a-f0-9]{64}$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\\.[0-9]{3}Z$"
+    },
+    "candidate": {
+      "description": "Exact release candidate the run was admitted for. Every field must equal the deciding gate's own facts; verification rejects any difference.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "application",
+        "environment",
+        "contractFingerprint",
+        "sourceRevision",
+        "release",
+        "artifactFingerprint"
+      ],
+      "properties": {
+        "application": { "$ref": "#/$defs/identifier" },
+        "environment": { "$ref": "#/$defs/identifier" },
+        "contractFingerprint": { "$ref": "#/$defs/digest" },
+        "sourceRevision": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40,128}$"
+        },
+        "release": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "artifactFingerprint": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["format", "formatVersion", "evidence", "candidate", "observer", "observedAt"],
+      "properties": {
+        "format": {
+          "description": "Serialized format marker; readers must reject any other value.",
+          "const": "vize.test-run.check"
+        },
+        "formatVersion": {
+          "description": "Serialized format version; readers must reject a higher value until they explicitly support it.",
+          "const": 1
+        },
+        "evidence": { "$ref": "#/$defs/admissionId" },
+        "candidate": { "$ref": "#/$defs/candidate" },
+        "observer": {
+          "description": "Identity of the independent observer that recorded the admission — the trusted promotion boundary, never the runner that executed the tests. Verification rejects a check whose observer equals the run's runner identity.",
+          "$ref": "#/$defs/identifier"
+        },
+        "observedAt": {
+          "description": "Millisecond-precision UTC instant the admission was observed. Verification rejects an observation earlier than the run's completed verification.",
+          "$ref": "#/$defs/timestamp"
+        }
+      }
+    }
+  }
+}

--- a/crates/vize_marquette/src/lib.rs
+++ b/crates/vize_marquette/src/lib.rs
@@ -61,15 +61,16 @@ pub use model::{
     RuntimeFamily, Target,
 };
 pub use test_run::{
-    CanonicalTestRunError, TEST_RUN_ADMISSION_PREFIX, TEST_RUN_DENIAL_CODES,
-    TEST_RUN_EVIDENCE_FORMAT, TEST_RUN_EVIDENCE_FORMAT_VERSION, TEST_RUN_MAX_SHARDS,
-    TEST_RUN_MAX_SUITES, TEST_RUN_MAX_TARGETS, TestRunAdmissionDecision, TestRunArtifact,
-    TestRunCandidate, TestRunDenialCode, TestRunEvidence, TestRunIsolation,
-    TestRunRetainedEvidence, TestRunRunner, TestRunSelection, TestRunSuiteExecution,
-    TestRunSuiteKind, TestRunSuiteOutcome, TestRunTargetExecution, TestRunTargetKind,
-    TestRunVerification, TestRunVerificationOutcome, admit_test_run, canonical_test_run_json,
-    decide_test_run_admission, parse_test_run_admission_id, test_run_admission_id,
-    test_run_denial_code, test_run_fingerprint, validate_test_run,
+    CanonicalTestRunError, TEST_RUN_ADMISSION_PREFIX, TEST_RUN_CHECK_FORMAT,
+    TEST_RUN_CHECK_FORMAT_VERSION, TEST_RUN_DENIAL_CODES, TEST_RUN_EVIDENCE_FORMAT,
+    TEST_RUN_EVIDENCE_FORMAT_VERSION, TEST_RUN_MAX_SHARDS, TEST_RUN_MAX_SUITES,
+    TEST_RUN_MAX_TARGETS, TestRunAdmissionDecision, TestRunArtifact, TestRunCandidate,
+    TestRunCheck, TestRunDenialCode, TestRunEvidence, TestRunIsolation, TestRunRetainedEvidence,
+    TestRunRunner, TestRunSelection, TestRunSuiteExecution, TestRunSuiteKind, TestRunSuiteOutcome,
+    TestRunTargetExecution, TestRunTargetKind, TestRunVerification, TestRunVerificationOutcome,
+    admit_test_run, canonical_test_run_json, decide_test_run_admission,
+    parse_test_run_admission_id, test_run_admission_id, test_run_denial_code, test_run_fingerprint,
+    validate_test_run, validate_test_run_check, verify_test_run_check,
 };
 pub use validate::{ContractDiagnostic, DiagnosticSeverity, validate_contract};
 
@@ -95,6 +96,15 @@ pub const TEST_RUN_EVIDENCE_JSON_SCHEMA: &str =
 /// contract without resolving a filesystem path.
 pub const TEST_RUN_ADMISSION_JSON_SCHEMA: &str =
     include_str!("../schema/test-run-admission.schema.json");
+
+/// Canonical JSON Schema for retained release-bound tests checks.
+///
+/// The schema declares the record a release decision must retain as its
+/// `tests` evidence: the exact `test-run:<sha256>` admission id, the six
+/// candidate facts, and the independent observer. It replaces every generic
+/// test-result reference and is embedded so deployment gates and tooling
+/// can expose the exact contract without resolving a filesystem path.
+pub const TEST_RUN_CHECK_JSON_SCHEMA: &str = include_str!("../schema/test-run-check.schema.json");
 
 #[cfg(test)]
 mod schema_tests {
@@ -129,5 +139,17 @@ mod schema_tests {
             .map(|code| serde_json::to_value(code).unwrap())
             .to_vec();
         assert_eq!(declared, &implemented);
+    }
+
+    #[test]
+    fn embedded_check_schema_tracks_the_current_format() {
+        let schema: serde_json::Value =
+            serde_json::from_str(super::TEST_RUN_CHECK_JSON_SCHEMA).unwrap();
+        let check = &schema["$defs"]["check"]["properties"];
+        assert_eq!(check["format"]["const"], super::TEST_RUN_CHECK_FORMAT);
+        assert_eq!(
+            check["formatVersion"]["const"],
+            super::TEST_RUN_CHECK_FORMAT_VERSION
+        );
     }
 }

--- a/crates/vize_marquette/src/test_run.rs
+++ b/crates/vize_marquette/src/test_run.rs
@@ -13,6 +13,7 @@
 
 mod admission;
 mod canonical;
+mod check;
 mod decision;
 mod model;
 mod validate;
@@ -25,6 +26,10 @@ pub use admission::{
     test_run_admission_id,
 };
 pub use canonical::{CanonicalTestRunError, canonical_test_run_json, test_run_fingerprint};
+pub use check::{
+    TEST_RUN_CHECK_FORMAT, TEST_RUN_CHECK_FORMAT_VERSION, TestRunCheck, validate_test_run_check,
+    verify_test_run_check,
+};
 pub use decision::{
     TEST_RUN_DENIAL_CODES, TestRunAdmissionDecision, TestRunDenialCode, decide_test_run_admission,
     test_run_denial_code,

--- a/crates/vize_marquette/src/test_run/check.rs
+++ b/crates/vize_marquette/src/test_run/check.rs
@@ -1,0 +1,315 @@
+use serde::{Deserialize, Serialize};
+use vize_carton::{String, cstr};
+
+use crate::ContractDiagnostic;
+
+use super::admission::{TestRunCandidate, admit_test_run, parse_test_run_admission_id};
+use super::decision::{TestRunAdmissionDecision, decision_from_diagnostics};
+use super::model::TestRunEvidence;
+use super::validate::is_strict_timestamp_value;
+use super::validate::rules::{
+    check_digest, check_identifier, check_source_revision, check_timestamp,
+};
+
+/// Serialized `format` marker for retained tests-check records.
+///
+/// Readers must reject any other value before trusting the record.
+pub const TEST_RUN_CHECK_FORMAT: &str = "vize.test-run.check";
+
+/// Current serialized tests-check format.
+///
+/// Readers must reject a higher value until they explicitly support it.
+pub const TEST_RUN_CHECK_FORMAT_VERSION: u32 = 1;
+
+/// Retained, release-bound `tests` check for one deployment decision.
+///
+/// The record replaces every generic test-result reference — a summary blob,
+/// a report path, or a green workflow label — with the exact
+/// `test-run:<sha256>` admission id of an independently verified run, the
+/// six candidate facts the run was admitted for, and the identity and
+/// instant of the independent observer that recorded the admission. A
+/// release decision retaining anything else as its tests evidence cannot
+/// pass [`verify_test_run_check`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TestRunCheck {
+    /// Serialized format marker; always [`TEST_RUN_CHECK_FORMAT`].
+    pub format: String,
+    /// Serialized format version.
+    ///
+    /// Defaults to [`TEST_RUN_CHECK_FORMAT_VERSION`].
+    #[serde(default = "default_test_run_check_format_version")]
+    pub format_version: u32,
+    /// Exact `test-run:<sha256>` admission id of the observed run.
+    pub evidence: String,
+    /// Exact candidate facts the run was admitted for.
+    pub candidate: TestRunCandidate,
+    /// Identity of the independent observer that recorded the admission.
+    ///
+    /// The observer is the trusted promotion boundary, never the runner
+    /// that executed the tests.
+    pub observer: String,
+    /// Millisecond-precision UTC instant the admission was observed.
+    pub observed_at: String,
+}
+
+const fn default_test_run_check_format_version() -> u32 {
+    TEST_RUN_CHECK_FORMAT_VERSION
+}
+
+/// Validates a retained tests-check record structurally.
+///
+/// Diagnostics use `check.` paths and are deterministic and sorted by path,
+/// code, and message. A generic evidence reference fails here with
+/// `VIZE_MARQUETTE_141`: only an exact `test-run:<sha256>` admission id can
+/// name retained test evidence. Structural validity never admits anything by
+/// itself; [`verify_test_run_check`] must confirm the record against the
+/// caller's candidate and the retained run.
+pub fn validate_test_run_check(check: &TestRunCheck) -> Vec<ContractDiagnostic> {
+    let mut diagnostics = Vec::new();
+
+    if check.format.as_str() != TEST_RUN_CHECK_FORMAT {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_101",
+            "check.format",
+            "unsupported tests-check format marker",
+        ));
+    }
+    if check.format_version != TEST_RUN_CHECK_FORMAT_VERSION {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_102",
+            "check.formatVersion",
+            "unsupported tests-check format version",
+        ));
+    }
+
+    if parse_test_run_admission_id(&check.evidence).is_none() {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_141",
+            "check.evidence",
+            "check evidence must be test-run: followed by 64 lowercase hexadecimal characters",
+        ));
+    }
+
+    let candidate = &check.candidate;
+    check_identifier(
+        &candidate.application,
+        "check.candidate.application",
+        &mut diagnostics,
+    );
+    check_identifier(
+        &candidate.environment,
+        "check.candidate.environment",
+        &mut diagnostics,
+    );
+    check_digest(
+        &candidate.contract_fingerprint,
+        "check.candidate.contractFingerprint",
+        &mut diagnostics,
+    );
+    check_source_revision(
+        &candidate.source_revision,
+        "check.candidate.sourceRevision",
+        &mut diagnostics,
+    );
+    if candidate.release.is_empty() || candidate.release.len() > 256 {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_106",
+            "check.candidate.release",
+            "release must be between 1 and 256 characters",
+        ));
+    }
+    check_digest(
+        &candidate.artifact_fingerprint,
+        "check.candidate.artifactFingerprint",
+        &mut diagnostics,
+    );
+
+    check_identifier(&check.observer, "check.observer", &mut diagnostics);
+    check_timestamp(&check.observed_at, "check.observedAt", &mut diagnostics);
+
+    diagnostics.sort_by(|left, right| {
+        (&left.path, left.code, &left.message).cmp(&(&right.path, right.code, &right.message))
+    });
+    diagnostics
+}
+
+/// Verifies one retained tests check against the caller's own facts.
+///
+/// The caller supplies the candidate it is deciding from its own trusted
+/// facts; the retained check must validate structurally, bind that candidate
+/// exactly, name an observer independent from the run's runner, and be
+/// observed no earlier than the run's completed verification. The referenced
+/// record is then admitted exactly like
+/// [`admit_test_run`](super::admit_test_run): canonical fingerprint,
+/// candidate bindings, expiry at `now`, verification outcome, and
+/// skipped-test accounting all fail closed. Diagnostics, denial codes, and
+/// ordering are identical in every host family, as pinned by the shared
+/// `tests/fixtures/test-run-evidence` check-decision fixtures.
+pub fn verify_test_run_check(
+    check: &TestRunCheck,
+    candidate: &TestRunCandidate,
+    evidence: &TestRunEvidence,
+    now: &str,
+) -> TestRunAdmissionDecision {
+    let mut diagnostics = validate_test_run_check(check);
+
+    let bindings = [
+        (
+            check.candidate.application.as_str(),
+            candidate.application.as_str(),
+            "check.candidate.application",
+            "application",
+        ),
+        (
+            check.candidate.environment.as_str(),
+            candidate.environment.as_str(),
+            "check.candidate.environment",
+            "environment",
+        ),
+        (
+            check.candidate.contract_fingerprint.as_str(),
+            candidate.contract_fingerprint.as_str(),
+            "check.candidate.contractFingerprint",
+            "contract fingerprint",
+        ),
+        (
+            check.candidate.source_revision.as_str(),
+            candidate.source_revision.as_str(),
+            "check.candidate.sourceRevision",
+            "source revision",
+        ),
+        (
+            check.candidate.release.as_str(),
+            candidate.release.as_str(),
+            "check.candidate.release",
+            "release",
+        ),
+        (
+            check.candidate.artifact_fingerprint.as_str(),
+            candidate.artifact_fingerprint.as_str(),
+            "check.candidate.artifactFingerprint",
+            "artifact fingerprint",
+        ),
+    ];
+    for (recorded, expected, path, field) in bindings {
+        if recorded != expected {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_149",
+                path,
+                cstr!("check does not bind the candidate {field}"),
+            ));
+        }
+    }
+
+    if check.observer == evidence.runner.identity {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_151",
+            "check.observer",
+            "check observer must be independent from the run's runner",
+        ));
+    }
+    if is_strict_timestamp_value(&check.observed_at)
+        && check.observed_at < evidence.verification.completed_at
+    {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_150",
+            "check.observedAt",
+            "observation must not precede the completed verification",
+        ));
+    }
+
+    diagnostics.extend(admit_test_run(evidence, candidate, &check.evidence, now));
+    diagnostics.sort_by(|left, right| {
+        (&left.path, left.code, &left.message).cmp(&(&right.path, right.code, &right.message))
+    });
+    decision_from_diagnostics(diagnostics)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_run::admission::test_run_admission_id;
+    use crate::test_run::decision::TestRunDenialCode;
+    use crate::test_run::model_tests::example_evidence;
+
+    use super::*;
+
+    const NOW: &str = "2026-07-22T00:00:00.000Z";
+
+    fn example_candidate() -> TestRunCandidate {
+        let evidence = example_evidence();
+        TestRunCandidate {
+            application: evidence.application,
+            environment: evidence.environment,
+            contract_fingerprint: evidence.contract_fingerprint,
+            source_revision: evidence.source_revision,
+            release: evidence.release,
+            artifact_fingerprint: evidence.artifact.fingerprint,
+        }
+    }
+
+    fn example_check() -> TestRunCheck {
+        TestRunCheck {
+            format: TEST_RUN_CHECK_FORMAT.into(),
+            format_version: TEST_RUN_CHECK_FORMAT_VERSION,
+            evidence: test_run_admission_id(&example_evidence()).unwrap(),
+            candidate: example_candidate(),
+            observer: "release.gate".into(),
+            observed_at: "2026-07-21T00:12:00.000Z".into(),
+        }
+    }
+
+    #[test]
+    fn a_release_bound_check_verifies() {
+        let decision = verify_test_run_check(
+            &example_check(),
+            &example_candidate(),
+            &example_evidence(),
+            NOW,
+        );
+        assert!(decision.allowed);
+        assert_eq!(decision.diagnostics, Vec::new());
+    }
+
+    #[test]
+    fn generic_test_result_references_fail_closed() {
+        let mut check = example_check();
+        check.evidence = "reports/junit-summary.xml".into();
+        let decision =
+            verify_test_run_check(&check, &example_candidate(), &example_evidence(), NOW);
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.denial_codes,
+            [TestRunDenialCode::AdmissionIdMalformed]
+        );
+    }
+
+    #[test]
+    fn substituted_checks_and_dependent_observers_are_rejected() {
+        let mut check = example_check();
+        check.candidate.release = "0.999.0".into();
+        check.observer = example_evidence().runner.identity;
+        check.observed_at = "2026-07-21T00:10:30.000Z".into();
+        let decision =
+            verify_test_run_check(&check, &example_candidate(), &example_evidence(), NOW);
+        assert_eq!(
+            decision.denial_codes,
+            [
+                TestRunDenialCode::CheckCandidateMismatch,
+                TestRunDenialCode::CheckInvalid,
+                TestRunDenialCode::CheckObserverNotIndependent,
+            ]
+        );
+    }
+
+    #[test]
+    fn malformed_checks_are_check_invalid() {
+        let mut check = example_check();
+        check.format = "vize.test-results".into();
+        check.observer = "Release Gate!".into();
+        let decision =
+            verify_test_run_check(&check, &example_candidate(), &example_evidence(), NOW);
+        assert_eq!(decision.denial_codes, [TestRunDenialCode::CheckInvalid]);
+        assert_eq!(decision.diagnostics.len(), 2);
+    }
+}

--- a/crates/vize_marquette/src/test_run/decision.rs
+++ b/crates/vize_marquette/src/test_run/decision.rs
@@ -35,6 +35,12 @@ pub enum TestRunDenialCode {
     CandidateReleaseMismatch,
     /// The record does not bind the candidate source revision.
     CandidateSourceRevisionMismatch,
+    /// The retained tests check does not bind the caller's candidate.
+    CheckCandidateMismatch,
+    /// The retained tests check record itself failed validation.
+    CheckInvalid,
+    /// The tests check observer is not independent from the run's runner.
+    CheckObserverNotIndependent,
     /// The record is expired at the admission time.
     RecordExpired,
     /// The record failed structural or consistency validation.
@@ -46,7 +52,7 @@ pub enum TestRunDenialCode {
 }
 
 /// Every denial code, in the stable lexicographic decision order.
-pub const TEST_RUN_DENIAL_CODES: [TestRunDenialCode; 13] = [
+pub const TEST_RUN_DENIAL_CODES: [TestRunDenialCode; 16] = [
     TestRunDenialCode::AdmissionIdMalformed,
     TestRunDenialCode::AdmissionIdMismatch,
     TestRunDenialCode::AdmissionTimeMalformed,
@@ -56,6 +62,9 @@ pub const TEST_RUN_DENIAL_CODES: [TestRunDenialCode; 13] = [
     TestRunDenialCode::CandidateEnvironmentMismatch,
     TestRunDenialCode::CandidateReleaseMismatch,
     TestRunDenialCode::CandidateSourceRevisionMismatch,
+    TestRunDenialCode::CheckCandidateMismatch,
+    TestRunDenialCode::CheckInvalid,
+    TestRunDenialCode::CheckObserverNotIndependent,
     TestRunDenialCode::RecordExpired,
     TestRunDenialCode::RecordInvalid,
     TestRunDenialCode::SkippedTestsRecorded,
@@ -86,7 +95,10 @@ pub struct TestRunAdmissionDecision {
 /// The mapping is total and identical in every host family: admission codes
 /// `VIZE_MARQUETTE_141` through `VIZE_MARQUETTE_148` map to their exact
 /// cause, `VIZE_MARQUETTE_144` distinguishes the mismatched candidate
-/// binding by its diagnostic path, and every other diagnostic is a
+/// binding by its diagnostic path, `VIZE_MARQUETTE_149` through
+/// `VIZE_MARQUETTE_151` map to their tests-check cause, every other
+/// diagnostic at a `check.` path is a [`TestRunDenialCode::CheckInvalid`]
+/// tests-check validation failure, and every remaining diagnostic is a
 /// [`TestRunDenialCode::RecordInvalid`] record-validation failure.
 pub fn test_run_denial_code(diagnostic: &ContractDiagnostic) -> TestRunDenialCode {
     match (diagnostic.code, diagnostic.path.as_str()) {
@@ -108,7 +120,26 @@ pub fn test_run_denial_code(diagnostic: &ContractDiagnostic) -> TestRunDenialCod
         ("VIZE_MARQUETTE_146", _) => TestRunDenialCode::VerificationNotAccepted,
         ("VIZE_MARQUETTE_147", _) => TestRunDenialCode::SkippedTestsRecorded,
         ("VIZE_MARQUETTE_148", _) => TestRunDenialCode::AdmissionTimeMalformed,
+        ("VIZE_MARQUETTE_149", _) => TestRunDenialCode::CheckCandidateMismatch,
+        ("VIZE_MARQUETTE_150", _) => TestRunDenialCode::CheckInvalid,
+        ("VIZE_MARQUETTE_151", _) => TestRunDenialCode::CheckObserverNotIndependent,
+        (_, path) if path.starts_with("check.") => TestRunDenialCode::CheckInvalid,
         _ => TestRunDenialCode::RecordInvalid,
+    }
+}
+
+/// Builds the structured decision for one complete diagnostic set.
+pub(crate) fn decision_from_diagnostics(
+    diagnostics: Vec<ContractDiagnostic>,
+) -> TestRunAdmissionDecision {
+    let mut denial_codes: Vec<TestRunDenialCode> =
+        diagnostics.iter().map(test_run_denial_code).collect();
+    denial_codes.sort_unstable();
+    denial_codes.dedup();
+    TestRunAdmissionDecision {
+        allowed: diagnostics.is_empty(),
+        denial_codes,
+        diagnostics,
     }
 }
 
@@ -125,16 +156,7 @@ pub fn decide_test_run_admission(
     admission_id: &str,
     now: &str,
 ) -> TestRunAdmissionDecision {
-    let diagnostics = admit_test_run(evidence, candidate, admission_id, now);
-    let mut denial_codes: Vec<TestRunDenialCode> =
-        diagnostics.iter().map(test_run_denial_code).collect();
-    denial_codes.sort_unstable();
-    denial_codes.dedup();
-    TestRunAdmissionDecision {
-        allowed: diagnostics.is_empty(),
-        denial_codes,
-        diagnostics,
-    }
+    decision_from_diagnostics(admit_test_run(evidence, candidate, admission_id, now))
 }
 
 #[cfg(test)]
@@ -160,13 +182,14 @@ mod tests {
 
     #[test]
     fn the_vocabulary_is_sorted_and_serializes_kebab_case() {
-        let serialized: [vize_carton::String; 13] = TEST_RUN_DENIAL_CODES
+        let serialized: [vize_carton::String; 16] = TEST_RUN_DENIAL_CODES
             .map(|code| serde_json::to_value(code).unwrap().as_str().unwrap().into());
         let mut sorted = serialized.clone();
         sorted.sort();
         assert_eq!(serialized, sorted);
         assert_eq!(serialized[0], "admission-id-malformed");
-        assert_eq!(serialized[10], "record-invalid");
+        assert_eq!(serialized[10], "check-invalid");
+        assert_eq!(serialized[13], "record-invalid");
 
         let mut ordered = TEST_RUN_DENIAL_CODES;
         ordered.sort_unstable();

--- a/crates/vize_marquette/src/test_run/validate.rs
+++ b/crates/vize_marquette/src/test_run/validate.rs
@@ -4,7 +4,7 @@ use crate::validate::rules::contract_path;
 use crate::{ContractDiagnostic, TestRunEvidence};
 
 mod executions;
-mod rules;
+pub(crate) mod rules;
 #[cfg(test)]
 mod tests;
 
@@ -63,7 +63,11 @@ pub fn validate_test_run(evidence: &TestRunEvidence) -> Vec<ContractDiagnostic> 
         "contractFingerprint",
         &mut diagnostics,
     );
-    rules::check_source_revision(&evidence.source_revision, &mut diagnostics);
+    rules::check_source_revision(
+        &evidence.source_revision,
+        "sourceRevision",
+        &mut diagnostics,
+    );
     if evidence.release.is_empty() || evidence.release.len() > 256 {
         diagnostics.push(ContractDiagnostic::error(
             "VIZE_MARQUETTE_106",

--- a/crates/vize_marquette/src/test_run/validate/rules.rs
+++ b/crates/vize_marquette/src/test_run/validate/rules.rs
@@ -6,7 +6,7 @@ use crate::validate::rules::{contract_path, validate_identifier};
 const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 
 /// Validates the shared identifier grammar and the schema length bound.
-pub(super) fn check_identifier(id: &str, path: &str, diagnostics: &mut Vec<ContractDiagnostic>) {
+pub(crate) fn check_identifier(id: &str, path: &str, diagnostics: &mut Vec<ContractDiagnostic>) {
     validate_identifier(id, path, "VIZE_MARQUETTE_103", diagnostics);
     if id.is_empty() || id.len() > 128 {
         diagnostics.push(ContractDiagnostic::error(
@@ -18,7 +18,7 @@ pub(super) fn check_identifier(id: &str, path: &str, diagnostics: &mut Vec<Contr
 }
 
 /// Validates a lowercase 64-character SHA-256 fingerprint.
-pub(super) fn check_digest(value: &str, path: &str, diagnostics: &mut Vec<ContractDiagnostic>) {
+pub(crate) fn check_digest(value: &str, path: &str, diagnostics: &mut Vec<ContractDiagnostic>) {
     if !is_lower_hex(value, 64, 64) {
         diagnostics.push(ContractDiagnostic::error(
             "VIZE_MARQUETTE_104",
@@ -29,11 +29,15 @@ pub(super) fn check_digest(value: &str, path: &str, diagnostics: &mut Vec<Contra
 }
 
 /// Validates an exact source revision digest.
-pub(super) fn check_source_revision(value: &str, diagnostics: &mut Vec<ContractDiagnostic>) {
+pub(crate) fn check_source_revision(
+    value: &str,
+    path: &str,
+    diagnostics: &mut Vec<ContractDiagnostic>,
+) {
     if !is_lower_hex(value, 40, 128) {
         diagnostics.push(ContractDiagnostic::error(
             "VIZE_MARQUETTE_105",
-            "sourceRevision",
+            path,
             "source revision must be 40 to 128 lowercase hexadecimal characters",
         ));
     }
@@ -44,7 +48,7 @@ pub(super) fn check_source_revision(value: &str, diagnostics: &mut Vec<ContractD
 ///
 /// The fixed-width format keeps lexicographic and chronological order
 /// identical, which the ordering rules rely on.
-pub(super) fn check_timestamp(value: &str, path: &str, diagnostics: &mut Vec<ContractDiagnostic>) {
+pub(crate) fn check_timestamp(value: &str, path: &str, diagnostics: &mut Vec<ContractDiagnostic>) {
     if !is_strict_timestamp(value.as_bytes()) {
         diagnostics.push(ContractDiagnostic::error(
             "VIZE_MARQUETTE_107",

--- a/crates/vize_marquette/tests/test_run_conformance.rs
+++ b/crates/vize_marquette/tests/test_run_conformance.rs
@@ -6,8 +6,9 @@
 use std::{fs, path::PathBuf};
 
 use vize_marquette::{
-    TestRunCandidate, TestRunEvidence, canonical_test_run_json, decide_test_run_admission,
-    parse_test_run_admission_id, test_run_admission_id, test_run_fingerprint,
+    TestRunCandidate, TestRunCheck, TestRunEvidence, canonical_test_run_json,
+    decide_test_run_admission, parse_test_run_admission_id, test_run_admission_id,
+    test_run_fingerprint, verify_test_run_check,
 };
 
 fn fixture(name: &str) -> PathBuf {
@@ -73,6 +74,32 @@ fn reproduces_every_shared_admission_decision() {
             case["admissionId"].as_str().unwrap(),
             case["now"].as_str().unwrap(),
         );
+        assert!(case["decision"].is_object(), "{name} must pin a decision");
+        assert_eq!(
+            serde_json::to_value(&decision).unwrap(),
+            case["decision"],
+            "decision mismatch for case {name}",
+        );
+    }
+}
+
+#[test]
+fn reproduces_every_shared_check_decision() {
+    let document: serde_json::Value =
+        serde_json::from_slice(&fs::read(fixture("check-decisions.json")).unwrap()).unwrap();
+    let cases = document["cases"].as_array().unwrap();
+    assert!(!cases.is_empty());
+
+    for case in cases {
+        let name = case["name"].as_str().unwrap();
+        let evidence: TestRunEvidence =
+            serde_json::from_slice(&fs::read(fixture(case["evidence"].as_str().unwrap())).unwrap())
+                .unwrap();
+        let check: TestRunCheck = serde_json::from_value(case["check"].clone()).unwrap();
+        let candidate: TestRunCandidate =
+            serde_json::from_value(case["candidate"].clone()).unwrap();
+        let decision =
+            verify_test_run_check(&check, &candidate, &evidence, case["now"].as_str().unwrap());
         assert!(case["decision"].is_object(), "{name} must pin a decision");
         assert_eq!(
             serde_json::to_value(&decision).unwrap(),

--- a/crates/vize_marquette/tests/test_run_schema.rs
+++ b/crates/vize_marquette/tests/test_run_schema.rs
@@ -92,3 +92,37 @@ fn admission_schema_is_strict_and_documents_the_append_only_policy() {
         "every object schema must reject unknown properties"
     );
 }
+
+#[test]
+fn check_schema_is_strict_and_rejects_generic_references() {
+    let schema: Value = serde_json::from_slice(
+        &fs::read(repository_file(
+            "crates/vize_marquette/schema/test-run-check.schema.json",
+        ))
+        .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        schema["$schema"],
+        "https://json-schema.org/draft/2020-12/schema"
+    );
+    assert_eq!(
+        schema["$defs"]["check"]["properties"]["format"]["const"],
+        "vize.test-run.check"
+    );
+    assert_eq!(
+        schema["$defs"]["check"]["properties"]["formatVersion"]["const"],
+        1
+    );
+    assert_eq!(
+        schema["$defs"]["admissionId"]["pattern"], "^test-run:[a-f0-9]{64}$",
+        "tests evidence must be an exact admission id, never a generic reference"
+    );
+
+    assert_eq!(
+        count_open_object_schemas(&schema),
+        0,
+        "every object schema must reject unknown properties"
+    );
+}

--- a/npm/marquette/README.md
+++ b/npm/marquette/README.md
@@ -100,6 +100,7 @@ import { defineTestRunEvidence } from "@vizejs/marquette/test-run";
 import { validateTestRunEvidence } from "@vizejs/marquette/test-run/validate";
 import { testRunAdmissionId } from "@vizejs/marquette/test-run/canonical";
 import { admitTestRun, decideTestRunAdmission } from "@vizejs/marquette/test-run/admission";
+import { verifyTestRunCheck } from "@vizejs/marquette/test-run/check";
 
 const diagnostics = validateTestRunEvidence(evidence);
 const admissionId = await testRunAdmissionId(evidence); // test-run:<sha256>
@@ -108,6 +109,7 @@ const decision = await decideTestRunAdmission(evidence, candidate, admissionId, 
 if (!decision.allowed) {
   console.error(decision.denialCodes); // e.g. ["record-expired"]
 }
+const release = await verifyTestRunCheck(retainedCheck, candidate, evidence, now);
 ```
 
 Validation shares its `VIZE_MARQUETTE_1xx` codes, paths, and ordering with the
@@ -116,9 +118,13 @@ serialization and SHA-256 fingerprints, proven by the shared fixtures in
 `tests/fixtures/test-run-evidence/`. Admission decisions carry the stable,
 append-only denial-code vocabulary shared by every backend family; the same
 fixtures pin every decision so a JavaScript, Rust, Go, or JVM gate denies for
-identical machine-readable causes. The published record schema is available
-from `@vizejs/marquette/test-run/schema`, and the decision contract from
-`@vizejs/marquette/test-run/admission/schema`.
+identical machine-readable causes. The check entry replaces every generic
+test-result reference in release evidence: a retained `vize.test-run.check`
+record may only name the exact `test-run:<sha256>` admission id, bind the six
+candidate facts, and record an observer independent from the runner. The
+published record schema is available from `@vizejs/marquette/test-run/schema`,
+the decision contract from `@vizejs/marquette/test-run/admission/schema`, and
+the tests-check contract from `@vizejs/marquette/test-run/check/schema`.
 
 ## Guarantees
 

--- a/npm/marquette/package.json
+++ b/npm/marquette/package.json
@@ -56,9 +56,15 @@
       "import": "./dist/test-run-admission.mjs",
       "default": "./dist/test-run-admission.mjs"
     },
+    "./test-run/check": {
+      "types": "./dist/test-run-check.d.mts",
+      "import": "./dist/test-run-check.mjs",
+      "default": "./dist/test-run-check.mjs"
+    },
     "./schema": "./dist/application-contract.schema.json",
     "./test-run/schema": "./dist/test-run-evidence.schema.json",
-    "./test-run/admission/schema": "./dist/test-run-admission.schema.json"
+    "./test-run/admission/schema": "./dist/test-run-admission.schema.json",
+    "./test-run/check/schema": "./dist/test-run-check.schema.json"
   },
   "publishConfig": {
     "access": "public"

--- a/npm/marquette/scripts/check-size.mjs
+++ b/npm/marquette/scripts/check-size.mjs
@@ -27,6 +27,11 @@ const budgets = [
     file: "dist/test-run-admission.mjs",
     maximumGzipBytes: 3072,
   },
+  {
+    entry: "@vizejs/marquette/test-run/check",
+    file: "dist/test-run-check.mjs",
+    maximumGzipBytes: 3072,
+  },
 ];
 
 for (const { entry, file, maximumGzipBytes } of budgets) {

--- a/npm/marquette/src/test-run-admission.ts
+++ b/npm/marquette/src/test-run-admission.ts
@@ -161,6 +161,9 @@ export const TEST_RUN_DENIAL_CODES = [
   "candidate-environment-mismatch",
   "candidate-release-mismatch",
   "candidate-source-revision-mismatch",
+  "check-candidate-mismatch",
+  "check-invalid",
+  "check-observer-not-independent",
   "record-expired",
   "record-invalid",
   "skipped-tests-recorded",
@@ -203,8 +206,10 @@ const CANDIDATE_MISMATCH_CODES: ReadonlyMap<string, TestRunDenialCode> = new Map
  * The mapping is total and identical in every host family: admission codes
  * `VIZE_MARQUETTE_141` through `VIZE_MARQUETTE_148` map to their exact
  * cause, `VIZE_MARQUETTE_144` distinguishes the mismatched candidate binding
- * by its diagnostic path, and every other diagnostic is a `record-invalid`
- * record-validation failure.
+ * by its diagnostic path, `VIZE_MARQUETTE_149` through `VIZE_MARQUETTE_151`
+ * map to their tests-check cause, every other diagnostic at a `check.` path
+ * is a `check-invalid` tests-check validation failure, and every remaining
+ * diagnostic is a `record-invalid` record-validation failure.
  */
 export function testRunDenialCode(diagnostic: MarquetteDiagnostic): TestRunDenialCode {
   switch (diagnostic.code) {
@@ -212,8 +217,13 @@ export function testRunDenialCode(diagnostic: MarquetteDiagnostic): TestRunDenia
       return "admission-id-malformed";
     case "VIZE_MARQUETTE_142":
       return "admission-id-mismatch";
-    case "VIZE_MARQUETTE_144":
-      return CANDIDATE_MISMATCH_CODES.get(diagnostic.path) ?? "record-invalid";
+    case "VIZE_MARQUETTE_144": {
+      const mismatch = CANDIDATE_MISMATCH_CODES.get(diagnostic.path);
+      if (mismatch !== undefined) {
+        return mismatch;
+      }
+      break;
+    }
     case "VIZE_MARQUETTE_145":
       return "record-expired";
     case "VIZE_MARQUETTE_146":
@@ -222,9 +232,16 @@ export function testRunDenialCode(diagnostic: MarquetteDiagnostic): TestRunDenia
       return "skipped-tests-recorded";
     case "VIZE_MARQUETTE_148":
       return "admission-time-malformed";
+    case "VIZE_MARQUETTE_149":
+      return "check-candidate-mismatch";
+    case "VIZE_MARQUETTE_150":
+      return "check-invalid";
+    case "VIZE_MARQUETTE_151":
+      return "check-observer-not-independent";
     default:
-      return "record-invalid";
+      break;
   }
+  return diagnostic.path.startsWith("check.") ? "check-invalid" : "record-invalid";
 }
 
 /**

--- a/npm/marquette/src/test-run-check.test.ts
+++ b/npm/marquette/src/test-run-check.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import type { TestRunEvidence } from "./test-run.js";
+import type { TestRunAdmissionDecision, TestRunCandidate } from "./test-run-admission.js";
+import { validateTestRunCheck, verifyTestRunCheck, type TestRunCheck } from "./test-run-check.js";
+import { testRunAdmissionId } from "./test-run-canonical.js";
+
+function fixture(name: string): URL {
+  return new URL(`../../../tests/fixtures/test-run-evidence/${name}`, import.meta.url);
+}
+
+function readEvidence(name = "valid.json"): TestRunEvidence {
+  return JSON.parse(readFileSync(fixture(name), "utf8")) as TestRunEvidence;
+}
+
+function candidateFor(evidence: TestRunEvidence): TestRunCandidate {
+  return {
+    application: evidence.application,
+    environment: evidence.environment,
+    contractFingerprint: evidence.contractFingerprint,
+    sourceRevision: evidence.sourceRevision,
+    release: evidence.release,
+    artifactFingerprint: evidence.artifact.fingerprint,
+  };
+}
+
+async function checkFor(evidence: TestRunEvidence): Promise<TestRunCheck> {
+  return {
+    format: "vize.test-run.check",
+    formatVersion: 1,
+    evidence: await testRunAdmissionId(evidence),
+    candidate: candidateFor(evidence),
+    observer: "release.gate",
+    observedAt: "2026-07-21T00:12:00.000Z",
+  };
+}
+
+const NOW = "2026-07-22T00:00:00.000Z";
+
+void test("a release-bound check verifies", async () => {
+  const evidence = readEvidence();
+  const check = await checkFor(evidence);
+  assert.deepEqual(validateTestRunCheck(check), []);
+  const decision = await verifyTestRunCheck(check, candidateFor(evidence), evidence, NOW);
+  assert.equal(decision.allowed, true);
+  assert.deepEqual(decision.denialCodes, []);
+  assert.deepEqual(decision.diagnostics, []);
+});
+
+void test("generic test-result references fail closed", async () => {
+  const evidence = readEvidence();
+  const check = { ...(await checkFor(evidence)), evidence: "reports/junit-summary.xml" };
+  const decision = await verifyTestRunCheck(check, candidateFor(evidence), evidence, NOW);
+  assert.equal(decision.allowed, false);
+  assert.deepEqual(decision.denialCodes, ["admission-id-malformed"]);
+});
+
+void test("substituted checks and dependent observers are rejected", async () => {
+  const evidence = readEvidence();
+  const base = await checkFor(evidence);
+  const check = {
+    ...base,
+    candidate: { ...base.candidate, release: "0.999.0" },
+    observer: evidence.runner.identity,
+    observedAt: "2026-07-21T00:10:30.000Z",
+  };
+  const decision = await verifyTestRunCheck(check, candidateFor(evidence), evidence, NOW);
+  assert.deepEqual(decision.denialCodes, [
+    "check-candidate-mismatch",
+    "check-invalid",
+    "check-observer-not-independent",
+  ]);
+});
+
+interface SharedCheckCase {
+  readonly name: string;
+  readonly family: string;
+  readonly evidence: string;
+  readonly check: TestRunCheck;
+  readonly candidate: TestRunCandidate;
+  readonly now: string;
+  readonly decision: TestRunAdmissionDecision;
+}
+
+void test("reproduces every shared check decision", async () => {
+  const document = JSON.parse(readFileSync(fixture("check-decisions.json"), "utf8")) as {
+    cases: SharedCheckCase[];
+  };
+  assert.ok(document.cases.length > 0);
+
+  for (const sharedCase of document.cases) {
+    const decision = await verifyTestRunCheck(
+      sharedCase.check,
+      sharedCase.candidate,
+      readEvidence(sharedCase.evidence),
+      sharedCase.now,
+    );
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(decision)),
+      sharedCase.decision,
+      `decision mismatch for case ${sharedCase.name}`,
+    );
+  }
+});

--- a/npm/marquette/src/test-run-check.ts
+++ b/npm/marquette/src/test-run-check.ts
@@ -1,0 +1,219 @@
+import type { TestRunEvidence } from "./test-run-model.js";
+import type { MarquetteDiagnostic } from "./validate.js";
+import {
+  admitTestRun,
+  testRunDenialCode,
+  type TestRunAdmissionDecision,
+  type TestRunCandidate,
+  type TestRunDenialCode,
+} from "./test-run-admission.js";
+import { parseTestRunAdmissionId } from "./test-run-canonical.js";
+import {
+  checkDigest,
+  checkIdentifier,
+  checkSourceRevision,
+  checkTimestamp,
+  error,
+  isStrictTimestamp,
+} from "./test-run-validate-rules.js";
+
+/**
+ * Serialized `format` marker for retained tests-check records.
+ *
+ * Readers must reject any other value before trusting the record.
+ */
+export const TEST_RUN_CHECK_FORMAT = "vize.test-run.check";
+
+/**
+ * Current serialized tests-check format.
+ *
+ * Readers must reject a higher value until they explicitly support it.
+ */
+export const TEST_RUN_CHECK_FORMAT_VERSION = 1;
+
+/**
+ * Retained, release-bound `tests` check for one deployment decision.
+ *
+ * The record replaces every generic test-result reference — a summary blob,
+ * a report path, or a green workflow label — with the exact
+ * `test-run:<sha256>` admission id of an independently verified run, the six
+ * candidate facts the run was admitted for, and the identity and instant of
+ * the independent observer that recorded the admission. A release decision
+ * retaining anything else as its tests evidence cannot pass
+ * {@link verifyTestRunCheck}.
+ */
+export interface TestRunCheck {
+  /** Serialized format marker; always {@link TEST_RUN_CHECK_FORMAT}. */
+  readonly format: typeof TEST_RUN_CHECK_FORMAT;
+  /**
+   * Serialized format version.
+   *
+   * Defaults to {@link TEST_RUN_CHECK_FORMAT_VERSION}.
+   */
+  readonly formatVersion?: typeof TEST_RUN_CHECK_FORMAT_VERSION;
+  /** Exact `test-run:<sha256>` admission id of the observed run. */
+  readonly evidence: string;
+  /** Exact candidate facts the run was admitted for. */
+  readonly candidate: TestRunCandidate;
+  /**
+   * Identity of the independent observer that recorded the admission.
+   *
+   * The observer is the trusted promotion boundary, never the runner that
+   * executed the tests.
+   */
+  readonly observer: string;
+  /** Millisecond-precision UTC instant the admission was observed. */
+  readonly observedAt: string;
+}
+
+/**
+ * Validates a retained tests-check record structurally.
+ *
+ * Diagnostics use `check.` paths and are deterministic and sorted by path,
+ * code, and message. A generic evidence reference fails here with
+ * `VIZE_MARQUETTE_141`: only an exact `test-run:<sha256>` admission id can
+ * name retained test evidence. Structural validity never admits anything by
+ * itself; {@link verifyTestRunCheck} must confirm the record against the
+ * caller's candidate and the retained run. Codes, paths, messages, and
+ * ordering are identical to the native implementation.
+ */
+export function validateTestRunCheck(check: TestRunCheck): MarquetteDiagnostic[] {
+  const diagnostics: MarquetteDiagnostic[] = [];
+
+  if ((check.format as string) !== TEST_RUN_CHECK_FORMAT) {
+    diagnostics.push(
+      error("VIZE_MARQUETTE_101", "check.format", "unsupported tests-check format marker"),
+    );
+  }
+  if ((check.formatVersion ?? TEST_RUN_CHECK_FORMAT_VERSION) !== TEST_RUN_CHECK_FORMAT_VERSION) {
+    diagnostics.push(
+      error("VIZE_MARQUETTE_102", "check.formatVersion", "unsupported tests-check format version"),
+    );
+  }
+
+  if (parseTestRunAdmissionId(check.evidence) === undefined) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_141",
+        "check.evidence",
+        "check evidence must be test-run: followed by 64 lowercase hexadecimal characters",
+      ),
+    );
+  }
+
+  const candidate = check.candidate;
+  checkIdentifier(candidate.application, "check.candidate.application", diagnostics);
+  checkIdentifier(candidate.environment, "check.candidate.environment", diagnostics);
+  checkDigest(candidate.contractFingerprint, "check.candidate.contractFingerprint", diagnostics);
+  checkSourceRevision(candidate.sourceRevision, "check.candidate.sourceRevision", diagnostics);
+  if (candidate.release.length === 0 || candidate.release.length > 256) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_106",
+        "check.candidate.release",
+        "release must be between 1 and 256 characters",
+      ),
+    );
+  }
+  checkDigest(candidate.artifactFingerprint, "check.candidate.artifactFingerprint", diagnostics);
+
+  checkIdentifier(check.observer, "check.observer", diagnostics);
+  checkTimestamp(check.observedAt, "check.observedAt", diagnostics);
+
+  sortDiagnostics(diagnostics);
+  return diagnostics;
+}
+
+/**
+ * Verifies one retained tests check against the caller's own facts.
+ *
+ * The caller supplies the candidate it is deciding from its own trusted
+ * facts; the retained check must validate structurally, bind that candidate
+ * exactly, name an observer independent from the run's runner, and be
+ * observed no earlier than the run's completed verification. The referenced
+ * record is then admitted exactly like {@link admitTestRun}: canonical
+ * fingerprint, candidate bindings, expiry at `now`, verification outcome,
+ * and skipped-test accounting all fail closed. Diagnostics, denial codes,
+ * and ordering are identical to the native implementation, as pinned by the
+ * shared check-decision fixtures.
+ */
+export async function verifyTestRunCheck(
+  check: TestRunCheck,
+  candidate: TestRunCandidate,
+  evidence: TestRunEvidence,
+  now: string,
+): Promise<TestRunAdmissionDecision> {
+  const diagnostics = validateTestRunCheck(check);
+
+  const bindings = [
+    [check.candidate.application, candidate.application, "application", "application"],
+    [check.candidate.environment, candidate.environment, "environment", "environment"],
+    [
+      check.candidate.contractFingerprint,
+      candidate.contractFingerprint,
+      "contractFingerprint",
+      "contract fingerprint",
+    ],
+    [check.candidate.sourceRevision, candidate.sourceRevision, "sourceRevision", "source revision"],
+    [check.candidate.release, candidate.release, "release", "release"],
+    [
+      check.candidate.artifactFingerprint,
+      candidate.artifactFingerprint,
+      "artifactFingerprint",
+      "artifact fingerprint",
+    ],
+  ] as const;
+  for (const [recorded, expected, property, field] of bindings) {
+    if (recorded !== expected) {
+      diagnostics.push(
+        error(
+          "VIZE_MARQUETTE_149",
+          `check.candidate.${property}`,
+          `check does not bind the candidate ${field}`,
+        ),
+      );
+    }
+  }
+
+  if (check.observer === evidence.runner.identity) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_151",
+        "check.observer",
+        "check observer must be independent from the run's runner",
+      ),
+    );
+  }
+  if (isStrictTimestamp(check.observedAt) && check.observedAt < evidence.verification.completedAt) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_150",
+        "check.observedAt",
+        "observation must not precede the completed verification",
+      ),
+    );
+  }
+
+  diagnostics.push(...(await admitTestRun(evidence, candidate, check.evidence, now)));
+  sortDiagnostics(diagnostics);
+  const denialCodes: TestRunDenialCode[] = [...new Set(diagnostics.map(testRunDenialCode))].sort();
+  return { allowed: diagnostics.length === 0, denialCodes, diagnostics };
+}
+
+function sortDiagnostics(diagnostics: MarquetteDiagnostic[]): void {
+  diagnostics.sort((left, right) =>
+    left.path !== right.path
+      ? left.path < right.path
+        ? -1
+        : 1
+      : left.code !== right.code
+        ? left.code < right.code
+          ? -1
+          : 1
+        : left.message < right.message
+          ? -1
+          : left.message > right.message
+            ? 1
+            : 0,
+  );
+}

--- a/npm/marquette/src/test-run-validate-rules.ts
+++ b/npm/marquette/src/test-run-validate-rules.ts
@@ -56,12 +56,16 @@ export function checkDigest(value: string, path: string, diagnostics: MarquetteD
 }
 
 /** Validates an exact source revision digest. */
-export function checkSourceRevision(value: string, diagnostics: MarquetteDiagnostic[]): void {
+export function checkSourceRevision(
+  value: string,
+  path: string,
+  diagnostics: MarquetteDiagnostic[],
+): void {
   if (!SOURCE_REVISION.test(value)) {
     diagnostics.push(
       error(
         "VIZE_MARQUETTE_105",
-        "sourceRevision",
+        path,
         "source revision must be 40 to 128 lowercase hexadecimal characters",
       ),
     );

--- a/npm/marquette/src/test-run-validate.ts
+++ b/npm/marquette/src/test-run-validate.ts
@@ -52,7 +52,7 @@ export function validateTestRunEvidence(evidence: TestRunEvidence): MarquetteDia
   checkIdentifier(evidence.application, "application", diagnostics);
   checkIdentifier(evidence.environment, "environment", diagnostics);
   checkDigest(evidence.contractFingerprint, "contractFingerprint", diagnostics);
-  checkSourceRevision(evidence.sourceRevision, diagnostics);
+  checkSourceRevision(evidence.sourceRevision, "sourceRevision", diagnostics);
   if (evidence.release.length === 0 || evidence.release.length > 256) {
     diagnostics.push(
       error("VIZE_MARQUETTE_106", "release", "release must be between 1 and 256 characters"),

--- a/npm/marquette/vite.config.ts
+++ b/npm/marquette/vite.config.ts
@@ -11,6 +11,7 @@ const contractSchemas = [
   "application-contract.schema.json",
   "test-run-evidence.schema.json",
   "test-run-admission.schema.json",
+  "test-run-check.schema.json",
 ];
 
 export default defineConfig({
@@ -31,6 +32,7 @@ export default defineConfig({
       "src/test-run-validate.ts",
       "src/test-run-canonical.ts",
       "src/test-run-admission.ts",
+      "src/test-run-check.ts",
     ],
     format: "esm",
     dts: true,

--- a/tests/fixtures/test-run-evidence/check-decisions.json
+++ b/tests/fixtures/test-run-evidence/check-decisions.json
@@ -1,0 +1,397 @@
+{
+  "cases": [
+    {
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "check": {
+        "candidate": {
+          "application": "example",
+          "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+          "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+          "environment": "production",
+          "release": "0.298.0",
+          "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "evidence": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+        "format": "vize.test-run.check",
+        "formatVersion": 1,
+        "observedAt": "2026-07-21T00:12:00.000Z",
+        "observer": "release.gate"
+      },
+      "decision": {
+        "allowed": true,
+        "denialCodes": [],
+        "diagnostics": []
+      },
+      "evidence": "valid.json",
+      "family": "verified",
+      "name": "verified-release-bound-check",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "check": {
+        "candidate": {
+          "application": "example",
+          "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+          "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+          "environment": "production",
+          "release": "0.298.0",
+          "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "evidence": "reports/junit-summary.xml",
+        "format": "vize.test-run.check",
+        "formatVersion": 1,
+        "observedAt": "2026-07-21T00:12:00.000Z",
+        "observer": "release.gate"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["admission-id-malformed"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_141",
+            "message": "admission id must be test-run: followed by 64 lowercase hexadecimal characters",
+            "path": "admission.id",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_141",
+            "message": "check evidence must be test-run: followed by 64 lowercase hexadecimal characters",
+            "path": "check.evidence",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "unbound-reference",
+      "name": "unbound-generic-reference",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "check": {
+        "candidate": {
+          "application": "example",
+          "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+          "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+          "environment": "production",
+          "release": "0.999.0",
+          "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "evidence": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+        "format": "vize.test-run.check",
+        "formatVersion": 1,
+        "observedAt": "2026-07-21T00:12:00.000Z",
+        "observer": "release.gate"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["check-candidate-mismatch"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_149",
+            "message": "check does not bind the candidate release",
+            "path": "check.candidate.release",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "mismatched-candidate",
+      "name": "check-candidate-mismatch",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "check": {
+        "candidate": {
+          "application": "example",
+          "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+          "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+          "environment": "production",
+          "release": "0.298.0",
+          "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "evidence": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+        "format": "vize.test-run.check",
+        "formatVersion": 1,
+        "observedAt": "2026-07-21T00:12:00.000Z",
+        "observer": "release.gate"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["record-expired"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_145",
+            "message": "record is expired at the admission time",
+            "path": "validUntil",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "expired-run",
+      "name": "expired-run",
+      "now": "2026-07-28T00:10:00.000Z"
+    },
+    {
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "staging",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "check": {
+        "candidate": {
+          "application": "example",
+          "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+          "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+          "environment": "staging",
+          "release": "0.298.0",
+          "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "evidence": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+        "format": "vize.test-run.check",
+        "formatVersion": 1,
+        "observedAt": "2026-07-21T00:12:00.000Z",
+        "observer": "release.gate"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["candidate-environment-mismatch"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_144",
+            "message": "record does not bind the candidate environment",
+            "path": "environment",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "cross-scope",
+      "name": "cross-scope-evidence",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "check": {
+        "candidate": {
+          "application": "example",
+          "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+          "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+          "environment": "production",
+          "release": "0.298.0",
+          "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "evidence": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+        "format": "vize.test-run.check",
+        "formatVersion": 1,
+        "observedAt": "2026-07-21T00:12:00.000Z",
+        "observer": "ci.runner-1"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["check-observer-not-independent"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_151",
+            "message": "check observer must be independent from the run's runner",
+            "path": "check.observer",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "observer",
+      "name": "dependent-observer",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "check": {
+        "candidate": {
+          "application": "example",
+          "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+          "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+          "environment": "production",
+          "release": "0.298.0",
+          "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "evidence": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+        "format": "vize.test-run.check",
+        "formatVersion": 1,
+        "observedAt": "2026-07-21T00:10:30.000Z",
+        "observer": "release.gate"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["check-invalid"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_150",
+            "message": "observation must not precede the completed verification",
+            "path": "check.observedAt",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "malformed-check",
+      "name": "stale-observation",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "check": {
+        "candidate": {
+          "application": "example",
+          "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+          "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+          "environment": "production",
+          "release": "0.298.0",
+          "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "evidence": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+        "format": "vize.test-results",
+        "formatVersion": 1,
+        "observedAt": "2026-07-21T00:12:00.000Z",
+        "observer": "Release Gate!"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["check-invalid"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_101",
+            "message": "unsupported tests-check format marker",
+            "path": "check.format",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_103",
+            "message": "identifier must use lowercase ASCII letters, digits, dash, underscore, or dot",
+            "path": "check.observer",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "malformed-check",
+      "name": "malformed-check",
+      "now": "2026-07-22T00:00:00.000Z"
+    },
+    {
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "check": {
+        "candidate": {
+          "application": "example",
+          "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+          "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+          "environment": "production",
+          "release": "0.999.0",
+          "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "evidence": "test-summary: passed",
+        "format": "vize.test-run.check",
+        "formatVersion": 1,
+        "observedAt": "2026-07-21T00:12:00.000Z",
+        "observer": "release.gate"
+      },
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["admission-id-malformed", "check-candidate-mismatch", "record-expired"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_141",
+            "message": "admission id must be test-run: followed by 64 lowercase hexadecimal characters",
+            "path": "admission.id",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_149",
+            "message": "check does not bind the candidate release",
+            "path": "check.candidate.release",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_141",
+            "message": "check evidence must be test-run: followed by 64 lowercase hexadecimal characters",
+            "path": "check.evidence",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_145",
+            "message": "record is expired at the admission time",
+            "path": "validUntil",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "valid.json",
+      "family": "multi-cause",
+      "name": "multi-cause-unbound-expired-substituted",
+      "now": "2026-07-28T00:10:00.000Z"
+    }
+  ],
+  "description": "Shared host-side tests-check verification cases. Each case feeds one retained check, the caller's own candidate facts, one evidence record, and one instant to the verification gate; every backend family must produce exactly the pinned decision. See crates/vize_marquette/schema/test-run-check.schema.json for the record contract that replaces generic test-result references."
+}


### PR DESCRIPTION
## Design

The producer and admission side of release-bound test evidence exist (`test-run:<sha256>`, `decide_test_run_admission` / `decideTestRunAdmission`, stable denial codes — #3233), but nothing defined what a release decision may retain as its `tests` evidence, so a package could still point at a generic test-result reference no host can verify. This PR adds the retained record and its fail-closed verification:

- **`vize.test-run.check`** (`TestRunCheck`, `schema/test-run-check.schema.json`, published as `@vizejs/marquette/test-run/check/schema`): the exact `test-run:<sha256>` admission id, the six exact candidate facts, and the independent `observer`/`observedAt` that recorded the admission. The schema's `admissionId` pattern makes summary blobs, report paths, run URLs, and green workflow labels structurally inadmissible.
- **`validate_test_run_check` / `validateTestRunCheck`**: structural validation with `check.*` paths (existing grammar codes; `VIZE_MARQUETTE_141` for an unbound reference).
- **`verify_test_run_check` / `verifyTestRunCheck`**: takes the caller's own candidate facts, the retained check, the retained `TestRunEvidence`, and `now`; returns the structured `TestRunAdmissionDecision`. The check must bind the caller's candidate exactly (`VIZE_MARQUETTE_149`), be observed no earlier than the run's completed verification (`VIZE_MARQUETTE_150`), and name an observer independent from the runner (`VIZE_MARQUETTE_151`); the referenced record is then admitted exactly like `admit_test_run` (fingerprint, bindings, expiry, verification outcome, skipped accounting).
- **Vocabulary**: `check-candidate-mismatch`, `check-invalid`, `check-observer-not-independent` added in lexicographic position (append-only: no existing code renamed, renumbered, reused, or removed); the published mapping gains the `check.`-path rule in both hosts and the schema description.

## Fixture coverage

`tests/fixtures/test-run-evidence/check-decisions.json` pins 9 cases (`check + candidate + evidence + now -> full decision`), executed byte-equivalently by `crates/vize_marquette/tests/test_run_conformance.rs` and `npm/marquette/src/test-run-check.test.ts`: verified (allowed), unbound generic reference, substituted check candidate, expired run, cross-scope evidence, dependent observer, stale observation, malformed check, and a multi-cause decision `[admission-id-malformed, check-candidate-mismatch, record-expired]` with deterministic ordering.

## Verification

- `cargo test -p vize_marquette` (55 tests incl. doctest), `cargo fmt --all -- --check`, `cargo clippy -p vize_marquette --all-targets -- -D warnings` clean.
- `vp run --filter './npm/marquette' check build test`: 33 tests green, lint/format/typecheck clean, all four schemas emitted into `dist/`; new check entry is 1,852 / 3,072 gzip bytes and the admission entry stays at 2,456 / 3,072.
- Export resolution verified from a consumer: `@vizejs/marquette/test-run/check` and `.../check/schema` resolve and agree with the runtime vocabulary (16 codes).

Part of #3145.
Fixes #3239

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->