### PR TITLE
bench(tools): rank type-canon engine classes separately

### DIFF
--- a/bench/benchmark-notes.mjs
+++ b/bench/benchmark-notes.mjs
@@ -9,6 +9,6 @@ export function buildFairnessNotes(fileCount) {
     "Vite build timings exclude fixture copy/setup; the Vize max lane sets `precompileBatchSize` to the benchmark file count so Blacksmith max runs one native precompile batch instead of the memory-safe default chunks.",
     "Nuxt SPA build timings exclude synthetic app generation and compare `nuxt build` with Nuxt's default compiler against the same app with `@vizejs/nuxt` installed.",
     "Single-thread lanes are shown where useful, and the primary speedup compares the incumbent default/single-thread lane with Vize's max runner lane.",
-    "Type-check rows compare across TypeScript engines: vue-tsc runs the JavaScript compiler while Vize check runs native tsgo (Corsa), so the cross-row speedup includes TypeScript's Go rewrite and must not be read as a Vue-layer comparison alone; bench/check-gate.mjs publishes the per-engine-class report.",
+    "Type-check rows span two TypeScript engines: vue-tsc runs the JavaScript compiler while Vize check runs native tsgo (Corsa). No cross-engine ratio is published for that surface — it is ranked within each engine class instead, so TypeScript's Go rewrite is never credited to the Vue layer; bench/check-gate.mjs publishes the same per-engine-class split with planted-diagnostic gating.",
   ];
 }

