### PR TITLE
fix(maestro): derive legacy Vue lowering from the configured dialect (#3297)

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -107,9 +107,9 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     #[cfg(not(feature = "legacy"))]
     if loaded_config.features.type_checker_legacy_vue2 {
         eprintln!(
-            "\x1b[33mwarning:\x1b[0m `type_checker_legacy_vue2` is set but this `vize` build \
-             has no legacy Vue support; rebuild with `--features legacy` to enable Vue 2 \
-             Options API type checking."
+            "\x1b[33mwarning:\x1b[0m a Vue 2 dialect is configured (`typeChecker.legacyVue2` \
+             or `vue.version` 2/2.7) but this `vize` build has no legacy Vue support; rebuild \
+             with `--features legacy` to enable Vue 2 Options API type checking."
         );
     }
     let config = loaded_config.config;

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -20,7 +20,7 @@ mod vapor;
 
 use std::path::{Path, PathBuf};
 
-use discovery::{resolve_dir_path, resolve_file_path};
+use discovery::{CONFIG_FILE_NAMES, resolve_dir_path, resolve_file_path};
 use parse::{parse_raw_config_file, try_parse_raw_candidate};
 
 use super::model::{
@@ -30,14 +30,6 @@ use super::model::{
 
 pub use lint_features::load_config_and_linter_with_lint_features_and_source;
 pub use vapor::load_compiler_vapor;
-
-const CONFIG_FILE_NAMES: [&str; 5] = [
-    "vize.config.pkl",
-    "vize.config.ts",
-    "vize.config.js",
-    "vize.config.mjs",
-    "vize.config.json",
-];
 
 #[derive(Debug, Clone)]
 pub struct LoadedConfig {

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -9,6 +9,8 @@ mod discovery;
 #[cfg(test)]
 mod experimental_tests;
 mod js;
+#[cfg(test)]
+mod legacy_dialect_tests;
 mod lint_features;
 mod parse;
 mod pkl;

--- a/crates/vize_carton/src/config/loader/discovery.rs
+++ b/crates/vize_carton/src/config/loader/discovery.rs
@@ -6,6 +6,15 @@
 
 use std::path::{Path, PathBuf};
 
+/// Config file names in precedence order for directory auto-discovery.
+pub(super) const CONFIG_FILE_NAMES: [&str; 5] = [
+    "vize.config.pkl",
+    "vize.config.ts",
+    "vize.config.js",
+    "vize.config.mjs",
+    "vize.config.json",
+];
+
 /// Return a direct config file path when the user supplied a file.
 pub(super) fn resolve_file_path(base: &Path) -> Option<PathBuf> {
     if base.is_file() {

--- a/crates/vize_carton/src/config/loader/legacy_dialect_tests.rs
+++ b/crates/vize_carton/src/config/loader/legacy_dialect_tests.rs
@@ -1,0 +1,54 @@
+//! A Vue 2 / 2.7 dialect implies legacy template lowering (#3297).
+//!
+//! `typeChecker.legacyVue2` gates slot-scope and filter lowering. Deriving it
+//! from the dialect keeps `vize check` and `vize lsp` agreeing with each other
+//! and with the compiler, which already treats `vue.version` 2/2.7 as legacy.
+
+use super::load_config_with_features_and_source;
+use crate::config::VueVersion;
+
+fn features_for(config_json: &str) -> crate::config::ConfigFeatureFlags {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("vize.config.json");
+    std::fs::write(&path, config_json).unwrap();
+    load_config_with_features_and_source(Some(&path)).features
+}
+
+#[test]
+fn vue_version_2_7_implies_legacy_vue2() {
+    let features = features_for(r#"{ "vue": { "version": "2.7" } }"#);
+    assert_eq!(features.vue_version, Some(VueVersion::V2_7));
+    assert!(features.type_checker_legacy_vue2);
+}
+
+#[test]
+fn vue_version_2_implies_legacy_vue2() {
+    let features = features_for(r#"{ "vue": { "version": "2" } }"#);
+    assert_eq!(features.vue_version, Some(VueVersion::V2));
+    assert!(features.type_checker_legacy_vue2);
+}
+
+#[test]
+fn compiler_compatibility_vue_version_implies_legacy_vue2() {
+    let features = features_for(r#"{ "compiler": { "compatibility": { "vueVersion": "2" } } }"#);
+    assert_eq!(features.vue_version, Some(VueVersion::V2));
+    assert!(features.type_checker_legacy_vue2);
+}
+
+#[test]
+fn explicit_legacy_vue2_still_wins_without_a_dialect() {
+    let features = features_for(r#"{ "typeChecker": { "legacyVue2": true } }"#);
+    assert_eq!(features.vue_version, None);
+    assert!(features.type_checker_legacy_vue2);
+}
+
+#[test]
+fn vue_3_keeps_legacy_vue2_disabled() {
+    for config in [
+        r#"{ "vue": { "version": "3" } }"#,
+        r#"{ "typeChecker": { "optionsApi": true } }"#,
+    ] {
+        let features = features_for(config);
+        assert!(!features.type_checker_legacy_vue2, "config {config}");
+    }
+}

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -263,7 +263,17 @@ impl RawVizeConfig {
 
         // Default-on (matches vue-tsc); explicit `false` opts out.
         let type_checker_options_api = raw_type_checker.options_api.unwrap_or(true);
-        let type_checker_legacy_vue2 = raw_type_checker.legacy_vue2;
+        let vue_version = vue.version.or(compiler.compatibility.vue_version);
+        // A Vue 2 / 2.7 dialect implies legacy template lowering. Every consumer
+        // downstream of the virtual-TS generator already collapses the two into
+        // `legacy_vue2 || dialect ∈ {V2, V2_7}`, but the flag itself gates
+        // slot-scope and filter lowering, so without this fold `vize check` and
+        // `vize lsp` both reported "Cannot find name" on pristine Vue 2.7 files
+        // unless `typeChecker.legacyVue2` was *also* set (#3297). This is the
+        // mirror of `LinterFeatureFlags::from_config_features`, which derives
+        // the dialect from the legacy flags.
+        let type_checker_legacy_vue2 = raw_type_checker.legacy_vue2
+            || matches!(vue_version, Some(VueVersion::V2 | VueVersion::V2_7));
         let experimental_jsx_vapor = experimentals.jsx_vapor_enabled();
         let type_checker_jsx_typecheck = raw_type_checker.jsx_typecheck || experimental_jsx_vapor;
         let mut type_checker = raw_type_checker.config;
@@ -293,7 +303,7 @@ impl RawVizeConfig {
             type_checker_legacy_vue2,
             type_checker_jsx_typecheck,
             language_server_legacy_vue2: language_server_raw.legacy_vue2,
-            vue_version: vue.version.or(compiler.compatibility.vue_version),
+            vue_version,
             jsx_mode: compiler
                 .jsx_mode
                 .or_else(|| experimental_jsx_vapor.then_some(JsxMode::Vapor)),

--- a/crates/vize_maestro/src/server/state/config.rs
+++ b/crates/vize_maestro/src/server/state/config.rs
@@ -89,6 +89,9 @@ impl ServerState {
 
     fn apply_config_features(&self, features: vize_carton::config::ConfigFeatureFlags) {
         *self.type_checker_options_api.write() = features.type_checker_options_api;
+        // `type_checker_legacy_vue2` already folds in a Vue 2 / 2.7 dialect
+        // (`ConfigFeatureFlags::from`), so the LSP and `vize check` agree on
+        // slot-scope and filter lowering for `vue.version: "2.7"` alone (#3297).
         *self.type_checker_legacy_vue2.write() = features.type_checker_legacy_vue2;
         *self.type_checker_jsx_typecheck.write() = features.type_checker_jsx_typecheck;
 

--- a/crates/vize_maestro/src/server/state/config_tests.rs
+++ b/crates/vize_maestro/src/server/state/config_tests.rs
@@ -123,3 +123,56 @@ fn both_config_loaders_preserve_exact_template_globals() {
         );
     }
 }
+
+#[test]
+fn vue_version_2_7_alone_enables_legacy_lowering() {
+    // `vize check` honors `vue.version: "2.7"` without `typeChecker.legacyVue2`;
+    // the LSP must derive legacy template lowering from the same key or it
+    // publishes TS2304/TS2552 on pristine slot-scope/filter files that the CLI
+    // accepts under the identical config (#3297).
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("vize.config.json"),
+        r#"{ "vue": { "version": "2.7" } }"#,
+    )
+    .unwrap();
+
+    let state = ServerState::new();
+    state.load_workspace_config(dir.path());
+
+    assert!(state.legacy_vue2_enabled());
+    assert!(
+        state.options_api_enabled(),
+        "legacy mode implies Options API"
+    );
+}
+
+#[test]
+fn compiler_compatibility_vue_version_2_alone_enables_legacy_lowering() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("vize.config.json"),
+        r#"{ "compiler": { "compatibility": { "vueVersion": "2" } } }"#,
+    )
+    .unwrap();
+
+    let state = ServerState::new();
+    state.load_workspace_config(dir.path());
+
+    assert!(state.legacy_vue2_enabled());
+}
+
+#[test]
+fn vue_version_3_keeps_legacy_lowering_disabled() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("vize.config.json"),
+        r#"{ "vue": { "version": "3" } }"#,
+    )
+    .unwrap();
+
+    let state = ServerState::new();
+    state.load_workspace_config(dir.path());
+
+    assert!(!state.legacy_vue2_enabled());
+}

--- a/tests/snapshots/check/vue-element-admin-legacy-lsp-oracle.ts
+++ b/tests/snapshots/check/vue-element-admin-legacy-lsp-oracle.ts
@@ -69,6 +69,18 @@ const dialectVariants: DialectVariant[] = [
     }),
     initializationOptions: { editor: true, legacyVue2: true, lint: false, typecheck: true },
   },
+  // `vue.version: "2.7"` with no `legacyVue2` anywhere must drive the same
+  // lowering: the LSP used to publish TS2304/TS2552 on the pristine file that
+  // `vize check` accepted under this exact config (#3297).
+  {
+    name: 'Vue 2.7 dialect alone (vue.version: "2.7", no legacyVue2)',
+    config: (corsaPath) => ({
+      vue: { version: "2.7" },
+      globalTypes: { toThousandFilter: "any" },
+      typeChecker: { corsaPath },
+    }),
+    initializationOptions: { editor: true, lint: false, typecheck: true },
+  },
 ];
 
 for (const variant of dialectVariants) {
@@ -128,19 +140,6 @@ for (const variant of dialectVariants) {
     );
   });
 }
-
-// Known gap (found while adding this oracle): with only `vue.version: "2.7"`
-// in vize.config.json (no `typeChecker.legacyVue2`, no `legacyVue2`
-// initialization option), `vize check` accepts the pristine TransactionTable
-// (`slot-scope` scopes and filters resolve), but `vize lsp` publishes TS2304 /
-// TS2552 for `scope`, `row`, and the filter names on the same clean document.
-// The LSP must derive legacy template lowering from `vue.version` exactly like
-// the CLI before this can be asserted.
-test("vue-element-admin vue.version 2.7 alone drives legacy lowering in the LSP", {
-  skip:
-    "vize lsp ignores the vue.version 2.7 dialect for slot-scope/filter lowering " +
-    "unless legacyVue2 is also set, diverging from vize check on the clean file",
-});
 
 async function waitForDiagnostics(
   session: LspSession,


### PR DESCRIPTION
## Summary

`typeChecker.legacyVue2` gates slot-scope and filter lowering, but a Vue 2 dialect (`vue.version: "2"`/`"2.7"`, or `compiler.compatibility.vueVersion`) did not imply it. Configuring only the dialect produced "Cannot find name 'scope'" / "Cannot find name 'orderNoFilter'" on pristine Vue 2.7 files.

While reproducing #3297 I found the divergence is **not** LSP-only as reported: `vize check` fails the same way under `{ "vue": { "version": "2.7" } }` alone. The oracle that motivated the issue also set `typeChecker.legacyVue2: true`, which masked the CLI half.

So the fold belongs in shared config derivation, not in the LSP:

- `ConfigFeatureFlags::from` now derives `type_checker_legacy_vue2 |= dialect ∈ {V2, V2_7}`. This is the mirror of the existing `LinterFeatureFlags::from_config_features`, which derives the dialect from the legacy flags, and it matches every downstream consumer (virtual-TS generator, batch project, vue codegen), which already collapse the pair into `legacy_vue2 || dialect ∈ {V2, V2_7}`.
- `vize_maestro` drops its own copy of the decision and just consumes the derived flag.
- The non-legacy-build warning in `vize check` now names both spellings, since it can now be triggered by `vue.version` alone.

## Verification

- New `vize_carton` derivation tests: `vue.version` 2/2.7 and `compiler.compatibility.vueVersion` each imply the flag; explicit `legacyVue2` still works with no dialect; Vue 3 stays disabled.
- New `vize_maestro` state tests asserting `legacy_vue2_enabled()`/`options_api_enabled()` from dialect-only config (the 2.7 case fails before the fix).
- The legacy LSP oracle gains a third variant — `vue.version: "2.7"` with **no** `legacyVue2` anywhere — and the corresponding documented skip is removed. All three variants pass the full clean → broken → repaired `didChange` cycle with CLI agreement at each state (3/3 green, one server PID per cycle).
- CLI before/after on a minimal slot-scope + filter SFC under `vue.version: "2.7"` alone: `error:5:18 [TS2304] Cannot find name 'scope'` before, "No type errors found!" after.
- `cargo test -p vize_carton -p vize_maestro -p vize`: 88 suites green, 0 failures. fmt + clippy clean.

Note for anyone running these oracles locally: the helpers prefer `target/debug/vize` over `target/ci/vize`, so a stale debug binary silently shadows a fresh build — pass `VIZE_TEST_BIN` and `VIZE_LSP_BIN` explicitly.

Closes #3297

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->