### PR TITLE
fix(cli): refuse a default canon run that resolves an unrelated project

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -20,7 +20,6 @@ use vize_curator::profile::{ProfilePhase, ProfilePhaseKind, ProfileReport, print
 use super::{
     CheckArgs,
     path_cache::CanonicalPathCache,
-    patterns::CHECK_INPUTS_DISPLAY,
     reporting::{JsonFileResult, JsonOutput},
     tsconfig_inputs::{TsconfigInputCache, resolve_tsconfig_for_files},
 };
@@ -29,6 +28,7 @@ mod default_imports;
 mod diagnostics;
 mod global_components;
 mod ignores;
+mod input_scope;
 mod nuxt_tsconfig;
 mod resolve;
 #[cfg(unix)]
@@ -49,6 +49,7 @@ use global_components::{
     template_syntax_mode,
 };
 use ignores::load_check_ignore_set;
+use input_scope::{exit_if_default_run_leaves_cwd, report_no_inputs};
 use nuxt_tsconfig::resolve_checker_tsconfig_path;
 #[cfg(test)]
 use nuxt_tsconfig::write_nuxt_fallback_tsconfig;
@@ -161,6 +162,13 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             &mut canonical_paths,
             check_ignore_set.as_ref(),
         );
+        exit_if_default_run_leaves_cwd(
+            &files,
+            &cwd,
+            &project_root,
+            tsconfig_path.as_deref(),
+            args.quiet,
+        );
         (files, Vec::new(), reported_files)
     } else {
         let files = collect_check_files_with_ignores(
@@ -175,20 +183,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let collect_time = collect_start.elapsed();
 
     if files.is_empty() {
-        if args.format == "json" {
-            emit_json_output(JsonOutput {
-                files: Vec::new(),
-                error_count: 0,
-                warning_count: 0,
-                file_count: 0,
-                declarations: None,
-            });
-            return;
-        }
-        eprintln!(
-            "No {CHECK_INPUTS_DISPLAY} files found matching inputs: {:?}",
-            args.patterns
-        );
+        report_no_inputs(args);
         return;
     }
 

--- a/crates/vize/src/commands/check/runner/input_scope.rs
+++ b/crates/vize/src/commands/check/runner/input_scope.rs
@@ -1,0 +1,185 @@
+//! What a `vize check` run's collected inputs actually cover, and what to
+//! report when that scope does not match the directory the run was invoked
+//! from.
+//!
+//! A run with no explicit inputs takes its file set from the nearest
+//! `tsconfig.json` at or above the working directory, and that walk-up has no
+//! stop condition: it keeps going until some ancestor happens to own a
+//! `tsconfig.json`. When the project it lands on contains no file under the
+//! working directory, the run type-checks that unrelated project and reports
+//! success — the working directory's own broken sources are never looked at
+//! (#3320). The failure mode is a silent false negative, so it is reported as
+//! an error instead of being checked around.
+
+use std::path::{Path, PathBuf};
+
+use vize_carton::{String, cstr};
+
+use super::super::{CheckArgs, patterns::CHECK_INPUTS_DISPLAY, reporting::JsonOutput};
+use super::{collect::path_is_inside_root, diagnostics::emit_json_output};
+
+/// Exit code for a run that could not determine what to check. Distinct from
+/// `1`, which means "type errors were reported".
+const UNRESOLVED_SCOPE_EXIT_CODE: i32 = 2;
+
+/// How a default run's collected inputs relate to the working directory.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum DefaultRunScope {
+    /// The project root is the working directory or below it, or every input
+    /// already lives inside the working directory. Nothing to surface.
+    Owned,
+    /// The project root sits above the working directory and part of its
+    /// program lives outside it. Legitimate — a monorepo-root `tsconfig.json`
+    /// that owns this directory's sources alongside its siblings' — but the run
+    /// covers more than the invocation implies, so the scope is surfaced.
+    Widened { inputs: usize, outside: usize },
+    /// The project root sits above the working directory and *no* input lives
+    /// inside it: discovery walked past the working directory into a project
+    /// that does not contain it.
+    Unowned { inputs: usize },
+}
+
+/// Classify what `files` covers relative to `cwd`.
+///
+/// Paths are compared through [`path_is_inside_root`], which canonicalizes both
+/// sides. That is what makes the classification stable for the layouts in
+/// #3320: a `node_modules` symlinked into an out-of-tree store, an individual
+/// package symlinked in from a pnpm store, or the whole project reached through
+/// a symlinked path all produce inputs whose spelling differs from the
+/// invocation directory's while still belonging to it. Comparing resolved paths
+/// — rather than asking whether any component is a link — also keeps Windows
+/// directory junctions equivalent to symlinks here, since `canonicalize`
+/// resolves both.
+///
+/// A project root that is neither the working directory nor an ancestor of it
+/// (an explicit `--tsconfig` pointing at a sibling tree, say) is left alone:
+/// only the unbounded walk-up is under judgement here.
+pub(super) fn classify_default_run_scope(
+    files: &[PathBuf],
+    cwd: &Path,
+    project_root: &Path,
+) -> DefaultRunScope {
+    if files.is_empty() || !is_strict_ancestor(project_root, cwd) {
+        return DefaultRunScope::Owned;
+    }
+
+    let outside = files
+        .iter()
+        .filter(|file| !path_is_inside_root(cwd, file))
+        .count();
+    if outside == 0 {
+        DefaultRunScope::Owned
+    } else if outside == files.len() {
+        DefaultRunScope::Unowned {
+            inputs: files.len(),
+        }
+    } else {
+        DefaultRunScope::Widened {
+            inputs: files.len(),
+            outside,
+        }
+    }
+}
+
+/// Report the resolved scope of a default run, and exit when the resolved
+/// project does not contain the working directory at all.
+///
+/// `tsconfig_path` is `None` only when no config was adopted, which means no
+/// walk-up happened and there is nothing to judge.
+pub(super) fn exit_if_default_run_leaves_cwd(
+    files: &[PathBuf],
+    cwd: &Path,
+    project_root: &Path,
+    tsconfig_path: Option<&Path>,
+    quiet: bool,
+) {
+    let Some(tsconfig_path) = tsconfig_path else {
+        return;
+    };
+    match classify_default_run_scope(files, cwd, project_root) {
+        DefaultRunScope::Owned => {}
+        DefaultRunScope::Widened { inputs, outside } => {
+            if !quiet {
+                eprintln!("{}", widened_scope_note(cwd, project_root, inputs, outside));
+            }
+        }
+        DefaultRunScope::Unowned { inputs } => {
+            eprintln!(
+                "\x1b[31mError:\x1b[0m {}",
+                unowned_project_error(cwd, project_root, tsconfig_path, inputs)
+            );
+            std::process::exit(UNRESOLVED_SCOPE_EXIT_CODE);
+        }
+    }
+}
+
+/// Message for a run whose resolved project contains nothing under the working
+/// directory. It names both directories, the config that was adopted, and the
+/// size of the program that would have been reported instead, because the
+/// symptom users see otherwise is an unexplained clean run.
+pub(super) fn unowned_project_error(
+    cwd: &Path,
+    project_root: &Path,
+    tsconfig_path: &Path,
+    inputs: usize,
+) -> String {
+    cstr!(
+        "`{}` has no tsconfig.json, and the nearest one above it (`{}`) type-checks {} files \
+         under `{}`, none of them inside `{}`. Reporting that project's result for this \
+         directory would hide every error here, so nothing was checked: add a tsconfig.json to \
+         `{}`, pass `--tsconfig <path>`, or name the files to check.",
+        cwd.display(),
+        tsconfig_path.display(),
+        inputs,
+        project_root.display(),
+        cwd.display(),
+        cwd.display()
+    )
+}
+
+/// Note for a run whose resolved project legitimately owns this directory but
+/// reaches beyond it, so a root resolved higher than intended stays visible
+/// instead of hiding inside the file count.
+pub(super) fn widened_scope_note(
+    cwd: &Path,
+    project_root: &Path,
+    inputs: usize,
+    outside: usize,
+) -> String {
+    cstr!(
+        "vize check: the project root resolved to `{}`, above the working directory `{}`; {} of \
+         {} checked files are outside `{}`.",
+        project_root.display(),
+        cwd.display(),
+        outside,
+        inputs,
+        cwd.display()
+    )
+}
+
+/// Report a run that collected no inputs at all.
+pub(super) fn report_no_inputs(args: &CheckArgs) {
+    if args.format == "json" {
+        emit_json_output(JsonOutput {
+            files: Vec::new(),
+            error_count: 0,
+            warning_count: 0,
+            file_count: 0,
+            declarations: None,
+        });
+        return;
+    }
+    eprintln!(
+        "No {CHECK_INPUTS_DISPLAY} files found matching inputs: {:?}",
+        args.patterns
+    );
+}
+
+fn is_strict_ancestor(ancestor: &Path, path: &Path) -> bool {
+    let ancestor = vize_carton::path::canonicalize_non_verbatim(ancestor);
+    let path = vize_carton::path::canonicalize_non_verbatim(path);
+    path != ancestor && path.starts_with(&ancestor)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize/src/commands/check/runner/input_scope/tests.rs
+++ b/crates/vize/src/commands/check/runner/input_scope/tests.rs
@@ -1,0 +1,296 @@
+//! Scope classification for default `vize check` runs (#3320).
+//!
+//! Every case builds a real layout on disk — links included — because the
+//! classification compares resolved paths, which only a real filesystem
+//! answers. Workspaces live under `std::env::temp_dir()` so the tests run from
+//! a clean checkout with no build artifacts.
+
+use std::path::{Path, PathBuf};
+
+use super::{
+    DefaultRunScope, classify_default_run_scope, unowned_project_error, widened_scope_note,
+};
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    std::env::temp_dir().join(
+        vize_carton::cstr!("vize-input-scope-{name}-{}-{case_id}", std::process::id()).as_str(),
+    )
+}
+
+fn symlink_dir(source: &Path, target: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(source, target)
+    }
+}
+
+/// Ancestor `tsconfig.json`, nested app with no config of its own, and the
+/// ancestor's program covering only its own sources: the #3320 layout. The app
+/// directory is not part of the resolved project, so a run there must not be
+/// reported as that project's result.
+#[test]
+fn nested_directory_outside_the_resolved_program_is_unowned() {
+    let workspace = unique_case_dir("unowned");
+    let app = workspace.join("nested/app");
+    std::fs::create_dir_all(app.join("src")).unwrap();
+    std::fs::create_dir_all(workspace.join("helpers")).unwrap();
+    std::fs::write(workspace.join("tsconfig.json"), "{}").unwrap();
+    let helpers = ["h1.ts", "h2.ts", "h3.ts"].map(|name| {
+        let path = workspace.join("helpers").join(name);
+        std::fs::write(&path, "export const helper = 1;\n").unwrap();
+        path
+    });
+    std::fs::write(app.join("src/Broken.vue"), "<template />").unwrap();
+
+    assert_eq!(
+        classify_default_run_scope(&helpers, &app, &workspace),
+        DefaultRunScope::Unowned { inputs: 3 }
+    );
+
+    let _ = std::fs::remove_dir_all(&workspace);
+}
+
+/// A `package.json` in the nested directory does not change the verdict: a
+/// package boundary declares a package, not a type-checking program, and the
+/// resolved project still contains none of its files.
+#[test]
+fn package_json_in_the_nested_directory_is_still_unowned() {
+    let workspace = unique_case_dir("unowned-package");
+    let app = workspace.join("nested/app");
+    std::fs::create_dir_all(app.join("src")).unwrap();
+    std::fs::write(workspace.join("tsconfig.json"), "{}").unwrap();
+    std::fs::write(app.join("package.json"), "{}").unwrap();
+    let inputs = vec![workspace.join("helper.ts")];
+    std::fs::write(&inputs[0], "export const helper = 1;\n").unwrap();
+
+    assert_eq!(
+        classify_default_run_scope(&inputs, &app, &workspace),
+        DefaultRunScope::Unowned { inputs: 1 }
+    );
+
+    let _ = std::fs::remove_dir_all(&workspace);
+}
+
+/// `node_modules` symlinked to a sibling directory inside the project. The
+/// dependency input resolves to the sibling spelling, outside the working
+/// directory, while the working directory's own source keeps the run owned.
+#[test]
+fn node_modules_symlinked_to_a_sibling_keeps_the_run_owned() {
+    let workspace = unique_case_dir("sibling-store");
+    let store = workspace.join("vendor");
+    std::fs::create_dir_all(store.join("acme")).unwrap();
+    std::fs::create_dir_all(workspace.join("src")).unwrap();
+    symlink_dir(&store, &workspace.join("node_modules")).unwrap();
+    let source = workspace.join("src/App.vue");
+    let dependency = workspace.join("node_modules/acme/index.ts");
+    std::fs::write(&source, "<template />").unwrap();
+    std::fs::write(store.join("acme/index.ts"), "export const acme = 1;\n").unwrap();
+
+    assert_eq!(
+        classify_default_run_scope(&[source, dependency], &workspace.join("src"), &workspace),
+        DefaultRunScope::Widened {
+            inputs: 2,
+            outside: 1
+        }
+    );
+
+    let _ = std::fs::remove_dir_all(&workspace);
+}
+
+/// `node_modules` symlinked to a store outside the project — a pnpm store, a
+/// hoisting shim, a bind-mounted dependency tree. The dependency's resolved
+/// path leaves the project entirely and must not make the run unowned when the
+/// working directory's own sources are in the program.
+#[test]
+fn node_modules_symlinked_outside_the_project_keeps_the_run_owned() {
+    let workspace = unique_case_dir("outside-store");
+    let store = unique_case_dir("outside-store-target");
+    std::fs::create_dir_all(store.join("acme")).unwrap();
+    std::fs::create_dir_all(workspace.join("app/src")).unwrap();
+    symlink_dir(&store, &workspace.join("node_modules")).unwrap();
+    std::fs::write(workspace.join("tsconfig.json"), "{}").unwrap();
+    let source = workspace.join("app/src/App.vue");
+    let dependency = workspace.join("node_modules/acme/index.ts");
+    std::fs::write(&source, "<template />").unwrap();
+    std::fs::write(store.join("acme/index.ts"), "export const acme = 1;\n").unwrap();
+
+    assert_eq!(
+        classify_default_run_scope(&[source, dependency], &workspace.join("app"), &workspace),
+        DefaultRunScope::Widened {
+            inputs: 2,
+            outside: 1
+        }
+    );
+
+    let _ = std::fs::remove_dir_all(&workspace);
+    let _ = std::fs::remove_dir_all(&store);
+}
+
+/// pnpm's isolated linker shape: `node_modules` is a real directory and the
+/// individual package inside it is the link. The package's resolved path is
+/// outside the working directory; the working directory's own sources are not.
+#[test]
+fn symlinked_package_inside_node_modules_keeps_the_run_owned() {
+    let workspace = unique_case_dir("pnpm-package");
+    let store = workspace.join(".pnpm/acme@1.0.0/node_modules/acme");
+    std::fs::create_dir_all(&store).unwrap();
+    std::fs::create_dir_all(workspace.join("app/src")).unwrap();
+    std::fs::create_dir_all(workspace.join("node_modules")).unwrap();
+    symlink_dir(&store, &workspace.join("node_modules/acme")).unwrap();
+    let source = workspace.join("app/src/App.vue");
+    let dependency = workspace.join("node_modules/acme/index.ts");
+    std::fs::write(&source, "<template />").unwrap();
+    std::fs::write(store.join("index.ts"), "export const acme = 1;\n").unwrap();
+
+    assert_eq!(
+        classify_default_run_scope(&[source, dependency], &workspace.join("app"), &workspace),
+        DefaultRunScope::Widened {
+            inputs: 2,
+            outside: 1
+        }
+    );
+
+    let _ = std::fs::remove_dir_all(&workspace);
+}
+
+/// The whole project reached through a symlinked path: the working directory is
+/// spelled through the link while the collected inputs carry the resolved
+/// spelling. A spelling comparison would call every input "outside" and fail
+/// the run; the resolved comparison keeps it owned.
+#[test]
+fn project_reached_through_a_symlinked_path_is_owned() {
+    let workspace = unique_case_dir("linked-project");
+    let link = unique_case_dir("linked-project-link");
+    std::fs::create_dir_all(workspace.join("src")).unwrap();
+    std::fs::write(workspace.join("tsconfig.json"), "{}").unwrap();
+    let source = workspace.join("src/App.vue");
+    std::fs::write(&source, "<template />").unwrap();
+    symlink_dir(&workspace, &link).unwrap();
+
+    assert_eq!(
+        classify_default_run_scope(&[source], &link.join("src"), &link),
+        DefaultRunScope::Owned
+    );
+
+    let _ = std::fs::remove_file(&link);
+    let _ = std::fs::remove_dir_all(&workspace);
+}
+
+/// A `tsconfig.json` in both the working directory and an ancestor: discovery
+/// stops at the nearest one, so the root is the working directory and there is
+/// nothing to surface.
+#[test]
+fn nearest_tsconfig_root_is_owned() {
+    let workspace = unique_case_dir("nearest");
+    let app = workspace.join("app");
+    std::fs::create_dir_all(app.join("src")).unwrap();
+    std::fs::write(workspace.join("tsconfig.json"), "{}").unwrap();
+    std::fs::write(app.join("tsconfig.json"), "{}").unwrap();
+    let source = app.join("src/App.vue");
+    std::fs::write(&source, "<template />").unwrap();
+
+    assert_eq!(
+        classify_default_run_scope(&[source], &app, &app),
+        DefaultRunScope::Owned
+    );
+
+    let _ = std::fs::remove_dir_all(&workspace);
+}
+
+/// The negative direction: no config in the working directory and an ancestor
+/// program that does own its sources. Walking up is correct here, and the run
+/// must proceed — only the wider scope is surfaced.
+#[test]
+fn ancestor_program_that_owns_the_working_directory_is_widened_not_unowned() {
+    let workspace = unique_case_dir("widened");
+    let app = workspace.join("nested/app");
+    std::fs::create_dir_all(app.join("src")).unwrap();
+    std::fs::create_dir_all(workspace.join("helpers")).unwrap();
+    std::fs::write(workspace.join("tsconfig.json"), "{}").unwrap();
+    let helper = workspace.join("helpers/h1.ts");
+    let source = app.join("src/App.vue");
+    std::fs::write(&helper, "export const helper = 1;\n").unwrap();
+    std::fs::write(&source, "<template />").unwrap();
+
+    assert_eq!(
+        classify_default_run_scope(&[helper, source], &app, &workspace),
+        DefaultRunScope::Widened {
+            inputs: 2,
+            outside: 1
+        }
+    );
+
+    let _ = std::fs::remove_dir_all(&workspace);
+}
+
+/// An ancestor program whose inputs all live in the working directory needs no
+/// note: the wider root changes nothing about what is checked.
+#[test]
+fn ancestor_root_whose_inputs_are_all_local_is_owned() {
+    let workspace = unique_case_dir("all-local");
+    let app = workspace.join("nested/app");
+    std::fs::create_dir_all(app.join("src")).unwrap();
+    std::fs::write(workspace.join("tsconfig.json"), "{}").unwrap();
+    let source = app.join("src/App.vue");
+    std::fs::write(&source, "<template />").unwrap();
+
+    assert_eq!(
+        classify_default_run_scope(&[source], &app, &workspace),
+        DefaultRunScope::Owned
+    );
+
+    let _ = std::fs::remove_dir_all(&workspace);
+}
+
+/// An empty input set is reported by the "no files found" path, not here.
+#[test]
+fn empty_input_set_is_owned() {
+    let workspace = unique_case_dir("empty");
+    let app = workspace.join("app");
+    std::fs::create_dir_all(&app).unwrap();
+    std::fs::write(workspace.join("tsconfig.json"), "{}").unwrap();
+
+    assert_eq!(
+        classify_default_run_scope(&[], &app, &workspace),
+        DefaultRunScope::Owned
+    );
+
+    let _ = std::fs::remove_dir_all(&workspace);
+}
+
+#[test]
+fn unowned_project_error_names_both_directories_and_the_adopted_config() {
+    assert_eq!(
+        unowned_project_error(
+            Path::new("/workspace/nested/app"),
+            Path::new("/workspace"),
+            Path::new("/workspace/tsconfig.json"),
+            3
+        ),
+        "`/workspace/nested/app` has no tsconfig.json, and the nearest one above it \
+         (`/workspace/tsconfig.json`) type-checks 3 files under `/workspace`, none of them inside \
+         `/workspace/nested/app`. Reporting that project's result for this directory would hide \
+         every error here, so nothing was checked: add a tsconfig.json to \
+         `/workspace/nested/app`, pass `--tsconfig <path>`, or name the files to check."
+    );
+}
+
+#[test]
+fn widened_scope_note_reports_the_root_and_the_input_counts() {
+    assert_eq!(
+        widened_scope_note(
+            Path::new("/workspace/nested/app"),
+            Path::new("/workspace"),
+            4,
+            3
+        ),
+        "vize check: the project root resolved to `/workspace`, above the working directory \
+         `/workspace/nested/app`; 3 of 4 checked files are outside `/workspace/nested/app`."
+    );
+}

