### PR TITLE
test(patina): pin exhaustive eslint-plugin-vue rule map

### DIFF
--- a/crates/vize_patina/src/preset.rs
+++ b/crates/vize_patina/src/preset.rs
@@ -111,6 +111,7 @@ pub(crate) const fn builtin_css_rule_names(preset: LintPreset) -> &'static [&'st
 mod tests {
     use super::LintPreset;
     use crate::rule::RuleRegistry;
+    use std::collections::BTreeSet;
 
     #[test]
     fn parses_common_aliases() {
@@ -250,6 +251,58 @@ mod tests {
 
         assert!(!incremental.has_rule("vue/require-v-for-key"));
         assert!(super::builtin_script_rule_names(LintPreset::Incremental).is_empty());
+    }
+
+    #[test]
+    fn eslint_vue_rule_map_matches_registered_patina_rules() {
+        let rule_map: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../tests/_fixtures/patina-eslint-vue-rule-map.json"
+        ))
+        .unwrap();
+        let mappings = rule_map["entries"].as_object().unwrap();
+
+        let mut available: BTreeSet<_> = RuleRegistry::with_all()
+            .rule_names()
+            .iter()
+            .copied()
+            .collect();
+        available.extend(
+            RuleRegistry::with_opt_in_rules()
+                .rule_names()
+                .iter()
+                .copied(),
+        );
+        available.extend(
+            crate::linter::script_rules::all_builtin_script_rule_names()
+                .iter()
+                .copied(),
+        );
+
+        for (eslint_rule, entry) in mappings {
+            if entry["status"] == "mapped" {
+                let target = entry["patinaRule"].as_str().unwrap();
+                assert!(
+                    available.contains(target),
+                    "{eslint_rule} maps to unavailable Patina rule {target}"
+                );
+                continue;
+            }
+
+            let script_rule = eslint_rule.replacen("vue/", "script/", 1);
+            let alias = match eslint_rule.as_str() {
+                "vue/attributes-order" => Some("vue/attribute-order"),
+                "vue/block-order" => Some("vue/sfc-element-order"),
+                "vue/no-async-in-computed-properties" => Some("script/no-async-in-computed"),
+                _ => None,
+            };
+            let hidden_rule = available.contains(eslint_rule.as_str())
+                || available.contains(script_rule.as_str())
+                || alias.is_some_and(|rule| available.contains(rule));
+            assert!(
+                !hidden_rule,
+                "{eslint_rule} is marked unimplemented despite a registered Patina counterpart"
+            );
+        }
     }
 
     fn rule_names(preset: LintPreset) -> Vec<&'static str> {

