### PR TITLE
fix(canon): keep the type side of plain-script enum and class exports

### DIFF
--- a/crates/vize/tests/check_plain_script_named_exports_cli.rs
+++ b/crates/vize/tests/check_plain_script_named_exports_cli.rs
@@ -17,23 +17,45 @@ fn unique_case_dir(name: &str) -> std::path::PathBuf {
         .join(format!("{name}-{}-{case_id}", std::process::id()))
 }
 
-fn link_workspace_node_modules(project_root: &Path) {
+/// Mirror the workspace dependencies into a **real** `node_modules` directory.
+///
+/// A `node_modules` that is itself a symlink made the Corsa CLI drop every
+/// diagnostic for the project (fixed separately in #3374), which silently turned
+/// the `errorCount` assertions below into no-ops. Installed trees keep a real
+/// directory at `node_modules` and link the individual packages inside it, so
+/// this reproduces that shape and the assertions stay load-bearing.
+///
+/// `.vize` is deliberately not mirrored: that is where vize writes the virtual
+/// TypeScript for the project, and linking it out to the shared workspace copy
+/// puts the generated files behind a symlink again — the same layout that
+/// swallows the diagnostics, plus a collision with every concurrent case.
+fn mirror_workspace_node_modules(project_root: &Path) {
     let source = workspace_root().join("node_modules");
     let target = project_root.join("node_modules");
     if target.exists() {
         return;
     }
-    #[cfg(unix)]
-    std::os::unix::fs::symlink(source, target).unwrap();
-    #[cfg(windows)]
-    std::os::windows::fs::symlink_dir(source, target).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
+    let Ok(entries) = std::fs::read_dir(&source) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if entry.file_name() == std::ffi::OsStr::new(".vize") {
+            continue;
+        }
+        let link = target.join(entry.file_name());
+        #[cfg(unix)]
+        let _ = std::os::unix::fs::symlink(entry.path(), &link);
+        #[cfg(windows)]
+        let _ = std::os::windows::fs::symlink_dir(entry.path(), &link);
+    }
 }
 
 fn create_cli_project(name: &str, files: &[(&str, &str)]) -> std::path::PathBuf {
     let project_root = unique_case_dir(name);
     let _ = std::fs::remove_dir_all(&project_root);
     std::fs::create_dir_all(&project_root).unwrap();
-    link_workspace_node_modules(&project_root);
+    mirror_workspace_node_modules(&project_root);
     std::fs::write(
         project_root.join("tsconfig.json"),
         r#"{
@@ -73,6 +95,15 @@ fn resolve_test_corsa_path() -> Option<String> {
         .then(|| workspace_bin.display().to_string())
 }
 
+fn run_check_json(project_root: &Path, corsa_path: &str) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", ".", "--format", "json"])
+        .output()
+        .unwrap()
+}
+
 #[test]
 fn check_preserves_named_exports_from_normal_script_vue() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
@@ -96,44 +127,138 @@ export enum DiffDisplayMode {
   Unified = 'unified',
   Split = 'split',
 }
+
+export enum DiffRevision {
+  Head,
+  Base,
+}
+
+export const enum DiffMarker {
+  Added = 'added',
+}
+
+export class DiffCursor {
+  line = 0;
+}
 </script>
 "#,
             ),
             (
                 "src/pages/Consumer.vue",
                 r#"<script setup lang="ts">
-import { DiffDisplayMode, setupParseMdFileDialogCtx } from "../components/ParseMdFileDialog.vue";
+import {
+  DiffCursor,
+  DiffDisplayMode,
+  DiffMarker,
+  DiffRevision,
+  setupParseMdFileDialogCtx,
+} from "../components/ParseMdFileDialog.vue";
 
 const ctx = setupParseMdFileDialogCtx();
 const ready: boolean = ctx.ready;
+
+// Every value+type declaration has to survive the plain-<script> export bridge
+// in *both* declaration spaces: the annotation is the type side, the
+// initializer the value side.
 const mode: DiffDisplayMode = DiffDisplayMode.Unified;
+const revision: DiffRevision = DiffRevision.Head;
+const marker: DiffMarker = DiffMarker.Added;
+const cursor: DiffCursor = new DiffCursor();
+
+// The enum type must stay nominal rather than widen to its member primitives,
+// which is what a `typeof`-only bridge would have produced.
+const line: number = cursor.line;
 </script>
 
 <template>
-  <div>{{ ready }} {{ mode }}</div>
+  <div>{{ ready }} {{ mode }} {{ revision }} {{ marker }} {{ cursor }} {{ line }}</div>
 </template>
 "#,
             ),
         ],
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
-        .current_dir(&project_root)
-        .env("CORSA_PATH", corsa_path)
-        .args(["check", ".", "--format", "json"])
-        .output()
-        .unwrap();
-
-    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
-    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let output = run_check_json(&project_root, &corsa_path);
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
     assert!(
         output.status.success(),
         "check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
 
-    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
     assert_eq!(json["errorCount"], 0, "{stdout}\n{stderr}");
     assert!(!stdout.contains("TS2614"), "{stdout}\n{stderr}");
+    assert!(!stdout.contains("TS2749"), "{stdout}\n{stderr}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+/// The mirror of the test above: a value-only export must not be handed a type
+/// meaning it never had. `TS2749` here is the *correct* answer, and its presence
+/// also proves the harness above is not passing vacuously on a project whose
+/// diagnostics were dropped.
+#[test]
+fn check_reports_value_only_plain_script_exports_used_as_types() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "normal-script-value-only-exports",
+        &[
+            (
+                "src/components/ValueOnly.vue",
+                r#"<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "ValueOnly",
+});
+
+export const pageSize = 20;
+
+export function toPageCount(total: number) {
+  return Math.ceil(total / pageSize);
+}
+</script>
+"#,
+            ),
+            (
+                "src/pages/ValueOnlyConsumer.vue",
+                r#"<script setup lang="ts">
+import { pageSize, toPageCount } from "../components/ValueOnly.vue";
+
+const size: number = pageSize;
+const count: number = toPageCount(100);
+
+const badSize: pageSize = 20;
+const badCount: toPageCount = 5;
+</script>
+
+<template>
+  <div>{{ size }} {{ count }} {{ badSize }} {{ badCount }}</div>
+</template>
+"#,
+            ),
+        ],
+    );
+
+    // No `status.success()` assertion here: reporting the errors is the point,
+    // and `vize check` exits non-zero when it finds any.
+    let output = run_check_json(&project_root, &corsa_path);
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(json["errorCount"], 2, "{stdout}\n{stderr}");
+    assert!(
+        stdout.contains("'pageSize' refers to a value, but is being used as a type here"),
+        "an exported const must not gain a type meaning:\n{stdout}\n{stderr}"
+    );
+    assert!(
+        stdout.contains("'toPageCount' refers to a value, but is being used as a type here"),
+        "an exported function must not gain a type meaning:\n{stdout}\n{stderr}"
+    );
 
     let _ = std::fs::remove_dir_all(&project_root);
 }

