### PR TITLE
perf(vite): persist the pre-compile cache across processes

### DIFF
--- a/npm/builder/vite/src/plugin/index.ts
+++ b/npm/builder/vite/src/plugin/index.ts
@@ -11,9 +11,9 @@ import {
   DEFAULT_PRECOMPILE_IGNORE_PATTERNS,
   clearBuildCaches,
   type VizePluginState,
-  compileAll,
   normalizePrecompileBatchSize,
 } from "./state.ts";
+import { compileAll } from "./precompile-run.ts";
 import { resolveIdHook } from "./resolve.ts";
 import { loadHook, transformHook } from "./load.ts";
 import {

--- a/npm/builder/vite/src/plugin/precompile-cache-key.ts
+++ b/npm/builder/vite/src/plugin/precompile-cache-key.ts
@@ -1,0 +1,109 @@
+/**
+ * Identity of a persistent pre-compile cache.
+ *
+ * A stale hit would hand Vite *wrong* compiled output, which is far worse than
+ * being slow, so the cache is split into two independent gates and both fail
+ * toward recompilation. This module owns them:
+ *
+ * - **Manifest identity** (`computePrecompileCacheKey`) covers everything
+ *   outside the source text that determines the batch output: the manifest
+ *   format version, the resolved `@vizejs/native` version, the size and mtime of
+ *   the native binary actually loaded, and the fully resolved native batch
+ *   compile options (Vue dialect/`vueVersion`, `vapor`, `ssr`, `mode`,
+ *   `templateSyntax`, `customRenderer`, runtime module/global names, and every
+ *   experimental flag). The key names the manifest file, so a different
+ *   configuration reads a different file and a version bump abandons every old
+ *   manifest at once.
+ * - **Source identity** (`hashPrecompileSource`) is a SHA-256 of the exact
+ *   source text that was compiled. `mtime` is never trusted on its own, so a
+ *   same-size edit, a `git checkout` that rewrites content while preserving
+ *   `mtime`, and a container with a reset clock all miss.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+/** Bump when the persisted entry shape changes; abandons every old manifest. */
+export const PRECOMPILE_CACHE_FORMAT = 1;
+
+/** SHA-256 of the exact source text handed to the compiler. */
+export function hashPrecompileSource(source: string): string {
+  return crypto.createHash("sha256").update(source, "utf8").digest("hex");
+}
+
+/** Key-independent JSON: object key order must not change the hash. */
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (typeof value === "object" && value !== null) {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    const body = entries
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+      .join(",");
+    return `{${body}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function describeBinary(binary: string): string {
+  try {
+    const stat = fs.statSync(binary);
+    return `${path.basename(binary)}:${stat.size}:${stat.mtimeMs}`;
+  } catch {
+    return `${path.basename(binary)}:unresolved`;
+  }
+}
+
+/**
+ * Identity of the native compiler that produced (or would produce) the output.
+ *
+ * The package version covers releases; the binary's size and mtime cover local
+ * `pnpm --dir npm/native build:debug` rebuilds, which change codegen without
+ * changing any version. Hashing the binary itself would be airtight but costs
+ * hundreds of milliseconds for a >30 MB artifact, so a rebuild is treated as a
+ * new identity — a miss, never a stale hit.
+ */
+function resolveCompilerIdentity(): unknown {
+  const configured = process.env.NAPI_RS_NATIVE_LIBRARY_PATH;
+  try {
+    const manifestPath = createRequire(import.meta.url).resolve("@vizejs/native/package.json");
+    const packageDir = path.dirname(manifestPath);
+    const version = (JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as { version?: unknown })
+      .version;
+    const binaries = configured
+      ? [configured]
+      : fs
+          .readdirSync(packageDir)
+          .filter((name) => name.endsWith(".node"))
+          .sort()
+          .map((name) => path.join(packageDir, name));
+    return {
+      version: typeof version === "string" ? version : "unknown",
+      binaries: binaries.map(describeBinary),
+    };
+  } catch {
+    // Without a resolvable compiler identity there is nothing safe to key on;
+    // the literal below is stable, so such a run simply shares one namespace.
+    return { version: "unresolved", binaries: [configured ?? "unresolved"] };
+  }
+}
+
+/**
+ * Hash of everything outside the source text that changes compiled output.
+ *
+ * `compileOptions` must be the object actually handed to the native batch
+ * compiler, so a newly added compile option cannot be forgotten here.
+ */
+export function computePrecompileCacheKey(compileOptions: unknown): string {
+  const material = stableStringify({
+    format: PRECOMPILE_CACHE_FORMAT,
+    compiler: resolveCompilerIdentity(),
+    options: compileOptions,
+  });
+  return crypto.createHash("sha256").update(material, "utf8").digest("hex").slice(0, 32);
+}

--- a/npm/builder/vite/src/plugin/precompile-cache-manifest.test.ts
+++ b/npm/builder/vite/src/plugin/precompile-cache-manifest.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit-level tests for the pre-compile cache manifest.
+ *
+ * The staleness tests that drive `compileAll` end to end live in
+ * `./precompile-cache.test.ts`; this file exercises the cache object directly.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  PRECOMPILE_CACHE_DIR,
+  PRECOMPILE_CACHE_ENV,
+  createDisabledPrecompileCache,
+  isPersistablePrecompileModule,
+  isPrecompileCacheDisabledByEnv,
+  openPrecompileCache,
+} from "./precompile-cache.ts";
+import { computePrecompileCacheKey } from "./precompile-cache-key.ts";
+import type { CompiledModule } from "../types.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const testRoot = path.join(
+  path.resolve(__dirname, "../../../.."),
+  "target",
+  "vize-tests",
+  "tests",
+  "vite-plugin-vize",
+  "precompile-cache-manifest",
+);
+fs.rmSync(testRoot, { recursive: true, force: true });
+fs.mkdirSync(testRoot, { recursive: true });
+
+assert.equal(isPrecompileCacheDisabledByEnv({ [PRECOMPILE_CACHE_ENV]: "0" }), true);
+assert.equal(isPrecompileCacheDisabledByEnv({ [PRECOMPILE_CACHE_ENV]: "false" }), true);
+assert.equal(isPrecompileCacheDisabledByEnv({}), false);
+assert.equal(isPrecompileCacheDisabledByEnv({ [PRECOMPILE_CACHE_ENV]: "1" }), false);
+
+const module: CompiledModule = {
+  code: "export default {}",
+  scopeId: "data-v-1",
+  hasScoped: false,
+  styles: [],
+  macroArtifacts: [],
+  dependencies: [],
+};
+
+assert.equal(isPersistablePrecompileModule(module), true);
+assert.equal(isPersistablePrecompileModule({ ...module, dependencies: ["/x.js"] }), false);
+
+const disabled = createDisabledPrecompileCache();
+disabled.set("/a.vue", "hash", module);
+assert.equal(disabled.file, null);
+assert.equal(disabled.get("/a.vue", "hash"), undefined);
+assert.equal(disabled.flush(), false, "a disabled cache never reports a write");
+
+const root = path.join(testRoot, "unit");
+fs.mkdirSync(root, { recursive: true });
+const options = { ssr: false, vapor: false };
+const cache = openPrecompileCache({ root, compileOptions: options });
+assert.equal(cache.flush(), false, "an untouched cache must not write");
+cache.set("/a.vue", "hash-a", module);
+assert.equal(cache.flush(), true);
+assert.equal(cache.flush(), false, "a clean cache must not rewrite");
+
+const reopened = openPrecompileCache({ root, compileOptions: options });
+assert.deepEqual(reopened.get("/a.vue", "hash-a"), module);
+assert.equal(reopened.get("/a.vue", "hash-b"), undefined, "a different hash must miss");
+assert.equal(reopened.get("/b.vue", "hash-a"), undefined, "an unknown path must miss");
+
+// A module with `src` dependencies is refused, and evicts any prior entry.
+reopened.set("/a.vue", "hash-a", { ...module, dependencies: ["/dep.js"] });
+assert.equal(reopened.get("/a.vue", "hash-a"), undefined);
+
+// Different compile options must land in a different manifest.
+assert.notEqual(
+  computePrecompileCacheKey({ ssr: false, vapor: true }),
+  computePrecompileCacheKey(options),
+);
+const other = openPrecompileCache({ root, compileOptions: { ssr: false, vapor: true } });
+assert.notEqual(other.file, cache.file);
+assert.equal(other.get("/a.vue", "hash-a"), undefined);
+
+// Key order inside the options object must not change the key.
+assert.equal(
+  computePrecompileCacheKey({ ssr: false, vapor: true }),
+  computePrecompileCacheKey({ vapor: true, ssr: false }),
+);
+
+// Atomic writes must not leave temp files behind.
+assert.deepEqual(
+  fs.readdirSync(path.join(root, PRECOMPILE_CACHE_DIR)).filter((name) => name.endsWith(".tmp")),
+  [],
+);
+
+// An unwritable cache directory must not fail the build.
+const readonlyRoot = path.join(testRoot, "readonly");
+fs.mkdirSync(path.join(readonlyRoot, "node_modules"), { recursive: true });
+fs.writeFileSync(path.join(readonlyRoot, "node_modules", ".vize"), "not a directory\n");
+const diagnostics: string[] = [];
+const blocked = openPrecompileCache({
+  root: readonlyRoot,
+  compileOptions: options,
+  onDiagnostic: (message) => diagnostics.push(message),
+});
+blocked.set("/a.vue", "hash-a", module);
+assert.equal(blocked.flush(), false, "an unwritable manifest must report failure, not throw");
+assert.equal(diagnostics.length, 1, "the write failure must be surfaced as a diagnostic");
+
+console.log("✅ vite-plugin-vize precompile cache manifest tests passed!");

--- a/npm/builder/vite/src/plugin/precompile-cache.test.ts
+++ b/npm/builder/vite/src/plugin/precompile-cache.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Persistent pre-compile cache tests.
+ *
+ * The point of this suite is the *miss* path: every way a cache entry can go
+ * stale must force a recompile, because a stale hit serves wrong output. The
+ * hit path is covered too, but on its own it would prove nothing.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  DEFAULT_PRECOMPILE_BATCH_SIZE,
+  hasFileMetadataChanged,
+  type VizePluginState,
+} from "./state.ts";
+import { compileAll } from "./precompile-run.ts";
+import {
+  PRECOMPILE_CACHE_DIR,
+  PRECOMPILE_CACHE_ENV,
+  PRECOMPILE_CACHE_FORMAT,
+  hashPrecompileSource,
+} from "./precompile-cache.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = path.resolve(__dirname, "../../../..");
+const testRoot = path.join(
+  workspaceRoot,
+  "target",
+  "vize-tests",
+  "tests",
+  "vite-plugin-vize",
+  "precompile-cache",
+);
+fs.rmSync(testRoot, { recursive: true, force: true });
+fs.mkdirSync(testRoot, { recursive: true });
+
+let caseId = 0;
+function makeProject(source: string): { root: string; file: string } {
+  const root = path.join(testRoot, `case-${++caseId}`);
+  const srcDir = path.join(root, "src");
+  fs.mkdirSync(srcDir, { recursive: true });
+  const file = path.join(srcDir, "App.vue");
+  fs.writeFileSync(file, source);
+  return { root, file };
+}
+
+function makeState(root: string, options: VizePluginState["mergedOptions"] = {}): VizePluginState {
+  return {
+    cache: new Map(),
+    ssrCache: new Map(),
+    collectedCss: new Map(),
+    precompileMetadata: new Map(),
+    pendingHmrUpdateTypes: new Map(),
+    isProduction: false,
+    root,
+    clientViteBase: "/",
+    serverViteBase: "/",
+    server: null,
+    filter: () => true,
+    scanPatterns: ["src/**/*.vue"],
+    precompileBatchSize: DEFAULT_PRECOMPILE_BATCH_SIZE,
+    ignorePatterns: [],
+    mergedOptions: options,
+    initialized: true,
+    dynamicImportAliasRules: [],
+    cssAliasRules: [],
+    extractCss: false,
+    componentsCssFileName: "assets/vize-components.css",
+    clientViteDefine: {},
+    serverViteDefine: {},
+    logger: { log() {}, info() {}, warn() {}, error() {} } as never,
+  };
+}
+
+/** Runs one cold `compileAll` (fresh state == fresh process) and reports the log. */
+async function coldRun(
+  root: string,
+  options: VizePluginState["mergedOptions"] = {},
+): Promise<{ state: VizePluginState; log: string }> {
+  const state = makeState(root, options);
+  const lines: string[] = [];
+  state.logger = {
+    log() {},
+    info: (...args: unknown[]) => lines.push(args.join(" ")),
+    warn() {},
+    error() {},
+  } as never;
+  await compileAll(state);
+  return { state, log: lines.join("\n") };
+}
+
+function restoredCount(log: string): number {
+  return Number(/(\d+) restored from disk/.exec(log)?.[1] ?? "-1");
+}
+
+function recompiledCount(log: string): number {
+  return Number(/(\d+) recompiled/.exec(log)?.[1] ?? "-1");
+}
+
+function manifestFiles(root: string): string[] {
+  const dir = path.join(root, PRECOMPILE_CACHE_DIR);
+  return fs.existsSync(dir) ? fs.readdirSync(dir).filter((name) => name.endsWith(".json")) : [];
+}
+
+const BASE_SOURCE = `<template><div class="a">one</div></template>
+<script setup>const label = "one";</script>
+<style scoped>.a { color: red; }</style>
+`;
+
+// ---------------------------------------------------------------------------
+// Hit path: a second cold process reuses the manifest.
+// ---------------------------------------------------------------------------
+{
+  const { root, file } = makeProject(BASE_SOURCE);
+
+  const first = await coldRun(root);
+  assert.equal(recompiledCount(first.log), 1, "first cold run must compile");
+  assert.equal(restoredCount(first.log), 0, "first cold run has nothing to restore");
+  assert.equal(manifestFiles(root).length, 1, "first cold run must persist one manifest");
+
+  const second = await coldRun(root);
+  assert.equal(restoredCount(second.log), 1, "second cold run must restore from disk");
+  assert.equal(recompiledCount(second.log), 0, "second cold run must not recompile");
+  assert.deepEqual(
+    second.state.cache.get(file),
+    first.state.cache.get(file),
+    "restored module must be byte-identical to the compiled one",
+  );
+  assert.ok(second.state.precompileMetadata.has(file), "restore must repopulate scan metadata");
+}
+
+// ---------------------------------------------------------------------------
+// Stale case 1: content changes while the size stays identical.
+// ---------------------------------------------------------------------------
+{
+  const { root, file } = makeProject(BASE_SOURCE);
+  // Pin mtime to an exact millisecond so it can be restored bit-for-bit later.
+  const pinned = new Date(1_700_000_000_000);
+  fs.utimesSync(file, pinned, pinned);
+  const before = fs.statSync(file);
+
+  const first = await coldRun(root);
+  const compiled = first.state.cache.get(file)!;
+
+  // Same byte length, different bytes, and mtime forced back to the original.
+  const original = fs.readFileSync(file, "utf-8");
+  const edited = original.replace('class="a">one', 'class="a">two');
+  assert.equal(edited.length, original.length, "edit must preserve the file size");
+  assert.notEqual(edited, original);
+  fs.writeFileSync(file, edited);
+  fs.utimesSync(file, pinned, pinned);
+  const after = fs.statSync(file);
+  assert.equal(
+    hasFileMetadataChanged(
+      { mtimeMs: before.mtimeMs, size: before.size },
+      { mtimeMs: after.mtimeMs, size: after.size },
+    ),
+    false,
+    "the mtime+size heuristic must be blind to this edit -- that is the point",
+  );
+
+  const second = await coldRun(root);
+  assert.equal(
+    restoredCount(second.log),
+    0,
+    "a same-size same-mtime content change must not hit the cache",
+  );
+  assert.equal(recompiledCount(second.log), 1, "the edited file must be recompiled");
+  const recompiled = second.state.cache.get(file)!;
+  assert.notEqual(recompiled.code, compiled.code, "recompiled output must reflect the new source");
+  assert.match(recompiled.code, /two/, "recompiled output must contain the new text");
+}
+
+// ---------------------------------------------------------------------------
+// Stale case 2: a compiler option that changes output changes the key.
+// ---------------------------------------------------------------------------
+{
+  const { root, file } = makeProject(BASE_SOURCE);
+  const first = await coldRun(root);
+  const vdom = first.state.cache.get(file)!;
+
+  const switched = await coldRun(root, { vapor: true });
+  assert.equal(
+    restoredCount(switched.log),
+    0,
+    "changing a compile option must not reuse the previous option's output",
+  );
+  assert.equal(recompiledCount(switched.log), 1);
+  assert.notEqual(
+    switched.state.cache.get(file)!.code,
+    vdom.code,
+    "vapor output must differ from vdom output",
+  );
+  assert.equal(manifestFiles(root).length, 2, "each option set gets its own manifest");
+
+  // ...and the original option set still hits its own manifest.
+  const backToVdom = await coldRun(root);
+  assert.equal(restoredCount(backToVdom.log), 1, "the original manifest must still be valid");
+  assert.equal(backToVdom.state.cache.get(file)!.code, vdom.code);
+}
+
+// ---------------------------------------------------------------------------
+// Stale case 3: a format/version bump abandons the manifest wholesale.
+// ---------------------------------------------------------------------------
+{
+  const { root } = makeProject(BASE_SOURCE);
+  await coldRun(root);
+  const [name] = manifestFiles(root);
+  const manifestPath = path.join(root, PRECOMPILE_CACHE_DIR, name!);
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as Record<string, unknown>;
+
+  // A manifest written by a different plugin/compiler build: same file name (as
+  // if the key algorithm itself changed), older format stamp.
+  fs.writeFileSync(
+    manifestPath,
+    JSON.stringify({ ...manifest, format: PRECOMPILE_CACHE_FORMAT - 1 }),
+  );
+  const stale = await coldRun(root);
+  assert.equal(restoredCount(stale.log), 0, "an older manifest format must be ignored");
+  assert.equal(recompiledCount(stale.log), 1);
+
+  // A manifest whose recorded key does not match the key it is filed under.
+  fs.writeFileSync(manifestPath, JSON.stringify({ ...manifest, key: "not-the-real-key" }));
+  const mismatched = await coldRun(root);
+  assert.equal(restoredCount(mismatched.log), 0, "a key mismatch must be ignored");
+  assert.equal(recompiledCount(mismatched.log), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Corruption: truncated, non-JSON, and malformed entries all degrade to compile.
+// ---------------------------------------------------------------------------
+{
+  const { root, file } = makeProject(BASE_SOURCE);
+  await coldRun(root);
+  const [name] = manifestFiles(root);
+  const manifestPath = path.join(root, PRECOMPILE_CACHE_DIR, name!);
+  const good = fs.readFileSync(manifestPath, "utf-8");
+
+  for (const [label, contents] of [
+    ["truncated", good.slice(0, Math.floor(good.length / 2))],
+    ["empty", ""],
+    ["not json", "<html>nope</html>"],
+    ["json but not an object", "[]"],
+    ["null", "null"],
+  ] as const) {
+    fs.writeFileSync(manifestPath, contents);
+    const run = await coldRun(root);
+    assert.equal(restoredCount(run.log), 0, `${label} manifest must not be restored`);
+    assert.equal(recompiledCount(run.log), 1, `${label} manifest must fall back to compiling`);
+    assert.ok(run.state.cache.has(file), `${label} manifest must still yield compiled output`);
+  }
+
+  // An entry whose module is not a CompiledModule is dropped on its own.
+  const manifest = JSON.parse(good) as { entries: Record<string, unknown> };
+  manifest.entries[file] = { hash: hashPrecompileSource(BASE_SOURCE), module: { code: 42 } };
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+  const malformed = await coldRun(root);
+  assert.equal(restoredCount(malformed.log), 0, "a malformed entry must not be restored");
+  assert.equal(recompiledCount(malformed.log), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Deleted files are pruned rather than accumulating forever.
+// ---------------------------------------------------------------------------
+{
+  const { root, file } = makeProject(BASE_SOURCE);
+  const other = path.join(path.dirname(file), "Other.vue");
+  fs.writeFileSync(other, `<template><span>other</span></template>\n`);
+  await coldRun(root);
+  const manifestPath = path.join(root, PRECOMPILE_CACHE_DIR, manifestFiles(root)[0]!);
+  let entries = (JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as { entries: object }).entries;
+  assert.equal(Object.keys(entries).length, 2, "both files must be persisted");
+
+  fs.rmSync(other);
+  fs.writeFileSync(file, `${BASE_SOURCE}<!-- touched -->\n`);
+  await coldRun(root);
+  entries = (JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as { entries: object }).entries;
+  assert.deepEqual(Object.keys(entries), [file], "the deleted file must be pruned");
+}
+
+// ---------------------------------------------------------------------------
+// `src` imports are deliberately never persisted: their inputs are not hashed.
+// ---------------------------------------------------------------------------
+{
+  const { root, file } = makeProject(
+    `<template><div>src import</div></template>\n<script src="./setup.js"></script>\n`,
+  );
+  const dependency = path.join(path.dirname(file), "setup.js");
+  fs.writeFileSync(dependency, `export default { name: "one" };\n`);
+
+  const first = await coldRun(root);
+  assert.ok(first.state.cache.get(file)?.dependencies?.length, "the SFC must record a dependency");
+  const second = await coldRun(root);
+  assert.equal(
+    restoredCount(second.log),
+    0,
+    "an SFC with `src` imports must never be restored from disk",
+  );
+  assert.equal(recompiledCount(second.log), 1);
+
+  // Proof of why: the dependency can change with the SFC untouched.
+  fs.writeFileSync(dependency, `export default { name: "two" };\n`);
+  const third = await coldRun(root);
+  assert.equal(restoredCount(third.log), 0);
+  assert.match(third.state.cache.get(file)!.code, /two/, "the new dependency must be compiled in");
+}
+
+// ---------------------------------------------------------------------------
+// Env kill switch: no reads, no writes.
+// ---------------------------------------------------------------------------
+{
+  const { root } = makeProject(BASE_SOURCE);
+  const previous = process.env[PRECOMPILE_CACHE_ENV];
+  process.env[PRECOMPILE_CACHE_ENV] = "0";
+  try {
+    await coldRun(root);
+    assert.deepEqual(manifestFiles(root), [], "a disabled cache must not write a manifest");
+    const second = await coldRun(root);
+    assert.equal(restoredCount(second.log), 0, "a disabled cache must never restore");
+  } finally {
+    if (previous === undefined) {
+      delete process.env[PRECOMPILE_CACHE_ENV];
+    } else {
+      process.env[PRECOMPILE_CACHE_ENV] = previous;
+    }
+  }
+}
+
+console.log("✅ vite-plugin-vize precompile cache staleness tests passed!");

--- a/npm/builder/vite/src/plugin/precompile-cache.ts
+++ b/npm/builder/vite/src/plugin/precompile-cache.ts
@@ -1,0 +1,279 @@
+/**
+ * Persistent (on-disk) pre-compile cache.
+ *
+ * `state.precompileMetadata` plus `state.cache` already skip recompilation
+ * inside one process, but both are empty on every process start, so `vite
+ * build`, CI, and each dev-server start recompile the whole scan from scratch.
+ * This module backs them with a manifest under
+ * `node_modules/.vize/vite-precompile/` so a cold process can restore the
+ * previous run's output.
+ *
+ * The two invalidation gates -- manifest identity and per-entry source hash --
+ * live in `./precompile-cache-key.ts`, which documents why each one is safe.
+ * Two more gates live here:
+ *
+ * - **Shape.** Entries are validated before use and dropped individually if
+ *   they do not describe a complete `CompiledModule`. The manifest's own
+ *   `format`/`key` are re-checked after parsing, so a manifest reached by any
+ *   route other than its key still gets rejected.
+ * - **`src` imports.** SFCs that pull blocks in through `<script src>` /
+ *   `<template src>` / `<style src>` are never persisted: their output depends
+ *   on files whose content this cache does not hash.
+ *
+ * A missing, truncated, or corrupt manifest degrades to a full recompile: every
+ * read is guarded and any failure yields an empty cache. Writes go through a
+ * sibling temp file and a rename, so an interrupted write cannot be read back.
+ *
+ * Set `VIZE_PRECOMPILE_CACHE=0` to force a full recompile without editing any
+ * config.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import type { CompiledModule } from "../types.ts";
+import { PRECOMPILE_CACHE_FORMAT, computePrecompileCacheKey } from "./precompile-cache-key.ts";
+
+export { hashPrecompileSource, PRECOMPILE_CACHE_FORMAT } from "./precompile-cache-key.ts";
+
+/** Manifest location, relative to the Vite root. */
+export const PRECOMPILE_CACHE_DIR = path.join("node_modules", ".vize", "vite-precompile");
+
+/** Set to `0`/`false` to force a full recompile without editing the config. */
+export const PRECOMPILE_CACHE_ENV = "VIZE_PRECOMPILE_CACHE";
+
+type Diagnostic = (message: string, error?: unknown) => void;
+
+interface PrecompileCacheEntry {
+  hash: string;
+  module: CompiledModule;
+}
+
+interface PrecompileCacheManifest {
+  format: number;
+  key: string;
+  entries: Record<string, PrecompileCacheEntry>;
+}
+
+export interface PrecompileCache {
+  /** Absolute manifest path, or `null` when the cache is disabled. */
+  readonly file: string | null;
+  /** Compiled module for `file` when the persisted source hash matches. */
+  get(file: string, sourceHash: string): CompiledModule | undefined;
+  /** Stage `module` for the next process. No-op for non-persistable modules. */
+  set(file: string, sourceHash: string, module: CompiledModule): void;
+  /** Forget `file` (compile failure, unreadable source, deleted file). */
+  delete(file: string): void;
+  /** Drop every entry outside `files`, so deleted files do not accumulate. */
+  retain(files: Iterable<string>): void;
+  /** Write the manifest atomically when something changed. Never throws. */
+  flush(): boolean;
+}
+
+/**
+ * Whether `module` may be persisted.
+ *
+ * Modules assembled from `src` imports depend on sibling files that this cache
+ * does not hash, so they are recompiled on every cold start instead.
+ */
+export function isPersistablePrecompileModule(module: CompiledModule): boolean {
+  return !module.dependencies || module.dependencies.length === 0;
+}
+
+function isCompiledModule(value: unknown): value is CompiledModule {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const module = value as Partial<CompiledModule>;
+  if (typeof module.code !== "string" || typeof module.scopeId !== "string") {
+    return false;
+  }
+  if (typeof module.hasScoped !== "boolean") {
+    return false;
+  }
+  if (module.css !== undefined && typeof module.css !== "string") {
+    return false;
+  }
+  if (module.styles !== undefined && !Array.isArray(module.styles)) {
+    return false;
+  }
+  if (module.macroArtifacts !== undefined && !Array.isArray(module.macroArtifacts)) {
+    return false;
+  }
+  // `src`-import modules are never written; reject them if one shows up anyway.
+  return isPersistablePrecompileModule(module as CompiledModule);
+}
+
+function isCacheEntry(value: unknown): value is PrecompileCacheEntry {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const entry = value as Partial<PrecompileCacheEntry>;
+  return typeof entry.hash === "string" && entry.hash.length > 0 && isCompiledModule(entry.module);
+}
+
+/** Whether the environment forces the cache off. */
+export function isPrecompileCacheDisabledByEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  const value = env[PRECOMPILE_CACHE_ENV];
+  return value === "0" || value === "false";
+}
+
+const disabledCache: PrecompileCache = {
+  file: null,
+  get: () => undefined,
+  set: () => {},
+  delete: () => {},
+  retain: () => {},
+  flush: () => false,
+};
+
+/** A cache that never hits and never writes. */
+export function createDisabledPrecompileCache(): PrecompileCache {
+  return disabledCache;
+}
+
+export interface OpenPrecompileCacheOptions {
+  /** Vite root; the manifest lives under `<root>/node_modules/.vize`. */
+  root: string;
+  /** Resolved native batch compile options for this run. */
+  compileOptions: unknown;
+  /** Reports read/write problems without failing the build. */
+  onDiagnostic?: Diagnostic;
+  env?: NodeJS.ProcessEnv;
+}
+
+export function openPrecompileCache(options: OpenPrecompileCacheOptions): PrecompileCache {
+  const { root, compileOptions, onDiagnostic, env = process.env } = options;
+  if (!root || isPrecompileCacheDisabledByEnv(env)) {
+    return createDisabledPrecompileCache();
+  }
+
+  const key = computePrecompileCacheKey(compileOptions);
+  const file = path.join(root, PRECOMPILE_CACHE_DIR, `${key}.json`);
+  const entries = readManifestEntries(file, key, onDiagnostic);
+  let dirty = false;
+
+  return {
+    file,
+    get(filePath, sourceHash) {
+      const entry = entries.get(filePath);
+      return entry && entry.hash === sourceHash ? entry.module : undefined;
+    },
+    set(filePath, sourceHash, module) {
+      if (!isPersistablePrecompileModule(module)) {
+        if (entries.delete(filePath)) {
+          dirty = true;
+        }
+        return;
+      }
+      const existing = entries.get(filePath);
+      if (existing?.hash === sourceHash && existing.module === module) {
+        return;
+      }
+      entries.set(filePath, { hash: sourceHash, module });
+      dirty = true;
+    },
+    delete(filePath) {
+      if (entries.delete(filePath)) {
+        dirty = true;
+      }
+    },
+    retain(files) {
+      const keep = files instanceof Set ? files : new Set(files);
+      // Deleting the entry a Map iterator is currently on is well defined.
+      for (const filePath of entries.keys()) {
+        if (!keep.has(filePath)) {
+          entries.delete(filePath);
+          dirty = true;
+        }
+      }
+    },
+    flush() {
+      if (!dirty) {
+        return false;
+      }
+      const manifest: PrecompileCacheManifest = {
+        format: PRECOMPILE_CACHE_FORMAT,
+        key,
+        entries: Object.fromEntries(entries),
+      };
+      if (!writeManifest(file, manifest, onDiagnostic)) {
+        return false;
+      }
+      dirty = false;
+      return true;
+    },
+  };
+}
+
+/**
+ * Parse the manifest, or return an empty map.
+ *
+ * A missing, truncated, corrupt, or foreign manifest is indistinguishable from
+ * no cache at all, which is exactly the safe outcome: recompile everything.
+ */
+function readManifestEntries(
+  file: string,
+  key: string,
+  onDiagnostic?: Diagnostic,
+): Map<string, PrecompileCacheEntry> {
+  const entries = new Map<string, PrecompileCacheEntry>();
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, "utf-8");
+  } catch {
+    return entries;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    onDiagnostic?.(`Discarding corrupt pre-compile cache ${file}:`, error);
+    return entries;
+  }
+
+  const manifest = parsed as Partial<PrecompileCacheManifest> | null;
+  if (
+    typeof manifest !== "object" ||
+    manifest === null ||
+    manifest.format !== PRECOMPILE_CACHE_FORMAT ||
+    manifest.key !== key ||
+    typeof manifest.entries !== "object" ||
+    manifest.entries === null
+  ) {
+    onDiagnostic?.(`Ignoring pre-compile cache ${file}: unrecognized manifest`);
+    return entries;
+  }
+
+  for (const [filePath, entry] of Object.entries(manifest.entries)) {
+    if (isCacheEntry(entry)) {
+      entries.set(filePath, entry);
+    }
+  }
+  return entries;
+}
+
+/** Write through a sibling temp file so a crash cannot leave a partial manifest. */
+function writeManifest(
+  file: string,
+  manifest: PrecompileCacheManifest,
+  onDiagnostic?: Diagnostic,
+): boolean {
+  const temp = `${file}.${process.pid}.${crypto.randomBytes(4).toString("hex")}.tmp`;
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(temp, JSON.stringify(manifest));
+    fs.renameSync(temp, file);
+    return true;
+  } catch (error) {
+    try {
+      fs.rmSync(temp, { force: true });
+    } catch {
+      // best effort
+    }
+    onDiagnostic?.(`Failed to write pre-compile cache ${file}:`, error);
+    return false;
+  }
+}

--- a/npm/builder/vite/src/plugin/precompile-run.ts
+++ b/npm/builder/vite/src/plugin/precompile-run.ts
@@ -1,0 +1,242 @@
+/**
+ * The pre-compilation pass.
+ *
+ * Scans the configured patterns, diffs them against the previous in-process
+ * run, restores whatever the persistent cache can prove is still valid, and
+ * batch-compiles the rest. Extracted from `state.ts` so the state module stays
+ * a state module.
+ */
+
+import fs from "node:fs";
+import { glob } from "tinyglobby";
+
+import { compileBatch, formatCompileErrorMessage } from "../compiler.ts";
+import { buildCompileBatchOptions, type CompileBatchOptions } from "../compile-options.ts";
+import {
+  chunkPrecompileFiles,
+  diffPrecompileFiles,
+  isPrecompileSfcPath,
+  type PrecompileFileMetadata,
+} from "./precompile.ts";
+import {
+  createDisabledPrecompileCache,
+  hashPrecompileSource,
+  openPrecompileCache,
+  type PrecompileCache,
+} from "./precompile-cache.ts";
+import { syncCollectedCssForFile, type VizePluginState } from "./state.ts";
+
+/**
+ * The options the pre-compile batch actually compiles with.
+ *
+ * Also the input to the cache key, so the two can never drift: a new option
+ * that reaches the native compiler reaches the key with it.
+ */
+function resolvePrecompileBatchOptions(state: VizePluginState): CompileBatchOptions {
+  return {
+    ssr: false,
+    vapor: state.mergedOptions.vapor ?? false,
+    mode: state.mergedOptions.mode,
+    customRenderer: state.mergedOptions.customRenderer ?? false,
+    templateSyntax: state.mergedOptions.templateSyntax ?? "standard",
+    experimentalInTagComments: state.mergedOptions.experimentalInTagComments ?? false,
+    experimentalPatternedTemplate: state.mergedOptions.experimentalPatternedTemplate ?? false,
+    experimentalServerScript: state.mergedOptions.experimentalServerScript ?? false,
+    runtimeModuleName: state.mergedOptions.runtimeModuleName,
+    runtimeGlobalName: state.mergedOptions.runtimeGlobalName,
+    vueVersion: state.mergedOptions.vueVersion,
+  };
+}
+
+function openCacheForRun(
+  state: VizePluginState,
+  batchOptions: CompileBatchOptions,
+): PrecompileCache {
+  if (!state.root) {
+    return createDisabledPrecompileCache();
+  }
+  return openPrecompileCache({
+    root: state.root,
+    compileOptions: buildCompileBatchOptions(batchOptions),
+    onDiagnostic: (message, error) =>
+      error === undefined ? state.logger.warn(message) : state.logger.warn(message, error),
+  });
+}
+
+/**
+ * Pre-compile all Vue files matching scan patterns.
+ */
+export async function compileAll(state: VizePluginState): Promise<void> {
+  const startTime = performance.now();
+  const files = await glob(state.scanPatterns!, {
+    cwd: state.root,
+    ignore: state.ignorePatterns,
+    absolute: true,
+  });
+  const sfcFiles = files.filter(isPrecompileSfcPath);
+
+  const currentMetadata = new Map<string, PrecompileFileMetadata>();
+  for (const file of sfcFiles) {
+    try {
+      const stat = fs.statSync(file);
+      currentMetadata.set(file, {
+        mtimeMs: stat.mtimeMs,
+        size: stat.size,
+      });
+    } catch (e) {
+      state.logger.error(`Failed to stat ${file}:`, e);
+    }
+  }
+
+  const { changedFiles, deletedFiles } = diffPrecompileFiles(
+    sfcFiles,
+    currentMetadata,
+    state.precompileMetadata,
+  );
+  const cachedFileCount = sfcFiles.length - changedFiles.length;
+
+  for (const file of deletedFiles) {
+    state.cache.delete(file);
+    state.ssrCache.delete(file);
+    if (state.extractCss) {
+      state.collectedCss.delete(file);
+    }
+    state.precompileMetadata.delete(file);
+    state.pendingHmrUpdateTypes.delete(file);
+  }
+
+  state.logger.info(
+    `Pre-compiling ${sfcFiles.length} Vue files... (${changedFiles.length} changed, ${cachedFileCount} cached, ${deletedFiles.length} removed)`,
+  );
+
+  if (changedFiles.length === 0) {
+    const elapsed = (performance.now() - startTime).toFixed(2);
+    state.logger.info(`Pre-compilation complete: cache reused (${elapsed}ms)`);
+    return;
+  }
+
+  for (const file of changedFiles) {
+    if (state.extractCss) {
+      state.collectedCss.delete(file);
+    }
+    state.pendingHmrUpdateTypes.delete(file);
+  }
+
+  const batchOptions = resolvePrecompileBatchOptions(state);
+  const cache = openCacheForRun(state, batchOptions);
+  // A disabled cache must not pay for hashing it will never consult.
+  const cacheEnabled = cache.file !== null;
+
+  let successCount = 0;
+  let restoredCount = 0;
+  let failedCount = 0;
+  let nativeTimeMs = 0;
+  const precompileFailures: string[] = [];
+  const chunks = chunkPrecompileFiles(changedFiles, state.precompileBatchSize, {
+    metadata: currentMetadata,
+  });
+
+  for (const chunk of chunks) {
+    const fileContents: { path: string; source: string }[] = [];
+    const sourceHashes = new Map<string, string>();
+    for (const file of chunk) {
+      let source: string;
+      try {
+        source = fs.readFileSync(file, "utf-8");
+      } catch (e) {
+        failedCount++;
+        state.cache.delete(file);
+        if (state.extractCss) {
+          state.collectedCss.delete(file);
+        }
+        state.precompileMetadata.delete(file);
+        cache.delete(file);
+        precompileFailures.push(`[vize] Failed to read ${file}: ${formatUnknownError(e)}`);
+        state.logger.error(`Failed to read ${file}:`, e);
+        continue;
+      }
+
+      // The hash is taken from the bytes just read, so a cache hit means the
+      // stored output was produced from exactly this source text.
+      const sourceHash = cacheEnabled ? hashPrecompileSource(source) : undefined;
+      const restored = sourceHash === undefined ? undefined : cache.get(file, sourceHash);
+      if (restored) {
+        state.cache.set(file, restored);
+        const metadata = currentMetadata.get(file);
+        if (metadata) {
+          state.precompileMetadata.set(file, metadata);
+        }
+        syncCollectedCssForFile(state, file, restored);
+        restoredCount++;
+        continue;
+      }
+
+      if (sourceHash !== undefined) {
+        sourceHashes.set(file, sourceHash);
+      }
+      fileContents.push({ path: file, source });
+    }
+
+    if (fileContents.length === 0) {
+      continue;
+    }
+
+    const result = compileBatch(fileContents, state.cache, batchOptions);
+
+    const chunkFailedCount = result.results.filter(
+      (fileResult) => fileResult.errors.length > 0,
+    ).length;
+    failedCount += chunkFailedCount;
+    successCount += result.results.length - chunkFailedCount;
+    nativeTimeMs += result.timeMs;
+
+    // Collect CSS for production extraction.
+    // Skip files with delegated styles (preprocessor/CSS Modules) -- those go through
+    // Vite's CSS pipeline and are extracted by Vite itself.
+    for (const fileResult of result.results) {
+      const metadata = currentMetadata.get(fileResult.path);
+
+      if (fileResult.errors.length > 0) {
+        state.cache.delete(fileResult.path);
+        if (state.extractCss) {
+          state.collectedCss.delete(fileResult.path);
+        }
+        state.precompileMetadata.delete(fileResult.path);
+        cache.delete(fileResult.path);
+        precompileFailures.push(formatCompileErrorMessage(fileResult.path, fileResult.errors));
+        continue;
+      }
+
+      if (metadata) {
+        state.precompileMetadata.set(fileResult.path, metadata);
+      }
+
+      const compiled = state.cache.get(fileResult.path);
+      const sourceHash = sourceHashes.get(fileResult.path);
+      if (compiled && sourceHash !== undefined) {
+        cache.set(fileResult.path, sourceHash, compiled);
+      }
+
+      syncCollectedCssForFile(state, fileResult.path, compiled);
+    }
+  }
+
+  // Files that vanished from the scan must not accumulate in the manifest.
+  cache.retain(new Set(sfcFiles));
+  cache.flush();
+
+  const elapsed = (performance.now() - startTime).toFixed(2);
+  const batchLabel = chunks.length === 1 ? "batch" : "batches";
+  state.logger.info(
+    `Pre-compilation complete: ${successCount} recompiled, ${restoredCount} restored from disk, ${cachedFileCount} reused, ${failedCount} failed (${elapsed}ms, native ${batchLabel}: ${nativeTimeMs.toFixed(2)}ms)`,
+  );
+
+  if (failedCount > 0) {
+    const details = precompileFailures.length > 0 ? `\n\n${precompileFailures.join("\n\n")}` : "";
+    throw new Error(`[vize] Pre-compilation failed for ${failedCount} file(s).${details}`);
+  }
+}
+
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/npm/builder/vite/src/plugin/precompile.test.ts
+++ b/npm/builder/vite/src/plugin/precompile.test.ts
@@ -3,7 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { compileAll, DEFAULT_PRECOMPILE_BATCH_SIZE, type VizePluginState } from "./state.ts";
+import { DEFAULT_PRECOMPILE_BATCH_SIZE, type VizePluginState } from "./state.ts";
+import { compileAll } from "./precompile-run.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/npm/builder/vite/src/plugin/state.test.ts
+++ b/npm/builder/vite/src/plugin/state.test.ts
@@ -9,7 +9,6 @@ import {
   DEFAULT_PRECOMPILE_IGNORE_PATTERNS,
   clearBuildCaches,
   chunkPrecompileFiles,
-  compileAll,
   diffPrecompileFiles,
   getCompileOptionsForRequest,
   hasFileMetadataChanged,
@@ -18,6 +17,7 @@ import {
   type PrecompileFileMetadata,
   type VizePluginState,
 } from "./state.ts";
+import { compileAll } from "./precompile-run.ts";
 import type { CompiledModule } from "../types.ts";
 
 const previousMetadata = new Map<string, PrecompileFileMetadata>([

--- a/npm/builder/vite/src/plugin/state.ts
+++ b/npm/builder/vite/src/plugin/state.ts
@@ -1,24 +1,18 @@
 /**
- * Plugin state type and batch compilation logic.
+ * Plugin state type and the caches derived from it.
+ *
+ * The pre-compilation pass itself lives in `./precompile-run.ts`.
  */
 
 import type { ViteDevServer } from "vite";
-import fs from "node:fs";
-import { glob } from "tinyglobby";
 
 import type { VizeOptions, CompiledModule } from "../types.ts";
-import { compileBatch, formatCompileErrorMessage } from "../compiler.ts";
 import { resolveCssImports, type CssAliasRule } from "../utils/css.ts";
 import { hasDelegatedStyles } from "../utils/index.ts";
 import { type DynamicImportAliasRule } from "../virtual.ts";
 import { createLogger } from "../transform.ts";
 import type { HmrUpdateType } from "../hmr.ts";
-import {
-  chunkPrecompileFiles,
-  diffPrecompileFiles,
-  type PrecompileFileMetadata,
-  isPrecompileSfcPath,
-} from "./precompile.ts";
+import type { PrecompileFileMetadata } from "./precompile.ts";
 
 export {
   DEFAULT_PRECOMPILE_BATCH_MAX_BYTES,
@@ -171,154 +165,4 @@ export function clearBuildCaches(
   state.precompileMetadata.clear();
   state.pendingHmrUpdateTypes.clear();
   state.viteResolveCache?.clear();
-}
-
-/**
- * Pre-compile all Vue files matching scan patterns.
- */
-export async function compileAll(state: VizePluginState): Promise<void> {
-  const startTime = performance.now();
-  const files = await glob(state.scanPatterns!, {
-    cwd: state.root,
-    ignore: state.ignorePatterns,
-    absolute: true,
-  });
-  const sfcFiles = files.filter(isPrecompileSfcPath);
-
-  const currentMetadata = new Map<string, PrecompileFileMetadata>();
-  for (const file of sfcFiles) {
-    try {
-      const stat = fs.statSync(file);
-      currentMetadata.set(file, {
-        mtimeMs: stat.mtimeMs,
-        size: stat.size,
-      });
-    } catch (e) {
-      state.logger.error(`Failed to stat ${file}:`, e);
-    }
-  }
-
-  const { changedFiles, deletedFiles } = diffPrecompileFiles(
-    sfcFiles,
-    currentMetadata,
-    state.precompileMetadata,
-  );
-  const cachedFileCount = sfcFiles.length - changedFiles.length;
-
-  for (const file of deletedFiles) {
-    state.cache.delete(file);
-    state.ssrCache.delete(file);
-    if (state.extractCss) {
-      state.collectedCss.delete(file);
-    }
-    state.precompileMetadata.delete(file);
-    state.pendingHmrUpdateTypes.delete(file);
-  }
-
-  state.logger.info(
-    `Pre-compiling ${sfcFiles.length} Vue files... (${changedFiles.length} changed, ${cachedFileCount} cached, ${deletedFiles.length} removed)`,
-  );
-
-  if (changedFiles.length === 0) {
-    const elapsed = (performance.now() - startTime).toFixed(2);
-    state.logger.info(`Pre-compilation complete: cache reused (${elapsed}ms)`);
-    return;
-  }
-
-  for (const file of changedFiles) {
-    if (state.extractCss) {
-      state.collectedCss.delete(file);
-    }
-    state.pendingHmrUpdateTypes.delete(file);
-  }
-
-  let successCount = 0;
-  let failedCount = 0;
-  let nativeTimeMs = 0;
-  const precompileFailures: string[] = [];
-  const chunks = chunkPrecompileFiles(changedFiles, state.precompileBatchSize, {
-    metadata: currentMetadata,
-  });
-
-  for (const chunk of chunks) {
-    const fileContents: { path: string; source: string }[] = [];
-    for (const file of chunk) {
-      try {
-        const source = fs.readFileSync(file, "utf-8");
-        fileContents.push({ path: file, source });
-      } catch (e) {
-        failedCount++;
-        state.cache.delete(file);
-        if (state.extractCss) {
-          state.collectedCss.delete(file);
-        }
-        state.precompileMetadata.delete(file);
-        precompileFailures.push(`[vize] Failed to read ${file}: ${formatUnknownError(e)}`);
-        state.logger.error(`Failed to read ${file}:`, e);
-      }
-    }
-
-    if (fileContents.length === 0) {
-      continue;
-    }
-
-    const result = compileBatch(fileContents, state.cache, {
-      ssr: false,
-      vapor: state.mergedOptions.vapor ?? false,
-      mode: state.mergedOptions.mode,
-      customRenderer: state.mergedOptions.customRenderer ?? false,
-      templateSyntax: state.mergedOptions.templateSyntax ?? "standard",
-      experimentalInTagComments: state.mergedOptions.experimentalInTagComments ?? false,
-      experimentalPatternedTemplate: state.mergedOptions.experimentalPatternedTemplate ?? false,
-      experimentalServerScript: state.mergedOptions.experimentalServerScript ?? false,
-      runtimeModuleName: state.mergedOptions.runtimeModuleName,
-      runtimeGlobalName: state.mergedOptions.runtimeGlobalName,
-      vueVersion: state.mergedOptions.vueVersion,
-    });
-
-    const chunkFailedCount = result.results.filter(
-      (fileResult) => fileResult.errors.length > 0,
-    ).length;
-    failedCount += chunkFailedCount;
-    successCount += result.results.length - chunkFailedCount;
-    nativeTimeMs += result.timeMs;
-
-    // Collect CSS for production extraction.
-    // Skip files with delegated styles (preprocessor/CSS Modules) -- those go through
-    // Vite's CSS pipeline and are extracted by Vite itself.
-    for (const fileResult of result.results) {
-      const metadata = currentMetadata.get(fileResult.path);
-
-      if (fileResult.errors.length > 0) {
-        state.cache.delete(fileResult.path);
-        if (state.extractCss) {
-          state.collectedCss.delete(fileResult.path);
-        }
-        state.precompileMetadata.delete(fileResult.path);
-        precompileFailures.push(formatCompileErrorMessage(fileResult.path, fileResult.errors));
-        continue;
-      }
-
-      if (metadata) {
-        state.precompileMetadata.set(fileResult.path, metadata);
-      }
-
-      syncCollectedCssForFile(state, fileResult.path, state.cache.get(fileResult.path));
-    }
-  }
-
-  const elapsed = (performance.now() - startTime).toFixed(2);
-  const batchLabel = chunks.length === 1 ? "batch" : "batches";
-  state.logger.info(
-    `Pre-compilation complete: ${successCount} recompiled, ${cachedFileCount} reused, ${failedCount} failed (${elapsed}ms, native ${batchLabel}: ${nativeTimeMs.toFixed(2)}ms)`,
-  );
-
-  if (failedCount > 0) {
-    const details = precompileFailures.length > 0 ? `\n\n${precompileFailures.join("\n\n")}` : "";
-    throw new Error(`[vize] Pre-compilation failed for ${failedCount} file(s).${details}`);
-  }
-}
-
-function formatUnknownError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -27,6 +27,8 @@ import "./plugin/resolve-dependency-style.test.ts";
 import "./plugin/resolve-relative-vue.test.ts";
 import "./plugin/resolve.test.ts";
 import "./plugin/precompile.test.ts";
+import "./plugin/precompile-cache.test.ts";
+import "./plugin/precompile-cache-manifest.test.ts";
 import "./plugin/state.test.ts";
 import "./plugin/unocss.test.ts";
 import "./plugin/vite-transform.test.ts";


### PR DESCRIPTION
Closes part of #3363 (opportunity 1). Opportunity 2 was measured and **is not a win** — see the last section; nothing was changed for it.

`state.precompileMetadata` + `state.cache` only skip recompilation inside one process, so every cold build recompiled the whole scan. This backs them with a manifest under `node_modules/.vize/vite-precompile/`.

## Invalidation design

A stale hit serves **wrong compiled output**, so every gate fails toward recompilation. There are four independent ones.

**1. Manifest identity — `computePrecompileCacheKey` (`precompile-cache-key.ts`).**
The manifest's *file name* is `sha256` of everything outside the source text that determines batch output:

| in the key | why |
| --- | --- |
| `PRECOMPILE_CACHE_FORMAT` | bump abandons every old manifest at once |
| resolved `@vizejs/native` version | the compiler that produces the output |
| size + mtime of the `.node` actually loaded (or `NAPI_RS_NATIVE_LIBRARY_PATH`) | a local `pnpm --dir npm/native build:debug` changes codegen without changing any version; this repo's own `test` script rebuilds it |
| `buildCompileBatchOptions(...)` — the object literally handed to the native batch compiler | Vue dialect/`vueVersion`, `vapor`, `ssr`, `mode`, `templateSyntax`, `customRenderer`, `runtimeModuleName`, `runtimeGlobalName`, and every experimental flag |

Two properties worth calling out:

- The key is derived from **the same object the compiler receives**, not a hand-copied list, so a compile option added later reaches the key automatically. `resolvePrecompileBatchOptions()` is the single source for both.
- The key names the file, so nothing is ever shared between configurations, and `format`/`key` are *re-checked after parsing* — a manifest reached by any other route is still rejected.

Hashing the 33 MB `.node` would be airtight but costs hundreds of ms, so a rebuild is treated as a **new identity** (a miss, never a stale hit).

**2. Source identity.** Each entry stores `sha256` of the exact source text it was compiled from, and a hit requires that hash to match a fresh read. **`mtime` is never trusted on its own**, so a same-size edit, a `git checkout` that rewrites content while preserving `mtime`, and a container with a reset clock all miss. This is the conservative option from the issue: we pay a read + hash per file rather than trusting metadata.

**3. Shape.** Entries are validated before use (`code`/`scopeId` strings, `hasScoped` boolean, `css`/`styles`/`macroArtifacts` well-typed) and dropped individually if not.

**4. `src` imports are never persisted.** An SFC with `<script src>` / `<template src>` / `<style src>` depends on files this cache does not hash, so those recompile on every cold start. The test proves *why*: the dependency can change with the SFC byte-identical.

**Corruption / partial writes.** Missing, empty, truncated, non-JSON, `null`, or non-object manifests all yield an empty cache → full recompile. Writes go to `<file>.<pid>.<rand>.tmp` and are `rename`d, so an interrupted write is never readable; on failure the temp file is removed and a diagnostic is logged without failing the build. Concurrent builds are safe: the rename is atomic, so a racing writer loses entries, never corrupts them.

**Escape hatch.** `VIZE_PRECOMPILE_CACHE=0` disables reads *and* writes, and also skips hashing, so it is a true zero-overhead path identical to `main`.

**Location.** `<root>/node_modules/.vize/vite-precompile/<key>.json`, following the repo's `.vize/` convention and staying out of Vite's own `cacheDir` (so `vite --force` does not silently drop it). For CI to benefit, `node_modules/.vize` has to be in the CI cache.

## Measurements

15 cores, macOS, node v24.15.0, release `@vizejs/native` built from this branch, corpus from `node bench/generate.mjs` (300 SFCs / 1.2 MB, and 3000 SFCs).

### `node bench/vite.ts 300` — the existing harness

The harness runs warmup and measured builds in **separate Vite instances in one process**, so before this change the measured run reported `0 cached`. After it, the warmup writes the manifest and the measured run restores from it — the cold-start improvement, visible in the existing harness:

```
before:  [vize] Pre-compilation complete: 300 recompiled, 0 restored from disk, 0 reused, 0 failed (26.47ms, native batches: 12.75ms)
after:   [vize] Pre-compilation complete: 0 recompiled, 300 restored from disk, 0 reused, 0 failed (17.58ms, native batches: 0.00ms)
```

A/B with the same plugin build, arms alternated so machine noise hits both (`VIZE_PRECOMPILE_CACHE=0` vs default), median of 7 rounds:

| | total build | pre-compilation | native batch |
| --- | --- | --- | --- |
| cache off | 184.0 ms | 26.47 ms | 12.75 ms |
| cache on | 171.0 ms | **17.58 ms (−34%)** | 0.00 ms |

Wall-clock build time on this machine varies 150–350 ms run to run, so treat the −13 ms build column as directional; the pre-compilation column is the measurement.

### Cold vs warm, isolated (one Vite build per child process)

The A/B above only shows the *restore* side. This isolates the cost of the cold build that has to hash and write the manifest. Medians of 5 rounds (300) / 3 rounds (3000):

| 300 SFCs | total | pre-compilation | native batch |
| --- | --- | --- | --- |
| cache off | 277 ms | 38.32 ms | 14.07 ms |
| cache on, cold (writes manifest) | 294 ms | 55.16 ms (**+17 ms**) | 18.44 ms |
| cache on, warm | 259 ms | 28.35 ms (**−10 ms**) | 0.00 ms |

| 3000 SFCs | total | pre-compilation | native batch |
| --- | --- | --- | --- |
| cache off | 2047 ms | 278.04 ms | 114.14 ms |
| cache on, cold (writes manifest) | 1915 ms | 329.75 ms (**+52 ms**) | 115.52 ms |
| cache on, warm | 1779 ms | 201.15 ms (**−77 ms**) | 0.00 ms |

Reading that honestly: **the first cold build after any cache-invalidating change is slower** (hash + `JSON.stringify` + write), and every build after it is faster. Break-even is under one warm build at 3000 files and ~1.7 warm builds at 300. That is net positive for the cases the issue names — repeated `vite build`, dev-server restarts — and a small loss (≈2% of the pre-compile step, ≈0.5% of the build) for a single-shot cold CI build with no restored `node_modules`.

Manifest size is ~8.6 KB per SFC (2.59 MB at 300, 25.86 MB at 3000). A compact index+payload format would cut both the write and the read; I kept plain JSON because it is trivially validatable, which matters more here than the last few ms. Flagging it as the obvious follow-up rather than claiming it.

### End-to-end output parity

Strongest correctness evidence: 300 SFCs built three ways in one process — cache disabled, cache cold, cache warm — comparing per-asset SHA-256 with content hashes in filenames normalized:

```
no-cache   ==  cold-cache : true
cold-cache ==  warm-cache : true
✅ 300 SFCs: bundle output identical with and without the cache
```

The compared set includes the extracted components CSS, not just JS, so the `collectedCss` side of the restore path is covered too — a smaller run printing the asset list:

```
assets compared (cache off):
  __entry__.css     13888B  51b7bce0bfc4f398
  __entry__.js    242585B  cae000484518154a
css assets present: 1
off == warm: true
```

## Tests

New `src/plugin/precompile-cache.test.ts` drives `compileAll` end to end with a fresh state per run (a fresh state is a fresh process for this cache). The suite is built around the **miss** path:

- **content change with identical size and identical mtime** — `utimesSync` pins mtime to an exact ms, and the test first asserts `hasFileMetadataChanged(...) === false`, i.e. the mtime+size heuristic is provably blind to the edit — then asserts no restore, a recompile, and that the new output contains the new text.
- **compile option change** (`vapor: true`) — no restore, different output, a second manifest appears, and the original option set still hits *its* manifest.
- **version/format bump** — a manifest with `format: FORMAT - 1` is ignored; so is one whose recorded `key` does not match the file it is filed under.
- **corruption** — truncated, empty, non-JSON, `[]`, `null`, and a well-formed manifest with a malformed entry: each falls back to compiling and still produces output.
- **pruning** — a deleted SFC drops out of the manifest instead of accumulating.
- **`src` imports** — never restored, and changing the dependency with the SFC untouched still recompiles.
- **env kill switch** — no manifest written, nothing ever restored.
- **hit path** — second cold run restores, `deepEqual` against the freshly compiled module, and scan metadata is repopulated.

`src/plugin/precompile-cache-manifest.test.ts` covers the cache object directly: disabled-cache no-ops, `flush()` only writing when dirty, hash/path misses, refusal + eviction of `src`-dependency modules, key stability under object-key reordering, key divergence across options, no leftover `.tmp` files, and an unwritable cache directory reporting a diagnostic instead of throwing.

## Refactor note

`compileAll` moved from `state.ts` to a new `precompile-run.ts`. `state.ts` was 324 lines and the cache integration would have pushed it past the 350-line source gate; the move also keeps `state.ts` a state module. `state.ts` 324 → 168, and every new file is under the gate (`precompile-run.ts` 242, `precompile-cache.ts` 279, `precompile-cache-key.ts` 109, tests 332 / 112). `state.test.ts` was at exactly 350, so its `compileAll` import was moved to its own line at no net line change.

## Opportunity 2 (serial `fs.statSync` loop): measured, not a win

The issue flagged the serial stat loop and explicitly asked for a measurement before any claim. I implemented the bounded concurrent `fs.promises.stat` pool, benchmarked it against the serial loop over the same glob result, and **reverted it** — it is slower at every concurrency level:

```
15000 files across nested dirs, 15 cores, node v24.15.0   (median of 9)

serial statSync                 31.96ms
pool(4) promises.stat           80.95ms
pool(8) promises.stat           56.16ms
pool(16) promises.stat          44.08ms
pool(32) promises.stat          37.59ms
pool(64) promises.stat          36.40ms
pool(128) promises.stat         34.61ms
pool(512) promises.stat         34.30ms
unbounded Promise.all           34.86ms
serial statSync (again)         32.03ms
```

`UV_THREADPOOL_SIZE=16` makes every concurrent arm *worse* (~97 ms vs 33 ms serial). A cached `stat` is cheap enough that promise allocation + libuv dispatch dominates it. Taking stats from the glob walk is also not available: `tinyglobby` returns `string[]`, and the `fdir` walk under it gets `d_type` from `readdir` but not size/mtime, so there are no free stats to harvest. So this is 32 ms at 15k files and ~0.7 ms at 300 — real, but not worth making slower. No code change in this PR for it.

## Verification

```
$ cd npm/builder/vite && node src/test.ts        # (the `test` script's `pnpm --dir ../../native build:debug` step skipped;
ℹ tests 23                                       #  a release native build from this branch was already in place)
ℹ pass 23
ℹ fail 0
✅ vite-plugin-vize precompile cache staleness tests passed!
✅ vite-plugin-vize precompile cache manifest tests passed!

$ cd npm/builder/vite && vp check src
pass: All 74 files are correctly formatted (148ms, 15 threads)
pass: Found no warnings or lint errors in 74 files (293ms, 15 threads)

$ node --experimental-strip-types --test tests/tooling/package-manifests.test.ts
ℹ tests 17
ℹ pass 17
ℹ fail 0
```

`tests/tooling/source-file-lengths.test.ts` needs the MoonBit toolchain, which is not available in this checkout; line counts were checked by hand against `origin/main` (see the refactor note — no file over 350 lines grew, none crossed it, no new file exceeds it).

No existing correctness gate was weakened. Not touched: docs (`docs/content/**` is tri-locale, so documenting `VIZE_PRECOMPILE_CACHE` there is a separate change) and `VizeOptions` (`types.ts` is 401 lines, already over the source gate, so a config flag could not be added there without an unrelated extraction — the env var is the escape hatch for now).
