### PR TITLE
fix(canon): resolve relative extensionless .vue imports

### DIFF
--- a/crates/vize_canon/src/batch/executor/diagnostics/module_resolution.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics/module_resolution.rs
@@ -42,8 +42,20 @@ pub(crate) fn relative_module_resolves_on_disk(message: &str, importer: &Path) -
     relative_specifier_resolves(dir, specifier)
 }
 
-/// Source extensions a relative specifier may resolve to.
-const SOURCE_EXTENSIONS: &[&str] = &["ts", "tsx", "d.ts", "d.mts", "d.cts", "mts", "cts", "vue"];
+/// Source extensions a relative specifier may resolve to when appended to the
+/// stem. `vue` is deliberately absent (#3329): the import rewriter redirects an
+/// extensionless specifier whose target is a `.vue` file onto that file's mirror
+/// module, so a surviving `Cannot find module "./svg"` means the redirect did
+/// not fire and the module is genuinely unresolved — excusing it would convert a
+/// loud module error into a silent `any` at every usage site. The subset run
+/// this suppression exists for still reports the redirected `"./svg.vue.ts"`
+/// spelling, which [`relative_specifier_resolves`] keeps suppressing below.
+const SOURCE_EXTENSIONS: &[&str] = &["ts", "tsx", "d.ts", "d.mts", "d.cts", "mts", "cts"];
+
+/// Extensions an `index` directory module may use. `vue` stays listed: the
+/// rewriter only redirects the direct `<stem>.vue` spelling, so a directory
+/// whose entry point is `index.vue` still needs the subset-run suppression.
+const INDEX_EXTENSIONS: &[&str] = &["ts", "tsx", "d.ts", "d.mts", "d.cts", "mts", "cts", "vue"];
 
 /// Resolve `specifier` against `dir` the way TypeScript would for a Vue/TS
 /// project: an explicit supported extension, an extension appended to the
@@ -75,7 +87,7 @@ fn relative_specifier_resolves(dir: &Path, specifier: &str) -> bool {
         }
     }
     let base = dir.join(specifier);
-    for extension in SOURCE_EXTENSIONS {
+    for extension in INDEX_EXTENSIONS {
         if base.join(cstr!("index.{extension}").as_str()).is_file() {
             return true;
         }
@@ -157,5 +169,34 @@ mod tests {
             &importer
         ));
         assert!(!relative_module_resolves_on_disk(bare_package, &importer));
+    }
+
+    #[test]
+    fn ts2307_for_an_extensionless_sfc_specifier_is_no_longer_suppressed() {
+        let dir = TempDir::new().unwrap();
+        let importer = dir.path().join("App.vue");
+        std::fs::write(&importer, "").unwrap();
+        std::fs::write(dir.path().join("Panel.vue"), "<template />").unwrap();
+        std::fs::create_dir_all(dir.path().join("widget")).unwrap();
+        std::fs::write(dir.path().join("widget").join("index.vue"), "").unwrap();
+
+        // The import rewriter redirects `./Panel` onto `./Panel.vue.ts`, so the
+        // extensionless spelling reaching tsgo means the module is genuinely
+        // unresolved and must stay loud (#3329)...
+        let extensionless = "Cannot find module './Panel' or its corresponding type declarations.";
+        assert!(!relative_module_resolves_on_disk(extensionless, &importer));
+
+        // ...while the redirected spelling a partial-subset run reports for a
+        // sibling outside the checked set stays suppressed, as does the
+        // `index.vue` directory module the rewriter does not redirect.
+        let redirected =
+            "Cannot find module './Panel.vue.ts' or its corresponding type declarations.";
+        let directory_module =
+            "Cannot find module './widget' or its corresponding type declarations.";
+        assert!(relative_module_resolves_on_disk(redirected, &importer));
+        assert!(relative_module_resolves_on_disk(
+            directory_module,
+            &importer
+        ));
     }
 }

--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -1,21 +1,22 @@
 //! Import rewriter for transforming .vue imports to .vue.ts.
 
+use std::path::Path;
+
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{
-    CallExpression, ExportAllDeclaration, ExportNamedDeclaration, Expression, ImportDeclaration,
-    ImportExpression, StringLiteral, TSExternalModuleReference, TSImportType,
-    TSModuleDeclarationName,
-};
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast_visit::Visit;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_carton::{String, ToCompactString, cstr};
+
+#[path = "import_rewriter_collect.rs"]
+mod collect;
+use collect::ModuleSpecifierCollector;
 
 #[path = "import_rewriter_virtual.rs"]
 mod virtual_rewrite;
 use virtual_rewrite::{
     absolute_import_needs_virtual_rewrite, is_rewritable_project_specifier,
-    is_rewritable_vue_specifier,
+    is_rewritable_vue_specifier, rewrite_relative_vue_specifier,
 };
 
 #[path = "import_rewriter_dts.rs"]
@@ -79,8 +80,19 @@ impl ImportRewriter {
         Self
     }
 
