### PR TITLE
fix(canon): fall back to junctions for directory links on stock Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,6 +1386,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e770254dd7802184595b1d30da2a15cb72569e2aca2b177aef8d22eac8a693"
 
 [[package]]
+name = "junction"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
+dependencies = [
+ "scopeguard",
+ "windows-sys",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3580,6 +3590,7 @@ dependencies = [
  "dashmap 6.1.0",
  "dirs",
  "insta",
+ "junction",
  "libc",
  "lsp-types 0.97.0",
  "oxc_allocator",

--- a/crates/vize_canon/Cargo.toml
+++ b/crates/vize_canon/Cargo.toml
@@ -52,6 +52,10 @@ corsa = { workspace = true, optional = true }
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+# Directory junctions as a privilege-free fallback for directory links.
+junction = "2"
+
 [dev-dependencies]
 tempfile.workspace = true
 insta.workspace = true

--- a/crates/vize_canon/src/batch/runtime_deps.rs
+++ b/crates/vize_canon/src/batch/runtime_deps.rs
@@ -135,8 +135,11 @@ fn write_vite_stub(node_modules_dir: &Path) -> std::io::Result<()> {
 }
 
 fn ensure_stub_dir(path: &Path) -> std::io::Result<()> {
+    // A link (symlink or junction) must be replaced, never written through:
+    // std reports junctions as plain directories, so probe `read_link`.
+    let is_link = std::fs::read_link(path).is_ok();
     match std::fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() => {}
+        Ok(metadata) if metadata.file_type().is_dir() && !is_link => {}
         Ok(_) => {
             remove_path(path)?;
             ensure_dir(path)?;
@@ -174,7 +177,11 @@ fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
     #[cfg(windows)]
     {
         if source.is_dir() {
+            // Directory junctions need no special privilege, unlike symlinks:
+            // fall back so directory links still materialize on stock Windows
+            // without Developer Mode or an elevated shell.
             std::os::windows::fs::symlink_dir(source, target)
+                .or_else(|_| junction::create(source, target))
         } else {
             std::os::windows::fs::symlink_file(source, target)
         }
@@ -182,16 +189,19 @@ fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
 }
 
 fn symlink_matches(source: &Path, target: &Path) -> std::io::Result<bool> {
-    let metadata = match std::fs::symlink_metadata(target) {
-        Ok(metadata) => metadata,
+    match std::fs::symlink_metadata(target) {
+        Ok(_) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
         Err(error) => return Err(error),
-    };
-    if !metadata.file_type().is_symlink() {
-        return Ok(false);
     }
-    let linked = std::fs::read_link(target)?;
-    Ok(linked == source)
+    // `FileType::is_symlink` is false for junctions, so probe with
+    // `read_link`: it resolves both symlinks and junctions and fails for
+    // real files and directories. Junction targets come back in a `\??\`
+    // verbatim spelling, so compare canonicalized forms.
+    let Ok(linked) = std::fs::read_link(target) else {
+        return Ok(false);
+    };
+    Ok(linked == source || package_link_source(&linked) == package_link_source(source))
 }
 
 fn prune_stub_dir(dir: &Path, file_names: &[&str]) -> std::io::Result<()> {


### PR DESCRIPTION
Follow-up to #3384 (the Windows piece of closed #3381, rebased as offered in https://github.com/ubugeeei-prod/vize/pull/3384#issuecomment-5131607302).

## Change class

Virtual TypeScript and type checking (mirror materialization, platform behavior).

## Defect

`std::os::windows::fs::symlink_dir` requires a privilege that Windows shells without Developer Mode or elevation do not have. On stock Windows every canon directory link therefore fails and the mirrors silently degrade:

- the per-package `node_modules` links from #3384 — `vize check` keeps reporting the spurious TS2307 from #3366
- the `vue`/`vite`/`@vue` runtime-deps links — they fall back to ambient stubs instead of the real packages

Linking is best-effort, so nothing errors; the platform just gets pre-fix resolution.

## Fix

- `symlink_path` (Windows arm): when `symlink_dir` is denied, fall back to a **directory junction** (`junction` crate, Windows-only dependency). Junctions need no privilege — the same reason pnpm links with junctions on Windows.
- `symlink_matches`: probe `read_link` instead of `FileType::is_symlink` (false for junctions) and compare canonicalized spellings (junction targets read back `\??\`-verbatim). Links now round-trip idempotently instead of being torn down and recreated every materialize run.
- `ensure_stub_dir`: same probe, so ambient stubs are never written through a link into a real package.

No behavior change on Unix or on Windows shells that can already create symlinks (symlink stays the first attempt).

## Verification

Machine: Windows 11, no Developer Mode, unelevated (`New-Item -ItemType SymbolicLink` → access denied; `Junction` → works).

- `cargo test -p vize_canon --lib runtime_deps` — 3/3 pass
- #3366 minimal repro, pnpm-installed (pnpm links via junctions, so the fixture itself needs no privilege): patched CLI reports **No type errors found**, and `<canon>/apps/app/node_modules` materializes as a junction to the real install
- Anti-suppression control: same repro plus `import "totally-not-installed"` still reports exactly one module-not-found diagnostic naming the missing package
- `cargo clippy -p vize_canon --all-targets` — no new warnings from the touched file
- `cargo fmt -p vize_canon -- --check` — clean

## Note for #3384's tooling test

`tests/tooling/cli-check-sub-package-dependency.test.ts` cannot build its own fixture on stock Windows: `createWorkspace` calls `fs.symlinkSync`, which EPERMs before vize ever runs. Worth a junction fallback there too if Windows CI coverage is wanted — happy to send it as a separate tooling PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788012832&installation_model_id=422833&pr_number=3388&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F3388&signature=7568f80c0e3d6118b3006dbe7d3ffb6b95394ac98579087f840a7905d3c8e5e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows compatibility when setting up runtime dependency directories.
  - Directory links are now created reliably using supported Windows linking methods, with a fallback when symbolic links are unavailable.
  - Existing symbolic links and junctions are detected and refreshed correctly, preventing stale or incorrect directory mappings.
  - Link target validation is now consistent across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->