### PR TITLE
fix(canon): report the authored specifier for an unresolved SFC import

### DIFF
--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -582,10 +582,10 @@ fn parse_cli_diagnostic_line(
     }
 
     Some(Diagnostic {
-        file: original.path,
+        message: mapper.devirtualized_module_message(&original, message.into()),
         line: original.line,
         column: original.column,
-        message: message.into(),
+        file: original.path,
         code,
         severity,
         block_type: original.block_type,

--- a/crates/vize_canon/src/batch/executor/diagnostics.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics.rs
@@ -145,10 +145,10 @@ impl<'a> DiagnosticMapper<'a> {
 
         if let Some(original) = original {
             return Some(Diagnostic {
-                file: original.path,
+                message: self.devirtualized_module_message(&original, diagnostic.message),
                 line: original.line,
                 column: original.column,
-                message: diagnostic.message,
+                file: original.path,
                 code,
                 severity: parse_severity(diagnostic.severity),
                 block_type: original.block_type,
@@ -515,9 +515,9 @@ import MissingPanel from './MissingPanel.vue'
         assert_eq!(diagnostic.file, app_path);
         assert_eq!(diagnostic.code, Some(2307));
         assert_eq!(diagnostic.line, 1);
-        assert!(
-            diagnostic.message.contains("MissingPanel.vue.ts"),
-            "{diagnostic:?}"
+        assert_eq!(
+            diagnostic.message,
+            "Cannot find module './MissingPanel.vue' or its corresponding type declarations."
         );
     }
 

--- a/crates/vize_canon/src/batch/executor/diagnostics/module_resolution.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics/module_resolution.rs
@@ -3,11 +3,13 @@
 //! Type-checking a partial file subset can surface a spurious `Cannot find
 //! module` diagnostic for a sibling that exists on disk but was not registered
 //! in the virtual project. These helpers detect that case so the diagnostic can
-//! be suppressed.
+//! be suppressed. The same specifier vocabulary is reused to restore the
+//! authored spelling in a genuinely unresolved import's message.
 
 use std::path::Path;
 
-use vize_carton::cstr;
+use super::{DiagnosticMapper, OriginalPosition};
+use vize_carton::{String, cstr};
 
 /// Extract the specifier from the first `Cannot find module "<spec>"` in
 /// `message`, handling straight and smart quotes.
@@ -40,6 +42,76 @@ pub(crate) fn relative_module_resolves_on_disk(message: &str, importer: &Path) -
         return false;
     };
     relative_specifier_resolves(dir, specifier)
+}
+
+/// The authored `.vue` spelling behind a generated mirror-module specifier, or
+/// `None` when `specifier` is not one. `./Panel.vue.ts` is what the import
+/// rewriter writes for an authored `./Panel.vue`; `./Panel.vue.tsx` is the TSX
+/// SFC form. Anything else — including an authored `./util.ts` — is left alone.
+fn mirror_module_specifier_source(specifier: &str) -> Option<&str> {
+    specifier
+        .strip_suffix(".ts")
+        .or_else(|| specifier.strip_suffix(".tsx"))
+        .filter(|source| source.ends_with(".vue"))
+}
+
+impl DiagnosticMapper<'_> {
+    /// Restore the authored specifier in a `Cannot find module` message.
+    ///
+    /// The import rewriter redirects an SFC import onto that file's generated
+    /// mirror module (`./Panel.vue` -> `./Panel.vue.ts`), so a genuinely
+    /// unresolved SFC import reaches the checker under the mirror spelling and
+    /// the message quotes a path the author never wrote — while `vue-tsc`
+    /// quotes `./Panel.vue`. Rewriting is gated on the authored bytes at the
+    /// diagnostic position really being the `.vue` spelling, so a hand-written
+    /// `import x from "./Panel.vue.ts"` keeps reporting exactly what it says.
+    pub(crate) fn devirtualized_module_message(
+        &mut self,
+        original: &OriginalPosition,
+        message: String,
+    ) -> String {
+        let Some(reported) = module_not_found_specifier(&message) else {
+            return message;
+        };
+        let Some(authored) = mirror_module_specifier_source(reported) else {
+            return message;
+        };
+        if !self.source_specifier_matches(original, authored) {
+            return message;
+        }
+        let Some((before, after)) = message.split_once(reported) else {
+            return message;
+        };
+        cstr!("{before}{authored}{after}")
+    }
+
+    /// Whether the authored bytes at `original` are the string literal
+    /// `specifier`. The diagnostic position of an unresolved import points at
+    /// the specifier's opening quote, so this reads the literal that starts
+    /// there and compares it verbatim.
+    fn source_specifier_matches(&mut self, original: &OriginalPosition, specifier: &str) -> bool {
+        let Some(source) = self.original_source(&original.path) else {
+            return false;
+        };
+        let content = &source.content;
+        let index = &source.line_index;
+        let Some(offset) = index.line_col_to_offset(content, original.line, original.column) else {
+            return false;
+        };
+        let Some(rest) = content.get(offset as usize..) else {
+            return false;
+        };
+        let Some(quote) = rest
+            .chars()
+            .next()
+            .filter(|character| matches!(character, '\'' | '"' | '`'))
+        else {
+            return false;
+        };
+        rest[quote.len_utf8()..]
+            .split_once(quote)
+            .is_some_and(|(literal, _)| literal == specifier)
+    }
 }
 
 /// Source extensions a relative specifier may resolve to when appended to the
@@ -108,9 +180,27 @@ fn specifier_has_source_extension(specifier: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::relative_module_resolves_on_disk;
+    use super::{mirror_module_specifier_source, relative_module_resolves_on_disk};
 
     use tempfile::TempDir;
+
+    #[test]
+    fn only_generated_mirror_specifiers_map_back_to_an_authored_spelling() {
+        assert_eq!(
+            mirror_module_specifier_source("./Panel.vue.ts"),
+            Some("./Panel.vue")
+        );
+        assert_eq!(
+            mirror_module_specifier_source("../widgets/Panel.vue.tsx"),
+            Some("../widgets/Panel.vue")
+        );
+        // An authored TypeScript specifier is not a mirror module, so its
+        // message must keep the spelling the author wrote.
+        assert_eq!(mirror_module_specifier_source("./util.ts"), None);
+        assert_eq!(mirror_module_specifier_source("./Panel.vue"), None);
+        assert_eq!(mirror_module_specifier_source("./types.d.ts"), None);
+        assert_eq!(mirror_module_specifier_source("vue-router"), None);
+    }
 
     #[test]
     fn ts2307_for_resolvable_relative_siblings_is_suppressed() {

--- a/crates/vize_canon/src/batch/type_checker/tests/package_exports_types.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/package_exports_types.rs
@@ -2,8 +2,66 @@ use std::path::Path;
 
 use super::{
     BatchTypeChecker, TypeChecker, create_project_case, relative_path, resolve_test_tsgo_binary,
+    snapshot_project_diagnostics,
 };
 use vize_carton::{String, cstr};
+
+/// An unresolved SFC import must quote the specifier the author wrote.
+///
+/// The import rewriter redirects `./Absent.vue` onto the generated mirror
+/// module `./Absent.vue.ts`, so before the fix `TS2307` named a path that
+/// appears nowhere in the source while `vue-tsc` 3.3.4 reports
+/// `Cannot find module './Absent.vue' ...` at the identical position. The
+/// second import pins the other direction: a hand-written `./Literal.vue.ts`
+/// is not a mirror module and keeps its own spelling.
+#[test]
+fn unresolved_sfc_import_reports_the_authored_specifier() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "unresolved-sfc-import-specifier",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+import Absent from "./Absent.vue";
+import Literal from "./Literal.vue.ts";
+</script>
+
+<template>
+  <Absent />
+  <Literal />
+</template>
+"#,
+        )],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else {
+        return;
+    };
+
+    assert_eq!(
+        snapshot,
+        vec![
+            (
+                String::from("src/App.vue"),
+                Some(2307),
+                String::from(
+                    "2:20:error Cannot find module './Absent.vue' or its corresponding type declarations."
+                ),
+            ),
+            (
+                String::from("src/App.vue"),
+                Some(2307),
+                String::from(
+                    "3:21:error Cannot find module './Literal.vue.ts' or its corresponding type declarations."
+                ),
+            ),
+        ]
+    );
+}
 
 #[test]
 fn node_module_resolution_uses_package_types_hidden_by_exports() {


### PR DESCRIPTION
Part of the #3222 parity scorecard (dimension 1: diagnostic parity), found while building vue-tsc oracles for `vize check`.

## Divergence

`vize check` and `vue-tsc` 3.3.4 report an unresolved SFC import at the **same
position with the same code and severity**, but with different text: vize quotes
the generated mirror module, a path that appears nowhere in the source.

Minimal reproduction — `src/App.vue`, no sibling `Absent.vue` on disk:

```vue
<script setup lang="ts">
import Absent from "./Absent.vue";
import Literal from "./Literal.vue.ts";
</script>

<template>
  <Absent />
  <Literal />
</template>
```

| | line 2 (authored `.vue`) | line 3 (authored `.vue.ts`) |
| --- | --- | --- |
| vue-tsc 3.3.4 (oracle) | `2:20 error TS2307: Cannot find module './Absent.vue' ...` | `3:21 error TS2307: Cannot find module './Literal.vue.ts' ...` |
| vize check (before) | `2:20 error TS2307: Cannot find module './Absent.vue.ts' ...` | `3:21 error TS2307: Cannot find module './Literal.vue.ts' ...` |
| vize check (after) | `2:20 error TS2307: Cannot find module './Absent.vue' ...` | `3:21 error TS2307: Cannot find module './Literal.vue.ts' ...` |

The import rewriter redirects `./Absent.vue` onto that file's generated mirror
module `./Absent.vue.ts` (#3329), so a genuinely unresolved SFC import reaches
the checker under the mirror spelling and the message leaked it. This is the
single most common Vue typecheck error — a renamed or moved SFC — and the user
is told about a filename they never wrote.

## Fix

Both diagnostic paths (`DiagnosticMapper::map_lsp_diagnostic` and the Corsa CLI
text path in `executor/cli.rs`) now restore the authored specifier.

The rewrite is gated on the authored bytes at the diagnostic position really
being the `.vue` spelling — the diagnostic position of an unresolved import
points at the specifier's opening quote, so the literal that starts there is read
and compared verbatim. A hand-written `import x from "./Panel.vue.ts"` is
therefore untouched, which the second import in the test pins.

## Tests

- `unresolved_sfc_import_reports_the_authored_specifier` (new, in
  `type_checker/tests/package_exports_types.rs`) asserts the **full** diagnostic
  list with `assert_eq!` — exact file, code, line, column, severity and message
  for both imports.
- `only_generated_mirror_specifiers_map_back_to_an_authored_spelling` (new unit
  test) pins the mirror-specifier classification, including the negative cases
  `./util.ts`, `./types.d.ts`, `./Panel.vue` and `vue-router`.
- `maps_missing_vue_ts2307_back_to_source_file` had encoded the old behavior with
  `assert!(message.contains("MissingPanel.vue.ts"))`; it now asserts the full
  message with `assert_eq!`.

### Verified failing before the fix

`git stash` of the three source files, leaving the new test in place:

```
---- unresolved_sfc_import_reports_the_authored_specifier stdout ----
assertion `left == right` failed
  left: [("src/App.vue", Some(2307), "2:20:error Cannot find module './Absent.vue.ts' or its corresponding type declarations."), ...]
 right: [("src/App.vue", Some(2307), "2:20:error Cannot find module './Absent.vue' or its corresponding type declarations."), ...]
test result: FAILED. 0 passed; 1 failed
```

## Ledger impact

None. `tools/fixtures/typecheck-divergence.mjs` keys diagnostic identity on
(file, severity, line, column, code) and not on the message, so this divergence
was already counted as `shared` and the compat baseline does not move.

## Gates

- `cargo test -p vize_canon --lib` — 644 passed, 0 failed
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports` — clean
- `rustfmt --edition 2024 --config style_edition=2024 --check` on all four changed files — clean
- File lengths unchanged for the two files already over the 350-line budget
  (`diagnostics.rs` 712, `cli.rs` 659 — both identical to base)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected unresolved module diagnostics to display the authored `.vue` import path instead of an internal generated module path.
  * Preserved TypeScript module specifiers and unrelated diagnostic messages without unnecessary rewriting.
  * Improved diagnostic locations and messages for unresolved single-file component imports.

* **Tests**
  * Added regression coverage for unresolved `.vue` imports and verified expected diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->