### PR TITLE
fix(glyph): lex interpolation expressions when computing the raw-line mask

### DIFF
--- a/crates/vize_glyph/src/formatter/raw_mask.rs
+++ b/crates/vize_glyph/src/formatter/raw_mask.rs
@@ -17,11 +17,10 @@ pub(super) fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
     let mut open_quote: Option<OpenQuote> = None;
     let mut pending_raw_tag: Option<&'static str> = None;
     let mut in_comment = false;
-    // Inside a `{{ … }}` interpolation, and inside a template literal within
-    // it. The template formatter already emits those quasi lines verbatim; the
-    // SFC layer must not indent them on top.
-    let mut interpolation_depth = 0usize;
-    let mut in_interpolation_literal = false;
+    // Lexer state for the inside of a `{{ … }}` interpolation. The template
+    // formatter already emits template-literal quasi lines verbatim; the SFC
+    // layer must not indent them on top.
+    let mut interpolation = InterpolationScan::default();
     const TAGS: [(&str, &str, &str); 2] = [
         ("pre", "<pre", "</pre>"),
         ("textarea", "<textarea", "</textarea>"),
@@ -31,7 +30,7 @@ pub(super) fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
         if !depth_stack.is_empty()
             || open_quote.is_some_and(OpenQuote::marks_line_raw)
             || in_comment
-            || in_interpolation_literal
+            || interpolation.line_starts_in_quasi()
         {
             mask[i] = true;
         }
@@ -81,21 +80,15 @@ pub(super) fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
                 cursor += 1;
                 continue;
             }
-            if interpolation_depth > 0 && bytes[cursor] == b'`' && !is_escaped(bytes, cursor) {
-                in_interpolation_literal = !in_interpolation_literal;
-                cursor += 1;
+            // Inside an interpolation the bytes are a JS expression, not
+            // markup: `<` is a comparison and `}}` only closes the
+            // interpolation when reached in code position.
+            if interpolation.active {
+                cursor = interpolation.step(bytes, cursor);
                 continue;
             }
-            if !in_interpolation_literal && bytes[cursor..].starts_with(b"{{") {
-                interpolation_depth += 1;
-                cursor += 2;
-                continue;
-            }
-            if !in_interpolation_literal
-                && interpolation_depth > 0
-                && bytes[cursor..].starts_with(b"}}")
-            {
-                interpolation_depth -= 1;
+            if bytes[cursor..].starts_with(b"{{") {
+                interpolation.active = true;
                 cursor += 2;
                 continue;
             }
@@ -145,6 +138,119 @@ pub(super) fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
         }
     }
     mask
