### PR TITLE
chore(relief): centralize the recovered-parse code classification

### DIFF
--- a/crates/vize_armature/src/parser/element/errors.rs
+++ b/crates/vize_armature/src/parser/element/errors.rs
@@ -26,6 +26,14 @@ impl<'a> Parser<'a> {
     }
 
     fn recovery_error_message(&self, code: ErrorCode) -> Option<String> {
+        // `RECOVERED_PARSE_CODES` (vize_relief) is the single source of truth
+        // for which defects the parser recovers from, and patina keys its
+        // analysis gating off the same classification (#3294). Consulting it
+        // here means the message table below cannot claim a recovery the
+        // classification does not know about.
+        if !code.has_documented_parse_recovery() {
+            return None;
+        }
         match code {
             ErrorCode::EofBeforeTagName => Some(
                 "Unexpected end of input after `<`; treating it as text so parsing can continue."
@@ -95,6 +103,9 @@ impl<'a> Parser<'a> {
             ErrorCode::IncorrectlyOpenedComment => Some(
                 "Declaration or comment syntax is malformed; skipping it until the next `>`.".into(),
             ),
+            // Unreachable in practice: the guard above admits only
+            // `RECOVERED_PARSE_CODES`, and every entry there has an arm above
+            // (pinned by `recovery_messages_and_recovered_parse_classification_agree`).
             _ => None,
         }
     }
@@ -103,35 +114,23 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use vize_carton::Bump;
-    use vize_relief::errors::{CompilerError, ErrorCode};
+    use vize_relief::errors::{CompilerError, ErrorCode, RECOVERED_PARSE_CODES};
 
     use crate::parser::Parser;
 
-    /// `CompilerError::is_recovered_parse` (vize_relief) mirrors the recovery
-    /// messages constructed above; this pin keeps the two crates' lists from
-    /// drifting apart (#3294). When a new recovery message is added above,
-    /// add its code here and to `is_recovered_parse`. `DuplicateAttribute`
-    /// is recovered without a custom message, so it is the one allowed
-    /// asymmetry.
+    /// `CompilerError::is_recovered_parse` (vize_relief) and the recovery
+    /// messages constructed above must describe the same set of defects
+    /// (#3294). Both sides now read the shared `RECOVERED_PARSE_CODES`
+    /// classification rather than keeping their own copies, so this pins every
+    /// classified code to a real message: adding a recovery message means
+    /// adding the code to that list, and adding it to the list without a
+    /// message fails here. `DuplicateAttribute` is recovered without a custom
+    /// message, so it is the one allowed asymmetry.
     #[test]
     fn recovery_messages_and_recovered_parse_classification_agree() {
         let bump = Bump::new();
         let parser = Parser::new(&bump, "");
-        for code in [
-            ErrorCode::EofBeforeTagName,
-            ErrorCode::EofInTag,
-            ErrorCode::EofInComment,
-            ErrorCode::InvalidFirstCharacterOfTagName,
-            ErrorCode::MissingAttributeValue,
-            ErrorCode::MissingDynamicDirectiveArgumentEnd,
-            ErrorCode::MissingInterpolationEnd,
-            ErrorCode::UnexpectedCharacterInAttributeName,
-            ErrorCode::UnexpectedCharacterInUnquotedAttributeValue,
-            ErrorCode::UnexpectedEqualsSignBeforeAttributeName,
-            ErrorCode::MissingWhitespaceBetweenAttributes,
-            ErrorCode::IncorrectlyClosedComment,
-            ErrorCode::IncorrectlyOpenedComment,
-        ] {
+        for &code in RECOVERED_PARSE_CODES {
             assert!(
                 parser.recovery_error_message(code).is_some(),
                 "expected a recovery message for {code:?}"

--- a/crates/vize_armature/src/parser/element/errors.rs
+++ b/crates/vize_armature/src/parser/element/errors.rs
@@ -114,7 +114,7 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use vize_carton::Bump;
-    use vize_relief::errors::{CompilerError, ErrorCode, RECOVERED_PARSE_CODES};
+    use vize_relief::errors::{CompilerError, ErrorCode, recovery::RECOVERED_PARSE_CODES};
 
     use crate::parser::Parser;
 

--- a/crates/vize_relief/src/errors.rs
+++ b/crates/vize_relief/src/errors.rs
@@ -2,6 +2,7 @@
 mod compatibility;
 mod recovery;
 use crate::SourceLocation;
+pub use recovery::RECOVERED_PARSE_CODES;
 use thiserror::Error;
 use vize_carton::{CompactString, ToCompactString};
 /// Compiler error

--- a/crates/vize_relief/src/errors.rs
+++ b/crates/vize_relief/src/errors.rs
@@ -1,8 +1,7 @@
 //! Compiler error types and codes.
 mod compatibility;
-mod recovery;
+pub mod recovery;
 use crate::SourceLocation;
-pub use recovery::RECOVERED_PARSE_CODES;
 use thiserror::Error;
 use vize_carton::{CompactString, ToCompactString};
 /// Compiler error

--- a/crates/vize_relief/src/errors/recovery.rs
+++ b/crates/vize_relief/src/errors/recovery.rs
@@ -2,64 +2,75 @@
 
 use super::{CompilerError, ErrorCode};
 
-impl CompilerError {
+/// Parse error codes for which the template parser documents a concrete
+/// recovery strategy: parsing continues past the defect and still yields a
+/// complete tree, so semantic analysis over that tree stays meaningful
+/// (#3294).
+///
+/// This is the single source of truth for that contract. `vize_armature`'s
+/// `recovery_error_message` consults
+/// [`ErrorCode::has_documented_parse_recovery`] before building a message, so
+/// the parser cannot describe a recovery for a code this list does not
+/// classify, and a test there pins every entry below to a real message. Keep
+/// the two in sync by editing this list.
+pub const RECOVERED_PARSE_CODES: &[ErrorCode] = &[
+    ErrorCode::EofBeforeTagName,
+    ErrorCode::EofInTag,
+    ErrorCode::EofInComment,
+    ErrorCode::InvalidFirstCharacterOfTagName,
+    ErrorCode::MissingAttributeValue,
+    ErrorCode::MissingDynamicDirectiveArgumentEnd,
+    ErrorCode::MissingInterpolationEnd,
+    ErrorCode::UnexpectedCharacterInAttributeName,
+    ErrorCode::UnexpectedCharacterInUnquotedAttributeValue,
+    ErrorCode::UnexpectedEqualsSignBeforeAttributeName,
+    ErrorCode::MissingWhitespaceBetweenAttributes,
+    ErrorCode::IncorrectlyClosedComment,
+    ErrorCode::IncorrectlyOpenedComment,
+];
+
+impl ErrorCode {
     /// Returns true when the template parser documents a concrete recovery
-    /// strategy for this code: parsing continues past the defect and still
-    /// yields a complete tree, so semantic analysis over that tree stays
+    /// strategy for this code, i.e. it appears in [`RECOVERED_PARSE_CODES`].
+    #[must_use]
+    pub fn has_documented_parse_recovery(self) -> bool {
+        RECOVERED_PARSE_CODES.contains(&self)
+    }
+}
+
+impl CompilerError {
+    /// Returns true when the parse defect behind this error still left a
+    /// complete tree behind, so semantic analysis over that tree stays
     /// meaningful (#3294).
     ///
     /// This is deliberately broader than [`CompilerError::is_recoverable`],
     /// which additionally implies downstream codegen may proceed without
-    /// gating. The code list mirrors the recovery messages constructed in
-    /// `vize_armature`'s `recovery_error_message`; the armature parser tests
-    /// pin the two lists together.
+    /// gating. It covers every code in [`RECOVERED_PARSE_CODES`] (the codes
+    /// `vize_armature` builds a recovery message for) plus the already
+    /// recoverable ones.
     #[must_use]
     pub fn is_recovered_parse(&self) -> bool {
-        matches!(
-            self.code,
-            ErrorCode::EofBeforeTagName
-                | ErrorCode::EofInTag
-                | ErrorCode::EofInComment
-                | ErrorCode::InvalidFirstCharacterOfTagName
-                | ErrorCode::MissingAttributeValue
-                | ErrorCode::MissingDynamicDirectiveArgumentEnd
-                | ErrorCode::MissingInterpolationEnd
-                | ErrorCode::UnexpectedCharacterInAttributeName
-                | ErrorCode::UnexpectedCharacterInUnquotedAttributeValue
-                | ErrorCode::UnexpectedEqualsSignBeforeAttributeName
-                | ErrorCode::MissingWhitespaceBetweenAttributes
-                | ErrorCode::IncorrectlyClosedComment
-                | ErrorCode::IncorrectlyOpenedComment
-        ) || self.is_recoverable()
+        self.code.has_documented_parse_recovery() || self.is_recoverable()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::super::{CompilerError, ErrorCode};
+    use super::RECOVERED_PARSE_CODES;
 
     #[test]
     fn recovered_parse_covers_the_documented_recovery_codes() {
-        for code in [
-            ErrorCode::EofBeforeTagName,
-            ErrorCode::EofInTag,
-            ErrorCode::EofInComment,
-            ErrorCode::InvalidFirstCharacterOfTagName,
-            ErrorCode::MissingAttributeValue,
-            ErrorCode::MissingDynamicDirectiveArgumentEnd,
-            ErrorCode::MissingInterpolationEnd,
-            ErrorCode::UnexpectedCharacterInAttributeName,
-            ErrorCode::UnexpectedCharacterInUnquotedAttributeValue,
-            ErrorCode::UnexpectedEqualsSignBeforeAttributeName,
-            ErrorCode::MissingWhitespaceBetweenAttributes,
-            ErrorCode::IncorrectlyClosedComment,
-            ErrorCode::IncorrectlyOpenedComment,
-            // is_recoverable ⊂ is_recovered_parse
-            ErrorCode::DuplicateAttribute,
-        ] {
+        for &code in RECOVERED_PARSE_CODES {
             let error = CompilerError::new(code, None);
             assert!(error.is_recovered_parse(), "{code:?}");
+            assert!(
+                code.is_parse_error(),
+                "{code:?} is not a parse-level code, so the parser cannot recover from it"
+            );
         }
+        // is_recoverable ⊂ is_recovered_parse, and needs no recovery message.
+        assert!(CompilerError::new(ErrorCode::DuplicateAttribute, None).is_recovered_parse());
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #3310, which merged before this review comment could be addressed on its branch.

#3310 introduced the recovered-parse contract but kept the same 13 error codes in three places: the `is_recovered_parse` matcher, the relief classification test, and the armature consistency test. Because both tests iterated their own copy of the list, a new recovery message could be added to the parser's `recovery_error_message` without either test detecting that the parser and `is_recovered_parse` had drifted, and a missing classification silently disables patina's analysis-dependent rules (the #3294 failure mode).

`RECOVERED_PARSE_CODES` in `vize_relief` is now the single source of truth, surfaced as `ErrorCode::has_documented_parse_recovery()`, and all three call sites read it instead of a copy. The parser consults the classification before building a message, so the message table cannot claim a recovery the classification does not know about:

```rust
fn recovery_error_message(&self, code: ErrorCode) -> Option<String> {
    // `RECOVERED_PARSE_CODES` (vize_relief) is the single source of truth
    // for which defects the parser recovers from, and patina keys its
    // analysis gating off the same classification (#3294).
    if !code.has_documented_parse_recovery() {
        return None;
    }
    match code {
        ErrorCode::EofBeforeTagName => Some(/* ... */),
        // ...
    }
}
```

That closes both drift directions: adding a message now requires adding the code to the shared list for it to take effect at all, and adding a code to the list without a message fails the armature test that iterates it. `DuplicateAttribute` stays the one intentional asymmetry (recovered via `is_recoverable`, no custom message).

No behavior change: the shared list holds exactly the codes the previous matcher covered, so diagnostic severity, codegen gating, and patina's analysis gating are all unaffected.

A fully compiler-enforced invariant over every `ErrorCode` variant would need enum reflection (a new `strum`-style dependency) or a second exhaustive 56-variant match, i.e. reintroducing the duplication this removes, so the shared-source route is the tighter tradeoff.

`cargo test -p vize_relief -p vize_armature`, `cargo clippy --all-targets`, and `cargo fmt --check` are green on these crates; the three remaining clippy warnings in `vize_armature` are pre-existing in `parser/tests.rs` and untouched here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency between documented parser recovery codes and the recovery messages shown during error handling.
  * Prevented misleading recovery messages when recovery is not documented.
  * Preserved existing behavior for other recoverable parsing errors, including duplicate attributes.
* **Tests**
  * Expanded validation to ensure documented recovery cases are classified and reported correctly using the shared documented code list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->