--- a/tests/_fixtures/patina-eslint-vue-rule-map.json
+++ b/tests/_fixtures/patina-eslint-vue-rule-map.json
@@ -1,0 +1,1022 @@
+{
+  "schemaVersion": 1,
+  "upstream": {
+    "package": "eslint-plugin-vue",
+    "version": "10.9.2",
+    "ruleCount": 252
+  },
+  "summary": {
+    "mapped": 120,
+    "unimplemented": 132
+  },
+  "entries": {
+    "vue/array-bracket-newline": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/array-bracket-spacing": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/array-element-newline": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/arrow-spacing": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/attribute-hyphenation": {
+      "status": "mapped",
+      "patinaRule": "vue/attribute-hyphenation"
+    },
+    "vue/attributes-order": {
+      "status": "mapped",
+      "patinaRule": "vue/attribute-order"
+    },
+    "vue/block-lang": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/block-order": {
+      "status": "mapped",
+      "patinaRule": "vue/sfc-element-order"
+    },
+    "vue/block-spacing": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/block-tag-newline": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/brace-style": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/camelcase": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/comma-dangle": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/comma-spacing": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/comma-style": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/comment-directive": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/component-api-style": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/component-definition-name-casing": {
+      "status": "mapped",
+      "patinaRule": "vue/component-definition-name-casing"
+    },
+    "vue/component-name-in-template-casing": {
+      "status": "mapped",
+      "patinaRule": "vue/component-name-in-template-casing"
+    },
+    "vue/component-options-name-casing": {
+      "status": "mapped",
+      "patinaRule": "script/component-options-name-casing"
+    },
+    "vue/custom-event-name-casing": {
+      "status": "mapped",
+      "patinaRule": "script/custom-event-name-casing"
+    },
+    "vue/define-emits-declaration": {
+      "status": "mapped",
+      "patinaRule": "script/define-emits-declaration"
+    },
+    "vue/define-macros-order": {
+      "status": "mapped",
+      "patinaRule": "script/define-macros-order"
+    },
+    "vue/define-props-declaration": {
+      "status": "mapped",
+      "patinaRule": "script/define-props-declaration"
+    },
+    "vue/define-props-destructuring": {
+      "status": "mapped",
+      "patinaRule": "script/define-props-destructuring"
+    },
+    "vue/dot-location": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/dot-notation": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/enforce-style-attribute": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/eqeqeq": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/first-attribute-linebreak": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/func-call-spacing": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/html-button-has-type": {
+      "status": "mapped",
+      "patinaRule": "vue/html-button-has-type"
+    },
+    "vue/html-closing-bracket-newline": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/html-closing-bracket-spacing": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/html-comment-content-newline": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/html-comment-content-spacing": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/html-comment-indent": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/html-end-tags": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/html-indent": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/html-quotes": {
+      "status": "mapped",
+      "patinaRule": "vue/html-quotes"
+    },
+    "vue/html-self-closing": {
+      "status": "mapped",
+      "patinaRule": "vue/html-self-closing"
+    },
+    "vue/jsx-uses-vars": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/key-spacing": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/keyword-spacing": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/match-component-file-name": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/match-component-import-name": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/max-attributes-per-line": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/max-len": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/max-lines-per-block": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/max-props": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/max-template-depth": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/multi-word-component-names": {
+      "status": "mapped",
+      "patinaRule": "vue/multi-word-component-names"
+    },
+    "vue/multiline-html-element-content-newline": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/multiline-ternary": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/mustache-interpolation-spacing": {
+      "status": "mapped",
+      "patinaRule": "vue/mustache-interpolation-spacing"
+    },
+    "vue/new-line-between-multi-line-property": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/next-tick-style": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-arrow-functions-in-watch": {
+      "status": "mapped",
+      "patinaRule": "script/no-arrow-functions-in-watch"
+    },
+    "vue/no-async-in-computed-properties": {
+      "status": "mapped",
+      "patinaRule": "script/no-async-in-computed"
+    },
+    "vue/no-bare-strings-in-template": {
+      "status": "mapped",
+      "patinaRule": "vue/no-bare-strings-in-template"
+    },
+    "vue/no-boolean-default": {
+      "status": "mapped",
+      "patinaRule": "script/no-boolean-default"
+    },
+    "vue/no-child-content": {
+      "status": "mapped",
+      "patinaRule": "vue/no-child-content"
+    },
+    "vue/no-computed-properties-in-data": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-console": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-constant-condition": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-custom-modifiers-on-v-model": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-deprecated-data-object-declaration": {
+      "status": "mapped",
+      "patinaRule": "script/no-deprecated-data-object-declaration"
+    },
+    "vue/no-deprecated-delete-set": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-deprecated-destroyed-lifecycle": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-deprecated-dollar-listeners-api": {
+      "status": "mapped",
+      "patinaRule": "script/no-deprecated-dollar-listeners-api"
+    },
+    "vue/no-deprecated-dollar-scopedslots-api": {
+      "status": "mapped",
+      "patinaRule": "script/no-deprecated-dollar-scopedslots-api"
+    },
+    "vue/no-deprecated-events-api": {
+      "status": "mapped",
+      "patinaRule": "script/no-deprecated-events-api"
+    },
+    "vue/no-deprecated-filter": {
+      "status": "mapped",
+      "patinaRule": "vue/no-deprecated-filter"
+    },
+    "vue/no-deprecated-functional-template": {
+      "status": "mapped",
+      "patinaRule": "vue/no-deprecated-functional-template"
+    },
+    "vue/no-deprecated-html-element-is": {
+      "status": "mapped",
+      "patinaRule": "vue/no-deprecated-html-element-is"
+    },
+    "vue/no-deprecated-inline-template": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-deprecated-model-definition": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-deprecated-props-default-this": {
+      "status": "mapped",
+      "patinaRule": "script/no-deprecated-props-default-this"
+    },
+    "vue/no-deprecated-router-link-tag-prop": {
+      "status": "mapped",
+      "patinaRule": "vue/no-deprecated-router-link-tag-prop"
+    },
+    "vue/no-deprecated-scope-attribute": {
+      "status": "mapped",
+      "patinaRule": "vue/no-deprecated-scope-attribute"
+    },
+    "vue/no-deprecated-slot-attribute": {
+      "status": "mapped",
+      "patinaRule": "vue/no-deprecated-slot-attribute"
+    },
+    "vue/no-deprecated-slot-scope-attribute": {
+      "status": "mapped",
+      "patinaRule": "vue/no-deprecated-slot-scope-attribute"
+    },
+    "vue/no-deprecated-v-bind-sync": {
+      "status": "mapped",
+      "patinaRule": "vue/no-deprecated-v-bind-sync"
+    },
+    "vue/no-deprecated-v-is": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-deprecated-v-on-native-modifier": {
+      "status": "mapped",
+      "patinaRule": "vue/no-deprecated-v-on-native-modifier"
+    },
+    "vue/no-deprecated-v-on-number-modifiers": {
+      "status": "mapped",
+      "patinaRule": "vue/no-deprecated-v-on-number-modifiers"
+    },
+    "vue/no-deprecated-vue-config-keycodes": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-dupe-keys": {
+      "status": "mapped",
+      "patinaRule": "script/no-dupe-keys"
+    },
+    "vue/no-dupe-v-else-if": {
+      "status": "mapped",
+      "patinaRule": "vue/no-dupe-v-else-if"
+    },
+    "vue/no-duplicate-attr-inheritance": {
+      "status": "mapped",
+      "patinaRule": "script/no-duplicate-attr-inheritance"
+    },
+    "vue/no-duplicate-attributes": {
+      "status": "mapped",
+      "patinaRule": "vue/no-duplicate-attributes"
+    },
+    "vue/no-duplicate-class-names": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-empty-component-block": {
+      "status": "mapped",
+      "patinaRule": "vue/no-empty-component-block"
+    },
+    "vue/no-empty-pattern": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-export-in-script-setup": {
+      "status": "mapped",
+      "patinaRule": "script/no-export-in-script-setup"
+    },
+    "vue/no-expose-after-await": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-extra-parens": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-implicit-coercion": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-import-compiler-macros": {
+      "status": "mapped",
+      "patinaRule": "script/no-import-compiler-macros"
+    },
+    "vue/no-irregular-whitespace": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-lifecycle-after-await": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-literals-in-template": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-lone-template": {
+      "status": "mapped",
+      "patinaRule": "vue/no-lone-template"
+    },
+    "vue/no-loss-of-precision": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-multi-spaces": {
+      "status": "mapped",
+      "patinaRule": "vue/no-multi-spaces"
+    },
+    "vue/no-multiple-objects-in-class": {
+      "status": "mapped",
+      "patinaRule": "vue/no-multiple-objects-in-class"
+    },
+    "vue/no-multiple-slot-args": {
+      "status": "mapped",
+      "patinaRule": "script/no-multiple-slot-args"
+    },
+    "vue/no-multiple-template-root": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-mutating-props": {
+      "status": "mapped",
+      "patinaRule": "vue/no-mutating-props"
+    },
+    "vue/no-negated-condition": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-negated-v-if-condition": {
+      "status": "mapped",
+      "patinaRule": "vue/no-negated-v-if-condition"
+    },
+    "vue/no-parsing-error": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-potential-component-option-typo": {
+      "status": "mapped",
+      "patinaRule": "script/no-potential-component-option-typo"
+    },
+    "vue/no-ref-as-operand": {
+      "status": "mapped",
+      "patinaRule": "script/no-ref-as-operand"
+    },
+    "vue/no-ref-object-reactivity-loss": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-required-prop-with-default": {
+      "status": "mapped",
+      "patinaRule": "script/no-required-prop-with-default"
+    },
+    "vue/no-reserved-component-names": {
+      "status": "mapped",
+      "patinaRule": "vue/no-reserved-component-names"
+    },
+    "vue/no-reserved-keys": {
+      "status": "mapped",
+      "patinaRule": "script/no-reserved-keys"
+    },
+    "vue/no-reserved-props": {
+      "status": "mapped",
+      "patinaRule": "script/no-reserved-props"
+    },
+    "vue/no-restricted-block": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-restricted-call-after-await": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-restricted-class": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-restricted-component-names": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-restricted-component-options": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-restricted-custom-event": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-restricted-html-elements": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-restricted-props": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-restricted-static-attribute": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-restricted-syntax": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-restricted-v-bind": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-restricted-v-on": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-root-v-if": {
+      "status": "mapped",
+      "patinaRule": "vue/no-root-v-if"
+    },
+    "vue/no-setup-props-reactivity-loss": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-shared-component-data": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-side-effects-in-computed-properties": {
+      "status": "mapped",
+      "patinaRule": "script/no-side-effects-in-computed-properties"
+    },
+    "vue/no-spaces-around-equal-signs-in-attribute": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-sparse-arrays": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-static-inline-styles": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-template-key": {
+      "status": "mapped",
+      "patinaRule": "vue/no-template-key"
+    },
+    "vue/no-template-shadow": {
+      "status": "mapped",
+      "patinaRule": "vue/no-template-shadow"
+    },
+    "vue/no-template-target-blank": {
+      "status": "mapped",
+      "patinaRule": "vue/no-template-target-blank"
+    },
+    "vue/no-textarea-mustache": {
+      "status": "mapped",
+      "patinaRule": "vue/no-textarea-mustache"
+    },
+    "vue/no-this-in-before-route-enter": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-undef-components": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-undef-directives": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-undef-properties": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-unsupported-features": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-unused-components": {
+      "status": "mapped",
+      "patinaRule": "vue/no-unused-components"
+    },
+    "vue/no-unused-emit-declarations": {
+      "status": "mapped",
+      "patinaRule": "script/no-unused-emit-declarations"
+    },
+    "vue/no-unused-properties": {
+      "status": "mapped",
+      "patinaRule": "vue/no-unused-properties"
+    },
+    "vue/no-unused-refs": {
+      "status": "mapped",
+      "patinaRule": "vue/no-unused-refs"
+    },
+    "vue/no-unused-vars": {
+      "status": "mapped",
+      "patinaRule": "vue/no-unused-vars"
+    },
+    "vue/no-use-computed-property-like-method": {
+      "status": "mapped",
+      "patinaRule": "script/no-use-computed-property-like-method"
+    },
+    "vue/no-use-v-else-with-v-for": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-use-v-if-with-v-for": {
+      "status": "mapped",
+      "patinaRule": "vue/no-use-v-if-with-v-for"
+    },
+    "vue/no-useless-concat": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-useless-mustaches": {
+      "status": "mapped",
+      "patinaRule": "vue/no-useless-mustaches"
+    },
+    "vue/no-useless-template-attributes": {
+      "status": "mapped",
+      "patinaRule": "vue/no-useless-template-attributes"
+    },
+    "vue/no-useless-v-bind": {
+      "status": "mapped",
+      "patinaRule": "vue/no-useless-v-bind"
+    },
+    "vue/no-v-for-template-key": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-v-for-template-key-on-child": {
+      "status": "mapped",
+      "patinaRule": "vue/no-v-for-template-key-on-child"
+    },
+    "vue/no-v-html": {
+      "status": "mapped",
+      "patinaRule": "vue/no-v-html"
+    },
+    "vue/no-v-model-argument": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/no-v-text": {
+      "status": "mapped",
+      "patinaRule": "vue/no-v-text"
+    },
+    "vue/no-v-text-v-html-on-component": {
+      "status": "mapped",
+      "patinaRule": "vue/no-v-text-v-html-on-component"
+    },
+    "vue/no-watch-after-await": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/object-curly-newline": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/object-curly-spacing": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/object-property-newline": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/object-shorthand": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/one-component-per-file": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/operator-linebreak": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/order-in-components": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/padding-line-between-blocks": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/padding-line-between-tags": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/padding-lines-in-component-definition": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/prefer-define-options": {
+      "status": "mapped",
+      "patinaRule": "script/prefer-define-options"
+    },
+    "vue/prefer-import-from-vue": {
+      "status": "mapped",
+      "patinaRule": "script/prefer-import-from-vue"
+    },
+    "vue/prefer-prop-type-boolean-first": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/prefer-separate-static-class": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/prefer-single-event-payload": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/prefer-template": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/prefer-true-attribute-shorthand": {
+      "status": "mapped",
+      "patinaRule": "vue/prefer-true-attribute-shorthand"
+    },
+    "vue/prefer-use-template-ref": {
+      "status": "mapped",
+      "patinaRule": "script/prefer-use-template-ref"
+    },
+    "vue/prefer-v-model": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/prop-name-casing": {
+      "status": "mapped",
+      "patinaRule": "vue/prop-name-casing"
+    },
+    "vue/quote-props": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/require-component-is": {
+      "status": "mapped",
+      "patinaRule": "vue/require-component-is"
+    },
+    "vue/require-default-export": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/require-default-prop": {
+      "status": "mapped",
+      "patinaRule": "script/require-default-prop"
+    },
+    "vue/require-direct-export": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/require-emit-validator": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/require-explicit-emits": {
+      "status": "mapped",
+      "patinaRule": "script/require-explicit-emits"
+    },
+    "vue/require-explicit-slots": {
+      "status": "mapped",
+      "patinaRule": "script/require-explicit-slots"
+    },
+    "vue/require-expose": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/require-macro-variable-name": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/require-name-property": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/require-prop-comment": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/require-prop-type-constructor": {
+      "status": "mapped",
+      "patinaRule": "script/require-prop-type-constructor"
+    },
+    "vue/require-prop-types": {
+      "status": "mapped",
+      "patinaRule": "script/require-prop-types"
+    },
+    "vue/require-render-return": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/require-slots-as-functions": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/require-toggle-inside-transition": {
+      "status": "mapped",
+      "patinaRule": "vue/require-toggle-inside-transition"
+    },
+    "vue/require-typed-object-prop": {
+      "status": "mapped",
+      "patinaRule": "script/require-typed-object-prop"
+    },
+    "vue/require-typed-ref": {
+      "status": "mapped",
+      "patinaRule": "script/require-typed-ref"
+    },
+    "vue/require-v-for-key": {
+      "status": "mapped",
+      "patinaRule": "vue/require-v-for-key"
+    },
+    "vue/require-valid-default-prop": {
+      "status": "mapped",
+      "patinaRule": "script/require-valid-default-prop"
+    },
+    "vue/restricted-component-names": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/return-in-computed-property": {
+      "status": "mapped",
+      "patinaRule": "script/return-in-computed-property"
+    },
+    "vue/return-in-emits-validator": {
+      "status": "mapped",
+      "patinaRule": "script/return-in-emits-validator"
+    },
+    "vue/script-indent": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/singleline-html-element-content-newline": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/slot-name-casing": {
+      "status": "mapped",
+      "patinaRule": "vue/slot-name-casing"
+    },
+    "vue/sort-keys": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/space-in-parens": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/space-infix-ops": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/space-unary-ops": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/static-class-names-order": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/template-curly-spacing": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/this-in-template": {
+      "status": "mapped",
+      "patinaRule": "vue/this-in-template"
+    },
+    "vue/use-v-on-exact": {
+      "status": "mapped",
+      "patinaRule": "vue/use-v-on-exact"
+    },
+    "vue/v-bind-style": {
+      "status": "mapped",
+      "patinaRule": "vue/v-bind-style"
+    },
+    "vue/v-for-delimiter-style": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/v-if-else-key": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/v-on-event-hyphenation": {
+      "status": "mapped",
+      "patinaRule": "vue/v-on-event-hyphenation"
+    },
+    "vue/v-on-handler-style": {
+      "status": "mapped",
+      "patinaRule": "vue/v-on-handler-style"
+    },
+    "vue/v-on-style": {
+      "status": "mapped",
+      "patinaRule": "vue/v-on-style"
+    },
+    "vue/v-slot-style": {
+      "status": "mapped",
+      "patinaRule": "vue/v-slot-style"
+    },
+    "vue/valid-attribute-name": {
+      "status": "mapped",
+      "patinaRule": "vue/valid-attribute-name"
+    },
+    "vue/valid-define-emits": {
+      "status": "mapped",
+      "patinaRule": "script/valid-define-emits"
+    },
+    "vue/valid-define-options": {
+      "status": "mapped",
+      "patinaRule": "script/valid-define-options"
+    },
+    "vue/valid-define-props": {
+      "status": "mapped",
+      "patinaRule": "script/valid-define-props"
+    },
+    "vue/valid-model-definition": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/valid-next-tick": {
+      "status": "mapped",
+      "patinaRule": "script/valid-next-tick"
+    },
+    "vue/valid-template-root": {
+      "status": "mapped",
+      "patinaRule": "vue/valid-template-root"
+    },
+    "vue/valid-v-bind": {
+      "status": "mapped",
+      "patinaRule": "vue/valid-v-bind"
+    },
+    "vue/valid-v-bind-sync": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/valid-v-cloak": {
+      "status": "mapped",
+      "patinaRule": "vue/valid-v-cloak"
+    },
+    "vue/valid-v-else": {
+      "status": "mapped",
+      "patinaRule": "vue/valid-v-else"
+    },
+    "vue/valid-v-else-if": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/valid-v-for": {
+      "status": "mapped",
+      "patinaRule": "vue/valid-v-for"
+    },
+    "vue/valid-v-html": {
+      "status": "mapped",
+      "patinaRule": "vue/valid-v-html"
+    },
+    "vue/valid-v-if": {
+      "status": "mapped",
+      "patinaRule": "vue/valid-v-if"
+    },
+    "vue/valid-v-is": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/valid-v-memo": {
+      "status": "mapped",
+      "patinaRule": "vue/valid-v-memo"
+    },
+    "vue/valid-v-model": {
+      "status": "mapped",
+      "patinaRule": "vue/valid-v-model"
+    },
+    "vue/valid-v-on": {
+      "status": "mapped",
+      "patinaRule": "vue/valid-v-on"
+    },
+    "vue/valid-v-once": {
+      "status": "mapped",
+      "patinaRule": "vue/valid-v-once"
+    },
+    "vue/valid-v-pre": {
+      "status": "unimplemented",
+      "issue": 3223
+    },
+    "vue/valid-v-show": {
+      "status": "mapped",
+      "patinaRule": "vue/valid-v-show"
+    },
+    "vue/valid-v-slot": {
+      "status": "mapped",
+      "patinaRule": "vue/valid-v-slot"
+    },
+    "vue/valid-v-text": {
+      "status": "mapped",
+      "patinaRule": "vue/valid-v-text"
+    }
+  }
+}

