### PR TITLE
feat(canon): add TypeScript content mapper bridge

### DIFF
--- a/crates/vize/src/cli.rs
+++ b/crates/vize/src/cli.rs
@@ -49,6 +49,9 @@ enum Commands {
     #[cfg(unix)]
     CheckServer(crate::commands::check_server::CheckServerArgs),
 
+    /// Start the experimental TypeScript content-mapper protocol server
+    ContentMapper(crate::commands::content_mapper::ContentMapperArgs),
+
     /// Start component gallery server
     Musea(crate::commands::musea::MuseaArgs),
 
@@ -93,6 +96,7 @@ fn run(cli: Cli) {
         Some(Commands::Clean(args)) => crate::commands::clean::run(args),
         #[cfg(unix)]
         Some(Commands::CheckServer(args)) => crate::commands::check_server::run(args),
+        Some(Commands::ContentMapper(args)) => crate::commands::content_mapper::run(args),
         Some(Commands::Musea(args)) => crate::commands::musea::run(args),
         #[cfg(feature = "maestro")]
         Some(Commands::Lsp(args)) => crate::commands::lsp::run(args),

--- a/crates/vize/src/commands.rs
+++ b/crates/vize/src/commands.rs
@@ -4,6 +4,7 @@ pub mod check;
 #[cfg(unix)]
 pub mod check_server;
 pub mod clean;
+pub mod content_mapper;
 pub mod curator;
 pub mod doctor;
 pub mod env_info;

--- a/crates/vize/src/commands/content_mapper.rs
+++ b/crates/vize/src/commands/content_mapper.rs
@@ -1,0 +1,221 @@
+//! TypeScript content-mapper protocol server.
+
+use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::path::Path;
+
+use clap::Args;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use vize_canon::generate_vue_content_mapper_transform;
+use vize_carton::{String as CompactString, cstr};
+
+const PROTOCOL_VERSION: u8 = 1;
+const MAX_MESSAGE_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Args, Default)]
+pub struct ContentMapperArgs {}
+
+pub fn run(_: ContentMapperArgs) {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut reader = BufReader::new(stdin.lock());
+    let mut writer = BufWriter::new(stdout.lock());
+    if let Err(error) = serve(&mut reader, &mut writer) {
+        eprintln!("vize content-mapper: {error}");
+        std::process::exit(1);
+    }
+}
+
+#[derive(Deserialize)]
+struct Request {
+    #[allow(dead_code)]
+    jsonrpc: Option<CompactString>,
+    id: Option<Value>,
+    method: CompactString,
+    #[serde(default)]
+    params: Value,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct InitializeParams {
+    protocol_version: u8,
+    #[allow(dead_code)]
+    locale: Option<CompactString>,
+    position_encodings: Vec<CompactString>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TransformParams {
+    file_name: CompactString,
+    content: CompactString,
+    #[allow(dead_code)]
+    compiler_options: Value,
+}
+
+fn serve<R: BufRead, W: Write>(reader: &mut R, writer: &mut W) -> io::Result<()> {
+    let mut initialized = false;
+    while let Some(body) = read_frame(reader)? {
+        let request = match serde_json::from_slice::<Request>(&body) {
+            Ok(request) => request,
+            Err(error) => {
+                let message = cstr!("Parse error: {error}");
+                write_error(writer, Value::Null, -32700, &message)?;
+                continue;
+            }
+        };
+        let id = request.id.unwrap_or(Value::Null);
+
+        match request.method.as_str() {
+            "initialize" => {
+                let params = match serde_json::from_value::<InitializeParams>(request.params) {
+                    Ok(params) => params,
+                    Err(error) => {
+                        let message = cstr!("Invalid initialize params: {error}");
+                        write_error(writer, id, -32602, &message)?;
+                        continue;
+                    }
+                };
+                if params.protocol_version != PROTOCOL_VERSION {
+                    let message = cstr!(
+                        "Unsupported protocol version {} (expected {PROTOCOL_VERSION})",
+                        params.protocol_version
+                    );
+                    write_error(writer, id, -32602, &message)?;
+                    continue;
+                }
+                if !params
+                    .position_encodings
+                    .iter()
+                    .any(|encoding| encoding == "utf-8")
+                {
+                    write_error(
+                        writer,
+                        id,
+                        -32602,
+                        "Vize requires the utf-8 position encoding",
+                    )?;
+                    continue;
+                }
+
+                initialized = true;
+                write_result(
+                    writer,
+                    id,
+                    json!({
+                        "protocolVersion": PROTOCOL_VERSION,
+                        "positionEncoding": "utf-8",
+                        "diagnosticSource": "vize",
+                    }),
+                )?;
+            }
+            "transform" if !initialized => {
+                write_error(writer, id, -32002, "Content mapper is not initialized")?;
+            }
+            "transform" => {
+                let params = match serde_json::from_value::<TransformParams>(request.params) {
+                    Ok(params) => params,
+                    Err(error) => {
+                        let message = cstr!("Invalid transform params: {error}");
+                        write_error(writer, id, -32602, &message)?;
+                        continue;
+                    }
+                };
+                match generate_vue_content_mapper_transform(
+                    Path::new(params.file_name.as_str()),
+                    params.content.as_str(),
+                ) {
+                    Ok(result) => write_result(writer, id, result)?,
+                    Err(error) => {
+                        let message = cstr!("Transform failed: {error}");
+                        write_error(writer, id, -32603, &message)?;
+                    }
+                }
+            }
+            _ => {
+                let message = cstr!("Method not found: {}", request.method);
+                write_error(writer, id, -32601, &message)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn read_frame<R: BufRead>(reader: &mut R) -> io::Result<Option<Vec<u8>>> {
+    let mut content_length = None;
+    let mut saw_header = false;
+    loop {
+        let mut line = Vec::new();
+        let bytes = reader.read_until(b'\n', &mut line)?;
+        if bytes == 0 {
+            if saw_header {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "EOF inside content-mapper headers",
+                ));
+            }
+            return Ok(None);
+        }
+        saw_header = true;
+        if line == b"\r\n" || line == b"\n" {
+            break;
+        }
+        if let Some(separator) = line.iter().position(|byte| *byte == b':')
+            && line[..separator].eq_ignore_ascii_case(b"content-length")
+        {
+            let value = std::str::from_utf8(&line[separator + 1..])
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid Content-Length"))?
+                .trim();
+            content_length = Some(value.parse::<usize>().map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidData, "invalid Content-Length")
+            })?);
+        }
+    }
+
+    let content_length = content_length.ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "missing Content-Length header")
+    })?;
+    if content_length > MAX_MESSAGE_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "content-mapper message exceeds 64 MiB",
+        ));
+    }
+    let mut body = vec![0; content_length];
+    reader.read_exact(&mut body)?;
+    Ok(Some(body))
+}
+
+fn write_result<W: Write>(
+    writer: &mut W,
+    id: Value,
+    result: impl serde::Serialize,
+) -> io::Result<()> {
+    write_frame(
+        writer,
+        &json!({"jsonrpc": "2.0", "id": id, "result": result}),
+    )
+}
+
+fn write_error<W: Write>(writer: &mut W, id: Value, code: i32, message: &str) -> io::Result<()> {
+    write_frame(
+        writer,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": {"code": code, "message": message},
+        }),
+    )
+}
+
+fn write_frame<W: Write>(writer: &mut W, value: &Value) -> io::Result<()> {
+    let body = serde_json::to_vec(value).map_err(io::Error::other)?;
+    write!(writer, "Content-Length: {}\r\n\r\n", body.len())?;
+    writer.write_all(&body)?;
+    writer.flush()
+}
+
+#[cfg(test)]
+#[path = "content_mapper/tests.rs"]
+mod tests;

