### PR TITLE
test(glyph): treat wrapped bare-identifier bindings as parse-preserving

### DIFF
--- a/tests/tooling/glyph-corpus-parse-preservation.test.ts
+++ b/tests/tooling/glyph-corpus-parse-preservation.test.ts
@@ -133,6 +133,18 @@ test("glyph corpus parse-preservation comparator flags structural corruption", (
     ),
     [],
   );
+  // Collapsing whitespace wrapped around a bare-identifier binding is a
+  // legitimate reprint. Vue fast-paths the clean identifier to `ast: null` but
+  // attaches a Babel Identifier to the wrapped form, so the signature must
+  // treat both as the same expression rather than flag a false violation.
+  assert.deepEqual(
+    compareFile(
+      '<template>\n  <Widget\n    v-model:pos="\n      buttonPosition\n    "\n  />\n</template>\n',
+      '<template>\n  <Widget v-model:pos="buttonPosition" />\n</template>\n',
+      "App.vue",
+    ),
+    [],
+  );
   // Dropping an attribute is corruption.
   assert.match(
     compareFile(


### PR DESCRIPTION
The corpus-wide `glyph corpus parse-preservation` property (added in #3255) reported a false positive on `vue-vben-admin`'s `preferences-drawer.vue`, where a `v-model` value is wrapped across lines:

```vue
v-model:app-preferences-button-position="
  appPreferencesButtonPosition
"
```

`vize fmt` correctly collapses this to a clean single-line identifier, but the signature machinery flagged it as corruption:

```
["dir","model",["app-preferences-button-position",true],{"name":"appPreferencesButtonPosition","type":"Identifier"},[]]
  -> ["dir","model",["app-preferences-button-position",true],"appPreferencesButtonPosition",[]]
```

## Root cause

`@vue/compiler-sfc` fast-paths a clean lone identifier to `ast: null`, so `expressionSignature` signs it via its whitespace-stripped text branch as `"appPreferencesButtonPosition"`. When surrounding whitespace defeats that fast path (the wrapped form), Vue attaches a Babel `Identifier` node, so the same expression signs as the structured object `{name, type:"Identifier"}`. The two encodings of an identical identifier are not comparable, so the reprint reads as corruption. Only lone identifiers are affected: member and compound expressions get a Babel node in both forms and already compare equal.

## What this PR now contains

The `expressionSignature` fix (signing a bare top-level `Identifier` as its name so both parses agree) landed on `main` independently, because #3255 merged before its CI failure could be addressed on the original branch. After rebasing onto latest `main`, that change is already present, so this PR now contributes only the **machinery regression test** in `glyph-corpus-parse-preservation.test.ts`: a wrapped `v-model:pos` bare-identifier collapsing to single-line must yield `[]` diffs, locking the wrapped-identifier collapse as parse-preserving so the false positive cannot regress.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comparison handling for formatted Vue bindings with surrounding whitespace.
  * Prevented false structural-difference reports when equivalent binding expressions are formatted differently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->