--- a/crates/vize/tests/check_default_run_project_root_cli.rs
+++ b/crates/vize/tests/check_default_run_project_root_cli.rs
@@ -1,0 +1,290 @@
+//! Regression for #3320: a `vize check` run with no explicit inputs must not
+//! report an unrelated ancestor project's result as the working directory's
+//! result.
+//!
+//! Project-root discovery walks up from the working directory until some
+//! ancestor owns a `tsconfig.json`. When that project's program contains no
+//! file under the working directory, the run used to type-check the ancestor's
+//! files, find nothing wrong with them, and exit `0` — while the working
+//! directory's own broken sources were never checked. The failure mode is a
+//! silent false negative, so every layout below pins the *presence* of the
+//! report, and the layouts that reach dependencies through links are pinned
+//! alongside the plain one because the original report arrived through a
+//! symlinked `node_modules`.
+
+use vize_carton::cstr;
+
+#[path = "support/default_run_root.rs"]
+mod default_run_root;
+
+use default_run_root::{
+    ANCESTOR_TSCONFIG_OWNING_THE_APP, Layout, NodeModulesLayout, build_case, link_vue_packages,
+    resolve_test_corsa_path, run_check, run_check_with_corsa, stderr_lines, symlink_path,
+    unowned_error, unowned_error_for, workspace_vue_package,
+};
+
+/// The reported layout: an ancestor `tsconfig.json` that owns only its own
+/// sources, and a nested app with no config of its own.
+#[test]
+fn default_run_outside_the_resolved_program_reports_the_wrong_root() {
+    let case = build_case("plain", Layout::unowned());
+    let output = run_check(&case.app, &[]);
+
+    assert_eq!(output.stdout, "");
+    assert_eq!(output.stderr, unowned_error(&case));
+    assert_eq!(output.code, Some(2));
+
+    case.cleanup();
+}
+
+/// `--format json` must not turn the wrong root into an empty-but-valid report.
+#[test]
+fn default_run_outside_the_resolved_program_writes_no_json_report() {
+    let case = build_case("json", Layout::unowned());
+    let output = run_check(&case.app, &["--format", "json"]);
+
+    assert_eq!(output.stdout, "");
+    assert_eq!(output.stderr, unowned_error(&case));
+    assert_eq!(output.code, Some(2));
+
+    case.cleanup();
+}
+
+/// `--quiet` suppresses progress output, never the wrong root.
+#[test]
+fn default_run_outside_the_resolved_program_reports_even_when_quiet() {
+    let case = build_case("quiet", Layout::unowned());
+    let output = run_check(&case.app, &["--quiet"]);
+
+    assert_eq!(output.stdout, "");
+    assert_eq!(output.stderr, unowned_error(&case));
+    assert_eq!(output.code, Some(2));
+
+    case.cleanup();
+}
+
+/// A real `node_modules` in the workspace: the same verdict as with none.
+#[test]
+fn default_run_outside_the_resolved_program_with_a_real_node_modules() {
+    let case = build_case(
+        "real-node-modules",
+        Layout {
+            node_modules: NodeModulesLayout::RealDirectory,
+            ..Layout::unowned()
+        },
+    );
+    let output = run_check(&case.app, &[]);
+
+    assert_eq!(output.stdout, "");
+    assert_eq!(output.stderr, unowned_error(&case));
+    assert_eq!(output.code, Some(2));
+
+    case.cleanup();
+}
+
+/// `node_modules` symlinked to a store outside the workspace — the layout the
+/// issue was reported from. Discovery must reach the same verdict as with a real
+/// directory, in the same run, with the same message.
+#[test]
+fn default_run_outside_the_resolved_program_with_a_symlinked_node_modules() {
+    let case = build_case(
+        "symlinked-node-modules",
+        Layout {
+            node_modules: NodeModulesLayout::SymlinkedStore,
+            ..Layout::unowned()
+        },
+    );
+    let output = run_check(&case.app, &[]);
+
+    assert_eq!(output.stdout, "");
+    assert_eq!(output.stderr, unowned_error(&case));
+    assert_eq!(output.code, Some(2));
+
+    case.cleanup();
+}
+
+/// pnpm's isolated linker: `node_modules` is real and the package inside it is
+/// the link.
+#[test]
+fn default_run_outside_the_resolved_program_with_a_symlinked_package() {
+    let case = build_case(
+        "symlinked-package",
+        Layout {
+            node_modules: NodeModulesLayout::SymlinkedPackage,
+            ..Layout::unowned()
+        },
+    );
+    let output = run_check(&case.app, &[]);
+
+    assert_eq!(output.stdout, "");
+    assert_eq!(output.stderr, unowned_error(&case));
+    assert_eq!(output.code, Some(2));
+
+    case.cleanup();
+}
+
+/// A `package.json` in the app declares a package, not a type-checking program:
+/// the ancestor project still owns none of its files, so the run is still
+/// refused rather than silently reporting the ancestor's result.
+#[test]
+fn default_run_outside_the_resolved_program_with_a_package_boundary() {
+    let case = build_case(
+        "package-boundary",
+        Layout {
+            app_package_json: true,
+            ..Layout::unowned()
+        },
+    );
+    let output = run_check(&case.app, &[]);
+
+    assert_eq!(output.stdout, "");
+    assert_eq!(output.stderr, unowned_error(&case));
+    assert_eq!(output.code, Some(2));
+
+    case.cleanup();
+}
+
+/// The whole workspace reached through a symlinked path: the working directory
+/// is spelled through the link while collected inputs carry the resolved
+/// spelling. The verdict must be about ownership, not spelling — so this is
+/// still the unowned case, reported against the resolved spelling.
+#[test]
+fn default_run_through_a_symlinked_workspace_path_reports_the_wrong_root() {
+    let case = build_case("linked-workspace", Layout::unowned());
+    let link = case.workspace.with_extension("link");
+    let _ = std::fs::remove_file(&link);
+    symlink_path(&case.workspace, &link).unwrap();
+    let linked_app = link.join("nested/app");
+    let output = run_check(&linked_app, &[]);
+
+    assert_eq!(output.stdout, "");
+    assert_eq!(
+        output.stderr,
+        unowned_error_for(&case.workspace, &case.app, 3)
+    );
+    assert_eq!(output.code, Some(2));
+
+    let _ = std::fs::remove_file(&link);
+    case.cleanup();
+}
+
+/// The negative direction. An ancestor `tsconfig.json` that *does* own the app's
+/// sources is legitimate ancestor discovery: the run proceeds, reports the
+/// app's real error, and surfaces the wider scope instead of failing.
+#[test]
+fn default_run_inside_an_owning_ancestor_program_checks_the_app_and_notes_the_scope() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        eprintln!("skipping owning-ancestor case: tsgo not found");
+        return;
+    };
+    let Some(vue_package) = workspace_vue_package() else {
+        eprintln!("skipping owning-ancestor case: workspace Vue package missing");
+        return;
+    };
+    let case = build_case(
+        "owning-ancestor",
+        Layout {
+            tsconfig: ANCESTOR_TSCONFIG_OWNING_THE_APP,
+            node_modules: NodeModulesLayout::RealDirectory,
+            ..Layout::unowned()
+        },
+    );
+    link_vue_packages(&vue_package, &case.workspace.join("node_modules")).unwrap();
+
+    let output = run_check_with_corsa(&case.app, &["--format", "json"], Some(&corsa_path));
+
+    assert_eq!(
+        stderr_lines(&output.stderr),
+        vec![
+            cstr!(
+                "vize check: the project root resolved to `{}`, above the working directory \
+                 `{}`; 3 of 4 checked files are outside `{}`.",
+                case.workspace.display(),
+                case.app.display(),
+                case.app.display()
+            ),
+            cstr!(
+                "Building Corsa virtual project for 4 files under {}...",
+                case.workspace.display()
+            ),
+            cstr!("Running Corsa diagnostics for 4 files..."),
+        ]
+    );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&output.stdout).unwrap(),
+        serde_json::json!({
+            "files": [
+                { "file": case.workspace.join("helpers/h1.ts"), "diagnostics": [] },
+                { "file": case.workspace.join("helpers/h2.ts"), "diagnostics": [] },
+                { "file": case.workspace.join("helpers/h3.ts"), "diagnostics": [] },
+                {
+                    "file": "src/Broken.vue",
+                    "diagnostics": [
+                        "error:2:7 [TS2322] Type 'string' is not assignable to type 'number'."
+                    ]
+                },
+            ],
+            "errorCount": 1,
+            "warningCount": 0,
+            "fileCount": 4
+        })
+    );
+    assert_eq!(output.code, Some(1));
+
+    case.cleanup();
+}
+
+/// The app's own `tsconfig.json` ends the walk-up at the nearest project: no
+/// scope note, and the app's error is reported.
+#[test]
+fn default_run_with_a_local_tsconfig_stays_in_the_app() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        eprintln!("skipping local-tsconfig case: tsgo not found");
+        return;
+    };
+    let Some(vue_package) = workspace_vue_package() else {
+        eprintln!("skipping local-tsconfig case: workspace Vue package missing");
+        return;
+    };
+    let case = build_case(
+        "local-tsconfig",
+        Layout {
+            node_modules: NodeModulesLayout::RealDirectory,
+            app_tsconfig: true,
+            ..Layout::unowned()
+        },
+    );
+    link_vue_packages(&vue_package, &case.workspace.join("node_modules")).unwrap();
+
+    let output = run_check_with_corsa(&case.app, &["--format", "json"], Some(&corsa_path));
+
+    assert_eq!(
+        stderr_lines(&output.stderr),
+        vec![
+            cstr!(
+                "Building Corsa virtual project for 1 files under {}...",
+                case.app.display()
+            ),
+            cstr!("Running Corsa diagnostics for 1 files..."),
+        ]
+    );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&output.stdout).unwrap(),
+        serde_json::json!({
+            "files": [
+                {
+                    "file": "src/Broken.vue",
+                    "diagnostics": [
+                        "error:2:7 [TS2322] Type 'string' is not assignable to type 'number'."
+                    ]
+                },
+            ],
+            "errorCount": 1,
+            "warningCount": 0,
+            "fileCount": 1
+        })
+    );
+    assert_eq!(output.code, Some(1));
+
+    case.cleanup();
+}

