### PR TITLE
test(glyph): parse-preservation false positive on bare identifier expressions

### DIFF
--- a/tests/tooling/support/babel-expression-signature.ts
+++ b/tests/tooling/support/babel-expression-signature.ts
@@ -12,12 +12,23 @@ export type ExpressionNode = { content: string; isStatic?: boolean; ast?: unknow
  * Expression equivalence: prefer the Babel AST the Vue parser attaches.
  * Static args compare as text; unparsed expressions fall back to text
  * stripped of whitespace, which cannot distinguish whitespace inside string
- * literals but never rejects a legitimate reprint.
+ * literals but never rejects a legitimate reprint. Vue skips Babel entirely
+ * for simple identifiers, and formatting can turn a multiline identifier
+ * expression into that fast path, so a bare-identifier AST must produce the
+ * same signature as the no-AST text fallback.
  */
 export function expressionSignature(expression: ExpressionNode): unknown {
   if (expression.isStatic === true) return expression.content;
   if (expression.ast != null && typeof expression.ast === "object") {
-    return babelSignature(unwrapSingleExpressionProgram(expression.ast));
+    const unwrapped = unwrapSingleExpressionProgram(expression.ast) as {
+      type?: string;
+      name?: string;
+      typeAnnotation?: unknown;
+    };
+    if (unwrapped.type === "Identifier" && unwrapped.typeAnnotation == null) {
+      return unwrapped.name;
+    }
+    return babelSignature(unwrapped);
   }
   return expression.content.replace(/\s+/g, "");
 }


### PR DESCRIPTION
Unbreaks the `vue-parity` lane after #3255: the corpus parse-preservation suite flags `vue-vben-admin`'s `preferences-drawer.vue` because a multiline `v-model` expression carries a Babel AST before formatting while the formatted single-line identifier takes Vue's no-Babel fast path, so an AST signature was compared against the stripped-text fallback.

A bare-identifier AST (no type annotation) now produces the same signature as the no-AST text fallback — the identifier name — so both parse paths of the same expression agree, while any actual identifier change still differs.

Verified locally with a release binary over 11 hydrated projects (create-vue, element-plus, misskey, mint-ui, pinia, shadcn-vue, vitepress, vue-element-admin, vue-router, vue-vben-admin, vux; 9,128 SFCs): all three glyph corpus property suites pass 10/10 with only the tracked skip-list entries (#3247-#3252), including the vue-vben-admin file the parity lane failed on.

Fixes #3261

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->