### PR TITLE
test(canon): enforce LSP latency and memory budgets per fixture

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -33,6 +33,26 @@
         "hangTimeoutMs": 300000,
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
+      },
+      "lspIncrementalBudget": {
+        "suite": "vben-lsp-incremental",
+        "laneHardTimeoutMs": 60000,
+        "maxPeakRssMiB": 256,
+        "laneBudgetsMs": {
+          "initialize": 1000,
+          "coldOpen": 8000,
+          "coldOpenSecondApp": 1500,
+          "completion": 1000,
+          "hover": 1000,
+          "warmNoop": 1500,
+          "leafBroken": 1500,
+          "leafRepaired": 1500,
+          "sharedBroken": 3000,
+          "sharedBrokenSecondApp": 3000,
+          "sharedRepaired": 3000,
+          "sharedRepairedSecondApp": 3000,
+          "warmNoopSecondApp": 1500
+        }
       }
     },
     {
@@ -352,6 +372,22 @@
         "maxFalsePositiveRatio": 0.02,
         "maxFalseNegativeRatio": 0.02,
         "largeProjectRegressionTarget": true
+      },
+      "lspIncrementalBudget": {
+        "suite": "misskey-lsp-incremental",
+        "laneHardTimeoutMs": 60000,
+        "maxPeakRssMiB": 256,
+        "laneBudgetsMs": {
+          "initialize": 1000,
+          "coldOpen": 8000,
+          "completion": 1000,
+          "hover": 1000,
+          "warmNoop": 1500,
+          "leafBroken": 1500,
+          "leafRepaired": 1500,
+          "sharedBroken": 3000,
+          "sharedRepaired": 3000
+        }
       }
     },
     {

--- a/tests/performance/support/incremental-metrics.ts
+++ b/tests/performance/support/incremental-metrics.ts
@@ -14,8 +14,73 @@ export type IncrementalSuite = {
   title: string;
 };
 
+/** Enforced ceilings for one incremental LSP suite, checked into the registry. */
+export type LspIncrementalBudget = {
+  suite: string;
+  laneHardTimeoutMs: number;
+  maxPeakRssMiB: number;
+  laneBudgetsMs: Record<string, number>;
+};
+
+export const budgetRegistryPath = "tests/_fixtures/vue-ecosystem-fixtures.json";
+export const budgetScaleVariable = "VIZE_PERF_BUDGET_SCALE";
+
 export function incrementalMetricsDir(suiteId: string): string {
   return path.join(repoRoot, "target/vize-tests/metrics", suiteId);
+}
+
+/**
+ * Reads the enforced latency, hang, and RSS ceilings for one incremental LSP
+ * suite from the fixture registry. Exactly one project must own the suite, so
+ * a new suite cannot run report-only by accident.
+ */
+export function loadLspIncrementalBudget(suiteId: string): {
+  fixtureId: string;
+  budget: LspIncrementalBudget;
+} {
+  const registry = JSON.parse(fs.readFileSync(path.join(repoRoot, budgetRegistryPath), "utf8")) as {
+    projects: Array<{ id: string; lspIncrementalBudget?: LspIncrementalBudget }>;
+  };
+  const owners = registry.projects.filter(
+    (project) => project.lspIncrementalBudget?.suite === suiteId,
+  );
+  if (owners.length !== 1) {
+    throw new Error(
+      `Expected exactly one lspIncrementalBudget block with suite "${suiteId}" in ` +
+        `${budgetRegistryPath}, found ${owners.length}`,
+    );
+  }
+  const budget = owners[0].lspIncrementalBudget!;
+  assertBudgetMs(budget.laneHardTimeoutMs, suiteId, "laneHardTimeoutMs");
+  assertBudgetMs(budget.maxPeakRssMiB, suiteId, "maxPeakRssMiB");
+  const lanes = Object.entries(budget.laneBudgetsMs ?? {});
+  if (lanes.length === 0) {
+    throw new Error(`${suiteId} laneBudgetsMs must contain every measured lane`);
+  }
+  for (const [lane, value] of lanes) {
+    assertBudgetMs(value, suiteId, `laneBudgetsMs.${lane}`);
+    if (value > budget.laneHardTimeoutMs) {
+      throw new Error(`${suiteId} laneBudgetsMs.${lane} must not exceed laneHardTimeoutMs`);
+    }
+  }
+  return { fixtureId: owners[0].id, budget };
+}
+
+/**
+ * Uniform multiplier for every ceiling. CI runs at scale 1 (the vue-parity
+ * step sets no override); slow local machines may loosen the ceilings with
+ * e.g. `VIZE_PERF_BUDGET_SCALE=2` without editing the registry.
+ */
+export function resolveBudgetScale(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env[budgetScaleVariable];
+  if (raw == null || raw === "") return 1;
+  const scale = Number(raw);
+  if (!Number.isFinite(scale) || scale <= 0) {
+    throw new Error(
+      `${budgetScaleVariable} must be a finite number greater than 0, got ${JSON.stringify(raw)}`,
+    );
+  }
+  return scale;
 }
 
 type MetricContext = {
@@ -31,20 +96,44 @@ export class IncrementalMetrics {
   private readonly rssSamplesKiB: Record<string, number> = {};
   private readonly processId: number;
   private readonly suite: IncrementalSuite;
+  private readonly fixtureId: string;
+  private readonly budget: LspIncrementalBudget;
+  private readonly scale: number;
 
   constructor(processId: number, suite: IncrementalSuite) {
     this.processId = processId;
     this.suite = suite;
+    const { fixtureId, budget } = loadLspIncrementalBudget(suite.id);
+    this.fixtureId = fixtureId;
+    this.budget = budget;
+    this.scale = resolveBudgetScale();
   }
 
   async measure<T>(name: string, operation: () => Promise<T>): Promise<T> {
+    const budgetMs = this.budget.laneBudgetsMs[name];
+    if (budgetMs == null) {
+      throw new Error(
+        `Lane "${name}" has no laneBudgetsMs entry for suite ${this.suite.id}; add its ceiling ` +
+          `to the "${this.fixtureId}" lspIncrementalBudget block in ${budgetRegistryPath}`,
+      );
+    }
     const startedAt = performance.now();
+    let result: T;
     try {
-      return await operation();
+      result = await this.raceLaneHardTimeout(name, operation());
     } finally {
       this.timingsMs[name] = performance.now() - startedAt;
       this.sampleRss(name);
     }
+    const elapsedMs = this.timingsMs[name];
+    if (elapsedMs > budgetMs * this.scale) {
+      throw this.budgetViolation(
+        `lane "${name}" took ${elapsedMs.toFixed(1)} ms, over its ${budgetMs * this.scale} ms ` +
+          `budget${this.scaleSuffix()}.`,
+        `laneBudgetsMs.${name}`,
+      );
+    }
+    return result;
   }
 
   sampleRss(name: string): void {
@@ -52,12 +141,47 @@ export class IncrementalMetrics {
     if (rss != null) this.rssSamplesKiB[name] = rss;
   }
 
+  /**
+   * End-of-run gates: the sampled peak RSS must stay under its ceiling and
+   * every budgeted lane must actually have run, so a renamed or deleted lane
+   * cannot leave a stale ceiling behind. Called by `write` on success; public
+   * so tooling tests can exercise it without touching metric artifacts.
+   */
+  assertBudgetsSettled(): void {
+    const peakKiB = this.sampledPeakRssKiB();
+    const ceilingKiB = this.budget.maxPeakRssMiB * 1024 * this.scale;
+    if (peakKiB > ceilingKiB) {
+      throw this.budgetViolation(
+        `sampled peak RSS ${(peakKiB / 1024).toFixed(1)} MiB is over its ` +
+          `${this.budget.maxPeakRssMiB * this.scale} MiB budget${this.scaleSuffix()}.`,
+        "maxPeakRssMiB",
+      );
+    }
+    for (const lane of Object.keys(this.budget.laneBudgetsMs)) {
+      if (this.timingsMs[lane] == null) {
+        throw new Error(
+          `${this.suite.title}: budgeted lane "${lane}" was never measured; fix the suite or ` +
+            `remove the lane from the "${this.fixtureId}" lspIncrementalBudget block in ` +
+            `${budgetRegistryPath}`,
+        );
+      }
+    }
+  }
+
   write(context: MetricContext, failure?: unknown): void {
+    let budgetFailure: Error | null = null;
+    if (failure == null) {
+      try {
+        this.assertBudgetsSettled();
+      } catch (error) {
+        budgetFailure = error as Error;
+        failure = error;
+      }
+    }
     const outputDir = incrementalMetricsDir(this.suite.id);
     fs.mkdirSync(outputDir, { recursive: true });
-    const sampledPeakRssKiB = Math.max(0, ...Object.values(this.rssSamplesKiB));
     const data = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       status: failure == null ? "passed" : "failed",
       failure:
         failure instanceof Error ? failure.message : failure == null ? null : inspect(failure),
@@ -76,13 +200,70 @@ export class IncrementalMetrics {
         cpuCount: os.cpus().length,
         cpuModel: os.cpus()[0]?.model ?? "unknown",
       },
+      budget: {
+        scale: this.scale,
+        laneHardTimeoutMs: this.budget.laneHardTimeoutMs,
+        maxPeakRssMiB: this.budget.maxPeakRssMiB,
+        laneBudgetsMs: this.budget.laneBudgetsMs,
+      },
       timingsMs: this.timingsMs,
       rssSamplesKiB: this.rssSamplesKiB,
-      sampledPeakRssKiB,
-      note: "Latency and RSS are report-only; diagnostic, completion, hover, and repair oracles are gated.",
+      sampledPeakRssKiB: this.sampledPeakRssKiB(),
+      note:
+        "Latency, RSS, and hang ceilings are enforced from the registry lspIncrementalBudget " +
+        "block; diagnostic, completion, hover, and repair oracles are gated.",
     };
     fs.writeFileSync(path.join(outputDir, "metrics.json"), `${JSON.stringify(data, null, 2)}\n`);
     fs.writeFileSync(path.join(outputDir, "summary.md"), renderMarkdown(this.suite.title, data));
+    if (budgetFailure != null) throw budgetFailure;
+  }
+
+  private sampledPeakRssKiB(): number {
+    // RSS sampling is unavailable on Windows, where the peak stays 0 and the
+    // ceiling is effectively latency-only; CI enforcement runs on Linux.
+    return Math.max(0, ...Object.values(this.rssSamplesKiB));
+  }
+
+  /**
+   * Fails a hung lane after its hard timeout instead of waiting for the
+   * 120s diagnostics timeout or the 300s suite timeout.
+   */
+  private async raceLaneHardTimeout<T>(name: string, operation: Promise<T>): Promise<T> {
+    const hardTimeoutMs = this.budget.laneHardTimeoutMs * this.scale;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const hardTimeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(
+          this.budgetViolation(
+            `lane "${name}" is still not settled after its ${hardTimeoutMs} ms hard ` +
+              `timeout${this.scaleSuffix()}; the server is likely hung.`,
+            "laneHardTimeoutMs",
+          ),
+        );
+      }, hardTimeoutMs);
+    });
+    try {
+      return await Promise.race([operation, hardTimeout]);
+    } finally {
+      clearTimeout(timer);
+      // The losing operation can still reject later (for example through the
+      // session transport timeout once the server is shut down); swallow that
+      // so a budget failure is not followed by an unhandled rejection.
+      void operation.catch(() => {});
+    }
+  }
+
+  private budgetViolation(detail: string, registryField: string): Error {
+    return new Error(
+      `${this.suite.title}: ${detail} Fixture: ${this.fixtureId}. If this is intentional, ` +
+        `rebaseline by raising ${registryField} in the "${this.fixtureId}" lspIncrementalBudget ` +
+        `block of ${budgetRegistryPath}. On a slow local machine, rerun with ` +
+        `${budgetScaleVariable}=2 (or higher) to scale every ceiling; CI runs at scale 1.`,
+    );
+  }
+
+  private scaleSuffix(): string {
+    return this.scale === 1 ? "" : ` (${budgetScaleVariable}=${this.scale})`;
   }
 }
 
