### PR TITLE
fix(maestro): map textDocument/references results to authored ranges

### DIFF
--- a/crates/vize_maestro/src/ide/references.rs
+++ b/crates/vize_maestro/src/ide/references.rs
@@ -35,10 +35,11 @@ impl ReferencesService {
         }
 
         let mut locations = Vec::new();
+        let declaration = Self::find_definition_location(ctx, &word);
 
         // Find definition location if requested
-        if include_declaration && let Some(def_loc) = Self::find_definition_location(ctx, &word) {
-            locations.push(def_loc);
+        if include_declaration && let Some(ref def_loc) = declaration {
+            locations.push(def_loc.clone());
         }
 
         // Find references in template
@@ -49,6 +50,12 @@ impl ReferencesService {
 
         // Find references in style
         locations.extend(Self::find_references_in_style(ctx, &word));
+
+        // The block scans report every occurrence of the word, the declaration
+        // included, so `includeDeclaration: false` has to drop it explicitly.
+        if !include_declaration && let Some(ref def_loc) = declaration {
+            locations.retain(|location| location.range != def_loc.range);
+        }
 
         if locations.is_empty() {
             None

--- a/crates/vize_maestro/src/ide/references/script.rs
+++ b/crates/vize_maestro/src/ide/references/script.rs
@@ -60,6 +60,12 @@ impl ReferencesService {
     }
 
     /// Find references to a symbol in the script block.
+    ///
+    /// Occurrences are collected as byte offsets inside the block content and
+    /// rebased onto the authored SFC through `loc.start`, the mapping `rename`
+    /// already uses. Deriving a position from block-relative *line numbers*
+    /// instead placed every script hit one line below the authored one and
+    /// could overrun the end of the line it landed on (#3325).
     pub(super) fn find_references_in_script(ctx: &IdeContext, word: &str) -> Vec<Location> {
         let mut locations = Vec::new();
 
@@ -68,49 +74,14 @@ impl ReferencesService {
             return locations;
         };
 
-        // Check script setup
-        if let Some(ref script_setup) = descriptor.script_setup {
-            let script_content = script_setup.content.as_ref();
-            let script_start_line = script_setup.loc.start_line as u32;
-
-            let refs = Self::find_identifier_references_in_script(script_content, word);
-            for (line, character) in refs {
-                locations.push(Location {
-                    uri: ctx.uri.clone(),
-                    range: Range {
-                        start: Position {
-                            line: script_start_line + line - 1,
-                            character,
-                        },
-                        end: Position {
-                            line: script_start_line + line - 1,
-                            character: character + word.len() as u32,
-                        },
-                    },
-                });
-            }
-        }
-
-        // Check regular script
-        if let Some(ref script) = descriptor.script {
-            let script_content = script.content.as_ref();
-            let script_start_line = script.loc.start_line as u32;
-
-            let refs = Self::find_identifier_references_in_script(script_content, word);
-            for (line, character) in refs {
-                locations.push(Location {
-                    uri: ctx.uri.clone(),
-                    range: Range {
-                        start: Position {
-                            line: script_start_line + line - 1,
-                            character,
-                        },
-                        end: Position {
-                            line: script_start_line + line - 1,
-                            character: character + word.len() as u32,
-                        },
-                    },
-                });
+        let blocks = [descriptor.script_setup.as_ref(), descriptor.script.as_ref()];
+        for block in blocks.into_iter().flatten() {
+            for offset in Self::find_identifier_references_in_script(&block.content, word) {
+                locations.push(Self::location_from_sfc_offset(
+                    ctx,
+                    block.loc.start + offset,
+                    word,
+                ));
             }
         }
 
@@ -127,76 +98,46 @@ impl ReferencesService {
         };
 
         for style in &descriptor.styles {
-            let style_content = style.content.as_ref();
-            let style_start_line = style.loc.start_line as u32;
-
-            // Find v-bind() references
-            let refs = Self::find_vbind_references_in_style(style_content, word);
-            for (line, character) in refs {
-                locations.push(Location {
-                    uri: ctx.uri.clone(),
-                    range: Range {
-                        start: Position {
-                            line: style_start_line + line - 1,
-                            character,
-                        },
-                        end: Position {
-                            line: style_start_line + line - 1,
-                            character: character + word.len() as u32,
-                        },
-                    },
-                });
+            for offset in Self::find_vbind_references_in_style(&style.content, word) {
+                locations.push(Self::location_from_sfc_offset(
+                    ctx,
+                    style.loc.start + offset,
+                    word,
+                ));
             }
         }
 
         locations
     }
 
-    /// Find identifier references in script content.
-    pub(super) fn find_identifier_references_in_script(
-        content: &str,
-        word: &str,
-    ) -> Vec<(u32, u32)> {
-        let mut refs = Vec::new();
-
-        for (line_idx, line) in content.lines().enumerate() {
-            let positions = Self::find_word_occurrences(line, word);
-
-            for pos in positions {
-                refs.push((
-                    line_idx as u32 + 1,
-                    crate::ide::offset_to_position(line, pos).1,
-                ));
-            }
-        }
-
-        refs
+    /// Byte offsets, relative to the block content, of every standalone
+    /// occurrence of `word` in script code.
+    pub(super) fn find_identifier_references_in_script(content: &str, word: &str) -> Vec<usize> {
+        Self::find_word_occurrences(content, word)
     }
 
-    /// Find v-bind references in style content.
-    pub(super) fn find_vbind_references_in_style(content: &str, word: &str) -> Vec<(u32, u32)> {
+    /// Byte offsets, relative to the block content, of every `v-bind()`
+    /// argument that names `word`.
+    pub(super) fn find_vbind_references_in_style(content: &str, word: &str) -> Vec<usize> {
         let mut refs = Vec::new();
+        let mut line_start = 0usize;
 
-        for (line_idx, line) in content.lines().enumerate() {
+        for line in content.split_inclusive('\n') {
             let mut search_start = 0;
             while let Some(relative_vbind_pos) = line[search_start..].find("v-bind(") {
                 let vbind_pos = search_start + relative_vbind_pos;
-                let after_vbind = &line[vbind_pos + 7..];
-                if let Some(close_paren) = after_vbind.find(')') {
-                    let binding_name = after_vbind[..close_paren].trim();
-                    if binding_name == word {
-                        let binding_offset =
-                            vbind_pos + 7 + (binding_name.len() - binding_name.trim_start().len());
-                        refs.push((
-                            line_idx as u32 + 1,
-                            crate::ide::offset_to_position(line, binding_offset).1,
-                        ));
-                    }
-                    search_start = vbind_pos + 7 + close_paren + 1;
-                } else {
+                let argument = &line[vbind_pos + 7..];
+                let Some(close_paren) = argument.find(')') else {
                     break;
+                };
+                let raw = &argument[..close_paren];
+                if raw.trim() == word {
+                    let leading = raw.len() - raw.trim_start().len();
+                    refs.push(line_start + vbind_pos + 7 + leading);
                 }
+                search_start = vbind_pos + 7 + close_paren + 1;
             }
+            line_start += line.len();
         }
 
         refs
@@ -255,5 +196,87 @@ impl ReferencesService {
             }
         }
         offset
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tower_lsp::lsp_types::Url;
+
+    use crate::ide::{IdeContext, ReferencesService};
+    use crate::server::ServerState;
+
+    /// Authored 0-based lines: 0 `<script setup>`, 3 `const visitCount`,
+    /// 4 `const doubled`, 5 `</script>`, 8 the `@click` handler.
+    const SOURCE: &str = r#"<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+const visitCount = ref(0)
+const doubled = computed(() => visitCount.value * 2)
+</script>
+
+<template>
+  <button @click="visitCount++">bump</button>
+</template>
+"#;
+
+    fn reference_spans(source: &str, cursor_text: &str) -> Vec<(u32, u32, u32)> {
+        spans(source, cursor_text, true)
+    }
+
+    fn spans(source: &str, cursor_text: &str, include_declaration: bool) -> Vec<(u32, u32, u32)> {
+        let state = ServerState::new();
+        let uri = Url::parse("file:///App.vue").unwrap();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        let offset = source.find(cursor_text).unwrap();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+
+        ReferencesService::references(&ctx, include_declaration)
+            .unwrap()
+            .into_iter()
+            .map(|location| {
+                assert_eq!(location.uri, uri);
+                (
+                    location.range.start.line,
+                    location.range.start.character,
+                    location.range.end.character,
+                )
+            })
+            .collect()
+    }
+
+    /// #3325: script hits were rebased from block-relative line numbers, so
+    /// they answered one line below the authored occurrence — `5:31-41` even
+    /// overran the 9-character `</script>` line while the real use at `4:31-41`
+    /// went missing.
+    #[test]
+    fn script_references_land_on_authored_ranges() {
+        assert_eq!(
+            reference_spans(SOURCE, "visitCount = ref"),
+            [(3, 6, 16), (4, 31, 41), (8, 18, 28)],
+        );
+    }
+
+    /// The block scan reports the declaration site too, so once it maps to the
+    /// authored span `includeDeclaration: false` has to drop it by range.
+    #[test]
+    fn excluding_the_declaration_drops_only_the_declaration_span() {
+        assert_eq!(
+            spans(SOURCE, "visitCount = ref", false),
+            [(4, 31, 41), (8, 18, 28)],
+        );
+    }
+
+    /// A style `v-bind()` argument maps through the same block offset rebase.
+    #[test]
+    fn style_vbind_references_land_on_authored_ranges() {
+        let source = "<script setup>\nconst textColor = 'red'\n</script>\n\n<style>\n.a {\n  color: v-bind(textColor);\n}\n</style>\n";
+
+        assert_eq!(
+            reference_spans(source, "textColor = "),
+            [(1, 6, 15), (6, 16, 25)],
+        );
     }
 }

--- a/tests/snapshots/check/create-vue-editor-range-oracle.ts
+++ b/tests/snapshots/check/create-vue-editor-range-oracle.ts
@@ -166,31 +166,24 @@ test("create-vue editor features answer in authored Vue ranges", async (t) => {
           }
         });
 
-        // GAP: references leaks raw virtual-TS coordinates for script-side
-        // hits. Probed here it answers [3:6-16, 4:6-16, 5:31-41, 9:18-28]: the
-        // two script occurrences appear one line below authored, and 5:31-41
-        // cannot exist (line 5 is the 9-character `</script>`), so the authored
-        // use at 4:31-41 is absent. `rename` and `documentHighlight` map the
-        // identical occurrence set correctly, so this is references-only.
-        await t.test(
-          "references map script-side hits to authored ranges",
-          {
-            skip: "textDocument/references returns unmapped virtual-TS ranges for script hits (#2971 audit item 8)",
-          },
-          async () => {
-            const references = (await ask("textDocument/references", {
-              position: scriptVisitCount,
-              context: { includeDeclaration: true },
-            })) as LspLocation[];
-            const hit = references.map((reference) => reference.range);
-            assert.deepEqual(hit, [
-              VISIT_COUNT_DECL,
-              VISIT_COUNT_SCRIPT_USE,
-              VISIT_COUNT_TEMPLATE_USE,
-            ]);
-            assertAuthoredRanges(source, hit);
-          },
-        );
+        // Regression for #3325: script-side hits used to leak block-relative
+        // coordinates, answering [3:6-16, 4:6-16, 5:31-41, 9:18-28] — the two
+        // script occurrences one line below authored, with 5:31-41 landing past
+        // the end of the 9-character `</script>` line and the authored use at
+        // 4:31-41 missing entirely.
+        await t.test("references map script-side hits to authored ranges", async () => {
+          const references = (await ask("textDocument/references", {
+            position: scriptVisitCount,
+            context: { includeDeclaration: true },
+          })) as LspLocation[];
+          const hit = references.map((reference) => reference.range);
+          assert.deepEqual(hit, [
+            VISIT_COUNT_DECL,
+            VISIT_COUNT_SCRIPT_USE,
+            VISIT_COUNT_TEMPLATE_USE,
+          ]);
+          assertAuthoredRanges(source, hit);
+        });
 
         await t.test("prepareRename and rename touch only authored spans", async () => {
           const prepared = (await ask("textDocument/prepareRename", {

--- a/tests/tooling/lsp-definition-navigation.test.ts
+++ b/tests/tooling/lsp-definition-navigation.test.ts
@@ -173,7 +173,17 @@ const doubled = price * 2
         })) as Location[];
 
         assert.ok(Array.isArray(withDeclaration), JSON.stringify(withDeclaration));
-        assert.equal(withDeclaration.length, 4);
+        // Every authored `price`: the declaration, the script-side use, and the
+        // interpolation. Before #3325 the script hits were rebased one line
+        // down, so the declaration appeared twice — once authored, once shifted.
+        assert.deepEqual(
+          withDeclaration.map((reference) => reference.range),
+          [
+            { start: { line: 1, character: 6 }, end: { line: 1, character: 11 } },
+            { start: { line: 2, character: 16 }, end: { line: 2, character: 21 } },
+            { start: { line: 6, character: 5 }, end: { line: 6, character: 10 } },
+          ],
+        );
         assert.ok(
           withDeclaration.every((reference) => reference.uri === uri),
           JSON.stringify(withDeclaration),
@@ -193,7 +203,13 @@ const doubled = price * 2
         })) as Location[];
 
         assert.ok(Array.isArray(withoutDeclaration), JSON.stringify(withoutDeclaration));
-        assert.equal(withoutDeclaration.length, 3);
+        assert.deepEqual(
+          withoutDeclaration.map((reference) => reference.range),
+          [
+            { start: { line: 2, character: 16 }, end: { line: 2, character: 21 } },
+            { start: { line: 6, character: 5 }, end: { line: 6, character: 10 } },
+          ],
+        );
         assert.ok(
           withoutDeclaration.every((reference) => reference.uri === uri),
           JSON.stringify(withoutDeclaration),


### PR DESCRIPTION
## Root cause

`textDocument/references` never mapped script-side hits out of block-relative
coordinates. `ReferencesService::find_references_in_script` collected the
1-based line index inside the block content and rebased it with
`block.loc.start_line + line - 1`, but `loc.start_line` is already the 1-based
line of the block's opening tag — so every script hit landed exactly one line
below its authored occurrence. The style `v-bind()` scan had the same
arithmetic.

`rename` gets this right because `find_all_occurrences` collects block-relative
*byte offsets* and rebases them through `block.loc.start`; `documentHighlight`
never leaves the authored document at all. References is now routed through the
same offset rebase (`Self::location_from_sfc_offset`, already used by the
definition path).

Mapping the declaration site onto its authored span makes it collide with the
location `includeDeclaration: true` prepends, so `references` now drops the
declaration range when the client asks for uses only. The old shift hid this:
`includeDeclaration: false` still returned the declaration, just at a wrong
position.

## Before / after

Probed against a freshly built `target/ci/vize` on the pinned create-vue
fixture, cursor on `const visitCount`, `includeDeclaration: true`. `text` is
the authored source covered by each returned range:

Before:

```
3:6-16  "visitCount"
4:6-16  "doubled = "     <- shifted; not a visitCount use
5:31-41 ""               <- past the end of the 9-char `</script>` line
9:18-28 "visitCount"
```

After:

```
3:6-16  "visitCount"
4:31-41 "visitCount"     <- the authored script use, previously dropped
9:18-28 "visitCount"
```

## Test evidence

`cargo build --profile ci -p vize --features legacy`, then `VIZE_TEST_BIN` /
`VIZE_LSP_BIN` pointed at that binary with `VIZE_TEST_REQUIRE_TSGO=1`.

- `tests/snapshots/check/create-vue-editor-range-oracle.ts` — the pinned
  `references map script-side hits to authored ranges` skip is removed and the
  assertion passes for real (`assert.deepEqual` on exact authored ranges plus
  `assertAuthoredRanges`). 10 pass / 0 fail / 1 skipped (the remaining skip is
  the unrelated `Hover.range` gap). Before the fix the same test file reported
  8 pass / 2 fail.
- `tests/tooling/lsp-*.test.ts` + `tooling/vscode-extension-core-behavior.test.ts`
  — 2112 pass / 0 fail and 279 pass / 0 fail across the two batches.
- `cargo test -p vize_maestro --features legacy` — 567 pass / 0 fail, including
  three new Rust regression tests in
  `crates/vize_maestro/src/ide/references/script.rs`:
  `script_references_land_on_authored_ranges` (pins `[(3,6,16), (4,31,41),
  (8,18,28)]`), `excluding_the_declaration_drops_only_the_declaration_span`,
  and `style_vbind_references_land_on_authored_ranges`.
- `cargo fmt --check -p vize_maestro` clean; `cargo clippy -p vize_maestro
  --features legacy --all-targets` reports nothing on the touched files;
  `oxfmt --check` / `oxlint` clean on both changed `.ts` files.

`tests/tooling/lsp-definition-navigation.test.ts` previously asserted
`length === 4` / `length === 3` for the two `includeDeclaration` modes. The 4th
entry was the shifted duplicate of the declaration, so those counts encoded the
bug; the suite now pins the exact authored ranges instead.

## codeLens

Not covered by this change. `CodeLensService::collect_binding_lenses` has its
own independent copy of the same off-by-one (`base_line + line - 1` over a
1-based line index from `find_declarations`) in
`crates/vize_maestro/src/ide/code_lens.rs`, so fixing references does not touch
it. It is also currently pinned as characterized behavior by
`tests/tooling/lsp-inlay-codelens.test.ts` ("The lens sits exactly one line
below the declaration it annotates"), which would have to change with it —
separate work, tracked outside this PR.

Closes #3325

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected reference locations in scripts so they point to the exact authored line and character.
  * Improved navigation for style `v-bind()` references.
  * Respecting “include declaration” now properly includes or excludes only the definition occurrence.
  * Reference results are more accurate and consistent across script, template, and style sections.

* **Tests**
  * Added coverage verifying precise reference ranges and declaration filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->