### PR TITLE
fix(patina): run analysis-dependent rules on recovered template parses (#3294)

### DIFF
--- a/crates/vize_armature/src/parser/element/errors.rs
+++ b/crates/vize_armature/src/parser/element/errors.rs
@@ -99,3 +99,64 @@ impl<'a> Parser<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use vize_carton::Bump;
+    use vize_relief::errors::{CompilerError, ErrorCode};
+
+    use crate::parser::Parser;
+
+    /// `CompilerError::is_recovered_parse` (vize_relief) mirrors the recovery
+    /// messages constructed above; this pin keeps the two crates' lists from
+    /// drifting apart (#3294). When a new recovery message is added above,
+    /// add its code here and to `is_recovered_parse`. `DuplicateAttribute`
+    /// is recovered without a custom message, so it is the one allowed
+    /// asymmetry.
+    #[test]
+    fn recovery_messages_and_recovered_parse_classification_agree() {
+        let bump = Bump::new();
+        let parser = Parser::new(&bump, "");
+        for code in [
+            ErrorCode::EofBeforeTagName,
+            ErrorCode::EofInTag,
+            ErrorCode::EofInComment,
+            ErrorCode::InvalidFirstCharacterOfTagName,
+            ErrorCode::MissingAttributeValue,
+            ErrorCode::MissingDynamicDirectiveArgumentEnd,
+            ErrorCode::MissingInterpolationEnd,
+            ErrorCode::UnexpectedCharacterInAttributeName,
+            ErrorCode::UnexpectedCharacterInUnquotedAttributeValue,
+            ErrorCode::UnexpectedEqualsSignBeforeAttributeName,
+            ErrorCode::MissingWhitespaceBetweenAttributes,
+            ErrorCode::IncorrectlyClosedComment,
+            ErrorCode::IncorrectlyOpenedComment,
+        ] {
+            assert!(
+                parser.recovery_error_message(code).is_some(),
+                "expected a recovery message for {code:?}"
+            );
+            assert!(
+                CompilerError::new(code, None).is_recovered_parse(),
+                "expected is_recovered_parse for {code:?}"
+            );
+        }
+        for code in [
+            ErrorCode::MissingEndTagName,
+            ErrorCode::UnexpectedNullCharacter,
+            ErrorCode::CdataInHtmlContent,
+        ] {
+            assert!(parser.recovery_error_message(code).is_none(), "{code:?}");
+            assert!(
+                !CompilerError::new(code, None).is_recovered_parse(),
+                "{code:?}"
+            );
+        }
+        assert!(CompilerError::new(ErrorCode::DuplicateAttribute, None).is_recovered_parse());
+        assert!(
+            parser
+                .recovery_error_message(ErrorCode::DuplicateAttribute)
+                .is_none()
+        );
+    }
+}

--- a/crates/vize_patina/src/linter/engine/parse_diagnostics.rs
+++ b/crates/vize_patina/src/linter/engine/parse_diagnostics.rs
@@ -95,8 +95,14 @@ impl Linter {
         }
     }
 