@@ -102,6 +283,12 @@ export function countFiles(
     }
   }
   return count;
+}
+
+function assertBudgetMs(value: number, suiteId: string, field: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${suiteId} ${field} must be a positive safe integer, got ${inspect(value)}`);
+  }
 }
 
 function processRssKiB(processId: number): number | null {
@@ -124,10 +311,12 @@ function renderMarkdown(
     fixture: string;
     fixtureRevision: string;
     corpus: { vueFiles: number; vueAndTypeScriptFiles: number; baselineDiagnostics: number };
+    budget: { scale: number; maxPeakRssMiB: number; laneBudgetsMs: Record<string, number> };
     timingsMs: Record<string, number>;
     sampledPeakRssKiB: number;
   },
 ): string {
+  const scale = data.budget.scale;
   const lines = [
     `## ${title}`,
     "",
@@ -135,17 +324,25 @@ function renderMarkdown(
     "",
     `Corpus: ${data.corpus.vueFiles} Vue files; ${data.corpus.vueAndTypeScriptFiles} Vue/TS files; ${data.corpus.baselineDiagnostics} baseline diagnostics.`,
     "",
-    "| Stage | Time |",
-    "| --- | ---: |",
+    "| Stage | Time | Budget |",
+    "| --- | ---: | ---: |",
   ];
   for (const [stage, milliseconds] of Object.entries(data.timingsMs)) {
-    lines.push(`| ${stage} | ${milliseconds.toFixed(1)} ms |`);
+    const budgetMs = data.budget.laneBudgetsMs[stage];
+    const budgetCell = budgetMs == null ? "—" : `${budgetMs * scale} ms`;
+    lines.push(`| ${stage} | ${milliseconds.toFixed(1)} ms | ${budgetCell} |`);
   }
   lines.push(
     "",
-    `Sampled peak LSP RSS: ${data.sampledPeakRssKiB > 0 ? `${(data.sampledPeakRssKiB / 1024).toFixed(1)} MiB` : "unavailable"}.`,
+    `Sampled peak LSP RSS: ${
+      data.sampledPeakRssKiB > 0
+        ? `${(data.sampledPeakRssKiB / 1024).toFixed(1)} MiB`
+        : "unavailable"
+    } (budget ${data.budget.maxPeakRssMiB * scale} MiB).`,
     "",
-    "Timing and RSS are report-only. The clean/broken/repaired diagnostics, completion, hover, and dependency propagation are hard assertions.",
+    `Latency, RSS, and hang ceilings are enforced at scale ${scale} from the registry ` +
+      "lspIncrementalBudget block. The clean/broken/repaired diagnostics, completion, hover, " +
+      "and dependency propagation are hard assertions.",
     "",
   );
   return lines.join("\n");

--- a/tests/tooling/lsp-incremental-budgets.test.ts
+++ b/tests/tooling/lsp-incremental-budgets.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  budgetRegistryPath,
+  budgetScaleVariable,
+  IncrementalMetrics,
+  loadLspIncrementalBudget,
+  resolveBudgetScale,
+} from "../performance/support/incremental-metrics.ts";
+
+const misskeySuite = { id: "misskey-lsp-incremental", title: "Misskey LSP Incremental Oracle" };
+
+function withBudgetScale<T>(scale: string, run: () => T): T {
+  const previous = process.env[budgetScaleVariable];
+  process.env[budgetScaleVariable] = scale;
+  try {
+    return run();
+  } finally {
+    if (previous == null) delete process.env[budgetScaleVariable];
+    else process.env[budgetScaleVariable] = previous;
+  }
+}
+
+test("suite budgets resolve from the registry and unknown suites are rejected", () => {
+  const misskey = loadLspIncrementalBudget("misskey-lsp-incremental");
+  assert.equal(misskey.fixtureId, "misskey");
+  assert.ok(misskey.budget.laneBudgetsMs.coldOpen > 0);
+
+  const vben = loadLspIncrementalBudget("vben-lsp-incremental");
+  assert.equal(vben.fixtureId, "vue-vben-admin");
+  assert.ok(vben.budget.laneBudgetsMs.sharedBrokenSecondApp > 0);
+
+  assert.throws(
+    () => loadLspIncrementalBudget("unbudgeted-suite"),
+    /exactly one lspIncrementalBudget block/,
+  );
+});
+
+test("the budget scale escape hatch parses strictly and defaults to 1", () => {
+  assert.equal(resolveBudgetScale({}), 1);
+  assert.equal(resolveBudgetScale({ [budgetScaleVariable]: "" }), 1);
+  assert.equal(resolveBudgetScale({ [budgetScaleVariable]: "2.5" }), 2.5);
+  for (const invalid of ["0", "-1", "banana", "Infinity"]) {
+    assert.throws(
+      () => resolveBudgetScale({ [budgetScaleVariable]: invalid }),
+      new RegExp(budgetScaleVariable),
+      `${invalid} should be rejected`,
+    );
+  }
+});
+
+test("a lane over its latency budget fails with rebaseline instructions", async () => {
+  // Scale 0.01 shrinks the checked-in coldOpen ceiling to tens of
+  // milliseconds while the hard timeout stays hundreds of milliseconds
+  // away, so a slightly slower operation completes and trips the latency
+  // gate rather than the hang gate.
+  const scale = 0.01;
+  const { budget } = loadLspIncrementalBudget(misskeySuite.id);
+  const scaledBudgetMs = budget.laneBudgetsMs.coldOpen * scale;
+  const sleepMs = scaledBudgetMs + 70;
+  assert.ok(
+    sleepMs < budget.laneHardTimeoutMs * scale - 200,
+    "the lane must finish safely before the scaled hard timeout",
+  );
+  const metrics = withBudgetScale(
+    String(scale),
+    () => new IncrementalMetrics(process.pid, misskeySuite),
+  );
+  await assert.rejects(
+    metrics.measure("coldOpen", () => new Promise((resolve) => setTimeout(resolve, sleepMs))),
+    (error: Error) => {
+      assert.match(error.message, /lane "coldOpen" took/);
+      assert.ok(error.message.includes(`over its ${scaledBudgetMs} ms budget`));
+      assert.match(error.message, /Fixture: misskey\./);
+      assert.match(error.message, /raising laneBudgetsMs\.coldOpen/);
+      assert.ok(error.message.includes(budgetRegistryPath));
+      assert.ok(error.message.includes(`${budgetScaleVariable}=2`));
+      return true;
+    },
+  );
+});
+
+test("a lane without a registry budget entry cannot be measured", async () => {
+  const metrics = new IncrementalMetrics(process.pid, misskeySuite);
+  await assert.rejects(
+    metrics.measure("unbudgetedLane", async () => {}),
+    /Lane "unbudgetedLane" has no laneBudgetsMs entry/,
+  );
+});
+
+test("a hung lane trips the scaled hard timeout instead of the suite timeout", async () => {
+  // Scale 0.001 turns the 60s hard timeout into 60ms; the lane operation
+  // stays pending for far longer than that.
+  const metrics = withBudgetScale("0.001", () => new IncrementalMetrics(process.pid, misskeySuite));
+  const startedAt = Date.now();
+  await assert.rejects(
+    metrics.measure("coldOpen", () => new Promise((resolve) => setTimeout(resolve, 5_000).unref())),
+    (error: Error) => {
+      assert.match(error.message, /lane "coldOpen" is still not settled after its 60 ms hard/);
+      assert.match(error.message, /likely hung/);
+      assert.match(error.message, /raising laneHardTimeoutMs/);
+      return true;
+    },
+  );
+  assert.ok(Date.now() - startedAt < 4_000, "hard timeout must fire well before the operation");
+});
+
+test("peak RSS over its ceiling fails settlement with rebaseline instructions", () => {
+  // Scale 0.001 shrinks the 256 MiB ceiling to ~262 KiB, which any live
+  // Node.js process exceeds.
+  const metrics = withBudgetScale("0.001", () => new IncrementalMetrics(process.pid, misskeySuite));
+  metrics.sampleRss("probe");
+  assert.throws(
+    () => metrics.assertBudgetsSettled(),
+    (error: Error) => {
+      assert.match(error.message, /sampled peak RSS .* MiB is over its 0\.256 MiB budget/);
+      assert.match(error.message, /raising maxPeakRssMiB/);
+      assert.ok(error.message.includes(budgetRegistryPath));
+      return true;
+    },
+  );
+});
+
+test("a budgeted lane that never ran fails settlement", () => {
+  // A huge scale keeps the RSS ceiling out of the way so the completeness
+  // check is what trips.
+  const metrics = withBudgetScale("1000", () => new IncrementalMetrics(process.pid, misskeySuite));
+  metrics.sampleRss("probe");
+  assert.throws(
+    () => metrics.assertBudgetsSettled(),
+    /budgeted lane "initialize" was never measured/,
+  );
+});

