### PR TITLE
fix(maestro): release the document lock before awaiting a diagnostics pass

### DIFF
--- a/crates/vize_maestro/src/document/store.rs
+++ b/crates/vize_maestro/src/document/store.rs
@@ -156,6 +156,19 @@ impl DocumentStore {
         self.documents.get_mut(uri)
     }
 
+    /// Owned snapshot of a document's text, holding no lock on return.
+    ///
+    /// Prefer this over [`Self::get`] whenever the text outlives a statement:
+    /// [`Self::get`] hands back a `DashMap` shard read guard, and the LSP runs
+    /// every handler on one executor thread. A guard that is still alive at an
+    /// `.await` therefore blocks the whole server the moment a concurrently
+    /// polled handler writes the same shard — `apply_changes`/`open`/`close`
+    /// all park forever on the shard's write lock, which the suspended reader
+    /// can only release by being polled on that same parked thread (#3315).
+    pub fn text(&self, uri: &Url) -> Option<String> {
+        self.documents.get(uri).map(|document| document.text())
+    }
+
     /// Apply changes to a document.
     pub fn apply_changes(
         &self,

--- a/crates/vize_maestro/src/document/store/tests.rs
+++ b/crates/vize_maestro/src/document/store/tests.rs
@@ -286,3 +286,22 @@ fn test_document_store_rename_does_not_overwrite_open_target() {
     assert_eq!(target.text(), "target");
     assert_eq!(target.version, 7);
 }
+
+// Regression (#3315): `text` must hand back an owned snapshot with no shard
+// lock still held, so a live snapshot can never block a concurrent write. The
+// LSP polls handlers concurrently on a single thread, where a leaked guard
+// turns the next `didChange` into a permanent server-wide deadlock; here it
+// would hang this test instead.
+#[test]
+fn test_document_store_text_snapshot_holds_no_shard_lock() {
+    let store = DocumentStore::new();
+    let uri = test_uri();
+    store.open(uri.clone(), "before".to_string(), 1, "vue".to_string());
+
+    let snapshot = store.text(&uri).unwrap();
+    store.apply_changes(&uri, vec![full_change("after")], 2);
+
+    assert_eq!(snapshot, "before");
+    assert_eq!(store.text(&uri).as_deref(), Some("after"));
+    assert_eq!(store.text(&Url::parse("file:///absent.vue").unwrap()), None);
+}

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
@@ -81,12 +81,15 @@ impl DiagnosticService {
             return Ok(vec![]);
         }
 
-        // Get document content
-        let Some(doc) = state.documents.get(uri) else {
+        // Own the document text up front: every `.await` below (bridge
+        // acquisition, the background declaration scan, the bridge calls) can
+        // hand the single executor thread to another queued handler, and a live
+        // `documents.get` shard guard would deadlock the server against that
+        // handler's `didOpen`/`didChange`/`didClose` write (#3315).
+        let Some(content) = state.documents.text(uri) else {
             tracing::warn!("document not found: {}", uri);
             return Ok(vec![]);
         };
-        let content = doc.text();
 
         // Get the shared Corsa bridge.
         tracing::info!("getting corsa bridge...");

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -109,9 +109,7 @@ impl LanguageServer for MaestroServer {
             .documents
             .apply_changes(&uri, params.content_changes, version);
 
-        if let Some(doc) = self.state.documents.get(&uri) {
-            let content = doc.text();
-            drop(doc);
+        if let Some(content) = self.state.documents.text(&uri) {
             self.publish_changed_diagnostics(&uri, &content).await;
         }
     }
@@ -140,11 +138,9 @@ impl LanguageServer for MaestroServer {
         let uri = &params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let content = doc.text();
         let Some(offset) = position_to_offset(&content, position.line, position.character) else {
             return Ok(None);
         };
@@ -188,11 +184,9 @@ impl LanguageServer for MaestroServer {
         let uri = &params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let content = doc.text();
         let Some(offset) = position_to_offset(&content, position.line, position.character) else {
             return Ok(None);
         };
@@ -254,11 +248,9 @@ impl LanguageServer for MaestroServer {
         let uri = &params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let content = doc.text();
         let Some(offset) = position_to_offset(&content, position.line, position.character) else {
             return Ok(None);
         };
@@ -308,11 +300,9 @@ impl LanguageServer for MaestroServer {
         let position = params.text_document_position.position;
         let include_declaration = params.context.include_declaration;
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let content = doc.text();
         let Some(offset) = position_to_offset(&content, position.line, position.character) else {
             return Ok(None);
         };
@@ -376,11 +366,9 @@ impl LanguageServer for MaestroServer {
         let uri = &params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let content = doc.text();
         let Some(offset) = position_to_offset(&content, position.line, position.character) else {
             return Ok(None);
         };
@@ -401,11 +389,9 @@ impl LanguageServer for MaestroServer {
 
         let uri = &params.text_document.uri;
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let content = doc.text();
 
         // `.jsx`/`.tsx` documents have no SFC blocks; list their component
         // functions instead. Structural (parse-based), so it is not gated on
@@ -573,11 +559,9 @@ impl LanguageServer for MaestroServer {
         let uri = &params.text_document.uri;
         let range = params.range;
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let content = doc.text();
 
         // `.jsx`/`.tsx`: surface the fixable Patina/JSX-compiler diagnostics as
         // quickfix code actions. Lint-based (parse-only), so not gated on
@@ -616,11 +600,9 @@ impl LanguageServer for MaestroServer {
         let uri = &params.text_document.uri;
         let position = params.position;
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let content = doc.text();
         let Some(offset) = position_to_offset(&content, position.line, position.character) else {
             return Ok(None);
         };
@@ -658,11 +640,9 @@ impl LanguageServer for MaestroServer {
         let position = params.text_document_position.position;
         let new_name = &params.new_name;
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let content = doc.text();
         let Some(offset) = position_to_offset(&content, position.line, position.character) else {
             return Ok(None);
         };
@@ -703,11 +683,9 @@ impl LanguageServer for MaestroServer {
 
         let uri = &params.text_document.uri;
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let content = doc.text();
 
         // `.jsx`/`.tsx`: highlight the dynamic JSX expressions. Structural, so
         // not gated on `typeChecker.jsxTypecheck`.
@@ -728,11 +706,9 @@ impl LanguageServer for MaestroServer {
 
         let uri = &params.text_document.uri;
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let content = doc.text();
 
         if crate::utils::is_jsx_path(uri.path()) {
             return Ok(crate::ide::JsxSemanticTokensService::tokens_range(
@@ -756,11 +732,9 @@ impl LanguageServer for MaestroServer {
 
         let uri = &params.text_document.uri;
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let content = doc.text();
         let lenses = CodeLensService::get_lenses(&content, uri);
 
         if lenses.is_empty() {
@@ -815,11 +789,9 @@ impl LanguageServer for MaestroServer {
 
         let uri = &params.text_document.uri;
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let content = doc.text();
         let links = DocumentLinkService::get_links(&content, uri);
 
         if links.is_empty() {
@@ -838,11 +810,9 @@ impl LanguageServer for MaestroServer {
         let uri = &params.text_document.uri;
         let range = params.range;
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let content = doc.text();
         let hints =
             InlayHintService::get_hints_with_ecosystem(&content, uri, range, features.ecosystem);
 
@@ -860,11 +830,9 @@ impl LanguageServer for MaestroServer {
 
         let uri = &params.text_document.uri;
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let content = doc.text();
         let mut ranges = Vec::new();
 
         let options = vize_atelier_sfc::SfcParseOptions {
@@ -947,11 +915,9 @@ impl LanguageServer for MaestroServer {
             return Ok(None);
         }
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(_content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let _content = doc.text();
         #[cfg(feature = "glyph")]
         {
             let options = self.state.get_format_options();
@@ -976,11 +942,9 @@ impl LanguageServer for MaestroServer {
             return Ok(None);
         }
 
-        let Some(doc) = self.state.documents.get(uri) else {
+        let Some(_content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-
-        let _content = doc.text();
         let valid_position =
             |position: Position| position_to_offset(&_content, position.line, position.character);
         if valid_position(params.range.start).is_none()

--- a/tests/tooling/lsp-concurrent-edit-deadlock.test.ts
+++ b/tests/tooling/lsp-concurrent-edit-deadlock.test.ts
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { isDiagnosticsForUri } from "./support/lsp/assertions.ts";
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+// Concurrent-edit publish deadlock (#3315).
+//
+// tower-lsp polls up to four queued messages concurrently on the LSP's single
+// executor thread. The Corsa diagnostics collector used to hold a `DashMap`
+// shard read guard on the open-document store (`documents.get`) across its
+// `.await` points. Whenever one of those awaits actually yielded — the
+// background workspace `*.d.ts` declaration scan does, on a cold or
+// invalidated cache — the next queued `didChange` ran on the same thread,
+// took the shard *write* lock in `apply_changes`, and parked forever: the
+// suspended reader can only release its guard by being polled on the very
+// thread that is now parked. The server went permanently silent, publishing
+// nothing and answering nothing, with normal memory use.
+//
+// Both windows below are exercised because they are independently reachable:
+// the cold scan at the first diagnostics pass, and a mid-session rescan after
+// a watched declaration file changes (the sustained-churn shape).
+
+function resolveTsgoBinary(): string | undefined {
+  return [
+    path.join(root, "../corsa-bind/.cache/tsgo"),
+    path.join(root, "node_modules/.bin/tsgo"),
+    path.join(root, "tests/node_modules/.bin/tsgo"),
+  ].find((candidate) => fs.existsSync(candidate));
+}
+
+const VUE_SHIM = `declare module "vue" {
+  export interface Ref<T = any> {
+    value: T;
+  }
+
+  export interface ShallowRef<T = any> {
+    value: T;
+  }
+
+  export interface ComponentPublicInstance {
+    $attrs: Record<string, unknown>;
+    $slots: Record<string, unknown>;
+    $refs: Record<string, unknown>;
+    $emit: (...args: any[]) => void;
+  }
+
+  export interface GlobalComponents {}
+}
+`;
+
+/**
+ * Each revision references one unique undeclared identifier, so the published
+ * `vize/types` diagnostic identifies which revision produced it. A stale
+ * republish therefore cannot masquerade as the awaited version's result.
+ */
+function appSource(marker: string): string {
+  return `<script setup lang="ts">
+const count: number = ${marker}
+</script>
+
+<template>
+  <p>{{ count }}</p>
+</template>
+`;
+}
+
+function markersOf(publish: PublishDiagnosticsParams): string[] {
+  return publish.diagnostics
+    .filter((diagnostic) => diagnostic.source === "vize/types")
+    .map((diagnostic) => /Cannot find name '(\w+)'/.exec(diagnostic.message ?? "")?.[1] ?? "")
+    .filter((marker) => marker !== "");
+}
+
+test("vize lsp keeps publishing when edits race an in-flight diagnostics pass", async (t) => {
+  const corsaPath = resolveTsgoBinary();
+  if (corsaPath == null) {
+    t.skip("tsgo binary not found; skipping concurrent-edit deadlock test");
+    return;
+  }
+
+  const testRootDir = path.join(testOutputRoot, "lsp-concurrent-edit-deadlock");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+  const declarationPath = path.join(workspaceDir, "src/vue-shim.d.ts");
+
+  try {
+    fs.mkdirSync(path.join(workspaceDir, "src"), { recursive: true });
+    fs.writeFileSync(declarationPath, VUE_SHIM, "utf8");
+    fs.writeFileSync(
+      path.join(workspaceDir, "vize.config.json"),
+      JSON.stringify({ lsp: { lint: false, typecheck: true }, typeChecker: { corsaPath } }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          module: "ESNext",
+          moduleResolution: "bundler",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src/**/*"],
+      }),
+      "utf8",
+    );
+    await session.initialize(workspaceDir, {
+      editor: true,
+      hover: true,
+      lint: false,
+      typecheck: true,
+    });
+
+    const filePath = path.join(workspaceDir, "src/App.vue");
+    const uri = pathToFileURL(filePath).href;
+    const publishes: Array<number | null> = [];
+    session.notificationObservers.push((method, params) => {
+      if (method !== "textDocument/publishDiagnostics") return;
+      publishes.push((params as PublishDiagnosticsParams).version ?? null);
+    });
+
+    let version = 0;
+    const edit = (marker: string, notification: "didOpen" | "didChange"): void => {
+      version += 1;
+      const text = appSource(marker);
+      fs.writeFileSync(filePath, text, "utf8");
+      session.notify(
+        `textDocument/${notification}`,
+        notification === "didOpen"
+          ? { textDocument: { uri, languageId: "vue", version, text } }
+          : { textDocument: { uri, version }, contentChanges: [{ text }] },
+      );
+    };
+
+    /**
+     * Awaits the publish for the newest version sent. Deterministic: the LSP
+     * spec makes `didChange` versions monotonic, so only one publish can carry
+     * it, and the assertion is on that publish's content — never on timing.
+     */
+    const awaitFinalPublish = async (marker: string, label: string): Promise<void> => {
+      const publish = (await session.waitForNotification(
+        "textDocument/publishDiagnostics",
+        (params) => isDiagnosticsForUri(params, uri) && params.version === version,
+        45_000,
+      )) as PublishDiagnosticsParams;
+      assert.deepEqual(
+        markersOf(publish),
+        [marker],
+        `${label}: version ${version} must publish exactly its own revision's diagnostic`,
+      );
+      t.diagnostic(`${label}: published v${version} (${publishes.length} publishes so far)`);
+    };
+
+    // Window 1: the very first diagnostics pass runs the cold declaration
+    // scan, and the edit lands while it is suspended.
+    edit("missingOne", "didOpen");
+    edit("missingTwo", "didChange");
+    await awaitFinalPublish("missingTwo", "cold scan window");
+
+    // Window 2: the same suspension point mid-session. Changing a watched
+    // declaration file invalidates the cached scan, so the next diagnostics
+    // pass yields again while two further edits are already queued — the
+    // sustained-churn shape from the churn-stress suite.
+    for (const round of [1, 2, 3]) {
+      fs.writeFileSync(declarationPath, `${VUE_SHIM}// round ${round}\n`, "utf8");
+      session.notify("workspace/didChangeWatchedFiles", {
+        changes: [{ uri: pathToFileURL(declarationPath).href, type: 2 }],
+      });
+      edit(`churnBroken${round}`, "didChange");
+      edit(`churnFinal${round}`, "didChange");
+      await awaitFinalPublish(`churnFinal${round}`, `churn round ${round}`);
+    }
+
+    // A wedged executor thread also stops answering requests, so a successful
+    // round-trip proves the thread is still running the message loop.
+    const symbols = await session.request("textDocument/documentSymbol", {
+      textDocument: { uri },
+    });
+    assert.ok(
+      Array.isArray(symbols),
+      `server must still answer requests: ${JSON.stringify(symbols)}`,
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes a **permanent, reproducible LSP publish deadlock** with exactly the signature reported in #3315: the server goes completely silent mid-session — no `publishDiagnostics`, no responses to any request — against a recompute that normally takes ~200ms, with normal RSS and no leak signature.

Please read the honesty section at the bottom before merging: the defect below is proven and fixed, but I cannot prove it is the *same* stall the reporter hit at cycle 13 of the churn suite.

## Reproduction

Deterministic, three lines of protocol traffic. On a workspace with `lsp.typecheck: true` and a reachable tsgo:

```
initialize
textDocument/didOpen   App.vue v1
textDocument/didChange App.vue v2     # sent immediately, no wait
```

Pre-fix, no publish ever arrives for v2 — and none for v1 either. `shutdown` also times out. The server log stops mid-collection, always at the same line:

```
INFO ide::diagnostics::corsa::collect: getting corsa bridge...
INFO server::state::corsa: corsa bridge initialized successfully
INFO ide::diagnostics::corsa::collect: corsa bridge acquired
<nothing, ever>
```

`sample` on the wedged process shows the single executor thread parked, permanently, on a `DashMap` shard write lock (chain trimmed):

```
runtime::block_on
  tower_lsp::transport::Server::serve          (join! read_input / print_output / process_server_tasks)
    BufferUnordered::poll_next                 (max_concurrency = 4)
      FuturesUnordered::poll_next
        tower_lsp::generated::register_lsp_methods::did_change
          vize_maestro::server::handlers::did_change
            vize_maestro::document::store::DocumentStore::apply_changes
              dashmap::DashMap::get_mut
                dashmap::_yield_write_shard
                  lock_api::RwLock::write
                    dashmap::lock::RawRwLock::lock_exclusive_slow
                      parking_lot_core::park
                        _pthread_cond_wait      <-- forever
```

## Root cause

`try_collect_corsa_diagnostics` bound the document guard and then awaited with it still alive:

```rust
let Some(doc) = state.documents.get(uri) else { ... };   // DashMap shard READ guard
let content = doc.text();
// ...
let Some(bridge) = state.get_corsa_bridge().await else { ... };
virtual_ts_options.reference_paths = state.global_component_reference_paths().await ...
```

Three facts combine into a hard deadlock:

1. **tower-lsp runs handlers concurrently on one thread.** `Server::serve` uses `buffer_unordered(DEFAULT_MAX_CONCURRENCY = 4)`, and `vize lsp` drives it with `runtime::block_on` on the main thread. Up to four queued messages — notifications included — interleave on that single thread.
2. **`global_component_reference_paths()` really yields.** It spawns the workspace `*.d.ts` scan on a helper thread and awaits a oneshot (`discover_in_background`). Every other await on this path (`get_corsa_bridge`, all `CorsaBridge` calls) is synchronous underneath — which is exactly why the churn suite observes strictly serial publishes. This is the one await that hands the thread over.
3. **The handover lands on a shard writer.** `did_change` → `apply_changes` → `get_mut` takes the shard *write* lock for the same key; `did_open`'s `insert` and `did_close`'s `remove` do too. `parking_lot` parks the thread — the only thread that could poll the suspended reader and release its read guard. Nothing recovers it: the timer thread and the discovery thread wake a waker on a thread that is no longer in `park()`.

Two independently reachable windows, both covered by the new test:

- **Cold scan**, at the first diagnostics pass of a session: open a file and type before its first diagnostics land.
- **Mid-session rescan**, any time after: a watched declaration change (`workspace/didChangeWatchedFiles` on `**/*.d.{ts,mts,cts}`, which the server registers itself when the client supports it) invalidates the cached scan, so the next diagnostics pass yields again — while edits are already queued behind it. Verified separately: with the cold-open race removed, the pre-fix server still deadlocks in this window.

## The fix

Add `DocumentStore::text(&Url) -> Option<String>`: an owned snapshot that holds no lock once it returns, with the hazard documented at the definition. Then use it at every site where document text outlives a statement — the Corsa collector, plus the seventeen request handlers (`hover`, `completion`, `goto_definition`, `references`, `document_highlight`, `document_symbol`, `code_action`, `prepare_rename`, `rename`, `semantic_tokens_full`/`_range`, `code_lens`, `document_link`, `inlay_hint`, `folding_range`, `formatting`, `range_formatting`) that were each carrying a live guard across their Corsa-bridge awaits.

Behavior is unchanged: those sites already materialized the text and only used the guard to reach it. `handlers.rs` shrinks 1363 → 1327 lines.

Convergence after the fix comes from the pre-existing stale-version rule, and it is correct: the superseded v1 pass finishes, sees `current_version != 1`, and drops its publish; v2 publishes. The new test asserts on that publish's content, not on timing.

## Tests

**`tests/tooling/lsp-concurrent-edit-deadlock.test.ts`** (new, 192 lines). Drives a real `vize lsp` over stdio and covers both windows: the cold-scan race, then three mid-session churn rounds that invalidate the declaration cache and queue two edits behind the rescan. Each revision carries a unique undeclared identifier, so the assertion is that the newest version's publish contains exactly that version's diagnostic — a stale republish cannot satisfy it. Finishes with a `documentSymbol` round-trip, since a wedged executor thread also stops answering requests. Skips cleanly when tsgo is absent, matching `lsp-corsa-crash-recovery.test.ts`.

Deterministic rather than probabilistic: the LSP spec makes versions monotonic, so exactly one publish can carry the awaited version, and every assertion is on that publish's payload.

**`document/store/tests.rs`**: `test_document_store_text_snapshot_holds_no_shard_lock` pins the accessor's contract at unit level (a live snapshot must not block a same-shard write), so `cargo test -p vize_maestro` catches a regression without needing tsgo.

### Verified the test fails without the fix

Stashed the three source files, rebuilt, saved that binary, restored, rebuilt.

| binary | result |
| --- | --- |
| pre-fix (`crates/` changes stashed) | **3/3 runs fail**, each hanging out the 60s wait, then `Timed out waiting for shutdown` |
| pre-fix, cold-open race removed | still hangs, in the mid-session churn window |
| with fix | **8/8 runs pass**, ~0.85s each |

## Commands run

| command | result |
| --- | --- |
| `cargo test -p vize_maestro` | 570 lib passed, 0 failed, 1 ignored; +3 integration, +1 doctest |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p vize_maestro --all-targets` | 0 errors; 39 warnings, identical count on a stashed baseline (all pre-existing `disallowed_macros` in test snapshots) |
| `node --test tests/tooling/lsp-concurrent-edit-deadlock.test.ts` | 1 passed (8/8 across repeats) |
| `node --test` over `lsp-concurrent-edit-deadlock`, `lsp-smoke`, `lsp-diagnostics-lifecycle`, `lsp-corsa-crash-recovery`, `lsp-typecheck-template` | 20 passed, 0 failed, 0 skipped |
| `pnpm dlx oxfmt@0.49.0 --check` / `oxlint@1.64.0` on the new test | clean; 0 warnings, 0 errors |
| `node --test tests/performance/lsp-churn-stress.test.ts` | passed, 39.7s |

Binary resolved explicitly with `VIZE_LSP_BIN=target/ci/vize` (`cargo build --profile ci -p vize --features legacy`), since `launch.ts` prefers a possibly stale `target/debug/vize`.

Source-length gate checked by hand against `origin/main`, because `source-file-lengths.test.ts` cannot run in this checkout (`error: not in a Moon project (no moon.mod.json found)` — environmental, unrelated to this diff). `handlers.rs` 1363 → 1327 (over limit, shrinks); `store.rs` 200 → 213; `store/tests.rs` 288 → 307; `collect.rs` 248 → 251; new test 192. All under 350 except the one that shrinks.

## What I could not confirm

Stated plainly, because the issue asked about the cycle-13 stall specifically:

- **This is a proven deadlock with the reported signature, but it is not proven to be the reported occurrence.** The churn-stress suite passes on both the pre-fix and post-fix binaries (34.4s / 39.7s), and it cannot reach this bug: nothing invalidates the declaration cache during a churn run, the harness never sends `didChangeWatchedFiles`, and its client does not advertise `didChangeWatchedFiles.dynamicRegistration`, so the server registers no watcher. With a warm cache the collector never yields — which is precisely why the issue observed strictly serial, never-superseded publishes. So the cycle-13 stall was likely a different mechanism, and this PR does not close that question. Keeping #3315 open (or reopening for the residual) is reasonable.
- **A second candidate for the reported stall, not addressed here: every Corsa bridge call is synchronous.** `CorsaBridge::with_client` takes a blocking `std::sync::Mutex` and calls straight into `corsa::runtime::block_on`, so a slow or stuck backend request blocks the whole executor thread. The 10s `runtime::timeout` in `collect_async` cannot fire (the future it guards never yields), and `CorsaBridgeConfig::timeout_ms` is dead config — set to 30000, never read. That yields 60s+ of total silence for one slow tsgo request, unbounded and undiagnosable. Not filed as an issue yet, flagged for follow-up; fixing it means moving bridge IPC off the executor thread.
- **A third, same-class hazard I deliberately left alone: `IdeContext` holds a live `virtual_docs_cache` shard guard** (`pub virtual_docs: Option<dashmap::mapref::one::Ref<...>>`), and `&ctx` is passed across awaits in hover/completion/definition/rename. A concurrent `didChange` → `update_virtual_docs` → `insert` on that shard is the identical deadlock, one DashMap over. I could not construct a repro (the hover path's awaits all appear synchronous underneath), and removing it means cloning `VirtualDocuments` per request — a perf decision that does not belong in a hang fix. Not filed as an issue yet, flagged for follow-up.
- The remaining sync callers (`DiagnosticService::collect`, `collect_lint_only`, `TypeService::collect_diagnostics*`) still bind guards, which is safe today because those functions contain no awaits. Left unchanged to keep the diff on the hazard.

Refs #3315
