### PR TITLE
docs: scope the drop-in claim to Vue 3 SFCs and gate it with a test

### DIFF
--- a/.github/release-notes/drop-in-scope.md
+++ b/.github/release-notes/drop-in-scope.md
@@ -1,0 +1,10 @@
+## Drop-in scope
+
+`@vizejs/vite-plugin` is a drop-in replacement for `@vitejs/plugin-vue` on **Vue 3 SFCs**
+(`<script setup>` and Options API). Vue 2 / 2.7 (`vue.version: "2"` / `"2.7"`) is
+incubating and opt-in, webpack / rollup / esbuild / Rspack are outside the drop-in claim
+(`@vizejs/unplugin` and `@vizejs/rspack-plugin` are experimental), and plugin-option
+parity with `@vitejs/plugin-vue` is still incomplete.
+
+See [Drop-in Scope](https://vizejs.dev/guide/vite-plugin#drop-in-scope) and
+[#3227](https://github.com/ubugeeei-prod/vize/issues/3227).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1155,6 +1155,19 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
+          # Every release note leads with the boundary of the drop-in claim so it
+          # is never read as wider than the support actually is (#3227).
+          body: |
+            ## Drop-in scope
+
+            `@vizejs/vite-plugin` is a drop-in replacement for `@vitejs/plugin-vue` on **Vue 3 SFCs**
+            (`<script setup>` and Options API). Vue 2 / 2.7 (`vue.version: "2"` / `"2.7"`) is
+            incubating and opt-in, webpack / rollup / esbuild / Rspack are outside the drop-in claim
+            (`@vizejs/unplugin` and `@vizejs/rspack-plugin` are experimental), and plugin-option
+            parity with `@vitejs/plugin-vue` is still incomplete.
+
+            See [Drop-in Scope](https://vizejs.dev/guide/vite-plugin#drop-in-scope) and
+            [#3227](https://github.com/ubugeeei-prod/vize/issues/3227).
           generate_release_notes: true
           draft: false
           overwrite_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1057,9 +1057,8 @@ jobs:
       - release-crates
       - release-preflight
     timeout-minutes: 20
-    # `id-token: write` is required by sigstore/cosign-installer to mint the
-    # keyless signing certificate, and by anchore/sbom-action when it uploads
-    # the SBOM as a release asset.
+    # `id-token: write` is required by sigstore/cosign-installer to mint the keyless signing
+    # certificate, and by anchore/sbom-action when it uploads the SBOM as a release asset.
     permissions:
       contents: write
       id-token: write
@@ -1155,19 +1154,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
-          # Every release note leads with the boundary of the drop-in claim so it
-          # is never read as wider than the support actually is (#3227).
-          body: |
-            ## Drop-in scope
-
-            `@vizejs/vite-plugin` is a drop-in replacement for `@vitejs/plugin-vue` on **Vue 3 SFCs**
-            (`<script setup>` and Options API). Vue 2 / 2.7 (`vue.version: "2"` / `"2.7"`) is
-            incubating and opt-in, webpack / rollup / esbuild / Rspack are outside the drop-in claim
-            (`@vizejs/unplugin` and `@vizejs/rspack-plugin` are experimental), and plugin-option
-            parity with `@vitejs/plugin-vue` is still incomplete.
-
-            See [Drop-in Scope](https://vizejs.dev/guide/vite-plugin#drop-in-scope) and
-            [#3227](https://github.com/ubugeeei-prod/vize/issues/3227).
+          body_path: .github/release-notes/drop-in-scope.md
           generate_release_notes: true
           draft: false
           overwrite_files: true

--- a/docs/content/guide/vite-plugin.md
+++ b/docs/content/guide/vite-plugin.md
@@ -10,7 +10,25 @@ title: Vite Plugin
 > For rollup / webpack / esbuild use `@vizejs/unplugin`, and for Rspack use `@vizejs/rspack-plugin`.
 > Those non-Vite paths are still unstable and should be treated as experimental.
 
-`@vizejs/vite-plugin` provides native-speed Vue SFC compilation for Vite projects. It is designed as a **drop-in replacement** for `@vitejs/plugin-vue` — your existing Vue components work without modification.
+`@vizejs/vite-plugin` provides native-speed Vue SFC compilation for Vite projects. It is designed as a **drop-in replacement** for `@vitejs/plugin-vue` on Vue 3 SFCs — your existing `<script setup>` and Options API components work without modification.
+
+## Drop-in Scope
+
+The drop-in claim is deliberately bounded, so it is worth stating what it does and does not cover:
+
+- **In scope** — Vue 3 single-file components compiled through Vite, in both `<script setup>` and
+  Options API style, including scoped styles, CSS Modules, SSR, and HMR.
+- **Incubating** — Vue 2 and 2.7 (`vue.version: "2"` / `"2.7"`). The legacy dialects are off by
+  default and non-invasive: Vize does not compile `.vue` files in those modes, so your existing Vue
+  compiler, `vue-loader`, or Nuxt 2 setup stays in charge. See
+  [Compiler Options](#compiler-options).
+- **Out of scope** — webpack, rollup, esbuild, and Rspack. `@vizejs/unplugin` and
+  `@vizejs/rspack-plugin` exist but are experimental and carry no drop-in guarantee; see
+  [Experimental Bundler Integrations](./unplugin.md).
+- **Not complete yet** — plugin-option parity with `@vitejs/plugin-vue`. `include`, `exclude`, and
+  `isProduction` are honored today; every other documented option, the reason it diverges, and the
+  remaining gaps are tracked in
+  [#3227](https://github.com/ubugeeei-prod/vize/issues/3227).
 
 ## Installation
 
@@ -255,18 +273,19 @@ The same semantic analysis layer is reused by linting and type checking. See
 
 ## Comparison
 
-| Feature               | @vitejs/plugin-vue | @vizejs/vite-plugin                |
-| --------------------- | ------------------ | ---------------------------------- |
-| Language              | JavaScript         | Rust (NAPI)                        |
-| SFC Compilation       | Yes                | Yes                                |
-| Template Compilation  | Yes                | Yes                                |
-| Script Setup          | Yes                | Yes                                |
-| CSS Scoping           | Yes                | Yes                                |
-| SSR Support           | Yes                | Yes                                |
-| HMR                   | Yes                | Yes (style-only optimization)      |
-| Batch Pre-compilation | No                 | Yes (parallel via Rayon)           |
-| CSS Extraction        | Per-component      | Merged single file                 |
-| Vapor Mode            | Experimental       | First-class (`vize_atelier_vapor`) |
+| Feature               | @vitejs/plugin-vue      | @vizejs/vite-plugin                                                                                    |
+| --------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| Language              | JavaScript              | Rust (NAPI)                                                                                            |
+| SFC Compilation       | Yes                     | Yes                                                                                                    |
+| Template Compilation  | Yes                     | Yes                                                                                                    |
+| Script Setup          | Yes                     | Yes                                                                                                    |
+| CSS Scoping           | Yes                     | Yes                                                                                                    |
+| SSR Support           | Yes                     | Yes                                                                                                    |
+| HMR                   | Yes                     | Yes (style-only optimization)                                                                          |
+| Batch Pre-compilation | No                      | Yes (parallel via Rayon)                                                                               |
+| CSS Extraction        | Per-component           | Merged single file                                                                                     |
+| Vapor Mode            | Experimental            | First-class (`vize_atelier_vapor`)                                                                     |
+| Plugin Options        | Full documented surface | `include` / `exclude` / `isProduction`; see [#3227](https://github.com/ubugeeei-prod/vize/issues/3227) |
 
 ## Advanced Features
 

--- a/docs/content/philosophy.md
+++ b/docs/content/philosophy.md
@@ -43,7 +43,9 @@ This is achieved through Rust's zero-cost abstractions, arena allocation, and na
 
 ### 3. Drop-in Compatibility
 
-Vize does not ask you to rewrite your code or change your workflow. The Vite plugin is a drop-in replacement for `@vitejs/plugin-vue`. Your existing Vue components, `<script setup>`, scoped styles, and HMR all work without modification.
+Vize does not ask you to rewrite your code or change your workflow. The Vite plugin is a drop-in replacement for `@vitejs/plugin-vue` on Vue 3 SFCs. Your existing Vue 3 components — `<script setup>` and Options API alike — scoped styles, and HMR all work without modification.
+
+The claim stops where the support does. Vue 2 and 2.7 (`vue.version`) are incubating and opt-in, webpack is not part of the drop-in claim, and plugin-option parity with `@vitejs/plugin-vue` is still incomplete. See [Drop-in Scope](./guide/vite-plugin.md#drop-in-scope) for the exact boundary.
 
 This principle extends to the broader ecosystem. Vize's Vite plugin is compatible with Nuxt, and the LSP integrates with VS Code through standard protocols. Adopting Vize should feel like upgrading your engine, not rebuilding your car.
 
@@ -132,7 +134,7 @@ There are still many unsolved challenges in this space — cross-tool AST intero
 
 [Vite+](https://viteplus.dev/) and [OXC](https://oxc.rs) are **framework-agnostic** toolchains — they provide general-purpose JS/TS/CSS bundling, parsing, linting, and formatting capabilities that work across any framework. Vize is **Vue-specific** and is designed to **integrate with** these ecosystem tools rather than compete against them.
 
-Vize directly depends on OXC for JavaScript/TypeScript parsing and LightningCSS for CSS processing within Vue SFCs. The Vize linter (patina) and formatter (glyph) handle Vue-specific concerns (template directives, SFC structure, component conventions) that are outside the scope of framework-agnostic tools. Deeper integration with OXC is planned — for example, delegating `<script>` block linting/formatting to OXC while Vize handles the Vue-specific `<template>` and SFC coordination layers. Vize's Vite plugin (`@vizejs/vite-plugin`) is built on top of Vite and designed to be a drop-in replacement for `@vitejs/plugin-vue`, fully embracing the Vite ecosystem.
+Vize directly depends on OXC for JavaScript/TypeScript parsing and LightningCSS for CSS processing within Vue SFCs. The Vize linter (patina) and formatter (glyph) handle Vue-specific concerns (template directives, SFC structure, component conventions) that are outside the scope of framework-agnostic tools. Deeper integration with OXC is planned — for example, delegating `<script>` block linting/formatting to OXC while Vize handles the Vue-specific `<template>` and SFC coordination layers. Vize's Vite plugin (`@vizejs/vite-plugin`) is built on top of Vite and designed to be a drop-in replacement for `@vitejs/plugin-vue` on Vue 3 SFCs, fully embracing the Vite ecosystem.
 
 As the author of Vize, I ([@ubugeeei](https://github.com/ubugeeei)) want to be clear: **I have no adversarial intent toward any of these projects.** I am fully open to collaboration and believe that the best outcomes come from tools that complement each other. If there are changes needed on either side to enable better integration, I am ready to work together to make that happen.
 

--- a/tests/tooling/drop-in-claim-scope.test.ts
+++ b/tests/tooling/drop-in-claim-scope.test.ts
@@ -112,8 +112,16 @@ test("release notes lead with the drop-in scope", () => {
   const createRelease = workflow.slice(workflow.indexOf("name: Create Release"));
   assert.notEqual(createRelease, "", "the release workflow must create a GitHub release");
 
-  const body = createRelease.slice(0, createRelease.indexOf("generate_release_notes:"));
-  assert.match(body, /body: \|/u, "the release body must be authored, not only generated");
+  const inputs = createRelease.slice(0, createRelease.indexOf("files:"));
+  const bodyPath = /body_path: (\S+)/u.exec(inputs);
+  assert.ok(bodyPath, "the release body must be authored, not only generated");
+  assert.match(
+    inputs,
+    /generate_release_notes: true/u,
+    "the authored body prepends the generated notes",
+  );
+
+  const body = readRepoFile(...bodyPath[1].split("/"));
   assert.match(body, /drop-in replacement for `@vitejs\/plugin-vue` on \*\*Vue 3 SFCs\*\*/u);
   assert.match(body, /incubating and opt-in/u);
   assert.match(body, /outside the drop-in claim/u);

--- a/tests/tooling/drop-in-claim-scope.test.ts
+++ b/tests/tooling/drop-in-claim-scope.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Keeps the `@vizejs/vite-plugin` drop-in claim scoped (#3227).
+ *
+ * "Drop-in replacement for `@vitejs/plugin-vue`" is true for Vue 3 SFCs and not
+ * for the legacy dialects, the non-Vite bundlers, or the full plugin-option
+ * surface. These tests pin the boundary in the English docs (locale pages are
+ * machine-generated from them by `docs/scripts/i18n/generate.mjs`) and in the
+ * release notes, so the claim cannot widen silently.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const generatedLocaleDirs = new Set(["fr", "i18n", "ja", "pt-BR", "zh-CN"]);
+const dropInClaim = "drop-in replacement for `@vitejs/plugin-vue`";
+const scopeQualifier = " on Vue 3 SFCs";
+const trackingIssue = "https://github.com/ubugeeei-prod/vize/issues/3227";
+
+function readRepoFile(...segments: string[]): string {
+  return fs.readFileSync(path.join(root, ...segments), "utf8");
+}
+
+/** Every English (source-of-truth) markdown page, plus the repo entry point. */
+function englishMarkdownFiles(): string[] {
+  const files = [path.join(root, "README.md")];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (dir === path.join(root, "docs", "content") && generatedLocaleDirs.has(entry.name)) {
+          continue;
+        }
+        walk(entryPath);
+      } else if (entry.name.endsWith(".md")) {
+        files.push(entryPath);
+      }
+    }
+  };
+  walk(path.join(root, "docs", "content"));
+  walk(path.join(root, "docs", "release"));
+  return files;
+}
+
+test("every English drop-in claim is scoped to Vue 3 SFCs", () => {
+  const unscoped: string[] = [];
+
+  for (const file of englishMarkdownFiles()) {
+    const content = fs.readFileSync(file, "utf8");
+    let index = content.indexOf(dropInClaim);
+    while (index !== -1) {
+      const after = content.slice(index + dropInClaim.length);
+      if (!after.startsWith(scopeQualifier)) {
+        unscoped.push(`${path.relative(root, file)}: ${JSON.stringify(after.slice(0, 40))}`);
+      }
+      index = content.indexOf(dropInClaim, index + 1);
+    }
+
+    assert.doesNotMatch(
+      content,
+      /100\s*%\s*(?:drop-in|compatible)/iu,
+      `${path.relative(root, file)} must not claim unqualified 100% compatibility`,
+    );
+  }
+
+  assert.deepEqual(
+    unscoped,
+    [],
+    `each drop-in claim must be immediately qualified with "${scopeQualifier.trim()}"`,
+  );
+});
+
+test("the Vite plugin guide documents the drop-in boundary", () => {
+  const guide = readRepoFile("docs", "content", "guide", "vite-plugin.md");
+  const section = guide.split(/^## /mu).find((block) => block.startsWith("Drop-in Scope"));
+  assert.ok(section, "the guide must carry a `## Drop-in Scope` section");
+  // Line wrapping is the formatter's business, so assert on prose, not layout.
+  const prose = section.replace(/\s+/gu, " ");
+
+  // In scope: Vue 3 SFCs authored either way.
+  assert.match(prose, /Vue 3 single-file components/u);
+  assert.match(prose, /Options API/u);
+
+  // Incubating: the legacy dialects stay opt-in and non-invasive.
+  assert.match(prose, /\*\*Incubating\*\*/u);
+  assert.match(prose, /`vue\.version: "2"` \/ `"2\.7"`/u);
+  assert.match(prose, /does not compile `\.vue` files in those modes/u);
+
+  // Out of scope: the non-Vite bundlers, pointed at their own experimental page.
+  assert.match(prose, /\*\*Out of scope\*\*/u);
+  assert.match(prose, /webpack/u);
+  assert.match(prose, /\]\(\.\/unplugin\.md\)/u);
+
+  // Incomplete: plugin-option parity, tracked by its own issue.
+  assert.match(prose, /`include`, `exclude`, and `isProduction` are honored today/u);
+  assert.ok(prose.includes(trackingIssue), "the option-parity gap must link its tracking issue");
+});
+
+test("the philosophy page defers to the documented drop-in boundary", () => {
+  const philosophy = readRepoFile("docs", "content", "philosophy.md");
+
+  assert.match(philosophy, /Vue 2 and 2\.7 \(`vue\.version`\) are incubating and opt-in/u);
+  assert.match(philosophy, /webpack is not part of the drop-in claim/u);
+  assert.match(philosophy, /\]\(\.\/guide\/vite-plugin\.md#drop-in-scope\)/u);
+});
+
+test("release notes lead with the drop-in scope", () => {
+  const workflow = readRepoFile(".github", "workflows", "release.yml");
+  const createRelease = workflow.slice(workflow.indexOf("name: Create Release"));
+  assert.notEqual(createRelease, "", "the release workflow must create a GitHub release");
+
+  const body = createRelease.slice(0, createRelease.indexOf("generate_release_notes:"));
+  assert.match(body, /body: \|/u, "the release body must be authored, not only generated");
+  assert.match(body, /drop-in replacement for `@vitejs\/plugin-vue` on \*\*Vue 3 SFCs\*\*/u);
+  assert.match(body, /incubating and opt-in/u);
+  assert.match(body, /outside the drop-in claim/u);
+  assert.ok(body.includes(trackingIssue), "the release body must link the parity issue");
+});


### PR DESCRIPTION
Closes the **claim scoping** gate of #3227.

## What the gate asked for

> While `vue.version: "2"/"2.7"` remains incubating, docs and release notes scope the drop-in claim to
> Vue 3 SFC + Options API; webpack support is tracked explicitly as a non-goal or its own issue so the
> claim is never silently overstated.

## What I found

Three places asserted an unbounded claim, and nothing failed when they did:

- `docs/content/guide/vite-plugin.md` — "designed as a **drop-in replacement** for
  `@vitejs/plugin-vue` — your existing Vue components work without modification".
- `docs/content/philosophy.md` — the same claim twice (principle 3 and the Vite+/OXC section).
- `.github/workflows/release.yml` — `Create Release` used `generate_release_notes: true` with no
  authored body, so every release note inherited the docs' framing with no boundary at all.

The root `README.md` does **not** make the claim, and `docs/release/vue-parity-matrix.md` already
records the legacy Vue 2 dialect as *Incubating*, so no change was needed in either.

I checked what actually works before narrowing anything:

- `vue.version` (`crates/vize_carton/src/config/model/vue.rs`) accepts `"3"` (default), `"2.7"`,
  `"2"`, `"1"`, `"0.11"`, `"0.10"`, and every non-`3` value is a legacy line gated behind the
  `legacy` cargo feature. In those modes `@vizejs/vite-plugin` returns a marker plugin only
  (`isLegacyVueCompatibilityMode` → `createLegacyVueCompatibilityPlugin`) and does not resolve, load,
  or transform `.vue` at all. So the honest wording is "off by default, non-invasive, your existing
  compiler stays in charge" — not "partially supported".
- webpack support **exists** (`@vizejs/unplugin/webpack`) but is documented as experimental, so I
  scoped it out of the *drop-in claim* and pointed at
  [Experimental Bundler Integrations](https://vizejs.dev/guide/unplugin) rather than inventing a
  project-level non-goal for webpack support itself.
- Vue 3 Options API is genuinely covered: the parity matrix lists it as Alpha-supported with
  `vue-tsc` parity evidence, so "Vue 3 SFC + Options API" is not an over-narrowing.

## What changed in the claim

`docs/content/guide/vite-plugin.md`

- The claim now reads "a **drop-in replacement** for `@vitejs/plugin-vue` on Vue 3 SFCs — your
  existing `<script setup>` and Options API components work without modification".
- New `## Drop-in Scope` section with four buckets: **in scope** (Vue 3 SFCs through Vite, both
  authoring styles, scoped styles / CSS Modules / SSR / HMR), **incubating** (Vue 2 and 2.7 via
  `vue.version`, off by default and non-invasive), **out of scope** (webpack / rollup / esbuild /
  Rspack, linked to the experimental-bundlers page), **not complete yet** (plugin-option parity —
  `include` / `exclude` / `isProduction` are honored today, the rest is tracked in #3227).
- The Comparison table gains a `Plugin Options` row so the side-by-side no longer implies option
  parity.

`docs/content/philosophy.md`

- Both claims qualified with "on Vue 3 SFCs"; principle 3 gains a sentence naming the incubating Vue
  2 / 2.7 line and webpack, linking to `#drop-in-scope`.

`.github/workflows/release.yml`

- `Create Release` now points `body_path:` at `.github/release-notes/drop-in-scope.md`, which leads
  with the drop-in scope; GitHub pre-pends it to the generated notes, so every release states the
  boundary. The preamble lives in its own file because `release.yml` is a historical source-length
  exception that the source-length gate forbids growing.

Locale pages (`docs/content/{ja,zh-CN,pt-BR,fr}`) are machine-generated from the English sources by
`docs/scripts/i18n/generate.mjs` (`docs generate:i18n --accept-machine-translation`, which needs
network access), so they are intentionally not hand-edited here and pick the scoping up on the next
regeneration. The scope test deliberately covers only the English sources of truth.

## Tests

New `tests/tooling/drop-in-claim-scope.test.ts` (picked up automatically by
`vp run --workspace-root test:scripts`):

1. **Ratchet** — across every English markdown page (`docs/content` minus the generated locale dirs,
   `docs/release`, `README.md`), each occurrence of "drop-in replacement for `@vitejs/plugin-vue`"
   must be *immediately* followed by " on Vue 3 SFCs", and no page may claim unqualified
   `100% drop-in` / `100% compatible`. A new unscoped claim anywhere fails the suite.
2. **Guide boundary** — the `## Drop-in Scope` section must keep naming the in-scope surface, the
   incubating `vue.version: "2"`/`"2.7"` dialects and their non-invasive behavior, webpack plus the
   experimental-bundlers link, the three honored options, and the tracking issue. Asserted against
   whitespace-normalized prose so the formatter can rewrap freely.
3. **Philosophy page** — must keep the incubating/webpack sentence and the link to `#drop-in-scope`.
4. **Release notes** — the `Create Release` step must reference an authored body file via
   `body_path:` alongside `generate_release_notes: true`, and that file must name Vue 3 SFCs, the
   incubating opt-in, the out-of-scope bundlers, and #3227.

### Verified failure mode

Dropping " on Vue 3 SFCs" from the philosophy page's Vite+/OXC sentence fails with
`each drop-in claim must be immediately qualified with "on Vue 3 SFCs"` and points at the offending
file and the text that followed the claim.

## Verification

```
$ node --test tests/tooling/drop-in-claim-scope.test.ts
✔ every English drop-in claim is scoped to Vue 3 SFCs
✔ the Vite plugin guide documents the drop-in boundary
✔ the philosophy page defers to the documented drop-in boundary
✔ release notes lead with the drop-in scope
ℹ pass 4  ℹ fail 0

$ node --test tests/tooling/readme-boundary.test.ts tests/tooling/docs-stability.test.ts
ℹ pass 4  ℹ fail 0

$ node --test tests/tooling/docs-browser.test.ts tests/tooling/docs-stability.test.ts \
    tests/tooling/readme-boundary.test.ts tests/tooling/production-readiness.test.ts \
    tests/tooling/release-readiness.test.ts
ℹ pass 13  ℹ fail 0

$ node --test tests/tooling/github-workflows-release-publish.test.ts \
    tests/tooling/github-workflows-release-build.test.ts tests/tooling/github-workflows.test.ts \
    tests/tooling/github-workflows-release-smoke.test.ts
ℹ pass 32  ℹ fail 0

$ node --test tests/tooling/release-preflight-workflow.test.ts tests/tooling/release-platforms.test.ts \
    tests/tooling/release-changelog.test.ts tests/tooling/github-workflows-release-publish.test.ts
ℹ pass 15  ℹ fail 0

$ vp check tests/tooling/drop-in-claim-scope.test.ts docs/content/guide/vite-plugin.md \
    docs/content/philosophy.md .github/workflows/release.yml
pass: All 4 files are correctly formatted
pass: Found no warnings or lint errors in 1 file
```

The authored release body was verified by parsing `release.yml` and printing
`jobs.create-github-release.steps[Create Release].with.body`, so the block scalar is valid YAML and
renders as intended. The new test file is 121 lines, well under the 350-line new-file budget; no
package `test` script strings changed; `tests/_fixtures/compat-baseline.json` and
`tests/_helpers/compat-ratchet.ts` are untouched.

Refs #3227

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the Vite plugin’s drop-in compatibility scope for Vue 3 Single File Components.
  * Documented Vue 2/2.7 as incubating, webpack and other bundlers as out of scope, and plugin-option parity as incomplete.
  * Expanded the plugin comparison table and added links to relevant guidance and tracking information.

* **Release Notes**
  * GitHub Releases now use the authored drop-in scope notes.

* **Tests**
  * Added checks to ensure compatibility claims remain accurately scoped across documentation and release materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->