--- a/tests/tooling/lsp-incremental-budgets.test.ts
+++ b/tests/tooling/lsp-incremental-budgets.test.ts
@@ -152,10 +152,12 @@ test("incremental LSP suites carry complete enforced budget blocks", () => {
   const owners = readBudgetOwners();
 
   assert.deepEqual(
-    owners.map(({ id, budget }) => ({ id, suite: budget.suite })),
+    owners
+      .map(({ id, budget }) => ({ id, suite: budget.suite }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
     [
-      { id: "vue-vben-admin", suite: "vben-lsp-incremental" },
       { id: "misskey", suite: "misskey-lsp-incremental" },
+      { id: "vue-vben-admin", suite: "vben-lsp-incremental" },
     ],
   );
 

--- a/tests/tooling/lsp-incremental-budgets.test.ts
+++ b/tests/tooling/lsp-incremental-budgets.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   budgetRegistryPath,
@@ -8,6 +11,18 @@ import {
   loadLspIncrementalBudget,
   resolveBudgetScale,
 } from "../performance/support/incremental-metrics.ts";
+import type { LspIncrementalBudget } from "../performance/support/incremental-metrics.ts";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readBudgetOwners(): Array<{ id: string; budget: LspIncrementalBudget }> {
+  const registry = JSON.parse(fs.readFileSync(path.join(repoRoot, budgetRegistryPath), "utf8")) as {
+    projects: Array<{ id: string; lspIncrementalBudget?: LspIncrementalBudget }>;
+  };
+  return registry.projects
+    .filter((project) => project.lspIncrementalBudget != null)
+    .map((project) => ({ id: project.id, budget: project.lspIncrementalBudget! }));
+}
 
 const misskeySuite = { id: "misskey-lsp-incremental", title: "Misskey LSP Incremental Oracle" };
 
@@ -131,4 +146,68 @@ test("a budgeted lane that never ran fails settlement", () => {
     () => metrics.assertBudgetsSettled(),
     /budgeted lane "initialize" was never measured/,
   );
+});
+
+test("incremental LSP suites carry complete enforced budget blocks", () => {
+  const owners = readBudgetOwners();
+
+  assert.deepEqual(
+    owners.map(({ id, budget }) => ({ id, suite: budget.suite })),
+    [
+      { id: "vue-vben-admin", suite: "vben-lsp-incremental" },
+      { id: "misskey", suite: "misskey-lsp-incremental" },
+    ],
+  );
+
+  const sharedLanes = [
+    "initialize",
+    "coldOpen",
+    "completion",
+    "hover",
+    "warmNoop",
+    "leafBroken",
+    "leafRepaired",
+    "sharedBroken",
+    "sharedRepaired",
+  ];
+  const expectedLanes: Record<string, string[]> = {
+    "misskey-lsp-incremental": sharedLanes,
+    "vben-lsp-incremental": [
+      ...sharedLanes,
+      "coldOpenSecondApp",
+      "sharedBrokenSecondApp",
+      "sharedRepairedSecondApp",
+      "warmNoopSecondApp",
+    ],
+  };
+
+  for (const { id, budget } of owners) {
+    assert.deepEqual(
+      Object.keys(budget.laneBudgetsMs).sort(),
+      [...expectedLanes[budget.suite]].sort(),
+      `${id} should budget exactly the lanes its suite measures`,
+    );
+    assert.ok(
+      Number.isSafeInteger(budget.laneHardTimeoutMs) && budget.laneHardTimeoutMs > 0,
+      `${id} laneHardTimeoutMs must be a positive integer`,
+    );
+    assert.ok(
+      budget.laneHardTimeoutMs < 300_000,
+      `${id} hard timeout must fire before the 300s suite timeout`,
+    );
+    assert.ok(
+      Number.isSafeInteger(budget.maxPeakRssMiB) && budget.maxPeakRssMiB > 0,
+      `${id} maxPeakRssMiB must be a positive integer`,
+    );
+    for (const [lane, budgetMs] of Object.entries(budget.laneBudgetsMs)) {
+      assert.ok(
+        Number.isSafeInteger(budgetMs) && budgetMs > 0,
+        `${id} ${lane} budget must be a positive integer`,
+      );
+      assert.ok(
+        budgetMs <= budget.laneHardTimeoutMs,
+        `${id} ${lane} budget must fit under the hard timeout`,
+      );
+    }
+  }
 });

--- a/tests/tooling/support/lsp/session.ts
+++ b/tests/tooling/support/lsp/session.ts
@@ -86,7 +86,7 @@ export class LspSession {
     });
   }
 
-  /** Operating-system process id for report-only latency/RSS measurements. */
+  /** Operating-system process id for budget-enforced latency/RSS measurements. */
   get processId(): number {
     assert.ok(this.process.pid, "vize lsp process id is unavailable");
     return this.process.pid;

--- a/tests/tooling/vue-ecosystem-fixtures.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures.test.ts
@@ -38,12 +38,6 @@ interface FixtureProject {
     maxFalseNegativeRatio: number;
     largeProjectRegressionTarget?: boolean;
   };
-  lspIncrementalBudget?: {
-    suite: string;
-    laneHardTimeoutMs: number;
-    maxPeakRssMiB: number;
-    laneBudgetsMs: Record<string, number>;
-  };
 }
 
 interface FixtureRegistry {
@@ -336,73 +330,6 @@ test("typecheck baselines have complete budgets and one target per matrix shard"
     assert.ok(performance.hangTimeoutMs > 0 && performance.hangTimeoutMs <= 300_000);
     assert.ok(performance.maxFalsePositiveRatio >= 0 && performance.maxFalsePositiveRatio <= 1);
     assert.equal(performance.maxFalseNegativeRatio, performance.maxFalsePositiveRatio);
-  }
-});
-
-test("incremental LSP suites carry complete enforced budget blocks", () => {
-  const registry = readRegistry();
-  const owners = registry.projects
-    .filter((project) => project.lspIncrementalBudget != null)
-    .map((project) => ({ id: project.id, budget: project.lspIncrementalBudget! }));
-
-  assert.deepEqual(
-    owners.map(({ id, budget }) => ({ id, suite: budget.suite })),
-    [
-      { id: "vue-vben-admin", suite: "vben-lsp-incremental" },
-      { id: "misskey", suite: "misskey-lsp-incremental" },
-    ],
-  );
-
-  const sharedLanes = [
-    "initialize",
-    "coldOpen",
-    "completion",
-    "hover",
-    "warmNoop",
-    "leafBroken",
-    "leafRepaired",
-    "sharedBroken",
-    "sharedRepaired",
-  ];
-  const expectedLanes: Record<string, string[]> = {
-    "misskey-lsp-incremental": sharedLanes,
-    "vben-lsp-incremental": [
-      ...sharedLanes,
-      "coldOpenSecondApp",
-      "sharedBrokenSecondApp",
-      "sharedRepairedSecondApp",
-      "warmNoopSecondApp",
-    ],
-  };
-
-  for (const { id, budget } of owners) {
-    assert.deepEqual(
-      Object.keys(budget.laneBudgetsMs).sort(),
-      [...expectedLanes[budget.suite]].sort(),
-      `${id} should budget exactly the lanes its suite measures`,
-    );
-    assert.ok(
-      Number.isSafeInteger(budget.laneHardTimeoutMs) && budget.laneHardTimeoutMs > 0,
-      `${id} laneHardTimeoutMs must be a positive integer`,
-    );
-    assert.ok(
-      budget.laneHardTimeoutMs < 300_000,
-      `${id} hard timeout must fire before the 300s suite timeout`,
-    );
-    assert.ok(
-      Number.isSafeInteger(budget.maxPeakRssMiB) && budget.maxPeakRssMiB > 0,
-      `${id} maxPeakRssMiB must be a positive integer`,
-    );
-    for (const [lane, budgetMs] of Object.entries(budget.laneBudgetsMs)) {
-      assert.ok(
-        Number.isSafeInteger(budgetMs) && budgetMs > 0,
-        `${id} ${lane} budget must be a positive integer`,
-      );
-      assert.ok(
-        budgetMs <= budget.laneHardTimeoutMs,
-        `${id} ${lane} budget must fit under the hard timeout`,
-      );
-    }
   }
 });
 

