### PR TITLE
test(vite): gate the plugin-vue option surface with an intentional-gap ledger

### DIFF
--- a/tests/_fixtures/README.md
+++ b/tests/_fixtures/README.md
@@ -17,3 +17,10 @@ vize/vue-tsc typecheck divergence over pinned probe workspaces cut from the hydr
 fixtures. `tests/tooling/compat-ratchet.test.ts` recomputes the divergence on every PR and only
 allows it to hold or improve; regenerate with `UPDATE_COMPAT_BASELINE=1` after intentional
 compatibility improvements or pinned toolchain moves.
+
+`vite-plugin-vue-option-parity.json` is the intentional-gap ledger behind the `@vizejs/vite-plugin`
+drop-in claim: one entry per documented `@vitejs/plugin-vue` option, `Api` member, and plugin hook,
+each recorded as `honored` (with the behavioral probe that proves it),
+`intentional-divergence` (with a reason), or `unimplemented` (with issue #3227 and a reason).
+`tests/tooling/vite-plugin-vue-option-parity.test.ts` re-enumerates the pinned upstream surface and
+fails when an entry is missing, so a new or newly honored option cannot pass unrecorded.

--- a/tests/_fixtures/vite-plugin-vue-option-parity.json
+++ b/tests/_fixtures/vite-plugin-vue-option-parity.json
@@ -1,0 +1,201 @@
+{
+  "schemaVersion": 1,
+  "upstream": {
+    "apiCount": 4,
+    "hookCount": 10,
+    "optionCount": 26,
+    "package": "@vitejs/plugin-vue",
+    "version": "6.0.7"
+  },
+  "summary": {
+    "honored": 11,
+    "intentional-divergence": 9,
+    "unimplemented": 20
+  },
+  "options": {
+    "compiler": {
+      "status": "intentional-divergence",
+      "reason": "SFC compilation runs in Rust through @vizejs/native; a JavaScript @vue/compiler-sfc instance cannot drive the native pipeline."
+    },
+    "customElement": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "Deprecated alias of features.customElement, and shares its gap: the Vite plugin has no custom-element output mode."
+    },
+    "exclude": {
+      "status": "honored",
+      "evidence": "exclude-filter"
+    },
+    "features.componentIdGenerator": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "Scope ids always come from Vize's own generateScopeId(filePath) hash; the strategy is not configurable and does not vary between dev and production."
+    },
+    "features.customElement": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "No custom-element output mode: .ce.vue files compile as ordinary components with no shadow-DOM style inlining. @vizejs/rspack-plugin implements the option, the Vite plugin does not."
+    },
+    "features.optionsAPI": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "The config hook hard-codes __VUE_OPTIONS_API__: true, so Options API support cannot be dropped from production bundles."
+    },
+    "features.prodDevtools": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "The config hook hard-codes __VUE_PROD_DEVTOOLS__ to `command === \"serve\"`, so devtools cannot be enabled in production builds."
+    },
+    "features.prodHydrationMismatchDetails": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "The config hook hard-codes __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false, so detailed production hydration errors cannot be enabled."
+    },
+    "features.propsDestructure": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "Reactive defineProps destructure is always on, matching the Vue 3.5+ default, but there is no opt-out for projects that need the 3.4 behavior."
+    },
+    "include": {
+      "status": "honored",
+      "evidence": "include-filter"
+    },
+    "isProduction": {
+      "status": "honored",
+      "evidence": "production-css-import"
+    },
+    "script.babelParserPlugins": {
+      "status": "intentional-divergence",
+      "reason": "<script> blocks are parsed by OXC in Rust; Babel parser plugins have no equivalent extension point."
+    },
+    "script.defineModel": {
+      "status": "intentional-divergence",
+      "reason": "Deprecated upstream. defineModel is always enabled, matching @vitejs/plugin-vue's own behavior on Vue 3.4+."
+    },
+    "script.fs": {
+      "status": "intentional-divergence",
+      "reason": "Macro type resolution reads through the host filesystem in Rust; a JavaScript fs shim cannot be injected into the native pipeline."
+    },
+    "script.globalTypeFiles": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "The plugin exposes no macro global-type files. globalTypes in vize.config.* only feeds `vize check` and the language server, not SFC compilation."
+    },
+    "script.hoistStatic": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "No <script setup> static-constant hoisting toggle is accepted or forwarded to the native compiler."
+    },
+    "script.propsDestructure": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "Deprecated alias of features.propsDestructure, and shares its gap: there is no opt-out."
+    },
+    "script.vapor": {
+      "status": "intentional-divergence",
+      "reason": "Vapor output is selected by Vize's own top-level `vapor` and `jsxMode` options (or compiler.vapor in vize.config.*) rather than per compile block."
+    },
+    "style.inMap": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "The plugin accepts no incoming style source map to chain preprocessor output onto."
+    },
+    "style.trim": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "No style trim toggle is accepted or forwarded to the native style pipeline."
+    },
+    "template.compiler": {
+      "status": "intentional-divergence",
+      "reason": "Template compilation runs in Rust; a JavaScript template compiler instance cannot replace the native backend."
+    },
+    "template.compilerOptions": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "The whole @vue/compiler-dom option bag (whitespace, delimiters, comments, isCustomElement, nodeTransforms, directiveTransforms, ...) is neither accepted nor forwarded. Vize's nearest analogues are its own templateSyntax and customRenderer options."
+    },
+    "template.preprocessCustomRequire": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "Template preprocessors are not implemented at all: <template lang=\"pug\"> is compiled as literal text rather than preprocessed."
+    },
+    "template.preprocessOptions": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "Template preprocessors are not implemented at all, so there are no preprocessor options to pass through."
+    },
+    "template.transformAssetUrls": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "Asset-URL rewriting is always on with fixed behavior; it can neither be reconfigured nor disabled."
+    },
+    "template.vapor": {
+      "status": "intentional-divergence",
+      "reason": "Vapor output is selected by Vize's own top-level `vapor` option (or compiler.vapor in vize.config.*) rather than per template block."
+    }
+  },
+  "api": {
+    "exclude": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "The vite:vue shim exposes no exclude accessor, so host frameworks cannot read or extend the file filter through the plugin api."
+    },
+    "include": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "The vite:vue shim exposes no include accessor, so host frameworks cannot read or extend the file filter through the plugin api."
+    },
+    "options": {
+      "status": "intentional-divergence",
+      "reason": "Read-only probing shim: it reports compiler/isProduction/root/template so tools such as Nuxt can detect a Vue plugin, but assignments and in-place mutation are ignored because Vize's compiler options live in VizeOptions and vize.config.*. `compiler` falls back to a parse-only stub when @vue/compiler-sfc is not resolvable from the plugin."
+    },
+    "version": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "The shim reports no @vitejs/plugin-vue version, so tools that branch on api.version see undefined."
+    }
+  },
+  "hooks": {
+    "buildStart": {
+      "status": "honored",
+      "evidence": "hook-implemented"
+    },
+    "config": {
+      "status": "honored",
+      "evidence": "hook-implemented"
+    },
+    "configResolved": {
+      "status": "honored",
+      "evidence": "hook-implemented"
+    },
+    "configureServer": {
+      "status": "honored",
+      "evidence": "hook-implemented"
+    },
+    "handleHotUpdate": {
+      "status": "honored",
+      "evidence": "hot-update-style-only"
+    },
+    "load": {
+      "status": "honored",
+      "evidence": "hook-implemented"
+    },
+    "options": {
+      "status": "intentional-divergence",
+      "reason": "Upstream finalizes its include/exclude filter in the Rollup options hook; Vize builds the same filter in configResolved, which the include/exclude evidence covers."
+    },
+    "resolveId": {
+      "status": "honored",
+      "evidence": "hook-implemented"
+    },
+    "shouldTransformCachedModule": {
+      "status": "unimplemented",
+      "issue": 3227,
+      "reason": "Vize does not opt into Vite's cached-module transform shortcut; dev and SSR reuse follow its own compile cache instead."
+    },
+    "transform": {
+      "status": "honored",
+      "evidence": "hook-implemented"
+    }
+  }
+}

