### PR TITLE
test(atelier): pin the upstream OXC tuple-type span boundary matrix

### DIFF
--- a/crates/vize_atelier_core/tests/upstream_tuple_type_span_assertion.rs
+++ b/crates/vize_atelier_core/tests/upstream_tuple_type_span_assertion.rs
@@ -1,0 +1,260 @@
+//! Boundary matrix for the upstream OXC tuple-type span assertion (#3307).
+//!
+//! Inside a TS tuple type that already has an optional member, OXC's tuple
+//! element recovery builds the element span as `Span::new(start_span(),
+//! prev_token_end)`. When the element parse consumes *nothing* — the token after
+//! the comma cannot start a type — `start_span()` has already skipped the trivia
+//! past `prev_token_end`, so the span comes out inverted (`start > end`).
+//! `TS1257 required element cannot follow an optional element` then labels that
+//! span and `oxc_span::Span::size` trips `debug_assert!(self.start <= self.end)`.
+//!
+//! Two properties fully determine the class, and the matrix below pins both:
+//! - the tuple needs a preceding optional member (`r?`, `a?:`), and
+//! - the element after a comma must consume nothing, which needs at least one
+//!   byte of trivia after that comma (`<[r?,\x07]` parses cleanly, `<[r?, \x07]`
+//!   does not) followed by a token that cannot start a type.
+//!
+//! `#3296` minimized this to `<[r?, \x07]` with `cargo fuzz tmin`, which made
+//! the class look specific to `<[` type arguments and to C0 control bytes. It is
+//! neither: `f<[a?, , b]>(x)` is printable, balanced ASCII and panics
+//! identically, and `,`, `;` and `@` all reach the same recovery.
+//!
+//! Replay evidence (dev profile, debug assertions on): the panic reproduces on
+//! the pinned rev `8265ed94` (0.127.0) through 0.140.0 and stops at oxc 0.141.0,
+//! where the lazy `ParserDiagnostic` refactor leaves TS1257 unmaterialized so
+//! the inverted span is never labeled. The inverted span is still constructed
+//! upstream, so oxc-project/oxc#23670 stays open; only the panic is out of
+//! reach.
+//!
+//! When the pinned revision moves to 0.141.0 or later, every
+//! `UpstreamSpanAssertion` row here fails. That is the signal to flip those rows
+//! to the diagnostics they then produce and to delete the `js_ts_expression`
+//! fuzz-target skip.
+
+use std::panic::{self, AssertUnwindSafe};
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use upstream_span_assertion_skip::hits_known_upstream_span_assertion_shape;
+use vize_atelier_core::steps::expression::expression_is_safe_to_parse;
+
+// The predicate the `js_ts_expression` fuzz target uses to skip this class, so
+// the matrix below asserts the shipped predicate rather than a copy of it.
+#[path = "../../../tests/fuzz/fuzz_targets/upstream_span_assertion_skip.rs"]
+mod upstream_span_assertion_skip;
+
+/// What Vize's guarded expression-parsing path does with one input.
+#[derive(Debug, PartialEq, Eq)]
+enum Outcome {
+    /// Rejected by Vize's own guard, so OXC never sees it.
+    RejectedByGuard,
+    /// Handed to OXC, which returned exactly these diagnostic messages.
+    Diagnostics(Vec<String>),
+    /// Handed to OXC, which tripped the upstream span assertion with exactly
+    /// this panic payload.
+    UpstreamSpanAssertion(String),
+}
+
+/// Runs one input through the same guard-then-parse path as the
+/// `js_ts_expression` fuzz target, catching the upstream assertion instead of
+/// aborting the test binary.
+fn classify(source: &str) -> Outcome {
+    if !expression_is_safe_to_parse(source) {
+        return Outcome::RejectedByGuard;
+    }
+
+    let previous_hook = panic::take_hook();
+    panic::set_hook(Box::new(|_| {}));
+    let parsed = panic::catch_unwind(AssertUnwindSafe(|| {
+        let allocator = Allocator::default();
+        let parser = Parser::new(
+            &allocator,
+            source,
+            SourceType::default()
+                .with_module(true)
+                .with_typescript(true),
+        );
+        match parser.parse_expression() {
+            Ok(_) => Vec::new(),
+            Err(errors) => errors
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect(),
+        }
+    }));
+    panic::set_hook(previous_hook);
+
+    match parsed {
+        Ok(messages) => Outcome::Diagnostics(messages),
+        Err(payload) => Outcome::UpstreamSpanAssertion(
+            payload
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| {
+                    payload
+                        .downcast_ref::<&str>()
+                        .map(|text| (*text).to_string())
+                })
+                .unwrap_or_else(|| "<non-string panic payload>".to_string()),
+        ),
+    }
+}
+
+fn diagnostic(message: &str) -> Outcome {
+    Outcome::Diagnostics(vec![message.to_string()])
+}
+
+fn span_assertion() -> Outcome {
+    Outcome::UpstreamSpanAssertion("assertion failed: self.start <= self.end".to_string())
+}
+
+/// Every input in the class, with the outcome the pinned OXC revision produces.
+fn matrix() -> Vec<(&'static str, Outcome)> {
+    vec![
+        // The #3296 `cargo fuzz tmin` reproducer and its neighbours.
+        ("<[r?, \u{7}]", span_assertion()),
+        ("<[r?,\u{7}]", diagnostic("Invalid Character `\u{7}`")),
+        ("<[r?, \u{1f}]", span_assertion()),
+        ("f<[a?, \u{7}]>(x)", span_assertion()),
+        ("a<[b?, \u{7}]", span_assertion()),
+        // Documented clean neighbours: printable element, no optional member,
+        // no second element.
+        ("<[r?, x]", diagnostic("Expected `>` but found `EOF`")),
+        ("<[\u{7}]", diagnostic("Expected `]` but found `Unknown`")),
+        ("<[r?]", diagnostic("Expected `>` but found `EOF`")),
+        // oxc-project/oxc#23670's own reproducer: the trivia is a newline and
+        // the tuple never closes, so Vize's balance guard rejects it first.
+        ("<[m?,\n\n", Outcome::RejectedByGuard),
+        ("<[m?,", Outcome::RejectedByGuard),
+        // Printable members of the same class: the byte after the comma only
+        // has to be unable to start a type.
+        ("<[r?, , x]", span_assertion()),
+        ("f<[a?, , b]>(x)", span_assertion()),
+        ("<[r?,,x]", diagnostic("Unexpected token")),
+        ("<[r?, ; ]", span_assertion()),
+        ("<[r?, @ ]", span_assertion()),
+        ("<[r? , , x]", span_assertion()),
+        ("<[a?: T, , b]", span_assertion()),
+        ("f<[a?: T, , b]>(x)", span_assertion()),
+        // Tuple types reached without `<[` type arguments at all.
+        ("(x as [a?, , b])", span_assertion()),
+        ("f(y as [a?, , b])", span_assertion()),
+        ("(x satisfies [a?, , b])", span_assertion()),
+        ("<[a?, , b]>x", span_assertion()),
+        // TS1257 with a well-formed span: reported, never inverted.
+        (
+            "f<[a?, b]>(x)",
+            diagnostic("A required element cannot follow an optional element."),
+        ),
+        (
+            "(x as [a?, b])",
+            diagnostic("A required element cannot follow an optional element."),
+        ),
+    ]
+}
+
+#[test]
+fn upstream_tuple_type_span_assertion_boundary_matrix() {
+    let expected = matrix();
+    let actual: Vec<(&str, Outcome)> = expected
+        .iter()
+        .map(|(source, _)| (*source, classify(source)))
+        .collect();
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn fuzz_skip_predicate_covers_every_panicking_input() {
+    // `false` rows are the ones the fuzzer keeps exercising. Clean inputs may be
+    // skipped too: `<[r?,\x07]` parses cleanly but the predicate counts the C0
+    // byte after the comma as trivia, and `<[r?, x]` / `f<[a?, b]>(x)` are the
+    // well-formed neighbours the shape match cannot separate.
+    let expected_skips: Vec<(&str, bool)> = vec![
+        ("<[r?, \u{7}]", true),
+        ("<[r?,\u{7}]", true),
+        ("<[r?, \u{1f}]", true),
+        ("f<[a?, \u{7}]>(x)", true),
+        ("a<[b?, \u{7}]", true),
+        ("<[r?, x]", true),
+        ("<[\u{7}]", false),
+        ("<[r?]", false),
+        ("<[m?,\n\n", true),
+        ("<[m?,", true),
+        ("<[r?, , x]", true),
+        ("f<[a?, , b]>(x)", true),
+        ("<[r?,,x]", false),
+        ("<[r?, ; ]", true),
+        ("<[r?, @ ]", true),
+        ("<[r? , , x]", true),
+        ("<[a?: T, , b]", true),
+        ("f<[a?: T, , b]>(x)", true),
+        ("(x as [a?, , b])", true),
+        ("f(y as [a?, , b])", true),
+        ("(x satisfies [a?, , b])", true),
+        ("<[a?, , b]>x", true),
+        ("f<[a?, b]>(x)", true),
+        ("(x as [a?, b])", true),
+    ];
+    let actual_skips: Vec<(&str, bool)> = matrix()
+        .iter()
+        .map(|(source, _)| {
+            (
+                *source,
+                hits_known_upstream_span_assertion_shape(source.as_bytes()),
+            )
+        })
+        .collect();
+
+    assert_eq!(actual_skips, expected_skips);
+
+    // The invariant the fuzz job depends on: over-skipping a clean input only
+    // costs coverage, but leaving a panicking input unskipped re-reports the
+    // known upstream crash.
+    for (source, outcome) in matrix() {
+        if matches!(outcome, Outcome::UpstreamSpanAssertion(_)) {
+            assert!(
+                hits_known_upstream_span_assertion_shape(source.as_bytes()),
+                "panicking input {source:?} is not skipped by the fuzz predicate"
+            );
+        }
+    }
+}
+
+/// Expressions that never reach the class stay fuzzable: the predicate must not
+/// swallow ternaries, optional chaining or nullish coalescing near an array.
+#[test]
+fn fuzz_skip_predicate_keeps_ordinary_expressions() {
+    let sources = [
+        "a[0] ? f(1, 2) : g",
+        "[cond ? a : b, c]",
+        "[a?.b, c]",
+        "a[x ?? y, z]",
+        "[a, b, c]",
+        "f<[a, b]>(x)",
+        "x ? y : z",
+    ];
+    let actual: Vec<(&str, bool)> = sources
+        .iter()
+        .map(|source| {
+            (
+                *source,
+                hits_known_upstream_span_assertion_shape(source.as_bytes()),
+            )
+        })
+        .collect();
+
+    assert_eq!(
+        actual,
+        vec![
+            ("a[0] ? f(1, 2) : g", false),
+            ("[cond ? a : b, c]", false),
+            ("[a?.b, c]", false),
+            ("a[x ?? y, z]", false),
+            ("[a, b, c]", false),
+            ("f<[a, b]>(x)", false),
+            ("x ? y : z", false),
+        ]
+    );
+}

--- a/crates/vize_atelier_core/tests/upstream_tuple_type_span_typescript_strip.rs
+++ b/crates/vize_atelier_core/tests/upstream_tuple_type_span_typescript_strip.rs
@@ -1,0 +1,102 @@
+//! The upstream tuple-type span assertion (#3307) is reachable from a public
+//! Vize API, not only from the `js_ts_expression` fuzz target.
+//!
+//! `prefix_identifiers_in_expression` parses without the `typescript` source
+//! option, so `<[` is never speculated as type arguments and the class cannot be
+//! reached there. `strip_typescript_from_expression` parses `SourceType::ts()`
+//! once `needs_typescript_stripping` sees a generic call, so a template
+//! expression such as `{{ f<[a?, , b]>(x) }}` aborts any build with debug
+//! assertions on (dev / test / the `ci` profile). Release builds are unaffected:
+//! the assertion is `debug_assert`-only and the label just gets a garbage span.
+//!
+//! Both rows below are asserted so the exposure cannot be quietly widened, and
+//! so the panic rows fail loudly once the pinned OXC revision reaches 0.141.0.
+//! See `upstream_tuple_type_span_assertion.rs` for the full boundary matrix.
+
+use std::panic::{self, AssertUnwindSafe};
+
+use vize_atelier_core::steps::expression::{
+    prefix_identifiers_in_expression, strip_typescript_from_expression,
+};
+
+/// What a public expression transform does with one input.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum TransformOutcome {
+    /// Returned the input unchanged — a guard rejection or a failed parse.
+    Unchanged,
+    /// Rewrote the input to exactly this string.
+    Rewritten(String),
+    /// Tripped the upstream span assertion with exactly this panic payload.
+    UpstreamSpanAssertion(String),
+}
+
+fn classify(transform: fn(&str) -> vize_carton::String, source: &str) -> TransformOutcome {
+    let previous_hook = panic::take_hook();
+    panic::set_hook(Box::new(|_| {}));
+    let transformed =
+        panic::catch_unwind(AssertUnwindSafe(|| transform(source).as_str().to_string()));
+    panic::set_hook(previous_hook);
+
+    match transformed {
+        Ok(output) if output == source => TransformOutcome::Unchanged,
+        Ok(output) => TransformOutcome::Rewritten(output),
+        Err(payload) => TransformOutcome::UpstreamSpanAssertion(
+            payload
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| {
+                    payload
+                        .downcast_ref::<&str>()
+                        .map(|text| (*text).to_string())
+                })
+                .unwrap_or_else(|| "<non-string panic payload>".to_string()),
+        ),
+    }
+}
+
+fn span_assertion() -> TransformOutcome {
+    TransformOutcome::UpstreamSpanAssertion("assertion failed: self.start <= self.end".to_string())
+}
+
+const SOURCES: [&str; 8] = [
+    "<[r?, \u{7}]",
+    "f<[a?, \u{7}]>(x)",
+    "<[r?, , x]",
+    "f<[a?, , b]>(x)",
+    "<[r?, ; ]",
+    "<[r?, @ ]",
+    "<[m?,\n\n",
+    "f<[a?, b]>(x)",
+];
+
+#[test]
+fn identifier_prefixing_never_reaches_the_upstream_span_assertion() {
+    let actual: Vec<TransformOutcome> = SOURCES
+        .iter()
+        .map(|source| classify(prefix_identifiers_in_expression, source))
+        .collect();
+
+    assert_eq!(actual, vec![TransformOutcome::Unchanged; SOURCES.len()]);
+}
+
+#[test]
+fn typescript_stripping_reaches_the_upstream_span_assertion_on_generic_calls() {
+    let actual: Vec<(&str, TransformOutcome)> = SOURCES
+        .iter()
+        .map(|source| (*source, classify(strip_typescript_from_expression, source)))
+        .collect();
+
+    assert_eq!(
+        actual,
+        vec![
+            ("<[r?, \u{7}]", TransformOutcome::Unchanged),
+            ("f<[a?, \u{7}]>(x)", span_assertion()),
+            ("<[r?, , x]", TransformOutcome::Unchanged),
+            ("f<[a?, , b]>(x)", span_assertion()),
+            ("<[r?, ; ]", TransformOutcome::Unchanged),
+            ("<[r?, @ ]", TransformOutcome::Unchanged),
+            ("<[m?,\n\n", TransformOutcome::Unchanged),
+            ("f<[a?, b]>(x)", TransformOutcome::Unchanged),
+        ]
+    );
+}