--- a/tests/tooling/vue-ecosystem-fixtures.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures.test.ts
@@ -38,6 +38,12 @@ interface FixtureProject {
     maxFalseNegativeRatio: number;
     largeProjectRegressionTarget?: boolean;
   };
+  lspIncrementalBudget?: {
+    suite: string;
+    laneHardTimeoutMs: number;
+    maxPeakRssMiB: number;
+    laneBudgetsMs: Record<string, number>;
+  };
 }
 
 interface FixtureRegistry {
@@ -330,6 +336,73 @@ test("typecheck baselines have complete budgets and one target per matrix shard"
     assert.ok(performance.hangTimeoutMs > 0 && performance.hangTimeoutMs <= 300_000);
     assert.ok(performance.maxFalsePositiveRatio >= 0 && performance.maxFalsePositiveRatio <= 1);
     assert.equal(performance.maxFalseNegativeRatio, performance.maxFalsePositiveRatio);
+  }
+});
+
+test("incremental LSP suites carry complete enforced budget blocks", () => {
+  const registry = readRegistry();
+  const owners = registry.projects
+    .filter((project) => project.lspIncrementalBudget != null)
+    .map((project) => ({ id: project.id, budget: project.lspIncrementalBudget! }));
+
+  assert.deepEqual(
+    owners.map(({ id, budget }) => ({ id, suite: budget.suite })),
+    [
+      { id: "vue-vben-admin", suite: "vben-lsp-incremental" },
+      { id: "misskey", suite: "misskey-lsp-incremental" },
+    ],
+  );
+
+  const sharedLanes = [
+    "initialize",
+    "coldOpen",
+    "completion",
+    "hover",
+    "warmNoop",
+    "leafBroken",
+    "leafRepaired",
+    "sharedBroken",
+    "sharedRepaired",
+  ];
+  const expectedLanes: Record<string, string[]> = {
+    "misskey-lsp-incremental": sharedLanes,
+    "vben-lsp-incremental": [
+      ...sharedLanes,
+      "coldOpenSecondApp",
+      "sharedBrokenSecondApp",
+      "sharedRepairedSecondApp",
+      "warmNoopSecondApp",
+    ],
+  };
+
+  for (const { id, budget } of owners) {
+    assert.deepEqual(
+      Object.keys(budget.laneBudgetsMs).sort(),
+      [...expectedLanes[budget.suite]].sort(),
+      `${id} should budget exactly the lanes its suite measures`,
+    );
+    assert.ok(
+      Number.isSafeInteger(budget.laneHardTimeoutMs) && budget.laneHardTimeoutMs > 0,
+      `${id} laneHardTimeoutMs must be a positive integer`,
+    );
+    assert.ok(
+      budget.laneHardTimeoutMs < 300_000,
+      `${id} hard timeout must fire before the 300s suite timeout`,
+    );
+    assert.ok(
+      Number.isSafeInteger(budget.maxPeakRssMiB) && budget.maxPeakRssMiB > 0,
+      `${id} maxPeakRssMiB must be a positive integer`,
+    );
+    for (const [lane, budgetMs] of Object.entries(budget.laneBudgetsMs)) {
+      assert.ok(
+        Number.isSafeInteger(budgetMs) && budgetMs > 0,
+        `${id} ${lane} budget must be a positive integer`,
+      );
+      assert.ok(
+        budgetMs <= budget.laneHardTimeoutMs,
+        `${id} ${lane} budget must fit under the hard timeout`,
+      );
+    }
   }
 });
 


