### PR TITLE
chore(glyph): re-pin the two idempotence drifts that survived #3346

### DIFF
--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -1,5 +1,17 @@
 [
   {
+    "property": "idempotence",
+    "project": "scalar",
+    "path": "projects/scalar-app/src/features/collection/components/Environment.vue",
+    "issue": "https://github.com/ubugeeei-prod/vize/issues/3379"
+  },
+  {
+    "property": "idempotence",
+    "project": "vue-data-ui",
+    "path": "src/components/vue-ui-flow.vue",
+    "issue": "https://github.com/ubugeeei-prod/vize/issues/3379"
+  },
+  {
     "property": "parse-preservation",
     "project": "crater",
     "path": "resources/scripts/components/base/BaseModal.vue",


### PR DESCRIPTION
Refs #3379.

## Why

#3368 fixed #3346 and removed all three `idempotence` pins from `tests/_fixtures/glyph-corpus-known-violations.json`. **Two of the three files still drift.** The ledger therefore claims zero idempotence suppressions while the corpus property will fail on the next Real Project Matrix run.

## Verified on current `main` (`e3000a5c5`)

`cargo build --profile ci -p vize --features legacy`, then two `vize fmt --write --no-config` passes per file:

| fixture | result |
|---|---|
| `dashy` `src/components/Settings/CustomThemeMaker.vue` | **idempotent** — #3368 genuinely fixed this |
| `scalar` `projects/scalar-app/.../Environment.vue` | **still drifts** |
| `vue-data-ui` `src/components/vue-ui-flow.vue` | **still drifts** |

## They are three different shapes

#3347 recorded them as one family and #3368 relied on that. The diffs disagree:

- **`dashy`** — statement-sequence continuation in a directive value; `format_js_expression` cannot parse `foo(1); bar(2)` in its `void (…)` wrapper, so the `None` arm returned bytes unanchored. Fixed.
- **`scalar`** — an interpolation/whitespace boundary, not a directive value at all: the drift is on `{{ variable }}` / `</code>`.
- **`vue-data-ui`** — a **ternary** continuation carrying an `&&` sub-continuation: `? selectedNodes.includes(path.source) &&`. That is the path that *parses*, and the shape #3368's own regression test asserts is anchored correctly — so something else re-breaks it here.

## Why #3368 could not see it

It was developed in a worktree with no hydrated fixtures, so its corpus runs exercised machinery subtests only rather than the 33k-file sweep, and only `dashy` was locally reproducible from #3346's issue text. Its substitute signal (0/168 non-idempotent across the repo's own `.vue` files) was sound but blind to these two.

Corroborated independently: the #3343 work ran the real corpus over 129 hydrated projects and reported `idempotence 33484 files / 2 waivers used` — exactly these two files, consuming waivers that no longer exist on `main`.

## What this PR does

Re-pins both files to #3379, same lifecycle as the #3334 and #3343 entries: the property stays strict everywhere else while the two remaining shapes are fixed on their own merits.

Ledger goes 88 → 90 entries (`parse-preservation` 87, `idempotence` 2, `lint-agreement` 1). **No product change** — fixture data only.

## Note

This is a deliberate re-pin, not a revert of #3368. The `dashy` fix is correct and stays; #3379 tracks the two distinct shapes it did not cover, with explicit warning not to assume they share a cause.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added known idempotence issue cases to the test fixture corpus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->