### PR TITLE
feat(cli): add one-command project setup

### DIFF
--- a/npm/cli/README.md
+++ b/npm/cli/README.md
@@ -17,6 +17,42 @@ Need `vp` first? Install Vite+ once from the [Vite+ install guide](https://vitep
 
 ## Installation
 
+For an existing Vite or Vite+ project, run the setup command from the project root:
+
+```bash
+vp dlx vize setup
+```
+
+The command:
+
+- installs `vize`, the Vite and Musea plugins, Oxlint, and `oxlint-plugin-vize`;
+- creates `vize.config.ts` and, for plain Vite projects, `oxlint.config.ts` when no supported config
+  already exists;
+- enables the Vize Oxlint preset in the `lint` block of a standard Vite+ config, so `vp lint`
+  checks Vue files;
+- adds non-conflicting `vize:*` package scripts for build, format, lint, check, Musea, and `ready`;
+- replaces a canonical zero-option `@vitejs/plugin-vue` import with `@vizejs/vite-plugin`, then
+  removes the old dependency.
+
+Setup is idempotent. It preserves existing config files and package scripts, and it leaves custom
+Vite plugin calls such as `vue({ ... })` unchanged because those options need a deliberate
+migration. Use `vize setup --no-install` to generate the files and scripts without changing
+dependencies.
+
+After installation, `vz` is a short alias for the same CLI:
+
+```bash
+vz ready src
+```
+
+The remaining work for the full
+[Vize Plus proposal](https://github.com/ubugeeei-prod/vize/issues/3278) is safe merging into existing
+Vize and Vite+ lint/Oxlint configs, option-aware migration of custom or multiple Vite configs, and
+project-specific Musea plugin injection. Those cases are intentionally reported and preserved by
+this first setup slice instead of being rewritten heuristically.
+
+For manual installation:
+
 ```bash
 vp install -D vize
 ```

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -22,7 +22,8 @@
     "directory": "npm/cli"
   },
   "bin": {
-    "vize": "bin/vize"
+    "vize": "bin/vize",
+    "vz": "bin/vize"
   },
   "files": [
     "bin",
@@ -53,10 +54,11 @@
   },
   "scripts": {
     "build": "vp run --workspace-root generate:rule-types && vp pack",
-    "check": "vp check src vite.config.ts",
-    "check:fix": "vp check --fix src vite.config.ts",
-    "fmt": "vp fmt --write src vite.config.ts",
-    "generate:rule-types": "vp run --workspace-root generate:rule-types"
+    "check": "vp check src tests vite.config.ts",
+    "check:fix": "vp check --fix src tests vite.config.ts",
+    "fmt": "vp fmt --write src tests vite.config.ts",
+    "generate:rule-types": "vp run --workspace-root generate:rule-types",
+    "test": "vp pack && vp test run tests/setup.test.ts"
   },
   "dependencies": {
     "@vizejs/native": "workspace:*",

--- a/npm/cli/src/cli.ts
+++ b/npm/cli/src/cli.ts
@@ -1,6 +1,19 @@
 import { createRequire } from "node:module";
 
-const require = createRequire(import.meta.url);
-const native = require("@vizejs/native") as typeof import("@vizejs/native");
+import { runSetupCli } from "./setup.ts";
 
-native.runCli(process.argv.slice(2));
+const require = createRequire(import.meta.url);
+
+try {
+  const args = process.argv.slice(2);
+  if (args[0] === "setup") {
+    runSetupCli(args.slice(1));
+  } else {
+    const native = require("@vizejs/native") as typeof import("@vizejs/native");
+    native.runCli(args);
+  }
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`[vize] ${message}\n`);
+  process.exitCode = 1;
+}

--- a/npm/cli/src/setup.ts
+++ b/npm/cli/src/setup.ts
@@ -1,0 +1,243 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  addDefaultScripts,
+  atomicWriteFile,
+  DEFAULT_OXLINT_CONFIG,
+  DEFAULT_VIZE_CONFIG,
+  dependencyNames,
+  detectJsonIndent,
+  OXLINT_CONFIG_FILES,
+  parsePackageJson,
+  planGeneratedConfig,
+  readRequiredFile,
+  REQUIRED_DEV_DEPENDENCIES,
+  VIZE_CONFIG_FILES,
+  type PlannedFile,
+} from "./setup/config.ts";
+import { planViteMigration } from "./setup/vite.ts";
+
+export interface SetupCommand {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+}
+
+export interface SetupResult {
+  readonly root: string;
+  readonly createdFiles: readonly string[];
+  readonly preservedFiles: readonly string[];
+  readonly addedScripts: readonly string[];
+  readonly preservedScripts: readonly string[];
+  readonly migratedViteConfig: string | null;
+  readonly enabledVitePlusLint: boolean;
+  readonly installCommand: SetupCommand | null;
+  readonly removeCommand: SetupCommand | null;
+}
+
+export interface SetupOptions {
+  readonly root: string;
+  readonly install?: boolean;
+  readonly runCommand?: (command: SetupCommand) => void;
+}
+
+export function setupProject(options: SetupOptions): SetupResult {
+  const root = path.resolve(options.root);
+  const packagePath = path.join(root, "package.json");
+  const packageSource = readRequiredFile(packagePath, "No package.json found");
+  const packageJson = parsePackageJson(packagePath, packageSource);
+  const packageIndent = detectJsonIndent(packageSource);
+  const existingDependencies = dependencyNames(packageJson);
+  const missingDependencies = REQUIRED_DEV_DEPENDENCIES.filter(
+    (dependency) => !existingDependencies.has(dependency),
+  );
+
+  const createdFiles: string[] = [];
+  const preservedFiles: string[] = [];
+  const plannedFiles: PlannedFile[] = [];
+  planGeneratedConfig(
+    root,
+    VIZE_CONFIG_FILES,
+    "vize.config.ts",
+    DEFAULT_VIZE_CONFIG,
+    plannedFiles,
+    createdFiles,
+    preservedFiles,
+  );
+
+  const existingOxlintConfig = OXLINT_CONFIG_FILES.find((candidate) =>
+    fs.existsSync(path.join(root, candidate)),
+  );
+  const viteMigration = planViteMigration(root, existingOxlintConfig === undefined);
+  if (viteMigration.file) {
+    plannedFiles.push(viteMigration.file);
+  }
+  if (viteMigration.preserved) {
+    preservedFiles.push(viteMigration.preserved);
+  }
+  if (
+    viteMigration.usesVitePlus &&
+    !viteMigration.enablesVitePlusLint &&
+    existingOxlintConfig === undefined
+  ) {
+    preservedFiles.push("Vite+ lint configuration");
+  }
+  if (existingOxlintConfig) {
+    preservedFiles.push(existingOxlintConfig);
+  } else if (!viteMigration.enablesVitePlusLint && !viteMigration.usesVitePlus) {
+    planGeneratedConfig(
+      root,
+      OXLINT_CONFIG_FILES,
+      "oxlint.config.ts",
+      DEFAULT_OXLINT_CONFIG,
+      plannedFiles,
+      createdFiles,
+      preservedFiles,
+    );
+  }
+
+  const { addedScripts, preservedScripts } = addDefaultScripts(packageJson);
+  if (addedScripts.length > 0) {
+    plannedFiles.push({
+      filename: packagePath,
+      source: `${JSON.stringify(packageJson, null, packageIndent)}\n`,
+    });
+  }
+  for (const file of plannedFiles) {
+    atomicWriteFile(file.filename, file.source);
+  }
+
+  const runCommand = options.runCommand ?? runSetupCommand;
+  let installCommand: SetupCommand | null = null;
+  if (options.install !== false && missingDependencies.length > 0) {
+    installCommand = {
+      command: "vp",
+      args: ["add", "-D", ...missingDependencies],
+      cwd: root,
+    };
+    runCommand(installCommand);
+  }
+
+  let removeCommand: SetupCommand | null = null;
+  if (
+    options.install !== false &&
+    viteMigration.removesOfficialPlugin &&
+    existingDependencies.has("@vitejs/plugin-vue")
+  ) {
+    removeCommand = {
+      command: "vp",
+      args: ["remove", "@vitejs/plugin-vue"],
+      cwd: root,
+    };
+    runCommand(removeCommand);
+  }
+
+  return {
+    root,
+    createdFiles,
+    preservedFiles,
+    addedScripts,
+    preservedScripts,
+    migratedViteConfig:
+      viteMigration.file && viteMigration.removesOfficialPlugin
+        ? path.basename(viteMigration.file.filename)
+        : null,
+    enabledVitePlusLint: viteMigration.enablesVitePlusLint,
+    installCommand,
+    removeCommand,
+  };
+}
+
+export function runSetupCli(args: readonly string[]): void {
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(setupHelp());
+    return;
+  }
+
+  let install = true;
+  let root: string | undefined;
+  for (const arg of args) {
+    if (arg === "--no-install") {
+      install = false;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`Unknown setup option: ${arg}`);
+    }
+    if (root) {
+      throw new Error(`Unexpected setup argument: ${arg}`);
+    }
+    root = arg;
+  }
+
+  const result = setupProject({ root: root ?? process.cwd(), install });
+  printSetupResult(result, install);
+}
+
+function setupHelp(): string {
+  return `Configure Vize in an existing Vite or Vite+ project
+
+Usage: vize setup [ROOT] [OPTIONS]
+
+Arguments:
+  [ROOT]  Project root containing package.json (default: current directory)
+
+Options:
+  --no-install  Write project configuration without changing dependencies
+  -h, --help    Print help
+`;
+}
+
+function printSetupResult(result: SetupResult, install: boolean): void {
+  let dependenciesMissing = false;
+  for (const filename of result.createdFiles) {
+    process.stdout.write(`[vize setup] created ${filename}\n`);
+  }
+  if (result.migratedViteConfig) {
+    process.stdout.write(
+      `[vize setup] migrated ${result.migratedViteConfig} to @vizejs/vite-plugin\n`,
+    );
+  }
+  if (result.enabledVitePlusLint) {
+    process.stdout.write("[vize setup] enabled oxlint-plugin-vize for vp lint\n");
+  }
+  if (result.addedScripts.length > 0) {
+    process.stdout.write(`[vize setup] added scripts: ${result.addedScripts.join(", ")}\n`);
+  }
+  for (const filename of result.preservedFiles) {
+    process.stdout.write(`[vize setup] preserved existing ${filename}\n`);
+  }
+  if (result.preservedScripts.length > 0) {
+    process.stdout.write(`[vize setup] preserved scripts: ${result.preservedScripts.join(", ")}\n`);
+  }
+  if (!install) {
+    const packagePath = path.join(result.root, "package.json");
+    const packageJson = parsePackageJson(packagePath, fs.readFileSync(packagePath, "utf8"));
+    const missing = REQUIRED_DEV_DEPENDENCIES.filter(
+      (dependency) => !dependencyNames(packageJson).has(dependency),
+    );
+    if (missing.length > 0) {
+      dependenciesMissing = true;
+      process.stdout.write(
+        `[vize setup] install dependencies with: vp add -D ${missing.join(" ")}\n`,
+      );
+    }
+  }
+  if (result.removeCommand) {
+    process.stdout.write("[vize setup] removed @vitejs/plugin-vue\n");
+  }
+  process.stdout.write(
+    dependenciesMissing
+      ? "[vize setup] configuration written; install dependencies before running Vize\n"
+      : "[vize setup] ready; run vp run vize:ready\n",
+  );
+}
+
+function runSetupCommand(command: SetupCommand): void {
+  execFileSync(command.command, [...command.args], {
+    cwd: command.cwd,
+    stdio: "inherit",
+  });
+}

