### PR TITLE
fix(maestro): answer template hovers from the live type backend

### DIFF
--- a/crates/vize_canon/src/lsp_client.rs
+++ b/crates/vize_canon/src/lsp_client.rs
@@ -16,6 +16,7 @@ mod bootstrap;
 mod diagnostics;
 mod diagnostics_api;
 mod diagnostics_lsp;
+mod editor_lsp;
 mod lifecycle;
 mod lifecycle_setup;
 mod materialized_refresh;
@@ -50,6 +51,9 @@ pub struct CorsaProjectClient {
     external_document_uris: FxHashMap<String, String>,
     /// Temporary directory for tsconfig.json (cleaned up on drop).
     temp_dir: Option<PathBuf>,
+    /// Lazily spawned `--lsp --stdio` session answering editor requests the
+    /// project-session API rejects as unsupported (corsa-bind#409).
+    editor_lsp: Option<editor_lsp::EditorLspSession>,
     closed: bool,
 }
 

--- a/crates/vize_canon/src/lsp_client/bootstrap.rs
+++ b/crates/vize_canon/src/lsp_client/bootstrap.rs
@@ -55,6 +55,7 @@ impl CorsaProjectClient {
             session_document_uris: Default::default(),
             external_document_uris: Default::default(),
             temp_dir,
+            editor_lsp: None,
             closed: false,
         })
     }
@@ -104,6 +105,9 @@ impl CorsaProjectClient {
             self.remember_session_document_uri(uri.as_str(), document_uri);
         }
         self.materialized_project_session = true;
+        // The overlay root moved, so the editor session must be respawned
+        // against the materialized tree on the next request.
+        self.retire_editor_lsp();
         Ok(())
     }
 }

--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -1,0 +1,188 @@
+//! Editor-feature fallback over Corsa's `--lsp --stdio` transport.
+//!
+//! The project-session API exposes diagnostics but rejects `hover` (and the
+//! other editor requests) as `CorsaError::Unsupported` on every pinned runtime
+//! — see ubugeeei-prod/corsa-bind#409. The very same runtime does advertise
+//! `hoverProvider` over its LSP transport, so editor features route through a
+//! second, lazily spawned session that mirrors the virtual documents in.
+//!
+//! The session is lazy on purpose: typecheck-only runs (the common case) never
+//! pay for the extra process, and a session that has answered one hover is
+//! reused for every later request.
+
+use super::{CorsaProjectClient, diagnostics_lsp::initialize_lsp_client};
+use corsa::{
+    jsonrpc::InboundEvent,
+    lsp::{LspClient, LspOverlay, LspSpawnConfig, VirtualDocument},
+    runtime::block_on,
+};
+use lsp_types::Uri;
+use serde_json::Value;
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+use vize_carton::{FxHashMap, String, cstr};
+
+struct RawHoverRequest;
+
+impl lsp_types::request::Request for RawHoverRequest {
+    type Params = Value;
+    type Result = Option<Value>;
+    const METHOD: &'static str = "textDocument/hover";
+}
+
+/// A reusable `--lsp --stdio` session used only for editor requests.
+pub(super) struct EditorLspSession {
+    client: LspClient,
+    overlay: LspOverlay,
+    stop: Arc<AtomicBool>,
+    responder: Option<std::thread::JoinHandle<()>>,
+    /// Last text mirrored into the server, keyed by session document URI.
+    documents: FxHashMap<String, String>,
+}
+
+impl EditorLspSession {
+    fn spawn(executable: &str, cwd: &Path, project_root: &Path) -> Result<Self, String> {
+        let client = block_on(LspClient::spawn(
+            LspSpawnConfig::new(executable).with_cwd(cwd.to_path_buf()),
+        ))
+        .map_err(|error| cstr!("Failed to start Corsa editor LSP session: {error}"))?;
+        let stop = Arc::new(AtomicBool::new(false));
+        let responder = spawn_responder(client.clone(), stop.clone());
+
+        if let Err(error) = initialize_lsp_client(&client, project_root) {
+            stop.store(true, Ordering::Relaxed);
+            let _ = block_on(client.close());
+            let _ = responder.join();
+            return Err(error);
+        }
+
+        Ok(Self {
+            overlay: client.overlay(),
+            client,
+            stop,
+            responder: Some(responder),
+            documents: Default::default(),
+        })
+    }
+
+    /// Mirror `text` into the server, opening the document on first sight.
+    fn mirror(&mut self, document_uri: &str, text: &str) -> Result<Uri, String> {
+        let uri = Uri::from_str(document_uri)
+            .map_err(|error| cstr!("Invalid LSP document URI {document_uri}: {error}"))?;
+        match self.documents.get(document_uri) {
+            Some(previous) if previous.as_str() == text => return Ok(uri),
+            Some(_) => {
+                self.overlay.replace(&uri, text).map_err(|error| {
+                    cstr!("Failed to update editor LSP overlay for {document_uri}: {error}")
+                })?;
+            }
+            None => {
+                let language_id =
+                    if document_uri.ends_with(".tsx") || document_uri.ends_with(".jsx") {
+                        "typescriptreact"
+                    } else {
+                        "typescript"
+                    };
+                self.overlay
+                    .open(VirtualDocument::new(uri.clone(), language_id, text))
+                    .map_err(|error| {
+                        cstr!("Failed to open editor LSP overlay for {document_uri}: {error}")
+                    })?;
+            }
+        }
+        self.documents.insert(document_uri.into(), text.into());
+        Ok(uri)
+    }
+
+    fn hover(
+        &mut self,
+        document_uri: &str,
+        text: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        let uri = self.mirror(document_uri, text)?;
+        block_on(self.client.request::<RawHoverRequest>(serde_json::json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
+        })))
+        .map_err(|error| cstr!("Failed to request editor LSP hover: {error}"))
+    }
+}
+
+impl Drop for EditorLspSession {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        let _ = block_on(self.client.close());
+        if let Some(responder) = self.responder.take() {
+            let _ = responder.join();
+        }
+    }
+}
+
+/// Answers the server-initiated requests tsgo makes during startup; without a
+/// reply the server blocks before it ever serves an editor request.
+fn spawn_responder(client: LspClient, stop: Arc<AtomicBool>) -> std::thread::JoinHandle<()> {
+    let events = client.subscribe();
+    std::thread::spawn(move || {
+        while !stop.load(Ordering::Relaxed) {
+            if let Ok(InboundEvent::Request { id, method, .. }) =
+                events.recv_timeout(Duration::from_millis(50))
+            {
+                let response = match method.as_ref() {
+                    "workspace/configuration" => serde_json::json!([]),
+                    _ => Value::Null,
+                };
+                let _ = client.respond(id, response);
+            }
+        }
+    })
+}
+
+impl CorsaProjectClient {
+    /// Answer a hover through the editor LSP transport, spawning the session on
+    /// first use.
+    pub(super) fn hover_via_editor_lsp(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        let document_uri = self.session_document_uri(uri);
+        let Some(text) = self.document_texts.get(uri).cloned() else {
+            return Ok(None);
+        };
+
+        if self.editor_lsp.is_none() {
+            let root = self.editor_lsp_root();
+            let executable = self.executable.clone();
+            let cwd = self.cwd.clone();
+            self.editor_lsp = Some(EditorLspSession::spawn(executable.as_str(), &cwd, &root)?);
+        }
+        let Some(session) = self.editor_lsp.as_mut() else {
+            return Ok(None);
+        };
+        session.hover(document_uri.as_str(), text.as_str(), line, character)
+    }
+
+    /// Drop the editor session so the next request respawns it. Used when the
+    /// overlay root moves under a materialized project session.
+    pub(super) fn retire_editor_lsp(&mut self) {
+        self.editor_lsp = None;
+    }
+
+    fn editor_lsp_root(&self) -> PathBuf {
+        if self.materialized_project_session {
+            super::session_paths::overlay_root_for_project(&self.project_root)
+        } else {
+            self.project_root.clone()
+        }
+    }
+}

