### PR TITLE
fix(glyph): keep v-pre content out of the SFC template indent step

### DIFF
--- a/crates/vize_glyph/src/formatter/raw_mask.rs
+++ b/crates/vize_glyph/src/formatter/raw_mask.rs
@@ -1,8 +1,10 @@
 mod interpolation;
+mod tags;
 #[cfg(test)]
 mod tests;
 
 use interpolation::InterpolationScan;
+use tags::{RawRegion, starts_v_pre_attribute, tag_name_at};
 
 /// Per-line "this line is inside a whitespace-significant block" mask.
 ///
@@ -16,12 +18,22 @@ use interpolation::InterpolationScan;
 /// part of the string's runtime value. Indenting those lines rewrote the
 /// emitted string, and since each pass re-indented the spaces the previous one
 /// added, `vize fmt` drifted the content further on every run (#3334).
-pub(super) fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
+///
+/// `v-pre` needs the same treatment for the same reason. Its content is copied
+/// verbatim by the template formatter, so an SFC indent laid on top of it moved
+/// the content two columns further on every `vize fmt` run — unbounded drift,
+/// not a one-off reformat (#3379).
+pub(super) fn compute_raw_line_mask<'a>(lines: &[&'a [u8]]) -> Vec<bool> {
     let mut mask = vec![false; lines.len()];
-    let mut depth_stack: Vec<&'static str> = Vec::new();
+    let mut depth_stack: Vec<RawRegion<'a>> = Vec::new();
     let mut in_tag = false;
     let mut open_quote: Option<OpenQuote> = None;
     let mut pending_raw_tag: Option<&'static str> = None;
+    // The element the opening tag currently being lexed declares, and whether
+    // it has shown a `v-pre` attribute yet. Both outlive a single line: an
+    // opening tag may be split across lines with `v-pre` on its own.
+    let mut open_tag_name: Option<&'a [u8]> = None;
+    let mut open_tag_is_pre = false;
     let mut in_comment = false;
     // Lexer state for the inside of a `{{ … }}` interpolation. The template
     // formatter already emits template-literal quasi lines verbatim; the SFC
@@ -86,11 +98,29 @@ pub(super) fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
                     }
                     b'>' => {
                         in_tag = false;
+                        // `<Foo v-pre />` has no content to keep raw. The
+                        // template formatter takes its self-closing branch
+                        // before the whitespace-significant one, so the mask
+                        // must not open a region the formatter never opened.
+                        let self_closing = cursor > 0 && bytes[cursor - 1] == b'/';
                         if let Some(tag) = pending_raw_tag.take() {
-                            depth_stack.push(tag);
+                            depth_stack.push(RawRegion {
+                                tag: tag.as_bytes(),
+                                v_pre: false,
+                            });
+                        } else if let Some(tag) = open_tag_name.filter(|_| open_tag_is_pre)
+                            && !self_closing
+                        {
+                            depth_stack.push(RawRegion { tag, v_pre: true });
+                        }
+                        open_tag_name = None;
+                        open_tag_is_pre = false;
+                    }
+                    _ => {
+                        if starts_v_pre_attribute(bytes, cursor) {
+                            open_tag_is_pre = true;
                         }
                     }
-                    _ => {}
                 }
                 cursor += 1;
                 continue;
