### PR TITLE
fix(cli): harden project setup

### DIFF
--- a/npm/cli/src/cli.ts
+++ b/npm/cli/src/cli.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module";
 
-import { runSetupCli } from "./setup.ts";
+import { runSetupCli } from "./setup.js";
 
 const require = createRequire(import.meta.url);
 

--- a/npm/cli/src/setup.ts
+++ b/npm/cli/src/setup.ts
@@ -16,8 +16,8 @@ import {
   REQUIRED_DEV_DEPENDENCIES,
   VIZE_CONFIG_FILES,
   type PlannedFile,
-} from "./setup/config.ts";
-import { planViteMigration } from "./setup/vite.ts";
+} from "./setup/config.js";
+import { planViteMigration } from "./setup/vite.js";
 
 export interface SetupCommand {
   readonly command: string;
@@ -41,6 +41,7 @@ export interface SetupOptions {
   readonly root: string;
   readonly install?: boolean;
   readonly runCommand?: (command: SetupCommand) => void;
+  readonly writeFile?: (filename: string, source: string) => void;
 }
 
 export function setupProject(options: SetupOptions): SetupResult {
@@ -79,14 +80,14 @@ export function setupProject(options: SetupOptions): SetupResult {
   }
   if (
     viteMigration.usesVitePlus &&
-    !viteMigration.enablesVitePlusLint &&
+    !viteMigration.hasVitePlusLint &&
     existingOxlintConfig === undefined
   ) {
     preservedFiles.push("Vite+ lint configuration");
   }
   if (existingOxlintConfig) {
     preservedFiles.push(existingOxlintConfig);
-  } else if (!viteMigration.enablesVitePlusLint && !viteMigration.usesVitePlus) {
+  } else if (!viteMigration.hasVitePlusLint && !viteMigration.usesVitePlus) {
     planGeneratedConfig(
       root,
       OXLINT_CONFIG_FILES,
@@ -105,9 +106,7 @@ export function setupProject(options: SetupOptions): SetupResult {
       source: `${JSON.stringify(packageJson, null, packageIndent)}\n`,
     });
   }
-  for (const file of plannedFiles) {
-    atomicWriteFile(file.filename, file.source);
-  }
+  writePlannedFiles(root, plannedFiles, options.writeFile ?? atomicWriteFile);
 
   const runCommand = options.runCommand ?? runSetupCommand;
   let installCommand: SetupCommand | null = null;
@@ -240,4 +239,27 @@ function runSetupCommand(command: SetupCommand): void {
     cwd: command.cwd,
     stdio: "inherit",
   });
+}
+
+function writePlannedFiles(
+  root: string,
+  plannedFiles: readonly PlannedFile[],
+  writeFile: (filename: string, source: string) => void,
+): void {
+  const writtenFiles: string[] = [];
+  for (const file of plannedFiles) {
+    try {
+      writeFile(file.filename, file.source);
+    } catch (error) {
+      if (writtenFiles.length === 0) {
+        throw error;
+      }
+      const failedFile = path.relative(root, file.filename);
+      throw new Error(
+        `Setup partially completed: wrote ${writtenFiles.join(", ")} before ${failedFile} failed. Run setup again to finish.`,
+        { cause: error },
+      );
+    }
+    writtenFiles.push(path.relative(root, file.filename));
+  }
 }

--- a/npm/cli/src/setup/vite.ts
+++ b/npm/cli/src/setup/vite.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import type { PlannedFile } from "./config.ts";
+import type { PlannedFile } from "./config.js";
 
 const VITE_CONFIG_FILES = [
   "vite.config.ts",
@@ -31,6 +31,7 @@ export interface ViteMigrationPlan {
   readonly preserved: string | null;
   readonly removesOfficialPlugin: boolean;
   readonly enablesVitePlusLint: boolean;
+  readonly hasVitePlusLint: boolean;
   readonly usesVitePlus: boolean;
 }
 
@@ -47,6 +48,7 @@ export function planViteMigration(
       preserved: null,
       removesOfficialPlugin: false,
       enablesVitePlusLint: false,
+      hasVitePlusLint: false,
       usesVitePlus: false,
     };
   }
@@ -56,6 +58,7 @@ export function planViteMigration(
       preserved: `Vite configs (${existing.join(", ")})`,
       removesOfficialPlugin: false,
       enablesVitePlusLint: false,
+      hasVitePlusLint: false,
       usesVitePlus: false,
     };
   }
@@ -98,10 +101,14 @@ export function planViteMigration(
     }
   }
 
-  let enablesVitePlusLint = source.includes("oxlint-plugin-vize");
-  if (mayConfigureVitePlusLint && !enablesVitePlusLint && canInjectVitePlusLint(migratedSource)) {
-    migratedSource = injectVitePlusLint(migratedSource);
-    enablesVitePlusLint = true;
+  const hadVitePlusLint = usesVitePlus && source.includes("oxlint-plugin-vize");
+  let enablesVitePlusLint = false;
+  if (mayConfigureVitePlusLint && !hadVitePlusLint && canInjectVitePlusLint(migratedSource)) {
+    const injectedSource = injectVitePlusLint(migratedSource);
+    if (injectedSource !== null) {
+      migratedSource = injectedSource;
+      enablesVitePlusLint = true;
+    }
   }
 
   return {
@@ -113,6 +120,7 @@ export function planViteMigration(
         : null),
     removesOfficialPlugin,
     enablesVitePlusLint,
+    hasVitePlusLint: hadVitePlusLint || enablesVitePlusLint,
     usesVitePlus,
   };
 }