--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -133,17 +133,29 @@ fn spawn_responder(client: LspClient, stop: Arc<AtomicBool>) -> std::thread::Joi
     let events = client.subscribe();
     std::thread::spawn(move || {
         while !stop.load(Ordering::Relaxed) {
-            if let Ok(InboundEvent::Request { id, method, .. }) =
+            if let Ok(InboundEvent::Request { id, method, params }) =
                 events.recv_timeout(Duration::from_millis(50))
             {
                 let response = match method.as_ref() {
-                    "workspace/configuration" => serde_json::json!([]),
+                    "workspace/configuration" => configuration_response(&params),
                     _ => Value::Null,
                 };
                 let _ = client.respond(id, response);
             }
         }
     })
+}
+
+/// `workspace/configuration` results are positional: the array must hold one
+/// entry per requested item, in request order, with `null` for settings the
+/// client cannot supply. We supply none, so every slot is `null`. A bare `[]`
+/// would misalign servers that read `result[i]` for `items[i]`.
+fn configuration_response(params: &Value) -> Value {
+    let requested = params
+        .get("items")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    Value::Array(vec![Value::Null; requested])
 }
 
 impl CorsaProjectClient {

--- a/crates/vize_canon/src/lsp_client/lifecycle.rs
+++ b/crates/vize_canon/src/lsp_client/lifecycle.rs
@@ -83,6 +83,7 @@ impl CorsaProjectClient {
         }
 
         let _ = corsa::runtime::block_on(self.session.close());
+        self.retire_editor_lsp();
         self.document_texts.clear();
         self.diagnostics.clear();
         self.overlay_versions.clear();

--- a/crates/vize_canon/src/lsp_client/queries.rs
+++ b/crates/vize_canon/src/lsp_client/queries.rs
@@ -1,5 +1,5 @@
 use super::{CorsaProjectClient, session::uri_document_identifier, utils::value_to_json};
-use corsa::runtime::block_on;
+use corsa::{CorsaError, runtime::block_on};
 use lsp_types::CompletionContext;
 use serde_json::Value;
 use vize_carton::{String, cstr};
@@ -28,18 +28,24 @@ impl CorsaProjectClient {
         line: u32,
         character: u32,
     ) -> Result<Option<Value>, String> {
+        // The project-session API rejects hover as unsupported on every pinned
+        // runtime (corsa-bind#409), either up front through
+        // `describeCapabilities` or at request time. Both roads lead to the
+        // editor LSP transport, which the same runtime does serve.
         let Some(position) = self.api_position(uri, line, character, self.supports_hover_api())?
         else {
-            return Ok(None);
+            return self.hover_via_editor_lsp(uri, line, character);
         };
 
         let document_uri = self.session_document_uri(uri);
-        let response = block_on(
+        match block_on(
             self.session
                 .get_hover_at_position(uri_document_identifier(document_uri.as_str()), position),
-        )
-        .map_err(|error| cstr!("Failed to request hover: {error}"))?;
-        response.map(value_to_json).transpose()
+        ) {
+            Ok(response) => response.map(value_to_json).transpose(),
+            Err(CorsaError::Unsupported(_)) => self.hover_via_editor_lsp(uri, line, character),
+            Err(error) => Err(cstr!("Failed to request hover: {error}")),
+        }
     }
 
     pub(crate) fn definition_raw(

--- a/crates/vize_maestro/src/ide/hover.rs
+++ b/crates/vize_maestro/src/ide/hover.rs
@@ -13,6 +13,7 @@
     clippy::disallowed_macros
 )]
 
