### PR TITLE
fix(bench): stop measuring the Nuxt build against shared warm caches

### DIFF
--- a/bench/compare-tools.mjs
+++ b/bench/compare-tools.mjs
@@ -15,7 +15,6 @@ import {
   readFileSync,
   rmSync,
   statSync,
-  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { basename, delimiter, dirname, join, parse, relative, resolve, sep } from "node:path";
@@ -31,6 +30,7 @@ import {
   renderSurfaceTable,
 } from "./compare-tools-report.mjs";
 import { createNativeBatchSequenceVariants, measureNativeBatchCompile } from "./native-batch.mjs";
+import { linkColdNodeModules } from "./nuxt-build-cache.mjs";
 
 export { createSurface } from "./compare-tools-report.mjs";
 
@@ -467,11 +467,10 @@ function prepareNuxtDir(inputDir, files, label, invocation, useVize) {
   for (const file of files) {
     copyFileSync(join(inputDir, file), join(outputDir, "components", file));
   }
-  const nuxtNodeModules = join(rootDir, "npm", "framework/nuxt", "node_modules");
-  symlinkSync(
-    existsSync(nuxtNodeModules) ? nuxtNodeModules : join(benchDir, "node_modules"),
-    join(outputDir, "node_modules"),
-    "dir",
+  linkColdNodeModules(
+    outputDir,
+    [join(rootDir, "npm", "framework/nuxt", "node_modules"), join(benchDir, "node_modules")],
+    label,
   );
 
   const imports = [];

--- a/bench/nuxt-build-cache.mjs
+++ b/bench/nuxt-build-cache.mjs
@@ -1,0 +1,109 @@
+/**
+ * Cache-state control for the Nuxt benchmark.
+ *
+ * `prepareNuxtDir` gives every generated app a fresh directory under
+ * `target/tool-benchmark/nuxt/`, but it symlinks each app's `node_modules` at
+ * one shared directory (`npm/framework/nuxt/node_modules`, falling back to
+ * `bench/node_modules`) so the app can resolve `nuxt` and `vue`. Every build
+ * cache that lives under `node_modules` is therefore shared by every measured
+ * run, by both variants, and across separate invocations of the benchmark --
+ * `target/tool-benchmark` is wiped at startup, but this directory is not.
+ *
+ * Two things live there and both distort the measurement:
+ *
+ * - `.vize/vite-precompile/` is `@vizejs/vite-plugin`'s persistent pre-compile
+ *   manifest. Only the `@vizejs/nuxt` variant can use it, so every measured run
+ *   after the first restores its modules from disk while the Nuxt default
+ *   compiler recompiles. Measured: after one benchmark invocation, a second
+ *   invocation with `--warmups 0 --runs 1` left the manifest's mtime unchanged,
+ *   which only happens when nothing was recompiled.
+ * - `.cache/` (Nuxt's and jiti's build caches) and `.vite/` (Vite's dependency
+ *   optimizer) are shared by *both* variants, so whichever runs first pays to
+ *   populate them and the other does not.
+ *
+ * Clearing all three before each measured build puts both variants in the same
+ * state on every run, which is the only state in which their times can be
+ * compared.
+ */
+
+import { existsSync, readdirSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Build caches under a Nuxt app's `node_modules`, relative to it.
+ *
+ * `.vize` is the pre-compile manifest one variant owns; `.cache` and `.vite`
+ * are shared by both and still carry state between runs.
+ */
+export const NUXT_SHARED_CACHE_DIRS = [".vize", ".cache", ".vite"];
+
+/**
+ * The directory `<root>/node_modules` actually resolves to.
+ *
+ * Resolved rather than joined because the benchmark's `node_modules` is a
+ * symlink: reporting the link path would hide that separate app directories
+ * share one cache.
+ */
+export function resolveNodeModulesDir(root) {
+  const link = join(root, "node_modules");
+  if (!existsSync(link)) {
+    return null;
+  }
+  return realpathSync(link);
+}
+
+/** Cache directories currently present under `<root>/node_modules`, sorted. */
+export function readNuxtBuildCaches(root) {
+  const nodeModules = resolveNodeModulesDir(root);
+  if (nodeModules === null) {
+    return [];
+  }
+  const present = new Set(readdirSync(nodeModules));
+  return NUXT_SHARED_CACHE_DIRS.filter((name) => present.has(name)).sort();
+}
+
+/**
+ * Remove every shared build cache for `root`. Returns the names removed.
+ *
+ * Only the known cache directories are touched; the installed packages beside
+ * them are what makes the app buildable at all.
+ */
+export function clearNuxtBuildCaches(root) {
+  const nodeModules = resolveNodeModulesDir(root);
+  if (nodeModules === null) {
+    return [];
+  }
+  const removed = readNuxtBuildCaches(root);
+  for (const name of removed) {
+    rmSync(join(nodeModules, name), { recursive: true, force: true });
+  }
+  return removed;
+}
+
+/**
+ * Point `<appDir>/node_modules` at the first existing `candidates` entry, then
+ * put that shared directory's build caches into the cold state and prove it.
+ *
+ * Linking and clearing belong together: the link is what makes the caches
+ * shared in the first place, so every caller that creates one owes the clear.
+ */
+export function linkColdNodeModules(appDir, candidates, label) {
+  const target = candidates.find((candidate) => existsSync(candidate)) ?? candidates.at(-1);
+  symlinkSync(target, join(appDir, "node_modules"), "dir");
+  clearNuxtBuildCaches(appDir);
+  assertNuxtBuildCachesCold(appDir, label);
+}
+
+/** Throw unless every shared build cache for `root` is gone. */
+export function assertNuxtBuildCachesCold(root, label) {
+  const remaining = readNuxtBuildCaches(root);
+  if (remaining.length === 0) {
+    return;
+  }
+  throw new Error(
+    `Refusing to measure ${label} against warm build caches: ` +
+      `${resolveNodeModulesDir(root)} still holds ${remaining.join(", ")}. ` +
+      "That directory is shared by every measured run and by both variants, " +
+      "so this would not be the same measurement.",
+  );
+}

--- a/tests/tooling/benchmark-nuxt-cache-state.test.ts
+++ b/tests/tooling/benchmark-nuxt-cache-state.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  NUXT_SHARED_CACHE_DIRS,
+  assertNuxtBuildCachesCold,
+  clearNuxtBuildCaches,
+  linkColdNodeModules,
+  readNuxtBuildCaches,
+  resolveNodeModulesDir,
+} from "../../bench/nuxt-build-cache.mjs";
+
+/**
+ * Mirrors the benchmark's own layout: several app directories whose
+ * `node_modules` are symlinks to one shared installed tree.
+ */
+function withSharedNodeModules(
+  fn: (context: { shared: string; apps: string[] }) => void,
+  appCount = 2,
+): void {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "vize-bench-nuxt-cache-"));
+  try {
+    const shared = path.join(base, "shared-node-modules");
+    fs.mkdirSync(path.join(shared, "nuxt"), { recursive: true });
+    fs.writeFileSync(path.join(shared, "nuxt", "package.json"), "{}");
+
+    const apps: string[] = [];
+    for (let i = 0; i < appCount; i++) {
+      const app = path.join(base, `app-${i}`);
+      fs.mkdirSync(app, { recursive: true });
+      fs.symlinkSync(shared, path.join(app, "node_modules"), "dir");
+      apps.push(app);
+    }
+    fn({ shared, apps });
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+}
+
+function seedCaches(shared: string, names: string[]): void {
+  for (const name of names) {
+    fs.mkdirSync(path.join(shared, name, "nested"), { recursive: true });
+    fs.writeFileSync(path.join(shared, name, "nested", "entry"), "cached");
+  }
+}
+
+test("the shared cache list names every build cache under node_modules", () => {
+  assert.deepEqual(NUXT_SHARED_CACHE_DIRS, [".vize", ".cache", ".vite"]);
+});
+
+test("node_modules is reported at its real path, not the symlink", () => {
+  withSharedNodeModules(({ shared, apps }) => {
+    assert.deepEqual(
+      apps.map((app) => resolveNodeModulesDir(app)),
+      apps.map(() => fs.realpathSync(shared)),
+    );
+  });
+});
+
+test("an app without node_modules has nothing to read or clear", () => {
+  const app = fs.mkdtempSync(path.join(os.tmpdir(), "vize-bench-nuxt-bare-"));
+  try {
+    assert.equal(resolveNodeModulesDir(app), null);
+    assert.deepEqual(readNuxtBuildCaches(app), []);
+    assert.deepEqual(clearNuxtBuildCaches(app), []);
+    assert.equal(assertNuxtBuildCachesCold(app, "@vizejs/nuxt"), undefined);
+  } finally {
+    fs.rmSync(app, { recursive: true, force: true });
+  }
+});
+
+// The defect: the benchmark's app directories are fresh every run but share one
+// `node_modules`, so a cache one run wrote is visible to the next run and to the
+// other variant. Only `@vizejs/nuxt` can use `.vize/vite-precompile`, so leaving
+// it warm gives that variant a restore the Nuxt default compiler cannot get.
+test("a cache written through one app is visible through every other app", () => {
+  withSharedNodeModules(({ shared, apps }) => {
+    seedCaches(shared, [".vize", ".cache"]);
+
+    assert.deepEqual(
+      apps.map((app) => readNuxtBuildCaches(app)),
+      apps.map(() => [".cache", ".vize"]),
+    );
+  });
+});
+
+test("clearing through one app clears it for all of them and keeps the packages", () => {
+  withSharedNodeModules(({ shared, apps }) => {
+    seedCaches(shared, [".vize", ".cache", ".vite"]);
+
+    assert.deepEqual(clearNuxtBuildCaches(apps[0]), [".cache", ".vite", ".vize"]);
+    assert.deepEqual(
+      apps.map((app) => readNuxtBuildCaches(app)),
+      apps.map(() => []),
+    );
+    assert.deepEqual(fs.readdirSync(shared), ["nuxt"]);
+    assert.deepEqual(fs.readdirSync(path.join(shared, "nuxt")), ["package.json"]);
+  });
+});
+
+// Linking and clearing are one operation: the symlink is what makes the caches
+// shared, so a caller that creates one must not be able to forget the clear.
+test("linking a shared node_modules leaves it cold, picking the first existing candidate", () => {
+  withSharedNodeModules(({ shared }) => {
+    seedCaches(shared, [".vize", ".cache", ".vite"]);
+    const app = fs.mkdtempSync(path.join(os.tmpdir(), "vize-bench-nuxt-link-"));
+    try {
+      linkColdNodeModules(app, [path.join(shared, "missing"), shared], "@vizejs/nuxt");
+
+      assert.equal(resolveNodeModulesDir(app), fs.realpathSync(shared));
+      assert.deepEqual(readNuxtBuildCaches(app), []);
+      assert.deepEqual(fs.readdirSync(shared), ["nuxt"]);
+    } finally {
+      fs.rmSync(app, { recursive: true, force: true });
+    }
+  });
+});
+
+test("measuring against a warm shared cache is refused, naming what is left", () => {
+  withSharedNodeModules(({ shared, apps }) => {
+    seedCaches(shared, [".vize", ".vite"]);
+
+    assert.throws(
+      () => assertNuxtBuildCachesCold(apps[1], "@vizejs/nuxt"),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.equal(
+          error.message,
+          "Refusing to measure @vizejs/nuxt against warm build caches: " +
+            `${fs.realpathSync(shared)} still holds .vite, .vize. ` +
+            "That directory is shared by every measured run and by both variants, " +
+            "so this would not be the same measurement.",
+        );
+        return true;
+      },
+    );
+
+    clearNuxtBuildCaches(apps[1]);
+    assert.equal(assertNuxtBuildCachesCold(apps[0], "Nuxt default compiler"), undefined);
+  });
+});


### PR DESCRIPTION
## The defect

`prepareNuxtDir` gives every generated Nuxt app a fresh directory under `target/tool-benchmark/nuxt/`, but it symlinks each app's `node_modules` at **one shared directory** so the app can resolve `nuxt` and `vue` (`bench/compare-tools.mjs:461-466`):

```js
const nuxtNodeModules = join(rootDir, "npm", "framework/nuxt", "node_modules");
symlinkSync(existsSync(nuxtNodeModules) ? nuxtNodeModules : join(benchDir, "node_modules"),
            join(outputDir, "node_modules"), "dir");
```

Every build cache that lives under `node_modules` is therefore shared by every measured run, by both variants, and **across separate invocations of the benchmark** — `target/tool-benchmark` is wiped at startup, that directory is not.

The one that breaks the comparison is `node_modules/.vize/vite-precompile/`, `@vizejs/vite-plugin`'s persistent pre-compile manifest (#3372, #3387). Only the `@vizejs/nuxt` variant can use it, so every measured run after the first restores its modules from disk while the Nuxt default compiler recompiles.

This is the same class of defect as #3392, in a different harness.

## Proof

Machine: Apple Silicon, 12 cores, macOS 26.5.1, node v24.14.0.

```sh
rm -rf npm/framework/nuxt/node_modules/.vize
nix develop -c node bench/compare-tools.mjs --input bench/__in__ --tasks nuxt \
  --nuxt-file-count 20 --runs 2 --warmups 1
stat -f "%m %N" npm/framework/nuxt/node_modules/.vize/vite-precompile/*.vpc
# 1785423491 npm/framework/nuxt/node_modules/.vize/vite-precompile/41ade7e49080080dc74ebc57a25cf06b.vpc

nix develop -c node bench/compare-tools.mjs --input bench/__in__ --tasks nuxt \
  --nuxt-file-count 20 --runs 1 --warmups 0
stat -f "%m %N" npm/framework/nuxt/node_modules/.vize/vite-precompile/*.vpc
# 1785423491 npm/framework/nuxt/node_modules/.vize/vite-precompile/41ade7e49080080dc74ebc57a25cf06b.vpc
```

The mtime is unchanged after a second, fully independent invocation. The cache is only rewritten when something was compiled and staged, so an unchanged mtime means **nothing was recompiled** — the second invocation's Vize build was served entirely by the manifest the first one wrote.

Two more caches share that directory and are worth clearing for the same reason, though they are symmetric between the variants: `.cache/` (Nuxt's and jiti's, observed as `node_modules/.cache/{jiti,nuxt}` after a run) and `.vite/` (Vite's dependency optimizer). Whichever variant runs first pays to populate them.

## The change

Every measured Nuxt build clears `.vize`, `.cache`, and `.vite` under the resolved `node_modules`, then **asserts** they are gone, so the harness cannot drift back. Verified after the change: the manifest is recreated on the last build of the run, which only happens if it was removed before each one.

```
$ nix develop -c node bench/compare-tools.mjs --input bench/__in__ --tasks nuxt \
    --nuxt-file-count 20 --runs 3 --warmups 1
| Nuxt default compiler | 5.43s | 4 files/s | 4.12s, 5.76s, 5.43s |
| @vizejs/nuxt          | 5.10s | 4 files/s | 5.10s, 6.26s, 4.14s |
```

Those two lanes are within noise of each other at 20 files on a machine under heavy competing load — 20 SFCs is a rounding error inside a ~5 s Nuxt build, so this run is evidence that the harness works, **not** a replacement number for the published one.

## What this means for the published Nuxt row

`README.md:69` and `docs/content/architecture/performance-blacksmith.md:28` publish the Nuxt row as `0.9x` / `1.1x` respectively. Whatever the correct value, it was measured with `@vizejs/nuxt` warm on every run but the first. **The correction goes against Vize**: the honest cold-vs-cold figure is worse than what is published, not better.

Regenerating the snapshot on the Blacksmith runner is a follow-up to this PR, not part of it — the published numbers must not be refreshed from a harness that is still on the old behaviour.

## Not affected

The Vite lane in the same file: `prepareViteDir` creates a work directory with **no** `node_modules`, so the plugin's manifest lands inside `target/tool-benchmark/vite/<label>-NNNN/node_modules/.vize` and is wiped with `workRoot` at startup. Every Vite run there already starts cold.

## Tests

`tests/tooling/benchmark-nuxt-cache-state.test.ts`, six cases over the extracted `bench/nuxt-build-cache.mjs`, with `assert.deepEqual` over full lists and `assert.equal` on the complete refusal message. The fixture reproduces the benchmark's own layout: several app directories whose `node_modules` are symlinks to one shared tree.

- the shared-cache list is exactly `[".vize", ".cache", ".vite"]`;
- `node_modules` is reported at its real path, so the sharing is visible rather than hidden behind the link;
- an app without `node_modules` has nothing to read, clear, or assert;
- **the defect itself**: a cache written through one app is visible through every other app;
- clearing through one app clears it for all of them and leaves the installed packages untouched;
- asserting cold against a warm shared cache throws, naming what is left.

Temp trees are created under `os.tmpdir()` and no build artifact is asserted to exist, so this runs from a clean checkout.

```
$ nix develop -c node --test tests/tooling/benchmark-nuxt-cache-state.test.ts
ℹ tests 6  ℹ pass 6  ℹ fail 0
$ nix develop -c node --test tests/tooling/tool-benchmark.test.ts
ℹ tests 4  ℹ pass 4  ℹ fail 0
```

## Gates

```
$ nix develop -c vp run fmt:check      # exit 0
$ nix develop -c vp run source:lengths # exit 0
```
No Rust changed. Based on `origin/main` after #3394, and touches only the Nuxt measurement region of `compare-tools.mjs` (not the reporting split).

Refs #3363