### PR TITLE
fix(patina): anchor no-v-html suppression to the element opening tag

### DIFF
--- a/crates/vize_patina/src/context/directives.rs
+++ b/crates/vize_patina/src/context/directives.rs
@@ -40,6 +40,18 @@ impl LintContext<'_> {
         false
     }
 
+    /// Returns true if `rule_name` is disabled at the line containing
+    /// `offset`.
+    ///
+    /// A rule can anchor a suppression check to a stable offset (for example,
+    /// an element's opening-tag start) so that an `eslint-disable-next-line`
+    /// keeps applying even when the formatter moves the exact diagnostic span
+    /// onto a different line. (#3252)
+    #[inline]
+    pub fn is_rule_disabled_at_offset(&self, rule_name: &str, offset: u32) -> bool {
+        self.is_disabled_at(rule_name, self.offset_to_line(offset))
+    }
+
     /// Disable all rules starting from a line.
     pub fn disable_all(&mut self, start_line: u32, end_line: Option<u32>) {
         self.disabled_all.push(DisabledRange {

--- a/crates/vize_patina/src/rules/vue/no_v_html.rs
+++ b/crates/vize_patina/src/rules/vue/no_v_html.rs
@@ -60,10 +60,21 @@ impl Rule for NoVHtml {
     fn check_directive<'a>(
         &self,
         ctx: &mut LintContext<'a>,
-        _element: &ElementNode<'a>,
+        element: &ElementNode<'a>,
         directive: &DirectiveNode<'a>,
     ) {
         if directive.name == "html" {
+            // An `eslint-disable-next-line vue/no-v-html` is written above the
+            // element, but the formatter may wrap a long opening tag so the
+            // `v-html` attribute no longer lands on the line the suppression
+            // covers. Anchor the suppression to the element's opening-tag
+            // start (which formatting keeps on the line right after the
+            // comment) so the suppression survives and `vize fmt` does not
+            // introduce a finding (lint-agreement, #3252). The diagnostic is
+            // still reported at the precise directive span.
+            if ctx.is_rule_disabled_at_offset(META.name, element.loc.start.offset) {
+                return;
+            }
             ctx.warn_with_help(
                 ctx.t("vue/no-v-html.message"),
                 &directive.loc,
@@ -98,5 +109,37 @@ mod tests {
         let result = linter.lint_template(r#"<div v-html="content"></div>"#, "test.vue");
         assert_eq!(result.warning_count, 1);
         insta::assert_debug_snapshot!(result.diagnostics);
+    }
+
+    #[test]
+    fn test_disable_next_line_suppresses_single_line_element() {
+        // Baseline: the suppression works when the element (and its `v-html`)
+        // sit on the single line right after the comment.
+        let linter = create_linter();
+        let src = "<!-- eslint-disable-next-line vue/no-v-html -->\n<div v-html=\"content\"></div>";
+        let result = linter.lint_template(src, "test.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_disable_next_line_survives_wrapped_opening_tag() {
+        // The formatter wraps a long opening tag, so `v-html` lands several
+        // lines below the element's start. The `eslint-disable-next-line`
+        // above the element must still suppress the finding, otherwise
+        // formatting would introduce a warning (lint-agreement, #3252).
+        let linter = create_linter();
+        let src = "<!-- eslint-disable-next-line vue/no-v-html -->\n<div\n  class=\"a-really-long-class-name\"\n  v-html=\"content\"\n></div>";
+        let result = linter.lint_template(src, "test.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_multiline_v_html_without_suppression_still_warns() {
+        // Regression guard: without a disable comment, a wrapped element with
+        // `v-html` still reports exactly one warning.
+        let linter = create_linter();
+        let src = "<div\n  class=\"a-really-long-class-name\"\n  v-html=\"content\"\n></div>";
+        let result = linter.lint_template(src, "test.vue");
+        assert_eq!(result.warning_count, 1);
     }
 }

--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -136,12 +136,5 @@
     "project": "mint-ui",
     "path": "packages/field/src/field.vue",
     "issue": "https://github.com/ubugeeei-prod/vize/issues/3250"
-  },
-  {
-    "property": "lint-agreement",
-    "project": "misskey",
-    "path": "packages/frontend/src/components/MkAutocomplete.vue",
-    "rule": "vue/no-v-html",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3252"
   }
 ]


### PR DESCRIPTION
The corpus lint-agreement property (#3223) flagged misskey's `MkAutocomplete.vue`: an `<!-- eslint-disable-next-line vue/no-v-html -->` sits above a long `<span … v-html=…>`. `eslint-disable-next-line` only covers the single line after the comment, but `vize fmt` wraps the opening tag so `v-html` moves several lines down. The suppression stops applying and formatting introduces a `vue/no-v-html` finding (0 -> 1).

`vue/no-v-html` reports at the directive's own line (`directive.loc`), which the formatter moves. But the element's opening-tag start (`<span`) stays on the line right after the comment regardless of attribute wrapping. So the fix anchors the suppression check to the element start while still reporting the diagnostic at the precise directive span:

```rust
if directive.name == "html" {
    if ctx.is_rule_disabled_at_offset(META.name, element.loc.start.offset) {
        return;
    }
    ctx.warn_with_help(ctx.t("vue/no-v-html.message"), &directive.loc, ctx.t("vue/no-v-html.help"));
}
```

`is_rule_disabled_at_offset` is a thin wrapper over the existing line-based suppression check. This only ever adds a suppression path anchored at the element; it never changes a diagnostic's position and never introduces a finding, so it can't regress reported spans or snapshots. Blast radius is limited to `vue/no-v-html` when a disable comment sits above a multi-line element.

### Verification
`cargo test -p vize_patina` passes (2210 tests). Added tests: suppression on a single-line element (baseline), suppression surviving a wrapped multi-line opening tag (the bug), and a regression guard that a wrapped `v-html` without a disable comment still warns exactly once. Removes the resolved misskey entry from the corpus known-violations list.

Closes #3252

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->