### PR TITLE
docs: capitalize box ID in testbox helper snippet in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ run_testbox_checks() {
     return "$warmup_status"
   fi
   if [ -z "$BLACKSMITH_TESTBOX_ID" ]; then
-    printf '%s\n' "Testbox warmup returned no box id." >&2
+    printf '%s\n' "Testbox warmup returned no box ID." >&2
     unset BLACKSMITH_TESTBOX_ID testbox_output
     return 1
   fi


### PR DESCRIPTION
## Description
This PR fixes acronym capitalization in `CONTRIBUTING.md`.

## Details
Updated `no box id.` -> `no box ID.` in the testbox error message string within the shell helper snippet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787460222&installation_model_id=422833&pr_number=3273&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F3273&signature=19f1c71bfaa463a5b07276678693a1b7eddb805485dd7ce9f1844d83f76d5fdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the capitalization of “ID” in a Testbox warmup error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->