+mod backend;
 mod builder;
 mod component_prop;
 mod component_tag;
@@ -536,7 +537,9 @@ const message = ref('hello')
         let value = hover_markdown(hover);
 
         assert!(value.contains("message"));
-        assert!(value.contains("Ref<string>"));
+        // The binding still resolves at the identifier boundary; its *type* is
+        // the backend's to answer now, so the heuristic reports provenance only.
+        assert!(value.contains("_Template binding_"));
     }
 
     #[test]
@@ -556,26 +559,18 @@ const message = ref('hello')
         let value = hover_markdown(hover);
 
         assert!(value.contains("message"));
-        assert!(value.contains("Ref<string>"));
+        assert!(value.contains("_Template binding_"));
     }
 
     #[test]
     fn test_hover_infers_computed_getter_return_type() {
-        let source = r#"<script setup lang="ts">
-const count = ref(0)
-const double = computed(() => count.value * 2)
-</script>
-"#;
-        let (state, uri) = state_with_document("ComputedHover.vue", source);
+        // Exercises the inference directly: on a typecheck session the hover
+        // surface hands type text to the backend (see `hover::backend`).
+        let script = "const count = ref(0)\nconst double = computed(() => count.value * 2)\n";
+        let inferred =
+            HoverService::infer_type_from_script(script, "double", BindingType::SetupRef);
 
-        let offset = source.rfind("double").unwrap() + "double".len();
-        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-        let hover = HoverService::hover(&ctx).unwrap();
-        let value = hover_markdown(hover);
-
-        assert!(value.contains("double"));
-        assert!(value.contains("ComputedRef<number>"));
-        assert!(!value.contains("ComputedRef<unknown>"));
+        assert_eq!(inferred.as_deref(), Some("ComputedRef<number>"));
     }
 
     #[test]
@@ -733,7 +728,7 @@ const secondaryLabel = ref('secondary')
         let value = hover_markdown(hover);
 
         assert!(value.contains("secondaryLabel"));
-        assert!(value.contains("Ref<string>"));
+        assert!(value.contains("_Template expression_"));
     }
 
     #[cfg(feature = "native")]
@@ -765,7 +760,7 @@ const count = ref(0)
             let value = hover_markdown(hover);
 
             assert!(value.contains("count"));
-            assert!(value.contains("Ref<number>"));
+            assert!(value.contains("_Template binding_"));
         });
     }
 

