### PR TITLE
docs: reconcile the README Vite and Nuxt benchmark rows with the snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,17 +56,31 @@ reasonably large Vue projects to use as test beds.
 
 ## Benchmarks
 
-Measured on Blacksmith `blacksmith-32vcpu-ubuntu-2404`, 15,000 generated Vue SFCs, median of 5 runs
-([latest run](https://github.com/ubugeeei-prod/vize/actions/runs/29004198781)):
+Measured on Blacksmith `blacksmith-32vcpu-ubuntu-2404`, median of 5 runs. The corpus is **not** the
+same size for every row — it is given per row below, and only SFC compile, Lint, and Format run at
+15,000 SFCs.
 
-| Surface     | Existing tool      | Existing |    Vize |    Speedup |
-| ----------- | ------------------ | -------: | ------: | ---------: |
-| SFC compile | @vue/compiler-sfc  |   18.38s | 333.8ms |  **55.1×** |
-| Lint        | eslint-plugin-vue  |   56.66s | 270.9ms | **209.2×** |
-| Format      | Prettier           |  150.34s |   2.22s |  **67.8×** |
-| Type check  | vue-tsc            |    5.42s | 438.3ms |  **12.4×** |
-| Vite build  | @vitejs/plugin-vue |    1.70s |   1.52s |   **1.1×** |
-| Nuxt build  | Nuxt compiler      |    6.68s |   7.35s |   **0.9×** |
+| Surface     |  Files | Existing tool      | Existing |    Vize |    Speedup |
+| ----------- | -----: | ------------------ | -------: | ------: | ---------: |
+| SFC compile | 15,000 | @vue/compiler-sfc  |   18.38s | 333.8ms |  **55.1×** |
+| Lint        | 15,000 | eslint-plugin-vue  |   56.66s | 270.9ms | **209.2×** |
+| Format      | 15,000 | Prettier           |  150.34s |   2.22s |  **67.8×** |
+| Type check  |    500 | vue-tsc            |    5.42s | 438.3ms |  **12.4×** |
+| Vite build  |  1,000 | @vitejs/plugin-vue |    1.66s | 732.5ms |   **2.3×** |
+| Nuxt build  |    500 | Nuxt compiler      |    6.79s |   6.42s |  **1.1×**† |
+
+The Vite build and Nuxt build rows are taken from the committed snapshot
+`bench/results/tool-benchmark-latest.json`
+([run 29010164013](https://github.com/ubugeeei-prod/vize/actions/runs/29010164013)) — the same
+artifact the published [Blacksmith benchmark snapshot](https://vizejs.dev/architecture/performance-blacksmith)
+renders — and `tests/tooling/readme-benchmark-rows.test.ts` pins them to it so the two cannot drift
+apart again. The other rows are from
+[run 29004198781](https://github.com/ubugeeei-prod/vize/actions/runs/29004198781).
+
+† **Pending regeneration.** The Nuxt row was measured before the benchmark stopped letting the
+`@vizejs/nuxt` variant inherit a warm pre-compile cache the Nuxt default compiler has no counterpart
+for. The correction runs against Vize: the honest cold-vs-cold figure is worse than the 1.1× shown
+here. It will be replaced by a fresh Blacksmith run rather than by a hand-written estimate.
 
 See the [Blacksmith benchmark snapshot](https://vizejs.dev/architecture/performance-blacksmith) for
 methodology and per-variant numbers.

--- a/tests/tooling/readme-benchmark-rows.test.ts
+++ b/tests/tooling/readme-benchmark-rows.test.ts
@@ -1,0 +1,158 @@
+/**
+ * The README benchmark table and the generated Blacksmith snapshot are two
+ * renderings of the same measurements, and they had drifted: the README
+ * published the Vite row as `1.70s / 1.52s / 1.1x` and the Nuxt row as
+ * `6.68s / 7.35s / 0.9x` while `bench/results/tool-benchmark-latest.json` --
+ * the artifact `docs/content/architecture/performance-blacksmith.md` is
+ * rendered from -- held `1.66s / 732.5ms / 2.3x` and `6.79s / 6.42s / 1.1x`.
+ * A reader got a different answer depending on which page they opened.
+ *
+ * This pins the README's Vite and Nuxt rows to the artifact. The remaining rows
+ * are deliberately not covered here: the type-check rows are being reworked
+ * separately as a cross-engine retraction, and the compile/lint/format rows
+ * come from a different run.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+type Surface = {
+  id: string;
+  files: number;
+  primarySpeedup: number;
+  variants: { id: string; medianMs: number }[];
+};
+
+function readSnapshot(): Surface[] {
+  return JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "bench/results/tool-benchmark-latest.json"), "utf8"),
+  ).surfaces as Surface[];
+}
+
+/** README table rows, keyed by their first cell. */
+function readReadmeRows(): Map<string, string[]> {
+  const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");
+  const rows = new Map<string, string[]>();
+  for (const line of readme.split("\n")) {
+    if (!line.startsWith("| ") || !line.endsWith(" |")) {
+      continue;
+    }
+    const cells = line
+      .slice(1, -1)
+      .split("|")
+      .map((cell) => cell.trim());
+    if (cells.length === 6 && !cells[0].startsWith("-")) {
+      rows.set(cells[0], cells);
+    }
+  }
+  return rows;
+}
+
+/** The README's own formatting: `1.66s` above a second, `732.5ms` below it. */
+function formatMs(ms: number): string {
+  return ms >= 1000
+    ? `${(ms / 1000).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}s`
+    : `${ms.toLocaleString("en-US", { minimumFractionDigits: 1, maximumFractionDigits: 1 })}ms`;
+}
+
+function expectedRow(
+  surfaces: Surface[],
+  surfaceId: string,
+  label: string,
+  tool: string,
+  baselineId: string,
+  vizeId: string,
+  speedupSuffix = "",
+): string[] {
+  const surface = surfaces.find((candidate) => candidate.id === surfaceId);
+  assert.ok(surface, `snapshot is missing the ${surfaceId} surface`);
+  const variant = (id: string) => {
+    const found = surface.variants.find((candidate) => candidate.id === id);
+    assert.ok(found, `snapshot is missing the ${id} variant`);
+    return found;
+  };
+  return [
+    label,
+    surface.files.toLocaleString("en-US"),
+    tool,
+    formatMs(variant(baselineId).medianMs),
+    formatMs(variant(vizeId).medianMs),
+    `**${surface.primarySpeedup.toFixed(1)}×**${speedupSuffix}`,
+  ];
+}
+
+test("the README Vite and Nuxt rows match the committed benchmark snapshot", () => {
+  const surfaces = readSnapshot();
+  const rows = readReadmeRows();
+
+  assert.deepEqual(
+    [rows.get("Vite build"), rows.get("Nuxt build")],
+    [
+      expectedRow(
+        surfaces,
+        "vite",
+        "Vite build",
+        "@vitejs/plugin-vue",
+        "vite-plugin-vue",
+        "vize-vite-plugin",
+      ),
+      expectedRow(
+        surfaces,
+        "nuxt",
+        "Nuxt build",
+        "Nuxt compiler",
+        "nuxt-default",
+        "vize-nuxt",
+        "†",
+      ),
+    ],
+  );
+});
+
+// The header used to assert "15,000 generated Vue SFCs" for the whole table
+// while the type-check, Vite, and Nuxt rows ran at 500, 1,000, and 500 files.
+// Those are exactly the three rows that look weakest, so the overstatement made
+// them look worse than they are on a corpus they never used.
+test("the README states a per-row corpus size instead of one blanket figure", () => {
+  const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");
+  const benchmarks = readme.slice(readme.indexOf("## Benchmarks"));
+  const heading = benchmarks.slice(0, benchmarks.indexOf("| Surface"));
+
+  assert.equal(
+    /\b15,000 generated Vue SFCs\b/.test(heading),
+    false,
+    "the heading must not claim a single corpus size for rows measured at different sizes",
+  );
+
+  const rows = readReadmeRows();
+  const surfaces = readSnapshot();
+  const filesFor = (id: string) => {
+    const surface = surfaces.find((candidate) => candidate.id === id);
+    assert.ok(surface, `snapshot is missing the ${id} surface`);
+    return surface.files.toLocaleString("en-US");
+  };
+
+  assert.deepEqual(
+    [
+      rows.get("SFC compile")?.[1],
+      rows.get("Lint")?.[1],
+      rows.get("Format")?.[1],
+      rows.get("Type check")?.[1],
+      rows.get("Vite build")?.[1],
+      rows.get("Nuxt build")?.[1],
+    ],
+    [
+      filesFor("compile"),
+      filesFor("lint"),
+      filesFor("fmt"),
+      filesFor("check"),
+      filesFor("vite"),
+      filesFor("nuxt"),
+    ],
+  );
+});


### PR DESCRIPTION
## The defect

The README table and the generated Blacksmith snapshot published **different numbers for the same two surfaces**, both presented as current:

| Surface | `README.md` | `bench/results/tool-benchmark-latest.json` / `performance-blacksmith.md` |
| --- | --- | --- |
| Vite build | `1.70s` / `1.52s` / **1.1×** | `1.66s` / `732.5ms` / **2.3×** (1,000 files) |
| Nuxt build | `6.68s` / `7.35s` / **0.9×** | `6.79s` / `6.42s` / **1.1×** (500 files) |

That is not rounding — they are different runs. A reader got a different answer depending on which page they opened, and the README's version was the pessimistic one on both rows.

Second, separate problem: the README header asserted

> Measured on Blacksmith `blacksmith-32vcpu-ubuntu-2404`, **15,000 generated Vue SFCs**, median of 5 runs

as a blanket claim, but only SFC compile, Lint, and Format run at 15,000. From the snapshot's own `surfaces[].files`: Type check **500**, Vite build **1,000**, Nuxt build **500**. The overstatement applied to exactly the three rows that look weakest.

## The change

- The **Vite build** and **Nuxt build** rows now come from `bench/results/tool-benchmark-latest.json` — the artifact `docs/content/architecture/performance-blacksmith.md` is rendered from — and the table names that run ([29010164013](https://github.com/ubugeeei-prod/vize/actions/runs/29010164013)) rather than leaving one global link that does not apply to them.
- A per-row **Files** column, populated from each surface's own `files` value.
- The Nuxt row carries a **pending regeneration** marker.

**No number in this PR is invented.** Every cell comes from the committed artifact. Where a fresh measurement is needed, the cell is marked rather than estimated.

## The Nuxt row is marked, not replaced

#3409 shows the Nuxt benchmark let `@vizejs/nuxt` inherit a warm persistent pre-compile cache through a `node_modules` symlink shared by every run and both variants — a cache the Nuxt default compiler has no counterpart for. The `1.1×` in the artifact was measured under that harness.

**The correction runs against Vize**: the honest cold-vs-cold figure is *worse* than `1.1×`, not better. The row is therefore footnoted as pending a fresh Blacksmith run once #3409 is on `main`. I have not substituted a local estimate, and the local runs I do have are not comparable — my machine was under heavy competing load throughout.

## Scope

The **type-check row is deliberately untouched** — it is being retracted separately as an invalid cross-engine ratio (`vue-tsc` is the JavaScript TypeScript compiler, `vize check` is native tsgo). The compile/lint/format rows are from run 29004198781 and are not reconciled here; the table now says so instead of implying one provenance for everything.

## Test

`tests/tooling/readme-benchmark-rows.test.ts` — two cases, both `assert.deepEqual` over whole rows so a failure shows the entire expected row:

1. the README's Vite and Nuxt rows equal the rows derived from `bench/results/tool-benchmark-latest.json`, formatted with the same `formatMs` rule the snapshot uses;
2. the header does not assert one corpus size, and every row's Files cell equals that surface's `files` in the artifact.

Both **fail on the pre-fix README**, verified by stashing only `README.md`:

```
✖ the README Vite and Nuxt rows match the committed benchmark snapshot
  actual: [ undefined, undefined ]
  expected: [ [ 'Vite build', '1,000', '@vitejs/plugin-vue', '1.66s', '732.5ms', '**2.3×**' ],
              [ 'Nuxt build', '500', 'Nuxt compiler', '6.79s', '6.42s', '**1.1×**†' ] ]
✖ the README states a per-row corpus size instead of one blanket figure
  actual: true  expected: false
ℹ pass 0  ℹ fail 2
```

and pass after:

```
✔ the README Vite and Nuxt rows match the committed benchmark snapshot
✔ the README states a per-row corpus size instead of one blanket figure
ℹ pass 2  ℹ fail 0
```

The existing `tests/tooling/readme-boundary.test.ts` still passes (2/2), so the README stays within its size and funnel constraints.

## Gates

```
$ nix develop -c vp run fmt:check       # exit 0
$ nix develop -c vp run source:lengths  # exit 0
```
No Rust changed. Should land after #3409.

Refs #3363

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->