+    /// A parse error is fatal for semantic analysis only when the parser did
+    /// not document a recovery for it. Recovered parses still yield a
+    /// complete tree, and skipping analysis there silently disabled every
+    /// `has_analysis`-guarded rule on exactly the files that most need them
+    /// (#3294). Diagnostic severity intentionally stays keyed on
+    /// `is_recoverable`, so these defects still lint as errors.
     pub(crate) fn has_fatal_template_parse_errors(parse_errors: &[CompilerError]) -> bool {
-        parse_errors.iter().any(|error| !error.is_recoverable())
+        parse_errors.iter().any(|error| !error.is_recovered_parse())
     }
 
     pub(super) fn sfc_parse_lint_result(

--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -10,6 +10,7 @@ mod jsx_fallback;
 mod no_mutating_props;
 mod no_top_level_ref;
 mod nuxt;
+mod recovered_parse_analysis;
 mod script;
 mod severity_overrides;
 mod sfc;

--- a/crates/vize_patina/src/linter/tests/recovered_parse_analysis.rs
+++ b/crates/vize_patina/src/linter/tests/recovered_parse_analysis.rs
@@ -1,0 +1,73 @@
+//! Analysis-dependent rules must keep running on recovered template parses.
+//!
+//! Found while hydrating the pinned `vue2-elm` fixture (#3294): a recovered
+//! attribute boundary (`version="1.1"class="x"`) used to classify the whole
+//! parse as fatal, so croquis analysis was skipped and every
+//! `has_analysis`-guarded rule silently reported nothing. A recovered parse
+//! yields a complete tree, and it is exactly the shape where a silent rule
+//! skip is least acceptable.
+
+use super::Linter;
+use vize_carton::ToCompactString;
+
+fn rule_names(result: &crate::linter::config::LintResult) -> Vec<&'static str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name)
+        .collect()
+}
+
+#[test]
+fn recovered_attribute_boundary_still_runs_analysis_rules() {
+    let linter =
+        Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-vars".to_compact_string()]));
+    // The missing whitespace between `version="1.1"` and `class="x"` is
+    // reported (MissingWhitespaceBetweenAttributes) and recovered with an
+    // inferred attribute boundary; the unused v-for `index` must still be
+    // seen by the analysis-guarded rule on that recovered tree.
+    let source = "<template><div version=\"1.1\"class=\"x\">\
+<span v-for=\"(item, index) in items\" :key=\"item\">{{ item }}</span>\
+</div></template>";
+    let result = linter.lint_sfc(source, "test.vue");
+    let rules = rule_names(&result);
+
+    assert!(rules.contains(&"parser/template"), "{rules:?}");
+    assert!(rules.contains(&"vue/no-unused-vars"), "{rules:?}");
+}
+
+#[test]
+fn recovered_parse_and_clean_parse_report_the_same_analysis_rules() {
+    // The formatted twin of the recovered source (whitespace restored) must
+    // agree with it on every non-parser rule, so pristine and formatted
+    // trees lint identically (#3294's lint-agreement property).
+    let linter =
+        Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-vars".to_compact_string()]));
+    let recovered = "<template><div version=\"1.1\"class=\"x\">\
+<span v-for=\"(item, index) in items\" :key=\"item\">{{ item }}</span>\
+</div></template>";
+    let clean = "<template><div version=\"1.1\" class=\"x\">\
+<span v-for=\"(item, index) in items\" :key=\"item\">{{ item }}</span>\
+</div></template>";
+
+    let mut recovered_rules = rule_names(&linter.lint_sfc(recovered, "test.vue"));
+    recovered_rules.retain(|rule| *rule != "parser/template");
+    let clean_rules = rule_names(&linter.lint_sfc(clean, "test.vue"));
+
+    assert_eq!(recovered_rules, clean_rules);
+    assert_eq!(recovered_rules, ["vue/no-unused-vars"]);
+}
+
+#[test]
+fn unrecovered_parse_errors_still_disable_analysis_rules() {
+    // A truly broken template (no documented recovery) keeps the previous
+    // behavior: parse diagnostics only, no analysis-dependent output.
+    let linter =
+        Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-vars".to_compact_string()]));
+    let source =
+        "<template><div><span v-for=\"(item, index) in items\">{{ item }}</span></template>";
+    let result = linter.lint_sfc(source, "test.vue");
+    let rules = rule_names(&result);
+
+    assert!(!rules.contains(&"vue/no-unused-vars"), "{rules:?}");
+}

--- a/crates/vize_relief/src/errors.rs
+++ b/crates/vize_relief/src/errors.rs
@@ -1,9 +1,9 @@
 //! Compiler error types and codes.
 mod compatibility;
+mod recovery;
 use crate::SourceLocation;
 use thiserror::Error;
 use vize_carton::{CompactString, ToCompactString};
-
 /// Compiler error
 #[derive(Debug, Clone, Error)]
 #[error("{message}")]

