### PR TITLE
fix(canon): resolve extensionless .vue imports through path mappings

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -929,11 +929,11 @@ fn materialized_tsconfig_reanchors_paths_into_virtual_mirror() {
         serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
     let paths = value["compilerOptions"]["paths"].as_object().unwrap();
 
-    // Each target gets a mirror candidate (relative to the virtual tsconfig
-    // in `node_modules/.vize/canon`) first, then the real-tree fallback.
+    // Mirror candidate first, then the real-tree fallback, then a trailing
+    // `.vue.ts` mirror candidate for extensionless SFC aliases (#3300).
     assert_eq!(
         paths["@/*"],
-        serde_json::json!(["./src/*", "../../../src/*"])
+        serde_json::json!(["./src/*", "../../../src/*", "./src/*.vue.ts"])
     );
     assert_eq!(
         paths["#shared"],
@@ -984,14 +984,14 @@ fn materialized_tsconfig_reanchors_extended_paths_from_declaring_config_dir() {
         serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
     let paths = value["compilerOptions"]["paths"].as_object().unwrap();
 
-    assert_eq!(
-        paths["~/*"],
-        serde_json::json!(["./app/*", "../../../app/*"])
-    );
-    assert_eq!(
-        paths["#imports"],
-        serde_json::json!(["./.nuxt/imports", "../../../.nuxt/imports"])
-    );
+    let app = ["./app/*", "../../../app/*", "./app/*.vue.ts"];
+    let imports = [
+        "./.nuxt/imports",
+        "../../../.nuxt/imports",
+        "./.nuxt/imports.vue.ts",
+    ];
+    assert_eq!(paths["~/*"], serde_json::json!(app));
+    assert_eq!(paths["#imports"], serde_json::json!(imports));
 
     let _ = fs::remove_dir_all(&case_dir);
 }

--- a/crates/vize_canon/src/batch/virtual_project/tests/graphql_generated.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/graphql_generated.rs
@@ -108,7 +108,7 @@ expectQuestion(question)
         serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
     assert_eq!(
         value["compilerOptions"]["paths"]["~/*"],
-        serde_json::json!(["./*", "../../../*"])
+        serde_json::json!(["./*", "../../../*", "./*.vue.ts"])
     );
 
     let _ = fs::remove_dir_all(&case_dir);

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
@@ -1,4 +1,5 @@
 mod native_options;
+mod vue_alias;
 
 use std::path::{Path, PathBuf};
 
@@ -14,6 +15,7 @@ use super::tsconfig_paths::{
 };
 use super::{SHARED_HELPERS_FILE, VirtualProject};
 use native_options::normalize_native_removed_options;
+use vue_alias::remap_path_targets;
 
 const PATH_SENSITIVE_COMPILER_OPTIONS: &[&str] = &[
     "baseUrl",
@@ -376,8 +378,9 @@ impl VirtualProject {
     /// Re-anchor tsconfig `paths` targets into the virtual mirror. Each relative
     /// target yields two candidates: the mirror copy (resolved relative to the
     /// virtual tsconfig, which lives in the mirror root) followed by the real
-    /// source-tree path as a fallback. Absolute and non-string targets pass
-    /// through unchanged.
+    /// source-tree path as a fallback, plus a trailing `.vue.ts` mirror
+    /// candidate so extensionless SFC aliases resolve (see [`remap_path_targets`]).
+    /// Absolute and non-string targets pass through unchanged.
     #[allow(clippy::disallowed_types)]
     fn remap_paths(
         &self,
@@ -390,21 +393,10 @@ impl VirtualProject {
                 remapped.insert(alias.clone(), targets.clone());
                 continue;
             };
-            let mut candidates = Vec::with_capacity(targets.len() * 2);
-            for target in targets {
-                let Some(target) = target.as_str() else {
-                    candidates.push(target.clone());
-                    continue;
-                };
-                if Path::new(target).is_absolute() {
-                    candidates.push(Value::String(target.to_owned()));
-                    continue;
-                }
-                let core = target.strip_prefix("./").unwrap_or(target);
-                candidates.push(Value::String(cstr!("./{core}").into()));
-                candidates.push(Value::String(cstr!("{up}{core}").into()));
-            }
-            remapped.insert(alias.clone(), Value::Array(candidates));
+            remapped.insert(
+                alias.clone(),
+                Value::Array(remap_path_targets(targets, &up)),
+            );
         }
         remapped
     }

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen/vue_alias.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen/vue_alias.rs
@@ -1,0 +1,135 @@
+//! Expansion of tsconfig `paths` targets into virtual-mirror candidates.
+//!
+//! Webpack-era Vue apps import SFCs through an alias without the extension
+//! (`import Head from "src/components/header/head"` for `head.vue`). Neither
+//! the mirror candidate nor the real-tree fallback resolves such a specifier:
+//! the mirror holds `head.vue.ts` and the real tree holds `head.vue`, and
+//! TypeScript appends extensions to the specifier rather than replacing them.
+//! Each alias therefore also gets a `<target>.vue.ts` mirror candidate, appended
+//! after every ordinary candidate so it can only turn a previously failing
+//! resolution into a success (#3300).
+
+use std::path::Path;
+
+use serde_json::Value;
+use vize_carton::cstr;
+
+/// Extensions that make a `paths` target name a concrete file. Such a target
+/// already points at a module, so the `.vue.ts` mirror candidate would only ever
+/// name a path that cannot exist.
+const TARGET_SOURCE_EXTENSIONS: &[&str] = &[
+    ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".vue", ".json",
+];
+
+/// Expand one alias's `paths` targets into virtual-mirror candidates: the mirror
+/// copy (relative to the virtual tsconfig) then the real-tree fallback for every
+/// relative target, followed by the `.vue.ts` mirror candidates. `up` is the
+/// relative prefix from the virtual root back to the project root.
+pub(super) fn remap_path_targets(targets: &[Value], up: &str) -> Vec<Value> {
+    let mut candidates = Vec::with_capacity(targets.len() * 2);
+    let mut vue_candidates = Vec::new();
+    for target in targets {
+        let Some(target) = target.as_str() else {
+            candidates.push(target.clone());
+            continue;
+        };
+        if Path::new(target).is_absolute() {
+            // Absolute targets are not mirrored, so a `.vue.ts` sibling of one
+            // never exists; pass them through untouched.
+            candidates.push(Value::String(target.to_owned()));
+            continue;
+        }
+        let core = target.strip_prefix("./").unwrap_or(target);
+        candidates.push(Value::String(cstr!("./{core}").into()));
+        candidates.push(Value::String(cstr!("{up}{core}").into()));
+        if !has_source_extension(core) {
+            vue_candidates.push(Value::String(cstr!("./{core}.vue.ts").into()));
+        }
+    }
+    candidates.extend(vue_candidates);
+    candidates
+}
+
+fn has_source_extension(target: &str) -> bool {
+    TARGET_SOURCE_EXTENSIONS
+        .iter()
+        .any(|extension| target.ends_with(extension))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use super::remap_path_targets;
+
+    fn remap(targets: Value) -> Value {
+        Value::Array(remap_path_targets(targets.as_array().unwrap(), "../../../"))
+    }
+
+    #[test]
+    fn wildcard_alias_gains_a_trailing_vue_mirror_candidate() {
+        assert_eq!(
+            remap(json!(["src/*"])),
+            json!(["./src/*", "../../../src/*", "./src/*.vue.ts"])
+        );
+    }
+
+    #[test]
+    fn extensionless_directory_alias_gains_a_vue_mirror_candidate() {
+        assert_eq!(
+            remap(json!(["./components/header/head"])),
+            json!([
+                "./components/header/head",
+                "../../../components/header/head",
+                "./components/header/head.vue.ts"
+            ])
+        );
+    }
+
+    #[test]
+    fn targets_naming_a_concrete_module_keep_the_original_candidate_pair() {
+        for target in [
+            "./shared/index.ts",
+            "shared/index.tsx",
+            "shared/index.js",
+            "shared/App.vue",
+            "shared/data.json",
+            "shared/index.mjs",
+        ] {
+            let remapped = remap(json!([target]));
+            assert_eq!(
+                remapped.as_array().unwrap().len(),
+                2,
+                "{target} must not gain a .vue.ts candidate"
+            );
+        }
+    }
+
+    #[test]
+    fn vue_candidates_never_precede_an_ordinary_candidate() {
+        // A `.vue.ts` mirror candidate must not shadow a later target that the
+        // user declared as a fallback, so every one of them is appended last.
+        assert_eq!(
+            remap(json!(["primary/*", "secondary/*"])),
+            json!([
+                "./primary/*",
+                "../../../primary/*",
+                "./secondary/*",
+                "../../../secondary/*",
+                "./primary/*.vue.ts",
+                "./secondary/*.vue.ts"
+            ])
+        );
+    }
+
+    #[test]
+    fn absolute_and_non_string_targets_pass_through() {
+        let separator = if cfg!(windows) {
+            "C:\\lib\\*"
+        } else {
+            "/lib/*"
+        };
+        assert_eq!(remap(json!([separator])), json!([separator]));
+        assert_eq!(remap(json!([42])), json!([42]));
+    }
+}

--- a/tests/snapshots/check/__snapshots__/vue2-elm-check.snap
+++ b/tests/snapshots/check/__snapshots__/vue2-elm-check.snap
@@ -19,7 +19,6 @@
       "file": "src/components/common/computeTime.vue",
       "diagnostics": [
         "error:6:48 [TS2588] Cannot assign to 'showAlert' because it is a constant.",
-        "error:11:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations.",
         "error:53:39 [TS2345] Argument of type 'number' is not assignable to parameter of type 'string'.",
         "error:54:39 [TS2345] Argument of type 'number' is not assignable to parameter of type 'string'.",
         "error:56:21 [TS2322] Type 'string' is not assignable to type 'number'.",
@@ -65,18 +64,13 @@
     {
       "file": "src/page/balance/balance.vue",
       "diagnostics": [
-        "error:25:48 [TS2588] Cannot assign to 'showAlert' because it is a constant.",
-        "error:33:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:34:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations."
+        "error:25:48 [TS2588] Cannot assign to 'showAlert' because it is a constant."
       ]
     },
     {
       "file": "src/page/balance/children/detail.vue",
       "diagnostics": [
-        "error:17:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:18:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:20:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations.",
-        "error:21:25 [TS2307] Cannot find module 'src/components/common/loading' or its corresponding type declarations."
+        "error:18:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
     {
@@ -85,10 +79,7 @@
         "error:6:70 [TS2588] Cannot assign to 'categoryType' because it is a constant.",
         "error:7:70 [TS2588] Cannot assign to 'categoryType' because it is a constant.",
         "error:77:48 [TS2588] Cannot assign to 'showAlert' because it is a constant.",
-        "error:86:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:87:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:89:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations.",
-        "error:90:25 [TS2307] Cannot find module 'src/components/common/loading' or its corresponding type declarations.",
         "error:214:18 [TS2339] Property 'userInfo' does not exist on type '__VizeThis'.",
         "error:215:36 [TS1308] 'await' expressions are only allowed within async functions and at the top levels of modules.",
         "error:216:15 [TS2339] Property 'userInfo' does not exist on type '__VizeThis'."
@@ -98,53 +89,39 @@
       "file": "src/page/benefit/children/commend.vue",
       "diagnostics": [
         "error:36:48 [TS2588] Cannot assign to 'showAlert' because it is a constant.",
-        "error:41:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:42:28 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:44:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations."
+        "error:42:28 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
     {
       "file": "src/page/benefit/children/coupon.vue",
       "diagnostics": [
-        "error:23:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:24:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:26:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations.",
-        "error:27:25 [TS2307] Cannot find module 'src/components/common/loading' or its corresponding type declarations."
+        "error:24:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
     {
       "file": "src/page/benefit/children/exchange.vue",
       "diagnostics": [
         "error:18:48 [TS2588] Cannot assign to 'showAlert' because it is a constant.",
-        "error:23:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:24:28 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:26:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations."
+        "error:24:28 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
     {
       "file": "src/page/benefit/children/hbDescription.vue",
       "diagnostics": [
-        "error:50:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:51:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:53:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations.",
-        "error:54:25 [TS2307] Cannot find module 'src/components/common/loading' or its corresponding type declarations.",
         "error:55:25 [TS2307] Cannot find module 'better-scroll' or its corresponding type declarations."
       ]
     },
     {
       "file": "src/page/benefit/children/hbHistory.vue",
       "diagnostics": [
-        "error:35:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:36:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:38:25 [TS2307] Cannot find module 'src/components/common/loading' or its corresponding type declarations.",
         "error:39:25 [TS2307] Cannot find module 'better-scroll' or its corresponding type declarations."
       ]
     },
     {
       "file": "src/page/city/city.vue",
-      "diagnostics": [
-        "error:27:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations."
-      ]
+      "diagnostics": []
     },
     {
       "file": "src/page/confirmOrder/children/children/addAddress.vue",
@@ -153,15 +130,12 @@
         "error:38:127 [TS2304] Cannot find name 'searchAddress'.",
         "error:38:142 [TS2304] Cannot find name 'searchAddress'.",
         "error:51:48 [TS2588] Cannot assign to 'showAlert' because it is a constant.",
-        "error:59:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:60:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:62:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations."
+        "error:60:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
     {
       "file": "src/page/confirmOrder/children/children/children/searchAddress.vue",
       "diagnostics": [
-        "error:25:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:27:32 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
@@ -169,16 +143,13 @@
       "file": "src/page/confirmOrder/children/chooseAddress.vue",
       "diagnostics": [
         "error:51:48 [TS2588] Cannot assign to 'showAlert' because it is a constant.",
-        "error:59:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:60:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:62:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations.",
         "error:63:25 [TS2307] Cannot find module 'better-scroll' or its corresponding type declarations."
       ]
     },
     {
       "file": "src/page/confirmOrder/children/invoice.vue",
       "diagnostics": [
-        "error:15:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:16:32 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
@@ -189,9 +160,7 @@
         "error:10:42 [TS2304] Cannot find name 'cartPrice'.",
         "error:23:50 [TS2588] Cannot assign to 'payWay' because it is a constant.",
         "error:34:50 [TS2588] Cannot assign to 'payWay' because it is a constant.",
-        "error:45:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:46:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:48:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations.",
         "error:85:39 [TS2345] Argument of type 'number' is not assignable to parameter of type 'string'.",
         "error:87:21 [TS2322] Type 'string' is not assignable to type 'number'.",
         "error:89:39 [TS2345] Argument of type 'number' is not assignable to parameter of type 'string'.",
@@ -201,8 +170,6 @@
     {
       "file": "src/page/confirmOrder/children/remark.vue",
       "diagnostics": [
-        "error:24:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:26:25 [TS2307] Cannot find module 'src/components/common/loading' or its corresponding type declarations.",
         "error:27:32 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
@@ -210,9 +177,7 @@
       "file": "src/page/confirmOrder/children/userValidation.vue",
       "diagnostics": [
         "error:20:48 [TS2588] Cannot assign to 'showAlert' because it is a constant.",
-        "error:25:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:26:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:28:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations."
+        "error:26:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
     {
@@ -234,9 +199,6 @@
         "error:88:62 [TS2304] Cannot find name 'inputText'.",
         "error:126:48 [TS2588] Cannot assign to 'showAlert' because it is a constant.",
         "error:134:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:135:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:136:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations.",
-        "error:137:25 [TS2307] Cannot find module 'src/components/common/loading' or its corresponding type declarations.",
         "error:214:42 [TS2339] Property 'id' does not exist on type 'unknown'.",
         "error:215:44 [TS2339] Property 'name' does not exist on type 'unknown'.",
         "error:216:51 [TS2339] Property 'packing_fee' does not exist on type 'unknown'.",
@@ -282,17 +244,12 @@
     {
       "file": "src/page/download/download.vue",
       "diagnostics": [
-        "error:9:48 [TS2588] Cannot assign to 'showAlert' because it is a constant.",
-        "error:14:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:15:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations."
+        "error:9:48 [TS2588] Cannot assign to 'showAlert' because it is a constant."
       ]
     },
     {
       "file": "src/page/find/find.vue",
-      "diagnostics": [
-        "error:10:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:12:27 [TS2307] Cannot find module 'src/components/footer/footGuide' or its corresponding type declarations."
-      ]
+      "diagnostics": []
     },
     {
       "file": "src/page/food/food.vue",
@@ -308,8 +265,6 @@
         "error:172:233 [TS2304] Cannot find name 'latitude'.",
         "error:172:251 [TS2304] Cannot find name 'latitude'.",
         "error:178:40 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:179:21 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:180:22 [TS2307] Cannot find module 'src/components/common/shoplist' or its corresponding type declarations.",
         "error:350:7 [TS2339] Property '$route' does not exist on type '__VizeThis'.",
         "error:352:3 [TS2339] Property '$route' does not exist on type '__VizeThis'.",
         "error:357:16 [TS2339] Property '$route' does not exist on type '__VizeThis'.",
@@ -330,8 +285,6 @@
     {
       "file": "src/page/forget/forget.vue",
       "diagnostics": [
-        "error:36:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:37:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations.",
         "error:54:17 [TS1117] An object literal cannot have multiple properties with the same name."
       ]
     },
@@ -356,9 +309,6 @@
       "file": "src/page/msite/msite.vue",
       "diagnostics": [
         "error:44:28 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:46:21 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:47:23 [TS2307] Cannot find module 'src/components/footer/footGuide' or its corresponding type declarations.",
-        "error:48:22 [TS2307] Cannot find module 'src/components/common/shoplist' or its corresponding type declarations.",
         "error:92:14 [TS2304] Cannot find name 'Swiper'."
       ]
     },
@@ -381,8 +331,6 @@
         "error:65:34 [TS2552] Cannot find name 'orderDetail'. Did you mean 'orderData'?",
         "error:77:34 [TS2552] Cannot find name 'orderDetail'. Did you mean 'orderData'?",
         "error:90:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:91:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:94:25 [TS2307] Cannot find module 'src/components/common/loading' or its corresponding type declarations.",
         "error:95:25 [TS2307] Cannot find module 'better-scroll' or its corresponding type declarations.",
         "error:258:42 [TS2339] Property 'userInfo' does not exist on type '__VizeThis'.",
         "error:260:3 [TS2339] Property 'userInfo' does not exist on type '__VizeThis'.",
@@ -397,34 +345,24 @@
       "diagnostics": [
         "error:30:67 [TS18004] No value exists in scope for the shorthand property 'geohash'. Either declare one or provide an initializer.",
         "error:30:67 [TS2304] Cannot find name 'geohash'.",
-        "error:47:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:48:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:49:29 [TS2307] Cannot find module 'src/components/common/computeTime' or its corresponding type declarations.",
-        "error:50:25 [TS2307] Cannot find module 'src/components/common/loading' or its corresponding type declarations.",
-        "error:52:27 [TS2307] Cannot find module 'src/components/footer/footGuide' or its corresponding type declarations."
+        "error:47:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
     {
       "file": "src/page/points/children/detail.vue",
       "diagnostics": [
-        "error:24:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:25:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:27:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations.",
-        "error:28:25 [TS2307] Cannot find module 'src/components/common/loading' or its corresponding type declarations."
+        "error:25:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
     {
       "file": "src/page/points/points.vue",
       "diagnostics": [
-        "error:26:48 [TS2588] Cannot assign to 'showAlert' because it is a constant.",
-        "error:34:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:35:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations."
+        "error:26:48 [TS2588] Cannot assign to 'showAlert' because it is a constant."
       ]
     },
     {
       "file": "src/page/profile/children/children/address.vue",
       "diagnostics": [
-        "error:36:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:38:40 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
         "error:49:9 [TS2300] Duplicate identifier 'mounted'.",
         "error:53:9 [TS2300] Duplicate identifier 'mounted'."
@@ -435,22 +373,18 @@
       "diagnostics": [
         "error:13:87 [TS2304] Cannot find name 'addAddress'.",
         "error:37:48 [TS2588] Cannot assign to 'showAlert' because it is a constant.",
-        "error:42:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:44:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:46:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations."
+        "error:44:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
     {
       "file": "src/page/profile/children/children/children/children/addDetail.vue",
       "diagnostics": [
-        "error:28:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:31:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
     {
       "file": "src/page/profile/children/children/setusername.vue",
       "diagnostics": [
-        "error:20:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:22:41 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
@@ -462,8 +396,6 @@
         "error:9:62 [TS2304] Cannot find name 'userInfo'.",
         "error:98:48 [TS2588] Cannot assign to 'showAlert' because it is a constant.",
         "error:106:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:107:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:109:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations.",
         "error:179:47 [TS2339] Property 'files' does not exist on type 'Element'.",
         "error:315:10 [TS2339] Property 'timer' does not exist on type '__VizeThis'.",
         "error:318:19 [TS2339] Property 'timer' does not exist on type '__VizeThis'.",
@@ -489,8 +421,6 @@
         "error:7:45 [TS2304] Cannot find name 'userInfo'.",
         "error:7:89 [TS2304] Cannot find name 'userInfo'.",
         "error:7:99 [TS2304] Cannot find name 'userInfo'.",
-        "error:140:21 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:141:23 [TS2307] Cannot find module 'src/components/footer/footGuide' or its corresponding type declarations.",
         "error:142:38 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
         "error:238:33 [TS2551] Property 'getImgPath' does not exist on type '__VizeThis'. Did you mean 'imgpath'?",
         "error:240:13 [TS2339] Property 'SAVE_AVANDER' does not exist on type '__VizeThis'.",
@@ -512,7 +442,6 @@
       "file": "src/page/service/children/questionDetail.vue",
       "diagnostics": [
         "error:3:32 [TS2304] Cannot find name 'question'.",
-        "error:11:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:12:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
         "error:13:26 [TS2307] Cannot find module 'showdown' or its corresponding type declarations.",
         "error:14:25 [TS2307] Cannot find module 'better-scroll' or its corresponding type declarations."
@@ -521,7 +450,6 @@
     {
       "file": "src/page/service/service.vue",
       "diagnostics": [
-        "error:36:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:38:32 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
@@ -551,7 +479,6 @@
         "error:95:122 [TS2349] This expression is not callable.\nType '{ methods: { getImgPath(path: any): string; }; }' has no call signatures.",
         "error:95:133 [TS2304] Cannot find name 'shopDetail'.",
         "error:104:28 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:105:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:107:25 [TS2307] Cannot find module 'better-scroll' or its corresponding type declarations.",
         "error:108:14 [TS2305] Module '\"src/config/env\"' has no exported member 'localapi'.",
         "error:108:24 [TS2305] Module '\"src/config/env\"' has no exported member 'proapi'."
@@ -559,11 +486,7 @@
     },
     {
       "file": "src/page/shop/children/foodDetail.vue",
-      "diagnostics": [
-        "error:33:22 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:35:28 [TS2307] Cannot find module 'src/components/common/ratingStar' or its corresponding type declarations.",
-        "error:36:25 [TS2307] Cannot find module 'src/components/common/buyCart' or its corresponding type declarations."
-      ]
+      "diagnostics": []
     },
     {
       "file": "src/page/shop/children/shopDetail.vue",
@@ -578,7 +501,6 @@
         "error:56:39 [TS2304] Cannot find name 'shopDetail'.",
         "error:61:39 [TS2304] Cannot find name 'shopDetail'.",
         "error:69:78 [TS2588] Cannot assign to 'showlicenseImg' because it is a constant.",
-        "error:80:22 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:81:28 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
@@ -591,7 +513,6 @@
     {
       "file": "src/page/vipcard/children/invoiceRecord.vue",
       "diagnostics": [
-        "error:13:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:14:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
@@ -600,15 +521,12 @@
       "diagnostics": [
         "error:4:51 [TS2304] Cannot find name 'userInfo'.",
         "error:18:48 [TS2588] Cannot assign to 'showAlert' because it is a constant.",
-        "error:23:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
-        "error:24:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
-        "error:26:26 [TS2307] Cannot find module 'src/components/common/alertTip' or its corresponding type declarations."
+        "error:24:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
     {
       "file": "src/page/vipcard/children/vipDescription.vue",
       "diagnostics": [
-        "error:40:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:41:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     },
@@ -618,12 +536,11 @@
         "error:4:24 [TS2304] Cannot find name 'userInfo'.",
         "error:5:44 [TS2304] Cannot find name 'userInfo'.",
         "error:5:45 [TS2304] Cannot find name 'userInfo'.",
-        "error:75:25 [TS2307] Cannot find module 'src/components/header/head' or its corresponding type declarations.",
         "error:76:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     }
   ],
-  "errorCount": 353,
+  "errorCount": 273,
   "warningCount": 0,
   "fileCount": 55
 }


### PR DESCRIPTION
## Root cause

Not the ambient shims — the fix is entirely in path-mapping resolution.

The pinned vue2-elm fixture contains **no `.d.ts` at all**, and canon's own
`__vize_vue_modules.d.ts` is an inert marker comment (canon deliberately
materializes real `.vue.ts` modules instead of a `declare module "*.vue"`
wildcard). A `*.vue` wildcard shim could not match an extensionless specifier
anyway, so option (b) from the issue is a dead end.

What actually happens: `remap_paths` re-anchors each tsconfig `paths` target
into two candidates — the virtual-mirror copy and the real-tree fallback:

```json
"paths": { "src/*": ["./src/*", "../../../src/*"] }
```

For `import Head from 'src/components/header/head'` neither resolves. The
mirror holds `src/components/header/head.vue.ts`; the real tree holds
`head.vue`. TypeScript *appends* extensions to the mapped specifier rather
than replacing them, so it probes `head.ts`/`head.tsx`/`head.d.ts`/`head.js`
and `head/index.*` — never `head.vue.ts`. Result: TS2307.

(Note `baseUrl` is stripped from the generated tsconfig, so `paths` is the
only hook for bare specifiers.)

## Fix

Each relative alias target gains a third candidate, `./<target>.vue.ts`,
appended **after every ordinary candidate** so it can only turn a previously
failing resolution into a success — it can never shadow a real-tree `.ts` or
a later user-declared target. Targets that already name a concrete module
(`.ts`, `.tsx`, `.vue`, `.json`, `.js`, ...) and absolute targets are skipped.

```json
"paths": { "src/*": ["./src/*", "../../../src/*", "./src/*.vue.ts"] }
```

The import specifiers themselves are untouched, so no virtual offsets shift
and diagnostic source-mapping is unaffected.

New logic lives in `crates/vize_canon/src/batch/virtual_project/tsconfig_gen/vue_alias.rs`
(135 lines); `tsconfig_gen.rs` shrinks 454 → 446 lines.

## Snapshot delta

`tests/snapshots/check/__snapshots__/vue2-elm-check.snap`: **353 → 273
diagnostics, 80 removed, 0 added.** `fileCount` (55) and `warningCount` (0)
unchanged.

Verified by a per-file multiset diff of the JSON reports (not by reading the
line diff, which reflows because JSON array entries shift). **All 80 removed
diagnostics are TS2307 of the extensionless-alias class:**

| count | specifier |
| ----: | --------- |
| 41 | `src/components/header/head` |
| 20 | `src/components/common/alertTip` |
| 10 | `src/components/common/loading` |
| 4 | `src/components/footer/footGuide` |
| 2 | `src/components/common/shoplist` |
| 1 | `src/components/common/computeTime` |
| 1 | `src/components/common/ratingStar` |
| 1 | `src/components/common/buyCart` |

The remaining 45 TS2307 are genuinely uninstalled vendor packages (`vuex` 38,
`better-scroll` 6, `showdown` 1) and are untouched. No diagnostic of any other
code was removed, and resolving the components introduced no new errors.

## Tests

- New unit tests on the target expansion: wildcard alias, extensionless
  directory alias, concrete-module targets keeping the original pair,
  ordering (vue candidates never precede an ordinary candidate), and
  absolute/non-string passthrough.
- Updated the three existing materialized-tsconfig assertions
  (`materialized_tsconfig_reanchors_paths_into_virtual_mirror`,
  `materialized_tsconfig_reanchors_extended_paths_from_declaring_config_dir`,
  `materialized_project_keeps_generated_graphql_schema_on_real_path`).
- `cargo test -p vize_canon --features legacy`: 604 passed, 0 failed.
- `cargo test --workspace --features legacy`: green except
  `check_nuxt2_false_positive_fixture_matrix`, which fails identically on
  unmodified `main` in this environment (TS2339 `$emit`, unrelated).
- `npm run test:check:fixtures` (with `VIZE_TEST_BIN`/`VIZE_TEST_TSGO` pinned
  to the ci binary): the three failures are all pre-existing on `main` here
  (unhydrated vue-router submodule, vue-tsc manifest lookup, generic-build
  injected-error fixture).
- `cargo fmt --all --check` clean; clippy reports nothing on the touched files.

## Known remaining gap (not this PR)

**Relative** extensionless SFC imports are still unresolved — e.g.
`src/App.vue` does `import svgIcon from './components/common/svg'` for
`svg.vue`. tsgo raises TS2307 for 6 of these inside the virtual project, but
`relative_module_resolves_on_disk` suppresses the diagnostic because the
`.vue` sibling exists on disk, so they never appeared in the snapshot and the
count above is unaffected. The diagnostic is hidden but the module is
genuinely unresolved. Fixing it needs the import rewriter to gain the source
directory on the `.vue` path (`build_vue_registered_file` calls
`rewriter.rewrite`, which has neither roots nor source dir) and shifts
specifier offsets, so it is deliberately left out of this change.

Closes #3300