@@ -121,7 +151,10 @@ pub(super) fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
             let mut matched = false;
             for (tag, open_needle, close_needle) in &TAGS {
                 if starts_with_ascii_ci(&bytes[cursor..], close_needle.as_bytes()) {
-                    if let Some(idx) = depth_stack.iter().rposition(|t| t == tag) {
+                    if let Some(idx) = depth_stack
+                        .iter()
+                        .rposition(|region| !region.v_pre && region.tag == tag.as_bytes())
+                    {
                         depth_stack.remove(idx);
                     }
                     cursor += close_needle.len();
@@ -144,16 +177,54 @@ pub(super) fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
             if matched {
                 continue;
             }
+            // A `v-pre` region is named by the element that carries the
+            // directive, so it ends at that element's own `</tag>`.
+            if bytes[cursor..].starts_with(b"</")
+                && let Some(name) = tag_name_at(bytes, cursor + 2)
+                && let Some(idx) = depth_stack
+                    .iter()
+                    .rposition(|region| region.v_pre && region.tag.eq_ignore_ascii_case(name))
+            {
+                depth_stack.remove(idx);
+                cursor += 2 + name.len();
+                continue;
+            }
+            // Generic opening tags are not lexed inside a raw region, so a
+            // same-name element nested in a `v-pre` one has to be counted here
+            // or its `</tag>` would end the region early. This mirrors how a
+            // `<pre>` nested in a `<pre>` stacks through the `TAGS` loop above.
+            if let Some(region) = depth_stack.last().copied().filter(|region| region.v_pre)
+                && let Some(name) = tag_name_at(bytes, cursor + 1)
+                && name.eq_ignore_ascii_case(region.tag)
+                && !self_closes_on_this_line(bytes, cursor)
+            {
+                depth_stack.push(region);
+                cursor += 1 + name.len();
+                continue;
+            }
             if depth_stack.is_empty()
                 && let Some(after) = bytes.get(cursor + 1).copied()
                 && (after.is_ascii_alphabetic() || after == b'/')
             {
                 in_tag = true;
+                // `None` for a closing tag, which opens no region.
+                open_tag_name = tag_name_at(bytes, cursor + 1);
+                open_tag_is_pre = false;
             }
             cursor += 1;
         }
     }
     mask
+}
+
+/// Whether the tag starting at `cursor` closes itself before this line ends.
+///
+/// Only the current line is available here, and a tag name cannot be split, so
+/// an opening tag that runs past the line end is treated as not self-closing —
+/// the `/>` form is written on one line in every formatter output.
+fn self_closes_on_this_line(bytes: &[u8], cursor: usize) -> bool {
+    memchr::memchr(b'>', &bytes[cursor..])
+        .is_some_and(|offset| offset > 0 && bytes[cursor + offset - 1] == b'/')
 }
 
 fn literal_attr_quote(line: &[u8], quote_pos: usize) -> bool {

--- a/crates/vize_glyph/src/formatter/raw_mask/tags.rs
+++ b/crates/vize_glyph/src/formatter/raw_mask/tags.rs
@@ -1,0 +1,116 @@
+//! Tag lexing for the whitespace-significant regions of the raw-line mask.
+//!
+//! `<pre>` and `<textarea>` are whitespace-significant by name, so the mask can
+//! find them with fixed open/close needles. `v-pre` makes *any* element
+//! whitespace-significant — `is_whitespace_significant_element` treats an
+//! element carrying it exactly like `<pre>` and the template formatter copies
+//! its content verbatim — so for those the mask has to read the element's own
+//! name out of the source to know which `</tag>` ends the region. (#3379)
+
+/// A whitespace-significant region the mask is currently inside.
+#[derive(Clone, Copy)]
+pub(super) struct RawRegion<'a> {
+    /// The element's tag name, as spelled in the source.
+    pub(super) tag: &'a [u8],
+    /// Whether the region was opened by a `v-pre` attribute rather than by the
+    /// tag name itself. `<pre>`/`<textarea>` regions are closed by their fixed
+    /// close needles and `v-pre` regions by a tag-name comparison, so the two
+    /// mechanisms must never pop each other's entries.
+    pub(super) v_pre: bool,
+}
+
+/// The tag name starting at `start`, or `None` when the bytes there do not
+/// begin an ASCII-alphabetic tag name.
+///
+/// Vue element names carry more than letters — `<my-el>`, `<Foo.Bar>`,
+/// `<svg:rect>` — so the scan only stops at a byte that cannot appear in a
+/// name. An unterminated name (the tag continues on the next line) runs to the
+/// end of the line, which is the whole name in that case.
+pub(super) fn tag_name_at(bytes: &[u8], start: usize) -> Option<&[u8]> {
+    if !bytes.get(start)?.is_ascii_alphabetic() {
+        return None;
+    }
+    let end = bytes[start..]
+        .iter()
+        .position(|byte| !is_tag_name_byte(*byte))
+        .map_or(bytes.len(), |offset| start + offset);
+    Some(&bytes[start..end])
+}
+
+fn is_tag_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b':')
+}
+
+/// Whether a bare `v-pre` attribute starts at `cursor` inside an opening tag.
+///
+/// Vue ignores the directive's value, and so does
+/// `is_whitespace_significant_element`, so `=` terminates the name alongside
+/// whitespace, `/`, `>` and the end of the line — an opening tag may be split
+/// over several lines, which is exactly how the shape that motivated this
+/// appears in the wild (`<code`, then `v-pre`, then `class=…>`).
+///
+/// The byte before the name must be a separator, so `data-v-pre` and
+/// `:title="v-pre"` never match. A cursor at column 0 is a separator too: the
+/// attribute then opens a continuation line of the tag.
+pub(super) fn starts_v_pre_attribute(bytes: &[u8], cursor: usize) -> bool {
+    const NAME: &[u8] = b"v-pre";
+    if !bytes[cursor..]
+        .get(..NAME.len())
+        .is_some_and(|head| head.eq_ignore_ascii_case(NAME))
+    {
+        return false;
+    }
+    let terminated = bytes
+        .get(cursor + NAME.len())
+        .is_none_or(|byte| matches!(byte, b' ' | b'\t' | b'\r' | b'=' | b'/' | b'>'));
+    let separated = cursor == 0 || matches!(bytes[cursor - 1], b' ' | b'\t');
+    terminated && separated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{starts_v_pre_attribute, tag_name_at};
+
+    #[test]
+    fn tag_name_reads_component_and_namespaced_names() {
+        assert_eq!(tag_name_at(b"<my-el a>", 1), Some(&b"my-el"[..]));
+        assert_eq!(tag_name_at(b"<Foo.Bar>", 1), Some(&b"Foo.Bar"[..]));
+        assert_eq!(tag_name_at(b"<svg:rect/>", 1), Some(&b"svg:rect"[..]));
+        assert_eq!(tag_name_at(b"<code", 1), Some(&b"code"[..]));
+    }
+
+    #[test]
+    fn tag_name_rejects_a_non_alphabetic_start() {
+        assert_eq!(tag_name_at(b"</div>", 1), None);
+        assert_eq!(tag_name_at(b"<3>", 1), None);
+        assert_eq!(tag_name_at(b"<", 1), None);
+    }
+
+    #[test]
+    fn v_pre_attribute_is_recognized_in_every_bare_position() {
+        assert!(starts_v_pre_attribute(b"<div v-pre>", 5));
+        assert!(starts_v_pre_attribute(b"<div v-pre />", 5));
+        assert!(starts_v_pre_attribute(b"<div v-pre class=\"a\">", 5));
+        assert!(starts_v_pre_attribute(b"<div v-pre", 5));
+        assert!(
+            starts_v_pre_attribute(b"v-pre", 0),
+            "a tag split over lines"
+        );
+        assert!(
+            starts_v_pre_attribute(b"<div V-PRE>", 5),
+            "case-insensitive"
+        );
+        assert!(
+            starts_v_pre_attribute(b"<div v-pre=\"\">", 5),
+            "valued form"
+        );
+    }
+
+    #[test]
+    fn v_pre_attribute_rejects_look_alikes() {
+        assert!(!starts_v_pre_attribute(b"<div data-v-pre>", 10));
+        assert!(!starts_v_pre_attribute(b"<div v-precise>", 5));
+        assert!(!starts_v_pre_attribute(b"<div :t=\"v-pre\">", 9));
+        assert!(!starts_v_pre_attribute(b"<div v-show>", 5));
+    }
+}

