### PR TITLE
fix(vapor)!: keep the hydration index off the public IR struct

### DIFF
--- a/crates/vize_atelier_vapor/src/generate/context.rs
+++ b/crates/vize_atelier_vapor/src/generate/context.rs
@@ -4,6 +4,8 @@ use super::{
     destructure::{parse_destructure_bindings, parse_destructure_names, resolve_props_binding},
     expression,
 };
+
+mod complex_expression;
 use vize_atelier_core::options::BindingMetadata;
 use vize_carton::{FxHashMap, FxHashSet, String, ToCompactString, camelize, capitalize, cstr};
 use vize_croquis::builtins::is_global_allowed;
@@ -44,6 +46,12 @@ pub(crate) struct GenerateContext<'a> {
     pub(crate) delegate_events: FxHashSet<String>,
     /// Text node references (element_id -> text_node_var)
     pub(crate) text_nodes: FxHashMap<usize, String>,
+    /// Position of every node reached by a `ChildRef`/`NextRef` operation
+    /// (element_id -> (parent_id, absolute rendered index within the parent)).
+    /// Sibling navigation needs both to emit a hydration index (#3330), and a
+    /// `NextRef` only names its predecessor, so each operation records where it
+    /// landed for the next one to read.
+    node_positions: FxHashMap<usize, (usize, usize)>,
     /// Whether currently inside a non-root block (v-if, v-for)
     pub(crate) is_fragment: bool,
     /// For-loop scope stack
@@ -82,6 +90,7 @@ impl<'a> GenerateContext<'a> {
             used_helpers: FxHashSet::default(),
             delegate_events: FxHashSet::default(),
             text_nodes: FxHashMap::default(),
+            node_positions: FxHashMap::default(),
             is_fragment: false,
             for_scopes: std::vec::Vec::new(),
             slot_scopes: std::vec::Vec::new(),
@@ -94,6 +103,16 @@ impl<'a> GenerateContext<'a> {
         }
     }
 
