### PR TITLE
fix(ci): normalize only the conventional scope in issue and PR titles

### DIFF
--- a/tests/tooling/issue-pr-title-policy-scope.test.ts
+++ b/tests/tooling/issue-pr-title-policy-scope.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { assignCall, patchTitleCall, runPolicy } from "./support/title-policy.ts";
+
+const prNumber = 101;
+const issueNumber = 202;
+
+function prPayload(title: string, action = "edited") {
+  return {
+    action,
+    pull_request: { number: prNumber, title, assignees: [{ login: "ubugeeei" }] },
+  };
+}
+
+function issuePayload(
+  title: string,
+  action = "edited",
+  assignees: unknown[] = [{ login: "ubugeeei" }],
+) {
+  return { action, issue: { number: issueNumber, title, assignees } };
+}
+
+function runPr(title: string, action?: string) {
+  return runPolicy(prPayload(title, action), "pull_request_target");
+}
+
+// Every mapping in `title_replacement`, exercised in scope position. This is the
+// only position the tool is allowed to rewrite.
+const scopeRewrites: ReadonlyArray<readonly [string, string]> = [
+  ["fix(check): skip type-check on hidden files", "fix(canon): skip type-check on hidden files"],
+  ["fix(compiler): recover Vue compiler quirks", "fix(atelier): recover Vue compiler quirks"],
+  ["perf(lint): stream quiet lint aggregation", "perf(patina): stream quiet lint aggregation"],
+  ["perf(linter): stream quiet lint aggregation", "perf(patina): stream quiet lint aggregation"],
+  ["test(story): add a story for the button", "test(musea): add a story for the button"],
+  ["fix(format): format the output", "fix(glyph): format the output"],
+  ["fix(fmt): keep fmt idempotent", "fix(glyph): keep fmt idempotent"],
+  // Multi-segment scope: `/` is the only segment separator (see normalize_scope).
+  ["fix(check/lint): share the resolver", "fix(canon/patina): share the resolver"],
+  ["fix(check/cli/fmt): share the resolver", "fix(canon/cli/glyph): share the resolver"],
+  // The breaking-change marker sits outside the scope and must survive.
+  ["feat(check)!: drop the legacy flag", "feat(canon)!: drop the legacy flag"],
+];
+
+test("rewrites area names in the conventional scope and nowhere else", () => {
+  for (const [title, expected] of scopeRewrites) {
+    const { result, ghCalls } = runPr(title);
+    assert.equal(result.status, 0, `${title}\n${result.stderr}`);
+    assert.deepEqual(ghCalls, [patchTitleCall(prNumber, expected)], title);
+  }
+});
+
+// Titles whose subject prose (or scope) merely *mentions* an area word. None of
+// these may produce an API call at all: the title is already correct English.
+const untouchedPrTitles = [
+  // The live regression: PR #3394 was renamed to "rank type-canon engine classes".
+  "bench(tools): rank type-check engine classes separately",
+  // Landed on main as "fix(cli): canon sources under ..." — not English.
+  "fix(cli): check sources under an explicitly included hidden directory",
+  // Landed on main as "vize canon benchmark gate" — mangled a real command name.
+  "ci(bench): fail-closed vize check benchmark gate with reproducibility metadata",
+  "perf(cli): stream quiet lint aggregation",
+  "fix(parser): recover Vue compiler quirks",
+  "test(sfc): add Vue Router compiler oracle",
+  "fix(cli): preserve failed compiler artifacts",
+  // No scope at all: nothing is eligible for rewriting.
+  "docs: format the output",
+  "chore: check the story fixtures",
+  // Area name as a substring of a longer scope: must not become `canoner`.
+  "fix(checker): tighten diagnostics",
+  "fix(formatter): tighten diagnostics",
+  // `-`, `.` and `_` are scope characters but not segment separators, so a
+  // compound scope is matched whole and therefore left alone.
+  "fix(type-check): tighten diagnostics",
+  "fix(check.js): tighten diagnostics",
+  "fix(check_js): tighten diagnostics",
+];
+
+test("leaves subject prose and non-matching scopes untouched", () => {
+  for (const title of untouchedPrTitles) {
+    const { result, ghCalls } = runPr(title);
+    assert.equal(result.status, 0, `${title}\n${result.stderr}`);
+    assert.deepEqual(ghCalls, [], title);
+  }
+});
+
+test("an uppercase scope is not a conventional scope, so it is rejected unchanged", () => {
+  // `is_scope_char` is lowercase-only, so `fix(Check): ...` has no conventional
+  // prefix: nothing is rewritten and the PR gate fails. Pinned deliberately —
+  // silently lower-casing a title the author typed is the same class of bug.
+  const { result, ghCalls } = runPr("fix(Check): resolve alias imports");
+  assert.equal(result.status, 1);
+  assert.deepEqual(ghCalls, []);
+});
+
+test("issue titles are normalized by scope only, never in prose", () => {
+  const { result, ghCalls } = runPolicy(
+    issuePayload("check compiler lint linter story format fmt checklist formatting"),
+    "issues",
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(ghCalls, []);
+});
+
+test("issue titles with a conventional scope are still normalized", () => {
+  const { result, ghCalls } = runPolicy(
+    issuePayload("fix(fmt): formatting drifts on every second run", "opened", []),
+    "issues",
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(ghCalls, [
+    patchTitleCall(issueNumber, "fix(glyph): formatting drifts on every second run"),
+    assignCall(issueNumber),
+  ]);
+});
+
+test("a non-conventional PR title still fails without any rewrite", () => {
+  const { result, ghCalls } = runPr("fix lint issue");
+  assert.equal(result.status, 1);
+  assert.equal(
+    result.stdout,
+    "::error title=Invalid PR title::Use Conventional Commits format: type(scope): summary\n",
+  );
+  assert.deepEqual(ghCalls, []);
+});

--- a/tests/tooling/issue-pr-title-policy.test.ts
+++ b/tests/tooling/issue-pr-title-policy.test.ts
@@ -1,63 +1,15 @@
 import assert from "node:assert/strict";
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { test } from "node:test";
 
-import { root } from "./support/github-workflows.ts";
-import { runMoonScript } from "./_helpers/moonbit.ts";
+import { assignCall, patchTitleCall, runPolicy } from "./support/title-policy.ts";
 
-function runPolicy(payload: unknown, eventName: string) {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-title-policy-"));
-  const binDir = path.join(tempDir, "bin");
-  const eventPath = path.join(tempDir, "event.json");
-  const ghLogPath = path.join(tempDir, "gh.log");
-  const fakeGhPath = path.join(binDir, "gh");
-
-  fs.mkdirSync(binDir);
-  fs.writeFileSync(eventPath, JSON.stringify(payload));
-  fs.writeFileSync(
-    fakeGhPath,
-    [
-      "#!/usr/bin/env node",
-      'const fs = require("node:fs");',
-      "fs.appendFileSync(process.env.FAKE_GH_LOG, JSON.stringify(process.argv.slice(2)) + '\\n');",
-    ].join("\n"),
-  );
-  fs.chmodSync(fakeGhPath, 0o755);
-
-  const result = runMoonScript("github/issue_pr_title_policy", [], {
-    cwd: root,
-    env: {
-      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
-      FAKE_GH_LOG: ghLogPath,
-      GITHUB_EVENT_NAME: eventName,
-      GITHUB_EVENT_PATH: eventPath,
-      GITHUB_REPOSITORY: "ubugeeei/vize",
-    },
-  });
-
-  const ghCalls = fs.existsSync(ghLogPath)
-    ? fs
-        .readFileSync(ghLogPath, "utf8")
-        .trim()
-        .split("\n")
-        .filter(Boolean)
-        .map((line) => JSON.parse(line) as string[])
-    : [];
-
-  fs.rmSync(tempDir, { recursive: true, force: true });
-
-  return { result, ghCalls };
-}
-
-test("issue title policy normalizes titles and assigns new issues", () => {
+test("issue title policy normalizes the scope and assigns new issues", () => {
   const { result, ghCalls } = runPolicy(
     {
       action: "opened",
       issue: {
         number: 12,
-        title: "check compiler lint linter story format fmt checklist formatting",
+        title: "fix(check): checklist formatting is inconsistent",
         assignees: [],
       },
     },
@@ -66,29 +18,22 @@ test("issue title policy normalizes titles and assigns new issues", () => {
 
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(ghCalls, [
-    [
-      "api",
-      "--method",
-      "PATCH",
-      "-H",
-      "X-GitHub-Api-Version: 2022-11-28",
-      "--silent",
-      "/repos/ubugeeei/vize/issues/12",
-      "-f",
-      "title=canon atelier patina patina musea glyph glyph checklist formatting",
-    ],
-    [
-      "api",
-      "--method",
-      "POST",
-      "-H",
-      "X-GitHub-Api-Version: 2022-11-28",
-      "--silent",
-      "/repos/ubugeeei/vize/issues/12/assignees",
-      "-F",
-      "assignees[]=ubugeeei",
-    ],
+    patchTitleCall(12, "fix(canon): checklist formatting is inconsistent"),
+    assignCall(12),
   ]);
+});
+
+test("issue title policy assigns new issues without rewriting an already-correct title", () => {
+  const { result, ghCalls } = runPolicy(
+    {
+      action: "opened",
+      issue: { number: 23, title: "docs: check the formatting guide", assignees: [] },
+    },
+    "issues",
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(ghCalls, [assignCall(23)]);
 });
 
 test("PR title policy normalizes conventional titles before validation", () => {
@@ -97,7 +42,7 @@ test("PR title policy normalizes conventional titles before validation", () => {
       action: "opened",
       pull_request: {
         number: 34,
-        title: "check: update lint rules",
+        title: "fix(check): update lint rules",
         assignees: [{ login: "ubugeeei" }],
       },
     },
@@ -105,58 +50,23 @@ test("PR title policy normalizes conventional titles before validation", () => {
   );
 
   assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(ghCalls, [
-    [
-      "api",
-      "--method",
-      "PATCH",
-      "-H",
-      "X-GitHub-Api-Version: 2022-11-28",
-      "--silent",
-      "/repos/ubugeeei/vize/issues/34",
-      "-f",
-      "title=canon: update patina rules",
-    ],
-  ]);
+  assert.deepEqual(ghCalls, [patchTitleCall(34, "fix(canon): update lint rules")]);
 });
 
 test("PR title policy fails non-conventional titles after normalization", () => {
   const { result, ghCalls } = runPolicy(
     {
       action: "opened",
-      pull_request: {
-        number: 56,
-        title: "fix lint issue",
-        assignees: [],
-      },
+      pull_request: { number: 56, title: "fix lint issue", assignees: [] },
     },
     "pull_request_target",
   );
 
   assert.equal(result.status, 1);
-  assert.match(result.stdout, /Invalid PR title/);
-  assert.deepEqual(ghCalls, [
-    [
-      "api",
-      "--method",
-      "PATCH",
-      "-H",
-      "X-GitHub-Api-Version: 2022-11-28",
-      "--silent",
-      "/repos/ubugeeei/vize/issues/56",
-      "-f",
-      "title=fix patina issue",
-    ],
-    [
-      "api",
-      "--method",
-      "POST",
-      "-H",
-      "X-GitHub-Api-Version: 2022-11-28",
-      "--silent",
-      "/repos/ubugeeei/vize/issues/56/assignees",
-      "-F",
-      "assignees[]=ubugeeei",
-    ],
-  ]);
+  assert.equal(
+    result.stdout,
+    "Assigned pull_request #56 to ubugeeei\n" +
+      "::error title=Invalid PR title::Use Conventional Commits format: type(scope): summary\n",
+  );
+  assert.deepEqual(ghCalls, [assignCall(56)]);
 });

--- a/tests/tooling/support/title-policy.ts
+++ b/tests/tooling/support/title-policy.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { repoRoot, runMoonScript } from "../_helpers/moonbit.ts";
+import { writeFakeCommand } from "./fake-command.ts";
+
+export const repository = "ubugeeei/vize";
+
+export type PolicyRun = {
+  result: ReturnType<typeof runMoonScript>;
+  ghCalls: string[][];
+};
+
+/**
+ * Runs the `issue_pr_title_policy` MoonBit command against a real event payload
+ * with `gh` stubbed out. The stub records the exact argv of every invocation so
+ * tests can assert the complete API call list, including "no call at all".
+ */
+export function runPolicy(payload: unknown, eventName: string): PolicyRun {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-title-policy-"));
+  const binDir = path.join(tempDir, "bin");
+  const eventPath = path.join(tempDir, "event.json");
+  const ghLogPath = path.join(tempDir, "gh.log");
+
+  fs.mkdirSync(binDir);
+  fs.writeFileSync(eventPath, JSON.stringify(payload));
+  writeFakeCommand(
+    binDir,
+    "gh",
+    [
+      "const fs = require('node:fs');",
+      "fs.appendFileSync(process.env.FAKE_GH_LOG, JSON.stringify(process.argv.slice(2)) + '\\n');",
+    ].join("\n"),
+  );
+
+  const result = runMoonScript("github/issue_pr_title_policy", [], {
+    cwd: repoRoot,
+    env: {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      FAKE_GH_LOG: ghLogPath,
+      GITHUB_EVENT_NAME: eventName,
+      GITHUB_EVENT_PATH: eventPath,
+      GITHUB_REPOSITORY: repository,
+    },
+  });
+
+  const ghCalls = fs.existsSync(ghLogPath)
+    ? fs
+        .readFileSync(ghLogPath, "utf8")
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as string[])
+    : [];
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+
+  return { result, ghCalls };
+}
+
+/** The exact argv the tool uses to rewrite a title. */
+export function patchTitleCall(issueNumber: number, title: string): string[] {
+  return [
+    "api",
+    "--method",
+    "PATCH",
+    "-H",
+    "X-GitHub-Api-Version: 2022-11-28",
+    "--silent",
+    `/repos/${repository}/issues/${issueNumber}`,
+    "-f",
+    `title=${title}`,
+  ];
+}
+
+/** The exact argv the tool uses to assign the default maintainer. */
+export function assignCall(issueNumber: number): string[] {
+  return [
+    "api",
+    "--method",
+    "POST",
+    "-H",
+    "X-GitHub-Api-Version: 2022-11-28",
+    "--silent",
+    `/repos/${repository}/issues/${issueNumber}/assignees`,
+    "-F",
+    "assignees[]=ubugeeei",
+  ];
+}

--- a/tools/moon/cmd/github/issue_pr_title_policy/main.mbt
+++ b/tools/moon/cmd/github/issue_pr_title_policy/main.mbt
@@ -1,8 +1,9 @@
 /// Enforces repository issue and pull request title metadata policy.
 /// The workflow runs this from trusted base-branch code. It reads the GitHub
-/// event payload, normalizes repository area names in issue / PR titles,
-/// assigns opened and reopened issues / PRs to the maintainer, and exits
-/// non-zero when a normalized PR title is not Conventional Commits-shaped.
+/// event payload, normalizes repository area names in the Conventional Commits
+/// scope of issue / PR titles, assigns opened and reopened issues / PRs to the
+/// maintainer, and exits non-zero when a normalized PR title is not
+/// Conventional Commits-shaped. Subject prose is never rewritten.
 
 let default_assignee = "ubugeeei"
 
@@ -11,126 +12,6 @@ struct PolicySubject {
   number : String
   title : String
   assignees : Json?
-}
-
-fn is_word_char(code : UInt16) -> Bool {
-  (code >= 65 && code <= 90) || (code >= 97 && code <= 122) ||
-  (code >= 48 && code <= 57) || code == 95
-}
-
-fn is_lower_ascii(code : UInt16) -> Bool {
-  code >= 97 && code <= 122
-}
-
-fn is_digit(code : UInt16) -> Bool {
-  code >= 48 && code <= 57
-}
-
-fn is_type_char(code : UInt16) -> Bool {
-  is_lower_ascii(code) || is_digit(code) || code == 45
-}
-
-fn is_scope_char(code : UInt16) -> Bool {
-  is_lower_ascii(code) || is_digit(code) || code == 45 || code == 46 ||
-  code == 47 || code == 95
-}
-
-fn title_replacement(word : String) -> String? {
-  match word.to_lower() {
-    "check" => Some("canon")
-    "compiler" => Some("atelier")
-    "lint" => Some("patina")
-    "linter" => Some("patina")
-    "story" => Some("musea")
-    "format" => Some("glyph")
-    "fmt" => Some("glyph")
-    _ => None
-  }
-}
-
-fn normalize_title(title : String) -> String {
-  let parts : Array[String] = []
-  let mut i = 0
-  while i < title.length() {
-    let start = i
-    let word = is_word_char(title[i])
-    while i < title.length() && is_word_char(title[i]) == word {
-      i = i + 1
-    }
-    let part = title[start:i].to_owned()
-    if word {
-      match title_replacement(part) {
-        Some(replacement) => parts.push(replacement)
-        None => parts.push(part)
-      }
-    } else {
-      parts.push(part)
-    }
-  }
-  parts.join("")
-}
-
-fn has_newline(value : String) -> Bool {
-  for i in 0..<value.length() {
-    if value[i] == 10 || value[i] == 13 {
-      return true
-    }
-  }
-  false
-}
-
-fn colon_space_index(value : String) -> Int? {
-  let mut i = 0
-  while i + 1 < value.length() {
-    if value[i] == 58 && value[i + 1] == 32 {
-      return Some(i)
-    }
-    i = i + 1
-  }
-  None
-}
-
-fn is_conventional_prefix(prefix : String) -> Bool {
-  if prefix.length() == 0 || !is_lower_ascii(prefix[0]) {
-    return false
-  }
-
-  let mut i = 1
-  while i < prefix.length() && is_type_char(prefix[i]) {
-    i = i + 1
-  }
-
-  if i < prefix.length() && prefix[i] == 40 {
-    i = i + 1
-    let scope_start = i
-    while i < prefix.length() && is_scope_char(prefix[i]) {
-      i = i + 1
-    }
-    if i == scope_start || i >= prefix.length() || prefix[i] != 41 {
-      return false
-    }
-    i = i + 1
-  }
-
-  if i < prefix.length() && prefix[i] == 33 {
-    i = i + 1
-  }
-
-  i == prefix.length()
-}
-
-fn is_conventional_title(title : String) -> Bool {
-  if title == "" || has_newline(title) {
-    return false
-  }
-  let separator = match colon_space_index(title) {
-    Some(index) => index
-    None => return false
-  }
-  if separator + 2 >= title.length() || title[separator + 2] == 32 {
-    return false
-  }
-  is_conventional_prefix(title[0:separator].to_owned())
 }
 
 fn has_assignee(assignees : Json?) -> Bool {

--- a/tools/moon/cmd/github/issue_pr_title_policy/title.mbt
+++ b/tools/moon/cmd/github/issue_pr_title_policy/title.mbt
@@ -1,0 +1,183 @@
+/// Conventional Commits title parsing and area-name normalization.
+///
+/// Split out of `main.mbt` so the title grammar lives apart from the GitHub
+/// event / API plumbing. All character predicates work on UTF-16 code units,
+/// which is what `String` indexing yields.
+
+fn is_lower_ascii(code : UInt16) -> Bool {
+  code >= 97 && code <= 122
+}
+
+fn is_digit(code : UInt16) -> Bool {
+  code >= 48 && code <= 57
+}
+
+fn is_type_char(code : UInt16) -> Bool {
+  is_lower_ascii(code) || is_digit(code) || code == 45
+}
+
+fn is_scope_char(code : UInt16) -> Bool {
+  is_lower_ascii(code) || is_digit(code) || code == 45 || code == 46 ||
+  code == 47 || code == 95
+}
+
+/// Maps a colloquial area name to its internal Vize name. The argument is one
+/// whole scope segment, never a fragment of one. `is_scope_char` rejects
+/// uppercase, so a scope reaching here is already lower case; `to_lower` only
+/// keeps the table total for any future caller.
+fn title_replacement(word : String) -> String? {
+  match word.to_lower() {
+    "check" => Some("canon")
+    "compiler" => Some("atelier")
+    "lint" => Some("patina")
+    "linter" => Some("patina")
+    "story" => Some("musea")
+    "format" => Some("glyph")
+    "fmt" => Some("glyph")
+    _ => None
+  }
+}
+
+/// Rewrites each area name inside a Conventional Commits scope.
+///
+/// Segment rule: `/` is the ONLY segment separator, so `check/lint` normalizes
+/// to `canon/patina`. The other characters `is_scope_char` allows (`-`, `.`,
+/// `_`, digits) build compound scope names such as `type-check`, `check.js`, or
+/// `vue_compiler`; splitting on them would rewrite a fragment of a name that
+/// means something else as a whole. A segment therefore only changes when the
+/// entire segment is a known area name -- `checker` stays `checker`.
+fn normalize_scope(scope : String) -> String {
+  let segments : Array[String] = []
+  let mut start = 0
+  let mut i = 0
+  while i <= scope.length() {
+    if i == scope.length() || scope[i] == 47 {
+      let segment = scope[start:i].to_owned()
+      match title_replacement(segment) {
+        Some(replacement) => segments.push(replacement)
+        None => segments.push(segment)
+      }
+      start = i + 1
+    }
+    i = i + 1
+  }
+  segments.join("/")
+}
+
+/// Returns the half-open `[start, end)` range of the scope text inside a
+/// Conventional Commits prefix, or `None` when the prefix carries no scope.
+/// Only called on a prefix `is_conventional_prefix` already accepted, so the
+/// parentheses are known to be balanced and to enclose at least one character.
+fn scope_bounds(prefix : String) -> (Int, Int)? {
+  let mut open = 0
+  while open < prefix.length() && prefix[open] != 40 {
+    open = open + 1
+  }
+  if open >= prefix.length() {
+    return None
+  }
+  let mut close = open + 1
+  while close < prefix.length() && prefix[close] != 41 {
+    close = close + 1
+  }
+  if close >= prefix.length() {
+    return None
+  }
+  Some((open + 1, close))
+}
+
+/// Normalizes ONLY the scope of a `type(scope): subject` title.
+///
+/// The type, the `!` breaking marker, and the whole subject are left exactly as
+/// the author wrote them. Area words such as `check`, `format`, `story`, and
+/// `compiler` are ordinary English in a subject line ("rank type-check engine
+/// classes", "check sources under a hidden directory", "format the output"), so
+/// rewriting them there corrupts the title -- and, because the repository
+/// squash-merges with the PR title as the commit headline, corrupts permanent
+/// history and the generated changelog. A title without a conventional prefix
+/// carrying a scope is returned untouched.
+fn normalize_title(title : String) -> String {
+  let separator = match colon_space_index(title) {
+    Some(index) => index
+    None => return title
+  }
+  let prefix = title[0:separator].to_owned()
+  if !is_conventional_prefix(prefix) {
+    return title
+  }
+  let (scope_start, scope_end) = match scope_bounds(prefix) {
+    Some(bounds) => bounds
+    None => return title
+  }
+  let scope = prefix[scope_start:scope_end].to_owned()
+  let normalized_scope = normalize_scope(scope)
+  if normalized_scope == scope {
+    return title
+  }
+  let head = title[0:scope_start].to_owned()
+  let tail = title[scope_end:].to_owned()
+  "\{head}\{normalized_scope}\{tail}"
+}
+
+fn has_newline(value : String) -> Bool {
+  for i in 0..<value.length() {
+    if value[i] == 10 || value[i] == 13 {
+      return true
+    }
+  }
+  false
+}
+
+fn colon_space_index(value : String) -> Int? {
+  let mut i = 0
+  while i + 1 < value.length() {
+    if value[i] == 58 && value[i + 1] == 32 {
+      return Some(i)
+    }
+    i = i + 1
+  }
+  None
+}
+
+fn is_conventional_prefix(prefix : String) -> Bool {
+  if prefix.length() == 0 || !is_lower_ascii(prefix[0]) {
+    return false
+  }
+
+  let mut i = 1
+  while i < prefix.length() && is_type_char(prefix[i]) {
+    i = i + 1
+  }
+
+  if i < prefix.length() && prefix[i] == 40 {
+    i = i + 1
+    let scope_start = i
+    while i < prefix.length() && is_scope_char(prefix[i]) {
+      i = i + 1
+    }
+    if i == scope_start || i >= prefix.length() || prefix[i] != 41 {
+      return false
+    }
+    i = i + 1
+  }
+
+  if i < prefix.length() && prefix[i] == 33 {
+    i = i + 1
+  }
+
+  i == prefix.length()
+}
+
+fn is_conventional_title(title : String) -> Bool {
+  if title == "" || has_newline(title) {
+    return false
+  }
+  let separator = match colon_space_index(title) {
+    Some(index) => index
+    None => return false
+  }
+  if separator + 2 >= title.length() || title[separator + 2] == 32 {
+    return false
+  }
+  is_conventional_prefix(title[0:separator].to_owned())
+}


### PR DESCRIPTION
Closes #3419

## Defect

`tools/moon/cmd/github/issue_pr_title_policy` rewrites area names **anywhere in a title**, not just
in the Conventional Commits scope. `normalize_title` tokenized the whole title into word / non-word
runs and applied the `title_replacement` table to every word. `-` is not a word character, so
`type-check` tokenized as `type`, `-`, `check` and the `check` was rewritten.

The repository squash-merges with the PR title as the commit headline, so every mangled title
becomes a permanent commit subject and a `cliff.toml` changelog line.

## Reproduction

PR #3394, renamed by `github-actions[bot]` 60 seconds after opening:

```
$ gh api repos/ubugeeei/vize/issues/3394/timeline --jq '.[] | select(.event=="renamed")'
from: bench(tools): rank type-check engine classes separately
to:   bench(tools): rank type-canon engine classes separately
```

Still live — PR #3407, opened today, had a real command name corrupted:

```
from: fix(oxint): stop vp lint from silently running zero vize rules
to:   fix(oxint): stop vp patina from silently running zero vize rules
```

## Fix

`normalize_title` now finds the `type(scope): subject` prefix with the **existing**
`colon_space_index` / `is_conventional_prefix` helpers (no second parser) and rewrites only the text
inside `(...)`. The type, the `!` breaking marker, and the entire subject are left as the author
wrote them. A title with no conventional prefix carrying a scope is returned untouched.

**Segment rule, written down in the code:** `/` is the *only* scope segment separator, so
`fix(check/lint): ...` normalizes to `fix(canon/patina): ...`. The other characters `is_scope_char`
allows — `-`, `.`, `_`, digits — build compound scope names (`type-check`, `check.js`,
`vue_compiler`); splitting on them would rewrite a fragment of a name that means something else as a
whole. A segment therefore only changes when the *entire* segment is a known area name, so
`fix(checker): ...` stays `checker` and does not become `canoner`.

Preserved behavior: `is_conventional_title` is still checked against the **normalized** title, a
non-conventional PR title still exits non-zero, issues are still assigned, and the PATCH is still
skipped when normalization is a no-op.

`main.mbt` grew past the 350-line budget, so the title grammar moved to a sibling `title.mbt`
(179 + 183 lines). Multi-file MoonBit command packages are already established
(`cmd/publish_crates/registry.mbt`, `cmd/release/native_catalog.mbt`). The workflow sparse-checkout
already takes the whole package directory, so `.github/workflows/title-policy.yml` is unchanged and
`tests/tooling/github-workflows.test.ts` stays green.

## Tests

There was no test pinning the prose/scope boundary, which is why this shipped. The existing
`tests/tooling/issue-pr-title-policy.test.ts` actively asserted the buggy behavior
(`title=canon atelier patina patina musea glyph glyph checklist formatting`), so it is corrected
here; the shared `runPolicy` / `gh` stub moved to `tests/tooling/support/title-policy.ts` and now
uses `writeFakeCommand`.

New `tests/tooling/issue-pr-title-policy-scope.test.ts` writes a real event payload, runs the tool
with `gh` stubbed, and `assert.deepEqual`s the **complete** recorded argv — so each case asserts the
exact title PATCHed, or that no API call was made at all. No substring matching. It covers all seven
mappings in scope position, multi-segment scopes, the `!` marker, an uppercase scope, a substring
scope (`checker`), compound scopes (`type-check`, `check.js`, `check_js`), an issue with trigger
words in prose, a non-conventional PR title, and the historical mangles listed below replayed as
"must not touch".

### The tests fail before the fix

All 6 new tests fail on the pre-fix tool. Two representative diffs, verbatim:

```
✖ rewrites area names in the conventional scope and nowhere else
  AssertionError: fix(check): skip type-check on hidden files
  + actual - expected
  +     'title=fix(canon): skip type-canon on hidden files'
  -     'title=fix(canon): skip type-check on hidden files'

✖ leaves subject prose and non-matching scopes untouched
  AssertionError: bench(tools): rank type-check engine classes separately
  + actual - expected
  + [
  +   [
  +     'api', '--method', 'PATCH', '-H', 'X-GitHub-Api-Version: 2022-11-28',
  +     '--silent', '/repos/ubugeeei/vize/issues/101', '-f',
  +     'title=bench(tools): rank type-canon engine classes separately'
  +   ]
  + ]
  - []
```

```
pre-fix:  ℹ tests 6   ℹ pass 0   ℹ fail 6
post-fix: ℹ tests 10  ℹ pass 10  ℹ fail 0     (both title-policy test files)
```

## Damage already on `main`

28 bot renames confirmed against the GitHub timeline API — not inferred from commit subjects. The
full table is in #3419. Representative entries, all now permanent commit subjects and changelog
lines:

- #3357 `check sources under an explicitly included hidden directory` -> `canon sources ...`
- #3317 `fail-closed vize check benchmark gate` -> `vize canon benchmark gate` (command name)
- #3289 / #3197 `type-check ...` -> `type-canon ...`
- #3255 `... and lint-agreement properties` -> `patina-agreement properties`
- #2934 `recover Vue compiler quirks` -> `recover Vue atelier quirks`
- #2902 `stream quiet lint aggregation` -> `stream quiet patina aggregation`
- #2699/#2698/#2697 `story-like member spreads`, `unresolved story spreads`,
  `story object detection` -> `musea-...`

No history rewriting is attempted here; #3419 records the list so the changelog correction can be
decided separately.

## Gates

```
nix develop -c vp run fmt:check                                        pass
nix develop -c vp run check:js                                         pass  (18/18)
moon run ... source_file_lengths -- --check --base-ref origin/main     "No new or grown files exceed 350 lines"
nix develop -c node --test tests/tooling/moonbit-warnings.test.ts      pass  (all packages build --deny-warn --target native)
nix develop -c node --test tests/tooling/github-workflows.test.ts      pass  (10/10)
nix develop -c node --test tests/tooling/source-file-lengths.test.ts   pass  (7/7)
nix develop -c node --test tests/tooling/issue-pr-title-policy{,-scope}.test.ts   pass  (10/10)
```

Note: until this is on `main` the workflow keeps mangling, because it checks out the default branch.
Renaming the already-mangled open PRs (#3394, #3407) should wait until after this merges.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->