### PR TITLE
fix(glyph): anchor the continuation indentation of every multi-line directive value

### DIFF
--- a/crates/vize_glyph/src/template/directives.rs
+++ b/crates/vize_glyph/src/template/directives.rs
@@ -7,6 +7,7 @@ use crate::{options::FormatOptions, script};
 use vize_carton::{String, ToCompactString};
 
 use super::attributes::attribute_priority;
+use super::helpers::template_literal_state_after_line_from;
 
 /// Normalize directive shorthands and assign sort priority.
 #[allow(clippy::disallowed_macros)]
@@ -92,8 +93,107 @@ fn format_directive_value(name: &str, value: &str, options: &FormatOptions) -> (
             let indent_multiline_value = formatted.contains('\n');
             (formatted, indent_multiline_value)
         }
-        None => (value.to_compact_string(), false),
+        None => reanchor_continuation_lines(value, options),
     }
+}
+
+/// Re-derive the continuation indentation of a multi-line directive value the
+/// expression formatter could not parse — a statement sequence such as
+/// `foo(1); bar(2)`, or otherwise unparsable source.
+///
+/// The value's own bytes are kept, but the leading whitespace of every
+/// continuation line is rebuilt from the value's common indentation, so the
+/// printed line is `attribute indent + one level + relative depth` whatever the
+/// previous pass wrote. `write_rendered_attribute` then anchors those lines to
+/// the attribute's depth, exactly like the lines a formatted expression
+/// produces. Without the rebuild the value carries its absolute indentation and
+/// the SFC indent step adds one more level on top of it, so the line drifts two
+/// columns further on every `vize fmt` run (#3346).
+///
+/// A value whose first line is blank starts on the line *after* the attribute
+/// name. `compute_raw_line_mask` keeps every line of that shape verbatim, so it
+/// never receives SFC indentation and must not be re-anchored here.
+fn reanchor_continuation_lines(value: &str, options: &FormatOptions) -> (String, bool) {
+    let Some(first_break) = value.find('\n') else {
+        return (value.to_compact_string(), false);
+    };
+    let (first_line, rest) = (&value[..first_break], &value[first_break + 1..]);
+    if first_line.trim().is_empty() {
+        return (value.to_compact_string(), false);
+    }
+
+    let common_indent = common_continuation_indent(first_line, rest);
+    let indent = options.indent_string();
+    let mut reanchored = String::with_capacity(value.len() + indent.len());
+    reanchored.push_str(first_line);
+    let mut state = ContinuationScan::new(first_line);
+    for line in rest.split('\n') {
+        let line = line.trim_end_matches('\r');
+        if state.line_holds_code(line) {
+            reanchored.push('\n');
+            reanchored.push_str(&indent);
+            reanchored.push_str(dedent(line, common_indent));
+        } else if state.in_template_literal {
+            // Raw template-literal content: these bytes belong to the rendered
+            // string value, so the printer keeps them as they are.
+            reanchored.push('\n');
+            reanchored.push_str(line);
+        }
+        // Anything else is a blank line outside a template literal: it holds
+        // nothing to anchor and would print as bare indentation, so it is
+        // dropped, exactly as a formatted expression comes back without it.
+        state.advance(line);
+    }
+    (reanchored, true)
+}
+
+/// Tracks whether a continuation line starts inside a multiline template
+/// literal, mirroring how `write_rendered_attribute` renders the same lines.
+struct ContinuationScan {
+    in_template_literal: bool,
+}
+
+impl ContinuationScan {
+    fn new(first_line: &str) -> Self {
+        Self {
+            in_template_literal: template_literal_state_after_line_from(false, first_line),
+        }
+    }
+
+    /// A line whose indentation is the formatter's to choose: outside any
+    /// template literal and not blank (a blank line has nothing to anchor).
+    fn line_holds_code(&self, line: &str) -> bool {
+        !self.in_template_literal && !line.trim().is_empty()
+    }
+
+    fn advance(&mut self, line: &str) {
+        self.in_template_literal =
+            template_literal_state_after_line_from(self.in_template_literal, line);
+    }
+}
+
+/// The narrowest indentation shared by the continuation lines that hold code,
+/// which becomes the value's zero column when they are re-anchored.
+fn common_continuation_indent(first_line: &str, rest: &str) -> usize {
+    let mut state = ContinuationScan::new(first_line);
+    let mut common: Option<usize> = None;
+    for line in rest.split('\n') {
+        let line = line.trim_end_matches('\r');
+        if state.line_holds_code(line) {
+            let width = blank_prefix_len(line);
+            common = Some(common.map_or(width, |narrowest| narrowest.min(width)));
+        }
+        state.advance(line);
+    }
+    common.unwrap_or(0)
+}
+
+fn dedent(line: &str, columns: usize) -> &str {
+    &line[blank_prefix_len(line).min(columns)..]
+}
+
+fn blank_prefix_len(line: &str) -> usize {
+    line.len() - line.trim_start_matches([' ', '\t']).len()
 }
 
 fn decode_expression_attribute_entities(value: &str) -> Option<String> {

--- a/crates/vize_glyph/tests/template_directive_attributes.rs
+++ b/crates/vize_glyph/tests/template_directive_attributes.rs
@@ -140,6 +140,53 @@ fn sfc_multiline_directive_attribute_keeps_template_indent() {
 }
 
 #[test]
+fn sfc_multiline_directive_statement_continuation_is_anchored_like_a_ternary() {
+    // #3346: the ternary continuation is re-derived from the formatted
+    // expression on every pass and therefore holds still, but a statement
+    // sequence was reprinted exactly as authored, so the SFC indent step
+    // widened it by one level per pass (unbounded drift). Both shapes must land
+    // on attribute indent + one level: the ternary continuations move 4 -> 6
+    // columns, the statement continuation 8 -> 6, and neither moves again.
+    let source = "<template>\n  <button\n    :class='sort === \"name-asc\" || sort === \"name-desc\"\n    ? \"bg-ink text-paper border-ink\"\n    : \"border-rule text-ink-2 hover:text-ink hover:border-ink\"'\n    @click=\"toggleNameSort(sort);\n        applySort()\"\n  >\n    Name\n  </button>\n</template>\n";
+    let options = FormatOptions::default();
+    let first = format_sfc(source, &options).unwrap();
+    let second = format_sfc(&first.code, &options).unwrap();
+    let third = format_sfc(&second.code, &options).unwrap();
+
+    assert_eq!(
+        first.code.as_str(),
+        "<template>\n  <button\n    :class='sort === \"name-asc\" || sort === \"name-desc\"\n      ? \"bg-ink text-paper border-ink\"\n      : \"border-rule text-ink-2 hover:text-ink hover:border-ink\"'\n    @click=\"toggleNameSort(sort);\n      applySort()\"\n  >\n    Name\n  </button>\n</template>\n"
+    );
+    assert_eq!(first.code, second.code, "fmt; fmt must be a no-op");
+    assert_eq!(second.code, third.code, "fmt must stay at its fixed point");
+}
+
+#[test]
+fn sfc_multiline_directive_statement_continuation_keeps_relative_depth() {
+    // Anchoring re-derives the continuation indentation from the value's own
+    // common indent, so the nesting inside the statement sequence survives
+    // instead of collapsing onto a single level.
+    let source = r#"<template>
+  <button
+    @click="dispatch({
+        id: item.id,
+        kind: 'primary',
+      });
+      close()"
+  >
+    Go
+  </button>
+</template>
+"#;
+    let options = FormatOptions::default();
+    let first = format_sfc(source, &options).unwrap();
+    let second = format_sfc(&first.code, &options).unwrap();
+
+    assert_eq!(first.code.as_str(), source);
+    assert_eq!(first.code, second.code, "fmt; fmt must be a no-op");
+}
+
+#[test]
 fn sfc_single_multiline_directive_attribute_is_idempotent() {
     let source = r#"<template>
   <label

--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -1,23 +1,5 @@
 [
   {
-    "property": "idempotence",
-    "project": "dashy",
-    "path": "src/components/Settings/CustomThemeMaker.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3346"
-  },
-  {
-    "property": "idempotence",
-    "project": "scalar",
-    "path": "projects/scalar-app/src/features/collection/components/Environment.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3346"
-  },
-  {
-    "property": "idempotence",
-    "project": "vue-data-ui",
-    "path": "src/components/vue-ui-flow.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3346"
-  },
-  {
     "property": "lint-agreement",
     "project": "gogocode",
     "path": "packages/gogocode-vue-playground/packages/vue2/src/components/keycode-modifiers/Comp.vue",


### PR DESCRIPTION
The last `Real Project Matrix` idempotence failure, and the three pins it held open.

## The defect (#3346)

A multi-line directive value whose continuation is a **statement sequence** gained two columns on every `vize fmt` pass — unbounded drift, so a project with `vize fmt` in a pre-commit hook re-indents the line further on every commit.

```sh
cargo build --profile ci -p vize --features legacy
# S1.vue as in the issue: a ternary value and a statement-sequence value
target/ci/vize fmt S1.vue --write --no-config
cp S1.vue S2.vue && target/ci/vize fmt S2.vue --write --no-config
diff S1.vue S2.vue
```

Before:

```diff
       @input="foo(1);
-          bar(2)"
+            bar(2)"
```

The `?` / `:` continuations of the ternary in the same file were stable. After: `1 file(s) unchanged` on the second pass, and pass 1 leaves the authored column alone (`bar(2)` stays at attribute indent + 2 rather than being pushed to 10).

Same on the `dashy` shape from the issue:

```
    <input
      @input="customColors[colorName] = $event.target.value;
        setVariable(colorName, $event.target.value)"
    />
```

`fmt; fmt` is now byte-identical, and the continuation ends on the column it was authored at.

## Root cause

`format_directive_value` (`crates/vize_glyph/src/template/directives.rs`) sends the value through `script::format_js_expression`, which wraps it in `void (…)`. A statement sequence cannot parse that way, so the `None` arm returned the value's **original bytes** with `indent_multiline_value = false`:

```rust
None => (value.to_compact_string(), false),
```

Those bytes carry the *absolute* indentation of the previous pass, and the SFC indent step in `crates/vize_glyph/src/formatter.rs` then adds one template level on top of it, because `compute_raw_line_mask` correctly does not mark the line raw. Next pass, that wider line is the input. Two columns per run, forever.

The shapes the pretty-printer *can* parse never drifted: `format_js_expression` re-derives their continuation indentation from scratch every pass (relative to the expression's own column 0), and `write_rendered_attribute` then anchors those lines to the attribute's depth. The bug was that one shape opted out of that re-derivation.

## The fix

Re-derive the continuation indentation for **every** multi-line directive value, so the unparsable shapes are anchored exactly like the parsed ones. `reanchor_continuation_lines` keeps the value's bytes but rebuilds the leading whitespace of each continuation line from the value's own common indent, then reports `indent_multiline_value = true` so the printer anchors it to the attribute depth. Both shapes now land on `attribute indent + one level (+ relative depth)` whatever the previous pass wrote.

Details that keep it honest:

- **Relative nesting survives.** The lines are dedented by their *common* indent, not flattened to one level, so `dispatch({ … });` / `close()` keeps its inner two columns (second test below).
- **Values that start on the line after the attribute are untouched.** `compute_raw_line_mask` keeps every line of that shape verbatim (`value_starts_on_following_line`), so they never receive SFC indentation and must not be re-anchored. The gate is `first_line.trim().is_empty()`, which mirrors the mask exactly. `sfc_verbatim_multiline_directive_attribute_is_idempotent` covers that shape and still passes unchanged.
- **`v-for` is untouched** — it returns before this path and the mask treats it as verbatim.
- **Multiline template-literal content is not re-indented here**; the quasi lines are tracked with the existing `template_literal_state_after_line_from` helper and passed through, the same lines the printer already handles.
- **Blank lines outside a template literal are dropped** instead of being printed as bare indentation, which is the shape a formatted expression comes back with anyway.
- The raw mask is **not** touched.

## Why the raw-mask route was rejected

The issue offered a second option: mark the continuation raw in `compute_raw_line_mask` by extending `verbatim_multiline_directive_attr` to any value whose closing quote is not on the same line. That does stop the drift, but it breaks `sfc_multiline_directive_attribute_keeps_template_indent` in `crates/vize_glyph/tests/template_directive_attributes.rs`, which deliberately asserts the opposite for the ternary shape: a 4-space continuation is **re-derived** to attribute indent + 2 = 6 and is idempotent there. Marking the value raw preserves the authored 4 spaces and fails that assertion. Re-derivation is what makes the ternary idempotent in the first place, so the mask route would trade one shape's correctness for another's. That test is unchanged and still green here.

## Tests

`crates/vize_glyph/tests/template_directive_attributes.rs`, two new cases:

1. `sfc_multiline_directive_statement_continuation_is_anchored_like_a_ternary` — one fixture holding **both** shapes on the same element. Asserts the exact expected bytes (ternary continuations move 4 → 6 columns, the statement continuation 8 → 6) *and* `first == second == third`. The exact-output assertion is what makes it strict: a fix that made everything verbatim would satisfy idempotence alone.
2. `sfc_multiline_directive_statement_continuation_keeps_relative_depth` — a statement sequence with a nested object literal; asserts the output equals the source byte-for-byte, so the fix cannot collapse the nesting onto a single level.

**Verified the tests fail without the source change.** Stashing only `crates/vize_glyph/src/template/directives.rs` and re-running the file:

```
test sfc_multiline_directive_statement_continuation_is_anchored_like_a_ternary ... FAILED
   left: … @click="toggleNameSort(sort);\n          applySort()"   (10 columns, drifted)
  right: … @click="toggleNameSort(sort);\n      applySort()"       (6 columns, anchored)
test sfc_multiline_directive_statement_continuation_keeps_relative_depth ... FAILED
test result: FAILED. 11 passed; 2 failed
```

Restored, both green.

## Verification

| command | result |
|---|---|
| `cargo test -p vize_glyph` | **152 passed, 0 failed**, 1 ignored (doctest) — includes the 13 in `template_directive_attributes` |
| `cargo fmt --all -- --check` | clean, exit 0 |
| `cargo clippy -p vize_glyph --all-targets` | **0 errors**; 59 warnings, byte-identical count to `origin/main` (all pre-existing `insta`/`Default::default()`/`criterion::black_box` noise, none in the touched files) |
| `cargo test -p vize --features legacy --no-fail-fast` | 548 passed / 42 failed — **identical to the same run with the change stashed**, so no regression. The 42 are the `check_*` typecheck and `build_declaration_*` cases that need an installed `tests/node_modules` in this worktree |
| `cargo test -p vize_maestro --no-fail-fast` | 573 passed, 0 failed |
| `cd tests && node --test tooling/glyph-corpus-idempotence.test.ts` | 3/3 pass |
| `cd tests && node --test tooling/glyph-corpus-lint-agreement.test.ts` | 4/4 pass |
| `cd tests && node --test tooling/glyph-corpus-parse-preservation.test.ts` | **could not run locally** — `Cannot find module '@vue/compiler-sfc'`; `tests/node_modules` is not installed in this worktree |

Honest caveat on the corpus lane: **no fixture is hydrated in this checkout** (`tests/_fixtures/_git/*` are empty), so the idempotence and lint-agreement runs above exercised only the machinery subtests, not the 33k-file sweep. The sweep gate is the weekly `Real Project Matrix`. Of the three pinned files, only the `dashy` shape could be reproduced locally (from the source quoted in the issue) and it is fixed; `scalar` and `vue-data-ui` are the same family per #3347, which recorded all three as one defect.

To get some corpus-shaped signal anyway, the repo's own 168 `.vue` files (everything outside the unhydrated `_git` fixtures) were swept with the built binary:

- `fmt; fmt` over all of them — **0 / 168 non-idempotent**.
- Output of a binary built from `origin/main` vs. this branch, same 168 files — **0 / 168 differ**. The change is inert on every shape the expression formatter already parses; it only moves the lines that used to drift.

No insta snapshot was refreshed — none needed it.

## Pins removed

All three `idempotence` entries pinned to #3346 are deleted from `tests/_fixtures/glyph-corpus-known-violations.json` (`dashy`, `scalar`, `vue-data-ui`). The file goes 91 → 88 entries and the `idempotence` property now carries **zero** suppressions.

| property | pinned before | pinned after |
|---|---|---|
| idempotence | 3 (#3346) | **0** |
| parse-preservation | 87 (#3334) | 87 |
| lint-agreement | 1 (#3343) | 1 |

Fixes #3346

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting for multiline directive values when expressions cannot be fully parsed.
  * Preserved consistent indentation across continuation lines, including nested statement sequences and conditional expressions.
  * Prevented indentation drift during repeated formatting runs, ensuring stable, idempotent output.
  * Preserved raw template-literal content while avoiding stray whitespace-only lines.

* **Tests**
  * Added coverage for multiline directive formatting and repeated formatting stability.
  * Removed resolved formatting violations from the known-issues list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
