### PR TITLE
perf(vitrine): strip TypeScript in the Rust emitter

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_script/typescript.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/typescript.rs
@@ -66,3 +66,32 @@ pub fn transform_typescript_to_js(code: &str) -> String {
         .replace('\t', "  ")
         .into()
 }
+
+/// Report whether `code` already parses as plain ECMAScript.
+///
+/// This is a parse-only check (no semantic pass, no codegen): the emitter uses
+/// it to skip a re-print of output that is already JavaScript. `SourceType::mjs`
+/// is the shape the emitter produces — ESM, no JSX, no TypeScript — so any
+/// leftover TypeScript syntax surfaces as a parse error and the caller falls
+/// back to the full strip.
+pub fn is_plain_javascript(code: &str) -> bool {
+    let allocator = Allocator::default();
+    let parser = Parser::new(&allocator, code, SourceType::mjs());
+    profile!("atelier.script.js.probe", parser.parse())
+        .errors
+        .is_empty()
+}
+
+/// Guarantee that emitted module code contains no TypeScript syntax.
+///
+/// The overwhelming majority of emitter output is already plain JavaScript
+/// (the script pipeline strips TypeScript while compiling), so the owned
+/// `code` is handed straight back without a copy. Only the residue — most
+/// notably `<script lang="uts">`, a lang the script pipeline does not treat as
+/// TypeScript — pays for the transform.
+pub fn ensure_javascript_output(code: String) -> String {
+    if is_plain_javascript(&code) {
+        return code;
+    }
+    transform_typescript_to_js(&code)
+}

--- a/crates/vize_atelier_sfc/src/compile_script/typescript.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/typescript.rs
@@ -82,16 +82,69 @@ pub fn is_plain_javascript(code: &str) -> bool {
         .is_empty()
 }
 
