### PR TITLE
fix(atelier): bound unclosed-interpolation rescans in the template boundary scanner (#3275)

### DIFF
--- a/crates/vize_atelier_sfc/src/parse/template_boundary.rs
+++ b/crates/vize_atelier_sfc/src/parse/template_boundary.rs
@@ -14,6 +14,13 @@ use super::block::{
 use memchr::{memchr, memchr2, memchr3, memmem};
 use std::borrow::Cow;
 
+/// Failed JS-aware interpolation scans tolerated per template block before the
+/// boundary scanner falls back to structural scanning for the remaining `{{`.
+/// A failed scan means the interpolation never closes anywhere in the rest of
+/// the file, so real documents see at most a few; the cap bounds adversarial
+/// inputs at `MAX_FAILED_INTERPOLATION_SCANS` tail walks (#3275).
+const MAX_FAILED_INTERPOLATION_SCANS: usize = 8;
+
 #[inline]
 fn is_opening_tag_named(bytes: &[u8], pos: usize, len: usize, expected_name: &[u8]) -> bool {
     let name_start = pos + 1;
@@ -106,6 +113,14 @@ pub(super) fn find_template_block_end<'a>(search: BlockEndSearch<'a>) -> BlockPa
     let mut line = start_line;
     let mut last_newline = initial_last_newline;
     let mut depth = 1usize;
+    // Set once re-entering the JS-aware interpolation skipper is pointless:
+    // either no literal `}}` remains ahead (both interpolation exits need one,
+    // and later `{{` scan strict subranges of the proven-empty range), or the
+    // failed-scan budget below is spent. This keeps inputs dense in unclosed
+    // `{{` linear (#3275: a 45KB fuzz input with 1162 `{{` against 44 `}}`
+    // re-walked the tail through the string/regex machinery per occurrence).
+    let mut interpolation_close_exhausted = false;
+    let mut failed_interpolation_scans = 0usize;
 
     if let Some((content_end, end_pos)) = find_flat_template_end(bytes, content_start, len) {
         advance_line(
@@ -144,14 +159,33 @@ pub(super) fn find_template_block_end<'a>(search: BlockEndSearch<'a>) -> BlockPa
 
         if bytes[pos] == b'{' {
             if pos + 1 < len && bytes[pos + 1] == b'{' {
-                if let Some(interpolation_end) =
+                if !interpolation_close_exhausted
+                    && memmem::find(&bytes[pos + 2..], b"}}").is_none()
+                {
+                    interpolation_close_exhausted = true;
+                }
+                if interpolation_close_exhausted {
+                    // An unclosed interpolation is a template-parser error, not
+                    // an SFC block-boundary error. Resume structural scanning so
+                    // the root closing tag remains visible to that later stage.
+                    pos += 2;
+                } else if let Some(interpolation_end) =
                     skip_template_interpolation(bytes, pos, len, &mut line, &mut last_newline)
                 {
                     pos = interpolation_end;
                 } else {
-                    // An unclosed interpolation is a template-parser error, not
-                    // an SFC block-boundary error. Resume structural scanning so
-                    // the root closing tag remains visible to that later stage.
+                    // A failed scan already walked to the end of the source, so
+                    // every one costs the rest of the input. Real documents hold
+                    // at most a handful — each is an interpolation that never
+                    // closes again anywhere in the file — while the #3275 fuzz
+                    // shape packs hundreds whose scans stay expensive because a
+                    // brace-consumed or string-hidden `}}` survives near the
+                    // tail. Once the budget is spent, stop re-entering the JS
+                    // scanner and keep structural scanning only.
+                    failed_interpolation_scans += 1;
+                    if failed_interpolation_scans >= MAX_FAILED_INTERPOLATION_SCANS {
+                        interpolation_close_exhausted = true;
+                    }
                     pos += 2;
                 }
                 continue;

--- a/crates/vize_atelier_sfc/src/parse/template_boundary/interpolation.rs
+++ b/crates/vize_atelier_sfc/src/parse/template_boundary/interpolation.rs
@@ -25,9 +25,7 @@ pub(super) fn skip_template_interpolation(
     // cannot close. Returning before the JS recovery loop keeps a run of
     // unclosed `{{` linear instead of re-walking the rest of the source per
     // occurrence through the string/regex machinery (#3275).
-    let Some(close_offset) = memmem::find(&bytes[body_start..], b"}}") else {
-        return None;
-    };
+    let close_offset = memmem::find(&bytes[body_start..], b"}}")?;
 
     // Most interpolations are identifiers or simple expressions. Accept the
     // first delimiter immediately when no token before it can hide `}}`; this

--- a/crates/vize_atelier_sfc/src/parse/template_boundary/interpolation.rs
+++ b/crates/vize_atelier_sfc/src/parse/template_boundary/interpolation.rs
@@ -19,10 +19,20 @@ pub(super) fn skip_template_interpolation(
     let original_last_newline = *last_newline;
     let body_start = pos + 2;
 
+    // Every way out of this scan needs a literal `}}` ahead — the delimiter
+    // arm requires adjacent `}` bytes at depth zero and the malformed-string
+    // recovery searches for one — so its absence proves the interpolation
+    // cannot close. Returning before the JS recovery loop keeps a run of
+    // unclosed `{{` linear instead of re-walking the rest of the source per
+    // occurrence through the string/regex machinery (#3275).
+    let Some(close_offset) = memmem::find(&bytes[body_start..], b"}}") else {
+        return None;
+    };
+
     // Most interpolations are identifiers or simple expressions. Accept the
     // first delimiter immediately when no token before it can hide `}}`; this
     // keeps the common path on SIMD searches instead of the JS recovery loop.
-    if let Some(close_offset) = memmem::find(&bytes[body_start..], b"}}") {
+    {
         let close_start = body_start + close_offset;
         let body = &bytes[body_start..close_start];
         if memchr3(b'\'', b'"', b'`', body).is_none() && memchr2(b'/', b'{', body).is_none() {

--- a/crates/vize_atelier_sfc/src/parse/template_boundary/tests.rs
+++ b/crates/vize_atelier_sfc/src/parse/template_boundary/tests.rs
@@ -155,3 +155,82 @@ fn unclosed_interpolation_keeps_the_root_boundary_visible() {
     assert!(template.content.contains("{{ unclosed"));
     assert_eq!(result.styles.len(), 1);
 }
+
+#[test]
+fn later_interpolations_survive_an_unclosed_scan_that_consumed_delimiters() {
+    // The first `{{` never closes, but its JS scan walks over a `}}` that
+    // brace depth consumes, so raw delimiters do exist ahead. The linear-scan
+    // shortcut for exhausted delimiters (#3275) must not latch here: the later
+    // `{{ '</template>' }}` still has to be recognized as an interpolation, or
+    // the quoted closing tag would end the root template early.
+    let source = concat!(
+        "<template><p>{{ { }} {{ '</template>' }}</p><i>after</i></template>",
+        "<style>.ok {}</style>"
+    );
+    let result = parse_sfc(source, Default::default())
+        .expect("unclosed interpolation must not become a boundary error");
+
+    let template = result.template.expect("root template must be preserved");
+    assert!(
+        template.content.contains("'</template>'"),
+        "content: {}",
+        template.content
+    );
+    assert!(template.content.contains("after"));
+    assert_eq!(result.styles.len(), 1);
+}
+
+#[test]
+fn unclosed_interpolation_runs_scan_linearly() {
+    // Fuzz slow units #3275 (runs 30073026409): 45KB with 1162 `{{` against
+    // 44 `}}` made every unclosed `{{` re-walk the rest of the source through
+    // the JS string/regex machinery, one full pass per occurrence. Once no
+    // literal `}}` remains ahead the scan is provably unable to close, so the
+    // boundary scanner skips the JS loop for every later `{{`. This canary is
+    // quadratic-in-the-loop without that shortcut (tens of seconds in a debug
+    // build) and linear with it; the generous bound only guards the class.
+    let mut source = String::from("<template><div>");
+    for _ in 0..6000 {
+        source.push_str("{{a ");
+    }
+    source.push_str("</div></template>\n<style>.ok {}</style>");
+
+    let started = std::time::Instant::now();
+    let result = parse_sfc(&source, Default::default())
+        .expect("an interpolation-dense template must still parse");
+    let template = result.template.expect("root template must be preserved");
+    assert!(template.content.contains("{{a"));
+    assert_eq!(result.styles.len(), 1);
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(5),
+        "boundary scan took {:?}; the unclosed-interpolation shortcut regressed",
+        started.elapsed()
+    );
+}
+
+#[test]
+fn unclosed_interpolation_run_with_a_hidden_delimiter_stays_bounded() {
+    // Variant of the #3275 shape where a late raw `}}` survives (here inside
+    // the style block), so the no-delimiter-ahead shortcut never fires. Every
+    // unclosed `{{` would re-enter the JS scanner and walk the tail; the
+    // failed-scan budget caps the walks while the root boundary and the style
+    // block still parse exactly as before.
+    let mut source = String::from("<template><div>");
+    for _ in 0..6000 {
+        source.push_str("{{a ");
+    }
+    source.push_str("</div></template>\n<style>.ok {}}</style>");
+
+    let started = std::time::Instant::now();
+    let result = parse_sfc(&source, Default::default())
+        .expect("an interpolation-dense template must still parse");
+    let template = result.template.expect("root template must be preserved");
+    assert!(template.content.contains("{{a"));
+    assert_eq!(result.styles.len(), 1);
+    assert!(result.styles[0].content.contains(".ok"));
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(5),
+        "boundary scan took {:?}; the failed-interpolation-scan budget regressed",
+        started.elapsed()
+    );
+}


### PR DESCRIPTION
## Summary

The `sfc_parse` fuzz target reported two slow units (#3275, run 30073026409): 45–53KB inputs that parse for 7–10 seconds. Profiling (`sample` during replay) put ~98% of the time inside `skip_template_interpolation` → `skip_regex_literal`: the inputs contain **1162 `{{` against 44 `}}`**, so nearly every `{{` runs the JS-aware interpolation scan (strings, comments, regexes, brace depth) over the rest of the source, fails at EOF, advances two bytes, and the next `{{` re-walks the same tail — a quadratic rescan through the scanner's heaviest machinery.

Two bounded shortcuts in `find_template_block_end`, both preserving boundary semantics:

- **Delimiter exhaustion (provably lossless):** every exit from `skip_template_interpolation` requires a literal `}}` ahead (the close arm needs adjacent `}` bytes at depth zero; the malformed-string recovery searches for one). Once `memmem` proves no `}}` remains ahead, later `{{` scan strict subranges of the proven-empty range, so the scanner stops re-entering the JS skipper for the rest of the block. The same check short-circuits inside `skip_template_interpolation` before its recovery loop.
- **Failed-scan budget (documented cap):** when a raw `}}` survives near the tail (brace-consumed or string-hidden), each failed scan still walks to EOF. A failed scan means that interpolation never closes anywhere in the remaining file, so real documents see at most a few; after 8 failures the scanner falls back to structural scanning for the remaining `{{` of that block.

## Verification

- Replayed both fuzz artifacts against the rebuilt target: **7135 ms → 53 ms** and **9480 ms → 28 ms**.
- New tests: a soundness case where an unclosed scan walks over brace-consumed `}}` and a later `{{ '</template>' }}` must still be recognized (a wrongly latched shortcut would end the root template inside the string); a 6000-`{{` no-delimiter canary; and a hidden-delimiter variant that exercises the failed-scan budget — each asserts exact boundary outcomes plus a generous linearity bound.
- All existing template-boundary cases pass unchanged (interpolation strings/comments/regex/nesting semantics untouched); `cargo test -p vize_atelier_sfc --features native`: 572+ passed, with only the known local-env `pkl` fixture failures (identical on unmodified main, covered in CI).
- `cargo fmt` / `clippy --all-targets`: no new warnings.

Closes #3275

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unfinished template interpolations, ensuring the root template boundary remains correctly detected.
  * Prevented malformed or delimiter-heavy interpolations from causing excessive scanning delays.
  * Preserved recognition of later interpolations and content in subsequent style sections.

* **Tests**
  * Added coverage for unclosed interpolations, embedded delimiters, and performance under interpolation-heavy input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->