--- a/crates/vize_glyph/src/formatter/raw_mask/tests.rs
+++ b/crates/vize_glyph/src/formatter/raw_mask/tests.rs
@@ -67,3 +67,49 @@ fn a_closed_literal_does_not_leak_into_later_lines() {
     let source = "<div>\n  {{ `x` }}\n  <span>y</span>\n</div>";
     assert_eq!(mask(source), [false, false, false, false]);
 }
+
+#[test]
+fn lines_inside_a_v_pre_element_are_raw() {
+    // The template formatter copies a `v-pre` element's content verbatim, so
+    // the SFC layer must not indent it on top — doing so moved the content two
+    // columns further on every run (#3379). The closing tag's line begins
+    // inside the region, so it is raw too, exactly like `</pre>`.
+    let source = "<code v-pre>\n  {{ variable }}\n</code>\n<span>y</span>";
+    assert_eq!(mask(source), [false, true, true, false]);
+}
+
+#[test]
+fn a_v_pre_directive_on_a_later_line_of_the_opening_tag_still_opens_the_region() {
+    let source = "<code\n  v-pre\n  class=\"a\">\n  {{ variable }}\n</code>\n<span>y</span>";
+    assert_eq!(mask(source), [false, false, false, true, true, false]);
+}
+
+#[test]
+fn a_same_name_element_nested_in_a_v_pre_region_does_not_end_it() {
+    let source = "<div v-pre>\n  <div>x</div>\n  y\n</div>\n<span>z</span>";
+    assert_eq!(mask(source), [false, true, true, true, false]);
+}
+
+#[test]
+fn a_self_closing_v_pre_element_opens_no_region() {
+    let source = "<Foo v-pre />\n<span>\n  y\n</span>";
+    assert_eq!(mask(source), [false, false, false, false]);
+}
+
+#[test]
+fn a_v_pre_look_alike_attribute_opens_no_region() {
+    let source = "<div data-v-pre>\n  a\n</div>";
+    assert_eq!(mask(source), [false, false, false]);
+}
+
+#[test]
+fn a_v_pre_string_inside_an_attribute_value_opens_no_region() {
+    let source = "<div title=\"v-pre\">\n  a\n</div>";
+    assert_eq!(mask(source), [false, false, false]);
+}
+
+#[test]
+fn a_v_pre_region_on_a_hyphenated_component_closes_on_its_own_tag() {
+    let source = "<my-code v-pre>\n  a\n</my-code>\n<span>y</span>";
+    assert_eq!(mask(source), [false, true, true, false]);
+}