--- a/crates/vize_maestro/src/ide/hover/backend.rs
+++ b/crates/vize_maestro/src/ide/hover/backend.rs
@@ -1,0 +1,78 @@
+//! Provenance gate for hover *type* text.
+//!
+//! Vize carries a script-binding inference used to answer hovers before the
+//! type backend existed. It is a heuristic: it shows the script-side
+//! `Ref<string>` at template positions (where Vue unwraps the ref) and types a
+//! plain `string` const as `MaybeRef<unknown>`. Rendered as a `typescript`
+//! code block it is indistinguishable from a real answer, so a session whose
+//! backend never came up still looks like it is type checking (#3321).
+//!
+//! When the live backend owns the answer -- a `native` build with typecheck
+//! enabled -- the heuristic must not supply type text at all. Either the
+//! backend answers or hover declines the type; it never guesses.
+//!
+//! Only *type* text is gated. Documentation hovers are untouched: directives,
+//! the Vue API and macro reference, and the binding-provenance hovers that
+//! carry no signature all keep answering exactly as before.
+
+use tower_lsp::lsp_types::Hover;
+
+use super::HoverService;
+use crate::ide::IdeContext;
+
+/// True when the live type backend owns hover type text for this document.
+///
+/// `native` is the build that can reach a backend at all; `typecheck` is the
+/// per-session switch a client uses to ask for real types. With both set, a
+/// heuristic type would be a claim vize cannot stand behind.
+fn backend_owns_type_hovers(ctx: &IdeContext<'_>) -> bool {
+    cfg!(feature = "native") && ctx.state.lsp_features().typecheck
+}
+
+/// Template binding type hover from script analysis, gated on provenance.
+pub(super) fn binding_type_hover(ctx: &IdeContext<'_>, word: &str) -> Option<Hover> {
+    if backend_owns_type_hovers(ctx) {
+        return None;
+    }
+
+    HoverService::hover_ts_binding(ctx, word)
+}
+
+/// Script binding type hover from script analysis, gated on provenance.
+pub(super) fn script_binding_type_hover(ctx: &IdeContext<'_>, word: &str) -> Option<Hover> {
+    if backend_owns_type_hovers(ctx) {
+        return None;
+    }
+
+    HoverService::hover_ts_binding_in_script(ctx, word)
+}
+
+/// Template-expression type from vize's own inference, gated on provenance.
+pub(super) fn heuristic_type_at(ctx: &IdeContext<'_>) -> Option<vize_canon::TypeInfo> {
+    if backend_owns_type_hovers(ctx) {
+        return None;
+    }
+
+    crate::ide::TypeService::get_type_at(ctx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::backend_owns_type_hovers;
+    use crate::{ide::IdeContext, server::ServerState};
+    use tower_lsp::lsp_types::Url;
+
+    // The gate keys off the session's typecheck switch, not off whether a
+    // backend happened to answer: a session that asked for real types must
+    // never be handed a heuristic type, including when the backend is missing.
+    #[test]
+    fn typecheck_sessions_hand_type_hovers_to_the_backend() {
+        let source = "<template><p>{{ message }}</p></template>";
+        let state = ServerState::new();
+        let uri = Url::parse("file:///workspace/App.vue").unwrap();
+        let ctx = IdeContext::with_content(&state, &uri, 0, source.into());
+
+        assert!(state.lsp_features().typecheck);
+        assert_eq!(backend_owns_type_hovers(&ctx), cfg!(feature = "native"));
+    }
+}

--- a/crates/vize_maestro/src/ide/hover/script.rs
+++ b/crates/vize_maestro/src/ide/hover/script.rs
@@ -40,7 +40,7 @@ impl HoverService {
         }
 
         // Try to get TypeScript type information from croquis analysis
-        if let Some(hover) = Self::hover_ts_binding_in_script(ctx, &word) {
+        if let Some(hover) = super::backend::script_binding_type_hover(ctx, &word) {
             return Some(hover);
         }
 
@@ -98,7 +98,7 @@ impl HoverService {
     }
 
     /// Get hover for TypeScript binding in script using croquis analysis.
-    fn hover_ts_binding_in_script(ctx: &IdeContext, word: &str) -> Option<Hover> {
+    pub(super) fn hover_ts_binding_in_script(ctx: &IdeContext, word: &str) -> Option<Hover> {
         // Parse SFC to get script content
         let options = vize_atelier_sfc::SfcParseOptions {
             filename: ctx.uri.path().to_string().into(),

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -61,11 +61,11 @@ impl HoverService {
             return Some(hover);
         }
 
-        if let Some(hover) = Self::hover_ts_binding(ctx, &word) {
+        if let Some(hover) = super::backend::binding_type_hover(ctx, &word) {
             return Some(hover);
         }
 
-        if let Some(type_info) = crate::ide::TypeService::get_type_at(ctx) {
+        if let Some(type_info) = super::backend::heuristic_type_at(ctx) {
             #[allow(clippy::disallowed_macros)]
             let signature = format!("{word}: {}", type_info.display);
             let mut builder = HoverBuilder::new()

--- a/editors/vscode/test/suite/extension-host-real.cjs
+++ b/editors/vscode/test/suite/extension-host-real.cjs
@@ -143,14 +143,21 @@ async function runRealHoverSmoke(mismatchDocument) {
     .flatMap((hover) => hover.contents)
     .map((content) => (typeof content === "string" ? content : content.value))
     .join("\n");
-  assert.match(markdown, /\*\*label\*\*/);
+  // This profile enables typechecking, so the hover type text comes from the
+  // live backend (#3321): the real literal type of the const, not the
+  // script-binding heuristic that used to answer here.
+  assert.match(markdown, /\*\*TypeScript quick info\*\*/);
   assert.ok(
-    markdown.includes("label: literal const"),
-    `hover must report the binding type fragment: ${JSON.stringify(markdown)}`,
+    markdown.includes('const label: "hello from vize"'),
+    `hover must report the backend type of the binding: ${JSON.stringify(markdown)}`,
   );
   assert.ok(
-    markdown.includes("Template binding from script"),
-    `hover must identify the script binding source: ${JSON.stringify(markdown)}`,
+    markdown.includes("Resolved through Vize virtual TypeScript"),
+    `hover must identify the type backend as its source: ${JSON.stringify(markdown)}`,
+  );
+  assert.ok(
+    !markdown.includes("Template binding from script"),
+    `hover must not fall back to the script-binding heuristic: ${JSON.stringify(markdown)}`,
   );
 }
 

--- a/tests/snapshots/check/create-vue-editor-range-oracle.ts
+++ b/tests/snapshots/check/create-vue-editor-range-oracle.ts
@@ -96,29 +96,29 @@ test("create-vue editor features answer in authored Vue ranges", async (t) => {
             contents: { kind: string; value: string };
           };
           assert.equal(hover.contents.kind, "markdown");
-          assert.equal(fencedBlock(hover.contents.value), "doubled: ComputedRef<number>");
-          assert.match(hover.contents.value, /_Template binding from script_/);
+          // Template scope, so the backend reports the *unwrapped* computed
+          // value rather than the script-side `ComputedRef` wrapper (#3321).
+          assert.equal(fencedBlock(hover.contents.value), "var doubled: number");
+          assert.match(hover.contents.value, /_Resolved through Vize virtual TypeScript_/);
 
           const scriptHover = (await ask("textDocument/hover", {
             position: scriptVisitCount,
           })) as { contents: { value: string } };
-          assert.equal(fencedBlock(scriptHover.contents.value), "visitCount: Ref<number>");
-          assert.match(scriptHover.contents.value, /_Script binding_/);
+          assert.equal(
+            fencedBlock(scriptHover.contents.value),
+            "const visitCount: Ref<number, number>",
+          );
+          assert.match(scriptHover.contents.value, /_Resolved through Vize virtual TypeScript_/);
         });
 
-        // GAP: `vize lsp` never populates the optional `Hover.range`, so an
-        // editor cannot underline the hovered authored span. The body below is
-        // the acceptance criterion — unskip it once the server returns a range.
-        await t.test(
-          "hover reports the authored range of the hovered binding",
-          { skip: "vize lsp omits the optional Hover.range field (#2971 audit item 8)" },
-          async () => {
-            const hover = (await ask("textDocument/hover", { position: templateDoubled })) as {
-              range?: LspRange;
-            };
-            assert.deepEqual(hover.range, DOUBLED_TEMPLATE_USE);
-          },
-        );
+        // Closed with #3321: backend-answered hovers carry the range tsgo
+        // reports, mapped back into authored `.vue` coordinates.
+        await t.test("hover reports the authored range of the hovered binding", async () => {
+          const hover = (await ask("textDocument/hover", { position: templateDoubled })) as {
+            range?: LspRange;
+          };
+          assert.deepEqual(hover.range, DOUBLED_TEMPLATE_USE);
+        });
 
         await t.test("definition lands on the authored declaration span", async () => {
           const fromTemplate = (await ask("textDocument/definition", {

--- a/tests/snapshots/check/element-plus-slot-oracle.ts
+++ b/tests/snapshots/check/element-plus-slot-oracle.ts
@@ -108,9 +108,13 @@ test("Element Plus badge slot contracts stay exact across editor revisions", asy
           ),
         })) as { contents?: unknown } | null;
         const hoverText = hoverToText(hover);
+        // Answered by the backend since #3321. The slot scope parameter still
+        // widens to `any` in the generated virtual TS — a separate gap, but the
+        // provenance is now the type backend rather than a generic fallback.
         assert.equal(
           hoverText,
-          "**value**\n\n_Template expression_\n\nExpression evaluated against the component template scope.",
+          "**TypeScript quick info**\n\n_Resolved through Vize virtual TypeScript_\n\n" +
+            "```typescript\n(parameter) value: any\n```",
         );
 
         const brokenSource = fixture.applyExactPatch(appPath, cleanExpression, brokenExpression);

--- a/tests/snapshots/check/nuxt-ui-ambient-oracle.ts
+++ b/tests/snapshots/check/nuxt-ui-ambient-oracle.ts
@@ -95,7 +95,11 @@ test("Nuxt UI generated ambient types stay exact across editor revisions", async
         })) as { contents?: unknown } | null;
         const hoverText = hoverToText(hover);
         assert.match(hoverText, /active/);
-        assert.match(hoverText, /Template binding from script|WritableComputedRef|string/);
+        // Backend-answered since #3321. The `v-model` binding still widens to
+        // `any` against the generated ambient component types; the point pinned
+        // here is the provenance, not the precision.
+        assert.match(hoverText, /_Resolved through Vize virtual TypeScript_/);
+        assert.doesNotMatch(hoverText, /Template binding from script/);
 
         const definition = (await session.request("textDocument/definition", {
           textDocument: { uri: appUri },

--- a/tests/snapshots/check/vitepress-theme-oracle.ts
+++ b/tests/snapshots/check/vitepress-theme-oracle.ts
@@ -120,9 +120,13 @@ test("VitePress theme exports refresh exact template diagnostics", async () => {
           position: offsetToPosition(source, codeUsage + "co".length),
         })) as { contents?: unknown } | null;
         const hoverText = hoverToText(hover);
+        // Since #3321 the backend resolves the optional theme property through
+        // the refreshed declaration instead of falling back to a generic
+        // template-expression hover.
         assert.equal(
           hoverText,
-          "**code**\n\n_Template expression_\n\nExpression evaluated against the component template scope.",
+          "**TypeScript quick info**\n\n_Resolved through Vize virtual TypeScript_\n\n" +
+            "```typescript\n(property) DefaultTheme.NotFoundOptions.code?: string | undefined\n```",
         );
 
         const themeUsage = source.indexOf("theme.notFound");

--- a/tests/snapshots/check/vue-benchmarks-lsp-ref-unwrap-oracle.ts
+++ b/tests/snapshots/check/vue-benchmarks-lsp-ref-unwrap-oracle.ts
@@ -26,13 +26,13 @@ import { LspSession } from "../../tooling/support/lsp/session.ts";
 //    `Ref<string>` shown at template positions, and `MaybeRef<unknown>` for a
 //    plain `string` const;
 // 3. a backend-missing session is identifiable: the exact
-//    `typecheck-unavailable` hint diagnostic while hovers keep answering
-//    heuristically.
+//    `typecheck-unavailable` hint diagnostic, and hovers that DECLINE the type
+//    rather than guessing one.
 //
 // The probe REJECTS (refuses to rank) any hover carrying a heuristic or
-// backend-missing signature; on current main every template hover is
-// heuristic, so the rejection paths are the required behavior and the
-// backend-unwrapped `string` hover is recorded as a known gap below.
+// backend-missing signature. Since #3321 a live session answers template
+// hovers from the backend, so the ranked classification is the required
+// behavior and the heuristic signatures must no longer appear at all.
 const cleanSource = `<script setup lang="ts">
 import { ref } from 'vue'
 const message = ref('hello')
@@ -135,38 +135,38 @@ test("ref-unwrap probe proves backend liveness and rejects heuristic hovers", as
     )) as PublishDiagnosticsParams;
     assert.deepEqual(repaired, { diagnostics: [], uri, version: 2 });
 
-    // Script-side hover: `Ref<string>` is the correct script type. Provenance
-    // says it comes from the script-binding analysis, not from Corsa.
+    // Script-side hover: `Ref<string>` is the correct script type, and it now
+    // arrives from the backend rather than the script-binding analysis.
     const scriptHover = await hoverText(
       session,
       uri,
       cleanSource.indexOf("const message") + "const mes".length,
     );
-    assert.match(scriptHover, /message: Ref<string>/);
-    assert.match(scriptHover, /_Script binding_/);
+    assert.match(scriptHover, /const message: Ref<string, string>/);
+    assert.match(scriptHover, /_Resolved through Vize virtual TypeScript_/);
+    assert.doesNotMatch(scriptHover, /_Script binding_/);
 
-    // Template-side hovers: a backend answer would present the unwrapped
-    // `string`; current main presents the script `Ref<string>` (and
-    // `MaybeRef<unknown>` for a plain `string` const) under the template
-    // provenance marker, so the probe must classify both as heuristic and
-    // reject them.
+    // Template-side hovers: the backend presents the unwrapped `string` at the
+    // interpolation position and the real `string` for the plain const, so both
+    // rank as backend evidence and neither may carry a heuristic signature.
     const templateMessageHover = await hoverText(
       session,
       uri,
       cleanSource.indexOf("{{ message") + "{{ mes".length,
     );
-    assert.match(templateMessageHover, /message: Ref<string>/);
-    assert.match(templateMessageHover, /_Template binding from script_/);
-    assert.doesNotMatch(templateMessageHover, /message: string/);
-    assert.equal(classifyTemplateHover(templateMessageHover, "message"), "heuristic");
+    assert.match(templateMessageHover, /var message: string/);
+    assert.doesNotMatch(templateMessageHover, /_Template binding from script_/);
+    assert.doesNotMatch(templateMessageHover, /Ref</);
+    assert.equal(classifyTemplateHover(templateMessageHover, "message"), "backend-template-type");
 
     const templateUpperHover = await hoverText(
       session,
       uri,
       cleanSource.lastIndexOf("upper }}") + 2,
     );
-    assert.match(templateUpperHover, /upper: MaybeRef<unknown>/);
-    assert.equal(classifyTemplateHover(templateUpperHover, "upper"), "heuristic");
+    assert.match(templateUpperHover, /var upper: string/);
+    assert.doesNotMatch(templateUpperHover, /MaybeRef<unknown>/);
+    assert.equal(classifyTemplateHover(templateUpperHover, "upper"), "backend-template-type");
 
     // The classifier itself must accept only the unwrapped backend shape.
     assert.equal(
@@ -204,15 +204,18 @@ test("ref-unwrap probe rejects backend-missing sessions by their exact hint", as
     )) as PublishDiagnosticsParams;
     assert.deepEqual(publish, { diagnostics: [typecheckUnavailableHint], uri, version: 1 });
 
-    // The session still answers hovers — through the heuristic layer. That is
-    // exactly the answer the probe exists to reject: without the liveness
-    // diagnostic above, this latency is not a measurement of type checking.
+    // The session still answers hovers, but it DECLINES the type: a typecheck
+    // session whose backend never came up hands back documentation only. The
+    // heuristic type signature that used to appear here is what made a hover
+    // latency look like a measurement of type checking.
     const templateHover = await hoverText(
       session,
       uri,
       cleanSource.indexOf("{{ message") + "{{ mes".length,
     );
-    assert.match(templateHover, /_Template binding from script_/);
+    assert.match(templateHover, /_Template binding_/);
+    assert.doesNotMatch(templateHover, /_Template binding from script_/);
+    assert.doesNotMatch(templateHover, /```typescript/);
     assert.equal(classifyTemplateHover(templateHover, "message"), "heuristic");
   } finally {
     await session.shutdown();
@@ -220,25 +223,64 @@ test("ref-unwrap probe rejects backend-missing sessions by their exact hint", as
   }
 });
 
-// Known gap (#3283): with a live Corsa backend the template hover still
-// presents the script-side `Ref<string>` under the `_Template binding from
-// script_` provenance and types a plain `string` const as
-// `MaybeRef<unknown>`. Once hover consults the Corsa-backed template types,
-// assert `message: string` (no `Ref<`) at the interpolation position and
-// `upper: string` for the plain const, and flip the rejection assertions
-// above into required backend classifications.
-test("template hover presents the backend-unwrapped string type", {
-  skip:
-    "vize lsp template hovers answer from the script-binding heuristic (Ref<string> / " +
-    "MaybeRef<unknown>) even when Corsa is live, so the unwrapped `string` cannot be asserted yet",
+// Closed gap (#3283 / #3321): the template hover now reports the template-scope
+// type the backend computes — `string`, the unwrapped ref — together with the
+// authored-coordinate range of the identifier under the cursor. The range is
+// the second half of the claim: a hover carrying virtual-TS coordinates would
+// highlight the wrong span even with the right text.
+test("template hover presents the backend-unwrapped string type", async () => {
+  const corsaPath = resolveTsgoBinary();
+  const workspaceDir = createWorkspace("unwrapped", corsaPath);
+  const filePath = path.join(workspaceDir, "App.vue");
+  const uri = pathToFileURL(filePath).href;
+  fs.writeFileSync(filePath, cleanSource, "utf8");
+
+  const session = new LspSession();
+  try {
+    await session.initialize(workspaceDir, { editor: true, lint: false, typecheck: true });
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: cleanSource },
+    });
+    await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri),
+      120_000,
+    );
+
+    const message = await hover(
+      session,
+      uri,
+      cleanSource.indexOf("{{ message") + "{{ mes".length,
+    );
+    assert.match(hoverToText(message), /var message: string/);
+    assert.deepEqual(message?.range, {
+      start: { line: 7, character: 8 },
+      end: { line: 7, character: 15 },
+    });
+
+    const upper = await hover(session, uri, cleanSource.lastIndexOf("upper }}") + 2);
+    assert.match(hoverToText(upper), /var upper: string/);
+    assert.deepEqual(upper?.range, {
+      start: { line: 7, character: 35 },
+      end: { line: 7, character: 40 },
+    });
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  }
 });
 
-async function hoverText(session: LspSession, uri: string, offset: number): Promise<string> {
-  const hover = (await session.request("textDocument/hover", {
+type HoverResponse = { contents?: unknown; range?: unknown } | null;
+
+async function hover(session: LspSession, uri: string, offset: number): Promise<HoverResponse> {
+  return (await session.request("textDocument/hover", {
     textDocument: { uri },
     position: offsetToPosition(cleanSource, offset),
-  })) as { contents?: unknown } | null;
-  return hoverToText(hover);
+  })) as HoverResponse;
+}
+
+async function hoverText(session: LspSession, uri: string, offset: number): Promise<string> {
+  return hoverToText(await hover(session, uri, offset));
 }
 
 function createWorkspace(label: string, corsaPath: string): string {

--- a/tests/snapshots/check/vue-benchmarks-lsp-ref-unwrap-oracle.ts
+++ b/tests/snapshots/check/vue-benchmarks-lsp-ref-unwrap-oracle.ts
@@ -247,11 +247,7 @@ test("template hover presents the backend-unwrapped string type", async () => {
       120_000,
     );
 
-    const message = await hover(
-      session,
-      uri,
-      cleanSource.indexOf("{{ message") + "{{ mes".length,
-    );
+    const message = await hover(session, uri, cleanSource.indexOf("{{ message") + "{{ mes".length);
     assert.match(hoverToText(message), /var message: string/);
     assert.deepEqual(message?.range, {
       start: { line: 7, character: 8 },

--- a/tests/tooling/lsp-smoke.test.ts
+++ b/tests/tooling/lsp-smoke.test.ts
@@ -137,7 +137,11 @@ const secondaryLabel = ref('secondary')
 
       const hoverText = hoverToText(hover);
       assert.match(hoverText, /secondaryLabel/);
-      assert.match(hoverText, /(Ref<string>|string)/);
+      // This session asks for typechecking, so type text belongs to the
+      // backend (#3321). No Corsa runtime is configured in this workspace, so
+      // the hover reports the template scope instead of guessing a type.
+      assert.match(hoverText, /template scope/);
+      assert.doesNotMatch(hoverText, /Ref</);
 
       const definition = (await session.request("textDocument/definition", {
         textDocument: { uri: artUri },

--- a/tests/tooling/lsp-smoke.test.ts
+++ b/tests/tooling/lsp-smoke.test.ts
@@ -137,11 +137,7 @@ const secondaryLabel = ref('secondary')
 
       const hoverText = hoverToText(hover);
       assert.match(hoverText, /secondaryLabel/);
-      // This session asks for typechecking, so type text belongs to the
-      // backend (#3321). No Corsa runtime is configured in this workspace, so
-      // the hover reports the template scope instead of guessing a type.
-      assert.match(hoverText, /template scope/);
-      assert.doesNotMatch(hoverText, /Ref</);
+      assert.ok(/template scope/.test(hoverText) && !/Ref</.test(hoverText), hoverText);
 
       const definition = (await session.request("textDocument/definition", {
         textDocument: { uri: artUri },


### PR DESCRIPTION
Template hovers were answered by vize's own script-binding inference even with a live type backend. At a template position that meant the script-side `Ref<string>` (Vue unwraps refs in templates) and, for a plain `string` const, `MaybeRef<unknown>`. The virtual TS already emitted `var message: __U<__R_message>` in template scope, so the unwrapped type was always available — nothing asked for it.

## Root cause

The corsa project-session API rejects every editor request on the pinned runtimes:

```
hover=Err(CommunicationError("Failed to request hover: unsupported: hover is not
  supported by this runtime; check describeCapabilities before requesting editor features"))
```

Same for `definition` and `references`. Diagnostics live in a different API scope and were unaffected, which is why typechecking looked healthy while hover quietly fell through to the heuristic. Filed upstream as ubugeeei-prod/corsa-bind#409.

The same runtime **does** advertise `hoverProvider: true` over its own `--lsp --stdio` transport and answers with the real type.

## Change

**`vize_canon`** — new `lsp_client/editor_lsp.rs`: a lazily spawned, reused `--lsp --stdio` session that mirrors the virtual documents in via `LspOverlay` and answers `textDocument/hover`. Lazy so diagnostics-only runs never pay for a second process; reused so a session that has answered one hover serves every later request. `queries.rs::hover_raw` routes both a negative capability handshake and a request-time `CorsaError::Unsupported` to it. The session is retired on shutdown and when `activate_materialized_project_session` moves the overlay root.

**`vize_maestro`** — new `ide/hover/backend.rs`: a provenance gate. On `native` builds with typecheck enabled, vize's own inference no longer supplies hover *type* text — only the backend may. A heuristic type rendered as a `typescript` code block is indistinguishable from a real one, which is exactly what let a session whose backend never came up still look like it was type checking. Documentation hovers (directives, Vue API, binding provenance) are unaffected; a typecheck session with no reachable backend now declines the type instead of guessing it.

## Before / after

All values derived from probe runs against a freshly built binary with a live tsgo.

| position | before | after |
|---|---|---|
| script `message` | `message: Ref<string>` | `const message: Ref<string, string>` @ 2:6–2:13 |
| template `message` | `message: Ref<string>` | `var message: string` @ 7:8–7:15 |
| template `upper` | `upper: MaybeRef<unknown>` | `var upper: string` @ 7:35–7:40 |

Raw payloads for the template `message` position:

```jsonc
// before
{"contents":{"kind":"markdown","value":"**message**\n\n_Template binding from script_\n\n```typescript\nmessage: Ref<string>\n```\n\n..."}}

// after
{"contents":{"kind":"markdown","value":"**TypeScript quick info**\n\n_Resolved through Vize virtual TypeScript_\n\n```typescript\nvar message: string\n```"},
 "range":{"start":{"line":7,"character":8},"end":{"line":7,"character":15}}}
```

Ranges arrive in authored `.vue` coordinates, which also closes the pinned `Hover.range` gap in the create-vue editor-range oracle (#2971 audit item 8) — that test is un-skipped here.

## Tests

- `vue-benchmarks-lsp-ref-unwrap-oracle.ts` — the pinned known-gap test is **un-skipped** and now asserts the unwrapped `string` plus its authored range; both rejection blocks flip to backend classifications; the backend-missing test asserts a **decline** (no `typescript` fence) instead of `_Template binding from script_`.
- `create-vue-editor-range-oracle.ts` — real tsgo text (`var doubled: number`, `const visitCount: Ref<number, number>`); the skipped `Hover.range` test is un-skipped and passes.
- `element-plus-slot-oracle.ts`, `nuxt-ui-ambient-oracle.ts`, `vitepress-theme-oracle.ts` — record backend provenance. VitePress now resolves a real `(property) DefaultTheme.NotFoundOptions.code?: string | undefined` where it previously fell back to a generic template-expression hover.
- `lsp-smoke.test.ts` — the art-variant hover (a default-init, typecheck-on session with no Corsa configured) asserts template scope and no type claim.
- Rust: the four identifier-boundary hover tests assert `_Template binding_` / `_Template expression_` provenance rather than heuristic types; `test_hover_infers_computed_getter_return_type` calls `infer_type_from_script` directly.
- `lsp-hover-template.test.ts`, `lsp-authoring-core.test.ts`, `lsp-editor-production-gates.test.ts`, `feature-isolation.ts` were checked and need no change — all run `typecheck: false`.

53 tests across the affected LSP suites pass; `cargo test -p vize_maestro` is green; `cargo fmt` and `cargo clippy` are clean.

The over-budget files did not grow: `hover.rs` 833 → 828, `hover/template.rs` 468 → 468, `hover/script.rs` 391 → 391.

## Residual gaps

- `definition` and `references` still return nothing when the project-session API rejects them; only `hover` is routed to the LSP transport here.
- `hover_art_variant_with_corsa` still forwards an unmapped range (pre-existing).
- Slot-scope and `v-model` bindings resolve to `any` against generated ambient types (element-plus, nuxt-ui) — a virtual-TS precision gap, unrelated to transport.

Closes #3321

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved editor hover support, including fallback handling for unsupported project-session requests.
  - Hover information now stays accurate when working with virtual or materialized project files.
  - Added clearer template provenance markers in hover results.

- **Bug Fixes**
  - Prevented duplicate or heuristic type information when live type data is available.
  - Improved hover behavior across different project variants and template contexts.

- **Tests**
  - Updated hover coverage to validate template scope, provenance markers, and computed type inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->