### PR TITLE
feat(marquette): make release decisions one durable atomic transition

### DIFF
--- a/crates/vize_marquette/schema/test-run-admission.schema.json
+++ b/crates/vize_marquette/schema/test-run-admission.schema.json
@@ -6,7 +6,7 @@
   "$ref": "#/$defs/decision",
   "$defs": {
     "denialCode": {
-      "description": "Stable machine-readable cause class of one admission denial. The vocabulary is append-only: codes are never renamed, renumbered, reused, or removed, and every new distinguishable rejection cause ships with a new code added to this enum in lexicographic position. Hosts must map every diagnostic to exactly one code: VIZE_MARQUETTE_141 to admission-id-malformed; VIZE_MARQUETTE_142 to admission-id-mismatch; VIZE_MARQUETTE_144 to the candidate-*-mismatch code named by its diagnostic path (application, artifact.fingerprint, contractFingerprint, environment, release, sourceRevision); VIZE_MARQUETTE_145 to record-expired; VIZE_MARQUETTE_146 to verification-not-accepted; VIZE_MARQUETTE_147 to skipped-tests-recorded; VIZE_MARQUETTE_148 to admission-time-malformed; VIZE_MARQUETTE_149 to check-candidate-mismatch; VIZE_MARQUETTE_150 to check-invalid; VIZE_MARQUETTE_151 to check-observer-not-independent; every other diagnostic whose path starts with check. to check-invalid; and every remaining diagnostic, including every record-validation code, to record-invalid.",
+      "description": "Stable machine-readable cause class of one admission denial. The vocabulary is append-only: codes are never renamed, renumbered, reused, or removed, and every new distinguishable rejection cause ships with a new code added to this enum in lexicographic position. Hosts must map every diagnostic to exactly one code: VIZE_MARQUETTE_141 to admission-id-malformed; VIZE_MARQUETTE_142 to admission-id-mismatch; VIZE_MARQUETTE_144 to the candidate-*-mismatch code named by its diagnostic path (application, artifact.fingerprint, contractFingerprint, environment, release, sourceRevision); VIZE_MARQUETTE_145 to record-expired; VIZE_MARQUETTE_146 to verification-not-accepted; VIZE_MARQUETTE_147 to skipped-tests-recorded; VIZE_MARQUETTE_148 to admission-time-malformed; VIZE_MARQUETTE_149 to check-candidate-mismatch; VIZE_MARQUETTE_150 to check-invalid; VIZE_MARQUETTE_151 to check-observer-not-independent; VIZE_MARQUETTE_156 to transition-state-mismatch; VIZE_MARQUETTE_157 to transition-chain-broken; VIZE_MARQUETTE_158 to transition-replayed; VIZE_MARQUETTE_159 to transition-state-mismatch; every other diagnostic whose path starts with check. to check-invalid; every other diagnostic whose path starts with transition. to transition-invalid; and every remaining diagnostic, including every record-validation code, to record-invalid.",
       "enum": [
         "admission-id-malformed",
         "admission-id-mismatch",
@@ -23,6 +23,10 @@
         "record-expired",
         "record-invalid",
         "skipped-tests-recorded",
+        "transition-chain-broken",
+        "transition-invalid",
+        "transition-replayed",
+        "transition-state-mismatch",
         "verification-not-accepted"
       ]
     },

--- a/crates/vize_marquette/schema/test-run-transition.schema.json
+++ b/crates/vize_marquette/schema/test-run-transition.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vizejs.dev/schemas/marquette/test-run-transition.schema.json",
+  "title": "Vize Release Transition",
+  "description": "One durable atomic release transition: a single canonical record binding one release decision to the complete accepted anti-replay state, chained to its predecessor by canonical SHA-256 fingerprint. Host durability contract: a conforming host must write the complete canonical bytes to a temporary location, flush them to durable storage, then atomically rename or commit so exactly one complete chain tip exists at every instant; on recovery it must verify the tip against its retained predecessor before deciding anything new, and discard - never repair - a torn or partial record. Verification is fail-closed and identical across JavaScript, Rust, Go, and JVM hosts; the shared tests/fixtures/test-run-evidence transition-decision fixtures are the conformance source of truth for new host implementations.",
+  "$ref": "#/$defs/transition",
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[a-z0-9][a-z0-9._-]*$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "admissionId": {
+      "description": "Exact test-run:<sha256> admission id; the only admissible form of accepted test evidence.",
+      "type": "string",
+      "pattern": "^test-run:[a-f0-9]{64}$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\\.[0-9]{3}Z$"
+    },
+    "candidate": {
+      "description": "Exact release candidate the decision was made for. Application and environment must stay constant along one chain.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "application",
+        "environment",
+        "contractFingerprint",
+        "sourceRevision",
+        "release",
+        "artifactFingerprint"
+      ],
+      "properties": {
+        "application": { "$ref": "#/$defs/identifier" },
+        "environment": { "$ref": "#/$defs/identifier" },
+        "contractFingerprint": { "$ref": "#/$defs/digest" },
+        "sourceRevision": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40,128}$"
+        },
+        "release": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "artifactFingerprint": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "diagnostic": {
+      "description": "One retained diagnostic, shaped and serialized exactly like a live diagnostic.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "severity", "path", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^VIZE_MARQUETTE_[0-9]{3}$"
+        },
+        "severity": { "enum": ["error", "warning"] },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "decision": {
+      "description": "Retained allow-or-deny decision exactly as it was produced. allowed must agree with the diagnostics, and denialCodes must equal the published mapping of the diagnostics; verification rejects a record claiming an outcome its own diagnostics contradict.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowed", "denialCodes", "diagnostics"],
+      "properties": {
+        "allowed": { "type": "boolean" },
+        "denialCodes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+          }
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/diagnostic" }
+        }
+      }
+    },
+    "transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format",
+        "formatVersion",
+        "sequence",
+        "previous",
+        "decidedAt",
+        "candidate",
+        "evidence",
+        "decision",
+        "accepted"
+      ],
+      "properties": {
+        "format": {
+          "description": "Serialized format marker; readers must reject any other value.",
+          "const": "vize.test-run.transition"
+        },
+        "formatVersion": {
+          "description": "Serialized format version; readers must reject a higher value until they explicitly support it.",
+          "const": 1
+        },
+        "sequence": {
+          "description": "One-based chain position; each transition extends its predecessor by exactly one.",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9007199254740991
+        },
+        "previous": {
+          "description": "Canonical SHA-256 fingerprint of the predecessor transition; null only at genesis (sequence 1).",
+          "anyOf": [{ "$ref": "#/$defs/digest" }, { "type": "null" }]
+        },
+        "decidedAt": {
+          "description": "Millisecond-precision UTC instant of the decision; never earlier than the predecessor's.",
+          "$ref": "#/$defs/timestamp"
+        },
+        "candidate": { "$ref": "#/$defs/candidate" },
+        "evidence": { "$ref": "#/$defs/admissionId" },
+        "decision": { "$ref": "#/$defs/decision" },
+        "accepted": {
+          "description": "Complete anti-replay state after this transition: every admission id ever accepted in this chain, sorted and unique. An allowed transition adds exactly its own evidence to its predecessor's state; a denied transition leaves the state unchanged; an already accepted id can never be accepted again.",
+          "type": "array",
+          "maxItems": 4096,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/admissionId" }
+        }
+      }
+    }
+  }
+}

--- a/crates/vize_marquette/src/lib.rs
+++ b/crates/vize_marquette/src/lib.rs
@@ -61,16 +61,20 @@ pub use model::{
     RuntimeFamily, Target,
 };
 pub use test_run::{
-    CanonicalTestRunError, TEST_RUN_ADMISSION_PREFIX, TEST_RUN_CHECK_FORMAT,
-    TEST_RUN_CHECK_FORMAT_VERSION, TEST_RUN_DENIAL_CODES, TEST_RUN_EVIDENCE_FORMAT,
-    TEST_RUN_EVIDENCE_FORMAT_VERSION, TEST_RUN_MAX_SHARDS, TEST_RUN_MAX_SUITES,
-    TEST_RUN_MAX_TARGETS, TestRunAdmissionDecision, TestRunArtifact, TestRunCandidate,
-    TestRunCheck, TestRunDenialCode, TestRunEvidence, TestRunIsolation, TestRunRetainedEvidence,
+    CanonicalTestRunError, CanonicalTransitionError, TEST_RUN_ADMISSION_PREFIX,
+    TEST_RUN_CHECK_FORMAT, TEST_RUN_CHECK_FORMAT_VERSION, TEST_RUN_DENIAL_CODES,
+    TEST_RUN_EVIDENCE_FORMAT, TEST_RUN_EVIDENCE_FORMAT_VERSION, TEST_RUN_MAX_SHARDS,
+    TEST_RUN_MAX_SUITES, TEST_RUN_MAX_TARGETS, TEST_RUN_TRANSITION_FORMAT,
+    TEST_RUN_TRANSITION_FORMAT_VERSION, TEST_RUN_TRANSITION_MAX_ACCEPTED, TestRunAdmissionDecision,
+    TestRunArtifact, TestRunCandidate, TestRunCheck, TestRunDenialCode, TestRunEvidence,
+    TestRunIsolation, TestRunRetainedDecision, TestRunRetainedDiagnostic, TestRunRetainedEvidence,
     TestRunRunner, TestRunSelection, TestRunSuiteExecution, TestRunSuiteKind, TestRunSuiteOutcome,
-    TestRunTargetExecution, TestRunTargetKind, TestRunVerification, TestRunVerificationOutcome,
-    admit_test_run, canonical_test_run_json, decide_test_run_admission,
-    parse_test_run_admission_id, test_run_admission_id, test_run_denial_code, test_run_fingerprint,
-    validate_test_run, validate_test_run_check, verify_test_run_check,
+    TestRunTargetExecution, TestRunTargetKind, TestRunTransition, TestRunVerification,
+    TestRunVerificationOutcome, admit_test_run, canonical_test_run_json,
+    canonical_test_run_transition_json, decide_test_run_admission, parse_test_run_admission_id,
+    test_run_admission_id, test_run_denial_code, test_run_fingerprint,
+    test_run_transition_fingerprint, validate_test_run, validate_test_run_check,
+    validate_test_run_transition, verify_test_run_check, verify_test_run_transition,
 };
 pub use validate::{ContractDiagnostic, DiagnosticSeverity, validate_contract};
 
@@ -105,6 +109,17 @@ pub const TEST_RUN_ADMISSION_JSON_SCHEMA: &str =
 /// test-result reference and is embedded so deployment gates and tooling
 /// can expose the exact contract without resolving a filesystem path.
 pub const TEST_RUN_CHECK_JSON_SCHEMA: &str = include_str!("../schema/test-run-check.schema.json");
