### PR TITLE
fix(vitrine): keep the emitter JavaScript guarantee off isTs callers

### DIFF
--- a/crates/vize_vitrine/src/napi/sfc/batch_results.rs
+++ b/crates/vize_vitrine/src/napi/sfc/batch_results.rs
@@ -189,7 +189,13 @@ fn compile_sfc_batch_with_results_inner(
                         // The emitter is the last stop before the bundler, so
                         // the code crossing this boundary must already be plain
                         // JavaScript — the JS plugin no longer re-strips it.
-                        code: ensure_javascript_output(result.code).into(),
+                        // `is_ts` callers opted out: they asked for TypeScript
+                        // in the output and strip it themselves.
+                        code: if is_ts {
+                            result.code.into()
+                        } else {
+                            ensure_javascript_output(result.code).into()
+                        },
                         css: result.css.map(Into::into),
                         scope_id: scope_id.into(),
                         has_scoped,

--- a/crates/vize_vitrine/src/napi/sfc/compile.rs
+++ b/crates/vize_vitrine/src/napi/sfc/compile.rs
@@ -117,8 +117,13 @@ pub fn compile_sfc(
         Ok(result) => Ok(SfcCompileResultNapi {
             // The emitter is the last stop before the bundler, so the code
             // crossing this boundary must already be plain JavaScript — the JS
-            // plugin no longer re-strips it.
-            code: ensure_javascript_output(result.code).into(),
+            // plugin no longer re-strips it. `is_ts` callers opted out: they
+            // asked for TypeScript in the output and strip it themselves.
+            code: if is_ts {
+                result.code.into()
+            } else {
+                ensure_javascript_output(result.code).into()
+            },
             css: result.css.map(Into::into),
             errors: result
                 .errors


### PR DESCRIPTION
#3348 landed with `ensure_javascript_output` applied to every module crossing the napi boundary, including calls that set `isTs` — an option whose contract is "preserve TypeScript in output".

`@vizejs/rspack-plugin` relies on that contract: `shared/compiler.ts` auto-detects `<script lang="ts">` and passes `isTs: true`, then strips TypeScript itself with the `builtin:swc-loader` post rule on `.vue`. With the guarantee applied unconditionally, the emitter's own printed output was re-printed by `oxc_codegen` instead, which changed string quoting (`'App'` → `"App"`), respaced the pure annotation (`/*@__PURE__*/` → `/* @__PURE__ */`), and dropped non-annotation comments (`2 /* CLASS */`). That broke all 10 `lang="ts"` fixture snapshots in `test-js-packages` (`integration`, `scoped-css`, `vapor`) on `main`.

The fix scopes the guarantee to callers that did not ask for TypeScript:

```rust
code: if is_ts {
    result.code.into()
} else {
    ensure_javascript_output(result.code).into()
},
```

Applied in both entry points, `napi/sfc/compile.rs` and `napi/sfc/batch_results.rs`. `@vizejs/vite-plugin` never sets `isTs`, so the guarantee #3348 relies on for dropping the JS-side re-strip is unchanged, and rspack output goes back to byte-identical.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TypeScript compilation output by preserving generated TypeScript code without unnecessary JavaScript-specific processing.
  - Updated batch and single-file compilation results to return TypeScript output more accurately.
  - JavaScript compilation behavior remains unchanged, including existing output normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->