### PR TITLE
fix(canon): keep type checking a file whose template parse recovered (#3323)

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -110,12 +110,22 @@ pub(super) fn generate_vue_virtual_ts(
         .as_ref()
         .map(|template| template.loc.start as u32)
         .unwrap_or(0);
+    // Script parse errors leave no AST, so they always abort to the fallback
+    // stub. Template diagnostics do not: they are counted separately below and
+    // only *hard* ones abort.
+    let script_hard_error = !diagnostics.is_empty();
     // Track whether the template produced any *hard* parse error. Only hard
-    // errors abort codegen and collapse the file to the fallback stub;
-    // recovery-level diagnostics (`ErrorCode::ExtendPoint`, pushed by the HTML
-    // tree-construction recovery path for self-closing rewrites, fostered
-    // elements, auto-closed `<p>`, etc.) describe repairs the parser already
-    // applied and must keep the real virtual TS (#1065/#1090 regression).
+    // errors abort codegen and collapse the file to the fallback stub.
+    // Recovery-level diagnostics keep the real virtual TS:
+    //   - `ErrorCode::ExtendPoint`, pushed by the HTML tree-construction
+    //     recovery path for self-closing rewrites, fostered elements,
+    //     auto-closed `<p>`, etc. (#1065/#1090 regression);
+    //   - every code in `RECOVERED_PARSE_CODES`, for which the parser
+    //     documents a concrete recovery and still yields a complete tree.
+    //     Treating those as hard meant a single missing space between
+    //     attributes collapsed the file to the stub and silenced every script
+    //     type diagnostic in it (#3323) — the same false-negative shape #3294
+    //     fixed in the linter, keyed off the same shared classification.
     let mut template_hard_error = false;
     let template_ast = descriptor.template.as_ref().and_then(|template| {
         profile!("canon.template.parse", {
@@ -132,7 +142,11 @@ pub(super) fn generate_vue_virtual_ts(
                 if error.code.is_recovery() {
                     continue;
                 }
-                template_hard_error = true;
+                // A documented recovery still yields a complete tree, so the
+                // defect is reported without suppressing the rest of the file.
+                if !error.code.has_documented_parse_recovery() {
+                    template_hard_error = true;
+                }
                 let start = error
                     .loc
                     .as_ref()
@@ -153,8 +167,10 @@ pub(super) fn generate_vue_virtual_ts(
     });
 
     // Abort to the fallback stub only on hard errors — from any block. Pure
-    // recovery-level template diagnostics must not suppress real codegen.
-    if !diagnostics.is_empty() {
+    // recovery-level template diagnostics must not suppress real codegen: the
+    // parse diagnostic is still reported, alongside the script's own type
+    // diagnostics, which is what `vize check` and the linter now agree on.
+    if script_hard_error || template_hard_error {
         return Ok(GeneratedVueFile {
             code: invalid_sfc_fallback_virtual_ts(),
             mappings: Vec::new(),

--- a/crates/vize_canon/tests/recovered_parse_codegen.rs
+++ b/crates/vize_canon/tests/recovered_parse_codegen.rs
@@ -1,0 +1,97 @@
+//! A recovered template parse defect must not collapse the file to the
+//! fallback stub (#3323).
+//!
+//! The parser documents a concrete recovery for `MissingWhitespaceBetweenAttributes`
+//! and twelve sibling codes (`vize_relief::errors::recovery::RECOVERED_PARSE_CODES`),
+//! and still yields a complete tree. Treating them as hard errors dropped the
+//! AST and emitted `invalid_sfc_fallback_virtual_ts()`, so every script type
+//! diagnostic in the file disappeared behind one missing space — the same
+//! false-negative shape #3294 fixed in the linter.
+
+use vize_canon::VirtualProject;
+
+const RECOVERED_TEMPLATE: &str = r#"<template>
+  <div id="a"class="b">{{ label }}</div>
+</template>
+
+<script setup lang="ts">
+const label: string = 'hi'
+const wrong: number = 'not a number'
+</script>
+"#;
+
+const CLEAN_TEMPLATE: &str = r#"<template>
+  <div id="a" class="b">{{ label }}</div>
+</template>
+
+<script setup lang="ts">
+const label: string = 'hi'
+const wrong: number = 'not a number'
+</script>
+"#;
+
+/// The whole body of the fallback stub emitted for unusable SFCs
+/// (`invalid_sfc_fallback_virtual_ts`).
+const FALLBACK_STUB: &str =
+    "declare const __vize_component: any;\nexport default __vize_component;\n";
+
+fn virtual_ts_for(source: &str) -> vize_carton::String {
+    let temp_dir = tempfile::tempdir().expect("temp project should be created");
+    let dir = temp_dir.path().canonicalize().unwrap();
+    let path = dir.join("App.vue");
+    std::fs::write(&path, source).unwrap();
+
+    let mut project = VirtualProject::new(&dir).unwrap();
+    project.register_path(&path).unwrap();
+    project
+        .find_by_original(&path)
+        .unwrap()
+        .content
+        .clone()
+        .into()
+}
+
+#[test]
+fn recovered_attribute_boundary_keeps_the_real_virtual_ts() {
+    let recovered = virtual_ts_for(RECOVERED_TEMPLATE);
+    let clean = virtual_ts_for(CLEAN_TEMPLATE);
+
+    assert!(
+        recovered != FALLBACK_STUB,
+        "a recovered parse must not collapse to the fallback stub:\n{recovered}"
+    );
+    // The script block is what carries the type diagnostics that used to
+    // vanish; it must be generated identically to the clean twin.
+    for binding in ["const label", "const wrong"] {
+        assert!(
+            recovered.contains(binding),
+            "{binding:?} missing from the recovered virtual TS:\n{recovered}"
+        );
+        assert!(
+            clean.contains(binding),
+            "{binding:?} missing from the clean twin"
+        );
+    }
+    // Both attributes survive the inferred boundary, so the template half is
+    // generated too rather than silently truncated.
+    assert!(recovered.contains("label"), "template binding lost");
+}
+
+#[test]
+fn unrecovered_parse_errors_still_collapse_to_the_fallback_stub() {
+    // No documented recovery for an unterminated element: the tree is not
+    // usable, so the previous behavior is preserved.
+    let source = r#"<template>
+  <div><span>{{ label }}</div>
+</template>
+
+<script setup lang="ts">
+const label: string = 'hi'
+</script>
+"#;
+    let generated = virtual_ts_for(source);
+    assert!(
+        generated == FALLBACK_STUB,
+        "an unrecovered parse must still emit the fallback stub:\n{generated}"
+    );
+}

--- a/tests/snapshots/check/__snapshots__/vue2-elm-check.snap
+++ b/tests/snapshots/check/__snapshots__/vue2-elm-check.snap
@@ -507,7 +507,47 @@
     {
       "file": "src/page/shop/shop.vue",
       "diagnostics": [
-        "error:272:101 Template parse error: Missing whitespace between attributes; inferred a new attribute boundary."
+        "error:68:85 [TS2588] Cannot assign to 'changeShowType' because it is a constant.",
+        "error:71:87 [TS2588] Cannot assign to 'changeShowType' because it is a constant.",
+        "error:80:48 [TS2349] This expression is not callable.\nType '{ methods: { getImgPath(path: any): string; }; }' has no call signatures.",
+        "error:109:67 [TS2304] Cannot find name 'attribute'.",
+        "error:234:48 [TS2349] This expression is not callable.\nType '{ methods: { getImgPath(path: any): string; }; }' has no call signatures.",
+        "error:248:60 [TS2349] This expression is not callable.\nType '{ methods: { getImgPath(path: any): string; }; }' has no call signatures.",
+        "error:272:101 Template parse error: Missing whitespace between attributes; inferred a new attribute boundary.",
+        "error:321:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
+        "error:328:25 [TS2307] Cannot find module 'better-scroll' or its corresponding type declarations.",
+        "error:456:54 [TS2339] Property 'offsetTop' does not exist on type 'unknown'.",
+        "error:458:23 [TS2339] Property 'cartList' does not exist on type '__VizeThis'.",
+        "error:466:15 [TS2339] Property 'latitude' does not exist on type '__VizeThis'.",
+        "error:468:26 [TS1308] 'await' expressions are only allowed within async functions and at the top levels of modules.",
+        "error:472:22 [TS2339] Property 'RECORD_ADDRESS' does not exist on type '__VizeThis'.",
+        "error:476:6 [TS1308] 'await' expressions are only allowed within async functions and at the top levels of modules.",
+        "error:476:42 [TS2339] Property 'latitude' does not exist on type '__VizeThis'.",
+        "error:477:1 [TS2339] Property 'longitude' does not exist on type '__VizeThis'.",
+        "error:479:6 [TS1308] 'await' expressions are only allowed within async functions and at the top levels of modules.",
+        "error:481:14 [TS1308] 'await' expressions are only allowed within async functions and at the top levels of modules.",
+        "error:483:1 [TS1308] 'await' expressions are only allowed within async functions and at the top levels of modules.",
+        "error:484:4 [TS1308] 'await' expressions are only allowed within async functions and at the top levels of modules.",
+        "error:485:4 [TS2339] Property 'RECORD_SHOPDETAIL' does not exist on type '__VizeThis'.",
+        "error:491:7 [TS2339] Property '$refs' does not exist on type '__VizeThis'.",
+        "error:496:35 [TS2339] Property 'offsetTop' does not exist on type 'unknown'.",
+        "error:511:14 [TS2339] Property '$refs' does not exist on type '__VizeThis'.",
+        "error:511:60 [TS2339] Property '$refs' does not exist on type '__VizeThis'.",
+        "error:515:55 [TS2339] Property '$refs' does not exist on type '__VizeThis'.",
+        "error:533:22 [TS2551] Property 'ADD_CART' does not exist on type '__VizeThis'. Did you mean 'addToCart'?",
+        "error:536:60 [TS2339] Property 'REDUCE_CART' does not exist on type '__VizeThis'.",
+        "error:589:7 [TS2551] Property 'CLEAR_CART' does not exist on type '__VizeThis'. Did you mean 'clearCart'?",
+        "error:595:39 [TS2339] Property '$refs' does not exist on type '__VizeThis'.",
+        "error:598:68 [TS2339] Property '$refs' does not exist on type '__VizeThis'.",
+        "error:609:5 [TS1308] 'await' expressions are only allowed within async functions and at the top levels of modules.",
+        "error:612:32 [TS2339] Property '$nextTick' does not exist on type '__VizeThis'.",
+        "error:623:1 [TS1308] 'await' expressions are only allowed within async functions and at the top levels of modules.",
+        "error:643:45 [TS2551] Property 'ADD_CART' does not exist on type '__VizeThis'. Did you mean 'addToCart'?",
+        "error:649:32 [TS2339] Property 'timer' does not exist on type '__VizeThis'.",
+        "error:649:61 [TS2339] Property 'timer' does not exist on type '__VizeThis'.",
+        "error:650:33 [TS2339] Property 'timer' does not exist on type '__VizeThis'.",
+        "error:687:78 [TS2339] Property '$router' does not exist on type '__VizeThis'.",
+        "error:1353:17 [TS2304] Cannot find name 'attribute'."
       ]
     },
     {
@@ -540,7 +580,7 @@
       ]
     }
   ],
-  "errorCount": 273,
+  "errorCount": 313,
   "warningCount": 0,
   "fileCount": 55
 }


### PR DESCRIPTION
## Summary

A single missing space between two attributes silenced every type diagnostic in the file. Two SFCs with identical script blocks:

```
src/Clean.vue      -> error:7:7 [TS2322] Type 'string' is not assignable to type 'number'.
src/Recovered.vue  -> error:2:14 Template parse error: Missing whitespace between attributes; ...
```

`Recovered.vue` differs only by `id="a"class="b"` in its template. Restoring the space brings the TS2322 straight back, so the type error was real and simply not reported.

`generate_vue_virtual_ts` treated every non-`ExtendPoint` parse error as hard: it dropped the template AST and returned `invalid_sfc_fallback_virtual_ts()`, so the script block was never generated and never checked. But the parser documents a concrete recovery for thirteen codes (`vize_relief::errors::recovery::RECOVERED_PARSE_CODES`) and still yields a complete tree for them.

This is the same false-negative shape #3294 fixed in the linter, keyed off the same shared classification introduced by #3310/#3311 — the type-check path just had not been converted. Now:

- a code with a documented recovery reports its parse diagnostic **and** keeps the real virtual TS;
- script parse errors (no AST at all) still abort to the stub, tracked separately from template diagnostics;
- an unrecovered template error still aborts exactly as before.

After the fix, `Recovered.vue` reports both diagnostics — the parse defect at 2:14 and the type error at 7:7.

## Verification

- New `vize_canon` regression tests: a recovered attribute boundary keeps the real virtual TS with both script bindings generated (fails before the fix), and an unrecovered parse still collapses to the fallback stub (passes on both sides, pinning the preserved behavior).
- End-to-end with a fresh `--profile ci --features legacy` binary on the reproduction above: 2 errors before (parse-only on the recovered file), 3 after (parse **and** type on the recovered file), with the clean twin unchanged.
- `cargo test -p vize_canon`: 19 suites green, 0 failures. fmt clean.

Closes #3323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Vue files with recoverable template syntax issues, preserving generated TypeScript output when possible.
  * Script parsing failures now correctly trigger safe fallback behavior.
  * Unrecoverable template syntax errors continue to use the fallback output.

* **Tests**
  * Added coverage for recovered template parsing and unrecoverable syntax scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->