--- a/tests/fuzz/fuzz_targets/js_ts_expression.rs
+++ b/tests/fuzz/fuzz_targets/js_ts_expression.rs
@@ -6,48 +6,28 @@
 // transforms and import-usage checks. Invalid expressions are expected and
 // reported as parser errors; panics are not.
 //
-// One upstream crash class is skip-listed below until the pinned OXC revision
-// carries a fix (#3296; retirement tracked in #3307): a speculative tuple type
-// with an optional member recovering over a C0 control byte builds a span
-// with `start > end`, tripping a `debug_assert` in `oxc_span::Span::size`
-// (`<[r?, \x07]` after `cargo fuzz tmin`). The shape is not a depth or
-// balance property, so the expression nesting guard cannot express it; the
-// skip costs fuzz coverage only.
+// One upstream crash class is skip-listed until the pinned OXC revision carries
+// a fix (#3296; retirement tracked in #3307): a TS tuple type with an optional
+// member, whose next element consumes no tokens, builds that element's span as
+// `Span::new(start_span(), prev_token_end)`. `start_span()` has already skipped
+// the trivia after the comma, so the span comes out inverted (`start > end`),
+// and labeling it for `TS1257 required element cannot follow an optional
+// element` trips `debug_assert!(self.start <= self.end)` in
+// `oxc_span::Span::size`.
+//
+// The shape is neither a depth nor a balance property, so the expression
+// nesting guard cannot express it; the skip costs fuzz coverage only. The
+// predicate lives in `upstream_span_assertion_skip.rs` and its boundary matrix
+// is pinned by `crates/vize_atelier_core/tests/upstream_tuple_type_span_assertion.rs`.
 use libfuzzer_sys::fuzz_target;
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
+use upstream_span_assertion_skip::hits_known_upstream_span_assertion_shape;
 use vize_atelier_core::steps::expression::expression_is_safe_to_parse;
 