--- a/crates/vize/src/commands/content_mapper/tests.rs
+++ b/crates/vize/src/commands/content_mapper/tests.rs
@@ -1,0 +1,132 @@
+use std::io::{BufReader, Cursor};
+
+use serde_json::{Value, json};
+use vize_carton::cstr;
+
+use super::serve;
+
+#[test]
+fn negotiates_utf8_and_transforms_vue_sfc() {
+    let input = frames(&[
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": 1,
+                "positionEncodings": ["utf-16", "utf-8"],
+                "locale": "en-US"
+            }
+        }),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "transform",
+            "params": {
+                "fileName": "/project/App.vue",
+                "content": "<script setup lang=\"ts\">\nconst count = 1\n</script>\n<template>{{ count }}</template>\n",
+                "compilerOptions": {}
+            }
+        }),
+    ]);
+    let responses = exchange(&input);
+
+    assert_eq!(responses[0]["result"]["protocolVersion"], 1);
+    assert_eq!(responses[0]["result"]["positionEncoding"], "utf-8");
+    assert_eq!(responses[0]["result"]["diagnosticSource"], "vize");
+    assert_eq!(responses[1]["result"]["scriptKind"], 3);
+    assert!(
+        responses[1]["result"]["text"]
+            .as_str()
+            .unwrap()
+            .contains("const count = 1")
+    );
+    assert!(
+        !responses[1]["result"]["mappings"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn parse_errors_are_successful_transform_results() {
+    let input = frames(&[
+        initialize_request(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "transform",
+            "params": {
+                "fileName": "Broken.vue",
+                "content": "<template><div></template>",
+                "compilerOptions": {}
+            }
+        }),
+    ]);
+    let responses = exchange(&input);
+
+    assert!(responses[1].get("error").is_none());
+    assert!(
+        !responses[1]["result"]["diagnostics"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn rejects_transform_before_initialize() {
+    let input = frames(&[json!({
+        "jsonrpc": "2.0",
+        "id": "early",
+        "method": "transform",
+        "params": {
+            "fileName": "App.vue",
+            "content": "<template />",
+            "compilerOptions": {}
+        }
+    })]);
+    let responses = exchange(&input);
+
+    assert_eq!(responses[0]["id"], "early");
+    assert_eq!(responses[0]["error"]["code"], -32002);
+}
+
+fn initialize_request() -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": 1,
+            "positionEncodings": ["utf-8"]
+        }
+    })
+}
+
+fn frames(values: &[Value]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    for value in values {
+        let body = serde_json::to_vec(value).unwrap();
+        bytes.extend_from_slice(cstr!("Content-Length: {}\r\n\r\n", body.len()).as_bytes());
+        bytes.extend_from_slice(&body);
+    }
+    bytes
+}
+
+fn exchange(input: &[u8]) -> Vec<Value> {
+    let mut reader = BufReader::new(Cursor::new(input));
+    let mut output = Vec::new();
+    serve(&mut reader, &mut output).unwrap();
+    decode_frames(&output)
+}
+
+fn decode_frames(output: &[u8]) -> Vec<Value> {
+    let mut reader = BufReader::new(Cursor::new(output));
+    let mut values = Vec::new();
+    while let Some(body) = super::read_frame(&mut reader).unwrap() {
+        values.push(serde_json::from_slice(&body).unwrap());
+    }
+    values
+}

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_long_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_long_help.snap
@@ -7,21 +7,22 @@ High-performance Vue.js toolchain in Rust
 Usage: vize [COMMAND]
 
 Commands:
-  build         Compile Vue SFC files (default command) [aliases: atelier]
-  fmt           Format Vue, JSX, and TSX files [aliases: glyph]
-  lint          Lint Vue, HTML, JSX, and TSX files [aliases: patina]
-  check         Type check Vue, JSX, and TSX files
-  inspector     Create playground compiler inspector payloads and agent reports
-  curator       Curator utilities for diagnostics and reports
-  doctor        Analyze whole-application health
-  clean         Remove Vize-generated cache artifacts
-  check-server  Start type check JSON-RPC server (Unix only)
-  musea         Start component gallery server
-  lsp           Start Language Server Protocol server [aliases: maestro]
-  ide           IDE integration - LSP server and editor extension management
-  upgrade       Update the installed Vize package [aliases: self-update]
-  ready         Run fmt, lint, check, and build
-  help          Print this message or the help of the given subcommand(s)
+  build           Compile Vue SFC files (default command) [aliases: atelier]
+  fmt             Format Vue, JSX, and TSX files [aliases: glyph]
+  lint            Lint Vue, HTML, JSX, and TSX files [aliases: patina]
+  check           Type check Vue, JSX, and TSX files
+  inspector       Create playground compiler inspector payloads and agent reports
+  curator         Curator utilities for diagnostics and reports
+  doctor          Analyze whole-application health
+  clean           Remove Vize-generated cache artifacts
+  check-server    Start type check JSON-RPC server (Unix only)
+  content-mapper  Start the experimental TypeScript content-mapper protocol server
+  musea           Start component gallery server
+  lsp             Start Language Server Protocol server [aliases: maestro]
+  ide             IDE integration - LSP server and editor extension management
+  upgrade         Update the installed Vize package [aliases: self-update]
+  ready           Run fmt, lint, check, and build
+  help            Print this message or the help of the given subcommand(s)
 
 Options:
   -v, --version

--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -34,8 +34,9 @@ pub use type_checker::{
     DeclarationOutput, TypeCheckResult, TypeChecker,
 };
 pub use virtual_project::{
-    OriginalPosition, VirtualFile, VirtualProject, VueDocumentVirtualTs,
-    VueDocumentVirtualTsOptions, generate_vue_document_virtual_ts,
+    ContentMapperDiagnostic, ContentMapperSpan, ContentMapperTransform, OriginalPosition,
+    VirtualFile, VirtualProject, VueDocumentVirtualTs, VueDocumentVirtualTsOptions,
+    generate_vue_content_mapper_transform, generate_vue_document_virtual_ts,
     generate_vue_document_virtual_ts_with_options,
 };
 pub use virtual_ts::VirtualTsGenerator;

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -26,6 +26,11 @@ use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 
 mod art_usage;
 mod build;