--- a/crates/vize_relief/src/errors/recovery.rs
+++ b/crates/vize_relief/src/errors/recovery.rs
@@ -1,0 +1,76 @@
+//! Classification of parse errors whose recovery yields a complete tree.
+
+use super::{CompilerError, ErrorCode};
+
+impl CompilerError {
+    /// Returns true when the template parser documents a concrete recovery
+    /// strategy for this code: parsing continues past the defect and still
+    /// yields a complete tree, so semantic analysis over that tree stays
+    /// meaningful (#3294).
+    ///
+    /// This is deliberately broader than [`CompilerError::is_recoverable`],
+    /// which additionally implies downstream codegen may proceed without
+    /// gating. The code list mirrors the recovery messages constructed in
+    /// `vize_armature`'s `recovery_error_message`; the armature parser tests
+    /// pin the two lists together.
+    #[must_use]
+    pub fn is_recovered_parse(&self) -> bool {
+        matches!(
+            self.code,
+            ErrorCode::EofBeforeTagName
+                | ErrorCode::EofInTag
+                | ErrorCode::EofInComment
+                | ErrorCode::InvalidFirstCharacterOfTagName
+                | ErrorCode::MissingAttributeValue
+                | ErrorCode::MissingDynamicDirectiveArgumentEnd
+                | ErrorCode::MissingInterpolationEnd
+                | ErrorCode::UnexpectedCharacterInAttributeName
+                | ErrorCode::UnexpectedCharacterInUnquotedAttributeValue
+                | ErrorCode::UnexpectedEqualsSignBeforeAttributeName
+                | ErrorCode::MissingWhitespaceBetweenAttributes
+                | ErrorCode::IncorrectlyClosedComment
+                | ErrorCode::IncorrectlyOpenedComment
+        ) || self.is_recoverable()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{CompilerError, ErrorCode};
+
+    #[test]
+    fn recovered_parse_covers_the_documented_recovery_codes() {
+        for code in [
+            ErrorCode::EofBeforeTagName,
+            ErrorCode::EofInTag,
+            ErrorCode::EofInComment,
+            ErrorCode::InvalidFirstCharacterOfTagName,
+            ErrorCode::MissingAttributeValue,
+            ErrorCode::MissingDynamicDirectiveArgumentEnd,
+            ErrorCode::MissingInterpolationEnd,
+            ErrorCode::UnexpectedCharacterInAttributeName,
+            ErrorCode::UnexpectedCharacterInUnquotedAttributeValue,
+            ErrorCode::UnexpectedEqualsSignBeforeAttributeName,
+            ErrorCode::MissingWhitespaceBetweenAttributes,
+            ErrorCode::IncorrectlyClosedComment,
+            ErrorCode::IncorrectlyOpenedComment,
+            // is_recoverable ⊂ is_recovered_parse
+            ErrorCode::DuplicateAttribute,
+        ] {
+            let error = CompilerError::new(code, None);
+            assert!(error.is_recovered_parse(), "{code:?}");
+        }
+    }
+
+    #[test]
+    fn recovered_parse_rejects_unrecovered_codes() {
+        for code in [
+            ErrorCode::MissingEndTagName,
+            ErrorCode::UnexpectedNullCharacter,
+            ErrorCode::CdataInHtmlContent,
+        ] {
+            let error = CompilerError::new(code, None);
+            assert!(!error.is_recovered_parse(), "{code:?}");
+        }
+    }
+}

--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -1,9 +1,1 @@
-[
-  {
-    "property": "lint-agreement",
-    "project": "vue2-elm",
-    "path": "src/page/shop/shop.vue",
-    "rule": "vue/no-unused-vars",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3294"
-  }
-]
+[]


### PR DESCRIPTION
## Summary

When the template parser recovered from a defect (e.g. `version="1.1"class="x"` → MissingWhitespaceBetweenAttributes with an inferred boundary), patina classified the parse as fatal, skipped croquis analysis, and every `has_analysis()`-guarded rule silently reported nothing — a pristine-side false-negative factory (#3294 hit `vue/no-unused-vars` on vue2-elm's `shop.vue`).

The parser documents a concrete recovery for 13 error codes (`recovery_error_message` in vize_armature) and still yields a complete tree for them, so analysis over that tree stays meaningful:

- `vize_relief`: new `CompilerError::is_recovered_parse()` in `errors/recovery.rs` covering the documented-recovery codes (⊇ `is_recoverable`). `is_recoverable` itself is untouched, so diagnostic severity and dom/ssr/wasm codegen gating do not change.
- `vize_patina`: `has_fatal_template_parse_errors` now keys on `is_recovered_parse`, so recovered parses keep analysis (both the template lint path and the type-aware driver).
- `vize_armature`: a consistency test pins the recovery-message list to the new classification so the two crates cannot drift.
- Removed the rule-scoped `shop.vue` pin from `glyph-corpus-known-violations.json` — the lint-agreement corpus property now holds without it.

## Verification

- New patina integration tests: recovered-boundary source reports **both** `parser/template` and `vue/no-unused-vars`; recovered and clean twins agree on non-parser rules; a truly unrecovered parse still disables analysis rules. The first two fail before the fix, the third passes on both sides (pins preserved behavior).
- relief/armature classification tests: 13 documented-recovery codes + DuplicateAttribute asymmetry + negative codes.
- Full `cargo test -p vize_patina` green; `cargo test -p vize_relief -p vize_armature` green; fmt + clippy clean.
- End-to-end with a fresh `--profile ci --features legacy` binary on the pinned vue2-elm `shop.vue` (the #3294 repro recipe): pristine lint now reports `parser/template: 1` **and** `vue/no-unused-vars: 1`; after `vize fmt --write` the file agrees on `vue/no-unused-vars` with only formatting-fixable style rules differing.

Closes #3294

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved linting behavior for templates that can be successfully recovered after parse errors.
  * Analysis-dependent lint rules now run on recoverable templates while remaining disabled for genuinely broken templates.
  * Corrected fatal-error classification for recovered template parses.

* **Tests**
  * Added regression coverage for recovered and unrecoverable template scenarios.
  * Updated parser recovery validation and known-violation fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->