### PR TITLE
test(maestro): cover multi-root workspaces and Corsa crash recovery

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -476,8 +476,10 @@ impl DiagnosticService {
         ecosystem_enabled: bool,
         line_index: &LineIndex<'_>,
     ) -> Vec<Diagnostic> {
-        let linter_config = state.get_linter_config();
-        let rule_options = state.get_linter_rule_options();
+        // Resolve the linter context from the document's own workspace folder
+        // so multi-root sessions do not leak one folder's lint policy into
+        // another folder's files (#3240).
+        let (linter_config, rule_options) = state.linter_settings_for_uri(uri);
         if !linter_config.enabled {
             return vec![];
         }

--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -476,9 +476,7 @@ impl DiagnosticService {
         ecosystem_enabled: bool,
         line_index: &LineIndex<'_>,
     ) -> Vec<Diagnostic> {
-        // Resolve the linter context from the document's own workspace folder
-        // so multi-root sessions do not leak one folder's lint policy into
-        // another folder's files (#3240).
+        // Resolve the linter context from the document's own folder so multi-root sessions keep lint policy isolated (#3240).
         let (linter_config, rule_options) = state.linter_settings_for_uri(uri);
         if !linter_config.enabled {
             return vec![];

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
@@ -1,6 +1,7 @@
 //! Orchestration of Corsa diagnostic collection for a single SFC document.
 
 use std::path::Path;
+use std::sync::Arc;
 
 use tower_lsp::lsp_types::{Diagnostic, Url};
 
@@ -10,27 +11,80 @@ use super::super::DiagnosticService;
 use super::collect_virtual::{
     collect_synced_virtual_result_diagnostics, collect_virtual_result_diagnostics,
 };
-use vize_canon::CorsaVueVirtualDocumentOptions;
+use vize_canon::{CorsaBridgeError, CorsaVueVirtualDocumentOptions};
 use vize_carton::cstr;
+
+/// One attempt either yields diagnostics (possibly empty for non-Corsa
+/// reasons such as unsupported documents) or fails on a bridge call.
+enum CollectFailure {
+    /// The backend session answered but the request failed; not retried.
+    Request(CorsaBridgeError),
+    /// The backend process/transport is gone (crashed, OOM-killed, or
+    /// otherwise unreachable). The carried bridge must be retired so a
+    /// fresh session can be spawned (#3240).
+    DeadBridge(Arc<vize_canon::CorsaBridge>, CorsaBridgeError),
+}
+
+fn classify(bridge: &Arc<vize_canon::CorsaBridge>, error: CorsaBridgeError) -> CollectFailure {
+    match error {
+        CorsaBridgeError::CommunicationError(_) | CorsaBridgeError::ProcessTerminated => {
+            CollectFailure::DeadBridge(bridge.clone(), error)
+        }
+        error => CollectFailure::Request(error),
+    }
+}
 
 impl DiagnosticService {
     /// Collect diagnostics from the Corsa project-session backend.
+    ///
+    /// The backend is an external process that can die mid-session. A failed
+    /// bridge call therefore retires the dead bridge and retries exactly once
+    /// against a freshly spawned session, so a single `didChange` after a
+    /// backend crash already republishes correct typecheck diagnostics.
+    /// Repeated crashes stay bounded: each collection performs at most one
+    /// respawn, and spawn failures latch `corsa_init_failed`.
     pub(in crate::ide::diagnostics) async fn collect_corsa_diagnostics(
         state: &ServerState,
         uri: &Url,
     ) -> Vec<Diagnostic> {
+        for attempt in 0..2 {
+            match Self::try_collect_corsa_diagnostics(state, uri).await {
+                Ok(diagnostics) => return diagnostics,
+                Err(CollectFailure::DeadBridge(bridge, error)) if attempt == 0 => {
+                    tracing::warn!(
+                        "corsa backend unreachable for {uri} ({error}); respawning and retrying"
+                    );
+                    state.retire_corsa_bridge(&bridge);
+                }
+                Err(CollectFailure::DeadBridge(_, error)) => {
+                    tracing::warn!("corsa retry failed for {uri}: {error}");
+                    return vec![];
+                }
+                Err(CollectFailure::Request(error)) => {
+                    tracing::warn!("corsa request failed for {uri}: {error}");
+                    return vec![];
+                }
+            }
+        }
+        vec![]
+    }
+
+    async fn try_collect_corsa_diagnostics(
+        state: &ServerState,
+        uri: &Url,
+    ) -> Result<Vec<Diagnostic>, CollectFailure> {
         tracing::info!("collect_corsa_diagnostics: {}", uri);
 
         // Only process .vue files
         if !uri.path().ends_with(".vue") {
             tracing::debug!("skipping non-vue file: {}", uri);
-            return vec![];
+            return Ok(vec![]);
         }
 
         // Get document content
         let Some(doc) = state.documents.get(uri) else {
             tracing::warn!("document not found: {}", uri);
-            return vec![];
+            return Ok(vec![]);
         };
         let content = doc.text();
 
@@ -38,7 +92,7 @@ impl DiagnosticService {
         tracing::info!("getting corsa bridge...");
         let Some(bridge) = state.get_corsa_bridge().await else {
             tracing::warn!("corsa bridge not available");
-            return vec![];
+            return Ok(vec![]);
         };
         tracing::info!("corsa bridge acquired");
 
@@ -60,7 +114,7 @@ impl DiagnosticService {
                 &virtual_ts_options,
             ) else {
                 tracing::warn!("failed to generate virtual ts for {}", uri);
-                return vec![];
+                return Ok(vec![]);
             };
             sync_art_vue_dependencies(
                 &bridge,
@@ -79,10 +133,11 @@ impl DiagnosticService {
                 art_virtual.virtual_result,
             )
             .await
+            .map_err(|error| classify(&bridge, error))?
         } else {
             let Ok(source_path) = uri.to_file_path() else {
                 tracing::warn!("cannot derive source path for {}", uri);
-                return vec![];
+                return Ok(vec![]);
             };
             let overlays = state
                 .documents
@@ -94,7 +149,7 @@ impl DiagnosticService {
                     ))
                 })
                 .collect::<Vec<(std::path::PathBuf, vize_carton::String)>>();
-            let opened = match bridge
+            let opened = bridge
                 .open_vue_virtual_document_with_overlays_and_options(
                     &source_path,
                     &content,
@@ -106,18 +161,12 @@ impl DiagnosticService {
                     &virtual_ts_options,
                 )
                 .await
-            {
-                Ok(opened) => opened,
-                Err(err) => {
-                    tracing::warn!("failed to open Vue virtual document for {uri}: {err}");
-                    return vec![];
-                }
-            };
+                .map_err(|error| classify(&bridge, error))?;
             let Some((virtual_uri, virtual_result)) =
                 Self::virtual_ts_result_from_corsa_vue_document(uri, &content, opened)
             else {
                 tracing::warn!("failed to map virtual ts metadata for {}", uri);
-                return vec![];
+                return Ok(vec![]);
             };
             collect_synced_virtual_result_diagnostics(
                 &bridge,
@@ -127,6 +176,7 @@ impl DiagnosticService {
                 virtual_result,
             )
             .await
+            .map_err(|error| classify(&bridge, error))?
         };
 
         if !is_art_file {
@@ -145,12 +195,13 @@ impl DiagnosticService {
                         cstr!("{}.inline_art_{variant_index}.ts", uri.path()).to_string(),
                         inline_virtual,
                     )
-                    .await,
+                    .await
+                    .map_err(|error| classify(&bridge, error))?,
                 );
             }
         }
 
-        diagnostics
+        Ok(diagnostics)
     }
 }
 

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
@@ -7,23 +7,20 @@ use super::super::{VirtualTsResult, sources};
 use super::mapping::{map_diagnostic_with_source_mappings, source_offset_to_position};
 use super::message::rewrite_corsa_message;
 
+// Both collectors surface bridge failures to the caller instead of mapping
+// them to an empty diagnostic list: `collect_corsa_diagnostics` uses the
+// error to distinguish a dead backend process (retire + respawn + retry,
+// #3240) from an ordinary per-request failure.
 pub(super) async fn collect_virtual_result_diagnostics(
     bridge: &std::sync::Arc<vize_canon::CorsaBridge>,
     host_uri: &Url,
     content: &str,
     virtual_name: String,
     virtual_result: VirtualTsResult,
-) -> Vec<Diagnostic> {
-    let virtual_uri = match bridge
+) -> Result<Vec<Diagnostic>, vize_canon::CorsaBridgeError> {
+    let virtual_uri = bridge
         .open_or_update_virtual_document(&virtual_name, &virtual_result.code)
-        .await
-    {
-        Ok(uri) => uri,
-        Err(e) => {
-            tracing::warn!("failed to open/update virtual document: {}", e);
-            return vec![];
-        }
-    };
+        .await?;
 
     collect_synced_virtual_result_diagnostics(
         bridge,
@@ -41,7 +38,7 @@ pub(super) async fn collect_synced_virtual_result_diagnostics(
     content: &str,
     virtual_uri: String,
     virtual_result: VirtualTsResult,
-) -> Vec<Diagnostic> {
+) -> Result<Vec<Diagnostic>, vize_canon::CorsaBridgeError> {
     let virtual_ts = &virtual_result.code;
     let user_code_start_line = virtual_result.user_code_start_line;
     let sfc_script_start_line = virtual_result.sfc_script_start_line;
@@ -61,10 +58,7 @@ pub(super) async fn collect_synced_virtual_result_diagnostics(
         "waiting for diagnostics from corsa bridge for {}",
         virtual_uri
     );
-    let Ok(corsa_diags) = bridge.get_diagnostics(&virtual_uri).await else {
-        tracing::warn!("failed to get diagnostics from corsa");
-        return vec![];
-    };
+    let corsa_diags = bridge.get_diagnostics(&virtual_uri).await?;
 
     tracing::info!(
         "corsa returned {} raw diagnostics for {}",
@@ -195,7 +189,7 @@ pub(super) async fn collect_synced_virtual_result_diagnostics(
         })
         .collect::<Vec<_>>();
 
-    deduplicate_diagnostics(mapped_diagnostics)
+    Ok(deduplicate_diagnostics(mapped_diagnostics))
 }
 
 fn deduplicate_diagnostics(mut diagnostics: Vec<Diagnostic>) -> Vec<Diagnostic> {

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/relative_import_tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/relative_import_tests.rs
@@ -169,7 +169,8 @@ defineSlots<{
                 virtual_uri,
                 virtual_result,
             )
-            .await;
+            .await
+            .ok()?;
             Some(diagnostics)
         }
         .await;

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -37,34 +37,16 @@ impl LanguageServer for MaestroServer {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
         super::workspace_files::record_watcher_support(&self.state, &params.capabilities);
         // Resolve workspace root
-        let workspace_path = params
-            .root_uri
-            .as_ref()
-            .and_then(|u| u.to_file_path().ok())
-            .or_else(|| {
-                params
-                    .workspace_folders
-                    .as_ref()
-                    .and_then(|f| f.first())
-                    .and_then(|f| f.uri.to_file_path().ok())
-            });
+        let workspace_path = self.state.primary_workspace_path(&params);
 
         // Load format config from workspace root (always, regardless of feature)
         if let Some(ref path) = workspace_path {
             self.state.load_workspace_config(path);
         }
 
-        // Record every workspace folder so per-document features resolve the
-        // configuration context of their own folder in multi-root sessions
-        // (#3240). The primary root above keeps driving process-wide config.
-        let folder_roots: Vec<std::path::PathBuf> = params
-            .workspace_folders
-            .as_deref()
-            .unwrap_or_default()
-            .iter()
-            .filter_map(|folder| folder.uri.to_file_path().ok())
-            .collect();
-        self.state.set_workspace_folders(folder_roots);
+        // Record every workspace folder so per-document features resolve their own folder's config in multi-root sessions (#3240).
+        self.state
+            .apply_initialize_workspace_folders(params.workspace_folders.as_deref());
 
         self.state
             .apply_lsp_initialization_options(params.initialization_options.as_ref());
@@ -95,23 +77,9 @@ impl LanguageServer for MaestroServer {
         );
     }
 
-    // The server advertises `workspaceFolders.changeNotifications`, so keep
-    // the per-folder configuration contexts in sync when the editor adds or
-    // removes roots mid-session (#3240).
+    // Keep the per-folder configuration contexts in sync when the editor adds or removes roots mid-session (#3240).
     async fn did_change_workspace_folders(&self, params: DidChangeWorkspaceFoldersParams) {
-        let added: Vec<std::path::PathBuf> = params
-            .event
-            .added
-            .iter()
-            .filter_map(|folder| folder.uri.to_file_path().ok())
-            .collect();
-        let removed: Vec<std::path::PathBuf> = params
-            .event
-            .removed
-            .iter()
-            .filter_map(|folder| folder.uri.to_file_path().ok())
-            .collect();
-        self.state.update_workspace_folders(added, &removed);
+        self.state.apply_workspace_folders_change(&params.event);
     }
 
     async fn shutdown(&self) -> Result<()> {

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -11,15 +11,15 @@ use tower_lsp::{
         CodeActionParams, CodeActionResponse, CodeLens, CodeLensParams, CompletionItem,
         CompletionParams, CompletionResponse, CreateFilesParams, DeleteFilesParams,
         DidChangeConfigurationParams, DidChangeTextDocumentParams, DidChangeWatchedFilesParams,
-        DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
-        DocumentFormattingParams, DocumentHighlight, DocumentHighlightParams, DocumentLink,
-        DocumentLinkParams, DocumentRangeFormattingParams, DocumentSymbol, DocumentSymbolParams,
-        DocumentSymbolResponse, FoldingRange, FoldingRangeKind, FoldingRangeParams,
-        GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams, InitializeParams,
-        InitializeResult, InitializedParams, InlayHint, InlayHintParams, Location, Position,
-        PrepareRenameResponse, Range, ReferenceParams, RenameFilesParams, RenameParams,
-        SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult,
-        SemanticTokensResult, ServerInfo, SymbolInformation, SymbolKind,
+        DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+        DidSaveTextDocumentParams, DocumentFormattingParams, DocumentHighlight,
+        DocumentHighlightParams, DocumentLink, DocumentLinkParams, DocumentRangeFormattingParams,
+        DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, FoldingRange,
+        FoldingRangeKind, FoldingRangeParams, GotoDefinitionParams, GotoDefinitionResponse, Hover,
+        HoverParams, InitializeParams, InitializeResult, InitializedParams, InlayHint,
+        InlayHintParams, Location, Position, PrepareRenameResponse, Range, ReferenceParams,
+        RenameFilesParams, RenameParams, SemanticTokensParams, SemanticTokensRangeParams,
+        SemanticTokensRangeResult, SemanticTokensResult, ServerInfo, SymbolInformation, SymbolKind,
         TextDocumentPositionParams, TextEdit, WorkspaceEdit, WorkspaceSymbolParams,
     },
 };
@@ -54,6 +54,18 @@ impl LanguageServer for MaestroServer {
             self.state.load_workspace_config(path);
         }
 
+        // Record every workspace folder so per-document features resolve the
+        // configuration context of their own folder in multi-root sessions
+        // (#3240). The primary root above keeps driving process-wide config.
+        let folder_roots: Vec<std::path::PathBuf> = params
+            .workspace_folders
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|folder| folder.uri.to_file_path().ok())
+            .collect();
+        self.state.set_workspace_folders(folder_roots);
+
         self.state
             .apply_lsp_initialization_options(params.initialization_options.as_ref());
 
@@ -81,6 +93,25 @@ impl LanguageServer for MaestroServer {
         tracing::debug!(
             "Received workspace/didChangeConfiguration; VS Code restarts the server for Vize configuration changes"
         );
+    }
+
+    // The server advertises `workspaceFolders.changeNotifications`, so keep
+    // the per-folder configuration contexts in sync when the editor adds or
+    // removes roots mid-session (#3240).
+    async fn did_change_workspace_folders(&self, params: DidChangeWorkspaceFoldersParams) {
+        let added: Vec<std::path::PathBuf> = params
+            .event
+            .added
+            .iter()
+            .filter_map(|folder| folder.uri.to_file_path().ok())
+            .collect();
+        let removed: Vec<std::path::PathBuf> = params
+            .event
+            .removed
+            .iter()
+            .filter_map(|folder| folder.uri.to_file_path().ok())
+            .collect();
+        self.state.update_workspace_folders(added, &removed);
     }
 
     async fn shutdown(&self) -> Result<()> {

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -4,6 +4,7 @@
 mod config;
 mod features;
 mod virtual_docs;
+mod workspace_folders;
 
 #[cfg(feature = "native")]
 mod batch_cache;
@@ -84,12 +85,18 @@ pub struct ServerState {
     /// Explicit Vue dialect from config (`dialect` key). `None` means the
     /// dialect is detected structurally per document.
     dialect_config: RwLock<Option<VueDialect>>,
+    /// Per-workspace-folder linter contexts for true multi-root sessions
+    /// (#3240). Empty for clients that only send `rootUri`.
+    workspace_folder_configs: RwLock<Vec<workspace_folders::WorkspaceFolderConfig>>,
     /// Formatting options (loaded from vize.config.json)
     #[cfg(feature = "glyph")]
     format_options: RwLock<vize_glyph::FormatOptions>,
-    /// Corsa bridge for native TypeScript language features (lazy initialized)
+    /// Corsa bridge for native TypeScript language features. Lazily
+    /// initialized; cleared again by [`Self::retire_corsa_bridge`] when the
+    /// backend process dies mid-session so the next request can respawn it
+    /// (#3240).
     #[cfg(feature = "native")]
-    corsa_bridge: OnceLock<Arc<CorsaBridge>>,
+    corsa_bridge: RwLock<Option<Arc<CorsaBridge>>>,
     /// Serializes Corsa bridge initialization without tying us to a runtime.
     #[cfg(feature = "native")]
     corsa_init_lock: AsyncMutex<()>,
@@ -150,10 +157,11 @@ impl ServerState {
             linter_config: RwLock::new(LinterConfig::default()),
             linter_rule_options: RwLock::new(vize_carton::config::LintRuleOptions::default()),
             dialect_config: RwLock::new(None),
+            workspace_folder_configs: RwLock::new(Vec::new()),
             #[cfg(feature = "glyph")]
             format_options: RwLock::new(vize_glyph::FormatOptions::default()),
             #[cfg(feature = "native")]
-            corsa_bridge: OnceLock::new(),
+            corsa_bridge: RwLock::new(None),
             #[cfg(feature = "native")]
             corsa_init_lock: AsyncMutex::new(()),
             #[cfg(feature = "native")]

--- a/crates/vize_maestro/src/server/state/corsa.rs
+++ b/crates/vize_maestro/src/server/state/corsa.rs
@@ -32,8 +32,8 @@ impl ServerState {
         }
 
         // If already initialized successfully, return it
-        if let Some(bridge) = self.corsa_bridge.get() {
-            return Some(bridge.clone());
+        if let Some(bridge) = self.corsa_bridge.read().clone() {
+            return Some(bridge);
         }
 
         // If initialization already failed, don't retry
@@ -44,8 +44,8 @@ impl ServerState {
         let _guard = self.corsa_init_lock.lock().await;
 
         // Another request may have completed initialization while we were waiting.
-        if let Some(bridge) = self.corsa_bridge.get() {
-            return Some(bridge.clone());
+        if let Some(bridge) = self.corsa_bridge.read().clone() {
+            return Some(bridge);
         }
 
         if self.corsa_init_failed.load(Ordering::SeqCst) {
@@ -70,7 +70,7 @@ impl ServerState {
             Ok(Ok(())) => {
                 tracing::info!("corsa bridge initialized successfully");
                 let bridge = Arc::new(bridge);
-                let _ = self.corsa_bridge.set(bridge.clone());
+                *self.corsa_bridge.write() = Some(bridge.clone());
                 Some(bridge)
             }
             Ok(Err(e)) => {
@@ -108,6 +108,29 @@ impl ServerState {
 
     /// Check if the Corsa bridge is available (without initializing).
     pub fn has_corsa_bridge(&self) -> bool {
-        self.is_lsp_typecheck_enabled() && self.corsa_bridge.get().is_some()
+        self.is_lsp_typecheck_enabled() && self.corsa_bridge.read().is_some()
+    }
+
+    /// Drop a Corsa bridge whose backend process died mid-session so the next
+    /// [`Self::get_corsa_bridge`] call spawns a fresh session (#3240).
+    ///
+    /// Passing the failed bridge (rather than clearing unconditionally) makes
+    /// concurrent retirement idempotent: only callers still holding the live
+    /// handle clear the slot, so a bridge respawned by another task is never
+    /// discarded because of a stale failure report. The one-shot
+    /// `corsa_init_failed` latch is left untouched — it marks *spawn*
+    /// failures, and a session that ran long enough to die proves spawning
+    /// works.
+    pub fn retire_corsa_bridge(&self, failed: &Arc<CorsaBridge>) {
+        let mut slot = self.corsa_bridge.write();
+        if slot
+            .as_ref()
+            .is_some_and(|current| Arc::ptr_eq(current, failed))
+        {
+            *slot = None;
+            tracing::warn!(
+                "corsa bridge retired after a backend failure; a fresh session will be spawned on demand"
+            );
+        }
     }
 }

--- a/crates/vize_maestro/src/server/state/workspace_folders.rs
+++ b/crates/vize_maestro/src/server/state/workspace_folders.rs
@@ -1,0 +1,178 @@
+//! Per-workspace-folder configuration contexts for multi-root sessions.
+//!
+//! `initialize` may carry several `workspaceFolders` (#3240). The primary
+//! root (rootUri, or the first folder) keeps driving the process-wide
+//! configuration — LSP feature flags, the type-checker/Corsa session root,
+//! formatting — matching the historical single-root behavior. Per-document
+//! lint diagnostics however must not leak one folder's lint policy into
+//! another folder's files, so each folder gets its own linter context here:
+//! a folder that ships its own `vize.config.*` uses that config, and a
+//! folder without one uses the built-in defaults (never a sibling folder's
+//! config, which would make behavior depend on folder order). Documents
+//! outside every folder fall back to the process-wide settings.
+
+use std::path::{Path, PathBuf};
+
+use tower_lsp::lsp_types::Url;
+use vize_carton::config::{LintRuleOptions, LinterConfig};
+
+use super::ServerState;
+
+/// Linter context resolved for one workspace folder at registration time.
+pub(super) struct WorkspaceFolderConfig {
+    root: PathBuf,
+    linter: LinterConfig,
+    rule_options: LintRuleOptions,
+}
+
+impl WorkspaceFolderConfig {
+    /// Load the folder's own `vize.config.*`; a folder without a config file
+    /// gets the built-in defaults so contexts stay order-independent.
+    fn load(root: PathBuf) -> Self {
+        let (loaded, linter) = vize_carton::config::load_config_and_linter_with_source(Some(&root));
+        if loaded.source_path.is_some() {
+            let rule_options = vize_carton::config::load_linter_rule_options(Some(&root));
+            Self {
+                root,
+                linter,
+                rule_options,
+            }
+        } else {
+            Self {
+                root,
+                linter: LinterConfig::default(),
+                rule_options: LintRuleOptions::default(),
+            }
+        }
+    }
+}
+
+impl ServerState {
+    /// Replace the workspace-folder contexts with the folders sent by
+    /// `initialize`.
+    pub(crate) fn set_workspace_folders(&self, roots: Vec<PathBuf>) {
+        let contexts = roots.into_iter().map(WorkspaceFolderConfig::load).collect();
+        *self.workspace_folder_configs.write() = contexts;
+    }
+
+    /// Apply a `workspace/didChangeWorkspaceFolders` event: removed roots
+    /// drop their contexts, added roots load theirs.
+    pub(crate) fn update_workspace_folders(&self, added: Vec<PathBuf>, removed: &[PathBuf]) {
+        let mut contexts = self.workspace_folder_configs.write();
+        contexts.retain(|context| !removed.contains(&context.root));
+        contexts.extend(added.into_iter().map(WorkspaceFolderConfig::load));
+    }
+
+    /// Linter settings for a document: its deepest enclosing workspace folder
+    /// wins; documents outside every folder use the process-wide settings.
+    pub(crate) fn linter_settings_for_uri(&self, uri: &Url) -> (LinterConfig, LintRuleOptions) {
+        if let Ok(path) = uri.to_file_path() {
+            let contexts = self.workspace_folder_configs.read();
+            if let Some(context) = deepest_enclosing_folder(&contexts, &path) {
+                return (context.linter.clone(), context.rule_options.clone());
+            }
+        }
+        (self.get_linter_config(), self.get_linter_rule_options())
+    }
+}
+
+fn deepest_enclosing_folder<'a>(
+    contexts: &'a [WorkspaceFolderConfig],
+    path: &Path,
+) -> Option<&'a WorkspaceFolderConfig> {
+    contexts
+        .iter()
+        .filter(|context| path.starts_with(&context.root))
+        .max_by_key(|context| context.root.components().count())
+}
+
+#[cfg(test)]
+mod tests {
+    use tower_lsp::lsp_types::Url;
+    use vize_carton::config::LintRuleSeverity;
+
+    use crate::server::ServerState;
+
+    fn folder_with_config(
+        parent: &std::path::Path,
+        name: &str,
+        config: &str,
+    ) -> std::path::PathBuf {
+        let dir = parent.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("vize.config.json"), config).unwrap();
+        dir
+    }
+
+    #[test]
+    fn documents_resolve_their_own_folder_config_regardless_of_order() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let parent = std::env::temp_dir().join(format!(
+            "vize-folder-configs-{}-{nonce}",
+            std::process::id()
+        ));
+        let strict = parent.join("strict-root");
+        std::fs::create_dir_all(&strict).unwrap();
+        let relaxed = folder_with_config(
+            &parent,
+            "relaxed-root",
+            r#"{ "linter": { "rules": { "vue/require-v-for-key": "off" } } }"#,
+        );
+
+        for roots in [
+            vec![strict.clone(), relaxed.clone()],
+            vec![relaxed.clone(), strict.clone()],
+        ] {
+            let state = ServerState::new();
+            state.set_workspace_folders(roots);
+
+            let strict_uri = Url::from_file_path(strict.join("List.vue")).unwrap();
+            let (strict_config, _) = state.linter_settings_for_uri(&strict_uri);
+            assert_eq!(strict_config.rules.get("vue/require-v-for-key"), None);
+
+            let relaxed_uri = Url::from_file_path(relaxed.join("List.vue")).unwrap();
+            let (relaxed_config, _) = state.linter_settings_for_uri(&relaxed_uri);
+            assert_eq!(
+                relaxed_config.rules.get("vue/require-v-for-key"),
+                Some(&LintRuleSeverity::Off),
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(parent);
+    }
+
+    #[test]
+    fn removed_folders_drop_their_context_and_outside_documents_use_globals() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let parent = std::env::temp_dir().join(format!(
+            "vize-folder-removal-{}-{nonce}",
+            std::process::id()
+        ));
+        let relaxed = folder_with_config(
+            &parent,
+            "relaxed-root",
+            r#"{ "linter": { "rules": { "vue/require-v-for-key": "off" } } }"#,
+        );
+
+        let state = ServerState::new();
+        state.set_workspace_folders(vec![relaxed.clone()]);
+        let uri = Url::from_file_path(relaxed.join("List.vue")).unwrap();
+        let (config, _) = state.linter_settings_for_uri(&uri);
+        assert_eq!(
+            config.rules.get("vue/require-v-for-key"),
+            Some(&LintRuleSeverity::Off),
+        );
+
+        state.update_workspace_folders(Vec::new(), &[relaxed.clone()]);
+        let (config, _) = state.linter_settings_for_uri(&uri);
+        assert_eq!(config.rules.get("vue/require-v-for-key"), None);
+
+        let _ = std::fs::remove_dir_all(parent);
+    }
+}

--- a/crates/vize_maestro/src/server/state/workspace_folders.rs
+++ b/crates/vize_maestro/src/server/state/workspace_folders.rs
@@ -13,7 +13,7 @@
 
 use std::path::{Path, PathBuf};
 
-use tower_lsp::lsp_types::Url;
+use tower_lsp::lsp_types::{InitializeParams, Url, WorkspaceFolder, WorkspaceFoldersChangeEvent};
 use vize_carton::config::{LintRuleOptions, LinterConfig};
 
 use super::ServerState;
@@ -48,11 +48,34 @@ impl WorkspaceFolderConfig {
 }
 
 impl ServerState {
+    /// Resolve the primary workspace root from `initialize`: `rootUri` when
+    /// present, otherwise the first workspace folder. This root keeps driving
+    /// process-wide config, the type-checker/Corsa session, and formatting.
+    pub(crate) fn primary_workspace_path(&self, params: &InitializeParams) -> Option<PathBuf> {
+        params
+            .root_uri
+            .as_ref()
+            .and_then(|u| u.to_file_path().ok())
+            .or_else(|| {
+                params
+                    .workspace_folders
+                    .as_ref()
+                    .and_then(|f| f.first())
+                    .and_then(|f| f.uri.to_file_path().ok())
+            })
+    }
+
     /// Replace the workspace-folder contexts with the folders sent by
     /// `initialize`.
     pub(crate) fn set_workspace_folders(&self, roots: Vec<PathBuf>) {
         let contexts = roots.into_iter().map(WorkspaceFolderConfig::load).collect();
         *self.workspace_folder_configs.write() = contexts;
+    }
+
+    /// Load a context for every folder carried by `initialize` (#3240),
+    /// keeping the wire types out of the request handler.
+    pub(crate) fn apply_initialize_workspace_folders(&self, folders: Option<&[WorkspaceFolder]>) {
+        self.set_workspace_folders(folder_roots(folders.unwrap_or_default()));
     }
 
     /// Apply a `workspace/didChangeWorkspaceFolders` event: removed roots
@@ -61,6 +84,11 @@ impl ServerState {
         let mut contexts = self.workspace_folder_configs.write();
         contexts.retain(|context| !removed.contains(&context.root));
         contexts.extend(added.into_iter().map(WorkspaceFolderConfig::load));
+    }
+
+    /// Sync the contexts from a `didChangeWorkspaceFolders` event (#3240).
+    pub(crate) fn apply_workspace_folders_change(&self, event: &WorkspaceFoldersChangeEvent) {
+        self.update_workspace_folders(folder_roots(&event.added), &folder_roots(&event.removed));
     }
 
     /// Linter settings for a document: its deepest enclosing workspace folder
@@ -74,6 +102,14 @@ impl ServerState {
         }
         (self.get_linter_config(), self.get_linter_rule_options())
     }
+}
+
+/// Filesystem roots of the given workspace folders, dropping non-`file:` URIs.
+fn folder_roots(folders: &[WorkspaceFolder]) -> Vec<PathBuf> {
+    folders
+        .iter()
+        .filter_map(|folder| folder.uri.to_file_path().ok())
+        .collect()
 }
 
 fn deepest_enclosing_folder<'a>(

--- a/tests/tooling/lsp-corsa-crash-recovery.test.ts
+++ b/tests/tooling/lsp-corsa-crash-recovery.test.ts
@@ -1,0 +1,301 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { hoverToText, isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+// Corsa mid-session crash recovery (#3240, audit item 6 of #2971): the type
+// checker backend (tsgo) is an external child process that can die at any
+// time (OOM kill, crash, operator kill). When that happens mid-session the
+// server must (a) not crash itself, (b) respawn the backend and republish
+// correct typecheck diagnostics for the next edit within a bounded time, and
+// (c) keep publishing monotonically-versioned, non-stale diagnostics. Two
+// kill+recover cycles guard against one-shot recovery paths.
+
+function resolveTsgoBinary(): string | undefined {
+  const candidates = [
+    path.join(root, "../corsa-bind/.cache/tsgo"),
+    path.join(root, "node_modules/.bin/tsgo"),
+    path.join(root, "tests/node_modules/.bin/tsgo"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+/**
+ * PIDs of live descendants of `rootPid` whose command mentions tsgo/corsa.
+ *
+ * The backend may be reached through wrapper layers (`sh` shim, `node`
+ * launcher, native binary), so the whole descendant tree is scanned rather
+ * than only direct children. `ps -axo` output is BSD/procps compatible and
+ * works on both macOS and Linux CI runners.
+ */
+function findCorsaDescendants(rootPid: number): number[] {
+  const table = execFileSync("ps", ["-axo", "pid=,ppid=,command="], { encoding: "utf8" })
+    .split("\n")
+    .map((line) => line.trim().match(/^(\d+)\s+(\d+)\s+(.*)$/))
+    .filter((match): match is RegExpMatchArray => match != null)
+    .map((match) => ({ pid: Number(match[1]), ppid: Number(match[2]), command: match[3] }));
+
+  const childrenByParent = new Map<number, Array<{ pid: number; command: string }>>();
+  for (const entry of table) {
+    const children = childrenByParent.get(entry.ppid) ?? [];
+    children.push(entry);
+    childrenByParent.set(entry.ppid, children);
+  }
+
+  const matches: number[] = [];
+  const queue = [rootPid];
+  while (queue.length > 0) {
+    const pid = queue.shift() as number;
+    for (const child of childrenByParent.get(pid) ?? []) {
+      queue.push(child.pid);
+      if (/tsgo|corsa/i.test(child.command)) {
+        matches.push(child.pid);
+      }
+    }
+  }
+  return matches;
+}
+
+async function waitForCorsaDescendants(rootPid: number, timeoutMs: number): Promise<number[]> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const pids = findCorsaDescendants(rootPid);
+    if (pids.length > 0) {
+      return pids;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  return [];
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * A SIGKILLed child counts as dead once it is gone or a zombie: the server
+ * only reaps the corpse when it retires the dead session, so `kill(pid, 0)`
+ * alone would keep reporting the zombie as alive.
+ */
+function isProcessDead(pid: number): boolean {
+  try {
+    const state = execFileSync("ps", ["-o", "state=", "-p", String(pid)], {
+      encoding: "utf8",
+    }).trim();
+    return state === "" || state.startsWith("Z");
+  } catch {
+    return true;
+  }
+}
+
+async function killAndAwaitExit(pids: number[]): Promise<void> {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Already gone; the assertion below still verifies it exited.
+    }
+  }
+  const deadline = Date.now() + 5000;
+  while (!pids.every(isProcessDead) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.ok(
+    pids.every(isProcessDead),
+    `corsa backend processes should exit after SIGKILL: ${pids.join(", ")}`,
+  );
+}
+
+/**
+ * Each document revision references one unique undeclared identifier, so the
+ * expected `vize/types` diagnostic ("Cannot find name '<marker>'") is
+ * distinguishable per revision — a stale republish of the previous revision's
+ * diagnostics cannot satisfy the next cycle's predicate.
+ */
+function appSource(marker: string): string {
+  return `<script setup lang="ts">
+const count: number = ${marker}
+</script>
+
+<template>
+  <p>{{ count }}</p>
+</template>
+`;
+}
+
+function typeErrorFor(publish: PublishDiagnosticsParams, marker: string): boolean {
+  return publish.diagnostics.some(
+    (diagnostic) =>
+      diagnostic.source === "vize/types" &&
+      diagnostic.message?.includes(`Cannot find name '${marker}'`),
+  );
+}
+
+test("vize lsp recovers typecheck diagnostics after the Corsa backend is killed", async (t) => {
+  const corsaPath = resolveTsgoBinary();
+  if (corsaPath == null) {
+    t.skip("tsgo binary not found; skipping Corsa crash-recovery test");
+    return;
+  }
+
+  const testRootDir = path.join(testOutputRoot, "lsp-corsa-crash-recovery");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    fs.mkdirSync(path.join(workspaceDir, "src"), { recursive: true });
+    // `vue` module shim so the virtual TS preamble resolves without linking a
+    // real node_modules into the fixture (mirrors the fallback shim used by
+    // lsp-typecheck-template.test.ts and keeps every publish noise-free).
+    fs.writeFileSync(
+      path.join(workspaceDir, "src/vue-shim.d.ts"),
+      `declare module "vue" {
+  export interface Ref<T = any> {
+    value: T;
+  }
+
+  export interface ShallowRef<T = any> {
+    value: T;
+  }
+
+  export interface ComponentPublicInstance {
+    $attrs: Record<string, unknown>;
+    $slots: Record<string, unknown>;
+    $refs: Record<string, unknown>;
+    $emit: (...args: any[]) => void;
+  }
+
+  export interface GlobalComponents {}
+}
+`,
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "vize.config.json"),
+      JSON.stringify({ lsp: { lint: false, typecheck: true }, typeChecker: { corsaPath } }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          module: "ESNext",
+          moduleResolution: "bundler",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src/**/*"],
+      }),
+      "utf8",
+    );
+    await session.initialize(workspaceDir, {
+      editor: true,
+      hover: true,
+      lint: false,
+      typecheck: true,
+    });
+
+    const filePath = path.join(workspaceDir, "src/App.vue");
+    const uri = pathToFileURL(filePath).href;
+    const initialSource = appSource("missingOne");
+    fs.writeFileSync(filePath, initialSource, "utf8");
+
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: initialSource },
+    });
+    const initialPublish = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri) && typeErrorFor(params, "missingOne"),
+    )) as PublishDiagnosticsParams;
+    assert.equal(initialPublish.version, 1);
+
+    // Two full kill+recover cycles: recovery must not be a one-shot affair.
+    let previousMarker = "missingOne";
+    let previousBackendPids: number[] = [];
+    for (const [cycle, marker] of [
+      [2, "missingTwo"],
+      [3, "missingThree"],
+    ] as const) {
+      const backendPids = await waitForCorsaDescendants(session.processId, 15000);
+      assert.ok(
+        backendPids.length > 0,
+        `cycle ${cycle}: expected a live tsgo/corsa descendant of the vize lsp process`,
+      );
+      if (previousBackendPids.length > 0) {
+        assert.notDeepEqual(
+          backendPids,
+          previousBackendPids,
+          `cycle ${cycle}: recovery must respawn a fresh backend process`,
+        );
+      }
+      previousBackendPids = backendPids;
+
+      await killAndAwaitExit(backendPids);
+
+      const changedSource = appSource(marker);
+      const editedAt = Date.now();
+      session.notify("textDocument/didChange", {
+        textDocument: { uri, version: cycle },
+        contentChanges: [{ text: changedSource }],
+      });
+
+      const recoveredPublish = (await session.waitForNotification(
+        "textDocument/publishDiagnostics",
+        (params) =>
+          isDiagnosticsForUri(params, uri) &&
+          params.version === cycle &&
+          typeErrorFor(params, marker),
+      )) as PublishDiagnosticsParams;
+      t.diagnostic(
+        `cycle ${cycle}: recovered typecheck diagnostics ${Date.now() - editedAt}ms after the edit`,
+      );
+
+      // The recovered publish must be fresh: correct version, no diagnostics
+      // left over from the pre-kill document state.
+      assert.equal(recoveredPublish.version, cycle);
+      assert.ok(
+        !typeErrorFor(recoveredPublish, previousMarker),
+        `cycle ${cycle}: stale "${previousMarker}" diagnostic republished: ${JSON.stringify(
+          recoveredPublish.diagnostics,
+        )}`,
+      );
+      previousMarker = marker;
+
+      assert.ok(
+        isProcessAlive(session.processId),
+        `cycle ${cycle}: vize lsp server must survive the backend crash`,
+      );
+    }
+
+    // The recovered backend also serves interactive requests again: hover
+    // over the template interpolation resolves through the respawned Corsa
+    // session (same coordinates the sibling typecheck suite exercises).
+    const finalSource = appSource(previousMarker);
+    const hover = (await session.request("textDocument/hover", {
+      textDocument: { uri },
+      position: offsetToPosition(finalSource, finalSource.lastIndexOf("count") + "count".length),
+    })) as { contents?: unknown } | null;
+    assert.match(
+      hoverToText(hover),
+      /count/,
+      "hover should work against the respawned Corsa backend",
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/lsp-multi-root-workspace.test.ts
+++ b/tests/tooling/lsp-multi-root-workspace.test.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import {
+  firstLocation,
+  hoverToText,
+  isDiagnosticsForUri,
+  offsetToPosition,
+} from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+// True multi-root workspace coverage (#3240, audit item 6 of #2971): a single
+// `vize lsp` session initialized with TWO `workspaceFolders` must
+//   (a) resolve diagnostics against each folder's own configuration context,
+//   (b) keep the folders independent (editing a file in one root neither
+//       clears nor perturbs the other root's published diagnostics, and
+//       per-document versions stay monotonic), and
+//   (c) answer definition/hover for documents of both roots.
+// Both roots carry their own tsconfig.json; root B additionally ships a
+// vize.config.json that turns `vue/require-v-for-key` off, so identical file
+// contents produce a lint diagnostic in root A but none in root B. That
+// asymmetry is what proves the configuration contexts are actually separate.
+
+const LIST_SOURCE = `<script setup lang="ts">
+const rows = ['alpha', 'beta']
+</script>
+
+<template>
+  <ul>
+    <li v-for="row in rows">{{ row }}</li>
+  </ul>
+</template>
+`;
+
+const V_FOR_KEY_RULE = "vue/require-v-for-key";
+
+type WorkspaceRoot = {
+  dir: string;
+  fileUri: string;
+};
+
+function createRoot(
+  parentDir: string,
+  name: string,
+  options: { strict: boolean; disableVForKeyRule: boolean },
+): WorkspaceRoot {
+  const dir = path.join(parentDir, name);
+  fs.mkdirSync(dir, { recursive: true });
+
+  // Each root owns a tsconfig so the fixture matches a real multi-root
+  // editor session where every folder is its own TypeScript project.
+  fs.writeFileSync(
+    path.join(dir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        module: "ESNext",
+        moduleResolution: "bundler",
+        noEmit: true,
+        strict: options.strict,
+        target: "ES2022",
+      },
+      include: ["**/*"],
+    }),
+    "utf8",
+  );
+
+  if (options.disableVForKeyRule) {
+    fs.writeFileSync(
+      path.join(dir, "vize.config.json"),
+      JSON.stringify({ linter: { rules: { [V_FOR_KEY_RULE]: "off" } } }),
+      "utf8",
+    );
+  }
+
+  const filePath = path.join(dir, "List.vue");
+  fs.writeFileSync(filePath, LIST_SOURCE, "utf8");
+  return { dir, fileUri: pathToFileURL(filePath).href };
+}
+
+function hasVForKeyDiagnostic(publish: PublishDiagnosticsParams): boolean {
+  return publish.diagnostics.some(
+    (diagnostic) => diagnostic.source === "vize/lint" && diagnostic.code === V_FOR_KEY_RULE,
+  );
+}
+
+async function openAndCollect(
+  session: LspSession,
+  root: WorkspaceRoot,
+): Promise<PublishDiagnosticsParams> {
+  session.notify("textDocument/didOpen", {
+    textDocument: { uri: root.fileUri, languageId: "vue", version: 1, text: LIST_SOURCE },
+  });
+  return (await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+    isDiagnosticsForUri(params, root.fileUri),
+  )) as PublishDiagnosticsParams;
+}
+
+test("vize lsp resolves per-root config and navigation across two workspace folders", async (t) => {
+  const testRootDir = path.join(testOutputRoot, "lsp-multi-root-workspace");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const parentDir = fs.mkdtempSync(path.join(testRootDir, "roots-"));
+  const rootA = createRoot(parentDir, "root-a", { strict: true, disableVForKeyRule: false });
+  const rootB = createRoot(parentDir, "root-b", { strict: false, disableVForKeyRule: true });
+  const session = new LspSession();
+
+  try {
+    await session.initialize([rootA.dir, rootB.dir], {
+      editor: true,
+      lint: true,
+      typecheck: false,
+    });
+
+    const publishA = await openAndCollect(session, rootA);
+    const publishB = await openAndCollect(session, rootB);
+
+    await t.test("diagnostics follow each folder's own lint configuration", () => {
+      assert.equal(publishA.version, 1);
+      assert.equal(publishB.version, 1);
+      assert.ok(
+        hasVForKeyDiagnostic(publishA),
+        `root A should surface ${V_FOR_KEY_RULE}: ${JSON.stringify(publishA.diagnostics)}`,
+      );
+      assert.ok(
+        !hasVForKeyDiagnostic(publishB),
+        `root B disables ${V_FOR_KEY_RULE} in its own vize.config.json: ${JSON.stringify(
+          publishB.diagnostics,
+        )}`,
+      );
+    });
+
+    await t.test("definition and hover work for documents of both roots", async () => {
+      for (const root of [rootA, rootB]) {
+        const usageOffset = LIST_SOURCE.lastIndexOf("rows") + "rows".length;
+        const definition = (await session.request("textDocument/definition", {
+          textDocument: { uri: root.fileUri },
+          position: offsetToPosition(LIST_SOURCE, usageOffset),
+        })) as
+          | { uri: string; range: { start: { line: number; character: number } } }
+          | Array<{ uri: string; range: { start: { line: number; character: number } } }>
+          | null;
+        assert.ok(definition, `definition should resolve in ${root.dir}`);
+        const location = firstLocation(definition);
+        assert.equal(location.uri, root.fileUri);
+        assert.deepEqual(
+          location.range.start,
+          offsetToPosition(LIST_SOURCE, LIST_SOURCE.indexOf("rows")),
+        );
+
+        const hover = (await session.request("textDocument/hover", {
+          textDocument: { uri: root.fileUri },
+          position: offsetToPosition(LIST_SOURCE, usageOffset),
+        })) as { contents?: unknown } | null;
+        assert.match(hoverToText(hover), /rows/);
+      }
+    });
+
+    await t.test("editing root A leaves root B's published diagnostics untouched", async () => {
+      const changedA = LIST_SOURCE.replace("'alpha', 'beta'", "'alpha', 'beta', 'gamma'");
+      session.notify("textDocument/didChange", {
+        textDocument: { uri: rootA.fileUri, version: 2 },
+        contentChanges: [{ text: changedA }],
+      });
+
+      const republishA = (await session.waitForNotification(
+        "textDocument/publishDiagnostics",
+        (params) => isDiagnosticsForUri(params, rootA.fileUri) && params.version === 2,
+      )) as PublishDiagnosticsParams;
+      assert.ok(
+        hasVForKeyDiagnostic(republishA),
+        `root A keeps its lint context after the edit: ${JSON.stringify(republishA.diagnostics)}`,
+      );
+
+      // Root B must not receive any publish triggered by root A's edit: no
+      // clearing, no config-context bleed, no version churn.
+      await assert.rejects(
+        session.waitForNotification(
+          "textDocument/publishDiagnostics",
+          (params) => isDiagnosticsForUri(params, rootB.fileUri),
+          1500,
+        ),
+        /Timed out/,
+        "root A's didChange must not republish root B's document",
+      );
+
+      // Root B's own next edit still resolves root B's config (rule stays
+      // off) and its version advances monotonically from 1 to 2.
+      const changedB = LIST_SOURCE.replace("'alpha', 'beta'", "'alpha'");
+      session.notify("textDocument/didChange", {
+        textDocument: { uri: rootB.fileUri, version: 2 },
+        contentChanges: [{ text: changedB }],
+      });
+      const republishB = (await session.waitForNotification(
+        "textDocument/publishDiagnostics",
+        (params) => isDiagnosticsForUri(params, rootB.fileUri) && params.version === 2,
+      )) as PublishDiagnosticsParams;
+      assert.ok(
+        !hasVForKeyDiagnostic(republishB),
+        `root B keeps its own lint context after edits: ${JSON.stringify(republishB.diagnostics)}`,
+      );
+    });
+  } finally {
+    await session.shutdown();
+    fs.rmSync(parentDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+// The same fixture with the folder order reversed must produce the same
+// per-root outcomes. This pins down that per-root behavior is derived from
+// each document's OWN enclosing folder, not from whichever folder happens to
+// be listed first (the classic "primary root wins" failure mode).
+test("vize lsp multi-root config contexts do not depend on folder order", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-multi-root-order");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const parentDir = fs.mkdtempSync(path.join(testRootDir, "roots-"));
+  const rootA = createRoot(parentDir, "root-a", { strict: true, disableVForKeyRule: false });
+  const rootB = createRoot(parentDir, "root-b", { strict: false, disableVForKeyRule: true });
+  const session = new LspSession();
+
+  try {
+    // Root B (the rule-off folder) is listed FIRST this time.
+    await session.initialize([rootB.dir, rootA.dir], {
+      editor: true,
+      lint: true,
+      typecheck: false,
+    });
+
+    const publishB = await openAndCollect(session, rootB);
+    const publishA = await openAndCollect(session, rootA);
+
+    assert.ok(
+      !hasVForKeyDiagnostic(publishB),
+      `root B's own config still disables ${V_FOR_KEY_RULE}: ${JSON.stringify(
+        publishB.diagnostics,
+      )}`,
+    );
+    assert.ok(
+      hasVForKeyDiagnostic(publishA),
+      `root A must not inherit root B's rule-off config just because B is first: ${JSON.stringify(
+        publishA.diagnostics,
+      )}`,
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(parentDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/support/lsp/session.ts
+++ b/tests/tooling/support/lsp/session.ts
@@ -92,16 +92,28 @@ export class LspSession {
     return this.process.pid;
   }
 
+  /**
+   * Initialize the session with one workspace folder (existing callers) or
+   * several (true multi-root sessions, #3240).
+   *
+   * The LSP spec prefers `workspaceFolders` over the deprecated `rootUri`, so
+   * multi-root sessions send `rootUri: null` to prove the server consumes the
+   * folder list itself; single-folder sessions keep the historical `rootUri`
+   * for parity with editors that still populate both fields.
+   */
   async initialize(
-    workspaceDir: string,
+    workspaceDir: string | readonly string[],
     initializationOptions: LspInitializationOptions = {
       editor: true,
       typecheck: true,
     },
   ): Promise<unknown> {
+    const workspaceDirs = typeof workspaceDir === "string" ? [workspaceDir] : [...workspaceDir];
+    assert.ok(workspaceDirs.length > 0, "initialize requires at least one workspace folder");
+
     const result = await this.request("initialize", {
       processId: process.pid,
-      rootUri: pathToFileURL(workspaceDir).href,
+      rootUri: workspaceDirs.length === 1 ? pathToFileURL(workspaceDirs[0]).href : null,
       capabilities: {
         textDocument: {
           completion: {
@@ -112,12 +124,10 @@ export class LspSession {
         },
       },
       initializationOptions,
-      workspaceFolders: [
-        {
-          uri: pathToFileURL(workspaceDir).href,
-          name: path.basename(workspaceDir),
-        },
-      ],
+      workspaceFolders: workspaceDirs.map((dir) => ({
+        uri: pathToFileURL(dir).href,
+        name: path.basename(dir),
+      })),
     });
 
     this.notify("initialized", {});


### PR DESCRIPTION
## Summary

Audit item 6 of #2971: the LSP smoke suites never initialized `vize lsp` with more than one `workspaceFolders` entry, and nothing killed the Corsa (tsgo) backend mid-session. Writing both suites to the LSP spec exposed two real server gaps, so this PR pairs the new coverage with the minimal `vize_maestro` fixes needed to pass it.

## Test coverage added

- `tests/tooling/support/lsp/session.ts`: `initialize` now accepts one folder (all existing callers, unchanged wire shape) or several; multi-root sessions send `rootUri: null` plus the full `workspaceFolders` list per spec.
- `tests/tooling/lsp-multi-root-workspace.test.ts`: one session, two roots, each with its own `tsconfig.json`; root B also ships a `vize.config.json` turning `vue/require-v-for-key` off.
  - (a) identical file contents produce the lint diagnostic in root A and none in root B (separate config contexts);
  - (b) editing root A republishes only root A (monotonic versions) and root B's next edit still resolves root B's config;
  - (c) definition + hover answer for documents of both roots;
  - a folder-order-reversal test pins that contexts derive from each document's own folder, not from whichever root is listed first.
- `tests/tooling/lsp-corsa-crash-recovery.test.ts` (skips when tsgo is absent, like the sibling typecheck suites): clean `vize/types` publish, then SIGKILL the tsgo descendant, `didChange`, and assert the same-version republish carries the corrected diagnostics with no stale leftovers; two full kill+recover cycles (fresh backend PID each time), plus hover against the respawned backend and a server-alive check.

## Server gaps confirmed (pre-fix binary)

- Multi-root: config was loaded from the first root only (`initialize` → `load_workspace_config(first)`); root B's own `vize.config.json` was ignored, so its file still surfaced the disabled rule. Reversing folder order flipped which root's policy leaked to the other.
- Corsa crash: after SIGKILL of tsgo, the next `didChange` published EMPTY diagnostics — the type error silently vanished — and the session never recovered (bridge lived in a `OnceLock`); hover went dead and the child stayed a zombie.

## vize_maestro fixes (minimal, ~180 lines)

- `server/state/workspace_folders.rs` (new): per-folder linter contexts. Folders with their own `vize.config.*` use it; folders without one use built-in defaults (order-independent); documents outside every folder keep the process-wide settings. Deepest enclosing folder wins. `initialize` records all folders and `workspace/didChangeWorkspaceFolders` (which the server already advertises) updates them.
- `ide/diagnostics/collectors.rs`: lint collection resolves `linter_settings_for_uri` instead of the global config.
- `server/state.rs` + `state/corsa.rs`: the Corsa bridge slot is now `RwLock<Option<Arc<CorsaBridge>>>` with `retire_corsa_bridge(&failed)` (pointer-identity guarded, so concurrent retirement cannot discard a freshly respawned bridge). The `corsa_init_failed` spawn-failure latch is untouched.
- `ide/diagnostics/corsa/collect.rs` + `collect_virtual.rs`: bridge errors now propagate; `CommunicationError`/`ProcessTerminated` classify as a dead backend, which retires the bridge and retries the collection exactly once against a fresh session — so the first `didChange` after a crash already republishes correct diagnostics. Other error kinds keep the previous warn-and-empty behavior.

Process-wide knobs (type-checker options, the Corsa session root, formatting) intentionally still follow the primary root; the per-folder contexts cover the per-document lint surface the spec tests exercise.

## Verification

- Both new suites green locally against a fresh `--release` binary (recovery timing logged via `t.diagnostic`).
- Full `tests/tooling/lsp-*.test.ts` battery green (session helper stays backward compatible).
- `cargo test -p vize_maestro`, `cargo clippy -p vize_maestro -- -D warnings -D clippy::wildcard_imports`, `cargo fmt` clean.
- New suites are picked up automatically by the `test:scripts` glob (`tests/tooling/*.test.ts`).

Fixes #3240

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->