### PR TITLE
test(canon): pin the typecheck divergence ratchet to the pull-request lane

### DIFF
--- a/tests/_helpers/compat-ratchet.ts
+++ b/tests/_helpers/compat-ratchet.ts
@@ -11,6 +11,7 @@ import {
   runVueTsc,
   symlinkVueTypes,
 } from "./realworld-typecheck.ts";
+import { resolveVueTscManifestPath } from "./vue-tsc-manifest.ts";
 
 /**
  * Per-PR drop-in compatibility probes. Each probe copies a pinned set of real
@@ -163,14 +164,14 @@ export function isFixtureHydrated(fixtureId: string): boolean {
 export function resolveCompatVueTscVersion(): string {
   // Derive the version from the same binary the probes execute so the pin can
   // never drift from the tool actually producing the baseline side.
-  const binary = fs.realpathSync(resolveVueTscBinary());
-  const packageRoot = binary.slice(0, binary.lastIndexOf(`${path.sep}vue-tsc${path.sep}`));
-  const vueTscPackage = [
-    path.join(packageRoot, "vue-tsc", "package.json"),
-    path.join(path.dirname(resolveVueTscBinary()), "..", "vue-tsc", "package.json"),
-  ].find((candidate) => fs.existsSync(candidate));
-  assert.ok(vueTscPackage, `vue-tsc package manifest not found next to ${binary}`);
-  const manifest = JSON.parse(fs.readFileSync(vueTscPackage, "utf8")) as { version?: unknown };
+  const binary = resolveVueTscBinary();
+  const manifestPath = resolveVueTscManifestPath(binary);
+  assert.ok(
+    manifestPath,
+    `vue-tsc package manifest not found for ${binary}; neither the bin entry itself nor any ` +
+      "cmd-shim target it names led to a package.json declaring vue-tsc",
+  );
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as { version?: unknown };
   assert.equal(typeof manifest.version, "string", "vue-tsc package version must be a string");
   return manifest.version as string;
 }

--- a/tests/_helpers/vue-tsc-manifest.ts
+++ b/tests/_helpers/vue-tsc-manifest.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Locates the manifest of the vue-tsc package a bin entry ultimately executes.
+ * pnpm writes `node_modules/.bin/vue-tsc` either as a store symlink or as a
+ * cmd-shim script naming its target only in the script body, and the version pin
+ * must read the same manifest either way. Slicing the bin path breaks on the
+ * shim — that path holds no `vue-tsc` segment — so follow the shim, then walk up
+ * to the nearest manifest that declares vue-tsc. Anchoring on the manifest
+ * `name` also keeps an enclosing workspace manifest from supplying the version.
+ */
+export function resolveVueTscManifestPath(binaryPath: string): string | undefined {
+  for (const candidate of [readShimTarget(binaryPath), binaryPath]) {
+    if (candidate == null) continue;
+    let resolved: string;
+    try {
+      resolved = fs.realpathSync(candidate);
+    } catch {
+      continue;
+    }
+    for (let directory = path.dirname(resolved); ; ) {
+      const manifestPath = path.join(directory, "package.json");
+      if (readPackageName(manifestPath) === "vue-tsc") return manifestPath;
+      const parent = path.dirname(directory);
+      if (parent === directory) break;
+      directory = parent;
+    }
+  }
+  return undefined;
+}
+
+/** Absolute target of a cmd-shim script, or undefined when not a shim. */
+function readShimTarget(binaryPath: string): string | undefined {
+  let content: string;
+  try {
+    content = fs.readFileSync(binaryPath, "utf8");
+  } catch {
+    return undefined;
+  }
+  const declared = /^#\s*cmd-shim-target=(.+)$/m.exec(content)?.[1]?.trim();
+  if (declared != null && declared !== "") return declared;
+  // Shims without that marker name the target relative to the bin directory, in
+  // their `exec node "$basedir/../<pkg>/bin/<entry>"` line. Requiring the `../`
+  // skips the `"$basedir/node"` interpreter argument on the same line.
+  const relative = /"\$basedir\/(\.\.\/[^"]+)"/.exec(content)?.[1];
+  return relative == null ? undefined : path.join(path.dirname(binaryPath), relative);
+}
+
+function readPackageName(manifestPath: string): string | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as { name?: unknown };
+    return typeof parsed.name === "string" ? parsed.name : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/tests/tooling/compat-ratchet.test.ts
+++ b/tests/tooling/compat-ratchet.test.ts
@@ -23,6 +23,8 @@
  */
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { after, test } from "node:test";
 
 import {
@@ -38,6 +40,7 @@ import {
   runCompatProbe,
   writeCompatBaseline,
 } from "../_helpers/compat-ratchet.ts";
+import { resolveVueTscManifestPath } from "../_helpers/vue-tsc-manifest.ts";
 
 const updateBaseline = process.env.UPDATE_COMPAT_BASELINE === "1";
 const baselineExists = fs.existsSync(compatBaselinePath);
@@ -201,6 +204,64 @@ test(
     }
   },
 );