+
+/// Canonical JSON Schema for durable release transitions.
+///
+/// The schema declares the single atomic record binding one release
+/// decision to the complete accepted anti-replay state, chained by
+/// canonical SHA-256 fingerprints, together with the durability contract a
+/// conforming host must guarantee. It is embedded so deployment gates and
+/// tooling can expose the exact contract without resolving a filesystem
+/// path.
+pub const TEST_RUN_TRANSITION_JSON_SCHEMA: &str =
+    include_str!("../schema/test-run-transition.schema.json");
 
 #[cfg(test)]
 mod schema_tests {
@@ -150,6 +165,25 @@ mod schema_tests {
         assert_eq!(
             check["formatVersion"]["const"],
             super::TEST_RUN_CHECK_FORMAT_VERSION
+        );
+    }
+
+    #[test]
+    fn embedded_transition_schema_tracks_the_current_format() {
+        let schema: serde_json::Value =
+            serde_json::from_str(super::TEST_RUN_TRANSITION_JSON_SCHEMA).unwrap();
+        let transition = &schema["$defs"]["transition"]["properties"];
+        assert_eq!(
+            transition["format"]["const"],
+            super::TEST_RUN_TRANSITION_FORMAT
+        );
+        assert_eq!(
+            transition["formatVersion"]["const"],
+            super::TEST_RUN_TRANSITION_FORMAT_VERSION
+        );
+        assert_eq!(
+            transition["accepted"]["maxItems"],
+            super::TEST_RUN_TRANSITION_MAX_ACCEPTED
         );
     }
 }

--- a/crates/vize_marquette/src/test_run.rs
+++ b/crates/vize_marquette/src/test_run.rs
@@ -16,6 +16,7 @@ mod canonical;
 mod check;
 mod decision;
 mod model;
+mod transition;
 mod validate;
 
 #[cfg(test)]