@@ -128,11 +136,15 @@ function canInjectVitePlusLint(source: string): boolean {
   return [...source.matchAll(/\bdefineConfig\s*\(\s*\{/gu)].length === 1;
 }
 
-function injectVitePlusLint(source: string): string {
-  const importLines = [...source.matchAll(/^import[^\r\n]*(?:\r?\n|$)/gmu)];
+function injectVitePlusLint(source: string): string | null {
+  const importLines = [
+    ...source.matchAll(
+      /^import[^\r\n]*(?:from\s+["'][^"']+["']|["'][^"']+["'])\s*;?[^\S\r\n]*(?:\r?\n|$)/gmu,
+    ),
+  ];
   const lastImport = importLines.at(-1);
   if (!lastImport || lastImport.index === undefined) {
-    return source;
+    return null;
   }
   const importEnd = lastImport.index + lastImport[0].length;
   const withImport = source.slice(0, importEnd) + VITE_PLUS_LINT_IMPORT + source.slice(importEnd);

--- a/npm/cli/tests/setup.test.ts
+++ b/npm/cli/tests/setup.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -133,6 +133,7 @@ export default defineConfig({
 
     assert.deepEqual(second.createdFiles, []);
     assert.equal(second.migratedViteConfig, null);
+    assert.equal(second.enabledVitePlusLint, false);
     for (const [filename, source] of firstSources) {
       assert.equal(read(root, filename), source, `${filename} changed on the second setup`);
     }
@@ -202,6 +203,35 @@ test("does not write any setup file when package.json is invalid", () => {
   }
 });
 
+test("reports files written before a later atomic write fails", () => {
+  const root = temporaryProject("partial-write");
+  try {
+    write(root, "package.json", `{"name":"partial-write-fixture","private":true}\n`);
+    let writes = 0;
+
+    assert.throws(
+      () =>
+        setupProject({
+          root,
+          install: false,
+          writeFile(filename, source) {
+            writes += 1;
+            if (writes === 2) {
+              throw new Error("simulated disk failure");
+            }
+            fs.writeFileSync(filename, source);
+          },
+        }),
+      /Setup partially completed: wrote vize\.config\.ts before oxlint\.config\.ts failed/u,
+    );
+    assert.ok(fs.existsSync(path.join(root, "vize.config.ts")));
+    assert.equal(fs.existsSync(path.join(root, "oxlint.config.ts")), false);
+    assert.deepEqual(packageJson(root), { name: "partial-write-fixture", private: true });
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
 test("preserves an existing Vite+ lint block without creating a second config", () => {
   const root = temporaryProject("vite-plus-lint");
   try {
@@ -224,6 +254,49 @@ export default defineConfig({
 
     assert.equal(read(root, "vite.config.ts"), viteConfig);
     assert.equal(fs.existsSync(path.join(root, "oxlint.config.ts")), false);
+    assert.equal(result.enabledVitePlusLint, false);
+    assert.ok(result.preservedFiles.includes("Vite+ lint configuration"));
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("does not mistake an oxlint plugin comment in plain Vite for a working config", () => {
+  const root = temporaryProject("plain-vite-comment");
+  try {
+    write(root, "package.json", `{"name":"plain-vite-fixture","private":true}\n`);
+    const viteConfig = `import { defineConfig } from "vite";
+
+// oxlint-plugin-vize should be configured separately in a plain Vite project.
+export default defineConfig({});
+`;
+    write(root, "vite.config.ts", viteConfig);
+
+    const result = setupProject({ root, install: false });
+
+    assert.equal(read(root, "vite.config.ts"), viteConfig);
+    assert.equal(result.enabledVitePlusLint, false);
+    assert.match(read(root, "oxlint.config.ts"), /from "oxlint-plugin-vize"/u);
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("preserves multiline Vite+ imports when lint injection has no safe anchor", () => {
+  const root = temporaryProject("multiline-import");
+  try {
+    write(root, "package.json", `{"name":"multiline-import-fixture","private":true}\n`);
+    const viteConfig = `import {
+  defineConfig,
+} from "vite-plus";
+
+export default defineConfig({});
+`;
+    write(root, "vite.config.ts", viteConfig);
+
+    const result = setupProject({ root, install: false });
+
+    assert.equal(read(root, "vite.config.ts"), viteConfig);
     assert.equal(result.enabledVitePlusLint, false);
     assert.ok(result.preservedFiles.includes("Vite+ lint configuration"));
   } finally {
@@ -256,6 +329,12 @@ export default { plugins: [vuePlugin()] }
     assert.ok(fs.existsSync(path.join(root, "oxlint.config.ts")));
     const scripts = packageJson(root).scripts as Record<string, string>;
     assert.equal(scripts["vize:ready"], "vize ready src");
+
+    const invalid = spawnSync(process.execPath, [cli, "setup", root, "--bogus"], {
+      encoding: "utf8",
+    });
+    assert.notEqual(invalid.status, 0);
+    assert.match(invalid.stderr, /\[vize\] Unknown setup option: --bogus/u);
   } finally {
     fs.rmSync(root, { force: true, recursive: true });
   }


### PR DESCRIPTION
## Summary

- separate existing Vite+ lint state from lint injected by the current setup run
- preserve multiline imports when no safe lint-injection anchor exists and generate plain-Vite Oxlint config despite unrelated comments
- report partial file-write completion clearly and use published-output-compatible relative specifiers
- cover packed CLI errors, idempotent reporting, partial writes, and conservative lint migration

Follow-up to #3287.

## Validation

- `vp run --filter vize check`
- `vp run --filter vize test` (8 setup tests)
- `npm pack --dry-run --json ./npm/cli`
- `nix develop --command vp run --workspace-root check:repo`
- `nix develop --command moon run --target native tools/moon/cmd/source_file_lengths -- --check --base-ref origin/main --max-lines 350 --limit 20`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->