### PR TITLE
fix(glyph): reach a fixed point for non-idempotent lightningcss shorthands

### DIFF
--- a/crates/vize_glyph/src/style.rs
+++ b/crates/vize_glyph/src/style.rs
@@ -8,6 +8,11 @@ use crate::options::FormatOptions;
 use lightningcss::stylesheet::{ParserOptions, PrinterOptions, StyleSheet};
 use vize_carton::{String, ToCompactString};
 
+/// Upper bound on lightningcss re-format passes when reaching a fixed point.
+/// A single extra pass fixes the known shorthand-normalization cases; the
+/// bound guards against a pathological non-converging value. (#3248)
+const MAX_STYLE_STABILIZATION_PASSES: usize = 4;
+
 /// Format CSS content using lightningcss.
 ///
 /// Top-level (depth 0) comments are extracted before parsing and re-inserted
@@ -67,6 +72,23 @@ fn format_with_preserved_top_level_comments(
 }
 
 fn format_chunk(trimmed: &str, options: &FormatOptions) -> Result<String, FormatError> {
+    let mut current = format_chunk_once(trimmed, options)?;
+    // lightningcss normalization is not always a fixed point: parsing its own
+    // output can normalize a value further (e.g. collapsing the CSS shorthand
+    // `background-position: 1em 50%` to `1em`, since a missing y-position
+    // defaults to center). Re-run to a fixed point so one `vize fmt` pass
+    // already emits the normal form and the formatter stays idempotent. (#3248)
+    for _ in 1..MAX_STYLE_STABILIZATION_PASSES {
+        let next = format_chunk_once(current.as_str(), options)?;
+        if next.as_str() == current.as_str() {
+            return Ok(next);
+        }
+        current = next;
+    }
+    Ok(current)
+}
+
+fn format_chunk_once(trimmed: &str, options: &FormatOptions) -> Result<String, FormatError> {
     let stylesheet = StyleSheet::parse(trimmed, ParserOptions::default())
         .map_err(|e| FormatError::StyleFormatError(e.to_compact_string()))?;
 
@@ -224,6 +246,22 @@ fn find_comment_end(bytes: &[u8], from: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::{FormatOptions, format_style_content};
+
+    #[test]
+    fn test_background_position_shorthand_reaches_fixed_point_in_one_pass() {
+        // `background-position: left 1em top 50%` is a non-idempotent case for
+        // lightningcss: it first prints `1em 50%`, then a re-parse collapses
+        // the redundant center `50%` to `1em`. The formatter must reach that
+        // normal form in a single `vize fmt` pass. (#3248)
+        let source = ".a { background-position: left 1em top 50%; }";
+        let options = FormatOptions::default();
+        let result = format_style_content(source, &options).unwrap();
+        assert_eq!(result.as_str(), ".a {\n  background-position: 1em;\n}\n");
+
+        // And formatting the result again is a no-op.
+        let again = format_style_content(&result, &options).unwrap();
+        assert_eq!(again, result);
+    }
 
     #[test]
     fn test_format_simple_css() {

--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -60,12 +60,6 @@
     "issue": "https://github.com/ubugeeei-prod/vize/issues/3247"
   },
   {
-    "property": "idempotence",
-    "project": "vux",
-    "path": "src/components/divider/index.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3248"
-  },
-  {
     "property": "parse-preservation",
     "project": "shadcn-vue",
     "path": "apps/v4/registry/bases/reka/ui/chart/ChartStyle.vue",


### PR DESCRIPTION
The corpus idempotence property (#3223) flagged `vux/src/components/divider/index.vue`. Its rule contains `background-position: left 1em top 50%`, which is not a fixed point for lightningcss:

- pass 1 normalizes the edge-offset syntax and prints `background-position: 1em 50%;`
- pass 2 re-parses that and collapses the redundant center `50%`, giving `background-position: 1em;`

So `fmt(fmt(x)) != fmt(x)`, even though every step is CSS-equivalent. The formatter must reach its normal form in one user-visible pass.

The fix re-runs lightningcss to a fixed point (bounded) inside `format_chunk`, mirroring the stabilization loop the script formatter already uses (`format_script_content_stable`):

```rust
fn format_chunk(trimmed: &str, options: &FormatOptions) -> Result<String, FormatError> {
    let mut current = format_chunk_once(trimmed, options)?;
    for _ in 1..MAX_STYLE_STABILIZATION_PASSES {
        let next = format_chunk_once(current.as_str(), options)?;
        if next.as_str() == current.as_str() {
            return Ok(next);
        }
        current = next;
    }
    Ok(current)
}
```

The bound guards against a pathological non-converging value; already-idempotent CSS returns after the confirming second pass with no change.

### Verification
`cargo test -p vize_glyph` passes (108 tests). Added a regression test asserting `background-position: left 1em top 50%` reaches `1em` in a single `format_style_content` call and that re-formatting is a no-op. Removes the divider entry from the corpus known-violations list.

Closes #3248

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS formatting consistency by repeatedly normalizing styles until they reach a stable result.
  * Fixed shorthand declarations, such as `background-position`, so formatting produces canonical output consistently.
  * Removed a previously documented formatting exception that is no longer reproducible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->