--- a/tests/tooling/_helpers/vite-plugin-vue-parity.ts
+++ b/tests/tooling/_helpers/vite-plugin-vue-parity.ts
@@ -1,0 +1,266 @@
+/**
+ * Upstream `@vitejs/plugin-vue` surface enumeration for the Vize Vite-plugin
+ * parity gate (#3227).
+ *
+ * The surface is read from the *installed* copy of `@vitejs/plugin-vue` instead
+ * of a hand-written list, so a new upstream option cannot silently escape the
+ * ledger: the parity test requires exactly one ledger entry per enumerated
+ * option, `Api` member, and plugin hook.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+export const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+export const ledgerPath = path.join(
+  repoRoot,
+  "tests",
+  "_fixtures",
+  "vite-plugin-vue-option-parity.json",
+);
+
+export const upstreamPackage = "@vitejs/plugin-vue";
+export const trackingIssue = 3227;
+
+/** Option groups whose members are enumerated as `<group>.<member>` leaves. */
+const optionGroups = ["features", "script", "style", "template"] as const;
+/** Plugin object keys that are not Rollup/Vite hooks. */
+const nonHookPluginKeys = new Set(["api", "name"]);
+
+const requireFromBench = createRequire(path.join(repoRoot, "bench", "package.json"));
+
+export interface UpstreamSurface {
+  apiMembers: string[];
+  hooks: string[];
+  options: string[];
+  version: string;
+}
+
+/** The `@vitejs/plugin-vue` version pinned by the `vite-stack` pnpm catalog. */
+export function catalogVersion(): string {
+  const workspaceYaml = fs.readFileSync(path.join(repoRoot, "pnpm-workspace.yaml"), "utf8");
+  const pin = workspaceYaml
+    .split("\n")
+    .map((line) => line.match(/^\s{4}"?(?<name>[^":]+)"?:\s*"(?<version>[^"]+)"\s*$/))
+    .find((match) => match?.groups?.name === upstreamPackage)?.groups?.version;
+  assert.ok(pin, `${upstreamPackage} must stay pinned in the pnpm catalog`);
+  assert.match(pin, /^\d+\.\d+\.\d+$/u, `${upstreamPackage} must be pinned to an exact version`);
+  return pin;
+}
+
+function installedVersion(): string {
+  const manifest = requireFromBench(`${upstreamPackage}/package.json`) as { version: string };
+  assert.equal(
+    manifest.version,
+    catalogVersion(),
+    `the installed ${upstreamPackage} must match the catalog pin`,
+  );
+  return manifest.version;
+}
+
+function createOptionsProgram(): { checker: ts.TypeChecker; source: ts.SourceFile } {
+  // `bench` owns the `@vitejs/plugin-vue` devDependency, so resolve the probe
+  // module from there.
+  const probePath = path.join(repoRoot, "bench", "__vize_plugin_vue_option_probe__.ts");
+  const probeSource = `import type { Options } from "${upstreamPackage}";\nexport declare const probe: Options;\n`;
+  const host = ts.createCompilerHost({}, true);
+  const isProbe = (fileName: string) => path.resolve(fileName) === probePath;
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (fileName, languageVersion, onError, shouldCreate) =>
+    isProbe(fileName)
+      ? ts.createSourceFile(fileName, probeSource, languageVersion, true)
+      : getSourceFile(fileName, languageVersion, onError, shouldCreate);
+  const fileExists = host.fileExists.bind(host);
+  host.fileExists = (fileName) => isProbe(fileName) || fileExists(fileName);
+  const readFile = host.readFile.bind(host);
+  host.readFile = (fileName) => (isProbe(fileName) ? probeSource : readFile(fileName));
+
+  const program = ts.createProgram({
+    rootNames: [probePath],
+    options: {
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      noEmit: true,
+      skipLibCheck: true,
+      strict: true,
+      types: [],
+    },
+    host,
+  });
+  const source = program.getSourceFile(probePath);
+  assert.ok(source, "the option probe module must be part of the program");
+  const diagnostics = program
+    .getSemanticDiagnostics(source)
+    .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, " "));
+  assert.deepEqual(diagnostics, [], `resolving ${upstreamPackage} option types failed`);
+  return { checker: program.getTypeChecker(), source };
+}
+
+function optionsType(checker: ts.TypeChecker, source: ts.SourceFile): ts.Type {
+  const statement = source.statements.find(ts.isVariableStatement);
+  assert.ok(statement, "the option probe module must declare the probe binding");
+  return checker.getTypeAtLocation(statement.declarationList.declarations[0]);
+}
+
+function memberNames(checker: ts.TypeChecker, type: ts.Type): string[] {
+  return checker
+    .getPropertiesOfType(type)
+    .map((property) => property.getName())
+    .toSorted();
+}
+
+/**
+ * Every documented `Options` leaf, as dotted paths. Nested option groups
+ * (`template`, `script`, `style`, `features`) expand one level so the ledger
+ * tracks `template.compilerOptions` rather than an opaque `template` blob.
+ */
+function enumerateOptions(): string[] {
+  const { checker, source } = createOptionsProgram();
+  const options = optionsType(checker, source);
+  const leaves: string[] = [];
+
+  for (const name of memberNames(checker, options)) {
+    if (!(optionGroups as readonly string[]).includes(name)) {
+      leaves.push(name);
+      continue;
+    }
+    const property = checker.getPropertyOfType(options, name);
+    assert.ok(property, `${name} must exist on the upstream Options type`);
+    const groupType = checker.getNonNullableType(
+      checker.getTypeOfSymbolAtLocation(property, source),
+    );
+    const members = memberNames(checker, groupType);
+    assert.notEqual(members.length, 0, `${name} must expose at least one documented sub-option`);
+    leaves.push(...members.map((member) => `${name}.${member}`));
+  }
+
+  return leaves.toSorted();
+}
+
+/** The `Api` members and plugin hooks the upstream plugin instance exposes. */
+function enumeratePluginSurface(): { apiMembers: string[]; hooks: string[] } {
+  const upstreamModule = requireFromBench(upstreamPackage) as
+    | ((options?: unknown) => Record<string, unknown>)
+    | { default: (options?: unknown) => Record<string, unknown> };
+  const factory = typeof upstreamModule === "function" ? upstreamModule : upstreamModule.default;
+  assert.equal(typeof factory, "function", `${upstreamPackage} must export a plugin factory`);
+
+  const plugin = factory();
+  const api = plugin.api;
+  assert.ok(api && typeof api === "object", `${upstreamPackage} must expose its framework api`);
+
+  return {
+    // `Api` is a plain object of accessors, so own property names cover the
+    // getter/setter pairs without walking `Object.prototype`.
+    apiMembers: Object.getOwnPropertyNames(api).toSorted(),
+    hooks: Object.keys(plugin)
+      .filter((key) => !nonHookPluginKeys.has(key))
+      .toSorted(),
+  };
+}
+
+export function upstreamSurface(): UpstreamSurface {
+  const { apiMembers, hooks } = enumeratePluginSurface();
+  return { apiMembers, hooks, options: enumerateOptions(), version: installedVersion() };
+}
+
+export type LedgerStatus = "honored" | "intentional-divergence" | "unimplemented";
+
+export interface LedgerEntry {
+  evidence?: string;
+  issue?: number;
+  reason?: string;
+  status: LedgerStatus;
+}
+
+export interface ParityLedger {
+  api: Record<string, LedgerEntry>;
+  hooks: Record<string, LedgerEntry>;
+  options: Record<string, LedgerEntry>;
+  schemaVersion: number;
+  summary: Record<LedgerStatus, number>;
+  upstream: {
+    apiCount: number;
+    hookCount: number;
+    optionCount: number;
+    package: string;
+    version: string;
+  };
+}
+
+export function readLedger(): ParityLedger {
+  return JSON.parse(fs.readFileSync(ledgerPath, "utf8")) as ParityLedger;
+}
+
+const sections = ["api", "hooks", "options"] as const;
+
+/**
+ * Structural validation: exhaustive over the upstream surface, and no entry may
+ * claim `honored` without naming the behavioral probe that proves it.
+ */
+export function validateLedger(ledger: ParityLedger, surface: UpstreamSurface): void {
+  assert.equal(ledger.schemaVersion, 1);
+  assert.deepEqual(ledger.upstream, {
+    apiCount: surface.apiMembers.length,
+    hookCount: surface.hooks.length,
+    optionCount: surface.options.length,
+    package: upstreamPackage,
+    version: surface.version,
+  });
+
+  const expected: Record<(typeof sections)[number], string[]> = {
+    api: surface.apiMembers,
+    hooks: surface.hooks,
+    options: surface.options,
+  };
+  const counts: Record<LedgerStatus, number> = {
+    honored: 0,
+    "intentional-divergence": 0,
+    unimplemented: 0,
+  };
+
+  for (const section of sections) {
+    assert.deepEqual(
+      Object.keys(ledger[section]),
+      expected[section],
+      `every upstream ${section} entry needs exactly one sorted ledger entry`,
+    );
+    for (const [name, entry] of Object.entries(ledger[section])) {
+      const label = `${section}.${name}`;
+      assert.equal(typeof entry, "object", `${label} needs a structured ledger entry`);
+      if (entry.status === "honored") {
+        assert.deepEqual(Object.keys(entry).toSorted(), ["evidence", "status"]);
+        assert.match(entry.evidence ?? "", /\S/u, `${label} must name its behavioral evidence`);
+      } else if (entry.status === "intentional-divergence") {
+        assert.deepEqual(Object.keys(entry).toSorted(), ["reason", "status"]);
+        assert.match(entry.reason ?? "", /\S/u, `${label} needs a non-empty divergence reason`);
+      } else if (entry.status === "unimplemented") {
+        assert.deepEqual(Object.keys(entry).toSorted(), ["issue", "reason", "status"]);
+        assert.equal(entry.issue, trackingIssue, `${label} must link the parity issue`);
+        assert.match(entry.reason ?? "", /\S/u, `${label} needs a non-empty gap reason`);
+      } else {
+        assert.fail(`${label} has unsupported status ${JSON.stringify(entry.status)}`);
+      }
+      counts[entry.status] += 1;
+    }
+  }
+
+  assert.deepEqual(ledger.summary, counts, "the ledger summary must match its entries");
+}
+
+/** Every `honored` entry, as `<section>.<name>` → evidence id. */
+export function honoredEvidence(ledger: ParityLedger): Map<string, string> {
+  const evidence = new Map<string, string>();
+  for (const section of sections) {
+    for (const [name, entry] of Object.entries(ledger[section])) {
+      if (entry.status === "honored") {
+        evidence.set(`${section}.${name}`, entry.evidence as string);
+      }
+    }
+  }
+  return evidence;
+}

