### PR TITLE
fix(fuzz): skip the upstream oxc tuple-type span assertion shape (#3296)

### DIFF
--- a/tests/fuzz/fuzz_targets/js_ts_expression.rs
+++ b/tests/fuzz/fuzz_targets/js_ts_expression.rs
@@ -5,17 +5,58 @@
 // Drives the same OXC expression parsing path used by template expression
 // transforms and import-usage checks. Invalid expressions are expected and
 // reported as parser errors; panics are not.
+//
+// One upstream crash class is skip-listed below until the pinned OXC revision
+// carries a fix (#3296; retirement tracked in #3307): a speculative tuple type
+// with an optional member recovering over a C0 control byte builds a span
+// with `start > end`, tripping a `debug_assert` in `oxc_span::Span::size`
+// (`<[r?, \x07]` after `cargo fuzz tmin`). The shape is not a depth or
+// balance property, so the expression nesting guard cannot express it; the
+// skip costs fuzz coverage only.
 use libfuzzer_sys::fuzz_target;
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_atelier_core::steps::expression::expression_is_safe_to_parse;
 
+/// Returns true when a `<[` span holds both a `?` and a C0 control byte
+/// (excluding tab/newline/carriage return) before its closing `]` — the
+/// empirical requirements of the upstream tuple-type span assertion (#3307):
+/// dropping either the optional member or the control byte parses cleanly.
+fn hits_known_upstream_span_assertion_shape(bytes: &[u8]) -> bool {
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'<' && bytes[i + 1] == b'[' {
+            let (mut has_question, mut has_control) = (false, false);
+            let mut j = i + 2;
+            while j < bytes.len() && bytes[j] != b']' {
+                match bytes[j] {
+                    b'?' => has_question = true,
+                    b'\t' | b'\n' | b'\r' => {}
+                    b if b < 0x20 => has_control = true,
+                    _ => {}
+                }
+                j += 1;
+            }
+            if has_question && has_control {
+                return true;
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+    false
+}
+
 fuzz_target!(|data: &[u8]| {
     let Ok(source) = std::str::from_utf8(data) else {
         return;
     };
     if !expression_is_safe_to_parse(source) {
+        return;
+    }
+    if hits_known_upstream_span_assertion_shape(source.as_bytes()) {
         return;
     }
 


### PR DESCRIPTION
## Summary

The `js_ts_expression` reproducer from run 30335797526 (#3296) is an upstream OXC defect, not a Vize guard gap: `cargo fuzz tmin` reduces it to 8 bytes — `<[r?, \x07]` — where speculative tuple-type parsing with an **optional member** recovering over a **C0 control byte** constructs a span with `start > end` and trips `oxc_span::Span::size`'s `debug_assert` (pinned rev 8265ed94, oxc 0.127.0).

Class mapping (each replayed): both ingredients are required — `<[r?, x]` (printable), `<[\x07]` (no optional member), and `<[r?]` (no control byte) all parse cleanly, while `f<[a?, \x07]>(x)` and whitespace/control variants panic. The shape is not a depth or balance property, so `expression_is_safe_to_parse` cannot express it; the assert is `debug_assert`-only, so release binaries are unaffected and the practical exposure is fuzz CI and dev-profile parsing of byte garbage.

Per the established pattern (css_parse / #3295), the fuzz target skips inputs where a `<[` span contains both a `?` and a C0 control byte (excluding \t \n \r) before its closing `]`/EOF. Coverage cost only; retirement (OXC fix + pin bump + skip removal) tracked in #3307, which also carries the upstream report material.

## Verification

Replayed against the rebuilt target: the #3296 artifact and every panic variant (`<[r?, \x07]`, `f<[a?, \x07]>(x)`, `\x1f` variant, prefixed forms) now skip cleanly, while the clean neighbors (`<[r?, x]`, `<[\x07]`, `<[r?]`) and unrelated guard shapes still execute the parser.

Closes #3296

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated JavaScript and TypeScript expression fuzz testing to skip malformed inputs that trigger an upstream assertion.
  * Preserved existing safety filtering and expression parsing coverage for supported inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->