### PR TITLE
perf(vite): stop resolving CSS imports the production output discards

### DIFF
--- a/npm/builder/vite/src/plugin/load.ts
+++ b/npm/builder/vite/src/plugin/load.ts
@@ -12,7 +12,7 @@ import {
 } from "./state.ts";
 import { getLoadableVueSfcPath, shouldLoadCompiledVueSfcPath } from "./load-sfc.ts";
 import { compileFile, compileJsxModule } from "../compiler.ts";
-import { generateOutput, hasDelegatedStyles } from "../utils/index.ts";
+import { embedsInlineCss, generateOutput, hasDelegatedStyles } from "../utils/index.ts";
 import {
   resolveCssImports,
   scopeCssForPipeline,
@@ -125,7 +125,22 @@ function loadCompiledSfcModule(
   const pendingHmrUpdateType = loadOptions?.ssr
     ? undefined
     : state.pendingHmrUpdateTypes.get(realPath);
-  if (compiled.css && !hasDelegated) {
+  const outputOptions = {
+    isProduction: state.isProduction,
+    isDev: state.server !== null && !isSsr,
+    ssr: isSsr,
+    hmrUpdateType: pendingHmrUpdateType,
+    extractCss,
+    filePath: realPath,
+  };
+  // Resolving `@import`s reads and inlines files and crosses the native
+  // boundary with the whole stylesheet, so it is only worth doing when
+  // `generateOutput` will actually embed the result. A production client build
+  // hands plain `<style>` blocks to Vite as virtual imports and an SSR build
+  // emits no CSS at all, so in both cases the resolved text was discarded --
+  // once per styled SFC, every build (270 discarded calls on the 300-file bench
+  // corpus).
+  if (compiled.css && !hasDelegated && embedsInlineCss(compiled, outputOptions)) {
     compiled = {
       ...compiled,
       css: resolveCssImports(
@@ -137,14 +152,7 @@ function loadCompiledSfcModule(
       ),
     };
   }
-  const generatedOutput = generateOutput(compiled, {
-    isProduction: state.isProduction,
-    isDev: state.server !== null && !isSsr,
-    ssr: isSsr,
-    hmrUpdateType: pendingHmrUpdateType,
-    extractCss,
-    filePath: realPath,
-  });
+  const generatedOutput = generateOutput(compiled, outputOptions);
   const output = rewriteStaticAssetUrls(
     rewriteDynamicTemplateImports(
       isSsr ? normalizeVueServerRendererImport(generatedOutput) : generatedOutput,

--- a/npm/builder/vite/src/plugin/load.ts
+++ b/npm/builder/vite/src/plugin/load.ts
@@ -122,24 +122,14 @@ function loadCompiledSfcModule(
   }
 
   const hasDelegated = hasDelegatedStyles(compiled);
-  const pendingHmrUpdateType = loadOptions?.ssr
-    ? undefined
-    : state.pendingHmrUpdateTypes.get(realPath);
   const outputOptions = {
     isProduction: state.isProduction,
     isDev: state.server !== null && !isSsr,
     ssr: isSsr,
-    hmrUpdateType: pendingHmrUpdateType,
+    hmrUpdateType: loadOptions?.ssr ? undefined : state.pendingHmrUpdateTypes.get(realPath),
     extractCss,
     filePath: realPath,
   };
-  // Resolving `@import`s reads and inlines files and crosses the native
-  // boundary with the whole stylesheet, so it is only worth doing when
-  // `generateOutput` will actually embed the result. A production client build
-  // hands plain `<style>` blocks to Vite as virtual imports and an SSR build
-  // emits no CSS at all, so in both cases the resolved text was discarded --
-  // once per styled SFC, every build (270 discarded calls on the 300-file bench
-  // corpus).
   if (compiled.css && !hasDelegated && embedsInlineCss(compiled, outputOptions)) {
     compiled = {
       ...compiled,

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -7,6 +7,7 @@ import "./internal/config-bridge.test.ts";
 import "./options-api-events.test.ts";
 import "./output-ast.test.ts";
 import "./utils-filter.test.ts";
+import "./utils-inline-css.test.ts";
 import "./utils.test.ts";
 import "./plugin/compat.test.ts";
 import "./plugin/config-bridge.test.ts";

--- a/npm/builder/vite/src/utils-inline-css.test.ts
+++ b/npm/builder/vite/src/utils-inline-css.test.ts
@@ -1,0 +1,152 @@
+/**
+ * `embedsInlineCss` is the single source of truth for "does the module output
+ * contain `compiled.css`". `loadCompiledSfcModule` consults it before paying for
+ * `@import` resolution, so if it ever disagreed with `generateOutput` the plugin
+ * would either do work it discards again (the defect it was introduced to fix)
+ * or -- much worse -- emit CSS whose `@import`s were never resolved.
+ *
+ * The matrix test below therefore does not assert the predicate against a
+ * hand-written expectation alone: it also compares it against what
+ * `generateOutput` actually emits for the same inputs, so the two cannot drift.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { embedsInlineCss, generateOutput } from "./utils/index.ts";
+import type { CompiledModule, StyleBlockInfo } from "./types.ts";
+
+const CSS_MARKER = ".marker-embedded-inline{color:red}";
+
+function styleBlock(overrides: Partial<StyleBlockInfo> = {}): StyleBlockInfo {
+  return {
+    content: CSS_MARKER,
+    src: null,
+    lang: "css",
+    scoped: false,
+    module: false,
+    index: 0,
+    ...overrides,
+  };
+}
+
+function compiled(overrides: Partial<CompiledModule> = {}): CompiledModule {
+  return {
+    code: 'const _sfc_main = { name: "Marker" }\nexport default _sfc_main\n',
+    css: CSS_MARKER,
+    scopeId: "marker01",
+    hasScoped: false,
+    styles: [styleBlock()],
+    ...overrides,
+  } as CompiledModule;
+}
+
+const FILE = "/src/Marker.vue";
+
+/**
+ * Every case that decides the branch, named so a failure says which one broke.
+ * `expected` is the predicate's answer; the test also derives the same answer
+ * from `generateOutput` and requires the two to agree.
+ */
+const cases = [
+  {
+    name: "dev, plain scoped style",
+    compiled: compiled({ hasScoped: true, styles: [styleBlock({ scoped: true })] }),
+    options: { isProduction: false, isDev: true, extractCss: false, filePath: FILE },
+    expected: true,
+  },
+  {
+    name: "dev, no style block but css present",
+    compiled: compiled({ styles: [] }),
+    options: { isProduction: false, isDev: true, extractCss: false, filePath: FILE },
+    expected: true,
+  },
+  {
+    name: "dev, no filePath",
+    compiled: compiled(),
+    options: { isProduction: false, isDev: true, extractCss: false },
+    expected: true,
+  },
+  {
+    name: "dev, SSR",
+    compiled: compiled(),
+    options: { isProduction: false, isDev: false, ssr: true, extractCss: false, filePath: FILE },
+    expected: false,
+  },
+  {
+    name: "dev, preprocessor block delegated to Vite",
+    compiled: compiled({ styles: [styleBlock({ lang: "scss" })] }),
+    options: { isProduction: false, isDev: true, extractCss: false, filePath: FILE },
+    expected: false,
+  },
+  {
+    name: "dev, CSS Modules block delegated to Vite",
+    compiled: compiled({ styles: [styleBlock({ module: "$style" })] }),
+    options: { isProduction: false, isDev: true, extractCss: false, filePath: FILE },
+    expected: false,
+  },
+  {
+    name: "production client build with CSS extraction",
+    compiled: compiled(),
+    options: { isProduction: true, isDev: false, extractCss: true, filePath: FILE },
+    expected: false,
+  },
+  {
+    name: "production client build, extraction off",
+    compiled: compiled(),
+    options: { isProduction: true, isDev: false, extractCss: false, filePath: FILE },
+    expected: true,
+  },
+  {
+    name: "production SSR build",
+    compiled: compiled(),
+    options: { isProduction: true, isDev: false, ssr: true, extractCss: false, filePath: FILE },
+    expected: false,
+  },
+  {
+    name: "production, extraction on, no style block",
+    compiled: compiled({ styles: [] }),
+    options: { isProduction: true, isDev: false, extractCss: true, filePath: FILE },
+    expected: false,
+  },
+  {
+    name: "no css at all",
+    compiled: compiled({ css: undefined, styles: [] }),
+    options: { isProduction: false, isDev: true, extractCss: false, filePath: FILE },
+    expected: false,
+  },
+] as const;
+
+void test("embedsInlineCss matches the declared expectation for every branch", () => {
+  assert.deepEqual(
+    cases.map((testCase) => [testCase.name, embedsInlineCss(testCase.compiled, testCase.options)]),
+    cases.map((testCase) => [testCase.name, testCase.expected]),
+  );
+});
+
+void test("embedsInlineCss agrees with what generateOutput emits", () => {
+  assert.deepEqual(
+    cases.map((testCase) => [
+      testCase.name,
+      generateOutput(testCase.compiled, testCase.options).includes(CSS_MARKER),
+    ]),
+    cases.map((testCase) => [testCase.name, testCase.expected]),
+  );
+});
+
+// Regression guard for over-skipping: a dev build must still embed the CSS, so
+// `loadCompiledSfcModule` must still resolve its `@import`s there. If the
+// predicate ever returned `false` for this case the plugin would ship an
+// unresolved `@import` to the browser.
+void test("a dev build still embeds plain CSS, so its @imports still need resolving", () => {
+  const withImport = compiled({ css: `@import "./partial.css";\n${CSS_MARKER}` });
+  const options = { isProduction: false, isDev: true, extractCss: false, filePath: FILE };
+
+  assert.equal(embedsInlineCss(withImport, options), true);
+  const output = generateOutput(withImport, options);
+  assert.equal(
+    output.includes(JSON.stringify(`@import "./partial.css";\n${CSS_MARKER}`)),
+    true,
+    "the dev module must carry the CSS verbatim so an unresolved @import would be visible",
+  );
+});

--- a/npm/builder/vite/src/utils/index.ts
+++ b/npm/builder/vite/src/utils/index.ts
@@ -127,6 +127,13 @@ function usesStyleImports(compiled: CompiledModule, options: GenerateOutputOptio
  * output. Callers that would otherwise resolve `compiled.css` eagerly consult
  * this first, which keeps the condition in one place instead of duplicating
  * `generateOutput`'s branch structure at the call site.
+ *
+ * That guard matters because resolving `@import`s reads and inlines files and
+ * crosses the native boundary with the whole stylesheet. A production client
+ * build hands plain `<style>` blocks to Vite as virtual imports and an SSR build
+ * emits no CSS at all, so in both cases the resolved text was previously built
+ * and discarded, once per styled SFC on every build (270 discarded calls on the
+ * 300-file bench corpus).
  */
 export function embedsInlineCss(compiled: CompiledModule, options: GenerateOutputOptions): boolean {
   return (

--- a/npm/builder/vite/src/utils/index.ts
+++ b/npm/builder/vite/src/utils/index.ts
@@ -103,6 +103,40 @@ export interface GenerateOutputOptions {
   filePath?: string;
 }
 
+/**
+ * Whether the SFC's `<style>` blocks are handed to Vite as virtual imports.
+ *
+ * Some blocks require Vite's CSS pipeline (preprocessor or CSS Modules), and a
+ * production client build routes plain CSS through it too so nesting,
+ * minification, and chunk ownership still apply. In both cases the blocks are
+ * emitted as imports and `compiled.css` is not used.
+ */
+function usesStyleImports(compiled: CompiledModule, options: GenerateOutputOptions): boolean {
+  return (
+    !!options.filePath &&
+    !!compiled.styles?.length &&
+    (hasDelegatedStyles(compiled) || (!options.ssr && options.isProduction && !!options.extractCss))
+  );
+}
+
+/**
+ * Whether `generateOutput` will embed `compiled.css` in the module.
+ *
+ * The only consumer of `compiled.css` is the inline `<style>` injection, so this
+ * is also the only case in which resolving the CSS's `@import`s affects the
+ * output. Callers that would otherwise resolve `compiled.css` eagerly consult
+ * this first, which keeps the condition in one place instead of duplicating
+ * `generateOutput`'s branch structure at the call site.
+ */
+export function embedsInlineCss(compiled: CompiledModule, options: GenerateOutputOptions): boolean {
+  return (
+    !usesStyleImports(compiled, options) &&
+    !options.ssr &&
+    !!compiled.css &&
+    !(options.isProduction && !!options.extractCss)
+  );
+}
+
 export function generateOutput(compiled: CompiledModule, options: GenerateOutputOptions): string {
   const { isProduction, isDev, ssr, hmrUpdateType, extractCss, filePath } = options;
 
@@ -148,10 +182,7 @@ export function generateOutput(compiled: CompiledModule, options: GenerateOutput
   // Determine whether to use style imports or inline CSS injection.
   // Production CSS extraction must still import plain CSS through Vite so its
   // CSS pipeline can apply nesting, minification, and chunk graph ownership.
-  const useStyleImports =
-    !!filePath &&
-    !!compiled.styles?.length &&
-    (hasDelegatedStyles(compiled) || (!ssr && isProduction && extractCss));
+  const useStyleImports = usesStyleImports(compiled, options);
 
   if (useStyleImports) {
     // --- Delegated style handling ---


### PR DESCRIPTION
## The defect

`loadCompiledSfcModule` resolves `compiled.css`'s `@import`s before handing the module to `generateOutput`:

```ts
if (compiled.css && !hasDelegated) {
  compiled = { ...compiled, css: resolveCssImports(compiled.css, realPath, state.cssAliasRules, ...) };
}
```

`generateOutput` reads `compiled.css` in exactly one place — the inline `<style>` injection. A production client build with CSS extraction hands plain `<style>` blocks to Vite as virtual `?vue&type=style` imports instead, and an SSR build emits no CSS at all. In both cases the resolved stylesheet is constructed and immediately discarded. That is one native `resolveViteCssImports` call, with the whole stylesheet crossing the boundary in each direction, per styled SFC, on every build.

## Measurement

300-file bench corpus (270 of the 300 SFCs carry a `<style>` block), production build. Machine: Apple Silicon, 12 cores, macOS 26.5.1, node v24.14.0, `@vizejs/native` release build.

Native calls counted by wrapping every `@vizejs/native` export before the plugin is imported and tallying on exit:

| | before | after |
| --- | --- | --- |
| `resolveViteCssImports` | **270 calls, 5.52 ms** | **0 calls** |
| `compileSfcBatchWithResults` | 3 calls | 3 calls |
| `classifyVitePluginRequest` | 6,934 calls | 6,934 calls |

Timed in isolation over the same corpus's real `compiled.css` values (median of 15 rounds, warm JIT, no alias rules):

| corpus | SFCs with CSS | CSS bytes | median |
| --- | --- | --- | --- |
| 300 | 270 | 105,720 | **0.624 ms** |
| 1500 | 1349 | 527,732 | **3.357 ms** |

It scales with file count and stylesheet size. A project with `resolve.alias` entries pays more than this, because each call also rebuilds the alias-rule array (`aliasRules.map(toNativeCssAliasRule)`).

The in-build figure (5.52 ms) is larger than the isolated one (0.62 ms) because the in-build calls are interleaved and pay cold-JIT and marshalling costs; both are reported rather than picking the flattering one.

Reproduction:

```sh
nix develop -c vp run build:native
nix develop -c vp run build:vite-plugin
# then a single production build of 300 bench SFCs, with @vizejs/native's
# exports wrapped in a call counter
```

## Output is unchanged — verified, not asserted

The 300-SFC production build before and after produces **per-asset SHA-256-identical** output, including the extracted components CSS:

```
assets/__entry__-DqN96FnK.js   36374508fac0c05d9467a3bb8d650d30d52872318510e4eebe75500401a101d9
assets/__entry__-PLHMPDhi.css  63258da1de82045874af44a6116e2ad44e5b90effa29b9bdeaabcea5d62f0512
```

## Why the condition cannot drift

The risk in a change like this is the call site's idea of "will the CSS be used" drifting from `generateOutput`'s. So the condition is not duplicated: `generateOutput`'s style-import branch is extracted as `usesStyleImports`, and the exported `embedsInlineCss` is derived from it. The load hook calls `embedsInlineCss`; `generateOutput` calls `usesStyleImports`. There is one expression of the rule.

## Tests

`npm/builder/vite/src/utils-inline-css.test.ts` (registered in `src/test.ts`):

1. **Branch matrix, 11 cases** — dev/production, SSR/client, extraction on/off, plain/scoped/preprocessor/CSS-Modules blocks, no-style, no-css, no-filePath. Asserted with `assert.deepEqual` over the full `[name, result]` table so a failure names the case.
2. **Predicate vs generator** — the same 11 cases asserted against whether `generateOutput`'s actual emitted module contains the CSS marker, again with `assert.deepEqual` over the full table. If `embedsInlineCss` and `generateOutput` ever disagree, this fails.
3. **Over-skipping guard** — a dev build must still embed plain CSS verbatim. That is the case where skipping the resolution would ship an unresolved `@import` to the browser, so it is pinned explicitly.

```
$ nix develop -c node npm/builder/vite/src/test.ts
ℹ tests 26  ℹ pass 26  ℹ fail 0
```
(3 of those are the new cases; the suite was 23 before.)

## Gates

```
$ nix develop -c vp run fmt:check      # exit 0
$ nix develop -c vp run source:lengths # exit 0
$ nix develop -c node npm/builder/vite/src/test.ts   # 26 pass, 0 fail
```
No Rust changed.

Refs #3363

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->