-    pub fn rewrite(&self, source: &str, source_type: SourceType) -> RewriteResult {
-        if !source.contains(".vue") {
+    /// Rewrite a generated module's `.vue` specifiers onto their mirror
+    /// modules. `source_dir` (the authored file's directory, when known) also
+    /// redirects a relative extensionless specifier whose target is a `.vue`
+    /// file on disk (`./components/svg` for `svg.vue`, #3329).
+    pub fn rewrite(
+        &self,
+        source: &str,
+        source_type: SourceType,
+        source_dir: Option<&Path>,
+    ) -> RewriteResult {
+        let relative_candidate =
+            source_dir.is_some() && source_may_contain_relative_specifier(source);
+        if !source.contains(".vue") && !relative_candidate {
             return RewriteResult {
                 code: source.to_compact_string(),
                 source_map: ImportSourceMap::empty(),
@@ -89,6 +101,7 @@ impl ImportRewriter {
 
         self.rewrite_with(source, source_type, |path| {
             self.rewrite_module_specifier(path)
+                .or_else(|| source_dir.and_then(|dir| rewrite_relative_vue_specifier(path, dir)))
         })
     }
 
@@ -180,12 +193,17 @@ impl ImportRewriter {
         }
     }
 
+    /// Relative SFC dependencies of `source`, always spelled with the `.vue`
+    /// extension. With `source_dir`, extensionless specifiers whose target is a
+    /// `.vue` file are reported too, so the caller opens the dependency the
+    /// rewriter redirects them to (#3329).
     pub fn collect_relative_vue_specifiers(
         &self,
         source: &str,
         source_type: SourceType,
+        source_dir: Option<&Path>,
     ) -> Vec<String> {
-        if !source.contains(".vue") {
+        if !source.contains(".vue") && source_dir.is_none() {
             return Vec::new();
         }
 
@@ -197,11 +215,18 @@ impl ImportRewriter {
         let mut collector = ModuleSpecifierCollector::new();
         collector.visit_program(&result.program);
         for (_, _, path) in collector.specifiers {
-            if path.ends_with(".vue") && (path.starts_with("./") || path.starts_with("../")) {
-                let candidate = path.to_compact_string();
-                if !specifiers.iter().any(|s| s.as_str() == candidate.as_str()) {
-                    specifiers.push(candidate);
-                }
+            let candidate =
+                if path.ends_with(".vue") && (path.starts_with("./") || path.starts_with("../")) {
+                    path.to_compact_string()
+                } else if source_dir
+                    .is_some_and(|dir| rewrite_relative_vue_specifier(&path, dir).is_some())
+                {
+                    cstr!("{path}.vue")
+                } else {
+                    continue;
+                };
+            if !specifiers.iter().any(|s| s.as_str() == candidate.as_str()) {
+                specifiers.push(candidate);
             }
         }
 
@@ -224,6 +249,7 @@ impl ImportRewriter {
     ) -> Option<String> {
         if let Some(source_dir) = source_dir
             && let Some(rewritten) = rewrite_relative_dts_specifier(path, source_dir, roots.0)
+                .or_else(|| rewrite_relative_vue_specifier(path, source_dir))
         {
             return Some(rewritten);
         }
@@ -276,75 +302,5 @@ fn source_may_contain_relative_specifier(source: &str) -> bool {
 impl Default for ImportRewriter {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-struct ModuleSpecifierCollector {
-    specifiers: Vec<(u32, u32, String)>,
-}
-
-impl ModuleSpecifierCollector {
-    fn new() -> Self {
-        Self {
-            specifiers: Vec::new(),
-        }
-    }
-
-    fn push(&mut self, start: u32, end: u32, specifier: &str) {
-        self.specifiers.push((start + 1, end - 1, specifier.into()));
-    }
-
-    fn push_literal(&mut self, lit: &StringLiteral<'_>) {
-        self.push(lit.span.start, lit.span.end, lit.value.as_str());
-    }
-}
-
-impl<'a> Visit<'a> for ModuleSpecifierCollector {
-    fn visit_import_declaration(&mut self, decl: &ImportDeclaration<'a>) {
-        self.push_literal(&decl.source);
-        walk::walk_import_declaration(self, decl);
-    }
-
-    fn visit_export_named_declaration(&mut self, decl: &ExportNamedDeclaration<'a>) {
-        if let Some(source) = &decl.source {
-            self.push_literal(source);
-        }
-        walk::walk_export_named_declaration(self, decl);
-    }
-
-    fn visit_export_all_declaration(&mut self, decl: &ExportAllDeclaration<'a>) {
-        self.push_literal(&decl.source);
-        walk::walk_export_all_declaration(self, decl);
-    }
-
-    fn visit_import_expression(&mut self, expr: &ImportExpression<'a>) {
-        if let Expression::StringLiteral(lit) = &expr.source {
-            self.push_literal(lit);
-        }
-        walk::walk_import_expression(self, expr);
-    }
-
-    fn visit_call_expression(&mut self, expr: &CallExpression<'a>) {
-        if let Some(lit) = expr.common_js_require() {
-            self.push(lit.span.start, lit.span.end, lit.value.as_str());
-        }
-        walk::walk_call_expression(self, expr);
-    }
-
-    fn visit_ts_import_type(&mut self, import_type: &TSImportType<'a>) {
-        self.push_literal(&import_type.source);
-        walk::walk_ts_import_type(self, import_type);
-    }
-
-    fn visit_ts_external_module_reference(&mut self, reference: &TSExternalModuleReference<'a>) {
-        self.push_literal(&reference.expression);
-        walk::walk_ts_external_module_reference(self, reference);
-    }
-
-    fn visit_ts_module_declaration_name(&mut self, name: &TSModuleDeclarationName<'a>) {
-        if let TSModuleDeclarationName::StringLiteral(lit) = name {
-            self.push_literal(lit);
-        }
-        walk::walk_ts_module_declaration_name(self, name);
     }
 }

--- a/crates/vize_canon/src/batch/import_rewriter_collect.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_collect.rs
@@ -1,0 +1,80 @@
+//! AST visitor collecting every module specifier literal the rewriter may
+//! replace, with the span of the literal's *contents* (quotes excluded).
+
+use oxc_ast::ast::{
+    CallExpression, ExportAllDeclaration, ExportNamedDeclaration, Expression, ImportDeclaration,
+    ImportExpression, StringLiteral, TSExternalModuleReference, TSImportType,
+    TSModuleDeclarationName,
+};
+use oxc_ast_visit::{Visit, walk};
+use vize_carton::String;
+
+pub(super) struct ModuleSpecifierCollector {
+    pub(super) specifiers: Vec<(u32, u32, String)>,
+}
+
+impl ModuleSpecifierCollector {
+    pub(super) fn new() -> Self {
+        Self {
+            specifiers: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, start: u32, end: u32, specifier: &str) {
+        self.specifiers.push((start + 1, end - 1, specifier.into()));
+    }
+
+    fn push_literal(&mut self, lit: &StringLiteral<'_>) {
+        self.push(lit.span.start, lit.span.end, lit.value.as_str());
+    }
+}
+
+impl<'a> Visit<'a> for ModuleSpecifierCollector {
+    fn visit_import_declaration(&mut self, decl: &ImportDeclaration<'a>) {
+        self.push_literal(&decl.source);
+        walk::walk_import_declaration(self, decl);
+    }
+
+    fn visit_export_named_declaration(&mut self, decl: &ExportNamedDeclaration<'a>) {
+        if let Some(source) = &decl.source {
+            self.push_literal(source);
+        }
+        walk::walk_export_named_declaration(self, decl);
+    }
+
+    fn visit_export_all_declaration(&mut self, decl: &ExportAllDeclaration<'a>) {
+        self.push_literal(&decl.source);
+        walk::walk_export_all_declaration(self, decl);
+    }
+
+    fn visit_import_expression(&mut self, expr: &ImportExpression<'a>) {
+        if let Expression::StringLiteral(lit) = &expr.source {
+            self.push_literal(lit);
+        }
+        walk::walk_import_expression(self, expr);
+    }
+
+    fn visit_call_expression(&mut self, expr: &CallExpression<'a>) {
+        if let Some(lit) = expr.common_js_require() {
+            self.push(lit.span.start, lit.span.end, lit.value.as_str());
+        }
+        walk::walk_call_expression(self, expr);
+    }
+
+    fn visit_ts_import_type(&mut self, import_type: &TSImportType<'a>) {
+        self.push_literal(&import_type.source);
+        walk::walk_ts_import_type(self, import_type);
+    }
+
+    fn visit_ts_external_module_reference(&mut self, reference: &TSExternalModuleReference<'a>) {
+        self.push_literal(&reference.expression);
+        walk::walk_ts_external_module_reference(self, reference);
+    }
+
+    fn visit_ts_module_declaration_name(&mut self, name: &TSModuleDeclarationName<'a>) {
+        if let TSModuleDeclarationName::StringLiteral(lit) = name {
+            self.push_literal(lit);
+        }
+        walk::walk_ts_module_declaration_name(self, name);
+    }
+}

--- a/crates/vize_canon/src/batch/import_rewriter_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_tests.rs
@@ -29,7 +29,7 @@ fn write(dir: &Path, rel: &str, contents: &str) -> PathBuf {
 fn test_rewrite_default_import() {
     let rewriter = ImportRewriter::new();
     let source = r#"import App from './App.vue';"#;
-    let result = rewriter.rewrite(source, SourceType::ts());
+    let result = rewriter.rewrite(source, SourceType::ts(), None);
 
     assert_eq!(result.code, r#"import App from './App.vue.ts';"#);
 }
@@ -38,7 +38,7 @@ fn test_rewrite_default_import() {
 fn test_rewrite_named_import() {
     let rewriter = ImportRewriter::new();
     let source = r#"import { helper, type Props } from './helper.vue';"#;
-    let result = rewriter.rewrite(source, SourceType::ts());
+    let result = rewriter.rewrite(source, SourceType::ts(), None);
 
     assert_eq!(
         result.code,
@@ -50,7 +50,7 @@ fn test_rewrite_named_import() {
 fn test_rewrite_side_effect_import() {
     let rewriter = ImportRewriter::new();
     let source = r#"import './global.vue';"#;
-    let result = rewriter.rewrite(source, SourceType::ts());
+    let result = rewriter.rewrite(source, SourceType::ts(), None);
 
     assert_eq!(result.code, r#"import './global.vue.ts';"#);
 }
@@ -59,7 +59,7 @@ fn test_rewrite_side_effect_import() {
 fn test_no_rewrite_npm_import() {
     let rewriter = ImportRewriter::new();
     let source = r#"import { ref } from 'vue';"#;
-    let result = rewriter.rewrite(source, SourceType::ts());
+    let result = rewriter.rewrite(source, SourceType::ts(), None);
 
     assert_eq!(result.code, r#"import { ref } from 'vue';"#);
 }
@@ -68,7 +68,7 @@ fn test_no_rewrite_npm_import() {
 fn test_no_rewrite_bare_vue_package_import() {
     let rewriter = ImportRewriter::new();
     let source = r#"import Emoji from 'emoji-mart-vue-fast/src/components/Emoji.vue';"#;
-    let result = rewriter.rewrite(source, SourceType::ts());
+    let result = rewriter.rewrite(source, SourceType::ts(), None);
 
     assert_eq!(result.code, source);
 }
@@ -77,7 +77,7 @@ fn test_no_rewrite_bare_vue_package_import() {
 fn test_rewrite_alias_import() {
     let rewriter = ImportRewriter::new();
     let source = r#"import App, { type Props } from '@/App.vue';"#;
-    let result = rewriter.rewrite(source, SourceType::ts());
+    let result = rewriter.rewrite(source, SourceType::ts(), None);
 
     assert_eq!(
         result.code,
@@ -278,7 +278,7 @@ fn test_keeps_absolute_node_modules_for_virtual_project() {
 fn test_rewrite_dynamic_import() {
     let rewriter = ImportRewriter::new();
     let source = r#"const App = () => import('./App.vue');"#;
-    let result = rewriter.rewrite(source, SourceType::ts());
+    let result = rewriter.rewrite(source, SourceType::ts(), None);
 
     assert_eq!(result.code, r#"const App = () => import('./App.vue.ts');"#);
 }
@@ -287,7 +287,7 @@ fn test_rewrite_dynamic_import() {
 fn test_rewrite_parent_path() {
     let rewriter = ImportRewriter::new();
     let source = r#"import Parent from '../Parent.vue';"#;
-    let result = rewriter.rewrite(source, SourceType::ts());
+    let result = rewriter.rewrite(source, SourceType::ts(), None);
 
     assert_eq!(result.code, r#"import Parent from '../Parent.vue.ts';"#);
 }
@@ -298,7 +298,7 @@ fn test_source_map_offset() {
     let source = r#"import App from './App.vue';
 import { ref } from 'vue';
 const x = 1;"#;
-    let result = rewriter.rewrite(source, SourceType::ts());
+    let result = rewriter.rewrite(source, SourceType::ts(), None);
 
     let virtual_offset = 30;
     let original_offset = result.source_map.get_original_offset(virtual_offset);
@@ -318,7 +318,7 @@ const Lazy2 = () => import('./Lazy.vue');
 type AppModule = typeof import('./Typed.vue');
 export { default as Re } from './Re.vue';
 "#;
-    let mut found = rewriter.collect_relative_vue_specifiers(source, SourceType::ts());
+    let mut found = rewriter.collect_relative_vue_specifiers(source, SourceType::ts(), None);
     found.sort();
     assert_eq!(
         found.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
@@ -338,7 +338,7 @@ fn test_multiple_rewrites() {
     let source = r#"import App from './App.vue';
 import Child from './Child.vue';
 import { ref } from 'vue';"#;
-    let result = rewriter.rewrite(source, SourceType::ts());
+    let result = rewriter.rewrite(source, SourceType::ts(), None);
 
     assert_eq!(
         result.code,

--- a/crates/vize_canon/src/batch/import_rewriter_type_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_type_tests.rs
@@ -7,7 +7,7 @@ fn rewrites_ts_import_type_specifiers() {
     let rewriter = ImportRewriter::new();
     let source = r#"type AppModule = typeof import('./App.vue');
 type AppProps = import("./App.vue").PublicProps;"#;
-    let result = rewriter.rewrite(source, SourceType::ts());
+    let result = rewriter.rewrite(source, SourceType::ts(), None);
 
     assert_eq!(
         result.code,
@@ -49,7 +49,7 @@ fn rewrites_ts_import_equals_external_module_references() {
     let rewriter = ImportRewriter::new();
     let source = r#"import App = require("./App.vue");
 export type AppModule = typeof App;"#;
-    let result = rewriter.rewrite(source, SourceType::ts());
+    let result = rewriter.rewrite(source, SourceType::ts(), None);
 
     assert_eq!(
         result.code,
@@ -63,7 +63,7 @@ fn rewrites_common_js_require_specifiers() {
     let rewriter = ImportRewriter::new();
     let source = r#"const App = require("./App.vue");
 const util = require("./util");"#;
-    let result = rewriter.rewrite(source, SourceType::ts());
+    let result = rewriter.rewrite(source, SourceType::ts(), None);
 
     assert_eq!(
         result.code,
@@ -93,7 +93,7 @@ fn collects_relative_vue_specifiers_from_require_forms() {
 const Other = require("../Other.vue");"#;
 
     assert_eq!(
-        rewriter.collect_relative_vue_specifiers(source, SourceType::ts()),
+        rewriter.collect_relative_vue_specifiers(source, SourceType::ts(), None),
         vec!["./App.vue", "../Other.vue"]
     );
 }
@@ -108,7 +108,7 @@ declare module "*.vue" {
   const component: unknown;
   export default component;
 }"#;
-    let result = rewriter.rewrite(source, SourceType::ts());
+    let result = rewriter.rewrite(source, SourceType::ts(), None);
 
     assert_eq!(
         result.code,
@@ -145,7 +145,7 @@ fn collects_relative_vue_specifiers_from_module_declarations() {
 declare module "*.vue" {}"#;
 
     assert_eq!(
-        rewriter.collect_relative_vue_specifiers(source, SourceType::ts()),
+        rewriter.collect_relative_vue_specifiers(source, SourceType::ts(), None),
         vec!["./App.vue"]
     );
 }

--- a/crates/vize_canon/src/batch/import_rewriter_virtual.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_virtual.rs
@@ -117,6 +117,54 @@ pub(super) fn is_rewritable_project_specifier(path: &Path) -> bool {
         })
 }
 
+/// Redirect a relative extensionless specifier whose target is a `.vue` file on
+/// disk onto that file's mirror module (`./components/svg` -> `./components/svg.vue.ts`).
+///
+/// Webpack-era apps spell SFC imports without the extension. TypeScript appends
+/// extensions to the specifier and never tries `.vue`, so neither the mirror
+/// (which holds `svg.vue.ts`) nor the real tree (which holds `svg.vue`) resolves
+/// it: the import silently types as `any` and every prop/event contract at the
+/// usage site disappears (#3329). The alias-mapped spelling is served by a
+/// trailing `paths` candidate instead (#3300), which `paths` cannot do for
+/// relative specifiers.
+///
+/// Like that alias candidate, this only ever turns a failing resolution into a
+/// successful one: a specifier TypeScript already resolves through an ordinary
+/// source sibling or directory module keeps its original spelling.
+pub(super) fn rewrite_relative_vue_specifier(specifier: &str, source_dir: &Path) -> Option<String> {
+    // `.`/`..` name a directory module, not a stem an extension can be appended
+    // to, so only the `./`-prefixed spellings are candidates here.
+    if !(specifier.starts_with("./") || specifier.starts_with("../")) {
+        return None;
+    }
+    if specifier_has_extension(specifier) {
+        return None;
+    }
+    let target = source_dir.join(specifier);
+    if !append_extension(&target, ".vue").is_file() || resolves_without_vue(&target) {
+        return None;
+    }
+    Some(cstr!("{specifier}.vue.ts"))
+}
+
+fn specifier_has_extension(specifier: &str) -> bool {
+    Path::new(specifier)
+        .extension()
+        .is_some_and(|extension| !extension.is_empty())
+}
+
+/// Whether TypeScript already resolves `target` without consulting `.vue`,
+/// through an ordinary source extension or an `index` directory module.
+fn resolves_without_vue(target: &Path) -> bool {
+    SOURCE_EXTENSIONS
+        .iter()
+        .filter(|extension| **extension != ".vue")
+        .any(|extension| {
+            append_extension(target, extension).is_file()
+                || target.join(cstr!("index{extension}").as_str()).is_file()
+        })
+}
+
 pub(super) fn is_rewritable_vue_specifier(path: &str) -> bool {
     path.ends_with(".vue")
         && (path.starts_with("./")
@@ -155,7 +203,10 @@ mod tests {
 
     use vize_carton::cstr;
 
-    use super::{absolute_import_needs_virtual_rewrite, collect_import_specifiers};
+    use super::{
+        absolute_import_needs_virtual_rewrite, collect_import_specifiers,
+        rewrite_relative_vue_specifier,
+    };
 
     fn unique_case_dir(name: &str) -> PathBuf {
         static NEXT_CASE_ID: std::sync::atomic::AtomicUsize =
@@ -197,6 +248,53 @@ mod tests {
         assert!(absolute_import_needs_virtual_rewrite(
             &root.join("src/feature")
         ));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn extensionless_relative_sfc_specifiers_target_the_mirror_module() {
+        let root = unique_case_dir("relative-vue");
+        let _ = fs::remove_dir_all(&root);
+        write(&root, "src/components/common/svg.vue", "<template />");
+        write(&root, "src/components/header/head.vue", "<template />");
+        write(&root, "src/page/home/home.vue", "<template />");
+        let src = root.join("src");
+        let home = root.join("src/page/home");
+
+        assert_eq!(
+            rewrite_relative_vue_specifier("./components/common/svg", &src).as_deref(),
+            Some("./components/common/svg.vue.ts")
+        );
+        assert_eq!(
+            rewrite_relative_vue_specifier("../../components/header/head", &home).as_deref(),
+            Some("../../components/header/head.vue.ts")
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn specifiers_typescript_already_resolves_keep_their_spelling() {
+        let root = unique_case_dir("relative-vue-precedence");
+        let _ = fs::remove_dir_all(&root);
+        write(&root, "src/Shadowed.vue", "<template />");
+        write(&root, "src/Shadowed.ts", "export default 1;\n");
+        write(&root, "src/Sibling.vue", "<template />");
+        write(&root, "src/Sibling/index.ts", "export default 1;\n");
+        write(&root, "src/Plain.vue", "<template />");
+        let src = root.join("src");
+
+        // Only a failing resolution may be redirected: an ordinary sibling
+        // module and a directory `index` module both keep winning.
+        assert_eq!(rewrite_relative_vue_specifier("./Shadowed", &src), None);
+        assert_eq!(rewrite_relative_vue_specifier("./Sibling", &src), None);
+        // Already-extensioned, bare, and absent specifiers are left alone.
+        assert_eq!(rewrite_relative_vue_specifier("./Plain.vue", &src), None);
+        assert_eq!(rewrite_relative_vue_specifier("./Plain.ts", &src), None);
+        assert_eq!(rewrite_relative_vue_specifier("Plain", &src), None);
+        assert_eq!(rewrite_relative_vue_specifier(".", &src), None);
+        assert_eq!(rewrite_relative_vue_specifier("./Absent", &src), None);
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -116,7 +116,7 @@ pub(super) fn build_vue_registered_file(
     let effective_options =
         virtual_ts_options_for_descriptor(context.virtual_ts_options, &descriptor);
     let use_tsx_virtual = descriptor_uses_jsx_script(&descriptor);
-    let virtual_source_type = if use_tsx_virtual {
+    let source_type = if use_tsx_virtual {
         SourceType::tsx()
     } else {
         SourceType::ts()
@@ -151,7 +151,7 @@ pub(super) fn build_vue_registered_file(
     }
     let rewritten = profile!(
         "canon.import.rewrite.vue",
-        context.rewriter.rewrite(&code, virtual_source_type)
+        context.rewriter.rewrite(&code, source_type, path.parent())
     );
     let source_map = CompositeSourceMap::new_vue(
         SfcSourceMap::new(mappings, collect_sfc_block_ranges(&descriptor)),

--- a/crates/vize_canon/src/batch/virtual_project/document.rs
+++ b/crates/vize_canon/src/batch/virtual_project/document.rs
@@ -106,7 +106,7 @@ pub fn generate_vue_document_virtual_ts_with_options(
         prepend_vue_jsx_reference(&mut code, &mut mappings);
     }
 
-    let rewritten = rewriter.rewrite(&code, source_type);
+    let rewritten = rewriter.rewrite(&code, source_type, path.parent());
     Ok(VueDocumentVirtualTs {
         code: rewritten.code,
         pre_rewrite_code: code,

--- a/crates/vize_canon/src/batch/virtual_project/jsx_build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_build.rs
@@ -29,7 +29,9 @@ pub(super) fn build_jsx_registered_file(
 
     let rewritten = profile!(
         "canon.import.rewrite.jsx",
-        context.rewriter.rewrite(&code, SourceType::ts())
+        context
+            .rewriter
+            .rewrite(&code, SourceType::ts(), path.parent())
     );
 
     let blocks = vec![crate::batch::source_map::SfcBlockRange {

--- a/crates/vize_canon/src/batch/virtual_ts.rs
+++ b/crates/vize_canon/src/batch/virtual_ts.rs
@@ -167,7 +167,7 @@ impl VirtualTsGenerator {
 
     /// Emit imports with `.vue -> .vue.ts` rewrite.
     fn emit_imports(&self, code: &mut String, script: &str) {
-        let rewritten = ImportRewriter::new().rewrite(script, oxc_span::SourceType::ts());
+        let rewritten = ImportRewriter::new().rewrite(script, oxc_span::SourceType::ts(), None);
         for line in rewritten.code.lines() {
             if line.trim().starts_with("import ") {
                 code.push_str("  ");

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -117,7 +117,7 @@ fn queue_vue_imports(
     code: &str,
     source_type: SourceType,
 ) {
-    for specifier in rewriter.collect_relative_vue_specifiers(code, source_type) {
+    for specifier in rewriter.collect_relative_vue_specifiers(code, source_type, Some(dir)) {
         let path = normalize_path(&dir.join(specifier.as_str()));
         let key = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
         if !imports.visited_vue.insert(key) {
@@ -200,7 +200,9 @@ fn queue_ts_imports(
             continue;
         };
         let dependency_source_type = source_type_for_path(&path);
-        let rewritten = rewriter.rewrite(&content, dependency_source_type).code;
+        let rewritten = rewriter
+            .rewrite(&content, dependency_source_type, path.parent())
+            .code;
         let uri = normalize_document_uri(path_to_file_uri(&path).as_str());
         imports.documents.push((uri, rewritten));
         imports.queue.push_back(DependencyScan::Script {

--- a/crates/vize_canon/tests/relative_extensionless_vue_imports.rs
+++ b/crates/vize_canon/tests/relative_extensionless_vue_imports.rs
@@ -1,0 +1,247 @@
+//! Relative extensionless `.vue` imports (#3329).
+//!
+//! Webpack-era apps spell SFC imports without the extension
+//! (`import svgIcon from './components/common/svg'`). TypeScript appends
+//! extensions to the specifier and never tries `.vue`, so it resolved to
+//! nothing: the component typed as `any`, every prop contract at the usage site
+//! silently disappeared, and the `TS2307` that would have made the hole visible
+//! was excused by the on-disk-sibling suppression. The import rewriter now
+//! redirects such a specifier onto the target's mirror module, the same
+//! resolution the alias-mapped spelling gets from its `paths` candidate (#3300).
+
+use std::path::{Path, PathBuf};
+
+use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait};
+use vize_carton::{String, ToCompactString};
+
+const CHILD: &str = r#"<script setup lang="ts">
+defineProps<{ count: number }>()
+</script>
+<template><div /></template>
+"#;
+
+const APP: &str = r#"<script setup lang="ts">
+import Child from './components/Child'
+const label: number = 'not a number'
+</script>
+<template>
+  <Child :count="'not a number'" />
+  <span>{{ label }}</span>
+</template>
+"#;
+
+/// A diagnostic reduced to `(file suffix, code, line, column, message)`.
+/// Lines and columns are zero-based authored positions in the `.vue` source.
+type Located = (String, Option<u32>, u32, u32, String);
+
+#[test]
+fn extensionless_sfc_import_enforces_the_component_contract_at_authored_ranges() {
+    let project = create_project(&[("src/App.vue", APP), ("src/components/Child.vue", CHILD)]);
+    let diagnostics = project_diagnostics(project.path(), None);
+
+    // Redirecting the specifier lengthens the virtual module at the import, so
+    // both a diagnostic before the shift (the template usage is emitted after
+    // the script, but authored above it) and one after it must still land on
+    // their exact authored positions.
+    assert_eq!(
+        diagnostics,
+        vec![
+            (
+                "src/App.vue".into(),
+                Some(2322),
+                2,
+                6,
+                "Type 'string' is not assignable to type 'number'.".into(),
+            ),
+            (
+                "src/App.vue".into(),
+                Some(2322),
+                5,
+                10,
+                "Type 'string' is not assignable to type 'number'.".into(),
+            ),
+        ],
+        "the redirected import must enforce the prop contract at `count` (line 6, column 11 \
+         as authored) without shifting the script diagnostic off `label`"
+    );
+}
+
+#[test]
+fn an_ordinary_sibling_module_still_wins_over_a_same_named_sfc() {
+    // The redirect may only turn a failing resolution into a successful one:
+    // `./Widget` already resolves to `Widget.ts`, which must keep winning.
+    let app = r#"<script setup lang="ts">
+import Widget from './Widget'
+const widget: Record<string, never> = Widget
+void widget
+</script>
+<template><div /></template>
+"#;
+    let project = create_project(&[
+        ("src/App.vue", app),
+        (
+            "src/Widget.ts",
+            "export default { fromTheScriptModule: true };\n",
+        ),
+        ("src/Widget.vue", CHILD),
+    ]);
+
+    // The sentinel property only exists on the script module: had the redirect
+    // fired, `Widget` would be the SFC's component type instead.
+    let diagnostics = project_diagnostics(project.path(), None);
+    let [(file, code, line, column, message)] = diagnostics.as_slice() else {
+        panic!("exactly one assignment must be rejected: {diagnostics:#?}");
+    };
+    assert_eq!(
+        (file.as_str(), *code, *line, *column),
+        ("src/App.vue", Some(2322), 2, 6)
+    );
+    assert!(
+        message.starts_with(
+            "Type '{ fromTheScriptModule: boolean; }' is not assignable to type \
+             'Record<string, never>'."
+        ),
+        "an extensionless specifier TypeScript already resolves must keep its spelling: {message}"
+    );
+}
+
+#[test]
+fn a_genuinely_missing_relative_module_still_reports_ts2307() {
+    let app = r#"<script setup lang="ts">
+import Absent from './Absent'
+void Absent
+</script>
+<template><div /></template>
+"#;
+    let project = create_project(&[("src/App.vue", app)]);
+    let codes: Vec<Option<u32>> = project_diagnostics(project.path(), None)
+        .into_iter()
+        .map(|(_, code, ..)| code)
+        .collect();
+
+    assert_eq!(
+        codes,
+        vec![Some(2307)],
+        "a specifier with no target on disk must stay loud"
+    );
+}
+
+#[test]
+fn a_partial_subset_run_still_suppresses_unregistered_siblings() {
+    // `vize check src/App.vue` registers only the named file, so siblings that
+    // exist on disk but sit outside the subset resolve for `tsc` and not for the
+    // virtual project. Both the redirected SFC spelling and a plain script
+    // sibling must stay suppressed.
+    let app = r#"<script setup lang="ts">
+import Child from './components/Child'
+import { label } from './util'
+void Child
+void label
+</script>
+<template><div /></template>
+"#;
+    let project = create_project(&[
+        ("src/App.vue", app),
+        ("src/components/Child.vue", CHILD),
+        ("src/util.ts", "export const label = 'ok';\n"),
+    ]);
+    let diagnostics = project_diagnostics(project.path(), Some(&["src/App.vue"]));
+
+    assert!(
+        diagnostics.is_empty(),
+        "a partial subset must not report its unregistered siblings: {diagnostics:#?}"
+    );
+}
+
+fn create_project(files: &[(&str, &str)]) -> tempfile::TempDir {
+    let project = tempfile::tempdir().expect("temporary project should be created");
+    write_file(
+        project.path(),
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write_file(
+        project.path(),
+        "node_modules/vue/package.json",
+        r#"{ "name": "vue", "types": "index.d.ts" }"#,
+    );
+    write_file(
+        project.path(),
+        "node_modules/vue/index.d.ts",
+        r#"export interface ComponentPublicInstance {
+  $attrs: Record<string, unknown>;
+  $slots: Record<string, unknown>;
+  $refs: Record<string, unknown>;
+  $emit: (...args: unknown[]) => void;
+}
+"#,
+    );
+    for (path, source) in files {
+        write_file(project.path(), path, source);
+    }
+    project
+}
+
+/// Type check `root`, either the whole project or only `subset`, and reduce every
+/// diagnostic to a project-relative [`Located`] tuple.
+fn project_diagnostics(root: &Path, subset: Option<&[&str]>) -> Vec<Located> {
+    let mut checker = BatchTypeChecker::new(root).expect("type checker should start");
+    match subset {
+        Some(paths) => {
+            // The checker canonicalizes its root, so a subset path must be
+            // canonical too or it will not mirror under the virtual root.
+            let canonical = std::fs::canonicalize(root).expect("project root should canonicalize");
+            let paths: Vec<PathBuf> = paths.iter().map(|path| canonical.join(path)).collect();
+            checker.scan_paths(&paths).expect("subset should scan");
+        }
+        None => checker.scan_project().expect("project should scan"),
+    }
+    let mut diagnostics: Vec<Located> = checker
+        .check_project()
+        .expect("project should type check")
+        .diagnostics
+        .into_iter()
+        .map(|diagnostic| {
+            (
+                relative_file(root, &diagnostic.file),
+                diagnostic.code,
+                diagnostic.line,
+                diagnostic.column,
+                diagnostic.message,
+            )
+        })
+        .collect();
+    diagnostics.sort();
+    diagnostics
+}
+
+/// Diagnostic paths are absolute and the project root is a symlinked temporary
+/// directory on macOS, so compare the trailing project-relative segments.
+fn relative_file(root: &Path, file: &Path) -> String {
+    let root = root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("temporary project should have a name");
+    let file = file.to_string_lossy();
+    match file.split_once(root) {
+        Some((_, relative)) => relative.trim_start_matches(['/', '\\']).to_compact_string(),
+        None => file.to_compact_string(),
+    }
+}
+
+fn write_file(root: &Path, path: &str, source: &str) {
+    let path = root.join(path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("parent directory should be created");
+    }
+    std::fs::write(path, source).expect("fixture should be written");
+}

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts.rs
@@ -24,7 +24,7 @@ struct VirtualTsMetadata {
 /// coordinate system the byte-range source mappings operate in).
 pub(super) fn rewrite_vue_imports(code: &str) -> (std::string::String, ImportSourceMap) {
     use oxc_span::SourceType;
-    let result = ImportRewriter::new().rewrite(code, SourceType::ts());
+    let result = ImportRewriter::new().rewrite(code, SourceType::ts(), None);
     #[allow(clippy::disallowed_methods)]
     (result.code.to_string(), result.source_map)
 }

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art_imports.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art_imports.rs
@@ -15,7 +15,7 @@ pub(super) fn collect_art_vue_dependency_paths(uri: &Url, code: &str) -> Vec<Pat
     let rewriter = ImportRewriter::new();
     let mut dependencies = Vec::new();
     let mut seen = std::collections::HashSet::<PathBuf>::new();
-    for specifier in rewriter.collect_relative_vue_specifiers(code, SourceType::ts()) {
+    for specifier in rewriter.collect_relative_vue_specifiers(code, SourceType::ts(), None) {
         let path = source_dir.join(specifier.as_str());
         let key = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
         if seen.insert(key) {


### PR DESCRIPTION
## Problem

A relative SFC import spelled without the extension resolved to nothing inside the virtual project:

```ts
import svgIcon from './components/common/svg'   // target is svg.vue
```

TypeScript appends extensions to a specifier and never tries `.vue`, so neither the mirror (which holds `svg.vue.ts`) nor the real tree (which holds `svg.vue`) matched. The component typed as `any` and every prop and event contract at the usage site silently disappeared. The `TS2307` that would have made the hole visible never reached the user: `relative_module_resolves_on_disk` saw a `.vue` sibling on disk and excused it.

#3328 fixed the alias-mapped spelling at the tsconfig `paths` layer, which by design does not apply to relative specifiers.

## Fix

`ImportRewriter::rewrite` now takes the authored file's directory and redirects a relative extensionless specifier whose target is a `.vue` file onto that file's mirror module (`./components/common/svg` → `./components/common/svg.vue.ts`) — the resolution the alias-mapped spelling already gets from its trailing `paths` candidate. Like that candidate, it can only turn a *failing* resolution into a successful one: a specifier TypeScript already resolves through an ordinary source sibling (`svg.ts`) or a directory `index` module keeps its spelling. The same helper runs on the script path (`rewrite_for_virtual_project`), the JSX path, and the editor document path, and the LSP dependency scanner now opens the redirected dependency so the editor gets the contracts too.

The suppression **narrows** rather than disappears: `vue` leaves the appended-extension list in `module_resolution.rs`, so an extensionless specifier that still reaches tsgo is reported instead of excused. The partial-subset false positive the suppression exists for now arrives as the redirected `./svg.vue.ts` spelling, which the `.vue.ts` → `.vue` branch keeps suppressing. `index.vue` directory modules, which the rewriter does not redirect, keep their own list.

`ModuleSpecifierCollector` moves to `import_rewriter_collect.rs` (pure move) so `import_rewriter.rs` stays inside the 350-line source budget.

## Evidence

All numbers below come from probe runs against `cargo build --profile ci -p vize --features legacy` with `VIZE_TEST_REQUIRE_TSGO=1`.

**The six vue2-elm imports resolve.** Raw `tsgo --noEmit -p node_modules/.vize/canon/tsconfig.json` over the materialized virtual project, before vs after, TS2307 only: **53 → 47**, and the six removed are exactly the relative extensionless SFC imports:

```
src/App.vue.ts(74,21):                  Cannot find module './components/common/svg'
src/page/home/home.vue.ts(74,21):       Cannot find module '../../components/header/head'
src/page/login/login.vue.ts(74,21):     Cannot find module '../../components/header/head'
src/page/login/login.vue.ts(75,22):     Cannot find module '../../components/common/alertTip'
src/page/search/search.vue.ts(74,21):   Cannot find module '../../components/header/head'
src/page/search/search.vue.ts(75,23):   Cannot find module '../../components/footer/footGuide'
```

Nothing was added; the 47 that remain are the intentionally uninstalled vendor modules (`vuex`, `better-scroll`, `showdown`). The rewritten specifier is visible in the mirror: `src/App.vue.ts:74` is now `import svgIcon from './components/common/svg.vue.ts';`.

**Snapshot delta: 0 added, 0 removed.** `tests/snapshots/check/__snapshots__/vue2-elm-check.snap` is unchanged and needed no `UPDATE_SNAPSHOTS=1` refresh. Compared as a multiset of `(file, diagnostic)` pairs over the full `vize check 'src/**/*.vue'` report, before vs after: **314 errors → 314 errors, empty added set, empty removed set.** This is the expected result and is explainable: all six diagnostics were already suppressed (invisible), and resolving them introduces no new findings on this legacy Options-API app, whose components declare no typed props. The value of the fix is the closed typing hole, which the new regression test pins directly.

**Regression test fails before the fix.** `crates/vize_canon/tests/relative_extensionless_vue_imports.rs` (new, 247 lines) pins exact authored positions; on `main` the prop-contract diagnostic is simply absent:

```
left:  [("src/App.vue", Some(2322), 2, 6, "Type 'string' is not assignable to type 'number'.")]
right: [("src/App.vue", Some(2322), 2, 6, ...), ("src/App.vue", Some(2322), 5, 10, ...)]
```

**Authored-range mapping holds.** The redirect lengthens the virtual module by 7 bytes at the import, so the test asserts both a diagnostic authored *above* the import site (the template usage at line 6, column 11 → `count`) and one authored *below* it (the script assignment at line 3, column 7 → `label`) land on their exact authored positions. The composite source map already threads `ImportSourceMap` for the pre-existing `.vue` → `.vue.ts` rewrite, so this uses the same, already-covered mapping path. `create-vue-editor-range-oracle.ts` (hover, definition, references, rename, semantic tokens, inlay hints, document features) and `vue-element-admin-unmapped-diagnostic-oracle.ts` are green.

**Subset-run suppression preserved.**

- `a_partial_subset_run_still_suppresses_unregistered_siblings` — `scan_paths(["src/App.vue"])` with a `Child.vue` and a `util.ts` sibling outside the subset reports nothing.
- `ts2307_for_an_extensionless_sfc_specifier_is_no_longer_suppressed` — pins the narrowing: `./Panel` is no longer excused, while `./Panel.vue.ts` and the `./widget` (`index.vue`) directory module still are.
- `ts2307_for_resolvable_relative_siblings_is_suppressed` (pre-existing) unchanged and green.

**Suites run green:** `cargo test -p vize_canon` (610 unit + integration), `cargo test -p vize_maestro` (565), `cargo fmt --check`, `cargo clippy` (no new warnings). Node snapshots: `vue2-elm`, `vuefes`, `npmx`, all three `vue-element-admin` oracles, all three `create-vue` oracles, `typecheck-errors`, `typecheck-vue-imports`, `compiler-macros`, `options-api`, `class-component`, `style-preprocessors` — 34 pass, 0 fail.

## Line budget

`build.rs` (365, already over the limit) stays at exactly 365 lines; `import_rewriter.rs` drops 350 → 306; `import_rewriter_tests.rs` stays at 349. New files: 80 and 247 lines.

Closes #3329

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->