--- a/crates/vize_canon/src/virtual_ts/generator/script_module.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module.rs
@@ -1,22 +1,18 @@
 //! Module-scope facts collected from normal Vue `<script>` blocks.
 
+mod plain_exports;
+
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{BindingPattern, Declaration, Statement, TSEnumDeclaration};
+use oxc_ast::ast::{Declaration, Statement, TSEnumDeclaration};
 use oxc_ast_visit::Visit;
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
-use vize_carton::{CompactString, FxHashSet, String as VizeString, append};
+use vize_carton::{CompactString, FxHashSet, String as VizeString};
 
-pub(super) fn collect_normal_script_named_value_exports(
-    script: Option<&str>,
-    has_script_setup: bool,
-    has_plain_script_scope: bool,
-) -> Vec<CompactString> {
-    if has_script_setup || !has_plain_script_scope {
-        return Vec::new();
-    }
-    script.map(collect_named_value_exports).unwrap_or_default()
-}
+pub(super) use plain_exports::{
+    collect_normal_script_named_value_exports, emit_setup_invocation_and_exports,
+    push_setup_return_fields,
+};
 
 pub(super) fn collect_line_module_spans(script: &str) -> Vec<(u32, u32)> {
     let mut spans = Vec::new();
@@ -96,26 +92,6 @@ pub(super) fn emit_import_meta_polyfill(ts: &mut VizeString, script: &str) -> bo
     uses_import_meta
 }
 
-pub(super) fn push_setup_return_fields(names: &[CompactString], fields: &mut Vec<CompactString>) {
-    fields.extend(names.iter().cloned());
-}
-
-pub(super) fn emit_setup_invocation_and_exports(ts: &mut VizeString, names: &[CompactString]) {
-    if names.is_empty() {
-        ts.push_str("__setup();\n\n");
-        return;
-    }
-
-    ts.push_str("const __vize_plain_script_exports = __setup();\n");
-    for name in names {
-        append!(
-            *ts,
-            "export const {name} = __vize_plain_script_exports.{name};\n"
-        );
-    }
-    ts.push('\n');
-}
-
 pub(super) fn collect_const_enum_names(script: &str) -> FxHashSet<CompactString> {
     let allocator = Allocator::default();
     let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
@@ -141,71 +117,6 @@ impl<'a> Visit<'a> for ConstEnumNames {
     }
 }
 
