### PR TITLE
fix(atelier): bound post-budget interpolation scans instead of dropping JS awareness

### DIFF
--- a/crates/vize_atelier_sfc/src/parse/template_boundary.rs
+++ b/crates/vize_atelier_sfc/src/parse/template_boundary.rs
@@ -15,11 +15,19 @@ use memchr::{memchr, memchr2, memchr3, memmem};
 use std::borrow::Cow;
 
 /// Failed JS-aware interpolation scans tolerated per template block before the
-/// boundary scanner falls back to structural scanning for the remaining `{{`.
-/// A failed scan means the interpolation never closes anywhere in the rest of
-/// the file, so real documents see at most a few; the cap bounds adversarial
-/// inputs at `MAX_FAILED_INTERPOLATION_SCANS` tail walks (#3275).
+/// boundary scanner bounds every later scan to
+/// `BOUNDED_INTERPOLATION_SCAN_WINDOW`. A failed scan means the interpolation
+/// never closes anywhere in the rest of the file, so real documents see at most
+/// a few; the cap bounds adversarial inputs at `MAX_FAILED_INTERPOLATION_SCANS`
+/// tail walks (#3275).
 const MAX_FAILED_INTERPOLATION_SCANS: usize = 8;
+
+/// Bytes a JS-aware interpolation scan may walk once the failed-scan budget is
+/// spent. Interpolations that close inside the window keep full opacity, so
+/// strings, comments, and regexes still hide markup from the structural
+/// scanner; only bodies that fail to close within the window degrade to the
+/// structural handling an unclosed interpolation already gets (#3275).
+const BOUNDED_INTERPOLATION_SCAN_WINDOW: usize = 4096;
 
 #[inline]
 fn is_opening_tag_named(bytes: &[u8], pos: usize, len: usize, expected_name: &[u8]) -> bool {
@@ -113,12 +121,12 @@ pub(super) fn find_template_block_end<'a>(search: BlockEndSearch<'a>) -> BlockPa
     let mut line = start_line;
     let mut last_newline = initial_last_newline;
     let mut depth = 1usize;
-    // Set once re-entering the JS-aware interpolation skipper is pointless:
-    // either no literal `}}` remains ahead (both interpolation exits need one,
-    // and later `{{` scan strict subranges of the proven-empty range), or the
-    // failed-scan budget below is spent. This keeps inputs dense in unclosed
-    // `{{` linear (#3275: a 45KB fuzz input with 1162 `{{` against 44 `}}`
-    // re-walked the tail through the string/regex machinery per occurrence).
+    // Set once no literal `}}` remains ahead. Both interpolation exits need
+    // one, and later `{{` scan strict subranges of the proven-empty range, so
+    // no interpolation in the rest of the block can close. This keeps inputs
+    // dense in unclosed `{{` linear (#3275: a 45KB fuzz input with 1162 `{{`
+    // against 44 `}}` re-walked the tail through the string/regex machinery
+    // per occurrence).
     let mut interpolation_close_exhausted = false;
     let mut failed_interpolation_scans = 0usize;
 
