### PR TITLE
fix(canon): exclude nested node_modules from wildcard include expansion

### DIFF
--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -13,6 +13,7 @@ use vize_carton::FxHashSet;
 mod ambient;
 mod collect;
 mod glob;
+mod implicit_exclude;
 mod jsonc;
 mod loader;
 mod matching;
@@ -25,6 +26,8 @@ mod codegen_tests;
 mod hidden_include_tests;
 #[cfg(test)]
 mod nuxt_manifest_tests;
+#[cfg(test)]
+mod package_folder_tests;
 #[cfg(test)]
 mod tests;
 

--- a/crates/vize/src/commands/check/tsconfig_inputs/glob.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/glob.rs
@@ -60,6 +60,14 @@ pub(super) fn normalize_tsconfig_glob_base(
     (base_dir, normalized)
 }
 
+/// The documented default `exclude`, anchored at `base_dir`.
+///
+/// This only covers the copies sitting directly below the tsconfig directory.
+/// `tsc` drops these three directory names from every wildcard segment at any
+/// depth instead, which [`super::implicit_exclude`] applies on the `include`
+/// side and which stays in force even when the user spells out their own
+/// `exclude`. What remains here is therefore stricter than `tsc`, whose own
+/// `exclude` default is only `outDir` and `declarationDir`: #3395.
 pub(super) fn default_exclude_specs(base_dir: &Path) -> Vec<GlobSpec> {
     ["node_modules", "bower_components", "jspm_packages"]
         .into_iter()

--- a/crates/vize/src/commands/check/tsconfig_inputs/implicit_exclude.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/implicit_exclude.rs
@@ -1,0 +1,100 @@
+//! TypeScript's implicit exclusion of package folders from wildcard `include`
+//! segments.
+//!
+//! `tsc` does not implement the `node_modules` / `bower_components` /
+//! `jspm_packages` default as an `exclude` entry. It bakes the exclusion into
+//! how an `include` pattern is compiled: every segment that carries a wildcard —
+//! and every directory a `**` consumes — is prefixed with
+//! `(?!(node_modules|bower_components|jspm_packages)(/|$))`
+//! (`implicitExcludePathRegexPattern`), while a literal segment is matched
+//! literally. Three consequences, each verified against
+//! `tsgo -p tsconfig.json --listFiles`:
+//!
+//! * The exclusion applies at *every* depth, not only directly below the
+//!   tsconfig directory. `include: ["packages/**/*.ts"]` never collects
+//!   `packages/a/node_modules/dep/index.ts`.
+//! * It is not the `exclude` field, so an explicit `exclude: []` does not switch
+//!   it off.
+//! * Spelling a package folder out as a literal segment keeps it:
+//!   `include: ["packages/*/node_modules/dep/*.ts"]` does collect that file.
+//!
+//! Anchoring the three directory names at the tsconfig directory only — the
+//! shape [`super::glob::default_exclude_specs`] produces — therefore misses
+//! nested copies, which is how files from a real nested `node_modules` became
+//! program roots (#3385).
+
+use std::path::Path;
+
+/// `commonPackageFolders` in TypeScript's `utilities.ts`.
+const COMMON_PACKAGE_FOLDERS: [&str; 3] = ["node_modules", "bower_components", "jspm_packages"];
+
+const RECURSIVE_SEGMENT: &str = "**";
+
+/// Whether `relative` — a path relative to the include spec's base directory —
+/// has a package folder in a segment that `pattern` matched with a wildcard.
+///
+/// The pattern is aligned against the path segment by segment: literally from
+/// the left up to the first `**`, literally from the right back to the last
+/// `**`, and everything still unclaimed in the middle is what the `**` consumed.
+/// A pattern without `**` therefore claims every segment one-to-one, and a
+/// pattern with several `**` treats the whole span between the outermost two as
+/// consumed — conservative in the same direction as `tsc`, whose `**` fragment
+/// rejects a package folder at any of the depths it spans.
+pub(super) fn wildcard_segment_hits_package_folder(pattern: &str, relative: &Path) -> bool {
+    let segments = relative
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    let pattern_segments = pattern
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+
+    // Unclaimed path segments live in `segments[head..tail]`.
+    let mut head = 0usize;
+    let mut tail = segments.len();
+
+    let mut recursive_at = None;
+    for (index, segment) in pattern_segments.iter().enumerate() {
+        if *segment == RECURSIVE_SEGMENT {
+            recursive_at = Some(index);
+            break;
+        }
+        // Fewer path segments than leading pattern segments means the pattern
+        // did not match this path at all; nothing is wildcard-claimed.
+        if head >= tail {
+            return false;
+        }
+        if is_wildcard_segment(segment) && is_package_folder(segments[head]) {
+            return true;
+        }
+        head += 1;
+    }
+
+    let Some(recursive_at) = recursive_at else {
+        return false;
+    };
+
+    for segment in pattern_segments[recursive_at + 1..].iter().rev() {
+        if *segment == RECURSIVE_SEGMENT {
+            break;
+        }
+        if tail <= head {
+            return false;
+        }
+        if is_wildcard_segment(segment) && is_package_folder(segments[tail - 1]) {
+            return true;
+        }
+        tail -= 1;
+    }
+
+    segments[head..tail].iter().copied().any(is_package_folder)
+}
+
+fn is_wildcard_segment(segment: &str) -> bool {
+    segment.contains(['*', '?', '['])
+}
+
+fn is_package_folder(segment: &str) -> bool {
+    COMMON_PACKAGE_FOLDERS.contains(&segment)
+}

--- a/crates/vize/src/commands/check/tsconfig_inputs/matching.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/matching.rs
@@ -35,7 +35,7 @@ pub(super) fn matches_tsconfig_patterns(
     includes: &[GlobSpec],
     excludes: &[GlobSpec],
 ) -> bool {
-    if !includes.is_empty() && !includes.iter().any(|glob| glob.matches(path)) {
+    if !includes.is_empty() && !includes.iter().any(|glob| glob.matches_include(path)) {
         return false;
     }
 

--- a/crates/vize/src/commands/check/tsconfig_inputs/package_folder_tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/package_folder_tests.rs
@@ -1,0 +1,213 @@
+//! Tests for TypeScript's implicit exclusion of `node_modules`,
+//! `bower_components` and `jspm_packages` from wildcard `include` segments
+//! (#3385).
+//!
+//! Every expectation here was taken from `tsgo -p tsconfig.json --listFiles` on
+//! the same tree; the case names say which behavior each one pins.
+//!
+//! The case directories deliberately live under [`std::env::temp_dir`] rather
+//! than the crate's `target/`: the collector walks with `ignore`'s standard
+//! filters, so inside the repository the checkout's `.gitignore` would hide
+//! `node_modules` on its own and the assertions would pass without the fix.
+
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
+use std::path::{Path, PathBuf};
+
+use vize_carton::cstr;
+
+use super::TsconfigInputCache;
+
+fn collect_default_check_files(project_root: &Path, tsconfig_path: &Path) -> Vec<PathBuf> {
+    super::collect_default_check_files(
+        project_root,
+        Some(tsconfig_path),
+        false,
+        &mut TsconfigInputCache::default(),
+    )
+}
+
+fn write(root: &Path, relative: &str, contents: &str) {
+    let path = root.join(relative);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, contents).unwrap();
+}
+
+/// A fresh case directory outside the repository, plus the workspace every case
+/// in this module shares: one real source file per package folder name, nested a
+/// package deep, and one ordinary source file beside them.
+fn workspace(name: &str, tsconfig: &str) -> PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let root = std::env::temp_dir().join(
+        cstr!(
+            "vize-package-folders-{name}-{}-{case_id}",
+            std::process::id()
+        )
+        .as_str(),
+    );
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+
+    write(&root, "packages/a/index.ts", "export const a = 1;\n");
+    write(&root, "packages/a/sub/deep.ts", "export const s = 1;\n");
+    write(
+        &root,
+        "packages/a/node_modules/dep/index.ts",
+        "export const d = 1;\n",
+    );
+    write(
+        &root,
+        "packages/a/bower_components/dep/index.ts",
+        "export const b = 1;\n",
+    );
+    write(
+        &root,
+        "packages/a/jspm_packages/dep/index.ts",
+        "export const j = 1;\n",
+    );
+    write(&root, "node_modules/top/index.ts", "export const t = 1;\n");
+    write(&root, "tsconfig.json", tsconfig);
+
+    // `temp_dir` is a symlink on macOS, and the collector returns canonicalized
+    // paths, so the case root has to be canonical for `relative_paths`.
+    vize_carton::path::canonicalize_non_verbatim(&root)
+}
+
+fn collected(root: &Path) -> Vec<String> {
+    collect_default_check_files(root, &root.join("tsconfig.json"))
+        .iter()
+        .map(|path| {
+            path.strip_prefix(root)
+                .unwrap()
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
+        .collect()
+}
+
+#[test]
+fn wildcard_include_skips_package_folders_nested_below_the_tsconfig_directory() {
+    // tsgo, same tree, `include: ["packages/**/*.ts"]`:
+    //   packages/a/index.ts
+    //   packages/a/sub/deep.ts
+    // Anchoring the default `exclude` at the tsconfig directory only, as vize
+    // did, let all three nested package folders in as program roots.
+    let root = workspace("nested", r#"{ "include": ["packages/**/*.ts"] }"#);
+
+    assert_eq!(
+        collected(&root),
+        vec!["packages/a/index.ts", "packages/a/sub/deep.ts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn an_explicit_empty_exclude_does_not_re_enable_nested_package_folders() {
+    // The exclusion is part of wildcard expansion, not of `exclude`: tsgo lists
+    // the same two files with `"exclude": []` as without it.
+    let root = workspace(
+        "empty-exclude",
+        r#"{ "include": ["packages/**/*.ts"], "exclude": [] }"#,
+    );
+
+    assert_eq!(
+        collected(&root),
+        vec!["packages/a/index.ts", "packages/a/sub/deep.ts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_user_exclude_still_narrows_the_wildcard_it_is_given() {
+    // The new filter must not swallow the user's own `exclude`: tsgo lists only
+    // `packages/a/index.ts` here.
+    let root = workspace(
+        "user-exclude",
+        r#"{ "include": ["packages/**/*.ts"], "exclude": ["packages/a/sub"] }"#,
+    );
+
+    assert_eq!(collected(&root), vec!["packages/a/index.ts"]);
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn an_include_entry_that_names_a_nested_package_folder_file_literally_is_kept() {
+    // A spec with no wildcards is matched literally, so tsgo lists
+    // `packages/a/node_modules/dep/index.ts` alongside the wildcard's files.
+    let root = workspace(
+        "literal-file",
+        r#"{ "include": ["packages/**/*.ts", "packages/a/node_modules/dep/index.ts"] }"#,
+    );
+
+    assert_eq!(
+        collected(&root),
+        vec![
+            "packages/a/index.ts",
+            "packages/a/node_modules/dep/index.ts",
+            "packages/a/sub/deep.ts",
+        ]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_literal_package_folder_segment_after_a_wildcard_segment_is_kept() {
+    // `packages/*/node_modules/dep/*.ts`: only `*` segments carry the implicit
+    // exclusion, so the literal `node_modules` segment resolves normally and
+    // tsgo lists exactly this one file.
+    let root = workspace(
+        "literal-segment",
+        r#"{ "include": ["packages/*/node_modules/dep/*.ts"] }"#,
+    );
+
+    assert_eq!(
+        collected(&root),
+        vec!["packages/a/node_modules/dep/index.ts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_recursive_wildcard_below_a_literal_package_folder_segment_stays_shallow() {
+    // `node_modules/**/*.ts` keeps its literal first segment but the `**` still
+    // rejects a package folder at the depths it consumes, so tsgo lists
+    // `node_modules/top/index.ts` and nothing from a deeper `node_modules`.
+    // The `exclude` is spelled out because vize's default `exclude` still
+    // shadows the literal first segment, which `tsc`'s does not: #3395.
+    let root = workspace(
+        "literal-root-segment",
+        r#"{ "include": ["node_modules/**/*.ts"], "exclude": [] }"#,
+    );
+    write(
+        &root,
+        "node_modules/top/node_modules/inner/index.ts",
+        "export const i = 1;\n",
+    );
+
+    assert_eq!(collected(&root), vec!["node_modules/top/index.ts"]);
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_files_entry_inside_a_nested_package_folder_is_kept() {
+    // `files` bypasses include expansion entirely in tsc, and tsgo lists the
+    // named file.
+    let root = workspace(
+        "files-entry",
+        r#"{ "files": ["packages/a/node_modules/dep/index.ts"] }"#,
+    );
+
+    assert_eq!(
+        collected(&root),
+        vec!["packages/a/node_modules/dep/index.ts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/vize/src/commands/check/tsconfig_inputs/spec.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/spec.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use glob::Pattern;
 
 use super::glob::{normalize_path_separators, normalize_tsconfig_glob_base};
+use super::implicit_exclude::wildcard_segment_hits_package_folder;
 use super::matching::glob_match_options;
 
 #[derive(Debug, Clone, Default)]
@@ -95,12 +96,27 @@ impl GlobSpec {
         })
     }
 
+    /// Whether `path` matches this spec as a plain glob. This is the `exclude`
+    /// semantics: TypeScript's exclude matcher has no implicit exclusions.
     pub(super) fn matches(&self, path: &Path) -> bool {
-        let Ok(relative) = path.strip_prefix(&self.base_dir) else {
-            return false;
-        };
+        self.matched_relative(path).is_some()
+    }
+
+    /// Whether `path` matches this spec as an `include` entry, i.e. as a plain
+    /// glob *and* without a package folder in any wildcard-matched segment. See
+    /// [`super::implicit_exclude`] for why `include` and `exclude` differ here.
+    pub(super) fn matches_include(&self, path: &Path) -> bool {
+        self.matched_relative(path).is_some_and(|relative| {
+            !wildcard_segment_hits_package_folder(&self.normalized, relative)
+        })
+    }
+
+    fn matched_relative<'path>(&self, path: &'path Path) -> Option<&'path Path> {
+        let relative = path.strip_prefix(&self.base_dir).ok()?;
         let normalized = normalize_path_separators(relative);
-        self.pattern.matches_with(&normalized, glob_match_options())
+        self.pattern
+            .matches_with(&normalized, glob_match_options())
+            .then_some(relative)
     }
 }
 

--- a/crates/vize_canon/src/batch/virtual_project/package_node_modules.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_node_modules.rs
@@ -45,6 +45,14 @@ pub(super) struct PackageNodeModulesLink {
 /// skipped. Those files are the mirror's own copies of a dependency, and
 /// linking the real directory over them would make every write inside the
 /// virtual project land in the user's real `node_modules`.
+///
+/// Since #3385 the input collector no longer sweeps a nested `node_modules` in
+/// through wildcard `include` expansion, so the #3366 shape — a workspace whose
+/// root `tsconfig.json` includes `packages/**/*` — never reaches that skip. It
+/// still can be reached deliberately: `tsc` honors a `files` entry or a literal
+/// `include` segment that names a file inside a nested `node_modules`, so the
+/// guard stays. In that shape the link is dropped and #3366's `TS2307` can still
+/// fire, which is the narrower defect tracked in #3396.
 pub(super) fn package_node_modules_links<'a>(
     project_root: &Path,
     virtual_root: &Path,


### PR DESCRIPTION
## Change class

Virtual TypeScript and type checking (tsconfig input collection — which files become program roots).

## Defect

`vize check` collected files out of a **nested** `node_modules` as program root inputs. `tsc` never does.

Vize modelled the documented `node_modules` / `bower_components` / `jspm_packages` default as three glob specs anchored at the tsconfig directory (`default_exclude_specs`). TypeScript does it somewhere else entirely: `implicitExcludePathRegexPattern` is compiled *into* the `include` pattern, so every segment carrying a wildcard — and every directory a `**` consumes — rejects those three names at any depth, while a literal segment is matched literally.

## Reproduction and verification against `tsgo`

Tree under a `mktemp -d` (outside any repo, so no `.gitignore` hides the package folders — that is exactly the reachability condition #3385 names):

```
node_modules/top/index.ts
packages/a/index.ts
packages/a/sub/deep.ts
packages/a/node_modules/dep/index.ts
packages/a/bower_components/dep/index.ts
packages/a/jspm_packages/dep/index.ts
```

Command, run per case with `@typescript/native-preview` from this repo's devDependencies:

```
cd "$D" && node_modules/.bin/tsgo -p tsconfig.json --listFiles | grep -v '/lib\.'
```

| `tsconfig.json` | `tsgo --listFiles` | vize before | vize after |
| --- | --- | --- | --- |
| `{"include":["packages/**/*.ts"]}` | `packages/a/index.ts`, `packages/a/sub/deep.ts` | + all three nested package folders | matches |
| `{"include":["packages/**/*.ts"],"exclude":[]}` | same two files | + all three | matches |
| `{"include":["packages/**/*.ts"],"exclude":["packages/a/sub"]}` | `packages/a/index.ts` | + all three | matches |
| `{"include":["packages/**/*.ts","packages/a/node_modules/dep/index.ts"]}` | those two files + `packages/a/node_modules/dep/index.ts` | + bower/jspm too | matches |
| `{"include":["packages/*/node_modules/dep/*.ts"]}` | `packages/a/node_modules/dep/index.ts` | matches | matches |
| `{"files":["packages/a/node_modules/dep/index.ts"]}` | `packages/a/node_modules/dep/index.ts` | matches | matches |

Two things fall out of the real `tsc` behavior and are pinned as tests so the fix cannot over-correct:

* `"exclude": []` does **not** switch the exclusion off — it is not the `exclude` field.
* A **literal** package-folder segment is honored, whether it is the first segment or sits after a wildcard, and a `files` entry is honored unconditionally.

## Fix

`crates/vize/src/commands/check/tsconfig_inputs/implicit_exclude.rs` (new) aligns an include pattern against a path segment by segment — literally from the left to the first `**`, literally from the right back to the last `**`, everything left in the middle being what the `**` consumed — and reports whether a package folder landed in a wildcard-claimed segment. `GlobSpec` grows `matches_include` for that, and `matches_tsconfig_patterns` uses it on the include side only; the `exclude` side keeps plain glob semantics, because TypeScript's exclude matcher carries no implicit exclusions.

This is a pure narrowing of the root set: no path that was excluded before becomes included.

## How the tests fail before the fix

`crates/vize/src/commands/check/tsconfig_inputs/package_folder_tests.rs`, 7 cases. With only `matches_include` reverted to `matches` on line 38 of `matching.rs`, 5 of the 7 fail and 2 pass (the 2 that guard against over-exclusion):

```
$ cargo test -p vize --lib package_folder_tests
test result: FAILED. 2 passed; 5 failed; ...

---- wildcard_include_skips_package_folders_nested_below_the_tsconfig_directory ----
  left: ["packages/a/bower_components/dep/index.ts", "packages/a/index.ts",
         "packages/a/jspm_packages/dep/index.ts", "packages/a/node_modules/dep/index.ts",
         "packages/a/sub/deep.ts"]
 right: ["packages/a/index.ts", "packages/a/sub/deep.ts"]
```

The case directories live under `std::env::temp_dir()` on purpose: the collector walks with `ignore`'s standard filters, so inside the checkout the repository's own `.gitignore` would hide `node_modules` and every assertion would pass without the fix.

## The #3384 carve-out

#3385 expected this to delete the `materialized_dependency_dirs` skip in `package_node_modules_links`. It cannot be deleted, so the doc comment there now records why rather than leaving a stale rationale:

* the skip's motivating shape — a workspace root `tsconfig.json` with `packages/**/*` sweeping a real nested `node_modules` into the inputs — is gone with this change, which was the point;
* but `tsc` still puts such a file in the program when it is named without a wildcard (rows 5 and 6 of the table above), and in that shape linking the real directory over the mirror's own copies would make virtual-project writes land in the user's real dependency tree. Dropping the guard trades a false diagnostic for that, which is worse.

Filed as #3396 with a suggested direction (merge the mirrored entries instead of choosing per package between a link and a real directory). Also filed #3395: `default_exclude_specs` is now strictly stricter than `tsc`, whose own `exclude` default is only `outDir` / `declarationDir`, so a literal `include: ["node_modules/**/*.ts"]` still collects nothing in vize where `tsgo` lists `node_modules/top/index.ts`. Both are separate defects in the opposite direction — they add roots — and are out of scope here.

## Interaction with #3388

No overlap, no rebase needed. #3388 (@mymx2, external — thanks for the Windows follow-up) changes `symlink_path`, `symlink_matches` and `ensure_stub_dir` in `crates/vize_canon/src/batch/runtime_deps.rs`; this PR touches `crates/vize/src/commands/check/tsconfig_inputs/*` plus one doc comment in `virtual_project/package_node_modules.rs`. Different files, no shared functions.

Its junction fallback stays necessary and is not made redundant by this change: this PR decides *which files become inputs*, #3388 decides *whether the mirror's directory links can be created at all* on a stock Windows shell. If anything the two compose in #3388's favor — with the nested-`node_modules` sweep gone, the carve-out stops suppressing links in the #3366 shape, so more links are actually attempted and a privilege-free fallback matters more, not less. The merge order does not matter either way.

## Verification

`export CARGO_TARGET_DIR=.claude/shared-target`, everything through `nix develop`:

- `cargo test -p vize` — 375 lib + all integration targets pass (5/7 of the new cases fail with the fix reverted, as above)
- `cargo test -p vize_canon` — pass
- `node --test tests/tooling/cli-check-collection.test.ts` — 4/4 pass
- `node --test tests/tooling/cli-check-sub-package-dependency.test.ts` — 2/2 pass (#3384's own gate)
- `node --test tests/tooling/cli-check-contract.test.ts cli-check-diagnostics cli-check-json-shape cli-check-args typecheck-divergence` — 36 pass, 1 skipped
- `node --test tests/tooling/compat-ratchet.test.ts` — 3 pass, 9 probes skipped (`… fixture is not hydrated` locally). No pinned count moved and none needed re-pinning: the change can only *remove* roots, and it can only remove files inside a `node_modules` / `bower_components` / `jspm_packages`, which the ratchet fixtures never collected in the first place — they are checkouts inside the repository, so the ignore-aware walk already dropped them via `.gitignore`. The weekly real-project matrix stays the authority.
- `vp run fmt:check`, `vp run lint:rust`, `vp run check:rust` — clean
- `moon run --target native tools/moon/cmd/source_file_lengths -- --check --base-ref origin/main` — "No new or grown files exceed 350 lines" (new files: 100 and 213 lines)

Closes #3385.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->