-fn collect_named_value_exports(script: &str) -> Vec<CompactString> {
-    let allocator = Allocator::default();
-    let parsed = Parser::new(&allocator, script, SourceType::ts().with_module(true)).parse();
-    let parsed = if parsed.panicked || !parsed.errors.is_empty() {
-        Parser::new(&allocator, script, SourceType::tsx().with_module(true)).parse()
-    } else {
-        parsed
-    };
-    if parsed.panicked || !parsed.errors.is_empty() {
-        return Vec::new();
-    }
-
-    let mut seen = FxHashSet::default();
-    let mut names = Vec::new();
-    for statement in &parsed.program.body {
-        collect_statement_exports(statement, &mut seen, &mut names);
-    }
-    names
-}
-
-fn collect_statement_exports(
-    statement: &Statement<'_>,
-    seen: &mut FxHashSet<CompactString>,
-    names: &mut Vec<CompactString>,
-) {
-    let Statement::ExportNamedDeclaration(export) = statement else {
-        return;
-    };
-    if export.source.is_some() || export.export_kind.is_type() {
-        return;
-    }
-    let Some(declaration) = export.declaration.as_ref() else {
-        return;
-    };
-    collect_declaration_exports(declaration, seen, names);
-}
-
-fn collect_declaration_exports(
-    declaration: &Declaration<'_>,
-    seen: &mut FxHashSet<CompactString>,
-    names: &mut Vec<CompactString>,
-) {
-    match declaration {
-        Declaration::VariableDeclaration(variable) => {
-            for declarator in &variable.declarations {
-                collect_binding_names(&declarator.id, seen, names);
-            }
-        }
-        Declaration::FunctionDeclaration(function) => {
-            if let Some(id) = &function.id {
-                push_name(id.name.as_str(), seen, names);
-            }
-        }
-        Declaration::ClassDeclaration(class) => {
-            if let Some(id) = &class.id {
-                push_name(id.name.as_str(), seen, names);
-            }
-        }
-        Declaration::TSEnumDeclaration(enumeration) => {
-            push_name(enumeration.id.name.as_str(), seen, names);
-        }
-        _ => {}
-    }
-}
-
 fn declaration_has_runtime_value(declaration: &Declaration<'_>) -> bool {
     matches!(
         declaration,
@@ -214,42 +125,6 @@ fn declaration_has_runtime_value(declaration: &Declaration<'_>) -> bool {
             | Declaration::ClassDeclaration(_)
             | Declaration::TSEnumDeclaration(_)
     )
-}
-
-fn collect_binding_names(
-    pattern: &BindingPattern<'_>,
-    seen: &mut FxHashSet<CompactString>,
-    names: &mut Vec<CompactString>,
-) {
-    match pattern {
-        BindingPattern::BindingIdentifier(id) => push_name(id.name.as_str(), seen, names),
-        BindingPattern::ObjectPattern(object) => {
-            for property in &object.properties {
-                collect_binding_names(&property.value, seen, names);
-            }
-            if let Some(rest) = &object.rest {
-                collect_binding_names(&rest.argument, seen, names);
-            }
-        }
-        BindingPattern::ArrayPattern(array) => {
-            for element in array.elements.iter().flatten() {
-                collect_binding_names(element, seen, names);
-            }
-            if let Some(rest) = &array.rest {
-                collect_binding_names(&rest.argument, seen, names);
-            }
-        }
-        BindingPattern::AssignmentPattern(assignment) => {
-            collect_binding_names(&assignment.left, seen, names);
-        }
-    }
-}
-
-fn push_name(name: &str, seen: &mut FxHashSet<CompactString>, names: &mut Vec<CompactString>) {
-    let name = CompactString::new(name);
-    if seen.insert(name.clone()) {
-        names.push(name);
-    }
 }
 
 fn include_leading_ts_directive_comments(script: &str, spans: Vec<(u32, u32)>) -> Vec<(u32, u32)> {
@@ -299,10 +174,7 @@ fn contains_ts_suppression_directive(comment: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        CompactString, collect_line_module_spans, collect_named_value_export_starts,
-        collect_named_value_exports,
-    };
+    use super::{collect_line_module_spans, collect_named_value_export_starts};
 
     #[test]
     fn collect_import_span_includes_adjacent_ts_ignore_comment_group() {
@@ -326,15 +198,6 @@ mod tests {
             &script[spans[0].0 as usize..spans[0].1 as usize],
             "import Chart from \"chart.js/auto/auto\";"
         );
-    }
-
-    #[test]
-    fn collect_named_value_exports_includes_ts_enums() {
-        let names = collect_named_value_exports(
-            "export enum DiffDisplayMode { Hidden = 'hidden' }\nexport type Props = {}\n",
-        );
-
-        assert_eq!(names, vec![CompactString::new("DiffDisplayMode")]);
     }
 
     #[test]

--- a/crates/vize_canon/src/virtual_ts/generator/script_module/plain_exports.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module/plain_exports.rs
@@ -1,0 +1,333 @@
+//! Re-exports for names a plain (non-setup) `<script>` block declares.
+//!
+//! The plain-`<script>` body is moved inside `__setup()` so its diagnostics stay
+//! anchored to user code, which puts every declaration out of reach of module
+//! consumers. A bridge at module scope hands the bindings back:
+//!
+//! ```ignore
+//! const __vize_plain_script_exports = __setup();
+//! export const Mode = __vize_plain_script_exports.Mode;
+//! ```
+//!
+//! That bridge carries only the *value* meaning. `enum` and `class` declare a
+//! value **and** a type, so a consumer writing `const m: Mode = Mode.Split`
+//! used to hit TS2749 ("refers to a value, but is being used as a type here").
+//! Those kinds get a matching type alias so both meanings survive the move,
+//! while `const`/`function` — value-only in the source — stay value-only here.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{BindingPattern, Declaration, Statement};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{CompactString, FxHashSet, String as VizeString, append};
+
+/// Which declaration spaces a plain-`<script>` export has to reach.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlainScriptExportKind {
+    /// `const`/`let`/`function`: a value only. A type alias here would invent a
+    /// type meaning the source never had.
+    Value,
+    /// `enum`/`const enum`: the type is the union of the member types, which
+    /// `(typeof E)[keyof typeof E]` reconstructs from the enum object without
+    /// widening string members to `string`.
+    Enum,
+    /// `class`: the type is the instance type. `InstanceType` accepts abstract
+    /// constructors, so abstract and generic classes ride the same shape.
+    Class,
+}
+
+impl PlainScriptExportKind {
+    /// The type-side alias body, or `None` when the declaration is value-only.
+    fn type_alias_body(self, name: &str) -> Option<VizeString> {
+        match self {
+            Self::Value => None,
+            Self::Enum => Some(vize_carton::cstr!("(typeof {name})[keyof typeof {name}]")),
+            Self::Class => Some(vize_carton::cstr!("InstanceType<typeof {name}>")),
+        }
+    }
+}
+
+/// A name a plain `<script>` exports, plus the declaration spaces it occupies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PlainScriptExport {
+    pub(crate) name: CompactString,
+    pub(crate) kind: PlainScriptExportKind,
+}
+
+pub(crate) fn collect_normal_script_named_value_exports(
+    script: Option<&str>,
+    has_script_setup: bool,
+    has_plain_script_scope: bool,
+) -> Vec<PlainScriptExport> {
+    if has_script_setup || !has_plain_script_scope {
+        return Vec::new();
+    }
+    script.map(collect_named_value_exports).unwrap_or_default()
+}
+
+pub(crate) fn push_setup_return_fields(
+    exports: &[PlainScriptExport],
+    fields: &mut Vec<CompactString>,
+) {
+    fields.extend(exports.iter().map(|export| export.name.clone()));
+}
+
+pub(crate) fn emit_setup_invocation_and_exports(
+    ts: &mut VizeString,
+    exports: &[PlainScriptExport],
+) {
+    if exports.is_empty() {
+        ts.push_str("__setup();\n\n");
+        return;
+    }
+
+    ts.push_str("const __vize_plain_script_exports = __setup();\n");
+    for export in exports {
+        let name = &export.name;
+        append!(
+            *ts,
+            "export const {name} = __vize_plain_script_exports.{name};\n"
+        );
+        // A value+type declaration loses its type meaning when the bridge only
+        // re-exports the value. The alias restores it in the type space, which
+        // is disjoint from the `const` above, so both names can coexist.
+        if let Some(body) = export.kind.type_alias_body(name) {
+            append!(*ts, "export type {name} = {body};\n");
+        }
+    }
+    ts.push('\n');
+}
+
+fn collect_named_value_exports(script: &str) -> Vec<PlainScriptExport> {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script, SourceType::ts().with_module(true)).parse();
+    let parsed = if parsed.panicked || !parsed.errors.is_empty() {
+        Parser::new(&allocator, script, SourceType::tsx().with_module(true)).parse()
+    } else {
+        parsed
+    };
+    if parsed.panicked || !parsed.errors.is_empty() {
+        return Vec::new();
+    }
+
+    let mut seen = FxHashSet::default();
+    let mut exports = Vec::new();
+    for statement in &parsed.program.body {
+        collect_statement_exports(statement, &mut seen, &mut exports);
+    }
+    exports
+}
+
+fn collect_statement_exports(
+    statement: &Statement<'_>,
+    seen: &mut FxHashSet<CompactString>,
+    exports: &mut Vec<PlainScriptExport>,
+) {
+    let Statement::ExportNamedDeclaration(export) = statement else {
+        return;
+    };
+    if export.source.is_some() || export.export_kind.is_type() {
+        return;
+    }
+    let Some(declaration) = export.declaration.as_ref() else {
+        return;
+    };
+    collect_declaration_exports(declaration, seen, exports);
+}
+
+fn collect_declaration_exports(
+    declaration: &Declaration<'_>,
+    seen: &mut FxHashSet<CompactString>,
+    exports: &mut Vec<PlainScriptExport>,
+) {
+    match declaration {
+        Declaration::VariableDeclaration(variable) => {
+            for declarator in &variable.declarations {
+                collect_binding_names(&declarator.id, seen, exports);
+            }
+        }
+        Declaration::FunctionDeclaration(function) => {
+            if let Some(id) = &function.id {
+                push_export(
+                    id.name.as_str(),
+                    PlainScriptExportKind::Value,
+                    seen,
+                    exports,
+                );
+            }
+        }
+        Declaration::ClassDeclaration(class) => {
+            if let Some(id) = &class.id {
+                push_export(
+                    id.name.as_str(),
+                    PlainScriptExportKind::Class,
+                    seen,
+                    exports,
+                );
+            }
+        }
+        Declaration::TSEnumDeclaration(enumeration) => {
+            // `const enum` shares the shape: its members are still reachable
+            // through the enum object in a type query.
+            push_export(
+                enumeration.id.name.as_str(),
+                PlainScriptExportKind::Enum,
+                seen,
+                exports,
+            );
+        }
+        _ => {}
+    }
+}
+
+fn collect_binding_names(
+    pattern: &BindingPattern<'_>,
+    seen: &mut FxHashSet<CompactString>,
+    exports: &mut Vec<PlainScriptExport>,
+) {
+    match pattern {
+        BindingPattern::BindingIdentifier(id) => {
+            push_export(
+                id.name.as_str(),
+                PlainScriptExportKind::Value,
+                seen,
+                exports,
+            );
+        }
+        BindingPattern::ObjectPattern(object) => {
+            for property in &object.properties {
+                collect_binding_names(&property.value, seen, exports);
+            }
+            if let Some(rest) = &object.rest {
+                collect_binding_names(&rest.argument, seen, exports);
+            }
+        }
+        BindingPattern::ArrayPattern(array) => {
+            for element in array.elements.iter().flatten() {
+                collect_binding_names(element, seen, exports);
+            }
+            if let Some(rest) = &array.rest {
+                collect_binding_names(&rest.argument, seen, exports);
+            }
+        }
+        BindingPattern::AssignmentPattern(assignment) => {
+            collect_binding_names(&assignment.left, seen, exports);
+        }
+    }
+}
+
+fn push_export(
+    name: &str,
+    kind: PlainScriptExportKind,
+    seen: &mut FxHashSet<CompactString>,
+    exports: &mut Vec<PlainScriptExport>,
+) {
+    let name = CompactString::new(name);
+    // Declaration merging (two `export enum Mode` blocks) surfaces one name
+    // twice; a second `export const`/`export type` pair would be a duplicate
+    // binding, so only the first occurrence is bridged.
+    if seen.insert(name.clone()) {
+        exports.push(PlainScriptExport { name, kind });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CompactString, PlainScriptExport, PlainScriptExportKind, collect_named_value_exports,
+        emit_setup_invocation_and_exports,
+    };
+
+    fn export(name: &str, kind: PlainScriptExportKind) -> PlainScriptExport {
+        PlainScriptExport {
+            name: CompactString::new(name),
+            kind,
+        }
+    }
+
+    #[test]
+    fn collect_named_value_exports_includes_ts_enums() {
+        let exports = collect_named_value_exports(
+            "export enum DiffDisplayMode { Hidden = 'hidden' }\nexport type Props = {}\n",
+        );
+
+        assert_eq!(
+            exports,
+            vec![export("DiffDisplayMode", PlainScriptExportKind::Enum)]
+        );
+    }
+
+    #[test]
+    fn declaration_kinds_are_classified_by_declaration_space() {
+        let exports = collect_named_value_exports(
+            "export const plain = 1;\nexport function helper() {}\nexport class Widget {}\nexport enum Mode { A = 'a' }\nexport const enum ConstMode { B = 'b' }\n",
+        );
+
+        assert_eq!(
+            exports,
+            vec![
+                export("plain", PlainScriptExportKind::Value),
+                export("helper", PlainScriptExportKind::Value),
+                export("Widget", PlainScriptExportKind::Class),
+                export("Mode", PlainScriptExportKind::Enum),
+                export("ConstMode", PlainScriptExportKind::Enum),
+            ]
+        );
+    }
+
+    #[test]
+    fn value_and_type_declarations_are_bridged_in_both_declaration_spaces() {
+        let mut ts = vize_carton::String::default();
+        emit_setup_invocation_and_exports(
+            &mut ts,
+            &[
+                export("Mode", PlainScriptExportKind::Enum),
+                export("Widget", PlainScriptExportKind::Class),
+            ],
+        );
+
+        assert!(ts.contains("export const Mode = __vize_plain_script_exports.Mode;\n"));
+        assert!(ts.contains("export type Mode = (typeof Mode)[keyof typeof Mode];\n"));
+        assert!(ts.contains("export const Widget = __vize_plain_script_exports.Widget;\n"));
+        assert!(ts.contains("export type Widget = InstanceType<typeof Widget>;\n"));
+    }
+
+    #[test]
+    fn value_only_declarations_never_gain_a_type_export() {
+        let mut ts = vize_carton::String::default();
+        emit_setup_invocation_and_exports(
+            &mut ts,
+            &[
+                export("plain", PlainScriptExportKind::Value),
+                export("helper", PlainScriptExportKind::Value),
+            ],
+        );
+
+        assert!(ts.contains("export const plain = __vize_plain_script_exports.plain;\n"));
+        assert!(ts.contains("export const helper = __vize_plain_script_exports.helper;\n"));
+        assert!(
+            !ts.contains("export type "),
+            "value-only exports must not invent a type meaning:\n{ts}"
+        );
+    }
+
+    #[test]
+    fn merged_enum_declarations_are_bridged_once() {
+        let exports = collect_named_value_exports(
+            "export enum Mode { A = 'a' }\nexport enum Mode { B = 'b' }\n",
+        );
+        assert_eq!(exports, vec![export("Mode", PlainScriptExportKind::Enum)]);
+
+        let mut ts = vize_carton::String::default();
+        emit_setup_invocation_and_exports(&mut ts, &exports);
+        assert_eq!(ts.matches("export const Mode =").count(), 1);
+        assert_eq!(ts.matches("export type Mode =").count(), 1);
+    }
+
+    #[test]
+    fn no_exports_keeps_the_bare_setup_invocation() {
+        let mut ts = vize_carton::String::default();
+        emit_setup_invocation_and_exports(&mut ts, &[]);
+        assert_eq!(ts.as_str(), "__setup();\n\n");
+    }
+}

