### PR TITLE
fix(oxint): stop vp patina from silently running zero vize rules

### DIFF
--- a/docs/content/guide/oxlint.md
+++ b/docs/content/guide/oxlint.md
@@ -70,6 +70,9 @@ stays silent.
 
 - `preset: "incremental"` runs only the rules you list.
 - `preset: "all"` runs every bundle at once.
+- `plugins` keeps the rest of your built-in Oxlint plugins. They are merged with `vue`, never
+  replaced, because narrowing the list would silently drop everything those plugins report. A
+  `create-vue` project passes `["eslint", "typescript", "unicorn", "oxc"]`.
 - Spread the result (`{ ...createVizeLintConfig(), ignorePatterns: ["dist/**"] }`) to merge it into
   an existing `lint` block.
 

--- a/docs/content/guide/oxlint.md
+++ b/docs/content/guide/oxlint.md
@@ -26,7 +26,54 @@ vp install -D oxlint oxlint-plugin-vize
 `oxlint-plugin-vize` resolves the matching Vize native binding through optional dependencies, so
 most users do not need to install `@vizejs/native` separately.
 
-## Basic Usage
+## Which File To Configure
+
+| Command                 | Reads                                |
+| ----------------------- | ------------------------------------ |
+| `vp lint`, `vp check`   | the `lint` block in `vite.config.ts` |
+| `oxlint`, `oxlint-vize` | `.oxlintrc.json` (or `-c <path>`)    |
+
+> [!WARNING]
+> Vite+ never reads `.oxlintrc.json`. A `.oxlintrc.json` carrying `jsPlugins` and `vize/*` rules
+> looks configured, but `vp lint` ignores the file, so Oxlint never sees a `vize/*` rule id and
+> reports **zero** Vize diagnostics while exiting `0`. `vp lint --init` does not migrate an existing
+> `.oxlintrc.json` either: it writes a fresh `lint` block and leaves the old file in place.
+
+## Basic Usage With `vp lint`
+
+`createVizeLintConfig()` returns the whole Vite+ `lint` block, so the `jsPlugins` entry that loads
+the bridge cannot go missing:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite-plus";
+import { createVizeLintConfig } from "oxlint-plugin-vize";
+
+export default defineConfig({
+  lint: createVizeLintConfig({
+    preset: "essential",
+    rules: {
+      "no-console": "warn",
+    },
+    settings: {
+      helpLevel: "short",
+    },
+  }),
+});
+```
+
+`preset` drives both the emitted rule map and `settings.vize.preset`. Keeping them in lockstep
+matters because the bridge silently drops any `vize/*` rule outside the active preset, so a rule
+listed under a mismatched preset reports nothing at all. `createVizeLintConfig` throws for that
+case, and for unknown `vize/*` ids, rather than leaving you with a config that looks enabled and
+stays silent.
+
+- `preset: "incremental"` runs only the rules you list.
+- `preset: "all"` runs every bundle at once.
+- Spread the result (`{ ...createVizeLintConfig(), ignorePatterns: ["dist/**"] }`) to merge it into
+  an existing `lint` block.
+
+## Basic Usage With `oxlint` And `oxlint-vize`
 
 ```json
 {

--- a/npm/oxint/README.md
+++ b/npm/oxint/README.md
@@ -13,6 +13,7 @@ This package lets Oxlint execute Patina through Vize's native binding while stil
 - Runs Vize Patina rules inside Oxlint as `vize/*` diagnostics, so Vue-specific findings can live beside Oxlint core rules in one command.
 - Keeps Oxlint's existing rules and built-in `vue` plugin active. The bridge adds Vize rules; it does not replace `eqeqeq`, `no-console`, or your existing `vue/*` setup.
 - Ships preset rule maps for JS/TS Oxlint configs: `configs.recommended`, `configs.essential`, `configs.ecosystem`, `configs.opinionated`, `configs.nuxt`, `configs.all`, and type-aware opt-in variants.
+- Ships `createVizeLintConfig()` for the Vite+ `lint` block in `vite.config.ts`, which is the only Oxlint configuration `vp lint` and `vp check` read.
 - Supports runtime settings through `settings.vize`, including `locale`, `preset`, and `helpLevel`.
 - Provides the `oxlint-vize` CLI wrapper, which runs Oxlint with a scriptless-SFC workaround and rewrites temporary paths back to the original `.vue` files.
 - Resolves Vize native bindings through platform-specific optional dependencies, so published installs do not need a separate `@vizejs/native` package.
@@ -45,6 +46,62 @@ vp install -D oxlint oxlint-plugin-vize
 `oxlint-plugin-vize` pulls the appropriate Vize native binding for the current platform through optional dependencies, so no separate `@vizejs/native` install is required for published builds.
 
 ## Usage
+
+Which file you configure depends on which command you run.
+
+| Command                 | Reads                                |
+| ----------------------- | ------------------------------------ |
+| `vp lint`, `vp check`   | the `lint` block in `vite.config.ts` |
+| `oxlint`, `oxlint-vize` | `.oxlintrc.json` (or `-c <path>`)    |
+
+> [!IMPORTANT]
+> Vite+ never reads `.oxlintrc.json`. A `.oxlintrc.json` carrying `jsPlugins` and `vize/*` rules
+> looks configured, but `vp lint` ignores the file, so Oxlint never sees a `vize/*` rule id and
+> reports **zero** Vize diagnostics while exiting `0`. `vp lint --init` does not migrate an existing
+> `.oxlintrc.json` either: it writes a fresh `lint` block and leaves the old file in place.
+> If you use `vp lint`, configure the `lint` block.
+
+### With `vp lint` (Vite+)
+
+`createVizeLintConfig()` returns the whole `lint` block, so the `jsPlugins` entry cannot go missing:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite-plus";
+import { createVizeLintConfig } from "oxlint-plugin-vize";
+
+export default defineConfig({
+  lint: createVizeLintConfig({
+    preset: "essential",
+    rules: {
+      "no-console": "warn",
+    },
+    settings: {
+      helpLevel: "short",
+    },
+  }),
+});
+```
+
+`preset` drives both the emitted rule map and `settings.vize.preset`, so the two can never disagree.
+That matters because the bridge silently drops any `vize/*` rule outside the active preset: listing
+`vize/ecosystem/router-link-require-to` while the active preset is `general-recommended` reports
+nothing at all. `createVizeLintConfig` throws for that case, and for unknown `vize/*` ids, instead of
+leaving you with a config that looks enabled and reports nothing. Use `preset: "incremental"` when
+you want only the rules you list, and `preset: "all"` for every bundle at once.
+
+Merge the block into an existing `lint` configuration by spreading it:
+
+```ts
+export default defineConfig({
+  lint: {
+    ...createVizeLintConfig(),
+    ignorePatterns: ["dist/**"],
+  },
+});
+```
+
+### With `oxlint` or `oxlint-vize`
 
 Enable Oxlint's built-in `vue` plugin as well as this JS plugin:
 

--- a/npm/oxint/README.md
+++ b/npm/oxint/README.md
@@ -90,12 +90,17 @@ nothing at all. `createVizeLintConfig` throws for that case, and for unknown `vi
 leaving you with a config that looks enabled and reports nothing. Use `preset: "incremental"` when
 you want only the rules you list, and `preset: "all"` for every bundle at once.
 
-Merge the block into an existing `lint` configuration by spreading it:
+The emitted block always enables Oxlint's built-in `vue` plugin. Pass `plugins` to keep the rest of
+your project's plugin list; they are merged with `vue`, never replaced, because narrowing the list
+would silently drop everything those plugins report. A `create-vue` project keeps its generated set
+like this:
 
 ```ts
 export default defineConfig({
   lint: {
-    ...createVizeLintConfig(),
+    ...createVizeLintConfig({
+      plugins: ["eslint", "typescript", "unicorn", "oxc"],
+    }),
     ignorePatterns: ["dist/**"],
   },
 });

--- a/npm/oxint/src/index.ts
+++ b/npm/oxint/src/index.ts
@@ -1,3 +1,5 @@
 export { default } from "./plugin.js";
 export { configs, createVizeRuleConfig } from "./configs.js";
 export type { OxlintRuleConfig, OxlintRuleSeverity, VizeRuleConfigOptions } from "./configs.js";
+export { createVizeLintConfig, VIZE_JS_PLUGIN_SPECIFIER } from "./vite-plus.js";
+export type { VizeLintConfig, VizeLintConfigOptions, VizeLintPreset } from "./vite-plus.js";

--- a/npm/oxint/src/test-support/suites.ts
+++ b/npm/oxint/src/test-support/suites.ts
@@ -1,0 +1,13 @@
+/**
+ * Sibling suites the `test.ts` integration entry pulls in.
+ *
+ * The list lives here rather than inline in `test.ts` so registering another
+ * suite never has to grow that entry file, which is already far over the
+ * repository's source-length limit.
+ */
+await Promise.all([
+  import("../cli/files.test.ts"),
+  import("../cli/output.test.ts"),
+  import("../vite-plus-lint.test.ts"),
+  import("../nuxt-preset.test.ts"),
+]);