--- a/crates/vize_glyph/tests/sfc_v_pre_idempotence.rs
+++ b/crates/vize_glyph/tests/sfc_v_pre_idempotence.rs
@@ -1,0 +1,89 @@
+//! `v-pre` regions must survive `vize fmt` byte-for-byte.
+//!
+//! The template formatter copies a whitespace-significant element's content
+//! verbatim, and the SFC layer then indents the template block by one level.
+//! `<pre>` and `<textarea>` were carved out of that indent step; `v-pre` — which
+//! makes *any* element whitespace-significant — was not, so every run pushed the
+//! content two more columns right. The drift was unbounded, not a one-off
+//! reformat: pass 2 differed from pass 1 and pass 3 from pass 2. (#3379)
+
+use vize_glyph::{FormatOptions, format_sfc};
+
+/// Format `source` three times: pass 1 must equal `expected`, and passes 2 and
+/// 3 must reproduce it byte-for-byte.
+#[track_caller]
+fn assert_stable(source: &str, expected: &str) {
+    let options = FormatOptions::default();
+    let first = format_sfc(source, &options).unwrap();
+    assert_eq!(first.code.as_str(), expected, "pass 1 output");
+    let second = format_sfc(&first.code, &options).unwrap();
+    assert_eq!(second.code, first.code, "fmt; fmt must be a no-op");
+    let third = format_sfc(&second.code, &options).unwrap();
+    assert_eq!(third.code, second.code, "fmt must stay at its fixed point");
+}
+
+#[test]
+fn v_pre_interpolation_child_keeps_its_indentation() {
+    // Minimized from scalar's `Environment.vue`, the file this issue pinned:
+    // an interpolation that is the sole child of a `v-pre` element. `{{ … }}`
+    // inside `v-pre` is literal text at runtime, so its leading whitespace is
+    // rendered output and must not move.
+    let source = "<template>\n  <code v-pre>\n    {{ variable }}\n  </code>\n</template>\n";
+    assert_stable(source, source);
+}
+
+#[test]
+fn v_pre_on_a_split_opening_tag_keeps_its_indentation() {
+    // scalar's original spelling: the directive sits on its own line of a
+    // multi-line opening tag, so the mask has to carry "this element is
+    // `v-pre`" across the line break while remembering the tag's name.
+    let source = "<template>\n  <code\n    v-pre\n    class=\"font-code\">\n    {{ variable }}\n  </code>\n</template>\n";
+    assert_stable(
+        source,
+        "<template>\n  <code v-pre class=\"font-code\">\n    {{ variable }}\n  </code>\n</template>\n",
+    );
+}
+
+#[test]
+fn v_pre_element_nesting_a_same_name_element_ends_at_the_outer_close() {
+    // The inner `</div>` must not end the raw region, or every line after it
+    // would pick up SFC indentation again.
+    let source = "<template>\n  <div v-pre>\n    <div>x</div>\n    y\n  </div>\n</template>\n";
+    assert_stable(source, source);
+}
+
+#[test]
+fn v_pre_with_other_attributes_is_stable_after_they_are_sorted() {
+    let source = "<template>\n  <code class=\"a\" v-pre>{{ v }}</code>\n</template>\n";
+    assert_stable(
+        source,
+        "<template>\n  <code v-pre class=\"a\">{{ v }}</code>\n</template>\n",
+    );
+}
+
+#[test]
+fn a_self_closing_v_pre_element_opens_no_raw_region() {
+    // `<Foo v-pre />` has no content, so the siblings after it are ordinary
+    // markup and must still be indented into the template block.
+    let source = "<template>\n  <Foo v-pre />\n  <span>\n    a\n  </span>\n</template>\n";
+    assert_stable(source, source);
+}
+
+#[test]
+fn a_data_v_pre_attribute_is_not_the_directive() {
+    // Negative guard: `data-v-pre` is a plain attribute, so the element's
+    // content is ordinary markup the formatter owns.
+    let source = "<template>\n  <div data-v-pre>\n    a\n  </div>\n</template>\n";
+    assert_stable(source, source);
+}
+
+#[test]
+fn an_interpolation_alone_in_a_pre_element_keeps_its_indentation() {
+    // Neighborhood guard for the same boundary in the two elements that are
+    // whitespace-significant by name.
+    let pre = "<template>\n  <pre>\n    {{ variable }}\n  </pre>\n</template>\n";
+    assert_stable(pre, pre);
+
+    let textarea = "<template>\n  <textarea>\n    {{ variable }}\n  </textarea>\n</template>\n";
+    assert_stable(textarea, textarea);
+}