--- a/crates/vize_canon/tests/plain_script_named_exports.rs
+++ b/crates/vize_canon/tests/plain_script_named_exports.rs
@@ -62,6 +62,102 @@ export const setupParseMdFileDialogCtx = () => ({ ready: true });
 }
 
 #[test]
+fn normal_script_value_and_type_declarations_are_exported_in_both_spaces() {
+    let case_dir = unique_case_dir("plain-script-value-and-type-exports");
+    let _ = fs::remove_dir_all(&case_dir);
+    let src_dir = case_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    let vue_path = src_dir.join("DiffViewer.vue");
+    let vue_content = r#"<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "DiffViewer",
+});
+
+export enum DiffDisplayMode {
+  Unified = 'unified',
+  Split = 'split',
+}
+
+export const enum DiffMarker {
+  Added = 'added',
+}
+
+export class DiffCursor {
+  line = 0;
+}
+
+export const pageSize = 20;
+
+export function toPageCount(total: number) {
+  return total;
+}
+</script>
+"#;
+    fs::write(&vue_path, vue_content).unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.register_vue_file(&vue_path, vue_content).unwrap();
+    let content = project
+        .find_by_original(&vue_path)
+        .unwrap()
+        .content
+        .as_str();
+
+    // An `enum`/`class` declares a value *and* a type. Bridging only the value
+    // out of `__setup()` is what made consumers hit TS2749.
+    for (value, type_side) in [
+        (
+            "export const DiffDisplayMode = __vize_plain_script_exports.DiffDisplayMode;",
+            "export type DiffDisplayMode = (typeof DiffDisplayMode)[keyof typeof DiffDisplayMode];",
+        ),
+        (
+            "export const DiffMarker = __vize_plain_script_exports.DiffMarker;",
+            "export type DiffMarker = (typeof DiffMarker)[keyof typeof DiffMarker];",
+        ),
+        (
+            "export const DiffCursor = __vize_plain_script_exports.DiffCursor;",
+            "export type DiffCursor = InstanceType<typeof DiffCursor>;",
+        ),
+    ] {
+        assert!(
+            content.contains(value),
+            "value side must stay available: {value}\n{content}"
+        );
+        assert!(
+            content.contains(type_side),
+            "type side must stay available: {type_side}\n{content}"
+        );
+    }
+
+    // A value-only declaration must not be handed a type meaning it never had.
+    for (value, absent_type_side) in [
+        (
+            "export const pageSize = __vize_plain_script_exports.pageSize;",
+            "export type pageSize ",
+        ),
+        (
+            "export const toPageCount = __vize_plain_script_exports.toPageCount;",
+            "export type toPageCount ",
+        ),
+    ] {
+        assert!(
+            content.contains(value),
+            "value-only export must stay available: {value}\n{content}"
+        );
+        assert!(
+            !content.contains(absent_type_side),
+            "value-only export must not gain a type export: {absent_type_side}\n{content}"
+        );
+    }
+
+    assert_ts_parses(content);
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
 fn normal_script_exported_type_body_stays_intact_with_exported_const_typeof() {
     let case_dir = unique_case_dir("plain-script-exported-type-body");
     let _ = fs::remove_dir_all(&case_dir);


### PR DESCRIPTION
## The defect

An `enum` exported from a plain (non-setup) `<script>` block in an SFC lost its **type** side. Using it as a type raised a false positive:

```
TS2749: 'DiffDisplayMode' refers to a value, but is being used as a type here. Did you mean 'typeof DiffDisplayMode'?
```

Reproduced on `origin/main` with this pair of SFCs (`vize check . --format json` → `errorCount 1`):

```vue
<!-- ParseMdFileDialog.vue -->
<script lang="ts">
export enum DiffDisplayMode { Unified = 'unified', Split = 'split' }
</script>
```
```vue
<!-- Consumer.vue -->
<script setup lang="ts">
import { DiffDisplayMode } from "../components/ParseMdFileDialog.vue";
const mode: DiffDisplayMode = DiffDisplayMode.Unified; // TS2749
</script>
```

## Root cause

A plain `<script>` body is moved *inside* `__setup()` so its diagnostics stay anchored to user code. That puts every declaration out of reach of module consumers, so a module-scope bridge hands the bindings back:

```ts
const __vize_plain_script_exports = __setup();
export const DiffDisplayMode = __vize_plain_script_exports.DiffDisplayMode;
```

`export const X = ...` reaches only the **value** declaration space. For a declaration that occupies both spaces, the type meaning is silently dropped at the module boundary.

## Why the existing test was vacuous

`crates/vize/tests/check_plain_script_named_exports_cli.rs::check_preserves_named_exports_from_normal_script_vue` already exercised exactly this shape and was green — because its fixture symlinked the whole workspace `node_modules` into the project root, and in that layout the Corsa CLI dropped **every** diagnostic for the project (the separate bug fixed in #3374). The `errorCount == 0` assertion could not fail.

Measured both ways on `origin/main`, same sources:

| project `node_modules` | result |
| --- | --- |
| real directory | `errorCount 1`, `TS2749` reported |
| symlink to the workspace copy | `errorCount 0`, all diagnostics swallowed |

That asymmetry is the proof this defect is pre-existing and not introduced by #3374.

The fixture now builds a **real** `node_modules` directory and links the individual packages inside it — the shape a real install has. `.vize` is deliberately *not* linked out: that is where vize writes the project's virtual TypeScript, and linking it to the shared workspace copy puts the generated files behind a symlink again (same swallowing layout, plus a collision between concurrent cases). Finding this was necessary to make the fixture report at all.

## The fix

`emit_setup_invocation_and_exports` now classifies each bridged export by the declaration spaces it occupies and emits a matching type alias for the value+type kinds:

| source declaration | emitted bridge |
| --- | --- |
| `enum E` / `const enum E` | `export const E = …;` + `export type E = (typeof E)[keyof typeof E];` |
| `class C` | `export const C = …;` + `export type C = InstanceType<typeof C>;` |
| `const` / `let` / `function` | `export const x = …;` (value only, unchanged) |

Shape notes, each checked against `tsgo` before wiring it in:

- The enum form reconstructs the union of *member* types, so the enum stays **nominal** — `const wrong: StrEnum = "unified"` is still an error rather than widening to `string`. This holds for numeric enums too (`typeof E` carries no reverse mapping).
- `InstanceType` has accepted `abstract new` since TS 4.2, so abstract and generic classes ride the same shape with no special case.
- `const enum` works: only the pre-existing value-bridge lines emit `TS2475`, and those land on generated positions that carry no source mapping, so they are dropped exactly as before. The new alias line itself is clean.

### Declaration kinds deliberately *not* covered

`namespace` / `module` exports are broken by a **different**, pre-existing defect and are untouched here. They are not collected by the export bridge at all, and the declaration is never hoisted out of `__setup()`, so on `origin/main` they fail with `TS1235: A namespace declaration is only allowed at the top level of a namespace or module` plus `TS2614` on the consumer. That is a hoisting problem, not a lost-type-side problem, and fixing it means moving the declaration to module scope — out of scope for a p0 unblock, and worth a follow-up of its own rather than bundling it here.

## Structure

`script_module.rs` was at exactly 350 lines and `generator.rs` at 984, both at/over the source-length gate boundary. The bridge logic moved to a new `generator/script_module/plain_exports.rs` (333 lines) re-exported through `script_module`, which:

- shrinks `script_module.rs` 350 → 213
- leaves `generator.rs` with a **zero-line diff** (call sites unchanged)

`node tests/tooling/source-file-lengths.test.ts` passes (7/7).

## Tests

**Verified failing without the fix.** Stashed the source change, restored only the two test files onto pristine `origin/main`, and ran them:

- `check_preserves_named_exports_from_normal_script_vue` → **FAILED**, `errorCount 4`, one `TS2749` each for the string enum, numeric enum, `const enum`, and class.
- `normal_script_value_and_type_declarations_are_exported_in_both_spaces` → **FAILED** on the missing `export type DiffDisplayMode = (typeof DiffDisplayMode)[keyof typeof DiffDisplayMode];`.
- `check_reports_value_only_plain_script_exports_used_as_types` → **PASSED** without the fix, as a negative control must.

Then restored the fix and confirmed all green.

Added:

- `check_preserves_named_exports_from_normal_script_vue` — extended to use a string enum, a numeric enum, a `const enum`, and a class as **both** a value and a type from a plain-`<script>` SFC.
- `check_reports_value_only_plain_script_exports_used_as_types` — negative case: an exported `const` and `function` used as types must **still** raise `TS2749` (`errorCount == 2`). This proves no bogus type export is invented, and doubles as an anti-vacuity guard: if diagnostics are ever swallowed for this layout again, this test fails instead of quietly passing.
- `normal_script_value_and_type_declarations_are_exported_in_both_spaces` — pins the emitted virtual TS for all five kinds and asserts `pageSize`/`toPageCount` gain **no** `export type`.
- Unit tests in `plain_exports.rs` for kind classification, both-space emission, value-only emission, merged-enum dedup, and the empty-export path.

## Verification

Layout used for the CLI fixture: **real `node_modules` directory** (packages linked inside it, `.vize` excluded) — not a symlinked `node_modules`.

| command | result |
| --- | --- |
| `cargo test -p vize_canon --lib` | 627 passed, 0 failed |
| `cargo test -p vize_canon` (all targets) | all green |
| `cargo test -p vize --features legacy --no-fail-fast` | 13 targets / 32 tests fail — **byte-identical to the stashed `origin/main` baseline, zero NEW failures** |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace` (CI's scope, `-D warnings`) | clean |
| `cargo clippy --workspace --all-targets` | no warnings in any changed file; `check_plain_script_named_exports_cli.rs` went 6 → 4 pre-existing warnings |
| `node tests/tooling/source-file-lengths.test.ts` | 7 passed, 0 failed |

The 32 pre-existing `vize` failures are all the environment class — `NotFound: "workspace Vue package missing"`, i.e. no installed `tests/node_modules` in this checkout. Captured a baseline by stashing the change, re-running the full suite, and diffing the sorted failing-test lists: identical.

**No insta snapshots were refreshed** — none needed it (`*.snap.new` count: 0).