### PR DESCRIPTION
## What

Makes the incremental LSP latency, hang, and peak-RSS lanes ENFORCING instead of report-only, completing the #2971 scale-gate item ("Enforce explicit hang, regression ... budgets from checked-in fixture metadata") and the #3222 performance scorecard dimension for `vue-parity`.

- `tests/_fixtures/vue-ecosystem-fixtures.json`: the `misskey` and `vue-vben-admin` entries gain an `lspIncrementalBudget` block (suite id, per-lane latency ceilings, 60s per-lane hard timeout, 256 MiB peak-RSS ceiling), colocated with the `typecheckPerformance` budgets the divergence report already enforces.
- `tests/performance/support/incremental-metrics.ts`: `IncrementalMetrics` now loads its suite's budget from the registry (a suite without a budget block cannot construct; a lane without a ceiling cannot be measured). `measure` races each lane against the scaled hard timeout so a hung server fails in seconds with the lane named — instead of burning the 120s diagnostics timeout or the 300s suite timeout — and fails any lane over its latency ceiling. `write` enforces the peak-RSS ceiling and that every budgeted lane actually ran, then still emits `metrics.json`/`summary.md` (status `failed` + message) so the CI artifact and step summary show the offending numbers. Failure text names the lane, ceiling, measured value, fixture, the exact registry field to raise for an intentional rebaseline, and the `VIZE_PERF_BUDGET_SCALE` escape hatch for slow local machines; CI runs at scale 1 (the `vue-parity` step env is pinned by `github-workflows-vue-parity.test.ts` with `deepEqual`, so a scale override cannot sneak into CI).
- `tests/tooling/lsp-incremental-budgets.test.ts` (new): behavior coverage — registry resolution, strict scale parsing, latency-gate message, unbudgeted-lane rejection, hard-timeout firing fast, RSS-gate message, never-measured-lane settlement failure.
- `tests/tooling/vue-ecosystem-fixtures.test.ts`: registry-shape test pinning exactly which projects own which suite and that each block budgets exactly the lanes its suite measures, with positive-integer ceilings under the hard timeout, which in turn stays under the 300s suite timeout.