-/// Returns true when a `<[` span holds both a `?` and a C0 control byte
-/// (excluding tab/newline/carriage return) before its closing `]` — the
-/// empirical requirements of the upstream tuple-type span assertion (#3307):
-/// dropping either the optional member or the control byte parses cleanly.
-fn hits_known_upstream_span_assertion_shape(bytes: &[u8]) -> bool {
-    let mut i = 0;
-    while i + 1 < bytes.len() {
-        if bytes[i] == b'<' && bytes[i + 1] == b'[' {
-            let (mut has_question, mut has_control) = (false, false);
-            let mut j = i + 2;
-            while j < bytes.len() && bytes[j] != b']' {
-                match bytes[j] {
-                    b'?' => has_question = true,
-                    b'\t' | b'\n' | b'\r' => {}
-                    b if b < 0x20 => has_control = true,
-                    _ => {}
-                }
-                j += 1;
-            }
-            if has_question && has_control {
-                return true;
-            }
-            i = j;
-        } else {
-            i += 1;
-        }
-    }
-    false
-}
+#[path = "upstream_span_assertion_skip.rs"]
+mod upstream_span_assertion_skip;
 
 fuzz_target!(|data: &[u8]| {
     let Ok(source) = std::str::from_utf8(data) else {

--- a/tests/fuzz/fuzz_targets/upstream_span_assertion_skip.rs
+++ b/tests/fuzz/fuzz_targets/upstream_span_assertion_skip.rs
@@ -1,0 +1,61 @@
+//! Skip predicate for the upstream OXC tuple-type span assertion (#3307).
+//!
+//! Included both by the `js_ts_expression` fuzz target and by
+//! `crates/vize_atelier_core/tests/upstream_tuple_type_span_assertion.rs`, so
+//! the predicate the fuzzer applies is the one CI asserts against the boundary
+//! matrix. It is not a fuzz-only heuristic living outside test coverage.
+
+/// Returns true when `bytes` can reach the upstream tuple-type span assertion.
+///
+/// The panic needs two things inside one TS tuple type, and nothing else:
+/// 1. an optional member before the offending comma — `[a?, …]`, `[a?]` or the
+///    named form `[a?: T, …]` — so the `?` is followed, after optional
+///    whitespace, by `,`, `]` or `:`; and
+/// 2. a later comma whose element consumes no tokens, which requires at least
+///    one byte of trivia after that comma: `<[r?,\x07]` parses cleanly while
+///    `<[r?, \x07]` panics.
+///
+/// Neither `<[` type arguments nor a control byte is part of the class:
+/// `f<[a?, , b]>(x)`, `(x as [a?, , b])` and `(x satisfies [a?, , b])` are
+/// printable, balanced ASCII and panic identically. The predicate therefore
+/// keys on the tuple shape rather than on the `cargo fuzz tmin` reproducer's
+/// `<[` prefix.
+///
+/// Over-skipping only costs fuzz coverage, while under-skipping re-reports a
+/// known upstream crash, so the match deliberately ignores bracket nesting and
+/// quoting, and searches for the trailing comma to the end of the input.
+pub fn hits_known_upstream_span_assertion_shape(bytes: &[u8]) -> bool {
+    let Some(first_bracket) = bytes.iter().position(|byte| *byte == b'[') else {
+        return false;
+    };
+
+    bytes
+        .iter()
+        .enumerate()
+        .skip(first_bracket + 1)
+        .filter(|(_, byte)| **byte == b'?')
+        .any(|(index, _)| {
+            let after_marker = &bytes[index + 1..];
+            let Some(offset) = after_marker
+                .iter()
+                .position(|byte| !byte.is_ascii_whitespace())
+            else {
+                return false;
+            };
+            let tail = &after_marker[offset..];
+            matches!(tail.first(), Some(b',' | b']' | b':')) && has_comma_followed_by_trivia(tail)
+        })
+}
+
+/// Returns true when `bytes` holds a comma followed by trivia — ASCII
+/// whitespace, a C0 control byte, or end of input — that is, a comma whose
+/// element can start past `prev_token_end`.
+fn has_comma_followed_by_trivia(bytes: &[u8]) -> bool {
+    bytes.iter().enumerate().any(|(index, byte)| {
+        *byte == b','
+            && match bytes.get(index + 1) {
+                None => true,
+                Some(next) => next.is_ascii_whitespace() || *next < 0x20,
+            }
+    })
+}


### PR DESCRIPTION
## Defect

The `js_ts_expression` fuzz skip for the upstream tuple-type span assertion (#3296 / #3307) was keyed on the `cargo fuzz tmin` reproducer's surface shape — a `<[` span holding both a `?` and a C0 control byte. That is not the class, so the skip **under-covers a live crash** and mislabels a clean input.

Replaying the reproducer's neighbours against the pinned rev `8265ed94` (oxc 0.127.0) in a dev profile, the panic needs exactly two things inside one TS tuple type:

1. an optional member before the offending comma (`[a?, …]`, `[a?]`, `[a?: T]`), and
2. a later comma whose element consumes no tokens, which requires **at least one byte of trivia** after that comma.

The element span is built as `Span::new(start_span(), prev_token_end)`; when the element consumes nothing, `start_span()` has already skipped the trivia past `prev_token_end`, so the span is inverted and labeling it for TS1257 trips `debug_assert!(self.start <= self.end)`.

Neither `<[` type arguments nor a control byte is part of the class.

## Minimal reproduction

| input | pinned `8265ed94` (0.127.0) | old skip | new skip |
|---|---|---|---|
| `<[r?, \x07]` | panic | skipped | skipped |
| `<[r?,\x07]` (no trivia) | **clean** — `Invalid Character` | skipped | skipped |
| `f<[a?, , b]>(x)` | **panic** | **not skipped** | skipped |
| `(x as [a?, , b])` | **panic** | **not skipped** | skipped |
| `(x satisfies [a?, , b])` | **panic** | **not skipped** | skipped |
| `<[a?, , b]>x` | **panic** | **not skipped** | skipped |
| `<[r?, ; ]`, `<[r?, @ ]`, `<[r? , , x]` | **panic** | **not skipped** | skipped |
| `<[r?, x]`, `<[r?]`, `<[\x07]` | clean | not skipped | over-skipped / kept |
| `a[0] ? f(1, 2) : g`, `[a?.b, c]`, `a[x ?? y, z]` | clean | not skipped | not skipped |

`<[r?,\x07]` is listed as a panic in #3307; it is not — without trivia the element span is empty rather than inverted.

## Expected vs actual

Expected: the fuzz target never re-reports the known upstream crash, and the class is written down somewhere CI enforces.

Actual: eight printable, balanced-ASCII members of the class went unskipped, and the class was documented only in an issue body that has two rows wrong.

Also new: the class is **reachable from a public Vize API**, not only from fuzzing. `strip_typescript_from_expression` parses `SourceType::ts()` once `needs_typescript_stripping` sees a generic call, so `{{ f<[a?, , b]>(x) }}` aborts any build with debug assertions on (dev / test / the `ci` profile). Release builds are unaffected — the assertion is `debug_assert`-only and the label just gets a garbage span. That row is asserted in `upstream_tuple_type_span_typescript_strip.rs` so the exposure cannot widen quietly.

## How the new test fails before the fix

`fuzz_skip_predicate_covers_every_panicking_input` fails on 8 rows against the old `<[`-and-control-byte predicate: `f<[a?, , b]>(x)`, `<[r?, ; ]`, `<[r?, @ ]`, `<[r? , , x]`, `(x as [a?, , b])`, `f(y as [a?, , b])`, `(x satisfies [a?, , b])`, `<[a?, , b]>x`. Each is a crash the old skip let through. The `assert!` invariant at the end of that test states the property directly: no input whose matrix row is `UpstreamSpanAssertion` may be left unskipped.

The predicate is not duplicated — `crates/vize_atelier_core/tests/upstream_tuple_type_span_assertion.rs` includes the fuzz module with `#[path]`, so CI asserts the predicate the fuzzer actually runs.

## Upstream status (for #3307's criterion 1)

Replayed with standalone probe crates under the system temp dir (dev profile, debug assertions on, `parse_expression` with `module + typescript`), over every matrix input:

| oxc version | result |
|---|---|
| pinned `8265ed94` (0.127.0) | panics |
| 0.134.0 / 0.138.0 / 0.140.0 | panics, identical rows |
| **0.141.0** | **all rows clean** |
| 0.142.0 (latest published) | all rows clean |
| `main` @ `8a47ff37` | all rows clean |

The fix is incidental, not a span fix: 0.141.0's lazy `ParserDiagnostic` refactor keeps TS1257 unmaterialized when the fatal error truncates it, so the inverted span is never labeled. The inverted span is still constructed, so oxc-project/oxc#23670 (filed upstream by another fuzzer, still open) remains valid.

Bumping the pin past 0.141.0 is therefore possible, but is a separate `chore(deps)` change: 0.127 → 0.142 renames `oxc_allocator::Box`/`Vec` to `ArenaBox`/`ArenaVec`, moves `AstBuilder`/`NONE` into a `builder` module, replaces `self.ast.*` builders with type constructors, and changes `parse_expression`'s error type. Not folded in here.

When the pin does move, every `UpstreamSpanAssertion` row in this matrix fails, which is the signal to flip those rows and delete the skip.

## Gates

- `nix develop -c vp run fmt:check` → `EXIT=0`
- `nix develop -c vp run lint:rust` → `EXIT=0`
- `nix develop -c vp run check:rust` → `EXIT=0`
- `nix develop -c vp run source:lengths` → `EXIT=0`
- `cargo test -p vize_atelier_core` → all suites pass, including the 5 new tests
- `cargo check --bin js_ts_expression` in `tests/fuzz` → clean
- `node --test tests/tooling/fuzz-setup.test.ts` → 4/4 pass

Refs #3307

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->