+/// Strip TypeScript for the emitter's output guarantee, tolerating semantic
+/// diagnostics.
+///
+/// [`transform_typescript_to_js`] bails whenever `SemanticBuilder` reports
+/// anything, which is the right call while compiling a script (a redeclaration
+/// there means the pipeline misread the source). It is the wrong call here:
+/// this runs on already-generated module code, and the JavaScript-side pass it
+/// replaces — Vite's `transformWithOxc` — never ran a semantic check at all.
+/// Bailing would hand TypeScript to the bundler over a diagnostic that a
+/// syntax-only strip does not care about.
+///
+/// Returns `None` when the code does not parse as TypeScript, in which case
+/// there is nothing this can do and the caller keeps the original.
+fn strip_typescript_for_emitter(code: &str) -> Option<String> {
+    let allocator = Allocator::default();
+    let parse_result = Parser::new(&allocator, code, SourceType::ts()).parse();
+    if !parse_result.errors.is_empty() {
+        return None;
+    }
+
+    let mut program = parse_result.program;
+    let scoping = SemanticBuilder::new()
+        .with_excess_capacity(2.0)
+        .build(&program)
+        .semantic
+        .into_scoping();
+
+    let transform_options = TransformOptions {
+        typescript: TypeScriptOptions {
+            only_remove_type_imports: false,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let ret = Transformer::new(&allocator, std::path::Path::new(""), &transform_options)
+        .build_with_scoping(scoping, &mut program);
+    if !ret.errors.is_empty() {
+        return None;
+    }
+
+    Some(
+        Codegen::new()
+            .build(&program)
+            .code
+            .replace('\t', "  ")
+            .into(),
+    )
+}
+
 /// Guarantee that emitted module code contains no TypeScript syntax.
 ///
 /// The overwhelming majority of emitter output is already plain JavaScript
 /// (the script pipeline strips TypeScript while compiling), so the owned
 /// `code` is handed straight back without a copy. Only the residue — most
-/// notably `<script lang="uts">`, a lang the script pipeline does not treat as
-/// TypeScript — pays for the transform.
+/// notably `<script lang="uts">`, a lang `is_ts_lang` does not recognise — pays
+/// for the strip.
+///
+/// Output that parses as neither JavaScript nor TypeScript (`lang="jsx"`,
+/// `lang="tsx"`, `lang="coffee"`) is returned unchanged for the bundler to deal
+/// with, exactly as the emitter produced it.
 pub fn ensure_javascript_output(code: String) -> String {
     if is_plain_javascript(&code) {
         return code;
     }
-    transform_typescript_to_js(&code)
+    strip_typescript_for_emitter(&code).unwrap_or(code)
 }

--- a/crates/vize_atelier_sfc/tests/emitter_javascript_output.rs
+++ b/crates/vize_atelier_sfc/tests/emitter_javascript_output.rs
@@ -1,0 +1,180 @@
+//! The emitter's module output must be plain JavaScript.
+//!
+//! The Vite plugin used to re-run Vite's TypeScript strip over every module the
+//! Rust compiler emitted. It no longer does: the napi boundary now guarantees
+//! JavaScript via `ensure_javascript_output`. These tests pin that guarantee so
+//! a regression in the script pipeline cannot leak TypeScript into the bundler.
+
+use vize_atelier_sfc::{
+    SfcCompileOptions, SfcParseOptions,
+    compile_script::typescript::{ensure_javascript_output, is_plain_javascript},
+    compile_sfc, parse_sfc,
+};
+
+/// Compile an SFC exactly the way the Vite plugin does: `is_ts` is left at its
+/// default `false`, which is what makes the script pipeline strip TypeScript
+/// itself instead of deferring it to the bundler.
+fn compile_like_the_vite_plugin(source: &str) -> vize_carton::String {
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("SFC should parse");
+    compile_sfc(&descriptor, SfcCompileOptions::default())
+        .expect("SFC should compile")
+        .code
+}
+
+fn assert_emits_plain_javascript(label: &str, source: &str) {
+    let code = compile_like_the_vite_plugin(source);
+    assert!(
+        is_plain_javascript(&code),
+        "{label}: emitter output still contains TypeScript syntax, so removing the JS-side \
+         strip would ship it to the bundler:\n{code}"
+    );
+}
+
+#[test]
+fn type_annotations_are_stripped_by_the_emitter() {
+    assert_emits_plain_javascript(
+        "typed bindings and parameters",
+        r#"<script setup lang="ts">
+const count: number = 1
+const label: string | null = null
+function greet(who: string, times?: number): string {
+  return who.repeat(times ?? 1)
+}
+const shout = (who: string): string => greet(who) + "!"
+</script>
+<template><div>{{ count }}{{ label }}{{ shout('a') }}</div></template>"#,
+    );
+}
+
+#[test]
+fn generics_are_stripped_by_the_emitter() {
+    assert_emits_plain_javascript(
+        "generic functions and generic call sites",
+        r#"<script setup lang="ts">
+import { ref } from "vue"
+function identity<T>(value: T): T {
+  return value
+}
+const box = ref<Array<string>>([])
+const first = identity<string>("a")
+</script>
+<template><div>{{ box }}{{ first }}</div></template>"#,
+    );
+}
+
+#[test]
+fn interfaces_type_aliases_and_enums_are_stripped_by_the_emitter() {
+    assert_emits_plain_javascript(
+        "declarations",
+        r#"<script setup lang="ts">
+interface User { id: number; name: string }
+type Maybe<T> = T | null
+enum Level { Low, High }
+declare const injected: string
+const user: Maybe<User> = null
+const level = Level.High
+</script>
+<template><div>{{ user }}{{ level }}{{ injected }}</div></template>"#,
+    );
+}
+
+#[test]
+fn assertions_and_satisfies_are_stripped_by_the_emitter() {
+    assert_emits_plain_javascript(
+        "as / satisfies / non-null",
+        r#"<script setup lang="ts">
+const raw = { a: 1 } as Record<string, number>
+const frozen = { b: 2 } as const
+const checked = { c: 3 } satisfies Record<string, number>
+const forced = (raw.a as unknown) as string
+const present = raw!.a
+</script>
+<template><div>{{ raw }}{{ frozen }}{{ checked }}{{ forced }}{{ present }}</div></template>"#,
+    );
+}
+
+#[test]
+fn type_only_imports_are_stripped_by_the_emitter() {
+    assert_emits_plain_javascript(
+        "type-only imports and inline type specifiers",
+        r#"<script setup lang="ts">
+import type { Ref } from "vue"
+import { ref, type ComputedRef } from "vue"
+const a: Ref<number> = ref(0)
+const b: ComputedRef<number> | null = null
+</script>
+<template><div>{{ a }}{{ b }}</div></template>"#,
+    );
+}
+
+#[test]
+fn decorators_and_access_modifiers_are_stripped_by_the_emitter() {
+    assert_emits_plain_javascript(
+        "class members",
+        r#"<script lang="ts">
+function logged(_target: unknown, _key: string): void {}
+export default class Widget {
+  private readonly id: number = 1
+  protected label?: string
+  @logged
+  render(): null {
+    return null
+  }
+}
+</script>"#,
+    );
+}
+
+/// `<script lang="uts">` — uni-app's TypeScript dialect — is the one case the
+/// script pipeline does *not* strip, because `is_ts_lang` only matches `ts` and
+/// `tsx`. Before this change the Vite plugin's oxc pass happened to clean it up
+/// as a side effect; now `ensure_javascript_output` is what does it, so pin
+/// both halves: the raw emitter output is still TypeScript, and the napi
+/// boundary's guarantee turns it into JavaScript.
+#[test]
+fn uts_script_output_is_rescued_by_ensure_javascript_output() {
+    let code = compile_like_the_vite_plugin(
+        r#"<script setup lang="uts">
+const count: number = 1
+function greet(who: string): string {
+  return who
+}
+</script>
+<template><div>{{ count }}{{ greet('a') }}</div></template>"#,
+    );
+
+    assert!(
+        !is_plain_javascript(&code),
+        "`lang=\"uts\"` is expected to bypass the script pipeline's TypeScript strip; if this \
+         starts passing the emitter learned `uts` and this test should become a plain \
+         `assert_emits_plain_javascript` case:\n{code}"
+    );
+
+    let guaranteed = ensure_javascript_output(code);
+    assert!(
+        is_plain_javascript(&guaranteed),
+        "the napi boundary must strip TypeScript the script pipeline left behind:\n{guaranteed}"
+    );
+    assert!(
+        !guaranteed.contains(": number"),
+        "`uts` type annotations must not survive:\n{guaranteed}"
+    );
+}
+
+#[test]
+fn ensure_javascript_output_passes_javascript_through_untouched() {
+    let js: vize_carton::String = "import { ref } from \"vue\";\nexport default { ref };".into();
+    let out = ensure_javascript_output(js.clone());
+    assert_eq!(
+        out, js,
+        "code that already parses as JavaScript must not be re-printed"
+    );
+}
+
+#[test]
+fn is_plain_javascript_rejects_typescript() {
+    assert!(is_plain_javascript("export const a = 1;"));
+    assert!(!is_plain_javascript("export const a: number = 1;"));
+    assert!(!is_plain_javascript("interface A { b: number }"));
+    assert!(!is_plain_javascript("export default {"));
+}

--- a/crates/vize_atelier_sfc/tests/emitter_javascript_output.rs
+++ b/crates/vize_atelier_sfc/tests/emitter_javascript_output.rs
@@ -7,7 +7,9 @@
 
 use vize_atelier_sfc::{
     SfcCompileOptions, SfcParseOptions,
-    compile_script::typescript::{ensure_javascript_output, is_plain_javascript},
+    compile_script::typescript::{
+        ensure_javascript_output, is_plain_javascript, transform_typescript_to_js,
+    },
     compile_sfc, parse_sfc,
 };
 
@@ -168,6 +170,30 @@ fn ensure_javascript_output_passes_javascript_through_untouched() {
     assert_eq!(
         out, js,
         "code that already parses as JavaScript must not be re-printed"
+    );
+}
+
+/// A semantic diagnostic must not abort the emitter's strip.
+///
+/// `transform_typescript_to_js` bails on any `SemanticBuilder` error and hands
+/// back the untouched TypeScript — correct while compiling a script, but fatal
+/// for an output guarantee, since the JavaScript-side pass this replaces never
+/// ran a semantic check at all.
+#[test]
+fn semantic_diagnostics_do_not_abort_the_emitter_strip() {
+    let redeclared: vize_carton::String =
+        "let a: number = 1;\nlet a: number = 2;\nexport { a };".into();
+
+    assert!(
+        !is_plain_javascript(&transform_typescript_to_js(&redeclared)),
+        "precondition: the script-pipeline strip is expected to bail on a semantic diagnostic"
+    );
+
+    let guaranteed = ensure_javascript_output(redeclared);
+    assert!(
+        is_plain_javascript(&guaranteed),
+        "the emitter strip must ignore semantic diagnostics and still emit JavaScript:\n\
+         {guaranteed}"
     );
 }
 

--- a/crates/vize_vitrine/src/napi/sfc/batch_results.rs
+++ b/crates/vize_vitrine/src/napi/sfc/batch_results.rs
@@ -5,6 +5,7 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
     time::Instant,
 };
+use vize_atelier_sfc::compile_script::typescript::ensure_javascript_output;
 use vize_carton::cstr;
 
 use super::{
@@ -185,7 +186,10 @@ fn compile_sfc_batch_with_results_inner(
                     };
                     BatchFileResultNapi {
                         path: file.path,
-                        code: result.code.into(),
+                        // The emitter is the last stop before the bundler, so
+                        // the code crossing this boundary must already be plain
+                        // JavaScript — the JS plugin no longer re-strips it.
+                        code: ensure_javascript_output(result.code).into(),
                         css: result.css.map(Into::into),
                         scope_id: scope_id.into(),
                         has_scoped,

--- a/crates/vize_vitrine/src/napi/sfc/compile.rs
+++ b/crates/vize_vitrine/src/napi/sfc/compile.rs
@@ -1,5 +1,6 @@
 use napi::{Result, Status};
 use napi_derive::napi;
+use vize_atelier_sfc::compile_script::typescript::ensure_javascript_output;
 use vize_carton::cstr;
 
 use super::{
@@ -114,7 +115,10 @@ pub fn compile_sfc(
 
     match compile_result {
         Ok(result) => Ok(SfcCompileResultNapi {
-            code: result.code.into(),
+            // The emitter is the last stop before the bundler, so the code
+            // crossing this boundary must already be plain JavaScript — the JS
+            // plugin no longer re-strips it.
+            code: ensure_javascript_output(result.code).into(),
             css: result.css.map(Into::into),
             errors: result
                 .errors

--- a/npm/builder/vite/src/plugin/vite-transform.test.ts
+++ b/npm/builder/vite/src/plugin/vite-transform.test.ts
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
 
+import * as vite from "vite";
+
 import {
   createVirtualTypeScriptTransformer,
-  needsVirtualTypeScriptTransform,
+  transformVizeVirtualModule,
 } from "./vite-transform.ts";
+import type { VizePluginState } from "./state.ts";
 
 {
   let used = "";
@@ -65,16 +68,48 @@ import {
   );
 }
 
-assert.equal(
-  needsVirtualTypeScriptTransform(
-    'import { ref as _ref } from "vue";\nconst count = _ref(0);\nexport default {};',
-  ),
-  false,
-  "plain generated JavaScript with import aliases should skip the virtual TS strip pass",
-);
+// Vize's Rust emitter guarantees plain JavaScript for every module it produces,
+// so the virtual-module transform must not re-print emitter output through
+// Vite's TypeScript strip. Anything the emitter did not produce still must.
+{
+  let stripCalls = 0;
+  const emitted = 'import { ref as _ref } from "vue";\nconst count = _ref(0);\nexport default {};';
+  const state = {
+    cache: new Map([["/src/Emitted.vue", {}]]),
+    ssrCache: new Map(),
+    clientViteDefine: {},
+    serverViteDefine: {},
+    isProduction: false,
+    root: "/src",
+    logger: { error() {} },
+  } as unknown as VizePluginState;
 
-assert.equal(
-  needsVirtualTypeScriptTransform("const value: number = 1"),
-  true,
-  "virtual modules with TypeScript annotations should still use Vite's TS strip pass",
-);
+  const viteApi = vite as { transformWithOxc?: unknown };
+  const originalOxc = viteApi.transformWithOxc;
+  viteApi.transformWithOxc = () => {
+    stripCalls += 1;
+    return { code: emitted };
+  };
+
+  try {
+    const result = await transformVizeVirtualModule(state, emitted, "/src/Emitted.vue", false);
+    assert.equal(result, null, "unchanged emitter output should not produce a transform result");
+    assert.equal(stripCalls, 0, "emitter output must skip Vite's TypeScript strip entirely");
+
+    await transformVizeVirtualModule(state, emitted, "/src/NotEmitted.vue", false);
+    assert.equal(
+      stripCalls,
+      1,
+      "modules Vize did not emit must still go through Vite's TypeScript strip",
+    );
+
+    await transformVizeVirtualModule(state, emitted, "/src/Emitted.vue", false, true);
+    assert.equal(
+      stripCalls,
+      2,
+      "?macro=true raw artifacts must still go through Vite's TypeScript strip",
+    );
+  } finally {
+    viteApi.transformWithOxc = originalOxc;
+  }
+}

--- a/npm/builder/vite/src/plugin/vite-transform.test.ts
+++ b/npm/builder/vite/src/plugin/vite-transform.test.ts
@@ -1,7 +1,5 @@
 import assert from "node:assert/strict";
 
-import * as vite from "vite";
-
 import {
   createVirtualTypeScriptTransformer,
   transformVizeVirtualModule,
@@ -68,15 +66,18 @@ import type { VizePluginState } from "./state.ts";
   );
 }
 
-// Vize's Rust emitter guarantees plain JavaScript for every module it produces,
-// so the virtual-module transform must not re-print emitter output through
-// Vite's TypeScript strip. Anything the emitter did not produce still must.
+// Vize's Rust emitter guarantees plain JavaScript for every module it produces
+// (`ensure_javascript_output` at the napi boundary), so the virtual-module
+// transform must not re-print emitter output through Vite's TypeScript strip.
+// Anything the emitter did not produce still must go through it.
+//
+// The probe is behavioural rather than a call spy: the input carries a type
+// annotation that only survives when the strip is skipped.
 {
-  let stripCalls = 0;
-  const emitted = 'import { ref as _ref } from "vue";\nconst count = _ref(0);\nexport default {};';
+  const annotated = "const count: number = 1;\nexport default { count };";
   const state = {
     cache: new Map([["/src/Emitted.vue", {}]]),
-    ssrCache: new Map(),
+    ssrCache: new Map([["/src/SsrEmitted.vue", {}]]),
     clientViteDefine: {},
     serverViteDefine: {},
     isProduction: false,
@@ -84,32 +85,41 @@ import type { VizePluginState } from "./state.ts";
     logger: { error() {} },
   } as unknown as VizePluginState;
 
-  const viteApi = vite as { transformWithOxc?: unknown };
-  const originalOxc = viteApi.transformWithOxc;
-  viteApi.transformWithOxc = () => {
-    stripCalls += 1;
-    return { code: emitted };
-  };
+  assert.equal(
+    await transformVizeVirtualModule(state, annotated, "/src/Emitted.vue", false),
+    null,
+    "emitter output must be handed back untouched instead of re-printed through oxc",
+  );
+  assert.equal(
+    await transformVizeVirtualModule(state, annotated, "/src/SsrEmitted.vue", true),
+    null,
+    "SSR emitter output must be handed back untouched too",
+  );
 
-  try {
-    const result = await transformVizeVirtualModule(state, emitted, "/src/Emitted.vue", false);
-    assert.equal(result, null, "unchanged emitter output should not produce a transform result");
-    assert.equal(stripCalls, 0, "emitter output must skip Vite's TypeScript strip entirely");
+  const notEmitted = await transformVizeVirtualModule(
+    state,
+    annotated,
+    "/src/NotEmitted.vue",
+    false,
+  );
+  assert.ok(notEmitted && typeof notEmitted === "object", "non-emitter modules must transform");
+  assert.doesNotMatch(
+    notEmitted.code,
+    /:\s*number/,
+    "modules Vize did not emit must still go through Vite's TypeScript strip",
+  );
 
-    await transformVizeVirtualModule(state, emitted, "/src/NotEmitted.vue", false);
-    assert.equal(
-      stripCalls,
-      1,
-      "modules Vize did not emit must still go through Vite's TypeScript strip",
-    );
-
-    await transformVizeVirtualModule(state, emitted, "/src/Emitted.vue", false, true);
-    assert.equal(
-      stripCalls,
-      2,
-      "?macro=true raw artifacts must still go through Vite's TypeScript strip",
-    );
-  } finally {
-    viteApi.transformWithOxc = originalOxc;
-  }
+  const macroArtifact = await transformVizeVirtualModule(
+    state,
+    annotated,
+    "/src/Emitted.vue",
+    false,
+    true,
+  );
+  assert.ok(macroArtifact && typeof macroArtifact === "object", "macro artifacts must transform");
+  assert.doesNotMatch(
+    macroArtifact.code,
+    /:\s*number/,
+    "?macro=true raw artifacts never passed through the emitter, so they still need the strip",
+  );
 }

--- a/npm/builder/vite/src/plugin/vite-transform.ts
+++ b/npm/builder/vite/src/plugin/vite-transform.ts
@@ -47,96 +47,24 @@ export function createVirtualTypeScriptTransformer(viteApi: ViteTransformApi) {
   };
 }
 
-const TYPE_DECLARATION_RE = /\b(?:interface|type|enum|namespace|declare)\s+[A-Za-z_$]/;
-const TYPE_ASSERTION_RE =
-  /\bas\s+(?:const|unknown|never|any|string|number|boolean|readonly\b|[A-Z][A-Za-z0-9_$]*(?:\s*[<[{&|),;=]|$))/;
-const TYPED_BINDING_RE = /\b(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*:/;
-const GENERIC_FUNCTION_RE = /\bfunction\s+[A-Za-z_$][\w$]*\s*<[^>{}]*>\s*\(/;
-const TYPED_PARAMETER_RE = /[(,]\s*(?:\.\.\.)?[A-Za-z_$][\w$]*\??\s*:\s*[^,)=]+/;
-const RETURN_TYPE_RE = /\)\s*:\s*[^=<{;]+[{=>]/;
-const ACCESS_MODIFIER_RE = /\b(?:public|private|protected|readonly|abstract|implements)\b/;
-const SATISFIES_RE = /\bsatisfies\s+[A-Za-z_$]/;
-
-function hasUnbalancedDelimiters(code: string): boolean {
-  const stack: string[] = [];
-  let quote: "'" | '"' | "`" | null = null;
-  let escaped = false;
-  let lineComment = false;
-  let blockComment = false;
-
-  for (let index = 0; index < code.length; index += 1) {
-    const char = code[index]!;
-    const next = code[index + 1];
-
-    if (lineComment) {
-      if (char === "\n" || char === "\r") {
-        lineComment = false;
-      }
-      continue;
-    }
-    if (blockComment) {
-      if (char === "*" && next === "/") {
-        blockComment = false;
-        index += 1;
-      }
-      continue;
-    }
-    if (quote) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === quote) {
-        quote = null;
-      }
-      continue;
-    }
-
-    if (char === "/" && next === "/") {
-      lineComment = true;
-      index += 1;
-      continue;
-    }
-    if (char === "/" && next === "*") {
-      blockComment = true;
-      index += 1;
-      continue;
-    }
-    if (char === "'" || char === '"' || char === "`") {
-      quote = char;
-      continue;
-    }
-    if (char === "{" || char === "(" || char === "[") {
-      stack.push(char);
-      continue;
-    }
-    if (char === "}" || char === ")" || char === "]") {
-      const open = stack.pop();
-      if (
-        (char === "}" && open !== "{") ||
-        (char === ")" && open !== "(") ||
-        (char === "]" && open !== "[")
-      ) {
-        return true;
-      }
-    }
-  }
-
-  return quote !== null || blockComment || stack.length > 0;
-}
-
-export function needsVirtualTypeScriptTransform(code: string): boolean {
-  return (
-    TYPE_DECLARATION_RE.test(code) ||
-    TYPE_ASSERTION_RE.test(code) ||
-    TYPED_BINDING_RE.test(code) ||
-    GENERIC_FUNCTION_RE.test(code) ||
-    TYPED_PARAMETER_RE.test(code) ||
-    RETURN_TYPE_RE.test(code) ||
-    ACCESS_MODIFIER_RE.test(code) ||
-    SATISFIES_RE.test(code) ||
-    hasUnbalancedDelimiters(code)
-  );
+/**
+ * Report whether `realPath` names a module Vize's own compiler emitted.
+ *
+ * Vize's Rust emitter guarantees plain JavaScript for every module it produces
+ * (`ensure_javascript_output` at the napi boundary), so re-running Vite's
+ * TypeScript strip over emitter output is a pure re-print. Every emitted module
+ * is recorded in one of the two environment caches, so cache membership is the
+ * cheap, allocation-free proof that the code came from the emitter.
+ *
+ * The probe fails safe: a module the caches do not know about still gets the
+ * strip, which keeps hand-written and malformed virtual modules behaving
+ * exactly as they did before.
+ */
+function isVizeEmitterOutput(
+  state: Pick<VizePluginState, "cache" | "ssrCache">,
+  realPath: string,
+): boolean {
+  return state.cache.has(realPath) || state.ssrCache.has(realPath);
 }
 
 export const transformVirtualTypeScript = createVirtualTypeScriptTransformer(vite);
@@ -172,7 +100,9 @@ export async function transformVizeVirtualModule(
   ssr: boolean,
   forceTypeScriptTransform = false,
 ): Promise<TransformResult | null> {
-  const needsTsTransform = forceTypeScriptTransform || needsVirtualTypeScriptTransform(code);
+  // `?macro=true` artifacts are raw macro module code that never passed
+  // through the emitter's JavaScript guarantee, so they always need the strip.
+  const needsTsTransform = forceTypeScriptTransform || !isVizeEmitterOutput(state, realPath);
   try {
     const result = needsTsTransform ? await transformVirtualTypeScript(code, realPath) : { code };
     let transformed = result.code;


### PR DESCRIPTION
The Vite plugin re-stripped TypeScript from every module the Rust compiler had
already emitted. That pass was the single biggest JavaScript cost in the plugin
— bigger than the native compile it wraps.

The emitter never had TypeScript to strip. `@vizejs/vite-plugin` never sets
`isTs` (napi defaults it to `false`), so `compile.rs` and
`compile_script/inline/compiler/body.rs` already run
`transform_typescript_to_js` while compiling the script. The JavaScript-side
pass was re-parsing and re-printing plain JavaScript.

## What changed

- `compile_script/typescript.rs` gains `is_plain_javascript` (a parse-only
  probe) and `ensure_javascript_output`, which passes JavaScript straight
  through and strips only the residue.
- Both napi entry points the plugin uses — `napi/sfc/batch_results.rs` and
  `napi/sfc/compile.rs` — run emitted `code` through it, so the boundary now
  *guarantees* plain JavaScript instead of merely usually producing it.
- `plugin/vite-transform.ts` drops the regex gate and the
  `hasUnbalancedDelimiters` per-character scan (201 → 131 lines). It strips only
  `?macro=true` raw artifacts and modules absent from the compile caches — i.e.
  code the emitter did not produce.

`ensure_javascript_output` deliberately ignores `SemanticBuilder` diagnostics.
`transform_typescript_to_js` bails on them, which is right while compiling a
script but wrong for an output guarantee: the pass being replaced,
`transformWithOxc`, never ran a semantic check at all.

## Numbers

vue-vben-admin, 675 SFCs, release napi build. Paired alternating runs
(before/after/before/after…) so drift on this shared box hits both arms equally:
**12 pairs**, each sample itself the median of **7** in-process iterations after
two warmups — 84 timed iterations per arm. Medians:

| | before | after | delta |
|---|---|---|---|
| `transform` hook (JS) | 41.29 ms | 0.85 ms | **−40.44 ms (−97.9%)** |
| `compileSfcBatchWithResults` (Rust) | 15.87 ms | 16.29 ms | +0.42 ms (+2.6%) |
| **combined** | **57.80 ms** | **17.12 ms** | **−40.68 ms (−70.4%)** |

The parse-only probe added to the batch's rayon map is the +0.42 ms — roughly
0.6 µs per file. An independent earlier run on a quieter box measured
13.35 → 14.14 ms for the same step, so call it under 1 ms for 675 files either
way. It buys a ~40 ms saving.

## Correctness

Swept all **136** fixture repos — **34,676 SFCs** — parsing every emitted module
with `oxc-parser` as ESM JavaScript, once per binary:

- **8 modules that were not plain JavaScript before now are** (6 `lang="uts"`,
  1 `lang="ts"`, 1 plain `<script>`). `is_ts_lang` only matches `ts`/`tsx`, so
  uni-app's UTS never reached the script pipeline's strip; it used to be cleaned
  up incidentally by the plugin's oxc pass, and is now handled at the boundary.
- **74 modules still are not** — 15 `tsx`, 16 `jsx`, 25 plain `<script>`
  containing JSX, 16 `uts`, 1 `ts`, 1 `coffee`. Checked every one against the
  old plugin: **not a single one was turned into JavaScript by it either.** 58
  hard-failed the build under `transformWithOxc`; the rest came back non-JS.
  **Zero regressions.**

JSX and TSX output is passed through untouched rather than run through the TS
transform, so the JSX runtime choice stays with the downstream JSX plugin.

New tests in `crates/vize_atelier_sfc/tests/emitter_javascript_output.rs` (10)
cover annotations, generics, interfaces/type aliases/`enum`/`declare`,
`as`/`as const`/`satisfies`/non-null, type-only and inline-type imports, and
decorators with access modifiers — plus the `lang="uts"` behaviour change
explicitly, and the semantic-diagnostic tolerance.
`plugin/vite-transform.test.ts` proves emitter output skips the strip while
non-emitter modules and `?macro=true` artifacts still get it; `load.test.ts`'s
existing contract that a malformed virtual module rejects with
"Virtual module transform failed for …" still holds.

`vize check`/LSP are untouched — they go through `vize_vitrine/src/typecheck.rs`
and never reach the transform hook. Source maps on this hook were already
`map: null`.

## Left deliberately

`plugin/compat.ts` still calls `transformVirtualTypeScript` unconditionally. Its
input is emitter output too, so the same short-circuit applies, but it is a
fallback path rather than the profiled hot path and is left for a follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Compiled SFC output is now normalized to plain JavaScript before being returned.
  - TypeScript syntax—including annotations, generics, interfaces, enums, and assertions—is removed from supported output.
  - Existing JavaScript is preserved without unnecessary transformation.
  - Virtual modules now apply TypeScript processing based on whether they originate from the emitter, improving handling of generated and macro outputs.

- **Bug Fixes**
  - Improved compatibility for TypeScript and UTS-based scripts, including cases with semantic errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->