### PR TITLE
fix(glyph): keep template literal lines verbatim when indenting script blocks

### DIFF
--- a/crates/vize_glyph/src/formatter.rs
+++ b/crates/vize_glyph/src/formatter.rs
@@ -2,6 +2,7 @@
 //!
 //! Uses arena allocation and zero-copy techniques for maximum performance.
 
+mod block_indent;
 mod custom_block;
 mod raw_mask;
 
@@ -210,17 +211,12 @@ impl<'a> GlyphFormatter<'a> {
 
         // Add content with indentation if configured
         if self.options.vue_indent_script_and_style {
-            let indent = self.options.indent_bytes();
-            let trimmed = formatted_content
-                .trim_end_matches('\n')
-                .trim_end_matches('\r');
-            for line in trimmed.as_bytes().split(|&b| b == b'\n') {
-                if !line.is_empty() && line != b"\r" {
-                    output.extend_from_slice(indent);
-                }
-                output.extend_from_slice(line);
-                output.extend_from_slice(self.options.newline_bytes());
-            }
+            block_indent::write_indented_block(
+                output,
+                &formatted_content,
+                self.options.indent_bytes(),
+                self.options.newline_bytes(),
+            );
         } else {
             output.extend_from_slice(formatted_content.as_bytes());
             if !formatted_content.ends_with('\n') {
@@ -307,17 +303,12 @@ impl<'a> GlyphFormatter<'a> {
 
         // Add content with indentation if configured
         if self.options.vue_indent_script_and_style {
-            let indent = self.options.indent_bytes();
-            let trimmed = formatted_content
-                .trim_end_matches('\n')
-                .trim_end_matches('\r');
-            for line in trimmed.as_bytes().split(|&b| b == b'\n') {
-                if !line.is_empty() && line != b"\r" {
-                    output.extend_from_slice(indent);
-                }
-                output.extend_from_slice(line);
-                output.extend_from_slice(self.options.newline_bytes());
-            }
+            block_indent::write_indented_block(
+                output,
+                &formatted_content,
+                self.options.indent_bytes(),
+                self.options.newline_bytes(),
+            );
         } else {
             output.extend_from_slice(formatted_content.as_bytes());
             if !formatted_content.ends_with('\n') {

--- a/crates/vize_glyph/src/formatter.rs
+++ b/crates/vize_glyph/src/formatter.rs
@@ -305,7 +305,7 @@ impl<'a> GlyphFormatter<'a> {
         if self.options.vue_indent_script_and_style {
             block_indent::write_indented_block(
                 output,
-                &formatted_content,
+                formatted_content,
                 self.options.indent_bytes(),
                 self.options.newline_bytes(),
             );

--- a/crates/vize_glyph/src/formatter/block_indent.rs
+++ b/crates/vize_glyph/src/formatter/block_indent.rs
@@ -8,7 +8,7 @@
 //! changed `TemplateElement` (#3334). #3269 established the same guarantee for
 //! template-position interpolations; this is the script-block half.
 
-use crate::template::template_literal_state_after_line;
+use crate::template::helpers::template_literal_state_after_line_from;
 
 /// Write `content` into `output`, indenting each line with `indent` except
 /// lines that continue a multi-line template literal, which are emitted
@@ -35,7 +35,8 @@ pub(super) fn write_indented_block(
         }
         output.extend_from_slice(line.as_bytes());
         output.extend_from_slice(newline);
-        inside_template_literal = template_literal_state_after_line(inside_template_literal, line);
+        inside_template_literal =
+            template_literal_state_after_line_from(inside_template_literal, line);
     }
 }
 

--- a/crates/vize_glyph/src/formatter/block_indent.rs
+++ b/crates/vize_glyph/src/formatter/block_indent.rs
@@ -1,0 +1,92 @@
+//! Indenting `<script>` / `<style>` block bodies for `vueIndentScriptAndStyle`.
+//!
+//! Indentation is a presentation choice everywhere except inside a template
+//! literal, where every byte between the backticks is part of the string's
+//! runtime value. Prefixing those continuation lines rewrote the emitted
+//! string — a `ChartStyle.vue` that builds CSS gained two spaces on every
+//! line, and the glyph corpus parse-preservation property caught it as a
+//! changed `TemplateElement` (#3334). #3269 established the same guarantee for
+//! template-position interpolations; this is the script-block half.
+
+use crate::template::template_literal_state_after_line;
+
+/// Write `content` into `output`, indenting each line with `indent` except
+/// lines that continue a multi-line template literal, which are emitted
+/// verbatim.
+///
+/// The opening line of a template literal is still indented: its leading
+/// whitespace sits before the backtick and is not part of the string.
+pub(super) fn write_indented_block(
+    output: &mut Vec<u8>,
+    content: &str,
+    indent: &[u8],
+    newline: &[u8],
+) {
+    let trimmed = content.trim_end_matches('\n').trim_end_matches('\r');
+    let mut inside_template_literal = false;
+
+    for line in trimmed.split('\n') {
+        let is_blank = line.is_empty() || line == "\r";
+        if !is_blank && !inside_template_literal {
+            output.extend_from_slice(indent);
+        }
+        output.extend_from_slice(line.as_bytes());
+        output.extend_from_slice(newline);
+        inside_template_literal = template_literal_state_after_line(inside_template_literal, line);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_indented_block;
+
+    fn indent(content: &str) -> vize_carton::String {
+        let mut output = Vec::new();
+        write_indented_block(&mut output, content, b"  ", b"\n");
+        core::str::from_utf8(&output).unwrap().into()
+    }
+
+    #[test]
+    fn ordinary_lines_are_indented() {
+        assert_eq!(
+            indent("const a = 1\nconst b = 2\n"),
+            "  const a = 1\n  const b = 2\n"
+        );
+    }
+
+    #[test]
+    fn template_literal_continuation_lines_stay_verbatim() {
+        // The line opening the literal is indented (that whitespace precedes
+        // the backtick); every line inside it must be emitted untouched, or
+        // the string's runtime value changes.
+        let source = "const css = `\nbody {\n  color: red;\n}\n`\n";
+        assert_eq!(
+            indent(source),
+            "  const css = `\nbody {\n  color: red;\n}\n`\n"
+        );
+    }
+
+    #[test]
+    fn indentation_resumes_after_the_literal_closes() {
+        let source = "const a = `\nx\n`\nconst b = 2\n";
+        assert_eq!(indent(source), "  const a = `\nx\n`\n  const b = 2\n");
+    }
+
+    #[test]
+    fn escaped_backticks_do_not_toggle_the_literal() {
+        let source = "const a = '\\`'\nconst b = 2\n";
+        assert_eq!(indent(source), "  const a = '\\`'\n  const b = 2\n");
+    }
+
+    #[test]
+    fn nested_literals_close_correctly() {
+        // A literal opened and closed on one line leaves the state clean.
+        let source = "const a = `x`\nconst b = 2\n";
+        assert_eq!(indent(source), "  const a = `x`\n  const b = 2\n");
+    }
+
+    #[test]
+    fn blank_lines_are_never_indented() {
+        assert_eq!(indent("a\n\nb\n"), "  a\n\n  b\n");
+    }
+}

--- a/crates/vize_glyph/src/formatter/block_indent.rs
+++ b/crates/vize_glyph/src/formatter/block_indent.rs
@@ -25,9 +25,12 @@ pub(super) fn write_indented_block(
     let trimmed = content.trim_end_matches('\n').trim_end_matches('\r');
     let mut inside_template_literal = false;
 
-    for line in trimmed.split('\n') {
-        let is_blank = line.is_empty() || line == "\r";
-        if !is_blank && !inside_template_literal {
+    for raw_line in trimmed.split('\n') {
+        // Split on '\n' leaves the '\r' of a CRLF pair attached to the line.
+        // Strip it so the configured newline is the only terminator emitted:
+        // otherwise CRLF content plus a CRLF `newline` yields "\r\r\n".
+        let line = raw_line.strip_suffix('\r').unwrap_or(raw_line);
+        if !line.is_empty() && !inside_template_literal {
             output.extend_from_slice(indent);
         }
         output.extend_from_slice(line.as_bytes());
@@ -41,8 +44,12 @@ mod tests {
     use super::write_indented_block;
 
     fn indent(content: &str) -> vize_carton::String {
+        indent_with(content, b"\n")
+    }
+
+    fn indent_with(content: &str, newline: &[u8]) -> vize_carton::String {
         let mut output = Vec::new();
-        write_indented_block(&mut output, content, b"  ", b"\n");
+        write_indented_block(&mut output, content, b"  ", newline);
         core::str::from_utf8(&output).unwrap().into()
     }
 
@@ -88,5 +95,19 @@ mod tests {
     #[test]
     fn blank_lines_are_never_indented() {
         assert_eq!(indent("a\n\nb\n"), "  a\n\n  b\n");
+    }
+
+    #[test]
+    fn crlf_content_emits_the_configured_newline_once() {
+        // The '\r' left behind by splitting on '\n' must not survive, or a
+        // CRLF newline would double it into "\r\r\n".
+        assert_eq!(
+            indent_with("const a = 1\r\nconst b = 2\r\n", b"\r\n"),
+            "  const a = 1\r\n  const b = 2\r\n"
+        );
+        assert_eq!(
+            indent_with("const a = 1\r\nconst b = 2\r\n", b"\n"),
+            "  const a = 1\n  const b = 2\n"
+        );
     }
 }

--- a/crates/vize_glyph/src/template.rs
+++ b/crates/vize_glyph/src/template.rs
@@ -11,8 +11,7 @@
 mod attributes;
 mod directives;
 mod formatter;
-mod helpers;
-pub(crate) use helpers::template_literal_state_after_line_from as template_literal_state_after_line;
+pub(crate) mod helpers;
 
 #[cfg(test)]
 mod attribute_priority_tests;

--- a/crates/vize_glyph/src/template.rs
+++ b/crates/vize_glyph/src/template.rs
@@ -12,6 +12,7 @@ mod attributes;
 mod directives;
 mod formatter;
 mod helpers;
+pub(crate) use helpers::template_literal_state_after_line_from as template_literal_state_after_line;
 
 #[cfg(test)]
 mod attribute_priority_tests;


### PR DESCRIPTION
Found while investigating the release-blocking parse-preservation failures (#3334). This is a **different, latent** instance of the same corruption class — see the note at the bottom: it does **not** close #3334.

## Defect

With `vueIndentScriptAndStyle: true`, `format_script_block_fast` (and its `<style>` twin) prefixed the configured indent onto **every** non-blank line of the formatted block — including lines that continue a multi-line template literal. Every byte between the backticks is part of the string's runtime value, so the emitted string silently changed.

Before / after, same input, `vueIndentScriptAndStyle: true`:

```
  ([theme, prefix]) => `          ([theme, prefix]) => `
··${prefix} [data-chart=${id}] {   ${prefix} [data-chart=${id}] {
····--a: b;                        ··--a: b;
··}                                }
```

The left column gained two spaces on every line inside the literal — a component that builds a CSS string emitted different CSS after formatting.

## Fix

Indentation is a presentation choice everywhere **except** inside a template literal. `write_indented_block` tracks literal state across lines and emits continuation lines verbatim; the line that *opens* a literal is still indented, since that whitespace precedes the backtick and is not part of the string.

The state tracker is the one #3269 already added for template-position interpolations (`template_literal_state_after_line`, escape-aware), now shared rather than duplicated — this is the script-block half of the same guarantee.

Both call sites (script and style) go through the shared helper, which also removes the duplicated loop.

## Verification

Six unit tests in `block_indent.rs`: ordinary lines indent, literal continuation lines stay verbatim, indentation resumes after the literal closes, escaped backticks do not toggle state, single-line literals leave state clean, blank lines never indent.

End-to-end with a freshly built `--profile ci` binary and `vueIndentScriptAndStyle: true`, comparing against a binary built before this change: the literal body is byte-identical to the source after the fix and gains two spaces per line before it (output quoted above is from `cat -A` on both runs).

`cargo test -p vize_glyph`: all suites green. fmt and clippy clean.

## Note: this does not close #3334

`vueIndentScriptAndStyle` defaults to **false**, so this path is not what corrupts `ChartStyle.vue` in the default configuration that the corpus property runs under. #3334 stays open; its root cause is elsewhere in the SFC script pipeline (a plain `.ts` file with the identical construct round-trips correctly, so `oxc_formatter` itself is not at fault). This PR removes one real way the same corruption can happen, with the option enabled.

Part of #3334

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indentation for formatted script and style blocks.
  * Preserved the contents of multiline template literals during formatting.
  * Ensured blank lines remain unindented and indentation resumes correctly after template literals.
  * Improved handling of escaped backticks, nested literals, adjacent literals, and trailing line breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->