### PR TITLE
feat(doctor): enforce canonical public SFC sections

### DIFF
--- a/crates/vize/src/commands/doctor.rs
+++ b/crates/vize/src/commands/doctor.rs
@@ -1,6 +1,7 @@
 //! Whole-application health analysis command.
 
 mod analysis;
+mod canonical_sfc;
 mod discovery;
 mod output;
 
@@ -46,6 +47,10 @@ pub struct DoctorArgs {
     /// Return success even when the report contains blocking findings. Defaults to false.
     #[arg(long)]
     pub exit_zero: bool,
+
+    /// Enforce the canonical public component SFC contract. Defaults to false.
+    #[arg(long)]
+    pub public_sfc: bool,
 }
 
 #[derive(Debug)]
@@ -165,7 +170,7 @@ fn execute(args: DoctorArgs) -> Result<DoctorOutcome, DoctorError> {
             source,
         })?;
     let sources = discover_sources(&root, &args.paths)?;
-    let report = analyze_application(&root, &sources)?;
+    let report = analyze_application(&root, &sources, args.public_sfc)?;
     Ok(DoctorOutcome {
         report,
         format: args.format,

--- a/crates/vize/src/commands/doctor/analysis.rs
+++ b/crates/vize/src/commands/doctor/analysis.rs
@@ -10,9 +10,11 @@ use vize_atelier_sfc::{
 use vize_carton::{Allocator, FxHashMap};
 use vize_croquis::{EffectGraphScript, build_effect_graph_from_sfc_scripts};
 use vize_croquis_cf::{CrossFileAnalyzer, CrossFileDiagnosticKind, CrossFileOptions, FileId};
-use vize_doctor::{DoctorReport, application_analysis::report_from_application_graph};
+use vize_doctor::{
+    DoctorFinding, DoctorReport, application_analysis::report_from_application_graph,
+};
 
-use super::{DoctorError, DoctorSource};
+use super::{DoctorError, DoctorSource, canonical_sfc};
 
 #[derive(Clone, Copy, Debug, Default)]
 struct SourceBlock {
@@ -31,9 +33,11 @@ struct SfcSourceMap {
 pub(super) fn analyze_application(
     root: &Path,
     sources: &[DoctorSource],
+    public_sfc: bool,
 ) -> Result<DoctorReport, DoctorError> {
     let mut analyzer = CrossFileAnalyzer::with_project_root(doctor_options(), root);
     let mut source_maps = FxHashMap::default();
+    let mut public_sfc_findings = Vec::new();
     let mut ordered_sources = sources.iter().collect::<Vec<_>>();
     ordered_sources.sort_unstable_by(|left, right| left.path.cmp(&right.path));
 
@@ -43,7 +47,13 @@ pub(super) fn analyze_application(
             .extension()
             .is_some_and(|extension| extension == "vue")
         {
-            add_sfc(&mut analyzer, &mut source_maps, source)?;
+            add_sfc(
+                &mut analyzer,
+                &mut source_maps,
+                &mut public_sfc_findings,
+                source,
+                public_sfc,
+            )?;
         } else {
             analyzer.add_file(&source.path, source.source.as_str());
         }
@@ -53,15 +63,27 @@ pub(super) fn analyze_application(
     analyzer.rebuild_component_edges();
     let mut result = analyzer.analyze();
     normalize_sfc_diagnostics(&mut result.diagnostics, &source_maps);
-    report_from_application_graph(".", &analyzer, &result).map_err(DoctorError::from)
+    let graph_report =
+        report_from_application_graph(".", &analyzer, &result).map_err(DoctorError::from)?;
+    Ok(DoctorReport::new(
+        graph_report.workspace(),
+        graph_report
+            .findings()
+            .iter()
+            .cloned()
+            .chain(public_sfc_findings),
+    ))
 }
 
 fn add_sfc(
     analyzer: &mut CrossFileAnalyzer,
     source_maps: &mut FxHashMap<FileId, SfcSourceMap>,
+    public_sfc_findings: &mut Vec<DoctorFinding>,
     source: &DoctorSource,
+    public_sfc: bool,
 ) -> Result<(), DoctorError> {
     let filename = source.path.to_string_lossy();
+    let doctor_path = filename.replace('\\', "/");
     let descriptor = parse_sfc(
         source.source.as_str(),
         SfcParseOptions {
@@ -73,6 +95,9 @@ fn add_sfc(
         path: source.path.clone(),
         message: error.message,
     })?;
+    if public_sfc && let Some(finding) = canonical_sfc::finding(&doctor_path, &descriptor) {
+        public_sfc_findings.push(finding);
+    }
     let analysis = if let Some(template) = descriptor.template.as_ref() {
         let allocator = Allocator::with_capacity((template.content.len() * 4).max(64 * 1024));
         let parser = Parser::new(allocator.as_bump(), template.content.as_ref());

--- a/crates/vize/src/commands/doctor/canonical_sfc.rs
+++ b/crates/vize/src/commands/doctor/canonical_sfc.rs
@@ -1,0 +1,222 @@
+//! Doctor rule for the opt-in public component authoring contract.
+
+use vize_atelier_sfc::{BlockLocation, SfcDescriptor};
+use vize_carton::cstr;
+use vize_doctor::{
+    AnalysisProvenance, DoctorCategory, DoctorFinding, EvidenceKind, FindingAssessment,
+    FindingConfidence, FindingEvidence, FindingImpact, FindingSeverity, HealthPenalty, RuleCost,
+    SourceLocation, SuppressionPolicy,
+};
+
+pub(super) const RULE_CODE: &str = "VIZE_DOCTOR_SFC_EXPLICIT_SECTIONS";
+
+const CONTRACT_CAPABILITY: &str = "public-sfc-contract";
+const GATE_RULE: &str = "explicit-sfc";
+
+#[derive(Clone)]
+struct ContractProblem {
+    requirement: &'static str,
+    location: SourceLocation,
+}
+
+/// Checks the same explicit-section invariant as the `@vizejs/ui-tooling`
+/// `explicit-sfc` authoring gate without rescanning SFC source text.
+///
+/// The caller must opt a source into the public component contract. Ordinary
+/// application SFCs intentionally remain outside this rule.
+pub(super) fn finding(path: &str, descriptor: &SfcDescriptor<'_>) -> Option<DoctorFinding> {
+    let source_end = bounded_offset(descriptor.source.len());
+    let insertion = || SourceLocation::new(path, source_end, source_end);
+    let mut problems = Vec::with_capacity(3);
+
+    match descriptor.script_setup.as_ref() {
+        Some(script) if script.lang.as_deref() == Some("ts") => {}
+        Some(script) => problems.push(problem(
+            "<script setup lang=\"ts\">",
+            opening_location(path, &script.loc),
+        )),
+        None => problems.push(problem(
+            "<script setup lang=\"ts\">",
+            descriptor
+                .script
+                .as_ref()
+                .map(|script| opening_location(path, &script.loc))
+                .unwrap_or_else(&insertion),
+        )),
+    }
+
+    if descriptor.template.is_none() {
+        problems.push(problem("<template>", insertion()));
+    }
+
+    if !descriptor.styles.iter().any(|style| style.scoped) {
+        problems.push(problem(
+            "<style scoped>",
+            descriptor
+                .styles
+                .first()
+                .map(|style| opening_location(path, &style.loc))
+                .unwrap_or_else(&insertion),
+        ));
+    }
+
+    let primary = problems.first()?.location.clone();
+    let problem_names = problems
+        .iter()
+        .map(|problem| problem.requirement)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut finding = DoctorFinding::new(
+        RULE_CODE,
+        DoctorCategory::Maintainability,
+        FindingAssessment::new(
+            FindingSeverity::Error,
+            FindingConfidence::Certain,
+            FindingImpact::Medium,
+            HealthPenalty::new(20, "Public component source contract is incomplete"),
+        ),
+        primary,
+        "Public component does not use canonical SFC sections",
+        cstr!(
+            "Declare every canonical public component section explicitly. Noncanonical sections: \
+             {}.",
+            problem_names
+        ),
+        AnalysisProvenance::new(CONTRACT_CAPABILITY, RuleCost::Low)
+            .with_invalidation_inputs([path]),
+    )
+    .with_failure_scenario(
+        "A public component bypasses the source-owned SFC contract used by quality gates, \
+         editors, and target adapters.",
+    )
+    .with_documentation("https://github.com/ubugeeei-prod/vize/issues/3134")
+    .with_suppression(SuppressionPolicy::Forbidden);
+
+    for problem in problems {
+        finding = finding.with_evidence(
+            FindingEvidence::new(
+                EvidenceKind::Contract,
+                cstr!("Expected explicit {} section", problem.requirement),
+            )
+            .with_location(problem.location)
+            .with_detail("authoringGateRule", GATE_RULE)
+            .with_detail("requirement", problem.requirement),
+        );
+    }
+    Some(finding)
+}
+
+fn problem(requirement: &'static str, location: SourceLocation) -> ContractProblem {
+    ContractProblem {
+        requirement,
+        location,
+    }
+}
+
+fn opening_location(path: &str, location: &BlockLocation) -> SourceLocation {
+    SourceLocation::new(
+        path,
+        bounded_offset(location.tag_start),
+        bounded_offset(location.start),
+    )
+}
+
+fn bounded_offset(offset: usize) -> u32 {
+    u32::try_from(offset).unwrap_or(u32::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
+    use vize_carton::String;
+
+    #[test]
+    fn accepts_semantic_attribute_order_and_companion_script() {
+        let source = r#"<script>export const version = 1</script>
+<script lang="ts" setup>const value = 1</script>
+<template><output>{{ value }}</output></template>
+<style lang="css" scoped>output { display: block }</style>
+"#;
+        let descriptor = parse(source);
+
+        assert!(finding("src/Output.vue", &descriptor).is_none());
+    }
+
+    #[test]
+    fn reports_exact_noncanonical_opening_tags() {
+        let source = r#"<script setup>const value = 1</script>
+<template><output>{{ value }}</output></template>
+<style>output { display: block }</style>
+"#;
+        let descriptor = parse(source);
+        let finding = finding("src/Output.vue", &descriptor).unwrap();
+        let script_end = source.find('>').unwrap() + 1;
+        let style_start = source.find("<style>").unwrap();
+
+        assert_eq!(finding.code, RULE_CODE);
+        assert_eq!(finding.primary.start, 0);
+        assert_eq!(finding.primary.end as usize, script_end);
+        assert_eq!(
+            &source[finding.primary.start as usize..finding.primary.end as usize],
+            "<script setup>"
+        );
+        assert_eq!(finding.evidence.len(), 2);
+        assert_eq!(
+            finding.evidence[1].location.as_ref().unwrap().start as usize,
+            style_start
+        );
+        assert_eq!(
+            &source[style_start..finding.evidence[1].location.as_ref().unwrap().end as usize],
+            "<style>"
+        );
+    }
+
+    #[test]
+    fn missing_sections_use_the_exact_eof_insertion_point() {
+        let source = "<template><p>Static</p></template>\n";
+        let descriptor = parse(source);
+        let finding = finding("src/Static.vue", &descriptor).unwrap();
+
+        assert_eq!(finding.primary.start as usize, source.len());
+        assert_eq!(finding.primary.end as usize, source.len());
+        assert_eq!(finding.evidence.len(), 2);
+        assert!(finding.evidence.iter().all(|evidence| {
+            evidence
+                .location
+                .as_ref()
+                .is_some_and(|location| location.start as usize == source.len())
+        }));
+    }
+
+    #[test]
+    fn large_source_keeps_diagnostic_output_bounded() {
+        let body = "const value = 1;\n".repeat(65_536);
+        let mut source = String::from("<script>");
+        source.push_str(&body);
+        source.push_str("</script>\n");
+        let descriptor = parse(&source);
+        let finding = finding("src/Large.vue", &descriptor).unwrap();
+        let serialized = serde_json::to_vec(&finding).unwrap();
+
+        assert!(source.len() > 1_000_000);
+        assert!(
+            serialized.len() < 3_072,
+            "diagnostic output grew to {} bytes",
+            serialized.len()
+        );
+        assert_eq!(finding.provenance.cost, RuleCost::Low);
+        assert_eq!(finding.evidence.len(), 3);
+    }
+
+    fn parse(source: &str) -> SfcDescriptor<'_> {
+        parse_sfc(
+            source,
+            SfcParseOptions {
+                filename: "fixture.vue".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+    }
+}

--- a/crates/vize/src/commands/doctor/tests.rs
+++ b/crates/vize/src/commands/doctor/tests.rs
@@ -47,7 +47,7 @@ const label = 'Email'
         doctor_source("src/Second.vue", second),
     ];
 
-    let report = analyze_application(directory.path(), &sources).unwrap();
+    let report = analyze_application(directory.path(), &sources, false).unwrap();
     let finding = report
         .findings()
         .iter()
@@ -90,7 +90,7 @@ const { item } = props
         doctor_source("src/Parent.vue", parent),
     ];
 
-    let report = analyze_application(directory.path(), &sources).unwrap();
+    let report = analyze_application(directory.path(), &sources, false).unwrap();
     let finding = report
         .findings()
         .iter()
@@ -108,13 +108,14 @@ fn serialized_report_is_deterministic_for_input_order() {
     let directory = tempfile::tempdir().unwrap();
     let a = doctor_source("src/A.vue", "<template><div id=\"shared\" /></template>");
     let b = doctor_source("src/B.vue", "<template><div id=\"shared\" /></template>");
-    let first = analyze_application(directory.path(), &[a, b]).unwrap();
+    let first = analyze_application(directory.path(), &[a, b], false).unwrap();
     let second = analyze_application(
         directory.path(),
         &[
             doctor_source("src/B.vue", "<template><div id=\"shared\" /></template>"),
             doctor_source("src/A.vue", "<template><div id=\"shared\" /></template>"),
         ],
+        false,
     )
     .unwrap();
 

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_doctor_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_doctor_help.snap
@@ -30,5 +30,8 @@ Options:
       --exit-zero
           Return success even when the report contains blocking findings. Defaults to false
 
+      --public-sfc
+          Enforce the canonical public component SFC contract. Defaults to false
+
   -h, --help
           Print help (see a summary with '-h')

--- a/crates/vize/tests/doctor_cli.rs
+++ b/crates/vize/tests/doctor_cli.rs
@@ -87,6 +87,71 @@ fn malformed_components_cannot_produce_a_healthy_report() {
     assert!(output.stdout.is_empty());
 }
 
+#[test]
+fn public_sfc_contract_is_explicit_and_source_accurate() {
+    let directory = tempfile::tempdir().unwrap();
+    let source = "<script setup>const label = 'Save'</script>\n\
+                  <template><button>{{ label }}</button></template>\n\
+                  <style>button { font: inherit }</style>\n";
+    write(directory.path(), "src/ActionButton.vue", source);
+
+    let ordinary = doctor(directory.path(), &["src", "--format", "json"]);
+    let audited = doctor(
+        directory.path(),
+        &["src", "--format", "json", "--public-sfc"],
+    );
+    let ordinary_report: DoctorReport = serde_json::from_slice(&ordinary.stdout).unwrap();
+    let audited_report: DoctorReport = serde_json::from_slice(&audited.stdout).unwrap();
+    let finding = audited_report
+        .findings()
+        .iter()
+        .find(|finding| finding.code == "VIZE_DOCTOR_SFC_EXPLICIT_SECTIONS")
+        .unwrap();
+
+    assert!(ordinary.status.success());
+    assert!(
+        ordinary_report
+            .findings()
+            .iter()
+            .all(|finding| finding.code != "VIZE_DOCTOR_SFC_EXPLICIT_SECTIONS")
+    );
+    assert_eq!(audited.status.code(), Some(1));
+    assert_eq!(finding.primary.path, "src/ActionButton.vue");
+    assert_eq!(
+        &source[finding.primary.start as usize..finding.primary.end as usize],
+        "<script setup>"
+    );
+    assert_eq!(finding.evidence.len(), 2);
+}
+
+#[test]
+fn public_sfc_json_is_deterministic_for_input_order() {
+    let directory = tempfile::tempdir().unwrap();
+    write(
+        directory.path(),
+        "src/A.vue",
+        "<template><p>A</p></template>",
+    );
+    write(
+        directory.path(),
+        "src/B.vue",
+        "<template><p>B</p></template>",
+    );
+
+    let first = doctor(
+        directory.path(),
+        &["src/A.vue", "src/B.vue", "--format", "json", "--public-sfc"],
+    );
+    let second = doctor(
+        directory.path(),
+        &["src/B.vue", "src/A.vue", "--format", "json", "--public-sfc"],
+    );
+
+    assert_eq!(first.status.code(), Some(1));
+    assert_eq!(second.status.code(), Some(1));
+    assert_eq!(first.stdout, second.stdout);
+}
+
 fn doctor(root: &Path, arguments: &[&str]) -> std::process::Output {
     Command::new(env!("CARGO_BIN_EXE_vize"))
         .arg("doctor")


### PR DESCRIPTION
## Summary

- add an explicit --public-sfc boundary for the public component authoring contract
- reuse parsed SFC descriptors to emit VIZE_DOCTOR_SFC_EXPLICIT_SECTIONS with exact authored spans and bounded evidence
- preserve ordinary application SFC behavior unless the contract is requested

## Validation

- cargo fmt --all -- --check
- cargo clippy -p vize --lib -- -D warnings
- cargo test -p vize --lib commands::doctor
- cargo test -p vize --test doctor_cli
- source_file_lengths --check --base-ref origin/main --max-lines 350 --limit 5

Part of #3138.
Aligns the Doctor rule with the existing public component contract in #3134.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--public-sfc` option to `vize doctor`.
  * Added validation for public component files, checking required TypeScript script setup, template, and scoped style sections.
  * Reports now include precise source locations and guidance for noncanonical SFC structures.

* **Bug Fixes**
  * Ensured public SFC diagnostics remain deterministic regardless of input file order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->