+
+test("vue-tsc version resolution survives every pnpm bin layout", (t) => {
+  // The version pin above is only as trustworthy as this resolution. pnpm picks
+  // between a store symlink and a cmd-shim script depending on platform and
+  // settings; a resolver that only understands one shape makes the whole gate
+  // unrunnable on the other, which is how it can stop being exercised unnoticed.
+  // realpath the sandbox: on macOS the temp dir is itself a symlink, and the
+  // resolver reports realpaths.
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-vue-tsc-bin-")));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const packageDir = path.join(root, "node_modules/.pnpm/vue-tsc@9.9.9/node_modules/vue-tsc");
+  fs.mkdirSync(path.join(packageDir, "bin"), { recursive: true });
+  const entry = path.join(packageDir, "bin/vue-tsc.js");
+  fs.writeFileSync(entry, "#!/usr/bin/env node\n");
+  const manifestPath = path.join(packageDir, "package.json");
+  fs.writeFileSync(manifestPath, `${JSON.stringify({ name: "vue-tsc", version: "9.9.9" })}\n`);
+  // An enclosing workspace manifest must never be mistaken for the package.
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    `${JSON.stringify({ name: "workspace-root", version: "0.0.0" })}\n`,
+  );
+
+  const binDir = path.join(root, "node_modules/.bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  const layouts: Array<[layout: string, write: (binPath: string) => void]> = [
+    ["store symlink", (binPath) => fs.symlinkSync(entry, binPath)],
+    [
+      "cmd-shim naming its target",
+      (binPath) =>
+        fs.writeFileSync(binPath, `#!/bin/sh\nexec node "$@"\n# cmd-shim-target=${entry}\n`),
+    ],
+    [
+      // Shaped like a real marker-less shim: the interpreter is named through
+      // `$basedir` too, and it comes first, so the target cannot be taken as
+      // simply the first `$basedir`-relative path in the script.
+      "cmd-shim without the target marker",
+      (binPath) =>
+        fs.writeFileSync(
+          binPath,
+          '#!/bin/sh\nbasedir_win="$basedir"\nexec "$basedir/node"  ' +
+            '"$basedir/../.pnpm/vue-tsc@9.9.9/node_modules/vue-tsc/bin/vue-tsc.js" "$@"\n',
+        ),
+    ],
+  ];
+
+  for (const [layout, write] of layouts) {
+    const binPath = path.join(binDir, "vue-tsc");
+    fs.rmSync(binPath, { force: true });
+    write(binPath);
+    assert.equal(resolveVueTscManifestPath(binPath), manifestPath, `${layout} must resolve`);
+  }
+
+  // A bin entry that leads nowhere must report that, not slice a bogus path.
+  const orphan = path.join(binDir, "vue-tsc-orphan");
+  fs.writeFileSync(orphan, "#!/bin/sh\nexec node /nowhere/vue-tsc.js\n");
+  assert.equal(resolveVueTscManifestPath(orphan), undefined);
+});
 
 after(() => {
   if (!updateBaseline || updatedEntries.size === 0) return;

--- a/tests/tooling/github-workflows-vue-parity.test.ts
+++ b/tests/tooling/github-workflows-vue-parity.test.ts
@@ -13,6 +13,25 @@ type CompositeActionStep = {
   with?: Record<string, number | string>;
 };
 
+test("the typecheck divergence ratchet runs on every pull request", () => {
+  // Dimension 1 of the vue-tsc parity scorecard (#3222) is a *per-PR* ratchet:
+  // tooling/compat-ratchet.test.ts may only hold or improve the divergence
+  // ledger in tests/_fixtures/compat-baseline.json. It reaches the PR lane only
+  // because the vue-parity job carries no event guard — three sibling jobs in
+  // this same workflow (nix-flake, source-coverage, branch-coverage) opt out of
+  // pull requests with exactly such a guard for runtime reasons. Adding one to
+  // vue-parity would silently un-gate the ledger with every other assertion in
+  // this file still passing, so pin the trigger and the absence of the guard.
+  const workflow = readRepoFile(".github", "workflows", "check.yml");
+
+  assert.match(workflow, /\n  pull_request:\n    branches: \[main\]\n/);
+  assert.doesNotMatch(
+    workflowJobBody(workflow, "vue-parity"),
+    /^ {4}if:/m,
+    "vue-parity must stay unconditional: it is the only pre-merge gate on the divergence ledger",
+  );
+});
+
 test("Vue parity structurally gates compiler fixtures and incremental LSP behavior", () => {
   const workflow = readRepoFile(".github", "workflows", "check.yml");
   const job = workflowJobBody(workflow, "vue-parity");


### PR DESCRIPTION
## Summary

Toward dimension 1 of #3222 (per-PR typecheck divergence ratchet). Two things, one commit each.

**The premise I started from did not hold, and that is the main finding.** The intent was to wire `tests/tooling/compat-ratchet.test.ts` into a pull-request-triggered job because nothing ran it. It already runs on every pull request. What was genuinely missing was (a) any assertion that keeps it there, and (b) a working local run — the version pin aborts on half of pnpm's bin layouts.

### Wiring trace — the ratchet is already on the PR lane

The audit comment on #3222 concluded "nothing runs it on a pull request", resting on `grep -rn "check:fixtures" .github/` finding nothing. That grep does find a hit:

```
.github/actions/check-vue-parity/action.yml:31:      run: vp run --filter './tests' test:check:fixtures
```

The full chain:

| step | evidence |
| --- | --- |
| `check.yml` triggers on pull requests | `on: pull_request: branches: [main]` (lines 6-7) |
| its `vue-parity` job has no event guard | job body is `runs-on` / `timeout-minutes` / `env` / `steps` — no `if:` |
| that job runs the composite action | `- uses: ./.github/actions/check-vue-parity` (line 237) |
| the action runs the fixtures lane | `vp run --filter './tests' test:check:fixtures` |
| the lane ends with the ratchet | `tests/package.json` `test:check:fixtures` last entry is `tooling/compat-ratchet.test.ts` |

Wired by #3245, which appended the ratchet to `test:check:fixtures`; `vue-parity` had used the composite action since #2977. Empirically confirmed, not just read — PR run [30536528594](https://github.com/ubugeeei-prod/vize/actions/runs/30536528594), job `vue-parity` (`90851053990`, `event: pull_request`, `success`):

```
create-vue: shared=0 falsePositives=0 (0.0000) falseNegatives=0 (0.0000)
element-plus: shared=3 falsePositives=0 ...      misskey: shared=8 falsePositives=0 ...
nuxt-ui: shared=11 falsePositives=1 (0.0833) falseNegatives=1 (0.0833)
pinia: shared=7 ...  vue-router: shared=0 ...  vue-element-admin: shared=0 ...
vitepress: shared=2 ...  vue-vben-admin: shared=16 ...
✔ compat ratchet holds or improves typecheck divergence for <all 9 probes>
✔ compat baseline is pinned to the workspace vue-tsc
```

### Placement: no new job

The smallest correct placement is the one that already exists. Measured from that run:

- `vue-parity` job total: **3 m 20 s** (10:55:14Z → 10:58:34Z)
- the `test:check:fixtures` step: **51.7 s**
- the ratchet's own share: **~6.0 s** for all 9 probes plus the version pin (10:57:46.1 → 10:57:52.1)

A dedicated job would have to re-pay hydration of 10 fixture submodules, `vp install`, and `cargo build --profile ci -p vize --features legacy` — minutes — to re-run six seconds of assertions that already run. So this PR adds no job and changes no workflow file (`git diff --name-only origin/main -- .github/` is empty).

What it adds instead is the missing invariant. The ratchet is on the PR lane *only* because `vue-parity` omits an `if:`, and that omission is load-bearing: `nix-flake`, `source-coverage`, and `branch-coverage` in the same workflow each carry `if: ${{ github.event_name != 'pull_request' }}` to drop off the PR lane for runtime reasons. One such line on `vue-parity` would move the only pre-merge gate on the divergence ledger to push-and-schedule, and every pre-existing assertion in `github-workflows-vue-parity.test.ts` would still pass. Now pinned.

### Also fixed: the version pin aborted on pnpm shim bins

`resolveCompatVueTscVersion` sliced the bin path at a `/vue-tsc/` segment, which only exists when pnpm writes `node_modules/.bin/vue-tsc` as a store symlink. Against a cmd-shim script, measured on this checkout:

```
OLD lastIndexOf('/vue-tsc/') = -1
OLD sliced packageRoot      = .../node_modules/.bin/vue-ts     # slice(0, -1)
OLD resolved manifest       = <none> -> assertion 'vue-tsc package manifest not found'
NEW resolved package dir    = .../.pnpm/vue-tsc@3.2.9_typescript@6.0.3/node_modules/vue-tsc
NEW version                 = 3.2.9
```

CI happens to get the symlink layout, so the gate is green there while being unrunnable on a shim checkout — part of how it went unnoticed that its per-PR half was never asserted. Now it follows the shim to its target and walks up to the nearest manifest whose `name` is `vue-tsc`; anchoring on `name` also stops an enclosing workspace manifest from supplying the version. Covered for three layouts plus a dead bin entry.

The bin-layout resolution lives in a new `tests/_helpers/vue-tsc-manifest.ts` — it is about pnpm bin layouts rather than about divergence probes, and keeping it out of `compat-ratchet.ts` matters concretely: inlined on top of #3369 that file would have crossed the 350-line gate.

## Change Class

- [x] Virtual TypeScript and type checking

## Behavior Reference

#3222 dimension 1 (per-PR divergence ratchet with a hold-or-improve baseline). Ratchet added in #3245; `vue-parity` composite action since #2977. Comparator is `tools/fixtures/typecheck-divergence.mjs` (schema `vize.fixtureTypecheckDivergence`), shared with the weekly `real-project-matrix.yml`.

## Verification Evidence

**The gate fails when a metric regresses.** Perturbed `tests/_fixtures/compat-baseline.json` locally, one metric at a time, covering all three comparator directions; each run failed, each was reverted:

| perturbation | rule | result |
| --- | --- | --- |
| pinia `sharedCount` 7 → 8 | `>=` | ✖ `sharedCount: baseline 8 -> current 7` |
| pinia `falsePositiveCount` 0 → -1 | `<=` | ✖ `falsePositiveCount: baseline -1 -> current 0` |
| pinia `baselineDiagnosticCount` 7 → 8 | `==` | ✖ `baselineDiagnosticCount: baseline 8 -> current 7` |

each as `AssertionError: pinia regressed drop-in typecheck compatibility`. The `sharedCount` case was re-run after rebasing onto #3369 and still fails, so the verification holds against the documented-differences ledger that landed there.

**`tests/_fixtures/compat-baseline.json` is not modified by this PR.** Restored after each perturbation and verified byte-identical to `origin/main` — `git hash-object` on the working file and on `git show origin/main:tests/_fixtures/compat-baseline.json` both give `936e5ddda42e03580e6018b4da6fc59a56de45d7`. The `nuxt-ui` entry from #3369 (issue #3358) is untouched, and this branch carries main's baseline verbatim.

**The new workflow assertion fails when the guard is added.** Injected `if: ${{ github.event_name != 'pull_request' }}` onto `vue-parity`:

```
✖ the typecheck divergence ratchet runs on every pull request
  AssertionError: vue-parity must stay unconditional: it is the only pre-merge gate on the divergence ledger
✔ Vue parity structurally gates compiler fixtures and incremental LSP behavior   # pre-existing test, still green
```

`check.yml` restored (703 lines, unchanged).

**Commands run:**

```
node --test tooling/github-workflows.test.ts tooling/github-workflows-check.test.ts \
  tooling/github-workflows-vue-parity.test.ts tooling/github-workflows-benchmark.test.ts \
  tooling/github-workflows-setup.test.ts tooling/github-workflows-release-build.test.ts \
  tooling/github-workflows-release-publish.test.ts tooling/github-workflows-release-smoke.test.ts
  -> 62 pass, 0 fail

node --test tooling/package-manifests.test.ts tooling/realworld-snapshot-scripts.test.ts \
  tooling/ecosystem-product-coverage.test.ts tooling/release-readiness.test.ts
  -> 24 pass, 0 fail   (script-string pins; test:check:fixtures is unchanged by this PR)

VIZE_TEST_BIN=target/ci/vize VIZE_TEST_VUE_TSC=<...>/vue-tsc@3.3.4_typescript@6.0.3/.../vue-tsc.js \
  node --test --test-concurrency=1 tooling/compat-ratchet.test.ts
  -> 6 pass, 0 fail, 6 skipped (2.8 s)

vp check tests/_helpers/compat-ratchet.ts tests/_helpers/vue-tsc-manifest.ts \
  tests/tooling/compat-ratchet.test.ts tests/tooling/github-workflows-vue-parity.test.ts
  -> formatted, no warnings or lint errors
```

The 6 skips are unhydrated fixtures in that worktree; `create-vue`, `pinia`, and `vitepress` were hydrated and ran for real. The local `.bin/vue-tsc` shim resolves to vue-tsc 3.2.9 while the baseline pins 3.3.4, hence the explicit `VIZE_TEST_VUE_TSC`. CI runs all 9 probes, as the trace above shows.

`actrun lint` / `actrun workflow run --dry-run` were not run: `actrun` is not installed on this machine, and this PR changes no file under `.github/`, so there is no workflow graph to validate.

**The resolver test fails on a too-loose shim pattern.** A real marker-less shim names its interpreter through `$basedir` as well, and that argument comes first on the line. Relaxing the fallback to the first `"$basedir/..."` match makes the test fail, so the `../` requirement is pinned rather than incidental:

```
✖ vue-tsc version resolution survives every pnpm bin layout
  AssertionError: cmd-shim without the target marker must resolve
```

Source-length gate (350), measured against `origin/main` after #3369: `tests/_helpers/compat-ratchet.ts` 325 → 326, `tests/_helpers/vue-tsc-manifest.ts` new at 57, `tests/tooling/compat-ratchet.test.ts` 224 → 285, `tests/tooling/github-workflows-vue-parity.test.ts` 120 → 139. All under the limit.

Rebased onto #3369 (`52a35feb`), which touched both files this PR edits. The conflict was two tests appended at the same point in `compat-ratchet.test.ts`; both are kept, and every command above was re-run on the final rebased tree.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — no baseline change; hash verified unchanged
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered — none; no dependency or permission change
- [x] Performance status or PR benchmark impact considered — no new CI job, no added runtime
- [ ] Fuzzing target or crash-reproducer coverage considered — n/a
- [x] Editor/LSP scenario coverage considered — n/a, gate is `vize check` vs `vue-tsc`
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed — no public behavior change

## Risk

Low: no workflow file changes, no baseline changes, no production code. The helper change only widens what `resolveCompatVueTscVersion` accepts — the symlink layout CI uses resolves identically.

**One gap remains and it needs a repo-settings change I did not make.** `vue-parity` is not among the required status checks on `main`. Current required contexts: `fmt-rust`, `check-js`, `check-vize-apps`, `clippy-and-test`, `playground-test`, `test-report`, `test-report-comment`, `test-scripts`, `build-js-packages`, `app-readiness`, `miri`, `pr-benchmark`. `test-report` *is* required and does `needs: vue-parity`, but it is `if: ${{ always() }}` with steps that only collect an inventory, so it goes green even when `vue-parity` fails. Net effect: the ratchet runs on every PR and reports red on a regression, but a red `vue-parity` does not block auto-merge. Closing dimension 1 fully means adding `vue-parity` to the required contexts for `main` — a ruleset change for a maintainer, not something a PR can land.