@@ -159,33 +167,52 @@ pub(super) fn find_template_block_end<'a>(search: BlockEndSearch<'a>) -> BlockPa
 
         if bytes[pos] == b'{' {
             if pos + 1 < len && bytes[pos + 1] == b'{' {
-                if !interpolation_close_exhausted
-                    && memmem::find(&bytes[pos + 2..], b"}}").is_none()
-                {
-                    interpolation_close_exhausted = true;
-                }
-                if interpolation_close_exhausted {
+                let close_ahead = if interpolation_close_exhausted {
+                    None
+                } else {
+                    let close_ahead = memmem::find(&bytes[pos + 2..], b"}}");
+                    interpolation_close_exhausted = close_ahead.is_none();
+                    close_ahead
+                };
+
+                // A failed scan already walked to the end of the source, so
+                // every one costs the rest of the input. Real documents hold at
+                // most a handful — each is an interpolation that never closes
+                // again anywhere in the file — while the #3275 fuzz shape packs
+                // hundreds whose scans stay expensive because a brace-consumed
+                // or string-hidden `}}` survives near the tail. Once the budget
+                // is spent, keep scanning JS-aware but only within a window, so
+                // a later well-formed interpolation stays opaque instead of
+                // exposing a quoted `</template>` to the structural scanner.
+                let scan_limit = if failed_interpolation_scans < MAX_FAILED_INTERPOLATION_SCANS {
+                    len
+                } else {
+                    (pos + 2)
+                        .saturating_add(BOUNDED_INTERPOLATION_SCAN_WINDOW)
+                        .min(len)
+                };
+
+                // Both interpolation exits need a literal `}}` within reach, so
+                // a nearest delimiter beyond the limit rules the scan out before
+                // it walks a single byte.
+                let close_within_limit =
+                    close_ahead.is_some_and(|offset| pos + 2 + offset + 2 <= scan_limit);
+
+                if !close_within_limit {
                     // An unclosed interpolation is a template-parser error, not
                     // an SFC block-boundary error. Resume structural scanning so
                     // the root closing tag remains visible to that later stage.
                     pos += 2;
-                } else if let Some(interpolation_end) =
-                    skip_template_interpolation(bytes, pos, len, &mut line, &mut last_newline)
-                {
+                } else if let Some(interpolation_end) = skip_template_interpolation(
+                    &bytes[..scan_limit],
+                    pos,
+                    scan_limit,
+                    &mut line,
+                    &mut last_newline,
+                ) {
                     pos = interpolation_end;
                 } else {
-                    // A failed scan already walked to the end of the source, so
-                    // every one costs the rest of the input. Real documents hold
-                    // at most a handful — each is an interpolation that never
-                    // closes again anywhere in the file — while the #3275 fuzz
-                    // shape packs hundreds whose scans stay expensive because a
-                    // brace-consumed or string-hidden `}}` survives near the
-                    // tail. Once the budget is spent, stop re-entering the JS
-                    // scanner and keep structural scanning only.
                     failed_interpolation_scans += 1;
-                    if failed_interpolation_scans >= MAX_FAILED_INTERPOLATION_SCANS {
-                        interpolation_close_exhausted = true;
-                    }
                     pos += 2;
                 }
                 continue;

--- a/crates/vize_atelier_sfc/src/parse/template_boundary/interpolation.rs
+++ b/crates/vize_atelier_sfc/src/parse/template_boundary/interpolation.rs
@@ -7,6 +7,11 @@ use memchr::{memchr, memchr2, memchr3, memmem};
 
 /// Skip a Vue interpolation while ignoring delimiter-like text inside JavaScript
 /// strings, template literals, comments, and regular expressions.
+///
+/// `bytes` may be a prefix of the source that ends at `len`, which the caller
+/// uses to bound the scan; positions stay absolute and everything past `len` is
+/// treated as unreachable, so a body that does not close within the prefix
+/// reports failure instead of walking the rest of the file (#3275).
 pub(super) fn skip_template_interpolation(
     bytes: &[u8],
     mut pos: usize,

--- a/crates/vize_atelier_sfc/src/parse/template_boundary/tests.rs
+++ b/crates/vize_atelier_sfc/src/parse/template_boundary/tests.rs
@@ -181,6 +181,37 @@ fn later_interpolations_survive_an_unclosed_scan_that_consumed_delimiters() {
 }
 
 #[test]
+fn valid_interpolations_survive_a_spent_failed_scan_budget() {
+    // Every `{{ { }}` group leaves a brace-consumed `}}` behind, so its scan
+    // walks to EOF and fails while raw delimiters still exist ahead. Enough
+    // groups spend the failed-scan budget (#3275), which must bound later scans
+    // rather than drop JS awareness for the rest of the block: the trailing
+    // `{{ '</template>' }}` is well-formed, so its quoted closing tag has to
+    // stay opaque instead of ending the root template early.
+    let mut source = String::from("<template><p>");
+    for _ in 0..8 {
+        source.push_str("{{ { }} ");
+    }
+    source.push_str("{{ '</template>' }}</p><i>after</i></template><style>.ok {}</style>");
+
+    let result = parse_sfc(&source, Default::default())
+        .expect("unclosed interpolations must not become a boundary error");
+
+    let template = result.template.expect("root template must be preserved");
+    assert!(
+        template.content.contains("'</template>'"),
+        "content: {}",
+        template.content
+    );
+    assert!(
+        template.content.contains("<i>after</i>"),
+        "content: {}",
+        template.content
+    );
+    assert_eq!(result.styles.len(), 1);
+}
+
+#[test]
 fn unclosed_interpolation_runs_scan_linearly() {
     // Fuzz slow units #3275 (runs 30073026409): 45KB with 1162 `{{` against
     // 44 `}}` made every unclosed `{{` re-walk the rest of the source through


### PR DESCRIPTION
Follow-up to #3305, which was merged before this review finding could land on its branch.

#3305 added two shortcuts to `find_template_block_end`, but both set the same `interpolation_close_exhausted` latch. Only one of them earns it. Delimiter exhaustion is provable: once no literal `}}` remains ahead, no later `{{` can close, so structural scanning loses nothing. The failed-scan budget has no such proof, and after 8 brace-consumed failures it disabled JS-aware handling for every remaining `{{` in the block, including well-formed ones. A trailing `{{ '</template>' }}` was then scanned as markup and its quoted closing tag ended the root template early, truncating content the template parser should have seen:

```
<p>{{ { }} {{ { }} {{ { }} {{ { }} {{ { }} {{ { }} {{ { }} {{ { }} {{ '
```

The budget now bounds each later scan instead of switching it off. Once spent, a scan may walk at most `BOUNDED_INTERPOLATION_SCAN_WINDOW` (4096) bytes, passed as a prefix slice so the string, comment, and regex helpers stay inside the window too. Since both interpolation exits need a literal `}}` in reach, the nearest-delimiter offset the scanner already computes rules a scan out before it walks a byte:

```rust
let scan_limit = if failed_interpolation_scans < MAX_FAILED_INTERPOLATION_SCANS {
    len
} else {
    (pos + 2).saturating_add(BOUNDED_INTERPOLATION_SCAN_WINDOW).min(len)
};

let close_within_limit =
    close_ahead.is_some_and(|offset| pos + 2 + offset + 2 <= scan_limit);

if !close_within_limit {
    pos += 2; // unclosed: a template-parser error, not a boundary error
} else if let Some(end) =
    skip_template_interpolation(&bytes[..scan_limit], pos, scan_limit, &mut line, &mut last_newline)
{
    pos = end;
} else {
    failed_interpolation_scans += 1;
    pos += 2;
}
```

Interpolations that close within the window keep full opacity no matter how many earlier scans failed, so only bodies that fail to close inside it degrade to the structural handling an unclosed interpolation already got. Documents with at most 8 failed scans, which is every real one, behave exactly as before: `scan_limit` stays `len`.

The #3275 shapes stay bounded. In the no-delimiter canary the exhaustion latch still fires on the first `{{`, and in the hidden-delimiter variant the nearest `}}` sits beyond the window for all but the tail occurrences, so the walk is skipped outright rather than repeated.

The new regression covers the reported case: 8 brace-consumed failures followed by `{{ '</template>' }}`, asserting the root template still contains both the quoted tag and the `<i>after</i>` that follows it. Verified it fails with the window disabled (the old global bypass) and passes with it. `cargo test -p vize_atelier_sfc --lib`: 574 pass, with only the known local-env `pkl` fixture failures; `cargo clippy -p vize_atelier_sfc --lib -- -D warnings -D clippy::wildcard_imports` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->