### PR TITLE
fix(canon): mirror per-package node_modules into the virtual project (#3366)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,6 +1386,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e770254dd7802184595b1d30da2a15cb72569e2aca2b177aef8d22eac8a693"
 
 [[package]]
+name = "junction"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
+dependencies = [
+ "scopeguard",
+ "windows-sys",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3580,6 +3590,7 @@ dependencies = [
  "dashmap 6.1.0",
  "dirs",
  "insta",
+ "junction",
  "libc",
  "lsp-types 0.97.0",
  "oxc_allocator",

--- a/crates/vize_canon/Cargo.toml
+++ b/crates/vize_canon/Cargo.toml
@@ -52,6 +52,10 @@ corsa = { workspace = true, optional = true }
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+# Directory junctions as a privilege-free fallback for directory links (#3366).
+junction = "2"
+
 [dev-dependencies]
 tempfile.workspace = true
 insta.workspace = true

--- a/crates/vize_canon/src/batch/materialize_fs.rs
+++ b/crates/vize_canon/src/batch/materialize_fs.rs
@@ -92,6 +92,57 @@ fn file_bytes_match(path: &Path, expected: &[u8]) -> io::Result<bool> {
     }
 }
 
+/// Create (or refresh) a symlink at `target` pointing to `source`, replacing
+/// whatever the target currently is. Shared by the runtime-deps mirror and the
+/// per-package `node_modules` mirror (#3366).
+pub(super) fn symlink_path(source: &Path, target: &Path) -> io::Result<()> {
+    if symlink_matches(source, target)? {
+        return Ok(());
+    }
+
+    if let Some(parent) = target.parent() {
+        ensure_dir(parent)?;
+    }
+
+    remove_path(target)?;
+
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+    }
+
+    #[cfg(windows)]
+    {
+        if source.is_dir() {
+            // Directory junctions need no special privilege, unlike symlinks:
+            // fall back so directory links still materialize on stock Windows
+            // without Developer Mode or an elevated shell (#3366).
+            std::os::windows::fs::symlink_dir(source, target)
+                .or_else(|_| junction::create(source, target))
+        } else {
+            std::os::windows::fs::symlink_file(source, target)
+        }
+    }
+}
+
+fn symlink_matches(source: &Path, target: &Path) -> io::Result<bool> {
+    match fs::symlink_metadata(target) {
+        Ok(_) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    }
+    // `FileType::is_symlink` is false for junctions, so probe with
+    // `read_link`: it resolves both symlinks and junctions and fails for
+    // real files and directories. Junction targets come back in a `\??\`
+    // verbatim spelling, so compare canonicalized forms.
+    let Ok(linked) = fs::read_link(target) else {
+        return Ok(false);
+    };
+    Ok(linked == source
+        || vize_carton::path::canonicalize_non_verbatim(&linked)
+            == vize_carton::path::canonicalize_non_verbatim(source))
+}
+
 pub(super) fn remove_path(path: &Path) -> io::Result<()> {
     let metadata = match fs::symlink_metadata(path) {
         Ok(metadata) => metadata,

--- a/crates/vize_canon/src/batch/runtime_deps.rs
+++ b/crates/vize_canon/src/batch/runtime_deps.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
 
 use super::error::CorsaResult;
-use super::materialize_fs::{ensure_dir, prune_dir_entries, remove_path, write_if_changed};
+use super::materialize_fs::{
+    ensure_dir, prune_dir_entries, remove_path, symlink_path, write_if_changed,
+};
 use vize_carton::FxHashSet;
 
 mod resolver;
@@ -135,8 +137,11 @@ fn write_vite_stub(node_modules_dir: &Path) -> std::io::Result<()> {
 }
 
 fn ensure_stub_dir(path: &Path) -> std::io::Result<()> {
+    // A link (symlink or junction) must be replaced, never written through:
+    // std reports junctions as plain directories, so probe `read_link`.
+    let is_link = std::fs::read_link(path).is_ok();
     match std::fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() => {}
+        Ok(metadata) if metadata.file_type().is_dir() && !is_link => {}
         Ok(_) => {
             remove_path(path)?;
             ensure_dir(path)?;
@@ -145,45 +150,6 @@ fn ensure_stub_dir(path: &Path) -> std::io::Result<()> {
         Err(error) => return Err(error),
     }
     Ok(())
-}
-
-fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
-    if symlink_matches(source, target)? {
-        return Ok(());
-    }
-
-    if let Some(parent) = target.parent() {
-        ensure_dir(parent)?;
-    }
-
-    remove_path(target)?;
-
-    #[cfg(unix)]
-    {
-        std::os::unix::fs::symlink(source, target)
-    }
-
-    #[cfg(windows)]
-    {
-        if source.is_dir() {
-            std::os::windows::fs::symlink_dir(source, target)
-        } else {
-            std::os::windows::fs::symlink_file(source, target)
-        }
-    }
-}
-
-fn symlink_matches(source: &Path, target: &Path) -> std::io::Result<bool> {
-    let metadata = match std::fs::symlink_metadata(target) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => return Err(error),
-    };
-    if !metadata.file_type().is_symlink() {
-        return Ok(false);
-    }
-    let linked = std::fs::read_link(target)?;
-    Ok(linked == source)
 }
 
 fn prune_stub_dir(dir: &Path, file_names: &[&str]) -> std::io::Result<()> {

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -43,6 +43,7 @@ mod jsx_build;
 mod jsx_codegen;
 mod mapping;
 mod materialize;
+mod package_node_modules;
 mod passthrough;
 mod paths;
 mod project;

--- a/crates/vize_canon/src/batch/virtual_project/declaration_emit.rs
+++ b/crates/vize_canon/src/batch/virtual_project/declaration_emit.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
@@ -9,13 +9,34 @@ use oxc_ast::ast::{
 use oxc_ast_visit::{Visit, walk};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::{String, ToCompactString, cstr};
+use vize_carton::{String, ToCompactString, cstr, profile};
 
 use crate::batch::CorsaResult;
 
 use super::{VirtualFile, VirtualProject};
 
 impl VirtualProject {
+    /// Write a declaration-emitting tsconfig and return its path.
+    pub fn write_declaration_tsconfig(
+        &self,
+        out_dir: &Path,
+        declaration_map: bool,
+    ) -> CorsaResult<PathBuf> {
+        let config_path = self.virtual_root.join("tsconfig.declaration.json");
+        self.rewrite_tsx_vue_declaration_inputs()?;
+        let include_paths = self.declaration_emit_include_paths();
+        profile!(
+            "canon.project.write_dts_tsconfig",
+            self.write_tsconfig_file_with_includes(
+                &config_path,
+                Some(out_dir),
+                declaration_map,
+                Some(&include_paths),
+            )
+        )?;
+        Ok(config_path)
+    }
+
     pub(super) fn rewrite_tsx_vue_declaration_inputs(&self) -> CorsaResult<()> {
         for file in self.virtual_files_sorted() {
             let path = file.virtual_path.as_path();

--- a/crates/vize_canon/src/batch/virtual_project/materialize.rs
+++ b/crates/vize_canon/src/batch/virtual_project/materialize.rs
@@ -31,22 +31,16 @@ impl VirtualProject {
     /// so TypeScript's own filesystem caches are not invalidated.
     pub fn materialize(&self) -> CorsaResult<()> {
         let expected_files = self.expected_materialized_files();
-        // Mirror symlinks from a previous run survive the GC only while their
-        // mapping still exists, so the preserved set is computed before
-        // pruning and the links are (re)created after it (#3366).
-        let package_node_modules = self.package_node_modules_mirrors();
-        let mut preserved_roots = Vec::with_capacity(package_node_modules.len() + 1);
-        preserved_roots.push(self.virtual_root.join("node_modules"));
-        preserved_roots.extend(
-            package_node_modules
-                .iter()
-                .map(|(target, _)| target.clone()),
-        );
         profile!(
             "canon.project.prepare_dir",
             ensure_materialize_root(&self.virtual_root)
         )?;
 
+        // Mirror links survive the GC only while their mapping exists (#3366).
+        let preserved_roots = profile!(
+            "canon.project.package_node_modules",
+            self.materialize_package_node_modules()
+        )?;
         profile!(
             "canon.project.gc",
             prune_unexpected_entries(&self.virtual_root, &expected_files, &preserved_roots)
@@ -55,11 +49,6 @@ impl VirtualProject {
         profile!(
             "canon.project.runtime_deps",
             materialize_runtime_dependencies(&self.project_root, &self.virtual_root)
-        )?;
-
-        profile!(
-            "canon.project.package_node_modules",
-            self.materialize_package_node_modules(&package_node_modules)
         )?;
 
         profile!(
@@ -144,27 +133,6 @@ impl VirtualProject {
         let content = b"{\n  \"type\": \"module\"\n}\n";
         write_if_changed(&self.virtual_root.join(PACKAGE_BOUNDARY_FILE), content)?;
         Ok(())
-    }
-
-    /// Write a declaration-emitting tsconfig and return its path.
-    pub fn write_declaration_tsconfig(
-        &self,
-        out_dir: &Path,
-        declaration_map: bool,
-    ) -> CorsaResult<PathBuf> {
-        let config_path = self.virtual_root.join("tsconfig.declaration.json");
-        self.rewrite_tsx_vue_declaration_inputs()?;
-        let include_paths = self.declaration_emit_include_paths();
-        profile!(
-            "canon.project.write_dts_tsconfig",
-            self.write_tsconfig_file_with_includes(
-                &config_path,
-                Some(out_dir),
-                declaration_map,
-                Some(&include_paths),
-            )
-        )?;
-        Ok(config_path)
     }
 
     fn write_auto_import_stubs(&self) -> CorsaResult<()> {

--- a/crates/vize_canon/src/batch/virtual_project/materialize.rs
+++ b/crates/vize_canon/src/batch/virtual_project/materialize.rs
@@ -31,6 +31,17 @@ impl VirtualProject {
     /// so TypeScript's own filesystem caches are not invalidated.
     pub fn materialize(&self) -> CorsaResult<()> {
         let expected_files = self.expected_materialized_files();
+        // Mirror symlinks from a previous run survive the GC only while their
+        // mapping still exists, so the preserved set is computed before
+        // pruning and the links are (re)created after it (#3366).
+        let package_node_modules = self.package_node_modules_mirrors();
+        let mut preserved_roots = Vec::with_capacity(package_node_modules.len() + 1);
+        preserved_roots.push(self.virtual_root.join("node_modules"));
+        preserved_roots.extend(
+            package_node_modules
+                .iter()
+                .map(|(target, _)| target.clone()),
+        );
         profile!(
             "canon.project.prepare_dir",
             ensure_materialize_root(&self.virtual_root)
@@ -38,16 +49,17 @@ impl VirtualProject {
 
         profile!(
             "canon.project.gc",
-            prune_unexpected_entries(
-                &self.virtual_root,
-                &expected_files,
-                &[self.virtual_root.join("node_modules")]
-            )
+            prune_unexpected_entries(&self.virtual_root, &expected_files, &preserved_roots)
         )?;
 
         profile!(
             "canon.project.runtime_deps",
             materialize_runtime_dependencies(&self.project_root, &self.virtual_root)
+        )?;
+
+        profile!(
+            "canon.project.package_node_modules",
+            self.materialize_package_node_modules(&package_node_modules)
         )?;
 
         profile!(

--- a/crates/vize_canon/src/batch/virtual_project/package_node_modules.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_node_modules.rs
@@ -1,0 +1,186 @@
+//! Mirroring per-package `node_modules` directories into the virtual tree
+//! (#3366).
+//!
+//! Mirrored files keep the project-relative shape of their originals
+//! (`apps/app/vite.config.ts` lands at `<canon>/apps/app/vite.config.ts`), so
+//! Corsa's ancestor walk for a bare specifier never passes through the
+//! original directory. In a pnpm workspace the package's own dependencies are
+//! linked into `<package>/node_modules`, which sits outside that walk — the
+//! virtual `<canon>/node_modules` only carries the special-cased
+//! `vue`/`vite`/`@vue` set — and the import dies with a spurious TS2307.
+//! Symlinking each real per-package `node_modules` into the mirror at the
+//! matching project-relative location restores the ancestor chain Node would
+//! walk from the original file.
+
+use std::path::{Path, PathBuf};
+
+use vize_carton::FxHashSet;
+
+use crate::batch::error::CorsaResult;
+use crate::batch::materialize_fs::symlink_path;
+
+use super::VirtualProject;
+
+/// One `(mirror target, real directory)` pair per ancestor of a registered
+/// original file that owns a real `node_modules` directory. The project root
+/// itself is excluded — its `node_modules` is the special-cased runtime-deps
+/// mirror — as is any ancestor already inside a `node_modules` tree (a
+/// `.pnpm` store path must not be mirrored back into the project shape).
+fn package_node_modules_mirrors(
+    project_root: &Path,
+    virtual_root: &Path,
+    original_paths: impl Iterator<Item = PathBuf>,
+) -> Vec<(PathBuf, PathBuf)> {
+    let mut mirrors = Vec::new();
+    let mut visited: FxHashSet<PathBuf> = FxHashSet::default();
+    for original in original_paths {
+        let mut ancestor = original.parent();
+        while let Some(dir) = ancestor {
+            if dir == project_root || !dir.starts_with(project_root) {
+                break;
+            }
+            ancestor = dir.parent();
+            if !visited.insert(dir.to_path_buf()) {
+                continue;
+            }
+            let Ok(relative) = dir.strip_prefix(project_root) else {
+                continue;
+            };
+            if relative
+                .components()
+                .any(|component| component.as_os_str() == "node_modules")
+            {
+                continue;
+            }
+            let real = dir.join("node_modules");
+            if real.is_dir() {
+                mirrors.push((virtual_root.join(relative).join("node_modules"), real));
+            }
+        }
+    }
+    mirrors.sort();
+    mirrors
+}
+
+impl VirtualProject {
+    /// Real per-package `node_modules` directories the mirror must expose at
+    /// the matching project-relative location, computed from every registered
+    /// original path (checked sources and passthrough dependencies alike).
+    pub(super) fn package_node_modules_mirrors(&self) -> Vec<(PathBuf, PathBuf)> {
+        package_node_modules_mirrors(
+            &self.project_root,
+            &self.virtual_root,
+            self.original_index
+                .keys()
+                .cloned()
+                .chain(self.passthrough_files.values().cloned()),
+        )
+    }
+
+    /// (Re)create the mirror symlinks. Best-effort like the runtime-deps
+    /// links: on a platform without symlink permission the run keeps the
+    /// pre-fix resolution behavior instead of failing materialization.
+    pub(super) fn materialize_package_node_modules(
+        &self,
+        mirrors: &[(PathBuf, PathBuf)],
+    ) -> CorsaResult<()> {
+        for (target, source) in mirrors {
+            let source = vize_carton::path::canonicalize_non_verbatim(source);
+            if symlink_path(&source, target).is_err() {
+                continue;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::package_node_modules_mirrors;
+    use std::path::{Path, PathBuf};
+
+    fn mirror_map(
+        project_root: &Path,
+        virtual_root: &Path,
+        originals: &[&str],
+    ) -> Vec<(PathBuf, PathBuf)> {
+        package_node_modules_mirrors(
+            project_root,
+            virtual_root,
+            originals.iter().map(|path| project_root.join(path)),
+        )
+    }
+
+    #[test]
+    fn maps_a_sub_package_node_modules_into_the_mirror() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let virtual_root = root.join("node_modules/.vize/canon");
+        std::fs::create_dir_all(root.join("apps/app/node_modules")).unwrap();
+
+        let mirrors = mirror_map(root, &virtual_root, &["apps/app/src/main.ts"]);
+
+        assert_eq!(
+            mirrors,
+            vec![(
+                virtual_root.join("apps/app/node_modules"),
+                root.join("apps/app/node_modules")
+            )]
+        );
+    }
+
+    #[test]
+    fn skips_the_project_root_and_ancestors_without_node_modules() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let virtual_root = root.join("node_modules/.vize/canon");
+        std::fs::create_dir_all(root.join("node_modules")).unwrap();
+        std::fs::create_dir_all(root.join("apps/app/src")).unwrap();
+
+        let mirrors = mirror_map(root, &virtual_root, &["apps/app/src/main.ts"]);
+
+        assert!(
+            mirrors.is_empty(),
+            "only the project root owns node_modules here, and it is the runtime-deps mirror's job: {mirrors:?}"
+        );
+    }
+
+    #[test]
+    fn skips_ancestors_inside_a_node_modules_tree() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let virtual_root = root.join("node_modules/.vize/canon");
+        std::fs::create_dir_all(root.join("node_modules/.pnpm/pkg@1/node_modules")).unwrap();
+
+        let mirrors = mirror_map(
+            root,
+            &virtual_root,
+            &["node_modules/.pnpm/pkg@1/node_modules/pkg/dist/index.d.ts"],
+        );
+
+        assert!(
+            mirrors.is_empty(),
+            "store-internal node_modules must not be mirrored: {mirrors:?}"
+        );
+    }
+
+    #[test]
+    fn deduplicates_ancestors_shared_by_many_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let virtual_root = root.join("node_modules/.vize/canon");
+        std::fs::create_dir_all(root.join("apps/app/node_modules")).unwrap();
+
+        let mirrors = mirror_map(
+            root,
+            &virtual_root,
+            &["apps/app/a.ts", "apps/app/b.ts", "apps/app/src/c.ts"],
+        );
+
+        assert_eq!(
+            mirrors.len(),
+            1,
+            "one shared apps/app ancestor: {mirrors:?}"
+        );
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/package_node_modules.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_node_modules.rs
@@ -62,35 +62,39 @@ fn package_node_modules_mirrors(
     mirrors
 }
 
+/// (Re)create the mirror symlinks. Best-effort like the runtime-deps links:
+/// on a platform without symlink permission the run keeps the pre-fix
+/// resolution behavior instead of failing materialization.
+fn materialize_mirrors(mirrors: &[(PathBuf, PathBuf)]) {
+    for (target, source) in mirrors {
+        let source = vize_carton::path::canonicalize_non_verbatim(source);
+        if symlink_path(&source, target).is_err() {
+            continue;
+        }
+    }
+}
+
 impl VirtualProject {
-    /// Real per-package `node_modules` directories the mirror must expose at
-    /// the matching project-relative location, computed from every registered
-    /// original path (checked sources and passthrough dependencies alike).
-    pub(super) fn package_node_modules_mirrors(&self) -> Vec<(PathBuf, PathBuf)> {
-        package_node_modules_mirrors(
+    /// Mirror per-package `node_modules` links into the virtual tree and
+    /// return the roots the materialize GC must preserve: the special-cased
+    /// runtime-deps mirror plus every per-package link target computed from
+    /// the registered original paths (checked sources and passthrough
+    /// dependencies alike). Folded into one call so `materialize` stays under
+    /// the source-length budget.
+    pub(super) fn materialize_package_node_modules(&self) -> CorsaResult<Vec<PathBuf>> {
+        let mirrors = package_node_modules_mirrors(
             &self.project_root,
             &self.virtual_root,
             self.original_index
                 .keys()
                 .cloned()
                 .chain(self.passthrough_files.values().cloned()),
-        )
-    }
-
-    /// (Re)create the mirror symlinks. Best-effort like the runtime-deps
-    /// links: on a platform without symlink permission the run keeps the
-    /// pre-fix resolution behavior instead of failing materialization.
-    pub(super) fn materialize_package_node_modules(
-        &self,
-        mirrors: &[(PathBuf, PathBuf)],
-    ) -> CorsaResult<()> {
-        for (target, source) in mirrors {
-            let source = vize_carton::path::canonicalize_non_verbatim(source);
-            if symlink_path(&source, target).is_err() {
-                continue;
-            }
-        }
-        Ok(())
+        );
+        let mut preserved = Vec::with_capacity(mirrors.len() + 1);
+        preserved.push(self.virtual_root.join("node_modules"));
+        preserved.extend(mirrors.iter().map(|(target, _)| target.clone()));
+        materialize_mirrors(&mirrors);
+        Ok(preserved)
     }
 }
 

--- a/crates/vize_canon/tests/subpackage_registry_dependency.rs
+++ b/crates/vize_canon/tests/subpackage_registry_dependency.rs
@@ -1,0 +1,108 @@
+//! Registry dependencies installed only in a sub-package's `node_modules`
+//! (#3366).
+//!
+//! A pnpm workspace links a package's own dependencies into
+//! `<package>/node_modules`, not the workspace root's. When the effective
+//! tsconfig lives at the workspace root, the virtual project anchors there
+//! and a mirrored file's ancestor walk never passes the sub-package's real
+//! `node_modules`, so a bare import died with a spurious TS2307 even though
+//! `tsgo` on the same tsconfig resolves it. The mirror now symlinks each
+//! per-package `node_modules` into the matching project-relative location,
+//! so the dependency's type contract is enforced instead of excused.
+
+use std::path::{Path, PathBuf};
+
+use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait};
+
+const MAIN: &str = r#"import { answer } from 'acme';
+export const bad: string = answer;
+"#;
+
+#[test]
+fn subpackage_registry_dependency_enforces_its_contract() {
+    let project = create_workspace();
+    let diagnostics = project_diagnostics(project.path());
+
+    assert!(
+        diagnostics.contains(&Some(2322)),
+        "the resolved dependency must enforce its contract (string ≠ number): {diagnostics:?}"
+    );
+    assert!(
+        !diagnostics.contains(&Some(2307)),
+        "the dependency exists in the sub-package's node_modules and must resolve: {diagnostics:?}"
+    );
+
+    let mirror = project
+        .path()
+        .join("node_modules/.vize/canon/apps/app/node_modules");
+    assert!(
+        std::fs::symlink_metadata(&mirror)
+            .map(|metadata| metadata.file_type().is_symlink())
+            .unwrap_or(false),
+        "the sub-package node_modules must be mirrored as a symlink at {}",
+        mirror.display()
+    );
+}
+
+fn project_diagnostics(root: &Path) -> Vec<Option<u32>> {
+    let mut checker = BatchTypeChecker::new(root).expect("type checker should start");
+    checker.scan_project().expect("project should scan");
+    checker
+        .check_project()
+        .expect("project should type check")
+        .diagnostics
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+fn create_workspace() -> tempfile::TempDir {
+    let project = tempfile::tempdir().expect("temporary project should be created");
+    write_file(
+        project.path(),
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["apps/**/*"]
+}"#,
+    );
+    // Ambient vue runtime stub, same as the other canon integration fixtures.
+    write_file(
+        project.path(),
+        "node_modules/vue/package.json",
+        r#"{ "name": "vue", "types": "index.d.ts" }"#,
+    );
+    write_file(
+        project.path(),
+        "node_modules/vue/index.d.ts",
+        "export interface ComponentPublicInstance {}\n",
+    );
+    // The registry dependency exists ONLY in the sub-package's node_modules.
+    write_file(
+        project.path(),
+        "apps/app/node_modules/acme/package.json",
+        r#"{ "name": "acme", "types": "index.d.ts" }"#,
+    );
+    write_file(
+        project.path(),
+        "apps/app/node_modules/acme/index.d.ts",
+        "export declare const answer: number;\n",
+    );
+    write_file(project.path(), "apps/app/src/main.ts", MAIN);
+    project
+}
+
+fn write_file(root: &Path, path: &str, source: &str) {
+    let path: PathBuf = root.join(path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("parent directory should be created");
+    }
+    std::fs::write(path, source).expect("fixture should be written");
+}


### PR DESCRIPTION
Closes #3366.

## Change class

Virtual TypeScript and type checking (module resolution inside the materialized project).

## Defect

In a pnpm workspace (default isolated linker), a package's own dependencies are linked into `<package>/node_modules`, not the workspace root's. When the effective tsconfig anchors the virtual project at the workspace root, a mirrored file keeps the project-relative shape of its original (`apps/app/vite.config.ts` → `<canon>/apps/app/vite.config.ts`), so Corsa's ancestor walk for a bare specifier never passes the sub-package's real `node_modules`. `<canon>/node_modules` only carries the special-cased `vue`/`vite`/`@vue` set, and the next real ancestor is the workspace-root `node_modules` — the import dies with a spurious TS2307 while `tsgo` on the same tsconfig resolves it.

The issue body has a six-file minimal repro (registry dep only in `apps/app/node_modules` + workspace-root tsconfig → TS2307; same dep at the root → clean).

## Fix

- Compute the real per-package `node_modules` directories from every registered original path (checked sources and passthrough dependencies), skipping the project root itself (kept special-cased) and any ancestor already inside a `node_modules` tree (store-internal paths must not be mirrored back). New `virtual_project/package_node_modules.rs`.
- Symlink each into the mirror at the matching project-relative location and preserve the links across the materialize GC (`preserved_roots`), so stale links from a previous file set are still pruned.
- Share `symlink_path`/`symlink_matches` in `materialize_fs` (moved out of `runtime_deps`).
- Windows: fall back to a **directory junction** when `symlink_dir` is denied — junctions need no privilege on stock Windows (no Developer Mode/elevation), the same reason pnpm links with junctions. Link detection now probes `read_link` instead of `FileType::is_symlink` (which is false for junctions), so junction links round-trip idempotently and stub dirs never write through a link into a real package. Adds the `junction` crate as a Windows-only dependency.

## Tests

- `virtual_project::package_node_modules` unit tests: sub-package mapping, project-root exclusion, `node_modules`-tree exclusion, ancestor dedup.
- `tests/subpackage_registry_dependency.rs` (integration): a workspace-root tsconfig plus a registry dep present only in `apps/app/node_modules` must enforce its contract (`TS2322` on a deliberate misuse) with no `TS2307`, and the mirror link must exist at `<canon>/apps/app/node_modules`.

## Verification

```sh
cargo test -p vize_canon --lib
cargo test -p vize_canon --test subpackage_registry_dependency
cargo fmt --all -- --check
cargo clippy -p vize_canon --all-targets
```

- New unit tests: 4/4 pass. New integration test: fails on the base tree (reproduces #3366), passes with the fix.
- Full `cargo test -p vize_canon --no-fail-fast`: failure set is byte-identical to the base tree on this machine (pre-existing Windows/symlink-privilege and path-separator environment failures); the fix adds 5 passes and 0 new failures.
- End-to-end with a locally built CLI on the #3366 minimal repro: pre-fix npm binary reports TS2307; patched binary reports no errors, and a deliberate `defineConfig` misuse reports `TS2322 Type 'UserConfigExport' is not assignable to type 'number'`, proving the package types are genuinely consumed through the mirror.

## Notes

- The fix also un-breaks `vize check` self-hosting in pnpm monorepos whose config files import `vize`/`@vizejs/*` from the app package while sharing a root tsconfig (the original report shape).
- Junction fallback additionally lets the existing `vue`/`vite`/`@vue` runtime-deps links materialize on privilege-less Windows instead of silently degrading to stubs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788006162&installation_model_id=422833&pr_number=3381&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F3381&signature=243a313b540be9040422c0b7872bdac3ba8f733fe08917d1dc55bf38f911b831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for dependencies installed in sub-package `node_modules` directories via automatic mirror/symlink materialization.
  * Enhanced filesystem link handling across Unix and Windows, including Windows junction fallback behavior.
  * Virtual project cleanup now preserves the relevant `node_modules` mirror roots so mappings survive pruning.
* **Bug Fixes**
  * Prevented incorrect removal/recreation of existing link/junction-style directories, improving TypeScript type resolution for sub-packages.
* **Tests**
  * Added an integration test validating sub-package `node_modules` mirroring (as symlinks) and enforcing the expected TypeScript contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->