+    /// Record where a node reference landed, for later sibling navigation.
+    pub(crate) fn record_node_position(&mut self, id: usize, parent_id: usize, index: usize) {
+        self.node_positions.insert(id, (parent_id, index));
+    }
+
+    /// Parent and absolute rendered index of a previously referenced node.
+    pub(crate) fn node_position(&self, id: usize) -> Option<(usize, usize)> {
+        self.node_positions.get(&id).copied()
+    }
+
     /// Resolve an expression, replacing for-loop aliases with _for_item/key references
     pub(crate) fn resolve_expression(&self, expr: &str) -> String {
         expression::resolve_expression(self, expr)
@@ -101,110 +120,7 @@ impl<'a> GenerateContext<'a> {
 
     /// Resolve complex expressions (object/array literals) by prefixing identifiers inside
     pub(super) fn resolve_complex_expression_fallback(&self, expr: &str) -> String {
-        let mut result = String::default();
-        let mut chars = expr.chars().peekable();
-        let mut in_string = false;
-        let mut string_char = ' ';
-        // Track whether we're in key position (after { or ,) vs value position (after :)
-        let mut in_object = false;
-        let mut is_key_position = false;
-
-        while let Some(&ch) = chars.peek() {
-            if in_string {
-                result.push(ch);
-                chars.next();
-                if ch == string_char {
-                    in_string = false;
-                }
-                continue;
-            }
-
-            match ch {
-                '"' | '\'' | '`' => {
-                    in_string = true;
-                    string_char = ch;
-                    result.push(ch);
-                    chars.next();
-                }
-                '{' => {
-                    in_object = true;
-                    is_key_position = true;
-                    result.push(ch);
-                    chars.next();
-                }
-                '}' => {
-                    in_object = false;
-                    result.push(ch);
-                    chars.next();
-                }
-                ':' => {
-                    is_key_position = false;
-                    result.push(ch);
-                    chars.next();
-                }
-                ',' => {
-                    if in_object {
-                        is_key_position = true;
-                    }
-                    result.push(ch);
-                    chars.next();
-                }
-                '[' => {
-                    // Computed property key: [expr] - contents should be prefixed
-                    if in_object && is_key_position {
-                        // Save state, temporarily treat as value position
-                        is_key_position = false;
-                    }
-                    result.push(ch);
-                    chars.next();
-                }
-                ']' => {
-                    // After computed key, we're back to key position until ':'
-                    if in_object {
-                        is_key_position = true;
-                    }
-                    result.push(ch);
-                    chars.next();
-                }
-                ' ' | '\n' | '\t' => {
-                    result.push(ch);
-                    chars.next();
-                }
-                _ => {
-                    // Collect identifier/value
-                    let mut ident = String::default();
-                    while let Some(&c) = chars.peek() {
-                        if c == ','
-                            || c == '}'
-                            || c == ']'
-                            || c == ':'
-                            || c == ' '
-                            || c == '\n'
-                            || c == '\t'
-                        {
-                            break;
-                        }
-                        ident.push(c);
-                        chars.next();
-                    }
-                    let trimmed_ident = ident.trim();
-                    if trimmed_ident.is_empty()
-                        || trimmed_ident == "true"
-                        || trimmed_ident == "false"
-                        || trimmed_ident == "null"
-                        || trimmed_ident == "undefined"
-                        || trimmed_ident.parse::<f64>().is_ok()
-                        || (in_object && is_key_position)
-                    {
-                        // Don't prefix: literals, empty, or object keys
-                        result.push_str(&ident);
-                    } else {
-                        result.push_str(&self.resolve_expression(trimmed_ident));
-                    }
-                }
-            }
-        }
-        result
+        complex_expression::resolve_complex_expression_fallback(self, expr)
     }
 
     pub(super) fn resolve_scope_binding(&self, name: &str) -> Option<String> {

--- a/crates/vize_atelier_vapor/src/generate/context/complex_expression.rs
+++ b/crates/vize_atelier_vapor/src/generate/context/complex_expression.rs
@@ -1,0 +1,116 @@
+//! Text-scanning fallback for object/array literal expressions.
+//!
+//! Walks the raw expression source and prefixes only the identifiers that sit
+//! in value position, leaving literals and object keys untouched.
+
+use vize_carton::String;
+
+use super::GenerateContext;
+
+/// Resolve complex expressions (object/array literals) by prefixing identifiers inside
+pub(super) fn resolve_complex_expression_fallback(ctx: &GenerateContext<'_>, expr: &str) -> String {
+    let mut result = String::default();
+    let mut chars = expr.chars().peekable();
+    let mut in_string = false;
+    let mut string_char = ' ';
+    // Track whether we're in key position (after { or ,) vs value position (after :)
+    let mut in_object = false;
+    let mut is_key_position = false;
+
+    while let Some(&ch) = chars.peek() {
+        if in_string {
+            result.push(ch);
+            chars.next();
+            if ch == string_char {
+                in_string = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' | '`' => {
+                in_string = true;
+                string_char = ch;
+                result.push(ch);
+                chars.next();
+            }
+            '{' => {
+                in_object = true;
+                is_key_position = true;
+                result.push(ch);
+                chars.next();
+            }
+            '}' => {
+                in_object = false;
+                result.push(ch);
+                chars.next();
+            }
+            ':' => {
+                is_key_position = false;
+                result.push(ch);
+                chars.next();
+            }
+            ',' => {
+                if in_object {
+                    is_key_position = true;
+                }
+                result.push(ch);
+                chars.next();
+            }
+            '[' => {
+                // Computed property key: [expr] - contents should be prefixed
+                if in_object && is_key_position {
+                    // Save state, temporarily treat as value position
+                    is_key_position = false;
+                }
+                result.push(ch);
+                chars.next();
+            }
+            ']' => {
+                // After computed key, we're back to key position until ':'
+                if in_object {
+                    is_key_position = true;
+                }
+                result.push(ch);
+                chars.next();
+            }
+            ' ' | '\n' | '\t' => {
+                result.push(ch);
+                chars.next();
+            }
+            _ => {
+                // Collect identifier/value
+                let mut ident = String::default();
+                while let Some(&c) = chars.peek() {
+                    if c == ','
+                        || c == '}'
+                        || c == ']'
+                        || c == ':'
+                        || c == ' '
+                        || c == '\n'
+                        || c == '\t'
+                    {
+                        break;
+                    }
+                    ident.push(c);
+                    chars.next();
+                }
+                let trimmed_ident = ident.trim();
+                if trimmed_ident.is_empty()
+                    || trimmed_ident == "true"
+                    || trimmed_ident == "false"
+                    || trimmed_ident == "null"
+                    || trimmed_ident == "undefined"
+                    || trimmed_ident.parse::<f64>().is_ok()
+                    || (in_object && is_key_position)
+                {
+                    // Don't prefix: literals, empty, or object keys
+                    result.push_str(&ident);
+                } else {
+                    result.push_str(&ctx.resolve_expression(trimmed_ident));
+                }
+            }
+        }
+    }
+    result
+}

--- a/crates/vize_atelier_vapor/src/generate/operations/refs.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/refs.rs
@@ -81,6 +81,9 @@ pub(super) fn generate_get_text_child(ctx: &mut GenerateContext, get_text: &GetT
 
 /// Generate ChildRef (_child helper)
 pub(super) fn generate_child_ref(ctx: &mut GenerateContext, child_ref: &ChildRefIRNode) {
+    // `offset` is the absolute rendered index within the parent. Record it so a
+    // `NextRef` hopping off this node can compute its own index (#3330).
+    ctx.record_node_position(child_ref.child_id, child_ref.parent_id, child_ref.offset);
     ctx.use_helper("child");
     if child_ref.offset == 0 {
         ctx.push_line_fmt(format_args!(
@@ -112,18 +115,38 @@ pub(super) fn generate_child_ref(ctx: &mut GenerateContext, child_ref: &ChildRef
 /// this node's **absolute** index so hydration resolves the same node — a
 /// literal `1` is only correct when the target happens to be the parent's
 /// second child (#3330).
+///
+/// The node only names its predecessor, so the parent and this node's absolute
+/// index come from the position the predecessor recorded: every sibling chain
+/// is anchored by a `ChildRef`, which knows both.
 pub(super) fn generate_next_ref(ctx: &mut GenerateContext, next_ref: &NextRefIRNode) {
-    let expr = if next_ref.offset > 1 {
-        ctx.use_helper("nthChild");
-        cstr!("_nthChild(n{}, {})", next_ref.parent_id, next_ref.index)
-    } else {
-        build_next_chain(
+    let position = ctx
+        .node_position(next_ref.prev_id)
+        .map(|(parent_id, prev_index)| (parent_id, prev_index + next_ref.offset));
+
+    let expr = match position {
+        Some((parent_id, index)) if next_ref.offset > 1 => {
+            ctx.use_helper("nthChild");
+            cstr!("_nthChild(n{}, {})", parent_id, index)
+        }
+        Some((_, index)) => {
+            build_next_chain(cstr!("n{}", next_ref.prev_id), next_ref.offset, index, ctx)
+        }
+        // Without an anchored predecessor there is no parent handle to look the
+        // node up on, so the hop stays relative and the index falls back to the
+        // offset. Sibling chains always start at a `ChildRef`, so this is only a
+        // safety net.
+        None => build_next_chain(
             cstr!("n{}", next_ref.prev_id),
             next_ref.offset,
-            next_ref.index,
+            next_ref.offset,
             ctx,
-        )
+        ),
     };
+
+    if let Some((parent_id, index)) = position {
+        ctx.record_node_position(next_ref.child_id, parent_id, index);
+    }
     ctx.push_line_fmt(format_args!("const n{} = {}", next_ref.child_id, expr));
 }
 

--- a/crates/vize_atelier_vapor/src/ir.rs
+++ b/crates/vize_atelier_vapor/src/ir.rs
@@ -333,13 +333,12 @@ pub struct ChildRefIRNode {
 /// and treats `i` as an absolute index into the parent while hydrating, so a
 /// jump of two or more must become `_nthChild(parent, index)` and a
 /// single-step jump must carry this node's real index — not a literal `1`
-/// (#3330). `parent_id` and `index` supply both.
+/// (#3330). The generator derives the parent and the absolute index by
+/// walking back to the `ChildRef` that anchors the sibling chain, so they do
+/// not have to be restated here.
 #[derive(Debug)]
 pub struct NextRefIRNode {
     pub child_id: usize,
     pub prev_id: usize,
-    pub parent_id: usize,
     pub offset: usize,
-    /// Absolute rendered index of this node within its parent.
-    pub index: usize,
 }

--- a/crates/vize_atelier_vapor/src/ir.rs
+++ b/crates/vize_atelier_vapor/src/ir.rs
@@ -336,6 +336,10 @@ pub struct ChildRefIRNode {
 /// (#3330). The generator derives the parent and the absolute index by
 /// walking back to the `ChildRef` that anchors the sibling chain, so they do
 /// not have to be restated here.
+///
+/// The short-lived `parent_id` and `index` fields from #3337 are gone again:
+/// this struct is externally constructible, so generation-only state belongs in
+/// the crate-private `GenerateContext` rather than on the public shape.
 #[derive(Debug)]
 pub struct NextRefIRNode {
     pub child_id: usize,

--- a/crates/vize_atelier_vapor/src/tests_sibling_navigation.rs
+++ b/crates/vize_atelier_vapor/src/tests_sibling_navigation.rs
@@ -18,7 +18,7 @@
 //! index in both modes — the same rule `@vue/compiler-vapor` follows.
 
 use super::compile_vapor;
-use vize_carton::{Bump, String, cstr};
+use vize_carton::{Bump, String};
 
 fn compile(template: &str) -> String {
     let allocator = Bump::new();
@@ -29,6 +29,35 @@ fn compile(template: &str) -> String {
         result.error_messages
     );
     result.code.clone()
+}
+
+/// Split every `_next(base, index)` call in `code` into its two arguments,
+/// balancing parentheses so a call base like `_child(n2)` stays intact. Calls
+/// without a top-level comma yield `None` as the index.
+fn next_calls(code: &str) -> Vec<(&str, Option<&str>)> {
+    let bytes = code.as_bytes();
+    let mut calls = Vec::new();
+    let mut from = 0;
+    while let Some(at) = code[from..].find("_next(") {
+        let open = from + at + "_next(".len();
+        let (mut depth, mut i, mut comma) = (1usize, open, None);
+        while i < bytes.len() && depth > 0 {
+            match bytes[i] {
+                b'(' => depth += 1,
+                b')' => depth -= 1,
+                b',' if depth == 1 && comma.is_none() => comma = Some(i),
+                _ => {}
+            }
+            i += 1;
+        }
+        let end = if depth == 0 { i - 1 } else { bytes.len() };
+        match comma {
+            Some(comma) => calls.push((&code[open..comma], Some(code[comma + 1..end].trim()))),
+            None => calls.push((&code[open..end], None)),
+        }
+        from = open;
+    }
+    calls
 }
 
 /// The reporter's minimal template (#3330): the compiler must navigate three
@@ -80,7 +109,12 @@ fn no_emitted_next_call_advances_more_than_one_sibling() {
         r#"<div><p/><p/><p/><span :id="x"><i/></span></div>"#,
         r#"<div><span :id="x"><i/></span><p/><p/><span :id="y"><i/></span></div>"#,
         r#"<div><p/><span :id="x"><i/></span><p/><p/><span :id="y"><i/></span><p/><span :id="z"><i/></span></div>"#,
+        // A nested parent: navigation inside `<section>` hangs off a `_child`
+        // of something other than the root, so the guard below must hold for
+        // every parent, not just `n1`.
+        r#"<div><section><p/><span :id="x"><i/></span><span :id="y"><i/></span></section><span :id="z"><i/></span></div>"#,
     ] {
+        let mut checked_child_bases = 0usize;
         let code = compile(template);
         assert!(
             code.contains("_next(") || code.contains("_nthChild("),
@@ -89,15 +123,24 @@ fn no_emitted_next_call_advances_more_than_one_sibling() {
         // Every `_next(base, i)` advances exactly one sibling at runtime, so
         // its second argument must never be read as a step count. The only
         // shapes the generator may emit are `_next(_child(nP), 1)` and
-        // `_next(nX, i)` for an adjacent hop; a `_next` starting from
-        // `_child` with an index above 1 is a counted jump — the #3330 defect.
-        for index in 2..=8 {
-            let counted = cstr!("_next(_child(n1), {})", index);
-            assert!(
-                !code.contains(counted.as_str()),
+        // `_next(nX, i)` for an adjacent hop; a `_next` starting from a
+        // `_child` of *any* parent with an index above 1 is a counted jump —
+        // the #3330 defect.
+        for (base, index) in next_calls(&code) {
+            if !base.starts_with("_child(") {
+                continue;
+            }
+            assert_eq!(
+                index,
+                Some("1"),
                 "a counted _next advances only one sibling at runtime:\n{template}\n{code}"
             );
+            checked_child_bases += 1;
         }
+        assert!(
+            checked_child_bases > 0 || code.contains("_nthChild("),
+            "expected a _child-anchored hop or an absolute lookup:\n{template}\n{code}"
+        );
     }
 }
 

--- a/crates/vize_atelier_vapor/src/transform/element/deferred.rs
+++ b/crates/vize_atelier_vapor/src/transform/element/deferred.rs
@@ -214,9 +214,7 @@ fn transform_dynamic_children_with_ids<'a>(
                 block.operation.push(OperationNode::NextRef(NextRefIRNode {
                     child_id,
                     prev_id: prev_child_id,
-                    parent_id,
                     offset: index.saturating_sub(prev_index),
-                    index,
                 }));
             } else {
                 block


### PR DESCRIPTION
Follow-up to #3337, which merged with `cargo-semver-checks (vize_atelier_vapor)` red ([run](https://github.com/ubugeeei-prod/vize/actions/runs/30425738724)). The hydration fix itself is correct and stays; only where the data lives changes.

`NextRefIRNode` gained `parent_id` and `index`, and the struct is externally constructible with no version bump, so `constructible_struct_adds_field` fires: any downstream `NextRefIRNode { .. }` literal stops compiling. Reverting the two fields and deriving both in the generator keeps the public API intact.

`GenerateContext` is crate-private, so it can carry the extra state safely. Every `ChildRef` records where it landed, and a `NextRef` reads its predecessor's entry to compute its own absolute index:

```rust
let position = ctx
    .node_position(next_ref.prev_id)
    .map(|(parent_id, prev_index)| (parent_id, prev_index + next_ref.offset));

let expr = match position {
    Some((parent_id, index)) if next_ref.offset > 1 => {
        ctx.use_helper("nthChild");
        cstr!("_nthChild(n{}, {})", parent_id, index)
    }
    Some((_, index)) => build_next_chain(cstr!("n{}", next_ref.prev_id), next_ref.offset, index, ctx),
    // Sibling chains always start at a `ChildRef`, so this is only a safety net.
    None => build_next_chain(cstr!("n{}", next_ref.prev_id), next_ref.offset, next_ref.offset, ctx),
};
```

Every sibling chain is anchored by a `ChildRef`, which knows both the parent and the child's absolute index, so the walk always has a starting point. Emitted code is byte-identical to the IR-field version: the five `tests_sibling_navigation` cases and the vapor snapshots pass unchanged.

The expression fallback scanner moves from `generate/context.rs` into a `generate/context/complex_expression.rs` submodule. `context.rs` is already above the 350-line limit, so the source-length ratchet rejects any growth; the move is mechanical and takes the file from 441 to 357 lines.

Removing the two fields is itself a public-API change against `main`, which now carries them, so the
gate needs the conventional breaking marker to accept it (the workflow passes `--release-type major`
when the title or body carries one).

BREAKING CHANGE: `NextRefIRNode` no longer exposes `parent_id` and `index`. Both were added in #3337
and were never released, so this restores the struct's published shape; the generator derives the
parent and the absolute index from the `ChildRef` that anchors the sibling chain instead.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