--- a/bench/compare-tools-report.mjs
+++ b/bench/compare-tools-report.mjs
@@ -1,0 +1,135 @@
+/**
+ * Reporting half of the tool comparison benchmark (bench/compare-tools.mjs).
+ *
+ * Engine classes are ranked separately (#3283). A surface whose incumbent tool
+ * and Vize lane run on different underlying engines — `vue-tsc` on the
+ * JavaScript TypeScript compiler versus `vize check` on native tsgo/Corsa —
+ * must not publish a single ratio: that ratio measures TypeScript's Go rewrite
+ * as much as the Vue layer. Such surfaces publish `speedup: null` with
+ * `speedupStatus: "cross-engine"` and are ranked within each engine class
+ * instead, mirroring bench/check-gate-report.mjs.
+ */
+
+import { ENGINE_CLASSES } from "./check-gate-report.mjs";
+
+export const CROSS_ENGINE_CELL = "n/a (cross-engine)";
+
+export function formatSpeedup(value) {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+  return `${value.toFixed(1)}x`;
+}
+
+export function getVariant(surface, id) {
+  if (!id) {
+    return null;
+  }
+  return surface.variants.find((variant) => variant.id === id) ?? null;
+}
+
+function engineClassOf(surface, id) {
+  return surface.engineClasses?.[id] ?? null;
+}
+
+/**
+ * Rank the variants of one engine class fastest-first. Only used for surfaces
+ * that declare `engineClasses`; every other surface keeps a single ordering.
+ */
+export function rankWithinEngineClasses(surface) {
+  const classes = surface.engineClasses;
+  if (classes == null) {
+    return null;
+  }
+  const grouped = new Map();
+  for (const variant of surface.variants) {
+    const engineClass = classes[variant.id];
+    if (engineClass == null) {
+      throw new Error(
+        `compare-tools: variant ${variant.id} of surface ${surface.id} has no engine class`,
+      );
+    }
+    if (!grouped.has(engineClass)) {
+      grouped.set(engineClass, []);
+    }
+    grouped.get(engineClass).push(variant);
+  }
+  return [...grouped.entries()].map(([engineClass, variants]) => {
+    const ordered = [...variants].sort((a, b) => a.medianMs - b.medianMs);
+    const fastest = ordered[0];
+    return {
+      engineClass,
+      label: ENGINE_CLASSES[engineClass] ?? engineClass,
+      rows: ordered.map((variant) => ({
+        id: variant.id,
+        label: variant.label,
+        medianMs: variant.medianMs,
+        // Ratio against the fastest row of the SAME engine class, so it is the
+        // Vue layer alone and is safe to publish.
+        relativeToFastest:
+          fastest.medianMs > 0 ? Number((variant.medianMs / fastest.medianMs).toFixed(3)) : null,
+      })),
+    };
+  });
+}
+
+/**
+ * Attach the primary speedup, refusing to compute one across engine classes.
+ */
+export function createSurface(surface) {
+  const baseline = getVariant(surface, surface.baselineId);
+  const vizeMax = getVariant(surface, surface.vizeMaxId);
+  const baselineClass = engineClassOf(surface, surface.baselineId);
+  const vizeMaxClass = engineClassOf(surface, surface.vizeMaxId);
+  const crossEngine =
+    baselineClass != null && vizeMaxClass != null && baselineClass !== vizeMaxClass;
+  const comparable = baseline != null && vizeMax != null && vizeMax.medianMs > 0;
+
+  return {
+    ...surface,
+    // `null`, not NaN: NaN serialises to `null` in the JSON artifact anyway, so
+    // the in-memory value must say the same thing the artifact says.
+    primarySpeedup: crossEngine || !comparable ? null : baseline.medianMs / vizeMax.medianMs,
+    speedupStatus: crossEngine ? "cross-engine" : comparable ? "ranked" : "unavailable",
+    engineClassRanking: rankWithinEngineClasses(surface),
+  };
+}
+
+function surfaceSpeedupCell(surface) {
+  return surface.speedupStatus === "cross-engine"
+    ? CROSS_ENGINE_CELL
+    : formatSpeedup(surface.primarySpeedup);
+}
+
+export function renderSurfaceTable(surface, formatMs) {
+  const baseline = getVariant(surface, surface.baselineId);
+  const vizeSingle = getVariant(surface, surface.vizeSingleId);
+  const vizeMax = getVariant(surface, surface.vizeMaxId);
+  return `| ${surface.label} | ${surface.files.toLocaleString()} | ${baseline?.label ?? "n/a"} | ${formatMs(baseline?.medianMs)} | ${vizeSingle ? formatMs(vizeSingle.medianMs) : "n/a"} | ${formatMs(vizeMax?.medianMs)} | ${surfaceSpeedupCell(surface)} |`;
+}
+
+export function renderEngineClassSections(surfaces, formatMs) {
+  const lines = [];
+  for (const surface of surfaces) {
+    if (surface.engineClassRanking == null) {
+      continue;
+    }
+    lines.push(`#### ${surface.label} — engine classes ranked separately`);
+    lines.push("");
+    lines.push("| Engine class | Row | Median | Relative to fastest in class |");
+    lines.push("| --- | --- | ---: | ---: |");
+    for (const group of surface.engineClassRanking) {
+      for (const row of group.rows) {
+        lines.push(
+          `| ${group.label} | ${row.label} | ${formatMs(row.medianMs)} | ${row.relativeToFastest == null ? "n/a" : `${row.relativeToFastest.toFixed(2)}x`} |`,
+        );
+      }
+    }
+    lines.push("");
+    lines.push(
+      `No cross-class ratio is published for ${surface.label}: the incumbent runs the JavaScript TypeScript compiler while Vize runs native tsgo, so a single number would credit TypeScript's Go rewrite to the Vue layer.`,
+    );
+    lines.push("");
+  }
+  return lines;
+}

--- a/bench/compare-tools.mjs
+++ b/bench/compare-tools.mjs
@@ -24,7 +24,14 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { Worker } from "node:worker_threads";
 
 import { buildFairnessNotes } from "./benchmark-notes.mjs";
+import {
+  createSurface,
+  renderEngineClassSections,
+  renderSurfaceTable,
+} from "./compare-tools-report.mjs";
 import { createNativeBatchSequenceVariants, measureNativeBatchCompile } from "./native-batch.mjs";
+
+export { createSurface } from "./compare-tools-report.mjs";
 
 const require = createRequire(import.meta.url);
 const benchDir = dirname(fileURLToPath(import.meta.url));