--- a/npm/oxint/src/test-support/vite-plus-workspace.ts
+++ b/npm/oxint/src/test-support/vite-plus-workspace.ts
@@ -1,0 +1,218 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import type { VizeLintConfig, VizeLintConfigOptions } from "../vite-plus.ts";
+
+/**
+ * Test support for the Vite+ `lint` block contract.
+ *
+ * These helpers build a throwaway project under `os.tmpdir()` and run the real
+ * `oxlint` binary against it. Vite+ forwards its `lint` block to Oxlint
+ * unchanged, so writing the block to `.oxlintrc.json` and invoking `oxlint`
+ * exercises the same configuration path `vp lint` takes without needing Vite+
+ * installed in the test environment.
+ *
+ * The project gets a `node_modules/oxlint-plugin-vize` symlink so the config can
+ * be written to disk verbatim, bare specifier included, instead of being rewritten
+ * to an absolute path that no real user would have.
+ */
+
+const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const workspaceRoot = path.resolve(packageDir, "..", "..");
+const distEntry = path.join(packageDir, "dist", "index.mjs");
+const packageRequire = createRequire(path.join(packageDir, "package.json"));
+
+export interface StableDiagnostic {
+  code: string;
+  filename: string;
+  labels: { column: number; line: number }[];
+  message: string;
+  severity: string;
+}
+
+interface OxlintJsonDiagnostic {
+  code: string;
+  filename: string;
+  labels: { span: { column: number; line: number } }[];
+  message: string;
+  severity: string;
+}
+
+/**
+ * Loads `createVizeLintConfig` from the built bundle rather than from source.
+ *
+ * The bundle is what Oxlint loads through `jsPlugins`, so both halves of the
+ * assertion have to come from the same artifact. `npm/oxint`'s `test` script runs
+ * `vp pack` first, matching `test.ts`, `nuxt-preset.test.ts`, and
+ * `type-aware.test.ts`.
+ */
+export async function createVizeLintConfigFromDist(): Promise<
+  (options?: VizeLintConfigOptions) => VizeLintConfig
+> {
+  const bundle = (await import(pathToFileURL(distEntry).href)) as {
+    createVizeLintConfig: (options?: VizeLintConfigOptions) => VizeLintConfig;
+  };
+  return bundle.createVizeLintConfig;
+}
+
+export function lintWorkspaceFixture(fixture: {
+  config: VizeLintConfig;
+  filename: string;
+  source: string;
+}): StableDiagnostic[] {
+  const root = createLintWorkspace();
+
+  try {
+    const target = path.join(root, fixture.filename);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, fixture.source);
+    fs.writeFileSync(
+      path.join(root, ".oxlintrc.json"),
+      `${JSON.stringify(fixture.config, null, 2)}\n`,
+    );
+
+    return parseDiagnostics(
+      runOxlint(root, ["-c", ".oxlintrc.json", "-f", "json", fixture.filename]),
+    );
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+}
+
+/**
+ * Imports a copy of the built plugin from a directory where the Vize native
+ * binding cannot be resolved, and reports how that import ended.
+ *
+ * The copy keeps `@oxlint/plugins` reachable so the failure is attributable to
+ * the missing binding rather than to a missing peer.
+ */
+export function runIsolatedPluginLoadProbe(): { outcome: string; reason: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "oxint-no-binding-"));
+
+  try {
+    fs.cpSync(path.join(packageDir, "dist"), path.join(root, "dist"), { recursive: true });
+    linkOxlintPluginsOnly(root);
+    const probePath = path.join(root, "probe.mjs");
+    fs.writeFileSync(probePath, createLoadProbeSource());
+
+    const stdout = execFileSync(process.execPath, [probePath], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    return JSON.parse(stdout.trim()) as { outcome: string; reason: string };
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+}
+
+function createLoadProbeSource(): string {
+  // `reason` is the first sentence of the thrown message so the assertion stays
+  // machine-independent: the full message lists the platform binding packages.
+  return `import("./dist/index.mjs").then(
+  () => {
+    process.stdout.write(JSON.stringify({ outcome: "loaded", reason: "" }));
+  },
+  (error) => {
+    process.stdout.write(
+      JSON.stringify({
+        outcome: error instanceof Error ? "threw" : "rejected-non-error",
+        reason: error instanceof Error ? error.message.split(".")[0] : "",
+      }),
+    );
+  },
+);
+`;
+}
+
+function createLintWorkspace(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "oxint-vite-plus-lint-"));
+  const nodeModules = path.join(root, "node_modules");
+  fs.mkdirSync(nodeModules, { recursive: true });
+  fs.symlinkSync(packageDir, path.join(nodeModules, "oxlint-plugin-vize"), "junction");
+  return root;
+}
+
+function linkOxlintPluginsOnly(root: string): void {
+  const scopeDir = path.join(root, "node_modules", "@oxlint");
+  fs.mkdirSync(scopeDir, { recursive: true });
+  fs.symlinkSync(resolveOxlintPluginsDir(), path.join(scopeDir, "plugins"), "junction");
+}
+
+function resolveOxlintPluginsDir(): string {
+  let current = path.dirname(packageRequire.resolve("@oxlint/plugins"));
+
+  for (;;) {
+    if (fs.existsSync(path.join(current, "package.json"))) {
+      return current;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new Error("Unable to locate the @oxlint/plugins package root.");
+    }
+
+    current = parent;
+  }
+}
+
+function runOxlint(cwd: string, args: readonly string[]): string {
+  const env = { ...process.env };
+  // Oxlint switches to GitHub annotation output when this is set, which would
+  // change the JSON payload under CI.
+  delete env.GITHUB_ACTIONS;
+
+  try {
+    return String(
+      execFileSync(findOxlintBin(), args, { cwd, encoding: "utf8", env, stdio: "pipe" }),
+    );
+  } catch (error) {
+    const execError = error as { status?: number; stdout?: string | Buffer; stderr?: string };
+    if (execError.status !== 1) {
+      throw new Error(
+        `oxlint exited with ${String(execError.status)}\n${String(execError.stderr ?? "")}`,
+      );
+    }
+
+    return String(execError.stdout ?? "");
+  }
+}
+
+function findOxlintBin(): string {
+  const pnpmStoreDir = path.join(workspaceRoot, "node_modules", ".pnpm");
+  const match = fs
+    .readdirSync(pnpmStoreDir)
+    .filter((entry) => entry.startsWith("oxlint@"))
+    .sort((left, right) => right.localeCompare(left))
+    .map((entry) => path.join(pnpmStoreDir, entry, "node_modules", "oxlint", "bin", "oxlint"))
+    .find((entry) => fs.existsSync(entry));
+
+  if (match == null) {
+    throw new Error(`Unable to locate the oxlint binary in ${pnpmStoreDir}`);
+  }
+
+  return match;
+}
+
+/**
+ * Projects Oxlint's JSON payload down to the fields that are stable across
+ * machines. `number_of_rules`, `threads_count`, and `start_time` are not.
+ */
+function parseDiagnostics(stdout: string): StableDiagnostic[] {
+  const payload = JSON.parse(stdout) as { diagnostics: OxlintJsonDiagnostic[] };
+
+  return payload.diagnostics.map((diagnostic) => ({
+    code: diagnostic.code,
+    filename: diagnostic.filename,
+    labels: diagnostic.labels.map((label) => ({
+      column: label.span.column,
+      line: label.span.line,
+    })),
+    message: diagnostic.message,
+    severity: diagnostic.severity,
+  }));
+}

