### PR TITLE
fix(canon): mirror nested package node_modules into the virtual project

### DIFF
--- a/crates/vize_canon/src/batch/runtime_deps.rs
+++ b/crates/vize_canon/src/batch/runtime_deps.rs
@@ -147,6 +147,14 @@ fn ensure_stub_dir(path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Link `target` to the canonicalized `source` package directory.
+///
+/// Shared with the nested-package `node_modules` mirror so both mirrors resolve
+/// through the same canonicalization and idempotence rules.
+pub(super) fn symlink_package_dir(source: &Path, target: &Path) -> std::io::Result<()> {
+    symlink_path(&package_link_source(source), target)
+}
+
 fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
     if symlink_matches(source, target)? {
         return Ok(());

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -43,6 +43,8 @@ mod jsx_build;
 mod jsx_codegen;
 mod mapping;
 mod materialize;
+mod materialize_stubs;
+mod package_node_modules;
 mod passthrough;
 mod paths;
 mod project;

--- a/crates/vize_canon/src/batch/virtual_project/materialize.rs
+++ b/crates/vize_canon/src/batch/virtual_project/materialize.rs
@@ -5,8 +5,7 @@
 use std::path::{Path, PathBuf};
 
 use rayon::prelude::*;
-use serde_json::Value;
-use vize_carton::{FxHashSet, String as CompactString, profile};
+use vize_carton::{FxHashSet, profile};
 
 use crate::batch::error::CorsaResult;
 use crate::batch::materialize_fs::{
@@ -14,9 +13,12 @@ use crate::batch::materialize_fs::{
 };
 use crate::batch::runtime_deps::materialize_runtime_dependencies;
 
+use super::package_node_modules::{
+    PackageNodeModulesLink, materialize_package_node_modules, package_node_modules_links,
+};
 use super::{
-    AUTO_IMPORT_STUBS_FILE, MODULE_AUGMENTATION_STUB_PREFIX, MODULE_AUGMENTATION_STUBS_FILE,
-    PACKAGE_BOUNDARY_FILE, SHARED_HELPERS_FILE, VUE_MODULE_STUBS_FILE, VirtualProject,
+    AUTO_IMPORT_STUBS_FILE, MODULE_AUGMENTATION_STUBS_FILE, PACKAGE_BOUNDARY_FILE,
+    SHARED_HELPERS_FILE, VUE_MODULE_STUBS_FILE, VirtualProject,
 };
 
 impl VirtualProject {
@@ -31,6 +33,7 @@ impl VirtualProject {
     /// so TypeScript's own filesystem caches are not invalidated.
     pub fn materialize(&self) -> CorsaResult<()> {
         let expected_files = self.expected_materialized_files();
+        let package_links = self.package_node_modules_links(&expected_files);
         profile!(
             "canon.project.prepare_dir",
             ensure_materialize_root(&self.virtual_root)
@@ -41,7 +44,7 @@ impl VirtualProject {
             prune_unexpected_entries(
                 &self.virtual_root,
                 &expected_files,
-                &[self.virtual_root.join("node_modules")]
+                &self.preserved_prune_roots(&package_links)
             )
         )?;
 
@@ -49,6 +52,11 @@ impl VirtualProject {
             "canon.project.runtime_deps",
             materialize_runtime_dependencies(&self.project_root, &self.virtual_root)
         )?;
+
+        profile!(
+            "canon.project.package_deps",
+            materialize_package_node_modules(&package_links)
+        );
 
         profile!(
             "canon.project.write_package_boundary",
@@ -155,110 +163,28 @@ impl VirtualProject {
         Ok(config_path)
     }
 
-    fn write_auto_import_stubs(&self) -> CorsaResult<()> {
-        if !self.has_global_auto_import_stubs() {
-            return Ok(());
-        }
-
-        let capacity = self
-            .virtual_ts_options
-            .auto_import_stubs
-            .iter()
-            .filter(|stub| !is_module_augmentation_stub(stub))
-            .fold(64usize, |acc, stub| acc + stub.len() + 1);
-        let mut content = CompactString::with_capacity(capacity);
-        content.push_str("// @ts-nocheck\n");
-        content.push_str("// Framework-provided globals for the virtual project.\n");
-        for stub in &self.virtual_ts_options.auto_import_stubs {
-            if is_module_augmentation_stub(stub) {
-                continue;
-            }
-            content.push_str(stub);
-            content.push('\n');
-        }
-
-        write_if_changed(
-            &self.virtual_root.join(AUTO_IMPORT_STUBS_FILE),
-            content.as_bytes(),
-        )?;
-        Ok(())
+    /// The real `node_modules` directories mirrored into the virtual project so
+    /// bare specifiers keep resolving from a nested package (#3366).
+    fn package_node_modules_links(
+        &self,
+        expected_files: &FxHashSet<PathBuf>,
+    ) -> Vec<PackageNodeModulesLink> {
+        package_node_modules_links(
+            &self.project_root,
+            &self.virtual_root,
+            expected_files.iter().map(PathBuf::as_path),
+        )
     }
 
-    fn write_module_augmentation_stubs(&self) -> CorsaResult<()> {
-        if !self.has_module_augmentation_stubs() {
-            return Ok(());
-        }
-
-        let capacity = self
-            .virtual_ts_options
-            .auto_import_stubs
-            .iter()
-            .filter(|stub| is_module_augmentation_stub(stub))
-            .fold(96usize, |acc, stub| acc + stub.len() + 1);
-        let mut content = CompactString::with_capacity(capacity);
-        content.push_str("// @ts-nocheck\n");
-        content.push_str("// External module augmentations for resolved framework packages.\n");
-        content.push_str("export {};\n");
-        for stub in &self.virtual_ts_options.auto_import_stubs {
-            if !is_module_augmentation_stub(stub) {
-                continue;
-            }
-            content.push_str(stub.trim_start_matches(MODULE_AUGMENTATION_STUB_PREFIX));
-            content.push('\n');
-        }
-
-        write_if_changed(
-            &self.virtual_root.join(MODULE_AUGMENTATION_STUBS_FILE),
-            content.as_bytes(),
-        )?;
-        Ok(())
-    }
-
-    fn write_vue_module_stubs(&self) -> CorsaResult<()> {
-        let content = "// Vue SFC modules resolve through materialized .vue.ts files.\n";
-        write_if_changed(
-            &self.virtual_root.join(VUE_MODULE_STUBS_FILE),
-            content.as_bytes(),
-        )?;
-        Ok(())
-    }
-
-    /// Write the shared ambient helpers file. The generated `.vue.ts` modules
-    /// hoist their common preamble (ImportMeta augmentation, type helpers,
-    /// compiler-macro signatures) into this single program-wide declaration.
-    fn write_shared_helpers(&self) -> CorsaResult<()> {
-        let mut content = CompactString::default();
-        if self.needs_vue_jsx_reference() {
-            content.push_str("/// <reference types=\"vue/jsx\" />\n");
-        }
-        content.push_str(crate::virtual_ts::SHARED_PREAMBLE_DTS);
-        write_if_changed(
-            &self.virtual_root.join(SHARED_HELPERS_FILE),
-            content.as_bytes(),
-        )?;
-        Ok(())
-    }
-
-    fn needs_vue_jsx_reference(&self) -> bool {
-        if self.needs_vue_jsx_compiler_options() {
-            return true;
-        }
-        let Ok(options) = self.load_compiler_options(self.resolved_tsconfig_path().as_deref())
-        else {
-            return false;
-        };
-        options
-            .get("jsxImportSource")
-            .and_then(Value::as_str)
-            .is_some_and(|source| source == "vue")
-            || options
-                .get("types")
-                .and_then(Value::as_array)
-                .is_some_and(|types| {
-                    types
-                        .iter()
-                        .any(|entry| entry.as_str().is_some_and(|entry| entry == "vue/jsx"))
-                })
+    /// Directories the garbage collector must leave alone: the runtime
+    /// dependency mirror plus every mirrored nested `node_modules`. Descending
+    /// into a mirrored `node_modules` would delete real dependencies, because
+    /// those paths resolve to the user's own install.
+    fn preserved_prune_roots(&self, package_links: &[PackageNodeModulesLink]) -> Vec<PathBuf> {
+        let mut roots = Vec::with_capacity(package_links.len() + 1);
+        roots.push(self.virtual_root.join("node_modules"));
+        roots.extend(package_links.iter().map(|link| link.virtual_dir.clone()));
+        roots
     }
 
     fn expected_materialized_files(&self) -> FxHashSet<PathBuf> {
@@ -279,30 +205,6 @@ impl VirtualProject {
         files.insert(self.virtual_root.join(PACKAGE_BOUNDARY_FILE));
         files.insert(self.virtual_root.join("tsconfig.json"));
         files
-    }
-
-    pub(super) fn has_global_auto_import_stubs(&self) -> bool {
-        self.virtual_ts_options
-            .auto_import_stubs
-            .iter()
-            .any(|stub| !is_module_augmentation_stub(stub))
-    }
-
-    pub(super) fn has_module_augmentation_stubs(&self) -> bool {
-        self.virtual_ts_options
-            .auto_import_stubs
-            .iter()
-            .any(|stub| is_module_augmentation_stub(stub))
-    }
-
-    pub(super) fn push_stub_include_paths(&self, includes: &mut Vec<CompactString>) {
-        if self.has_global_auto_import_stubs() {
-            includes.push(AUTO_IMPORT_STUBS_FILE.into());
-        }
-        if self.has_module_augmentation_stubs() {
-            includes.push(MODULE_AUGMENTATION_STUBS_FILE.into());
-        }
-        includes.push(VUE_MODULE_STUBS_FILE.into());
     }
 
     pub(super) fn common_virtual_source_dir(&self) -> PathBuf {
@@ -340,8 +242,4 @@ impl VirtualProject {
         self.resolved_tsconfig_path()
             .unwrap_or_else(|| self.project_root.clone())
     }
-}
-
-fn is_module_augmentation_stub(stub: &str) -> bool {
-    stub.starts_with(MODULE_AUGMENTATION_STUB_PREFIX)
 }

--- a/crates/vize_canon/src/batch/virtual_project/materialize_stubs.rs
+++ b/crates/vize_canon/src/batch/virtual_project/materialize_stubs.rs
@@ -1,0 +1,154 @@
+//! Writing the program-wide ambient stub files of the virtual project:
+//! framework-provided globals, external module augmentations, the `.vue` module
+//! marker, and the shared helper preamble.
+//!
+//! These are the parts of the materialized tree that no source file maps to, so
+//! they are kept apart from [`super::materialize`], which owns the mirrored
+//! source tree itself.
+
+use serde_json::Value;
+use vize_carton::String as CompactString;
+
+use crate::batch::error::CorsaResult;
+use crate::batch::materialize_fs::write_if_changed;
+
+use super::{
+    AUTO_IMPORT_STUBS_FILE, MODULE_AUGMENTATION_STUB_PREFIX, MODULE_AUGMENTATION_STUBS_FILE,
+    SHARED_HELPERS_FILE, VUE_MODULE_STUBS_FILE, VirtualProject,
+};
+
+impl VirtualProject {
+    pub(super) fn write_auto_import_stubs(&self) -> CorsaResult<()> {
+        if !self.has_global_auto_import_stubs() {
+            return Ok(());
+        }
+
+        let capacity = self
+            .virtual_ts_options
+            .auto_import_stubs
+            .iter()
+            .filter(|stub| !is_module_augmentation_stub(stub))
+            .fold(64usize, |acc, stub| acc + stub.len() + 1);
+        let mut content = CompactString::with_capacity(capacity);
+        content.push_str("// @ts-nocheck\n");
+        content.push_str("// Framework-provided globals for the virtual project.\n");
+        for stub in &self.virtual_ts_options.auto_import_stubs {
+            if is_module_augmentation_stub(stub) {
+                continue;
+            }
+            content.push_str(stub);
+            content.push('\n');
+        }
+
+        write_if_changed(
+            &self.virtual_root.join(AUTO_IMPORT_STUBS_FILE),
+            content.as_bytes(),
+        )?;
+        Ok(())
+    }
+
+    pub(super) fn write_module_augmentation_stubs(&self) -> CorsaResult<()> {
+        if !self.has_module_augmentation_stubs() {
+            return Ok(());
+        }
+
+        let capacity = self
+            .virtual_ts_options
+            .auto_import_stubs
+            .iter()
+            .filter(|stub| is_module_augmentation_stub(stub))
+            .fold(96usize, |acc, stub| acc + stub.len() + 1);
+        let mut content = CompactString::with_capacity(capacity);
+        content.push_str("// @ts-nocheck\n");
+        content.push_str("// External module augmentations for resolved framework packages.\n");
+        content.push_str("export {};\n");
+        for stub in &self.virtual_ts_options.auto_import_stubs {
+            if !is_module_augmentation_stub(stub) {
+                continue;
+            }
+            content.push_str(stub.trim_start_matches(MODULE_AUGMENTATION_STUB_PREFIX));
+            content.push('\n');
+        }
+
+        write_if_changed(
+            &self.virtual_root.join(MODULE_AUGMENTATION_STUBS_FILE),
+            content.as_bytes(),
+        )?;
+        Ok(())
+    }
+
+    pub(super) fn write_vue_module_stubs(&self) -> CorsaResult<()> {
+        let content = "// Vue SFC modules resolve through materialized .vue.ts files.\n";
+        write_if_changed(
+            &self.virtual_root.join(VUE_MODULE_STUBS_FILE),
+            content.as_bytes(),
+        )?;
+        Ok(())
+    }
+
+    /// Write the shared ambient helpers file. The generated `.vue.ts` modules
+    /// hoist their common preamble (ImportMeta augmentation, type helpers,
+    /// compiler-macro signatures) into this single program-wide declaration.
+    pub(super) fn write_shared_helpers(&self) -> CorsaResult<()> {
+        let mut content = CompactString::default();
+        if self.needs_vue_jsx_reference() {
+            content.push_str("/// <reference types=\"vue/jsx\" />\n");
+        }
+        content.push_str(crate::virtual_ts::SHARED_PREAMBLE_DTS);
+        write_if_changed(
+            &self.virtual_root.join(SHARED_HELPERS_FILE),
+            content.as_bytes(),
+        )?;
+        Ok(())
+    }
+
+    fn needs_vue_jsx_reference(&self) -> bool {
+        if self.needs_vue_jsx_compiler_options() {
+            return true;
+        }
+        let Ok(options) = self.load_compiler_options(self.resolved_tsconfig_path().as_deref())
+        else {
+            return false;
+        };
+        options
+            .get("jsxImportSource")
+            .and_then(Value::as_str)
+            .is_some_and(|source| source == "vue")
+            || options
+                .get("types")
+                .and_then(Value::as_array)
+                .is_some_and(|types| {
+                    types
+                        .iter()
+                        .any(|entry| entry.as_str().is_some_and(|entry| entry == "vue/jsx"))
+                })
+    }
+
+    pub(super) fn has_global_auto_import_stubs(&self) -> bool {
+        self.virtual_ts_options
+            .auto_import_stubs
+            .iter()
+            .any(|stub| !is_module_augmentation_stub(stub))
+    }
+
+    pub(super) fn has_module_augmentation_stubs(&self) -> bool {
+        self.virtual_ts_options
+            .auto_import_stubs
+            .iter()
+            .any(|stub| is_module_augmentation_stub(stub))
+    }
+
+    pub(super) fn push_stub_include_paths(&self, includes: &mut Vec<CompactString>) {
+        if self.has_global_auto_import_stubs() {
+            includes.push(AUTO_IMPORT_STUBS_FILE.into());
+        }
+        if self.has_module_augmentation_stubs() {
+            includes.push(MODULE_AUGMENTATION_STUBS_FILE.into());
+        }
+        includes.push(VUE_MODULE_STUBS_FILE.into());
+    }
+}
+
+fn is_module_augmentation_stub(stub: &str) -> bool {
+    stub.starts_with(MODULE_AUGMENTATION_STUB_PREFIX)
+}

--- a/crates/vize_canon/src/batch/virtual_project/package_node_modules.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_node_modules.rs
@@ -1,0 +1,197 @@
+//! Mirroring the real `node_modules` chain of nested packages into the virtual
+//! project so bare specifiers keep resolving.
+//!
+//! Corsa resolves a bare specifier by walking the `node_modules` directories on
+//! the ancestor chain of the *materialized* file. The virtual root lives at
+//! `<project_root>/node_modules/.vize/canon`, so that walk sees
+//! `<canon>/node_modules` (owned by [`crate::batch::runtime_deps`]) and then —
+//! because Node's algorithm skips `node_modules` path components — jumps
+//! straight to `<project_root>/node_modules`. Every real `node_modules`
+//! *between* the project root and the importing file is missing from the chain.
+//!
+//! That gap is invisible in a single-package project but not in a workspace
+//! whose `tsconfig.json` sits at the root: with pnpm's default isolated linker
+//! a dependency declared by `apps/app` is linked only into
+//! `apps/app/node_modules`, which the mirrored chain never reaches, so a
+//! specifier that `tsc`/`tsgo` resolve cleanly reports `TS2307` (#3366).
+//!
+//! The fix mirrors those directories as symlinks at their rebased location, so
+//! the mirrored ancestor chain matches the real one.
+
+use std::path::{Path, PathBuf};
+
+use vize_carton::FxHashSet;
+
+use crate::batch::runtime_deps::symlink_package_dir;
+
+/// A real `node_modules` directory and the mirrored path it is linked from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PackageNodeModulesLink {
+    /// Path inside the virtual root that must resolve to `real_dir`.
+    pub(super) virtual_dir: PathBuf,
+    /// The real `node_modules` directory being mirrored.
+    pub(super) real_dir: PathBuf,
+}
+
+/// The `node_modules` directories to mirror for `materialized_files`.
+///
+/// Candidates are the ancestors of every materialized file, relative to the
+/// virtual root, that have a real `node_modules` sibling. The virtual root
+/// itself is excluded: `<canon>/node_modules` belongs to the runtime-dependency
+/// materialization, and `<project_root>/node_modules` is already on the
+/// mirrored ancestor chain.
+///
+/// A candidate whose mirrored `node_modules` holds materialized files is
+/// skipped. Those files are the mirror's own copies of a dependency, and
+/// linking the real directory over them would make every write inside the
+/// virtual project land in the user's real `node_modules`.
+pub(super) fn package_node_modules_links<'a>(
+    project_root: &Path,
+    virtual_root: &Path,
+    materialized_files: impl Iterator<Item = &'a Path>,
+) -> Vec<PackageNodeModulesLink> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    let mut seen: FxHashSet<PathBuf> = FxHashSet::default();
+    let mut materialized_dependency_dirs: FxHashSet<PathBuf> = FxHashSet::default();
+
+    for file in materialized_files {
+        let Some(relative) = file
+            .strip_prefix(virtual_root)
+            .ok()
+            .and_then(Path::parent)
+            .filter(|relative| !relative.as_os_str().is_empty())
+        else {
+            continue;
+        };
+
+        let mut ancestor = PathBuf::new();
+        for component in relative.components() {
+            if component.as_os_str() == NODE_MODULES {
+                // The mirror materializes files under this `node_modules`, so
+                // its enclosing package keeps the mirrored copies.
+                materialized_dependency_dirs.insert(ancestor.clone());
+                break;
+            }
+            ancestor.push(component);
+            if seen.insert(ancestor.clone()) {
+                candidates.push(ancestor.clone());
+            }
+        }
+    }
+
+    candidates.sort();
+    candidates
+        .into_iter()
+        .filter(|relative| !materialized_dependency_dirs.contains(relative))
+        .filter_map(|relative| {
+            let real_dir = project_root.join(&relative).join(NODE_MODULES);
+            real_dir.is_dir().then(|| PackageNodeModulesLink {
+                virtual_dir: virtual_root.join(&relative).join(NODE_MODULES),
+                real_dir,
+            })
+        })
+        .collect()
+}
+
+/// Link every mirrored `node_modules` directory into the virtual project.
+///
+/// Linking is best-effort for the same reason the Vue and Vite mirrors are: a
+/// platform that refuses to create the symlink degrades to the pre-existing
+/// resolution behavior instead of failing the whole check.
+pub(super) fn materialize_package_node_modules(links: &[PackageNodeModulesLink]) {
+    for link in links {
+        let _ = symlink_package_dir(&link.real_dir, &link.virtual_dir);
+    }
+}
+
+const NODE_MODULES: &str = "node_modules";
+
+#[cfg(test)]
+mod tests {
+    use super::{PackageNodeModulesLink, package_node_modules_links};
+    use std::path::{Path, PathBuf};
+    use vize_carton::cstr;
+
+    fn case_dir(name: &str) -> PathBuf {
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("vize-tests")
+            .join("package-node-modules")
+            .join(cstr!("{name}-{}", std::process::id()).as_str());
+        let _ = std::fs::remove_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn links_a_sub_package_node_modules_onto_its_mirrored_path() {
+        let root = case_dir("sub-package");
+        std::fs::create_dir_all(root.join("apps/app/node_modules/dep")).unwrap();
+        let virtual_root = root.join("node_modules/.vize/canon");
+        let file = virtual_root.join("apps/app/main.ts");
+
+        let links = package_node_modules_links(&root, &virtual_root, [file.as_path()].into_iter());
+
+        assert_eq!(
+            links,
+            vec![PackageNodeModulesLink {
+                virtual_dir: virtual_root.join("apps/app/node_modules"),
+                real_dir: root.join("apps/app/node_modules"),
+            }]
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn skips_the_project_root_and_directories_without_node_modules() {
+        let root = case_dir("root-only");
+        std::fs::create_dir_all(root.join("node_modules/dep")).unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        let virtual_root = root.join("node_modules/.vize/canon");
+        let file = virtual_root.join("src/main.ts");
+
+        let links = package_node_modules_links(&root, &virtual_root, [file.as_path()].into_iter());
+
+        assert!(links.is_empty(), "{links:?}");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn keeps_mirrored_dependency_copies_instead_of_linking_over_them() {
+        let root = case_dir("mirrored-dependency");
+        std::fs::create_dir_all(root.join("apps/app/node_modules/dep")).unwrap();
+        let virtual_root = root.join("node_modules/.vize/canon");
+        let mirrored = virtual_root.join("apps/app/node_modules/dep/index.d.cts");
+
+        let links =
+            package_node_modules_links(&root, &virtual_root, [mirrored.as_path()].into_iter());
+
+        assert!(links.is_empty(), "{links:?}");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn links_every_ancestor_that_carries_its_own_node_modules() {
+        let root = case_dir("nested-chain");
+        std::fs::create_dir_all(root.join("apps/node_modules/dep")).unwrap();
+        std::fs::create_dir_all(root.join("apps/app/node_modules/dep")).unwrap();
+        let virtual_root = root.join("node_modules/.vize/canon");
+        let file = virtual_root.join("apps/app/src/main.ts");
+
+        let links = package_node_modules_links(&root, &virtual_root, [file.as_path()].into_iter());
+
+        assert_eq!(
+            links,
+            vec![
+                PackageNodeModulesLink {
+                    virtual_dir: virtual_root.join("apps/node_modules"),
+                    real_dir: root.join("apps/node_modules"),
+                },
+                PackageNodeModulesLink {
+                    virtual_dir: virtual_root.join("apps/app/node_modules"),
+                    real_dir: root.join("apps/app/node_modules"),
+                },
+            ]
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/package_node_modules.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_node_modules.rs
@@ -97,10 +97,22 @@ pub(super) fn package_node_modules_links<'a>(
 ///
 /// Linking is best-effort for the same reason the Vue and Vite mirrors are: a
 /// platform that refuses to create the symlink degrades to the pre-existing
-/// resolution behavior instead of failing the whole check.
+/// resolution behavior instead of failing the whole check. That degradation
+/// reintroduces the `TS2307` of #3366, so each failure records a structured
+/// `tracing::warn!` event naming the directory that stayed unmirrored; a run
+/// where every link succeeds stays silent.
 pub(super) fn materialize_package_node_modules(links: &[PackageNodeModulesLink]) {
     for link in links {
-        let _ = symlink_package_dir(&link.real_dir, &link.virtual_dir);
+        if let Err(error) = symlink_package_dir(&link.real_dir, &link.virtual_dir) {
+            tracing::warn!(
+                target: "vize_canon::canon::package_node_modules",
+                real_dir = %link.real_dir.display(),
+                virtual_dir = %link.virtual_dir.display(),
+                error = %error,
+                "could not mirror a nested package `node_modules`; bare specifiers \
+                 resolved from it may report TS2307",
+            );
+        }
     }
 }
 

--- a/tests/tooling/cli-check-sub-package-dependency.test.ts
+++ b/tests/tooling/cli-check-sub-package-dependency.test.ts
@@ -95,10 +95,7 @@ function createWorkspace(caseName: string, extraSource: string): string {
     `${JSON.stringify({ name: "repro", private: true, type: "module" }, null, 2)}\n`,
   );
   fs.writeFileSync(path.join(workspace, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
-  fs.writeFileSync(
-    path.join(workspace, "tsconfig.json"),
-    `${JSON.stringify(TSCONFIG, null, 2)}\n`,
-  );
+  fs.writeFileSync(path.join(workspace, "tsconfig.json"), `${JSON.stringify(TSCONFIG, null, 2)}\n`);
   fs.writeFileSync(
     path.join(app, "package.json"),
     `${JSON.stringify(
@@ -139,7 +136,10 @@ function createWorkspace(caseName: string, extraSource: string): string {
     "export interface AcmeConfig {\n  enabled?: boolean;\n}\n" +
       "export declare function defineConfig(config: AcmeConfig): AcmeConfig;\n",
   );
-  fs.writeFileSync(path.join(store, "index.js"), "export function defineConfig(c) {\n  return c;\n}\n");
+  fs.writeFileSync(
+    path.join(store, "index.js"),
+    "export function defineConfig(c) {\n  return c;\n}\n",
+  );
   fs.symlinkSync(
     ".pnpm/acme-config@1.0.0/node_modules/acme-config",
     path.join(app, "node_modules/acme-config"),

--- a/tests/tooling/cli-check-sub-package-dependency.test.ts
+++ b/tests/tooling/cli-check-sub-package-dependency.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Regression oracle for #3366: a dependency installed only in a sub-package of
+ * a pnpm workspace, checked through a `tsconfig.json` at the workspace root.
+ *
+ * The canon mirrors checked files under `<project_root>/node_modules/.vize/canon`
+ * and Corsa resolves bare specifiers by walking the `node_modules` directories
+ * on the ancestor chain of the *mirrored* path. That chain used to contain only
+ * `<canon>/node_modules` (the Vue/Vite runtime mirror) and then, because Node's
+ * algorithm skips `node_modules` path components, `<project_root>/node_modules`.
+ * With pnpm's default isolated linker a dependency declared by `apps/app` is
+ * linked only into `apps/app/node_modules`, which that chain never reaches, so
+ * a specifier `tsc`/`tsgo` resolve cleanly reported a false `TS2307`.
+ *
+ * The failure mode is a *spurious* diagnostic, so the primary assertion is that
+ * `TS2307` is absent. A control in the same layout imports a package that is
+ * genuinely not installed, which keeps the test from passing by suppressing
+ * module-resolution errors altogether.
+ */
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function resolveVizeCommand(): { command: string; prefix: string[] } {
+  const candidates = [
+    path.join(root, "target/ci/vize"),
+    path.join(root, "target/release/vize"),
+    path.join(root, "target/debug/vize"),
+    "vize",
+  ];
+  for (const candidate of candidates) {
+    const probe = spawnSync(candidate, ["--version"], { cwd: root, encoding: "utf8" });
+    if (probe.status === 0) {
+      return { command: candidate, prefix: [] };
+    }
+  }
+  return { command: "cargo", prefix: ["run", "-q", "-p", "vize", "--"] };
+}
+
+const VIZE = resolveVizeCommand();
+
+function resolveCheckerPath(): string | null {
+  const candidates = [
+    path.join(root, "node_modules/.bin/corsa"),
+    path.join(root, "node_modules/.bin/tsgo"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? null;
+}
+
+const CHECKER = resolveCheckerPath();
+const corsaSkip = CHECKER == null ? { skip: "no corsa/tsgo checker in node_modules/.bin" } : {};
+
+type ParsedCheck = {
+  files: Array<{ file: string; diagnostics: string[] }>;
+  errorCount: number;
+};
+
+const TSCONFIG = {
+  compilerOptions: {
+    module: "ESNext",
+    moduleResolution: "bundler",
+    noEmit: true,
+    strict: true,
+    target: "ESNext",
+    types: [] as string[],
+  },
+  include: ["apps/**/*.ts"],
+};
+
+/**
+ * A pnpm-shaped workspace: `tsconfig.json` at the root, and `acme-config`
+ * installed only under `apps/app`.
+ *
+ * The sub-package `node_modules` is a real directory holding a symlink to the
+ * package in a virtual store, which is exactly what pnpm's isolated linker
+ * writes — and, because the walker does not follow links, the reason the
+ * package's own declarations are never swept in as check inputs.
+ */
+function createWorkspace(caseName: string, extraSource: string): string {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), `vize-subpkg-${caseName}-`));
+  const app = path.join(workspace, "apps/app");
+  fs.mkdirSync(path.join(app, "src"), { recursive: true });
+  // A real `node_modules` at the root: the canon is written to
+  // `node_modules/.vize/canon`, and reaching that through a link would move the
+  // mirrored tree outside the project root.
+  fs.mkdirSync(path.join(workspace, "node_modules"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(workspace, "package.json"),
+    `${JSON.stringify({ name: "repro", private: true, type: "module" }, null, 2)}\n`,
+  );
+  fs.writeFileSync(path.join(workspace, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+  fs.writeFileSync(
+    path.join(workspace, "tsconfig.json"),
+    `${JSON.stringify(TSCONFIG, null, 2)}\n`,
+  );
+  fs.writeFileSync(
+    path.join(app, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "app",
+        private: true,
+        type: "module",
+        devDependencies: { "acme-config": "1.0.0" },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  fs.writeFileSync(path.join(app, "src/main.ts"), "export const answer: number = 42;\n");
+  fs.writeFileSync(
+    path.join(app, "vize.config.ts"),
+    `import { defineConfig } from "acme-config";\n${extraSource}`,
+  );
+
+  const store = path.join(app, "node_modules/.pnpm/acme-config@1.0.0/node_modules/acme-config");
+  fs.mkdirSync(store, { recursive: true });
+  fs.writeFileSync(
+    path.join(store, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "acme-config",
+        version: "1.0.0",
+        type: "module",
+        types: "./index.d.ts",
+        exports: { ".": { types: "./index.d.ts", import: "./index.js" } },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  fs.writeFileSync(
+    path.join(store, "index.d.ts"),
+    "export interface AcmeConfig {\n  enabled?: boolean;\n}\n" +
+      "export declare function defineConfig(config: AcmeConfig): AcmeConfig;\n",
+  );
+  fs.writeFileSync(path.join(store, "index.js"), "export function defineConfig(c) {\n  return c;\n}\n");
+  fs.symlinkSync(
+    ".pnpm/acme-config@1.0.0/node_modules/acme-config",
+    path.join(app, "node_modules/acme-config"),
+    "dir",
+  );
+
+  return workspace;
+}
+
+function runCheck(workspace: string): ParsedCheck {
+  const result = spawnSync(
+    VIZE.command,
+    [
+      ...VIZE.prefix,
+      "check",
+      "--tsconfig",
+      "../../tsconfig.json",
+      "--corsa-path",
+      CHECKER as string,
+      "--format",
+      "json",
+    ],
+    {
+      cwd: path.join(workspace, "apps/app"),
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  );
+  if (result.error) {
+    throw result.error;
+  }
+  assert.ok(
+    result.stdout.trim().startsWith("{"),
+    `expected a JSON envelope on stdout, got:\n${result.stdout}\n${result.stderr}`,
+  );
+  return JSON.parse(result.stdout) as ParsedCheck;
+}
+
+function diagnosticsFor(parsed: ParsedCheck, file: string): string[] {
+  const entry = parsed.files.find((candidate) => candidate.file === file);
+  assert.ok(entry, `${file} must be part of the checked program: ${JSON.stringify(parsed.files)}`);
+  return entry.diagnostics;
+}
+
+test(
+  "a dependency installed only in a sub-package resolves under a workspace-root tsconfig",
+  corsaSkip,
+  () => {
+    const workspace = createWorkspace(
+      "resolves",
+      "\nexport default defineConfig({ enabled: true });\n",
+    );
+    try {
+      const parsed = runCheck(workspace);
+      const diagnostics = diagnosticsFor(parsed, "vize.config.ts");
+      assert.deepEqual(
+        diagnostics.filter((entry) => entry.includes("TS2307")),
+        [],
+        "the sub-package dependency must resolve from the mirrored ancestor chain",
+      );
+      assert.equal(parsed.errorCount, 0, JSON.stringify(parsed.files));
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "a module that is genuinely not installed still reports TS2307 in the same layout",
+  corsaSkip,
+  () => {
+    const workspace = createWorkspace(
+      "control",
+      'import { nope } from "totally-not-installed";\n\nexport default defineConfig({ enabled: nope });\n',
+    );
+    try {
+      const parsed = runCheck(workspace);
+      const diagnostics = diagnosticsFor(parsed, "vize.config.ts");
+      const unresolved = diagnostics.filter((entry) => entry.includes("TS2307"));
+      assert.equal(unresolved.length, 1, JSON.stringify(diagnostics));
+      assert.match(unresolved[0] as string, /Cannot find module 'totally-not-installed'/);
+      assert.ok(
+        !diagnostics.some((entry) => entry.includes("'acme-config'")),
+        `the installed sub-package dependency must still resolve: ${JSON.stringify(diagnostics)}`,
+      );
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
Fixes #3366.

## Reproduction

A minimal pnpm workspace with the `tsconfig.json` at the **workspace root** and `acme-config` installed **only** under `apps/app`, using pnpm's default isolated linker (a real `apps/app/node_modules` directory holding a symlink into a virtual store):

```text
├─ package.json
├─ pnpm-workspace.yaml
├─ tsconfig.json                    # include: ["apps/**/*.ts"]
├─ node_modules/                    # empty; the canon is written here
└─ apps/app/
   ├─ package.json                  # devDependencies: { "acme-config": "1.0.0" }
   ├─ vize.config.ts                # import { defineConfig } from "acme-config"
   ├─ src/main.ts
   └─ node_modules/
      ├─ .pnpm/acme-config@1.0.0/node_modules/acme-config/   # real package
      └─ acme-config -> .pnpm/acme-config@1.0.0/node_modules/acme-config
```

Reference tools on the identical workspace, same tsconfig:

```console
$ tsgo -p tsconfig.json      ; echo $?
0
$ vue-tsc -p tsconfig.json --noEmit ; echo $?
0
```

`vize check` before this change:

```console
$ cd apps/app && vize check --tsconfig ../../tsconfig.json
Building Corsa virtual project for 2 files under <workspace-root>...
<workspace-root>/apps/app/vize.config.ts
  error:1:30 [TS2307] Cannot find module 'acme-config' or its corresponding type declarations.
✗ 1 error(s)
```

After this change: `✓ No type errors found!` — while an import of a package that is genuinely not installed still reports `TS2307` at the right position.

## Root cause

`VirtualProject` mirrors checked files under `<project_root>/node_modules/.vize/canon`, rebasing each path relative to the project root — which follows the tsconfig location. With a workspace-root tsconfig, `apps/app/vize.config.ts` lands at `<canon>/apps/app/vize.config.ts`.

Corsa then resolves bare specifiers by walking the `node_modules` directories on the ancestor chain of that **mirrored** path:

| ancestor | `node_modules` present? |
| --- | --- |
| `<canon>/apps/app` | no |
| `<canon>/apps` | no |
| `<canon>` | yes — but `runtime_deps::prune_runtime_node_modules` keeps only `vue`, `vite`, `@vue` |
| `<project_root>` | yes — Node's algorithm skips `node_modules` path components, so the walk jumps here directly |

Every real `node_modules` *between* the project root and the importing file — exactly where pnpm's isolated linker puts a sub-package's own dependencies — is absent from the mirrored chain. The package is therefore unresolvable, and `TS2307` fires even though the dependency is installed and both reference checkers resolve it.

This is invisible in a single-package project (the project root's own `node_modules` is on the chain), and masked for `vue`/`vite`/`@vue` (special-cased materialization) and for tsconfig `paths` aliases (re-anchored into the canon tsconfig), which is why it typically only surfaces for config files importing toolchain packages.

## The fix

`crates/vize_canon/src/batch/virtual_project/package_node_modules.rs` computes, from the materialized file set, every ancestor directory below the project root that has a real `node_modules`, and `materialize()` links each one into the mirror at its rebased path. The mirrored ancestor chain then matches the real one, so resolution is TypeScript's ordinary Node resolution — no `TS2307` suppression anywhere, and a genuinely missing module still errors.

Two safety properties, both covered by unit tests:

- **The prune never descends into a real install.** The mirrored `node_modules` paths join `<canon>/node_modules` as preserved roots for `prune_unexpected_entries`, so the cache GC cannot walk through a link into the user's dependencies. (`std::fs::remove_dir_all` does not follow symlinks, so a stale mirrored directory is unlinked rather than recursed into.)
- **No write inside the virtual project can land in a real install.** If the mirror materializes files *under* a nested `node_modules` (possible when the file walker descends into a real, non-gitignored, non-symlinked dependency directory), that path keeps its mirrored copies and is not linked. Behavior there is unchanged from today; the link never shadows a path the mirror writes to.

The ambient stub writers moved from `materialize.rs` to a new `materialize_stubs.rs` — `materialize.rs` was at 347 lines and could not grow past the 350-line budget. No behavior change in that move.

## Tests

`tests/tooling/cli-check-sub-package-dependency.test.ts` builds the pnpm-shaped workspace above and runs the real CLI:

1. **Primary** — asserts `TS2307` is *absent* on `vize.config.ts` and `errorCount === 0`. The failure mode is a spurious diagnostic, so this asserts absence.
2. **Control** — same layout, plus an import of `totally-not-installed`. Asserts *exactly one* `TS2307`, that it names `totally-not-installed`, and that no diagnostic mentions `acme-config`. This is what stops the test from passing if resolution errors were suppressed wholesale.

The root `node_modules` is a real directory and the sub-package `node_modules` is a real directory containing a per-package symlink, so nothing puts the generated canon behind a link.

`package_node_modules.rs` adds four unit tests: links a sub-package `node_modules`; skips the project root and directories without one; keeps mirrored dependency copies instead of linking over them; links every ancestor that carries its own `node_modules`.

### Verified the tests fail without the fix

Reverted only the `materialize_package_node_modules(&package_links)` call (leaving the module and the test in place), rebuilt, reran:

```text
✖ a dependency installed only in a sub-package resolves under a workspace-root tsconfig
  actual: ["error:1:30 [TS2307] Cannot find module 'acme-config' ..."]  expected: []
✖ a module that is genuinely not installed still reports TS2307 in the same layout
  2 !== 1   (both 'acme-config' and 'totally-not-installed' reported)
```

Both pass again with the call restored.

## Verification

| command | result |
| --- | --- |
| `cargo test -p vize_canon --lib` | **636 passed, 0 failed** |
| `cargo test -p vize --features legacy --no-fail-fast` | **591 passed, 1 failed** — `check_nuxt2_false_positive_fixture_matrix`, **pre-existing**: reproduced identically with the source change reverted and rebuilt. **0 new failures.** |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets` | no warnings from any file this PR touches or adds |
| compat ratchet (below) | **12/12 pass**, every probe holds |

Compat ratchet, all nine probe fixtures hydrated:

```console
$ VIZE_TEST_VUE_TSC=node_modules/.pnpm/vue-tsc@3.3.4_typescript@6.0.3/node_modules/vue-tsc/bin/vue-tsc.js \
  VIZE_TEST_BIN=target/ci/vize node --test tests/tooling/compat-ratchet.test.ts
create-vue:        shared=0  documented=0 falsePositives=0 falseNegatives=0
element-plus:      shared=3  documented=0 falsePositives=0 falseNegatives=0
misskey:           shared=8  documented=0 falsePositives=0 falseNegatives=0
nuxt-ui:           shared=11 documented=1 falsePositives=0 falseNegatives=0
pinia:             shared=7  documented=0 falsePositives=0 falseNegatives=0
vue-router:        shared=0  documented=0 falsePositives=0 falseNegatives=0
vue-element-admin: shared=0  documented=0 falsePositives=0 falseNegatives=0
vitepress:         shared=2  documented=0 falsePositives=0 falseNegatives=0
vue-vben-admin:    shared=16 documented=0 falsePositives=0 falseNegatives=0
ℹ pass 12   ℹ fail 0
```

**`compat-baseline.json` is deliberately not regenerated.** The run reports that `vue-element-admin` improved (`falsePositiveCount` 1 → 0), but that improvement is **not** caused by this PR: it reproduces byte-for-byte with the source change reverted and the binary rebuilt, so the baseline was already stale on `main`. Tightening it here would attribute an unrelated improvement to this change. It should be tightened in whichever PR actually earned it.

## Explicitly not confirmed

- Verified on macOS only. The mirroring reuses `runtime_deps`'s existing `symlink_path`, which already handles the Windows `symlink_dir`/`symlink_file` split, and linking is best-effort: a platform that refuses the symlink degrades to today's resolution behavior rather than failing the check. Windows CI is the first real exercise of that path.
- The LSP uses a different overlay root (`node_modules/.vize/corsa-overlay`) and is untouched by this change; whether the same gap exists there is #3320 territory and out of scope here.
- One corner is knowingly left as-is: if a nested `node_modules` is a *real* directory whose files the input walker sweeps in as check inputs (needs no `.gitignore` covering `node_modules` and no package symlinks — i.e. neither pnpm's nor npm's normal output), the mirrored copies win and the link is skipped, so `TS2307` can still fire there. Linking over those paths would make virtual-project writes land in the user's real `node_modules`, which is not an acceptable trade. Worth noting for a follow-up: `tsc` does not treat such files as root inputs at all (verified with `tsgo --listFiles`), so vize collecting them is itself a divergence — a separate defect from this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency resolution for nested packages and pnpm-style workspaces.
  * Prevented false “Cannot find module” diagnostics for dependencies installed in sub-package `node_modules` directories.
  * Preserved correct errors for genuinely missing packages.
  * Improved generation and updating of TypeScript declaration stubs, including framework and Vue-related helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->