### PR TITLE
fix(musea): surface a missing axe-core instead of failing the a11y panel silently

### DIFF
--- a/npm/builder/vite-musea/src/preview/addons.test.ts
+++ b/npm/builder/vite-musea/src/preview/addons.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MUSEA_ADDONS_INIT_CODE } from "./addons.js";
+
+void test("the a11y runner rejects a vendor response that is not axe-core", () => {
+  // axe-core is an optional peer, so a static export can ship without
+  // `vendor/axe-core.min.js`. Dev answers that route with a 404, which fires
+  // `script.onerror`, but a static host is free to answer a missing asset with
+  // an SPA fallback: 200 plus HTML. The script tag then loads successfully and
+  // `window.axe` is still undefined, so the next line used to fail with
+  // "cannot read properties of undefined (reading 'run')" — an opaque message
+  // that points nowhere near the missing dependency.
+  const loadBlock = MUSEA_ADDONS_INIT_CODE.slice(
+    MUSEA_ADDONS_INIT_CODE.indexOf("musea:run-a11y"),
+    MUSEA_ADDONS_INIT_CODE.indexOf("window.axe.run"),
+  );
+
+  assert.notEqual(loadBlock, "", "the run-a11y handler must precede the axe.run call");
+  assert.match(
+    loadBlock,
+    /if \(!window\.axe\) \{\s*throw new Error\(/u,
+    "the runner must verify window.axe after the vendor script loads, not just await the load event",
+  );
+  assert.match(
+    loadBlock,
+    /install axe-core/u,
+    "the failure must name the missing dependency so the message is actionable",
+  );
+  assert.match(
+    loadBlock,
+    /SPA fallback/u,
+    "the failure must mention the served-as-HTML case, which is how a deployed gallery hits this",
+  );
+});
+
+void test("the a11y runner reports failures back to the gallery instead of throwing away the request", () => {
+  // The gallery keys pending requests by requestId and times them out after
+  // 30s. A runner that throws without posting a result turns a clear error into
+  // a half-minute spinner, so pin that the catch path still answers.
+  const catchBlock = MUSEA_ADDONS_INIT_CODE.slice(MUSEA_ADDONS_INIT_CODE.indexOf("window.axe.run"));
+
+  assert.match(
+    catchBlock,
+    /catch \(err\)[\s\S]*musea:a11y-result[\s\S]*requestId/u,
+    "the catch path must post musea:a11y-result carrying the requestId",
+  );
+});

--- a/npm/builder/vite-musea/src/preview/addons.ts
+++ b/npm/builder/vite-musea/src/preview/addons.ts
@@ -262,6 +262,19 @@ function __museaInitAddons(container, variantName, extraCaptureEvents = []) {
                 script.onerror = reject;
                 document.head.appendChild(script);
               });
+              // A load event is not proof the vendor script exists. axe-core is
+              // an optional peer, so a static export can ship without it, and a
+              // static host is free to answer the missing asset with an SPA
+              // fallback: 200 plus HTML. The script tag then "loads" fine and
+              // window.axe is still undefined, which surfaced downstream as an
+              // opaque "cannot read properties of undefined" instead of the real
+              // cause.
+              if (!window.axe) {
+                throw new Error(
+                  'axe-core did not load from ' + script.src +
+                  ' - install axe-core so the gallery can ship it, and check that the path is served as JavaScript rather than an SPA fallback'
+                );
+              }
             }
             // Run axe-core on the .musea-variant container only (not the full document)
             const context = document.querySelector('.musea-variant') || document;

--- a/npm/builder/vite-musea/src/static-export.test.ts
+++ b/npm/builder/vite-musea/src/static-export.test.ts
@@ -146,17 +146,13 @@ void test("emitStaticGallery packages browser-facing static output", async () =>
     );
 
     // The A11y panel runs axe inside the preview iframe and loads it from this
-    // path, so a deployed gallery that does not ship the vendor script has a
-    // dead a11y feature. Nothing else in the suite covered the asset.
+    // path, so an export without the vendor script has a dead a11y feature.
+    const axeVendor = assets.get("__musea__/vendor/axe-core.min.js");
     assert.ok(
-      assets.has("__musea__/vendor/axe-core.min.js"),
+      axeVendor,
       `the export must ship the axe-core vendor script; emitted: ${[...assets.keys()].sort().join(", ")}`,
     );
-    assert.match(
-      assetText(assets, "__musea__/vendor/axe-core.min.js"),
-      /axe/,
-      "the vendor asset must be the real axe-core bundle",
-    );
+    assert.match(axeVendor, /axe/, "the vendor asset must be the real axe-core bundle");
   } finally {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   }

--- a/npm/builder/vite-musea/src/static-export.test.ts
+++ b/npm/builder/vite-musea/src/static-export.test.ts
@@ -144,6 +144,19 @@ void test("emitStaticGallery packages browser-facing static output", async () =>
       previewRuntimeSpecifier(assetText(assets, `__musea__/preview/${previewId}.html`)),
       "../../assets/musea-static-runtime.js",
     );