@@ -39,6 +40,12 @@ pub use model::{
     TestRunIsolation, TestRunRetainedEvidence, TestRunRunner, TestRunSelection,
     TestRunSuiteExecution, TestRunSuiteKind, TestRunSuiteOutcome, TestRunTargetExecution,
     TestRunTargetKind, TestRunVerification, TestRunVerificationOutcome,
+};
+pub use transition::{
+    CanonicalTransitionError, TEST_RUN_TRANSITION_FORMAT, TEST_RUN_TRANSITION_FORMAT_VERSION,
+    TEST_RUN_TRANSITION_MAX_ACCEPTED, TestRunRetainedDecision, TestRunRetainedDiagnostic,
+    TestRunTransition, canonical_test_run_transition_json, test_run_transition_fingerprint,
+    validate_test_run_transition, verify_test_run_transition,
 };
 pub use validate::{
     TEST_RUN_MAX_SHARDS, TEST_RUN_MAX_SUITES, TEST_RUN_MAX_TARGETS, validate_test_run,

--- a/crates/vize_marquette/src/test_run/decision.rs
+++ b/crates/vize_marquette/src/test_run/decision.rs
@@ -47,12 +47,20 @@ pub enum TestRunDenialCode {
     RecordInvalid,
     /// The record accounts skipped tests, which admission never approves.
     SkippedTestsRecorded,
+    /// The transition does not extend the verified chain tip exactly.
+    TransitionChainBroken,
+    /// The transition record itself failed validation.
+    TransitionInvalid,
+    /// The transition re-accepts evidence its predecessor already accepted.
+    TransitionReplayed,
+    /// The transition's accepted state does not match its decision.
+    TransitionStateMismatch,
     /// The independent verification did not accept the run.
     VerificationNotAccepted,
 }
 
 /// Every denial code, in the stable lexicographic decision order.
-pub const TEST_RUN_DENIAL_CODES: [TestRunDenialCode; 16] = [
+pub const TEST_RUN_DENIAL_CODES: [TestRunDenialCode; 20] = [
     TestRunDenialCode::AdmissionIdMalformed,
     TestRunDenialCode::AdmissionIdMismatch,
     TestRunDenialCode::AdmissionTimeMalformed,
@@ -68,6 +76,10 @@ pub const TEST_RUN_DENIAL_CODES: [TestRunDenialCode; 16] = [
     TestRunDenialCode::RecordExpired,
     TestRunDenialCode::RecordInvalid,
     TestRunDenialCode::SkippedTestsRecorded,
+    TestRunDenialCode::TransitionChainBroken,
+    TestRunDenialCode::TransitionInvalid,
+    TestRunDenialCode::TransitionReplayed,
+    TestRunDenialCode::TransitionStateMismatch,
     TestRunDenialCode::VerificationNotAccepted,
 ];
 
@@ -96,12 +108,21 @@ pub struct TestRunAdmissionDecision {
 /// `VIZE_MARQUETTE_141` through `VIZE_MARQUETTE_148` map to their exact
 /// cause, `VIZE_MARQUETTE_144` distinguishes the mismatched candidate
 /// binding by its diagnostic path, `VIZE_MARQUETTE_149` through
-/// `VIZE_MARQUETTE_151` map to their tests-check cause, every other
-/// diagnostic at a `check.` path is a [`TestRunDenialCode::CheckInvalid`]
-/// tests-check validation failure, and every remaining diagnostic is a
+/// `VIZE_MARQUETTE_151` map to their tests-check cause,
+/// `VIZE_MARQUETTE_156` through `VIZE_MARQUETTE_159` map to their
+/// transition cause, every other diagnostic at a `check.` path is a
+/// [`TestRunDenialCode::CheckInvalid`] tests-check validation failure,
+/// every other diagnostic at a `transition.` path is a
+/// [`TestRunDenialCode::TransitionInvalid`] transition validation failure,
+/// and every remaining diagnostic is a
 /// [`TestRunDenialCode::RecordInvalid`] record-validation failure.
 pub fn test_run_denial_code(diagnostic: &ContractDiagnostic) -> TestRunDenialCode {
-    match (diagnostic.code, diagnostic.path.as_str()) {
+    denial_code_for(diagnostic.code, diagnostic.path.as_str())
+}
+
+/// Total (code, path) form of the mapping shared with retained diagnostics.
+pub(crate) fn denial_code_for(code: &str, path: &str) -> TestRunDenialCode {
+    match (code, path) {
         ("VIZE_MARQUETTE_141", _) => TestRunDenialCode::AdmissionIdMalformed,
         ("VIZE_MARQUETTE_142", _) => TestRunDenialCode::AdmissionIdMismatch,
         ("VIZE_MARQUETTE_144", "application") => TestRunDenialCode::CandidateApplicationMismatch,
@@ -123,7 +144,12 @@ pub fn test_run_denial_code(diagnostic: &ContractDiagnostic) -> TestRunDenialCod
         ("VIZE_MARQUETTE_149", _) => TestRunDenialCode::CheckCandidateMismatch,
         ("VIZE_MARQUETTE_150", _) => TestRunDenialCode::CheckInvalid,
         ("VIZE_MARQUETTE_151", _) => TestRunDenialCode::CheckObserverNotIndependent,
+        ("VIZE_MARQUETTE_156", _) => TestRunDenialCode::TransitionStateMismatch,
+        ("VIZE_MARQUETTE_157", _) => TestRunDenialCode::TransitionChainBroken,
+        ("VIZE_MARQUETTE_158", _) => TestRunDenialCode::TransitionReplayed,
+        ("VIZE_MARQUETTE_159", _) => TestRunDenialCode::TransitionStateMismatch,
         (_, path) if path.starts_with("check.") => TestRunDenialCode::CheckInvalid,
+        (_, path) if path.starts_with("transition.") => TestRunDenialCode::TransitionInvalid,
         _ => TestRunDenialCode::RecordInvalid,
     }
 }
@@ -182,7 +208,7 @@ mod tests {
 
     #[test]
     fn the_vocabulary_is_sorted_and_serializes_kebab_case() {
-        let serialized: [vize_carton::String; 16] = TEST_RUN_DENIAL_CODES
+        let serialized: [vize_carton::String; 20] = TEST_RUN_DENIAL_CODES
             .map(|code| serde_json::to_value(code).unwrap().as_str().unwrap().into());
         let mut sorted = serialized.clone();
         sorted.sort();
@@ -190,6 +216,7 @@ mod tests {
         assert_eq!(serialized[0], "admission-id-malformed");
         assert_eq!(serialized[10], "check-invalid");
         assert_eq!(serialized[13], "record-invalid");
+        assert_eq!(serialized[16], "transition-invalid");
 
         let mut ordered = TEST_RUN_DENIAL_CODES;
         ordered.sort_unstable();

--- a/crates/vize_marquette/src/test_run/transition.rs
+++ b/crates/vize_marquette/src/test_run/transition.rs
@@ -1,0 +1,174 @@
+//! One durable atomic transition per release decision.
+//!
+//! A release gate must persist two facts together: the decision it made and
+//! the anti-replay state that decision accepted. This module defines the
+//! single canonical record carrying both, chained by canonical SHA-256
+//! fingerprints, so the durable write is one atomic unit and no crash point
+//! can separate a decision from its accepted state.
+//!
+//! # Host durability contract
+//!
+//! The contract defines validation, verification, and canonical bytes; the
+//! host implements the durability primitive. A conforming host must write
+//! the complete canonical bytes of the next transition to a temporary
+//! location, flush them to durable storage, and then atomically rename or
+//! commit them so that exactly one complete chain tip exists at every
+//! instant. On recovery the host must load the tip, verify it against its
+//! retained predecessor with [`verify_test_run_transition`], and discard —
+//! never repair — a torn or partial record before deciding anything new.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use vize_carton::String;
+
+use crate::validate::DiagnosticSeverity;
+
+use super::admission::TestRunCandidate;
+use super::decision::TestRunDenialCode;
+
+mod checks;
+#[cfg(test)]
+mod tests;
+
+pub use checks::{validate_test_run_transition, verify_test_run_transition};
+
+/// Serialized `format` marker for release-transition records.
+///
+/// Readers must reject any other value before trusting the record.
+pub const TEST_RUN_TRANSITION_FORMAT: &str = "vize.test-run.transition";
+
+/// Current serialized release-transition format.
+///
+/// Readers must reject a higher value until they explicitly support it.
+pub const TEST_RUN_TRANSITION_FORMAT_VERSION: u32 = 1;
+
+/// Maximum admission ids one transition may carry as accepted state.
+pub const TEST_RUN_TRANSITION_MAX_ACCEPTED: usize = 4096;
+
+/// One retained diagnostic inside a durable transition record.
+///
+/// The shape and serialization match live [`crate::ContractDiagnostic`]
+/// values exactly; the retained form owns its code so persisted records can
+/// be read back by any host.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TestRunRetainedDiagnostic {
+    /// Stable machine-readable diagnostic code.
+    pub code: String,
+    /// Severity recorded for the diagnostic; any diagnostic denies.
+    pub severity: DiagnosticSeverity,
+    /// JSON-style path into the decided input.
+    pub path: String,
+    /// Human-readable explanation recorded with the decision.
+    pub message: String,
+}
+
+/// One retained allow-or-deny decision inside a durable transition record.
+///
+/// The shape and serialization match live
+/// [`crate::TestRunAdmissionDecision`] values exactly. Validation rejects a
+/// retained decision whose `allowed` flag, denial codes, or diagnostic
+/// ordering disagree with the published mapping, so a record cannot claim an
+/// outcome its own diagnostics contradict.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TestRunRetainedDecision {
+    /// Whether the release decision admitted the candidate.
+    pub allowed: bool,
+    /// Deduplicated denial causes sorted lexicographically; empty if allowed.
+    pub denial_codes: Vec<TestRunDenialCode>,
+    /// Complete diagnostics in the stable path, code, message order.
+    pub diagnostics: Vec<TestRunRetainedDiagnostic>,
+}
+
+/// One durable atomic release transition.
+///
+/// The record binds the decision, the exact candidate and evidence it
+/// decided, and the complete accepted anti-replay state after the decision
+/// into one canonical document. `sequence` grows by exactly one per
+/// transition and `previous` names the predecessor's canonical SHA-256
+/// fingerprint, so a chain tip proves the entire decision history and the
+/// accepted set can never drift from the decision that produced it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TestRunTransition {
+    /// Serialized format marker; always [`TEST_RUN_TRANSITION_FORMAT`].
+    pub format: String,
+    /// Serialized format version.
+    ///
+    /// Defaults to [`TEST_RUN_TRANSITION_FORMAT_VERSION`].
+    #[serde(default = "default_test_run_transition_format_version")]
+    pub format_version: u32,
+    /// One-based position of this transition in its chain.
+    pub sequence: u64,
+    /// Canonical fingerprint of the predecessor; `None` only at genesis.
+    pub previous: Option<String>,
+    /// Millisecond-precision UTC instant the decision was made.
+    pub decided_at: String,
+    /// Exact candidate the decision was made for.
+    pub candidate: TestRunCandidate,
+    /// Exact `test-run:<sha256>` admission id the decision evaluated.
+    pub evidence: String,
+    /// Retained decision exactly as it was produced.
+    pub decision: TestRunRetainedDecision,
+    /// Complete anti-replay state after this transition: every admission id
+    /// ever accepted in this chain, sorted and unique.
+    pub accepted: Vec<String>,
+}
+
+const fn default_test_run_transition_format_version() -> u32 {
+    TEST_RUN_TRANSITION_FORMAT_VERSION
+}
+
+/// Failure to serialize a release transition canonically.
+#[derive(Debug)]
+pub struct CanonicalTransitionError(serde_json::Error);
+
+impl std::fmt::Display for CanonicalTransitionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("failed to serialize the release transition")
+    }
+}
+
+impl std::error::Error for CanonicalTransitionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+/// Serializes a release transition canonically.
+///
+/// Property order matches the record schema and the accepted state sorts
+/// lexicographically after deduplication, so equivalent transitions produce
+/// byte-identical JSON in every language. These are the exact bytes a host
+/// must write atomically and the exact bytes the chain fingerprint covers.
+/// Call validation before trusting the record; canonicalization does not
+/// make an invalid record valid.
+pub fn canonical_test_run_transition_json(
+    transition: &TestRunTransition,
+) -> Result<Vec<u8>, CanonicalTransitionError> {
+    let mut canonical = transition.clone();
+    canonical.accepted.sort_unstable();
+    canonical.accepted.dedup();
+    canonical.decision.denial_codes.sort_unstable();
+    canonical.decision.denial_codes.dedup();
+    serde_json::to_vec(&canonical).map_err(CanonicalTransitionError)
+}
+
+/// Returns a lowercase SHA-256 fingerprint of the canonical transition.
+///
+/// The fingerprint is the exact value the successor transition must name as
+/// `previous`, forming the durable chain.
+pub fn test_run_transition_fingerprint(
+    transition: &TestRunTransition,
+) -> Result<String, CanonicalTransitionError> {
+    let bytes = canonical_test_run_transition_json(transition)?;
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(64);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for byte in digest {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    Ok(output)
+}

--- a/crates/vize_marquette/src/test_run/transition/checks.rs
+++ b/crates/vize_marquette/src/test_run/transition/checks.rs
@@ -1,0 +1,328 @@
+use vize_carton::String;
+
+use crate::ContractDiagnostic;
+
+use super::super::admission::parse_test_run_admission_id;
+use super::super::decision::{
+    TestRunAdmissionDecision, TestRunDenialCode, decision_from_diagnostics, denial_code_for,
+};
+use super::super::validate::is_strict_timestamp_value;
+use super::super::validate::rules::{
+    check_digest, check_identifier, check_safe_integer, check_source_revision, check_timestamp,
+};
+use super::{
+    TEST_RUN_TRANSITION_FORMAT, TEST_RUN_TRANSITION_FORMAT_VERSION,
+    TEST_RUN_TRANSITION_MAX_ACCEPTED, TestRunTransition, test_run_transition_fingerprint,
+};
+
+/// Validates one release transition structurally.
+///
+/// Diagnostics use `transition.` paths and are deterministic and sorted by
+/// path, code, and message. Validation confirms the record alone is
+/// internally coherent — grammar, decision consistency against the
+/// published diagnostic mapping, and an allowed decision accepting its own
+/// evidence — but only [`verify_test_run_transition`] can confirm the
+/// record extends the durable chain.
+pub fn validate_test_run_transition(transition: &TestRunTransition) -> Vec<ContractDiagnostic> {
+    let mut diagnostics = Vec::new();
+
+    if transition.format.as_str() != TEST_RUN_TRANSITION_FORMAT {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_101",
+            "transition.format",
+            "unsupported release-transition format marker",
+        ));
+    }
+    if transition.format_version != TEST_RUN_TRANSITION_FORMAT_VERSION {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_102",
+            "transition.formatVersion",
+            "unsupported release-transition format version",
+        ));
+    }
+
+    if transition.sequence == 0 {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_152",
+            "transition.sequence",
+            "transition sequence must be at least one",
+        ));
+    }
+    check_safe_integer(transition.sequence, "transition.sequence", &mut diagnostics);
+    match &transition.previous {
+        Some(_) if transition.sequence == 1 => {
+            diagnostics.push(ContractDiagnostic::error(
+                "VIZE_MARQUETTE_153",
+                "transition.previous",
+                "genesis transition must not name a predecessor",
+            ));
+        }
+        Some(previous) => check_digest(previous, "transition.previous", &mut diagnostics),
+        None if transition.sequence > 1 => diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_153",
+            "transition.previous",
+            "transition must name its predecessor",
+        )),
+        None => {}
+    }
+    check_timestamp(
+        &transition.decided_at,
+        "transition.decidedAt",
+        &mut diagnostics,
+    );
+
+    let candidate = &transition.candidate;
+    check_identifier(
+        &candidate.application,
+        "transition.candidate.application",
+        &mut diagnostics,
+    );
+    check_identifier(
+        &candidate.environment,
+        "transition.candidate.environment",
+        &mut diagnostics,
+    );
+    check_digest(
+        &candidate.contract_fingerprint,
+        "transition.candidate.contractFingerprint",
+        &mut diagnostics,
+    );
+    check_source_revision(
+        &candidate.source_revision,
+        "transition.candidate.sourceRevision",
+        &mut diagnostics,
+    );
+    if candidate.release.is_empty() || candidate.release.len() > 256 {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_106",
+            "transition.candidate.release",
+            "release must be between 1 and 256 characters",
+        ));
+    }
+    check_digest(
+        &candidate.artifact_fingerprint,
+        "transition.candidate.artifactFingerprint",
+        &mut diagnostics,
+    );
+
+    if parse_test_run_admission_id(&transition.evidence).is_none() {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_141",
+            "transition.evidence",
+            "transition evidence must be test-run: followed by 64 lowercase hexadecimal characters",
+        ));
+    }
+    validate_accepted(transition, &mut diagnostics);
+    validate_decision(transition, &mut diagnostics);
+
+    diagnostics.sort_by(|left, right| {
+        (&left.path, left.code, &left.message).cmp(&(&right.path, right.code, &right.message))
+    });
+    diagnostics
+}
+
+fn validate_accepted(transition: &TestRunTransition, diagnostics: &mut Vec<ContractDiagnostic>) {
+    let accepted = &transition.accepted;
+    if accepted.len() > TEST_RUN_TRANSITION_MAX_ACCEPTED {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_131",
+            "transition.accepted",
+            "transition must accept at most 4096 admission ids",
+        ));
+    }
+    if accepted
+        .iter()
+        .any(|id| parse_test_run_admission_id(id).is_none())
+    {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_141",
+            "transition.accepted",
+            "accepted admission ids must be test-run: followed by 64 lowercase hexadecimal characters",
+        ));
+    }
+    if accepted.windows(2).any(|pair| pair[0] >= pair[1]) {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_154",
+            "transition.accepted",
+            "accepted admission ids must be sorted and unique",
+        ));
+    }
+    if transition.decision.allowed && !accepted.contains(&transition.evidence) {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_156",
+            "transition.accepted",
+            "an allowed transition must accept its own evidence",
+        ));
+    }
+}
+
+fn validate_decision(transition: &TestRunTransition, diagnostics: &mut Vec<ContractDiagnostic>) {
+    let decision = &transition.decision;
+    if decision.allowed && (!decision.denial_codes.is_empty() || !decision.diagnostics.is_empty()) {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_155",
+            "transition.decision",
+            "an allowed decision must carry no diagnostics",
+        ));
+    }
+    if !decision.allowed && decision.diagnostics.is_empty() {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_155",
+            "transition.decision",
+            "a denied decision must carry its diagnostics",
+        ));
+    }
+    if decision.diagnostics.iter().any(|diagnostic| {
+        !diagnostic
+            .code
+            .strip_prefix("VIZE_MARQUETTE_")
+            .is_some_and(|digits| {
+                digits.len() == 3 && digits.bytes().all(|byte| byte.is_ascii_digit())
+            })
+    }) {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_155",
+            "transition.decision",
+            "diagnostic codes must be stable VIZE_MARQUETTE codes",
+        ));
+    }
+    let sorted = decision.diagnostics.windows(2).all(|pair| {
+        (&pair[0].path, &pair[0].code, &pair[0].message)
+            <= (&pair[1].path, &pair[1].code, &pair[1].message)
+    });
+    if !sorted {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_155",
+            "transition.decision",
+            "decision diagnostics must be sorted by path, code, and message",
+        ));
+    }
+    let mut recomputed: Vec<TestRunDenialCode> = decision
+        .diagnostics
+        .iter()
+        .map(|diagnostic| denial_code_for(&diagnostic.code, &diagnostic.path))
+        .collect();
+    recomputed.sort_unstable();
+    recomputed.dedup();
+    if decision.denial_codes != recomputed {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_155",
+            "transition.decision",
+            "denial codes must match the published diagnostic mapping",
+        ));
+    }
+}
+
+/// Verifies one release transition against the durable chain tip.
+///
+/// `previous` is the retained, already-verified predecessor — `None` only
+/// when deciding the very first transition of a chain. The transition must
+/// validate structurally, extend the predecessor's sequence, fingerprint,
+/// scope, and decision time exactly, never re-accept evidence the
+/// predecessor already accepted, and carry an accepted state equal to the
+/// predecessor's state plus exactly the newly accepted evidence (unchanged
+/// for a denial). Any diagnostic rejects the transition: a conforming host
+/// must not persist it, and on recovery must discard a tip this function
+/// rejects. Diagnostics, denial codes, and ordering are identical in every
+/// host family, as pinned by the shared transition-decision fixtures.
+pub fn verify_test_run_transition(
+    transition: &TestRunTransition,
+    previous: Option<&TestRunTransition>,
+) -> TestRunAdmissionDecision {
+    let mut diagnostics = validate_test_run_transition(transition);
+
+    let mut prior_accepted: &[String] = &[];
+    match previous {
+        None => {
+            if transition.sequence != 1 {
+                diagnostics.push(ContractDiagnostic::error(
+                    "VIZE_MARQUETTE_157",
+                    "transition.sequence",
+                    "transition requires its predecessor to verify",
+                ));
+            }
+        }
+        Some(previous) => {
+            prior_accepted = &previous.accepted;
+            if transition.sequence != previous.sequence.saturating_add(1) {
+                diagnostics.push(ContractDiagnostic::error(
+                    "VIZE_MARQUETTE_157",
+                    "transition.sequence",
+                    "transition must extend its predecessor's sequence",
+                ));
+            }
+            match test_run_transition_fingerprint(previous) {
+                Ok(fingerprint) => {
+                    if transition.previous.as_deref() != Some(fingerprint.as_str()) {
+                        diagnostics.push(ContractDiagnostic::error(
+                            "VIZE_MARQUETTE_157",
+                            "transition.previous",
+                            "transition must name its predecessor's canonical fingerprint",
+                        ));
+                    }
+                }
+                Err(_) => diagnostics.push(ContractDiagnostic::error(
+                    "VIZE_MARQUETTE_157",
+                    "transition.previous",
+                    "predecessor could not be canonically fingerprinted",
+                )),
+            }
+            for (recorded, expected, path) in [
+                (
+                    &transition.candidate.application,
+                    &previous.candidate.application,
+                    "transition.candidate.application",
+                ),
+                (
+                    &transition.candidate.environment,
+                    &previous.candidate.environment,
+                    "transition.candidate.environment",
+                ),
+            ] {
+                if recorded != expected {
+                    diagnostics.push(ContractDiagnostic::error(
+                        "VIZE_MARQUETTE_157",
+                        path,
+                        "transition must stay within its predecessor's scope",
+                    ));
+                }
+            }
+            if is_strict_timestamp_value(&transition.decided_at)
+                && is_strict_timestamp_value(&previous.decided_at)
+                && transition.decided_at < previous.decided_at
+            {
+                diagnostics.push(ContractDiagnostic::error(
+                    "VIZE_MARQUETTE_157",
+                    "transition.decidedAt",
+                    "transition must not predate its predecessor",
+                ));
+            }
+            if transition.decision.allowed && previous.accepted.contains(&transition.evidence) {
+                diagnostics.push(ContractDiagnostic::error(
+                    "VIZE_MARQUETTE_158",
+                    "transition.evidence",
+                    "accepted evidence must not be accepted again",
+                ));
+            }
+        }
+    }
+
+    let mut expected: Vec<String> = prior_accepted.to_vec();
+    if transition.decision.allowed {
+        expected.push(transition.evidence.clone());
+    }
+    expected.sort_unstable();
+    expected.dedup();
+    if transition.accepted != expected {
+        diagnostics.push(ContractDiagnostic::error(
+            "VIZE_MARQUETTE_159",
+            "transition.accepted",
+            "accepted state must equal its predecessor's state plus exactly the newly accepted evidence",
+        ));
+    }
+
+    diagnostics.sort_by(|left, right| {
+        (&left.path, left.code, &left.message).cmp(&(&right.path, right.code, &right.message))
+    });
+    decision_from_diagnostics(diagnostics)
+}