--- a/npm/oxint/src/test.ts
+++ b/npm/oxint/src/test.ts
@@ -878,6 +878,7 @@ assert.equal(
 await Promise.all([
   import("./cli/files.test.ts"),
   import("./cli/output.test.ts"),
+  import("./vite-plus-lint.test.ts"),
   import("./nuxt-preset.test.ts"),
 ]);
 console.log("✅ oxlint-plugin-vize integration tests passed!");

--- a/npm/oxint/src/test.ts
+++ b/npm/oxint/src/test.ts
@@ -875,10 +875,5 @@ assert.equal(
   "<template>",
   "Diagnostics should map back to their containing SFC block",
 );
-await Promise.all([
-  import("./cli/files.test.ts"),
-  import("./cli/output.test.ts"),
-  import("./vite-plus-lint.test.ts"),
-  import("./nuxt-preset.test.ts"),
-]);
+await import("./test-support/suites.ts");
 console.log("✅ oxlint-plugin-vize integration tests passed!");

--- a/npm/oxint/src/vite-plus-lint.test.ts
+++ b/npm/oxint/src/vite-plus-lint.test.ts
@@ -62,6 +62,18 @@ void test("createVizeLintConfig emits the whole Vite+ lint block, including jsPl
   );
 });
 
+void test("createVizeLintConfig merges built-in Oxlint plugins instead of narrowing them", () => {
+  // Replacing a project's plugin list would silently drop every diagnostic those
+  // plugins produce, which is the same false negative this helper exists to stop.
+  assert.deepEqual(
+    createVizeLintConfig({
+      plugins: ["eslint", "typescript", "unicorn", "oxc", "vue"],
+      preset: "incremental",
+    }).plugins,
+    ["vue", "eslint", "typescript", "unicorn", "oxc"],
+  );
+});
+
 void test('createVizeLintConfig keeps the rule map and settings.vize.preset in lockstep for "all"', () => {
   const config = createVizeLintConfig({ preset: "all" });
 

--- a/npm/oxint/src/vite-plus-lint.test.ts
+++ b/npm/oxint/src/vite-plus-lint.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createVizeLintConfigFromDist,
+  lintWorkspaceFixture,
+  runIsolatedPluginLoadProbe,
+} from "./test-support/vite-plus-workspace.ts";
+
+const VIOLATING_SFC = `<script setup lang="ts">
+const items = ["a", "b", "c"];
+const html = "<strong>hi</strong>";
+</script>
+
+<template>
+  <ul>
+    <li v-for="item in items">{{ item }}</li>
+  </ul>
+  <div v-html="html" />
+</template>
+`;
+
+const CLEAN_SFC = `<script setup lang="ts">
+const items = ["a", "b", "c"];
+</script>
+
+<template>
+  <ul>
+    <li v-for="item in items" :key="item">{{ item }}</li>
+  </ul>
+</template>
+`;
+
+const createVizeLintConfig = await createVizeLintConfigFromDist();
+
+void test("createVizeLintConfig emits the whole Vite+ lint block, including jsPlugins", () => {
+  assert.deepEqual(
+    createVizeLintConfig({
+      preset: "incremental",
+      rules: {
+        "no-console": "warn",
+        "vize/vue/require-v-for-key": "error",
+        "vize/vue/no-v-html": "warn",
+      },
+      settings: { helpLevel: "none" },
+    }),
+    {
+      jsPlugins: ["oxlint-plugin-vize"],
+      plugins: ["vue"],
+      rules: {
+        "no-console": "warn",
+        "vize/vue/require-v-for-key": "error",
+        "vize/vue/no-v-html": "warn",
+      },
+      settings: {
+        vize: {
+          helpLevel: "none",
+          preset: "incremental",
+        },
+      },
+    },
+  );
+});
+
+void test('createVizeLintConfig keeps the rule map and settings.vize.preset in lockstep for "all"', () => {
+  const config = createVizeLintConfig({ preset: "all" });
+
+  // "all" spans every bundle, so the runtime gate has to be disabled entirely.
+  // Gating an all-bundles rule map by any single preset silently suppresses the
+  // rules that only belong to the other bundles.
+  assert.deepEqual(config.settings, { vize: { preset: "incremental" } });
+  assert.equal(config.rules["vize/ecosystem/router-link-require-to"], "error");
+  assert.equal(config.rules["vize/script/no-options-api"], "error");
+});
+
+void test("the emitted lint block makes Oxlint report exactly the configured vize diagnostics", () => {
+  const config = createVizeLintConfig({
+    preset: "incremental",
+    rules: {
+      "no-unused-vars": "off",
+      "vize/vue/require-v-for-key": "error",
+      "vize/vue/no-v-html": "warn",
+    },
+    settings: { helpLevel: "none" },
+  });
+
+  assert.deepEqual(
+    lintWorkspaceFixture({ config, filename: "src/Violating.vue", source: VIOLATING_SFC }),
+    [
+      {
+        code: "vize(vue/require-v-for-key)",
+        filename: "src/Violating.vue",
+        labels: [{ column: 2, line: 2 }],
+        message:
+          "Elements in iteration expect to have 'v-bind:key' directives. (at <template>:8:9)\n" +
+          "    Details:\n" +
+          "      Element: <li>",
+        severity: "error",
+      },
+      {
+        code: "vize(vue/no-v-html)",
+        filename: "src/Violating.vue",
+        labels: [{ column: 2, line: 2 }],
+        message:
+          "v-html can lead to XSS attacks. (at <template>:10:8)\n" +
+          "    Details:\n" +
+          "      Avoid using it with user-provided content",
+        severity: "warning",
+      },
+    ],
+  );
+});
+
+void test("the emitted lint block reports nothing for a clean SFC", () => {
+  const config = createVizeLintConfig({
+    preset: "incremental",
+    rules: {
+      "no-unused-vars": "off",
+      "vize/vue/require-v-for-key": "error",
+      "vize/vue/no-v-html": "warn",
+    },
+    settings: { helpLevel: "none" },
+  });
+
+  assert.deepEqual(
+    lintWorkspaceFixture({ config, filename: "src/Clean.vue", source: CLEAN_SFC }),
+    [],
+  );
+});
+
+void test("an unknown vize rule id throws instead of reporting nothing", () => {
+  assert.throws(
+    () =>
+      createVizeLintConfig({
+        preset: "incremental",
+        rules: { "vize/vue/require-v-for-keys": "error" },
+      }),
+    new Error(
+      "Unknown Vize rule id: vize/vue/require-v-for-keys. " +
+        "Check the id against the rules oxlint-plugin-vize registers.",
+    ),
+  );
+});
+
+void test("a preset-suppressed vize rule id throws instead of reporting nothing", () => {
+  // `script/no-options-api` belongs to the "opinionated" bundle only, so the
+  // bridge's runtime gate would drop it under "essential" and report nothing.
+  assert.throws(
+    () =>
+      createVizeLintConfig({
+        preset: "essential",
+        rules: { "vize/script/no-options-api": "error" },
+      }),
+    new Error(
+      'Vize rule id outside the "essential" preset: vize/script/no-options-api. ' +
+        'Use preset: "incremental" to run an explicit rule subset, or pick the preset that owns these rules.',
+    ),
+  );
+});
+
+void test("a plugin copy that cannot resolve the native binding refuses to load", () => {
+  // A binding that fails to load must be a loud error. Degrading to an
+  // importable plugin with zero rules would look exactly like a clean codebase.
+  assert.deepEqual(runIsolatedPluginLoadProbe(), {
+    outcome: "threw",
+    reason: "Failed to load the Vize native binding",
+  });
+});

--- a/npm/oxint/src/vite-plus.ts
+++ b/npm/oxint/src/vite-plus.ts
@@ -28,6 +28,15 @@ export interface VizeLintConfigOptions {
    */
   includeTypeAware?: boolean;
   /**
+   * Built-in Oxlint plugins to keep enabled alongside `vue`.
+   *
+   * The emitted block always lists `vue`, and narrowing a project's plugin list
+   * would silently drop the diagnostics those plugins produce, so anything passed
+   * here is merged rather than replaced. A `create-vue` project, for example,
+   * needs `["eslint", "typescript", "unicorn", "oxc"]` carried over.
+   */
+  plugins?: readonly string[];
+  /**
    * Rule bundle to enable. Defaults to `"general-recommended"`, the bridge's own
    * default. `"incremental"` emits no preset rules, so only `rules` run.
    */
@@ -94,7 +103,7 @@ export function createVizeLintConfig(options: VizeLintConfigOptions = {}): VizeL
 
   return {
     jsPlugins: [VIZE_JS_PLUGIN_SPECIFIER],
-    plugins: ["vue"],
+    plugins: [...new Set(["vue", ...(options.plugins ?? [])])],
     rules: {
       ...createPresetRules(preset, options.includeTypeAware),
       ...extraRules,

--- a/npm/oxint/src/vite-plus.ts
+++ b/npm/oxint/src/vite-plus.ts
@@ -1,0 +1,173 @@
+import { getPatinaRules } from "./binding.js";
+import { createVizeRuleConfig, type OxlintRuleConfig } from "./configs.js";
+import type { PatinaPreset, PatinaRuleMeta, PatinaSettings } from "./model.js";
+
+/**
+ * Bare specifier Oxlint uses to load this bridge as a JS plugin.
+ *
+ * Vite+ hands the `lint` block to Oxlint unchanged, so the same specifier works
+ * in `vite.config.ts` and in a hand-written `.oxlintrc.json`.
+ */
+export const VIZE_JS_PLUGIN_SPECIFIER = "oxlint-plugin-vize";
+
+const VIZE_RULE_PREFIX = "vize/";
+
+/**
+ * Rule bundles `createVizeLintConfig` accepts.
+ *
+ * `"all"` and `"incremental"` both disable preset gating in the bridge, which is
+ * what makes them usable: `"all"` needs every bundle's rules to run at once, and
+ * `"incremental"` needs only the rules the caller lists to run.
+ */
+export type VizeLintPreset = PatinaPreset | "all";
+
+export interface VizeLintConfigOptions {
+  /**
+   * Include Vize's unstable `vize/type/*` rules in the preset rule map. Off by
+   * default, matching `createVizeRuleConfig`.
+   */
+  includeTypeAware?: boolean;
+  /**
+   * Rule bundle to enable. Defaults to `"general-recommended"`, the bridge's own
+   * default. `"incremental"` emits no preset rules, so only `rules` run.
+   */
+  preset?: VizeLintPreset;
+  /**
+   * Extra Oxlint rules merged after the preset rules. Core Oxlint rule ids pass
+   * through untouched; `vize/*` ids are validated against the rules the native
+   * bridge registers and against the resolved preset.
+   */
+  rules?: OxlintRuleConfig;
+  /**
+   * Patina runtime settings forwarded through `settings.vize`. `preset` is
+   * intentionally absent: it is derived from `options.preset` so the rule map and
+   * the bridge's runtime gate can never disagree.
+   */
+  settings?: Omit<PatinaSettings, "preset">;
+}
+
+export interface VizeLintConfig {
+  jsPlugins: string[];
+  plugins: string[];
+  rules: OxlintRuleConfig;
+  settings: { vize: PatinaSettings };
+}
+
+/**
+ * Builds the Oxlint configuration block that runs Patina through this bridge.
+ *
+ * Vite+ (`vp lint` / `vp check`) reads its Oxlint configuration from the `lint`
+ * key of `vite.config.ts` and never reads `.oxlintrc.json`. Wiring the bridge by
+ * hand therefore has a silent failure mode: a `.oxlintrc.json` carrying
+ * `jsPlugins` and `vize/*` rules looks configured, Vite+ ignores the file, Oxlint
+ * never sees a `vize/*` rule id, and `vp lint` reports zero Vize diagnostics
+ * while exiting `0`. Spreading this object into `lint` removes the chance to get
+ * that wrong:
+ *
+ * ```ts
+ * import { defineConfig } from "vite-plus";
+ * import { createVizeLintConfig } from "oxlint-plugin-vize";
+ *
+ * export default defineConfig({
+ *   lint: createVizeLintConfig({ preset: "essential" }),
+ * });
+ * ```
+ *
+ * Both validations below exist because the bridge's normal failure modes are
+ * silent rather than loud:
+ *
+ * - An unknown `vize/*` id only produces Oxlint's
+ *   `Rule '...' not found in plugin 'vize'` error when Oxlint actually reads the
+ *   config. A typo in a config Oxlint never reads reports nothing at all.
+ * - A `vize/*` id that is outside the active preset is dropped by the bridge's
+ *   runtime preset gate (`plugin.ts`), so it stays listed in `rules` and reports
+ *   nothing. `preset: "incremental"` is the supported way to run an arbitrary
+ *   subset.
+ *
+ * @throws {Error} When `options.rules` names a `vize/*` id the native bridge does
+ *   not register, or one the resolved preset would silently suppress.
+ */
+export function createVizeLintConfig(options: VizeLintConfigOptions = {}): VizeLintConfig {
+  const preset = options.preset ?? "general-recommended";
+  const extraRules = options.rules ?? {};
+  assertUsableVizeRules(extraRules, preset);
+
+  return {
+    jsPlugins: [VIZE_JS_PLUGIN_SPECIFIER],
+    plugins: ["vue"],
+    rules: {
+      ...createPresetRules(preset, options.includeTypeAware),
+      ...extraRules,
+    },
+    settings: {
+      vize: {
+        ...options.settings,
+        preset: toRuntimePreset(preset),
+      },
+    },
+  };
+}
+
+function createPresetRules(
+  preset: VizeLintPreset,
+  includeTypeAware: boolean | undefined,
+): OxlintRuleConfig {
+  // "incremental" means "run exactly what the caller listed", so it contributes
+  // no preset rules of its own.
+  return preset === "incremental" ? {} : createVizeRuleConfig({ includeTypeAware, preset });
+}
+
+/**
+ * Maps a rule bundle to the `settings.vize.preset` the bridge must run with.
+ *
+ * `"all"` becomes `"incremental"` because the bridge gates each rule on preset
+ * membership; gating an all-bundles rule map by any single preset would suppress
+ * the rules that only belong to the other bundles.
+ */
+function toRuntimePreset(preset: VizeLintPreset): PatinaPreset {
+  return preset === "all" ? "incremental" : preset;
+}
+
+function assertUsableVizeRules(rules: OxlintRuleConfig, preset: VizeLintPreset): void {
+  const ruleMetaById = new Map(
+    getPatinaRules().map((ruleMeta) => [`${VIZE_RULE_PREFIX}${ruleMeta.name}`, ruleMeta]),
+  );
+  const configuredIds = Object.keys(rules)
+    .filter((ruleId) => ruleId.startsWith(VIZE_RULE_PREFIX))
+    .sort();
+
+  const unknownIds = configuredIds.filter((ruleId) => !ruleMetaById.has(ruleId));
+  if (unknownIds.length > 0) {
+    throw new Error(
+      `Unknown Vize rule ${pluralizeIds(unknownIds)}: ${unknownIds.join(", ")}. ` +
+        "Check the id against the rules oxlint-plugin-vize registers.",
+    );
+  }
+
+  const runtimePreset = toRuntimePreset(preset);
+  const suppressedIds = configuredIds.filter((ruleId) =>
+    isSuppressedByPreset(ruleMetaById.get(ruleId) as PatinaRuleMeta, runtimePreset),
+  );
+  if (suppressedIds.length > 0) {
+    throw new Error(
+      `Vize rule ${pluralizeIds(suppressedIds)} outside the "${preset}" preset: ${suppressedIds.join(", ")}. ` +
+        'Use preset: "incremental" to run an explicit rule subset, or pick the preset that owns these rules.',
+    );
+  }
+}
+
+/**
+ * Mirrors the runtime gate in `plugin.ts`: rules with no preset membership are
+ * never gated, and `"incremental"` skips gating entirely.
+ */
+function isSuppressedByPreset(ruleMeta: PatinaRuleMeta, runtimePreset: PatinaPreset): boolean {
+  return (
+    ruleMeta.presets.length > 0 &&
+    runtimePreset !== "incremental" &&
+    !ruleMeta.presets.includes(runtimePreset)
+  );
+}
+
+function pluralizeIds(ids: readonly string[]): string {
+  return ids.length === 1 ? "id" : "ids";
+}


### PR DESCRIPTION
Closes #3389

## The defect

In a brand-new Vue project, wiring `oxlint-plugin-vize` exactly the way the package README and
`docs/content/guide/oxlint.md` describe — a `.oxlintrc.json` with `plugins` / `jsPlugins` /
`vize/*` rules — and then running `vp lint` produces **zero** `vize/*` diagnostics and exits `0`.
Nothing warns, nothing errors. A false negative: the linter is silent about real violations.

`vp lint` / `vp check` (Vite+ `0.1.21`) read their Oxlint configuration from the **`lint` block of
`vite.config.ts`**. They never read `.oxlintrc.json`, so the `jsPlugins` entry that loads the bridge
and the `vize/*` rule ids that enable it never reach Oxlint. Oxlint never gets the chance to emit its
normal `Plugin 'vize' not found` error either, because it is never handed a `vize/*` id at all.

This repo's own root `vite.config.ts` already uses the `lint` block and ships no `.oxlintrc.json`,
but every user-facing document for the package only showed the `.oxlintrc.json` shape.

## Reproduction

```bash
npx create-vue@latest fresh-lint --ts --eslint
cd fresh-lint
npm install --legacy-peer-deps          # create-vue 3.23.0 has an oxlint peer conflict
npm install -D vite-plus@0.1.21 oxlint-plugin-vize

mkdir -p src/components
cat > src/components/Violating.vue <<'VUE'
<script setup lang="ts">
const items = ["a", "b", "c"];
const html = "<strong>hi</strong>";
</script>

<template>
  <ul>
    <li v-for="item in items">{{ item }}</li>
  </ul>
  <div v-html="html" />
</template>
VUE

cat > .oxlintrc.json <<'JSON'
{
  "plugins": ["vue"],
  "jsPlugins": ["oxlint-plugin-vize"],
  "rules": {
    "vize/vue/require-v-for-key": "error",
    "vize/vue/no-v-html": "warn"
  }
}
JSON

npx vp lint src
```

**Expected**

```
src/components/Violating.vue:2:2: error vize(vue/require-v-for-key): ...
src/components/Violating.vue:2:2: warning vize(vue/no-v-html): ...
```

**Actual (before this change)**

```
VITE+ - The Unified Toolchain for the Web

```

Exit code `0`. No diagnostics, no warning that the config was ignored.

Two extra observations from the same project:

- With `"categories": { "correctness": "error" }` in `.oxlintrc.json` and a `debugger` statement in a
  `.ts` file, `vp lint` reports it as a **warning**; moving the same `categories` block into
  `vite.config.ts` `lint` turns it into an **error**. That is the direct proof that `.oxlintrc.json`
  is not read.
- `vp lint --init` does not migrate an existing `.oxlintrc.json`. It writes a fresh
  `lint: { options: { typeAware: true, typeCheck: true } }` and leaves the old file on disk,
  orphaned.

## Which candidate cause it was, and how the others were ruled out

The cause is the config-file mismatch above. Everything else was checked in the same fresh project
against a locally built `npm/native` + `npm/oxint` (`vp run build:native:test`, then `pnpm pack` and
install from the tarball):

| Candidate | Verdict |
| --- | --- |
| Plugin resolution / ESM-CJS interop / `exports` map / Node engine gate | Ruled out. `./node_modules/oxlint/bin/oxlint -c .oxlintrc.json -f stylish src` with the bare specifier `"jsPlugins": ["oxlint-plugin-vize"]` reports both `vize/*` diagnostics. |
| Native binding load error swallowed into silence | Ruled out. With `node_modules/@vizejs` removed, the run fails loudly: `Failed to load the Vize native binding. Tried ...`, raised from `loadBinding()` while Oxlint imports the plugin. |
| Unresolvable `jsPlugins` entry silently skipped | Ruled out. Oxlint fails with `Failed to load JS plugin: ... Cannot find module ...`. |
| `vize/*` rules configured without the plugin | Ruled out. Oxlint fails with `Plugin 'vize' not found`. |
| Typo'd / unknown `vize/*` rule id silently ignored | Ruled out *when Oxlint reads the config*: `Rule 'vue/require-v-for-keys' not found in plugin 'vize'`. Silent when the config is one Oxlint never reads, which is exactly this bug — hence the new validation below. |
| Scriptless-SFC workaround dropping findings / temp-path rewriting | Ruled out. `oxlint-vize -c .oxlintrc.json -f stylish src` reports a template-only SFC correctly and rewrites `node_modules/.vize/oxlint-plugin-vize/...` back to the original `.vue` path. (`vp lint` does miss template-only SFCs, but that is the already-documented raw-`oxlint` limitation, not this bug.) |

## The change

`createVizeLintConfig()` returns the whole Vite+ `lint` block, so the `jsPlugins` entry cannot go
missing:

```ts
// vite.config.ts
import { defineConfig } from "vite-plus";
import { createVizeLintConfig } from "oxlint-plugin-vize";

export default defineConfig({
  lint: createVizeLintConfig({ preset: "essential" }),
});
```

Verified in the reproduction project above: `vp lint src/components` now reports both `vize/*`
diagnostics and exits `1`.

Two silences are made loud, both in the same helper:

- **Unknown `vize/*` id** throws
  `Unknown Vize rule id: vize/vue/require-v-for-keys. Check the id against the rules oxlint-plugin-vize registers.`
  Oxlint's own equivalent error only fires when Oxlint actually reads the config.
- **Preset-suppressed `vize/*` id** throws. The bridge's runtime gate in `plugin.ts` drops any rule
  whose `presets` do not include the active preset, so listing
  `vize/ecosystem/router-link-require-to` while the active preset is `general-recommended` reports
  nothing at all today. `createVizeLintConfig` also derives `settings.vize.preset` from the single
  `preset` option, so the rule map and the runtime gate can never disagree in the first place.
  (`preset: "all"` maps to the `"incremental"` runtime preset, because gating an all-bundles rule map
  by any single preset would suppress the other bundles' rules.)

A third silence is avoided by construction: the emitted block always enables Oxlint's built-in `vue`
plugin, and a `plugins` option merges the rest of the project's plugin list rather than replacing it.
Narrowing `plugins` would silently drop every diagnostic the other built-in plugins produce — a
`create-vue` project generates `plugins: ["eslint", "typescript", "unicorn", "oxc", "vue"]`, so a
replacing helper would have reintroduced the same class of false negative it exists to stop.

Docs: the package README and `docs/content/guide/oxlint.md` now open with a table of which command
reads which file, and warn that Vite+ ignores `.oxlintrc.json` and that `vp lint --init` does not
migrate it. The `ja` / `zh-CN` guide pages are machine-generated
(`docs/scripts/i18n/generate.mjs`) and are left for the normal regeneration pass.

Final end-to-end check in the reproduction project, with the plugin list carried over and
`categories: { correctness: "error" }` spread alongside the block:

```
src/components/Violating.vue:2:2: error vize(vue/require-v-for-key): Elements in iteration expect to have 'v-bind:key' directives. (at <template>:8:9) ...
src/components/Violating.vue:2:2: warning vize(vue/no-v-html): v-html can lead to XSS attacks. (at <template>:10:8) ...
src/probe.ts:3:3: error eslint(no-debugger): `debugger` statement is not allowed ...
```

## How the new test fails before the fix

`npm/oxint/src/vite-plus-lint.test.ts` (chained from `src/test.ts`, so it runs under the package's
existing `vp pack && node src/test.ts` pipeline). It builds a throwaway project under `os.tmpdir()`
with a `node_modules/oxlint-plugin-vize` symlink, writes the emitted block to `.oxlintrc.json`
verbatim — bare specifier included — and runs the real `oxlint` binary. Vite+ forwards its `lint`
block to Oxlint unchanged, so this exercises the same configuration path without needing Vite+
installed.

Assertions are full-output `assert.deepEqual` on the parsed JSON diagnostics (rule code, severity,
filename, message, line/column), plus exact-`Error` `assert.throws`. Both directions are covered: a
violating SFC yields exactly two diagnostics, a clean SFC yields exactly zero, and a plugin copy that
cannot resolve the native binding is asserted to *throw* rather than import with zero rules.

Verified pre-fix by stashing `src/index.ts` and moving `src/vite-plus.ts` aside, rebuilding `dist`,
and running the test file:

```
✖ createVizeLintConfig emits the whole Vite+ lint block, including jsPlugins
✖ createVizeLintConfig keeps the rule map and settings.vize.preset in lockstep for "all"
✖ the emitted lint block makes Oxlint report exactly the configured vize diagnostics
✖ the emitted lint block reports nothing for a clean SFC
✖ an unknown vize rule id throws instead of reporting nothing
✖ a preset-suppressed vize rule id throws instead of reporting nothing
✔ a plugin copy that cannot resolve the native binding refuses to load
ℹ pass 1
ℹ fail 6
```

After the fix, including the `plugins` merge case: `ℹ pass 8 / ℹ fail 0`.

## Gates

- `nix develop -c pnpm --filter oxlint-plugin-vize exec vp check src vite.config.ts` — 30 files
  formatted, no warnings or lint errors
- `nix develop -c pnpm --filter oxlint-plugin-vize run test` — all suites pass (13 `node:test` cases
  plus the existing snapshot suites)
- `nix develop -c vp run check:repo`
- `nix develop -c vp run source:lengths` — new files are 173 / 168 / 218 lines, all under the 350
  budget; no allowlist entries added

No Rust touched, so `lint:rust` / `check:rust` are unaffected.

## Filed separately

`examples/oxlint-vize` points `jsPlugins` at the removed `npm/lint-oxlint` directory and cannot run
at all — #3390. Independent defect, kept out of this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
