### PR TITLE
fix(glyph): emit template-literal directive-value lines verbatim

### DIFF
--- a/crates/vize_glyph/src/template/attributes.rs
+++ b/crates/vize_glyph/src/template/attributes.rs
@@ -262,15 +262,21 @@ fn write_rendered_attribute(
 
     for line in lines {
         output.extend_from_slice(newline);
-        if indent_continuation {
+        let line = line.trim_end_matches('\r');
+        // Every byte between the backticks is part of the string's runtime
+        // value, so a line that *starts* inside a template literal is emitted
+        // exactly as the expression formatter produced it — no attribute
+        // indent in front of it, no leading whitespace stripped off it.
+        //
+        // Rewriting that whitespace was not only a rendered-output change: it
+        // also moved the column at which every embedded `${…}` starts. The
+        // expression formatter measures its line-break budget from that
+        // column, so the next `vize fmt` pass — reading back the re-indented
+        // literal — made a different wrap decision and produced a different
+        // file. (#3379)
+        if indent_continuation && !in_template_literal {
             write_indent(output, indent, continuation_depth);
         }
-        let line = line.trim_end_matches('\r');
-        let line = if indent_continuation && in_template_literal {
-            line.trim_start()
-        } else {
-            line
-        };
         output.extend_from_slice(line.as_bytes());
         in_template_literal = template_literal_state_after_line_from(in_template_literal, line);
     }
@@ -283,68 +289,4 @@ fn write_indent(output: &mut Vec<u8>, indent: &[u8], depth: usize) {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{ParsedAttribute, render_attribute, write_rendered_attribute};
-
-    #[test]
-    fn render_attribute_uses_single_quotes_when_value_contains_double_quotes() {
-        let attr = ParsedAttribute {
-            name: "title".into(),
-            value: Some(r#"say "hello""#.into()),
-            priority: 0,
-            original_index: 0,
-            indent_multiline_value: false,
-        };
-
-        assert_eq!(render_attribute(&attr).as_str(), r#"title='say "hello"'"#);
-    }
-
-    #[test]
-    fn render_attribute_escapes_double_quotes_when_value_contains_both_quote_styles() {
-        let attr = ParsedAttribute {
-            name: "title".into(),
-            value: Some(r#"say "hello" and 'bye'"#.into()),
-            priority: 0,
-            original_index: 0,
-            indent_multiline_value: false,
-        };
-
-        assert_eq!(
-            render_attribute(&attr).as_str(),
-            r#"title="say &quot;hello&quot; and 'bye'""#
-        );
-    }
-
-    #[test]
-    fn write_rendered_attribute_indents_multiline_value_lines() {
-        let mut output = Vec::new();
-        write_rendered_attribute(
-            &mut output,
-            ":class='[\n  active\n]'",
-            b"\n",
-            b"  ",
-            2,
-            true,
-        );
-
-        assert_eq!(
-            String::from_utf8(output).unwrap(),
-            ":class='[\n      active\n    ]'"
-        );
-    }
-
-    #[test]
-    fn write_rendered_attribute_leaves_literal_multiline_values_verbatim() {
-        let mut output = Vec::new();
-        write_rendered_attribute(
-            &mut output,
-            "class=\"\n  active\n\"",
-            b"\n",
-            b"  ",
-            2,
-            false,
-        );
-
-        assert_eq!(String::from_utf8(output).unwrap(), "class=\"\n  active\n\"");
-    }
-}
+mod tests;

--- a/crates/vize_glyph/src/template/attributes/tests.rs
+++ b/crates/vize_glyph/src/template/attributes/tests.rs
@@ -1,0 +1,76 @@
+use super::{ParsedAttribute, render_attribute, write_rendered_attribute};
+
+fn write(attr: &str, continuation_depth: usize, indent_continuation: bool) -> String {
+    let mut output = Vec::new();
+    write_rendered_attribute(
+        &mut output,
+        attr,
+        b"\n",
+        b"  ",
+        continuation_depth,
+        indent_continuation,
+    );
+    String::from_utf8(output).unwrap()
+}
+
+#[test]
+fn render_attribute_uses_single_quotes_when_value_contains_double_quotes() {
+    let attr = ParsedAttribute {
+        name: "title".into(),
+        value: Some(r#"say "hello""#.into()),
+        priority: 0,
+        original_index: 0,
+        indent_multiline_value: false,
+    };
+
+    assert_eq!(render_attribute(&attr).as_str(), r#"title='say "hello"'"#);
+}
+
+#[test]
+fn render_attribute_escapes_double_quotes_when_value_contains_both_quote_styles() {
+    let attr = ParsedAttribute {
+        name: "title".into(),
+        value: Some(r#"say "hello" and 'bye'"#.into()),
+        priority: 0,
+        original_index: 0,
+        indent_multiline_value: false,
+    };
+
+    assert_eq!(
+        render_attribute(&attr).as_str(),
+        r#"title="say &quot;hello&quot; and 'bye'""#
+    );
+}
+
+#[test]
+fn write_rendered_attribute_indents_multiline_value_lines() {
+    assert_eq!(
+        write(":class='[\n  active\n]'", 2, true),
+        ":class='[\n      active\n    ]'"
+    );
+}
+
+#[test]
+fn write_rendered_attribute_leaves_literal_multiline_values_verbatim() {
+    assert_eq!(
+        write("class=\"\n  active\n\"", 2, false),
+        "class=\"\n  active\n\""
+    );
+}
+
+#[test]
+fn write_rendered_attribute_leaves_template_literal_lines_verbatim() {
+    // The `  w-full` line begins inside the literal, so its leading spaces are
+    // part of the string's runtime value: no attribute indent may go in front
+    // of them and none of them may be stripped. The line closing the literal
+    // begins inside it too, so its indentation is string content as well.
+    // Only the `]'` line, which begins outside, is re-anchored. (#3379)
+    assert_eq!(
+        write(":class='[`\n  w-full\n`]'", 2, true),
+        ":class='[`\n  w-full\n`]'"
+    );
+    assert_eq!(
+        write(":class='[`\n  w-full\n  `,\n  x]'", 2, true),
+        ":class='[`\n  w-full\n  `,\n      x]'"
+    );
+}

--- a/crates/vize_glyph/tests/sfc_template_literal_attribute_idempotence.rs
+++ b/crates/vize_glyph/tests/sfc_template_literal_attribute_idempotence.rs
@@ -1,0 +1,155 @@
+//! A multi-line template literal in a directive value must survive `vize fmt`
+//! byte-for-byte.
+//!
+//! Every byte between the backticks is part of the string's runtime value. The
+//! attribute writer used to strip the leading whitespace off those lines and
+//! re-indent them to the attribute's depth, which changed the rendered string
+//! *and* moved the column at which every embedded `${…}` starts. The expression
+//! formatter measures its line-break budget from that column, so the next pass
+//! read back a differently-indented literal and made a different wrap decision:
+//! `fmt(fmt(x)) != fmt(x)`. (#3379)
+
+use vize_glyph::{FormatOptions, format_sfc};
+
+/// Format `source` three times: pass 1 must equal `expected`, and passes 2 and
+/// 3 must reproduce it byte-for-byte.
+#[track_caller]
+fn assert_stable(source: &str, expected: &str) {
+    let options = FormatOptions::default();
+    let first = format_sfc(source, &options).unwrap();
+    assert_eq!(first.code.as_str(), expected, "pass 1 output");
+    let second = format_sfc(&first.code, &options).unwrap();
+    assert_eq!(second.code, first.code, "fmt; fmt must be a no-op");
+    let third = format_sfc(&second.code, &options).unwrap();
+    assert_eq!(third.code, second.code, "fmt must stay at its fixed point");
+}
+
+#[test]
+fn an_and_chain_in_a_ternary_arm_inside_a_template_literal_is_stable() {
+    // Minimized from vue-data-ui's `vue-ui-flow.vue`, the file this issue
+    // pinned. The literal's own indentation is deep enough that the `&&` chain
+    // does not fit on one line; flattening the quasi lines moved `${` sixteen
+    // columns left, so pass 2 joined what pass 1 had split.
+    let source = r#"<template>
+  <path
+    :style="`
+                        opacity:${
+                            selectedNodes
+                                ? selectedNodes.includes(path.source) &&
+                                  selectedNodes.includes(path.target)
+                                    ? 1
+                                    : 0.3
+                                : 1
+                        }
+                    `"
+  />
+</template>
+"#;
+    assert_stable(
+        source,
+        r#"<template>
+  <path
+    :style="`
+                        opacity:${
+                          selectedNodes
+                            ? selectedNodes.includes(path.source) &&
+                              selectedNodes.includes(path.target)
+                              ? 1
+                              : 0.3
+                            : 1
+                        }
+                    `"
+  />
+</template>
+"#,
+    );
+}
+
+#[test]
+fn a_ternary_nested_in_a_ternary_inside_a_template_literal_is_stable() {
+    let source = r#"<template>
+  <i
+    :class="`
+            a-${
+                x ? (y ? 1 : 2) : (z ? 3 : 4)
+            }-b
+        `"
+  />
+</template>
+"#;
+    assert_stable(
+        source,
+        r#"<template>
+  <i
+    :class="`
+            a-${x ? (y ? 1 : 2) : z ? 3 : 4}-b
+        `"
+  />
+</template>
+"#,
+    );
+}
+
+#[test]
+fn an_or_chain_in_a_ternary_test_inside_a_template_literal_is_stable() {
+    let source = r#"<template>
+  <i
+    :style="`
+            opacity:${
+                aVeryLongConditionName || anotherVeryLongConditionName || aThirdOne ? 1 : 0
+            }
+        `"
+  />
+</template>
+"#;
+    assert_stable(
+        source,
+        r#"<template>
+  <i
+    :style="`
+            opacity:${aVeryLongConditionName || anotherVeryLongConditionName || aThirdOne ? 1 : 0}
+        `"
+  />
+</template>
+"#,
+    );
+}
+
+#[test]
+fn a_template_literal_without_substitutions_keeps_its_content() {
+    // No `${…}` to re-measure here — this is the plain rendered-output half of
+    // the same defect: the class list is a string, and its indentation used to
+    // be rewritten.
+    let source = r#"<template>
+  <i
+    :class="`
+        w-full
+        px5
+    `"
+  />
+</template>
+"#;
+    assert_stable(source, source);
+}
+
+#[test]
+fn template_literals_in_both_ternary_arms_keep_their_content() {
+    // The #1965 fixture, which the flattening was originally added for. It is
+    // idempotent either way; what changes is that the emitted class strings are
+    // now the ones the source wrote.
+    let source = r#"<template>
+  <NuxtLink
+    :class="isSmallScreen
+      ? `
+        w-full
+        px5 sm:mxa
+      `
+      : `
+        w-fit rounded-3
+        px2 mx3 sm:mxa
+      `"
+  />
+</template>
+"#;
+    assert_stable(source, source);
+}

--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -1,11 +1,5 @@
 [
   {
-    "property": "idempotence",
-    "project": "vue-data-ui",
-    "path": "src/components/vue-ui-flow.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3379"
-  },
-  {
     "property": "parse-preservation",
     "project": "crater",
     "path": "resources/scripts/components/base/BaseModal.vue",


### PR DESCRIPTION
The second of the two idempotence drifts that survived #3368, and the last one. #3398 fixed
the `scalar` shape (`v-pre` missing from the SFC raw-line mask); this is the independent
`vue-data-ui` shape — a template literal in a directive value.

## Defect

`format_js_expression` hands back the formatted value with the template literal's quasi text
intact: prettier/oxfmt never reindents a template literal, because every byte between the
backticks is part of the string's runtime value. `write_rendered_attribute` then undid that
— for a line beginning inside a literal it wrote the attribute indent and `trim_start()`ed
the line.

Two consequences:

1. The emitted string changed. A `:style="\`…\`"` that builds CSS came out with different
   leading whitespace than the author wrote.
2. It moved the column at which every embedded `${…}` starts. In the pinned file that shift
   was 16 columns. The expression formatter measures its line-break budget from that column,
   so pass 2 — reading back the flattened literal — had room the first pass did not and
   joined a line the first pass had split. `fmt(fmt(x)) != fmt(x)`.

## Minimal reproduction

```vue
<template>
  <path
    :style="`
                        opacity:${
                            selectedNodes
                                ? selectedNodes.includes(path.source) &&
                                  selectedNodes.includes(path.target)
                                    ? 1
                                    : 0.3
                                : 1
                        }
                    `"
  />
</template>
```

`vize fmt --write --no-config` twice, `--profile ci --features legacy`:

```diff
     :style="`
   opacity:${
   selectedNodes
-  ? selectedNodes.includes(path.source) &&
-  selectedNodes.includes(path.target)
+  ? selectedNodes.includes(path.source) && selectedNodes.includes(path.target)
   ? 1
   : 0.3
```

Note what pass 1 alone already did to the literal: `opacity:` moved from column 24 to
column 2, so the CSS the component renders is not the CSS the file declares.

The same two-pass run on the pinned corpus file `vue-data-ui src/components/vue-ui-flow.vue`
(revision `3b7d82352cf7d0cf1f74557e2a5aaeb6b658c810`, the registry pin) produced exactly the
diff quoted in #3379:

```diff
-        ? selectedNodes.includes(path.source) &&
-        selectedNodes.includes(path.target)
+        ? selectedNodes.includes(path.source) && selectedNodes.includes(path.target)
```

**Expected:** the quasi text is preserved and pass 2 is a no-op.
**Actual:** the quasi text is flattened, and the wrap decision inside `${…}` flips on the
second run.

## Fix

A continuation line that *begins* inside a template literal is emitted exactly as the
expression formatter produced it: no attribute indent in front of it, no leading whitespace
stripped off it. Lines that begin outside one are re-anchored as before.

`compute_raw_line_mask` already marks those lines raw, so the SFC template-block indent step
does not add a level on top — the two layers now agree. After the fix the minimal repro
formats to:

```
    :style="`
                        opacity:${
                          selectedNodes
                            ? selectedNodes.includes(path.source) &&
                              selectedNodes.includes(path.target)
                              ? 1
                              : 0.3
                            : 1
                        }
                    `"
```

— the literal's own bytes untouched, the substitution formatted, and a fixed point.

## How the tests fail before the fix

Reverting only `crates/vize_glyph/src/template/attributes.rs`, keeping the new test file:

```
$ cargo test -p vize_glyph --profile ci --no-fail-fast \
    --test sfc_template_literal_attribute_idempotence
test template_literals_in_both_ternary_arms_keep_their_content ... FAILED
test a_template_literal_without_substitutions_keeps_its_content ... FAILED
test a_ternary_nested_in_a_ternary_inside_a_template_literal_is_stable ... FAILED
test an_or_chain_in_a_ternary_test_inside_a_template_literal_is_stable ... FAILED
test an_and_chain_in_a_ternary_arm_inside_a_template_literal_is_stable ... FAILED
assertion `left == right` failed: pass 1 output
test result: FAILED. 0 passed; 5 failed
```

Every assertion compares the full formatted file; `assert_stable` asserts pass 1 against the
complete expected output and then that passes 2 and 3 reproduce it byte-for-byte. The
neighborhood cases #3379 asked for are covered: an `&&` chain in a ternary arm, an `||`
chain in a ternary test, a ternary nested in a ternary, a literal with no substitution at
all, and the two-literal `:class` shape from #1965 (which stays idempotent — what changes is
that it now emits the class strings the source wrote).

`write_rendered_attribute`'s own unit tests gain the verbatim case directly, including the
mixed shape where one continuation line is inside the literal and the next is not.

## Ledger

`vue-data-ui`'s entry is removed from `tests/_fixtures/glyph-corpus-known-violations.json`.
With #3398 already merged, that leaves **zero `idempotence` suppressions**, and both files
#3379 pinned are verified idempotent on this branch:

```
$ vize fmt --write --no-config <file>   # twice, diff pass1 vs pass2
IDEMPOTENT: vue-data-ui/src/components/vue-ui-flow.vue
IDEMPOTENT: scalar/projects/scalar-app/src/features/collection/components/Environment.vue
```

(both fetched at the revisions `tests/_fixtures/vue-ecosystem-fixtures.json` pins.)

## Note on file length

`attributes.rs` would have crossed the 350-line budget, so its `mod tests` moves to
`attributes/tests.rs` — a mechanical move plus the new cases. `attributes.rs` is 292 lines.

## Verification

```
cargo test --profile ci -p vize_glyph -p vize            # green
node --test tests/tooling/glyph-corpus-idempotence.test.ts \
            tests/tooling/glyph-corpus-parse-preservation.test.ts   # 6 pass
two-pass sweep over all 168 .vue files in the repo       # 0 non-idempotent
cargo fmt --all -- --check                               # clean
vp run lint:rust                                         # clippy -D warnings, clean
vp run check:rust                                        # clean
vp run source:lengths                                    # attributes.rs 292
```

Closes #3379

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->