### PR TITLE
chore(glyph): pin the formatting-breaks-suppression defect to #3343

### DIFF
--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -1,5 +1,12 @@
 [
   {
+    "property": "lint-agreement",
+    "project": "gogocode",
+    "path": "packages/gogocode-vue-playground/packages/vue2/src/components/keycode-modifiers/Comp.vue",
+    "rule": "a11y/form-control-has-label",
+    "issue": "https://github.com/ubugeeei-prod/vize/issues/3343"
+  },
+  {
     "property": "parse-preservation",
     "project": "crater",
     "path": "resources/scripts/components/base/BaseModal.vue",


### PR DESCRIPTION
The last `Real Project Matrix` failure blocking the release. `parse-preservation` and `idempotence` now pass; this is the remaining `lint-agreement` violation.

## The defect (#3343)

`gogocode` `…/keycode-modifiers/Comp.vue` goes from 2 to 3 `a11y/form-control-has-label` findings after `vize fmt`, because formatting splits a line that an `eslint-disable-next-line` was covering:

```diff
   <!--eslint-disable-next-line-->
-  custom space: <input v-on:keyup.custom="keys('custom keycode space')" />
+  custom space:
+  <input @keyup.custom='keys("custom keycode space")' />
```

"Next line" becomes the bare text `custom space:`, so the `<input>` is no longer suppressed and the rule fires. Formatting silently disabled a suppression the user wrote deliberately.

## This pin

One rule-scoped entry (`rule: "a11y/form-control-has-label"`), so the property stays strict for every other rule in that same file and for all 33,485 other files.

Verified: `glyph lint-agreement: 33486 file(s) across 129 project(s), 1 known violation(s) skipped, 0 violation(s)` — pass 4, fail 0.

Like the #3334 entries, this is a temporary suppression with an open issue behind it, not a resolution. #3343 lays out the two defensible fixes (formatter treats a suppressed line as unsplittable, or the linter anchors `disable-next-line` to the next element the way #3270 anchored `no-v-html`).

Part of #3343

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated accessibility test fixtures to recognize a known form-control labeling violation and maintain consistent lint results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->