@@ -117,13 +124,6 @@ export function formatMs(ms) {
 
 function formatRunList(values) {
   return values.map(formatMs).join(", ");
-}
-
-function formatSpeedup(value) {
-  if (!Number.isFinite(value)) {
-    return "n/a";
-  }
-  return `${value.toFixed(1)}x`;
 }
 
 function formatThroughput(files, ms) {
@@ -1033,6 +1033,13 @@ async function measureCheck(inputDir, files, options) {
     baselineId: "vue-tsc",
     vizeSingleId: "vize-check-1t",
     vizeMaxId: "vize-check-max",
+    // vue-tsc drives the JavaScript TypeScript compiler; vize check drives
+    // native tsgo. Declaring the classes suppresses the cross-engine ratio.
+    engineClasses: {
+      "vue-tsc": "typescript-js",
+      "vize-check-1t": "tsgo-native",
+      "vize-check-max": "tsgo-native",
+    },
   });
 }
 
@@ -1152,25 +1159,6 @@ async function measureNuxt(inputDir, files, options) {
   });
 }
 
-function getVariant(surface, id) {
-  if (!id) {
-    return null;
-  }
-  return surface.variants.find((variant) => variant.id === id) ?? null;
-}
-
-export function createSurface(surface) {
-  const baseline = surface.variants.find((variant) => variant.id === surface.baselineId);
-  const vizeMax = surface.variants.find((variant) => variant.id === surface.vizeMaxId);
-  const speedup =
-    baseline && vizeMax && vizeMax.medianMs > 0 ? baseline.medianMs / vizeMax.medianMs : Number.NaN;
-
-  return {
-    ...surface,
-    primarySpeedup: speedup,
-  };
-}
-
 function githubRunUrl() {
   const server = process.env.GITHUB_SERVER_URL;
   const repo = process.env.GITHUB_REPOSITORY;
@@ -1284,14 +1272,10 @@ export function renderMarkdown(data) {
   );
   lines.push("| --- | ---: | --- | ---: | ---: | ---: | ---: |");
   for (const surface of data.surfaces) {
-    const baseline = getVariant(surface, surface.baselineId);
-    const vizeSingle = getVariant(surface, surface.vizeSingleId);
-    const vizeMax = getVariant(surface, surface.vizeMaxId);
-    lines.push(
-      `| ${surface.label} | ${surface.files.toLocaleString()} | ${baseline?.label ?? "n/a"} | ${formatMs(baseline?.medianMs)} | ${vizeSingle ? formatMs(vizeSingle.medianMs) : "n/a"} | ${formatMs(vizeMax?.medianMs)} | ${formatSpeedup(surface.primarySpeedup)} |`,
-    );
+    lines.push(renderSurfaceTable(surface, formatMs));
   }
   lines.push("");
+  lines.push(...renderEngineClassSections(data.surfaces, formatMs));
   lines.push("Fairness notes:");
   for (const note of data.fairness) {
     lines.push(`- ${note}`);

--- a/tests/tooling/tool-benchmark-engine-classes.test.ts
+++ b/tests/tooling/tool-benchmark-engine-classes.test.ts
@@ -1,0 +1,251 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildFairnessNotes } from "../../bench/benchmark-notes.mjs";
+import {
+  CROSS_ENGINE_CELL,
+  createSurface,
+  rankWithinEngineClasses,
+} from "../../bench/compare-tools-report.mjs";
+import { renderMarkdown } from "../../bench/compare-tools.mjs";
+
+const CHECK_VARIANTS = [
+  { id: "vue-tsc", label: "vue-tsc", medianMs: 8000, throughput: "62.5 files/s", runs: [8000] },
+  {
+    id: "vize-check-1t",
+    label: "Vize check (1T)",
+    medianMs: 2000,
+    throughput: "250.0 files/s",
+    runs: [2000],
+  },
+  {
+    id: "vize-check-max",
+    label: "Vize check (max)",
+    medianMs: 500,
+    throughput: "1.0k files/s",
+    runs: [500],
+  },
+];
+
+const CHECK_ENGINE_CLASSES = {
+  "vue-tsc": "typescript-js",
+  "vize-check-1t": "tsgo-native",
+  "vize-check-max": "tsgo-native",
+};
+
+function checkSurfaceInput(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "check",
+    label: "Type check",
+    files: 500,
+    bytes: 1_000_000,
+    baselineId: "vue-tsc",
+    vizeSingleId: "vize-check-1t",
+    vizeMaxId: "vize-check-max",
+    engineClasses: CHECK_ENGINE_CLASSES,
+    variants: CHECK_VARIANTS,
+    ...overrides,
+  };
+}
+
+test("a cross-engine surface publishes no primary speedup", () => {
+  const surface = createSurface(checkSurfaceInput());
+
+  assert.deepEqual(surface, {
+    id: "check",
+    label: "Type check",
+    files: 500,
+    bytes: 1_000_000,
+    baselineId: "vue-tsc",
+    vizeSingleId: "vize-check-1t",
+    vizeMaxId: "vize-check-max",
+    engineClasses: CHECK_ENGINE_CLASSES,
+    variants: CHECK_VARIANTS,
+    primarySpeedup: null,
+    speedupStatus: "cross-engine",
+    engineClassRanking: [
+      {
+        engineClass: "typescript-js",
+        label: "JS TypeScript engine (tsc)",
+        rows: [{ id: "vue-tsc", label: "vue-tsc", medianMs: 8000, relativeToFastest: 1 }],
+      },
+      {
+        engineClass: "tsgo-native",
+        label: "native TypeScript engine (tsgo)",
+        rows: [
+          {
+            id: "vize-check-max",
+            label: "Vize check (max)",
+            medianMs: 500,
+            relativeToFastest: 1,
+          },
+          {
+            id: "vize-check-1t",
+            label: "Vize check (1T)",
+            medianMs: 2000,
+            relativeToFastest: 4,
+          },
+        ],
+      },
+    ],
+  });
+});
+
+test("a same-engine surface keeps its ranked primary speedup", () => {
+  const surface = createSurface({
+    id: "fmt",
+    label: "Format",
+    files: 500,
+    bytes: 1_000_000,
+    baselineId: "prettier-cli",
+    vizeSingleId: "vize-fmt-1t",
+    vizeMaxId: "vize-fmt-max",
+    variants: [
+      { id: "prettier-cli", label: "prettier", medianMs: 4000, throughput: "n/a", runs: [4000] },
+      { id: "vize-fmt-1t", label: "Vize fmt (1T)", medianMs: 800, throughput: "n/a", runs: [800] },
+      {
+        id: "vize-fmt-max",
+        label: "Vize fmt (max)",
+        medianMs: 200,
+        throughput: "n/a",
+        runs: [200],
+      },
+    ],
+  });
+
+  assert.equal(surface.primarySpeedup, 20);
+  assert.equal(surface.speedupStatus, "ranked");
+  assert.equal(surface.engineClassRanking, null);
+});
+
+test("a surface without a measurable Vize lane reports no speedup at all", () => {
+  const surface = createSurface({
+    id: "check",
+    label: "Type check",
+    files: 1,
+    bytes: 1,
+    baselineId: "vue-tsc",
+    vizeSingleId: null,
+    vizeMaxId: "vize-check-max",
+    variants: [
+      { id: "vue-tsc", label: "vue-tsc", medianMs: 10, throughput: "n/a", runs: [10] },
+      {
+        id: "vize-check-max",
+        label: "Vize check (max)",
+        medianMs: 0,
+        throughput: "n/a",
+        runs: [0],
+      },
+    ],
+  });
+
+  assert.equal(surface.primarySpeedup, null);
+  assert.equal(surface.speedupStatus, "unavailable");
+});
+
+test("every variant of a class-declaring surface must carry an engine class", () => {
+  assert.throws(
+    () =>
+      rankWithinEngineClasses({
+        id: "check",
+        engineClasses: { "vue-tsc": "typescript-js" },
+        variants: CHECK_VARIANTS,
+      }),
+    {
+      name: "Error",
+      message: "compare-tools: variant vize-check-1t of surface check has no engine class",
+    },
+  );
+});
+
+test("the type-check summary renders separate engine classes and no cross ratio", () => {
+  const surface = createSurface(checkSurfaceInput());
+  const markdown = renderMarkdown({
+    schemaVersion: 1,
+    kind: "tool-comparison",
+    generatedAt: "2026-06-01T00:00:00.000Z",
+    commit: { sha: "0123456789abcdef", ref: "main", repository: "o/r", runUrl: "" },
+    runner: {
+      label: "local",
+      blacksmithMaxSpec: "",
+      cpuCount: 8,
+      cpuModel: "test cpu",
+      platform: "linux",
+      arch: "x64",
+      osRelease: "6.0.0",
+      node: "v24.0.0",
+    },
+    input: {
+      dir: "/tmp/bench",
+      fileCount: 500,
+      totalBytes: 1_000_000,
+      checkFileCount: 500,
+      viteFileCount: 0,
+      nuxtFileCount: 0,
+      largeBlocks: 0,
+      largeSfcBytes: 0,
+    },
+    settings: { runs: 1, warmups: 1, tasks: ["check"] },
+    commands: { workflowDispatch: "dispatch", generate: "generate", benchmark: "benchmark" },
+    fairness: ["only note"],
+    surfaces: [surface],
+  });
+
+  assert.deepEqual(markdown.split("\n"), [
+    "## Tool Benchmark",
+    "",
+    "Measured: 2026-06-01T00:00:00.000Z",
+    "Commit: `0123456789ab`",
+    "Runner: `local` (8 logical CPU, test cpu)",
+    "Input: 500 generated SFC files (976.6 KB). Median of 1 measured run(s) after 1 warmup run(s).",
+    "",
+    "| Surface | Files | Existing tool | Existing median | Vize 1T | Vize max | Speedup |",
+    "| --- | ---: | --- | ---: | ---: | ---: | ---: |",
+    `| Type check | 500 | vue-tsc | 8.00s | 2.00s | 500.0ms | ${CROSS_ENGINE_CELL} |`,
+    "",
+    "#### Type check — engine classes ranked separately",
+    "",
+    "| Engine class | Row | Median | Relative to fastest in class |",
+    "| --- | --- | ---: | ---: |",
+    "| JS TypeScript engine (tsc) | vue-tsc | 8.00s | 1.00x |",
+    "| native TypeScript engine (tsgo) | Vize check (max) | 500.0ms | 1.00x |",
+    "| native TypeScript engine (tsgo) | Vize check (1T) | 2.00s | 4.00x |",
+    "",
+    "No cross-class ratio is published for Type check: the incumbent runs the JavaScript TypeScript compiler while Vize runs native tsgo, so a single number would credit TypeScript's Go rewrite to the Vue layer.",
+    "",
+    "Fairness notes:",
+    "- only note",
+    "",
+    "Commands:",
+    "",
+    "```sh",
+    "dispatch",
+    "generate",
+    "benchmark",
+    "```",
+    "",
+    "<details>",
+    "<summary>Variant details and raw run times</summary>",
+    "",
+    "### Type check",
+    "",
+    "| Variant | Median | Throughput | Raw measured runs |",
+    "| --- | ---: | ---: | --- |",
+    "| vue-tsc | 8.00s | 62.5 files/s | 8.00s |",
+    "| Vize check (1T) | 2.00s | 250.0 files/s | 2.00s |",
+    "| Vize check (max) | 500.0ms | 1.0k files/s | 500.0ms |",
+    "",
+    "</details>",
+    "",
+    "",
+  ]);
+});
+
+test("the fairness notes state that no cross-engine ratio is published", () => {
+  assert.deepEqual(
+    buildFairnessNotes(500).filter((note) => note.startsWith("Type-check rows")),
+    [
+      "Type-check rows span two TypeScript engines: vue-tsc runs the JavaScript compiler while Vize check runs native tsgo (Corsa). No cross-engine ratio is published for that surface — it is ranked within each engine class instead, so TypeScript's Go rewrite is never credited to the Vue layer; bench/check-gate.mjs publishes the same per-engine-class split with planted-diagnostic gating.",
+    ],
+  );
+});


