### PR TITLE
fix(maestro): bound Corsa bridge requests where they actually block

### DIFF
--- a/crates/vize_canon/src/corsa_bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge.rs
@@ -5,12 +5,14 @@
 //! behind the bridge surface.
 
 mod bridge;
+mod session;
 mod types;
 mod vue_dependencies;
 mod vue_dependency_specifiers;
 mod vue_document;
 #[cfg(test)]
 mod vue_document_tests;
+mod worker;
 
 pub use bridge::{BatchTypeChecker, CorsaBridge};
 pub use types::{
@@ -25,11 +27,12 @@ pub(crate) use vue_document::{CorsaVueVirtualProject, build_vue_virtual_project}
 #[cfg(test)]
 mod tests {
     use super::{
-        CorsaBridgeConfig, LspDiagnostic, LspPosition, LspRange, TypeCheckResult,
-        VIRTUAL_URI_SCHEME, bridge,
+        CorsaBridge, CorsaBridgeConfig, CorsaBridgeError, LspDiagnostic, LspPosition, LspRange,
+        TypeCheckResult, VIRTUAL_URI_SCHEME, bridge,
     };
     use crate::file_uri::path_to_file_uri;
-    use std::path::Path;
+    use corsa::runtime::block_on;
+    use std::path::{Path, PathBuf};
     use vize_carton::cstr;
 
     #[test]
@@ -75,6 +78,69 @@ mod tests {
         assert!(config.working_dir.is_none());
         assert_eq!(config.timeout_ms, 30000);
         assert!(!config.enable_profiling);
+    }
+
+    /// Writes a backend that accepts stdio and never answers — the shape
+    /// #3376 describes, and the one a `timeout` combinator cannot rescue.
+    ///
+    /// `cat` drains the request stream so the writer never blocks, and the
+    /// shell keeps the stdout pipe open without ever writing to it, so the
+    /// reader sees neither a reply nor an EOF. Redirecting the *shell's*
+    /// stdout (or `exec`ing) would close that pipe and surface a spawn error
+    /// instead of the silence being reproduced here.
+    #[cfg(unix)]
+    fn write_hanging_backend(dir: &Path) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        let script = dir.join("hanging-corsa");
+        std::fs::write(&script, "#!/bin/sh\ncat > /dev/null\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        script
+    }
+
+    /// `timeout_ms` has to be asserted as behavior, not as a default value
+    /// (#3376). Bridge IPC is synchronous, so no `timeout` combinator wrapped
+    /// around a bridge call can enforce a deadline; before this the configured
+    /// bound was read by nothing at all, and a silent backend blocked the
+    /// caller until `corsa`'s own 30s transport backstop killed the session —
+    /// per request, on the single thread that drives the whole LSP server.
+    ///
+    /// The assertion is on the outcome, not the clock: pre-fix this call
+    /// answers `SpawnFailed` after `corsa` gives up, post-fix it answers
+    /// `Timeout` because vize's own bound fired first.
+    #[test]
+    #[cfg(unix)]
+    fn a_backend_that_never_answers_is_bounded_by_the_configured_timeout() {
+        // Not cleaned up afterwards on purpose: the abandoned handshake still
+        // owns the backend, and pulling the script out from under a process
+        // that has not finished starting only produces exec noise. The pid
+        // keys the directory and it is cleared on entry, so a run leaves at
+        // most one of these behind.
+        let dir = std::env::temp_dir()
+            .join(cstr!("vize-corsa-bridge-bound-{}", std::process::id()).as_str());
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let bridge = CorsaBridge::with_config(CorsaBridgeConfig {
+            corsa_path: Some(write_hanging_backend(&dir)),
+            working_dir: Some(dir.clone()),
+            timeout_ms: 250,
+            ..Default::default()
+        });
+
+        let first = block_on(bridge.spawn());
+        // The abandoned handshake still owns the worker, so the retry must be
+        // refused outright rather than pay the deadline a second time.
+        let second = block_on(bridge.spawn());
+
+        assert!(
+            matches!(first, Err(CorsaBridgeError::Timeout)),
+            "expected the configured bound to fire, got {first:?}"
+        );
+        assert!(
+            matches!(second, Err(CorsaBridgeError::Timeout)),
+            "expected the outstanding stall to be reported, got {second:?}"
+        );
+        assert!(!bridge.is_initialized());
     }
 
     #[test]

--- a/crates/vize_canon/src/corsa_bridge/bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge.rs
@@ -1,17 +1,20 @@
 //! Core Corsa bridge implementation backed by `corsa-bind`.
 
 use serde_json::Value;
-use std::sync::atomic::{AtomicBool, Ordering};
 #[allow(clippy::disallowed_types)]
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 use vize_carton::profiler::{CacheStats, Profiler};
 use vize_carton::{String, cstr};
 
+use super::session::build_client;
 use super::types::{
     CorsaBridgeConfig, CorsaBridgeError, LspCompletionItem, LspCompletionResponse,
     LspDefinitionResponse, LspDiagnostic, LspHover, LspLocation, TypeCheckResult,
     VIRTUAL_URI_SCHEME,
 };
+use super::worker::{BoundedWorker, WorkerError};
 use crate::corsa_client::CorsaProjectClient;
 
 /// Bridge to Corsa for type checking and editor queries via project sessions.
@@ -19,8 +22,8 @@ use crate::corsa_client::CorsaProjectClient;
 pub struct CorsaBridge {
     /// Configuration
     config: CorsaBridgeConfig,
-    /// Shared Corsa project-session state.
-    client: Arc<Mutex<Option<CorsaProjectClient>>>,
+    /// Worker thread owning the synchronous Corsa project session.
+    worker: BoundedWorker<Option<CorsaProjectClient>>,
     /// Whether the bridge is initialized
     initialized: AtomicBool,
     /// Profiler for performance tracking
@@ -46,15 +49,17 @@ impl CorsaBridge {
         };
 
         Self {
+            worker: BoundedWorker::new("vize-corsa-bridge", None),
             config,
-            client: Arc::new(Mutex::new(None)),
             initialized: AtomicBool::new(false),
             profiler,
             cache_stats: CacheStats::new(),
         }
     }
 
-    /// Spawn and initialize the Corsa process.
+    /// Spawn and initialize the Corsa process, bounded by `timeout_ms`. The
+    /// handshake is synchronous IPC: a backend that accepts stdio and never
+    /// answers otherwise blocks until `corsa`'s own 30s backstop gives up.
     pub async fn spawn(&self) -> Result<(), CorsaBridgeError> {
         let _timer = self.profiler.timer("corsa_spawn");
 
@@ -62,41 +67,14 @@ impl CorsaBridge {
             return Ok(());
         }
 
-        let mut guard = lock_client(&self.client)?;
-        if guard.is_some() {
-            return Ok(());
-        }
-
-        let corsa_path = self
-            .config
-            .corsa_path
-            .as_ref()
-            .map(|path| path.to_string_lossy().into_owned());
-        let working_dir = self
-            .config
-            .working_dir
-            .as_ref()
-            .map(|path| path.to_string_lossy().into_owned());
-
-        // Root the session at the real workspace when it is a TypeScript
-        // project: its own tsconfig (paths, baseUrl) then drives module
-        // resolution and virtual `.vue.ts` overlays can live at their real
-        // paths, so relative imports in `<script>` resolve exactly like
-        // `vize check`. The isolated scratch session — which synthesizes a
-        // tsconfig and `*.vue` stubs — remains the fallback for rootless or
-        // tsconfig-less usage.
-        let workspace_root = working_dir
-            .as_deref()
-            .map(std::path::Path::new)
-            .filter(|dir| {
-                dir.join("tsconfig.json").is_file() || dir.join("jsconfig.json").is_file()
-            });
-        let client = match workspace_root {
-            Some(dir) => CorsaProjectClient::new_for_workspace(corsa_path.as_deref(), dir),
-            None => CorsaProjectClient::new(corsa_path.as_deref(), working_dir.as_deref()),
-        }
-        .map_err(CorsaBridgeError::SpawnFailed)?;
-        *guard = Some(client);
+        let config = self.config.clone();
+        self.submit(move |slot| {
+            if slot.is_some() {
+                return Ok(());
+            }
+            *slot = Some(build_client(&config)?);
+            Ok(())
+        })?;
 
         self.initialized.store(true, Ordering::SeqCst);
 
@@ -241,16 +219,19 @@ impl CorsaBridge {
             return Ok(());
         }
 
-        let mut guard = lock_client(&self.client)?;
-        if let Some(client) = guard.as_mut() {
-            client
-                .shutdown()
-                .map_err(CorsaBridgeError::CommunicationError)?;
-        }
-        *guard = None;
+        let result = self.submit(|slot| {
+            let outcome = match slot.as_mut() {
+                Some(client) => client
+                    .shutdown()
+                    .map_err(CorsaBridgeError::CommunicationError),
+                None => Ok(()),
+            };
+            *slot = None;
+            outcome
+        });
 
         self.initialized.store(false, Ordering::SeqCst);
-        Ok(())
+        result
     }
 
     /// Check if bridge is initialized.
@@ -270,11 +251,12 @@ impl CorsaBridge {
 
     /// Clear diagnostics cache.
     pub fn clear_cache(&self) {
-        if let Ok(mut guard) = self.client.lock()
-            && let Some(client) = guard.as_mut()
-        {
-            client.clear_diagnostics_cache();
-        }
+        let _ = self.submit(|slot| {
+            if let Some(client) = slot.as_mut() {
+                client.clear_diagnostics_cache();
+            }
+            Ok(())
+        });
         self.cache_stats.set_entries(0);
         self.cache_stats.reset();
     }
@@ -441,15 +423,41 @@ impl CorsaBridge {
 
     pub(super) async fn with_client<R, F>(&self, f: F) -> Result<R, CorsaBridgeError>
     where
-        F: FnOnce(&mut CorsaProjectClient) -> Result<R, CorsaBridgeError>,
+        F: FnOnce(&mut CorsaProjectClient) -> Result<R, CorsaBridgeError> + Send + 'static,
+        R: Send + 'static,
     {
         if !self.initialized.load(Ordering::SeqCst) {
             return Err(CorsaBridgeError::NotInitialized);
         }
 
-        let mut guard = lock_client(&self.client)?;
-        let client = guard.as_mut().ok_or(CorsaBridgeError::ProcessTerminated)?;
-        f(client)
+        self.submit(move |slot| match slot.as_mut() {
+            Some(client) => f(client),
+            None => Err(CorsaBridgeError::ProcessTerminated),
+        })
+    }
+
+    /// Run `f` against the session on the worker thread under the configured
+    /// deadline — the one place the bound is real. The wait blocks on purpose:
+    /// the job never yields, so an async `timeout` around it could never be
+    /// polled, and making it yield would activate #3377's shard-guard hazard.
+    /// See [`super::worker`] for the full argument.
+    fn submit<R, F>(&self, f: F) -> Result<R, CorsaBridgeError>
+    where
+        F: FnOnce(&mut Option<CorsaProjectClient>) -> Result<R, CorsaBridgeError> + Send + 'static,
+        R: Send + 'static,
+    {
+        // Clamped so a misconfigured `0` stays loud instead of silently
+        // disabling the bridge; no value turns the bound off.
+        let deadline = Duration::from_millis(self.config.timeout_ms.max(1));
+        match self.worker.submit(deadline, f) {
+            Ok(result) => result,
+            Err(WorkerError::TimedOut) => {
+                let bound = self.config.timeout_ms;
+                tracing::warn!("corsa request outran the {bound}ms bridge bound; abandoned it");
+                Err(CorsaBridgeError::Timeout)
+            }
+            Err(WorkerError::Stopped) => Err(CorsaBridgeError::ProcessTerminated),
+        }
     }
 }
 
@@ -461,7 +469,8 @@ impl Default for CorsaBridge {
 
 impl Drop for CorsaBridge {
     fn drop(&mut self) {
-        // Async shutdown is handled by explicit callers.
+        // Async shutdown is handled by explicit callers; dropping the worker
+        // closes its job channel and the session is dropped on that thread.
     }
 }
 
@@ -562,13 +571,4 @@ where
     serde_json::from_value(value).map_err(|e| {
         CorsaBridgeError::CommunicationError(cstr!("Failed to parse Corsa result: {e}"))
     })
-}
-
-#[allow(clippy::disallowed_types)]
-fn lock_client<'a>(
-    client: &'a Arc<Mutex<Option<CorsaProjectClient>>>,
-) -> Result<std::sync::MutexGuard<'a, Option<CorsaProjectClient>>, CorsaBridgeError> {
-    client
-        .lock()
-        .map_err(|_| CorsaBridgeError::CommunicationError("Corsa client lock poisoned".into()))
 }

--- a/crates/vize_canon/src/corsa_bridge/session.rs
+++ b/crates/vize_canon/src/corsa_bridge/session.rs
@@ -1,0 +1,41 @@
+//! Corsa project-session construction, run on the bridge worker thread.
+#![allow(clippy::disallowed_types)]
+
+use super::types::{CorsaBridgeConfig, CorsaBridgeError};
+use crate::corsa_client::CorsaProjectClient;
+
+/// Spawn the Corsa project session described by `config`.
+///
+/// Runs on the bridge worker thread (see [`super::worker`]): the handshake
+/// this performs is synchronous IPC and is exactly as prone to hanging as any
+/// later request, so it has to be bounded the same way.
+pub(super) fn build_client(
+    config: &CorsaBridgeConfig,
+) -> Result<CorsaProjectClient, CorsaBridgeError> {
+    let corsa_path = config
+        .corsa_path
+        .as_ref()
+        .map(|path| path.to_string_lossy().into_owned());
+    let working_dir = config
+        .working_dir
+        .as_ref()
+        .map(|path| path.to_string_lossy().into_owned());
+
+    // Root the session at the real workspace when it is a TypeScript
+    // project: its own tsconfig (paths, baseUrl) then drives module
+    // resolution and virtual `.vue.ts` overlays can live at their real
+    // paths, so relative imports in `<script>` resolve exactly like
+    // `vize check`. The isolated scratch session — which synthesizes a
+    // tsconfig and `*.vue` stubs — remains the fallback for rootless or
+    // tsconfig-less usage.
+    let workspace_root = working_dir
+        .as_deref()
+        .map(std::path::Path::new)
+        .filter(|dir| dir.join("tsconfig.json").is_file() || dir.join("jsconfig.json").is_file());
+
+    match workspace_root {
+        Some(dir) => CorsaProjectClient::new_for_workspace(corsa_path.as_deref(), dir),
+        None => CorsaProjectClient::new(corsa_path.as_deref(), working_dir.as_deref()),
+    }
+    .map_err(CorsaBridgeError::SpawnFailed)
+}

--- a/crates/vize_canon/src/corsa_bridge/types.rs
+++ b/crates/vize_canon/src/corsa_bridge/types.rs
@@ -298,7 +298,13 @@ pub struct CorsaBridgeConfig {
     pub corsa_path: Option<PathBuf>,
     /// Working directory used for module resolution.
     pub working_dir: Option<PathBuf>,
-    /// Request timeout in milliseconds
+    /// Hard per-request bound, in milliseconds, on every call into the Corsa
+    /// session — the spawn handshake included.
+    ///
+    /// A request that outruns it is abandoned on the bridge worker thread and
+    /// reported as [`CorsaBridgeError::Timeout`], and calls arriving while an
+    /// abandoned request still drains fail fast with the same error. `0` is
+    /// clamped to 1ms: there is no value that disables the bound.
     pub timeout_ms: u64,
     /// Enable profiling
     pub enable_profiling: bool,

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -101,12 +101,15 @@ impl CorsaBridge {
         &self,
         documents: &[(String, String)],
     ) -> Result<(), CorsaBridgeError> {
-        let docs: Vec<(&str, &str)> = documents
-            .iter()
-            .map(|(uri, content)| (uri.as_str(), content.as_str()))
-            .collect();
+        // Owned pairs: the closure runs on the bridge worker thread, so it
+        // cannot borrow from this frame (see `super::worker`).
+        let owned: Vec<(String, String)> = documents.to_vec();
         let cache_len = self
             .with_client(move |client| {
+                let docs: Vec<(&str, &str)> = owned
+                    .iter()
+                    .map(|(uri, content)| (uri.as_str(), content.as_str()))
+                    .collect();
                 client
                     .did_open_batch_fast(&docs)
                     .map_err(CorsaBridgeError::CommunicationError)?;

--- a/crates/vize_canon/src/corsa_bridge/worker.rs
+++ b/crates/vize_canon/src/corsa_bridge/worker.rs
@@ -1,0 +1,253 @@
+//! Deadline-bounded worker thread for synchronous, un-cancellable state.
+//!
+//! Every Corsa bridge call is synchronous underneath: `corsa`'s project
+//! session drives its IPC through [`corsa::runtime::block_on`], so a bridge
+//! future never yields. Wrapping such a future in an async `timeout`
+//! combinator cannot bound it — the guarded future owns the executor thread
+//! and the timer half never gets polled again, which is why the diagnostics
+//! pass appeared to promise 10s while `CorsaBridgeConfig::timeout_ms` was read
+//! by nothing (#3376).
+//!
+//! What was left holding the line is `corsa`'s own transport backstop, 30s per
+//! request, applied per request and unaware of how many requests a pass makes
+//! or that a respawn retry follows. `vize lsp` drives tower-lsp on a single
+//! thread, so every one of those waits freezes the entire server — no
+//! diagnostics, no responses, no timeout of vize's own.
+//!
+//! This module bounds the wait where the blocking actually happens. The
+//! synchronous state lives on a dedicated worker thread and callers hand it a
+//! job plus a hard deadline. When the deadline elapses the caller gives up and
+//! reports [`WorkerError::TimedOut`], while the worker keeps draining the
+//! abandoned job so the backend transport is never left half-read. Callers
+//! that arrive while an abandoned job is still draining fail fast instead of
+//! queueing behind it, so a wedged backend costs one deadline in total rather
+//! than one deadline per request.
+//!
+//! The wait is deliberately blocking rather than an `.await`. Making bridge
+//! calls genuinely yield would activate the latent `IdeContext` shard-guard
+//! deadlock recorded in #3377; bounding without yielding keeps that hazard
+//! unreachable.
+#![allow(clippy::disallowed_types)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::thread;
+use std::time::Duration;
+
+/// A unit of work executed on the worker thread against the owned state.
+type Job<T> = Box<dyn FnOnce(&mut T) + Send>;
+
+/// Why a [`BoundedWorker::submit`] call did not produce a value.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(super) enum WorkerError {
+    /// The job outran its deadline, or an earlier abandoned job still owns the
+    /// worker. Either way the backend did not answer within the bound.
+    TimedOut,
+    /// The worker thread is gone, so no job can run any more.
+    Stopped,
+}
+
+/// Owns `T` on a dedicated thread and runs jobs against it under a deadline.
+pub(super) struct BoundedWorker<T> {
+    /// `None` when the worker thread could not be started.
+    jobs: Option<mpsc::Sender<Job<T>>>,
+    /// Jobs whose caller already gave up and which the worker is still
+    /// draining. Non-zero means the next `submit` must fail fast.
+    abandoned: Arc<AtomicUsize>,
+}
+
+impl<T: Send + 'static> BoundedWorker<T> {
+    /// Move `state` onto a worker thread named `name`.
+    ///
+    /// A failed thread spawn is not fatal: every later `submit` reports
+    /// [`WorkerError::Stopped`], which callers surface as a bridge error.
+    ///
+    /// Dropping the worker closes the job channel, so the thread finishes what
+    /// it is running and then drops `state`. A worker still draining an
+    /// abandoned job therefore outlives its owner until that job returns —
+    /// the price of never tearing down a transport mid-request.
+    pub(super) fn new(name: &str, mut state: T) -> Self {
+        let (sender, receiver) = mpsc::channel::<Job<T>>();
+        let spawned = thread::Builder::new()
+            .name(std::string::String::from(name))
+            .spawn(move || {
+                while let Ok(job) = receiver.recv() {
+                    job(&mut state);
+                }
+            });
+
+        Self {
+            jobs: spawned.is_ok().then_some(sender),
+            abandoned: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// Run `f` against the owned state, giving up after `deadline`.
+    ///
+    /// The returned value is whatever `f` produced. A job that outruns the
+    /// deadline is *abandoned*, not cancelled: it keeps running on the worker
+    /// thread until it finishes, and its result is dropped. That is deliberate
+    /// — the backend transport has no way to withdraw an in-flight request, so
+    /// dropping the job mid-request would desynchronize the session.
+    pub(super) fn submit<R, F>(&self, deadline: Duration, f: F) -> Result<R, WorkerError>
+    where
+        F: FnOnce(&mut T) -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        // A previous caller already gave up on a job that still owns the
+        // worker. Queueing behind it would make every following request pay
+        // the full deadline again, so report the outstanding stall directly.
+        if self.abandoned.load(Ordering::Acquire) > 0 {
+            return Err(WorkerError::TimedOut);
+        }
+
+        let Some(jobs) = self.jobs.as_ref() else {
+            return Err(WorkerError::Stopped);
+        };
+
+        // A rendezvous channel makes abandonment observable exactly once: the
+        // worker's `send` can only complete while this caller is still
+        // waiting, and fails as soon as the receiver below is dropped.
+        let (result_sender, result_receiver) = mpsc::sync_channel::<R>(0);
+        let abandoned = self.abandoned.clone();
+        let job: Job<T> = Box::new(move |state| {
+            let value = f(state);
+            if result_sender.send(value).is_err() {
+                abandoned.fetch_sub(1, Ordering::AcqRel);
+            }
+        });
+
+        if jobs.send(job).is_err() {
+            return Err(WorkerError::Stopped);
+        }
+
+        match result_receiver.recv_timeout(deadline) {
+            Ok(value) => Ok(value),
+            Err(RecvTimeoutError::Timeout) => {
+                // Recorded before `result_receiver` is dropped, so the worker
+                // cannot observe the disconnect before the count is raised.
+                self.abandoned.fetch_add(1, Ordering::AcqRel);
+                Err(WorkerError::TimedOut)
+            }
+            Err(RecvTimeoutError::Disconnected) => Err(WorkerError::Stopped),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BoundedWorker, WorkerError};
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    /// Generous upper bound for "the worker observed something"; the
+    /// assertions below are on outcomes, never on elapsed time.
+    const SETTLE: Duration = Duration::from_secs(10);
+    const DEADLINE: Duration = Duration::from_millis(50);
+
+    struct Gate {
+        release: mpsc::Sender<()>,
+        entered: mpsc::Receiver<()>,
+    }
+
+    /// A worker whose first job blocks until the returned gate releases it.
+    fn gated_worker() -> (BoundedWorker<()>, Gate, impl Fn(&mut ()) + Send + 'static) {
+        let (release, hold) = mpsc::channel::<()>();
+        let (entered_tx, entered) = mpsc::channel::<()>();
+        let block = move |_: &mut ()| {
+            let _ = entered_tx.send(());
+            let _ = hold.recv();
+        };
+        (
+            BoundedWorker::new("vize-test-worker", ()),
+            Gate { release, entered },
+            block,
+        )
+    }
+
+    #[test]
+    fn submit_returns_the_job_result_within_the_deadline() {
+        let worker = BoundedWorker::new("vize-test-worker", 40_u32);
+        let doubled = worker.submit(SETTLE, |state| {
+            *state *= 2;
+            *state + 2
+        });
+
+        assert_eq!(doubled, Ok(82));
+        assert_eq!(worker.submit(SETTLE, |state| *state), Ok(80));
+    }
+
+    #[test]
+    fn submit_times_out_when_a_job_outruns_the_deadline() {
+        let (worker, gate, block) = gated_worker();
+
+        let outcome = worker.submit(DEADLINE, block);
+
+        assert_eq!(outcome, Err(WorkerError::TimedOut));
+        gate.entered
+            .recv_timeout(SETTLE)
+            .expect("job must have run");
+        let _ = gate.release.send(());
+    }
+
+    #[test]
+    fn submit_fails_fast_without_running_a_job_while_an_abandoned_job_drains() {
+        let (worker, gate, block) = gated_worker();
+        assert_eq!(worker.submit(DEADLINE, block), Err(WorkerError::TimedOut));
+        gate.entered
+            .recv_timeout(SETTLE)
+            .expect("job must have run");
+
+        let (ran_tx, ran) = mpsc::channel::<()>();
+        let outcome = worker.submit(DEADLINE, move |_| {
+            let _ = ran_tx.send(());
+        });
+
+        // The point of the fast path: the second caller is refused outright
+        // rather than queued, so its job never reaches the worker.
+        assert_eq!(outcome, Err(WorkerError::TimedOut));
+        assert!(ran.try_recv().is_err(), "queued behind the abandoned job");
+
+        let _ = gate.release.send(());
+    }
+
+    #[test]
+    fn submit_recovers_once_the_abandoned_job_finishes() {
+        let (worker, gate, block) = gated_worker();
+        assert_eq!(worker.submit(DEADLINE, block), Err(WorkerError::TimedOut));
+        gate.entered
+            .recv_timeout(SETTLE)
+            .expect("job must have run");
+        let _ = gate.release.send(());
+
+        // The worker clears the abandoned job on its own thread, so retry
+        // until it has been observed. The assertion is that service returns,
+        // not how quickly it does.
+        let started = Instant::now();
+        let mut recovered = Err(WorkerError::TimedOut);
+        while started.elapsed() < SETTLE {
+            recovered = worker.submit(SETTLE, |_| 7_u8);
+            if recovered.is_ok() {
+                break;
+            }
+            std::thread::yield_now();
+        }
+
+        assert_eq!(recovered, Ok(7));
+    }
+
+    #[test]
+    fn submit_reports_a_stopped_worker_when_no_thread_is_backing_it() {
+        // Models a failed thread spawn: nothing can run the job, so the caller
+        // must be told instead of waiting out its deadline for a lost reply.
+        let stopped = BoundedWorker::<()> {
+            jobs: None,
+            abandoned: Arc::new(AtomicUsize::new(0)),
+        };
+
+        assert_eq!(stopped.submit(SETTLE, |_| ()), Err(WorkerError::Stopped));
+    }
+}

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
@@ -3,11 +3,11 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use tower_lsp::lsp_types::{Diagnostic, Url};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Range, Url};
 
 use crate::server::ServerState;
 
-use super::super::DiagnosticService;
+use super::super::{DiagnosticService, sources};
 use super::collect_virtual::{
     collect_synced_virtual_result_diagnostics, collect_virtual_result_diagnostics,
 };
@@ -62,7 +62,13 @@ impl DiagnosticService {
                 }
                 Err(CollectFailure::Request(error)) => {
                     tracing::warn!("corsa request failed for {uri}: {error}");
-                    return vec![];
+                    // A bound that fires has to be visible. Returning an empty
+                    // list would make a timed-out pass indistinguishable from a
+                    // clean file, which is the silence #3376 is about.
+                    return match error {
+                        CorsaBridgeError::Timeout => vec![typecheck_timed_out_hint()],
+                        _ => vec![],
+                    };
                 }
             }
         }
@@ -205,6 +211,27 @@ impl DiagnosticService {
         }
 
         Ok(diagnostics)
+    }
+}
+
+/// Diagnostic published when a Corsa request outran the bridge's hard bound.
+///
+/// The bound is enforced by the bridge worker thread, because the request is
+/// synchronous IPC and no async `timeout` around it can ever be polled
+/// (#3376). This diagnostic is how the enforcement reaches the client — the
+/// publish arriving promptly, and saying why the types are missing, is the
+/// observable difference from a frozen server.
+fn typecheck_timed_out_hint() -> Diagnostic {
+    Diagnostic {
+        range: Range::default(),
+        severity: Some(DiagnosticSeverity::WARNING),
+        code: Some(NumberOrString::String("typecheck-timed-out".to_string())),
+        source: Some(sources::TYPE_CHECKER.to_string()),
+        message: "Type checking timed out for this file: the Corsa runtime did not \
+            answer within the request timeout, so type errors are missing from \
+            these diagnostics."
+            .to_string(),
+        ..Default::default()
     }
 }
 