--- a/tests/tooling/patina-eslint-vue-rule-map.test.ts
+++ b/tests/tooling/patina-eslint-vue-rule-map.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { readRuleMap, validateRuleMap } from "../../tools/fixtures/patina-rule-map.mjs";
+
+test("the Patina scorecard exhaustively maps the pinned eslint-plugin-vue rule surface", () => {
+  const ruleMap = validateRuleMap(readRuleMap());
+
+  assert.equal(ruleMap.upstream.version, "10.9.2");
+  assert.equal(ruleMap.upstream.ruleCount, 252);
+  assert.ok(ruleMap.summary.mapped > 100, "the scorecard must expose existing Patina coverage");
+  assert.ok(
+    ruleMap.summary.unimplemented > 0,
+    "the scorecard must keep uncovered upstream rules explicit",
+  );
+});

--- a/tools/fixtures/patina-rule-map.mjs
+++ b/tools/fixtures/patina-rule-map.mjs
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+export const ruleMapPath = path.join(
+  repoRoot,
+  "tests",
+  "_fixtures",
+  "patina-eslint-vue-rule-map.json",
+);
+
+const upstreamPackage = "eslint-plugin-vue";
+const trackingIssue = 3223;
+const explicitPatinaAliases = new Map([
+  ["vue/attributes-order", "vue/attribute-order"],
+  ["vue/block-order", "vue/sfc-element-order"],
+  ["vue/no-async-in-computed-properties", "script/no-async-in-computed"],
+]);
+
+function loadUpstream() {
+  const requireFromBench = createRequire(path.join(repoRoot, "bench", "package.json"));
+  const plugin = requireFromBench(upstreamPackage);
+  const manifest = requireFromBench(`${upstreamPackage}/package.json`);
+  const benchManifest = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "bench", "package.json"), "utf8"),
+  );
+
+  assert.equal(
+    benchManifest.devDependencies?.[upstreamPackage],
+    manifest.version,
+    `${upstreamPackage} must stay exactly pinned in bench/package.json`,
+  );
+
+  return {
+    ruleIds: Object.keys(plugin.rules)
+      .map((name) => `vue/${name}`)
+      .sort(),
+    version: manifest.version,
+  };
+}
+
+async function loadPatinaRuleNames() {
+  const nativeEntry = process.env.VIZE_PATINA_NATIVE_MODULE
+    ? path.resolve(process.env.VIZE_PATINA_NATIVE_MODULE)
+    : path.join(repoRoot, "npm", "native", "index.js");
+  const nativeModule = await import(pathToFileURL(nativeEntry));
+  const binding = nativeModule.default ?? nativeModule;
+  assert.equal(
+    typeof binding.getPatinaRules,
+    "function",
+    "building the rule map requires a local @vizejs/native binding",
+  );
+  return new Set(binding.getPatinaRules().map((rule) => rule.name));
+}
+
+function patinaTargetFor(upstreamRule, patinaRules) {
+  if (patinaRules.has(upstreamRule)) {
+    return upstreamRule;
+  }
+
+  const scriptRule = `script/${upstreamRule.slice("vue/".length)}`;
+  if (patinaRules.has(scriptRule)) {
+    return scriptRule;
+  }
+
+  const alias = explicitPatinaAliases.get(upstreamRule);
+  return alias != null && patinaRules.has(alias) ? alias : null;
+}
+
+export async function generateRuleMap() {
+  const upstream = loadUpstream();
+  const patinaRules = await loadPatinaRuleNames();
+  const entries = {};
+  let mapped = 0;
+
+  for (const ruleId of upstream.ruleIds) {
+    const patinaRule = patinaTargetFor(ruleId, patinaRules);
+    if (patinaRule == null) {
+      entries[ruleId] = { status: "unimplemented", issue: trackingIssue };
+      continue;
+    }
+    entries[ruleId] = { status: "mapped", patinaRule };
+    mapped += 1;
+  }
+
+  return {
+    schemaVersion: 1,
+    upstream: {
+      package: upstreamPackage,
+      version: upstream.version,
+      ruleCount: upstream.ruleIds.length,
+    },
+    summary: {
+      mapped,
+      unimplemented: upstream.ruleIds.length - mapped,
+    },
+    entries,
+  };
+}
+
+export function readRuleMap() {
+  return JSON.parse(fs.readFileSync(ruleMapPath, "utf8"));
+}
+
+export function validateRuleMap(ruleMap = readRuleMap()) {
+  const upstream = loadUpstream();
+
+  assert.equal(ruleMap.schemaVersion, 1);
+  assert.deepEqual(ruleMap.upstream, {
+    package: upstreamPackage,
+    version: upstream.version,
+    ruleCount: upstream.ruleIds.length,
+  });
+  assert.deepEqual(
+    Object.keys(ruleMap.entries),
+    upstream.ruleIds,
+    "every pinned eslint-plugin-vue rule must have exactly one sorted map entry",
+  );
+
+  let mapped = 0;
+  let unimplemented = 0;
+  for (const [ruleId, entry] of Object.entries(ruleMap.entries)) {
+    assert.equal(typeof entry, "object", `${ruleId} must have a structured map entry`);
+    if (entry.status === "mapped") {
+      assert.match(entry.patinaRule, /^(?:script|vue)\/[a-z0-9-]+$/u);
+      assert.deepEqual(Object.keys(entry).sort(), ["patinaRule", "status"]);
+      mapped += 1;
+      continue;
+    }
+    if (entry.status === "unimplemented") {
+      assert.equal(entry.issue, trackingIssue, `${ruleId} must link the scorecard issue`);
+      assert.deepEqual(Object.keys(entry).sort(), ["issue", "status"]);
+      unimplemented += 1;
+      continue;
+    }
+    if (entry.status === "intentional-divergence") {
+      assert.match(entry.reason, /\S/u, `${ruleId} needs a non-empty divergence reason`);
+      assert.deepEqual(Object.keys(entry).sort(), ["reason", "status"]);
+      continue;
+    }
+    assert.fail(`${ruleId} has unsupported status ${JSON.stringify(entry.status)}`);
+  }
+
+  assert.deepEqual(ruleMap.summary, { mapped, unimplemented });
+  assert.equal(
+    mapped + unimplemented,
+    upstream.ruleIds.length,
+    "the initial scorecard may not hide rules behind an uncounted status",
+  );
+  return ruleMap;
+}
+
+async function main() {
+  if (process.argv[1] == null || path.resolve(process.argv[1]) !== fileURLToPath(import.meta.url)) {
+    return;
+  }
+  if (process.argv[2] === "--write") {
+    const ruleMap = await generateRuleMap();
+    fs.writeFileSync(ruleMapPath, `${JSON.stringify(ruleMap, null, 2)}\n`);
+    return;
+  }
+  if (process.argv.length === 2 || process.argv[2] === "--check") {
+    validateRuleMap();
+    return;
+  }
+  throw new Error("Usage: node tools/fixtures/patina-rule-map.mjs [--check|--write]");
+}
+
+await main();