### PR DESCRIPTION
## Defect

The tool comparison report published one headline **Speedup** for the type check surface, computed as `vue-tsc median / vize check (max) median`. `vue-tsc` drives the JavaScript TypeScript compiler; `vize check` drives native tsgo (Corsa). That single ratio therefore credits TypeScript's Go rewrite to the Vue layer.

#3283 asks explicitly for *"JS and native TypeScript engines in separate classes; do not attribute the tsgo rewrite speedup to the Vue layer."* Until now only a fairness note said so — the number itself was still published, and `bench/check-gate-report.mjs` did the right thing in isolation while `bench/compare-tools.mjs` did not.

## Minimal reproduction

Feeding the type-check surface's own variant ids and plausible medians (`vue-tsc=8000ms`, `1T=2000ms`, `max=500ms`) into `createSurface` on the pre-fix tree:

```
primarySpeedup: 16 | speedupStatus: undefined | engineClassRanking: undefined
```

Expected: no cross-engine ratio at all. Actual: `16` — published as `16.0x` in the summary table's Speedup column and in the generated `performance-blacksmith.md` snapshot.

## Change

A surface may now declare `engineClasses`, mapping each variant id to an engine class. The class ids and labels are imported from `bench/check-gate-report.mjs` (`ENGINE_CLASSES`) so both reports name them identically rather than growing a parallel vocabulary.

