### PR TITLE
fix(oxint): map script-block diagnostics to their real SFC position

### DIFF
--- a/npm/oxint/package.json
+++ b/npm/oxint/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "build": "vp pack",
-    "test": "vp pack && vp test run src/file-state.test.ts && node src/test.ts",
+    "test": "vp pack && vp test run src/file-state.test.ts && node src/test.ts && node src/script-location.test.ts",
     "check": "vp check src vite.config.ts",
     "check:fix": "vp check --fix src vite.config.ts",
     "fmt": "vp fmt --write src vite.config.ts"

--- a/npm/oxint/src/__snapshots__/stylish-incremental-combo-output.txt
+++ b/npm/oxint/src/__snapshots__/stylish-incremental-combo-output.txt
@@ -1,5 +1,5 @@
 <workspaceRoot>/target/vize-tests/oxlint-plugin-vize-test/IncrementalCombo.vue
-  2:2  error  Style block should use `scoped` or `module` attribute to prevent CSS leaking (at SFC:13:1)  vize(vue/require-scoped-style)
-  2:2  error  Options API component declarations are not supported (at <script>:2:16)  vize(script/no-options-api)
+  2:2   error  Style block should use `scoped` or `module` attribute to prevent CSS leaking (at SFC:13:1)  vize(vue/require-scoped-style)
+  2:16  error  Options API component declarations are not supported  vize(script/no-options-api)
 
 ✖ 2 problems (2 errors, 0 warnings)

--- a/npm/oxint/src/__snapshots__/stylish-opinionated-no-options-api-output.txt
+++ b/npm/oxint/src/__snapshots__/stylish-opinionated-no-options-api-output.txt
@@ -1,4 +1,4 @@
 <workspaceRoot>/target/vize-tests/oxlint-plugin-vize-test/OptionsApi.vue
-  2:2  error  Options API component declarations are not supported (at <script>:2:16)  vize(script/no-options-api)
+  2:16  error  Options API component declarations are not supported  vize(script/no-options-api)
 
 ✖ 1 problem (1 error, 0 warnings)

--- a/npm/oxint/src/__snapshots__/stylish-script-offset-output.txt
+++ b/npm/oxint/src/__snapshots__/stylish-script-offset-output.txt
@@ -1,4 +1,4 @@
-<workspaceRoot>/target/vize-tests/oxlint-plugin-vize-test/ScriptOffset.vue
+<workspaceRoot>/target/vize-tests/oxlint-plugin-vize-script-location-test/ScriptOffset.vue
   6:10  error  getCurrentInstance import is not supported in Vapor-oriented components  vize(script/no-get-current-instance)
   8:18  error  getCurrentInstance() is not supported in Vapor-oriented components  vize(script/no-get-current-instance)
 

--- a/npm/oxint/src/__snapshots__/stylish-script-offset-output.txt
+++ b/npm/oxint/src/__snapshots__/stylish-script-offset-output.txt
@@ -1,0 +1,5 @@
+<workspaceRoot>/target/vize-tests/oxlint-plugin-vize-test/ScriptOffset.vue
+  6:10  error  getCurrentInstance import is not supported in Vapor-oriented components  vize(script/no-get-current-instance)
+  8:18  error  getCurrentInstance() is not supported in Vapor-oriented components  vize(script/no-get-current-instance)
+
+✖ 2 problems (2 errors, 0 warnings)