## Budgets vs measured

Ceilings are ~3x the worst of four observations — the two most recent CI `*-lsp-incremental-metrics` artifacts from `main` (linux x64, commit 1fafc88a6) and two fresh local runs (M-series, ci-profile binary) — rounded up to friendly values. Micro-lanes (initialize/completion/hover) get a 1000 ms noise floor; coldOpen gets 8000 ms because a cold-file-cache first local run measured 2604 ms where steady state is ~700-900 ms. Effective CI headroom is ~10-26x: this gate exists to catch regression cliffs (hangs, quadratic re-checks, leaks), not scheduler noise.

| Lane | Budget | Local (this PR) | CI main |
| --- | ---: | ---: | ---: |
| misskey initialize | 1000 ms | 11.8 ms | 3.7 ms |
| misskey coldOpen | 8000 ms | 901.6 ms | 310.8 ms |
| misskey completion | 1000 ms | 7.2 ms | 3.2 ms |
| misskey hover | 1000 ms | 22.1 ms | 9.9 ms |
| misskey warmNoop | 1500 ms | 203.1 ms | 111.3 ms |
| misskey leafBroken / leafRepaired | 1500 ms | 199.6 / 232.2 ms | 106.9 / 107.9 ms |
| misskey sharedBroken / sharedRepaired | 3000 ms | 506.6 / 472.9 ms | 234.3 / 222.4 ms |
| misskey peak RSS | 256 MiB | 29.2 MiB | 60.1 MiB |
| vben initialize | 1000 ms | 12.1 ms | 5.6 ms |
| vben coldOpen | 8000 ms | 730.1 ms | 274.6 ms |
| vben coldOpenSecondApp | 1500 ms | 238.8 ms | 104.1 ms |
| vben completion | 1000 ms | 6.1 ms | 2.3 ms |
| vben hover | 1000 ms | 24.4 ms | 9.3 ms |
| vben warmNoop / warmNoopSecondApp | 1500 ms | 264.4 / 390.3 ms | 103.7 / 105.2 ms |
| vben leafBroken / leafRepaired | 1500 ms | 506.8 / 491.9 ms | 107.1 / 104.5 ms |
| vben sharedBroken / sharedBrokenSecondApp | 3000 ms | 705.2 / 253.9 ms | 203.8 / 90.8 ms |
| vben sharedRepaired / sharedRepairedSecondApp | 3000 ms | 600.1 / 290.5 ms | 209.0 / 101.7 ms |
| vben peak RSS | 256 MiB | 29.5 MiB | 61.5 MiB |