--- a/crates/vize/tests/support/default_run_root.rs
+++ b/crates/vize/tests/support/default_run_root.rs
@@ -1,0 +1,286 @@
+//! Fixture builder for the #3320 default-run project-root cases.
+//!
+//! Every case is the same shape — an ancestor `tsconfig.json`, a nested app,
+//! and a broken SFC in that app — varying only where the project's
+//! `node_modules` lives and which markers the app carries. Workspaces are built
+//! under `std::env::temp_dir()` so the tests run from a clean checkout.
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use vize_carton::cstr;
+
+/// Ancestor config whose program covers only the ancestor's own sources, so the
+/// nested app belongs to no project.
+pub const ANCESTOR_TSCONFIG_OWNING_ONLY_ITSELF: &str = r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["helpers/**/*.ts"]
+}
+"#;
+
+/// Ancestor config whose program covers the nested app too: legitimate ancestor
+/// discovery.
+pub const ANCESTOR_TSCONFIG_OWNING_THE_APP: &str = r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["helpers/**/*.ts", "nested/app/src/**/*"]
+}
+"#;
+
+const APP_TSCONFIG: &str = r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}
+"#;
+
+const BROKEN_SFC: &str = r#"<script setup lang="ts">
+const total: number = "definitely not a number";
+</script>
+
+<template>
+  <div>{{ total }}</div>
+</template>
+"#;
+
+/// Where the project's `node_modules` lives. The verdict must not depend on it.
+pub enum NodeModulesLayout {
+    /// No `node_modules` at all.
+    None,
+    /// A real `<workspace>/node_modules` directory.
+    RealDirectory,
+    /// `<workspace>/node_modules` symlinked to a store outside the workspace.
+    SymlinkedStore,
+    /// A real `<workspace>/node_modules` with one package symlinked in from a
+    /// pnpm-style store (the isolated linker shape).
+    SymlinkedPackage,
+}
+
+pub struct Layout {
+    pub tsconfig: &'static str,
+    pub node_modules: NodeModulesLayout,
+    pub app_package_json: bool,
+    pub app_tsconfig: bool,
+}
+
+impl Layout {
+    /// The reported layout: the app belongs to no project.
+    pub fn unowned() -> Self {
+        Self {
+            tsconfig: ANCESTOR_TSCONFIG_OWNING_ONLY_ITSELF,
+            node_modules: NodeModulesLayout::None,
+            app_package_json: false,
+            app_tsconfig: false,
+        }
+    }
+}
+
+pub struct Case {
+    pub workspace: PathBuf,
+    pub app: PathBuf,
+    store: PathBuf,
+}
+
+impl Case {
+    pub fn cleanup(&self) {
+        let _ = std::fs::remove_dir_all(&self.workspace);
+        let _ = std::fs::remove_dir_all(&self.store);
+    }
+}
+
+pub struct CommandOutput {
+    pub stdout: std::string::String,
+    pub stderr: std::string::String,
+    pub code: Option<i32>,
+}
+
+pub fn build_case(name: &str, layout: Layout) -> Case {
+    let workspace = unique_case_dir(name);
+    let store = unique_case_dir(&cstr!("{name}-store"));
+    let _ = std::fs::remove_dir_all(&workspace);
+    let _ = std::fs::remove_dir_all(&store);
+    let app = workspace.join("nested/app");
+    std::fs::create_dir_all(app.join("src")).unwrap();
+    std::fs::create_dir_all(workspace.join("helpers")).unwrap();
+    std::fs::write(workspace.join("tsconfig.json"), layout.tsconfig).unwrap();
+    std::fs::write(workspace.join("package.json"), "{}").unwrap();
+    for helper in ["h1.ts", "h2.ts", "h3.ts"] {
+        std::fs::write(
+            workspace.join("helpers").join(helper),
+            "export const helper = 1;\n",
+        )
+        .unwrap();
+    }
+    std::fs::write(app.join("src/Broken.vue"), BROKEN_SFC).unwrap();
+    if layout.app_package_json {
+        std::fs::write(app.join("package.json"), "{}").unwrap();
+    }
+    if layout.app_tsconfig {
+        std::fs::write(app.join("tsconfig.json"), APP_TSCONFIG).unwrap();
+    }
+    build_node_modules(&layout.node_modules, &workspace, &store);
+
+    // `vize` reports paths as the kernel resolves them, and the platform temp
+    // directory is itself reached through a link on macOS, so expectations are
+    // written against the resolved spelling.
+    Case {
+        workspace: vize_carton::path::canonicalize_non_verbatim(&workspace),
+        app: vize_carton::path::canonicalize_non_verbatim(&app),
+        store,
+    }
+}
+
+fn build_node_modules(layout: &NodeModulesLayout, workspace: &Path, store: &Path) {
+    match layout {
+        NodeModulesLayout::None => {}
+        NodeModulesLayout::RealDirectory => {
+            std::fs::create_dir_all(workspace.join("node_modules")).unwrap();
+        }
+        NodeModulesLayout::SymlinkedStore => {
+            std::fs::create_dir_all(store).unwrap();
+            symlink_path(store, &workspace.join("node_modules")).unwrap();
+        }
+        NodeModulesLayout::SymlinkedPackage => {
+            let package = store.join("acme@1.0.0/node_modules/acme");
+            std::fs::create_dir_all(&package).unwrap();
+            std::fs::write(package.join("package.json"), r#"{ "name": "acme" }"#).unwrap();
+            std::fs::create_dir_all(workspace.join("node_modules")).unwrap();
+            symlink_path(&package, &workspace.join("node_modules/acme")).unwrap();
+        }
+    }
+}
+
+pub fn run_check(cwd: &Path, args: &[&str]) -> CommandOutput {
+    run_check_with_corsa(cwd, args, None)
+}
+
+pub fn run_check_with_corsa(cwd: &Path, args: &[&str], corsa_path: Option<&Path>) -> CommandOutput {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vize"));
+    command.current_dir(cwd).arg("check").args(args);
+    if let Some(corsa_path) = corsa_path {
+        command.env("CORSA_PATH", corsa_path);
+    }
+    let output = command.output().unwrap();
+
+    CommandOutput {
+        stdout: std::string::String::from_utf8(output.stdout).unwrap(),
+        stderr: std::string::String::from_utf8(output.stderr).unwrap(),
+        code: output.status.code(),
+    }
+}
+
+/// Expected stderr for a run whose resolved project owns nothing under the app.
+pub fn unowned_error(case: &Case) -> std::string::String {
+    unowned_error_for(&case.workspace, &case.app, 3)
+}
+
+pub fn unowned_error_for(workspace: &Path, app: &Path, inputs: usize) -> std::string::String {
+    let workspace = workspace.display();
+    let app = app.display();
+    format!(
+        "\x1b[31mError:\x1b[0m `{app}` has no tsconfig.json, and the nearest one above it \
+         (`{workspace}/tsconfig.json`) type-checks {inputs} files under `{workspace}`, none of \
+         them inside `{app}`. Reporting that project's result for this directory would hide every \
+         error here, so nothing was checked: add a tsconfig.json to `{app}`, pass `--tsconfig \
+         <path>`, or name the files to check.\n"
+    )
+}
+
+pub fn stderr_lines(stderr: &str) -> Vec<vize_carton::String> {
+    stderr.lines().map(|line| cstr!("{line}")).collect()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    std::env::temp_dir()
+        .join(cstr!("vize-check-default-root-{name}-{}", std::process::id()).as_str())
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+pub fn resolve_test_corsa_path() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("CORSA_PATH") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let root = workspace_root();
+    [
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+pub fn workspace_vue_package() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.join("node_modules/vue"),
+        root.join("tests/node_modules/vue"),
+        root.join("playground/node_modules/vue"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+pub fn link_vue_packages(vue_package: &Path, node_modules: &Path) -> std::io::Result<()> {
+    symlink_path(vue_package, &node_modules.join("vue"))?;
+    let vue_namespace = vue_package
+        .parent()
+        .map(|parent| parent.join("@vue"))
+        .filter(|path| path.exists());
+    if let Some(vue_namespace) = vue_namespace {
+        symlink_path(&vue_namespace, &node_modules.join("@vue"))?;
+    }
+    Ok(())
+}
+
+/// Directory links here are `symlink`/`symlink_dir`, which need Developer Mode
+/// or an elevated shell on Windows; on a stock Windows box the link layouts fail
+/// to build their fixture rather than reporting a vize defect.
+pub fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    if target.is_symlink() || target.is_file() {
+        std::fs::remove_file(target)?;
+    } else if target.exists() {
+        std::fs::remove_dir_all(target)?;
+    }
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(source, target)
+    }
+}


### PR DESCRIPTION
## The defect

`vize check` with no explicit inputs takes its file set from the nearest `tsconfig.json` at or
above the working directory (`find_nearest_tsconfig_dir`, `crates/vize/src/commands/check/runner/resolve.rs`).
That walk-up has **no stop condition** — it keeps going until some ancestor happens to own a
`tsconfig.json`, and the run then type-checks *that* project's `include` set.

When the project it lands on contains no file under the working directory, the run reports a clean
result for files the user never asked about, while the working directory's own broken sources are
never looked at. Silent false negative — the dangerous direction, and exactly what #3320 describes
("root discovery walks up to `tests/`, pulls in 83 unrelated files, and a genuinely broken fixture
stops being reported").

## Reproduction (on `main`, `676f7bc6e`)

```
<workspace>/tsconfig.json      include: ["helpers/**/*.ts"]
<workspace>/package.json
<workspace>/helpers/h{1,2,3}.ts
<workspace>/nested/app/src/Broken.vue   <- const total: number = "definitely not a number"
```

```sh
cd <workspace>/nested/app && vize check --format json
```

**Actual (pre-fix)**

```
Building Corsa virtual project for 3 files under <workspace>...
{"files":[{"file":"<workspace>/helpers/h1.ts","diagnostics":[]},
          {"file":"<workspace>/helpers/h2.ts","diagnostics":[]},
          {"file":"<workspace>/helpers/h3.ts","diagnostics":[]}],
 "errorCount":0,"warningCount":0,"fileCount":3}
exit 0
```

The app's `TS2322` is never reported. Byte-identical output with `node_modules` as a real
directory, as a symlink to an out-of-tree store, and with a `package.json` in the app.

**Expected (post-fix)**

```
Error: `<workspace>/nested/app` has no tsconfig.json, and the nearest one above it
(`<workspace>/tsconfig.json`) type-checks 3 files under `<workspace>`, none of them inside
`<workspace>/nested/app`. Reporting that project's result for this directory would hide every
error here, so nothing was checked: add a tsconfig.json to `<workspace>/nested/app`, pass
`--tsconfig <path>`, or name the files to check.
exit 2
```

## The fix

`crates/vize/src/commands/check/runner/input_scope.rs` classifies what a default run collected
relative to the working directory:

- **Owned** — the root is the working directory or below it, or every input is already inside it.
  Unchanged behaviour.
- **Widened** — the root sits above the working directory and part of the program lives outside it.
  Legitimate ancestor discovery (a monorepo-root config that owns this directory's sources
  alongside its siblings'). The run proceeds and the resolved root plus the outside-input count are
  surfaced on stderr — the visibility half of the issue:
  ``vize check: the project root resolved to `<root>`, above the working directory `<cwd>`; 3 of 4 checked files are outside `<cwd>`.``
- **Unowned** — the root sits above the working directory and *no* input is inside it. The run is
  refused with the message above and exit code `2` (distinct from `1` = type errors reported).

Ownership is decided on **resolved** paths (`path_is_inside_root` canonicalizes both sides), never
on "does this path contain a link". That is what makes the verdict identical across the layouts
#3320 names — pnpm stores, hoisting shims, worktree CI lanes, bind-mounted dependencies — and it is
also why Windows directory junctions behave like symlinks here, since `canonicalize` resolves both
(relevant to #3388, which is otherwise untouched by this change).

Explicit inputs (`vize check src`) are not affected: they already report the app's diagnostics
correctly, and the guard only runs when no patterns were given.

### Why not "stop at the first real project marker"

#3320 suggests stopping the walk-up at the first real project marker. That does not fix the
reported layout: the directory the run escapes from carries **no** marker at all — no
`tsconfig.json`, no `package.json` (the `generic-build` fixture is a bare `src/`), so a
marker-based stop never fires. Adding `package.json` as a stop marker also silently changes
monorepo packages that legitimately rely on a root config, trading a false negative for false
positives from a program built without the root's `compilerOptions`. The case where the app *does*
carry a `package.json` is covered here as its own test and still refused, with the message naming
what to add.

The rule this PR uses is the same intent stated in terms of what discovery is actually for: a
project that contains none of your files is not your project. It fires exactly where the walk-up
went wrong, is decided on data the run already has (no extra tsconfig parsing, no extra globbing),
and leaves every layout where the ancestor genuinely owns the sources untouched.

## The symlink half of #3320 no longer reproduces

Same fixture with `node_modules` a real directory vs. a symlink to an out-of-tree store gives
byte-identical output on current `main`, so the *diagnostic-drop* half of #3320 is already fixed —
by #3374 (`277da1a23`, "map Corsa CLI diagnostics through a symlinked node_modules"), whose
`crates/vize/tests/check_symlinked_node_modules_cli.rs` pins it. This PR does not claim that half;
it pins the symlink-invariance of *root discovery* separately (symlinked store, symlinked package,
symlinked workspace path) so the two cannot drift apart again.

## Tests

`crates/vize/tests/check_default_run_project_root_cli.rs` (10 CLI cases, full stdout/stderr/exit
assertions, temp workspaces under `os.tmpdir()`):

| Layout | Expected |
| --- | --- |
| ancestor config owning only itself, no marker in the app | refused, exit 2 |
| same, `--format json` | refused, no JSON report written |
| same, `--quiet` | refused (quiet never hides a wrong root) |
| same, real `node_modules` | refused, identical message |
| same, `node_modules` symlinked to an out-of-tree store | refused, identical message |
| same, pnpm-style symlinked package inside `node_modules` | refused, identical message |
| same, `package.json` in the app | refused, identical message |
| whole workspace reached through a symlinked path | refused, identical message |
| ancestor config that *owns* the app's sources | runs, reports `TS2322`, emits the scope note |
| app has its own `tsconfig.json` | runs, reports `TS2322`, no note |

`crates/vize/src/commands/check/runner/input_scope/tests.rs` (12 unit cases) pins the
classification and the exact message text on real on-disk layouts, including `node_modules`
symlinked to a sibling, symlinked outside the project, a symlinked package, a project reached
through a symlinked path, a nearest-vs-ancestor config pair, and the negative direction where
walking up is correct.

**Pre-fix verification:** with the `runner.rs` hunk reverted and the tests kept,
`cargo test -p vize --test check_default_run_project_root_cli` fails 9 of 10 — the refused cases
report `Type checked 3 files ... No type errors found!` and exit 0, and the owning-ancestor case
misses the scope note. Only `default_run_with_a_local_tsconfig_stays_in_the_app` passes pre-fix,
which is the behaviour that was already correct.

**Windows note:** the link layouts build fixtures with `std::os::*::fs::symlink*`, which needs
Developer Mode or an elevated shell on stock Windows — the same limitation
`tests/tooling/cli-check-sub-package-dependency.test.ts` has. On such a box those cases fail while
building the fixture rather than reporting a vize defect; the non-link cases are unaffected.

## Gates

- `vp run fmt:check` — pass (plus `rustfmt --edition 2024 --config style_edition=2024 --check` on
  every touched file)
- `vp run lint:rust` — pass
- `vp run check:rust` — pass
- `vp run source:lengths --check --base-ref origin/main` — pass (`runner.rs` shrank 717 → 712; no
  new file over 350 lines)
- `cargo test -p vize` — 83 binaries, 609 tests, 0 failures (rebased on `fae854c89`)
- `tests/tooling/cli-check-{collection,contract,args,diagnostics,json-shape,sub-package-dependency}.test.ts`
  — 31 tests, all pass with `CORSA_PATH` set (without it, two pre-existing parse-error cases fail
  on corsa discovery in this environment, identically before and after this change)

The test-infra half of #3320 (`tests/snapshots/check/vue2-elm.ts` cannot run inside a git worktree,
because it asserts a pinned fixture SHA and worktrees get no submodules) is split out to #3417 so it
is not lost when #3320 closes.

Closes #3320
