### PR TITLE
fix(vapor): replace multi-step _next(base, N) with _nthChild or chained _next

### DIFF
--- a/crates/vize_atelier_vapor/src/generate/operations/refs.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/refs.rs
@@ -87,10 +87,19 @@ pub(super) fn generate_child_ref(ctx: &mut GenerateContext, child_ref: &ChildRef
             "const n{} = _child(n{})",
             child_ref.child_id, child_ref.parent_id
         ));
-    } else {
+    } else if child_ref.offset == 1 {
         ctx.use_helper("next");
-        let expr = build_next_chain(cstr!("_child(n{})", child_ref.parent_id), child_ref.offset);
+        let expr = build_next_chain(cstr!("_child(n{})", child_ref.parent_id), 1);
         ctx.push_line_fmt(format_args!("const n{} = {}", child_ref.child_id, expr));
+    } else {
+        // Outside hydration the runtime `next()` advances a single sibling, so
+        // absolute child positions beyond one step must go through `nthChild`
+        // (mirrors vue's compiler-vapor).
+        ctx.use_helper("nthChild");
+        ctx.push_line_fmt(format_args!(
+            "const n{} = _nthChild(n{}, {})",
+            child_ref.child_id, child_ref.parent_id, child_ref.offset
+        ));
     }
 }
 
@@ -104,7 +113,16 @@ pub(super) fn generate_next_ref(ctx: &mut GenerateContext, next_ref: &NextRefIRN
 fn build_next_chain(base: String, offset: usize) -> String {
     if offset == 0 {
         base
+    } else if offset == 1 {
+        cstr!("_next({}, 1)", base)
     } else {
-        cstr!("_next({}, {})", base, offset)
+        // Outside hydration the runtime `next()` only honors single-step
+        // advancement, so multi-step navigation must be a chain of calls
+        // instead of one call carrying the offset.
+        let mut expr = base;
+        for _ in 0..offset {
+            expr = cstr!("_next({})", expr);
+        }
+        expr
     }
 }

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_dynamic_child_after_multiple_static_siblings.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_dynamic_child_after_multiple_static_siblings.snap
@@ -1,12 +1,12 @@
 ---
-source: crates/vize_atelier_vapor/src/lib.rs
+source: crates/vize_atelier_vapor/src/tests.rs
 expression: code.as_str()
 ---
-import { child as _child, next as _next, setClass as _setClass, renderEffect as _renderEffect, template as _template } from 'vue';
+import { child as _child, setClass as _setClass, nthChild as _nthChild, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div><header>one</header><p>two</p><button>x</button></div>", true)
 export function render(_ctx) {
 const n1 = t0()
-const n0 = _next(_child(n1), 2)
+const n0 = _nthChild(n1, 2)
 _renderEffect(() => _setClass(n0, _ctx.cls))
 return n1
 }


### PR DESCRIPTION
vize's vapor codegen emitted `_next(base, offset)` for child refs with an offset > 1, but the vue 3.6.0-rc.2 runtime's `next()` helper only advances one sibling outside hydration; the second argument is the hydration-only logical index. That caused `null.firstChild` errors when navigating past multiple static siblings in vapor mode.

This change:
- Emits `_nthChild(parent, offset)` for absolute child positions (offset > 1), matching compiler-vapor's contract.
- Chains single-step `_next()` calls instead of passing an offset > 1.

Fixes #3330

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787855670&installation_model_id=422833&pr_number=3331&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F3331&signature=fba782a983f712b3ffd1e26b7741482e69415c2dd7d9b9cf669573e3b770db00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation through deeply nested and adjacent elements.
  * Corrected reference generation for multi-step sibling offsets, ensuring each step is traversed accurately.
  * Preserved optimized handling for direct and single-step navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->