--- a/crates/vize_marquette/src/test_run/transition/tests.rs
+++ b/crates/vize_marquette/src/test_run/transition/tests.rs
@@ -1,0 +1,162 @@
+use vize_carton::String;
+
+use crate::test_run::decision::TestRunDenialCode;
+use crate::test_run::model_tests::example_evidence;
+
+use super::super::admission::TestRunCandidate;
+use super::*;
+
+fn admission_id(fill: char) -> String {
+    let mut id = String::from("test-run:");
+    for _ in 0..64 {
+        id.push(fill);
+    }
+    id
+}
+
+fn example_candidate() -> TestRunCandidate {
+    let evidence = example_evidence();
+    TestRunCandidate {
+        application: evidence.application,
+        environment: evidence.environment,
+        contract_fingerprint: evidence.contract_fingerprint,
+        source_revision: evidence.source_revision,
+        release: evidence.release,
+        artifact_fingerprint: evidence.artifact.fingerprint,
+    }
+}
+
+fn allowed_decision() -> TestRunRetainedDecision {
+    TestRunRetainedDecision {
+        allowed: true,
+        denial_codes: Vec::new(),
+        diagnostics: Vec::new(),
+    }
+}
+
+fn genesis() -> TestRunTransition {
+    TestRunTransition {
+        format: TEST_RUN_TRANSITION_FORMAT.into(),
+        format_version: TEST_RUN_TRANSITION_FORMAT_VERSION,
+        sequence: 1,
+        previous: None,
+        decided_at: "2026-07-21T00:12:00.000Z".into(),
+        candidate: example_candidate(),
+        evidence: admission_id('a'),
+        decision: allowed_decision(),
+        accepted: vec![admission_id('a')],
+    }
+}
+
+fn next(previous: &TestRunTransition, evidence: String) -> TestRunTransition {
+    let mut accepted = previous.accepted.clone();
+    accepted.push(evidence.clone());
+    accepted.sort_unstable();
+    accepted.dedup();
+    TestRunTransition {
+        sequence: previous.sequence + 1,
+        previous: Some(test_run_transition_fingerprint(previous).unwrap()),
+        decided_at: "2026-07-22T00:00:00.000Z".into(),
+        evidence,
+        accepted,
+        ..previous.clone()
+    }
+}
+
+#[test]
+fn an_atomic_chain_verifies_transition_by_transition() {
+    let first = genesis();
+    assert_eq!(validate_test_run_transition(&first), Vec::new());
+    let opening = verify_test_run_transition(&first, None);
+    assert!(opening.allowed);
+
+    let second = next(&first, admission_id('b'));
+    let extension = verify_test_run_transition(&second, Some(&first));
+    assert!(extension.allowed);
+    assert_eq!(extension.diagnostics, Vec::new());
+}
+
+#[test]
+fn a_denied_decision_preserves_the_accepted_state() {
+    let first = genesis();
+    let mut denial = next(&first, admission_id('c'));
+    denial.decision = TestRunRetainedDecision {
+        allowed: false,
+        denial_codes: vec![TestRunDenialCode::RecordExpired],
+        diagnostics: vec![TestRunRetainedDiagnostic {
+            code: "VIZE_MARQUETTE_145".into(),
+            severity: crate::DiagnosticSeverity::Error,
+            path: "validUntil".into(),
+            message: "record is expired at the admission time".into(),
+        }],
+    };
+    denial.accepted = first.accepted.clone();
+    assert!(verify_test_run_transition(&denial, Some(&first)).allowed);
+}
+
+#[test]
+fn replayed_evidence_cannot_be_accepted_again() {
+    let first = genesis();
+    let mut replay = next(&first, admission_id('a'));
+    replay.accepted = first.accepted.clone();
+    let decision = verify_test_run_transition(&replay, Some(&first));
+    assert!(!decision.allowed);
+    assert_eq!(
+        decision.denial_codes,
+        [TestRunDenialCode::TransitionReplayed]
+    );
+}
+
+#[test]
+fn partial_and_split_states_fail_closed() {
+    let first = genesis();
+
+    let mut partial = next(&first, admission_id('b'));
+    partial.accepted = first.accepted.clone();
+    assert_eq!(
+        verify_test_run_transition(&partial, Some(&first)).denial_codes,
+        [TestRunDenialCode::TransitionStateMismatch]
+    );
+
+    let mut split = next(&first, admission_id('b'));
+    split.previous = Some(crate::test_run::model_tests::filled('9', 64));
+    assert_eq!(
+        verify_test_run_transition(&split, Some(&first)).denial_codes,
+        [TestRunDenialCode::TransitionChainBroken]
+    );
+}
+
+#[test]
+fn structural_faults_are_transition_invalid() {
+    let mut broken = genesis();
+    broken.format = "vize.release.log".into();
+    broken.accepted = vec![admission_id('b'), admission_id('a')];
+    let decision = verify_test_run_transition(&broken, None);
+    assert!(!decision.allowed);
+    assert_eq!(
+        decision.denial_codes,
+        [
+            TestRunDenialCode::TransitionInvalid,
+            TestRunDenialCode::TransitionStateMismatch,
+        ]
+    );
+}
+
+#[test]
+fn canonicalization_is_order_independent_and_binding() {
+    let first = genesis();
+    let second = next(&first, admission_id('b'));
+    let mut shuffled = second.clone();
+    shuffled.accepted.reverse();
+    assert_eq!(
+        canonical_test_run_transition_json(&second).unwrap(),
+        canonical_test_run_transition_json(&shuffled).unwrap()
+    );
+
+    let mut tampered = second.clone();
+    tampered.accepted.remove(0);
+    assert_ne!(
+        test_run_transition_fingerprint(&second).unwrap(),
+        test_run_transition_fingerprint(&tampered).unwrap()
+    );
+}

--- a/crates/vize_marquette/src/test_run/validate/rules.rs
+++ b/crates/vize_marquette/src/test_run/validate/rules.rs
@@ -59,7 +59,7 @@ pub(crate) fn check_timestamp(value: &str, path: &str, diagnostics: &mut Vec<Con
 }
 
 /// Rejects integers that lose precision in a consuming language.
