### PR TITLE
test(canon): correct the reka-ui as-child diagnostic attribution

### DIFF
--- a/tests/snapshots/check/__snapshots__/reka-ui-check.snap
+++ b/tests/snapshots/check/__snapshots__/reka-ui-check.snap
@@ -570,13 +570,13 @@
     {
       "file": "packages/core/src/Combobox/story/ComboboxCustom.story.vue",
       "diagnostics": [
-        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations."
+        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.\nType '\"as\"' is not assignable to type 'never'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'asChild' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'height' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'rounded' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'width' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'defer' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'disabled' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'forceMount' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'to' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'."
       ]
     },
     {
       "file": "packages/core/src/Combobox/story/ComboboxMultiple.story.vue",
       "diagnostics": [
-        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.\nType '\"as\"' is not assignable to type 'never'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'asChild' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'height' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'rounded' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'width' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'defer' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'disabled' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'forceMount' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'to' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'."
+        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations."
       ]
     },
     {


### PR DESCRIPTION
The last `App E2E` failure blocking the release. `reka-ui check (type checker)` reports a snapshot mismatch that is a **two-file swap**, and the old snapshot had it attributed to the wrong file.

## The swap

```diff
 "file": "packages/core/src/Combobox/story/ComboboxCustom.story.vue"
-  "error:2:22 [TS2307] Cannot find module '@iconify/vue' ..."
+  "error:2:22 [TS2307] Cannot find module '@iconify/vue' ...\nType '\"as\"' is not assignable to type 'never'. ..."

 "file": "packages/core/src/Combobox/story/ComboboxMultiple.story.vue"
-  "error:2:22 [TS2307] ... \nType '\"as\"' is not assignable to type 'never'. ..."
+  "error:2:22 [TS2307] Cannot find module '@iconify/vue' ..."
```

Nothing else changed: multiset diff over (file, diagnostic) pairs is **2 added, 2 removed**, and the two added are the two removed with their files exchanged.

## The new attribution is the correct one

Only `ComboboxCustom.story.vue` uses the attribute the diagnostic is about:

```
ComboboxCustom.story.vue:57:                as-child
ComboboxMultiple.story.vue: (no  attribute)
```

So the `Type '"as"' is not assignable to type 'never'` cascade belongs to `ComboboxCustom`, and the pinned snapshot had been asserting it against `ComboboxMultiple` — a file that cannot produce it. Refreshing the snapshot fixes the pin rather than papering over a regression.

Both files import `@iconify/vue` on line 2, which is why the TS2307 halves look interchangeable and the mis-attribution went unnoticed.

## Verification

Deterministic: the same 4-line diff on three consecutive runs, and the suite passes after the refresh (`pass 1, fail 0`). Neither file produces the `as` cascade when checked in isolation — it needs the full project scope, which is why the harness is the only place it shows up.

This is the third snapshot in this cycle found to have pinned incorrect output, after the two vapor navigation snapshots in #3332/#3337.