### PR TITLE
fix(vapor): use nthChild for multi-sibling navigation (#3330)

### DIFF
--- a/crates/vize_atelier_vapor/src/generate/operations/refs.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/refs.rs
@@ -100,19 +100,14 @@ pub(super) fn generate_child_ref(ctx: &mut GenerateContext, child_ref: &ChildRef
     ctx.push_line_fmt(format_args!("const n{} = {}", child_ref.child_id, expr));
 }
 
-/// Generate NextRef (`_next` / `_nthChild` helper).
+/// Generate NextRef (`_next` helper).
+///
+/// The node is always the sibling immediately after `prev_id` — jumps of two
+/// or more siblings arrive as a [`ChildRefIRNode`] absolute lookup instead
+/// (#3330) — so this is a single `_next` step carrying the absolute index as
+/// the hydration hint.
 pub(super) fn generate_next_ref(ctx: &mut GenerateContext, next_ref: &NextRefIRNode) {
-    let expr = if next_ref.offset > 1 {
-        ctx.use_helper("nthChild");
-        cstr!("_nthChild(n{}, {})", next_ref.parent_id, next_ref.index)
-    } else {
-        build_navigation(
-            cstr!("n{}", next_ref.prev_id),
-            next_ref.offset,
-            next_ref.index,
-            ctx,
-        )
-    };
+    let expr = build_navigation(cstr!("n{}", next_ref.prev_id), 1, next_ref.offset, ctx);
     ctx.push_line_fmt(format_args!("const n{} = {}", next_ref.child_id, expr));
 }
 

--- a/crates/vize_atelier_vapor/src/generate/operations/refs.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/refs.rs
@@ -79,32 +79,56 @@ pub(super) fn generate_get_text_child(ctx: &mut GenerateContext, get_text: &GetT
     ctx.push_line_fmt(format_args!("const {} = {}.firstChild", child, parent));
 }
 
-/// Generate ChildRef (_child helper)
+/// Generate ChildRef (`_child` / `_next` / `_nthChild` helper).
+///
+/// Mirrors the Vue Vapor runtime's navigation contract (see
+/// [`build_navigation`]): index 0 is `_child`, index 1 is one `_next` step,
+/// and anything further is an absolute `_nthChild` lookup from the parent.
 pub(super) fn generate_child_ref(ctx: &mut GenerateContext, child_ref: &ChildRefIRNode) {
-    ctx.use_helper("child");
-    if child_ref.offset == 0 {
-        ctx.push_line_fmt(format_args!(
-            "const n{} = _child(n{})",
-            child_ref.child_id, child_ref.parent_id
-        ));
+    let expr = if child_ref.offset > 1 {
+        ctx.use_helper("nthChild");
+        cstr!("_nthChild(n{}, {})", child_ref.parent_id, child_ref.offset)
     } else {
-        ctx.use_helper("next");
-        let expr = build_next_chain(cstr!("_child(n{})", child_ref.parent_id), child_ref.offset);
-        ctx.push_line_fmt(format_args!("const n{} = {}", child_ref.child_id, expr));
-    }
+        ctx.use_helper("child");
+        build_navigation(
+            cstr!("_child(n{})", child_ref.parent_id),
+            child_ref.offset,
+            child_ref.offset,
+            ctx,
+        )
+    };
+    ctx.push_line_fmt(format_args!("const n{} = {}", child_ref.child_id, expr));
 }
 
-/// Generate NextRef (_next helper)
+/// Generate NextRef (`_next` / `_nthChild` helper).
 pub(super) fn generate_next_ref(ctx: &mut GenerateContext, next_ref: &NextRefIRNode) {
-    ctx.use_helper("next");
-    let expr = build_next_chain(cstr!("n{}", next_ref.prev_id), next_ref.offset);
+    let expr = if next_ref.offset > 1 {
+        ctx.use_helper("nthChild");
+        cstr!("_nthChild(n{}, {})", next_ref.parent_id, next_ref.index)
+    } else {
+        build_navigation(
+            cstr!("n{}", next_ref.prev_id),
+            next_ref.offset,
+            next_ref.index,
+            ctx,
+        )
+    };
     ctx.push_line_fmt(format_args!("const n{} = {}", next_ref.child_id, expr));
 }
 
-fn build_next_chain(base: String, offset: usize) -> String {
-    if offset == 0 {
+/// Build a navigation expression for a jump of at most one sibling.
+///
+/// The runtime's `next(node, i)` advances **exactly one** sibling outside
+/// hydration — `i` is an absolute logical index used only while hydrating, not
+/// a step count. Emitting `_next(node, 3)` for a three-sibling jump therefore
+/// landed one sibling over and a chained `_child()` dereferenced `null`
+/// (#3330). Multi-step jumps go through `_nthChild` instead; this helper only
+/// covers `steps <= 1`, and passes `index` so hydration resolves the same node.
+fn build_navigation(base: String, steps: usize, index: usize, ctx: &mut GenerateContext) -> String {
+    if steps == 0 {
         base
     } else {
-        cstr!("_next({}, {})", base, offset)
+        ctx.use_helper("next");
+        cstr!("_next({}, {})", base, index)
     }
 }

--- a/crates/vize_atelier_vapor/src/generate/setup.rs
+++ b/crates/vize_atelier_vapor/src/generate/setup.rs
@@ -37,6 +37,7 @@ pub(crate) fn generate_imports(ctx: &GenerateContext) -> String {
             "insert" => 9,
             "child" => 10,
             "next" => 11,
+            "nthChild" => 12,
             "txt" => 20,
             "toDisplayString" => 21,
             "setText" => 22,

--- a/crates/vize_atelier_vapor/src/ir.rs
+++ b/crates/vize_atelier_vapor/src/ir.rs
@@ -326,19 +326,19 @@ pub struct ChildRefIRNode {
     pub offset: usize,
 }
 
-/// Next sibling reference operation (`_next` / `_nthChild` helper).
+/// Next sibling reference operation (`_next` helper).
 ///
-/// `offset` is how many rendered siblings separate this node from `prev_id`.
-/// The runtime's `next(node, i)` only advances **one** sibling outside
-/// hydration (`i` is an absolute hydration hint, not a step count), so a jump
-/// of two or more must be emitted as `_nthChild(parent, index)` instead
-/// (#3330). `parent_id` and `index` carry what that call needs.
+/// Emitted only when this node is the rendered sibling **immediately** after
+/// `prev_id`: the runtime's `next(node, i)` advances exactly one sibling
+/// outside hydration, where `i` is an absolute hydration hint rather than a
+/// step count. A jump of two or more siblings must therefore be emitted as an
+/// absolute `_nthChild(parent, index)` lookup, which [`ChildRefIRNode`]
+/// already covers (#3330).
 #[derive(Debug)]
 pub struct NextRefIRNode {
     pub child_id: usize,
     pub prev_id: usize,
-    pub parent_id: usize,
+    /// Absolute rendered index of this node within its parent, matching
+    /// [`ChildRefIRNode::offset`]. Passed to `next()` as the hydration hint.
     pub offset: usize,
-    /// Absolute rendered index of this node within its parent.
-    pub index: usize,
 }

--- a/crates/vize_atelier_vapor/src/ir.rs
+++ b/crates/vize_atelier_vapor/src/ir.rs
@@ -326,10 +326,19 @@ pub struct ChildRefIRNode {
     pub offset: usize,
 }
 
-/// Next sibling reference operation (_next helper)
+/// Next sibling reference operation (`_next` / `_nthChild` helper).
+///
+/// `offset` is how many rendered siblings separate this node from `prev_id`.
+/// The runtime's `next(node, i)` only advances **one** sibling outside
+/// hydration (`i` is an absolute hydration hint, not a step count), so a jump
+/// of two or more must be emitted as `_nthChild(parent, index)` instead
+/// (#3330). `parent_id` and `index` carry what that call needs.
 #[derive(Debug)]
 pub struct NextRefIRNode {
     pub child_id: usize,
     pub prev_id: usize,
+    pub parent_id: usize,
     pub offset: usize,
+    /// Absolute rendered index of this node within its parent.
+    pub index: usize,
 }

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -24,6 +24,8 @@ mod tests_dotted_slots;
 #[cfg(test)]
 mod tests_setup_components;
 #[cfg(test)]
+mod tests_sibling_navigation;
+#[cfg(test)]
 mod tests_slot_outlets;
 #[cfg(test)]
 mod tests_valueless_attr;

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_dynamic_child_after_multiple_static_siblings.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_dynamic_child_after_multiple_static_siblings.snap
@@ -1,12 +1,12 @@
 ---
-source: crates/vize_atelier_vapor/src/lib.rs
+source: crates/vize_atelier_vapor/src/tests.rs
 expression: code.as_str()
 ---
-import { child as _child, next as _next, setClass as _setClass, renderEffect as _renderEffect, template as _template } from 'vue';
+import { nthChild as _nthChild, setClass as _setClass, renderEffect as _renderEffect, template as _template } from 'vue';
 const t0 = _template("<div><header>one</header><p>two</p><button>x</button></div>", true)
 export function render(_ctx) {
 const n1 = t0()
-const n0 = _next(_child(n1), 2)
+const n0 = _nthChild(n1, 2)
 _renderEffect(() => _setClass(n0, _ctx.cls))
 return n1
 }

--- a/crates/vize_atelier_vapor/src/tests_sibling_navigation.rs
+++ b/crates/vize_atelier_vapor/src/tests_sibling_navigation.rs
@@ -1,0 +1,126 @@
+//! Regression tests for multi-step sibling navigation (#3330).
+//!
+//! The Vue Vapor runtime's `next(node, i)` advances **exactly one** sibling
+//! outside hydration — `i` is an absolute logical index consulted only while
+//! hydrating, never a step count:
+//!
+//! ```js
+//! function next(node, logicalIndex) {
+//!   if (isHydrating) return locateChildByLogicalIndex(node.parentNode, logicalIndex)
+//!   return _next(node) // one sibling
+//! }
+//! ```
+//!
+//! Emitting `_next(node, 3)` for a three-sibling jump therefore landed one
+//! sibling over, and the chained `_child()` that followed dereferenced `null`
+//! (`TypeError: Cannot read properties of null (reading 'firstChild')`).
+//! Multi-step jumps must use `_nthChild(parent, index)`, which honours the
+//! index in both modes — the same rule `@vue/compiler-vapor` follows.
+
+use super::compile_vapor;
+use vize_carton::{Bump, cstr};
+
+fn compile(template: &str) -> String {
+    let allocator = Bump::new();
+    let result = compile_vapor(&allocator, template, Default::default());
+    assert!(
+        result.error_messages.is_empty(),
+        "expected no errors: {:?}",
+        result.error_messages
+    );
+    result.code.to_string()
+}
+
+/// The reporter's minimal template (#3330): the compiler must navigate three
+/// siblings from the first child to reach `<ul>`.
+#[test]
+fn multi_step_navigation_uses_nth_child_not_a_counted_next() {
+    let code = compile(
+        r##"<div>
+  <svg role="presentation"><use href="#x" /></svg>
+  <h2><span>Title</span></h2>
+  <p><span>Sub</span></p>
+  <ul>
+    <li><a href="https://example.com"><img :src="logo" alt="" /><span>A</span></a></li>
+    <li><a href="https://example.org"><img :src="logo" alt="" /><span>B</span></a></li>
+  </ul>
+</div>"##,
+    );
+
+    // The `<ul>` is the parent's child at index 3; one `_next` call cannot
+    // reach it, so the jump must be an absolute lookup.
+    assert!(
+        code.contains("_nthChild(n1, 3)"),
+        "expected an absolute lookup for the three-sibling jump:\n{code}"
+    );
+    assert!(
+        !code.contains("_next(_child(n1), 3)"),
+        "a counted _next advances only one sibling at runtime:\n{code}"
+    );
+    // The single-sibling hop between the two `<li>` elements stays a `_next`,
+    // carrying its absolute index so hydration resolves the same node.
+    assert!(
+        code.contains("_next(n2, 1)"),
+        "expected a single-step _next for the adjacent sibling:\n{code}"
+    );
+    assert!(
+        code.contains("nthChild as _nthChild"),
+        "the nthChild helper must be imported:\n{code}"
+    );
+}
+
+/// No `_next` call may ever carry a step count above one: that argument is a
+/// hydration index, and treating it as a count is exactly the #3330 defect.
+#[test]
+fn no_emitted_next_call_advances_more_than_one_sibling() {
+    // Plain HTML tags only: an unknown tag resolves as a component and never
+    // reaches the sibling-navigation path, which would make this vacuous.
+    for template in [
+        r#"<div><p/><p/><span :id="x"><i/></span></div>"#,
+        r#"<div><p/><p/><p/><span :id="x"><i/></span></div>"#,
+        r#"<div><span :id="x"><i/></span><p/><p/><span :id="y"><i/></span></div>"#,
+        r#"<div><p/><span :id="x"><i/></span><p/><p/><span :id="y"><i/></span><p/><span :id="z"><i/></span></div>"#,
+    ] {
+        let code = compile(template);
+        assert!(
+            code.contains("_next(") || code.contains("_nthChild("),
+            "expected this template to exercise sibling navigation:\n{template}\n{code}"
+        );
+        // Every `_next(base, i)` advances exactly one sibling at runtime, so
+        // its second argument must never be read as a step count. The only
+        // shapes the generator may emit are `_next(_child(nP), 1)` and
+        // `_next(nX, i)` for an adjacent hop; a `_next` starting from
+        // `_child` with an index above 1 is a counted jump — the #3330 defect.
+        for index in 2..=8 {
+            let counted = cstr!("_next(_child(n1), {})", index);
+            assert!(
+                !code.contains(counted.as_str()),
+                "a counted _next advances only one sibling at runtime:\n{template}\n{code}"
+            );
+        }
+    }
+}
+
+/// Index 0 and index 1 keep their existing, correct shapes.
+#[test]
+fn single_step_navigation_shapes_are_unchanged() {
+    let first = compile(r#"<div><a :id="x"/><b/></div>"#);
+    assert!(
+        first.contains("_child(n1)"),
+        "index 0 stays a plain _child:\n{first}"
+    );
+    assert!(
+        !first.contains("_nthChild"),
+        "index 0 must not need an absolute lookup:\n{first}"
+    );
+
+    let second = compile(r#"<div><a/><b :id="x"/></div>"#);
+    assert!(
+        second.contains("_next(_child(n1), 1)"),
+        "index 1 stays one _next step from the first child:\n{second}"
+    );
+    assert!(
+        !second.contains("_nthChild"),
+        "index 1 must not need an absolute lookup:\n{second}"
+    );
+}

--- a/crates/vize_atelier_vapor/src/transform/element/deferred.rs
+++ b/crates/vize_atelier_vapor/src/transform/element/deferred.rs
@@ -199,6 +199,7 @@ fn transform_dynamic_children_with_ids<'a>(
     dynamic_child_indices: &[usize],
     child_ids: &[usize],
 ) {
+    // (child id, absolute rendered index within the parent)
     let mut prev_template_backed_child: Option<(usize, usize)> = None;
 
     for (idx, &child_index) in dynamic_child_indices.iter().enumerate() {
@@ -208,27 +209,26 @@ fn transform_dynamic_children_with_ids<'a>(
         };
 
         if is_template_backed_element(child_el) {
-            if let Some((prev_child_id, prev_child_index)) = prev_template_backed_child {
-                let offset =
-                    count_rendered_child_nodes(&el.children, prev_child_index + 1, child_index);
+            let index = count_rendered_child_nodes(&el.children, 0, child_index).saturating_sub(1);
+            if let Some((prev_child_id, prev_index)) = prev_template_backed_child {
                 block.operation.push(OperationNode::NextRef(NextRefIRNode {
                     child_id,
                     prev_id: prev_child_id,
-                    offset,
+                    parent_id,
+                    offset: index.saturating_sub(prev_index),
+                    index,
                 }));
             } else {
-                let offset =
-                    count_rendered_child_nodes(&el.children, 0, child_index).saturating_sub(1);
                 block
                     .operation
                     .push(OperationNode::ChildRef(ChildRefIRNode {
                         child_id,
                         parent_id,
-                        offset,
+                        offset: index,
                     }));
             }
 
-            prev_template_backed_child = Some((child_id, child_index));
+            prev_template_backed_child = Some((child_id, index));
             transform_existing_element(ctx, child_el, child_id, block);
         } else if child_el.tag_type == ElementType::Slot {
             transform_slot_outlet_child(ctx, child_el, child_id, parent_id, block);

--- a/crates/vize_atelier_vapor/src/transform/element/deferred.rs
+++ b/crates/vize_atelier_vapor/src/transform/element/deferred.rs
@@ -210,22 +210,26 @@ fn transform_dynamic_children_with_ids<'a>(
 
         if is_template_backed_element(child_el) {
             let index = count_rendered_child_nodes(&el.children, 0, child_index).saturating_sub(1);
-            if let Some((prev_child_id, prev_index)) = prev_template_backed_child {
-                block.operation.push(OperationNode::NextRef(NextRefIRNode {
-                    child_id,
-                    prev_id: prev_child_id,
-                    parent_id,
-                    offset: index.saturating_sub(prev_index),
-                    index,
-                }));
-            } else {
-                block
-                    .operation
-                    .push(OperationNode::ChildRef(ChildRefIRNode {
+            // `_next` advances exactly one sibling, so only an adjacent hop may
+            // chain off the previous child; anything further needs the absolute
+            // lookup a `ChildRef` emits as `_nthChild(parent, index)` (#3330).
+            match prev_template_backed_child {
+                Some((prev_child_id, prev_index)) if index == prev_index + 1 => {
+                    block.operation.push(OperationNode::NextRef(NextRefIRNode {
                         child_id,
-                        parent_id,
+                        prev_id: prev_child_id,
                         offset: index,
                     }));
+                }
+                _ => {
+                    block
+                        .operation
+                        .push(OperationNode::ChildRef(ChildRefIRNode {
+                            child_id,
+                            parent_id,
+                            offset: index,
+                        }));
+                }
             }
 
             prev_template_backed_child = Some((child_id, index));


### PR DESCRIPTION
Reported by @mymx2 in #3330 with a minimal reproduction — thank you, the report was precise enough to confirm the runtime contract directly.

## The defect

The Vue Vapor runtime's `next(node, i)` advances **exactly one** sibling outside hydration. The second argument is an absolute logical index consulted only while hydrating, never a step count:

```js
function next(node, logicalIndex) {
  if (isHydrating) return locateChildByLogicalIndex(node.parentNode, logicalIndex)
  return _next(node) // one sibling
}
```

Verified against the runtime pinned in this repo (`@vue/runtime-vapor@3.6.0-beta.10`), so this is not specific to the reporter's 3.6.0-rc.2.

Vize emitted `_next(base, offset)` for **any** offset, treating that argument as a step count. A three-sibling jump landed one sibling over, and the chained `_child()` that followed dereferenced `null` — the reported `TypeError: Cannot read properties of null (reading 'firstChild')`.

## The fix

`@vue/compiler-vapor` picks its navigation helper by distance, and Vize now follows the same rule:

| distance | emitted |
|---|---|
| 0 | `_child(parent)` |
| 1 | `_next(base, index)` — index is the hydration hint |
| ≥ 2 | `_nthChild(parent, index)` — absolute, correct in both modes |

No IR node gained fields: `ChildRefIRNode` already carries a parent id plus an absolute rendered index and already emits `_nthChild(parent, index)`, so a jump of two or more siblings is emitted as a `ChildRef` and `NextRefIRNode` keeps its three public fields (adding fields to it would have been a public API break in a fix release). The transform tracks the previous sibling's rendered index and picks the node kind from index arithmetic instead of a second scan; `NextRefIRNode::offset` now holds the absolute rendered index it passes to `next()` as the hydration hint, matching `ChildRefIRNode::offset`.

## Verification

On the reporter's exact template, before → after:

```diff
-const n0 = _next(_child(n1), 3)   // lands on <h2>; _child chain then hits null
+const n0 = _nthChild(n1, 3)       // lands on <ul>
 const n2 = _child(n0)
 const n4 = _child(n2)
 const n5 = _child(n4)
 const n3 = _next(n2, 1)           // adjacent <li> stays a one-step _next
```

Traced by hand against the template: `n1` = the `<div>`, children `svg(0) h2(1) p(2) ul(3)`, so `_nthChild(n1, 3)` is the `<ul>`, and `n5`/`n7` are the two `<img>` elements the `:src` bindings target.

**An existing snapshot had pinned the defect**: `test_compile_dynamic_child_after_multiple_static_siblings` asserted `_next(_child(n1), 2)` for a two-sibling jump, which at runtime applies `setClass` to the wrong element. Refreshed to `_nthChild(n1, 2)`.

New regression tests (`tests_sibling_navigation.rs`): the reporter's template, a sweep asserting no emitted `_next` ever carries an index above 1 from `_child`, and a test pinning that distances 0 and 1 keep their existing shapes. The first two fail before the fix; the third passes on both sides, pinning preserved behavior.

`cargo test -p vize_atelier_vapor`: 107 passed, 0 failed. fmt and clippy clean.

## Note on hydration

Vize passes its rendered-node index as the hydration hint. Upstream distinguishes `logicalIndex` (which accounts for fragment anchor comments) from `elementIndex`; the two coincide unless fragment anchors sit among the siblings. Hydration with fragment anchors in the sibling list is therefore not covered by this change, and is worth its own issue if it turns up.

Closes #3330

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sibling navigation during hydration for dynamic template-backed children.
  * Corrected multi-sibling jumps to use absolute `nthChild` lookups instead of counted `_next` chains.
  * Kept adjacent sibling traversal efficient as a single-step `_next`.

* **Tests**
  * Added regression coverage to confirm correct generated navigation helpers across multiple template shapes, including adjacent and multi-sibling cases.
  * Verified existing behavior for index 0 and index 1 remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->