When the incumbent lane and the Vize lane sit in different classes:

- `primarySpeedup` becomes `null` and `speedupStatus` becomes `"cross-engine"`, so the summary cell renders `n/a (cross-engine)`;
- the surface gains an `engineClassRanking`, rendered as a per-class table that ranks each row against the fastest row of the **same** class — same engine on both sides, so that ratio is the Vue layer alone and is safe to publish;
- the fairness note now states that no cross-engine ratio is published, instead of warning about the one that was.

`primarySpeedup` is `null` rather than `NaN` because `JSON.stringify` turns `NaN` into `null` anyway; the in-memory value must say what the artifact says.

Reporting moved into a new `bench/compare-tools-report.mjs`, so `bench/compare-tools.mjs` **shrinks** 1450 → 1434 lines rather than growing past its length budget. `createSurface` stays re-exported from `bench/compare-tools.mjs` so existing importers are unaffected.

## How the new test fails before the fix

`tests/tooling/tool-benchmark-engine-classes.test.ts` asserts the **complete** `createSurface` result with `assert.deepEqual` and the **complete** rendered Markdown line-for-line. On the pre-fix code the surface object has `primarySpeedup: 16` and no `speedupStatus`/`engineClassRanking` keys, and the rendered row reads `| Type check | 500 | vue-tsc | 8.00s | 2.00s | 500.0ms | 16.0x |` — both assertions fail. It also pins the `unavailable` case (no measurable Vize lane) and the error raised when a class-declaring surface has an unclassified variant.

## Verification

```sh
nix develop -c node --test tests/tooling/tool-benchmark-engine-classes.test.ts \
  tests/tooling/tool-benchmark.test.ts
# 10 pass / 0 fail

nix develop -c vp run fmt:check                                          # exit 0
nix develop -c vp run check:js                                           # exit 0
nix develop -c vp run source:lengths -- --check --base-ref origin/main    # exit 0
```

No Rust changed, so `check:rust`/`lint:rust` are not implicated.

Refs #3283

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark reports now separate results by tool engine class.
  * Added per-engine rankings and comparison tables for clearer performance analysis.
  * Cross-engine comparisons no longer display misleading speedup ratios.

* **Bug Fixes**
  * Improved fairness notes to clarify how TypeScript engine results are ranked.
  * Added validation for incomplete engine-class assignments.

* **Tests**
  * Added coverage for cross-engine, same-engine, unavailable, validation, and Markdown-reporting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->