-pub(super) fn check_safe_integer(
+pub(crate) fn check_safe_integer(
     value: u64,
     path: &str,
     diagnostics: &mut Vec<ContractDiagnostic>,

--- a/crates/vize_marquette/tests/test_run_conformance.rs
+++ b/crates/vize_marquette/tests/test_run_conformance.rs
@@ -6,9 +6,9 @@
 use std::{fs, path::PathBuf};
 
 use vize_marquette::{
-    TestRunCandidate, TestRunCheck, TestRunEvidence, canonical_test_run_json,
+    TestRunCandidate, TestRunCheck, TestRunEvidence, TestRunTransition, canonical_test_run_json,
     decide_test_run_admission, parse_test_run_admission_id, test_run_admission_id,
-    test_run_fingerprint, verify_test_run_check,
+    test_run_fingerprint, verify_test_run_check, verify_test_run_transition,
 };
 
 fn fixture(name: &str) -> PathBuf {
@@ -74,6 +74,31 @@ fn reproduces_every_shared_admission_decision() {
             case["admissionId"].as_str().unwrap(),
             case["now"].as_str().unwrap(),
         );
+        assert!(case["decision"].is_object(), "{name} must pin a decision");
+        assert_eq!(
+            serde_json::to_value(&decision).unwrap(),
+            case["decision"],
+            "decision mismatch for case {name}",
+        );
+    }
+}
+
+#[test]
+fn reproduces_every_shared_transition_decision() {
+    let document: serde_json::Value =
+        serde_json::from_slice(&fs::read(fixture("transition-decisions.json")).unwrap()).unwrap();
+    let transitions = &document["transitions"];
+    let load = |name: &str| -> TestRunTransition {
+        serde_json::from_value(transitions[name].clone()).unwrap()
+    };
+    let cases = document["cases"].as_array().unwrap();
+    assert!(!cases.is_empty());
+
+    for case in cases {
+        let name = case["name"].as_str().unwrap();
+        let current = load(case["current"].as_str().unwrap());
+        let previous = case["previous"].as_str().map(load);
+        let decision = verify_test_run_transition(&current, previous.as_ref());
         assert!(case["decision"].is_object(), "{name} must pin a decision");
         assert_eq!(
             serde_json::to_value(&decision).unwrap(),

--- a/crates/vize_marquette/tests/test_run_schema.rs
+++ b/crates/vize_marquette/tests/test_run_schema.rs
@@ -94,6 +94,35 @@ fn admission_schema_is_strict_and_documents_the_append_only_policy() {
 }
 
 #[test]
+fn transition_schema_is_strict_and_carries_the_durability_contract() {
+    let schema: Value = serde_json::from_slice(
+        &fs::read(repository_file(
+            "crates/vize_marquette/schema/test-run-transition.schema.json",
+        ))
+        .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        schema["$schema"],
+        "https://json-schema.org/draft/2020-12/schema"
+    );
+    assert_eq!(
+        schema["$defs"]["transition"]["properties"]["format"]["const"],
+        "vize.test-run.transition"
+    );
+    let description = schema["description"].as_str().unwrap();
+    assert!(description.contains("atomically rename or commit"));
+    assert!(description.contains("discard - never repair"));
+
+    assert_eq!(
+        count_open_object_schemas(&schema),
+        0,
+        "every object schema must reject unknown properties"
+    );
+}
+
+#[test]
 fn check_schema_is_strict_and_rejects_generic_references() {
     let schema: Value = serde_json::from_slice(
         &fs::read(repository_file(

--- a/npm/marquette/README.md
+++ b/npm/marquette/README.md
@@ -101,6 +101,7 @@ import { validateTestRunEvidence } from "@vizejs/marquette/test-run/validate";
 import { testRunAdmissionId } from "@vizejs/marquette/test-run/canonical";
 import { admitTestRun, decideTestRunAdmission } from "@vizejs/marquette/test-run/admission";
 import { verifyTestRunCheck } from "@vizejs/marquette/test-run/check";
+import { verifyTestRunTransition } from "@vizejs/marquette/test-run/transition";
 
 const diagnostics = validateTestRunEvidence(evidence);
 const admissionId = await testRunAdmissionId(evidence); // test-run:<sha256>
@@ -110,6 +111,7 @@ if (!decision.allowed) {
   console.error(decision.denialCodes); // e.g. ["record-expired"]
 }
 const release = await verifyTestRunCheck(retainedCheck, candidate, evidence, now);
+const journal = await verifyTestRunTransition(nextTransition, chainTip);
 ```
 
 Validation shares its `VIZE_MARQUETTE_1xx` codes, paths, and ordering with the
@@ -122,9 +124,14 @@ identical machine-readable causes. The check entry replaces every generic
 test-result reference in release evidence: a retained `vize.test-run.check`
 record may only name the exact `test-run:<sha256>` admission id, bind the six
 candidate facts, and record an observer independent from the runner. The
-published record schema is available from `@vizejs/marquette/test-run/schema`,
-the decision contract from `@vizejs/marquette/test-run/admission/schema`, and
-the tests-check contract from `@vizejs/marquette/test-run/check/schema`.
+transition entry makes each release decision and the complete accepted
+anti-replay state one durable atomic record, chained by canonical SHA-256
+fingerprints; hosts persist it with a write-then-atomic-rename and verify the
+recovered tip before deciding anything new. The published record schema is
+available from `@vizejs/marquette/test-run/schema`, the decision contract from
+`@vizejs/marquette/test-run/admission/schema`, the tests-check contract from
+`@vizejs/marquette/test-run/check/schema`, and the transition contract from
+`@vizejs/marquette/test-run/transition/schema`.
 
 ## Guarantees
 

--- a/npm/marquette/package.json
+++ b/npm/marquette/package.json
@@ -61,10 +61,16 @@
       "import": "./dist/test-run-check.mjs",
       "default": "./dist/test-run-check.mjs"
     },
+    "./test-run/transition": {
+      "types": "./dist/test-run-transition.d.mts",
+      "import": "./dist/test-run-transition.mjs",
+      "default": "./dist/test-run-transition.mjs"
+    },
     "./schema": "./dist/application-contract.schema.json",
     "./test-run/schema": "./dist/test-run-evidence.schema.json",
     "./test-run/admission/schema": "./dist/test-run-admission.schema.json",
-    "./test-run/check/schema": "./dist/test-run-check.schema.json"
+    "./test-run/check/schema": "./dist/test-run-check.schema.json",
+    "./test-run/transition/schema": "./dist/test-run-transition.schema.json"
   },
   "publishConfig": {
     "access": "public"

--- a/npm/marquette/scripts/check-size.mjs
+++ b/npm/marquette/scripts/check-size.mjs
@@ -32,6 +32,11 @@ const budgets = [
     file: "dist/test-run-check.mjs",
     maximumGzipBytes: 3072,
   },
+  {
+    entry: "@vizejs/marquette/test-run/transition",
+    file: "dist/test-run-transition.mjs",
+    maximumGzipBytes: 4096,
+  },
 ];
 
 for (const { entry, file, maximumGzipBytes } of budgets) {

--- a/npm/marquette/src/test-run-admission.ts
+++ b/npm/marquette/src/test-run-admission.ts
@@ -167,6 +167,10 @@ export const TEST_RUN_DENIAL_CODES = [
   "record-expired",
   "record-invalid",
   "skipped-tests-recorded",
+  "transition-chain-broken",
+  "transition-invalid",
+  "transition-replayed",
+  "transition-state-mismatch",
   "verification-not-accepted",
 ] as const;
 
@@ -207,8 +211,11 @@ const CANDIDATE_MISMATCH_CODES: ReadonlyMap<string, TestRunDenialCode> = new Map
  * `VIZE_MARQUETTE_141` through `VIZE_MARQUETTE_148` map to their exact
  * cause, `VIZE_MARQUETTE_144` distinguishes the mismatched candidate binding
  * by its diagnostic path, `VIZE_MARQUETTE_149` through `VIZE_MARQUETTE_151`
- * map to their tests-check cause, every other diagnostic at a `check.` path
- * is a `check-invalid` tests-check validation failure, and every remaining
+ * map to their tests-check cause, `VIZE_MARQUETTE_156` through
+ * `VIZE_MARQUETTE_159` map to their transition cause, every other
+ * diagnostic at a `check.` path is a `check-invalid` tests-check validation
+ * failure, every other diagnostic at a `transition.` path is a
+ * `transition-invalid` transition validation failure, and every remaining
  * diagnostic is a `record-invalid` record-validation failure.
  */
 export function testRunDenialCode(diagnostic: MarquetteDiagnostic): TestRunDenialCode {
@@ -238,10 +245,21 @@ export function testRunDenialCode(diagnostic: MarquetteDiagnostic): TestRunDenia
       return "check-invalid";
     case "VIZE_MARQUETTE_151":
       return "check-observer-not-independent";
+    case "VIZE_MARQUETTE_156":
+      return "transition-state-mismatch";
+    case "VIZE_MARQUETTE_157":
+      return "transition-chain-broken";
+    case "VIZE_MARQUETTE_158":
+      return "transition-replayed";
+    case "VIZE_MARQUETTE_159":
+      return "transition-state-mismatch";
     default:
       break;
   }
-  return diagnostic.path.startsWith("check.") ? "check-invalid" : "record-invalid";
+  if (diagnostic.path.startsWith("check.")) {
+    return "check-invalid";
+  }
+  return diagnostic.path.startsWith("transition.") ? "transition-invalid" : "record-invalid";
 }
 
 /**

--- a/npm/marquette/src/test-run-transition-model.ts
+++ b/npm/marquette/src/test-run-transition-model.ts
@@ -1,0 +1,156 @@
+import type { MarquetteDiagnosticSeverity } from "./validate.js";
+import type { TestRunCandidate, TestRunDenialCode } from "./test-run-admission.js";
+
+/**
+ * Serialized `format` marker for release-transition records.
+ *
+ * Readers must reject any other value before trusting the record.
+ */
+export const TEST_RUN_TRANSITION_FORMAT = "vize.test-run.transition";
+
+/**
+ * Current serialized release-transition format.
+ *
+ * Readers must reject a higher value until they explicitly support it.
+ */
+export const TEST_RUN_TRANSITION_FORMAT_VERSION = 1;
+
+/** Maximum admission ids one transition may carry as accepted state. */
+export const TEST_RUN_TRANSITION_MAX_ACCEPTED = 4096;
+
+/**
+ * One retained diagnostic inside a durable transition record.
+ *
+ * The shape and serialization match live diagnostics exactly; the retained
+ * form is plain data so persisted records can be read back by any host.
+ */
+export interface TestRunRetainedDiagnostic {
+  /** Stable machine-readable diagnostic code. */
+  readonly code: string;
+  /** Severity recorded for the diagnostic; any diagnostic denies. */
+  readonly severity: MarquetteDiagnosticSeverity;
+  /** JSON-style path into the decided input. */
+  readonly path: string;
+  /** Human-readable explanation recorded with the decision. */
+  readonly message: string;
+}
+
+/**
+ * One retained allow-or-deny decision inside a durable transition record.
+ *
+ * The shape and serialization match live decisions exactly. Validation
+ * rejects a retained decision whose `allowed` flag, denial codes, or
+ * diagnostic ordering disagree with the published mapping, so a record
+ * cannot claim an outcome its own diagnostics contradict.
+ */
+export interface TestRunRetainedDecision {
+  /** Whether the release decision admitted the candidate. */
+  readonly allowed: boolean;
+  /** Deduplicated denial causes sorted lexicographically; empty if allowed. */
+  readonly denialCodes: readonly TestRunDenialCode[];
+  /** Complete diagnostics in the stable path, code, message order. */
+  readonly diagnostics: readonly TestRunRetainedDiagnostic[];
+}
+
+/**
+ * One durable atomic release transition.
+ *
+ * The record binds the decision, the exact candidate and evidence it
+ * decided, and the complete accepted anti-replay state after the decision
+ * into one canonical document. `sequence` grows by exactly one per
+ * transition and `previous` names the predecessor's canonical SHA-256
+ * fingerprint, so a chain tip proves the entire decision history and the
+ * accepted set can never drift from the decision that produced it.
+ *
+ * Host durability contract: write the complete canonical bytes to a
+ * temporary location, flush them to durable storage, then atomically rename
+ * or commit so exactly one complete chain tip exists at every instant; on
+ * recovery, verify the tip against its retained predecessor with
+ * {@link verifyTestRunTransition} before deciding anything new, and discard
+ * — never repair — a torn or partial record.
+ */
+export interface TestRunTransition {
+  /** Serialized format marker; always {@link TEST_RUN_TRANSITION_FORMAT}. */
+  readonly format: typeof TEST_RUN_TRANSITION_FORMAT;
+  /**
+   * Serialized format version.
+   *
+   * Defaults to {@link TEST_RUN_TRANSITION_FORMAT_VERSION}.
+   */
+  readonly formatVersion?: typeof TEST_RUN_TRANSITION_FORMAT_VERSION;
+  /** One-based position of this transition in its chain. */
+  readonly sequence: number;
+  /** Canonical fingerprint of the predecessor; `null` only at genesis. */
+  readonly previous: string | null;
+  /** Millisecond-precision UTC instant the decision was made. */
+  readonly decidedAt: string;
+  /** Exact candidate the decision was made for. */
+  readonly candidate: TestRunCandidate;
+  /** Exact `test-run:<sha256>` admission id the decision evaluated. */
+  readonly evidence: string;
+  /** Retained decision exactly as it was produced. */
+  readonly decision: TestRunRetainedDecision;
+  /**
+   * Complete anti-replay state after this transition: every admission id
+   * ever accepted in this chain, sorted and unique.
+   */
+  readonly accepted: readonly string[];
+}
+
+/**
+ * Serializes a release transition canonically.
+ *
+ * Property order matches the record schema and the accepted state sorts
+ * lexicographically after deduplication, so equivalent transitions produce
+ * byte-identical JSON in every language. These are the exact bytes a host
+ * must write atomically and the exact bytes the chain fingerprint covers.
+ * Call validation before trusting the record; canonicalization does not
+ * make an invalid record valid.
+ */
+export function canonicalTestRunTransitionJson(transition: TestRunTransition): string {
+  const canonical = {
+    format: transition.format,
+    formatVersion: transition.formatVersion ?? TEST_RUN_TRANSITION_FORMAT_VERSION,
+    sequence: transition.sequence,
+    previous: transition.previous,
+    decidedAt: transition.decidedAt,
+    candidate: {
+      application: transition.candidate.application,
+      environment: transition.candidate.environment,
+      contractFingerprint: transition.candidate.contractFingerprint,
+      sourceRevision: transition.candidate.sourceRevision,
+      release: transition.candidate.release,
+      artifactFingerprint: transition.candidate.artifactFingerprint,
+    },
+    evidence: transition.evidence,
+    decision: {
+      allowed: transition.decision.allowed,
+      denialCodes: [...new Set(transition.decision.denialCodes)].sort(),
+      diagnostics: transition.decision.diagnostics.map((diagnostic) => ({
+        code: diagnostic.code,
+        severity: diagnostic.severity,
+        path: diagnostic.path,
+        message: diagnostic.message,
+      })),
+    },
+    accepted: [...new Set(transition.accepted)].sort(),
+  };
+  return JSON.stringify(canonical);
+}
+
+/**
+ * Returns the lowercase SHA-256 fingerprint of the canonical transition.
+ *
+ * The fingerprint is the exact value the successor transition must name as
+ * `previous`, forming the durable chain. Uses the Web Crypto API available
+ * in every supported runtime.
+ */
+export async function testRunTransitionFingerprint(transition: TestRunTransition): Promise<string> {
+  const bytes = new TextEncoder().encode(canonicalTestRunTransitionJson(transition));
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
+  let fingerprint = "";
+  for (const byte of new Uint8Array(digest)) {
+    fingerprint += byte.toString(16).padStart(2, "0");
+  }
+  return fingerprint;
+}

--- a/npm/marquette/src/test-run-transition-rules.ts
+++ b/npm/marquette/src/test-run-transition-rules.ts
@@ -1,0 +1,131 @@
+import type { MarquetteDiagnostic } from "./validate.js";
+import { testRunDenialCode } from "./test-run-admission.js";
+import { parseTestRunAdmissionId } from "./test-run-canonical.js";
+import {
+  TEST_RUN_TRANSITION_MAX_ACCEPTED,
+  type TestRunRetainedDiagnostic,
+  type TestRunTransition,
+} from "./test-run-transition-model.js";
+import { error } from "./test-run-validate-rules.js";
+
+/** Validates the accepted anti-replay state carried by one transition. */
+export function validateAccepted(
+  transition: TestRunTransition,
+  diagnostics: MarquetteDiagnostic[],
+): void {
+  const accepted = transition.accepted;
+  if (accepted.length > TEST_RUN_TRANSITION_MAX_ACCEPTED) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_131",
+        "transition.accepted",
+        "transition must accept at most 4096 admission ids",
+      ),
+    );
+  }
+  if (accepted.some((id) => parseTestRunAdmissionId(id) === undefined)) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_141",
+        "transition.accepted",
+        "accepted admission ids must be test-run: followed by 64 lowercase hexadecimal characters",
+      ),
+    );
+  }
+  if (accepted.some((id, index) => index > 0 && (accepted[index - 1] as string) >= id)) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_154",
+        "transition.accepted",
+        "accepted admission ids must be sorted and unique",
+      ),
+    );
+  }
+  if (transition.decision.allowed && !accepted.includes(transition.evidence)) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_156",
+        "transition.accepted",
+        "an allowed transition must accept its own evidence",
+      ),
+    );
+  }
+}
+
+const DIAGNOSTIC_CODE = /^VIZE_MARQUETTE_[0-9]{3}$/;
+
+/** Validates the retained decision carried by one transition. */
+export function validateDecision(
+  transition: TestRunTransition,
+  diagnostics: MarquetteDiagnostic[],
+): void {
+  const decision = transition.decision;
+  if (decision.allowed && (decision.denialCodes.length > 0 || decision.diagnostics.length > 0)) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_155",
+        "transition.decision",
+        "an allowed decision must carry no diagnostics",
+      ),
+    );
+  }
+  if (!decision.allowed && decision.diagnostics.length === 0) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_155",
+        "transition.decision",
+        "a denied decision must carry its diagnostics",
+      ),
+    );
+  }
+  if (decision.diagnostics.some((diagnostic) => !DIAGNOSTIC_CODE.test(diagnostic.code))) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_155",
+        "transition.decision",
+        "diagnostic codes must be stable VIZE_MARQUETTE codes",
+      ),
+    );
+  }
+  const sorted = decision.diagnostics.every((diagnostic, index) => {
+    if (index === 0) {
+      return true;
+    }
+    const left = decision.diagnostics[index - 1] as TestRunRetainedDiagnostic;
+    return (
+      left.path < diagnostic.path ||
+      (left.path === diagnostic.path &&
+        (left.code < diagnostic.code ||
+          (left.code === diagnostic.code && left.message <= diagnostic.message)))
+    );
+  });
+  if (!sorted) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_155",
+        "transition.decision",
+        "decision diagnostics must be sorted by path, code, and message",
+      ),
+    );
+  }
+  const recomputed = [
+    ...new Set(
+      decision.diagnostics.map((diagnostic) =>
+        testRunDenialCode(diagnostic as MarquetteDiagnostic),
+      ),
+    ),
+  ].sort();
+  const retained = [...decision.denialCodes];
+  if (
+    recomputed.length !== retained.length ||
+    recomputed.some((code, index) => code !== retained[index])
+  ) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_155",
+        "transition.decision",
+        "denial codes must match the published diagnostic mapping",
+      ),
+    );
+  }
+}

--- a/npm/marquette/src/test-run-transition.test.ts
+++ b/npm/marquette/src/test-run-transition.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import type { TestRunAdmissionDecision } from "./test-run-admission.js";
+import {
+  canonicalTestRunTransitionJson,
+  testRunTransitionFingerprint,
+  validateTestRunTransition,
+  verifyTestRunTransition,
+  type TestRunTransition,
+} from "./test-run-transition.js";
+
+interface SharedTransitionCase {
+  readonly name: string;
+  readonly family: string;
+  readonly current: string;
+  readonly previous: string | null;
+  readonly decision: TestRunAdmissionDecision;
+}
+
+interface SharedTransitionDocument {
+  readonly transitions: Readonly<Record<string, TestRunTransition>>;
+  readonly cases: readonly SharedTransitionCase[];
+}
+
+function readDocument(): SharedTransitionDocument {
+  return JSON.parse(
+    readFileSync(
+      new URL(
+        "../../../tests/fixtures/test-run-evidence/transition-decisions.json",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  ) as SharedTransitionDocument;
+}
+
+function transitionNamed(document: SharedTransitionDocument, name: string): TestRunTransition {
+  const transition = document.transitions[name];
+  assert.ok(transition, `fixture transition ${name} must exist`);
+  return transition;
+}
+
+void test("the fixture chain links by canonical fingerprint", async () => {
+  const document = readDocument();
+  const genesis = transitionNamed(document, "genesis");
+  const second = transitionNamed(document, "second");
+  assert.deepEqual(validateTestRunTransition(genesis), []);
+  assert.equal(second.previous, await testRunTransitionFingerprint(genesis));
+
+  const shuffled = { ...second, accepted: [...second.accepted].reverse() };
+  assert.equal(canonicalTestRunTransitionJson(shuffled), canonicalTestRunTransitionJson(second));
+});
+
+void test("reproduces every shared transition decision", async () => {
+  const document = readDocument();
+  assert.ok(document.cases.length > 0);
+
+  for (const sharedCase of document.cases) {
+    const current = transitionNamed(document, sharedCase.current);
+    const previous =
+      sharedCase.previous === null ? null : transitionNamed(document, sharedCase.previous);
+    const decision = await verifyTestRunTransition(current, previous);
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(decision)),
+      sharedCase.decision,
+      `decision mismatch for case ${sharedCase.name}`,
+    );
+  }
+});

--- a/npm/marquette/src/test-run-transition.ts
+++ b/npm/marquette/src/test-run-transition.ts
@@ -1,0 +1,268 @@
+import type { MarquetteDiagnostic } from "./validate.js";
+import {
+  testRunDenialCode,
+  type TestRunAdmissionDecision,
+  type TestRunDenialCode,
+} from "./test-run-admission.js";
+import { parseTestRunAdmissionId } from "./test-run-canonical.js";
+import {
+  TEST_RUN_TRANSITION_FORMAT,
+  TEST_RUN_TRANSITION_FORMAT_VERSION,
+  testRunTransitionFingerprint,
+  type TestRunTransition,
+} from "./test-run-transition-model.js";
+import { validateAccepted, validateDecision } from "./test-run-transition-rules.js";
+import {
+  checkDigest,
+  checkIdentifier,
+  checkSafeInteger,
+  checkSourceRevision,
+  checkTimestamp,
+  error,
+  isStrictTimestamp,
+} from "./test-run-validate-rules.js";
+
+export {
+  TEST_RUN_TRANSITION_FORMAT,
+  TEST_RUN_TRANSITION_FORMAT_VERSION,
+  TEST_RUN_TRANSITION_MAX_ACCEPTED,
+  canonicalTestRunTransitionJson,
+  testRunTransitionFingerprint,
+  type TestRunRetainedDecision,
+  type TestRunRetainedDiagnostic,
+  type TestRunTransition,
+} from "./test-run-transition-model.js";
+
+/**
+ * Validates one release transition structurally.
+ *
+ * Diagnostics use `transition.` paths and are deterministic and sorted by
+ * path, code, and message. Validation confirms the record alone is
+ * internally coherent — grammar, decision consistency against the published
+ * diagnostic mapping, and an allowed decision accepting its own evidence —
+ * but only {@link verifyTestRunTransition} can confirm the record extends
+ * the durable chain. Codes, paths, messages, and ordering are identical to
+ * the native implementation.
+ */
+export function validateTestRunTransition(transition: TestRunTransition): MarquetteDiagnostic[] {
+  const diagnostics: MarquetteDiagnostic[] = [];
+
+  if ((transition.format as string) !== TEST_RUN_TRANSITION_FORMAT) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_101",
+        "transition.format",
+        "unsupported release-transition format marker",
+      ),
+    );
+  }
+  const version = transition.formatVersion ?? TEST_RUN_TRANSITION_FORMAT_VERSION;
+  if (version !== TEST_RUN_TRANSITION_FORMAT_VERSION) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_102",
+        "transition.formatVersion",
+        "unsupported release-transition format version",
+      ),
+    );
+  }
+
+  if (!Number.isInteger(transition.sequence) || transition.sequence < 1) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_152",
+        "transition.sequence",
+        "transition sequence must be at least one",
+      ),
+    );
+  }
+  checkSafeInteger(transition.sequence, "transition.sequence", diagnostics);
+  if (transition.previous !== null && transition.sequence === 1) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_153",
+        "transition.previous",
+        "genesis transition must not name a predecessor",
+      ),
+    );
+  } else if (transition.previous !== null) {
+    checkDigest(transition.previous, "transition.previous", diagnostics);
+  } else if (transition.sequence > 1) {
+    diagnostics.push(
+      error("VIZE_MARQUETTE_153", "transition.previous", "transition must name its predecessor"),
+    );
+  }
+  checkTimestamp(transition.decidedAt, "transition.decidedAt", diagnostics);
+
+  const candidate = transition.candidate;
+  checkIdentifier(candidate.application, "transition.candidate.application", diagnostics);
+  checkIdentifier(candidate.environment, "transition.candidate.environment", diagnostics);
+  checkDigest(
+    candidate.contractFingerprint,
+    "transition.candidate.contractFingerprint",
+    diagnostics,
+  );
+  checkSourceRevision(candidate.sourceRevision, "transition.candidate.sourceRevision", diagnostics);
+  if (candidate.release.length === 0 || candidate.release.length > 256) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_106",
+        "transition.candidate.release",
+        "release must be between 1 and 256 characters",
+      ),
+    );
+  }
+  checkDigest(
+    candidate.artifactFingerprint,
+    "transition.candidate.artifactFingerprint",
+    diagnostics,
+  );
+
+  if (parseTestRunAdmissionId(transition.evidence) === undefined) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_141",
+        "transition.evidence",
+        "transition evidence must be test-run: followed by 64 lowercase hexadecimal characters",
+      ),
+    );
+  }
+  validateAccepted(transition, diagnostics);
+  validateDecision(transition, diagnostics);
+
+  sortDiagnostics(diagnostics);
+  return diagnostics;
+}
+
+/**
+ * Verifies one release transition against the durable chain tip.
+ *
+ * `previous` is the retained, already-verified predecessor — `null` only
+ * when deciding the very first transition of a chain. The transition must
+ * validate structurally, extend the predecessor's sequence, fingerprint,
+ * scope, and decision time exactly, never re-accept evidence the
+ * predecessor already accepted, and carry an accepted state equal to the
+ * predecessor's state plus exactly the newly accepted evidence (unchanged
+ * for a denial). Any diagnostic rejects the transition: a conforming host
+ * must not persist it, and on recovery must discard a tip this function
+ * rejects. Diagnostics, denial codes, and ordering are identical to the
+ * native implementation, as pinned by the shared transition-decision
+ * fixtures.
+ */
+export async function verifyTestRunTransition(
+  transition: TestRunTransition,
+  previous: TestRunTransition | null,
+): Promise<TestRunAdmissionDecision> {
+  const diagnostics = validateTestRunTransition(transition);
+
+  let priorAccepted: readonly string[] = [];
+  if (previous === null) {
+    if (transition.sequence !== 1) {
+      diagnostics.push(
+        error(
+          "VIZE_MARQUETTE_157",
+          "transition.sequence",
+          "transition requires its predecessor to verify",
+        ),
+      );
+    }
+  } else {
+    priorAccepted = previous.accepted;
+    if (transition.sequence !== previous.sequence + 1) {
+      diagnostics.push(
+        error(
+          "VIZE_MARQUETTE_157",
+          "transition.sequence",
+          "transition must extend its predecessor's sequence",
+        ),
+      );
+    }
+    if (transition.previous !== (await testRunTransitionFingerprint(previous))) {
+      diagnostics.push(
+        error(
+          "VIZE_MARQUETTE_157",
+          "transition.previous",
+          "transition must name its predecessor's canonical fingerprint",
+        ),
+      );
+    }
+    for (const [recorded, expected, path] of [
+      [
+        transition.candidate.application,
+        previous.candidate.application,
+        "transition.candidate.application",
+      ],
+      [
+        transition.candidate.environment,
+        previous.candidate.environment,
+        "transition.candidate.environment",
+      ],
+    ] as const) {
+      if (recorded !== expected) {
+        diagnostics.push(
+          error("VIZE_MARQUETTE_157", path, "transition must stay within its predecessor's scope"),
+        );
+      }
+    }
+    if (
+      isStrictTimestamp(transition.decidedAt) &&
+      isStrictTimestamp(previous.decidedAt) &&
+      transition.decidedAt < previous.decidedAt
+    ) {
+      diagnostics.push(
+        error(
+          "VIZE_MARQUETTE_157",
+          "transition.decidedAt",
+          "transition must not predate its predecessor",
+        ),
+      );
+    }
+    if (transition.decision.allowed && previous.accepted.includes(transition.evidence)) {
+      diagnostics.push(
+        error(
+          "VIZE_MARQUETTE_158",
+          "transition.evidence",
+          "accepted evidence must not be accepted again",
+        ),
+      );
+    }
+  }
+
+  const expected = [
+    ...new Set(
+      transition.decision.allowed ? [...priorAccepted, transition.evidence] : priorAccepted,
+    ),
+  ].sort();
+  const accepted = transition.accepted;
+  if (accepted.length !== expected.length || accepted.some((id, index) => id !== expected[index])) {
+    diagnostics.push(
+      error(
+        "VIZE_MARQUETTE_159",
+        "transition.accepted",
+        "accepted state must equal its predecessor's state plus exactly the newly accepted evidence",
+      ),
+    );
+  }
+
+  sortDiagnostics(diagnostics);
+  const denialCodes: TestRunDenialCode[] = [...new Set(diagnostics.map(testRunDenialCode))].sort();
+  return { allowed: diagnostics.length === 0, denialCodes, diagnostics };
+}
+
+function sortDiagnostics(diagnostics: MarquetteDiagnostic[]): void {
+  diagnostics.sort((left, right) =>
+    left.path !== right.path
+      ? left.path < right.path
+        ? -1
+        : 1
+      : left.code !== right.code
+        ? left.code < right.code
+          ? -1
+          : 1
+        : left.message < right.message
+          ? -1
+          : left.message > right.message
+            ? 1
+            : 0,
+  );
+}

--- a/npm/marquette/vite.config.ts
+++ b/npm/marquette/vite.config.ts
@@ -12,6 +12,7 @@ const contractSchemas = [
   "test-run-evidence.schema.json",
   "test-run-admission.schema.json",
   "test-run-check.schema.json",
+  "test-run-transition.schema.json",
 ];
 
 export default defineConfig({
@@ -33,6 +34,7 @@ export default defineConfig({
       "src/test-run-canonical.ts",
       "src/test-run-admission.ts",
       "src/test-run-check.ts",
+      "src/test-run-transition.ts",
     ],
     format: "esm",
     dts: true,

--- a/tests/fixtures/test-run-evidence/transition-decisions.json
+++ b/tests/fixtures/test-run-evidence/transition-decisions.json
@@ -1,0 +1,453 @@
+{
+  "cases": [
+    {
+      "current": "genesis",
+      "decision": {
+        "allowed": true,
+        "denialCodes": [],
+        "diagnostics": []
+      },
+      "family": "atomic-accept",
+      "name": "atomic-genesis-accept",
+      "previous": null
+    },
+    {
+      "current": "second",
+      "decision": {
+        "allowed": true,
+        "denialCodes": [],
+        "diagnostics": []
+      },
+      "family": "atomic-accept",
+      "name": "atomic-extension-accept",
+      "previous": "genesis"
+    },
+    {
+      "current": "second-retry",
+      "decision": {
+        "allowed": true,
+        "denialCodes": [],
+        "diagnostics": []
+      },
+      "family": "crash-recovery",
+      "name": "recovery-retry-after-torn-write",
+      "previous": "genesis"
+    },
+    {
+      "current": "denied-third",
+      "decision": {
+        "allowed": true,
+        "denialCodes": [],
+        "diagnostics": []
+      },
+      "family": "denied",
+      "name": "denied-decision-preserves-state",
+      "previous": "second"
+    },
+    {
+      "current": "replay-third",
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["transition-replayed"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_158",
+            "message": "accepted evidence must not be accepted again",
+            "path": "transition.evidence",
+            "severity": "error"
+          }
+        ]
+      },
+      "family": "replayed",
+      "name": "replayed-evidence-rejected",
+      "previous": "second"
+    },
+    {
+      "current": "partial-third",
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["transition-state-mismatch"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_156",
+            "message": "an allowed transition must accept its own evidence",
+            "path": "transition.accepted",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_159",
+            "message": "accepted state must equal its predecessor's state plus exactly the newly accepted evidence",
+            "path": "transition.accepted",
+            "severity": "error"
+          }
+        ]
+      },
+      "family": "partial-write",
+      "name": "partial-state-rejected",
+      "previous": "second"
+    },
+    {
+      "current": "split-third",
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["transition-chain-broken"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_157",
+            "message": "transition must name its predecessor's canonical fingerprint",
+            "path": "transition.previous",
+            "severity": "error"
+          }
+        ]
+      },
+      "family": "split-write",
+      "name": "split-stale-tip-rejected",
+      "previous": "second"
+    },
+    {
+      "current": "second",
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["transition-chain-broken", "transition-state-mismatch"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_159",
+            "message": "accepted state must equal its predecessor's state plus exactly the newly accepted evidence",
+            "path": "transition.accepted",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_157",
+            "message": "transition requires its predecessor to verify",
+            "path": "transition.sequence",
+            "severity": "error"
+          }
+        ]
+      },
+      "family": "split-write",
+      "name": "missing-predecessor-rejected",
+      "previous": null
+    },
+    {
+      "current": "cross-scope",
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["transition-chain-broken"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_157",
+            "message": "transition must stay within its predecessor's scope",
+            "path": "transition.candidate.application",
+            "severity": "error"
+          }
+        ]
+      },
+      "family": "cross-scope",
+      "name": "cross-scope-rejected",
+      "previous": "genesis"
+    },
+    {
+      "current": "malformed",
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["transition-invalid"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_107",
+            "message": "timestamp must be a millisecond-precision UTC instant like 2026-01-01T00:00:00.000Z",
+            "path": "transition.decidedAt",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_101",
+            "message": "unsupported release-transition format marker",
+            "path": "transition.format",
+            "severity": "error"
+          }
+        ]
+      },
+      "family": "malformed",
+      "name": "malformed-transition",
+      "previous": null
+    },
+    {
+      "current": "stale-replay",
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["transition-chain-broken", "transition-replayed"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_158",
+            "message": "accepted evidence must not be accepted again",
+            "path": "transition.evidence",
+            "severity": "error"
+          },
+          {
+            "code": "VIZE_MARQUETTE_157",
+            "message": "transition must name its predecessor's canonical fingerprint",
+            "path": "transition.previous",
+            "severity": "error"
+          }
+        ]
+      },
+      "family": "multi-cause",
+      "name": "multi-cause-stale-replay",
+      "previous": "second"
+    }
+  ],
+  "description": "Shared host-side release-transition verification cases. The transitions map forms one fingerprint-linked chain plus hostile variants; each case verifies one current transition against one retained predecessor (or none) and every backend family must produce exactly the pinned decision. The sequence genesis -> second -> denied-third narrates a crash-consistent journal: an accepted decision, a retried write after a simulated torn rename (second-retry), a denial preserving the accepted anti-replay state, and rejected replayed, partial, stale, and cross-scope tips. See crates/vize_marquette/schema/test-run-transition.schema.json for the record contract and the host durability obligations.",
+  "transitions": {
+    "cross-scope": {
+      "accepted": [
+        "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+        "test-run:151c16edbe166ccb54cd0a424ff6f725c82d2c67e9945ec7133a48e87bdbba52"
+      ],
+      "candidate": {
+        "application": "intruder",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decidedAt": "2026-07-22T00:00:00.000Z",
+      "decision": {
+        "allowed": true,
+        "denialCodes": [],
+        "diagnostics": []
+      },
+      "evidence": "test-run:151c16edbe166ccb54cd0a424ff6f725c82d2c67e9945ec7133a48e87bdbba52",
+      "format": "vize.test-run.transition",
+      "formatVersion": 1,
+      "previous": "22d86880f957c51dc603aea071b896d55fb8ee38f58d06028902a8df7dfa7c5f",
+      "sequence": 2
+    },
+    "denied-third": {
+      "accepted": [
+        "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+        "test-run:151c16edbe166ccb54cd0a424ff6f725c82d2c67e9945ec7133a48e87bdbba52"
+      ],
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decidedAt": "2026-07-22T03:00:00.000Z",
+      "decision": {
+        "allowed": false,
+        "denialCodes": ["record-expired"],
+        "diagnostics": [
+          {
+            "code": "VIZE_MARQUETTE_145",
+            "message": "record is expired at the admission time",
+            "path": "validUntil",
+            "severity": "error"
+          }
+        ]
+      },
+      "evidence": "test-run:d47ac1c117d5e81af4207211bd8d245b5f592eea1e388b43b1464442b535d68e",
+      "format": "vize.test-run.transition",
+      "formatVersion": 1,
+      "previous": "4092757a88f1afa656ee264b46167a8917dc1c3610e8f83129bc3aba2223ae4c",
+      "sequence": 3
+    },
+    "genesis": {
+      "accepted": ["test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b"],
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decidedAt": "2026-07-21T00:12:00.000Z",
+      "decision": {
+        "allowed": true,
+        "denialCodes": [],
+        "diagnostics": []
+      },
+      "evidence": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+      "format": "vize.test-run.transition",
+      "formatVersion": 1,
+      "previous": null,
+      "sequence": 1
+    },
+    "malformed": {
+      "accepted": ["test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b"],
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decidedAt": "whenever",
+      "decision": {
+        "allowed": true,
+        "denialCodes": [],
+        "diagnostics": []
+      },
+      "evidence": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+      "format": "vize.release.log",
+      "formatVersion": 1,
+      "previous": null,
+      "sequence": 1
+    },
+    "partial-third": {
+      "accepted": [
+        "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+        "test-run:151c16edbe166ccb54cd0a424ff6f725c82d2c67e9945ec7133a48e87bdbba52"
+      ],
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decidedAt": "2026-07-22T03:00:00.000Z",
+      "decision": {
+        "allowed": true,
+        "denialCodes": [],
+        "diagnostics": []
+      },
+      "evidence": "test-run:d47ac1c117d5e81af4207211bd8d245b5f592eea1e388b43b1464442b535d68e",
+      "format": "vize.test-run.transition",
+      "formatVersion": 1,
+      "previous": "4092757a88f1afa656ee264b46167a8917dc1c3610e8f83129bc3aba2223ae4c",
+      "sequence": 3
+    },
+    "replay-third": {
+      "accepted": [
+        "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+        "test-run:151c16edbe166ccb54cd0a424ff6f725c82d2c67e9945ec7133a48e87bdbba52"
+      ],
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decidedAt": "2026-07-22T03:00:00.000Z",
+      "decision": {
+        "allowed": true,
+        "denialCodes": [],
+        "diagnostics": []
+      },
+      "evidence": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+      "format": "vize.test-run.transition",
+      "formatVersion": 1,
+      "previous": "4092757a88f1afa656ee264b46167a8917dc1c3610e8f83129bc3aba2223ae4c",
+      "sequence": 3
+    },
+    "second": {
+      "accepted": [
+        "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+        "test-run:151c16edbe166ccb54cd0a424ff6f725c82d2c67e9945ec7133a48e87bdbba52"
+      ],
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decidedAt": "2026-07-22T00:00:00.000Z",
+      "decision": {
+        "allowed": true,
+        "denialCodes": [],
+        "diagnostics": []
+      },
+      "evidence": "test-run:151c16edbe166ccb54cd0a424ff6f725c82d2c67e9945ec7133a48e87bdbba52",
+      "format": "vize.test-run.transition",
+      "formatVersion": 1,
+      "previous": "22d86880f957c51dc603aea071b896d55fb8ee38f58d06028902a8df7dfa7c5f",
+      "sequence": 2
+    },
+    "second-retry": {
+      "accepted": [
+        "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+        "test-run:151c16edbe166ccb54cd0a424ff6f725c82d2c67e9945ec7133a48e87bdbba52"
+      ],
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decidedAt": "2026-07-22T02:00:00.000Z",
+      "decision": {
+        "allowed": true,
+        "denialCodes": [],
+        "diagnostics": []
+      },
+      "evidence": "test-run:151c16edbe166ccb54cd0a424ff6f725c82d2c67e9945ec7133a48e87bdbba52",
+      "format": "vize.test-run.transition",
+      "formatVersion": 1,
+      "previous": "22d86880f957c51dc603aea071b896d55fb8ee38f58d06028902a8df7dfa7c5f",
+      "sequence": 2
+    },
+    "split-third": {
+      "accepted": [
+        "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+        "test-run:151c16edbe166ccb54cd0a424ff6f725c82d2c67e9945ec7133a48e87bdbba52",
+        "test-run:d47ac1c117d5e81af4207211bd8d245b5f592eea1e388b43b1464442b535d68e"
+      ],
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decidedAt": "2026-07-22T03:00:00.000Z",
+      "decision": {
+        "allowed": true,
+        "denialCodes": [],
+        "diagnostics": []
+      },
+      "evidence": "test-run:d47ac1c117d5e81af4207211bd8d245b5f592eea1e388b43b1464442b535d68e",
+      "format": "vize.test-run.transition",
+      "formatVersion": 1,
+      "previous": "22d86880f957c51dc603aea071b896d55fb8ee38f58d06028902a8df7dfa7c5f",
+      "sequence": 3
+    },
+    "stale-replay": {
+      "accepted": [
+        "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+        "test-run:151c16edbe166ccb54cd0a424ff6f725c82d2c67e9945ec7133a48e87bdbba52"
+      ],
+      "candidate": {
+        "application": "example",
+        "artifactFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+        "contractFingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+        "environment": "production",
+        "release": "0.298.0",
+        "sourceRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "decidedAt": "2026-07-22T03:00:00.000Z",
+      "decision": {
+        "allowed": true,
+        "denialCodes": [],
+        "diagnostics": []
+      },
+      "evidence": "test-run:05d50948dac24df4c92e3ab6c67d96461fced0f28373d06e9a06755b2a40a85b",
+      "format": "vize.test-run.transition",
+      "formatVersion": 1,
+      "previous": "22d86880f957c51dc603aea071b896d55fb8ee38f58d06028902a8df7dfa7c5f",
+      "sequence": 3
+    }
+  }
+}


### PR DESCRIPTION
## Design

A release gate that admits test runs (#3233, #3242) must persist its decision and the anti-replay state that decision accepted; written separately, a crash between the writes loses an accepted decision or lets an admission id be accepted twice. This PR makes them one durable atomic transition:

- **`vize.test-run.transition`** (`TestRunTransition`, `schema/test-run-transition.schema.json`, published as `@vizejs/marquette/test-run/transition/schema`): monotonic `sequence`, `previous` canonical SHA-256 chain link (null only at genesis), `decidedAt`, the six candidate facts, the decided `evidence` id, the retained decision (`TestRunRetainedDecision`/`TestRunRetainedDiagnostic`, serialized identically to live decisions and checked against the published mapping), and `accepted` — the complete sorted anti-replay state, inside the same record.
- **`verify_test_run_transition` / `verifyTestRunTransition`**: fail-closed against the retained chain tip. Sequence, predecessor fingerprint, scope, and decision-time must chain exactly (`VIZE_MARQUETTE_157` → `transition-chain-broken`); an allowed transition must not re-accept evidence in the predecessor's state (`158` → `transition-replayed`); `accepted` must equal the predecessor's state plus exactly the newly accepted evidence, unchanged for a denial (`156`/`159` → `transition-state-mismatch`, catching both partial-write directions); structural faults at `transition.*` paths map to `transition-invalid`. Canonical bytes (`canonical_test_run_transition_json`) and fingerprints are byte-identical across hosts.
- **Host durability contract** (schema description + docs): write the complete canonical bytes to a temporary location, flush, atomically rename/commit so exactly one complete chain tip exists at every instant; on recovery verify the tip against its predecessor before deciding anything new; discard — never repair — torn records. Because decision and state are one document, no crash point can separate them.
- **Vocabulary**: `transition-chain-broken`, `transition-invalid`, `transition-replayed`, `transition-state-mismatch` added in lexicographic position (append-only preserved; 20 codes total), with new diagnostics `VIZE_MARQUETTE_152`–`159` and the `transition.`-path mapping rule in both hosts and the schema.

## Fixture coverage

`tests/fixtures/test-run-evidence/transition-decisions.json` pins a fingerprint-linked chain and 11 verification cases executed byte-equivalently by `crates/vize_marquette/tests/test_run_conformance.rs` and `npm/marquette/src/test-run-transition.test.ts`: atomic genesis and extension accepts, recovery retry after a simulated torn write, denied decision preserving state, replayed evidence, partial state (decision without state), stale-tip split write, missing predecessor, cross-scope tip, malformed transition, and a multi-cause `[transition-chain-broken, transition-replayed]` decision. The TS suite also proves the fixture's `previous` links equal its own recomputed fingerprints.

## Verification

- `cargo test -p vize_marquette` (69 tests incl. doctest), `cargo fmt --all -- --check`, `cargo clippy -p vize_marquette --all-targets -- -D warnings` clean.
- `vp run --filter './npm/marquette' check build test`: 35 tests green, lint/format/typecheck clean, all five schemas emitted; new transition entry is 3,306 / 4,096 gzip bytes and every existing budget holds.
- Export resolution verified from a consumer: `@vizejs/marquette/test-run/transition` and `.../transition/schema` resolve, and the 20-code vocabulary matches the published schema enum exactly.

Part of #3145 — completes its delivery sequence.
Fixes #3246

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->