### PR DESCRIPTION
## Summary

- check in a sorted, exhaustive map for all 252 rules in the pinned `eslint-plugin-vue@10.9.2`
- classify 120 existing Patina counterparts and keep all 132 gaps explicitly linked to #3223
- fail on upstream rule/version drift, invalid schema, stale coverage classifications, or mappings to unavailable Patina rules

## Validation

- `cargo test -p vize_patina` (2,211 passed)
- `cargo clippy -p vize_patina --lib -- -D warnings`
- `node tools/fixtures/patina-rule-map.mjs --check`
- `node --test tests/tooling/patina-eslint-vue-rule-map.test.ts`
- `vp fmt --check tools/fixtures/patina-rule-map.mjs tests/tooling/patina-eslint-vue-rule-map.test.ts tests/_fixtures/patina-eslint-vue-rule-map.json`
- `vp check tools/fixtures/patina-rule-map.mjs tests/tooling/patina-eslint-vue-rule-map.test.ts`
- `git diff --check`

Refs #3223

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation for Vue ESLint rule mappings.
  * Added checks confirming mapped rules correspond to registered Patina rules.
  * Added coverage checks for mapped and explicitly unimplemented rules.

* **Tooling**
  * Added tools to generate, validate, and inspect the Vue ESLint rule mapping.
  * Added a complete rule-mapping fixture covering all 252 upstream rules, including 120 mapped rules and 132 unimplemented rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->