--- a/crates/vize_maestro/src/server/state/corsa.rs
+++ b/crates/vize_maestro/src/server/state/corsa.rs
@@ -5,9 +5,19 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
-use vize_canon::{CorsaBridge, CorsaBridgeConfig};
+use vize_canon::{CorsaBridge, CorsaBridgeConfig, CorsaBridgeError};
 
 use super::ServerState;
+
+/// Hard bound on every Corsa request the editor makes, enforced by the bridge
+/// worker thread (#3376).
+///
+/// It matches the 10s the diagnostics pass already documents. That pass wraps
+/// the collection in `runtime::timeout`, but nothing on the bridge path yields,
+/// so the combinator can never fire and this is the bound that actually
+/// applies. It is per request: a diagnostics pass makes a small fixed number of
+/// them, and the first one to breach the bound short-circuits the rest.
+const CORSA_REQUEST_TIMEOUT_MS: u64 = 10_000;
 
 impl ServerState {
     /// Try to claim the right to fire the "type checking unavailable"
@@ -59,31 +69,34 @@ impl ServerState {
         let config = CorsaBridgeConfig {
             corsa_path: type_checker_config.runtime_path().map(PathBuf::from),
             working_dir: workspace_root,
-            timeout_ms: 30000, // Corsa needs time to build project state on first load.
+            timeout_ms: CORSA_REQUEST_TIMEOUT_MS,
             ..Default::default()
         };
         let working_dir = config.working_dir.clone();
         let corsa_path = config.corsa_path.clone();
         let bridge = CorsaBridge::with_config(config);
 
-        match crate::runtime::timeout(std::time::Duration::from_secs(5), bridge.spawn()).await {
-            Ok(Ok(())) => {
+        // No `runtime::timeout` wrapper here: `spawn()` never yields, so a
+        // combinator around it could not be polled and never fired (#3376).
+        // The bridge bounds the handshake itself and reports `Timeout`.
+        match bridge.spawn().await {
+            Ok(()) => {
                 tracing::info!("corsa bridge initialized successfully");
                 let bridge = Arc::new(bridge);
                 *self.corsa_bridge.write() = Some(bridge.clone());
                 Some(bridge)
             }
-            Ok(Err(e)) => {
+            Err(CorsaBridgeError::Timeout) => {
                 let reason = vize_carton::cstr!(
-                    "spawn failed: {e} (working_dir={working_dir:?}, corsa_path={corsa_path:?})"
+                    "spawn timed out after {CORSA_REQUEST_TIMEOUT_MS}ms (working_dir={working_dir:?}, corsa_path={corsa_path:?})"
                 );
                 tracing::warn!("corsa bridge {}", reason);
                 self.record_corsa_init_failure(reason.as_str());
                 None
             }
-            Err(_) => {
+            Err(e) => {
                 let reason = vize_carton::cstr!(
-                    "spawn timed out after 5s (working_dir={working_dir:?}, corsa_path={corsa_path:?})"
+                    "spawn failed: {e} (working_dir={working_dir:?}, corsa_path={corsa_path:?})"
                 );
                 tracing::warn!("corsa bridge {}", reason);
                 self.record_corsa_init_failure(reason.as_str());


### PR DESCRIPTION
Fixes #3376. This is the second route into #3315 — the one that needs nothing unusual to trigger, unlike the declaration-cache invalidation #3373 required.

Please read **What I could not confirm** before merging: the defect and the fix are real, but the issue's "unbounded" framing turned out to be one step off and the corrected version is below.

## Why the timeout cannot fire

Two combinators guard the Corsa path, and neither can ever run:

```rust
// ide/diagnostics/service.rs
match crate::runtime::timeout(Duration::from_secs(10), corsa_future).await { ... }
// server/state/corsa.rs
match crate::runtime::timeout(Duration::from_secs(5), bridge.spawn()).await { ... }
```

Every Corsa bridge call is synchronous underneath. `CorsaBridge::with_client` took a blocking `std::sync::Mutex` and called straight into `CorsaProjectClient`, whose every method is `corsa::runtime::block_on(...)`. Those `async fn` bodies contain no yield point, so the future is `Ready` on its first poll. `runtime::timeout` polls the guarded future first and returns `Ok` immediately; the sleep half is never polled again. A future that cannot yield cannot be cancelled by a timeout combinator — it just owns the thread until it returns.

`CorsaBridgeConfig::timeout_ms` was read by nothing. Confirmed exactly as the issue states: every occurrence was a declaration, a default, or `assert_eq!(config.timeout_ms, 30000)`.

`vize lsp` drives tower-lsp with `runtime::block_on` on one thread while `Server::serve` polls up to 4 queued messages concurrently, so whichever handler is blocked in the bridge freezes every other in-flight request too. That is why this presents as total silence rather than one slow response.

## What I changed

**`corsa_bridge/worker.rs` (new).** `BoundedWorker<T>` owns `T` on a dedicated thread. `submit(deadline, f)` sends the job and waits on a rendezvous channel with `recv_timeout`.

- A job that outruns its deadline is **abandoned, not cancelled**: it keeps running on the worker until it finishes and its result is dropped. Dropping a job mid-request would desynchronize the session — the transport has no way to withdraw an in-flight request.
- The rendezvous channel (`sync_channel(0)`) makes abandonment observable exactly once: the worker's `send` can only complete while the caller is still waiting, and fails as soon as the receiver is dropped. That failure is what decrements the abandoned count.
- Callers arriving while an abandoned job still drains **fail fast** instead of queueing behind it. A wedged backend costs one deadline in total, not one deadline per request.

**`corsa_bridge/bridge.rs`.** `client: Arc<Mutex<Option<CorsaProjectClient>>>` becomes `worker: BoundedWorker<Option<CorsaProjectClient>>`. `spawn`, `shutdown`, `clear_cache` and `with_client` all route through one `submit` that applies `Duration::from_millis(timeout_ms.max(1))` and maps `TimedOut` → `CorsaBridgeError::Timeout`, `Stopped` → `ProcessTerminated`. `lock_client` is gone. Session construction moved verbatim to `corsa_bridge/session.rs` so `bridge.rs` does not grow (574 → 574 lines).

**`timeout_ms` is now honored, on every call including the spawn handshake.** `0` is clamped to 1ms; there is deliberately no value that disables the bound.

**`server/state/corsa.rs`.** The editor's bound is `CORSA_REQUEST_TIMEOUT_MS = 10_000`, matching the 10s the diagnostics pass already documents, rather than the 30s that was never enforced. The `runtime::timeout(5s, bridge.spawn())` wrapper is removed — it could not fire, and the bridge now bounds the handshake itself and reports `Timeout`.

**`ide/diagnostics/corsa/collect.rs`.** A `CorsaBridgeError::Timeout` used to log a warning and return `vec![]`, which is indistinguishable from a clean file. It now publishes a `typecheck-timed-out` warning saying type errors are missing. A *spawn* timeout was already covered: `has_corsa_bridge()` goes false and `collect_async` emits the existing `typecheck-unavailable` hint.

Not touched: `vize check`. Its `batch::BatchTypeChecker` never goes through `CorsaBridge`, so the new bound applies to the LSP only.

## #3377 stays unreachable, deliberately

`IdeContext` still holds a live `virtual_docs` shard guard across awaits on the hover/completion/definition/rename paths. That stays safe because **this fix introduces no yield point**:

- `with_client` was `async fn` with a fully synchronous body (blocking `Mutex::lock` + call). It is still `async fn` with a fully synchronous body (blocking `recv_timeout`). Neither yields; both complete on the first poll.
- `spawn` is likewise still synchronous under its `async fn`.
- No `.await` was added to any request handler. Removing the `runtime::timeout` around `spawn` is yield-neutral: it polled the inner future first and returned `Ok` without ever registering the sleep.
- The worker thread never touches maestro state, so blocking on it while holding a `DashMap` guard cannot deadlock against it.

Bounding without yielding is the whole reason the wait is blocking rather than an `.await`, and that reasoning is recorded in `corsa_bridge/worker.rs`'s module doc and at `CorsaBridge::submit`, so the next person to reach for `.await` there finds the constraint. Making the bridge genuinely cancellable is still possible — `submit` would `.await` a oneshot instead of `recv_timeout` — but it activates #3377 and turns every bridge call into a real interleaving point for the whole LSP, a much larger behavioural change than a hang fix should carry. What it would take is spelled out at the bottom.

## Tests

**`corsa_bridge.rs`: `a_backend_that_never_answers_is_bounded_by_the_configured_timeout`.** Points `corsa_path` at a `#!/bin/sh` backend that drains stdin and never writes, sets `timeout_ms: 250`, and asserts `spawn()` reports `Timeout` — and that an immediate retry reports `Timeout` too, without queueing behind the abandoned handshake. The assertion is on the error variant, never on elapsed time. `test_config_default`'s `assert_eq!(config.timeout_ms, 30000)` stays, since pinning the default value is still worth doing; what it was standing in for — that the bound is enforced — is now covered for real.

The fake backend must not `exec` or redirect the *shell's* stdout: that closes the pipe and produces a spawn error instead of the silence being reproduced. Documented at the helper.

**`corsa_bridge/worker.rs`: five unit tests** covering the result path, the deadline, fail-fast-without-running-the-job while abandoned (asserted by the second job never signalling that it ran — not by timing), recovery once the abandoned job drains, and a worker with no thread behind it.

### Verified the test fails without the fix

Per instructions, `git diff --output=… crates/vize_canon/src/corsa_bridge/bridge.rs` then `git apply -R` (not `git stash`, which is shared across worktrees).

| `bridge.rs` | result |
| --- | --- |
| reverted to `main` | **fails**, `got Err(SpawnFailed("… `initialize` timed out after 30000 ms"))`, 60.0s wall for the two `spawn()` calls |
| with the fix | **passes 5/5 runs**, 0.26s each |

60s for two calls is 2 × `corsa`'s own 30s backstop: the configured 250ms bound was ignored entirely, and each call froze the caller for 30s.

## Commands and results

```
cargo test -p vize_maestro                    570 + 3 + 1 passed, 0 failed
cargo test -p vize_canon --lib                638 passed, 0 failed
cargo test -p vize_canon (incl. integration)  all suites passed, 0 failed
cargo fmt --all -- --check                    clean
cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports   clean
VIZE_LSP_BIN=target/ci/vize node --test tests/tooling/lsp-*.test.ts
                                              2185 passed, 0 failed
VIZE_LSP_BIN=target/ci/vize node --test tests/performance/lsp-churn-stress.test.ts
                                              1 passed, 0 failed (26.4s, misskey)
```

The typecheck-dependent suites really ran (tsgo present): `lsp-corsa-crash-recovery` reports its recovery timings, `lsp-concurrent-edit-deadlock` walks all four churn rounds, and the churn stress test drives real misskey sources — so the 10s bound is exercised against a real project and never fires on the happy path.

Source-length gate, checked with `wc -l` against `git show origin/main:<path>`:

| file | base | now |
| --- | --- | --- |
| `corsa_bridge/bridge.rs` | 574 | **574** (over limit, unchanged) |
| `corsa_bridge.rs` | 89 | 155 |
| `corsa_bridge/types.rs` | 316 | 322 |
| `corsa_bridge/vue_document.rs` | 236 | 239 |
| `diagnostics/corsa/collect.rs` | 251 | 278 |
| `server/state/corsa.rs` | 138 | 149 |
| `corsa_bridge/worker.rs` | new | 253 |
| `corsa_bridge/session.rs` | new | 41 |

`source-file-lengths.test.ts` itself does not run in this environment: the `moon` on PATH is moonrepo's, not MoonBit's, so every subtest that shells out fails with "not in a Moon project". Unrelated to this change; the table above is the manual equivalent.

## What I could not confirm

**The issue says "unbounded silence"; measured, it is 30s per request.** `corsa`'s transports default to `request_timeout: Some(Duration::from_secs(30))` and vize does not override it, so a silent backend was never literally infinite. That backstop is still the wrong thing to be relying on: it is not `timeout_ms` and not vize's to set, it kills the session when it fires, it applies per request while a diagnostics pass makes several plus a respawn retry, and 30s of a frozen single-threaded LSP is the reported symptom either way. This fix makes vize's own shorter bound the one that governs and stops the waits from stacking.

**The 10s editor bound is a judgement call.** It matches what `collect_async` documents and is well clear of anything observed (misskey's churn passes complete far inside it), but a first typecheck on a very large project that legitimately took 10–30s would now report a timeout, publish the warning, and get its types on a later pass instead. Easy to dial via `CORSA_REQUEST_TIMEOUT_MS` if you would rather keep 30s.

**Still not attributed to the #3315 report.** Same caveat #3373 carried: this is a real defect on the reported path, fixed and covered, but I cannot prove it is the stall the reporter hit.

**A wedged backend leaks its worker thread.** If the abandoned job never returns, the worker outlives the bridge and the backend process is never dropped. That is the price of not tearing down a live transport mid-request; previously the same situation wedged the whole server instead.

## What full cancellability would require

For the record, if the bridge should become genuinely async later: `BoundedWorker::submit` awaits a `oneshot` instead of `recv_timeout`, which is a small change and lets the existing `runtime::timeout` do its job. The cost is everything downstream — #3377 must be fixed first (owned `VirtualDocuments` snapshot in `IdeContext` instead of the shard guard, a clone per request on hot editor paths), and every bridge call becomes a real interleaving point, so the strictly-serial publish ordering the churn suite currently observes no longer holds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corsa requests now enforce a reliable timeout, preventing stalled operations from blocking future requests.
  - Bridge startup and communication failures are handled more consistently.
  - Virtual document batches are processed more reliably.

- **Diagnostics**
  - Type checking timeouts now display a warning indicating that type errors may be unavailable.
  - Corsa sessions automatically use the configured workspace when project configuration is detected.

- **Documentation**
  - Clarified request-timeout behavior, including timeout limits and subsequent request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->