### PR TITLE
fix(glyph): align default attribute order with vue/attribute-order

### DIFF
--- a/crates/vize_glyph/src/template.rs
+++ b/crates/vize_glyph/src/template.rs
@@ -13,6 +13,9 @@ mod directives;
 mod formatter;
 mod helpers;
 
+#[cfg(test)]
+mod attribute_priority_tests;
+
 use crate::{error::FormatError, options::FormatOptions};
 use vize_carton::String;
 
@@ -38,9 +41,8 @@ pub fn format_template_content(
 
 #[cfg(test)]
 mod tests {
-    use super::{attributes, directives, format_template_content, formatter, helpers};
+    use super::{directives, format_template_content, formatter, helpers};
     use crate::options::{AttributeSortOrder, FormatOptions};
-    use attributes::attribute_priority;
     use directives::{custom_attribute_priority, format_v_for_expression, matches_attr_pattern};
     use formatter::format_interpolations;
     use helpers::{is_tag_name_char, is_void_element_str};
@@ -333,40 +335,6 @@ mod tests {
         let result = format_template_content(source, &options).unwrap();
 
         insta::assert_snapshot!(result.as_str());
-    }
-
-    #[test]
-    fn test_attribute_priority_order() {
-        // Group order mirrors patina's vue/attribute-order (#3251).
-        assert!(attribute_priority("is") < attribute_priority("v-for"));
-        assert!(attribute_priority("v-for") < attribute_priority("v-if"));
-        // Conditionals are one group: v-if, v-else-if, v-else, v-show, v-cloak.
-        assert_eq!(attribute_priority("v-if"), attribute_priority("v-show"));
-        assert_eq!(attribute_priority("v-if"), attribute_priority("v-cloak"));
-        // Render modifiers sit between conditionals and id.
-        assert!(attribute_priority("v-show") < attribute_priority("v-pre"));
-        assert_eq!(attribute_priority("v-pre"), attribute_priority("v-once"));
-        assert!(attribute_priority("v-once") < attribute_priority("id"));
-        assert!(attribute_priority("id") < attribute_priority("ref"));
-        assert_eq!(attribute_priority("ref"), attribute_priority(":key"));
-        assert!(attribute_priority(":key") < attribute_priority("v-model"));
-        // Slots and custom directives precede plain attributes and bindings.
-        assert!(attribute_priority("v-model") < attribute_priority("#default"));
-        assert_eq!(
-            attribute_priority("#default"),
-            attribute_priority("v-tooltip")
-        );
-        assert!(attribute_priority("v-tooltip") < attribute_priority(":class"));
-        // :class and class share the same priority so they stay adjacent;
-        // patina treats :ref and :id as plain bindings.
-        assert_eq!(attribute_priority(":class"), attribute_priority("class"));
-        assert_eq!(attribute_priority(":style"), attribute_priority("style"));
-        assert_eq!(attribute_priority(":ref"), attribute_priority(":class"));
-        assert_eq!(attribute_priority(":id"), attribute_priority(":class"));
-        // Events come after attributes, content comes last.
-        assert!(attribute_priority("class") < attribute_priority("@click"));
-        assert!(attribute_priority("@click") < attribute_priority("v-html"));
-        assert_eq!(attribute_priority("v-html"), attribute_priority("v-text"));
     }
 
     // ---------------------------------------------------------------

--- a/crates/vize_glyph/src/template.rs
+++ b/crates/vize_glyph/src/template.rs
@@ -337,20 +337,36 @@ mod tests {
 
     #[test]
     fn test_attribute_priority_order() {
+        // Group order mirrors patina's vue/attribute-order (#3251).
         assert!(attribute_priority("is") < attribute_priority("v-for"));
         assert!(attribute_priority("v-for") < attribute_priority("v-if"));
-        assert!(attribute_priority("v-if") < attribute_priority("v-show"));
-        assert!(attribute_priority("v-show") < attribute_priority("id"));
+        // Conditionals are one group: v-if, v-else-if, v-else, v-show, v-cloak.
+        assert_eq!(attribute_priority("v-if"), attribute_priority("v-show"));
+        assert_eq!(attribute_priority("v-if"), attribute_priority("v-cloak"));
+        // Render modifiers sit between conditionals and id.
+        assert!(attribute_priority("v-show") < attribute_priority("v-pre"));
+        assert_eq!(attribute_priority("v-pre"), attribute_priority("v-once"));
+        assert!(attribute_priority("v-once") < attribute_priority("id"));
         assert!(attribute_priority("id") < attribute_priority("ref"));
-        assert!(attribute_priority("ref") < attribute_priority(":key"));
+        assert_eq!(attribute_priority("ref"), attribute_priority(":key"));
         assert!(attribute_priority(":key") < attribute_priority("v-model"));
-        assert!(attribute_priority("v-model") < attribute_priority(":class"));
-        // :class and class share the same priority so they stay adjacent
+        // Slots and custom directives precede plain attributes and bindings.
+        assert!(attribute_priority("v-model") < attribute_priority("#default"));
+        assert_eq!(
+            attribute_priority("#default"),
+            attribute_priority("v-tooltip")
+        );
+        assert!(attribute_priority("v-tooltip") < attribute_priority(":class"));
+        // :class and class share the same priority so they stay adjacent;
+        // patina treats :ref and :id as plain bindings.
         assert_eq!(attribute_priority(":class"), attribute_priority("class"));
         assert_eq!(attribute_priority(":style"), attribute_priority("style"));
+        assert_eq!(attribute_priority(":ref"), attribute_priority(":class"));
+        assert_eq!(attribute_priority(":id"), attribute_priority(":class"));
+        // Events come after attributes, content comes last.
         assert!(attribute_priority("class") < attribute_priority("@click"));
-        assert!(attribute_priority("@click") < attribute_priority("#default"));
-        assert!(attribute_priority("#default") < attribute_priority("v-html"));
+        assert!(attribute_priority("@click") < attribute_priority("v-html"));
+        assert_eq!(attribute_priority("v-html"), attribute_priority("v-text"));
     }
 
     // ---------------------------------------------------------------

--- a/crates/vize_glyph/src/template/attribute_priority_tests.rs
+++ b/crates/vize_glyph/src/template/attribute_priority_tests.rs
@@ -1,0 +1,39 @@
+//! Unit coverage for `attribute_priority`'s patina `vue/attribute-order` group
+//! ordering. Kept in its own file so the already-large `template.rs` stays
+//! within the source-file-length budget (#3251).
+
+use super::attributes::attribute_priority;
+
+#[test]
+fn test_attribute_priority_order() {
+    // Group order mirrors patina's vue/attribute-order (#3251).
+    assert!(attribute_priority("is") < attribute_priority("v-for"));
+    assert!(attribute_priority("v-for") < attribute_priority("v-if"));
+    // Conditionals are one group: v-if, v-else-if, v-else, v-show, v-cloak.
+    assert_eq!(attribute_priority("v-if"), attribute_priority("v-show"));
+    assert_eq!(attribute_priority("v-if"), attribute_priority("v-cloak"));
+    // Render modifiers sit between conditionals and id.
+    assert!(attribute_priority("v-show") < attribute_priority("v-pre"));
+    assert_eq!(attribute_priority("v-pre"), attribute_priority("v-once"));
+    assert!(attribute_priority("v-once") < attribute_priority("id"));
+    assert!(attribute_priority("id") < attribute_priority("ref"));
+    assert_eq!(attribute_priority("ref"), attribute_priority(":key"));
+    assert!(attribute_priority(":key") < attribute_priority("v-model"));
+    // Slots and custom directives precede plain attributes and bindings.
+    assert!(attribute_priority("v-model") < attribute_priority("#default"));
+    assert_eq!(
+        attribute_priority("#default"),
+        attribute_priority("v-tooltip")
+    );
+    assert!(attribute_priority("v-tooltip") < attribute_priority(":class"));
+    // :class and class share the same priority so they stay adjacent;
+    // patina treats :ref and :id as plain bindings.
+    assert_eq!(attribute_priority(":class"), attribute_priority("class"));
+    assert_eq!(attribute_priority(":style"), attribute_priority("style"));
+    assert_eq!(attribute_priority(":ref"), attribute_priority(":class"));
+    assert_eq!(attribute_priority(":id"), attribute_priority(":class"));
+    // Events come after attributes, content comes last.
+    assert!(attribute_priority("class") < attribute_priority("@click"));
+    assert!(attribute_priority("@click") < attribute_priority("v-html"));
+    assert_eq!(attribute_priority("v-html"), attribute_priority("v-text"));
+}

--- a/crates/vize_glyph/src/template/attribute_priority_tests.rs
+++ b/crates/vize_glyph/src/template/attribute_priority_tests.rs
@@ -37,3 +37,27 @@ fn test_attribute_priority_order() {
     assert!(attribute_priority("@click") < attribute_priority("v-html"));
     assert_eq!(attribute_priority("v-html"), attribute_priority("v-text"));
 }
+
+#[test]
+fn custom_directives_are_not_matched_by_builtin_prefixes() {
+    // `v-models`/`v-onboarding`/`v-binding` are custom directives, not the
+    // built-ins `v-model`/`v-on`/`v-bind`, so they must land in OtherDirectives
+    // (7), the same group as any other unmatched `v-` directive.
+    let other_directives = attribute_priority("v-tooltip");
+    assert_eq!(attribute_priority("v-models"), other_directives);
+    assert_eq!(attribute_priority("v-onboarding"), other_directives);
+    assert_eq!(attribute_priority("v-binding"), other_directives);
+    // Valid argument/modifier forms of the built-ins still match.
+    assert_eq!(
+        attribute_priority("v-model"),
+        attribute_priority("v-model.trim")
+    );
+    assert_eq!(
+        attribute_priority("v-on:click"),
+        attribute_priority("@click")
+    );
+    assert_eq!(
+        attribute_priority(":class"),
+        attribute_priority("v-bind:class")
+    );
+}

--- a/crates/vize_glyph/src/template/attributes.rs
+++ b/crates/vize_glyph/src/template/attributes.rs
@@ -99,60 +99,45 @@ fn attr_sort_key(name: &str, merge_bind: bool) -> (u8, String) {
 
 /// Attribute sort priority mirroring patina's `vue/attribute-order` groups
 /// (the eslint-plugin-vue `vue/attributes-order` default), so default fmt
-/// output can never introduce that lint finding (#3251):
+/// output can never introduce that lint finding (#3251). Patina quirks are
+/// mirrored on purpose: `:ref`/`:id` are plain bindings, only `:key`/`:is`
+/// are special, and unmatched directives (`v-is`, `v-memo`) join the slots.
 ///
-/// 0. Definition: `is` / `:is`
-/// 1. List rendering: `v-for`
-/// 2. Conditionals: `v-if` / `v-else-if` / `v-else` / `v-show` / `v-cloak`
-/// 3. Render modifiers: `v-pre` / `v-once`
-/// 4. Global awareness: `id`
-/// 5. Unique attributes: `ref` / `key` / `:key`
-/// 6. Two-way binding: `v-model`
-/// 7. Other directives: `v-slot` / `#xxx` and custom (or unmatched built-in)
-///    directives such as `v-is` and `v-memo` -- exactly the names patina
-///    buckets as OtherDirectives.
-/// 8. Other attributes: everything bound or static that is not matched above.
-///    Bound (`:class`) and static (`class`) share the priority so related
-///    pairs stay adjacent; patina's quirks are mirrored on purpose (`:ref`
-///    and `:id` are plain bindings, only `:key`/`:is` are special).
-/// 9. Events: `@xxx` / `v-on`
-/// 10. Content: `v-html` / `v-text`
+/// 0 `is`/`:is`; 1 `v-for`; 2 conditionals `v-if`/`v-else-if`/`v-else`/
+/// `v-show`/`v-cloak`; 3 render modifiers `v-pre`/`v-once`; 4 `id`; 5 unique
+/// `ref`/`key`/`:key`; 6 `v-model`; 7 other directives `v-slot`/`#xxx`; 8 other
+/// attributes (bound `:class` and static `class` share a priority); 9 events
+/// `@xxx`/`v-on`; 10 content `v-html`/`v-text`.
 pub(crate) fn attribute_priority(name: &str) -> u8 {
-    if name == "is" || name == ":is" || name == "v-bind:is" {
+    if matches!(name, "is" | ":is" | "v-bind:is") {
         return 0;
     }
     if name == "v-for" {
         return 1;
     }
-    if name == "v-if"
-        || name == "v-else-if"
-        || name == "v-else"
-        || name == "v-show"
-        || name == "v-cloak"
-    {
+    if matches!(name, "v-if" | "v-else-if" | "v-else" | "v-show" | "v-cloak") {
         return 2;
     }
-    if name == "v-pre" || name == "v-once" {
+    if matches!(name, "v-pre" | "v-once") {
         return 3;
     }
     if name == "id" {
         return 4;
     }
-    if name == "ref" || name == "key" || name == ":key" || name == "v-bind:key" {
+    if matches!(name, "ref" | "key" | ":key" | "v-bind:key") {
         return 5;
     }
     if name.starts_with("v-model") {
         return 6;
     }
-    if name == "v-html" || name == "v-text" {
+    if matches!(name, "v-html" | "v-text") {
         return 10;
     }
-    // Events (checked before the generic directive fallback; `v-once` was
-    // matched above so the `v-on` prefix cannot swallow it).
+    // Events precede the directive fallback so `v-on` cannot swallow `v-once`.
     if name.starts_with('@') || name.starts_with("v-on") {
         return 9;
     }
-    // Slots and every other directive form patina calls OtherDirectives.
+    // Slots and every other directive form are patina's OtherDirectives.
     if name.starts_with('#') || name.starts_with("v-slot") {
         return 7;
     }

--- a/crates/vize_glyph/src/template/attributes.rs
+++ b/crates/vize_glyph/src/template/attributes.rs
@@ -97,59 +97,73 @@ fn attr_sort_key(name: &str, merge_bind: bool) -> (u8, String) {
     }
 }
 
-/// Attribute sort priority based on the Vue.js style guide:
+/// Attribute sort priority mirroring patina's `vue/attribute-order` groups
+/// (the eslint-plugin-vue `vue/attributes-order` default), so default fmt
+/// output can never introduce that lint finding (#3251):
 ///
-/// 0. `is`
-/// 1. `v-for`
-/// 2. `v-if` / `v-else-if` / `v-else`
-/// 3. `v-show`
-/// 4. `id`
-/// 5. `ref`
-/// 6. `key` / `:key`
-/// 7. `v-model`
-/// 8. props & attributes -- both bound (`:class`) and static (`class`) share the
-///    same priority so that related pairs like `class`/`:class` stay adjacent.
-/// 9. events (`@xxx`)
-/// 10. `v-slot` / `#xxx`
-/// 11. `v-html` / `v-text`
+/// 0. Definition: `is` / `:is`
+/// 1. List rendering: `v-for`
+/// 2. Conditionals: `v-if` / `v-else-if` / `v-else` / `v-show` / `v-cloak`
+/// 3. Render modifiers: `v-pre` / `v-once`
+/// 4. Global awareness: `id`
+/// 5. Unique attributes: `ref` / `key` / `:key`
+/// 6. Two-way binding: `v-model`
+/// 7. Other directives: `v-slot` / `#xxx` and custom (or unmatched built-in)
+///    directives such as `v-is` and `v-memo` -- exactly the names patina
+///    buckets as OtherDirectives.
+/// 8. Other attributes: everything bound or static that is not matched above.
+///    Bound (`:class`) and static (`class`) share the priority so related
+///    pairs stay adjacent; patina's quirks are mirrored on purpose (`:ref`
+///    and `:id` are plain bindings, only `:key`/`:is` are special).
+/// 9. Events: `@xxx` / `v-on`
+/// 10. Content: `v-html` / `v-text`
 pub(crate) fn attribute_priority(name: &str) -> u8 {
-    if name == "is" || name == ":is" || name == "v-is" {
+    if name == "is" || name == ":is" || name == "v-bind:is" {
         return 0;
     }
     if name == "v-for" {
         return 1;
     }
-    if name == "v-if" || name == "v-else-if" || name == "v-else" {
+    if name == "v-if"
+        || name == "v-else-if"
+        || name == "v-else"
+        || name == "v-show"
+        || name == "v-cloak"
+    {
         return 2;
     }
-    if name == "v-show" {
+    if name == "v-pre" || name == "v-once" {
         return 3;
     }
     if name == "id" {
         return 4;
     }
-    if name == "ref" {
+    if name == "ref" || name == "key" || name == ":key" || name == "v-bind:key" {
         return 5;
     }
-    if name == "key" || name == ":key" {
+    if name.starts_with("v-model") {
         return 6;
     }
-    if name.starts_with("v-model") {
-        return 7;
+    if name == "v-html" || name == "v-text" {
+        return 10;
     }
-    // Events
+    // Events (checked before the generic directive fallback; `v-once` was
+    // matched above so the `v-on` prefix cannot swallow it).
     if name.starts_with('@') || name.starts_with("v-on") {
         return 9;
     }
-    // Slots
+    // Slots and every other directive form patina calls OtherDirectives.
     if name.starts_with('#') || name.starts_with("v-slot") {
-        return 10;
+        return 7;
     }
-    if name == "v-html" || name == "v-text" {
-        return 11;
+    // Bindings stay with plain attributes (patina: OtherAttrs).
+    if name.starts_with(':') || name.starts_with("v-bind") || name.starts_with('.') {
+        return 8;
     }
-    // Both bound props (:class, :style, :xxx) and regular attributes (class, style, xxx)
-    // share the same priority so that related pairs stay adjacent.
+    if name.starts_with("v-") {
+        return 7;
+    }
+    // Plain attributes (class, style, data-*, ...).
     8
 }
 

--- a/crates/vize_glyph/src/template/attributes.rs
+++ b/crates/vize_glyph/src/template/attributes.rs
@@ -102,13 +102,17 @@ fn attr_sort_key(name: &str, merge_bind: bool) -> (u8, String) {
 /// output can never introduce that lint finding (#3251). Patina quirks are
 /// mirrored on purpose: `:ref`/`:id` are plain bindings, only `:key`/`:is`
 /// are special, and unmatched directives (`v-is`, `v-memo`) join the slots.
-///
 /// 0 `is`/`:is`; 1 `v-for`; 2 conditionals `v-if`/`v-else-if`/`v-else`/
 /// `v-show`/`v-cloak`; 3 render modifiers `v-pre`/`v-once`; 4 `id`; 5 unique
 /// `ref`/`key`/`:key`; 6 `v-model`; 7 other directives `v-slot`/`#xxx`; 8 other
 /// attributes (bound `:class` and static `class` share a priority); 9 events
 /// `@xxx`/`v-on`; 10 content `v-html`/`v-text`.
 pub(crate) fn attribute_priority(name: &str) -> u8 {
+    // Exact directive name or an `:arg`/`.mod` boundary (so `v-models` etc. fall through to 7).
+    fn matches_directive(name: &str, directive: &str) -> bool {
+        name.strip_prefix(directive)
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with([':', '.']))
+    }
     if matches!(name, "is" | ":is" | "v-bind:is") {
         return 0;
     }
@@ -127,14 +131,14 @@ pub(crate) fn attribute_priority(name: &str) -> u8 {
     if matches!(name, "ref" | "key" | ":key" | "v-bind:key") {
         return 5;
     }
-    if name.starts_with("v-model") {
+    if matches_directive(name, "v-model") {
         return 6;
     }
     if matches!(name, "v-html" | "v-text") {
         return 10;
     }
     // Events precede the directive fallback so `v-on` cannot swallow `v-once`.
-    if name.starts_with('@') || name.starts_with("v-on") {
+    if name.starts_with('@') || matches_directive(name, "v-on") {
         return 9;
     }
     // Slots and every other directive form are patina's OtherDirectives.
@@ -142,7 +146,7 @@ pub(crate) fn attribute_priority(name: &str) -> u8 {
         return 7;
     }
     // Bindings stay with plain attributes (patina: OtherAttrs).
-    if name.starts_with(':') || name.starts_with("v-bind") || name.starts_with('.') {
+    if name.starts_with(':') || matches_directive(name, "v-bind") || name.starts_with('.') {
         return 8;
     }
     if name.starts_with("v-") {

--- a/crates/vize_glyph/tests/template_directive_attributes.rs
+++ b/crates/vize_glyph/tests/template_directive_attributes.rs
@@ -19,6 +19,37 @@ fn object_v_bind_stays_between_independently_sorted_attribute_groups() {
 }
 
 #[test]
+fn default_order_matches_patina_vue_attribute_order_groups() {
+    // #3251: default fmt output must satisfy patina's vue/attribute-order.
+    // Custom directives and slots precede plain attributes and bindings,
+    // v-show sits in the conditionals group, and v-once forms the
+    // render-modifier group before id.
+    let options = FormatOptions {
+        print_width: 200,
+        ..FormatOptions::default()
+    };
+
+    let source =
+        r#"<div class="_button" v-tooltip:dialog="tip" v-once v-show="open" id="help"></div>"#;
+    let first = format_template(source, &options).unwrap();
+    let second = format_template(&first, &options).unwrap();
+    assert_eq!(
+        first.as_str(),
+        r#"<div v-show="open" v-once id="help" v-tooltip:dialog="tip" class="_button"></div>"#
+    );
+    assert_eq!(first, second);
+
+    let slotted = r#"<Comp :data="d" #default="{ x }"></Comp>"#;
+    let first = format_template(slotted, &options).unwrap();
+    let second = format_template(&first, &options).unwrap();
+    assert_eq!(
+        first.as_str(),
+        r#"<Comp #default="{ x }" :data="d"></Comp>"#
+    );
+    assert_eq!(first, second);
+}
+
+#[test]
 fn object_v_on_stays_between_independently_sorted_event_groups() {
     let source = r#"<button @keyup="up" @click="click" v-on="listeners" @mouseup="up" @mousedown="down"></button>"#;
     let options = FormatOptions {

--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -145,13 +145,6 @@
   },
   {
     "property": "lint-agreement",
-    "project": "*",
-    "path": "*",
-    "rule": "vue/attribute-order",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3251"
-  },
-  {
-    "property": "lint-agreement",
     "project": "misskey",
     "path": "packages/frontend/src/components/MkAutocomplete.vue",
     "rule": "vue/no-v-html",


### PR DESCRIPTION
Aligns `vize fmt`'s default attribute order with patina's `vue/attribute-order` groups so default formatter output can never introduce that finding. Found at scale by the corpus lint-agreement property (#3238/#3255): formatting the hydrated ecosystem corpus introduced `vue/attribute-order` findings in 578 files (shadcn-vue 440+24, misskey 89, vue-element-admin 16, element-plus 9).

## Policy

Glyph's default order now mirrors patina's canonical group order, which mirrors the eslint-plugin-vue `vue/attributes-order` default — the ecosystem convention. The toolchain's formatter must never violate the toolchain's own default lint, so patina's `AttrCategory` (crates/vize_patina/src/rules/vue/attribute_order.rs) is the source of truth, including its deliberate quirks (`:key`/`:is` are special, `:ref`/`:id` are plain bindings, `v-is`/`v-memo` are other directives). Users who prefer a different order keep the `attribute_groups` formatter config, and `attribute_sort_order: "as-written"` still preserves in-group source order.

## What changed in `attribute_priority`

| | old default | new default (patina groups) |
| --- | --- | --- |
| `v-show` | its own group after conditionals | Conditionals, with `v-if`/`v-else-if`/`v-else` |
| `v-cloak` | other attributes | Conditionals |
| `v-pre` / `v-once` | other attributes (`v-once` even misread as an event via the `v-on` prefix) | RenderModifiers, between Conditionals and `id` |
| `v-slot` / `#x` | after events | OtherDirectives, before other attributes |
| custom directives (`v-tooltip`, ...) | mixed into other attributes | OtherDirectives, before other attributes |
| `v-html` / `v-text` | after slots | Content, last |

Within-group ordering is unchanged (patina does not constrain it): alphabetical by default with the stable original-index tie-break, and spread barriers (`v-bind="obj"` / `v-on="obj"`) still pin every attribute's position relative to object spreads so merge precedence cannot change.

Before (old default output, patina warns on `v-tooltip` after `class`):

```html
<div class="_button _help" v-tooltip:dialog="i18n.ts...forwardDescription">
```

After (patina-clean):

```html
<div v-tooltip:dialog="i18n.ts...forwardDescription" class="_button _help">
```

## Corpus validation (11 hydrated projects, 9,128 SFCs, ci-profile binary)

- The #3251 wildcard waiver is removed from `tests/_fixtures/glyph-corpus-known-violations.json`, so the lint-agreement property now enforces attribute-order harmony corpus-wide: introduced `vue/attribute-order` findings went 578 -> 0 (only the unrelated #3252 `vue/no-v-html` waiver remains).
- Idempotence: green, 9,117 files, unchanged known skips (#3247/#3248).
- Parse-preservation: green, 9,115 files, unchanged known skips (#3247/#3249/#3250) — the property's per-spread-segment multiset comparison is order-agnostic by design, and the vue-router formatter oracle passes unchanged.
- `cargo test -p vize_glyph` (updated `test_attribute_priority_order` expresses the new groups; new `default_order_matches_patina_vue_attribute_order_groups` integration test pins the #3251 repro end to end), `cargo test -p vize`, and `cargo clippy -p vize_glyph -- -D warnings` are green.

Fixes #3251

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Vue template attribute ordering, including additional directive and binding forms.
  * Enhanced handling of Vue slots and related directive patterns for more accurate ordering.

* **Bug Fixes**
  * Corrected ordering of directive groups, including Vue `v-html`/`v-text`, and refined default ordering behavior for common templates.
  * Updated known-violation fixtures to remove an outdated attribute-order entry.

* **Tests**
  * Expanded coverage for Vue attribute priority grouping and verified default ordering is stable (idempotent).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->