### PR TITLE
chore(glyph): pin the directive-continuation idempotence drift to #3346

### DIFF
--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -1,5 +1,23 @@
 [
   {
+    "property": "idempotence",
+    "project": "dashy",
+    "path": "src/components/Settings/CustomThemeMaker.vue",
+    "issue": "https://github.com/ubugeeei-prod/vize/issues/3346"
+  },
+  {
+    "property": "idempotence",
+    "project": "scalar",
+    "path": "projects/scalar-app/src/features/collection/components/Environment.vue",
+    "issue": "https://github.com/ubugeeei-prod/vize/issues/3346"
+  },
+  {
+    "property": "idempotence",
+    "project": "vue-data-ui",
+    "path": "src/components/vue-ui-flow.vue",
+    "issue": "https://github.com/ubugeeei-prod/vize/issues/3346"
+  },
+  {
     "property": "lint-agreement",
     "project": "gogocode",
     "path": "packages/gogocode-vue-playground/packages/vue2/src/components/keycode-modifiers/Comp.vue",


### PR DESCRIPTION
The last `Real Project Matrix` failure. With this, all three glyph corpus properties report **0 violations**.

## The defect (#3346)

A multi-line directive expression whose value starts on the attribute's own line gains two spaces on its continuation line with **every** `vize fmt` pass:

```diff
 @input="customColors[colorName] = $event.target.value;
-              setVariable(colorName, $event.target.value)"
+                setVariable(colorName, $event.target.value)"
```

Unbounded drift — the attribute-value counterpart of the interpolation drift #3338 fixed.

**Pre-existing.** Reproduced with a binary built at `09e2504b4`, the commit before both raw-line-mask changes in this cycle (#3338, #3340), with byte-identical drift. Neither introduced it.

## This pin

Three entries, one per affected file: `dashy`, `scalar`, `vue-data-ui`. Explicit `{project, path}` pairs, no wildcard — the property stays strict on the other 33,480 files.

```
glyph idempotence: 33483 file(s) across 129 project(s), 3 known violation(s) skipped, 0 violation(s)
pass 3, fail 0
```

## Gate status after this

| property | violations | pinned |
|---|---|---|
| idempotence | 0 | 3 (#3346) |
| parse-preservation | 0 | 87 (#3334) |
| lint-agreement | 0 | 1 (#3343) |

All three pins are temporary suppressions with open issues behind them. The entry count is the progress metric — entries come out as each family is fixed, and #3338 already removed one family at the root rather than pinning it.

Part of #3346

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test fixtures covering known idempotence validation cases.
  * Linked the cases to the relevant tracking issue for improved test coverage and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->