+
+    // The A11y panel runs axe inside the preview iframe and loads it from this
+    // path, so a deployed gallery that does not ship the vendor script has a
+    // dead a11y feature. Nothing else in the suite covered the asset.
+    assert.ok(
+      assets.has("__musea__/vendor/axe-core.min.js"),
+      `the export must ship the axe-core vendor script; emitted: ${[...assets.keys()].sort().join(", ")}`,
+    );
+    assert.match(
+      assetText(assets, "__musea__/vendor/axe-core.min.js"),
+      /axe/,
+      "the vendor asset must be the real axe-core bundle",
+    );
   } finally {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   }

--- a/npm/builder/vite-musea/src/static-export.ts
+++ b/npm/builder/vite-musea/src/static-export.ts
@@ -240,7 +240,16 @@ async function emitAxeVendor(
       source,
     });
   } catch {
-    // axe-core is an optional peer; static a11y keeps the same best-effort behavior as dev.
+    // axe-core is an optional peer, so the export stays best-effort like dev.
+    // Dev answers this route with a 404 the preview runner reports as a load
+    // error, but a static host may answer a missing asset with an SPA fallback
+    // (200 plus HTML), so an unresolvable axe-core would otherwise reach users
+    // as a runtime failure in the deployed gallery with no signal at build
+    // time. Say it here, where it is actionable.
+    console.warn(
+      "[musea] axe-core is not installed, so the exported gallery cannot run accessibility checks.\n" +
+        "        Install it to enable the A11y panel in the static build: vp install -D axe-core",
+    );
   }
 }
 


### PR DESCRIPTION
## Change class

Runtime packaging (Musea static export + preview runtime).

## How the a11y panel works

The A11y panel does not read pre-baked results — it runs axe live in the browser. The gallery posts `musea:run-a11y` into the preview iframe, the preview loads `<base>/vendor/axe-core.min.js`, runs `axe.run` on the `.musea-variant` container, and posts `musea:a11y-result` back. `useA11y` keys pending requests by `requestId` and times them out after 30s.

axe-core is an **optional peer**, and both ends were best-effort about that. In a deployed static gallery, that combination makes the whole feature fail without a usable signal.

## Defect 1 — the export silently ships no axe

`emitAxeVendor` swallowed an unresolvable axe-core and emitted nothing:

```ts
} catch {
  // axe-core is an optional peer; static a11y keeps the same best-effort behavior as dev.
}
```

The exported gallery then has no vendor script at all, and the build prints nothing. The first sign of trouble is a user clicking **Run** in the deployed panel. Nothing in the test suite covered the asset either, so a regression here was invisible.

## Defect 2 — a load event is treated as proof axe exists

```js
await new Promise((resolve, reject) => {
  script.onload = resolve;
  script.onerror = reject;
  document.head.appendChild(script);
});
// ...
const results = await window.axe.run(context, { ... });
```

Dev answers the vendor route with a **404**, so `onerror` fires and the runner reports a load failure — that path is fine.

A static host is free to answer a missing asset with an **SPA fallback: 200 plus HTML**, which is the default on several common hosts. The script tag then "loads" successfully, `window.axe` stays `undefined`, and `window.axe.run` fails with:

```
Cannot read properties of undefined (reading 'run')
```

which points nowhere near the missing dependency. This is the deployed-only failure: identical code works in dev because dev returns a real 404.

## Fix

- Warn at build time when axe-core cannot be resolved, naming the install command, so the omission is visible where it is actionable rather than in a user's browser.
- Verify `window.axe` after the load event and throw an error that names both the cause and the remedy (install axe-core; check the path is served as JavaScript rather than an SPA fallback).

The existing catch path already posts `musea:a11y-result` with the `requestId`, so the gallery renders the message immediately instead of spinning until its 30s timeout.

## Tests

`static-export.test.ts` — pins that the export ships `__musea__/vendor/axe-core.min.js` and that the asset is really axe-core rather than an empty or placeholder file. Previously uncovered.

`addons.test.ts` (new) — pins the runtime contract in the generated preview script:

- the `window.axe` check exists **after** the load await, not just the load event;
- the message names the missing dependency, so it is actionable;
- the message mentions the served-as-HTML case, which is specifically how a deployed gallery hits this;
- the catch path still posts `musea:a11y-result` carrying the `requestId`, so a failure cannot degrade into the 30s timeout.

Reverting `addons.ts` fails the first of these with `the runner must verify window.axe after the vendor script loads, not just await the load event`.

## Verification

```sh
cd npm/builder/vite-musea
vp exec tsx --test src/preview/addons.test.ts src/static-export.test.ts
vp check src
```

- 8 tests pass.
- `vp check`: 105 files formatted, no lint errors in 102 files.

## Note

`handleArtA11y` in `src/api-routes/handlers.ts` is a stub that always returns `{ violations: [], passes: 0, incomplete: 0 }` ("populated after VRT --a11y run"), and `createStaticGalleryPayload` bakes its output into `static.json` under `details[art].a11y`. The panel does not read that field — it runs axe live — so this PR does not change it. But it means `fetchA11y` reports "no violations" for every component in a static gallery, which is a false pass for any consumer that does read it. Worth its own issue; I did not want to change the payload shape inside a fix for the runtime path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->