--- a/tests/tooling/vite-plugin-vue-option-parity.test.ts
+++ b/tests/tooling/vite-plugin-vue-option-parity.test.ts
@@ -1,0 +1,248 @@
+/**
+ * `@vizejs/vite-plugin` vs `@vitejs/plugin-vue` option parity gate (#3227).
+ *
+ * The drop-in claim is only worth as much as the option surface behind it, so
+ * this test enumerates the installed `@vitejs/plugin-vue` surface and requires
+ * every option, `Api` member, and plugin hook to be either proven honored by a
+ * behavioral probe below, or recorded as an explicit gap in
+ * `tests/_fixtures/vite-plugin-vue-option-parity.json`.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import type { Plugin, ResolvedConfig } from "vite";
+
+import {
+  honoredEvidence,
+  readLedger,
+  upstreamSurface,
+  validateLedger,
+} from "./_helpers/vite-plugin-vue-parity.ts";
+import { vize } from "../../npm/builder/vite/src/plugin/index.ts";
+
+type AnyHook = (...args: never[]) => unknown;
+
+const templateOnly = `<template><div class="probe">probe</div></template>\n`;
+const withStyle = `${templateOnly}<style>.probe{color:red}</style>\n`;
+const restyled = `${templateOnly}<style>.probe{color:blue}</style>\n`;
+
+function hook<T extends AnyHook>(candidate: unknown): T {
+  const handler =
+    typeof candidate === "function" ? candidate : (candidate as { handler?: T })?.handler;
+  assert.equal(typeof handler, "function", "expected an implemented plugin hook");
+  return handler as T;
+}
+
+function resolvedConfig(root: string, overrides: Record<string, unknown> = {}): ResolvedConfig {
+  return {
+    root,
+    base: "/",
+    build: { assetsDir: "assets", ssr: false },
+    command: "serve",
+    define: {},
+    isProduction: false,
+    mode: "development",
+    plugins: [],
+    resolve: { alias: [] },
+    ...overrides,
+  } as unknown as ResolvedConfig;
+}
+
+function createFixture(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-vue-parity-"));
+  for (const [name, source] of Object.entries(files)) {
+    fs.writeFileSync(path.join(root, name), source);
+  }
+  return root;
+}
+
+/** Boot the plugin set against a fixture root and return the main plugin. */
+async function bootPlugin(
+  root: string,
+  options: Record<string, unknown> = {},
+  configOverrides: Record<string, unknown> = {},
+): Promise<Plugin> {
+  // `configMode: false` skips `vize.config.*` discovery and an empty
+  // `scanPatterns` skips startup pre-compilation, leaving the hook under test
+  // as the only thing being measured.
+  const plugins = vize({ configMode: false, scanPatterns: [], ...options }) as Plugin[];
+  const plugin = plugins.find((candidate) => candidate.name === "vite-plugin-vize");
+  assert.ok(plugin, "the Vize plugin set must expose its main plugin");
+  await hook<(config: ResolvedConfig) => Promise<void>>(plugin.configResolved).call(
+    {},
+    resolvedConfig(root, configOverrides),
+  );
+  return plugin;
+}
+
+async function resolveVueId(plugin: Plugin, id: string): Promise<string | null> {
+  const resolved = await hook<AnyHook>(plugin.resolveId).call(
+    { resolve: () => null },
+    id as never,
+    undefined as never,
+    {} as never,
+  );
+  return typeof resolved === "string" ? resolved : null;
+}
+
+async function loadVueModule(plugin: Plugin, id: string): Promise<string> {
+  const loaded = await hook<AnyHook>(plugin.load).call(
+    { addWatchFile() {} },
+    id as never,
+    {} as never,
+  );
+  const code = typeof loaded === "string" ? loaded : (loaded as { code?: string } | null)?.code;
+  assert.equal(typeof code, "string", `loading ${id} must produce module code`);
+  return code as string;
+}
+
+/** `include` narrows the set of files the plugin claims. */
+async function probeIncludeFilter(): Promise<void> {
+  const root = createFixture({ "Kept.vue": withStyle, "Other.vue": templateOnly });
+  const plugin = await bootPlugin(root, { include: [/Kept\.vue$/] });
+
+  assert.ok(await resolveVueId(plugin, path.join(root, "Kept.vue")), "included SFCs stay claimed");
+  assert.equal(
+    await resolveVueId(plugin, path.join(root, "Other.vue")),
+    null,
+    "an SFC outside `include` must be left to the rest of the pipeline",
+  );
+}
+
+/** `exclude` releases files the default include would otherwise claim. */
+async function probeExcludeFilter(): Promise<void> {
+  const root = createFixture({ "Kept.vue": withStyle, "Skipped.vue": templateOnly });
+  const plugin = await bootPlugin(root, { exclude: [/Skipped\.vue$/] });
+
+  assert.ok(
+    await resolveVueId(plugin, path.join(root, "Kept.vue")),
+    "unexcluded SFCs stay claimed",
+  );
+  assert.equal(
+    await resolveVueId(plugin, path.join(root, "Skipped.vue")),
+    null,
+    "an excluded SFC must be left to the rest of the pipeline",
+  );
+}
+
+/**
+ * `isProduction` overrides Vite's own flag: production output hands styles to
+ * Vite as a CSS import instead of injecting them at runtime.
+ */
+async function probeProductionCssImport(): Promise<void> {
+  const root = createFixture({ "Comp.vue": withStyle });
+  const id = path.join(root, "Comp.vue");
+
+  const devPlugin = await bootPlugin(root);
+  const devId = await resolveVueId(devPlugin, id);
+  assert.ok(devId);
+  const devCode = await loadVueModule(devPlugin, devId);
+  assert.match(devCode, /__vize_css__/, "development output injects component CSS at runtime");
+
+  // Vite still reports `isProduction: false`; only the plugin option changes.
+  const prodPlugin = await bootPlugin(root, { isProduction: true });
+  const prodId = await resolveVueId(prodPlugin, id);
+  assert.ok(prodId);
+  const prodCode = await loadVueModule(prodPlugin, prodId);
+  assert.doesNotMatch(
+    prodCode,
+    /__vize_css__/,
+    "`isProduction: true` must switch off runtime style injection",
+  );
+  assert.match(
+    prodCode,
+    /import ".*Comp\.vue\?vue=&type=style&index=0[^"]*"/,
+    "`isProduction: true` must emit an extractable CSS import",
+  );
+}
+
+/** A style-only edit produces a style-only HMR payload, not a component reload. */
+async function probeHotUpdateStyleOnly(): Promise<void> {
+  const root = createFixture({ "Comp.vue": withStyle });
+  const file = path.join(root, "Comp.vue");
+  const plugin = await bootPlugin(root);
+  const resolved = await resolveVueId(plugin, file);
+  assert.ok(resolved);
+  await loadVueModule(plugin, resolved);
+
+  const sent: Array<{ data?: { css?: string; type?: string }; event?: string }> = [];
+  const server = {
+    moduleGraph: { getModulesByFile: () => undefined, invalidateModule() {} },
+    ws: { send: (payload: never) => sent.push(payload) },
+  };
+
+  fs.writeFileSync(file, restyled);
+  const affected = await hook<AnyHook>(plugin.handleHotUpdate).call({}, {
+    file,
+    modules: [],
+    read: async () => restyled,
+    server,
+    timestamp: Date.now(),
+  } as never);
+
+  assert.deepEqual(affected, [], "a style-only edit must not invalidate the component module");
+  assert.equal(sent.length, 1, "a style-only edit must send exactly one HMR payload");
+  assert.equal(sent[0].event, "vize:update");
+  assert.equal(sent[0].data?.type, "style-only");
+  assert.match(sent[0].data?.css ?? "", /color:\s*blue/, "the payload carries the new CSS");
+}
+
+/** The named hook is implemented by one of the plugins Vize contributes. */
+function probeHookImplemented(name: string): void {
+  const plugins = vize({ configMode: false }) as Plugin[];
+  const implementations = plugins.filter(
+    (plugin) => typeof (plugin as unknown as Record<string, unknown>)[name] !== "undefined",
+  );
+  assert.notEqual(
+    implementations.length,
+    0,
+    `the Vize plugin set must implement the upstream \`${name}\` hook`,
+  );
+}
+
+const probes = new Map<string, () => Promise<void> | void>([
+  ["include-filter", probeIncludeFilter],
+  ["exclude-filter", probeExcludeFilter],
+  ["production-css-import", probeProductionCssImport],
+  ["hot-update-style-only", probeHotUpdateStyleOnly],
+]);
+
+test("the parity ledger stays exhaustive over the pinned @vitejs/plugin-vue surface", () => {
+  const surface = upstreamSurface();
+  const ledger = readLedger();
+  validateLedger(ledger, surface);
+
+  assert.ok(ledger.summary.honored > 0, "the ledger must record the surface Vize does honor");
+  assert.ok(
+    ledger.summary.unimplemented > 0,
+    "the ledger must keep the remaining gaps explicit rather than implying full parity",
+  );
+});
+
+test("every option the ledger calls honored is backed by a behavioral probe", async () => {
+  const evidence = honoredEvidence(readLedger());
+  assert.notEqual(evidence.size, 0, "at least one entry must be proven honored");
+
+  const executed = new Set<string>();
+  for (const [entry, evidenceId] of evidence) {
+    if (evidenceId === "hook-implemented") {
+      probeHookImplemented(entry.slice("hooks.".length));
+      continue;
+    }
+    const probe = probes.get(evidenceId);
+    assert.ok(probe, `${entry} names unknown evidence ${JSON.stringify(evidenceId)}`);
+    if (!executed.has(evidenceId)) {
+      await probe();
+      executed.add(evidenceId);
+    }
+  }
+
+  assert.deepEqual(
+    [...probes.keys()].filter((id) => !executed.has(id)),
+    [],
+    "every behavioral probe must back at least one honored ledger entry",
+  );
+});


