### PR TITLE
fix(glyph): stop splitting a line covered by a line-scoped patina suppression

### DIFF
--- a/crates/vize/tests/fmt_lint_agreement_cli.rs
+++ b/crates/vize/tests/fmt_lint_agreement_cli.rs
@@ -1,0 +1,120 @@
+//! `vize fmt` must not change which lint findings a file produces.
+//!
+//! The corpus-wide `glyph lint-agreement` property guards this over hydrated
+//! fixtures; this test pins the specific way it broke in #3343 — the formatter
+//! split a line covered by `eslint-disable-next-line`, so the suppression stopped
+//! applying and `a11y/form-control-has-label` went from 2 findings to 3.
+
+use std::{collections::BTreeMap, fs, path::Path, process::Command};
+
+/// The reduced `gogocode` keycode-modifiers fixture from the report: three
+/// unlabelled `<input>` elements, the third suppressed by a comment on the line
+/// above, sharing its line with the `custom space:` text.
+const SOURCE: &str = r#"<template>
+  <div class="mt20 text-left">
+    <div>space: <input type="text" v-on:keyup.space="keys('space')" /></div>
+    <div class="mt20">
+      space number 32:
+      <input type="text" v-on:keyup.32="keys('keycode 32 space')" />
+    </div>
+    <div class="mt20">
+      <!--eslint-disable-next-line-->
+      custom space: <input v-on:keyup.custom="keys('custom keycode space')" />
+    </div>
+  </div>
+</template>
+"#;
+
+fn run(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn details(output: &std::process::Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+/// Findings per rule id, the same multiset the corpus property compares.
+fn findings_by_rule(dir: &Path, file: &str) -> BTreeMap<String, usize> {
+    let output = run(
+        dir,
+        &[
+            "lint",
+            file,
+            "--format",
+            "json",
+            "--preset",
+            "ecosystem",
+            "--no-config",
+        ],
+    );
+    let code = output.status.code();
+    assert!(
+        code == Some(0) || code == Some(1),
+        "vize lint exited with {code:?}: {}",
+        details(&output)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|error| panic!("lint JSON: {error}: {}", details(&output)));
+    let mut counts = BTreeMap::new();
+    for entry in report.as_array().expect("lint report is an array") {
+        for message in entry["messages"].as_array().into_iter().flatten() {
+            let rule = message["ruleId"].as_str().unwrap_or_default().to_owned();
+            *counts.entry(rule).or_insert(0) += 1;
+        }
+    }
+    counts
+}
+
+#[test]
+fn formatting_does_not_introduce_lint_findings_for_a_suppressed_line() {
+    let project = tempfile::tempdir().unwrap();
+    let root = project.path();
+    fs::write(root.join("Comp.vue"), SOURCE).unwrap();
+
+    let before = findings_by_rule(root, "Comp.vue");
+    assert_eq!(
+        before.get("a11y/form-control-has-label"),
+        Some(&2),
+        "the suppressed third <input> must not be reported in the source: {before:?}"
+    );
+
+    let formatted = run(root, &["fmt", "Comp.vue", "--write", "--no-config"]);
+    assert_eq!(formatted.status.code(), Some(0), "{}", details(&formatted));
+
+    let after = findings_by_rule(root, "Comp.vue");
+    // Counts may shrink (formatting legitimately fixes findings such as
+    // `vue/v-on-style`); any rule whose count grows is the defect.
+    let introduced: Vec<_> = after
+        .iter()
+        .filter(|(rule, count)| *count > before.get(rule.as_str()).unwrap_or(&0))
+        .collect();
+    assert!(
+        introduced.is_empty(),
+        "vize fmt introduced findings: {introduced:?}\nbefore: {before:?}\nafter:  {after:?}\n{}",
+        fs::read_to_string(root.join("Comp.vue")).unwrap()
+    );
+
+    // The suppression still sits on the line it covers, and formatting again
+    // changes nothing.
+    let output = fs::read_to_string(root.join("Comp.vue")).unwrap();
+    assert!(
+        output
+            .contains("<!--eslint-disable-next-line-->\n      custom space: <input @keyup.custom="),
+        "suppressed line was split:\n{output}"
+    );
+    let again = run(root, &["fmt", "Comp.vue", "--write", "--no-config"]);
+    assert_eq!(again.status.code(), Some(0), "{}", details(&again));
+    assert_eq!(
+        fs::read_to_string(root.join("Comp.vue")).unwrap(),
+        output,
+        "formatting the joined line must be idempotent"
+    );
+}

--- a/crates/vize_glyph/src/template/formatter.rs
+++ b/crates/vize_glyph/src/template/formatter.rs
@@ -20,7 +20,11 @@ use super::{
 };
 
 mod interpolation;
+mod suppression;
 mod whitespace_significant;
+
+use suppression::{LineJoiner, TextRun};
+use whitespace_significant::is_whitespace_significant_element;
 
 /// High-performance template formatter.
 pub(crate) struct TemplateFormatter<'a> {
@@ -44,7 +48,9 @@ impl<'a> TemplateFormatter<'a> {
         let mut output = Vec::with_capacity(len + len / 4);
         let mut pos = 0;
         let mut depth: usize = 0;
-        let mut line_buffer = Vec::with_capacity(256);
+        let mut text = TextRun::new();
+        // Lines a line-scoped lint suppression covers must not be split. (#3343)
+        let mut joiner = LineJoiner::new(source);
 
         while pos < len {
             // Skip whitespace at line start (except newlines)
@@ -69,7 +75,7 @@ impl<'a> TemplateFormatter<'a> {
                     parse_interpolation_range(source, pos)
                 && source[pos..end_pos].contains(&b'\n')
             {
-                self.flush_text_buffer(&mut output, &mut line_buffer, depth);
+                self.flush_text_buffer(&mut output, &mut text, depth, &mut joiner);
                 let expr = std::str::from_utf8(&source[expr_start..expr_end]).unwrap_or("");
                 self.write_multiline_interpolation(&mut output, expr, depth);
                 pos = end_pos;
@@ -78,17 +84,18 @@ impl<'a> TemplateFormatter<'a> {
 
             // HTML comment <!-- ... -->
             if pos + 3 < len && &source[pos..pos + 4] == b"<!--" {
-                self.flush_text_buffer(&mut output, &mut line_buffer, depth);
+                self.flush_text_buffer(&mut output, &mut text, depth, &mut joiner);
                 let comment_start = pos;
+                let join = joiner.open(comment_start);
                 if let Some(end_offset) = find_bytes(&source[pos..], b"-->") {
                     let comment_end = pos + end_offset + 3;
-                    self.write_indent(&mut output, depth);
+                    self.open_chunk(&mut output, depth, join);
                     output.extend_from_slice(&source[comment_start..comment_end]);
                     output.extend_from_slice(self.newline);
                     pos = comment_end;
                 } else {
                     // Unclosed comment - write remainder
-                    self.write_indent(&mut output, depth);
+                    self.open_chunk(&mut output, depth, join);
                     output.extend_from_slice(&source[comment_start..]);
                     output.extend_from_slice(self.newline);
                     pos = len;
@@ -102,9 +109,10 @@ impl<'a> TemplateFormatter<'a> {
                     && source[pos + 1] == b'/'
                     && let Some((tag_name, end_pos)) = parse_closing_tag(source, pos)
                 {
-                    self.flush_text_buffer(&mut output, &mut line_buffer, depth);
+                    self.flush_text_buffer(&mut output, &mut text, depth, &mut joiner);
+                    let join = joiner.open(pos);
                     depth = depth.saturating_sub(1);
-                    self.write_indent(&mut output, depth);
+                    self.open_chunk(&mut output, depth, join);
                     output.extend_from_slice(b"</");
                     output.extend_from_slice(tag_name.as_bytes());
                     output.push(b'>');
@@ -115,13 +123,14 @@ impl<'a> TemplateFormatter<'a> {
                 if let Some((tag_name, attrs, is_self_closing, end_pos)) =
                     self.parse_opening_tag(source, pos)
                 {
-                    self.flush_text_buffer(&mut output, &mut line_buffer, depth);
+                    self.flush_text_buffer(&mut output, &mut text, depth, &mut joiner);
+                    let join = joiner.open(pos);
                     let mut sorted_attrs = attrs;
                     if self.options.sort_attributes {
                         sort_attributes(&mut sorted_attrs, self.options);
                     }
 
-                    self.write_indent(&mut output, depth);
+                    self.open_chunk(&mut output, depth, join);
                     output.push(b'<');
                     output.extend_from_slice(tag_name.as_bytes());
 
@@ -217,7 +226,7 @@ impl<'a> TemplateFormatter<'a> {
                     continue;
                 }
                 // Keep a non-tag `<` as text and advance past it.
-                line_buffer.push(b'<');
+                text.push_byte(pos, b'<');
                 pos += 1;
                 continue;
             }
@@ -252,22 +261,19 @@ impl<'a> TemplateFormatter<'a> {
                 }
 
                 if content_end > content_start {
-                    if !line_buffer.is_empty() {
-                        line_buffer.push(b' ');
-                    }
-                    line_buffer.extend_from_slice(&source[content_start..content_end]);
+                    text.push_source(source, content_start, content_end);
                 }
             }
 
             // Handle newline
             if pos < len && source[pos] == b'\n' {
-                self.flush_text_buffer(&mut output, &mut line_buffer, depth);
+                self.flush_text_buffer(&mut output, &mut text, depth, &mut joiner);
                 pos += 1;
             }
         }
 
         // Flush remaining content
-        self.flush_text_buffer(&mut output, &mut line_buffer, depth);
+        self.flush_text_buffer(&mut output, &mut text, depth, &mut joiner);
 
         // Remove trailing newline for consistency
         while output.last().is_some_and(|&b| b == b'\n' || b == b'\r') {
@@ -285,12 +291,19 @@ impl<'a> TemplateFormatter<'a> {
 
     /// Flush accumulated text content with interpolation formatting.
     #[inline]
-    fn flush_text_buffer(&self, output: &mut Vec<u8>, buffer: &mut Vec<u8>, depth: usize) {
-        if buffer.is_empty() {
+    fn flush_text_buffer(
+        &self,
+        output: &mut Vec<u8>,
+        text: &mut TextRun,
+        depth: usize,
+        joiner: &mut LineJoiner<'_>,
+    ) {
+        if text.is_empty() {
             return;
         }
-        let text = std::str::from_utf8(buffer).unwrap_or("");
-        let formatted = format_interpolations(text, self.options);
+        let formatted = format_interpolations(text.as_str(), self.options);
+        let start = text.start();
+        text.clear();
         // If the formatted expression wraps onto multiple lines, single-line
         // `{{ expr }}` emission would leave the wrapped lines indented
         // relative to column 0 instead of the interpolation's depth — so a
@@ -303,11 +316,13 @@ impl<'a> TemplateFormatter<'a> {
                 self.rewrap_text_with_multiline_interpolation(&formatted, depth)
         {
             output.extend_from_slice(rewrapped.as_bytes());
-            buffer.clear();
+            // This shape spans lines by design, so nothing may join onto it.
+            joiner.reset();
             return;
         }
-        self.write_indented_line(output, formatted.as_bytes(), depth);
-        buffer.clear();
+        self.open_chunk(output, depth, joiner.open(start));
+        output.extend_from_slice(formatted.as_bytes());
+        output.extend_from_slice(self.newline);
     }
 
     /// Rewrap a `format_interpolations` result into multi-line shape if any
@@ -741,81 +756,5 @@ fn parse_interpolation_range(source: &[u8], start: usize) -> Option<(usize, usiz
         }
     }
 
-    None
-}
-
-/// Returns true if the element's content must be preserved byte-for-byte:
-/// `<pre>`, `<textarea>`, or any element with the `v-pre` directive.
-/// Whitespace and interpolations inside these regions are rendered as-is
-/// at runtime, so the formatter must not touch them. (#963)
-fn is_whitespace_significant_element(tag_name: &str, attrs: &[ParsedAttribute]) -> bool {
-    if tag_name.eq_ignore_ascii_case("pre") || tag_name.eq_ignore_ascii_case("textarea") {
-        return true;
-    }
-    attrs
-        .iter()
-        .any(|attr| attr.name.eq_ignore_ascii_case("v-pre"))
-}
-
-/// Find the start of the matching `</tag_name>` for a content region that
-/// begins at `start` in `source`. Returns the byte index of the `<` of the
-/// closing tag, or `None` if no matching close is found.
-///
-/// This is a tag-name aware scan so nested elements with the same tag are
-/// handled correctly (e.g. `<pre>...<pre>x</pre>...</pre>`).
-fn find_matching_close_tag(source: &[u8], start: usize, tag_name: &str) -> Option<usize> {
-    let len = source.len();
-    let tag_bytes = tag_name.as_bytes();
-    let mut pos = start;
-    let mut depth: i32 = 1;
-    while pos < len {
-        let offset = memchr::memchr(b'<', &source[pos..])?;
-        pos += offset;
-        if pos + 1 >= len {
-            return None;
-        }
-        // Skip comments and CDATA to avoid false matches inside them.
-        if pos + 3 < len && &source[pos..pos + 4] == b"<!--" {
-            if let Some(end) = find_bytes(&source[pos..], b"-->") {
-                pos += end + 3;
-                continue;
-            }
-            return None;
-        }
-
-        let is_closing = source[pos + 1] == b'/';
-        let name_start = if is_closing { pos + 2 } else { pos + 1 };
-        if name_start >= len {
-            return None;
-        }
-        let name_bytes = &source[name_start..];
-        if name_bytes.len() >= tag_bytes.len()
-            && name_bytes[..tag_bytes.len()].eq_ignore_ascii_case(tag_bytes)
-        {
-            let after = name_bytes.get(tag_bytes.len()).copied().unwrap_or(0);
-            let after_is_terminator = matches!(after, b'>' | b'/' | b' ' | b'\t' | b'\n' | b'\r');
-            if after_is_terminator {
-                if is_closing {
-                    depth -= 1;
-                    if depth == 0 {
-                        return Some(pos);
-                    }
-                } else if !is_void_element_str(tag_name) {
-                    // Treat self-closing forms (`<tag … />`) as not opening
-                    // a new nesting level. Peek to the next `>` and check
-                    // for a preceding `/`.
-                    if let Some(gt) = memchr::memchr(b'>', &source[pos..]) {
-                        let close_at = pos + gt;
-                        if close_at > 0 && source[close_at - 1] != b'/' {
-                            depth += 1;
-                        }
-                        pos = close_at + 1;
-                        continue;
-                    }
-                }
-            }
-        }
-        pos += 1;
-    }
     None
 }

--- a/crates/vize_glyph/src/template/formatter/suppression.rs
+++ b/crates/vize_glyph/src/template/formatter/suppression.rs
@@ -1,0 +1,236 @@
+//! Line-scoped lint suppressions and the source ranges they pin to one line.
+//!
+//! `eslint-disable-next-line` is *physical line* scoped, exactly as in ESLint:
+//! the suppression covers the line that follows the comment. When the formatter
+//! breaks that line, the suppressed code moves out from under its own pragma and
+//! the finding comes back — with nothing in the formatting diff that looks like
+//! a cause. So a line covered by a line-scoped suppression is unsplittable: the
+//! template formatter re-joins the chunks it would otherwise have emitted as
+//! separate lines, keeping the suppression line-based and identical to ESLint's.
+//! (#3343)
+//!
+//! Only the line breaks this layer *chooses* are suppressed. An attribute value
+//! that is already multiline, or an interpolation the JS printer wraps, still
+//! spans lines; both keep the element's opening tag — where template diagnostics
+//! anchor (#3252, #3270) — on the suppressed line.
+
+use std::cmp::Ordering;
+
+use super::TemplateFormatter;
+use crate::template::helpers::is_whitespace;
+
+/// Pragmas whose suppression covers the line *after* the comment.
+const NEXT_LINE_PRAGMAS: [&[u8]; 4] = [
+    b"eslint-disable-next-line",
+    b"vize-disable-next-line",
+    b"@vize:expected",
+    b"@vize:level(",
+];
+
+/// Pragmas whose suppression covers the line the comment itself sits on.
+const SAME_LINE_PRAGMAS: [&[u8]; 2] = [b"eslint-disable-line", b"vize-disable-line"];
+
+/// Substrings shared by every pragma above, used to skip the line scan for the
+/// overwhelming majority of templates that carry no suppression at all.
+const PRAGMA_MARKERS: [&[u8]; 2] = [b"-disable-", b"@vize:"];
+
+/// Tracks which output line the formatter is currently filling, so chunks that
+/// share an unsplittable source line share an output line too.
+pub(super) struct LineJoiner<'s> {
+    source: &'s [u8],
+    /// Sorted, disjoint source byte ranges that must stay on one output line.
+    locked: Vec<(usize, usize)>,
+    /// Index into `locked` of the range the previously emitted chunk belonged
+    /// to, or `None` when that chunk was free to end its line.
+    current: Option<usize>,
+}
+
+impl<'s> LineJoiner<'s> {
+    pub(super) fn new(source: &'s [u8]) -> Self {
+        Self {
+            source,
+            locked: locked_line_ranges(source),
+            current: None,
+        }
+    }
+
+    /// Decide how to start the chunk that begins at `start` in the source.
+    ///
+    /// `None` starts a fresh line at the caller's indent — the ordinary case.
+    /// `Some(spaced)` continues the line the previous chunk opened, inserting a
+    /// single separating space when the source separated the two chunks with
+    /// whitespace. The gap between two chunks is whitespace by construction (the
+    /// scanner trims text runs and steps over inter-tag whitespace), so the byte
+    /// just before `start` decides it.
+    pub(super) fn open(&mut self, start: usize) -> Option<bool> {
+        let previous = self.current;
+        self.current = self.locked_index(start);
+        if self.current.is_none() || self.current != previous {
+            return None;
+        }
+        Some(start > 0 && is_whitespace(self.source[start - 1]))
+    }
+
+    /// Forget the line in progress so the next chunk starts a fresh one. Used by
+    /// emitters that deliberately span several lines.
+    pub(super) fn reset(&mut self) {
+        self.current = None;
+    }
+
+    fn locked_index(&self, pos: usize) -> Option<usize> {
+        self.locked
+            .binary_search_by(|&(start, end)| {
+                if pos < start {
+                    Ordering::Greater
+                } else if pos >= end {
+                    Ordering::Less
+                } else {
+                    Ordering::Equal
+                }
+            })
+            .ok()
+    }
+}
+
+impl TemplateFormatter<'_> {
+    /// Start a chunk of output, either on a fresh indented line or continuing
+    /// the current one. See [`LineJoiner::open`] for how `join` is decided.
+    pub(super) fn open_chunk(&self, output: &mut Vec<u8>, depth: usize, join: Option<bool>) {
+        let Some(spaced) = join else {
+            self.write_indent(output, depth);
+            return;
+        };
+        // The previous chunk already closed its line; take that newline back so
+        // both chunks stay on the line their suppression comment covers.
+        while output
+            .last()
+            .is_some_and(|&byte| byte == b'\n' || byte == b'\r')
+        {
+            output.pop();
+        }
+        if spaced {
+            output.push(b' ');
+        }
+    }
+}
+
+/// Text accumulated for the current output line, together with where it started
+/// in the source. The offset lets the joiner tell whether the run shares an
+/// unsplittable line with the chunk that follows it.
+pub(super) struct TextRun {
+    bytes: Vec<u8>,
+    start: usize,
+}
+
+impl TextRun {
+    pub(super) fn new() -> Self {
+        Self {
+            bytes: Vec::with_capacity(256),
+            start: 0,
+        }
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+
+    /// Source offset the buffered text begins at.
+    pub(super) fn start(&self) -> usize {
+        self.start
+    }
+
+    pub(super) fn as_str(&self) -> &str {
+        std::str::from_utf8(&self.bytes).unwrap_or("")
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.bytes.clear();
+    }
+
+    /// Append `source[start..end]`, separating it from already buffered text
+    /// with a single space (an interpolation or a stray `<` split the runs).
+    pub(super) fn push_source(&mut self, source: &[u8], start: usize, end: usize) {
+        if self.bytes.is_empty() {
+            self.start = start;
+        } else {
+            self.bytes.push(b' ');
+        }
+        self.bytes.extend_from_slice(&source[start..end]);
+    }
+
+    /// Append a single byte the tag scanner rejected as markup.
+    pub(super) fn push_byte(&mut self, at: usize, byte: u8) {
+        if self.bytes.is_empty() {
+            self.start = at;
+        }
+        self.bytes.push(byte);
+    }
+}
+
+/// Source byte ranges (trimmed to their content) that a line-scoped suppression
+/// covers, in ascending order and at most one per line.
+fn locked_line_ranges(source: &[u8]) -> Vec<(usize, usize)> {
+    let mut locked = Vec::new();
+    if !contains_any(source, &PRAGMA_MARKERS) {
+        return locked;
+    }
+
+    let mut line_start = 0;
+    let mut pragma_above = false;
+    loop {
+        let line_end = memchr::memchr(b'\n', &source[line_start..])
+            .map_or(source.len(), |offset| line_start + offset);
+        let line = &source[line_start..line_end];
+        // A blank line ends nothing and covers nothing: ESLint would apply the
+        // suppression to it and suppress no code at all.
+        if let Some((start, end)) = content_span(line)
+            && (pragma_above || contains_any(line, &SAME_LINE_PRAGMAS))
+        {
+            locked.push((line_start + start, line_start + end));
+        }
+        pragma_above = contains_any(line, &NEXT_LINE_PRAGMAS);
+        if line_end >= source.len() {
+            break;
+        }
+        line_start = line_end + 1;
+    }
+    locked
+}
+
+/// Offsets of the first and one-past-the-last non-whitespace byte of `line`.
+fn content_span(line: &[u8]) -> Option<(usize, usize)> {
+    let start = line.iter().position(|&byte| !is_whitespace(byte))?;
+    let end = line.iter().rposition(|&byte| !is_whitespace(byte))? + 1;
+    Some((start, end))
+}
+
+/// `memmem` rather than a naive window scan: the marker check in
+/// [`locked_line_ranges`] runs over every template the formatter sees, including
+/// the overwhelming majority that carry no suppression at all.
+fn contains_any(haystack: &[u8], needles: &[&[u8]]) -> bool {
+    needles
+        .iter()
+        .any(|needle| memchr::memmem::find(haystack, needle).is_some())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::locked_line_ranges;
+
+    #[test]
+    fn ranges_track_pragma_placement() {
+        assert!(locked_line_ranges(b"<div>\n  <p>x</p>\n</div>").is_empty());
+        // The range covers the trimmed content of the following line only, so
+        // indentation and the line break stay outside it.
+        let next_line = b"<!-- eslint-disable-next-line -->\n  a <b/>\n<p/>";
+        assert_eq!(locked_line_ranges(next_line), [(36, 42)]);
+        assert_eq!(&next_line[36..42], b"a <b/>");
+        // A blank line after the pragma pins nothing.
+        assert!(locked_line_ranges(b"<!-- eslint-disable-next-line -->\n\n<p/>").is_empty());
+        // A same-line pragma pins the line it sits on, and stacking both forms
+        // records one range per line rather than a duplicate.
+        let both = b"<!-- eslint-disable-next-line -->\n<p/> <!-- eslint-disable-line -->";
+        assert_eq!(locked_line_ranges(both), [(34, 67)]);
+        assert_eq!(&both[34..67], b"<p/> <!-- eslint-disable-line -->");
+    }
+}

--- a/crates/vize_glyph/src/template/formatter/whitespace_significant.rs
+++ b/crates/vize_glyph/src/template/formatter/whitespace_significant.rs
@@ -3,7 +3,11 @@
 //! the already-large `formatter.rs` stays within the source-file-length budget
 //! (#3251).
 
-use super::{TemplateFormatter, find_matching_close_tag};
+use super::TemplateFormatter;
+use crate::template::{
+    attributes::ParsedAttribute,
+    helpers::{find_bytes, is_void_element_str},
+};
 
 impl TemplateFormatter<'_> {
     /// Emit a whitespace-significant element verbatim, returning the source
@@ -46,6 +50,82 @@ impl TemplateFormatter<'_> {
         // as a stray text node and change the rendered output. (#3249)
         close_start + close_offset + 1
     }
+}
+
+/// Returns true if the element's content must be preserved byte-for-byte:
+/// `<pre>`, `<textarea>`, or any element with the `v-pre` directive.
+/// Whitespace and interpolations inside these regions are rendered as-is
+/// at runtime, so the formatter must not touch them. (#963)
+pub(super) fn is_whitespace_significant_element(tag_name: &str, attrs: &[ParsedAttribute]) -> bool {
+    if tag_name.eq_ignore_ascii_case("pre") || tag_name.eq_ignore_ascii_case("textarea") {
+        return true;
+    }
+    attrs
+        .iter()
+        .any(|attr| attr.name.eq_ignore_ascii_case("v-pre"))
+}
+
+/// Find the start of the matching `</tag_name>` for a content region that
+/// begins at `start` in `source`. Returns the byte index of the `<` of the
+/// closing tag, or `None` if no matching close is found.
+///
+/// This is a tag-name aware scan so nested elements with the same tag are
+/// handled correctly (e.g. `<pre>...<pre>x</pre>...</pre>`).
+fn find_matching_close_tag(source: &[u8], start: usize, tag_name: &str) -> Option<usize> {
+    let len = source.len();
+    let tag_bytes = tag_name.as_bytes();
+    let mut pos = start;
+    let mut depth: i32 = 1;
+    while pos < len {
+        let offset = memchr::memchr(b'<', &source[pos..])?;
+        pos += offset;
+        if pos + 1 >= len {
+            return None;
+        }
+        // Skip comments and CDATA to avoid false matches inside them.
+        if pos + 3 < len && &source[pos..pos + 4] == b"<!--" {
+            if let Some(end) = find_bytes(&source[pos..], b"-->") {
+                pos += end + 3;
+                continue;
+            }
+            return None;
+        }
+
+        let is_closing = source[pos + 1] == b'/';
+        let name_start = if is_closing { pos + 2 } else { pos + 1 };
+        if name_start >= len {
+            return None;
+        }
+        let name_bytes = &source[name_start..];
+        if name_bytes.len() >= tag_bytes.len()
+            && name_bytes[..tag_bytes.len()].eq_ignore_ascii_case(tag_bytes)
+        {
+            let after = name_bytes.get(tag_bytes.len()).copied().unwrap_or(0);
+            let after_is_terminator = matches!(after, b'>' | b'/' | b' ' | b'\t' | b'\n' | b'\r');
+            if after_is_terminator {
+                if is_closing {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(pos);
+                    }
+                } else if !is_void_element_str(tag_name) {
+                    // Treat self-closing forms (`<tag … />`) as not opening
+                    // a new nesting level. Peek to the next `>` and check
+                    // for a preceding `/`.
+                    if let Some(gt) = memchr::memchr(b'>', &source[pos..]) {
+                        let close_at = pos + gt;
+                        if close_at > 0 && source[close_at - 1] != b'/' {
+                            depth += 1;
+                        }
+                        pos = close_at + 1;
+                        continue;
+                    }
+                }
+            }
+        }
+        pos += 1;
+    }
+    None
 }
 
 #[cfg(test)]

--- a/crates/vize_glyph/tests/template_suppression_line.rs
+++ b/crates/vize_glyph/tests/template_suppression_line.rs
@@ -1,0 +1,178 @@
+//! A line covered by a line-scoped lint suppression must survive formatting on
+//! one line. `eslint-disable-next-line` is physical-line scoped, so breaking the
+//! line it covers silently disables the user's suppression and a finding that
+//! was suppressed in the source reappears after `vize fmt`. (#3343)
+
+use vize_glyph::{FormatOptions, format_template};
+
+/// Assert `source` formats to `expected`, and that a second pass is a no-op.
+fn assert_formatted(source: &str, expected: &str) {
+    let options = FormatOptions::default();
+    let first = format_template(source, &options).unwrap();
+    assert_eq!(first.as_str(), expected);
+    let second = format_template(&first, &options).unwrap();
+    assert_eq!(
+        second.as_str(),
+        first.as_str(),
+        "joining a suppressed line must be idempotent"
+    );
+}
+
+#[test]
+fn eslint_disable_next_line_keeps_text_and_element_together() {
+    // The gogocode fixture from the report: every text run used to be emitted as
+    // its own line, so the `<input>` moved off the line the comment covers and
+    // `a11y/form-control-has-label` went from 2 to 3 findings after formatting.
+    assert_formatted(
+        concat!(
+            "<div class=\"mt20\">\n",
+            "  <!--eslint-disable-next-line-->\n",
+            "  custom space: <input v-on:keyup.custom=\"keys('custom keycode space')\" />\n",
+            "</div>",
+        ),
+        concat!(
+            "<div class=\"mt20\">\n",
+            "  <!--eslint-disable-next-line-->\n",
+            "  custom space: <input @keyup.custom='keys(\"custom keycode space\")' />\n",
+            "</div>",
+        ),
+    );
+}
+
+#[test]
+fn suppression_pragma_variants_all_pin_the_next_line() {
+    // Inner spaces, a rule-scoped list, a trailing `--` reason, and this repo's
+    // own `vize-`/`@vize:` next-line directives must all pin the following line.
+    // Missing one leaves the defect in place for that spelling.
+    for source in [
+        "<div>\n  <!--eslint-disable-next-line-->\n  label: <input />\n</div>",
+        "<div>\n  <!-- eslint-disable-next-line -->\n  label: <input />\n</div>",
+        "<div>\n  <!--  eslint-disable-next-line  -->\n  label: <input />\n</div>",
+        "<div>\n  <!-- eslint-disable-next-line a11y/form-control-has-label -->\n  label: <input />\n</div>",
+        "<div>\n  <!-- eslint-disable-next-line a11y/form-control-has-label -- why -->\n  label: <input />\n</div>",
+        "<div>\n  <!-- vize-disable-next-line a11y/form-control-has-label -->\n  label: <input />\n</div>",
+        "<div>\n  <!-- @vize:expected -->\n  label: <input />\n</div>",
+        "<div>\n  <!-- @vize:level(off) -->\n  label: <input />\n</div>",
+    ] {
+        assert_formatted(source, source);
+    }
+}
+
+#[test]
+fn joined_chunks_reuse_the_source_spacing() {
+    // Whitespace between the joined chunks is replayed as a single space, and its
+    // absence is preserved, so re-joining cannot change what Vue renders.
+    assert_formatted(
+        "<div>\n  <!-- eslint-disable-next-line -->\n  <b>a</b><i>b</i>\n</div>",
+        "<div>\n  <!-- eslint-disable-next-line -->\n  <b>a</b><i>b</i>\n</div>",
+    );
+    assert_formatted(
+        "<div>\n  <!-- eslint-disable-next-line -->\n  <b>a</b>   <i>b</i>\n</div>",
+        "<div>\n  <!-- eslint-disable-next-line -->\n  <b>a</b> <i>b</i>\n</div>",
+    );
+    // Interpolations, closing tags and trailing text all stay on the line too.
+    assert_formatted(
+        "<p>\n  <!-- eslint-disable-next-line -->\n  a {{x}} <b>c</b> d\n</p>",
+        "<p>\n  <!-- eslint-disable-next-line -->\n  a {{ x }} <b>c</b> d\n</p>",
+    );
+}
+
+#[test]
+fn unsuppressed_lines_still_split() {
+    // Regression guard: splitting is the formatter's normal behaviour and only a
+    // line-scoped suppression comment turns it off.
+    assert_formatted(
+        "<div>\n  space: <input type=\"text\" />\n</div>",
+        "<div>\n  space:\n  <input type=\"text\" />\n</div>",
+    );
+    // An unrelated comment pins nothing.
+    assert_formatted(
+        "<div>\n  <!-- a note -->\n  space: <input />\n</div>",
+        "<div>\n  <!-- a note -->\n  space:\n  <input />\n</div>",
+    );
+    // Neither does a block `eslint-disable`: it is not line scoped, so it
+    // survives reflow on its own and needs no pinning.
+    assert_formatted(
+        "<div>\n  <!-- eslint-disable -->\n  space: <input />\n</div>",
+        "<div>\n  <!-- eslint-disable -->\n  space:\n  <input />\n</div>",
+    );
+    // A pragma two lines up covers neither the blank line nor the code below it.
+    assert_formatted(
+        "<div>\n  <!-- eslint-disable-next-line -->\n\n  space: <input />\n</div>",
+        "<div>\n  <!-- eslint-disable-next-line -->\n  space:\n  <input />\n</div>",
+    );
+}
+
+#[test]
+fn same_line_pragma_keeps_its_own_line_intact() {
+    // `eslint-disable-line` covers the line the comment sits on, so the comment
+    // must not be pushed onto a line of its own either.
+    let source = "<div>\n  label: <input /> <!-- eslint-disable-line -->\n</div>";
+    assert_formatted(source, source);
+}
+
+#[test]
+fn pinned_line_does_not_leak_into_neighbours() {
+    // Only the covered line is pinned: the lines around it keep splitting, and
+    // nesting opened on the pinned line still indents its children.
+    assert_formatted(
+        concat!(
+            "<div>\n",
+            "  before: <input />\n",
+            "  <!-- eslint-disable-next-line -->\n",
+            "  pinned: <input /><span>\n",
+            "  inner: <input />\n",
+            "  </span>\n",
+            "  after: <input />\n",
+            "</div>",
+        ),
+        concat!(
+            "<div>\n",
+            "  before:\n",
+            "  <input />\n",
+            "  <!-- eslint-disable-next-line -->\n",
+            "  pinned: <input /><span>\n",
+            "    inner:\n",
+            "    <input />\n",
+            "  </span>\n",
+            "  after:\n",
+            "  <input />\n",
+            "</div>",
+        ),
+    );
+}
+
+#[test]
+fn multiline_directive_value_on_a_pinned_line_stays_idempotent() {
+    // A directive value that is multiline in the source still spans lines, and
+    // its continuation indentation is anchored the same way on every pass even
+    // though the tag now starts mid-line (#3368 interaction).
+    let source = concat!(
+        "<div>\n",
+        "  <!-- eslint-disable-next-line -->\n",
+        "  label: <span :style=\"{\n",
+        "    color: 'red',\n",
+        "  }\">x</span>\n",
+        "</div>",
+    );
+    let options = FormatOptions::default();
+    let first = format_template(source, &options).unwrap();
+    let second = format_template(&first, &options).unwrap();
+    assert_eq!(
+        second.as_str(),
+        first.as_str(),
+        "multiline directive value on a pinned line must be idempotent"
+    );
+    assert!(
+        first.contains("label: <span"),
+        "the element must still join the suppressed line:\n{first}"
+    );
+}
+
+#[test]
+fn whitespace_significant_element_on_a_pinned_line_stays_verbatim() {
+    // `<pre>` content is still copied byte for byte (#963) while the element
+    // itself joins the suppressed line.
+    let source = "<div>\n  <!-- eslint-disable-next-line -->\n  a <pre>  x  </pre> b\n</div>";
+    assert_formatted(source, source);
+}

--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -1,12 +1,5 @@
 [
   {
-    "property": "lint-agreement",
-    "project": "gogocode",
-    "path": "packages/gogocode-vue-playground/packages/vue2/src/components/keycode-modifiers/Comp.vue",
-    "rule": "a11y/form-control-has-label",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3343"
-  },
-  {
     "property": "parse-preservation",
     "project": "crater",
     "path": "resources/scripts/components/base/BaseModal.vue",


### PR DESCRIPTION
## Summary

Fixes #3343.

`eslint-disable-next-line` is *physical line* scoped, exactly as in ESLint: it covers the line that follows the comment. `vize fmt` split that line, so the suppressed code moved out from under its own pragma and the finding came back — with nothing in the formatting diff that looks like a cause.

`tests/_fixtures/_git/gogocode/packages/gogocode-vue-playground/packages/vue2/src/components/keycode-modifiers/Comp.vue`, before:

```vue
<div class="mt20">
  <!--eslint-disable-next-line-->
  custom space: <input v-on:keyup.custom="keys('custom keycode space')" />
</div>
```

after `vize fmt --write --no-config` on `main`:

```vue
<div class="mt20">
  <!--eslint-disable-next-line-->
  custom space:
  <input @keyup.custom='keys("custom keycode space")' />
</div>
```

"Next line" is now the bare text `custom space:`, so the `<input>` is uncovered. Findings per rule, measured with `vize lint <file> --no-config -f json`:

| | pristine | formatted, `main` | formatted, this PR |
| --- | --- | --- | --- |
| `a11y/form-control-has-label` | 2 | **3** | 2 |
| `vue/v-on-style` | 2 | 0 | 0 |
| `vue/sfc-element-order` | 1 | 0 | 0 |
| `vue/component-definition-name-casing` | 1 | 1 | 1 |

Counts shrinking is fine — formatting legitimately fixes findings. `a11y/form-control-has-label` growing 2 -> 3 is the defect, and it was the last `glyph corpus lint-agreement` violation in the CI shard.

### Root cause

`TemplateFormatter::flush_text_buffer` ended with `write_indented_line`, so *every* text run became its own indented line. Any `text <element>` sequence on one source line therefore became two output lines; the suppression case is just where that is harmful. The comment and closing-tag emit paths had the same unconditional `write_indent`.

This is a different layer from `compute_raw_line_mask` in `crates/vize_glyph/src/formatter/raw_mask.rs`: that mask only stops the SFC layer from re-indenting lines and has no say in whether the template layer breaks one, so the `<pre>` / `v-pre` precedent does not extend here for free.

### Fix — option 1 from the issue (formatter)

New module `crates/vize_glyph/src/template/formatter/suppression.rs`:

- `locked_line_ranges` scans the template source once and records the trimmed byte range of every line a line-scoped pragma covers. Covered spellings: `eslint-disable-next-line` (bare, inner-spaced, rule-scoped, and with a trailing `-- reason`), `eslint-disable-line`, this repo's `vize-disable-next-line` / `vize-disable-line`, and the `@vize:expected` / `@vize:level(...)` next-line directives that `crates/vize_patina/src/context/directives.rs` also resolves per physical line. Templates with no pragma at all take a two-marker `memmem` bail-out and never pay for the line scan.
- `LineJoiner::open(start)` tells each emit site whether its chunk continues the line the previous chunk opened. `TemplateFormatter::open_chunk` then either indents a fresh line (unchanged behaviour) or takes back the newline the previous chunk wrote and replays the source's own spacing — one space where the source had whitespace, nothing where it had none. That matters: unconditionally inserting a space would change what Vue renders for `<b>a</b><i>b</i>`.
- `TextRun` replaces the bare `Vec<u8>` text buffer so a flushed run knows which source offset it started at.

Option 2 (re-anchoring `eslint-disable-next-line` to the next element in the linter, the #3270 shape) is deliberately **not** taken. It changes suppression semantics away from ESLint's line-based rule for every Vize user — a maintainer decision, not a bug fix. Option 1 keeps `eslint-disable-next-line` line-based and identical to ESLint.

**Scope boundary.** Only the line breaks this layer *chooses* are suppressed. An attribute value that is already multiline in the source, or an interpolation expression the JS printer wraps, still spans lines — and attribute wrapping on a pinned line still happens. Both keep the element's *opening tag* on the suppressed line, which is where template diagnostics anchor (#3252, #3270), and forcing a single line is not even achievable when a rendered attribute value contains a newline. Attribute wrapping is pre-existing behaviour that the corpus property does not flag on any hydrated fixture today. The script block's `// @vize forget: <reason>` next-line suppression is untouched — different layer, different line-breaking model.

`is_whitespace_significant_element` and `find_matching_close_tag` move verbatim to `whitespace_significant.rs`, their only consumer, so `crates/vize_glyph/src/template/formatter.rs` goes 821 -> 760 lines and stays inside the source-length budget. No behaviour change in the moved code.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [x] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

- #3343 — the defect report, including the two defensible fixes and why (2) needs a deliberate decision.
- ESLint's [`eslint-disable-next-line`](https://eslint.org/docs/latest/use/configure/rules#disabling-rules) is scoped to the next physical line; this keeps Vize identical to it.
- `crates/vize_patina/src/context/directives.rs` `prescan_eslint_disable_comments` — the consumer whose line-based semantics this preserves.
- `docs/content/guide/comment-annotations.md` — `@vize:expected` and `@vize:level(...)` are the repo's own next-line-scoped template directives, so they are pinned too.

## Verification Evidence

**The new tests were verified to fail without the source change.** With `crates/vize_glyph/src/template/formatter.rs` and `whitespace_significant.rs` reverted and the new tests kept:

- `cargo test -p vize_glyph --test template_suppression_line` -> `6 failed; 1 passed`. The one that passes is `unsuppressed_lines_still_split`, the regression guard that must hold both before and after.
- `cargo test --profile ci -p vize --test fmt_lint_agreement_cli` -> `1 failed`, reporting exactly `vize fmt introduced findings: [("a11y/form-control-has-label", 3)]`, `before: {"a11y/form-control-has-label": 2, "vue/v-on-style": 2}`.

Restored, both pass.

Commands run:

```
cargo test -p vize_glyph                            # 14 targets, all ok (8 new tests)
cargo test --profile ci -p vize --test fmt_lint_agreement_cli   # 1 passed
cargo fmt --all -- --check                          # clean
cargo clippy -p vize_glyph --all-targets            # 0 errors, no new warnings
cargo clippy -p vize_glyph -p vize -- -D warnings -D clippy::wildcard_imports   # clean (CI's invocation)
```

Manual, with `cargo build --profile ci -p vize --features legacy` on the gogocode fixture:

```
vize fmt C.vue --write --no-config    # suppressed line intact; second pass reports "unchanged"
vize lint C.vue --no-config -f json   # a11y/form-control-has-label 2 -> 2
```

Edge cases exercised by hand through the CLI, each idempotent on a second pass: CRLF sources, a pinned line whose element attributes wrap, `v-pre` content on a pinned line, and several interpolations on a pinned line.

### Corpus properties

This change alters line-breaking policy, which the glyph corpus properties exist to guard, so all three were run over the hydrated registry with a `--profile ci` build of this branch (`VIZE_TEST_BIN`):

```
glyph lint-agreement:     33486 file(s), 129 project(s),  0 known violation(s) skipped, 0 violation(s)
glyph idempotence:        33484 file(s), 129 project(s),  2 known violation(s) skipped, 0 violation(s)
glyph parse-preservation: 33399 file(s), 129 project(s), 87 known violation(s) skipped, 0 violation(s)
```

All three pass. **`0 known violation(s) skipped` on lint-agreement is the direct evidence that the #3343 pin can come out**: the waiver was still present in the ledger used for that run and nothing needed it. The 87 parse-preservation skips are the pre-existing #3334 entries.

#### Unrelated pre-existing finding: 2 of the 3 #3346 idempotence pins that #3368 removed still drift

The 2 idempotence skips above come from the #3346 entries, which #3368 removed from the ledger. They are not caused by this PR, and I did not re-add them — flagging rather than papering over:

| file | `origin/main` | this branch |
| --- | --- | --- |
| `dashy src/components/Settings/CustomThemeMaker.vue` | idempotent | idempotent |
| `scalar projects/scalar-app/src/features/collection/components/Environment.vue` | **drifts** | **drifts** |
| `vue-data-ui src/components/vue-ui-flow.vue` | **drifts** | **drifts** |

Measured by building `origin/main` and this branch and formatting each file twice. For both drifting files this branch produces output **byte-identical to the `origin/main` baseline on both passes**, and neither source contains any suppression pragma at all, so `locked_line_ranges` takes its bail-out and this change is inert on them. #3368 appears to have fixed one of the three files it un-pinned; the glyph idempotence corpus lane is therefore already red on `main` for those two, independently of this PR.

### Tests added

- `crates/vize_glyph/tests/template_suppression_line.rs` — the fixture case; every pragma spelling above pinning the next line; source spacing replayed exactly (`<b>a</b><i>b</i>` stays glued, `<b>a</b>   <i>b</i>` collapses to one space); pinned lines not leaking into their neighbours (surrounding lines still split, nesting opened on a pinned line still indents its children); `<pre>` content still verbatim on a pinned line; a multiline directive value on a pinned line staying idempotent (the #3368 interaction — the tag now starts mid-line); and the negatives — a plain comment, a non-line-scoped `eslint-disable`, and a pragma two lines up all still split. Every case asserts a second pass is a no-op.
- `crates/vize/tests/fmt_lint_agreement_cli.rs` — the end-to-end assertion: lint the reduced fixture, `vize fmt --write`, lint again, assert **no rule's count grew**, that the suppression still shares its line, and that a second `fmt` is a no-op. Goes through the real CLI so the SFC layer is covered, and needs no hydrated fixtures.
- `locked_line_ranges` unit test in `suppression.rs` — trimmed spans, a blank line after a pragma pinning nothing, one range per line when both pragma forms stack.

Checklist:

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — **no insta snapshot was refreshed**; none needed updating and there are no pending `.snap.new` files. The only ledger change is removing the #3343 `lint-agreement` pin from `tests/_fixtures/glyph-corpus-known-violations.json`, same lifecycle as the #3334 entries.
- [x] Parity or real-world fixture coverage considered — all three corpus properties run over 129 hydrated projects, results above.
- [x] Security/audit impact considered — no new dependency, no I/O, no unsafe; the one `unsafe` in `format()` (`String::from_utf8_unchecked`) is untouched and its invariant still holds, since joining only removes ASCII newlines and inserts an ASCII space between copied source ranges.
- [x] Performance status or PR benchmark impact considered — the scan is one `memmem` pass for two markers per template and bails out before the per-line work when neither marker appears; templates that do carry a pragma pay a per-line substring scan once, and lookups are a binary search over a usually one-element `Vec`.
- [x] Fuzzing target or crash-reproducer coverage considered — no new indexing on untrusted offsets: `open_chunk` only pops from a non-empty buffer (a join implies a preceding chunk), and `locked_line_ranges` derives ranges from `memchr` line bounds. Unterminated inputs (unclosed comment, split `</pre`) keep their existing paths and are covered by the existing tests.
- [x] Editor/LSP scenario coverage considered — `vize_maestro` formatting goes through the same `format_template_content`, so LSP format-on-save gets the fix; nothing LSP-specific changed.
- [x] Ecosystem or broad app compatibility impact considered — see the corpus run; output only changes for lines a line-scoped suppression covers.
- [ ] Docs, release, or stability notes updated when public behavior changed — not needed: this restores the documented ESLint-compatible behaviour rather than introducing new behaviour.

## Risk

Low, and narrowly scoped: output differs only for a line that a line-scoped suppression pragma covers. The joining rule replays the source's own inter-chunk spacing instead of normalising it, so rendered output cannot change; `<pre>` / `v-pre` regions still go through the verbatim path.

Two follow-ups deliberately left out of scope:

1. Attribute wrapping inside a pinned line (see the scope boundary above) — it keeps the opening tag on the suppressed line, and forcing a single line is impossible when a rendered attribute value is itself multiline.
2. Option 2 from the issue — anchoring `eslint-disable-next-line` to the next element/statement. More robust against any reflow, but it diverges from ESLint's semantics and deserves an explicit maintainer decision rather than riding along with a bug fix.

If the glyph idempotence corpus lane is red on this PR, compare it against `main`: the 2 drifting `scalar` / `vue-data-ui` files documented above fail there too and need their own fix or re-pin under #3346.