--- a/npm/oxint/src/model.ts
+++ b/npm/oxint/src/model.ts
@@ -83,4 +83,10 @@ export interface SfcBlock {
 
 export interface SingleScriptMap {
   block: SfcBlock;
+  /**
+   * SFC position of the extracted program's first character. Oxlint hands JS
+   * plugins the block body without the newline that follows the open tag, so
+   * this is not always `block.contentStart`.
+   */
+  scriptStart: LineColumn;
 }

--- a/npm/oxint/src/script-location.test.ts
+++ b/npm/oxint/src/script-location.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Script-block diagnostic location contract for the Oxlint bridge.
+ *
+ * Oxlint hands JS plugins the *extracted program*, not the `.vue` file, so the
+ * bridge has to translate Patina's authored SFC line/column back through the
+ * script block's own offset. When that translation silently fails, every
+ * `vize/*` diagnostic collapses onto the script block's first line: editors and
+ * CI annotations read `line`/`column` rather than the `(at <script setup>:L:C)`
+ * message suffix, so they send the reader to the wrong place and two findings on
+ * different lines become indistinguishable.
+ *
+ * The fixture is built so neither half of the translation can regress silently:
+ * the script block starts on line 5 rather than line 1, so a hardcoded
+ * line-1 anchor fails, and it carries diagnostics on two different lines, so
+ * collapsing them onto one position fails.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = path.dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = path.resolve(packageDir, "../../..");
+const pluginEntry = path.join(workspaceRoot, "npm/oxint/dist/index.mjs");
+const fixtureDir = path.join(
+  workspaceRoot,
+  "target",
+  "vize-tests",
+  "oxlint-plugin-vize-script-location-test",
+);
+const configPath = path.join(fixtureDir, ".oxlintrc.json");
+const scriptOffsetVuePath = path.join(fixtureDir, "ScriptOffset.vue");
+const snapshotPath = path.join(packageDir, "__snapshots__", "stylish-script-offset-output.txt");
+const ansiEscapePattern = new RegExp(String.raw`\[[0-9;]*m`, "gu");
+const workspaceRootPattern = new RegExp(escapeRegExp(workspaceRoot), "gu");
+
+function escapeRegExp(value: string): string {
+  return value.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`);
+}
+
+function findOxlintBin(): string {
+  const pnpmStoreDir = path.join(workspaceRoot, "node_modules", ".pnpm");
+  const candidates = fs
+    .readdirSync(pnpmStoreDir)
+    .filter((entry) => entry.startsWith("oxlint@"))
+    .map((entry) => path.join(pnpmStoreDir, entry, "node_modules", "oxlint", "bin", "oxlint"))
+    .filter((candidate) => fs.existsSync(candidate));
+  assert.ok(candidates.length > 0, "oxlint binary must be installed in the workspace");
+  return candidates[candidates.length - 1];
+}
+
+const oxlintBin = findOxlintBin();
+const oxlintEnv = { ...process.env };
+delete oxlintEnv.GITHUB_ACTIONS;
+
+function normalizeOutput(output: string): string {
+  return output
+    .replace(ansiEscapePattern, "")
+    .replace(workspaceRootPattern, "<workspaceRoot>")
+    .replace(/^WARNING: JS plugins are experimental and not subject to semver\.\n/gmu, "")
+    .replace(
+      /^Breaking changes are possible while JS plugins support is under development\.\n/gmu,
+      "",
+    )
+    .replace(/^Finished in .*$/gmu, "")
+    .trim();
+}
+
+function runOxlint(args: readonly string[]): { exitCode: number; output: string } {
+  try {
+    const output = String(
+      execFileSync(oxlintBin, args, {
+        cwd: fixtureDir,
+        encoding: "utf8",
+        env: oxlintEnv,
+        stdio: "pipe",
+      }),
+    );
+    return { exitCode: 0, output: normalizeOutput(output) };
+  } catch (error) {
+    const execError = error as {
+      status?: number;
+      stdout?: string | Buffer;
+      stderr?: string | Buffer;
+    };
+    return {
+      exitCode: execError.status ?? 1,
+      output: normalizeOutput(String(execError.stdout ?? "") + String(execError.stderr ?? "")),
+    };
+  }
+}
+
+fs.rmSync(fixtureDir, { force: true, recursive: true });
+fs.mkdirSync(fixtureDir, { recursive: true });
+
+fs.writeFileSync(
+  configPath,
+  JSON.stringify(
+    {
+      plugins: ["vue"],
+      jsPlugins: [pluginEntry],
+      settings: {
+        vize: {
+          helpLevel: "none",
+          preset: "opinionated",
+        },
+      },
+      rules: {
+        "no-unused-vars": "off",
+        "vize/script/no-get-current-instance": "error",
+      },
+    },
+    null,
+    2,
+  ),
+);
+
+fs.writeFileSync(
+  scriptOffsetVuePath,
+  `<template>
+  <div>{{ instance }}</div>
+</template>
+
+<script setup lang="ts">
+import { getCurrentInstance } from 'vue'
+
+const instance = getCurrentInstance()
+</script>
+`,
+);
+
+const scriptOffsetRun = runOxlint(["-c", ".oxlintrc.json", "-f", "stylish", "ScriptOffset.vue"]);
+assert.notEqual(
+  scriptOffsetRun.exitCode,
+  0,
+  "script-offset fixture should report opinionated script diagnostics",
+);
+
+// Patina reports these at SFC 6:10 and 8:18. Asserting the positions is the only
+// thing that catches a bridge which silently collapses every diagnostic onto one
+// line, because the message text is identical either way.
+assert.match(
+  scriptOffsetRun.output,
+  /^  6:10 {2}error {2}getCurrentInstance import is not supported in Vapor-oriented components {2}vize\(script\/no-get-current-instance\)$/mu,
+  "a diagnostic on the script block's first content line should keep its real SFC position",
+);
+assert.match(
+  scriptOffsetRun.output,
+  /^  8:18 {2}error {2}getCurrentInstance\(\) is not supported in Vapor-oriented components {2}vize\(script\/no-get-current-instance\)$/mu,
+  "a diagnostic further into the script block should keep its real SFC position",
+);
+assert.doesNotMatch(
+  scriptOffsetRun.output,
+  /\(at <script setup>:/u,
+  "mapped script diagnostics should not need the fallback location suffix",
+);
+assert.equal(scriptOffsetRun.output, normalizeOutput(fs.readFileSync(snapshotPath, "utf8")));
+
+console.log("✅ oxlint-plugin-vize script location tests passed!");

--- a/npm/oxint/src/script-map.ts
+++ b/npm/oxint/src/script-map.ts
@@ -19,7 +19,48 @@ export function createSingleScriptMap(
   }
 
   const [block] = blocks;
-  return block.content === extractedScript ? { block } : null;
+  const skipped = countSkippedPrefix(block.content, extractedScript);
+  if (skipped === null) {
+    return null;
+  }
+
+  return {
+    block,
+    scriptStart: advancePosition(block.contentStart, block.content.slice(0, skipped)),
+  };
+}
+
+/**
+ * Oxlint trims the leading newline (and any indentation on that line) from a
+ * `.vue` script block before handing the program to JS plugins, so the
+ * extracted text starts partway into `block.content`. Returns how many
+ * characters were dropped, or `null` when the extracted text is not this
+ * block's body.
+ */
+function countSkippedPrefix(content: string, extractedScript: string): number | null {
+  const skipped = content.length - extractedScript.length;
+  if (skipped < 0 || !content.endsWith(extractedScript)) {
+    return null;
+  }
+
+  return /^\s*$/u.test(content.slice(0, skipped)) ? skipped : null;
+}
+
+function advancePosition(from: LineColumn, text: string): LineColumn {
+  let { line, column } = from;
+
+  for (const character of text) {
+    if (character === "\n") {
+      line += 1;
+      column = 1;
+      continue;
+    }
+    if (character !== "\r") {
+      column += 1;
+    }
+  }
+
+  return { line, column };
 }
 
 export function mapToScriptLoc(
@@ -30,30 +71,34 @@ export function mapToScriptLoc(
     return null;
   }
 
-  const { block } = scriptMap;
+  const { block, scriptStart } = scriptMap;
   if (
-    compareLineColumn(diagnostic.location.start, block.contentStart) < 0 ||
+    compareLineColumn(diagnostic.location.start, scriptStart) < 0 ||
     compareLineColumn(diagnostic.location.end, block.contentEnd) > 0
   ) {
     return null;
   }
 
   return {
-    start: toScriptPosition(diagnostic.location.start, block.contentStart),
-    end: toScriptPosition(diagnostic.location.end, block.contentStart),
+    start: toScriptPosition(diagnostic.location.start, scriptStart),
+    end: toScriptPosition(diagnostic.location.end, scriptStart),
   };
 }
 
-function toScriptPosition(position: LineColumn, contentStart: LineColumn): LineColumn {
-  if (position.line === contentStart.line) {
+/**
+ * Patina reports 1-based SFC line/column; Oxlint expects 1-based lines and
+ * 0-based columns relative to the extracted program.
+ */
+function toScriptPosition(position: LineColumn, scriptStart: LineColumn): LineColumn {
+  if (position.line === scriptStart.line) {
     return {
       line: 1,
-      column: position.column - contentStart.column + 1,
+      column: position.column - scriptStart.column,
     };
   }
 
   return {
-    line: position.line - contentStart.line + 1,
-    column: position.column,
+    line: position.line - scriptStart.line + 1,
+    column: position.column - 1,
   };
 }

--- a/npm/oxint/src/test.ts
+++ b/npm/oxint/src/test.ts
@@ -25,6 +25,7 @@ const generalRecommendedScriptConfigPath = path.join(
 );
 const incrementalComboConfigPath = path.join(fixtureDir, ".oxlintrc.incremental-combo.json");
 const opinionatedScriptConfigPath = path.join(fixtureDir, ".oxlintrc.opinionated-script.json");
+const scriptOffsetConfigPath = path.join(fixtureDir, ".oxlintrc.script-offset.json");
 const coreRulesConfigPath = path.join(fixtureDir, ".oxlintrc.core-rules.json");
 const scriptlessConfigPath = path.join(fixtureDir, ".oxlintrc.scriptless.json");
 const largeJsonConfigPath = path.join(fixtureDir, ".oxlintrc.large-json.json");
@@ -32,6 +33,7 @@ const vuePath = path.join(fixtureDir, "App.vue");
 const scopedStyleVuePath = path.join(fixtureDir, "ScopedStyle.vue");
 const incrementalComboVuePath = path.join(fixtureDir, "IncrementalCombo.vue");
 const optionsApiVuePath = path.join(fixtureDir, "OptionsApi.vue");
+const scriptOffsetVuePath = path.join(fixtureDir, "ScriptOffset.vue");
 const dualScriptVuePath = path.join(fixtureDir, "DualScript.vue");
 const coreRulesVuePath = path.join(fixtureDir, "CoreRules.vue");
 const scriptlessVuePath = path.join(fixtureDir, "Scriptless.vue");
@@ -231,6 +233,28 @@ fs.writeFileSync(
 );
 
 fs.writeFileSync(
+  scriptOffsetConfigPath,
+  JSON.stringify(
+    {
+      plugins: ["vue"],
+      jsPlugins: [pluginEntry],
+      settings: {
+        vize: {
+          helpLevel: "none",
+          preset: "opinionated",
+        },
+      },
+      rules: {
+        "no-unused-vars": "off",
+        "vize/script/no-get-current-instance": "error",
+      },
+    },
+    null,
+    2,
+  ),
+);
+
+fs.writeFileSync(
   coreRulesConfigPath,
   JSON.stringify(
     {
@@ -361,6 +385,23 @@ export default {
 <style>
 .foo { color: red; }
   </style>
+`,
+);
+
+// The script block deliberately starts on line 5 and carries two diagnostics on
+// two different lines, so a regression in the extracted-program offset math
+// cannot pass by accident.
+fs.writeFileSync(
+  scriptOffsetVuePath,
+  `<template>
+  <div>{{ instance }}</div>
+</template>
+
+<script setup lang="ts">
+import { getCurrentInstance } from 'vue'
+
+const instance = getCurrentInstance()
+</script>
 `,
 );
 
@@ -778,6 +819,39 @@ assert.equal(
   opinionatedScriptRun.output,
   readSnapshot("stylish-opinionated-no-options-api-output.txt"),
 );
+
+const scriptOffsetRun = runOxlint([
+  "-c",
+  ".oxlintrc.script-offset.json",
+  "-f",
+  "stylish",
+  "ScriptOffset.vue",
+]);
+assert.notEqual(
+  scriptOffsetRun.exitCode,
+  0,
+  "script-offset fixture should report opinionated script diagnostics",
+);
+// Patina reports these at SFC 6:10 and 8:18. Oxlint hands JS plugins the
+// extracted program, so the bridge has to translate both back through the
+// script block's own offset; asserting the positions is the only thing that
+// catches a bridge that silently collapses every diagnostic onto one line.
+assert.match(
+  scriptOffsetRun.output,
+  /^  6:10 {2}error {2}getCurrentInstance import is not supported in Vapor-oriented components {2}vize\(script\/no-get-current-instance\)$/mu,
+  "a diagnostic on the script block's first content line should keep its real SFC position",
+);
+assert.match(
+  scriptOffsetRun.output,
+  /^  8:18 {2}error {2}getCurrentInstance\(\) is not supported in Vapor-oriented components {2}vize\(script\/no-get-current-instance\)$/mu,
+  "a diagnostic further into the script block should keep its real SFC position",
+);
+assert.doesNotMatch(
+  scriptOffsetRun.output,
+  /\(at <script setup>:/u,
+  "mapped script diagnostics should not need the fallback location suffix",
+);
+assert.equal(scriptOffsetRun.output, readSnapshot("stylish-script-offset-output.txt"));
 
 const dualScriptRun = runOxlint([
   "-c",

--- a/npm/oxint/src/test.ts
+++ b/npm/oxint/src/test.ts
@@ -25,7 +25,6 @@ const generalRecommendedScriptConfigPath = path.join(
 );
 const incrementalComboConfigPath = path.join(fixtureDir, ".oxlintrc.incremental-combo.json");
 const opinionatedScriptConfigPath = path.join(fixtureDir, ".oxlintrc.opinionated-script.json");
-const scriptOffsetConfigPath = path.join(fixtureDir, ".oxlintrc.script-offset.json");
 const coreRulesConfigPath = path.join(fixtureDir, ".oxlintrc.core-rules.json");
 const scriptlessConfigPath = path.join(fixtureDir, ".oxlintrc.scriptless.json");
 const largeJsonConfigPath = path.join(fixtureDir, ".oxlintrc.large-json.json");
@@ -33,7 +32,6 @@ const vuePath = path.join(fixtureDir, "App.vue");
 const scopedStyleVuePath = path.join(fixtureDir, "ScopedStyle.vue");
 const incrementalComboVuePath = path.join(fixtureDir, "IncrementalCombo.vue");
 const optionsApiVuePath = path.join(fixtureDir, "OptionsApi.vue");
-const scriptOffsetVuePath = path.join(fixtureDir, "ScriptOffset.vue");
 const dualScriptVuePath = path.join(fixtureDir, "DualScript.vue");
 const coreRulesVuePath = path.join(fixtureDir, "CoreRules.vue");
 const scriptlessVuePath = path.join(fixtureDir, "Scriptless.vue");
@@ -233,28 +231,6 @@ fs.writeFileSync(
 );
 
 fs.writeFileSync(
-  scriptOffsetConfigPath,
-  JSON.stringify(
-    {
-      plugins: ["vue"],
-      jsPlugins: [pluginEntry],
-      settings: {
-        vize: {
-          helpLevel: "none",
-          preset: "opinionated",
-        },
-      },
-      rules: {
-        "no-unused-vars": "off",
-        "vize/script/no-get-current-instance": "error",
-      },
-    },
-    null,
-    2,
-  ),
-);
-
-fs.writeFileSync(
   coreRulesConfigPath,
   JSON.stringify(
     {
@@ -385,23 +361,6 @@ export default {
 <style>
 .foo { color: red; }
   </style>
-`,
-);
-
-// The script block deliberately starts on line 5 and carries two diagnostics on
-// two different lines, so a regression in the extracted-program offset math
-// cannot pass by accident.
-fs.writeFileSync(
-  scriptOffsetVuePath,
-  `<template>
-  <div>{{ instance }}</div>
-</template>
-
-<script setup lang="ts">
-import { getCurrentInstance } from 'vue'
-
-const instance = getCurrentInstance()
-</script>
 `,
 );
 
@@ -819,39 +778,6 @@ assert.equal(
   opinionatedScriptRun.output,
   readSnapshot("stylish-opinionated-no-options-api-output.txt"),
 );
-
-const scriptOffsetRun = runOxlint([
-  "-c",
-  ".oxlintrc.script-offset.json",
-  "-f",
-  "stylish",
-  "ScriptOffset.vue",
-]);
-assert.notEqual(
-  scriptOffsetRun.exitCode,
-  0,
-  "script-offset fixture should report opinionated script diagnostics",
-);
-// Patina reports these at SFC 6:10 and 8:18. Oxlint hands JS plugins the
-// extracted program, so the bridge has to translate both back through the
-// script block's own offset; asserting the positions is the only thing that
-// catches a bridge that silently collapses every diagnostic onto one line.
-assert.match(
-  scriptOffsetRun.output,
-  /^  6:10 {2}error {2}getCurrentInstance import is not supported in Vapor-oriented components {2}vize\(script\/no-get-current-instance\)$/mu,
-  "a diagnostic on the script block's first content line should keep its real SFC position",
-);
-assert.match(
-  scriptOffsetRun.output,
-  /^  8:18 {2}error {2}getCurrentInstance\(\) is not supported in Vapor-oriented components {2}vize\(script\/no-get-current-instance\)$/mu,
-  "a diagnostic further into the script block should keep its real SFC position",
-);
-assert.doesNotMatch(
-  scriptOffsetRun.output,
-  /\(at <script setup>:/u,
-  "mapped script diagnostics should not need the fallback location suffix",
-);
-assert.equal(scriptOffsetRun.output, readSnapshot("stylish-script-offset-output.txt"));
 
 const dualScriptRun = runOxlint([
   "-c",

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -587,10 +587,8 @@ test("workspace TypeScript package builds use vp pack", () => {
     scripts?: Record<string, string>;
   };
   assert.equal(oxlintPackage.engines?.node, "^22 || >= 24");
-  const oxlintTest =
-    "vp pack && vp test run src/file-state.test.ts && node src/test.ts" +
-    " && node src/script-location.test.ts";
-  assert.equal(oxlintPackage.scripts?.test, oxlintTest);
+  const oxlintTest = "vp pack && vp test run src/file-state.test.ts && node src/test.ts";
+  assert.equal(oxlintPackage.scripts?.test, `${oxlintTest} && node src/script-location.test.ts`);
   const rootTasks = fs.readFileSync(path.join(root, "tools/vite-plus/tasks/build.ts"), "utf-8");
   assert.match(rootTasks, /pnpm exec vp pack/);
 });

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -587,7 +587,9 @@ test("workspace TypeScript package builds use vp pack", () => {
     scripts?: Record<string, string>;
   };
   assert.equal(oxlintPackage.engines?.node, "^22 || >= 24");
-  const oxlintTest = "vp pack && vp test run src/file-state.test.ts && node src/test.ts";
+  const oxlintTest =
+    "vp pack && vp test run src/file-state.test.ts && node src/test.ts" +
+    " && node src/script-location.test.ts";
   assert.equal(oxlintPackage.scripts?.test, oxlintTest);
   const rootTasks = fs.readFileSync(path.join(root, "tools/vite-plus/tasks/build.ts"), "utf-8");
   assert.match(rootTasks, /pnpm exec vp pack/);


### PR DESCRIPTION
## Change class

Semantic analysis, lint, and cross-file analysis (Oxlint bridge location mapping).

## Defect

Every `vize/*` diagnostic that Patina reports inside a `<script>` block was reported at the script block's first line instead of its real position.

`createSingleScriptMap` accepted the extracted program only when it was byte-identical to the script block body:

```ts
return block.content === extractedScript ? { block } : null;
```

Oxlint strips the newline that follows the `<script>` open tag before handing the program to JS plugins, so `block.content` starts with `"\n"` and `extractedScript` does not. The comparison never held for an ordinary SFC, `mapToScriptLoc` always returned `null`, and `plugin.ts` fell back to `{ line: 1, column: 1 }` of the extracted program.

Reproduction — `ScriptOffset.vue`:

```vue
<template>
  <div>{{ instance }}</div>
</template>

<script setup lang="ts">
import { getCurrentInstance } from 'vue'

const instance = getCurrentInstance()
</script>
```

`vize lint --preset opinionated` reports these at **6:10** and **8:18**. Through the Oxlint bridge, before this change:

```
6:2  error  getCurrentInstance import is not supported ... (at <script setup>:6:10)  vize(script/no-get-current-instance)
6:2  error  getCurrentInstance() is not supported ...     (at <script setup>:8:18)  vize(script/no-get-current-instance)
```

Both collapse onto one position. Editors and CI annotations consume `line`/`column` rather than the `(at <script setup>:...)` message suffix, so they send the reader to the wrong line, and the two findings are indistinguishable by position.

This affected every script-located Patina rule. Across the hydrated fixture corpus (`element-plus`, `vue-vben-admin`, `nuxt-ui`, `misskey`, `vitepress`, `dashy`) the script-block rules that fire are `script/no-options-api` (201 diagnostics), `script/no-get-current-instance` (43) and `type/require-typed-emits` (1).

## Fix

- Accept the extracted program when it is the block body minus a whitespace-only prefix, and record the SFC position where that program actually starts (`SingleScriptMap.scriptStart`).
- Anchor `mapToScriptLoc` on `scriptStart` instead of `block.contentStart`.
- Convert columns explicitly from Patina's 1-based convention to Oxlint's 0-based one. The previous code passed 1-based columns straight through for lines after the first, which would have been off by one had the path ever engaged.

After:

```
6:10  error  getCurrentInstance import is not supported in Vapor-oriented components  vize(script/no-get-current-instance)
8:18  error  getCurrentInstance() is not supported in Vapor-oriented components        vize(script/no-get-current-instance)
```

The default formatter's carets now underline exactly `getCurrentInstance` in both cases, so the end position is right too.

Template- and style-located diagnostics sit outside the extracted program's coordinate space and keep the documented best-effort fallback plus the `(at <template>:L:C)` suffix. Dual-script SFCs still return no map, as before.

## Tests

New `ScriptOffset.vue` fixture, deliberately built so the mapping cannot pass by accident:

- the script block starts on **line 5**, not line 1, so a hardcoded line-1 anchor fails;
- it carries diagnostics on **two different lines**, so collapsing them onto one position fails;
- assertions pin the exact `6:10` and `8:18` positions, and assert the fallback suffix is absent.

Reverting `script-map.ts` makes the run report `6:2` twice and fails all three assertions.

## Snapshot refresh

- `stylish-opinionated-no-options-api-output.txt`, `stylish-incremental-combo-output.txt`: `script/no-options-api` moves from `2:2 ... (at <script>:2:16)` to `2:16`. That is the position Patina reports; the suffix is dropped because the location is now mapped. The style diagnostic in the combo snapshot keeps the fallback position because it is outside the script block.
- `stylish-script-offset-output.txt`: new.

## Verification

```sh
cd npm/oxint
vp pack && node src/test.ts
vp check src vite.config.ts
```

Both pass. `node src/test.ts` covers the integration suite, the Nuxt preset suite, the type-aware suite and the CLI unit tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic location mapping for Vue `<script>` and `<script setup>` blocks when leading whitespace or newlines are trimmed.
  * Diagnostics now point to the correct lines and columns in the original single-file component.

* **Tests**
  * Added coverage for script offset scenarios to verify accurate diagnostic positions and output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Test layout

The script-location contract lives in its own `src/script-location.test.ts` rather than in `src/test.ts`. `test.ts` is 883 lines — already over the 350-line source-length budget — and that gate rejects growth in over-limit files, so adding the fixture there pushed it to 957 and failed `test-scripts`. The extracted file has its own fixture directory, matching how `nuxt-preset.test.ts` is structured, and `test.ts` is now byte-identical to main.

`package-manifests.test.ts` pins the oxint `test` script verbatim to catch accidental drift; extending the command is intentional here, so the pin moves in the same commit.