+mod content_mapper;
+pub use content_mapper::{
+    ContentMapperDiagnostic, ContentMapperSpan, ContentMapperTransform,
+    generate_vue_content_mapper_transform,
+};
 mod declaration_emit;
 mod document;
 pub use document::{

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -1,6 +1,5 @@
-//! Building a [`RegisteredFile`] from a source path. This owns the expensive,
-//! `&mut`-free work (SFC/template parse and virtual-TS generation) so it can run
-//! across rayon workers and return a self-contained result for the project.
+//! Builds an owned [`RegisteredFile`] so SFC/template parsing and virtual-TS generation can run
+//! across rayon workers without shared `&mut` state.
 
 use std::path::{Path, PathBuf};
 

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -138,6 +138,7 @@ pub(super) fn build_vue_registered_file(
                 template_syntax: context.template_syntax,
                 experimental_in_tag_comments: context.experimental_in_tag_comments,
                 hoist_shared_preamble: true,
+                omit_vite_client_reference: false,
             },
         )
     )?;

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
@@ -1,0 +1,278 @@
+//! TypeScript content-mapper projection for Vue single-file components.
+
+use std::ops::Range;
+use std::path::Path;
+
+use serde::Serialize;
+use vize_atelier_core::TemplateSyntaxMode;
+use vize_atelier_sfc::{SfcError, SfcParseOptions, parse_sfc};
+use vize_carton::{String as CompactString, ToCompactString, config::VueVersion};
+
+use crate::batch::Diagnostic;
+use crate::batch::error::CorsaResult;
+use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions, VizeMapping};
+
+use super::build::{
+    descriptor_uses_jsx_script, prepend_vue_jsx_reference, virtual_ts_options_for_descriptor,
+};
+use super::diagnostics::invalid_sfc_fallback_virtual_ts;
+use super::vue_codegen::{GeneratedVueFile, VueCodegenOptions, generate_vue_virtual_ts};
+
+const SCRIPT_KIND_TS: u8 = 3;
+const SCRIPT_KIND_TSX: u8 = 4;
+const MAPPING_KIND_VERBATIM: usize = 0;
+const MAPPING_KIND_ATOM: usize = 1;
+const MAPPING_PURPOSE_ALL: usize = 3;
+
+/// A TypeScript content-mapper transform result.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentMapperTransform {
+    pub text: CompactString,
+    pub script_kind: u8,
+    pub mappings: Vec<ContentMapperSpan>,
+    pub diagnostics: Vec<ContentMapperDiagnostic>,
+}
+
+/// A protocol v1 span tuple:
+/// `[generatedStart, generatedLength, originalStart, originalLength, kind, purpose]`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+pub struct ContentMapperSpan(pub [usize; 6]);
+
+/// A diagnostic expressed in the mapper's negotiated UTF-8 coordinates.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentMapperDiagnostic {
+    pub message_text: CompactString,
+    pub start: usize,
+    pub length: usize,
+}
+
+/// Generate self-contained TypeScript and protocol-v1 mappings for one Vue SFC.
+///
+/// Authored parse failures are returned as mapper diagnostics with a safe
+/// fallback module. They are not transport errors, so TypeScript can keep the
+/// mapper process alive while the user edits an invalid document.
+pub fn generate_vue_content_mapper_transform(
+    path: &Path,
+    content: &str,
+) -> CorsaResult<ContentMapperTransform> {
+    let descriptor = match parse_sfc(
+        content,
+        SfcParseOptions {
+            filename: path.to_string_lossy().to_compact_string(),
+            ..Default::default()
+        },
+    ) {
+        Ok(descriptor) => descriptor,
+        Err(error) => {
+            return Ok(ContentMapperTransform {
+                text: invalid_sfc_fallback_virtual_ts(),
+                script_kind: SCRIPT_KIND_TS,
+                mappings: Vec::new(),
+                diagnostics: vec![sfc_parse_diagnostic(content, &error)],
+            });
+        }
+    };
+
+    let options = virtual_ts_options_for_descriptor(&VirtualTsOptions::default(), &descriptor);
+    let use_tsx = descriptor_uses_jsx_script(&descriptor);
+    let GeneratedVueFile {
+        mut code,
+        mut mappings,
+        diagnostics,
+    } = generate_vue_virtual_ts(
+        path,
+        content,
+        &descriptor,
+        &options,
+        VueCodegenOptions {
+            check_options: VirtualTsCheckOptions::default(),
+            preserve_unused_diagnostics: false,
+            options_api: false,
+            legacy_vue2: false,
+            dialect: VueVersion::default(),
+            template_syntax: TemplateSyntaxMode::default(),
+            experimental_in_tag_comments: false,
+            hoist_shared_preamble: false,
+            omit_vite_client_reference: true,
+        },
+    )?;
+
+    if use_tsx {
+        prepend_vue_jsx_reference(&mut code, &mut mappings);
+    }
+
+    Ok(ContentMapperTransform {
+        mappings: protocol_spans(content, &code, &mappings),
+        diagnostics: diagnostics
+            .iter()
+            .map(|diagnostic| generated_diagnostic(content, diagnostic))
+            .collect(),
+        text: code,
+        script_kind: if use_tsx {
+            SCRIPT_KIND_TSX
+        } else {
+            SCRIPT_KIND_TS
+        },
+    })
+}
+
+fn sfc_parse_diagnostic(source: &str, error: &SfcError) -> ContentMapperDiagnostic {
+    let (start, length) = error
+        .loc
+        .as_ref()
+        .map(|loc| checked_source_span(source, loc.start, loc.end))
+        .unwrap_or_else(|| checked_source_span(source, 0, 0));
+    ContentMapperDiagnostic {
+        message_text: error.message.clone(),
+        start,
+        length,
+    }
+}
+
+fn generated_diagnostic(source: &str, diagnostic: &Diagnostic) -> ContentMapperDiagnostic {
+    let index = vize_carton::line_index::LineIndex::new(source);
+    let start = index
+        .line_col_to_offset(diagnostic.line, diagnostic.column)
+        .unwrap_or(0);
+    let (start, length) = checked_source_span(source, start, start);
+    ContentMapperDiagnostic {
+        message_text: diagnostic.message.clone(),
+        start,
+        length,
+    }
+}
+
+fn checked_source_span(source: &str, start: usize, end: usize) -> (usize, usize) {
+    let start = start.min(source.len());
+    let start = source.floor_char_boundary(start);
+    let end = end.min(source.len()).max(start);
+    let end = source.ceil_char_boundary(end);
+    let default_length = source[start..].chars().next().map_or(0, char::len_utf8);
+    (start, end.saturating_sub(start).max(default_length))
+}
+
+#[derive(Clone, Debug)]
+struct SpanCandidate {
+    generated: Range<usize>,
+    original: Range<usize>,
+    kind: usize,
+}
+
+fn protocol_spans(
+    source: &str,
+    generated: &str,
+    mappings: &[VizeMapping],
+) -> Vec<ContentMapperSpan> {
+    let mut candidates = mappings
+        .iter()
+        .filter_map(|mapping| {
+            if mapping.sub_spans.is_empty() {
+                Some(vec![candidate(
+                    source,
+                    generated,
+                    mapping.gen_range.clone(),
+                    mapping.src_range.clone(),
+                )?])
+            } else {
+                Some(
+                    mapping
+                        .sub_spans
+                        .iter()
+                        .filter_map(|span| {
+                            candidate(
+                                source,
+                                generated,
+                                span.gen_range.clone(),
+                                span.src_range.clone(),
+                            )
+                        })
+                        .collect(),
+                )
+            }
+        })
+        .flatten()
+        .collect::<Vec<_>>();
+
+    // Narrow authored spans win over enclosing synthetic projections.
+    candidates.sort_by_key(|candidate| {
+        (
+            candidate.generated.len(),
+            candidate.original.len(),
+            candidate.generated.start,
+        )
+    });
+
+    let mut accepted = Vec::<SpanCandidate>::new();
+    for candidate in candidates {
+        let generated_overlap = accepted
+            .iter()
+            .any(|span| ranges_overlap(&candidate.generated, &span.generated));
+        let invalid_original_overlap = accepted.iter().any(|span| {
+            candidate.original != span.original
+                && ranges_overlap(&candidate.original, &span.original)
+        });
+        if !generated_overlap && !invalid_original_overlap {
+            accepted.push(candidate);
+        }
+    }
+    accepted.sort_by_key(|candidate| candidate.generated.start);
+    accepted
+        .into_iter()
+        .map(|candidate| {
+            ContentMapperSpan([
+                candidate.generated.start,
+                candidate.generated.len(),
+                candidate.original.start,
+                candidate.original.len(),
+                candidate.kind,
+                MAPPING_PURPOSE_ALL,
+            ])
+        })
+        .collect()
+}
+
+fn candidate(
+    source: &str,
+    generated: &str,
+    generated_range: Range<usize>,
+    original_range: Range<usize>,
+) -> Option<SpanCandidate> {
+    if generated_range.is_empty()
+        || original_range.is_empty()
+        || generated_range.end > generated.len()
+        || original_range.end > source.len()
+        || !generated.is_char_boundary(generated_range.start)
+        || !generated.is_char_boundary(generated_range.end)
+        || !source.is_char_boundary(original_range.start)
+        || !source.is_char_boundary(original_range.end)
+    {
+        return None;
+    }
+
+    let generated_text = &generated[generated_range.clone()];
+    let original_text = &source[original_range.clone()];
+    if let Some(relative_start) = generated_text.find(original_text) {
+        let start = generated_range.start + relative_start;
+        return Some(SpanCandidate {
+            generated: start..start + original_text.len(),
+            original: original_range,
+            kind: MAPPING_KIND_VERBATIM,
+        });
+    }
+
+    Some(SpanCandidate {
+        generated: generated_range,
+        original: original_range,
+        kind: MAPPING_KIND_ATOM,
+    })
+}
+
+fn ranges_overlap(left: &Range<usize>, right: &Range<usize>) -> bool {
+    left.start < right.end && right.start < left.end
+}
+
+#[cfg(test)]
+#[path = "content_mapper_tests.rs"]
+mod tests;

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -1,0 +1,87 @@
+use std::path::Path;
+
+use crate::batch::generate_vue_content_mapper_transform;
+
+#[test]
+fn emits_protocol_v1_spans_without_forbidden_overlaps() {
+    let source = r#"<script setup lang="ts">
+const message = "hello"
+</script>
+<template>{{ message }}</template>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("App.vue"), source).expect("transform");
+
+    assert_eq!(result.script_kind, 3);
+    assert!(result.text.contains("const message = \"hello\""));
+    assert!(
+        !result
+            .text
+            .contains("/// <reference types=\"vite/client\" />")
+    );
+    assert!(!result.mappings.is_empty());
+    for pair in result.mappings.windows(2) {
+        let left = pair[0].0;
+        let right = pair[1].0;
+        assert!(left[0] + left[1] <= right[0], "{left:?} overlaps {right:?}");
+    }
+    for (index, left) in result.mappings.iter().enumerate() {
+        for right in &result.mappings[index + 1..] {
+            let left = left.0;
+            let right = right.0;
+            let originals_overlap = left[2] < right[2] + right[3] && right[2] < left[2] + left[3];
+            let originals_match = left[2] == right[2] && left[3] == right[3];
+            assert!(
+                !originals_overlap || originals_match,
+                "{left:?} partially overlaps {right:?}"
+            );
+        }
+    }
+    assert!(result.mappings.iter().all(|mapping| mapping.0[5] == 3));
+}
+
+#[test]
+fn keeps_mapper_offsets_in_utf8_bytes() {
+    let source = r#"<script setup lang="ts">
+const emoji = "😀"
+</script>
+<template>{{ emoji }}</template>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("Unicode.vue"), source).expect("transform");
+    let original = source.rfind("emoji").expect("template identifier");
+    assert!(
+        result
+            .mappings
+            .iter()
+            .any(|mapping| mapping.0[2] == original),
+        "expected a UTF-8 byte mapping at {original}: {:?}",
+        result.mappings
+    );
+}
+
+#[test]
+fn authored_parse_errors_are_mapper_diagnostics() {
+    let source = "<template><div></template>";
+    let result =
+        generate_vue_content_mapper_transform(Path::new("Broken.vue"), source).expect("transform");
+
+    assert!(!result.diagnostics.is_empty());
+    assert!(result.mappings.is_empty());
+    assert!(result.text.contains("__vize_component"));
+    assert!(result.diagnostics[0].start <= source.len());
+}
+
+#[test]
+fn jsx_scripts_report_tsx_script_kind() {
+    let source = "<script lang=\"tsx\">export default () => <div /></script>";
+    let result =
+        generate_vue_content_mapper_transform(Path::new("Jsx.vue"), source).expect("transform");
+
+    assert_eq!(result.script_kind, 4);
+    assert!(
+        result
+            .text
+            .starts_with("/// <reference types=\"vue/jsx\" />")
+    );
+}