+}
+
+/// Lexer state for the JS expression inside a `{{ … }}` interpolation.
+///
+/// `}}` and backticks are only structural in code position: inside a string,
+/// a comment, or a nested template literal they are ordinary characters. A
+/// scan that ignored that let `{{ "}}" + ` … ` }}` close the interpolation at
+/// the string's `}}`, so the literal's lines lost their raw marking and their
+/// runtime value was reformatted, and a single boolean could not represent a
+/// template literal nested inside a `${ … }` substitution.
+///
+/// This mirrors `template_literal_quasi_line_starts` (#3247), which decides
+/// the same question for the formatted expression, so both layers agree on
+/// which lines are quasi text. Regex literals are not modelled; a backtick
+/// inside one is rare and would at worst leave a line indented.
+#[derive(Default)]
+struct InterpolationScan {
+    /// Set by `{{`, cleared by the matching `}}`.
+    active: bool,
+    /// Nested template-literal / `${ … }` frames within the expression.
+    frames: Vec<ExprFrame>,
+    /// Open `'…'` / `"…"` string, if any.
+    string: Option<u8>,
+    /// Inside a `/* … */` comment.
+    in_block_comment: bool,
+}
+
+enum ExprFrame {
+    /// Inside backticks, in quasi text (part of the string's runtime value).
+    TemplateLiteral,
+    /// Inside `${ … }`; tracks `{`/`}` nesting within the substitution.
+    Substitution(u32),
+}
+
+impl InterpolationScan {
+    /// Whether the current line's first byte lies in template-literal quasi
+    /// text, which the SFC layer must leave unindented.
+    fn line_starts_in_quasi(&self) -> bool {
+        self.string.is_none()
+            && !self.in_block_comment
+            && matches!(self.frames.last(), Some(ExprFrame::TemplateLiteral))
+    }
+
+    /// Consume one token at `cursor`, returning the next cursor position.
+    fn step(&mut self, bytes: &[u8], cursor: usize) -> usize {
+        let byte = bytes[cursor];
+        if self.in_block_comment {
+            if bytes[cursor..].starts_with(b"*/") {
+                self.in_block_comment = false;
+                return cursor + 2;
+            }
+            return cursor + 1;
+        }
+        if let Some(quote) = self.string {
+            if byte == b'\\' {
+                return cursor + 2;
+            }
+            if byte == quote {
+                self.string = None;
+            }
+            return cursor + 1;
+        }
+        if matches!(self.frames.last(), Some(ExprFrame::TemplateLiteral)) {
+            return match byte {
+                b'\\' => cursor + 2,
+                b'`' => {
+                    self.frames.pop();
+                    cursor + 1
+                }
+                b'$' if bytes.get(cursor + 1) == Some(&b'{') => {
+                    self.frames.push(ExprFrame::Substitution(0));
+                    cursor + 2
+                }
+                _ => cursor + 1,
+            };
+        }
+        match byte {
+            b'/' if bytes.get(cursor + 1) == Some(&b'/') => bytes.len(),
+            b'/' if bytes.get(cursor + 1) == Some(&b'*') => {
+                self.in_block_comment = true;
+                cursor + 2
+            }
+            b'\'' | b'"' => {
+                self.string = Some(byte);
+                cursor + 1
+            }
+            b'`' => {
+                self.frames.push(ExprFrame::TemplateLiteral);
+                cursor + 1
+            }
+            b'{' => {
+                if let Some(ExprFrame::Substitution(depth)) = self.frames.last_mut() {
+                    *depth += 1;
+                }
+                cursor + 1
+            }
+            b'}' if self.frames.is_empty() && bytes[cursor..].starts_with(b"}}") => {
+                self.active = false;
+                cursor + 2
+            }
+            b'}' => {
+                match self.frames.last_mut() {
+                    Some(ExprFrame::Substitution(0)) => {
+                        self.frames.pop();
+                    }
+                    Some(ExprFrame::Substitution(depth)) => *depth -= 1,
+                    _ => {}
+                }
+                cursor + 1
+            }
+            _ => cursor + 1,
+        }
+    }
 }
 
 fn literal_attr_quote(line: &[u8], quote_pos: usize) -> bool {
@@ -266,6 +372,26 @@ mod interpolation_literal_tests {
     #[test]
     fn ordinary_interpolation_lines_stay_indentable() {
         let source = "<div>\n  {{ a\n    + b }}\n</div>";
+        assert_eq!(mask(source), [false, false, false, false]);
+    }
+
+    #[test]
+    fn a_closing_brace_pair_inside_a_string_does_not_end_the_interpolation() {
+        // The `}}` lives in a JS string, so the literal that follows it is
+        // still inside the interpolation and its lines stay raw.
+        let source = "<div>\n  {{ \"}}\" + `\nfoo\n` }}\n</div>";
+        assert_eq!(mask(source), [false, false, true, true, false]);
+    }
+
+    #[test]
+    fn a_template_literal_nested_in_a_substitution_is_tracked() {
+        let source = "<div>\n  {{ `${ xs.map((x) => `\na\n`) }\nb\n` }}\n</div>";
+        assert_eq!(mask(source), [false, false, true, true, true, true, false]);
+    }
+
+    #[test]
+    fn a_backtick_inside_a_comment_is_not_structural() {
+        let source = "<div>\n  {{ /* ` */ a }}\n  <span>y</span>\n</div>";
         assert_eq!(mask(source), [false, false, false, false]);
     }
 

--- a/crates/vize_glyph/src/formatter/raw_mask.rs
+++ b/crates/vize_glyph/src/formatter/raw_mask.rs
@@ -21,12 +21,21 @@ pub(super) fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
     // formatter already emits template-literal quasi lines verbatim; the SFC
     // layer must not indent them on top.
     let mut interpolation = InterpolationScan::default();
+    // A `{{` with no `}}` after it is text, not an interpolation (Vue treats
+    // an unterminated marker as plain text). Entering expression mode there
+    // would disable tag, comment and `<pre>`/`<textarea>` tracking for the
+    // rest of the document, so activation is gated on a closing pair
+    // actually following.
+    let last_close_line = lines.iter().rposition(|line| contains(line, b"}}"));
     const TAGS: [(&str, &str, &str); 2] = [
         ("pre", "<pre", "</pre>"),
         ("textarea", "<textarea", "</textarea>"),
     ];
 
     for (i, line) in lines.iter().enumerate() {
+        // `'…'` / `"…"` cannot span a newline in JS, so an unbalanced quote
+        // must not swallow the following lines as string content.
+        interpolation.string = None;
         if !depth_stack.is_empty()
             || open_quote.is_some_and(OpenQuote::marks_line_raw)
             || in_comment
@@ -88,7 +97,8 @@ pub(super) fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
                 continue;
             }
             if bytes[cursor..].starts_with(b"{{") {
-                interpolation.active = true;
+                interpolation.active = contains(&bytes[cursor + 2..], b"}}")
+                    || last_close_line.is_some_and(|last| last > i);
                 cursor += 2;
                 continue;
             }
@@ -159,7 +169,8 @@ struct InterpolationScan {
     active: bool,
     /// Nested template-literal / `${ … }` frames within the expression.
     frames: Vec<ExprFrame>,
-    /// Open `'…'` / `"…"` string, if any.
+    /// Open `'…'` / `"…"` string, if any. Reset at every line boundary,
+    /// since such strings cannot span a newline.
     string: Option<u8>,
     /// Inside a `/* … */` comment.
     in_block_comment: bool,
@@ -340,6 +351,10 @@ fn directive_expr_attr(name: &[u8]) -> bool {
         || name == b"v-text"
 }
 
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.len() >= needle.len() && haystack.windows(needle.len()).any(|w| w == needle)
+}
+
 fn starts_with_ascii_ci(haystack: &[u8], needle: &[u8]) -> bool {
     haystack.len() >= needle.len()
         && haystack[..needle.len()]
@@ -393,6 +408,26 @@ mod interpolation_literal_tests {
     fn a_backtick_inside_a_comment_is_not_structural() {
         let source = "<div>\n  {{ /* ` */ a }}\n  <span>y</span>\n</div>";
         assert_eq!(mask(source), [false, false, false, false]);
+    }
+
+    #[test]
+    fn an_unterminated_marker_stays_text_and_keeps_markup_tracking() {
+        // Vue treats a `{{` with no `}}` as text, so the scanner must not
+        // enter expression mode and lose the `<pre>` region behind it.
+        let source = "<div>\n  {{ mustache syntax, unclosed\n  <pre>\nx\n  </pre>\n</div>";
+        assert_eq!(
+            mask(source),
+            [false, false, false, true, true, false],
+            "an unmatched `{{{{` must not disable markup scanning"
+        );
+    }
+
+    #[test]
+    fn an_unbalanced_quote_does_not_swallow_later_lines() {
+        // `'a) }}` leaves a quote open at the line end; strings cannot span a
+        // newline, so the literal on the following lines is still tracked.
+        let source = "<div>\n  {{ t('a) }}\n  {{ `\nx\n` }}\n</div>";
+        assert_eq!(mask(source), [false, false, false, true, true, false]);
     }
 
     #[test]

--- a/crates/vize_glyph/src/formatter/raw_mask.rs
+++ b/crates/vize_glyph/src/formatter/raw_mask.rs
@@ -1,3 +1,9 @@
+mod interpolation;
+#[cfg(test)]
+mod tests;
+
+use interpolation::InterpolationScan;
+
 /// Per-line "this line is inside a whitespace-significant block" mask.
 ///
 /// Lines inside `<pre>`, `<textarea>`, `v-pre`, multi-line comments,
@@ -150,120 +156,6 @@ pub(super) fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
     mask
 }
 
-/// Lexer state for the JS expression inside a `{{ … }}` interpolation.
-///
-/// `}}` and backticks are only structural in code position: inside a string,
-/// a comment, or a nested template literal they are ordinary characters. A
-/// scan that ignored that let `{{ "}}" + ` … ` }}` close the interpolation at
-/// the string's `}}`, so the literal's lines lost their raw marking and their
-/// runtime value was reformatted, and a single boolean could not represent a
-/// template literal nested inside a `${ … }` substitution.
-///
-/// This mirrors `template_literal_quasi_line_starts` (#3247), which decides
-/// the same question for the formatted expression, so both layers agree on
-/// which lines are quasi text. Regex literals are not modelled; a backtick
-/// inside one is rare and would at worst leave a line indented.
-#[derive(Default)]
-struct InterpolationScan {
-    /// Set by `{{`, cleared by the matching `}}`.
-    active: bool,
-    /// Nested template-literal / `${ … }` frames within the expression.
-    frames: Vec<ExprFrame>,
-    /// Open `'…'` / `"…"` string, if any. Reset at every line boundary,
-    /// since such strings cannot span a newline.
-    string: Option<u8>,
-    /// Inside a `/* … */` comment.
-    in_block_comment: bool,
-}
-
-enum ExprFrame {
-    /// Inside backticks, in quasi text (part of the string's runtime value).
-    TemplateLiteral,
-    /// Inside `${ … }`; tracks `{`/`}` nesting within the substitution.
-    Substitution(u32),
-}
-
-impl InterpolationScan {
-    /// Whether the current line's first byte lies in template-literal quasi
-    /// text, which the SFC layer must leave unindented.
-    fn line_starts_in_quasi(&self) -> bool {
-        self.string.is_none()
-            && !self.in_block_comment
-            && matches!(self.frames.last(), Some(ExprFrame::TemplateLiteral))
-    }
-
-    /// Consume one token at `cursor`, returning the next cursor position.
-    fn step(&mut self, bytes: &[u8], cursor: usize) -> usize {
-        let byte = bytes[cursor];
-        if self.in_block_comment {
-            if bytes[cursor..].starts_with(b"*/") {
-                self.in_block_comment = false;
-                return cursor + 2;
-            }
-            return cursor + 1;
-        }
-        if let Some(quote) = self.string {
-            if byte == b'\\' {
-                return cursor + 2;
-            }
-            if byte == quote {
-                self.string = None;
-            }
-            return cursor + 1;
-        }
-        if matches!(self.frames.last(), Some(ExprFrame::TemplateLiteral)) {
-            return match byte {
-                b'\\' => cursor + 2,
-                b'`' => {
-                    self.frames.pop();
-                    cursor + 1
-                }
-                b'$' if bytes.get(cursor + 1) == Some(&b'{') => {
-                    self.frames.push(ExprFrame::Substitution(0));
-                    cursor + 2
-                }
-                _ => cursor + 1,
-            };
-        }
-        match byte {
-            b'/' if bytes.get(cursor + 1) == Some(&b'/') => bytes.len(),
-            b'/' if bytes.get(cursor + 1) == Some(&b'*') => {
-                self.in_block_comment = true;
-                cursor + 2
-            }
-            b'\'' | b'"' => {
-                self.string = Some(byte);
-                cursor + 1
-            }
-            b'`' => {
-                self.frames.push(ExprFrame::TemplateLiteral);
-                cursor + 1
-            }
-            b'{' => {
-                if let Some(ExprFrame::Substitution(depth)) = self.frames.last_mut() {
-                    *depth += 1;
-                }
-                cursor + 1
-            }
-            b'}' if self.frames.is_empty() && bytes[cursor..].starts_with(b"}}") => {
-                self.active = false;
-                cursor + 2
-            }
-            b'}' => {
-                match self.frames.last_mut() {
-                    Some(ExprFrame::Substitution(0)) => {
-                        self.frames.pop();
-                    }
-                    Some(ExprFrame::Substitution(depth)) => *depth -= 1,
-                    _ => {}
-                }
-                cursor + 1
-            }
-            _ => cursor + 1,
-        }
-    }
-}
-
 fn literal_attr_quote(line: &[u8], quote_pos: usize) -> bool {
     attr_name_before_quote(line, quote_pos).is_none_or(|name| {
         !directive_expr_attr(name) || verbatim_multiline_directive_attr(name, line, quote_pos)
@@ -361,78 +253,4 @@ fn starts_with_ascii_ci(haystack: &[u8], needle: &[u8]) -> bool {
             .iter()
             .zip(needle.iter())
             .all(|(a, b)| a.eq_ignore_ascii_case(b))
-}
-
-#[cfg(test)]
-mod interpolation_literal_tests {
-    use super::compute_raw_line_mask;
-
-    fn mask(source: &str) -> Vec<bool> {
-        let lines: Vec<&[u8]> = source.lines().map(|l| l.as_bytes()).collect();
-        compute_raw_line_mask(&lines)
-    }
-
-    #[test]
-    fn lines_inside_an_interpolation_template_literal_are_raw() {
-        // Every byte between the backticks is part of the string's runtime
-        // value, so the SFC layer must not indent these lines (#3334).
-        let source =
-            "<div>\n  {{ items.map((p) => `\n${p} {\n  --a: b;\n}\n`).join(\"\") }}\n</div>";
-        // Lines 2..=5 all *begin* inside the literal — including the line
-        // that closes it, whose leading bytes would otherwise be indented
-        // into the string's value.
-        assert_eq!(mask(source), [false, false, true, true, true, true, false]);
-    }
-
-    #[test]
-    fn ordinary_interpolation_lines_stay_indentable() {
-        let source = "<div>\n  {{ a\n    + b }}\n</div>";
-        assert_eq!(mask(source), [false, false, false, false]);
-    }
-
-    #[test]
-    fn a_closing_brace_pair_inside_a_string_does_not_end_the_interpolation() {
-        // The `}}` lives in a JS string, so the literal that follows it is
-        // still inside the interpolation and its lines stay raw.
-        let source = "<div>\n  {{ \"}}\" + `\nfoo\n` }}\n</div>";
-        assert_eq!(mask(source), [false, false, true, true, false]);
-    }
-
-    #[test]
-    fn a_template_literal_nested_in_a_substitution_is_tracked() {
-        let source = "<div>\n  {{ `${ xs.map((x) => `\na\n`) }\nb\n` }}\n</div>";
-        assert_eq!(mask(source), [false, false, true, true, true, true, false]);
-    }
-
-    #[test]
-    fn a_backtick_inside_a_comment_is_not_structural() {
-        let source = "<div>\n  {{ /* ` */ a }}\n  <span>y</span>\n</div>";
-        assert_eq!(mask(source), [false, false, false, false]);
-    }
-
-    #[test]
-    fn an_unterminated_marker_stays_text_and_keeps_markup_tracking() {
-        // Vue treats a `{{` with no `}}` as text, so the scanner must not
-        // enter expression mode and lose the `<pre>` region behind it.
-        let source = "<div>\n  {{ mustache syntax, unclosed\n  <pre>\nx\n  </pre>\n</div>";
-        assert_eq!(
-            mask(source),
-            [false, false, false, true, true, false],
-            "an unmatched `{{{{` must not disable markup scanning"
-        );
-    }
-
-    #[test]
-    fn an_unbalanced_quote_does_not_swallow_later_lines() {
-        // `'a) }}` leaves a quote open at the line end; strings cannot span a
-        // newline, so the literal on the following lines is still tracked.
-        let source = "<div>\n  {{ t('a) }}\n  {{ `\nx\n` }}\n</div>";
-        assert_eq!(mask(source), [false, false, false, true, true, false]);
-    }
-
-    #[test]
-    fn a_closed_literal_does_not_leak_into_later_lines() {
-        let source = "<div>\n  {{ `x` }}\n  <span>y</span>\n</div>";
-        assert_eq!(mask(source), [false, false, false, false]);
-    }
 }

--- a/crates/vize_glyph/src/formatter/raw_mask/interpolation.rs
+++ b/crates/vize_glyph/src/formatter/raw_mask/interpolation.rs
@@ -1,0 +1,113 @@
+/// Lexer state for the JS expression inside a `{{ … }}` interpolation.
+///
+/// `}}` and backticks are only structural in code position: inside a string,
+/// a comment, or a nested template literal they are ordinary characters. A
+/// scan that ignored that let `{{ "}}" + ` … ` }}` close the interpolation at
+/// the string's `}}`, so the literal's lines lost their raw marking and their
+/// runtime value was reformatted, and a single boolean could not represent a
+/// template literal nested inside a `${ … }` substitution.
+///
+/// This mirrors `template_literal_quasi_line_starts` (#3247), which decides
+/// the same question for the formatted expression, so both layers agree on
+/// which lines are quasi text. Regex literals are not modelled; a backtick
+/// inside one is rare and would at worst leave a line indented.
+#[derive(Default)]
+pub(super) struct InterpolationScan {
+    /// Set by `{{`, cleared by the matching `}}`.
+    pub(super) active: bool,
+    /// Nested template-literal / `${ … }` frames within the expression.
+    frames: Vec<ExprFrame>,
+    /// Open `'…'` / `"…"` string, if any. Reset at every line boundary,
+    /// since such strings cannot span a newline.
+    pub(super) string: Option<u8>,
+    /// Inside a `/* … */` comment.
+    in_block_comment: bool,
+}
+
+enum ExprFrame {
+    /// Inside backticks, in quasi text (part of the string's runtime value).
+    TemplateLiteral,
+    /// Inside `${ … }`; tracks `{`/`}` nesting within the substitution.
+    Substitution(u32),
+}
+
+impl InterpolationScan {
+    /// Whether the current line's first byte lies in template-literal quasi
+    /// text, which the SFC layer must leave unindented.
+    pub(super) fn line_starts_in_quasi(&self) -> bool {
+        self.string.is_none()
+            && !self.in_block_comment
+            && matches!(self.frames.last(), Some(ExprFrame::TemplateLiteral))
+    }
+
+    /// Consume one token at `cursor`, returning the next cursor position.
+    pub(super) fn step(&mut self, bytes: &[u8], cursor: usize) -> usize {
+        let byte = bytes[cursor];
+        if self.in_block_comment {
+            if bytes[cursor..].starts_with(b"*/") {
+                self.in_block_comment = false;
+                return cursor + 2;
+            }
+            return cursor + 1;
+        }
+        if let Some(quote) = self.string {
+            if byte == b'\\' {
+                return cursor + 2;
+            }
+            if byte == quote {
+                self.string = None;
+            }
+            return cursor + 1;
+        }
+        if matches!(self.frames.last(), Some(ExprFrame::TemplateLiteral)) {
+            return match byte {
+                b'\\' => cursor + 2,
+                b'`' => {
+                    self.frames.pop();
+                    cursor + 1
+                }
+                b'$' if bytes.get(cursor + 1) == Some(&b'{') => {
+                    self.frames.push(ExprFrame::Substitution(0));
+                    cursor + 2
+                }
+                _ => cursor + 1,
+            };
+        }
+        match byte {
+            b'/' if bytes.get(cursor + 1) == Some(&b'/') => bytes.len(),
+            b'/' if bytes.get(cursor + 1) == Some(&b'*') => {
+                self.in_block_comment = true;
+                cursor + 2
+            }
+            b'\'' | b'"' => {
+                self.string = Some(byte);
+                cursor + 1
+            }
+            b'`' => {
+                self.frames.push(ExprFrame::TemplateLiteral);
+                cursor + 1
+            }
+            b'{' => {
+                if let Some(ExprFrame::Substitution(depth)) = self.frames.last_mut() {
+                    *depth += 1;
+                }
+                cursor + 1
+            }
+            b'}' if self.frames.is_empty() && bytes[cursor..].starts_with(b"}}") => {
+                self.active = false;
+                cursor + 2
+            }
+            b'}' => {
+                match self.frames.last_mut() {
+                    Some(ExprFrame::Substitution(0)) => {
+                        self.frames.pop();
+                    }
+                    Some(ExprFrame::Substitution(depth)) => *depth -= 1,
+                    _ => {}
+                }
+                cursor + 1
+            }
+            _ => cursor + 1,
+        }
+    }
+}

--- a/crates/vize_glyph/src/formatter/raw_mask/tests.rs
+++ b/crates/vize_glyph/src/formatter/raw_mask/tests.rs
@@ -1,0 +1,69 @@
+use super::compute_raw_line_mask;
+
+fn mask(source: &str) -> Vec<bool> {
+    let lines: Vec<&[u8]> = source.lines().map(|l| l.as_bytes()).collect();
+    compute_raw_line_mask(&lines)
+}
+
+#[test]
+fn lines_inside_an_interpolation_template_literal_are_raw() {
+    // Every byte between the backticks is part of the string's runtime
+    // value, so the SFC layer must not indent these lines (#3334).
+    let source = "<div>\n  {{ items.map((p) => `\n${p} {\n  --a: b;\n}\n`).join(\"\") }}\n</div>";
+    // Lines 2..=5 all *begin* inside the literal — including the line
+    // that closes it, whose leading bytes would otherwise be indented
+    // into the string's value.
+    assert_eq!(mask(source), [false, false, true, true, true, true, false]);
+}
+
+#[test]
+fn ordinary_interpolation_lines_stay_indentable() {
+    let source = "<div>\n  {{ a\n    + b }}\n</div>";
+    assert_eq!(mask(source), [false, false, false, false]);
+}
+
+#[test]
+fn a_closing_brace_pair_inside_a_string_does_not_end_the_interpolation() {
+    // The `}}` lives in a JS string, so the literal that follows it is
+    // still inside the interpolation and its lines stay raw.
+    let source = "<div>\n  {{ \"}}\" + `\nfoo\n` }}\n</div>";
+    assert_eq!(mask(source), [false, false, true, true, false]);
+}
+
+#[test]
+fn a_template_literal_nested_in_a_substitution_is_tracked() {
+    let source = "<div>\n  {{ `${ xs.map((x) => `\na\n`) }\nb\n` }}\n</div>";
+    assert_eq!(mask(source), [false, false, true, true, true, true, false]);
+}
+
+#[test]
+fn a_backtick_inside_a_comment_is_not_structural() {
+    let source = "<div>\n  {{ /* ` */ a }}\n  <span>y</span>\n</div>";
+    assert_eq!(mask(source), [false, false, false, false]);
+}
+
+#[test]
+fn an_unterminated_marker_stays_text_and_keeps_markup_tracking() {
+    // Vue treats a `{{` with no `}}` as text, so the scanner must not
+    // enter expression mode and lose the `<pre>` region behind it.
+    let source = "<div>\n  {{ mustache syntax, unclosed\n  <pre>\nx\n  </pre>\n</div>";
+    assert_eq!(
+        mask(source),
+        [false, false, false, true, true, false],
+        "an unmatched `{{{{` must not disable markup scanning"
+    );
+}
+
+#[test]
+fn an_unbalanced_quote_does_not_swallow_later_lines() {
+    // `'a) }}` leaves a quote open at the line end; strings cannot span a
+    // newline, so the literal on the following lines is still tracked.
+    let source = "<div>\n  {{ t('a) }}\n  {{ `\nx\n` }}\n</div>";
+    assert_eq!(mask(source), [false, false, false, true, true, false]);
+}
+
+#[test]
+fn a_closed_literal_does_not_leak_into_later_lines() {
+    let source = "<div>\n  {{ `x` }}\n  <span>y</span>\n</div>";
+    assert_eq!(mask(source), [false, false, false, false]);
+}


### PR DESCRIPTION
Follow-up to #3338 (already merged), addressing review feedback on `compute_raw_line_mask`.

#3338 marked interpolation template-literal lines raw by toggling a single boolean on every backtick and dropping out of the interpolation on the first `}}`. That treats both bytes as structural wherever they appear, which is wrong in two real cases:

- `{{ "}}" + ` … ` }}` — the string's `}}` ended the interpolation, so the literal that follows was no longer tracked and its lines got indented back into the string's runtime value, the exact drift #3334 is about.
- a template literal nested inside a `${ … }` substitution — a boolean cannot represent the nesting, so the inner literal's closing backtick flipped the state off while the outer literal was still open.

The mask now lexes the expression instead: strings, `//` and `/* … */` comments, and a stack of template-literal / `${ … }` substitution frames, with `}}` closing the interpolation only in code position at the top level. A line is raw iff it begins in quasi text.

```rust
if matches!(self.frames.last(), Some(ExprFrame::TemplateLiteral)) {
    return match byte {
        b'\\' => cursor + 2,
        b'`' => { self.frames.pop(); cursor + 1 }
        b'$' if bytes.get(cursor + 1) == Some(&b'{') => {
            self.frames.push(ExprFrame::Substitution(0));
            cursor + 2
        }
        _ => cursor + 1,
    };
}
```

This is the same model `template_literal_quasi_line_starts` (#3247) already uses to answer the question for the formatted expression, so the two layers now agree on which lines are quasi text. Regex literals stay unmodelled in both.

Side effect: inside an interpolation, `<` is no longer probed as markup, so `{{ a<b }}` can no longer open a phantom tag scan.

Regressions added for the embedded `}}` string, the nested substitution literal, and a backtick inside a block comment. `cargo test -p vize_glyph --lib` (119 tests) and clippy are green; the integration suites could not be built in this sandbox (out of disk), so CI covers them.

Part of #3334

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of raw text around interpolations, including nested substitutions, template literals, strings, and block comments.
  * Prevented structural tokens inside embedded expressions from prematurely ending interpolation handling.
  * Improved line masking accuracy for complex nested interpolation scenarios.

* **Tests**
  * Added coverage for interpolation edge cases involving nested templates, comments, and JavaScript strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->