### PR TITLE
fix(glyph): consume split closing tags whole in whitespace-significant elements

### DIFF
--- a/crates/vize_glyph/src/template.rs
+++ b/crates/vize_glyph/src/template.rs
@@ -104,6 +104,51 @@ mod tests {
     }
 
     #[test]
+    fn test_pre_split_closing_tag_leaves_no_stray_gt() {
+        // A closing tag split across lines (`</pre\n  >`, the Prettier trick
+        // that keeps a trailing newline out of `<pre>` content) must be
+        // consumed whole. Leaving the trailing `>` behind reprinted it as a
+        // stray text node and changed the rendered output. (#3249)
+        let options = FormatOptions::default();
+
+        let source = "<pre>\npage: {{ x }}</pre\n  >";
+        let result = format_template_content(source, &options).unwrap();
+        assert_eq!(result.as_str(), "<pre>\npage: {{ x }}</pre>");
+        assert_eq!(
+            format_template_content(&result, &options).unwrap(),
+            result,
+            "collapsed close tag must be idempotent"
+        );
+
+        // Same trick on `<textarea>`.
+        let ta = "<textarea>value</textarea\n>";
+        assert_eq!(
+            format_template_content(ta, &options).unwrap().as_str(),
+            "<textarea>value</textarea>"
+        );
+
+        // A whitespace-significant element whose split close tag has no inner
+        // content still round-trips cleanly.
+        let empty_pre = "<pre></pre\n>";
+        assert_eq!(
+            format_template_content(empty_pre, &options).unwrap().as_str(),
+            "<pre></pre>"
+        );
+    }
+
+    #[test]
+    fn test_pre_ordinary_closing_tag_unaffected() {
+        // Regression guard: a normal `</pre>` (no split) is unchanged and the
+        // inner content stays byte-for-byte. (#3249)
+        let options = FormatOptions::default();
+        let source = "<pre>\n  a\n    b</pre>";
+        assert_eq!(
+            format_template_content(source, &options).unwrap().as_str(),
+            source
+        );
+    }
+
+    #[test]
     fn test_empty_element_stays_inline() {
         let source = "<div>\n</div>";
         let options = FormatOptions::default();

--- a/crates/vize_glyph/src/template.rs
+++ b/crates/vize_glyph/src/template.rs
@@ -131,7 +131,9 @@ mod tests {
         // content still round-trips cleanly.
         let empty_pre = "<pre></pre\n>";
         assert_eq!(
-            format_template_content(empty_pre, &options).unwrap().as_str(),
+            format_template_content(empty_pre, &options)
+                .unwrap()
+                .as_str(),
             "<pre></pre>"
         );
     }

--- a/crates/vize_glyph/src/template.rs
+++ b/crates/vize_glyph/src/template.rs
@@ -104,53 +104,6 @@ mod tests {
     }
 
     #[test]
-    fn test_pre_split_closing_tag_leaves_no_stray_gt() {
-        // A closing tag split across lines (`</pre\n  >`, the Prettier trick
-        // that keeps a trailing newline out of `<pre>` content) must be
-        // consumed whole. Leaving the trailing `>` behind reprinted it as a
-        // stray text node and changed the rendered output. (#3249)
-        let options = FormatOptions::default();
-
-        let source = "<pre>\npage: {{ x }}</pre\n  >";
-        let result = format_template_content(source, &options).unwrap();
-        assert_eq!(result.as_str(), "<pre>\npage: {{ x }}</pre>");
-        assert_eq!(
-            format_template_content(&result, &options).unwrap(),
-            result,
-            "collapsed close tag must be idempotent"
-        );
-
-        // Same trick on `<textarea>`.
-        let ta = "<textarea>value</textarea\n>";
-        assert_eq!(
-            format_template_content(ta, &options).unwrap().as_str(),
-            "<textarea>value</textarea>"
-        );
-
-        // A whitespace-significant element whose split close tag has no inner
-        // content still round-trips cleanly.
-        let empty_pre = "<pre></pre\n>";
-        assert_eq!(
-            format_template_content(empty_pre, &options)
-                .unwrap()
-                .as_str(),
-            "<pre></pre>"
-        );
-    }
-
-    #[test]
-    fn test_pre_ordinary_closing_tag_unaffected() {
-        // Regression guard: a normal `</pre>` (no split) is unchanged and the
-        // inner content stays byte-for-byte. (#3249)
-        let options = FormatOptions::default();
-        let source = "<pre>\n  a\n    b</pre>";
-        assert_eq!(
-            format_template_content(source, &options).unwrap().as_str(),
-            source
-        );
-    }
-
-    #[test]
     fn test_empty_element_stays_inline() {
         let source = "<div>\n</div>";
         let options = FormatOptions::default();

--- a/crates/vize_glyph/src/template/formatter.rs
+++ b/crates/vize_glyph/src/template/formatter.rs
@@ -202,6 +202,16 @@ impl<'a> TemplateFormatter<'a> {
                             find_matching_close_tag(source, end_pos, &tag_name)
                         {
                             output.extend_from_slice(&source[end_pos..close_start]);
+                            // If the closing tag is incomplete (no `>`, e.g. an
+                            // unterminated LSP buffer like `<pre>body</pre\n`),
+                            // preserve the remaining source verbatim instead of
+                            // fabricating a `>` and dropping the tail.
+                            let Some(close_offset) = memchr::memchr(b'>', &source[close_start..])
+                            else {
+                                output.extend_from_slice(&source[close_start..]);
+                                pos = len;
+                                continue;
+                            };
                             output.extend_from_slice(b"</");
                             output.extend_from_slice(tag_name.as_bytes());
                             output.push(b'>');
@@ -213,8 +223,7 @@ impl<'a> TemplateFormatter<'a> {
                             // `</tag_name>`. Skipping only the bare length would
                             // leave `  >` behind as a stray text node and change
                             // the rendered output. (#3249)
-                            pos = memchr::memchr(b'>', &source[close_start..])
-                                .map_or(len, |off| close_start + off + 1);
+                            pos = close_start + close_offset + 1;
                             continue;
                         } else {
                             // Unclosed — copy the rest and stop.

--- a/crates/vize_glyph/src/template/formatter.rs
+++ b/crates/vize_glyph/src/template/formatter.rs
@@ -206,8 +206,15 @@ impl<'a> TemplateFormatter<'a> {
                             output.extend_from_slice(tag_name.as_bytes());
                             output.push(b'>');
                             output.extend_from_slice(self.newline);
-                            // Move past `</tag_name>`
-                            pos = close_start + 2 + tag_name.len() + 1;
+                            // The closing tag may carry whitespace before `>`
+                            // (the Prettier `</pre\n  >` trick that keeps the
+                            // trailing newline out of `<pre>` content), so scan
+                            // to the actual `>` rather than assuming a bare
+                            // `</tag_name>`. Skipping only the bare length would
+                            // leave `  >` behind as a stray text node and change
+                            // the rendered output. (#3249)
+                            pos = memchr::memchr(b'>', &source[close_start..])
+                                .map_or(len, |off| close_start + off + 1);
                             continue;
                         } else {
                             // Unclosed — copy the rest and stop.

--- a/crates/vize_glyph/src/template/formatter.rs
+++ b/crates/vize_glyph/src/template/formatter.rs
@@ -19,6 +19,8 @@ use super::{
     },
 };
 
+mod whitespace_significant;
+
 /// High-performance template formatter.
 pub(crate) struct TemplateFormatter<'a> {
     options: &'a FormatOptions,
@@ -192,45 +194,17 @@ impl<'a> TemplateFormatter<'a> {
                         pos = closing_end_pos;
                         continue;
                     } else if is_whitespace_significant_element(&tag_name, &sorted_attrs) {
-                        // `<pre>`, `<textarea>`, and any element with `v-pre`
-                        // are whitespace-significant. Their content must be
-                        // emitted byte-for-byte: a formatter must never
-                        // change rendered output. Find the matching close
-                        // tag and copy the inner source verbatim. (#963)
-                        output.push(b'>');
-                        if let Some(close_start) =
-                            find_matching_close_tag(source, end_pos, &tag_name)
-                        {
-                            output.extend_from_slice(&source[end_pos..close_start]);
-                            // If the closing tag is incomplete (no `>`, e.g. an
-                            // unterminated LSP buffer like `<pre>body</pre\n`),
-                            // preserve the remaining source verbatim instead of
-                            // fabricating a `>` and dropping the tail.
-                            let Some(close_offset) = memchr::memchr(b'>', &source[close_start..])
-                            else {
-                                output.extend_from_slice(&source[close_start..]);
-                                pos = len;
-                                continue;
-                            };
-                            output.extend_from_slice(b"</");
-                            output.extend_from_slice(tag_name.as_bytes());
-                            output.push(b'>');
-                            output.extend_from_slice(self.newline);
-                            // The closing tag may carry whitespace before `>`
-                            // (the Prettier `</pre\n  >` trick that keeps the
-                            // trailing newline out of `<pre>` content), so scan
-                            // to the actual `>` rather than assuming a bare
-                            // `</tag_name>`. Skipping only the bare length would
-                            // leave `  >` behind as a stray text node and change
-                            // the rendered output. (#3249)
-                            pos = close_start + close_offset + 1;
-                            continue;
-                        } else {
-                            // Unclosed — copy the rest and stop.
-                            output.extend_from_slice(&source[end_pos..]);
-                            pos = len;
-                            continue;
-                        }
+                        // Copy `<pre>`/`<textarea>`/`v-pre` content verbatim so
+                        // the formatter never changes rendered output.
+                        // (#963, #3249)
+                        pos = self.copy_whitespace_significant_element(
+                            source,
+                            end_pos,
+                            &tag_name,
+                            len,
+                            &mut output,
+                        );
+                        continue;
                     } else {
                         output.push(b'>');
                         if !is_void {

--- a/crates/vize_glyph/src/template/formatter/whitespace_significant.rs
+++ b/crates/vize_glyph/src/template/formatter/whitespace_significant.rs
@@ -1,0 +1,102 @@
+//! Verbatim emission of whitespace-significant elements (`<pre>`,
+//! `<textarea>`, and any element carrying `v-pre`). Split into its own file so
+//! the already-large `formatter.rs` stays within the source-file-length budget
+//! (#3251).
+
+use super::{TemplateFormatter, find_matching_close_tag};
+
+impl TemplateFormatter<'_> {
+    /// Emit a whitespace-significant element verbatim, returning the source
+    /// offset to resume formatting from.
+    ///
+    /// The opening tag has already been rendered up to (but not including) its
+    /// `>`; `end_pos` points just past that `>` in `source`. The element's
+    /// content must be copied byte-for-byte because a formatter must never
+    /// change rendered output. (#963)
+    pub(super) fn copy_whitespace_significant_element(
+        &self,
+        source: &[u8],
+        end_pos: usize,
+        tag_name: &str,
+        len: usize,
+        output: &mut Vec<u8>,
+    ) -> usize {
+        output.push(b'>');
+        let Some(close_start) = find_matching_close_tag(source, end_pos, tag_name) else {
+            // Unclosed — copy the rest and stop.
+            output.extend_from_slice(&source[end_pos..]);
+            return len;
+        };
+        output.extend_from_slice(&source[end_pos..close_start]);
+        // If the closing tag is incomplete (no `>`, e.g. an unterminated LSP
+        // buffer like `<pre>body</pre\n`), preserve the remaining source
+        // verbatim instead of fabricating a `>` and dropping the tail.
+        let Some(close_offset) = memchr::memchr(b'>', &source[close_start..]) else {
+            output.extend_from_slice(&source[close_start..]);
+            return len;
+        };
+        output.extend_from_slice(b"</");
+        output.extend_from_slice(tag_name.as_bytes());
+        output.push(b'>');
+        output.extend_from_slice(self.newline);
+        // The closing tag may carry whitespace before `>` (the Prettier
+        // `</pre\n  >` trick that keeps the trailing newline out of `<pre>`
+        // content), so scan to the actual `>` rather than assuming a bare
+        // `</tag_name>`. Skipping only the bare length would leave `  >` behind
+        // as a stray text node and change the rendered output. (#3249)
+        close_start + close_offset + 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::options::FormatOptions;
+    use crate::template::format_template_content;
+
+    #[test]
+    fn test_pre_split_closing_tag_leaves_no_stray_gt() {
+        // A closing tag split across lines (`</pre\n  >`, the Prettier trick
+        // that keeps a trailing newline out of `<pre>` content) must be
+        // consumed whole. Leaving the trailing `>` behind reprinted it as a
+        // stray text node and changed the rendered output. (#3249)
+        let options = FormatOptions::default();
+
+        let source = "<pre>\npage: {{ x }}</pre\n  >";
+        let result = format_template_content(source, &options).unwrap();
+        assert_eq!(result.as_str(), "<pre>\npage: {{ x }}</pre>");
+        assert_eq!(
+            format_template_content(&result, &options).unwrap(),
+            result,
+            "collapsed close tag must be idempotent"
+        );
+
+        // Same trick on `<textarea>`.
+        let ta = "<textarea>value</textarea\n>";
+        assert_eq!(
+            format_template_content(ta, &options).unwrap().as_str(),
+            "<textarea>value</textarea>"
+        );
+
+        // A whitespace-significant element whose split close tag has no inner
+        // content still round-trips cleanly.
+        let empty_pre = "<pre></pre\n>";
+        assert_eq!(
+            format_template_content(empty_pre, &options)
+                .unwrap()
+                .as_str(),
+            "<pre></pre>"
+        );
+    }
+
+    #[test]
+    fn test_pre_ordinary_closing_tag_unaffected() {
+        // Regression guard: a normal `</pre>` (no split) is unchanged and the
+        // inner content stays byte-for-byte. (#3249)
+        let options = FormatOptions::default();
+        let source = "<pre>\n  a\n    b</pre>";
+        assert_eq!(
+            format_template_content(source, &options).unwrap().as_str(),
+            source
+        );
+    }
+}

--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -118,11 +118,5 @@
     "project": "shadcn-vue",
     "path": "apps/v4/styles/reka-vega/ui/chart/ChartStyle.vue",
     "issue": "https://github.com/ubugeeei-prod/vize/issues/3247"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "vue-router",
-    "path": "packages/playground-file-based/src/pages/test-params/query.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3249"
   }
 ]


### PR DESCRIPTION
When a closing tag is split across lines (the Prettier `</pre
  >` trick that keeps a trailing newline out of `<pre>` content), the formatter consumed it as a bare `</pre>` of fixed length (`close_start + 2 + tag_name.len() + 1`) and left the trailing `  >` behind as a stray text node, which then rendered a literal `>`. The corpus parse-preservation property (#3223) flagged this on `vue-router`'s `query.vue`.

Fix: scan to the actual `>` that ends the closing tag instead of assuming a bare `</tag>`:

```rust
pos = memchr::memchr(b'>', &source[close_start..])
    .map_or(len, |off| close_start + off + 1);
```

### Verification
`cargo test -p vize_glyph` passes (105 tests). Added tests for the split-close trick on `<pre>` and `<textarea>` (including the empty case), idempotence, and a regression guard that an ordinary `</pre>` and its inner bytes are unchanged. Removes the resolved `vue-router` entry from the corpus known-violations list.

Closes #3249

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed formatting for `<pre>`, `<textarea>`, and `v-pre` content when closing tags contain whitespace before `>`.
  - Prevented stray `>` characters from appearing in formatted output.
  - Preserved unchanged formatting for standard closing tags.

- **Tests**
  - Added regression coverage for split closing tags and formatting idempotence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->