### PR TITLE
fix(atelier): classify parenthesized types as speculative type angles in the nesting guard (#3277, #3279, #3281)

### DIFF
--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
@@ -28,9 +28,11 @@ fn analyze_expression_nesting(content: &str) -> (usize, bool) {
     // Plain `foo < bar` is indistinguishable from a type argument to a byte
     // scanner. Enter angle-tracking mode only for repeated speculative type
     // prefixes: the structural shapes of the parser-timeout class (`<{`, `<[`,
-    // #2944) and the JSDoc non-nullable shape (`<!`, #3213), where OXC's type
-    // speculation recurses once per `!` and per nested `<` until the Rust
-    // stack overflows. Both are discovered while scanning so strings and
+    // #2944), the JSDoc non-nullable shape (`<!`, #3213), and the
+    // parenthesized-type shape (`<(`, #3277/#3279/#3281), where OXC's type
+    // speculation recurses once per marker and per nested `<` until the Rust
+    // stack overflows or the rewind cascade goes super-linear. All are
+    // discovered while scanning so strings and
     // comments cannot activate the mode. Logical/nullish operators (`&&`, `||`,
     // `??`) cannot appear inside a type-argument list, so they reset this
     // speculation: a flat boolean chain of `<` comparisons is not a type run.

--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting/scan.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting/scan.rs
@@ -54,9 +54,15 @@ pub(super) fn is_speculative_type_angle_open(content: &str, open: usize) -> bool
     let after = &content[open + 1..];
     let marker = skip_type_angle_trivia(after);
     // `{`/`[` start structural types (#2944); `!` starts a JSDoc non-nullable
-    // type (#3213). Each keeps OXC inside type-argument speculation, so
-    // repeated occurrences make unclosed angles count toward the depth budget.
-    matches!(after.as_bytes().get(marker), Some(b'{' | b'[' | b'!'))
+    // type (#3213); `(` starts a parenthesized type (#3277, #3279, #3281 — a
+    // 2.8KB `<`-dense reproducer stayed 3ms with the `<(` adjacency broken and
+    // took ~10s with it intact). Each keeps OXC inside type-argument
+    // speculation, so repeated occurrences make unclosed angles count toward
+    // the depth budget.
+    matches!(
+        after.as_bytes().get(marker),
+        Some(b'{' | b'[' | b'!' | b'(')
+    )
 }
 
 /// Skip the lexer trivia OXC drops between `<` and the next token: ASCII and

--- a/crates/vize_atelier_core/tests/expression_nesting_guard_type_angles.rs
+++ b/crates/vize_atelier_core/tests/expression_nesting_guard_type_angles.rs
@@ -133,6 +133,60 @@ fn expression_guard_sees_type_angle_markers_behind_trivia() {
 }
 
 #[test]
+fn expression_guard_rejects_parenthesized_type_angle_runs() {
+    // Minimized from the js_ts_expression slow-unit/timeout reproducers
+    // (#3277, #3279, #3281): a 2.8KB `<`-dense input parsed for ~10 seconds,
+    // and neutralizing only its two `<(` adjacencies dropped it to 3ms. OXC's
+    // type-argument speculation enters a parenthesized type at `<(` and keeps
+    // re-running the whole `<` cascade when a late token fails the outer
+    // parse, so `<(` joins the speculative type-angle class: two occurrences
+    // latch the tracking and the unclosed `<` run counts toward the budget.
+    let reproducer = ["id<(xx) ".repeat(2), "sT<s<\\jjjjjjjjjj".repeat(16)].concat();
+    assert!(expression_nesting_depth(&reproducer) > MAX_EXPRESSION_NESTING_DEPTH);
+    assert!(expression_exceeds_max_depth(&reproducer));
+    assert!(!expression_is_safe_to_parse(&reproducer));
+    assert_eq!(
+        prefix_identifiers_in_expression(&reproducer).as_str(),
+        reproducer
+    );
+    assert_eq!(
+        strip_typescript_from_expression(&reproducer).as_str(),
+        reproducer
+    );
+
+    // Whitespace between `<` and `(` reaches the same speculation path.
+    let spaced = ["id< (xx) ".repeat(2), "sT<s<\\jjjjjjjjjj".repeat(16)].concat();
+    assert!(!expression_is_safe_to_parse(&spaced));
+}
+
+#[test]
+fn expression_guard_keeps_ordinary_parenthesized_shapes_safe() {
+    // A single generic call with a function-type argument opens one
+    // speculative angle: tracking needs two, so real code stays accepted.
+    let generic_call = "useHandler<(payload: MouseEvent) => void>(handler)";
+    assert!(expression_is_safe_to_parse(generic_call));
+
+    // Two latched `<(` opens whose angles close again stay within budget:
+    // latching alone rejects nothing, only unclosed accumulation does.
+    let closed = "f<(A)>(x) + g<(B)>(y)";
+    assert!(expression_is_safe_to_parse(closed));
+
+    // Comparisons against parenthesized operands reset at `&&`, so a flat
+    // boolean chain past the limit never latches.
+    let chain = std::iter::repeat_n("a < (b + 1)", MAX_EXPRESSION_NESTING_DEPTH + 5)
+        .collect::<Vec<_>>()
+        .join(" && ");
+    assert_eq!(expression_nesting_depth(&chain), 1);
+    assert!(expression_is_safe_to_parse(&chain));
+    let rewritten = prefix_identifiers_in_expression(&chain);
+    assert!(rewritten.contains("_ctx.a < (_ctx.b + 1)"), "{rewritten}");
+
+    // A latched ternary chain accumulates only as deep as its real nesting.
+    let ternary = "count < (limit) ? a : total < (max) ? b : c";
+    assert!(expression_is_safe_to_parse(ternary));
+}
+
+#[test]
 fn expression_guard_does_not_treat_relational_operators_as_type_angles() {
     let expression = std::iter::repeat_n("value < limit", MAX_EXPRESSION_NESTING_DEPTH + 1)
         .collect::<Vec<_>>()


### PR DESCRIPTION
## Summary

The `js_ts_expression` fuzz target reported one recurring slow unit across three CI runs (#3277, #3279, #3281 — same content hash) plus sibling slow/timeout variants: a 2.8KB bracket-free expression built from `<`-dense chains that OXC parses for ~10 seconds (25s+ under fuzz instrumentation).

Root cause, isolated byte-by-byte: the input is balanced only because an early `id<(xx` opens a paren that a closing `)` at byte 2761 matches — removing that one `)` drops parse time from 9.3s to 0ms (the guard then rejects on balance), and neutralizing only the `<(` adjacencies drops it to 3ms with everything else intact. OXC's type-argument speculation enters a *parenthesized type* at `<(` and re-runs the whole speculation cascade when a late token fails the outer parse.

`<(` is exactly the class the guard already models for `<{`/`<[` (#2944) and `<!` (#3213), so the fix adds `(` to `is_speculative_type_angle_open`'s marker set: two speculative opens latch angle tracking and the unclosed `<` run counts toward the depth budget.

## Verification

- New regression tests: the latch-and-reject shape (`id<(xx) …` + 32 unclosed `<`) fails before the fix and passes after; whitespace between `<` and `(` reaches the same path; and a safe-shapes test pins real code: `useHandler<(payload: MouseEvent) => void>(handler)`, `f<(A)>(x) + g<(B)>(y)`, an over-limit `a < (b + 1) && …` chain (resets at `&&`), and a latched-but-shallow ternary chain.
- Replayed every artifact against the rebuilt fuzz target: slow-unit 110613c2 (runs 30147643440/30192206724/30247933861), af1dfa1a, timeout-17d11e49, 8fa0ba1e, a2f47a17 — all now execute in 0–2 ms; the #3274 stack-overflow reproducer stays rejected.
- `cargo test -p vize_atelier_core`: all suites green. `cargo fmt` / `clippy --all-targets`: no new warnings.

Closes #3277
Closes #3279
Closes #3281

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->