--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -1,12 +1,6 @@
 [
   {
     "property": "idempotence",
-    "project": "scalar",
-    "path": "projects/scalar-app/src/features/collection/components/Environment.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3379"
-  },
-  {
-    "property": "idempotence",
     "project": "vue-data-ui",
     "path": "src/components/vue-ui-flow.vue",
     "issue": "https://github.com/ubugeeei-prod/vize/issues/3379"


### PR DESCRIPTION
One of the two idempotence drifts that survived #3368. This is the `scalar` shape from
#3379: an interpolation at a whitespace-significant boundary. It is unrelated to the
`vue-data-ui` one, which is a template-literal directive value and gets its own PR.

## Defect

`is_whitespace_significant_element` treats **any element carrying `v-pre`** exactly like
`<pre>`/`<textarea>`, and the template formatter copies its content byte-for-byte. The SFC
layer then indents the template block by one level, skipping lines the raw-line mask marks
raw. `compute_raw_line_mask` only ever recognized `<pre>` and `<textarea>` — `v-pre` was
named in its doc comment and in `format_template_block_fast`'s, but never implemented.

So every `vize fmt` run laid one more indent level on top of content the previous run had
already shifted. The drift is unbounded, not a one-off reformat: pass 2 differs from pass 1
and pass 3 from pass 2. It also silently rewrites rendered output, since whitespace inside
`v-pre` is literal.

## Minimal reproduction

```vue
<template>
  <code v-pre>
    {{ variable }}
  </code>
</template>
```

`vize fmt --write --no-config` twice, `--profile ci --features legacy`:

```diff
 <template>
   <code v-pre>
-      {{ variable }}
-    </code>
+        {{ variable }}
+      </code>
 </template>
```

**Expected:** the file is already at its fixed point — the content is verbatim, so pass 1
must return it unchanged and pass 2 must be a no-op.
**Actual:** pass 1 shifts the content 4 → 6 columns, pass 2 shifts it 6 → 8, and so on.

Same two-pass run on the pinned corpus file
`scalar projects/scalar-app/src/features/collection/components/Environment.vue`
(revision `6e7cc3a7ba2aa985026187117e430e6945b39a5c`, the registry pin):

```diff
       <code v-pre class="font-code text-c-2">
-          {{ variable }}
-        </code>
+            {{ variable }}
+          </code>
```

## Fix

Teach the raw-line mask about `v-pre`. `<pre>`/`<textarea>` are recognized by name, so fixed
needles suffice for them; `v-pre` can sit on any element, so the mask now reads the element's
own tag name out of the source and closes the region on that element's `</tag>`. New
`raw_mask/tags.rs` holds the tag-name and `v-pre`-attribute lexing (keeping `raw_mask.rs`
inside the file-length budget: 327 lines).

Edge cases handled, each with a test:

- the directive on a later line of a split opening tag (`<code`, then `v-pre`, then
  `class=…>`) — that is scalar's actual spelling, so the "is `v-pre`" bit and the tag name
  both have to survive the line break;
- a same-name element nested inside the region, which must not end it early;
- `<Foo v-pre />` — the template formatter takes its self-closing branch before the
  whitespace-significant one, so the mask must not open a region either;
- `data-v-pre`, `v-precise` and `:title="v-pre"`, which are not the directive;
- `v-pre` regions and `<pre>` regions never pop each other's stack entries.

## How the tests fail before the fix

Reverting only `crates/vize_glyph/src/formatter/raw_mask.rs` (tests kept):

```
$ cargo test -p vize_glyph --profile ci --no-fail-fast --test sfc_v_pre_idempotence
test v_pre_on_a_split_opening_tag_keeps_its_indentation ... FAILED
test v_pre_interpolation_child_keeps_its_indentation ... FAILED
test v_pre_element_nesting_a_same_name_element_ends_at_the_outer_close ... FAILED
assertion `left == right` failed: pass 1 output
test result: FAILED. 4 passed; 3 failed

$ cargo test -p vize_glyph --profile ci        # unit lib target
test formatter::raw_mask::tests::lines_inside_a_v_pre_element_are_raw ... FAILED
test formatter::raw_mask::tests::a_v_pre_directive_on_a_later_line_of_the_opening_tag_still_opens_the_region ... FAILED
test formatter::raw_mask::tests::a_v_pre_region_on_a_hyphenated_component_closes_on_its_own_tag ... FAILED
test formatter::raw_mask::tests::a_same_name_element_nested_in_a_v_pre_region_does_not_end_it ... FAILED
test result: FAILED. 125 passed; 4 failed
```

The negative guards (`data-v-pre`, self-closing, `<pre>`/`<textarea>`) pass both before and
after, as they should.

Every assertion compares the full formatted output; `assert_stable` asserts pass 1 against
the complete expected file and then that passes 2 and 3 reproduce it byte-for-byte.

## Ledger

`scalar`'s `idempotence` entry is removed from
`tests/_fixtures/glyph-corpus-known-violations.json` in this PR. The `vue-data-ui` entry
stays pinned — that is the second, independent shape, fixed separately.

## Verification

```
cargo test --profile ci -p vize_glyph -p vize     # all green
node --test tests/tooling/glyph-corpus-idempotence.test.ts   # 3 pass
cargo fmt --all -- --check                        # clean
vp run lint:rust                                  # clippy -D warnings, clean
vp run check:rust                                 # clean
vp run source:lengths                             # raw_mask.rs 327, tags.rs 116
```

Refs #3379

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->