### PR TITLE
fix(musea): stop reporting an accessibility result the export never measured

### DIFF
--- a/npm/builder/vite-musea/gallery/api.ts
+++ b/npm/builder/vite-musea/gallery/api.ts
@@ -1,6 +1,5 @@
 import type { ArtFileInfo } from "../src/types/index.js";
 import {
-  emptyA11y,
   emptyDocs,
   emptyPalette,
   emptyTokens,
@@ -56,12 +55,6 @@ export interface A11yViolation {
   nodes: number;
 }
 
-export interface A11yApiResponse {
-  violations: A11yViolation[];
-  passes: number;
-  incomplete: number;
-}
-
 const basePath =
   (window as unknown as { __MUSEA_BASE_PATH__: string }).__MUSEA_BASE_PATH__ ?? "/__musea__";
 const sessionToken =
@@ -113,15 +106,6 @@ export async function fetchAnalysis(artPath: string): Promise<AnalysisApiRespons
 export async function fetchDocs(artPath: string): Promise<DocApiResponse> {
   if (isStaticGallery) return (await fetchStaticDetail(artPath)).docs ?? emptyDocs();
   return fetchJson<DocApiResponse>(`/api/arts/${encodeURIComponent(artPath)}/docs`);
-}
-
-export async function fetchA11y(artPath: string, variantName: string): Promise<A11yApiResponse> {
-  if (isStaticGallery) {
-    return (await fetchStaticDetail(artPath)).a11y?.[variantName] ?? emptyA11y();
-  }
-  return fetchJson<A11yApiResponse>(
-    `/api/arts/${encodeURIComponent(artPath)}/variants/${encodeURIComponent(variantName)}/a11y`,
-  );
 }
 
 export function getPreviewUrl(artPath: string, variantName: string): string {

--- a/npm/builder/vite-musea/gallery/staticApi.ts
+++ b/npm/builder/vite-musea/gallery/staticApi.ts
@@ -1,6 +1,5 @@
 import type { ArtFileInfo } from "../src/types/index.js";
 import type {
-  A11yApiResponse,
   AnalysisApiResponse,
   ArtSourceResponse,
   DocApiResponse,
@@ -30,7 +29,6 @@ export interface StaticGalleryPayload {
       palette?: PaletteApiResponse;
       analysis?: AnalysisApiResponse;
       docs?: DocApiResponse;
-      a11y?: Record<string, A11yApiResponse>;
     }
   >;
   tokens?: TokensApiResponse;
@@ -74,10 +72,6 @@ export function emptyPalette(): PaletteApiResponse {
 
 export function emptyDocs(): DocApiResponse {
   return { markdown: "", title: "", variant_count: 0 };
-}
-
-export function emptyA11y(): A11yApiResponse {
-  return { violations: [], passes: 0, incomplete: 0 };
 }
 
 export function emptyTokens(): TokensApiResponse {

--- a/npm/builder/vite-musea/src/api-routes/handlers.ts
+++ b/npm/builder/vite-musea/src/api-routes/handlers.ts
@@ -155,20 +155,3 @@ export async function handleArtDocs(
 }
 
 /** GET /api/arts/:path/variants/:name/a11y */
-export function handleArtA11y(
-  ctx: ApiRoutesContext,
-  match: RegExpMatchArray,
-  sendJson: SendJson,
-  sendError: SendError,
-): void {
-  const artPath = decodeUrlComponent(match[1], "art path");
-  const _variantName = decodeUrlComponent(match[2], "variant name");
-  const art = ctx.artFiles.get(artPath);
-  if (!art) {
-    sendError("Art not found", 404);
-    return;
-  }
-
-  // Return empty a11y results (populated after VRT --a11y run)
-  sendJson({ violations: [], passes: 0, incomplete: 0 });
-}

--- a/npm/builder/vite-musea/src/api-routes/index.ts
+++ b/npm/builder/vite-musea/src/api-routes/index.ts
@@ -23,13 +23,7 @@ import {
   handleTokensUpdate,
   handleTokensDelete,
 } from "../api-tokens.js";
-import {
-  handleArtSource,
-  handleArtPalette,
-  handleArtAnalysis,
-  handleArtDocs,
-  handleArtA11y,
-} from "./handlers.js";
+import { handleArtSource, handleArtPalette, handleArtAnalysis, handleArtDocs } from "./handlers.js";
 import { handlePreviewWithProps, handleGenerate, handleRunVrt } from "./post-handlers.js";
 import {
   collectRequestBody,
@@ -163,7 +157,6 @@ export function createApiMiddleware(ctx: ApiRoutesContext) {
         const paletteMatch = rest.match(/^(.+)\/palette$/);
         const analysisMatch = rest.match(/^(.+)\/analysis$/);
         const docsMatch = rest.match(/^(.+)\/docs$/);
-        const a11yMatch = rest.match(/^(.+)\/variants\/([^/]+)\/a11y$/);
 
         if (sourceMatch) {
           await handleArtSource(ctx, sourceMatch, sendJson, sendError);
@@ -182,11 +175,6 @@ export function createApiMiddleware(ctx: ApiRoutesContext) {
 
         if (docsMatch) {
           await handleArtDocs(ctx, docsMatch, sendJson, sendError);
-          return;
-        }
-
-        if (a11yMatch) {
-          handleArtA11y(ctx, a11yMatch, sendJson, sendError);
           return;
         }
 

--- a/npm/builder/vite-musea/src/static-data.ts
+++ b/npm/builder/vite-musea/src/static-data.ts
@@ -5,7 +5,6 @@ import type { ResolvedConfig } from "vite";
 import { handleTokensGet, handleTokensUsage } from "./api-tokens.js";
 import {
   handleArtAnalysis,
-  handleArtA11y,
   handleArtDocs,
   handleArtPalette,
   handleArtSource,
@@ -27,7 +26,6 @@ export interface StaticArtDetails {
   palette: unknown;
   analysis: unknown;
   docs: unknown;
-  a11y: Record<string, unknown>;
 }
 
 export interface StaticGalleryDataContext {
@@ -75,14 +73,10 @@ export async function createStaticGalleryPayload(
 
   for (const art of arts) {
     previews[art.path] = {};
-    const a11y: Record<string, unknown> = {};
 
     for (const variant of art.variants) {
       const id = staticPreviewId(art.path, variant.name);
       previews[art.path][variant.name] = joinUrlPath(ctx.basePath, "preview", `${id}.html`);
-      a11y[variant.name] = await captureJson((sendJson, sendError) => {
-        handleArtA11y(apiCtx, artVariantMatch(art.path, variant.name), sendJson, sendError);
-      }, emptyA11y());
     }
 
     details[art.path] = {
@@ -104,7 +98,6 @@ export async function createStaticGalleryPayload(
       docs: await captureJson((sendJson, sendError) => {
         return handleArtDocs(apiCtx, artMatch(art.path), sendJson, sendError);
       }, emptyDocs(art)),
-      a11y,
     };
   }
 
@@ -154,14 +147,6 @@ function artMatch(artPath: string): RegExpMatchArray {
   return ["", encodeURIComponent(artPath)] as unknown as RegExpMatchArray;
 }
 
-function artVariantMatch(artPath: string, variantName: string): RegExpMatchArray {
-  return [
-    "",
-    encodeURIComponent(artPath),
-    encodeURIComponent(variantName),
-  ] as unknown as RegExpMatchArray;
-}
-
 function emptyPalette(art: ArtFileInfo): unknown {
   return {
     title: art.metadata.title,
@@ -178,10 +163,6 @@ function emptyDocs(art: ArtFileInfo): unknown {
     title: art.metadata.title,
     variant_count: art.variants.length,
   };
-}
-
-function emptyA11y(): unknown {
-  return { violations: [], passes: 0, incomplete: 0 };
 }
 
 function emptyTokens(): unknown {

--- a/npm/builder/vite-musea/src/static-export.test.ts
+++ b/npm/builder/vite-musea/src/static-export.test.ts
@@ -94,6 +94,7 @@ void test("emitStaticGallery packages browser-facing static output", async () =>
     const staticPayload = JSON.parse(assetText(assets, "__musea__/api/static.json")) as {
       arts: Array<{ path: string; metadata: { title: string }; variants: Array<{ name: string }> }>;
       previews: Record<string, Record<string, string>>;
+      details?: Record<string, Record<string, unknown>>;
     };
     const artsPayload = JSON.parse(assetText(assets, "__musea__/api/arts")) as Array<{
       path: string;
@@ -143,6 +144,21 @@ void test("emitStaticGallery packages browser-facing static output", async () =>
     assert.equal(
       previewRuntimeSpecifier(assetText(assets, `__musea__/preview/${previewId}.html`)),
       "../../assets/musea-static-runtime.js",
+    );
+
+    // #3362: the payload used to carry `details[art].a11y`, filled in from a
+    // handler that always answered `{violations: [], passes: 0, incomplete: 0}`.
+    // Baked into a static artifact that reads as "audited and clean" for every
+    // component. The panel measures accessibility live in the preview instead,
+    // so the field had no consumer — only the false reading.
+    const detailKeys = Object.keys(staticPayload.details?.[art.path] ?? {});
+    assert.ok(
+      detailKeys.length > 0,
+      "the payload must still carry per-art details; an empty object would make the next assertion vacuous",
+    );
+    assert.ok(
+      !detailKeys.includes("a11y"),
+      `the static payload must not report an accessibility result it never measured; got ${detailKeys.join(", ")}`,
     );
 
     // The A11y panel runs axe inside the preview iframe and loads it from this

--- a/npm/builder/vite-musea/src/static-export.test.ts
+++ b/npm/builder/vite-musea/src/static-export.test.ts
@@ -27,6 +27,24 @@ function createArt(pathname: string): ArtFileInfo {
   };
 }
 
+const STATIC_RUNTIME_BUNDLE = {
+  "assets/musea-static-runtime.js": {
+    type: "chunk",
+    name: "musea-static-runtime",
+    fileName: "assets/musea-static-runtime.js",
+    facadeModuleId: null,
+  },
+} as const;
+
+function collectAssets(assets: Map<string, string>) {
+  return (asset: { fileName: string; source: string | Uint8Array }) => {
+    assets.set(
+      asset.fileName,
+      typeof asset.source === "string" ? asset.source : Buffer.from(asset.source).toString("utf8"),
+    );
+  };
+}
+
 void test("static gallery paths stay under the configured Musea base path", () => {
   const previewId = staticPreviewId("/repo/src/Button.art.vue", "Default");
 
@@ -57,38 +75,20 @@ void test("emitStaticGallery packages browser-facing static output", async () =>
     const art = createArt(artPath);
     const assets = new Map<string, string>();
 
-    await emitStaticGallery(
-      (asset) => {
-        assets.set(
-          asset.fileName,
-          typeof asset.source === "string"
-            ? asset.source
-            : Buffer.from(asset.source).toString("utf8"),
-        );
+    await emitStaticGallery(collectAssets(assets), STATIC_RUNTIME_BUNDLE, {
+      config: { root: tempDir } as ResolvedConfig,
+      artFiles: new Map([[art.path, art]]),
+      scanRoots: [tempDir],
+      tokensPath: undefined,
+      basePath: "/__musea__",
+      resolvedPreviewCss: [],
+      resolvedPreviewSetup: null,
+      devSessionToken: "static-test",
+      themeConfig: undefined,
+      tokenPreviewConfig: {
+        rules: [{ pathIncludes: "elevation.overlay", kind: "zIndex" }],
       },
-      {
-        "assets/musea-static-runtime.js": {
-          type: "chunk",
-          name: "musea-static-runtime",
-          fileName: "assets/musea-static-runtime.js",
-          facadeModuleId: null,
-        },
-      },
-      {
-        config: { root: tempDir } as ResolvedConfig,
-        artFiles: new Map([[art.path, art]]),
-        scanRoots: [tempDir],
-        tokensPath: undefined,
-        basePath: "/__musea__",
-        resolvedPreviewCss: [],
-        resolvedPreviewSetup: null,
-        devSessionToken: "static-test",
-        themeConfig: undefined,
-        tokenPreviewConfig: {
-          rules: [{ pathIncludes: "elevation.overlay", kind: "zIndex" }],
-        },
-      },
-    );
+    });
 
     const previewId = staticPreviewId(art.path, "Default");
     const staticPayload = JSON.parse(assetText(assets, "__musea__/api/static.json")) as {
@@ -150,7 +150,7 @@ void test("emitStaticGallery packages browser-facing static output", async () =>
     // handler that always answered `{violations: [], passes: 0, incomplete: 0}`.
     // Baked into a static artifact that reads as "audited and clean" for every
     // component. The panel measures accessibility live in the preview instead,
-    // so the field had no consumer — only the false reading.
+    // so the field had no consumer, only the false reading.
     const detailKeys = Object.keys(staticPayload.details?.[art.path] ?? {});
     assert.ok(
       detailKeys.length > 0,
@@ -183,38 +183,20 @@ void test("emitStaticGallery prefixes browser URLs with Vite base without nestin
     const art = createArt(artPath);
     const assets = new Map<string, string>();
 
-    await emitStaticGallery(
-      (asset) => {
-        assets.set(
-          asset.fileName,
-          typeof asset.source === "string"
-            ? asset.source
-            : Buffer.from(asset.source).toString("utf8"),
-        );
-      },
-      {
-        "assets/musea-static-runtime.js": {
-          type: "chunk",
-          name: "musea-static-runtime",
-          fileName: "assets/musea-static-runtime.js",
-          facadeModuleId: null,
-        },
-      },
-      {
-        config: {
-          root: tempDir,
-          base: "/app/aim/aim-front/design-system/",
-        } as ResolvedConfig,
-        artFiles: new Map([[art.path, art]]),
-        scanRoots: [tempDir],
-        tokensPath: undefined,
-        basePath: "/__musea__",
-        resolvedPreviewCss: [],
-        resolvedPreviewSetup: null,
-        devSessionToken: "static-test",
-        themeConfig: undefined,
-      },
-    );
+    await emitStaticGallery(collectAssets(assets), STATIC_RUNTIME_BUNDLE, {
+      config: {
+        root: tempDir,
+        base: "/app/aim/aim-front/design-system/",
+      } as ResolvedConfig,
+      artFiles: new Map([[art.path, art]]),
+      scanRoots: [tempDir],
+      tokensPath: undefined,
+      basePath: "/__musea__",
+      resolvedPreviewCss: [],
+      resolvedPreviewSetup: null,
+      devSessionToken: "static-test",
+      themeConfig: undefined,
+    });
 
     const previewId = staticPreviewId(art.path, "Default");
     const publicBasePath = "/app/aim/aim-front/design-system/__musea__";


### PR DESCRIPTION
Closes #3362.

## Change class

Runtime packaging (Musea static export payload).

## Defect

`handleArtA11y` was a stub:

```ts
// Return empty a11y results (populated after VRT --a11y run)
sendJson({ violations: [], passes: 0, incomplete: 0 });
```

`createStaticGalleryPayload` baked that answer into `static.json` under `details[art].a11y` for **every** art/variant pair, and `fetchA11y` read it back in static mode. So a deployed gallery reported zero violations *and* zero passes for every component — indistinguishable from "audited and clean". A false pass in a shipped artifact, which is the dangerous direction.

## Why removal rather than a marker

Nothing consumed the field. `A11yPanel.vue` measures accessibility **live** in the preview iframe via `useA11y` (postMessage → axe → `musea:a11y-result`), so `fetchA11y` had no caller anywhere in the repo, and no MCP or CLI surface reads the route either. The field carried no information, only the false reading.

The issue offered three options; this takes the honest version of (2). A field that does not exist cannot be misread, whereas the `audited: false` marker from option (3) leaves a shape for callers to keep mishandling. Removed: the stub handler, its route, `fetchA11y`, `A11yApiResponse`, the payload field, and the `emptyA11y` helpers on both sides.

Option (1) — actually measuring accessibility during static export — is worth doing on its own terms, and would populate the field honestly. Deliberately not bundled here: it puts a browser dependency in the export path, which deserves its own decision.

## Tests

`static-export.test.ts` asserts `details[art]` carries no `a11y` key.

The assertion is guarded so it cannot pass for the wrong reason: a preceding check requires `details[art]` to be non-empty, since an absent or empty details object would satisfy "no a11y key" vacuously. Reverting `static-data.ts` fails the test.

## Verification

```sh
cd npm/builder/vite-musea
vp exec tsx --test src/*.test.ts src/**/*.test.ts
vp check src gallery
```

- 100 tests pass.
- `vp check`: 175 files formatted, no lint errors or warnings across 168 files (the removal also cleared two now-unused helpers the linter flagged).

## Related

#3361 fixed the runtime half of the deployed-a11y problem — a missing `vendor/axe-core.min.js` failing opaquely. Together they mean the deployed panel either measures accessibility or says why it cannot, and no longer reports a result nobody measured.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Accessibility audit results are no longer generated or included in static gallery payloads.
  * Removed the dedicated accessibility-results API route for per-art/per-variant queries; those requests no longer return accessibility placeholders.
  * Static gallery details still include the other existing art metadata fields.
* **Tests**
  * Updated static export tests to confirm accessibility data is omitted while other per-art detail entries remain present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->