--- a/npm/cli/src/setup/config.ts
+++ b/npm/cli/src/setup/config.ts
@@ -1,0 +1,187 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const VIZE_CONFIG_FILES = [
+  "vize.config.pkl",
+  "vize.config.ts",
+  "vize.config.js",
+  "vize.config.mjs",
+  "vize.config.json",
+] as const;
+
+export const OXLINT_CONFIG_FILES = [
+  ".oxlintrc.json",
+  ".oxlintrc.jsonc",
+  "oxlint.config.ts",
+  "oxlint.config.mts",
+  "oxlint.config.js",
+  "oxlint.config.mjs",
+  "oxlint.config.cjs",
+  "oxlint.config.cts",
+] as const;
+
+export const REQUIRED_DEV_DEPENDENCIES = [
+  "vize",
+  "@vizejs/vite-plugin",
+  "@vizejs/vite-plugin-musea",
+  "oxlint",
+  "oxlint-plugin-vize",
+] as const;
+
+export const DEFAULT_SCRIPTS = {
+  "vize:build": "vize build src",
+  "vize:fmt": "vize fmt --check src",
+  "vize:fmt:fix": "vize fmt --write src",
+  "vize:lint": "vize lint --preset happy-path --max-warnings 0 src",
+  "vize:check": "vize check src",
+  "vize:musea": "vize musea",
+  "vize:ready": "vize ready src",
+} as const;
+
+export const DEFAULT_VIZE_CONFIG = `import { defineConfig } from "vize";
+
+export default defineConfig({
+  compiler: {
+    templateSyntax: "standard",
+  },
+  linter: {
+    preset: "happy-path",
+  },
+  typeChecker: {
+    enabled: true,
+    strict: true,
+  },
+  vite: {
+    scanPatterns: ["src/**/*.vue"],
+  },
+});
+`;
+
+export const DEFAULT_OXLINT_CONFIG = `import { defineConfig } from "oxlint";
+import { configs } from "oxlint-plugin-vize";
+
+export default defineConfig({
+  plugins: ["vue"],
+  jsPlugins: ["oxlint-plugin-vize"],
+  settings: {
+    vize: {
+      preset: "general-recommended",
+      helpLevel: "short",
+    },
+  },
+  rules: configs.recommended,
+});
+`;
+
+type JsonObject = Record<string, unknown>;
+
+export interface PlannedFile {
+  readonly filename: string;
+  readonly source: string;
+}
+
+export function readRequiredFile(filename: string, message: string): string {
+  try {
+    return fs.readFileSync(filename, "utf8");
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      throw new Error(`${message}: ${filename}`, { cause: error });
+    }
+    throw error;
+  }
+}
+
+export function parsePackageJson(filename: string, source: string): JsonObject {
+  try {
+    const parsed = JSON.parse(source) as unknown;
+    if (!isJsonObject(parsed)) {
+      throw new Error("package.json must contain an object");
+    }
+    return parsed;
+  } catch (error) {
+    throw new Error(`Invalid package.json: ${filename}`, { cause: error });
+  }
+}
+
+export function detectJsonIndent(source: string): string | number {
+  const match = source.match(/^[\t ]+(?=")/mu);
+  return match?.[0] ?? 2;
+}
+
+export function dependencyNames(packageJson: JsonObject): Set<string> {
+  const names = new Set<string>();
+  for (const field of ["dependencies", "devDependencies", "optionalDependencies"] as const) {
+    const dependencies = packageJson[field];
+    if (!isJsonObject(dependencies)) {
+      continue;
+    }
+    for (const name of Object.keys(dependencies)) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
+export function addDefaultScripts(packageJson: JsonObject): {
+  readonly addedScripts: string[];
+  readonly preservedScripts: string[];
+} {
+  if (packageJson.scripts !== undefined && !isJsonObject(packageJson.scripts)) {
+    throw new Error("package.json scripts must contain an object");
+  }
+
+  const scripts = (packageJson.scripts ?? {}) as JsonObject;
+  const addedScripts: string[] = [];
+  const preservedScripts: string[] = [];
+  for (const [name, command] of Object.entries(DEFAULT_SCRIPTS)) {
+    if (name in scripts) {
+      preservedScripts.push(name);
+      continue;
+    }
+    scripts[name] = command;
+    addedScripts.push(name);
+  }
+  if (addedScripts.length > 0) {
+    packageJson.scripts = scripts;
+  }
+  return { addedScripts, preservedScripts };
+}
+
+export function planGeneratedConfig(
+  root: string,
+  candidates: readonly string[],
+  generatedName: string,
+  source: string,
+  plannedFiles: PlannedFile[],
+  createdFiles: string[],
+  preservedFiles: string[],
+): void {
+  const existing = candidates.find((candidate) => fs.existsSync(path.join(root, candidate)));
+  if (existing) {
+    preservedFiles.push(existing);
+    return;
+  }
+  plannedFiles.push({ filename: path.join(root, generatedName), source });
+  createdFiles.push(generatedName);
+}
+
+export function atomicWriteFile(filename: string, source: string): void {
+  const temporary = path.join(
+    path.dirname(filename),
+    `.${path.basename(filename)}.${process.pid}.${Date.now()}.tmp`,
+  );
+  try {
+    fs.writeFileSync(temporary, source, { encoding: "utf8", flag: "wx" });
+    fs.renameSync(temporary, filename);
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(value: unknown): value is NodeJS.ErrnoException {
+  return value instanceof Error;
+}

--- a/npm/cli/src/setup/vite.ts
+++ b/npm/cli/src/setup/vite.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { PlannedFile } from "./config.ts";
+
+const VITE_CONFIG_FILES = [
+  "vite.config.ts",
+  "vite.config.mts",
+  "vite.config.js",
+  "vite.config.mjs",
+] as const;
+
+const VITE_PLUS_LINT_IMPORT =
+  'import { configs as vizePlusLintConfigs } from "oxlint-plugin-vize";\n';
+
+const VITE_PLUS_LINT_BLOCK = `  lint: {
+    plugins: ["vue"],
+    jsPlugins: ["oxlint-plugin-vize"],
+    settings: {
+      vize: {
+        preset: "general-recommended",
+        helpLevel: "short",
+      },
+    },
+    rules: vizePlusLintConfigs.recommended,
+  },
+`;
+
+export interface ViteMigrationPlan {
+  readonly file: PlannedFile | null;
+  readonly preserved: string | null;
+  readonly removesOfficialPlugin: boolean;
+  readonly enablesVitePlusLint: boolean;
+  readonly usesVitePlus: boolean;
+}
+
+export function planViteMigration(
+  root: string,
+  mayConfigureVitePlusLint: boolean,
+): ViteMigrationPlan {
+  const existing = VITE_CONFIG_FILES.filter((candidate) =>
+    fs.existsSync(path.join(root, candidate)),
+  );
+  if (existing.length === 0) {
+    return {
+      file: null,
+      preserved: null,
+      removesOfficialPlugin: false,
+      enablesVitePlusLint: false,
+      usesVitePlus: false,
+    };
+  }
+  if (existing.length > 1) {
+    return {
+      file: null,
+      preserved: `Vite configs (${existing.join(", ")})`,
+      removesOfficialPlugin: false,
+      enablesVitePlusLint: false,
+      usesVitePlus: false,
+    };
+  }
+
+  const relativeFilename = existing[0]!;
+  const filename = path.join(root, relativeFilename);
+  const source = fs.readFileSync(filename, "utf8");
+  const usesVitePlus = /from\s+["']vite-plus["']/u.test(source);
+  let migratedSource = source;
+  let removesOfficialPlugin = false;
+  let preserved: string | null = null;
+
+  if (!source.includes("@vizejs/vite-plugin")) {
+    const importPattern =
+      /^([^\S\r\n]*import[^\S\r\n]+)([$A-Z_a-z][$\w]*)([^\S\r\n]+from[^\S\r\n]+)(["'])@vitejs\/plugin-vue\4([^\S\r\n]*;?[^\S\r\n]*)$/gmu;
+    const imports = [...source.matchAll(importPattern)];
+    if (imports.length === 1) {
+      const localName = imports[0]![2]!;
+      const zeroArgumentCallPattern = new RegExp(
+        `\\b${escapeRegExp(localName)}\\s*\\(\\s*\\)`,
+        "gu",
+      );
+      const calls = [...source.matchAll(zeroArgumentCallPattern)];
+      const importIndex = imports[0]!.index!;
+      const importSource = imports[0]![0];
+      const sourceWithoutExpectedUse =
+        source.slice(0, importIndex) +
+        source.slice(importIndex + importSource.length).replace(zeroArgumentCallPattern, "");
+      const hasOtherUses = new RegExp(`\\b${escapeRegExp(localName)}\\b`, "u").test(
+        sourceWithoutExpectedUse,
+      );
+      if (calls.length === 1 && !hasOtherUses) {
+        migratedSource = source.replace(importPattern, `$1$2$3$4@vizejs/vite-plugin$4$5`);
+        removesOfficialPlugin = true;
+      } else {
+        preserved = relativeFilename;
+      }
+    } else if (source.includes("@vitejs/plugin-vue")) {
+      preserved = relativeFilename;
+    }
+  }
+
+  let enablesVitePlusLint = source.includes("oxlint-plugin-vize");
+  if (mayConfigureVitePlusLint && !enablesVitePlusLint && canInjectVitePlusLint(migratedSource)) {
+    migratedSource = injectVitePlusLint(migratedSource);
+    enablesVitePlusLint = true;
+  }
+
+  return {
+    file: migratedSource === source ? null : { filename, source: migratedSource },
+    preserved:
+      preserved ??
+      (migratedSource === source && source.includes("@vizejs/vite-plugin")
+        ? relativeFilename
+        : null),
+    removesOfficialPlugin,
+    enablesVitePlusLint,
+    usesVitePlus,
+  };
+}
+
+function canInjectVitePlusLint(source: string): boolean {
+  if (
+    !/from\s+["']vite-plus["']/u.test(source) ||
+    /^\s*lint\s*:/mu.test(source) ||
+    /\bvizePlusLintConfigs\b/u.test(source)
+  ) {
+    return false;
+  }
+  return [...source.matchAll(/\bdefineConfig\s*\(\s*\{/gu)].length === 1;
+}
+
+function injectVitePlusLint(source: string): string {
+  const importLines = [...source.matchAll(/^import[^\r\n]*(?:\r?\n|$)/gmu)];
+  const lastImport = importLines.at(-1);
+  if (!lastImport || lastImport.index === undefined) {
+    return source;
+  }
+  const importEnd = lastImport.index + lastImport[0].length;
+  const withImport = source.slice(0, importEnd) + VITE_PLUS_LINT_IMPORT + source.slice(importEnd);
+  return withImport.replace(
+    /\bdefineConfig\s*\(\s*\{/u,
+    (opening) => `${opening}\n${VITE_PLUS_LINT_BLOCK}`,
+  );
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}

--- a/npm/cli/tests/setup.test.ts
+++ b/npm/cli/tests/setup.test.ts
@@ -1,0 +1,262 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { test } from "vite-plus/test";
+
+import { setupProject, type SetupCommand } from "../src/setup.ts";
+
+function temporaryProject(name: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `vize-setup-${name}-`));
+}
+
+function write(root: string, filename: string, source: string): void {
+  fs.writeFileSync(path.join(root, filename), source);
+}
+
+function read(root: string, filename: string): string {
+  return fs.readFileSync(path.join(root, filename), "utf8");
+}
+
+function packageJson(root: string): Record<string, unknown> {
+  return JSON.parse(read(root, "package.json")) as Record<string, unknown>;
+}
+
+test("configures a canonical Vite+ project and is byte-idempotent", () => {
+  const root = temporaryProject("canonical");
+  const commands: SetupCommand[] = [];
+  try {
+    write(
+      root,
+      "package.json",
+      `${JSON.stringify(
+        {
+          name: "fixture",
+          private: true,
+          type: "module",
+          scripts: { dev: "vp dev" },
+          devDependencies: {
+            "@vitejs/plugin-vue": "^6.0.0",
+            "vite-plus": "^0.1.0",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    write(
+      root,
+      "vite.config.ts",
+      `import { defineConfig } from "vite-plus";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig({
+  plugins: [vue()],
+});
+`,
+    );
+
+    const result = setupProject({
+      root,
+      runCommand(command) {
+        commands.push(command);
+        const manifest = packageJson(root);
+        const devDependencies = (manifest.devDependencies ?? {}) as Record<string, string>;
+        if (command.args[0] === "add") {
+          for (const dependency of command.args.slice(2)) {
+            devDependencies[dependency] = "^0.300.0";
+          }
+        } else {
+          delete devDependencies["@vitejs/plugin-vue"];
+        }
+        manifest.devDependencies = devDependencies;
+        write(root, "package.json", `${JSON.stringify(manifest, null, 2)}\n`);
+      },
+    });
+
+    assert.deepEqual(commands, [
+      {
+        command: "vp",
+        args: [
+          "add",
+          "-D",
+          "vize",
+          "@vizejs/vite-plugin",
+          "@vizejs/vite-plugin-musea",
+          "oxlint",
+          "oxlint-plugin-vize",
+        ],
+        cwd: root,
+      },
+      {
+        command: "vp",
+        args: ["remove", "@vitejs/plugin-vue"],
+        cwd: root,
+      },
+    ]);
+    assert.deepEqual(result.createdFiles, ["vize.config.ts"]);
+    assert.equal(result.migratedViteConfig, "vite.config.ts");
+    assert.equal(result.enabledVitePlusLint, true);
+    assert.match(read(root, "vite.config.ts"), /from "@vizejs\/vite-plugin"/u);
+    assert.match(read(root, "vite.config.ts"), /plugins: \[vue\(\)\]/u);
+    assert.match(read(root, "vite.config.ts"), /rules: vizePlusLintConfigs\.recommended/u);
+    assert.match(read(root, "vize.config.ts"), /defineConfig/u);
+    assert.equal(fs.existsSync(path.join(root, "oxlint.config.ts")), false);
+
+    const scripts = packageJson(root).scripts as Record<string, string>;
+    assert.equal(scripts.dev, "vp dev");
+    assert.equal(scripts["vize:fmt"], "vize fmt --check src");
+    assert.equal(scripts["vize:fmt:fix"], "vize fmt --write src");
+    assert.equal(scripts["vize:lint"], "vize lint --preset happy-path --max-warnings 0 src");
+    assert.equal(scripts["vize:check"], "vize check src");
+    assert.equal(scripts["vize:build"], "vize build src");
+    assert.equal(scripts["vize:musea"], "vize musea");
+    assert.equal(scripts["vize:ready"], "vize ready src");
+
+    const firstSources = new Map(
+      ["package.json", "vite.config.ts", "vize.config.ts"].map((filename) => [
+        filename,
+        read(root, filename),
+      ]),
+    );
+    const second = setupProject({
+      root,
+      runCommand(command) {
+        assert.fail(
+          `idempotent setup unexpectedly ran ${command.command} ${command.args.join(" ")}`,
+        );
+      },
+    });
+
+    assert.deepEqual(second.createdFiles, []);
+    assert.equal(second.migratedViteConfig, null);
+    for (const [filename, source] of firstSources) {
+      assert.equal(read(root, filename), source, `${filename} changed on the second setup`);
+    }
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("preserves custom configs and scripts instead of guessing migrations", () => {
+  const root = temporaryProject("no-clobber");
+  try {
+    const vizeConfig = `{"compiler":{"vapor":true}}\n`;
+    const oxlintConfig = `{\n  // custom rules stay byte-for-byte intact\n  "rules": { "no-console": "error" }\n}\n`;
+    const viteConfig = `import { defineConfig } from "vite-plus";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig({
+  plugins: [vue({ template: { compilerOptions: { whitespace: "preserve" } } })],
+});
+`;
+    write(
+      root,
+      "package.json",
+      `{
+\t"name": "custom-fixture",
+\t"scripts": {
+\t\t"vize:check": "vize check --tsconfig tsconfig.app.json"
+\t}
+}
+`,
+    );
+    write(root, "vize.config.json", vizeConfig);
+    write(root, ".oxlintrc.jsonc", oxlintConfig);
+    write(root, "vite.config.ts", viteConfig);
+
+    const result = setupProject({ root, install: false });
+
+    assert.deepEqual(result.preservedFiles, [
+      "vize.config.json",
+      "vite.config.ts",
+      ".oxlintrc.jsonc",
+    ]);
+    assert.deepEqual(result.preservedScripts, ["vize:check"]);
+    assert.equal(read(root, "vize.config.json"), vizeConfig);
+    assert.equal(read(root, ".oxlintrc.jsonc"), oxlintConfig);
+    assert.equal(read(root, "vite.config.ts"), viteConfig);
+    const scripts = packageJson(root).scripts as Record<string, string>;
+    assert.equal(scripts["vize:check"], "vize check --tsconfig tsconfig.app.json");
+    assert.equal(scripts["vize:ready"], "vize ready src");
+    assert.match(read(root, "package.json"), /^\t"scripts"/mu);
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("does not write any setup file when package.json is invalid", () => {
+  const root = temporaryProject("invalid-package");
+  try {
+    write(root, "package.json", "{ invalid");
+    const before = read(root, "package.json");
+
+    assert.throws(() => setupProject({ root, install: false }), /Invalid package\.json/u);
+    assert.equal(read(root, "package.json"), before);
+    assert.deepEqual(fs.readdirSync(root), ["package.json"]);
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("preserves an existing Vite+ lint block without creating a second config", () => {
+  const root = temporaryProject("vite-plus-lint");
+  try {
+    write(root, "package.json", `{"name":"lint-fixture","private":true}\n`);
+    const viteConfig = `import { defineConfig } from "vite-plus";
+import vize from "@vizejs/vite-plugin";
+
+export default defineConfig({
+  plugins: [vize()],
+  lint: {
+    rules: {
+      "no-console": "error",
+    },
+  },
+});
+`;
+    write(root, "vite.config.ts", viteConfig);
+
+    const result = setupProject({ root, install: false });
+
+    assert.equal(read(root, "vite.config.ts"), viteConfig);
+    assert.equal(fs.existsSync(path.join(root, "oxlint.config.ts")), false);
+    assert.equal(result.enabledVitePlusLint, false);
+    assert.ok(result.preservedFiles.includes("Vite+ lint configuration"));
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("the packed CLI configures a strict temporary project without native loading", () => {
+  const root = temporaryProject("packed-cli");
+  try {
+    write(root, "package.json", `{"name":"packed-fixture","private":true}\n`);
+    write(
+      root,
+      "vite.config.mjs",
+      `import vuePlugin from '@vitejs/plugin-vue'
+export default { plugins: [vuePlugin()] }
+`,
+    );
+    const packageDir = path.dirname(fileURLToPath(import.meta.url));
+    const cli = path.join(packageDir, "../dist/cli.mjs");
+
+    const output = execFileSync(process.execPath, [cli, "setup", root, "--no-install"], {
+      encoding: "utf8",
+    });
+
+    assert.match(output, /\[vize setup\] created vize\.config\.ts/u);
+    assert.match(output, /install dependencies with: vp add -D/u);
+    assert.match(output, /configuration written; install dependencies before running Vize/u);
+    assert.match(read(root, "vite.config.mjs"), /@vizejs\/vite-plugin/u);
+    assert.ok(fs.existsSync(path.join(root, "oxlint.config.ts")));
+    const scripts = packageJson(root).scripts as Record<string, string>;
+    assert.equal(scripts["vize:ready"], "vize ready src");
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});

--- a/tools/vite-plus/task-inputs.ts
+++ b/tools/vite-plus/task-inputs.ts
@@ -72,6 +72,7 @@ export const packedPackages = [
 ] satisfies PackagePath[];
 
 export const testedPackages = [
+  "./npm/cli",
   "./npm/builder/vite",
   "./npm/oxint",
   "./npm/builder/vite-musea",


### PR DESCRIPTION
## Summary

- add `vize setup` for existing Vite and Vite+ projects, including dependency installation, default Vize configuration, standard package scripts, and the safe zero-option `@vitejs/plugin-vue` migration
- enable `oxlint-plugin-vize` in a standard Vite+ `lint` block, with a standalone Oxlint config fallback for plain Vite projects
- expose `vz` as an alias for the existing CLI and document the first-slice safety boundary
- add strict temporary-project regression coverage for packed CLI execution, idempotence, invalid input, and no-clobber behavior

## Safety boundary

Setup only rewrites a single canonical Vite config whose Vue plugin has one zero-argument call. Existing Vize/Oxlint configs, existing scripts, custom `vue({ ... })` options, multiple Vite configs, and pre-existing Vite+ lint blocks are preserved.

## Remaining #3278 work

- safely merge defaults into existing Vize and Vite+ lint/Oxlint configs
- migrate custom Vue plugin options and multiple/custom Vite config layouts with an option-aware transform
- inject project-specific Musea plugin options instead of only installing the package and adding the Musea script

## Validation

- `vp run --filter './npm/cli' check`
- `vp run --filter './npm/cli' test` (5 temporary-project tests)
- `nix develop --command vp run --workspace-root check:repo`
- `nix develop --command moon run --target native tools/moon/cmd/source_file_lengths -- --check --base-ref origin/main --max-lines 350 --limit 20`
- `node --test tests/tooling/local-default-tasks.test.ts`
- `npm pack --dry-run --json ./npm/cli`

Part of #3278.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `vize setup` command for configuring existing Vite and Vite+ projects.
  * Automatically generates configuration files, adds recommended scripts, enables linting, and manages required packages.
  * Added `--no-install` and `--help` options, plus the `vz` command alias.
  * Setup safely preserves existing configuration and can be run repeatedly without unnecessary changes.

* **Documentation**
  * Expanded installation guidance with automated setup instructions and manual installation steps.

* **Bug Fixes**
  * CLI errors now display a clear message and exit with a failure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->