--- a/crates/vize_canon/src/batch/virtual_project/document.rs
+++ b/crates/vize_canon/src/batch/virtual_project/document.rs
@@ -99,6 +99,7 @@ pub fn generate_vue_document_virtual_ts_with_options(
             template_syntax: TemplateSyntaxMode::default(),
             experimental_in_tag_comments: false,
             hoist_shared_preamble,
+            omit_vite_client_reference: false,
         },
     )?;
     if use_tsx_virtual {

--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -53,6 +53,8 @@ pub(super) struct VueCodegenOptions {
     /// Hoist shared helpers to the batch ambient `.d.ts`; socket sessions keep
     /// them inline because they do not materialize that file.
     pub(super) hoist_shared_preamble: bool,
+    /// Content-mapper transforms can run outside Vite projects.
+    pub(super) omit_vite_client_reference: bool,
 }
 
 pub(super) fn generate_vue_virtual_ts(
@@ -222,6 +224,7 @@ pub(super) fn generate_vue_virtual_ts(
                 ),
                 hoist_shared_preamble,
                 lib_references: None,
+                omit_vite_client_reference: codegen_options.omit_vite_client_reference,
             },
         )
     );

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -119,11 +119,12 @@ pub use corsa_bridge::{
 // Re-export batch type checker
 #[cfg(feature = "native")]
 pub use batch::{
-    BatchTypeChecker, BatchTypeCheckerOptions, CorsaError, CorsaExecutor, CorsaNotFoundError,
-    DeclarationEmitOptions, DeclarationEmitResult, DeclarationOutput,
-    Diagnostic as BatchDiagnostic, ImportRewriter, ImportSourceMap, PackageManager, SfcBlockType,
-    TypeCheckResult as BatchTypeCheckResult, TypeChecker as BatchTypeCheckerTrait, VirtualFile,
-    VirtualProject, VirtualTsGenerator, sfc_block_fallback_offset,
+    BatchTypeChecker, BatchTypeCheckerOptions, ContentMapperDiagnostic, ContentMapperSpan,
+    ContentMapperTransform, CorsaError, CorsaExecutor, CorsaNotFoundError, DeclarationEmitOptions,
+    DeclarationEmitResult, DeclarationOutput, Diagnostic as BatchDiagnostic, ImportRewriter,
+    ImportSourceMap, PackageManager, SfcBlockType, TypeCheckResult as BatchTypeCheckResult,
+    TypeChecker as BatchTypeCheckerTrait, VirtualFile, VirtualProject, VirtualTsGenerator,
+    generate_vue_content_mapper_transform, sfc_block_fallback_offset,
 };
 
 #[cfg(feature = "native")]

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -12,6 +12,7 @@ mod dynamic_component_names_tests;
 mod expressions;
 mod generator;
 mod helpers;
+mod import_meta;
 pub mod incremental;
 #[cfg(test)]
 mod interface_extends_tests;

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -41,7 +41,7 @@ use self::spans::{
 };
 use super::{
     helpers::{
-        IMPORT_META_AUGMENTATION, SETUP_SCOPE_HELPER_NAMES, generate_template_context,
+        SETUP_SCOPE_HELPER_NAMES, emit_import_meta_augmentation, generate_template_context,
         to_safe_identifier,
     },
     props::{
@@ -188,7 +188,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         ts.push_str("// Shared preamble hoisted to the program-wide __vize_helpers.d.ts\n");
     } else {
         // ImportMeta augmentation (must be at top level, before any code)
-        ts.push_str(IMPORT_META_AUGMENTATION);
+        emit_import_meta_augmentation(&mut ts, !generation_options.omit_vite_client_reference);
         ts.push('\n');
     }
 

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -40,10 +40,8 @@ use self::spans::{
     template_usage,
 };
 use super::{
-    helpers::{
-        SETUP_SCOPE_HELPER_NAMES, emit_import_meta_augmentation, generate_template_context,
-        to_safe_identifier,
-    },
+    helpers::{SETUP_SCOPE_HELPER_NAMES, generate_template_context, to_safe_identifier},
+    import_meta::emit_import_meta_augmentation,
     props::{
         OptionsApiPropsSource, add_generic_defaults, collect_template_prop_names,
         extract_generic_names, strip_const_modifiers,

--- a/crates/vize_canon/src/virtual_ts/helpers.rs
+++ b/crates/vize_canon/src/virtual_ts/helpers.rs
@@ -125,12 +125,19 @@ pub(crate) const VUE_SETUP_HELPERS: &str = r#"  // Compiler macros (only valid i
   // Mark compiler macros as used
   void defineProps; void defineEmits; void defineExpose; void defineModel; void defineSlots; void withDefaults; void useTemplateRef;"#;
 
-/// ImportMeta augmentation for Vite/Nuxt projects.
-/// Uses `/// <reference types="..." />` to pull in existing type definitions
-/// from frameworks like Vite, Nuxt, etc. when available.
-pub(crate) const IMPORT_META_AUGMENTATION: &str = r#"// ImportMeta augmentation (reference existing framework types)
-/// <reference types="vite/client" />
-declare global {
+/// Emit the ImportMeta augmentation used by generated virtual TypeScript.
+///
+/// Batch Vize projects retain the Vite client reference for compatibility.
+/// External content mappers omit it because they run in arbitrary TypeScript
+/// projects and must not introduce a package dependency the project did not
+/// declare.
+pub(crate) fn emit_import_meta_augmentation(output: &mut vize_carton::String, include_vite: bool) {
+    output.push_str("// ImportMeta augmentation (reference existing framework types)\n");
+    if include_vite {
+        output.push_str("/// <reference types=\"vite/client\" />\n");
+    }
+    output.push_str(
+        r#"declare global {
   // Extend ImportMeta with Nuxt-specific properties not covered by vite/client
   interface ImportMeta {
     client: boolean;
@@ -140,7 +147,9 @@ declare global {
     ssr: boolean;
   }
 }
-"#;
+"#,
+    );
+}
 
 /// Per-file setup-scope helper block emitted when the shared preamble is
 /// hoisted: the macro signatures live once in the ambient helpers file as

--- a/crates/vize_canon/src/virtual_ts/helpers.rs
+++ b/crates/vize_canon/src/virtual_ts/helpers.rs
@@ -125,32 +125,6 @@ pub(crate) const VUE_SETUP_HELPERS: &str = r#"  // Compiler macros (only valid i
   // Mark compiler macros as used
   void defineProps; void defineEmits; void defineExpose; void defineModel; void defineSlots; void withDefaults; void useTemplateRef;"#;
 
-/// Emit the ImportMeta augmentation used by generated virtual TypeScript.
-///
-/// Batch Vize projects retain the Vite client reference for compatibility.
-/// External content mappers omit it because they run in arbitrary TypeScript
-/// projects and must not introduce a package dependency the project did not
-/// declare.
-pub(crate) fn emit_import_meta_augmentation(output: &mut vize_carton::String, include_vite: bool) {
-    output.push_str("// ImportMeta augmentation (reference existing framework types)\n");
-    if include_vite {
-        output.push_str("/// <reference types=\"vite/client\" />\n");
-    }
-    output.push_str(
-        r#"declare global {
-  // Extend ImportMeta with Nuxt-specific properties not covered by vite/client
-  interface ImportMeta {
-    client: boolean;
-    server: boolean;
-    dev: boolean;
-    prod: boolean;
-    ssr: boolean;
-  }
-}
-"#,
-    );
-}
-
 /// Per-file setup-scope helper block emitted when the shared preamble is
 /// hoisted: the macro signatures live once in the ambient helpers file as
 /// `__vize_*` globals and are aliased into setup scope here, so compiler

--- a/crates/vize_canon/src/virtual_ts/import_meta.rs
+++ b/crates/vize_canon/src/virtual_ts/import_meta.rs
@@ -1,0 +1,23 @@
+//! ImportMeta augmentation for generated virtual TypeScript.
+
+use vize_carton::String;
+
+pub(super) fn emit_import_meta_augmentation(output: &mut String, include_vite: bool) {
+    output.push_str("// ImportMeta augmentation (reference existing framework types)\n");
+    if include_vite {
+        output.push_str("/// <reference types=\"vite/client\" />\n");
+    }
+    output.push_str(
+        r#"declare global {
+  // Extend ImportMeta with Nuxt-specific properties not covered by vite/client
+  interface ImportMeta {
+    client: boolean;
+    server: boolean;
+    dev: boolean;
+    prod: boolean;
+    ssr: boolean;
+  }
+}
+"#,
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/types.rs
+++ b/crates/vize_canon/src/virtual_ts/types.rs
@@ -159,6 +159,8 @@ pub(crate) struct VirtualTsGenerationOptions<'a> {
     pub(crate) hoist_shared_preamble: bool,
     /// Override standard library triple-slash references for this generation.
     pub(crate) lib_references: Option<&'a [&'a str]>,
+    /// Avoid introducing a `vite/client` type dependency in arbitrary projects.
+    pub(crate) omit_vite_client_reference: bool,
 }
 
 /// Default plugin globals.

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -76,21 +76,22 @@ vize [COMMAND]
 
 When invoked without a command, `vize` defaults to `build`.
 
-| Command        | Description                                     |
-| -------------- | ----------------------------------------------- |
-| `build`        | Compile Vue SFC files                           |
-| `fmt`          | Format Vue SFC files                            |
-| `lint`         | Lint Vue SFC files                              |
-| `check`        | Type check Vue SFC, TS, TSX, and `.d.ts` inputs |
-| `doctor`       | Analyze whole-application health                |
-| `inspector`    | Create playground compiler inspector payloads   |
-| `clean`        | Remove Vize-generated cache artifacts           |
-| `ready`        | Run `fmt`, `lint`, `check`, and `build`         |
-| `upgrade`      | Update the installed CLI                        |
-| `check-server` | Start the Unix JSON-RPC typecheck server        |
-| `musea`        | Musea subcommands and scaffolding               |
-| `lsp`          | Start the language server                       |
-| `ide`          | Install or manage editor integrations           |
+| Command          | Description                                     |
+| ---------------- | ----------------------------------------------- |
+| `build`          | Compile Vue SFC files                           |
+| `fmt`            | Format Vue SFC files                            |
+| `lint`           | Lint Vue SFC files                              |
+| `check`          | Type check Vue SFC, TS, TSX, and `.d.ts` inputs |
+| `doctor`         | Analyze whole-application health                |
+| `inspector`      | Create playground compiler inspector payloads   |
+| `clean`          | Remove Vize-generated cache artifacts           |
+| `ready`          | Run `fmt`, `lint`, `check`, and `build`         |
+| `upgrade`        | Update the installed CLI                        |
+| `check-server`   | Start the Unix JSON-RPC typecheck server        |
+| `content-mapper` | Start the experimental TypeScript mapper server |
+| `musea`          | Musea subcommands and scaffolding               |
+| `lsp`            | Start the language server                       |
+| `ide`            | Install or manage editor integrations           |
 
 ## Build
 
@@ -215,6 +216,34 @@ Key options:
 Use `--corsa-path` to pin a custom Corsa executable while developing Vize or a local `corsa-bind`
 checkout. The shared config key is `typeChecker.corsaPath`; `typeChecker.tsgoPath` remains only as a
 compatibility alias.
+
+### Experimental TypeScript content mapper
+
+The `vize` npm package declares the content-mapper metadata proposed by
+[microsoft/typescript-go#4712](https://github.com/microsoft/typescript-go/pull/4712). A compatible
+`tsgo` build can therefore typecheck `.vue` files through Vize directly:
+
+```json
+{
+  "compilerOptions": {
+    "module": "preserve",
+    "strict": true
+  },
+  "contentMappers": [{ "package": "vize", "extensions": [".vue"] }],
+  "include": ["src"]
+}
+```
+
+```bash
+tsgo --loadExternalPlugins --noEmit -p tsconfig.json
+```
+
+This is an upstream-dependent preview. The protocol is not present in a released TypeScript native
+preview yet, so use the exact PR build for evaluation and retain `vize check` in supported CI.
+Vize's bridge already covers protocol v1 initialization, UTF-8 source mappings, mapper-authored
+diagnostics, TS/TSX script kinds, and the package entrypoint. Remaining work is gated on upstream
+stabilizing the protocol, extension-provided mappers, declaration maps, and the final release
+channel.
 
 Project-wide template values and Vue ambient types should be visible through TypeScript project
 configuration. Include generated files such as `auto-imports.d.ts`, `components.d.ts`, or your own

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -213,37 +213,8 @@ Key options:
 | `--declaration`     | Emit `.d.ts` output                                |
 | `--declaration-dir` | Output directory for emitted declarations          |
 
-Use `--corsa-path` to pin a custom Corsa executable while developing Vize or a local `corsa-bind`
-checkout. The shared config key is `typeChecker.corsaPath`; `typeChecker.tsgoPath` remains only as a
-compatibility alias.
-
-### Experimental TypeScript content mapper
-
-The `vize` npm package declares the content-mapper metadata proposed by
-[microsoft/typescript-go#4712](https://github.com/microsoft/typescript-go/pull/4712). A compatible
-`tsgo` build can therefore typecheck `.vue` files through Vize directly:
-
-```json
-{
-  "compilerOptions": {
-    "module": "preserve",
-    "strict": true
-  },
-  "contentMappers": [{ "package": "vize", "extensions": [".vue"] }],
-  "include": ["src"]
-}
-```
-
-```bash
-tsgo --loadExternalPlugins --noEmit -p tsconfig.json
-```
-
-This is an upstream-dependent preview. The protocol is not present in a released TypeScript native
-preview yet, so use the exact PR build for evaluation and retain `vize check` in supported CI.
-Vize's bridge already covers protocol v1 initialization, UTF-8 source mappings, mapper-authored
-diagnostics, TS/TSX script kinds, and the package entrypoint. Remaining work is gated on upstream
-stabilizing the protocol, extension-provided mappers, declaration maps, and the final release
-channel.
+Use `--corsa-path` to pin a local Corsa build. The shared config key is `typeChecker.corsaPath`;
+`typeChecker.tsgoPath` remains only as a compatibility alias.
 
 Project-wide template values and Vue ambient types should be visible through TypeScript project
 configuration. Include generated files such as `auto-imports.d.ts`, `components.d.ts`, or your own

--- a/editors/vscode/src/content-mapper-discovery.ts
+++ b/editors/vscode/src/content-mapper-discovery.ts
@@ -1,0 +1,57 @@
+import {
+  type ExtensionContext,
+  type OutputChannel,
+  type Uri,
+  commands,
+  extensions,
+  workspace,
+} from "vscode";
+
+function vueUri(document: { languageId: string; uri: Uri }): Uri | undefined {
+  return document.uri.scheme === "file" &&
+    (document.languageId === "vue" || document.languageId === "art-vue") &&
+    document.uri.path.endsWith(".vue")
+    ? document.uri
+    : undefined;
+}
+
+export function registerTypeScriptContentMapperDiscovery(
+  context: ExtensionContext,
+  outputChannel: OutputChannel,
+): void {
+  const discover = (uris: readonly Uri[]) => {
+    if (!workspace.isTrusted || uris.length === 0) {
+      return;
+    }
+    const nativePreview = extensions.getExtension("TypeScriptTeam.native-preview");
+    if (!nativePreview) {
+      return;
+    }
+    void (async () => {
+      try {
+        await nativePreview.activate();
+        const discovered = await commands.executeCommand(
+          "typescript.native-preview.discoverContentMappers",
+          { uris, extensions: [".vue"] },
+        );
+        if (Array.isArray(discovered) && discovered.includes(".vue")) {
+          outputChannel.appendLine("TypeScript native preview discovered the Vize .vue mapper.");
+        }
+      } catch (error: unknown) {
+        outputChannel.appendLine(
+          `TypeScript content mapper discovery is unavailable: ${String(error)}`,
+        );
+      }
+    })();
+  };
+
+  discover(workspace.textDocuments.map(vueUri).filter((uri): uri is Uri => uri !== undefined));
+  context.subscriptions.push(
+    workspace.onDidOpenTextDocument((document) => {
+      const uri = vueUri(document);
+      if (uri) {
+        discover([uri]);
+      }
+    }),
+  );
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -13,7 +13,6 @@ import {
   Uri,
   commands,
   env,
-  extensions,
   window,
   workspace,
   type QuickPickItem,
@@ -37,6 +36,7 @@ import {
   shouldStartFromConfiguration,
   type LspInitializationOptions,
 } from "./extension-core";
+import { registerTypeScriptContentMapperDiscovery } from "./content-mapper-discovery";
 
 const execFileAsync = promisify(execFile);
 let client: LanguageClient | undefined;
@@ -96,7 +96,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   outputChannel = window.createOutputChannel("Vize");
   outputChannel.appendLine("Vize extension activating...");
   context.subscriptions.push(outputChannel);
-  registerTypeScriptContentMapperDiscovery(context);
+  registerTypeScriptContentMapperDiscovery(context, outputChannel);
 
   statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 95);
   statusBarItem.command = "vize.showStatus";
@@ -160,53 +160,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
   );
 
   await syncClientToConfiguration(context, "initial activation");
-}
-
-function registerTypeScriptContentMapperDiscovery(context: ExtensionContext): void {
-  const discover = (uris: readonly Uri[]) => {
-    if (!workspace.isTrusted || uris.length === 0) {
-      return;
-    }
-    const nativePreview = extensions.getExtension("TypeScriptTeam.native-preview");
-    if (!nativePreview) {
-      return;
-    }
-    void (async () => {
-      try {
-        await nativePreview.activate();
-        const discovered = await commands.executeCommand(
-          "typescript.native-preview.discoverContentMappers",
-          {
-            uris,
-            extensions: [".vue"],
-          },
-        );
-        if (Array.isArray(discovered) && discovered.includes(".vue")) {
-          outputChannel.appendLine("TypeScript native preview discovered the Vize .vue mapper.");
-        }
-      } catch (error: unknown) {
-        outputChannel.appendLine(
-          `TypeScript content mapper discovery is unavailable: ${String(error)}`,
-        );
-      }
-    })();
-  };
-  const vueUri = (document: { languageId: string; uri: Uri }): Uri | undefined =>
-    document.uri.scheme === "file" &&
-    (document.languageId === "vue" || document.languageId === "art-vue") &&
-    document.uri.path.endsWith(".vue")
-      ? document.uri
-      : undefined;
-
-  discover(workspace.textDocuments.map(vueUri).filter((uri): uri is Uri => uri !== undefined));
-  context.subscriptions.push(
-    workspace.onDidOpenTextDocument((document) => {
-      const uri = vueUri(document);
-      if (uri) {
-        discover([uri]);
-      }
-    }),
-  );
 }
 
 function scheduleClientSync(context: ExtensionContext, reason: string): void {
@@ -919,12 +872,9 @@ function getWorkspaceDevPaths(exeName: string): string[] {
   return paths;
 }
 
-/// Resolve the user-/machine-scoped value of `vize.serverPath` only.
-/// Workspace-scoped values (e.g. a `.vscode/settings.json` shipped in a
-/// cloned repo) are intentionally ignored — that file is repo-controlled
-/// and could otherwise point the extension at any executable. The
-/// untrusted-workspace branch declared in `package.json::capabilities`
-/// covers the first defense in depth; this is the second. (#969)
+/// Resolve only user-/machine-scoped `vize.serverPath` values. Workspace settings are
+/// repo-controlled and could point at arbitrary executables; package capabilities and this
+/// check provide two layers of protection. (#969)
 function resolveTrustedServerPath(
   config: ReturnType<typeof workspace.getConfiguration>,
 ): string | undefined {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -13,6 +13,7 @@ import {
   Uri,
   commands,
   env,
+  extensions,
   window,
   workspace,
   type QuickPickItem,
@@ -95,6 +96,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   outputChannel = window.createOutputChannel("Vize");
   outputChannel.appendLine("Vize extension activating...");
   context.subscriptions.push(outputChannel);
+  registerTypeScriptContentMapperDiscovery(context);
 
   statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 95);
   statusBarItem.command = "vize.showStatus";
@@ -158,6 +160,53 @@ export async function activate(context: ExtensionContext): Promise<void> {
   );
 
   await syncClientToConfiguration(context, "initial activation");
+}
+
+function registerTypeScriptContentMapperDiscovery(context: ExtensionContext): void {
+  const discover = (uris: readonly Uri[]) => {
+    if (!workspace.isTrusted || uris.length === 0) {
+      return;
+    }
+    const nativePreview = extensions.getExtension("TypeScriptTeam.native-preview");
+    if (!nativePreview) {
+      return;
+    }
+    void (async () => {
+      try {
+        await nativePreview.activate();
+        const discovered = await commands.executeCommand(
+          "typescript.native-preview.discoverContentMappers",
+          {
+            uris,
+            extensions: [".vue"],
+          },
+        );
+        if (Array.isArray(discovered) && discovered.includes(".vue")) {
+          outputChannel.appendLine("TypeScript native preview discovered the Vize .vue mapper.");
+        }
+      } catch (error: unknown) {
+        outputChannel.appendLine(
+          `TypeScript content mapper discovery is unavailable: ${String(error)}`,
+        );
+      }
+    })();
+  };
+  const vueUri = (document: { languageId: string; uri: Uri }): Uri | undefined =>
+    document.uri.scheme === "file" &&
+    (document.languageId === "vue" || document.languageId === "art-vue") &&
+    document.uri.path.endsWith(".vue")
+      ? document.uri
+      : undefined;
+
+  discover(workspace.textDocuments.map(vueUri).filter((uri): uri is Uri => uri !== undefined));
+  context.subscriptions.push(
+    workspace.onDidOpenTextDocument((document) => {
+      const uri = vueUri(document);
+      if (uri) {
+        discover([uri]);
+      }
+    }),
+  );
 }
 
 function scheduleClientSync(context: ExtensionContext, reason: string): void {

--- a/npm/cli/README.md
+++ b/npm/cli/README.md
@@ -193,6 +193,38 @@ Use the Rust CLI when you need Corsa project diagnostics across Vue, TS, TSX, an
 
 `vize ready` runs `fmt --write`, `lint`, `check`, and `build` in that order.
 
+## Experimental TypeScript Content Mapper
+
+Vize publishes the package metadata and protocol server proposed by
+[microsoft/typescript-go#4712](https://github.com/microsoft/typescript-go/pull/4712). This lets a
+compatible `tsgo` build ask Vize to transform `.vue` files directly instead of materializing a
+parallel `.vue.ts` project.
+
+```json
+{
+  "compilerOptions": {
+    "module": "preserve",
+    "strict": true
+  },
+  "contentMappers": [
+    {
+      "package": "vize",
+      "extensions": [".vue"]
+    }
+  ],
+  "include": ["src"]
+}
+```
+
+```bash
+tsgo --loadExternalPlugins --noEmit -p tsconfig.json
+```
+
+The content-mapper API is not in a released TypeScript native preview yet. Use the exact PR build
+while evaluating it, keep `--loadExternalPlugins` explicit, and keep `vize check` as the supported
+typecheck path until TypeScript ships the protocol. Vize currently negotiates protocol v1 with
+UTF-8 mappings and does not declare compiler-option dependencies.
+
 ## Compiler and Tool Options
 
 Important shared fields:

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -91,5 +91,12 @@
   },
   "engines": {
     "node": ">=22"
+  },
+  "tsContentMapper": {
+    "exec": [
+      "node",
+      "./bin/vize",
+      "content-mapper"
+    ]
   }
 }

--- a/tests/tooling/content-mapper-manifest.test.ts
+++ b/tests/tooling/content-mapper-manifest.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("vize package exposes an executable TypeScript content mapper", () => {
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(root, "npm/cli/package.json"), "utf-8"),
+  ) as {
+    bin?: Record<string, string>;
+    files?: string[];
+    tsContentMapper?: {
+      compilerOptions?: string[];
+      exec?: string[];
+    };
+  };
+  const binPath = path.join(root, "npm/cli/bin/vize");
+
+  assert.deepEqual(packageJson.tsContentMapper, {
+    exec: ["node", "./bin/vize", "content-mapper"],
+  });
+  assert.equal(packageJson.tsContentMapper?.compilerOptions, undefined);
+  assert.equal(packageJson.bin?.vize, "bin/vize");
+  assert.ok(packageJson.files?.includes("bin"));
+  assert.notEqual(
+    fs.statSync(binPath).mode & 0o111,
+    0,
+    "content mapper entrypoint must be executable",
+  );
+  assert.match(fs.readFileSync(binPath, "utf-8"), /^#!\/usr\/bin\/env node\n/);
+});
+
+test("VS Code discovers Vize through the trusted native preview command", () => {
+  const discovery = fs.readFileSync(
+    path.join(root, "editors/vscode/src/content-mapper-discovery.ts"),
+    "utf-8",
+  );
+
+  assert.match(discovery, /extensions\.getExtension\("TypeScriptTeam\.native-preview"\)/);
+  assert.match(
+    discovery,
+    /commands\.executeCommand\(\s*"typescript\.native-preview\.discoverContentMappers"/,
+  );
+  assert.match(discovery, /workspace\.isTrusted/);
+  assert.match(discovery, /extensions: \["\.vue"\]/);
+});

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -321,31 +321,6 @@ test("native preview runtime is declared for vize check users", () => {
   assert.equal(packageJson.peerDependenciesMeta?.["@typescript/native-preview"], undefined);
 });
 
-test("vize package exposes an executable TypeScript content mapper", () => {
-  const packageJson = JSON.parse(readRepoFile("npm/cli/package.json")) as {
-    bin?: Record<string, string>;
-    files?: string[];
-    tsContentMapper?: {
-      compilerOptions?: string[];
-      exec?: string[];
-    };
-  };
-  const binPath = path.join(root, "npm/cli/bin/vize");
-
-  assert.deepEqual(packageJson.tsContentMapper, {
-    exec: ["node", "./bin/vize", "content-mapper"],
-  });
-  assert.equal(packageJson.tsContentMapper?.compilerOptions, undefined);
-  assert.equal(packageJson.bin?.vize, "bin/vize");
-  assert.ok(packageJson.files?.includes("bin"));
-  assert.notEqual(
-    fs.statSync(binPath).mode & 0o111,
-    0,
-    "content mapper entrypoint must be executable",
-  );
-  assert.match(fs.readFileSync(binPath, "utf-8"), /^#!\/usr\/bin\/env node\n/);
-});
-
 test("vize package leaves Vue type versions to the consuming project", () => {
   const packageJson = JSON.parse(readRepoFile("npm/cli/package.json")) as {
     dependencies?: Record<string, string>;
@@ -471,7 +446,6 @@ test("editor extension manifests keep expected defaults and version alignment", 
     scripts?: Record<string, string>;
     version?: string;
   };
-  const vscodeExtension = readRepoFile("editors/vscode/src/extension.ts");
 
   assert.equal(vscodePackage.version, workspaceVersion);
   assert.equal(
@@ -503,13 +477,6 @@ test("editor extension manifests keep expected defaults and version alignment", 
     vscodePackage.devDependencies?.["@typescript/native-preview"],
     "7.0.0-dev.20260421.1",
   );
-  assert.match(vscodeExtension, /extensions\.getExtension\("TypeScriptTeam\.native-preview"\)/);
-  assert.match(
-    vscodeExtension,
-    /commands\.executeCommand\(\s*"typescript\.native-preview\.discoverContentMappers"/,
-  );
-  assert.match(vscodeExtension, /workspace\.isTrusted/);
-  assert.match(vscodeExtension, /extensions: \["\.vue"\]/);
 
   const zedManifest = fs.readFileSync(path.join(root, "editors/zed/extension.toml"), "utf-8");
   const zedVersion = zedManifest.match(/^version = "(.+)"$/m)?.[1];

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -321,6 +321,31 @@ test("native preview runtime is declared for vize check users", () => {
   assert.equal(packageJson.peerDependenciesMeta?.["@typescript/native-preview"], undefined);
 });
 
+test("vize package exposes an executable TypeScript content mapper", () => {
+  const packageJson = JSON.parse(readRepoFile("npm/cli/package.json")) as {
+    bin?: Record<string, string>;
+    files?: string[];
+    tsContentMapper?: {
+      compilerOptions?: string[];
+      exec?: string[];
+    };
+  };
+  const binPath = path.join(root, "npm/cli/bin/vize");
+
+  assert.deepEqual(packageJson.tsContentMapper, {
+    exec: ["node", "./bin/vize", "content-mapper"],
+  });
+  assert.equal(packageJson.tsContentMapper?.compilerOptions, undefined);
+  assert.equal(packageJson.bin?.vize, "bin/vize");
+  assert.ok(packageJson.files?.includes("bin"));
+  assert.notEqual(
+    fs.statSync(binPath).mode & 0o111,
+    0,
+    "content mapper entrypoint must be executable",
+  );
+  assert.match(fs.readFileSync(binPath, "utf-8"), /^#!\/usr\/bin\/env node\n/);
+});
+
 test("vize package leaves Vue type versions to the consuming project", () => {
   const packageJson = JSON.parse(readRepoFile("npm/cli/package.json")) as {
     dependencies?: Record<string, string>;
@@ -446,6 +471,7 @@ test("editor extension manifests keep expected defaults and version alignment", 
     scripts?: Record<string, string>;
     version?: string;
   };
+  const vscodeExtension = readRepoFile("editors/vscode/src/extension.ts");
 
   assert.equal(vscodePackage.version, workspaceVersion);
   assert.equal(
@@ -477,6 +503,13 @@ test("editor extension manifests keep expected defaults and version alignment", 
     vscodePackage.devDependencies?.["@typescript/native-preview"],
     "7.0.0-dev.20260421.1",
   );
+  assert.match(vscodeExtension, /extensions\.getExtension\("TypeScriptTeam\.native-preview"\)/);
+  assert.match(
+    vscodeExtension,
+    /commands\.executeCommand\(\s*"typescript\.native-preview\.discoverContentMappers"/,
+  );
+  assert.match(vscodeExtension, /workspace\.isTrusted/);
+  assert.match(vscodeExtension, /extensions: \["\.vue"\]/);
 
   const zedManifest = fs.readFileSync(path.join(root, "editors/zed/extension.toml"), "utf-8");
   const zedVersion = zedManifest.match(/^version = "(.+)"$/m)?.[1];


### PR DESCRIPTION
## Summary

- add a protocol-v1 TypeScript content mapper server backed by Canon virtual TS generation
- publish `tsContentMapper` metadata and discover `.vue` mappers from the TypeScript native-preview VS Code extension in trusted workspaces
- convert Vize byte mappings into validated UTF-8 span-map tuples, return authored parse failures as mapper diagnostics, and avoid imposing `vite/client` on non-Vite projects
- document the experimental opt-in and the remaining upstream-dependent stabilization work

Refs #3282
Refs #3283

## Validation

- `cargo test -p vize_canon --lib`
- `cargo test -p vize --lib`
- `cargo clippy -p vize_canon -p vize --lib --bins -- -D warnings`
- `node --test tests/tooling/package-manifests.test.ts`
- `pnpm --dir editors/vscode run check`
- built microsoft/typescript-go#4712 head `1d38c36ec83516923ad417382214d5fc55a01475` and verified mapped Vue prop diagnostics plus a clean corrected project with `--loadExternalPlugins`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->