### PR DESCRIPTION
Closes the **Vite-plugin API parity** gate of #3227.

## What the gate asked for

> `@vizejs/vite-plugin` accepts and honors every documented `@vitejs/plugin-vue` option
> (`template.compilerOptions`, `script`, `customElement`, `include/exclude`, HMR hooks), asserted by
> a dedicated parity test with an intentional-gap ledger (today only package-exports shape is
> tested).

The gate is closed by making the claim *measurable*, not by asserting it. Before this PR nothing in
the repo failed when an upstream option was unhandled.

## What I found

The claim is currently far from true, and the ledger says so.

`@vitejs/plugin-vue@6.0.7` documents 26 option leaves (9 top-level, with `features`/`script`/
`style`/`template` expanded one level). Of those, **3 are accepted and honored** — `include`,
`exclude`, `isProduction`. The other 23 are not even *accepted*: `template`, `script`, `style`,
`features`, `customElement`, and `compiler` are excess properties on `VizeOptions`, so
`vize({ template: { compilerOptions: … } })` is a type error and a silent no-op at runtime.

**Real gaps (20 across all three sections, tracked by #3227):**

| Entry | Gap |
| --- | --- |
| `customElement`, `features.customElement` | No custom-element output mode. `.ce.vue` compiles as an ordinary component with no shadow-DOM style inlining. `@vizejs/rspack-plugin` implements this; the Vite plugin does not. |
| `features.optionsAPI` / `prodDevtools` / `prodHydrationMismatchDetails` | The `config` hook hard-codes all three Vue feature flags, so Options API cannot be tree-shaken out, prod devtools cannot be enabled, and prod hydration-mismatch details cannot be enabled. |
| `features.propsDestructure`, `script.propsDestructure` | Reactive destructure is unconditionally on (matches the Vue 3.5+ default) with no opt-out. |
| `features.componentIdGenerator` | Scope ids always come from Vize's own `generateScopeId(filePath)`. |
| `template.compilerOptions` | The whole `@vue/compiler-dom` option bag (`whitespace`, `delimiters`, `comments`, `isCustomElement`, `nodeTransforms`, `directiveTransforms`, …) is neither accepted nor forwarded. Nearest analogues are Vize's own `templateSyntax` / `customRenderer`. |
| `template.preprocessOptions`, `template.preprocessCustomRequire` | Template preprocessors are not implemented **at all** — `<template lang="pug">` compiles to a literal text vnode rather than being preprocessed. |
| `template.transformAssetUrls` | Asset-URL rewriting is always on with fixed behavior; it cannot be reconfigured or disabled. |
| `script.globalTypeFiles`, `script.hoistStatic`, `style.trim`, `style.inMap` | Not accepted or forwarded. |
| `api.include`, `api.exclude`, `api.version` | The `vite:vue` shim exposes only `api.options`, so tools that read the filter or branch on the plugin-vue version see `undefined`. |
| `hooks.shouldTransformCachedModule` | Not implemented; dev/SSR reuse follows Vize's own compile cache. |

**Intentional divergences (9), recorded with reasons rather than silently:** `compiler` and
`template.compiler` (a JS `@vue/compiler-sfc` instance cannot drive the native pipeline),
`script.babelParserPlugins` (OXC parses `<script>`), `script.fs` (Rust-side FS access),
`script.defineModel` (deprecated upstream, always on), `template.vapor` / `script.vapor` (spelled as
Vize's top-level `vapor` / `jsxMode`), `api.options` (read-only probing shim — assignment and
in-place mutation are ignored, and `compiler` degrades to a `parse`-only stub when
`@vue/compiler-sfc` is not resolvable from the plugin), and `hooks.options` (upstream finalizes its
filter in the Rollup `options` hook; Vize builds the same filter in `configResolved`).

**Honored (11):** `include`, `exclude`, `isProduction`, and 8 of the 10 upstream plugin hooks
including `handleHotUpdate`.

## Ledger design

`tests/_fixtures/vite-plugin-vue-option-parity.json`, in the same spirit as
`patina-eslint-vue-rule-map.json`:

- Three sections — `options` (26 dotted leaves), `api` (4 `Api` members), `hooks` (10 upstream plugin
  hooks) — each exhaustive and sorted.
- `upstream` pins the package version and the three surface counts; the version must equal both the
  installed copy and the `vite-stack` pnpm catalog pin, so an upstream bump cannot drift silently.
- Statuses: `honored` (requires an `evidence` id naming a behavioral probe), `intentional-divergence`
  (requires a non-empty `reason`), `unimplemented` (requires `issue: 3227` **and** a `reason`). Key
  sets are asserted exactly, so an entry cannot smuggle extra fields, and `summary` must match the
  entries.

The upstream surface is **enumerated, not hard-coded**: the options come from a TypeScript program
over the installed `@vitejs/plugin-vue` types (which resolves the `Omit<SFCTemplateCompileOptions, …>`
wrappers properly), and the `Api`/hook names come from an actual upstream plugin instance. A new
upstream option therefore lands in the enumeration and fails the test until it is recorded.

## Tests

`tests/tooling/vite-plugin-vue-option-parity.test.ts` (picked up automatically by
`vp run --workspace-root test:scripts`):

1. **Exhaustiveness** — the ledger must have exactly one sorted entry per enumerated option, `Api`
   member, and hook, and the summary must match.
2. **No unbacked `honored`** — every entry claiming `honored` must name a probe that exists and
   passes, and every probe must back at least one entry. The probes assert observable behavior, not
   just acceptance:
   - `include-filter` / `exclude-filter` — `resolveId` releases SFCs outside the filter.
   - `production-css-import` — with Vite still reporting `isProduction: false`, `isProduction: true`
     switches output from the runtime style injector to an extractable `?vue&type=style` import.
   - `hot-update-style-only` — a style-only edit sends exactly one `vize:update` payload carrying the
     new CSS and invalidates no component module.
   - `hook-implemented` — the hook is implemented by one of the plugins Vize contributes.

### Verified failure modes

- Removing `template.compilerOptions` from the ledger and fixing up `optionCount` to match:
  `every upstream options entry needs exactly one sorted ledger entry` (diff shows the missing key).
  Leaving `optionCount` stale fails earlier on the `upstream` pin.
- Marking `template.compilerOptions` as `honored` with an invented evidence id:
  `options.template.compilerOptions names unknown evidence "wishful-thinking"` — so the ledger cannot
  be made green by relabelling a gap.
- Breaking the `production-css-import` expectation makes the probe test fail, confirming the probes
  really execute rather than being registered and skipped.

## Verification

```
$ node --test tests/tooling/vite-plugin-vue-option-parity.test.ts
✔ the parity ledger stays exhaustive over the pinned @vitejs/plugin-vue surface (1018ms)
✔ every option the ledger calls honored is backed by a behavioral probe (96ms)
ℹ pass 2  ℹ fail 0

$ cd npm/builder/vite && vp check src vite.config.ts
pass: All 70 files are correctly formatted
pass: Found no warnings or lint errors in 70 files

$ cd npm/builder/vite && node src/test.ts        # package `test` script, native prebuilt
ℹ tests 23  ℹ pass 23  ℹ fail 0

$ vp check tests/tooling/vite-plugin-vue-option-parity.test.ts tests/tooling/_helpers/vite-plugin-vue-parity.ts
pass: Found no warnings or lint errors in 2 files
```

New files are 248 and 266 lines, both under the 350-line new-file budget. No package `test` script
strings changed, and `compat-baseline.json` / `compat-ratchet.ts` are untouched (the per-PR compat
ratchet gate is a separate PR).

Refs #3227