## Gate proven

With `misskey.lspIncrementalBudget.laneBudgetsMs.warmNoop` temporarily set to 50 (then restored), the real suite fails with:

```
Error: Misskey LSP Incremental Oracle: lane "warmNoop" took 462.3 ms, over its 50 ms budget. Fixture: misskey.
If this is intentional, rebaseline by raising laneBudgetsMs.warmNoop in the "misskey" lspIncrementalBudget block
of tests/_fixtures/vue-ecosystem-fixtures.json. On a slow local machine, rerun with VIZE_PERF_BUDGET_SCALE=2
(or higher) to scale every ceiling; CI runs at scale 1.
```

and `metrics.json` records `status: "failed"` with the same message, so the uploaded artifact and step summary explain the red build.

Both suites pass fresh against a ci-profile binary built at this commit, and the budget/registry/parity tooling tests pass.

Fixes #3244

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added enforced latency, timeout, and memory limits for incremental LSP performance suites.
  * Added per-stage budgets for the Vue Vben Admin and Misskey suites.
  * Added configurable budget scaling for performance runs.
  * Reports now include enforced thresholds, scale information, and completeness status.

* **Bug Fixes**
  * Runs now fail clearly when stages exceed limits, hang, exceed memory caps, or are not measured.

* **Tests**
  * Added coverage for budget loading, validation, scaling, timeout handling, memory limits, and registry consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->